### PR TITLE
fix problem with get_pathrecord posting too many recv requests

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_sl.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_sl.c
@@ -127,8 +127,8 @@ static int init_ud_qp(struct ibv_context *context_arg,
     memset(&iattr, 0, sizeof(iattr));
     iattr.send_cq = cache->cq;
     iattr.recv_cq = cache->cq;
-    iattr.cap.max_send_wr = 2;
-    iattr.cap.max_recv_wr = 2;
+    iattr.cap.max_send_wr = 1;
+    iattr.cap.max_recv_wr = 1;
     iattr.cap.max_send_sge = 1;
     iattr.cap.max_recv_sge = 1;
     iattr.qp_type = IBV_QPT_UD;
@@ -257,24 +257,24 @@ static int get_pathrecord_info(struct mca_btl_openib_sa_qp_cache *cache,
 
         while (0 == got_sl_value) {
             ne = ibv_poll_cq(cache->cq, 1, &wc);
-            if (ne > 0 &&
-                IBV_WC_SUCCESS == wc.status &&
-                IBV_WC_RECV == wc.opcode &&
-                wc.byte_len >= MAD_BLOCK_SIZE &&
-                resp_mad->trans_id == req_mad->trans_id) {
+            if (ne > 0 && IBV_WC_RECV == wc.opcode) {
+                /* We only care about the status of receive work requests.    */
+                /* If the status of the send work request was anything other  */
+                /* than success, we'll eventually retransmit, so ignore them. */
                 if (0 == resp_mad->status &&
                     req_path_record->slid == htons(lid) &&
-                    req_path_record->dlid == htons(rem_lid)) {
+                    req_path_record->dlid == htons(rem_lid) &&
+                    IBV_WC_SUCCESS == wc.status &&
+                    wc.byte_len >= MAD_BLOCK_SIZE &&
+                    resp_mad->trans_id == req_mad->trans_id) {
                     /* Everything matches, so we have the desired SL */
                     cache->sl_values[rem_lid] = ib_path_rec_sl(resp_path_record);
-                    got_sl_value = 1; /* still must repost recieve buf */
-                } else {
-                    /* Probably bad status, unlikely bad lid match. We will */
-                    /* ignore response and let it time out so that we do a  */
-                    /* retry, but after a delay. We must make a new TID so  */
-                    /* the SM doesn't see it as the same request.           */
-                    req_mad->trans_id += hton64(1);
+                    got_sl_value = 1;
+                    break;
                 }
+                /* Probably bad status, unlikely bad lid match. We will */
+                /* ignore response and let it time out so that we do a  */
+                /* retry, but after a delay. Need to repost receive WR. */
                 rc = ibv_post_recv(cache->qp, &(cache->rwr), &brwr);
                 if (0 != rc) {
                     BTL_ERROR(("error posing receive on QP[%x] errno says: %s [%d]",
@@ -295,7 +295,10 @@ static int get_pathrecord_info(struct mca_btl_openib_sa_qp_cache *cache,
                                 MAX_GET_SL_REC_RETRIES));
                         return OPAL_ERROR;
                     }
-                    break;  /* retransmit request */
+                    /* Need to retransmit request. We must make a new TID */
+                    /* so the SM doesn't see it as the same request.      */
+                    req_mad->trans_id += hton64(1);
+                    break;
                 }
                 usleep(100);  /* otherwise pause before polling again */
             } else if (ne < 0) {


### PR DESCRIPTION
Jobs with non-trivial numbers of nodes running with 
btl_openib_ib_path_record_service_level set were showing errors like this:

```
[connect/btl_openib_connect_sl.c:237:get_pathrecord_info] error posting 
receive on QP [0x500077] errno says: Success [0]
```

previous pull request #376 fixes this error message.

It seems the SA query work request posting isn't quite right.

First, when initializing the queue pair, init_ud_qp() sets the max number of
work requests to two, even though there is never more than one send and one
receive work request structure allocated.

Then, calls to get_pathrecord_info() can go like this:

```
call get_pathrecord_info()
  ibv_post_recv()
  no SL yet ==>
    ibv_post_send()
    ibv_poll_cq() succeeds ==>
      got valid SL
      ibv_post_recv()
```

I.e., each successful call to get_pathrecord_info() leaves one more receive
work request posted on exit than was there on entry.

So, on the next call after two successful calls, at least, the original code
was guaranteed to exceed the number of allowable work requests on the queue.

Instead, only repost the receive work request in the event we got a response
that was bad, so that there is always at most one receive and one send work
request posted at any time.

@hppritcha please review, thanks.
