### PR TITLE
osc/rdma: fix issue identified by Berk Hess

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -424,8 +424,8 @@ static inline void mark_incoming_completion (ompi_osc_rdma_module_t *module, int
 {
     if (MPI_PROC_NULL == source) {
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                             "mark_incoming_completion marking active incoming complete. count = %d",
-                             (int) module->active_incoming_frag_count + 1));
+                             "mark_incoming_completion marking active incoming complete. count = %d. signal = %d",
+                             (int) module->active_incoming_frag_count + 1, module->active_incoming_frag_signal_count));
         OPAL_THREAD_ADD32(&module->active_incoming_frag_count, 1);
         if (module->active_incoming_frag_count >= module->active_incoming_frag_signal_count) {
             opal_condition_broadcast(&module->cond);

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -461,7 +461,7 @@ ompi_osc_rdma_wait(ompi_win_t *win)
 
     OPAL_THREAD_LOCK(&module->lock);
     while (0 != module->num_complete_msgs ||
-             module->active_incoming_frag_count < module->active_incoming_frag_signal_count) {
+             module->active_incoming_frag_count != module->active_incoming_frag_signal_count) {
         OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,
                              "num_complete_msgs = %d, active_incoming_frag_count = %d, active_incoming_frag_signal_count = %d",
                              module->num_complete_msgs, module->active_incoming_frag_count, module->active_incoming_frag_signal_count));
@@ -501,7 +501,7 @@ ompi_osc_rdma_test(ompi_win_t *win,
     OPAL_THREAD_LOCK(&(module->lock));
 
     if (0 != module->num_complete_msgs || 
-           module->active_incoming_frag_count < module->active_incoming_frag_signal_count) {
+           module->active_incoming_frag_count != module->active_incoming_frag_signal_count) {
         *flag = 0;
         ret = OMPI_SUCCESS;
         goto cleanup;

--- a/ompi/mca/osc/rdma/osc_rdma_data_move.c
+++ b/ompi/mca/osc/rdma/osc_rdma_data_move.c
@@ -1335,8 +1335,10 @@ static inline int process_complete (ompi_osc_rdma_module_t *module, int source,
                                     ompi_osc_rdma_header_complete_t *complete_header)
 {
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc rdma:  process_complete got complete message from %d. expected fragment count %d",
-                         source, complete_header->frag_count));
+                         "osc rdma:  process_complete got complete message from %d. expected fragment count %d. "
+                         "current signal count %d. current incomming count: %d",
+                         source, complete_header->frag_count, module->active_incoming_frag_signal_count,
+                         module->active_incoming_frag_count));
 
     OPAL_THREAD_LOCK(&module->lock);
 
@@ -1681,8 +1683,12 @@ static int ompi_osc_rdma_callback (ompi_request_t *request)
     /* restart the receive request */
     OPAL_THREAD_LOCK(&module->lock);
 
-    mark_incoming_completion (module, (base_header->flags & OMPI_OSC_RDMA_HDR_FLAG_PASSIVE_TARGET) ?
-                              source : MPI_PROC_NULL);
+    /* post messages come unbuffered and should NOT increment the incoming completion
+     * counters */
+    if (OMPI_OSC_RDMA_HDR_TYPE_POST != base_header->type) {
+        mark_incoming_completion (module, (base_header->flags & OMPI_OSC_RDMA_HDR_FLAG_PASSIVE_TARGET) ?
+                                  source : MPI_PROC_NULL);
+    }
 
     osc_rdma_gc_clean ();
 


### PR DESCRIPTION
osc/rdma uses counters to determine if all messages have been received
before exiting synchronization calls. The problem is that the active
target counter is always increasing (never zeroed). If over 2^31-1
messages are sent this causes the counter to overflow (in itself this
isn't an error). This causes test/wait to return before the communication
is complete. There is an additional error in the use of the fragment
flush function. If PSCW synchronization is in use this function CAN NOT
be called unless a post message has arrived.

Relevant mailing list thread: http://www.open-mpi.org/community/lists/devel/2014/10/16016.php

This commit fixes both issues. Tested against MTT and issue reproducer.

Closes #224.
