### PR TITLE
Fix cache line size detection on power

### DIFF
--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -88,13 +88,13 @@ libnbc_open(void)
     int ret;
 
     OBJ_CONSTRUCT(&mca_coll_libnbc_component.requests, opal_free_list_t);
+    OBJ_CONSTRUCT(&mca_coll_libnbc_component.active_requests, opal_list_t);
     ret = opal_free_list_init (&mca_coll_libnbc_component.requests,
                                sizeof(ompi_coll_libnbc_request_t), 8,
                                OBJ_CLASS(ompi_coll_libnbc_request_t),
                                0, 0, 0, -1, 8, NULL, 0, NULL, NULL, NULL);
     if (OMPI_SUCCESS != ret) return ret;
 
-    OBJ_CONSTRUCT(&mca_coll_libnbc_component.active_requests, opal_list_t);
     /* note: active comms is the number of communicators who have had
        a non-blocking collective started */
     mca_coll_libnbc_component.active_comms = 0;

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -211,27 +211,32 @@ int opal_hwloc_base_filter_cpus(hwloc_topology_t topo)
 
 static void fill_cache_line_size(void)
 {
-    int i = 0;
+    int i = 0, cache_level = 2;
     unsigned size;
     hwloc_obj_t obj;
     bool found = false;
 
     /* Look for the smallest L2 cache size */
     size = 4096;
-    while (1) {
-        obj = opal_hwloc_base_get_obj_by_type(opal_hwloc_topology,
-                                              HWLOC_OBJ_CACHE, 2,
-                                              i, OPAL_HWLOC_LOGICAL);
-        if (NULL == obj) {
-            break;
-        } else { 
-            found = true;
-            if (NULL != obj->attr &&
-                size > obj->attr->cache.linesize) {
-                size = obj->attr->cache.linesize;
+    while (cache_level > 0 && !found) {
+        i=0;
+        while (1) {
+            obj = opal_hwloc_base_get_obj_by_type(opal_hwloc_topology,
+                                                  HWLOC_OBJ_CACHE, cache_level,
+                                                  i, OPAL_HWLOC_LOGICAL);
+            if (NULL == obj) {
+                --cache_level;
+                break;
+            } else {
+                if (NULL != obj->attr &&
+                    obj->attr->cache.linesize > 0 &&
+                    size > obj->attr->cache.linesize) {
+                    size = obj->attr->cache.linesize;
+                    found = true;
+                }
             }
+            ++i;
         }
-        ++i;
     }
 
     /* If we found an L2 cache size in the hwloc data, save it in


### PR DESCRIPTION
Due to the nature of the cache architecture on power,
we don't export coherency_line_size for L2 in sysfs.
If we are unable to get the L2 cache line size, try L1.

See open-mpi/ompi#383 for more information.