### PR TITLE
btl/ugni: use PMIX_GLOBAL for modex_send in ugni

### DIFF
--- a/opal/mca/common/ugni/common_ugni.c
+++ b/opal/mca/common/ugni/common_ugni.c
@@ -190,7 +190,12 @@ static int opal_common_ugni_send_modex (int my_cdm_id)
         msg_offset += modex_size;
     }
 
-    OPAL_MODEX_SEND(rc, PMIX_ASYNC_RDY, PMIX_REMOTE,
+    /*
+     * need global for edge cases like MPI_Comm_spawn support with
+     * new ranks started on the same nodes as the spawnee ranks, etc.
+     */
+
+    OPAL_MODEX_SEND(rc, PMIX_ASYNC_RDY, PMIX_GLOBAL,
                     &opal_common_ugni_component,
                     modex_msg, total_msg_size);
 


### PR DESCRIPTION
Using PMIX_REMOTE is not the right thing for ugni
BTL when its possible that spawned ranks end up
on the same node as some of the spawnee ranks.

@hjelmn  FYI.  

For what its worth, vader doesn't seem to work for on-node spawn
case.  I thought vader can work with spawn, but it
doesn't appear to at least on Cray.  Hence the need for PMIX_GLOBAL
in the ugni MODEX_SEND stuff.
