### PR TITLE
mtl/ofi: Disable 'sockets' provider by default.

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -197,6 +197,20 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
     prov = providers;
 
     /**
+     * Skip the 'sockets' provider by default unless it has been
+     * specifically selected via the command line option.
+     *
+     * e.g. --mca mtl_ofi_provider sockets
+     */
+    if (0 == (strncmp(prov->fabric_attr->prov_name, "sockets", 7)) &&
+        (NULL == ompi_mtl_ofi.provider_name ||
+         0 != (strncmp(ompi_mtl_ofi.provider_name, "sockets", 7)))) {
+        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+                "Skipping 'sockets' provider.\n");
+        goto error;
+    }
+
+    /**
      * Open fabric
      * The getinfo struct returns a fabric attribute struct that can be used to
      * instantiate the virtual or physical network. This opens a "fabric


### PR DESCRIPTION
Disable 'sockets' provider by default unless specified on the
command line.
e.g. --mca mtl_ofi_provider sockets