### PR TITLE
add a disable function for coll module

### DIFF
--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2012      Oak Ridge National Laboratory.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -49,7 +51,7 @@ struct avail_coll_t {
     opal_list_item_t super;
 
     int ac_priority;
-    mca_coll_base_module_2_0_0_t *ac_module;
+    mca_coll_base_module_2_1_0_t *ac_module;
 };
 typedef struct avail_coll_t avail_coll_t;
 
@@ -61,16 +63,16 @@ static opal_list_t *check_components(opal_list_t * components,
                                      ompi_communicator_t * comm);
 static int check_one_component(ompi_communicator_t * comm,
                                const mca_base_component_t * component,
-                               mca_coll_base_module_2_0_0_t ** module);
+                               mca_coll_base_module_2_1_0_t ** module);
 
 static int query(const mca_base_component_t * component,
                  ompi_communicator_t * comm, int *priority,
-                 mca_coll_base_module_2_0_0_t ** module);
+                 mca_coll_base_module_2_1_0_t ** module);
 
 static int query_2_0_0(const mca_coll_base_component_2_0_0_t *
                        coll_component, ompi_communicator_t * comm,
                        int *priority,
-                       mca_coll_base_module_2_0_0_t ** module);
+                       mca_coll_base_module_2_1_0_t ** module);
 
 /*
  * Stuff for the OBJ interface
@@ -267,7 +269,7 @@ static opal_list_t *check_components(opal_list_t * components,
     int priority;
     const mca_base_component_t *component;
     mca_base_component_list_item_t *cli;
-    mca_coll_base_module_2_0_0_t *module;
+    mca_coll_base_module_2_1_0_t *module;
     opal_list_t *selectable;
     avail_coll_t *avail;
 
@@ -309,7 +311,7 @@ static opal_list_t *check_components(opal_list_t * components,
  */
 static int check_one_component(ompi_communicator_t * comm,
                                const mca_base_component_t * component,
-                               mca_coll_base_module_2_0_0_t ** module)
+                               mca_coll_base_module_2_1_0_t ** module)
 {
     int err;
     int priority = -1;
@@ -343,7 +345,7 @@ static int check_one_component(ompi_communicator_t * comm,
  */
 static int query(const mca_base_component_t * component,
                  ompi_communicator_t * comm,
-                 int *priority, mca_coll_base_module_2_0_0_t ** module)
+                 int *priority, mca_coll_base_module_2_1_0_t ** module)
 {
     *module = NULL;
     if (2 == component->mca_type_major_version &&
@@ -363,9 +365,9 @@ static int query(const mca_base_component_t * component,
 
 static int query_2_0_0(const mca_coll_base_component_2_0_0_t * component,
                        ompi_communicator_t * comm, int *priority,
-                       mca_coll_base_module_2_0_0_t ** module)
+                       mca_coll_base_module_2_1_0_t ** module)
 {
-    mca_coll_base_module_2_0_0_t *ret;
+    mca_coll_base_module_2_1_0_t *ret;
 
     /* There's currently no need for conversion */
 

--- a/ompi/mca/coll/base/coll_base_comm_unselect.c
+++ b/ompi/mca/coll/base/coll_base_comm_unselect.c
@@ -36,6 +36,12 @@
 #define CLOSE(comm, func)                                       \
     do {                                                        \
         if (NULL != comm->c_coll.coll_ ## func ## _module) {    \
+            if (NULL != comm->c_coll.coll_ ## func ## _module-> \
+                coll_module_disable) {                          \
+                comm->c_coll.coll_ ## func ## _module->         \
+                coll_module_disable(                            \
+                comm->c_coll.coll_ ## func ## _module, comm);   \
+            }                                                   \
             OBJ_RELEASE(comm->c_coll.coll_ ## func ## _module); \
             comm->c_coll.coll_## func = NULL;                   \
             comm->c_coll.coll_## func ## _module = NULL;        \

--- a/ompi/mca/coll/base/coll_base_frame.c
+++ b/ompi/mca/coll/base/coll_base_frame.c
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -46,6 +48,7 @@ static void coll_base_module_construct(mca_coll_base_module_t *m)
 {
     /* zero out all functions */
     memset ((char *) m + sizeof (m->super), 0, sizeof (*m) - sizeof (m->super));
+    m->coll_module_disable = NULL;
 }
 
 OBJ_CLASS_INSTANCE(mca_coll_base_module_t, opal_object_t, 

--- a/ompi/mca/coll/coll.h
+++ b/ompi/mca/coll/coll.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2012      Oak Rigde National Laboratory. All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -134,7 +136,7 @@ typedef int (*mca_coll_base_component_init_query_fn_t)
  * provide a module with the requested functionality or NULL if the
  * component should not be used on the given communicator.
  */
-typedef struct mca_coll_base_module_2_0_0_t *
+typedef struct mca_coll_base_module_2_1_0_t *
   (*mca_coll_base_component_comm_query_2_0_0_fn_t)
     (struct ompi_communicator_t *comm, int *priority);
 
@@ -145,7 +147,7 @@ typedef struct mca_coll_base_module_2_0_0_t *
 /**
  * Enable module for collective communication
  *
- * Enable the module for collective commuication.  Modules are enabled
+ * Enable the module for collective communication.  Modules are enabled
  * in order from lowest to highest priority.  At each component,
  * collective functions with priority higher than the existing
  * function are copied into the communicator's function table and the
@@ -174,147 +176,162 @@ typedef struct mca_coll_base_module_2_0_0_t *
  * @param[in]     comm       Communicator being created
  */
 typedef int
-(*mca_coll_base_module_enable_1_1_0_fn_t)(struct mca_coll_base_module_2_0_0_t* module,
+(*mca_coll_base_module_enable_1_1_0_fn_t)(struct mca_coll_base_module_2_1_0_t* module,
+                                          struct ompi_communicator_t *comm);
+
+
+/**
+ * Disable module for collective communication
+ *
+ * Disable the module for collective communication. This callback is
+ * meant to avoid unused modules referencing unused modules
+ * (and hence avoid memory leaks).
+ *
+ * @param[in/out] module     Module disabled during mca_coll_base_comm_unselect
+ * @param[in]     comm       Communicator being disabled
+ */
+typedef int
+(*mca_coll_base_module_disable_1_1_0_fn_t)(struct mca_coll_base_module_2_1_0_t* module,
                                           struct ompi_communicator_t *comm);
 
 
 typedef int (*mca_coll_base_module_allgather_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_allgatherv_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void * rbuf, int *rcounts, int *disps,  struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_allreduce_fn_t)
   (void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_alltoall_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_alltoallv_fn_t)
   (void *sbuf, int *scounts, int *sdisps, struct ompi_datatype_t *sdtype,
    void *rbuf, int *rcounts, int *rdisps, struct ompi_datatype_t *rdtype,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_alltoallw_fn_t)
   (void *sbuf, int *scounts, int *sdisps, struct ompi_datatype_t **sdtypes,
    void *rbuf, int *rcounts, int *rdisps, struct ompi_datatype_t **rdtypes,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_barrier_fn_t)
-  (struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+  (struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_bcast_fn_t)
   (void *buff, int count, struct ompi_datatype_t *datatype, int root,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_exscan_fn_t)
   (void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_gather_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_gatherv_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int *rcounts, int *disps, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_reduce_fn_t)
   (void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_fn_t)
   (void *sbuf, void *rbuf, int *rcounts, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_reduce_scatter_block_fn_t)
   (void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_scan_fn_t)
   (void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
-   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_op_t *op, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_scatter_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_scatterv_fn_t)
   (void *sbuf, int *scounts, int *disps, struct ompi_datatype_t *sdtype,
    void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
-   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   int root, struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 
 /* nonblocking collectives */
 typedef int (*mca_coll_base_module_iallgather_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_iallgatherv_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void * rbuf, int *rcounts, int *disps,  struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_iallreduce_fn_t)
   (void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm,
-   ompi_request_t ** request, struct mca_coll_base_module_2_0_0_t *module);
+   ompi_request_t ** request, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ialltoall_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ialltoallv_fn_t)
   (void *sbuf, int *scounts, int *sdisps, struct ompi_datatype_t *sdtype,
    void *rbuf, int *rcounts, int *rdisps, struct ompi_datatype_t *rdtype,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ialltoallw_fn_t)
   (void *sbuf, int *scounts, int *sdisps, struct ompi_datatype_t **sdtypes,
    void *rbuf, int *rcounts, int *rdisps, struct ompi_datatype_t **rdtypes,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ibarrier_fn_t)
   (struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ibcast_fn_t)
   (void *buff, int count, struct ompi_datatype_t *datatype, int root,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_iexscan_fn_t)
   (void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_igather_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_igatherv_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int *rcounts, int *disps, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_fn_t)
   (void *sbuf, void* rbuf, int count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_scatter_fn_t)
   (void *sbuf, void *rbuf, int *rcounts, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ireduce_scatter_block_fn_t)
   (void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_iscan_fn_t)
   (void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,
    struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_iscatter_fn_t)
   (void *sbuf, int scount, struct ompi_datatype_t *sdtype,
    void *rbuf, int rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_iscatterv_fn_t)
   (void *sbuf, int *scounts, int *disps, struct ompi_datatype_t *sdtype,
    void* rbuf, int rcount, struct ompi_datatype_t *rdtype,
    int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 
 /*
  * The signature of the neighborhood alltoallw differs from alltoallw
@@ -322,12 +339,12 @@ typedef int (*mca_coll_base_module_iscatterv_fn_t)
 typedef int (*mca_coll_base_module_neighbor_alltoallw_fn_t)
   (void *sbuf, int *scounts, MPI_Aint *sdisps, struct ompi_datatype_t **sdtypes,
    void *rbuf, int *rcounts, MPI_Aint *rdisps, struct ompi_datatype_t **rdtypes,
-   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_0_0_t *module);
+   struct ompi_communicator_t *comm, struct mca_coll_base_module_2_1_0_t *module);
 typedef int (*mca_coll_base_module_ineighbor_alltoallw_fn_t)
   (void *sbuf, int *scounts, MPI_Aint *sdisps, struct ompi_datatype_t **sdtypes,
    void *rbuf, int *rcounts, MPI_Aint *rdisps, struct ompi_datatype_t **rdtypes,
    struct ompi_communicator_t *comm, ompi_request_t ** request,
-   struct mca_coll_base_module_2_0_0_t *module);
+   struct mca_coll_base_module_2_1_0_t *module);
 
 /**
  * Fault Tolerance Awareness function.
@@ -387,7 +404,7 @@ typedef struct mca_coll_base_component_2_0_0_t mca_coll_base_component_t;
  * function, so the component is free to create a structure that
  * inherits from this one for use as the module structure.
  */
-struct mca_coll_base_module_2_0_0_t {
+struct mca_coll_base_module_2_1_0_t {
     /** Collective modules all inherit from opal_object */
     opal_object_t super;
 
@@ -448,13 +465,18 @@ struct mca_coll_base_module_2_0_0_t {
 
     /** Fault tolerance event trigger function */
     mca_coll_base_module_ft_event_fn_t ft_event;
+
+    /** Disable function called when a collective module will not 
+        be used for the given communicator */
+    mca_coll_base_module_disable_1_1_0_fn_t coll_module_disable;
+
 };
-typedef struct mca_coll_base_module_2_0_0_t mca_coll_base_module_2_0_0_t;
+typedef struct mca_coll_base_module_2_1_0_t mca_coll_base_module_2_1_0_t;
 
 /** Per guidence in mca.h, use the unversioned struct name if you just
     want to always keep up with the most recent version of the
     interace. */
-typedef struct mca_coll_base_module_2_0_0_t mca_coll_base_module_t;
+typedef struct mca_coll_base_module_2_1_0_t mca_coll_base_module_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_module_t);
 
 /**
@@ -468,97 +490,97 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_module_t);
  */
 struct mca_coll_base_comm_coll_t {
     mca_coll_base_module_allgather_fn_t coll_allgather;
-    mca_coll_base_module_2_0_0_t *coll_allgather_module;
+    mca_coll_base_module_2_1_0_t *coll_allgather_module;
     mca_coll_base_module_allgatherv_fn_t coll_allgatherv;
-    mca_coll_base_module_2_0_0_t *coll_allgatherv_module;
+    mca_coll_base_module_2_1_0_t *coll_allgatherv_module;
     mca_coll_base_module_allreduce_fn_t coll_allreduce;
-    mca_coll_base_module_2_0_0_t *coll_allreduce_module;
+    mca_coll_base_module_2_1_0_t *coll_allreduce_module;
     mca_coll_base_module_alltoall_fn_t coll_alltoall;
-    mca_coll_base_module_2_0_0_t *coll_alltoall_module;
+    mca_coll_base_module_2_1_0_t *coll_alltoall_module;
     mca_coll_base_module_alltoallv_fn_t coll_alltoallv;
-    mca_coll_base_module_2_0_0_t *coll_alltoallv_module;
+    mca_coll_base_module_2_1_0_t *coll_alltoallv_module;
     mca_coll_base_module_alltoallw_fn_t coll_alltoallw;
-    mca_coll_base_module_2_0_0_t *coll_alltoallw_module;
+    mca_coll_base_module_2_1_0_t *coll_alltoallw_module;
     mca_coll_base_module_barrier_fn_t coll_barrier;
-    mca_coll_base_module_2_0_0_t *coll_barrier_module;
+    mca_coll_base_module_2_1_0_t *coll_barrier_module;
     mca_coll_base_module_bcast_fn_t coll_bcast;
-    mca_coll_base_module_2_0_0_t *coll_bcast_module;
+    mca_coll_base_module_2_1_0_t *coll_bcast_module;
     mca_coll_base_module_exscan_fn_t coll_exscan;
-    mca_coll_base_module_2_0_0_t *coll_exscan_module;
+    mca_coll_base_module_2_1_0_t *coll_exscan_module;
     mca_coll_base_module_gather_fn_t coll_gather;
-    mca_coll_base_module_2_0_0_t *coll_gather_module;
+    mca_coll_base_module_2_1_0_t *coll_gather_module;
     mca_coll_base_module_gatherv_fn_t coll_gatherv;
-    mca_coll_base_module_2_0_0_t *coll_gatherv_module;
+    mca_coll_base_module_2_1_0_t *coll_gatherv_module;
     mca_coll_base_module_reduce_fn_t coll_reduce;
-    mca_coll_base_module_2_0_0_t *coll_reduce_module;
+    mca_coll_base_module_2_1_0_t *coll_reduce_module;
     mca_coll_base_module_reduce_scatter_fn_t coll_reduce_scatter;
-    mca_coll_base_module_2_0_0_t *coll_reduce_scatter_module;
+    mca_coll_base_module_2_1_0_t *coll_reduce_scatter_module;
     mca_coll_base_module_reduce_scatter_block_fn_t coll_reduce_scatter_block;
-    mca_coll_base_module_2_0_0_t *coll_reduce_scatter_block_module;
+    mca_coll_base_module_2_1_0_t *coll_reduce_scatter_block_module;
     mca_coll_base_module_scan_fn_t coll_scan;
-    mca_coll_base_module_2_0_0_t *coll_scan_module;
+    mca_coll_base_module_2_1_0_t *coll_scan_module;
     mca_coll_base_module_scatter_fn_t coll_scatter;
-    mca_coll_base_module_2_0_0_t *coll_scatter_module;
+    mca_coll_base_module_2_1_0_t *coll_scatter_module;
     mca_coll_base_module_scatterv_fn_t coll_scatterv;
-    mca_coll_base_module_2_0_0_t *coll_scatterv_module;
+    mca_coll_base_module_2_1_0_t *coll_scatterv_module;
     /* nonblocking collectives */
     mca_coll_base_module_iallgather_fn_t coll_iallgather;
-    mca_coll_base_module_2_0_0_t *coll_iallgather_module;
+    mca_coll_base_module_2_1_0_t *coll_iallgather_module;
     mca_coll_base_module_iallgatherv_fn_t coll_iallgatherv;
-    mca_coll_base_module_2_0_0_t *coll_iallgatherv_module;
+    mca_coll_base_module_2_1_0_t *coll_iallgatherv_module;
     mca_coll_base_module_iallreduce_fn_t coll_iallreduce;
-    mca_coll_base_module_2_0_0_t *coll_iallreduce_module;
+    mca_coll_base_module_2_1_0_t *coll_iallreduce_module;
     mca_coll_base_module_ialltoall_fn_t coll_ialltoall;
-    mca_coll_base_module_2_0_0_t *coll_ialltoall_module;
+    mca_coll_base_module_2_1_0_t *coll_ialltoall_module;
     mca_coll_base_module_ialltoallv_fn_t coll_ialltoallv;
-    mca_coll_base_module_2_0_0_t *coll_ialltoallv_module;
+    mca_coll_base_module_2_1_0_t *coll_ialltoallv_module;
     mca_coll_base_module_ialltoallw_fn_t coll_ialltoallw;
-    mca_coll_base_module_2_0_0_t *coll_ialltoallw_module;
+    mca_coll_base_module_2_1_0_t *coll_ialltoallw_module;
     mca_coll_base_module_ibarrier_fn_t coll_ibarrier;
-    mca_coll_base_module_2_0_0_t *coll_ibarrier_module;
+    mca_coll_base_module_2_1_0_t *coll_ibarrier_module;
     mca_coll_base_module_ibcast_fn_t coll_ibcast;
-    mca_coll_base_module_2_0_0_t *coll_ibcast_module;
+    mca_coll_base_module_2_1_0_t *coll_ibcast_module;
     mca_coll_base_module_iexscan_fn_t coll_iexscan;
-    mca_coll_base_module_2_0_0_t *coll_iexscan_module;
+    mca_coll_base_module_2_1_0_t *coll_iexscan_module;
     mca_coll_base_module_igather_fn_t coll_igather;
-    mca_coll_base_module_2_0_0_t *coll_igather_module;
+    mca_coll_base_module_2_1_0_t *coll_igather_module;
     mca_coll_base_module_igatherv_fn_t coll_igatherv;
-    mca_coll_base_module_2_0_0_t *coll_igatherv_module;
+    mca_coll_base_module_2_1_0_t *coll_igatherv_module;
     mca_coll_base_module_ireduce_fn_t coll_ireduce;
-    mca_coll_base_module_2_0_0_t *coll_ireduce_module;
+    mca_coll_base_module_2_1_0_t *coll_ireduce_module;
     mca_coll_base_module_ireduce_scatter_fn_t coll_ireduce_scatter;
-    mca_coll_base_module_2_0_0_t *coll_ireduce_scatter_module;
+    mca_coll_base_module_2_1_0_t *coll_ireduce_scatter_module;
     mca_coll_base_module_ireduce_scatter_block_fn_t coll_ireduce_scatter_block;
-    mca_coll_base_module_2_0_0_t *coll_ireduce_scatter_block_module;
+    mca_coll_base_module_2_1_0_t *coll_ireduce_scatter_block_module;
     mca_coll_base_module_iscan_fn_t coll_iscan;
-    mca_coll_base_module_2_0_0_t *coll_iscan_module;
+    mca_coll_base_module_2_1_0_t *coll_iscan_module;
     mca_coll_base_module_iscatter_fn_t coll_iscatter;
-    mca_coll_base_module_2_0_0_t *coll_iscatter_module;
+    mca_coll_base_module_2_1_0_t *coll_iscatter_module;
     mca_coll_base_module_iscatterv_fn_t coll_iscatterv;
-    mca_coll_base_module_2_0_0_t *coll_iscatterv_module;
+    mca_coll_base_module_2_1_0_t *coll_iscatterv_module;
 
     /* neighborhood collectives */
     mca_coll_base_module_allgather_fn_t coll_neighbor_allgather;
-    mca_coll_base_module_2_0_0_t *coll_neighbor_allgather_module;
+    mca_coll_base_module_2_1_0_t *coll_neighbor_allgather_module;
     mca_coll_base_module_allgatherv_fn_t coll_neighbor_allgatherv;
-    mca_coll_base_module_2_0_0_t *coll_neighbor_allgatherv_module;
+    mca_coll_base_module_2_1_0_t *coll_neighbor_allgatherv_module;
     mca_coll_base_module_alltoall_fn_t coll_neighbor_alltoall;
-    mca_coll_base_module_2_0_0_t *coll_neighbor_alltoall_module;
+    mca_coll_base_module_2_1_0_t *coll_neighbor_alltoall_module;
     mca_coll_base_module_alltoallv_fn_t coll_neighbor_alltoallv;
-    mca_coll_base_module_2_0_0_t *coll_neighbor_alltoallv_module;
+    mca_coll_base_module_2_1_0_t *coll_neighbor_alltoallv_module;
     mca_coll_base_module_neighbor_alltoallw_fn_t coll_neighbor_alltoallw;
-    mca_coll_base_module_2_0_0_t *coll_neighbor_alltoallw_module;
+    mca_coll_base_module_2_1_0_t *coll_neighbor_alltoallw_module;
 
     mca_coll_base_module_iallgather_fn_t coll_ineighbor_allgather;
-    mca_coll_base_module_2_0_0_t *coll_ineighbor_allgather_module;
+    mca_coll_base_module_2_1_0_t *coll_ineighbor_allgather_module;
     mca_coll_base_module_iallgatherv_fn_t coll_ineighbor_allgatherv;
-    mca_coll_base_module_2_0_0_t *coll_ineighbor_allgatherv_module;
+    mca_coll_base_module_2_1_0_t *coll_ineighbor_allgatherv_module;
     mca_coll_base_module_ialltoall_fn_t coll_ineighbor_alltoall;
-    mca_coll_base_module_2_0_0_t *coll_ineighbor_alltoall_module;
+    mca_coll_base_module_2_1_0_t *coll_ineighbor_alltoall_module;
     mca_coll_base_module_ialltoallv_fn_t coll_ineighbor_alltoallv;
-    mca_coll_base_module_2_0_0_t *coll_ineighbor_alltoallv_module;
+    mca_coll_base_module_2_1_0_t *coll_ineighbor_alltoallv_module;
     mca_coll_base_module_ineighbor_alltoallw_fn_t coll_ineighbor_alltoallw;
-    mca_coll_base_module_2_0_0_t *coll_ineighbor_alltoallw_module;
+    mca_coll_base_module_2_1_0_t *coll_ineighbor_alltoallw_module;
 };
 typedef struct mca_coll_base_comm_coll_t mca_coll_base_comm_coll_t;
 

--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -145,132 +147,132 @@ int NBC_Progress(NBC_Handle *handle);
 
 int ompi_coll_libnbc_iallgather(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module);
+                                struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iallgatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *displs, 
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                 struct mca_coll_base_module_2_0_0_t *module);
+                                 struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iallreduce(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op, 
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module);
+                                struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ialltoall(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                               struct mca_coll_base_module_2_0_0_t *module);
+                               struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ialltoallv(void* sendbuf, int *sendcounts, int *sdispls,
                                 MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *rdispls,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module);
+                                struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ialltoallw(void *sbuf, int *scounts, int *sdisps, struct ompi_datatype_t **sdtypes, 
                                 void *rbuf, int *rcounts, int *rdisps, struct ompi_datatype_t **rdtypes, 
                                 struct ompi_communicator_t *comm, ompi_request_t **request, 
-                                struct mca_coll_base_module_2_0_0_t *module);
+                                struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ibarrier(struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module);
+                              struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
-                            struct mca_coll_base_module_2_0_0_t *module);
+                            struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iexscan(void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype, 
                              struct ompi_op_t *op, struct ompi_communicator_t *comm, ompi_request_t **request,
-                             struct mca_coll_base_module_2_0_0_t *module);
+                             struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_igather(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                              MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                             struct mca_coll_base_module_2_0_0_t *module);
+                             struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_igatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype, 
                               void* recvbuf, int *recvcounts, int *displs, MPI_Datatype recvtype, 
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module);
+                              struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ireduce(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, 
                              MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                             struct mca_coll_base_module_2_0_0_t *module);
+                             struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ireduce_scatter(void* sendbuf, void* recvbuf, int *recvcounts, MPI_Datatype datatype, 
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                     struct mca_coll_base_module_2_0_0_t *module);
+                                     struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ireduce_scatter_block(void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
                                            struct ompi_op_t *op, struct ompi_communicator_t *comm, 
                                            ompi_request_t **request,
-                                           struct mca_coll_base_module_2_0_0_t *module);
+                                           struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iscan(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op, 
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
-                           struct mca_coll_base_module_2_0_0_t *module);
+                           struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iscatter(void* sendbuf, int sendcount, MPI_Datatype sendtype, 
                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root, 
                               struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module);
+                              struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iscatterv(void* sendbuf, int *sendcounts, int *displs, MPI_Datatype sendtype, 
                                void* recvbuf, int recvcount, MPI_Datatype recvtype, int root, 
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
-                               struct mca_coll_base_module_2_0_0_t *module);
+                               struct mca_coll_base_module_2_1_0_t *module);
 
 
 int ompi_coll_libnbc_iallgather_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module);
+                                struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iallgatherv_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *displs, 
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                 struct mca_coll_base_module_2_0_0_t *module);
+                                 struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iallreduce_inter(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op, 
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module);
+                                struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ialltoall_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                               struct mca_coll_base_module_2_0_0_t *module);
+                               struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ialltoallv_inter(void* sendbuf, int *sendcounts, int *sdispls,
                                 MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *rdispls,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module);
+                                struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ialltoallw_inter(void *sbuf, int *scounts, int *sdisps, struct ompi_datatype_t **sdtypes, 
                                       void *rbuf, int *rcounts, int *rdisps, struct ompi_datatype_t **rdtypes, 
                                       struct ompi_communicator_t *comm, ompi_request_t **request, 
-                                      struct mca_coll_base_module_2_0_0_t *module);
+                                      struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ibarrier_inter(struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module);
+                              struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
-                            struct mca_coll_base_module_2_0_0_t *module);
+                            struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_igather_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                              MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                             struct mca_coll_base_module_2_0_0_t *module);
+                             struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_igatherv_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, 
                               void* recvbuf, int *recvcounts, int *displs, MPI_Datatype recvtype, 
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module);
+                              struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ireduce_inter(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, 
                              MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                             struct mca_coll_base_module_2_0_0_t *module);
+                             struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ireduce_scatter_inter(void* sendbuf, void* recvbuf, int *recvcounts, MPI_Datatype datatype, 
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                     struct mca_coll_base_module_2_0_0_t *module);
+                                     struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ireduce_scatter_block_inter(void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
                                                  struct ompi_op_t *op, struct ompi_communicator_t *comm, 
                                                  ompi_request_t **request,
-                                                 struct mca_coll_base_module_2_0_0_t *module);
+                                                 struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iscatter_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, 
                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root, 
                               struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module);
+                              struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_iscatterv_inter(void* sendbuf, int *sendcounts, int *displs, MPI_Datatype sendtype, 
                                void* recvbuf, int recvcount, MPI_Datatype recvtype, int root, 
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
-                               struct mca_coll_base_module_2_0_0_t *module);
+                               struct mca_coll_base_module_2_1_0_t *module);
 
 
 int ompi_coll_libnbc_ineighbor_allgather(void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
                                          int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
-                                         ompi_request_t ** request, struct mca_coll_base_module_2_0_0_t *module);
+                                         ompi_request_t ** request, struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ineighbor_allgatherv(void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
                                           int *rcounts, int *displs, MPI_Datatype rtype,
                                           struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                          struct mca_coll_base_module_2_0_0_t *module);
+                                          struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ineighbor_alltoall(void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
                                         int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
-                                        ompi_request_t ** request, struct mca_coll_base_module_2_0_0_t *module);
+                                        ompi_request_t ** request, struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ineighbor_alltoallv(void *sbuf, int *scounts, int *sdispls, MPI_Datatype stype,
                                          void *rbuf, int *rcounts, int *rdispls, MPI_Datatype rtype,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                         struct mca_coll_base_module_2_0_0_t *module);
+                                         struct mca_coll_base_module_2_1_0_t *module);
 int ompi_coll_libnbc_ineighbor_alltoallw(void *sbuf, int *scounts, MPI_Aint *sdisps, MPI_Datatype *stypes,
                                          void *rbuf, int *rcounts, MPI_Aint *rdisps, MPI_Datatype *rtypes,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                         struct mca_coll_base_module_2_0_0_t *module);
+                                         struct mca_coll_base_module_2_1_0_t *module);
 
 
 END_C_DECLS

--- a/ompi/mca/coll/libnbc/coll_libnbc_ireduce_scatter_block.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_ireduce_scatter_block.c
@@ -1,12 +1,14 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All 
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All 
+ *                         rights reserved.
  * Copyright (c) 2012      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -32,7 +34,7 @@
 
 int ompi_coll_libnbc_ireduce_scatter_block(void* sendbuf, void* recvbuf, int recvcount, MPI_Datatype datatype, 
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                     struct mca_coll_base_module_2_0_0_t *module) {
+                                     struct mca_coll_base_module_2_1_0_t *module) {
   int peer, rank, maxr, p, r, res, count, offset, firstred;
   MPI_Aint ext;
   char *redbuf, *sbuf, inplace;
@@ -151,7 +153,7 @@ int ompi_coll_libnbc_ireduce_scatter_block(void* sendbuf, void* recvbuf, int rec
 
 int ompi_coll_libnbc_ireduce_scatter_block_inter(void *sbuf, void *rbuf, int rcount, struct ompi_datatype_t *dtype,
 						 struct ompi_op_t *op, struct ompi_communicator_t *comm,
-						 ompi_request_t **request, struct mca_coll_base_module_2_0_0_t *module) {
+						 ompi_request_t **request, struct mca_coll_base_module_2_1_0_t *module) {
   int peer, rank, res, count, rsize;
   MPI_Aint ext;
   NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_iallgather.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgather.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All 
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All 
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -35,7 +37,7 @@ int NBC_Allgather_args_compare(NBC_Allgather_args *a, NBC_Allgather_args *b, voi
  * each node receives from it's left (modulo p) neighbor */
 int ompi_coll_libnbc_iallgather(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module)
+                                struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, p, res, r;
   MPI_Aint rcvext;
@@ -138,7 +140,7 @@ int ompi_coll_libnbc_iallgather(void* sendbuf, int sendcount, MPI_Datatype sendt
 
 int ompi_coll_libnbc_iallgather_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
 				      MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-				      struct mca_coll_base_module_2_0_0_t *module)
+				      struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, res, r, rsize;
   MPI_Aint rcvext;

--- a/ompi/mca/coll/libnbc/nbc_iallgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgatherv.c
@@ -1,15 +1,17 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All 
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All 
+ *                         rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  */
 #include "nbc_internal.h"
@@ -28,7 +30,7 @@
  *   each node receives from node (rank-2)%p recvcounts[(rank+2)%p] elements */
 int ompi_coll_libnbc_iallgatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *displs, 
                                  MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                 struct mca_coll_base_module_2_0_0_t *module)
+                                 struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, p, res, r, speer, rpeer;
   MPI_Aint rcvext;
@@ -92,7 +94,7 @@ int ompi_coll_libnbc_iallgatherv(void* sendbuf, int sendcount, MPI_Datatype send
 
 int ompi_coll_libnbc_iallgatherv_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *displs,
 				       MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-				       struct mca_coll_base_module_2_0_0_t *module)
+				       struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, res, r, rsize;
   MPI_Aint rcvext;

--- a/ompi/mca/coll/libnbc/nbc_iallreduce.c
+++ b/ompi/mca/coll/libnbc/nbc_iallreduce.c
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2006       The Trustees of Indiana University and Indiana
- *                          University Research and Technology
- *                          Corporation.  All rights reserved.
- * Copyright (c) 2006       The Technical University of Chemnitz. All
- *                          rights reserved.
- * Copyright (c) 2013       Los Alamos National Security, LLC. All rights
- *                          reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -40,7 +42,7 @@ int NBC_Allreduce_args_compare(NBC_Allreduce_args *a, NBC_Allreduce_args *b, voi
 
 int ompi_coll_libnbc_iallreduce(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
                                 struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                struct mca_coll_base_module_2_0_0_t *module)
+                                struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, p, res;
   OPAL_PTRDIFF_TYPE ext, lb;
@@ -143,7 +145,7 @@ int ompi_coll_libnbc_iallreduce(void* sendbuf, void* recvbuf, int count, MPI_Dat
 
 int ompi_coll_libnbc_iallreduce_inter(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
                                       struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                      struct mca_coll_base_module_2_0_0_t *module)
+                                      struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, res, size, rsize;
   MPI_Aint ext;

--- a/ompi/mca/coll/libnbc/nbc_ialltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoall.c
@@ -7,6 +7,8 @@
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -39,7 +41,7 @@ int NBC_Alltoall_args_compare(NBC_Alltoall_args *a, NBC_Alltoall_args *b, void *
 /* simple linear MPI_Ialltoall the (simple) algorithm just sends to all nodes */
 int ompi_coll_libnbc_ialltoall(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount, 
                                MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                               struct mca_coll_base_module_2_0_0_t *module)
+                               struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, p, res, a2asize, sndsize, datasize;
   NBC_Schedule *schedule;
@@ -200,7 +202,7 @@ int ompi_coll_libnbc_ialltoall(void* sendbuf, int sendcount, MPI_Datatype sendty
 
 int ompi_coll_libnbc_ialltoall_inter (void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
 				      MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-				      struct mca_coll_base_module_2_0_0_t *module)
+				      struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, res, i, rsize;
   MPI_Aint sndext, rcvext;

--- a/ompi/mca/coll/libnbc/nbc_ialltoallv.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallv.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All 
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -18,7 +20,7 @@
 int ompi_coll_libnbc_ialltoallv(void* sendbuf, int *sendcounts, int *sdispls,
                                 MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *rdispls,
                                 MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                               struct mca_coll_base_module_2_0_0_t *module)
+                               struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, p, res, i;
   MPI_Aint sndext, rcvext;
@@ -89,7 +91,7 @@ int ompi_coll_libnbc_ialltoallv(void* sendbuf, int *sendcounts, int *sdispls,
 int ompi_coll_libnbc_ialltoallv_inter (void* sendbuf, int *sendcounts, int *sdispls,
 				       MPI_Datatype sendtype, void* recvbuf, int *recvcounts, int *rdispls,
 				       MPI_Datatype recvtype, struct ompi_communicator_t *comm, ompi_request_t ** request,
-				       struct mca_coll_base_module_2_0_0_t *module)
+				       struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, res, i, rsize;
   MPI_Aint sndext, rcvext;

--- a/ompi/mca/coll/libnbc/nbc_ialltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallw.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -18,7 +20,7 @@
 int ompi_coll_libnbc_ialltoallw(void* sendbuf, int *sendcounts, int *sdispls,
                                 MPI_Datatype sendtypes[], void* recvbuf, int *recvcounts, int *rdispls,
                                 MPI_Datatype recvtypes[], struct ompi_communicator_t *comm, ompi_request_t ** request,
-				struct mca_coll_base_module_2_0_0_t *module)
+				struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, p, res, i;
   NBC_Schedule *schedule;
@@ -84,7 +86,7 @@ int ompi_coll_libnbc_ialltoallw(void* sendbuf, int *sendcounts, int *sdispls,
 int ompi_coll_libnbc_ialltoallw_inter (void* sendbuf, int *sendcounts, int *sdispls,
 				       MPI_Datatype sendtypes[], void* recvbuf, int *recvcounts, int *rdispls,
 				       MPI_Datatype recvtypes[], struct ompi_communicator_t *comm, ompi_request_t ** request,
-				       struct mca_coll_base_module_2_0_0_t *module)
+				       struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, res, i, rsize;
   NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_ibarrier.c
+++ b/ompi/mca/coll/libnbc/nbc_ibarrier.c
@@ -6,6 +6,8 @@
  *                         rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -14,7 +16,7 @@
 
 /* Dissemination implementation of MPI_Ibarrier */
 int ompi_coll_libnbc_ibarrier(struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module)
+                              struct mca_coll_base_module_2_1_0_t *module)
 {
   int round, rank, p, maxround, res, recvpeer, sendpeer;
   NBC_Schedule *schedule;
@@ -91,7 +93,7 @@ int ompi_coll_libnbc_ibarrier(struct ompi_communicator_t *comm, ompi_request_t *
 }
 
 int ompi_coll_libnbc_ibarrier_inter(struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                    struct mca_coll_base_module_2_0_0_t *module)
+                                    struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, res, rsize, peer;
   NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_ibcast.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast.c
@@ -2,8 +2,10 @@
  * Copyright (c) 2006 The Trustees of Indiana University and Indiana
  *                    University Research and Technology
  *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All 
+ * Copyright (c) 2006 The Technical University of Chemnitz. All
  *                    rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -33,7 +35,7 @@ int NBC_Bcast_args_compare(NBC_Bcast_args *a, NBC_Bcast_args *b, void *param) {
 
 int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int root,
                             struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module)
+                              struct mca_coll_base_module_2_1_0_t *module)
 {
   int rank, p, res, size, segsize;
   NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_ibcast_inter.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast_inter.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All 
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -12,7 +14,7 @@
 
 int ompi_coll_libnbc_ibcast_inter(void *buffer, int count, MPI_Datatype datatype, int root,
                                   struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                  struct mca_coll_base_module_2_0_0_t *module) {
+                                  struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res, size, peer;
   NBC_Schedule *schedule;
   NBC_Handle *handle;

--- a/ompi/mca/coll/libnbc/nbc_iexscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iexscan.c
@@ -7,6 +7,8 @@
  *                         rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -40,7 +42,7 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param) {
  */
 int ompi_coll_libnbc_iexscan(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
                              struct ompi_communicator_t *comm, ompi_request_t ** request,
-                             struct mca_coll_base_module_2_0_0_t *module) {
+                             struct mca_coll_base_module_2_1_0_t *module) {
     int rank, p, res;
     MPI_Aint ext;
     NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_igather.c
+++ b/ompi/mca/coll/libnbc/nbc_igather.c
@@ -7,6 +7,8 @@
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -35,7 +37,7 @@ int NBC_Gather_args_compare(NBC_Gather_args *a, NBC_Gather_args *b, void *param)
 
 int ompi_coll_libnbc_igather(void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
                              MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                             struct mca_coll_base_module_2_0_0_t *module) {
+                             struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res, i;
   MPI_Aint rcvext = 0;
   NBC_Schedule *schedule;
@@ -140,7 +142,7 @@ int ompi_coll_libnbc_igather(void* sendbuf, int sendcount, MPI_Datatype sendtype
 
 int ompi_coll_libnbc_igather_inter (void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                    struct mca_coll_base_module_2_0_0_t *module) {
+                                    struct mca_coll_base_module_2_1_0_t *module) {
     int rank, p, res, i, rsize;
     MPI_Aint rcvext = 0;
     NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_igatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_igatherv.c
@@ -2,11 +2,13 @@
  * Copyright (c) 2006      The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2006      The Technical University of Chemnitz. All 
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
  *                         rights reserved.
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -18,10 +20,10 @@
  * would not be sufficient ... we simply do not cache it */
 
 
-int ompi_coll_libnbc_igatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype, 
-                              void* recvbuf, int *recvcounts, int *displs, MPI_Datatype recvtype, 
+int ompi_coll_libnbc_igatherv(void* sendbuf, int sendcount, MPI_Datatype sendtype,
+                              void* recvbuf, int *recvcounts, int *displs, MPI_Datatype recvtype,
                               int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module) {
+                              struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res, i;
   MPI_Aint rcvext = 0;
   NBC_Schedule *schedule;
@@ -84,7 +86,7 @@ int ompi_coll_libnbc_igatherv(void* sendbuf, int sendcount, MPI_Datatype sendtyp
 int ompi_coll_libnbc_igatherv_inter (void* sendbuf, int sendcount, MPI_Datatype sendtype,
 				     void* recvbuf, int *recvcounts, int *displs, MPI_Datatype recvtype,
 				     int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-				     struct mca_coll_base_module_2_0_0_t *module) {
+				     struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res, i, rsize;
   MPI_Aint rcvext;
   NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgather.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -34,7 +36,7 @@ int NBC_Ineighbor_allgather_args_compare(NBC_Ineighbor_allgather_args *a, NBC_In
 
 int ompi_coll_libnbc_ineighbor_allgather(void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
                                          int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
-                                         ompi_request_t ** request, struct mca_coll_base_module_2_0_0_t *module) {
+                                         ompi_request_t ** request, struct mca_coll_base_module_2_1_0_t *module) {
   int rank, size, res, worldsize;
   MPI_Aint sndext, rcvext;
   NBC_Handle *handle;

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_allgatherv.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -35,7 +37,7 @@ int NBC_Ineighbor_allgatherv_args_compare(NBC_Ineighbor_allgatherv_args *a, NBC_
 int ompi_coll_libnbc_ineighbor_allgatherv(void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
 					  int *rcounts, int *displs, MPI_Datatype rtype,
 					  struct ompi_communicator_t *comm, ompi_request_t ** request,
-					  struct mca_coll_base_module_2_0_0_t *module) {
+					  struct mca_coll_base_module_2_1_0_t *module) {
   int rank, size, res, worldsize;
   MPI_Aint sndext, rcvext;
   NBC_Handle *handle;

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoall.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -33,7 +35,7 @@ int NBC_Ineighbor_alltoall_args_compare(NBC_Ineighbor_alltoall_args *a, NBC_Inei
 
 int ompi_coll_libnbc_ineighbor_alltoall(void *sbuf, int scount, MPI_Datatype stype, void *rbuf,
                                         int rcount, MPI_Datatype rtype, struct ompi_communicator_t *comm,
-                                        ompi_request_t ** request, struct mca_coll_base_module_2_0_0_t *module) {
+                                        ompi_request_t ** request, struct mca_coll_base_module_2_1_0_t *module) {
   int rank, size, res, worldsize;
   MPI_Aint sndext, rcvext;
   NBC_Handle *handle;

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallv.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallv.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -35,7 +37,7 @@ int NBC_Ineighbor_alltoallv_args_compare(NBC_Ineighbor_alltoallv_args *a, NBC_In
 int ompi_coll_libnbc_ineighbor_alltoallv(void *sbuf, int *scounts, int *sdispls, MPI_Datatype stype,
                                          void *rbuf, int *rcounts, int *rdispls, MPI_Datatype rtype,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                         struct mca_coll_base_module_2_0_0_t *module) {
+                                         struct mca_coll_base_module_2_1_0_t *module) {
   int rank, size, res, worldsize;
   MPI_Aint sndext, rcvext;
   NBC_Handle *handle;

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -34,7 +36,7 @@ int NBC_Ineighbor_alltoallw_args_compare(NBC_Ineighbor_alltoallw_args *a, NBC_In
 int ompi_coll_libnbc_ineighbor_alltoallw(void *sbuf, int *scounts, MPI_Aint *sdisps, MPI_Datatype *stypes,
                                          void *rbuf, int *rcounts, MPI_Aint *rdisps, MPI_Datatype *rtypes,
                                          struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                         struct mca_coll_base_module_2_0_0_t *module) {
+                                         struct mca_coll_base_module_2_1_0_t *module) {
   int rank, size, res, worldsize;
   MPI_Aint *sndexts, *rcvexts;
   NBC_Handle *handle;

--- a/ompi/mca/coll/libnbc/nbc_ireduce.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce.c
@@ -6,6 +6,8 @@
  *                         rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -36,9 +38,9 @@ int NBC_Reduce_args_compare(NBC_Reduce_args *a, NBC_Reduce_args *b, void *param)
 #endif
 
 /* the non-blocking reduce */
-int ompi_coll_libnbc_ireduce(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, 
+int ompi_coll_libnbc_ireduce(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
                              MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                             struct mca_coll_base_module_2_0_0_t *module) {
+                             struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res, segsize, size;
   MPI_Aint ext;
   NBC_Schedule *schedule;
@@ -149,7 +151,7 @@ int ompi_coll_libnbc_ireduce(void* sendbuf, void* recvbuf, int count, MPI_Dataty
 
 int ompi_coll_libnbc_ireduce_inter(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
 				   MPI_Op op, int root, struct ompi_communicator_t *comm, ompi_request_t ** request,
-				   struct mca_coll_base_module_2_0_0_t *module) {
+				   struct mca_coll_base_module_2_1_0_t *module) {
   int rank, res, rsize;
   NBC_Schedule *schedule;
   MPI_Aint ext;

--- a/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce_scatter.c
@@ -6,6 +6,8 @@
  *                         rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -29,9 +31,9 @@
  *    
  */
 
-int ompi_coll_libnbc_ireduce_scatter(void* sendbuf, void* recvbuf, int *recvcounts, MPI_Datatype datatype, 
+int ompi_coll_libnbc_ireduce_scatter(void* sendbuf, void* recvbuf, int *recvcounts, MPI_Datatype datatype,
                                      MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                     struct mca_coll_base_module_2_0_0_t *module) {
+                                     struct mca_coll_base_module_2_1_0_t *module) {
   int peer, rank, maxr, p, r, res, count, offset, firstred;
   MPI_Aint ext;
   char *redbuf, *sbuf, inplace;
@@ -154,7 +156,7 @@ submit_and_return:
 
 int ompi_coll_libnbc_ireduce_scatter_inter(void* sendbuf, void* recvbuf, int *recvcounts, MPI_Datatype datatype,
 					   MPI_Op op, struct ompi_communicator_t *comm, ompi_request_t ** request,
-					   struct mca_coll_base_module_2_0_0_t *module) {
+					   struct mca_coll_base_module_2_1_0_t *module) {
   int peer, rank, r, res, count, rsize, offset;
   MPI_Aint ext;
   NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_iscan.c
+++ b/ompi/mca/coll/libnbc/nbc_iscan.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2006 The Trustees of Indiana University and Indiana
- *                    University Research and Technology
- *                    Corporation.  All rights reserved.
- * Copyright (c) 2006 The Technical University of Chemnitz. All 
- *                    rights reserved.
+ * Copyright (c) 2006      The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      The Technical University of Chemnitz. All
+ *                         rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -35,9 +37,9 @@ int NBC_Scan_args_compare(NBC_Scan_args *a, NBC_Scan_args *b, void *param) {
  * 3. all but rank p-1 do sends to it's right neigbor and exits
  *
  */
-int ompi_coll_libnbc_iscan(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op, 
+int ompi_coll_libnbc_iscan(void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
                            struct ompi_communicator_t *comm, ompi_request_t ** request,
-                           struct mca_coll_base_module_2_0_0_t *module) {
+                           struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res;
   MPI_Aint ext;
   NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_iscatter.c
+++ b/ompi/mca/coll/libnbc/nbc_iscatter.c
@@ -9,6 +9,8 @@
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -38,7 +40,7 @@ int NBC_Scatter_args_compare(NBC_Scatter_args *a, NBC_Scatter_args *b, void *par
 int ompi_coll_libnbc_iscatter(void* sendbuf, int sendcount, MPI_Datatype sendtype,
                               void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
                               struct ompi_communicator_t *comm, ompi_request_t ** request,
-                              struct mca_coll_base_module_2_0_0_t *module) {
+                              struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res, i;
   MPI_Aint sndext = 0;
   NBC_Schedule *schedule;
@@ -142,7 +144,7 @@ int ompi_coll_libnbc_iscatter(void* sendbuf, int sendcount, MPI_Datatype sendtyp
 int ompi_coll_libnbc_iscatter_inter(void* sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
                                     struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                    struct mca_coll_base_module_2_0_0_t *module) {
+                                    struct mca_coll_base_module_2_1_0_t *module) {
     int rank, res, i, rsize;
     MPI_Aint sndext;
     NBC_Schedule *schedule;

--- a/ompi/mca/coll/libnbc/nbc_iscatterv.c
+++ b/ompi/mca/coll/libnbc/nbc_iscatterv.c
@@ -9,6 +9,8 @@
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -23,7 +25,7 @@
 int ompi_coll_libnbc_iscatterv(void* sendbuf, int *sendcounts, int *displs, MPI_Datatype sendtype,
                                void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
                                struct ompi_communicator_t *comm, ompi_request_t ** request,
-                               struct mca_coll_base_module_2_0_0_t *module) {
+                               struct mca_coll_base_module_2_1_0_t *module) {
   int rank, p, res, i;
   MPI_Aint sndext;
   NBC_Schedule *schedule;
@@ -87,7 +89,7 @@ int ompi_coll_libnbc_iscatterv(void* sendbuf, int *sendcounts, int *displs, MPI_
 int ompi_coll_libnbc_iscatterv_inter (void* sendbuf, int *sendcounts, int *displs, MPI_Datatype sendtype,
                                       void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
                                       struct ompi_communicator_t *comm, ompi_request_t ** request,
-                                      struct mca_coll_base_module_2_0_0_t *module) {
+                                      struct mca_coll_base_module_2_1_0_t *module) {
     int rank, res, i, rsize;
     MPI_Aint sndext;
     NBC_Schedule *schedule;

--- a/ompi/mca/coll/ml/coll_ml_custom_utils.c
+++ b/ompi/mca/coll/ml/coll_ml_custom_utils.c
@@ -7,6 +7,8 @@
  * Copyright (c) 2014      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,7 +53,7 @@
 struct avail_coll_t {
     opal_list_item_t super;
     int ac_priority;
-    mca_coll_base_module_2_0_0_t *ac_module;
+    mca_coll_base_module_2_1_0_t *ac_module;
 };
 typedef struct avail_coll_t avail_coll_t;
 

--- a/ompi/mca/coll/ml/coll_ml_module.c
+++ b/ompi/mca/coll/ml/coll_ml_module.c
@@ -2510,7 +2510,7 @@ static int mca_coll_ml_fill_in_route_tab(mca_coll_ml_topology_t *topo, ompi_comm
 
 static void init_coll_func_pointers(mca_coll_ml_module_t *ml_module)
 {
-    mca_coll_base_module_2_0_0_t *coll_base = &ml_module->super;
+    mca_coll_base_module_2_1_0_t *coll_base = &ml_module->super;
 
     int iboffload_used =
         mca_coll_ml_check_if_bcol_is_used("iboffload", ml_module, COLL_ML_TOPO_MAX);

--- a/ompi/mca/coll/portals4/coll_portals4_barrier.c
+++ b/ompi/mca/coll/portals4/coll_portals4_barrier.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2013      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -171,7 +173,7 @@ ompi_coll_portals4_barrier_intra(struct ompi_communicator_t *comm,
 int
 ompi_coll_portals4_ibarrier_intra(struct ompi_communicator_t *comm, 
                                   ompi_request_t **ompi_req,
-                                  struct mca_coll_base_module_2_0_0_t *module)
+                                  struct mca_coll_base_module_2_1_0_t *module)
 {
     mca_coll_portals4_module_t *portals4_module = (mca_coll_portals4_module_t*) module;
     int ret, i, dim, hibit, mask, num_msgs;

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -78,6 +78,8 @@ static int sm_module_enable(mca_coll_base_module_t *module,
 static bool have_local_peers(ompi_group_t *group, size_t size);
 static int bootstrap_comm(ompi_communicator_t *comm,
                           mca_coll_sm_module_t *module);
+static int mca_coll_sm_module_disable(mca_coll_base_module_t *module,
+                          struct ompi_communicator_t *comm);
 
 /*
  * Module constructor
@@ -88,6 +90,7 @@ static void mca_coll_sm_module_construct(mca_coll_sm_module_t *module)
     module->sm_comm_data = NULL;
     module->previous_reduce = NULL;
     module->previous_reduce_module = NULL;
+    module->super.coll_module_disable = mca_coll_sm_module_disable;
 }
 
 /*
@@ -114,6 +117,20 @@ static void mca_coll_sm_module_destruct(mca_coll_sm_module_t *module)
     }
 
     module->enabled = false;
+}
+
+/*
+ * Module disable
+ */
+static int mca_coll_sm_module_disable(mca_coll_base_module_t *module, struct ompi_communicator_t *comm)
+{
+    mca_coll_sm_module_t *sm_module = (mca_coll_sm_module_t*) module;
+    if (NULL != sm_module->previous_reduce_module) {
+	sm_module->previous_reduce = NULL;
+        OBJ_RELEASE(sm_module->previous_reduce_module);
+	sm_module->previous_reduce_module = NULL;
+    }
+    return OMPI_SUCCESS;
 }
 
 


### PR DESCRIPTION
This is a fix for issue #196 

the coll/sm module has circular references that causes a memory leak.
this patch introduce a new coll_module_disable function so the circle can be broken
and all objects can be released, and hence fix the memory leak

@bosilca could you please review this before it lands into the master ?
