### PR TITLE
Per-RFC: remove the --disable-smp-locks configure option

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -842,20 +842,6 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
     esac
     OPAL_VAR_SCOPE_POP
 
-    AC_MSG_CHECKING([whether to enable smp locks])
-    AC_ARG_ENABLE([smp-locks], 
-        [AC_HELP_STRING([--enable-smp-locks],
-            [enable smp locks in atomic ops.  Do not disable if code will ever run in SMP or multi-threaded environment. (default: enabled)])])
-    if test "$enable_smp_locks" != "no"; then
-        AC_MSG_RESULT([yes])
-        want_smp_locks=1
-    else
-        AC_MSG_RESULT([no])
-        want_smp_locks=0
-    fi
-    AC_DEFINE_UNQUOTED([OPAL_WANT_SMP_LOCKS], [$want_smp_locks],
-                       [whether we want to have smp locks in atomic ops or not])
-
     AC_ARG_ENABLE([builtin-atomics],
       [AC_HELP_STRING([--enable-builtin-atomics],
          [Enable use of __sync builtin atomics (default: disabled)])])

--- a/opal/asm/asm.c
+++ b/opal/asm/asm.c
@@ -23,8 +23,6 @@
 
 #if OPAL_ASSEMBLY_ARCH == OPAL_SPARC
 
-#if OPAL_WANT_SMP_LOCKS
-
 #define LOCKS_TABLE_SIZE 8
 /* make sure to get into reasonably useful bits (so shift at least 5) */
 #define FIND_LOCK(addr) (&(locks_table[(((unsigned long) addr) >> 8) &  \
@@ -41,15 +39,6 @@ static opal_atomic_lock_t locks_table[LOCKS_TABLE_SIZE] = {
     { { OPAL_ATOMIC_UNLOCKED } },
     { { OPAL_ATOMIC_UNLOCKED } }
 };
-
-# else /* OPAL_WANT_SMP_LOCKS */
-
-#define LOCKS_TABLE_SIZE 1
-#define FIND_LOCK(addr) (&(locks_table[0]))
-
-static opal_atomic_lock_t locks_table[1] = { OPAL_ATOMIC_UNLOCKED };
-
-#endif /* OPAL_WANT_SMP_LOCKS */
 
 
 int32_t

--- a/opal/include/opal/sys/alpha/atomic.h
+++ b/opal/include/opal/sys/alpha/atomic.h
@@ -23,20 +23,9 @@
  * On alpha, everything is load-locked, store-conditional...
  */
 
-#if OPAL_WANT_SMP_LOCKS
-
 #define MB()  __asm__ __volatile__ ("mb");
 #define RMB() __asm__ __volatile__ ("mb");
 #define WMB() __asm__ __volatile__ ("wmb");
-
-#else
-
-#define MB()
-#define RMB()
-#define WMB()
-
-#endif
-
 
 /**********************************************************************
  *

--- a/opal/include/opal/sys/alpha/update.sh
+++ b/opal/include/opal/sys/alpha/update.sh
@@ -29,7 +29,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "atomic.h"
 EOF
 

--- a/opal/include/opal/sys/amd64/atomic.h
+++ b/opal/include/opal/sys/amd64/atomic.h
@@ -27,13 +27,8 @@
  */
 
 
-#if OPAL_WANT_SMP_LOCKS
 #define SMPLOCK "lock; "
 #define MB() __asm__ __volatile__("": : :"memory")
-#else
-#define SMPLOCK
-#define MB()
-#endif
 
 
 /**********************************************************************

--- a/opal/include/opal/sys/amd64/update.sh
+++ b/opal/include/opal/sys/amd64/update.sh
@@ -29,7 +29,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "atomic.h"
 #include "timer.h"
 EOF

--- a/opal/include/opal/sys/arm/atomic.h
+++ b/opal/include/opal/sys/arm/atomic.h
@@ -31,8 +31,6 @@
 #ifndef OPAL_SYS_ARCH_ATOMIC_H
 #define OPAL_SYS_ARCH_ATOMIC_H 1
 
-#if OPAL_WANT_SMP_LOCKS
-
 #if (OPAL_ASM_ARM_VERSION >= 7)
 
 #define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
@@ -61,16 +59,6 @@
 #define WMB() MB()
 
 #endif
-
-#else
-
-#define MB()
-#define RMB()
-#define WMB()
-
-#endif /* OPAL_WANT_SMP_LOCKS */
-
-
 
 /**********************************************************************
  *

--- a/opal/include/opal/sys/arm/update.sh
+++ b/opal/include/opal/sys/arm/update.sh
@@ -29,7 +29,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "../architecture.h"
 #include "atomic.h"
 EOF

--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -26,13 +26,8 @@
  * On ia32, we use cmpxchg.
  */
 
-#if OPAL_WANT_SMP_LOCKS
 #define SMPLOCK "lock; "
 #define MB() __asm__ __volatile__("": : :"memory")
-#else
-#define SMPLOCK
-#define MB()
-#endif
 
 
 /**********************************************************************

--- a/opal/include/opal/sys/ia32/update.sh
+++ b/opal/include/opal/sys/ia32/update.sh
@@ -29,7 +29,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "atomic.h"
 #include "timer.h"
 EOF

--- a/opal/include/opal/sys/ia64/update.sh
+++ b/opal/include/opal/sys/ia64/update.sh
@@ -30,7 +30,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "atomic.h"
 #include "timer.h"
 EOF

--- a/opal/include/opal/sys/mips/atomic.h
+++ b/opal/include/opal/sys/mips/atomic.h
@@ -20,8 +20,6 @@
 #define OPAL_SYS_ARCH_ATOMIC_H 1
 
 
-#if OPAL_WANT_SMP_LOCKS
-
 /* BWB - FIX ME! */
 #ifdef __linux__
 #define MB() __asm__ __volatile__(".set mips2; sync; .set mips0": : :"memory")
@@ -33,15 +31,6 @@
 #define RMB() __asm__ __volatile__("sync": : :"memory")
 #define WMB() __asm__ __volatile__("sync": : :"memory")
 #define SMP_SYNC "sync"
-#endif
-
-#else
-
-#define MB()
-#define RMB()
-#define WMB()
-#define SMP_SYNC  ""
-
 #endif
 
 

--- a/opal/include/opal/sys/mips/update.sh
+++ b/opal/include/opal/sys/mips/update.sh
@@ -29,7 +29,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "../architecture.h"
 #include "atomic.h"
 EOF

--- a/opal/include/opal/sys/osx/atomic.h
+++ b/opal/include/opal/sys/osx/atomic.h
@@ -26,11 +26,7 @@
 #include <libkern/OSAtomic.h>
 
 
-#if OPAL_WANT_SMP_LOCKS
 #define MB() OSMemoryBarrier
-#else
-#define MB()
-#endif
 
 
 /**********************************************************************
@@ -79,11 +75,7 @@ static inline void opal_atomic_wmb(void)
 static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
                                         int32_t oldval, int32_t newval)
 {
-#if OPAL_WANT_SMP_LOCKS
-    return OSAtomicCompareAndSwap32Barrier(oldval, newval, addr);
-#else
-    return OSAtomicCompareAndSwap32(oldval, newval, addr);
-#endif
+    return OSAtomicCompareAndSwap32 (oldval, newval, addr);
 }
 
 #define opal_atomic_cmpset_acq_32 opal_atomic_cmpset_32
@@ -93,11 +85,7 @@ static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
 static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
                                          int64_t oldval, int64_t newval)
 {
-#if OPAL_WANT_SMP_LOCKS
-    return OSAtomicCompareAndSwap64Barrier(oldval, newval, addr);
-#else
-    return OSAtomicCompareAndSwap64(oldval, newval, addr);
-#endif
+    return OSAtomicCompareAndSwap64 (oldval, newval, addr);
 }
 
 #define opal_atomic_cmpset_acq_64 opal_atomic_cmpset_64
@@ -112,11 +100,7 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
  */
 static inline int32_t opal_atomic_add_32(volatile int32_t* v, int i)
 {
-#if OPAL_WANT_SMP_LOCKS
-    return OSAtomicAdd32Barrier (i, v);
-#else
     return OSAtomicAdd32 (i, v);
-#endif
 }
 
 /**
@@ -128,11 +112,7 @@ static inline int32_t opal_atomic_add_32(volatile int32_t* v, int i)
  */
 static inline int64_t opal_atomic_add_64(volatile int64_t* v, int64_t i)
 {
-#if OPAL_WANT_SMP_LOCKS
-    return OSAtomicAdd64Barrier (i, v);
-#else
     return OSAtomicAdd64 (i, v);
-#endif
 }
 
 /**
@@ -144,11 +124,7 @@ static inline int64_t opal_atomic_add_64(volatile int64_t* v, int64_t i)
  */
 static inline int32_t opal_atomic_sub_32(volatile int32_t* v, int i)
 {
-#if OPAL_WANT_SMP_LOCKS
-    return OSAtomicAdd32Barrier (-i, v);
-#else
     return OSAtomicAdd32 (-i, v);
-#endif
 }
 
 /**
@@ -160,11 +136,7 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t* v, int i)
  */
 static inline int64_t opal_atomic_sub_64(volatile int64_t* v, int64_t i)
 {
-#if OPAL_WANT_SMP_LOCKS
-    return OSAtomicAdd64Barrier (-i, v);
-#else
     return OSAtomicAdd64 (-i, v);
-#endif
 }
 
 static inline void opal_atomic_init(opal_atomic_lock_t* lock, int32_t value)

--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -24,23 +24,11 @@
  * On powerpc ...
  */
 
-#if OPAL_WANT_SMP_LOCKS
-
 #define MB()  __asm__ __volatile__ ("sync" : : : "memory")
 #define RMB() __asm__ __volatile__ ("lwsync" : : : "memory")
 #define WMB() __asm__ __volatile__ ("eieio" : : : "memory")
 #define SMP_SYNC  "sync \n\t"
 #define SMP_ISYNC "\n\tisync"
-
-#else
-
-#define MB()
-#define RMB()
-#define WMB()
-#define SMP_SYNC  ""
-#define SMP_ISYNC
-
-#endif
 
 
 /**********************************************************************

--- a/opal/include/opal/sys/powerpc/update.sh
+++ b/opal/include/opal/sys/powerpc/update.sh
@@ -29,7 +29,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "../architecture.h"
 #include "atomic.h"
 #include "timer.h"

--- a/opal/include/opal/sys/sparcv9/atomic.h
+++ b/opal/include/opal/sys/sparcv9/atomic.h
@@ -26,11 +26,7 @@
 
 #define ASI_P "0x80"
 
-#if OPAL_WANT_SMP_LOCKS
 #define MEMBAR(type) __asm__  __volatile__ ("membar " type : : : "memory")
-#else
-#define MEMBAR(type)
-#endif
 
 
 /**********************************************************************

--- a/opal/include/opal/sys/sparcv9/update.sh
+++ b/opal/include/opal/sys/sparcv9/update.sh
@@ -30,7 +30,6 @@ cat > $CFILE<<EOF
 #define static
 #define inline
 #define OPAL_GCC_INLINE_ASSEMBLY 1
-#define OPAL_WANT_SMP_LOCKS 1
 #include "atomic.h"
 EOF
 

--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -45,11 +45,7 @@ static inline void opal_atomic_wmb(void)
     __sync_synchronize();
 }
 
-#if OPAL_WANT_SMP_LOCKS
 #define MB() opal_atomic_mb()
-#else
-#define MB()
-#endif
 
 /**********************************************************************
  *


### PR DESCRIPTION
Use of this configuration option can cause crashing, hanging, and
(worse) incorrect results when btl/sm, btl/scif, or btl/vader are
in use. We discussed this at the January 2015 developers meeting
and it was decided to remove the option entirely. This commit does
just that. All usage of OPAL_WANT_SMP_LOCKS has been removed.