### PR TITLE
libfabric: add optional PSM provider.

### DIFF
--- a/opal/mca/common/libfabric/Makefile.am
+++ b/opal/mca/common/libfabric/Makefile.am
@@ -155,15 +155,44 @@ libfabric_usnic_sources = \
 	libfabric/prov/usnic/src/usnic_direct/vnic_rq.c \
 	libfabric/prov/usnic/src/usnic_direct/vnic_wq.c
 
+libfabric_psm_headers = \
+	libfabric/prov/psm/src/psm_am.h \
+	libfabric/prov/psm/src/psmx.h
+
+libfabric_psm_sources = \
+	libfabric/prov/psm/src/psmx_init.c \
+	libfabric/prov/psm/src/psmx_domain.c \
+	libfabric/prov/psm/src/psmx_cq.c \
+	libfabric/prov/psm/src/psmx_cntr.c \
+	libfabric/prov/psm/src/psmx_av.c \
+	libfabric/prov/psm/src/psmx_ep.c \
+	libfabric/prov/psm/src/psmx_cm.c \
+	libfabric/prov/psm/src/psmx_tagged.c \
+	libfabric/prov/psm/src/psmx_msg.c \
+	libfabric/prov/psm/src/psmx_msg2.c \
+	libfabric/prov/psm/src/psmx_rma.c \
+	libfabric/prov/psm/src/psmx_atomic.c \
+	libfabric/prov/psm/src/psmx_am.c \
+	libfabric/prov/psm/src/psmx_mr.c \
+	libfabric/prov/psm/src/psmx_wait.c \
+	libfabric/prov/psm/src/psmx_poll.c \
+	libfabric/prov/psm/src/psmx_util.c
+
 sources = $(libfabric_core_sources)
 if OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_USNIC
 sources += $(libfabric_usnic_sources)
 endif OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_USNIC
+if OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_PSM
+sources += $(libfabric_psm_sources)
+endif OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_PSM
 
 headers = $(libfabric_core_headers)
 if OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_USNIC
 headers += $(libfabric_usnic_headers)
 endif OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_USNIC
+if OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_PSM
+headers += $(libfabric_psm_headers)
+endif OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_PSM
 
 lib@OPAL_LIB_PREFIX@mca_common_libfabric_la_SOURCES = $(headers) $(sources)
 lib@OPAL_LIB_PREFIX@mca_common_libfabric_la_CPPFLAGS = $(cppflags)

--- a/opal/mca/common/libfabric/configure.m4
+++ b/opal/mca/common/libfabric/configure.m4
@@ -157,6 +157,7 @@ AC_DEFUN([_OPAL_COMMON_LIBFABRIC_SETUP_LIBFABRIC_EMBEDDED_CONDITIONALS],[
     AM_CONDITIONAL([HAVE_DIRECT], [false])
 
     _OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_USNIC_CONDITIONALS
+    _OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_PSM_CONDITIONALS
 ])
 
 AC_DEFUN([_OPAL_COMMON_LIBFABRIC_SETUP_LIBFABRIC_EMBEDDED],[
@@ -192,6 +193,7 @@ AC_DEFUN([_OPAL_COMMON_LIBFABRIC_SETUP_LIBFABRIC_EMBEDDED],[
 
             # Do stuff for specific providers
             _OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_USNIC
+            _OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_PSM
            ])
 ])
 
@@ -287,4 +289,29 @@ AC_DEFUN([_OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_USNIC],[
 AC_DEFUN([_OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_USNIC_CONDITIONALS],[
     AM_CONDITIONAL([OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_USNIC],
                    [test $opal_common_libfabric_usnic_happy -eq 1])
+])
+
+# --------------------------------------------------------
+# Internal helper macro to look for the things the psm provider
+# needs
+# --------------------------------------------------------
+AC_DEFUN([_OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_PSM],[
+    opal_common_libfabric_psm_happy=1
+    AC_CHECK_HEADER([psm.h], [], [opal_common_libfabric_psm_happy=0])
+    AC_CHECK_LIB([psm_infinipath], [psm_init], [],
+                 [opal_common_libfabric_psm_happy=0])
+
+    opal_common_libfabric_CPPFLAGS="$opal_common_libfabric_CPPFLAGS -I$OPAL_TOP_SRCDIR/opal/mca/common/libfabric/libfabric/prov/psm/src"
+    opal_common_libfabric_LIBADD="\$(OPAL_TOP_BUILDDIR)/opal/mca/common/libfabric/lib${OPAL_LIB_PREFIX}mca_common_libfabric.la"
+
+    opal_common_libfabric_embedded_LIBADD="-lpsm_infinipath"
+])
+
+# --------------------------------------------------------
+# Internal helper macro for psm AM conditionals (that must be run
+# unconditionally)
+# --------------------------------------------------------
+AC_DEFUN([_OPAL_COMMON_LIBFABRIC_EMBEDDED_PROVIDER_PSM_CONDITIONALS],[
+    AM_CONDITIONAL([OPAL_COMMON_LIBFABRIC_HAVE_PROVIDER_PSM],
+                   [test $opal_common_libfabric_psm_happy -eq 1])
 ])


### PR DESCRIPTION
Add the option of building the embedded libfabric with the PSM provider.
