### PR TITLE
OSHMEM: Fix application abort

### DIFF
--- a/config/oshmem_configure_options.m4
+++ b/config/oshmem_configure_options.m4
@@ -98,6 +98,10 @@ fi
 AC_DEFINE_UNQUOTED(OSHMEM_PARAM_CHECK, $shmem_param_check,
     [Whether we want to check OSHMEM parameters always or never])
 
+#
+# check for on_exit
+#
+AC_CHECK_FUNCS([on_exit])
 
 #
 #  OSHMEM profiling support

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -197,6 +197,7 @@ static void* shmem_opal_thread(void* argc)
 #endif
 
 int inGlobalExit;
+int inGlobalExit_Status;
 
 static void sighandler__SIGUSR1(int signum)
 {

--- a/oshmem/shmem/c/shmem_finalize.c
+++ b/oshmem/shmem/c/shmem_finalize.c
@@ -22,10 +22,15 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+extern int inGlobalExit_Status;
+
 void shmem_finalize(void)
 {
     OPAL_CR_FINALIZE_LIBRARY();
-
+    if (inGlobalExit_Status != 0)
+    {
+        return;
+    }
     oshmem_shmem_finalize();
 }
 

--- a/oshmem/shmem/c/shmem_init.c
+++ b/oshmem/shmem/c/shmem_init.c
@@ -29,10 +29,17 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+extern int inGlobalExit_Status;
+
 void start_pes(int npes)
 {
     /* spec says that npes are ignored for now */
     shmem_init();
+}
+
+static void shmem_onexit(int exitcode, void *arg)
+{
+    inGlobalExit_Status = exitcode;
 }
 
 void shmem_init(void)
@@ -56,5 +63,8 @@ void shmem_init(void)
     }
 
     OPAL_CR_INIT_LIBRARY();
+#if HAVE_ON_EXIT
+    on_exit(shmem_onexit, NULL);
+#endif
 }
 


### PR DESCRIPTION
register on_exit() hook to know exit status inorder to
skip shmem_finalize destructor in case of non-zero exit status
