### PR TITLE
MTL MXM cleanup: unnecessary OMPI_MTL_MXM_CONNECT_ON_FIRST_COMM variable removed

### DIFF
--- a/ompi/mca/mtl/mxm/mtl_mxm.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm.c
@@ -413,14 +413,6 @@ int ompi_mtl_mxm_add_procs(struct mca_mtl_base_module_t *mtl, size_t nprocs,
 
     assert(mtl == &ompi_mtl_mxm.super);
 
-    char *envvar = getenv("OMPI_MTL_MXM_CONNECT_ON_FIRST_COMM");
-    if ((envvar != NULL) && (strlen(envvar) > 0) &&
-        ((strcmp(envvar, "yes") == 0 || strcmp(envvar, "true") == 0 || strcmp(envvar, "1") == 0)))
-    {
-        MXM_VERBOSE(80, "Set endpoint connection on first communication. Skip it now.");
-        return OMPI_SUCCESS;
-    }
-
 #if MXM_API < MXM_VERSION(2,0)
     /* Allocate connection requests */
     conn_reqs = calloc(nprocs, sizeof(mxm_conn_req_t));

--- a/opal/mca/pmix/base/pmix_base_frame.c
+++ b/opal/mca/pmix/base/pmix_base_frame.c
@@ -37,7 +37,6 @@ static int opal_pmix_base_frame_register(mca_base_register_flag_t flags)
 
 static int opal_pmix_base_frame_close(void)
 {
-    unsetenv("OMPI_MTL_MXM_CONNECT_ON_FIRST_COMM");
     return mca_base_framework_components_close(&opal_pmix_base_framework, NULL);
 }
 


### PR DESCRIPTION
unnecessary OMPI_MTL_MXM_CONNECT_ON_FIRST_COMM  variable removed
