### PR TITLE
mtl/psm: fix problem with cancel sends

### DIFF
--- a/ompi/mca/mtl/psm/mtl_psm_cancel.c
+++ b/ompi/mca/mtl/psm/mtl_psm_cancel.c
@@ -31,6 +31,11 @@ int ompi_mtl_psm_cancel(struct mca_mtl_base_module_t* mtl,
   mca_mtl_psm_request_t *mtl_psm_request = 
     (mca_mtl_psm_request_t*) mtl_request; 
   
+  /* PSM does not support canceling sends */
+  if(OMPI_MTL_PSM_ISEND == mtl_psm_request->type) {
+    return OMPI_SUCCESS;
+  }
+
   err = psm_mq_cancel(&mtl_psm_request->psm_request); 
   if(PSM_OK == err) { 
     err = psm_mq_test(&mtl_psm_request->psm_request, &status);


### PR DESCRIPTION
incorporate patch from @afriedle-intel to fix
problem with psm mtl cancel of sends.

Sorry for the delay in getting to this.

Fixes  #347 