### PR TITLE
configury: disable f08 fortran bindings if the compiler does

### DIFF
--- a/config/ompi_fortran_check_c_funloc.m4
+++ b/config/ompi_fortran_check_c_funloc.m4
@@ -1,0 +1,48 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2014      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# Check whether or not the Fortran compiler implements or not
+# TS 29113 subclause 8.1 :
+# Removed restrictions on ISO_C_BINDING module procedures.
+
+# OMPI_FORTRAN_CHECK_C_FUNLOC([action if found],
+#                             [action if not found])
+# ----------------------------------------------------
+AC_DEFUN([OMPI_FORTRAN_CHECK_C_FUNLOC],[
+    AS_VAR_PUSHDEF([c_funloc], [ompi_cv_fortran_c_funloc])
+
+    AC_CACHE_CHECK([if Fortran compiler implements TS 29113], c_funloc,
+       [AC_LANG_PUSH([Fortran])
+        AC_COMPILE_IFELSE([AC_LANG_SOURCE([[program main
+abstract interface
+  subroutine MPI_Comm_errhandler_function(comm, error_code)
+    implicit none
+    integer :: comm, error_code
+  end subroutine
+end interface
+
+contains
+
+subroutine  mysub(fn)
+    use, intrinsic :: iso_c_binding, only : c_funloc, c_funptr
+    procedure(MPI_Comm_errhandler_function) :: comm_errhandler_fn
+    type(c_funptr) :: comm_errhandler_fn_c
+    comm_errhandler_fn_c = c_funloc(comm_errhandler_fn)
+end subroutine mysub
+end program]])],
+             [AS_VAR_SET(c_funloc, yes)],
+             [AS_VAR_SET(c_funloc, no)])
+        AC_LANG_POP([Fortran])
+       ])
+
+    AS_VAR_IF(c_funloc, [yes], [$1], [$2])
+    AS_VAR_POPDEF([c_funloc])dnl
+])

--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -15,6 +15,8 @@
 # Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
 #                         reserved. 
 # Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -426,6 +428,16 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
                [OMPI_FORTRAN_HAVE_OPTIONAL_ARGS=0
                 OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS=0])])
 
+    OMPI_FORTRAN_HAVE_C_FUNLOC=0
+    AS_IF([test $OMPI_WANT_FORTRAN_USEMPIF08_BINDINGS -eq 1 -a \
+           $OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS -eq 1],
+          [ # Does the compiler supports c_funloc per
+            # TS 29113 subclause 8.1 ?
+           OMPI_FORTRAN_CHECK_C_FUNLOC(
+               [OMPI_FORTRAN_HAVE_C_FUNLOC=1],
+               [OMPI_FORTRAN_HAVE_C_FUNLOC=0
+                OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS=0])])
+
     OMPI_FORTRAN_HAVE_PRIVATE=0
     AS_IF([test $OMPI_WANT_FORTRAN_USEMPIF08_BINDINGS -eq 1 -a \
            $OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS -eq 1],
@@ -741,6 +753,13 @@ end type test_mpi_handle],
     AC_DEFINE_UNQUOTED([OMPI_FORTRAN_HAVE_PROCEDURE], 
                        [$OMPI_FORTRAN_HAVE_PROCEDURE],
                        [For ompi/mpi/fortran/use-mpi-f08/blah.F90 and blah.h and ompi_info: whether the compiler supports the "procedure" keyword or not])
+
+    # For configure-fortran-output.h, various files in
+    # ompi/mpi/fortran/use-mpi-f08/*.F90 and *.h files (and ompi_info)
+    AC_SUBST([OMPI_FORTRAN_HAVE_C_FUNLOC])
+    AC_DEFINE_UNQUOTED([OMPI_FORTRAN_HAVE_C_FUNLOC], 
+                       [$OMPI_FORTRAN_HAVE_C_FUNLOC],
+                       [For ompi/mpi/fortran/use-mpi-f08/blah.F90 and blah.h and ompi_info: whether the compiler supports c_funloc or not])
 
     # For configure-fortran-output.h
     AC_SUBST(OMPI_FORTRAN_HAVE_BIND_C)

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -100,6 +102,7 @@ void ompi_info_do_config(bool want_all)
     char *fortran_have_abstract;
     char *fortran_have_asynchronous;
     char *fortran_have_procedure;
+    char *fortran_have_c_funloc;
     char *fortran_08_using_wrappers_for_choice_buffer_functions;
     char *fortran_build_sizeof;
     char *java;
@@ -186,6 +189,7 @@ void ompi_info_do_config(bool want_all)
     fortran_have_abstract = OMPI_FORTRAN_HAVE_ABSTRACT ? "yes" : "no";
     fortran_have_asynchronous = OMPI_FORTRAN_HAVE_ASYNCHRONOUS ? "yes" : "no";
     fortran_have_procedure = OMPI_FORTRAN_HAVE_PROCEDURE ? "yes" : "no";
+    fortran_have_c_funloc = OMPI_FORTRAN_HAVE_C_FUNLOC ? "yes" : "no";
     fortran_08_using_wrappers_for_choice_buffer_functions = 
         OMPI_FORTRAN_NEED_WRAPPER_ROUTINES ? "yes" : "no";
     fortran_build_sizeof = OMPI_FORTRAN_BUILD_SIZEOF ?
@@ -203,6 +207,7 @@ void ompi_info_do_config(bool want_all)
             OMPI_FORTRAN_HAVE_ABSTRACT &&
             OMPI_FORTRAN_HAVE_ASYNCHRONOUS &&
             OMPI_FORTRAN_HAVE_PROCEDURE &&
+            OMPI_FORTRAN_HAVE_C_FUNLOC &&
             OMPI_FORTRAN_NEED_WRAPPER_ROUTINES) {
             fortran_usempif08_compliance = strdup("The mpi_f08 module is available, and is fully compliant.  w00t!");
         } else {
@@ -225,6 +230,9 @@ void ompi_info_do_config(bool want_all)
             }
             if (!OMPI_FORTRAN_HAVE_PROCEDURE) {
                 append(f08, sizeof(f08), &first, "PROCEDUREs");
+            }
+            if (!OMPI_FORTRAN_HAVE_C_FUNLOC) {
+                append(f08, sizeof(f08), &first, "C_FUNLOCs");
             }
             if (OMPI_FORTRAN_NEED_WRAPPER_ROUTINES) {
                 append(f08, sizeof(f08), &first, "direct passthru (where possible) to underlying Open MPI's C functionality");
@@ -425,6 +433,9 @@ void ompi_info_do_config(bool want_all)
     opal_info_out("Fort PROCEDURE", 
                   "compiler:fortran:procedure",
                   fortran_have_procedure);
+    opal_info_out("Fort C_FUNLOC",
+                  "compiler:fortran:c_funloc",
+                  fortran_have_c_funloc);
     opal_info_out("Fort f08 using wrappers", 
                   "compiler:fortran:08_wrappers",
                   fortran_08_using_wrappers_for_choice_buffer_functions);

--- a/oshmem/tools/oshmem_info/param.c
+++ b/oshmem/tools/oshmem_info/param.c
@@ -3,6 +3,8 @@
  *                         All rights reserved.
  *
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,6 +93,7 @@ void oshmem_info_do_config(bool want_all)
     char *fortran_have_abstract;
     char *fortran_have_asynchronous;
     char *fortran_have_procedure;
+    char *fortran_have_c_funloc;
     char *fortran_08_using_wrappers_for_choice_buffer_functions;
     char *java;
     char *heterogeneous;
@@ -165,6 +168,7 @@ void oshmem_info_do_config(bool want_all)
     fortran_have_abstract = OMPI_FORTRAN_HAVE_ABSTRACT ? "yes" : "no";
     fortran_have_asynchronous = OMPI_FORTRAN_HAVE_ASYNCHRONOUS ? "yes" : "no";
     fortran_have_procedure = OMPI_FORTRAN_HAVE_PROCEDURE ? "yes" : "no";
+    fortran_have_c_funloc = OMPI_FORTRAN_HAVE_C_FUNLOC ? "yes" : "no";
     fortran_08_using_wrappers_for_choice_buffer_functions =
         OMPI_FORTRAN_NEED_WRAPPER_ROUTINES ? "yes" : "no";
 
@@ -178,6 +182,7 @@ void oshmem_info_do_config(bool want_all)
             OMPI_FORTRAN_HAVE_ABSTRACT &&
             OMPI_FORTRAN_HAVE_ASYNCHRONOUS &&
             OMPI_FORTRAN_HAVE_PROCEDURE &&
+            OMPI_FORTRAN_HAVE_C_FUNLOC &&
             OMPI_FORTRAN_NEED_WRAPPER_ROUTINES) {
             fortran_usempif08_compliance = strdup("The mpi_f08 module is available, and is fully compliant.  w00t!");
         } else {
@@ -200,6 +205,9 @@ void oshmem_info_do_config(bool want_all)
             }
             if (!OMPI_FORTRAN_HAVE_PROCEDURE) {
                 append(f08, sizeof(f08), &first, "PROCEDUREs");
+            }
+            if (!OMPI_FORTRAN_HAVE_C_FUNLOC) {
+                append(f08, sizeof(f08), &first, "C_FUNLOCs");
             }
             if (OMPI_FORTRAN_NEED_WRAPPER_ROUTINES) {
                 append(f08, sizeof(f08), &first, "direct passthru (where possible) to underlying Open MPI's C functionality");
@@ -376,6 +384,9 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("Fort PROCEDURE",
                   "compiler:fortran:procedure",
                   fortran_have_procedure);
+    opal_info_out("Fort C_FUNLOC",
+                  "compiler:fortran:c_funloc",
+                  fortran_have_c_funloc);
     opal_info_out("Fort f08 using wrappers",
                   "compiler:fortran:08_wrappers",
                   fortran_08_using_wrappers_for_choice_buffer_functions);


### PR DESCRIPTION
not implement TS 29113

Per http://www.open-mpi.org/community/lists/users/2014/12/25963.php sunstudio compiler 12.4 fail compiling Open MPI (f08 bindings).

The root cause is these compilers do not implement TS 29113 subclause 8.1 :
Removed restrictions on ISO_C_BINDING module procedures

This PR disables f08 fortran bindings support if TS 29113 8.1 is not implemented.

@jsquyres could you please review this ?
