### PR TITLE
Fix SLURM PMI2 component. set s2_nrank to the relative position of a pro...

### DIFF
--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -260,7 +260,7 @@ static int s2_init(void)
     for (i=0; i < s2_nlranks; i++) {
         if (s2_rank == s2_lranks[i]) {
             s2_lrank = i;
-            s2_nrank = my_node;
+            s2_nrank = i;
             break;
         }
     }


### PR DESCRIPTION
...cess inside the node
(not relative position of a node inside the allocation).

stumbled on this thread (http://www.open-mpi.org/community/lists/devel/2014/09/15924.php) and found that finaly s2 component followed one way and cray's - the other:

cray:

```
    pmix_lranks = pmix_cray_parse_pmap(pmapping, pmix_rank, &my_node, &pmix_nlranks);

    /* find ourselves */
    for (i=0; i < pmix_nlranks; i++) {
        if (pmix_rank == pmix_lranks[i]) {
            pmix_lrank = i;
            pmix_nrank = i;
            break;
        }
    }
```

s2:

```
    s2_lranks = mca_common_pmi2_parse_pmap(pmapping, s2_pname.vpid, &my_node, &s2_nlranks);
    /* find ourselves */
    for (i=0; i < s2_nlranks; i++) {
        if (s2_rank == s2_lranks[i]) {
            s2_lrank = i;
            s2_nrank = my_node;
            break;
        }
    }
```

According to PMIx draft specifcation node rank is "rank on this node spanning all jobs". SLURM PMI2 implementation doesn't track processes of other job steps (only the current one). In this case local rank will be equal to node rank (as in Cray component). 
