### PR TITLE
odls/alps: check if PMI gni rdma creds already set

### DIFF
--- a/orte/mca/odls/alps/odls_alps_utils.c
+++ b/orte/mca/odls/alps/odls_alps_utils.c
@@ -53,6 +53,17 @@ int orte_odls_alps_get_rdma_creds(void)
     alpsAppGni_t *rdmacred_buf;
     char *ptr;
     char env_buffer[1024];
+    static int already_got_creds = 0;
+
+    /*
+     * If we already put the GNI RDMA credentials into orte_launch_environ,
+     * no need to do anything.
+     * TODO: kind of ugly, need to implement an opal_getenv
+     */
+
+    if (1 == already_got_creds) {
+        return ORTE_SUCCESS;
+    }
 
     /*
      * get the Cray HSN RDMA credentials here and stuff them in to the
@@ -234,6 +245,7 @@ int orte_odls_alps_get_rdma_creds(void)
     } 
 
    fn_exit:
+    if (ORTE_SUCCESS == ret) already_got_creds = 1;
     return ret;
 }
 


### PR DESCRIPTION
Need to check if the alps odls component has already
read the rdma creds from alps.  Its okay to ask apshepherd
multiple times for rdma creds, but opal_setenv gets
a bit picky about this.  Rather than check for the OPAL_EXISTS
return value from opal_setenv, for now just check with
a static variable whether or not orte_odls_alps_get_rdma_creds
has already been successfully called before.

Would be nice to have an opal_getenv function for checking
if an env. variable had already been set by opal_putenv.

Needed to make progress on issue #346
This commit at least allows for further single node work on Cray XE/XC systems using
just the vader and self BTLs.  

@bturrubiates adding you so you know about the issue and PR.