### PR TITLE
rml/oob: check peer param in send methods

### DIFF
--- a/orte/mca/rml/oob/rml_oob_send.c
+++ b/orte/mca/rml/oob/rml_oob_send.c
@@ -224,6 +224,14 @@ int orte_rml_oob_send_nb(orte_process_name_t* peer,
         ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
         return ORTE_ERR_BAD_PARAM;
     }
+
+    if( NULL == peer ||
+        OPAL_EQUAL == orte_util_compare_name_fields(ORTE_NS_CMP_ALL, ORTE_NAME_INVALID, peer) ) {
+        /* cannot send to an invalid peer */
+        ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;
+    }
+
     /* get ourselves into an event to protect against
      * race conditions and threads
      */
@@ -258,6 +266,13 @@ int orte_rml_oob_send_buffer_nb(orte_process_name_t* peer,
 
     if (ORTE_RML_TAG_INVALID == tag) {
         /* cannot send to an invalid tag */
+        ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;
+    }
+
+    if( NULL == peer ||
+        OPAL_EQUAL == orte_util_compare_name_fields(ORTE_NS_CMP_ALL, ORTE_NAME_INVALID, peer) ) {
+        /* cannot send to an invalid peer */
         ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
         return ORTE_ERR_BAD_PARAM;
     }


### PR DESCRIPTION
The rml/oob was not doing sanity checks on the input peer
parameter for the orte_rml_oob_send_nb and orte_rml_oob_send_buffer_nd.
Owing to the fact that there are places in the ompi/orte stack
where things like orte_show_help_norender are called way before
ORTE_PROC_MY_HNP, etc. are setup properly, all kinds of weird
startup failures can occur as the rml/oob tries to process send
requests where the peer is junk.

Rather than try to expand this kind of thing:

    /* if we are the HNP, or the RML has not yet been setup,
     * or ROUTED has not been setup,
     * or we weren't given an HNP, or we are running in standalone
     * mode, then all we can do is process this locally
     */
    if (ORTE_PROC_IS_HNP || orte_standalone_operation ||
        NULL == orte_rml.send_buffer_nb ||
        NULL == orte_routed.get_route ||
        NULL == orte_process_info.my_hnp_uri) {
        rc = show_help(filename, topic, output, ORTE_PROC_MY_NAME);
    }

do the right thing in the rml level and return an error rather than
eventually failing in the send owing to peer not being valid.

@jsquyres please review