### PR TITLE
openib btl: add Soft iWARP device to the ini file

### DIFF
--- a/opal/mca/btl/openib/mca-btl-openib-device-params.ini
+++ b/opal/mca/btl/openib/mca-btl-openib-device-params.ini
@@ -288,3 +288,15 @@ max_inline_data = 64
 vendor_id = 0x8086
 vendor_part_id = 0
 ignore_device = 1
+
+############################################################################
+
+# IBM Soft iWARP device.
+
+[IBM Soft iWARP]
+vendor_id =  0x626d74
+vendor_part_id = 0
+use_eager_rdma = 1
+mtu = 2048
+receive_queues = P,65536,64
+max_inline_data = 72


### PR DESCRIPTION
This enables IBM's software iWARP provider.  With this driver you can
run iWARP/RDMA over any ethernet NIC.  Useful for testing OMPI RDMA
logic without requiring an expensive RDMA adapter/infrastructure.

The Soft iWARP code is at: https://www.gitorious.org/softiwarp
