### PR TITLE
btl: expose local registration thresholds

### DIFF
--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -1119,6 +1119,10 @@ struct mca_btl_base_module_t {
     size_t      btl_put_limit;        /**< maximum size supported by the btl_put function */
     size_t      btl_put_alignment;    /**< minimum alignment/size needed by btl_put (power of 2) */
 
+    /* minimum transaction sizes for which registration is required for local memory */
+    size_t      btl_get_local_registration_threshold;
+    size_t      btl_put_local_registration_threshold;
+
     /* BTL function table */
     mca_btl_base_module_add_procs_fn_t      btl_add_procs;
     mca_btl_base_module_del_procs_fn_t      btl_del_procs;

--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -816,6 +816,9 @@ static int init_one_port(opal_list_t *btl_list, mca_btl_openib_device_t *device,
                 openib_btl->super.btl_put_limit = openib_btl->ib_port_attr.max_msg_sz;
             }
 
+            openib_btl->super.btl_put_local_registration_threshold = openib_btl->device->max_inline_data;
+            openib_btl->super.btl_get_local_registration_threshold = 0;
+
 #if HAVE_DECL_IBV_ATOMIC_HCA
             if (openib_btl->device->ib_dev_attr.atomic_cap == IBV_ATOMIC_NONE) {
                 openib_btl->super.btl_flags &= ~MCA_BTL_FLAGS_ATOMIC_FOPS;

--- a/opal/mca/btl/ugni/btl_ugni_component.c
+++ b/opal/mca/btl/ugni/btl_ugni_component.c
@@ -251,6 +251,9 @@ btl_ugni_component_register(void)
     mca_btl_ugni_module.super.btl_bandwidth = 40000; /* Mbs */
     mca_btl_ugni_module.super.btl_latency   = 2;     /* Microsecs */
 
+    mca_btl_ugni_module.super.btl_get_local_registration_threshold = 0;
+    mca_btl_ugni_module.super.btl_put_local_registration_threshold = mca_btl_ugni_component.ugni_fma_limit;
+
     /* Call the BTL based to register its MCA params */
     mca_btl_base_param_register(&mca_btl_ugni_component.super.btl_version,
                                 &mca_btl_ugni_module.super);
@@ -320,6 +323,8 @@ mca_btl_ugni_component_init (int *num_btl_modules,
     if (65536 < mca_btl_ugni_component.ugni_fma_limit) {
         mca_btl_ugni_component.ugni_fma_limit = 65536;
     }
+
+    mca_btl_ugni_module.super.btl_put_local_registration_threshold = mca_btl_ugni_component.ugni_fma_limit;
 
     if (enable_mpi_threads && mca_btl_ugni_component.progress_thread_requested) {
         mca_btl_ugni_component.progress_thread_enabled = 1;

--- a/opal/mca/btl/ugni/btl_ugni_rdma.h
+++ b/opal/mca/btl/ugni/btl_ugni_rdma.h
@@ -53,7 +53,12 @@ static inline int mca_btl_ugni_post_fma (struct mca_btl_base_endpoint_t *endpoin
                                          void *cbcontext, void *cbdata)
 {
     mca_btl_ugni_post_descriptor_t *post_desc;
+    gni_mem_handle_t local_gni_handle = {0, 0};
     gni_return_t grc;
+
+    if (local_handle) {
+        local_gni_handle = local_handle->gni_handle;
+    }
 
     mca_btl_ugni_alloc_post_descriptor (endpoint, local_handle, cbfunc, cbcontext, cbdata, &post_desc);
     if (OPAL_UNLIKELY(NULL == post_desc)) {
@@ -62,7 +67,7 @@ static inline int mca_btl_ugni_post_fma (struct mca_btl_base_endpoint_t *endpoin
 
     /* Post descriptor (CQ is ignored for FMA transactions) -- The CQ associated with the endpoint
      * is used. */
-    init_gni_post_desc (&post_desc->desc, order, op_type, (intptr_t) local_address, local_handle->gni_handle,
+    init_gni_post_desc (&post_desc->desc, order, op_type, (intptr_t) local_address, local_gni_handle,
                         remote_address, remote_handle->gni_handle, size, 0);
 
     OPAL_THREAD_LOCK(&endpoint->btl->device->dev_lock);


### PR DESCRIPTION
Some BTLs do not require local registration for some rdma
transactions. For example: inline put on openib, fma put on ugni. This
commit adds code to expose the local registration thresholds to BTL
users. Optimized code can take advantage of this information to
improve rdma performance.