### PR TITLE
xpmem/config: simple xpmem search on Cray's

### DIFF
--- a/config/opal_check_cray_xpmem.m4
+++ b/config/opal_check_cray_xpmem.m4
@@ -1,0 +1,64 @@
+# -*- shell-script ; indent-tabs-mode:nil -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2014      Intel, Inc. All rights reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# special check for cray xpmem, uses macro(s) from pkg.m4
+#
+# OPAL_CHECK_CRAY_XPMEM(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+AC_DEFUN([OPAL_CHECK_CRAY_XPMEM],[
+    AC_ARG_WITH([cray_xpmem],
+                [AC_HELP_STRING([--with-cray-xpmem(=yes/no)],
+                [Build Cray XPMEM support(default: auto)])],
+                 [], with_cray_xpmem=auto)
+
+   AC_MSG_CHECKING([for Cray XPMEM support])
+   AS_IF([test "$with_cray_xpmem" = "no"],
+         [AC_MSG_RESULT([no])
+          $3],
+         [AS_IF([test "$with_cray_xpmem" = "auto" -o "$with_cray_xpmem" = "yes"],
+                 [PKG_CHECK_MODULES_STATIC([CRAY_XPMEM], [cray-xpmem],
+                                    [opal_check_cray_xpmem_happy="yes"],
+                                    [opal_check_cray_xpmem_happy="no"]
+                                    [AS_IF([test "$with_cray_xpmem" = "yes"],
+                                           [AC_MSG_WARN([Cray XPMEM support requested but pkg-config failed.])
+                                            AC_MSG_ERROR([Aborting])],[])]
+                                     )],
+                 [])
+         ])
+
+    AS_IF([test "$opal_check_cray_xpmem_happy" = "yes" -a "$enable_static" = "yes"],
+          [CRAY_XPMEM_LIBS = $CRAY_XPMEM_STATIC_LIBS],[])
+
+    AS_IF([test "$opal_check_cray_xpmem_happy" = "yes"],
+          [$1_LDFLAGS="$CRAY_XPMEM_LIBS"
+           $1_CPPFLAGS="$CRAY_XPMEM_CFLAGS"
+           $1_LIBS="$CRAY_XPMEM_LIBS"
+           AC_DEFINE_UNQUOTED([HAVE_XPMEM_H], [1],[is xpmem.h available])
+           $2], [$3])
+])
+
+
+

--- a/opal/mca/btl/vader/configure.m4
+++ b/opal/mca/btl/vader/configure.m4
@@ -63,7 +63,12 @@ AC_DEFUN([MCA_opal_btl_vader_CONFIG],[
     OPAL_VAR_SCOPE_PUSH([btl_vader_xpmem_happy btl_vader_cma_happy btl_vader_knem_happy])
 
     # Check for single-copy APIs
-    OPAL_CHECK_XPMEM([btl_vader], [btl_vader_xpmem_happy=1], [btl_vader_xpmem_happy=0])
+
+    OPAL_CHECK_CRAY_XPMEM([btl_vader], [btl_vader_xpmem_happy=1], [btl_vader_xpmem_happy=0])
+
+    AS_IF([test "$btl_vader_xpmem_happy" -eq 0],
+          [OPAL_CHECK_XPMEM([btl_vader], [btl_vader_xpmem_happy=1], [btl_vader_xpmem_happy=0])],[])
+
     OPAL_CHECK_KNEM([btl_vader], [btl_vader_knem_happy=1],[btl_vader_knem_happy=0])
     OPAL_CHECK_CMA([btl_vader], [AC_CHECK_HEADER([sys/prctl.h]) btl_vader_cma_happy=1], [btl_vader_cma_happy=0])
 


### PR DESCRIPTION
Use the pkg-config related m4 functions to find out where
Cray's xpmem.h and libxpmem are located on a system.

With this commit, there is no longer any need to have to
explicitly indicate an xpmem install location on the configure
line, at least for Cray systems running CLE 4.X and 5.X.
