### PR TITLE
Introduce call to idle for a short period of time.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -869,8 +869,9 @@ OPAL_SEARCH_LIBS_CORE([dirname], [gen])
 # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
 OPAL_SEARCH_LIBS_CORE([ceil], [m])
 
-# -lrt might be needed for clock_gettime
+# -lrt might be needed for clock_gettime and nanosleep
 OPAL_SEARCH_LIBS_CORE([clock_gettime], [rt])
+OPAL_SEARCH_LIBS_CORE([nanosleep], [rt])
 
 AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf openpty isatty getpwuid fork waitpid execve pipe ptsname setsid mmap tcgetpgrp posix_memalign strsignal sysconf syslog vsyslog regcmp regexec regfree _NSGetEnviron socketpair strncpy_s usleep mkfifo dbopen dbm_open statfs statvfs setpgid setenv])
 

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -28,14 +28,9 @@
 #include "opal/class/opal_list.h"
 
 #include "opal/sys/atomic.h"
-#include "opal/threads/mutex.h"
+#include "opal/threads/threads.h"
 
 BEGIN_C_DECLS
-
-/* NTH: temporarily suppress warnings about this not being defined */
-#if !defined(OPAL_HAVE_ATOMIC_CMPSET_128)
-#define OPAL_HAVE_ATOMIC_CMPSET_128 0
-#endif
 
 /**
  * Counted pointer to avoid the ABA problem.
@@ -124,7 +119,8 @@ static inline opal_list_item_t *opal_lifo_push_atomic (opal_lifo_t *lifo,
         if (opal_atomic_cmpset_ptr (&lifo->opal_lifo_head.data.item, next, item)) {
             return next;
         }
-        /* DO some kind of pause to release the bus */
+
+        opal_thread_idle ();
     } while (1);
 }
 
@@ -150,6 +146,8 @@ static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
             item->opal_list_next = NULL;
             return item;
         }
+
+        opal_thread_idle ();
     } while (1);
 }
 
@@ -174,7 +172,8 @@ static inline opal_list_item_t *opal_lifo_push_atomic (opal_lifo_t *lifo,
             item->item_free = 0;
             return next;
         }
-        /* DO some kind of pause to release the bus */
+
+        opal_thread_idle ();
     } while (1);
 }
 
@@ -189,6 +188,7 @@ static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
 
         /* ensure it is safe to pop the head */
         if (opal_atomic_swap_32((volatile int32_t *) &item->item_free, 1)) {
+            opal_thread_idle ();
             continue;
         }
 
@@ -199,7 +199,8 @@ static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
         }
         /* NTH: don't need another atomic here */
         item->item_free = 0;
-        /* Do some kind of pause to release the bus */
+
+        opal_thread_idle ();
     }
 
     if (item == &lifo->opal_lifo_ghost) {

--- a/opal/threads/threads.h
+++ b/opal/threads/threads.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -124,6 +127,18 @@ OPAL_DECLSPEC int  opal_thread_join(opal_thread_t *, void **thread_return);
 OPAL_DECLSPEC bool opal_thread_self_compare(opal_thread_t*);
 OPAL_DECLSPEC opal_thread_t *opal_thread_get_self(void);
 OPAL_DECLSPEC void opal_thread_kill(opal_thread_t *, int sig);
+
+/**
+ * Idle the calling thread for a short period of time.
+ */
+static inline void opal_thread_idle (void)
+{
+#if OPAL_HAVE_NANOSLEEP
+    static struct timespec interval = {.tv_sec = 0, .tv_nsec = 5};
+
+    nanosleep (&interval, NULL);
+#endif
+}
 
 END_C_DECLS
 


### PR DESCRIPTION
Good idea: when hitting contention on the lifo or fifo idle the thread.

Bad idea: use sched_yield to idle a thread.

This commit adds a new abstraction to the opal thread interface:
opal_thread_idle (). This call uses nanosleep to sleep the calling thread
for a very short amount of time (currently 5 ns). Using this function
when contention is detected in either the opal_lifo_t or opal_fifo_t
greatly improves threading performance.

Ex opal_fifo threading test (tested on a Retina Macbook Pro running 10.9.5):

w/ opal_thread_idle

```sh
pn1246003% ./opal_fifo
Single thread test. Time: 0 s 2864 us 2 nsec/poppush
Atomics thread finished. Time: 0 s 20909 us 20 nsec/poppush
Atomics thread finished. Time: 0 s 175782 us 175 nsec/poppush
Atomics thread finished. Time: 0 s 191908 us 191 nsec/poppush
Atomics thread finished. Time: 0 s 192573 us 192 nsec/poppush
Atomics thread finished. Time: 0 s 193216 us 193 nsec/poppush
Atomics thread finished. Time: 0 s 195594 us 195 nsec/poppush
Atomics thread finished. Time: 0 s 195880 us 195 nsec/poppush
Atomics thread finished. Time: 0 s 197659 us 197 nsec/poppush
Atomics thread finished. Time: 0 s 198213 us 198 nsec/poppush
All threads finished. Thread count: 8 Time: 0 s 198343 us 24 nsec/poppush
Exhaustive atomics thread finished. Popped 649662 items. Time: 0 s 174389 us 268 nsec/poppush
Exhaustive atomics thread finished. Popped 670632 items. Time: 0 s 175257 us 261 nsec/poppush
Exhaustive atomics thread finished. Popped 692673 items. Time: 0 s 181763 us 262 nsec/poppush
Exhaustive atomics thread finished. Popped 681356 items. Time: 0 s 185193 us 271 nsec/poppush
Exhaustive atomics thread finished. Popped 663348 items. Time: 0 s 185895 us 280 nsec/poppush
Exhaustive atomics thread finished. Popped 695761 items. Time: 0 s 187089 us 268 nsec/poppush
Exhaustive atomics thread finished. Popped 712464 items. Time: 0 s 187513 us 263 nsec/poppush
Exhaustive atomics thread finished. Popped 712244 items. Time: 0 s 188061 us 264 nsec/poppush
All threads finished. Thread count: 8 Time: 0 s 188164 us 23 nsec/poppush
SUPPORT: OMPI Test Passed: opal_fifo_t: (8 tests)
```

w/out opal_thread_idle:

```
Single thread test. Time: 0 s 2850 us 2 nsec/poppush
Atomics thread finished. Time: 0 s 21451 us 21 nsec/poppush
Atomics thread finished. Time: 1 s 448048 us 1448 nsec/poppush
Atomics thread finished. Time: 1 s 453196 us 1453 nsec/poppush
Atomics thread finished. Time: 1 s 458207 us 1458 nsec/poppush
Atomics thread finished. Time: 1 s 460438 us 1460 nsec/poppush
Atomics thread finished. Time: 1 s 466642 us 1466 nsec/poppush
Atomics thread finished. Time: 1 s 467402 us 1467 nsec/poppush
Atomics thread finished. Time: 1 s 467713 us 1467 nsec/poppush
Atomics thread finished. Time: 1 s 467856 us 1467 nsec/poppush
All threads finished. Thread count: 8 Time: 1 s 468034 us 183 nsec/poppush
Exhaustive atomics thread finished. Popped 616810 items. Time: 1 s 40889 us 1687 nsec/poppush
Exhaustive atomics thread finished. Popped 617083 items. Time: 1 s 41604 us 1687 nsec/poppush
Exhaustive atomics thread finished. Popped 617736 items. Time: 1 s 53726 us 1705 nsec/poppush
Exhaustive atomics thread finished. Popped 614711 items. Time: 1 s 63529 us 1730 nsec/poppush
Exhaustive atomics thread finished. Popped 612983 items. Time: 1 s 64248 us 1736 nsec/poppush
Exhaustive atomics thread finished. Popped 615214 items. Time: 1 s 65507 us 1731 nsec/poppush
Exhaustive atomics thread finished. Popped 615318 items. Time: 1 s 66123 us 1732 nsec/poppush
Exhaustive atomics thread finished. Popped 619068 items. Time: 1 s 66113 us 1722 nsec/poppush
All threads finished. Thread count: 8 Time: 1 s 66253 us 133 nsec/poppush
SUPPORT: OMPI Test Passed: opal_fifo_t: (8 tests)
```

I see similar performance benefits under Linux with kernel 3.13. I will
also test kernel 2.6.32.