### PR TITLE
btl/openib: fix build of btl/openib on cray

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_base.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_base.c
@@ -46,11 +46,19 @@ static opal_btl_openib_connect_base_component_t *all[] = {
 
     /* Always have an entry here so that the CP indexes will always be
        the same: if RDMA CM is not available, use the "empty" CPC */
+#if OPAL_HAVE_RDMACM
     &opal_btl_openib_connect_rdmacm,
+#else
+    &opal_btl_openib_connect_empty,
+#endif
 
     /* Always have an entry here so that the CP indexes will always be
        the same: if UD CM is not enabled, use the "empty" CPC */
+#if OPAL_HAVE_UDCM
     &opal_btl_openib_connect_udcm,
+#else
+    &opal_btl_openib_connect_empty,
+#endif
 
     NULL
 };


### PR DESCRIPTION
The conditional inclusion of
btl_openib_connect_udcm.h
and
btl_openib_connect_rdmacm.h
in
btl_openib_connect_base.c

can break the build of OMPI on systems
that don't have the full librdmacm package installed,
but have enough portions of the OFED stack installed
to cause OMPI to try to build the openib/btl.

@miked-mellanox or @jladd-mlnx  Please take a look.