### PR TITLE
orte/util: minor improvement to show_help

### DIFF
--- a/orte/util/show_help.c
+++ b/orte/util/show_help.c
@@ -666,6 +666,8 @@ int orte_show_help_norender(const char *filename, const char *topic,
                                                               orte_rml_send_callback, NULL))) {
                 ORTE_ERROR_LOG(rc);
                 OBJ_RELEASE(buf);
+                /* okay, that didn't work, just process locally error, just ignore return  */
+                show_help(filename, topic, NULL, ORTE_PROC_MY_NAME);
             } else {
                 rc = ORTE_SUCCESS;
             }
@@ -732,6 +734,8 @@ int orte_show_help_suppress(const char *filename, const char *topic)
                                                               orte_rml_send_callback, NULL))) {
                 ORTE_ERROR_LOG(rc);
                 OBJ_RELEASE(buf);
+                /* okay, that didn't work, just process locally error, just ignore return  */
+                show_help(filename, topic, NULL, ORTE_PROC_MY_NAME);
             }
             am_inside = false;
         }


### PR DESCRIPTION
Make sure the show help gives it a good try to
print an error message locally if the
send_buffer_nb method returns an error.

@rhc54 minor improvement to show help, could you check this?
