### PR TITLE
fixes OpenIB connect error reporting for ibv_* calls that return an errn...

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_sl.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_sl.c
@@ -241,16 +241,16 @@ static int get_pathrecord_info(struct mca_btl_openib_sa_qp_cache *cache,
 
     rc = ibv_post_recv(cache->qp, &(cache->rwr), &brwr);
     if (0 != rc) {
-        BTL_ERROR(("error posting receive on QP [0x%x] errno says: %s [%d]",
-                   cache->qp->qp_num, strerror(errno), errno));
+        BTL_ERROR(("error posting receive on QP [0x%x] rc says: %s [%d]",
+                   cache->qp->qp_num, strerror(rc), rc));
         return OPAL_ERROR;
     }
 
     while (0 == got_sl_value) {
         rc = ibv_post_send(cache->qp, swr, &bswr);
         if (0 != rc) {
-            BTL_ERROR(("error posting send on QP [0x%x] errno says: %s [%d]",
-                       cache->qp->qp_num, strerror(errno), errno));
+            BTL_ERROR(("error posting send on QP [0x%x] rc says: %s [%d]",
+                       cache->qp->qp_num, strerror(rc), rc));
             return OPAL_ERROR;
         }
         gettimeofday(&get_sl_rec_last_sent, NULL);
@@ -277,8 +277,8 @@ static int get_pathrecord_info(struct mca_btl_openib_sa_qp_cache *cache,
                 }
                 rc = ibv_post_recv(cache->qp, &(cache->rwr), &brwr);
                 if (0 != rc) {
-                    BTL_ERROR(("error posing receive on QP[%x] errno says: %s [%d]",
-                               cache->qp->qp_num, strerror(errno), errno));
+                    BTL_ERROR(("error posing receive on QP[%x] rc says: %s [%d]",
+                               cache->qp->qp_num, strerror(rc), rc));
                     return OPAL_ERROR;
                 }
             } else if (0 == ne) {    /* poll did not find anything */
@@ -299,8 +299,7 @@ static int get_pathrecord_info(struct mca_btl_openib_sa_qp_cache *cache,
                 }
                 usleep(100);  /* otherwise pause before polling again */
             } else if (ne < 0) {
-                BTL_ERROR(("error polling CQ with %d: %s\n",
-                    ne, strerror(errno)));
+                BTL_ERROR(("error polling CQ returned %d\n", ne));
                 return OPAL_ERROR;
             }
         }


### PR DESCRIPTION
Calls to ibv_post_recv() from get_pathrecord_info() were returning non-zero
status, but the error message was reporting a success code.

It turns out that ibv_post_recv() and ibv_post_send() do not actually set
errno on error.  Instead, they just return errno values as their return
values.  E.g., the ibv_post_recv() man page says:

```
RETURN VALUE
       ibv_post_recv() returns 0 on success, or the value of errno on failure 
       (which indicates the failure reason).
```

This behavior can be verified by examining ibv_post_recv() from, e.g.,
libibverbs-1.1.6, together with mlx4_post_recv() from, e.g, libmlx4-1.0.4.

Also, the return value from ibv_poll_cq() has nothing to do with errno either.
The man page says:

```
RETURN VALUE
       On  success,  ibv_poll_cq() returns a non-negative value equal to the
       number of completions found.  On failure, a negative  value is returned.
```

Consulting the source for libmlx4-1.0.4, e.g., shows that mlx4_poll_cq() calls
mlx4_poll_one() repeatedly.  That function returns the non-positive values CQ_OK,
CQ_EMPTY, or CQ_POLL_ERR, which are 0, -1, -2 respectively.  The result is that
mlx4_poll_cq() returns either the number of work requests, or CQ_POLL_ERR (i.e. -2).

@hppritcha 