### PR TITLE
configure: fix pmi check

### DIFF
--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -48,6 +48,7 @@ AC_DEFUN([OPAL_CHECK_PMI_LIB],
            AC_MSG_CHECKING([for $2.h in $1/include/slurm])
            AS_IF([test -f $1/include/slurm/$2.h],
                  [AC_MSG_RESULT([found])
+                  added_flags="yes"
                   mycppflags="-I$1/include/slurm"],
                  [AC_MSG_RESULT([not found])
                   hdr_happy=no])])
@@ -154,7 +155,7 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                               [pmi2], [PMI2_Init],
                               [have_pmi2=yes
                                opal_have_pmi2=1
-                               AS_IF([test "$default_loc" = "no" && test "$added_flags" = "no"],
+                               AS_IF([test "$default_loc" = "no" || test "$added_flags" = "yes"],
                                      [$1_CPPFLAGS="$pmi2_CPPFLAGS"
                                       $1_LDFLAGS="$pmi2_LDFLAGS"
                                       have_rpath="$pmi2_rpath"])


### PR DESCRIPTION
this commits fixes a regression introduced by open-mpi/ompi@75d8a7f25b467bd052b875a515b69bdbf98193a4
-I/usr/include/slurm is now added if needed to
- pmix_CPPFLAGS
- pmix_s1_CPPFLAGS
- pmix_s2_CPPFLAGS
