### PR TITLE
Add  "-I$srcdir/opal/libltdl/" so conftest will allways set lt_dladvise.

### DIFF
--- a/config/opal_setup_libltdl.m4
+++ b/config/opal_setup_libltdl.m4
@@ -174,7 +174,7 @@ AC_DEFUN([_OPAL_SETUP_LIBLTDL_INTERNAL],[
         OPAL_LIBLTDL_INTERNAL=1
 
         CPPFLAGS_save=$CPPFLAGS
-        CPPFLAGS="-I$srcdir"
+        CPPFLAGS="-I$srcdir -I$srcdir/opal/libltdl"
         AC_EGREP_HEADER([lt_dladvise_init], [opal/libltdl/ltdl.h],
                         [OPAL_HAVE_LTDL_ADVISE=1])
         CPPFLAGS=$CPPFLAGS_save


### PR DESCRIPTION
This PR address the conftest compilation problem where gcc is unable to find subsequent includes in ltdl.h:

``` c
#include < libltdl/lt_system.h >
#include < libltdl/lt_error.h >
```

@edgargabriel @jsquyres could you verify this?
