### PR TITLE
move down jobid,vpid from ORTE to OPAL layer

### DIFF
--- a/ompi/mca/dpm/orte/dpm_orte.c
+++ b/ompi/mca/dpm/orte/dpm_orte.c
@@ -16,6 +16,8 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -459,7 +461,7 @@ static int connect_accept(ompi_communicator_t *comm, int root,
         }
         OPAL_LIST_DESTRUCT(&all_procs);
         /* perform it */
-        opal_pmix.fence(ids, i);
+        opal_pmix.fence((opal_process_name_t *)ids, i);
         free(ids);
 
         OPAL_OUTPUT_VERBOSE((3, ompi_dpm_base_framework.framework_output,
@@ -711,7 +713,7 @@ static int disconnect(ompi_communicator_t *comm)
     OPAL_OUTPUT_VERBOSE((3, ompi_dpm_base_framework.framework_output,
                          "%s dpm:orte:disconnect calling barrier on comm_cid %d with %d participants",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), comm->c_contextid, i));
-    opal_pmix.fence(ids, i);
+    opal_pmix.fence((opal_process_name_t *)ids, i);
     free(ids);
 
     OPAL_OUTPUT_VERBOSE((3, ompi_dpm_base_framework.framework_output,
@@ -1667,7 +1669,7 @@ static int dpm_pconnect(char *port,
 }
 
 static void paccept_recv(int status,
-                         struct orte_process_name_t* peer,
+                         orte_process_name_t* peer,
                          struct opal_buffer_t* buffer,
                          orte_rml_tag_t tag,
                          void* cbdata)

--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -100,6 +100,7 @@ int ompi_proc_init(void)
 
     /* create proc structures and find self */
     for( i = 0; i < ompi_process_info.num_procs; i++ ) {
+        opal_value_t kv;
         ompi_proc_t *proc = OBJ_NEW(ompi_proc_t);
         opal_list_append(&ompi_proc_list, (opal_list_item_t*)proc);
 
@@ -115,8 +116,13 @@ int ompi_proc_init(void)
             opal_proc_local_set(&proc->super);
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT
             /* add our arch to the modex */
-            OPAL_MODEX_SEND_STRING(ret, PMIX_SYNC_REQD, PMIX_REMOTE, OPAL_DSTORE_ARCH,
-                                   &proc->super.proc_arch, OPAL_UINT32);
+            OBJ_CONSTRUCT(&kv, opal_value_t);
+            kv.key = strdup(OPAL_DSTORE_ARCH);
+            kv.type = OPAL_UINT32;
+            kv.data.uint32 = opal_local_arch;
+            ret = opal_pmix.put(PMIX_REMOTE, &kv);
+            OBJ_DESTRUCT(&kv);
+
             if (OPAL_SUCCESS != ret) {
                 return ret;
             }

--- a/opal/dss/dss_compare.c
+++ b/opal/dss/dss_compare.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved. 
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -241,6 +243,17 @@ int opal_dss_compare_time(time_t *value1, time_t *value2, opal_data_type_t type)
 {
     if (value1 > value2) return OPAL_VALUE1_GREATER;
     if (value2 > value1) return OPAL_VALUE2_GREATER;
+
+    return OPAL_EQUAL;
+}
+
+/* PROCESS_NAME */
+int opal_dss_compare_name(opal_process_name_t *value1, opal_process_name_t *value2, opal_data_type_t type)
+{
+    if (value1->name.jobid > value2->name.jobid) return OPAL_VALUE1_GREATER;
+    if (value2->name.jobid > value1->name.jobid) return OPAL_VALUE2_GREATER;
+    if (value1->name.vpid > value2->name.vpid) return OPAL_VALUE1_GREATER;
+    if (value2->name.vpid > value1->name.vpid) return OPAL_VALUE2_GREATER;
 
     return OPAL_EQUAL;
 }

--- a/opal/dss/dss_internal.h
+++ b/opal/dss/dss_internal.h
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved. 
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +34,8 @@
 #include "opal/class/opal_pointer_array.h"
 
 #include "opal/dss/dss.h"
+
+#include "opal/util/proc.h"
 
 #ifdef HAVE_STRING_H
 #    if !defined(STDC_HEADERS) && HAVE_MEMORY_H
@@ -321,6 +325,9 @@ int opal_dss_pack_timeval(opal_buffer_t *buffer, const void *src,
 int opal_dss_pack_time(opal_buffer_t *buffer, const void *src,
                        int32_t num_vals, opal_data_type_t type);
 
+int opal_dss_pack_name(opal_buffer_t *buffer, const void *src,
+                       int32_t num_vals, opal_data_type_t type);
+
 /*
  * Internal unpack functions
  */
@@ -379,6 +386,9 @@ int opal_dss_unpack_timeval(opal_buffer_t *buffer, void *dest,
                             int32_t *num_vals, opal_data_type_t type);
 
 int opal_dss_unpack_time(opal_buffer_t *buffer, void *dest,
+                         int32_t *num_vals, opal_data_type_t type);
+
+int opal_dss_unpack_name(opal_buffer_t *buffer, void *dest,
                          int32_t *num_vals, opal_data_type_t type);
 
 /*
@@ -457,6 +467,8 @@ int opal_dss_compare_timeval(struct timeval *value1, struct timeval *value2, opa
 
 int opal_dss_compare_time(time_t *value1, time_t *value2, opal_data_type_t type);
 
+int opal_dss_compare_name(opal_process_name_t *value1, opal_process_name_t *value2, opal_data_type_t type);
+
 /*
  * Internal print functions
  */
@@ -493,6 +505,7 @@ int opal_dss_print_float(char **output, char *prefix, float *src, opal_data_type
 int opal_dss_print_double(char **output, char *prefix, double *src, opal_data_type_t type);
 int opal_dss_print_timeval(char **output, char *prefix, struct timeval *src, opal_data_type_t type);
 int opal_dss_print_time(char **output, char *prefix, time_t *src, opal_data_type_t type);
+int opal_dss_print_name(char **output, char *prefix, opal_process_name_t *src, opal_data_type_t type);
 
 
 /*

--- a/opal/dss/dss_open_close.c
+++ b/opal/dss/dss_open_close.c
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved. 
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -565,7 +567,7 @@ int opal_dss_open(void)
                                                      "OPAL_TIMEVAL", &tmp))) {
         return rc;
     }
-     tmp = OPAL_TIME;
+    tmp = OPAL_TIME;
     if (OPAL_SUCCESS != (rc = opal_dss.register_type(opal_dss_pack_time,
                                                      opal_dss_unpack_time,
                                                      (opal_dss_copy_fn_t)opal_dss_std_copy,
@@ -573,6 +575,16 @@ int opal_dss_open(void)
                                                      (opal_dss_print_fn_t)opal_dss_print_time,
                                                      OPAL_DSS_UNSTRUCTURED,
                                                      "OPAL_TIME", &tmp))) {
+        return rc;
+    }
+    tmp = OPAL_NAME;
+    if (OPAL_SUCCESS != (rc = opal_dss.register_type(opal_dss_pack_name,
+                                                     opal_dss_unpack_name,
+                                                     (opal_dss_copy_fn_t)opal_dss_std_copy,
+                                                     (opal_dss_compare_fn_t)opal_dss_compare_name,
+                                                     (opal_dss_print_fn_t)opal_dss_print_name,
+                                                     OPAL_DSS_UNSTRUCTURED,
+                                                     "OPAL_NAME", &tmp))) {
         return rc;
     }
    /* All done */

--- a/opal/dss/dss_print.c
+++ b/opal/dss/dss_print.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved. 
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -548,6 +550,33 @@ int opal_dss_print_timeval(char **output, char *prefix,
     return OPAL_SUCCESS;
 }
 
+int opal_dss_print_name(char **output, char *prefix,
+                           opal_process_name_t *src, opal_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) asprintf(&prefx, " ");
+    else prefx = prefix;
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        asprintf(output, "%sData type: OPAL_NAME\tValue: NULL pointer", prefx);
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return OPAL_SUCCESS;
+    }
+
+    asprintf(output, "%sData type: OPAL_NAME\tValue: (%u,%u)", prefx,
+             src->name.jobid, src->name.vpid);
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return OPAL_SUCCESS;
+}
+
 int opal_dss_print_null(char **output, char *prefix, void *src, opal_data_type_t type)
 {
     char *prefx;
@@ -796,6 +825,10 @@ int opal_dss_print_value(char **output, char *prefix, opal_value_t *src, opal_da
     case OPAL_PTR:
         asprintf(output, "%sOPAL_VALUE: Data type: OPAL_PTR\tKey: %s", prefx, src->key);
         break;
+    case OPAL_NAME:
+        asprintf(output, "%sOPAL_VALUE: Data type: OPAL_NAME\tKey: %s\tValue: (%u,%u)", prefx,
+                 src->key, src->data.name.name.jobid, src->data.name.name.vpid);
+        break;
     case OPAL_FLOAT_ARRAY:
         asprintf(output, "%sOPAL_VALUE: Data type: OPAL_FLOAT_ARRAY\tKey: %s \tSIZE: %d \tDATA: ",
                  prefx, src->key, src->data.fval_array.size);
@@ -967,6 +1000,17 @@ int opal_dss_print_value(char **output, char *prefix, opal_value_t *src, opal_da
             asprintf(&t2, "%s\n%s\t%ld.%06ld", *output, prefx,
                      (long)src->data.tv_array.data[i].tv_sec,
                      (long)src->data.tv_array.data[i].tv_usec);
+            free(*output);
+            *output = t2;
+        }
+        break;
+    case OPAL_NAME_ARRAY:
+        asprintf(output, "%sOPAL_VALUE: Data type: OPAL_NAME_ARRAY\tKey: %s \tSIZE: %d \tDATA: ",
+                 prefx, src->key, src->data.name_array.size);
+        for (i = 0; i < src->data.name_array.size; i++) {
+            asprintf(&t2, "%s\n%s\t(%u.%u)", *output, prefx,
+                     src->data.name_array.data[i].name.jobid,
+                     src->data.name_array.data[i].name.vpid);
             free(*output);
             *output = t2;
         }

--- a/opal/dss/dss_types.h
+++ b/opal/dss/dss_types.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +39,7 @@
 #include "opal/class/opal_object.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/class/opal_list.h"
+#include "opal/include/opal/types.h"
 
 BEGIN_C_DECLS
 
@@ -50,6 +53,26 @@ typedef struct {
     int32_t size;
     uint8_t *bytes;
 } opal_byte_object_t;
+
+/**
+ * This is a transparent handle proposed to the upper layer as a mean
+ * to store whatever information it needs in order to efficiently
+ * retrieve the RTE process naming scheme, and get access to the RTE
+ * information associated with it. The only direct usage of this type
+ * is to be copied from one structure to another, otherwise it should
+ * only be used via the accessors defined below.
+ */
+typedef uint32_t opal_jobid_t;
+typedef uint32_t opal_vpid_t;
+typedef struct {
+    opal_jobid_t jobid;
+    opal_jobid_t vpid;
+} opal_proc_name_t ;
+
+typedef union {
+    opal_proc_name_t name;
+    opal_identifier_t id;
+} opal_process_name_t;
 
 /* Type defines for packing and unpacking */
 #define    OPAL_UNDEF               (opal_data_type_t)    0 /**< type hasn't been defined yet */
@@ -86,6 +109,7 @@ typedef struct {
 #define    OPAL_VALUE               (opal_data_type_t)   26 /**< opal value structure */
 #define    OPAL_BUFFER              (opal_data_type_t)   27 /**< pack the remaining contents of a buffer as an object */
 #define    OPAL_PTR                 (opal_data_type_t)   28 /**< pointer to void* */
+#define    OPAL_NAME                (opal_data_type_t)   29 /**< process name* */
     /* OPAL Dynamic */
 #define    OPAL_DSS_ID_DYNAMIC      (opal_data_type_t)   30
     /* OPAL Array types */
@@ -108,6 +132,7 @@ typedef struct {
 #define    OPAL_BYTE_OBJECT_ARRAY   (opal_data_type_t)   47
 #define    OPAL_PID_ARRAY           (opal_data_type_t)   48
 #define    OPAL_TIMEVAL_ARRAY       (opal_data_type_t)   49
+#define    OPAL_NAME_ARRAY          (opal_data_type_t)   50
 
 
 /* define the results values for comparisons so we can change them in only one place */
@@ -206,6 +231,11 @@ typedef struct {
     int32_t size;
     struct timeval *data;
 } opal_timeval_array_t;
+/* name array object */
+typedef struct {
+    int32_t size;
+    opal_process_name_t *data;
+} opal_process_name_array_t;
 
 /* Data value object */
 typedef struct {
@@ -251,6 +281,8 @@ typedef struct {
         opal_double_array_t dval_array;
         opal_pid_array_t pid_array;
         opal_timeval_array_t tv_array;
+        opal_process_name_t name;
+        opal_process_name_array_t name_array;
         void *ptr;  // never packed or passed anywhere
     } data;
 } opal_value_t;

--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1077,7 +1077,7 @@ int mca_btl_openib_add_procs(
             rc = mca_btl_openib_ib_address_add_new(
                     ib_proc->proc_ports[j].pm_port_info.lid,
                     ib_proc->proc_ports[j].pm_port_info.subnet_id,
-                    opal_process_name_jobid(proc->proc_name), endpoint);
+                    proc->proc_name, endpoint);
             if (OPAL_SUCCESS != rc ) {
                 OPAL_THREAD_UNLOCK(&ib_proc->proc_lock);
                 return OPAL_ERROR;

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2008-2010 Oracle and/or its affiliates.  All rights reserved
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -79,7 +81,7 @@ void mca_btl_tcp_proc_destruct(mca_btl_tcp_proc_t* tcp_proc)
     /* remove from list of all proc instances */
     OPAL_THREAD_LOCK(&mca_btl_tcp_component.tcp_lock);
     opal_hash_table_remove_value_uint64(&mca_btl_tcp_component.tcp_procs, 
-                                        tcp_proc->proc_opal->proc_name);
+                                        tcp_proc->proc_opal->proc_name.id);
     OPAL_THREAD_UNLOCK(&mca_btl_tcp_component.tcp_lock);
 
     /* release resources */
@@ -99,7 +101,7 @@ void mca_btl_tcp_proc_destruct(mca_btl_tcp_proc_t* tcp_proc)
 
 mca_btl_tcp_proc_t* mca_btl_tcp_proc_create(const opal_proc_t* proc)
 {
-    uint64_t hash = proc->proc_name;
+    uint64_t hash = proc->proc_name.id;
     mca_btl_tcp_proc_t* btl_proc;
     size_t size;
     int rc;
@@ -721,7 +723,7 @@ mca_btl_tcp_proc_t* mca_btl_tcp_proc_lookup(const opal_process_name_t *name)
     mca_btl_tcp_proc_t* proc = NULL;
     OPAL_THREAD_LOCK(&mca_btl_tcp_component.tcp_lock);
     opal_hash_table_get_value_uint64(&mca_btl_tcp_component.tcp_procs, 
-                                     *name, (void**)&proc);
+                                     name->id, (void**)&proc);
     OPAL_THREAD_UNLOCK(&mca_btl_tcp_component.tcp_lock);
     return proc;
 }

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -16,6 +16,8 @@
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -459,7 +461,7 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
 
     /* initialization */
     mca_btl_usnic_component.my_hashed_rte_name =
-        opal_proc_local_get()->proc_name;
+        opal_proc_local_get()->proc_name.id;
     MSGDEBUG1_OUT("%s: my_hashed_rte_name=0x%" PRIx64,
                    __func__, mca_btl_usnic_component.my_hashed_rte_name);
 

--- a/opal/mca/btl/usnic/btl_usnic_proc.c
+++ b/opal/mca/btl/usnic/btl_usnic_proc.c
@@ -13,6 +13,8 @@
  *                         reserved.
  * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -152,7 +154,7 @@ opal_btl_usnic_proc_lookup_endpoint(opal_btl_usnic_module_t *receiver,
            working to give handles instead of proc names, and then
            have a function pointer to perform comparisons.  This would
            be bad here in the critical path, though... */
-        if (proc->proc_opal->proc_name == sender_proc_name) {
+        if (proc->proc_opal->proc_name.id == sender_proc_name) {
             MSGDEBUG1_OUT("lookup_endpoint: matched endpoint=%p",
                           (void *)endpoint);
             opal_mutex_unlock(&receiver->all_endpoints_lock);
@@ -576,8 +578,8 @@ static int match_modex(opal_btl_usnic_module_t *module,
          * sides are always setting up the exact same graph by always putting
          * the process with the lower (jobid,vpid) on the "left".
          */
-        proc_is_left = (proc->proc_opal->proc_name <
-                        opal_proc_local_get()->proc_name);
+        proc_is_left = (proc->proc_opal->proc_name.id <
+                        opal_proc_local_get()->proc_name.id);
 
         err = create_proc_module_graph(proc, proc_is_left, &g);
         if (OPAL_SUCCESS != err) {

--- a/opal/mca/dstore/hash/dstore_hash.c
+++ b/opal/mca/dstore/hash/dstore_hash.c
@@ -6,6 +6,8 @@
  *                         reserved.
  * Copyright (c) 2011-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -102,25 +104,25 @@ static int store(struct opal_dstore_base_module_t *imod,
 {
     opal_dstore_proc_data_t *proc_data;
     opal_value_t *kv;
-    opal_identifier_t id;
+    opal_process_name_t name;
     mca_dstore_hash_module_t *mod;
     int rc;
 
     mod = (mca_dstore_hash_module_t*)imod;
 
     /* to protect alignment, copy the identifier across */
-    memcpy(&id, uid, sizeof(opal_identifier_t));
+    memcpy(&name, uid, sizeof(opal_process_name_t));
 
     opal_output_verbose(1, opal_dstore_base_framework.framework_output,
                         "%s dstore:hash:store storing data for proc %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(id));
+                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(name));
 
     /* lookup the proc data object for this proc */
-    if (NULL == (proc_data = opal_dstore_base_lookup_proc(&mod->hash_data, id))) {
+    if (NULL == (proc_data = opal_dstore_base_lookup_proc(&mod->hash_data, name.id))) {
         /* unrecoverable error */
         OPAL_OUTPUT_VERBOSE((5, opal_dstore_base_framework.framework_output,
                              "%s dstore:hash:store: storing data for proc %s unrecoverably failed",
-                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(id)));
+                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(name)));
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
@@ -134,7 +136,7 @@ static int store(struct opal_dstore_base_module_t *imod,
                          "%s dstore:hash:store: %s key %s[%s] for proc %s",
                          OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
                          (NULL == kv ? "storing" : "updating"),
-                         val->key, _data_type, OPAL_NAME_PRINT(id)));
+                         val->key, _data_type, OPAL_NAME_PRINT(name)));
     free (_data_type);
 #endif
 
@@ -158,26 +160,26 @@ static int fetch(struct opal_dstore_base_module_t *imod,
 {
     opal_dstore_proc_data_t *proc_data;
     opal_value_t *kv, *knew;
-    opal_identifier_t id;
+    opal_process_name_t name;
     mca_dstore_hash_module_t *mod;
     int rc;
 
     mod = (mca_dstore_hash_module_t*)imod;
 
     /* to protect alignment, copy the identifier across */
-    memcpy(&id, uid, sizeof(opal_identifier_t));
+    memcpy(&name, uid, sizeof(opal_process_name_t));
 
     OPAL_OUTPUT_VERBOSE((5, opal_dstore_base_framework.framework_output,
                          "%s dstore:hash:fetch: searching for key %s on proc %s",
                          OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                         (NULL == key) ? "NULL" : key, OPAL_NAME_PRINT(id)));
+                         (NULL == key) ? "NULL" : key, OPAL_NAME_PRINT(name)));
 
     /* lookup the proc data object for this proc */
-    if (NULL == (proc_data = opal_dstore_base_lookup_proc(&mod->hash_data, id))) {
+    if (NULL == (proc_data = opal_dstore_base_lookup_proc(&mod->hash_data, name.id))) {
         OPAL_OUTPUT_VERBOSE((5, opal_dstore_base_framework.framework_output,
                              "%s dstore_hash:fetch data for proc %s not found",
                              OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                             OPAL_NAME_PRINT(id)));
+                             OPAL_NAME_PRINT(name)));
         return OPAL_ERR_NOT_FOUND;
     }
 
@@ -193,7 +195,7 @@ static int fetch(struct opal_dstore_base_module_t *imod,
                                  "%s dstore:hash:fetch: adding data for key %s on proc %s",
                                  OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
                                  (NULL == kv->key) ? "NULL" : kv->key,
-                                 OPAL_NAME_PRINT(id)));
+                                 OPAL_NAME_PRINT(name)));
 
             /* add it to the output list */
             opal_list_append(kvs, &knew->super);
@@ -207,7 +209,7 @@ static int fetch(struct opal_dstore_base_module_t *imod,
                              "%s dstore_hash:fetch key %s for proc %s not found",
                              OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
                              (NULL == key) ? "NULL" : key,
-                             OPAL_NAME_PRINT(id)));
+                             OPAL_NAME_PRINT(name)));
         return OPAL_ERR_NOT_FOUND;
     }
 
@@ -227,16 +229,16 @@ static int remove_data(struct opal_dstore_base_module_t *imod,
 {
     opal_dstore_proc_data_t *proc_data;
     opal_value_t *kv;
-    opal_identifier_t id;
+    opal_process_name_t name;
     mca_dstore_hash_module_t *mod;
 
     mod = (mca_dstore_hash_module_t*)imod;
 
     /* to protect alignment, copy the identifier across */
-    memcpy(&id, uid, sizeof(opal_identifier_t));
+    memcpy(&name, uid, sizeof(opal_process_name_t));
 
     /* lookup the specified proc */
-    if (NULL == (proc_data = opal_dstore_base_lookup_proc(&mod->hash_data, id))) {
+    if (NULL == (proc_data = opal_dstore_base_lookup_proc(&mod->hash_data, name.id))) {
         /* no data for this proc */
         return OPAL_SUCCESS;
     }
@@ -247,7 +249,7 @@ static int remove_data(struct opal_dstore_base_module_t *imod,
             OBJ_RELEASE(kv);
         }
         /* remove the proc_data object itself from the jtable */
-        opal_hash_table_remove_value_uint64(&mod->hash_data, id);
+        opal_hash_table_remove_value_uint64(&mod->hash_data, name.id);
         /* cleanup */
         OBJ_RELEASE(proc_data);
         return OPAL_SUCCESS;

--- a/opal/mca/pmix/base/pmix_base_fns.c
+++ b/opal/mca/pmix/base/pmix_base_fns.c
@@ -206,7 +206,7 @@ int opal_pmix_base_get_packed(const opal_identifier_t* proc, char **packed_data,
 
         sprintf (tmp_key, "key%d", remote_key);
 
-        if (NULL == (pmikey = setup_key(proc, tmp_key, vallen))) {
+        if (NULL == (pmikey = setup_key((opal_process_name_t *)proc, tmp_key, vallen))) {
             rc = OPAL_ERR_OUT_OF_RESOURCE;
             OPAL_ERROR_LOG(rc);
             return rc;
@@ -400,7 +400,7 @@ static char* setup_key(const opal_process_name_t* name, const char *key, int pmi
     char *pmi_kvs_key;
 
     if (pmix_keylen_max <= asprintf(&pmi_kvs_key, "%" PRIu64 "-%s",
-                                        *name, key)) {
+                                        name->id, key)) {
         free(pmi_kvs_key);
         return NULL;
     }

--- a/opal/mca/pmix/native/pmix_native_component.c
+++ b/opal/mca/pmix/native/pmix_native_component.c
@@ -126,7 +126,7 @@ static int pmix_native_component_query(mca_base_module_t **module, int *priority
         /* if PMIx is present, then we need to use it */
         mca_pmix_native_component.uri = strdup(t);
         mca_pmix_native_component.id = strtoull(id, NULL, 10);
-        opal_proc_set_name(&mca_pmix_native_component.id);
+        opal_proc_set_name((opal_process_name_t *)&mca_pmix_native_component.id);
         *priority = 100;
     }
     *module = (mca_base_module_t *)&opal_pmix_native_module;

--- a/opal/mca/pmix/native/usock.c
+++ b/opal/mca/pmix/native/usock.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -354,12 +356,12 @@ int usock_send_connect_ack(void)
                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
 
     /* setup the header */
-    hdr.id = OPAL_PROC_MY_NAME;
+    hdr.id = OPAL_PROC_MY_NAME.id;
     hdr.tag = UINT32_MAX;
     hdr.type = PMIX_USOCK_IDENT;
 
     /* get our security credential */
-    if (OPAL_SUCCESS != (rc = opal_sec.get_my_credential(opal_dstore_internal, &OPAL_PROC_MY_NAME, &cred))) {
+    if (OPAL_SUCCESS != (rc = opal_sec.get_my_credential(opal_dstore_internal, &OPAL_PROC_MY_NAME.id, &cred))) {
         return rc;
     }
 

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -174,7 +176,7 @@ typedef void (*opal_pmix_cbfunc_t)(int status, opal_value_t *kv, void *cbdata);
 #define OPAL_MODEX_RECV_VALUE(r, s, p, d, t)                            \
     do {                                                                \
         opal_value_t *kv;                                               \
-        if (OPAL_SUCCESS != ((r) = opal_pmix.get(&(p)->proc_name,       \
+        if (OPAL_SUCCESS != ((r) = opal_pmix.get(&(p)->proc_name.id,    \
                                                  (s), &kv))) {          \
             *(d) = NULL;                                                \
         } else {                                                        \
@@ -199,7 +201,7 @@ typedef void (*opal_pmix_cbfunc_t)(int status, opal_value_t *kv, void *cbdata);
 #define OPAL_MODEX_RECV_STRING(r, s, p, d, sz)                          \
     do {                                                                \
         opal_value_t *kv;                                               \
-        if (OPAL_SUCCESS == ((r) = opal_pmix.get(&(p)->proc_name,       \
+        if (OPAL_SUCCESS == ((r) = opal_pmix.get(&(p)->proc_name.id,    \
                                                  (s), &kv)) &&          \
             NULL != kv) {                                               \
             *(d) = kv->data.bo.bytes;                                   \

--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2013      Inria.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -31,7 +33,7 @@ opal_process_info_t opal_process_info = {
 static opal_proc_t opal_local_proc = {
     { .opal_list_next = NULL,
       .opal_list_prev = NULL},
-    OPAL_NAME_INVALID,
+    { .id = OPAL_NAME_INVALID},
     0,
     0,
     NULL,
@@ -44,13 +46,13 @@ static void opal_proc_construct(opal_proc_t* proc)
     proc->proc_arch = opal_local_arch;
     proc->proc_convertor = NULL;
     proc->proc_flags = 0;
-    proc->proc_name = 0;
+    proc->proc_name.id = 0;
 }
 
 static void opal_proc_destruct(opal_proc_t* proc)
 {
     proc->proc_flags     = 0;
-    proc->proc_name      = 0;
+    proc->proc_name.id = 0;
     proc->proc_hostname  = NULL;
     proc->proc_convertor = NULL;
 }
@@ -62,8 +64,8 @@ static int
 opal_compare_opal_procs(const opal_process_name_t proc1,
                         const opal_process_name_t proc2)
 {
-    if( proc1 == proc2 ) return  0;
-    if( proc1 <  proc2 ) return -1;
+    if( proc1.id == proc2.id ) return  0;
+    if( proc1.id <  proc2.id ) return -1;
     return 1;
 }
 

--- a/opal/util/proc.h
+++ b/opal/util/proc.h
@@ -26,33 +26,18 @@
 #include <arpa/inet.h>
 #endif
 
-/**
- * This is a transparent handle proposed to the upper layer as a mean
- * to store whatever information it needs in order to efficiently
- * retrieve the RTE process naming scheme, and get access to the RTE
- * information associated with it. The only direct usage of this type
- * is to be copied from one structure to another, otherwise it should
- * only be used via the accessors defined below.
- */
-typedef opal_identifier_t opal_process_name_t;
-
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT && !defined(WORDS_BIGENDIAN)
-#define OPAL_PROCESS_NAME_NTOH(guid) opal_process_name_ntoh_intr(&(guid))
-static inline __opal_attribute_always_inline__ void
-opal_process_name_ntoh_intr(opal_process_name_t *name)
-{
-    uint32_t * w = (uint32_t *)name;
-    w[0] = ntohl(w[0]);
-    w[1] = ntohl(w[1]);
-}
-#define OPAL_PROCESS_NAME_HTON(guid) opal_process_name_hton_intr(&(guid))
-static inline __opal_attribute_always_inline__ void
-opal_process_name_hton_intr(opal_process_name_t *name)
-{
-    uint32_t * w = (uint32_t *)name;
-    w[0] = htonl(w[0]);
-    w[1] = htonl(w[1]);
-}
+#define OPAL_PROCESS_NAME_NTOH(n)       \
+do {                                    \
+    n.name.jobid = ntohl(n.name.jobid); \
+    n.name.vpid  = ntohl(n.name.vpid);  \
+} while (0);
+    
+#define OPAL_PROCESS_NAME_HTON(n)       \
+do {                                    \
+    n.name.jobid = htonl(n.name.jobid); \
+    n.name.vpid  = htonl(n.name.vpid);  \
+} while (0);
 #else
 #define OPAL_PROCESS_NAME_NTOH(guid)
 #define OPAL_PROCESS_NAME_HTON(guid)

--- a/orte/include/orte/types.h
+++ b/orte/include/orte/types.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +29,7 @@
 #include <sys/types.h>
 #endif
 #include "opal/dss/dss_types.h"
+#include "opal/util/proc.h"
 
 /**
  * Supported datatypes for messaging and storage operations.
@@ -74,11 +77,11 @@ typedef uint32_t orte_app_idx_t;
  * the other, and it will cause problems in the communication subsystems
  */
 
-typedef uint32_t orte_jobid_t;
+typedef opal_jobid_t orte_jobid_t;
 #define ORTE_JOBID_T        OPAL_UINT32
 #define ORTE_JOBID_MAX      UINT32_MAX-2
 #define ORTE_JOBID_MIN      0
-typedef uint32_t orte_vpid_t;
+typedef opal_vpid_t orte_vpid_t;
 #define ORTE_VPID_T         OPAL_UINT32
 #define ORTE_VPID_MAX       UINT32_MAX-2
 #define ORTE_VPID_MIN       0
@@ -116,11 +119,7 @@ do {                                    \
 /*
  * define the process name structure
  */
-struct orte_process_name_t {
-    orte_jobid_t jobid;     /**< Job number */
-    orte_vpid_t vpid;       /**< Process id - equivalent to rank */
-};
-typedef struct orte_process_name_t orte_process_name_t;
+typedef opal_proc_name_t orte_process_name_t;
 
 
 /**

--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved. 
  * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -288,7 +290,7 @@ static int rte_init(void)
     /* if our URI was not provided by the system, then
      * push our URI so others can find us */
     OBJ_CONSTRUCT(&vals, opal_list_t);
-    if (OPAL_SUCCESS != opal_dstore.fetch(opal_dstore_internal, &OPAL_PROC_MY_NAME,
+    if (OPAL_SUCCESS != opal_dstore.fetch(opal_dstore_internal, &OPAL_PROC_MY_NAME.id,
                                           OPAL_DSTORE_URI, &vals)) {
         /* construct the RTE string */
         rmluri = orte_rml.get_contact_info();
@@ -322,7 +324,7 @@ static int rte_init(void)
     /* if our local rank was not provided by the system, then
      * push our local rank so others can access it */
     OBJ_CONSTRUCT(&vals, opal_list_t);
-    if (OPAL_SUCCESS != opal_dstore.fetch(opal_dstore_internal, &OPAL_PROC_MY_NAME,
+    if (OPAL_SUCCESS != opal_dstore.fetch(opal_dstore_internal, &OPAL_PROC_MY_NAME.id,
                                           OPAL_DSTORE_LOCALRANK, &vals)) {
         OBJ_CONSTRUCT(&kvn, opal_value_t);
         kvn.key = strdup(OPAL_DSTORE_LOCALRANK);
@@ -340,7 +342,7 @@ static int rte_init(void)
     /* if our node rank was not provided by the system, then
      * push our node rank so others can access it */
     OBJ_CONSTRUCT(&vals, opal_list_t);
-    if (OPAL_SUCCESS != opal_dstore.fetch(opal_dstore_internal, &OPAL_PROC_MY_NAME,
+    if (OPAL_SUCCESS != opal_dstore.fetch(opal_dstore_internal, &OPAL_PROC_MY_NAME.id,
                                           OPAL_DSTORE_NODERANK, &vals)) {
         OBJ_CONSTRUCT(&kvn, opal_value_t);
         kvn.key = strdup(OPAL_DSTORE_NODERANK);

--- a/orte/mca/rml/base/base.h
+++ b/orte/mca/rml/base/base.h
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -250,23 +252,23 @@ ORTE_DECLSPEC void orte_rml_base_process_msg(int fd, short flags, void *cbdata);
 ORTE_DECLSPEC void orte_rml_base_process_error(int fd, short flags, void *cbdata);
 
 /* null functions */
-int orte_rml_base_null_send_nb(struct orte_process_name_t* peer,
+int orte_rml_base_null_send_nb(orte_process_name_t* peer,
                                struct iovec* msg,
                                int count,
                                orte_rml_tag_t tag,
                                orte_rml_callback_fn_t cbfunc,
                                void* cbdata);
-int orte_rml_base_null_send_buffer_nb(struct orte_process_name_t* peer,
+int orte_rml_base_null_send_buffer_nb(orte_process_name_t* peer,
                                       struct opal_buffer_t* buffer,
                                       orte_rml_tag_t tag,
                                       orte_rml_buffer_callback_fn_t cbfunc,
                                       void* cbdata);
-void orte_rml_base_null_recv_nb(struct orte_process_name_t* peer,
+void orte_rml_base_null_recv_nb(orte_process_name_t* peer,
                                 orte_rml_tag_t tag,
                                 bool persistent,
                                 orte_rml_callback_fn_t cbfunc,
                                 void* cbdata);
-void orte_rml_base_null_recv_buffer_nb(struct orte_process_name_t* peer,
+void orte_rml_base_null_recv_buffer_nb(orte_process_name_t* peer,
                                        orte_rml_tag_t tag,
                                        bool persistent,
                                        orte_rml_buffer_callback_fn_t cbfunc,

--- a/orte/mca/rml/rml.h
+++ b/orte/mca/rml/rml.h
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,7 +54,6 @@ BEGIN_C_DECLS
 
 
 struct opal_buffer_t;
-struct orte_process_name_t;
 struct orte_rml_module_t;
 typedef struct {
     opal_object_t super;
@@ -146,7 +147,7 @@ typedef struct orte_rml_component_2_0_0_t orte_rml_component_t;
  * @param[in] cbdata  User data passed to send_nb()
  */
 typedef void (*orte_rml_callback_fn_t)(int status,
-                                       struct orte_process_name_t* peer,
+                                       orte_process_name_t* peer,
                                        struct iovec* msg,
                                        int count,
                                        orte_rml_tag_t tag,
@@ -171,7 +172,7 @@ typedef void (*orte_rml_callback_fn_t)(int status,
  * @param[in] cbdata  User data passed to send_buffer_nb() or recv_buffer_nb()
  */
 typedef void (*orte_rml_buffer_callback_fn_t)(int status,
-                                              struct orte_process_name_t* peer,
+                                              orte_process_name_t* peer,
                                               struct opal_buffer_t* buffer,
                                               orte_rml_tag_t tag,
                                               void* cbdata);
@@ -315,7 +316,7 @@ typedef int (*orte_rml_module_ping_fn_t)(const char* contact_info,
  *                    receiving process is not available
  * @retval ORTE_ERROR  An unspecified error occurred
  */
-typedef int (*orte_rml_module_send_nb_fn_t)(struct orte_process_name_t* peer,
+typedef int (*orte_rml_module_send_nb_fn_t)(orte_process_name_t* peer,
                                             struct iovec* msg,
                                             int count,
                                             orte_rml_tag_t tag,
@@ -345,7 +346,7 @@ typedef int (*orte_rml_module_send_nb_fn_t)(struct orte_process_name_t* peer,
  *                    receiving process is not available
  * @retval ORTE_ERROR  An unspecified error occurred
  */
-typedef int (*orte_rml_module_send_buffer_nb_fn_t)(struct orte_process_name_t* peer,
+typedef int (*orte_rml_module_send_buffer_nb_fn_t)(orte_process_name_t* peer,
                                                    struct opal_buffer_t* buffer,
                                                    orte_rml_tag_t tag,
                                                    orte_rml_buffer_callback_fn_t cbfunc,
@@ -360,7 +361,7 @@ typedef int (*orte_rml_module_send_buffer_nb_fn_t)(struct orte_process_name_t* p
  * @param[in] cbfunc   Callback function on message comlpetion
  * @param[in] cbdata   User data to provide during completion callback
  */
-typedef void (*orte_rml_module_recv_nb_fn_t)(struct orte_process_name_t* peer,
+typedef void (*orte_rml_module_recv_nb_fn_t)(orte_process_name_t* peer,
                                              orte_rml_tag_t tag,
                                              bool persistent,
                                              orte_rml_callback_fn_t cbfunc,
@@ -376,7 +377,7 @@ typedef void (*orte_rml_module_recv_nb_fn_t)(struct orte_process_name_t* peer,
  * @param[in] cbfunc   Callback function on message comlpetion
  * @param[in] cbdata   User data to provide during completion callback
  */
-typedef void (*orte_rml_module_recv_buffer_nb_fn_t)(struct orte_process_name_t* peer,
+typedef void (*orte_rml_module_recv_buffer_nb_fn_t)(orte_process_name_t* peer,
                                                     orte_rml_tag_t tag,
                                                     bool persistent,
                                                     orte_rml_buffer_callback_fn_t cbfunc,
@@ -427,7 +428,7 @@ typedef int  (*orte_rml_module_ft_event_fn_t)(int state);
  * to/from a specified process. Used when a process aborts
  * and is to be restarted
  */
-typedef void (*orte_rml_module_purge_fn_t)(struct orte_process_name_t *peer);
+typedef void (*orte_rml_module_purge_fn_t)(orte_process_name_t *peer);
 
 /* ******************************************************************** */
 

--- a/orte/mca/routed/routed.h
+++ b/orte/mca/routed/routed.h
@@ -6,6 +6,8 @@
  * Copyright (c) 2004-2011 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,7 +51,6 @@ BEGIN_C_DECLS
 
 
 struct opal_buffer_t;
-struct orte_process_name_t;
 struct orte_rml_module_t;
 
 

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -605,7 +607,7 @@ static void pmix_server_recv(int status, orte_process_name_t* sender,
     /* unpack the id of the proc involved - must be one
      * of my local children */
     cnt = 1;
-    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &id, &cnt, OPAL_UINT64))) {
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &id, &cnt, OPAL_NAME))) {
         ORTE_ERROR_LOG(rc);
         return;
     }
@@ -731,7 +733,7 @@ static void pmix_server_dmdx_recv(int status, orte_process_name_t* sender,
 
     /* unpack the id of the proc whose data is being requested */
     cnt = 1;
-    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &idreq, &cnt, OPAL_UINT64))) {
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &idreq, &cnt, OPAL_NAME))) {
         ORTE_ERROR_LOG(rc);
         return;
     }
@@ -749,7 +751,7 @@ static void pmix_server_dmdx_recv(int status, orte_process_name_t* sender,
         /* send back an error - they obviously have made a mistake */
         reply = OBJ_NEW(opal_buffer_t);
         /* pack the id of the requested proc */
-        if (OPAL_SUCCESS != (rc = opal_dss.pack(reply, &idreq, 1, OPAL_UINT64))) {
+        if (OPAL_SUCCESS != (rc = opal_dss.pack(reply, &idreq, 1, OPAL_NAME))) {
             ORTE_ERROR_LOG(rc);
             OBJ_RELEASE(reply);
             return;
@@ -810,7 +812,7 @@ static void pmix_server_dmdx_recv(int status, orte_process_name_t* sender,
     /* return it */
     reply = OBJ_NEW(opal_buffer_t);
     /* pack the id of the requested proc */
-    if (OPAL_SUCCESS != (rc = opal_dss.pack(reply, &idreq, 1, OPAL_UINT64))) {
+    if (OPAL_SUCCESS != (rc = opal_dss.pack(reply, &idreq, 1, OPAL_NAME))) {
         ORTE_ERROR_LOG(rc);
         OBJ_RELEASE(reply);
         return;
@@ -921,7 +923,7 @@ static void pmix_server_dmdx_resp(int status, orte_process_name_t* sender,
 
     /* unpack the id of the target whose info we just received */
     cnt = 1;
-    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &target, &cnt, OPAL_UINT64))) {
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &target, &cnt, OPAL_NAME))) {
         ORTE_ERROR_LOG(rc);
         return;
     }

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -13,6 +13,8 @@
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved. 
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -156,7 +158,7 @@ OBJ_CLASS_DECLARATION(pmix_server_dmx_req_t);
                             ORTE_NAME_PRINT(&(p)->name));               \
         msg = OBJ_NEW(pmix_server_send_t);                              \
         /* setup the header */                                          \
-        msg->hdr.id = OPAL_PROC_MY_NAME;                                \
+        msg->hdr.id = OPAL_PROC_MY_NAME.id;                             \
         msg->hdr.type = PMIX_USOCK_USER;                                \
         msg->hdr.tag = (t);                                             \
         msg->hdr.nbytes = (b)->bytes_used;                              \

--- a/oshmem/mca/scoll/mpi/scoll_mpi_module.c
+++ b/oshmem/mca/scoll/mpi/scoll_mpi_module.c
@@ -1,11 +1,13 @@
 /**
-  Copyright (c) 2011 Mellanox Technologies. All rights reserved.
-  Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
-  $COPYRIGHT$
-
-  Additional copyrights may follow
-
- $HEADER$
+ * Copyright (c) 2011 Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
  */
 
 #include "ompi_config.h"
@@ -125,7 +127,7 @@ mca_scoll_mpi_comm_query(oshmem_group_t *osh_group, int *priority)
             ompi_proc_t* ompi_proc;
             for( int j = 0; j < ompi_group_size(parent_group); j++ ) {
                 ompi_proc = ompi_group_peer_lookup(parent_group, j);
-                if( ompi_proc->super.proc_name == osh_group->proc_array[i]->super.proc_name) {
+                if( ompi_proc->super.proc_name.id == osh_group->proc_array[i]->super.proc_name.id) {
                     ranks[i] = j;
                     break;
                 }


### PR DESCRIPTION
opal_process_name_t is now an union of :
- opal_identifier_t (id)
- opal_proc_name_t (name)
  and orte_process_name_t is typedef'ed to opal_proc_name_t

the OPAL_NAME DSS type was introduced in order to correctly pack/unpack
an opal_process_name_t on an heterogeneous cluster

@rhc54 @bosilca this is working proof of concept to move jobid/vpid from the ORTE into the OPAL layer
