### PR TITLE
RFC/weak symbols status ignore

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -95,15 +95,23 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
     AC_DEFINE_UNQUOTED([OMPI_FORTRAN_DOUBLE_UNDERSCORE],
         [$ompi_fortran_double_underscore], 
         [Whether fortran symbols have a trailing double underscore or not])
+    OMPI_FORTRAN_DOUBLE_UNDERSCORE=$ompi_fortran_double_underscore
+    AC_SUBST(OMPI_FORTRAN_DOUBLE_UNDERSCORE)
     AC_DEFINE_UNQUOTED([OMPI_FORTRAN_SINGLE_UNDERSCORE], 
         [$ompi_fortran_single_underscore],
         [Whether fortran symbols have a trailing underscore or not])
+    OMPI_FORTRAN_SINGLE_UNDERSCORE=$ompi_fortran_single_underscore
+    AC_SUBST(OMPI_FORTRAN_SINGLE_UNDERSCORE)
     AC_DEFINE_UNQUOTED([OMPI_FORTRAN_CAPS],
         [$ompi_fortran_caps],
         [Whether fortran symbols are all caps or not])
+    OMPI_FORTRAN_CAPS=$ompi_fortran_caps
+    AC_SUBST(OMPI_FORTRAN_CAPS)
     AC_DEFINE_UNQUOTED([OMPI_FORTRAN_PLAIN], 
         [$ompi_fortran_plain],
         [Whether fortran symbols have no trailing underscore or not])
+    OMPI_FORTRAN_PLAIN=$ompi_fortran_plain
+    AC_SUBST(OMPI_FORTRAN_PLAIN)
 
     # Check to see if any of the MPI Fortran bindings were
     # specifically requested.  If so, and we weren't able to setup the

--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -15,6 +15,8 @@
 # Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
 #                         reserved. 
 # Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -751,4 +753,10 @@ end type test_mpi_handle],
     # safe, too.
     AM_CONDITIONAL(OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS, 
                    [test $OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS -eq 1])
+
+    AM_CONDITIONAL(OMPI_BUILD_FORTRAN_BINDINGS,
+                   [test $OMPI_BUILD_FORTRAN_MPIFH_BINDINGS -eq 1 || \
+                    test $OMPI_BUILD_FORTRAN_USEMPI_BINDINGS -eq 1 || \
+                    test $OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS -eq 1])
+
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,11 @@ m4_ifdef([project_ompi],
 m4_ifdef([project_oshmem],
          [AC_CONFIG_HEADER([oshmem/include/shmem.h])])
 
+# A preprocessor header file just for Fortran.  We cannot use AC
+# CONFIG_HEADER because it adds a /* */-style comment at the top,
+# and this header file must be usable in .F90 files.  :-(
+AC_CONFIG_FILES([opal/include/opal_fortran_config.h])
+
 opal_show_subtitle "Initialization, setup"
 
 OMPI_TOP_BUILDDIR="`pwd`"

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -15,6 +15,8 @@
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -103,7 +105,6 @@ libmpi_c_mpi_la_SOURCES = \
         cart_sub.c \
         close_port.c \
         comm_accept.c \
-        comm_c2f.c \
         comm_call_errhandler.c \
         comm_compare.c \
         comm_connect.c \
@@ -116,7 +117,6 @@ libmpi_c_mpi_la_SOURCES = \
         comm_dup.c \
         comm_dup_with_info.c \
         comm_idup.c \
-        comm_f2c.c \
         comm_free.c \
         comm_free_keyval.c \
         comm_get_attr.c \
@@ -145,9 +145,7 @@ libmpi_c_mpi_la_SOURCES = \
         comm_test_inter.c \
 	compare_and_swap.c \
         dims_create.c \
-        errhandler_c2f.c \
         errhandler_create.c \
-        errhandler_f2c.c \
         errhandler_free.c \
         errhandler_get.c \
         errhandler_set.c \
@@ -179,11 +177,9 @@ libmpi_c_mpi_la_SOURCES = \
         graphdims_get.c \
         grequest_complete.c \
         grequest_start.c \
-        group_c2f.c \
         group_compare.c \
         group_difference.c \
         group_excl.c \
-        group_f2c.c \
         group_free.c \
         group_incl.c \
         group_intersection.c \
@@ -196,11 +192,9 @@ libmpi_c_mpi_la_SOURCES = \
         ibsend.c \
         improbe.c \
         imrecv.c \
-        info_c2f.c \
         info_create.c \
         info_delete.c \
         info_dup.c \
-        info_f2c.c \
         info_free.c \
         info_get.c \
         info_get_nkeys.c \
@@ -221,8 +215,6 @@ libmpi_c_mpi_la_SOURCES = \
         keyval_create.c \
         keyval_free.c \
         lookup_name.c \
-        message_f2c.c \
-        message_c2f.c \
         mprobe.c \
         mrecv.c \
         neighbor_allgather.c \
@@ -235,10 +227,8 @@ libmpi_c_mpi_la_SOURCES = \
         ineighbor_alltoallv.c \
         neighbor_alltoallw.c \
         ineighbor_alltoallw.c \
-        op_c2f.c \
         op_commutative.c \
         op_create.c \
-        op_f2c.c \
         op_free.c \
         open_port.c \
         pack_external.c \
@@ -259,8 +249,6 @@ libmpi_c_mpi_la_SOURCES = \
         ireduce_scatter.c \
         reduce_scatter_block.c \
         ireduce_scatter_block.c \
-        request_c2f.c \
-        request_f2c.c \
         request_free.c \
         request_get_status.c \
 	rget.c \
@@ -282,8 +270,6 @@ libmpi_c_mpi_la_SOURCES = \
         ssend.c \
         start.c \
         startall.c \
-        status_c2f.c \
-        status_f2c.c \
         status_set_cancelled.c \
         status_set_elements.c \
         status_set_elements_x.c \
@@ -293,7 +279,6 @@ libmpi_c_mpi_la_SOURCES = \
         test_cancelled.c \
         testsome.c \
         topo_test.c \
-        type_c2f.c \
         type_commit.c \
         type_contiguous.c \
         type_create_darray.c \
@@ -311,7 +296,6 @@ libmpi_c_mpi_la_SOURCES = \
         type_delete_attr.c \
         type_dup.c \
         type_extent.c \
-        type_f2c.c \
         type_free.c \
         type_free_keyval.c \
         type_get_attr.c \
@@ -349,7 +333,6 @@ libmpi_c_mpi_la_SOURCES = \
 	win_allocate.c \
 	win_allocate_shared.c \
 	win_attach.c \
-        win_c2f.c \
         win_call_errhandler.c \
         win_complete.c  \
         win_create_errhandler.c \
@@ -358,7 +341,6 @@ libmpi_c_mpi_la_SOURCES = \
 	win_create_dynamic.c \
         win_delete_attr.c \
 	win_detach.c \
-        win_f2c.c \
         win_fence.c \
 	win_flush.c \
 	win_flush_all.c \
@@ -386,14 +368,36 @@ libmpi_c_mpi_la_SOURCES = \
 	win_unlock_all.c \
         win_wait.c
 
+if OMPI_BUILD_FORTRAN_BINDINGS
+libmpi_c_mpi_la_SOURCES += \
+        comm_c2f.c \
+        comm_f2c.c \
+        errhandler_c2f.c \
+        errhandler_f2c.c \
+        group_c2f.c \
+        group_f2c.c \
+        info_f2c.c \
+        info_c2f.c \
+        message_c2f.c \
+        message_f2c.c \
+        op_c2f.c \
+        op_f2c.c \
+        request_c2f.c \
+        request_f2c.c \
+        status_c2f.c \
+        status_f2c.c \
+        type_c2f.c \
+        type_f2c.c \
+        win_c2f.c \
+        win_f2c.c
+endif
+
 if OMPI_PROVIDE_MPI_FILE_INTERFACE
 libmpi_c_mpi_la_SOURCES += \
-        file_c2f.c \
         file_call_errhandler.c \
         file_close.c \
         file_create_errhandler.c \
         file_delete.c \
-        file_f2c.c \
         file_get_amode.c \
         file_get_atomicity.c \
         file_get_byte_offset.c \
@@ -446,6 +450,13 @@ libmpi_c_mpi_la_SOURCES += \
         file_write_ordered_end.c \
         file_write_shared.c \
         register_datarep.c
+
+if OMPI_BUILD_FORTRAN_BINDINGS
+libmpi_c_mpi_la_SOURCES += \
+        file_c2f.c \
+        file_f2c.c
+endif
+
 endif
 
 # Conditionally install the header files

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -16,6 +16,8 @@
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -87,7 +89,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pcart_sub.c \
         pclose_port.c \
         pcomm_accept.c \
-        pcomm_c2f.c \
         pcomm_call_errhandler.c \
         pcomm_compare.c \
         pcomm_connect.c \
@@ -100,7 +101,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pcomm_dup.c \
         pcomm_dup_with_info.c \
         pcomm_idup.c \
-        pcomm_f2c.c \
         pcomm_free.c \
         pcomm_free_keyval.c \
         pcomm_get_attr.c \
@@ -129,9 +129,7 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pcomm_test_inter.c \
 	pcompare_and_swap.c \
         pdims_create.c \
-        perrhandler_c2f.c \
         perrhandler_create.c \
-        perrhandler_f2c.c \
         perrhandler_free.c \
         perrhandler_get.c \
         perrhandler_set.c \
@@ -163,11 +161,9 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pgraphdims_get.c \
         pgrequest_complete.c \
         pgrequest_start.c \
-        pgroup_c2f.c \
         pgroup_compare.c \
         pgroup_difference.c \
         pgroup_excl.c \
-        pgroup_f2c.c \
         pgroup_free.c \
         pgroup_incl.c \
         pgroup_intersection.c \
@@ -180,11 +176,9 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pibsend.c \
 	pimprobe.c \
 	pimrecv.c \
-        pinfo_c2f.c \
         pinfo_create.c \
         pinfo_delete.c \
         pinfo_dup.c \
-        pinfo_f2c.c \
         pinfo_free.c \
         pinfo_get.c \
         pinfo_get_nkeys.c \
@@ -205,8 +199,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pkeyval_create.c \
         pkeyval_free.c \
         plookup_name.c \
-        pmessage_f2c.c \
-        pmessage_c2f.c \
         pmprobe.c \
         pmrecv.c \
         pneighbor_allgather.c \
@@ -219,10 +211,8 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pineighbor_alltoallv.c \
         pneighbor_alltoallw.c \
         pineighbor_alltoallw.c \
-        pop_c2f.c \
         pop_create.c \
         pop_commutative.c \
-        pop_f2c.c \
         pop_free.c \
         popen_port.c \
         ppack_external.c \
@@ -243,8 +233,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pireduce_scatter.c \
         preduce_scatter_block.c \
         pireduce_scatter_block.c \
-        prequest_c2f.c \
-        prequest_f2c.c \
         prequest_free.c \
         prequest_get_status.c \
 	prget.c \
@@ -266,8 +254,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pssend.c \
         pstart.c \
         pstartall.c \
-        pstatus_c2f.c \
-        pstatus_f2c.c \
         pstatus_set_cancelled.c \
         pstatus_set_elements.c \
         pstatus_set_elements_x.c \
@@ -277,7 +263,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         ptest_cancelled.c \
         ptestsome.c \
         ptopo_test.c \
-        ptype_c2f.c \
         ptype_commit.c \
         ptype_contiguous.c \
         ptype_create_darray.c \
@@ -295,7 +280,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         ptype_delete_attr.c \
         ptype_dup.c \
         ptype_extent.c \
-        ptype_f2c.c \
         ptype_free.c \
         ptype_free_keyval.c \
         ptype_get_attr.c \
@@ -333,7 +317,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
 	pwin_allocate.c \
 	pwin_allocate_shared.c \
 	pwin_attach.c \
-        pwin_c2f.c \
         pwin_call_errhandler.c \
         pwin_complete.c  \
         pwin_create_errhandler.c \
@@ -342,7 +325,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
 	pwin_create_dynamic.c \
         pwin_delete_attr.c \
 	pwin_detach.c \
-        pwin_f2c.c \
         pwin_fence.c \
 	pwin_flush.c \
 	pwin_flush_all.c \
@@ -370,14 +352,36 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
 	pwin_unlock_all.c \
         pwin_wait.c
 
+if OMPI_BUILD_FORTRAN_BINDINGS
+nodist_libmpi_c_pmpi_la_SOURCES += \
+        pcomm_c2f.c \
+        pcomm_f2c.c \
+        perrhandler_c2f.c \
+        perrhandler_f2c.c \
+        pgroup_c2f.c \
+        pgroup_f2c.c \
+        pinfo_c2f.c \
+        pinfo_f2c.c \
+        pmessage_c2f.c \
+        pmessage_f2c.c \
+        pop_c2f.c \
+        pop_f2c.c \
+        prequest_c2f.c \
+        prequest_f2c.c \
+        pstatus_c2f.c \
+        pstatus_f2c.c \
+        ptype_c2f.c \
+        ptype_f2c.c \
+        pwin_c2f.c \
+        pwin_f2c.c
+endif
+
 if OMPI_PROVIDE_MPI_FILE_INTERFACE
 nodist_libmpi_c_pmpi_la_SOURCES += \
-        pfile_c2f.c \
         pfile_call_errhandler.c \
         pfile_close.c \
         pfile_create_errhandler.c \
         pfile_delete.c \
-        pfile_f2c.c \
         pfile_get_amode.c \
         pfile_get_atomicity.c \
         pfile_get_byte_offset.c \
@@ -430,6 +434,13 @@ nodist_libmpi_c_pmpi_la_SOURCES += \
         pfile_write_ordered_end.c \
         pfile_write_shared.c \
         pregister_datarep.c
+
+if OMPI_BUILD_FORTRAN_BINDINGS
+nodist_libmpi_c_pmpi_la_SOURCES += \
+        pfile_c2f.c \
+        pfile_f2c.c
+endif
+
 endif
 
 #

--- a/ompi/mpi/fortran/base/constants.h
+++ b/ompi/mpi/fortran/base/constants.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
  * Copyright (c) 2011-2012 Universite Bordeaux 1
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -85,11 +87,21 @@
  * file.
  */
 
+#if OMPI_FORTRAN_CAPS
 #define DECL(type, upper_case, lower_case, single_u, double_u)   \
-OMPI_DECLSPEC extern type upper_case; \
-OMPI_DECLSPEC extern type lower_case; \
-OMPI_DECLSPEC extern type single_u; \
+OMPI_DECLSPEC extern type upper_case
+#elif OMPI_FORTRAN_PLAIN
+#define DECL(type, upper_case, lower_case, single_u, double_u)   \
+OMPI_DECLSPEC extern type lower_case
+#elif OMPI_FORTRAN_SINGLE_UNDERSCORE
+#define DECL(type, upper_case, lower_case, single_u, double_u)   \
+OMPI_DECLSPEC extern type single_u
+#elif OMPI_FORTRAN_DOUBLE_UNDERSCORE
+#define DECL(type, upper_case, lower_case, single_u, double_u)   \
 OMPI_DECLSPEC extern type double_u
+#else
+#error Unrecognized Fortran name mangling scheme
+#endif
 
 /* Note that the rationale for the types of each of these variables is
    discussed in ompi/include/mpif-common.h.  Do not change the types
@@ -116,57 +128,10 @@ DECL(int *, MPI_FORTRAN_STATUSES_IGNORE, mpi_fortran_statuses_ignore,
      mpi_fortran_statuses_ignore_, mpi_fortran_statuses_ignore__);
 
 /*
- * Create macros to do the checking.  Only check for all 4 if we have
- * weak symbols.  Otherwise, just check for the one relevant symbol.
+ * Create macros to do the checking.
+ * Just check for the one and only relevant symbol.
  */
-#if OPAL_HAVE_WEAK_SYMBOLS
-#define OMPI_IS_FORTRAN_BOTTOM(addr) \
-  (addr == (void*) &MPI_FORTRAN_BOTTOM || \
-   addr == (void*) &mpi_fortran_bottom || \
-   addr == (void*) &mpi_fortran_bottom_ || \
-   addr == (void*) &mpi_fortran_bottom__)
-#define OMPI_IS_FORTRAN_IN_PLACE(addr) \
-  (addr == (void*) &MPI_FORTRAN_IN_PLACE || \
-   addr == (void*) &mpi_fortran_in_place || \
-   addr == (void*) &mpi_fortran_in_place_ || \
-   addr == (void*) &mpi_fortran_in_place__)
-#define OMPI_IS_FORTRAN_UNWEIGHTED(addr) \
-  (addr == (void*) &MPI_FORTRAN_UNWEIGHTED || \
-   addr == (void*) &mpi_fortran_unweighted || \
-   addr == (void*) &mpi_fortran_unweighted_ || \
-   addr == (void*) &mpi_fortran_unweighted__)
-#define OMPI_IS_FORTRAN_WEIGHTS_EMPTY(addr) \
-  (addr == (void*) &MPI_FORTRAN_WEIGHTS_EMPTY || \
-   addr == (void*) &mpi_fortran_weights_empty || \
-   addr == (void*) &mpi_fortran_weights_empty_ || \
-   addr == (void*) &mpi_fortran_weights_empty__)
-#define OMPI_IS_FORTRAN_ARGV_NULL(addr) \
-  (addr == (void*) &MPI_FORTRAN_ARGV_NULL || \
-   addr == (void*) &mpi_fortran_argv_null || \
-   addr == (void*) &mpi_fortran_argv_null_ || \
-   addr == (void*) &mpi_fortran_argv_null__)
-#define OMPI_IS_FORTRAN_ARGVS_NULL(addr) \
-  (addr == (void*) &MPI_FORTRAN_ARGVS_NULL || \
-   addr == (void*) &mpi_fortran_argvs_null || \
-   addr == (void*) &mpi_fortran_argvs_null_ || \
-   addr == (void*) &mpi_fortran_argvs_null__)
-#define OMPI_IS_FORTRAN_ERRCODES_IGNORE(addr) \
-  (addr == (void*) &MPI_FORTRAN_ERRCODES_IGNORE || \
-   addr == (void*) &mpi_fortran_errcodes_ignore || \
-   addr == (void*) &mpi_fortran_errcodes_ignore_ || \
-   addr == (void*) &mpi_fortran_errcodes_ignore__)
-#define OMPI_IS_FORTRAN_STATUS_IGNORE(addr) \
-  (addr == (void*) &MPI_FORTRAN_STATUS_IGNORE || \
-   addr == (void*) &mpi_fortran_status_ignore || \
-   addr == (void*) &mpi_fortran_status_ignore_ || \
-   addr == (void*) &mpi_fortran_status_ignore__)
-#define OMPI_IS_FORTRAN_STATUSES_IGNORE(addr) \
-  (addr == (void*) &MPI_FORTRAN_STATUSES_IGNORE || \
-   addr == (void*) &mpi_fortran_statuses_ignore || \
-   addr == (void*) &mpi_fortran_statuses_ignore_ || \
-   addr == (void*) &mpi_fortran_statuses_ignore__)
-
-#elif OMPI_FORTRAN_CAPS
+#if OMPI_FORTRAN_CAPS
 #define OMPI_IS_FORTRAN_BOTTOM(addr) \
   (addr == (void*) &MPI_FORTRAN_BOTTOM)
 #define OMPI_IS_FORTRAN_IN_PLACE(addr) \
@@ -226,7 +191,7 @@ DECL(int *, MPI_FORTRAN_STATUSES_IGNORE, mpi_fortran_statuses_ignore,
 #define OMPI_IS_FORTRAN_STATUSES_IGNORE(addr) \
    (addr == (void*) &mpi_fortran_statuses_ignore_)
 
-#else
+#elif OMPI_FORTRAN_DOUBLE_UNDERSCORE
 #define OMPI_IS_FORTRAN_BOTTOM(addr) \
    (addr == (void*) &mpi_fortran_bottom__)
 #define OMPI_IS_FORTRAN_IN_PLACE(addr) \
@@ -246,7 +211,10 @@ DECL(int *, MPI_FORTRAN_STATUSES_IGNORE, mpi_fortran_statuses_ignore,
 #define OMPI_IS_FORTRAN_STATUSES_IGNORE(addr) \
    (addr == (void*) &mpi_fortran_statuses_ignore__)
 
-#endif /* weak / specific symbol type */
+#else
+#error Unrecognized Fortran name mangling scheme
+
+#endif /* specific symbol type */
 
 /* Convert between Fortran and C MPI_BOTTOM */
 #define OMPI_F2C_BOTTOM(addr)      (OMPI_IS_FORTRAN_BOTTOM(addr) ? MPI_BOTTOM : (addr))

--- a/ompi/mpi/fortran/configure-fortran-output.h.in
+++ b/ompi/mpi/fortran/configure-fortran-output.h.in
@@ -3,6 +3,8 @@
 ! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
+! Copyright (c) 2014      Research Organization for Information Science
+!                         and Technology (RIST). All rights reserved.
 !
 ! $COPYRIGHT$
 !
@@ -108,5 +110,6 @@
 ! Include some post-processing, based on the values from above
 
 #include "ompi/mpi/fortran/configure-fortran-output-bottom.h"
+#include "opal/include/opal_fortran_config.h"
 
 #endif

--- a/ompi/mpi/fortran/use-mpi-f08-desc/mpi-f08-types.f90
+++ b/ompi/mpi/fortran/use-mpi-f08-desc/mpi-f08-types.f90
@@ -3,6 +3,8 @@
 ! Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
+! Copyright (c) 2014      Research Organization for Information Science
+!                         and Technology (RIST). All rights reserved.
 !
 ! This file creates mappings between MPI C types (e.g., MPI_Comm) and
 ! variables (e.g., MPI_COMM_WORLD) and corresponding Fortran names
@@ -13,6 +15,7 @@ module mpi_f08_types
    use, intrinsic :: ISO_C_BINDING
 
    include "mpif-config.h"
+   include "opal/include/opal_fortran_config.h"
 
    !
    ! constants (these must agree with those in mpif-common.h, mpif-config.h)
@@ -151,7 +154,48 @@ module mpi_f08_types
 !
 ! STATUS/STATUSES_IGNORE
 !
-  type(MPI_STATUS), bind(C, name="mpi_fortran_status_ignore")   :: MPI_STATUS_IGNORE
+#if OMPI_FORTRAN_CAPS
+  type(MPI_STATUS), bind(C, name="MPI_FORTRAN_STATUS_IGNORE") :: MPI_STATUS_IGNORE
+  type(MPI_STATUS), bind(C, name="MPI_FORTRAN_STATUSES_IGNORE") :: MPI_STATUSES_IGNORE(1)
+  integer, bind(C, name="MPI_FORTRAN_BOTTOM")          :: MPI_BOTTOM
+  integer, bind(C, name="MPI_FORTRAN_IN_PLACE")        :: MPI_IN_PLACE
+  integer, bind(C, name="MPI_FORTRAN_ARGV_NULL")       :: MPI_ARGV_NULL
+  integer, bind(C, name="MPI_FORTRAN_ARGVS_NULL")      :: MPI_ARGVS_NULL
+  integer, bind(C, name="MPI_FORTRAN_ERRCODES_IGNORE") :: MPI_ERRCODES_IGNORE
+  integer, bind(C, name="MPI_FORTRAN_UNWEIGHTED")      :: MPI_UNWEIGHTED
+  integer, bind(C, name="MPI_FORTRAN_WEIGHTS_EMPTY")   :: MPI_WEIGHTS_EMPTY
+#elif OMPI_FORTRAN_PLAIN
+  type(MPI_STATUS), bind(C, name="mpi_fortran_status_ignore") :: MPI_STATUS_IGNORE
   type(MPI_STATUS), bind(C, name="mpi_fortran_statuses_ignore") :: MPI_STATUSES_IGNORE(1)
+  integer, bind(C, name="mpi_fortran_bottom")          :: MPI_BOTTOM
+  integer, bind(C, name="mpi_fortran_in_place")        :: MPI_IN_PLACE
+  integer, bind(C, name="mpi_fortran_argv_null")       :: MPI_ARGV_NULL
+  integer, bind(C, name="mpi_fortran_argvs_null")      :: MPI_ARGVS_NULL
+  integer, bind(C, name="mpi_fortran_errcodes_ignore") :: MPI_ERRCODES_IGNORE
+  integer, bind(C, name="mpi_fortran_unweighted")      :: MPI_UNWEIGHTED
+  integer, bind(C, name="mpi_fortran_weights_empty")   :: MPI_WEIGHTS_EMPTY
+#elif OMPI_FORTRAN_SINGLE_UNDERSCORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_status_ignore_") :: MPI_STATUS_IGNORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_statuses_ignore_") :: MPI_STATUSES_IGNORE(1)
+  integer, bind(C, name="mpi_fortran_bottom_")          :: MPI_BOTTOM
+  integer, bind(C, name="mpi_fortran_in_place_")        :: MPI_IN_PLACE
+  integer, bind(C, name="mpi_fortran_argv_null_")       :: MPI_ARGV_NULL
+  integer, bind(C, name="mpi_fortran_argvs_null_")      :: MPI_ARGVS_NULL
+  integer, bind(C, name="mpi_fortran_errcodes_ignore_") :: MPI_ERRCODES_IGNORE
+  integer, bind(C, name="mpi_fortran_unweighted_")      :: MPI_UNWEIGHTED
+  integer, bind(C, name="mpi_fortran_weights_empty_")   :: MPI_WEIGHTS_EMPTY
+#elif OMPI_FORTRAN_DOUBLE_UNDERSCORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_status_ignore__") :: MPI_STATUS_IGNORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_statuses_ignore__") :: MPI_STATUSES_IGNORE(1)
+  integer, bind(C, name="mpi_fortran_bottom__")          :: MPI_BOTTOM
+  integer, bind(C, name="mpi_fortran_in_place__")        :: MPI_IN_PLACE
+  integer, bind(C, name="mpi_fortran_argv_null__")       :: MPI_ARGV_NULL
+  integer, bind(C, name="mpi_fortran_argvs_null__")      :: MPI_ARGVS_NULL
+  integer, bind(C, name="mpi_fortran_errcodes_ignore__") :: MPI_ERRCODES_IGNORE
+  integer, bind(C, name="mpi_fortran_unweighted__")      :: MPI_UNWEIGHTED
+  integer, bind(C, name="mpi_fortran_weights_empty__")   :: MPI_WEIGHTS_EMPTY
+#else
+#error Unrecognized Fortran name mangling scheme
+#endif
 
 end module mpi_f08_types

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f08-types.F90
@@ -3,6 +3,8 @@
 ! Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
+! Copyright (c) 2014      Research Organization for Information Science
+!                         and Technology (RIST). All rights reserved.
 ! $COPYRIGHT$
 !
 ! This file creates mappings between MPI C types (e.g., MPI_Comm) and
@@ -164,6 +166,17 @@ module mpi_f08_types
 
 !... Special sentinel constants
 !------------------------------
+#if OMPI_FORTRAN_CAPS
+  type(MPI_STATUS), bind(C, name="MPI_FORTRAN_STATUS_IGNORE") :: MPI_STATUS_IGNORE
+  type(MPI_STATUS), bind(C, name="MPI_FORTRAN_STATUSES_IGNORE") :: MPI_STATUSES_IGNORE(1)
+  integer, bind(C, name="MPI_FORTRAN_BOTTOM")          :: MPI_BOTTOM
+  integer, bind(C, name="MPI_FORTRAN_IN_PLACE")        :: MPI_IN_PLACE
+  integer, bind(C, name="MPI_FORTRAN_ARGV_NULL")       :: MPI_ARGV_NULL
+  integer, bind(C, name="MPI_FORTRAN_ARGVS_NULL")      :: MPI_ARGVS_NULL
+  integer, bind(C, name="MPI_FORTRAN_ERRCODES_IGNORE") :: MPI_ERRCODES_IGNORE
+  integer, bind(C, name="MPI_FORTRAN_UNWEIGHTED")      :: MPI_UNWEIGHTED
+  integer, bind(C, name="MPI_FORTRAN_WEIGHTS_EMPTY")   :: MPI_WEIGHTS_EMPTY
+#elif OMPI_FORTRAN_PLAIN
   type(MPI_STATUS), bind(C, name="mpi_fortran_status_ignore") :: MPI_STATUS_IGNORE
   type(MPI_STATUS), bind(C, name="mpi_fortran_statuses_ignore") :: MPI_STATUSES_IGNORE(1)
   integer, bind(C, name="mpi_fortran_bottom")          :: MPI_BOTTOM
@@ -173,6 +186,29 @@ module mpi_f08_types
   integer, bind(C, name="mpi_fortran_errcodes_ignore") :: MPI_ERRCODES_IGNORE
   integer, bind(C, name="mpi_fortran_unweighted")      :: MPI_UNWEIGHTED
   integer, bind(C, name="mpi_fortran_weights_empty")   :: MPI_WEIGHTS_EMPTY
+#elif OMPI_FORTRAN_SINGLE_UNDERSCORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_status_ignore_") :: MPI_STATUS_IGNORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_statuses_ignore_") :: MPI_STATUSES_IGNORE(1)
+  integer, bind(C, name="mpi_fortran_bottom_")          :: MPI_BOTTOM
+  integer, bind(C, name="mpi_fortran_in_place_")        :: MPI_IN_PLACE
+  integer, bind(C, name="mpi_fortran_argv_null_")       :: MPI_ARGV_NULL
+  integer, bind(C, name="mpi_fortran_argvs_null_")      :: MPI_ARGVS_NULL
+  integer, bind(C, name="mpi_fortran_errcodes_ignore_") :: MPI_ERRCODES_IGNORE
+  integer, bind(C, name="mpi_fortran_unweighted_")      :: MPI_UNWEIGHTED
+  integer, bind(C, name="mpi_fortran_weights_empty_")   :: MPI_WEIGHTS_EMPTY
+#elif OMPI_FORTRAN_DOUBLE_UNDERSCORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_status_ignore__") :: MPI_STATUS_IGNORE
+  type(MPI_STATUS), bind(C, name="mpi_fortran_statuses_ignore__") :: MPI_STATUSES_IGNORE(1)
+  integer, bind(C, name="mpi_fortran_bottom__")          :: MPI_BOTTOM
+  integer, bind(C, name="mpi_fortran_in_place__")        :: MPI_IN_PLACE
+  integer, bind(C, name="mpi_fortran_argv_null__")       :: MPI_ARGV_NULL
+  integer, bind(C, name="mpi_fortran_argvs_null__")      :: MPI_ARGVS_NULL
+  integer, bind(C, name="mpi_fortran_errcodes_ignore__") :: MPI_ERRCODES_IGNORE
+  integer, bind(C, name="mpi_fortran_unweighted__")      :: MPI_UNWEIGHTED
+  integer, bind(C, name="mpi_fortran_weights_empty__")   :: MPI_WEIGHTS_EMPTY
+#else
+#error Unrecognized Fortran name mangling scheme
+#endif
 
 !... Interfaces for operators with handles
 !-----------------------------------------

--- a/ompi/request/grequest.c
+++ b/ompi/request/grequest.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -216,11 +218,15 @@ int ompi_grequest_invoke_query(ompi_request_t *request,
         if (g->greq_funcs_are_c) {
             rc = g->greq_query.c_query(g->greq_state, status);
         } else {
+#if OMPI_BUILD_FORTRAN_BINDINGS
             MPI_Fint ierr;
             MPI_Fint fstatus[sizeof(MPI_Status) / sizeof(int)];
             g->greq_query.f_query((MPI_Aint*)g->greq_state, fstatus, &ierr);
             MPI_Status_f2c(fstatus, status);
             rc = OMPI_FINT_2_INT(ierr);
+#else
+            rc = OMPI_ERROR;
+#endif
         }
     }
 

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -258,11 +258,22 @@ MPI_Fint *MPI_F_STATUSES_IGNORE = NULL;
    ompi/include/mpif-common.h.
  */
 
+#if OMPI_BUILD_FORTRAN_BINDINGS
+#  if OMPI_FORTRAN_CAPS
 #define INST(type, upper_case, lower_case, single_u, double_u)   \
-type lower_case; \
-type upper_case; \
-type single_u;  \
+type lower_case
+#  elif OMPI_FORTRAN_PLAIN
+#define INST(type, upper_case, lower_case, single_u, double_u)   \
+type upper_case
+#  elif OMPI_FORTRAN_SINGLE_UNDERSCORE
+#define INST(type, upper_case, lower_case, single_u, double_u)   \
+type single_u
+#  elif OMPI_FORTRAN_DOUBLE_UNDERSCORE
+#define INST(type, upper_case, lower_case, single_u, double_u)   \
 type double_u
+#  else
+#    error Unrecognized Fortran name mangling scheme
+#  endif
 
 INST(int, MPI_FORTRAN_BOTTOM, mpi_fortran_bottom,
      mpi_fortran_bottom_, mpi_fortran_bottom__);
@@ -282,6 +293,7 @@ INST(int *, MPI_FORTRAN_STATUS_IGNORE, mpi_fortran_status_ignore,
      mpi_fortran_status_ignore_, mpi_fortran_status_ignore__);
 INST(int *, MPI_FORTRAN_STATUSES_IGNORE, mpi_fortran_statuses_ignore,
       mpi_fortran_statuses_ignore_, mpi_fortran_statuses_ignore__);
+#endif  /* OMPI_BUILD_FORTRAN_BINDINGS */
 
 /*
  * Hash tables for MPI_Type_create_f90* functions

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * $COPYRIGHT$
  * 
@@ -59,7 +61,9 @@
 #include "opal/util/timings.h"
 
 #include "ompi/constants.h"
+#if OMPI_BUILD_FORTRAN_BINDINGS
 #include "ompi/mpi/fortran/base/constants.h"
+#endif
 #include "ompi/runtime/mpiruntime.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/opal/include/opal_fortran_config.h.in
+++ b/opal/include/opal_fortran_config.h.in
@@ -1,0 +1,31 @@
+! -*- fortran -*-
+!
+! Copyright (c) 2014      Research Organization for Information Science
+!                         and Technology (RIST). All rights reserved.
+!
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+! 
+! $HEADER$
+!
+
+!     This file exists to have a Fortran-safe header file that has
+!     results from configure tests.
+
+#ifndef OMPI_FORTRAN_CONFIGURE_H
+#define OMPI_FORTRAN_CONFIGURE_H
+
+! Whether fortran symbols are all caps or not
+#define OMPI_FORTRAN_CAPS @OMPI_FORTRAN_CAPS@
+
+! Whether fortran symbols have no trailing underscore or not
+#define OMPI_FORTRAN_PLAIN @OMPI_FORTRAN_PLAIN@
+
+! Whether fortran symbols have a trailing underscore or not
+#define OMPI_FORTRAN_SINGLE_UNDERSCORE @OMPI_FORTRAN_SINGLE_UNDERSCORE@
+
+! Whether fortran symbols have a trailing double underscore or not
+#define OMPI_FORTRAN_DOUBLE_UNDERSCORE @OMPI_FORTRAN_DOUBLE_UNDERSCORE@
+
+#endif

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * $COPYRIGHT$
  * 
@@ -130,11 +132,22 @@ opal_thread_t *oshmem_mpi_main_thread = NULL;
  ompi/include/mpif-common.h.
  */
 
+#if OMPI_BUILD_FORTRAN_BINDINGS
+#  if OMPI_FORTRAN_CAPS
 #define INST(type, upper_case, lower_case, single_u, double_u)   \
-    type lower_case; \
-type upper_case; \
-type single_u;  \
+type lower_case
+#  elif OMPI_FORTRAN_PLAIN
+#define INST(type, upper_case, lower_case, single_u, double_u)   \
+type upper_case
+#  elif OMPI_FORTRAN_SINGLE_UNDERSCORE
+#define INST(type, upper_case, lower_case, single_u, double_u)   \
+type single_u
+#  elif OMPI_FORTRAN_DOUBLE_UNDERSCORE
+#define INST(type, upper_case, lower_case, single_u, double_u)   \
 type double_u
+#  else
+#    error Unrecognized Fortran name mangling scheme
+#  endif
 
 INST(int,
      MPI_FORTRAN_BOTTOM,
@@ -171,6 +184,7 @@ INST(double,
      mpi_fortran_statuses_ignore,
      mpi_fortran_statuses_ignore_,
      mpi_fortran_statuses_ignore__);
+#endif /* OMPI_BUILD_FORTRAN_BINDINGS */
 
 /*
  * Hash tables for MPI_Type_create_f90* functions


### PR DESCRIPTION
Fix fortran 2008 when OpenMPI is configure'd with --disable-weak-symbols.

this was initially introduced in http://www.open-mpi.org/community/lists/devel/2014/09/15774.php

a simpler but suboptimal workaround can be provided for the v1.8 branch if this one is too big.

This fixes the failure of the following tests from the ibm test suite (except many_to_one) reported at
http://mtt.open-mpi.org/index.php?do_redir=2212

this PR has a simple conflict with PR #228 and i will fix it when/if #228 lands into the master

@jsquyres could you please review this ?