### PR TITLE
Fix the lt_dladvise test noted by Edgar

### DIFF
--- a/config/opal_setup_libltdl.m4
+++ b/config/opal_setup_libltdl.m4
@@ -5,19 +5,19 @@ dnl                         Corporation.  All rights reserved.
 dnl Copyright (c) 2004-2005 The University of Tennessee and The University
 dnl                         of Tennessee Research Foundation.  All rights
 dnl                         reserved.
-dnl Copyright (c) 2004-2007 High Performance Computing Center Stuttgart, 
+dnl Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
-dnl                         reserved. 
+dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl $COPYRIGHT$
-dnl 
+dnl
 dnl Additional copyrights may follow
-dnl 
+dnl
 dnl $HEADER$
 dnl
 
@@ -74,9 +74,9 @@ AC_DEFUN([OPAL_SETUP_LIBLTDL],[
               libltdl_location=
               libltdl_need_external=1
               ;;
-           *) 
+           *)
               AC_MSG_RESULT([external copy ($libltdl_location)])
-              OPAL_CHECK_WITHDIR([libltdl], [$libltdl_location], 
+              OPAL_CHECK_WITHDIR([libltdl], [$libltdl_location],
                                  [include/ltdl.h])
               # If we're using an extern libltdl, then reset the
               # LTDLINCL that was set earlier (ie., there's no need to
@@ -139,7 +139,7 @@ AC_DEFUN([OPAL_SETUP_LIBLTDL],[
     AC_DEFINE_UNQUOTED(OPAL_LIBLTDL_INTERNAL, $OPAL_LIBLTDL_INTERNAL,
         [Whether we are using the internal libltdl or not])
 
-    AM_CONDITIONAL(OPAL_HAVE_DLOPEN, 
+    AM_CONDITIONAL(OPAL_HAVE_DLOPEN,
                    [test "$OPAL_ENABLE_DLOPEN_SUPPORT" = "1"])
     OPAL_VAR_SCOPE_POP([HAPPY])
 ])dnl
@@ -163,21 +163,21 @@ AC_DEFUN([_OPAL_SETUP_LIBLTDL_INTERNAL],[
         opal_subdir_args="$opal_subdir_args --disable-static"
     fi
 
-    CFLAGS_save="$CFLAGS"
+    CFLAGS_save=$CFLAGS
     CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"
 
     # VPATH support will be included by default in CONFIG_SUBDIR
-    OPAL_CONFIG_SUBDIR(opal/libltdl, [$opal_subdir_args], 
+    OPAL_CONFIG_SUBDIR(opal/libltdl, [$opal_subdir_args],
                        [HAPPY=1], [HAPPY=0])
-    if test "$HAPPY" = "1"; then
+    if test $HAPPY -eq 1; then
         LIBLTDL_SUBDIR=libltdl
         OPAL_LIBLTDL_INTERNAL=1
 
-        CPPFLAGS_save="$CPPFLAGS"
+        CPPFLAGS_save=$CPPFLAGS
         CPPFLAGS="-I$srcdir"
         AC_EGREP_HEADER([lt_dladvise_init], [opal/libltdl/ltdl.h],
                         [OPAL_HAVE_LTDL_ADVISE=1])
-        CPPFLAGS="$CPPFLAGS_save"
+        CPPFLAGS=$CPPFLAGS_save
 
         # --export-dynamic allows exported symbols to be resolved via
         # --dlsym and friends.
@@ -189,7 +189,7 @@ AC_DEFUN([_OPAL_SETUP_LIBLTDL_INTERNAL],[
         AC_MSG_WARN([dynamic shared object loading, by configuring with --disable-dlopen.])
         AC_MSG_ERROR([Cannot continue])
     fi
-    CFLAGS="$CFLAGS_save"
+    CFLAGS=$CFLAGS_save
 
     OPAL_VAR_SCOPE_POP
 ])dnl


### PR DESCRIPTION
The thread that started with RTLD_GLOBAL discussion and a SLURM issue turned into a configury issue w.r.t. the lt_dladvise_init test.

@edgargabriel can you confirm that this fixes your issue (i.e., lt_dtladvise_init is now found and the system now uses RTLD_GLOBAL)?
