### PR TITLE
mtl/query: squash compiler warning

### DIFF
--- a/ompi/mca/mtl/mxm/mtl_mxm_component.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm_component.c
@@ -267,7 +267,7 @@ static int ompi_mtl_mxm_component_query(mca_base_module_t **module, int *priorit
      */
 
     *priority = param_priority;
-    *module = &ompi_mtl_mxm.super;
+    *module = (mca_base_module_t *)&ompi_mtl_mxm.super;
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -108,7 +108,7 @@ static int
 ompi_mtl_ofi_component_query(mca_base_module_t **module, int *priority)
 {
     *priority = param_priority;
-    *module = &ompi_mtl_ofi.base;
+    *module = (mca_base_module_t *)&ompi_mtl_ofi.base;
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -232,7 +232,7 @@ ompi_mtl_portals4_component_query(mca_base_module_t **module, int *priority)
      */
  
     *priority = param_priority;
-    *module = &ompi_mtl_portals4.base;
+    *module = (mca_base_module_t *)&ompi_mtl_portals4.base;
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/mtl/psm/mtl_psm_component.c
+++ b/ompi/mca/mtl/psm/mtl_psm_component.c
@@ -200,7 +200,7 @@ ompi_mtl_psm_component_query(mca_base_module_t **module, int *priority)
      */
 
     *priority = param_priority;
-    *module = &ompi_mtl_psm.super;
+    *module = (mca_base_module_t *)&ompi_mtl_psm.super;
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/mtl/psm/mtl_psm_types.h
+++ b/ompi/mca/mtl/psm/mtl_psm_types.h
@@ -70,7 +70,7 @@ struct mca_mtl_psm_component_t {
 };
 typedef struct mca_mtl_psm_component_t mca_mtl_psm_component_t;
 
-OMPI_DECLSPEC mca_mtl_psm_component_t mca_mtl_psm_component;
+OMPI_DECLSPEC extern mca_mtl_psm_component_t mca_mtl_psm_component;
     
 #define PSM_MAKE_MQTAG(ctxt,rank,utag)		    \
         ( (((ctxt)&0xffffULL)<<48)| (((rank)&0xffffULL)<<32)| \


### PR DESCRIPTION
Squash compiler warnings now showing up in the
query methods for the mtls.  Cast pointers to the different
mtl module specific types to the mca_base_module_t.

Also, fix up a missing extern in mtl_psm_types.h.
This was causing "multiple definition" errors when building
the mca_mtl_psm.so shared library.

@yburette 
@regrant 
@jladd-mlnx 