### PR TITLE
add owner files to opa/ompi/orte mca directories

### DIFF
--- a/ompi/mca/bcol/base/owner.txt
+++ b/ompi/mca/bcol/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ORNL?
+status: unmaintained

--- a/ompi/mca/bcol/iboffload/owner.txt
+++ b/ompi/mca/bcol/iboffload/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ORNL?
+status: unmaintained

--- a/ompi/mca/bcol/ptpcoll/owner.txt
+++ b/ompi/mca/bcol/ptpcoll/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ORNL?
+status: unmaintained

--- a/ompi/mca/bml/base/owner.txt
+++ b/ompi/mca/bml/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/ompi/mca/bml/r2/owner.txt
+++ b/ompi/mca/bml/r2/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: maintenance

--- a/ompi/mca/coll/base/owner.txt
+++ b/ompi/mca/coll/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/ompi/mca/coll/basic/owner.txt
+++ b/ompi/mca/coll/basic/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: maintenance

--- a/ompi/mca/coll/cuda/owner.txt
+++ b/ompi/mca/coll/cuda/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: NVIDIA
+status: maintenance

--- a/ompi/mca/coll/demo/owner.txt
+++ b/ompi/mca/coll/demo/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/ompi/mca/coll/fca/owner.txt
+++ b/ompi/mca/coll/fca/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: MELLANOX
+status: active

--- a/ompi/mca/coll/hcoll/owner.txt
+++ b/ompi/mca/coll/hcoll/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: unmaintained

--- a/ompi/mca/coll/hcoll/owner.txt
+++ b/ompi/mca/coll/hcoll/owner.txt
@@ -3,5 +3,5 @@
 # owner: institution that is responsible for this package
 # status: e.g. active, maintenance, unmaintained
 #
-owner: ?
-status: unmaintained
+owner: MELLANOX
+status: active

--- a/ompi/mca/coll/hierarch/owner.txt
+++ b/ompi/mca/coll/hierarch/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: unmaintained

--- a/ompi/mca/coll/inter/owner.txt
+++ b/ompi/mca/coll/inter/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: maintenance

--- a/ompi/mca/coll/libnbc/owner.txt
+++ b/ompi/mca/coll/libnbc/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/ompi/mca/coll/ml/owner.txt
+++ b/ompi/mca/coll/ml/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ORNL?
+status: unmaintained

--- a/ompi/mca/coll/portals4/owner.txt
+++ b/ompi/mca/coll/portals4/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: active

--- a/ompi/mca/coll/self/owner.txt
+++ b/ompi/mca/coll/self/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: CISCO
+status: maintenance

--- a/ompi/mca/coll/sm/owner.txt
+++ b/ompi/mca/coll/sm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL?
+status: maintenance

--- a/ompi/mca/coll/tuned/owner.txt
+++ b/ompi/mca/coll/tuned/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/ompi/mca/crcp/base/owner.txt
+++ b/ompi/mca/crcp/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/ompi/mca/crcp/bkmrk/owner.txt
+++ b/ompi/mca/crcp/bkmrk/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/ompi/mca/dpm/base/owner.txt
+++ b/ompi/mca/dpm/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/ompi/mca/dpm/orte/owner.txt
+++ b/ompi/mca/dpm/orte/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/ompi/mca/fbtl/base/owner.txt
+++ b/ompi/mca/fbtl/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fbtl/plfs/owner.txt
+++ b/ompi/mca/fbtl/plfs/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fbtl/posix/owner.txt
+++ b/ompi/mca/fbtl/posix/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fbtl/pvfs2/owner.txt
+++ b/ompi/mca/fbtl/pvfs2/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fcoll/base/owner.txt
+++ b/ompi/mca/fcoll/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fcoll/dynamic/owner.txt
+++ b/ompi/mca/fcoll/dynamic/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fcoll/individual/owner.txt
+++ b/ompi/mca/fcoll/individual/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fcoll/static/owner.txt
+++ b/ompi/mca/fcoll/static/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fcoll/two_phase/owner.txt
+++ b/ompi/mca/fcoll/two_phase/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fs/base/owner.txt
+++ b/ompi/mca/fs/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fs/lustre/owner.txt
+++ b/ompi/mca/fs/lustre/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fs/plfs/owner.txt
+++ b/ompi/mca/fs/plfs/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fs/pvfs2/owner.txt
+++ b/ompi/mca/fs/pvfs2/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/fs/ufs/owner.txt
+++ b/ompi/mca/fs/ufs/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/io/base/owner.txt
+++ b/ompi/mca/io/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/ompi/mca/io/ompio/owner.txt
+++ b/ompi/mca/io/ompio/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: active

--- a/ompi/mca/io/romio/owner.txt
+++ b/ompi/mca/io/romio/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL/RIST
+status: active

--- a/ompi/mca/mtl/base/owner.txt
+++ b/ompi/mca/mtl/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/ompi/mca/mtl/mxm/owner.txt
+++ b/ompi/mca/mtl/mxm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: MELLANOX
+status: active

--- a/ompi/mca/mtl/ofi/owner.txt
+++ b/ompi/mca/mtl/ofi/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/ompi/mca/mtl/portals4/owner.txt
+++ b/ompi/mca/mtl/portals4/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: active

--- a/ompi/mca/mtl/psm/owner.txt
+++ b/ompi/mca/mtl/psm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/ompi/mca/op/base/owner.txt
+++ b/ompi/mca/op/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/ompi/mca/op/example/owner.txt
+++ b/ompi/mca/op/example/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: CISCO
+status: maintenance

--- a/ompi/mca/op/x86/owner.txt
+++ b/ompi/mca/op/x86/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: CISCO
+status: maintenance

--- a/ompi/mca/osc/base/owner.txt
+++ b/ompi/mca/osc/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/ompi/mca/osc/portals4/owner.txt
+++ b/ompi/mca/osc/portals4/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: active

--- a/ompi/mca/osc/pt2pt/owner.txt
+++ b/ompi/mca/osc/pt2pt/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/ompi/mca/osc/rdma/owner.txt
+++ b/ompi/mca/osc/rdma/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: dead?

--- a/ompi/mca/osc/sm/owner.txt
+++ b/ompi/mca/osc/sm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: maintenance?

--- a/ompi/mca/pml/base/owner.txt
+++ b/ompi/mca/pml/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/ompi/mca/pml/bfo/owner.txt
+++ b/ompi/mca/pml/bfo/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: unmaintained

--- a/ompi/mca/pml/cm/owner.txt
+++ b/ompi/mca/pml/cm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: maintenance

--- a/ompi/mca/pml/crcpw/owner.txt
+++ b/ompi/mca/pml/crcpw/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/ompi/mca/pml/ob1/owner.txt
+++ b/ompi/mca/pml/ob1/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: active

--- a/ompi/mca/pml/v/owner.txt
+++ b/ompi/mca/pml/v/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance?

--- a/ompi/mca/pml/yalla/owner.txt
+++ b/ompi/mca/pml/yalla/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: MELLANOX
+status: active

--- a/ompi/mca/pubsub/base/owner.txt
+++ b/ompi/mca/pubsub/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/ompi/mca/pubsub/orte/owner.txt
+++ b/ompi/mca/pubsub/orte/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/ompi/mca/pubsub/pmi/owner.txt
+++ b/ompi/mca/pubsub/pmi/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/ompi/mca/sbgp/base/owner.txt
+++ b/ompi/mca/sbgp/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/ompi/mca/sbgp/basesmsocket/owner.txt
+++ b/ompi/mca/sbgp/basesmsocket/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/ompi/mca/sbgp/basesmuma/owner.txt
+++ b/ompi/mca/sbgp/basesmuma/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/ompi/mca/sbgp/ibnet/owner.txt
+++ b/ompi/mca/sbgp/ibnet/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/ompi/mca/sbgp/p2p/owner.txt
+++ b/ompi/mca/sbgp/p2p/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/ompi/mca/sharedfp/addproc/owner.txt
+++ b/ompi/mca/sharedfp/addproc/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: maintenance

--- a/ompi/mca/sharedfp/base/owner.txt
+++ b/ompi/mca/sharedfp/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: maintenance

--- a/ompi/mca/sharedfp/individual/owner.txt
+++ b/ompi/mca/sharedfp/individual/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: maintenance

--- a/ompi/mca/sharedfp/lockedfile/owner.txt
+++ b/ompi/mca/sharedfp/lockedfile/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: maintenance

--- a/ompi/mca/sharedfp/sm/owner.txt
+++ b/ompi/mca/sharedfp/sm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UH
+status: maintenance

--- a/ompi/mca/topo/base/owner.txt
+++ b/ompi/mca/topo/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/ompi/mca/topo/basic/owner.txt
+++ b/ompi/mca/topo/basic/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/ompi/mca/topo/example/owner.txt
+++ b/ompi/mca/topo/example/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/ompi/mca/vprotocol/base/owner.txt
+++ b/ompi/mca/vprotocol/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/ompi/mca/vprotocol/example/owner.txt
+++ b/ompi/mca/vprotocol/example/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/ompi/mca/vprotocol/pessimist/owner.txt
+++ b/ompi/mca/vprotocol/pessimist/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/opal/mca/allocator/base/owner.txt
+++ b/opal/mca/allocator/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: maintenance

--- a/opal/mca/allocator/basic/owner.txt
+++ b/opal/mca/allocator/basic/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: NVIDIA
+status: maintenance

--- a/opal/mca/allocator/bucket/owner.txt
+++ b/opal/mca/allocator/bucket/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: NVIDIA
+status: maintenance

--- a/opal/mca/backtrace/base/owner.txt
+++ b/opal/mca/backtrace/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status:maintenance

--- a/opal/mca/backtrace/execinfo/owner.txt
+++ b/opal/mca/backtrace/execinfo/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status:maintenance

--- a/opal/mca/backtrace/none/owner.txt
+++ b/opal/mca/backtrace/none/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status:maintenance

--- a/opal/mca/backtrace/printstack/owner.txt
+++ b/opal/mca/backtrace/printstack/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: maintenance

--- a/opal/mca/btl/base/owner.txt
+++ b/opal/mca/btl/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file 
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: btl owners
+status:active

--- a/opal/mca/btl/openib/owner.txt
+++ b/opal/mca/btl/openib/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:MELLANOX
+status:maintenance

--- a/opal/mca/btl/portals4/owner.txt
+++ b/opal/mca/btl/portals4/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:SNL
+status:active?

--- a/opal/mca/btl/scif/owner.txt
+++ b/opal/mca/btl/scif/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file 
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:LANL
+status: maintenance

--- a/opal/mca/btl/self/owner.txt
+++ b/opal/mca/btl/self/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:UTK
+status:active

--- a/opal/mca/btl/sm/owner.txt
+++ b/opal/mca/btl/sm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:UTK
+status:active

--- a/opal/mca/btl/smcuda/owner.txt
+++ b/opal/mca/btl/smcuda/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:NVIDIA
+status:active

--- a/opal/mca/btl/tcp/owner.txt
+++ b/opal/mca/btl/tcp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:UTK
+status:active

--- a/opal/mca/btl/template/owner.txt
+++ b/opal/mca/btl/template/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status:active

--- a/opal/mca/btl/ugni/owner.txt
+++ b/opal/mca/btl/ugni/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:LANL
+status:active

--- a/opal/mca/btl/usnic/owner.txt
+++ b/opal/mca/btl/usnic/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:CISCO
+status:active

--- a/opal/mca/btl/vader/owner.txt
+++ b/opal/mca/btl/vader/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:LANL
+status:active

--- a/opal/mca/common/cuda/owner.txt
+++ b/opal/mca/common/cuda/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: NVIDIA
+status:active

--- a/opal/mca/common/ofacm/owner.txt
+++ b/opal/mca/common/ofacm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: nobody
+status: dead?

--- a/opal/mca/common/sm/owner.txt
+++ b/opal/mca/common/sm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/opal/mca/common/ugni/owner.txt
+++ b/opal/mca/common/ugni/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: active

--- a/opal/mca/common/verbs/owner.txt
+++ b/opal/mca/common/verbs/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: MELLANOX
+status: maintenance

--- a/opal/mca/compress/base/owner.txt
+++ b/opal/mca/compress/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status:maintenance

--- a/opal/mca/compress/bzip/owner.txt
+++ b/opal/mca/compress/bzip/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status:maintenance

--- a/opal/mca/compress/gzip/owner.txt
+++ b/opal/mca/compress/gzip/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status:maintenance

--- a/opal/mca/crs/base/owner.txt
+++ b/opal/mca/crs/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/opal/mca/crs/criu/owner.txt
+++ b/opal/mca/crs/criu/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: CISCO
+status: maintenance

--- a/opal/mca/crs/dmtcp/owner.txt
+++ b/opal/mca/crs/dmtcp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: inactive

--- a/opal/mca/crs/none/owner.txt
+++ b/opal/mca/crs/none/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/opal/mca/crs/self/owner.txt
+++ b/opal/mca/crs/self/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: maintenance

--- a/opal/mca/dstore/base/owner.txt
+++ b/opal/mca/dstore/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/opal/mca/dstore/hash/owner.txt
+++ b/opal/mca/dstore/hash/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: active

--- a/opal/mca/dstore/sm/owner.txt
+++ b/opal/mca/dstore/sm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL/MELLANOX
+status: active

--- a/opal/mca/event/base/owner.txt
+++ b/opal/mca/event/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file 
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status: maintenance

--- a/opal/mca/event/external/owner.txt
+++ b/opal/mca/event/external/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:CISCO
+status: maintenance

--- a/opal/mca/event/libevent2021/owner.txt
+++ b/opal/mca/event/libevent2021/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:INTEL
+status: obsolete?

--- a/opal/mca/event/libevent2022/owner.txt
+++ b/opal/mca/event/libevent2022/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:INTEL
+status:active

--- a/opal/mca/hwloc/base/owner.txt
+++ b/opal/mca/hwloc/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status: maintenance

--- a/opal/mca/hwloc/external/owner.txt
+++ b/opal/mca/hwloc/external/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:CISCO
+status: maintenance

--- a/opal/mca/hwloc/hwloc191/owner.txt
+++ b/opal/mca/hwloc/hwloc191/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:INTEL
+status: maintenance

--- a/opal/mca/if/base/owner.txt
+++ b/opal/mca/if/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status:active

--- a/opal/mca/if/bsdx_ipv4/owner.txt
+++ b/opal/mca/if/bsdx_ipv4/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/if/bsdx_ipv6/owner.txt
+++ b/opal/mca/if/bsdx_ipv6/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/if/linux_ipv6/owner.txt
+++ b/opal/mca/if/linux_ipv6/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/if/posix_ipv4/owner.txt
+++ b/opal/mca/if/posix_ipv4/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/if/solaris_ipv6/owner.txt
+++ b/opal/mca/if/solaris_ipv6/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ORACLE?
+status: maintenance

--- a/opal/mca/installdirs/base/owner.txt
+++ b/opal/mca/installdirs/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status:active

--- a/opal/mca/installdirs/config/owner.txt
+++ b/opal/mca/installdirs/config/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: maintenance

--- a/opal/mca/installdirs/env/owner.txt
+++ b/opal/mca/installdirs/env/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: maintenance

--- a/opal/mca/memchecker/base/owner.txt
+++ b/opal/mca/memchecker/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status:active

--- a/opal/mca/memchecker/valgrind/owner.txt
+++ b/opal/mca/memchecker/valgrind/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: HLRS?
+status: maintenance

--- a/opal/mca/memcpy/base/owner.txt
+++ b/opal/mca/memcpy/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/opal/mca/memory/base/owner.txt
+++ b/opal/mca/memory/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/opal/mca/memory/linux/owner.txt
+++ b/opal/mca/memory/linux/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: MELLANOX,CISCO
+status: maintenance

--- a/opal/mca/memory/malloc_solaris/owner.txt
+++ b/opal/mca/memory/malloc_solaris/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: nobody
+status: unmaintained

--- a/opal/mca/mpool/base/owner.txt
+++ b/opal/mca/mpool/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/opal/mca/mpool/gpusm/owner.txt
+++ b/opal/mca/mpool/gpusm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: NVIDIA
+status: maintenance

--- a/opal/mca/mpool/grdma/owner.txt
+++ b/opal/mca/mpool/grdma/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/mpool/rgpusm/owner.txt
+++ b/opal/mca/mpool/rgpusm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: NVIDIA
+status: maintenance

--- a/opal/mca/mpool/sm/owner.txt
+++ b/opal/mca/mpool/sm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/mpool/udreg/owner.txt
+++ b/opal/mca/mpool/udreg/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/pmix/cray/owner.txt
+++ b/opal/mca/pmix/cray/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: active

--- a/opal/mca/pmix/s1/owner.txt
+++ b/opal/mca/pmix/s1/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/opal/mca/pmix/s2/owner.txt
+++ b/opal/mca/pmix/s2/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/opal/mca/pstat/linux/owner.txt
+++ b/opal/mca/pstat/linux/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/pstat/test/owner.txt
+++ b/opal/mca/pstat/test/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/rcache/vma/owner.txt
+++ b/opal/mca/rcache/vma/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/reachable/base/owner.txt
+++ b/opal/mca/reachable/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/opal/mca/reachable/netlink/owner.txt
+++ b/opal/mca/reachable/netlink/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/opal/mca/reachable/weighted/owner.txt
+++ b/opal/mca/reachable/weighted/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/opal/mca/sec/base/owner.txt
+++ b/opal/mca/sec/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/opal/mca/sec/basic/owner.txt
+++ b/opal/mca/sec/basic/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/sec/keystone/owner.txt
+++ b/opal/mca/sec/keystone/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/opal/mca/sec/munge/owner.txt
+++ b/opal/mca/sec/munge/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/opal/mca/shmem/base/owner.txt
+++ b/opal/mca/shmem/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/shmem/mmap/owner.txt
+++ b/opal/mca/shmem/mmap/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/shmem/posix/owner.txt
+++ b/opal/mca/shmem/posix/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/shmem/sysv/owner.txt
+++ b/opal/mca/shmem/sysv/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/opal/mca/timer/aix/owner.txt
+++ b/opal/mca/timer/aix/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IBM?
+status: unmaintained

--- a/opal/mca/timer/altix/owner.txt
+++ b/opal/mca/timer/altix/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL?
+status: unmaintained

--- a/opal/mca/timer/base/owner.txt
+++ b/opal/mca/timer/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: maintenance

--- a/opal/mca/timer/darwin/owner.txt
+++ b/opal/mca/timer/darwin/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: unmaintained

--- a/opal/mca/timer/linux/owner.txt
+++ b/opal/mca/timer/linux/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: maintenance

--- a/opal/mca/timer/solaris/owner.txt
+++ b/opal/mca/timer/solaris/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: nobody
+status: unmaintained

--- a/orte/mca/common/alps/owner.txt
+++ b/orte/mca/common/alps/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: active

--- a/orte/mca/dfs/app/owner.txt
+++ b/orte/mca/dfs/app/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/orte/mca/dfs/base/owner.txt
+++ b/orte/mca/dfs/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/orte/mca/dfs/orted/owner.txt
+++ b/orte/mca/dfs/orted/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/orte/mca/errmgr/base/owner.txt
+++ b/orte/mca/errmgr/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/errmgr/default_app/owner.txt
+++ b/orte/mca/errmgr/default_app/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/errmgr/default_hnp/owner.txt
+++ b/orte/mca/errmgr/default_hnp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/errmgr/default_orted/owner.txt
+++ b/orte/mca/errmgr/default_orted/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/errmgr/default_tool/owner.txt
+++ b/orte/mca/errmgr/default_tool/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ess/alps/owner.txt
+++ b/orte/mca/ess/alps/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/orte/mca/ess/base/owner.txt
+++ b/orte/mca/ess/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/orte/mca/ess/env/owner.txt
+++ b/orte/mca/ess/env/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: Intel
+status: maintenance

--- a/orte/mca/ess/hnp/owner.txt
+++ b/orte/mca/ess/hnp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ess/lsf/owner.txt
+++ b/orte/mca/ess/lsf/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ess/pmi/owner.txt
+++ b/orte/mca/ess/pmi/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ess/singleton/owner.txt
+++ b/orte/mca/ess/singleton/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ess/slurm/owner.txt
+++ b/orte/mca/ess/slurm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ess/tm/owner.txt
+++ b/orte/mca/ess/tm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ess/tool/owner.txt
+++ b/orte/mca/ess/tool/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/filem/base/owner.txt
+++ b/orte/mca/filem/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/filem/raw/owner.txt
+++ b/orte/mca/filem/raw/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/grpcomm/base/owner.txt
+++ b/orte/mca/grpcomm/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/grpcomm/brks/owner.txt
+++ b/orte/mca/grpcomm/brks/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/grpcomm/direct/owner.txt
+++ b/orte/mca/grpcomm/direct/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/grpcomm/rcd/owner.txt
+++ b/orte/mca/grpcomm/rcd/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/iof/base/owner.txt
+++ b/orte/mca/iof/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/iof/hnp/owner.txt
+++ b/orte/mca/iof/hnp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/iof/mr_hnp/owner.txt
+++ b/orte/mca/iof/mr_hnp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/iof/mr_orted/owner.txt
+++ b/orte/mca/iof/mr_orted/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/iof/orted/owner.txt
+++ b/orte/mca/iof/orted/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/iof/tool/owner.txt
+++ b/orte/mca/iof/tool/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/odls/alps/owner.txt
+++ b/orte/mca/odls/alps/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: active

--- a/orte/mca/odls/base/owner.txt
+++ b/orte/mca/odls/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/orte/mca/odls/default/owner.txt
+++ b/orte/mca/odls/default/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/oob/base/owner.txt
+++ b/orte/mca/oob/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/orte/mca/oob/tcp/owner.txt
+++ b/orte/mca/oob/tcp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/oob/ud/owner.txt
+++ b/orte/mca/oob/ud/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: MELLANOX
+status: maintenance

--- a/orte/mca/oob/usock/owner.txt
+++ b/orte/mca/oob/usock/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/plm/alps/owner.txt
+++ b/orte/mca/plm/alps/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/orte/mca/plm/base/owner.txt
+++ b/orte/mca/plm/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: project
+status: maintenance

--- a/orte/mca/plm/isolated/owner.txt
+++ b/orte/mca/plm/isolated/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/plm/lsf/owner.txt
+++ b/orte/mca/plm/lsf/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/plm/rsh/owner.txt
+++ b/orte/mca/plm/rsh/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/plm/slurm/owner.txt
+++ b/orte/mca/plm/slurm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/plm/tm/owner.txt
+++ b/orte/mca/plm/tm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ras/alps/owner.txt
+++ b/orte/mca/ras/alps/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: active

--- a/orte/mca/ras/base/owner.txt
+++ b/orte/mca/ras/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ras/gridengine/owner.txt
+++ b/orte/mca/ras/gridengine/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: unmaintained

--- a/orte/mca/ras/loadleveler/owner.txt
+++ b/orte/mca/ras/loadleveler/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IBM?
+status: unmaintained

--- a/orte/mca/ras/lsf/owner.txt
+++ b/orte/mca/ras/lsf/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ras/simulator/owner.txt
+++ b/orte/mca/ras/simulator/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ras/slurm/owner.txt
+++ b/orte/mca/ras/slurm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/ras/tm/owner.txt
+++ b/orte/mca/ras/tm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rmaps/base/owner.txt
+++ b/orte/mca/rmaps/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rmaps/lama/owner.txt
+++ b/orte/mca/rmaps/lama/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/orte/mca/rmaps/mindist/owner.txt
+++ b/orte/mca/rmaps/mindist/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: ?

--- a/orte/mca/rmaps/ppr/owner.txt
+++ b/orte/mca/rmaps/ppr/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rmaps/rank_file/owner.txt
+++ b/orte/mca/rmaps/rank_file/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rmaps/resilient/owner.txt
+++ b/orte/mca/rmaps/resilient/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rmaps/round_robin/owner.txt
+++ b/orte/mca/rmaps/round_robin/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rmaps/seq/owner.txt
+++ b/orte/mca/rmaps/seq/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rmaps/staged/owner.txt
+++ b/orte/mca/rmaps/staged/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rml/base/owner.txt
+++ b/orte/mca/rml/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rml/ftrm/owner.txt
+++ b/orte/mca/rml/ftrm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: ?
+status: unmaintained

--- a/orte/mca/rml/oob/owner.txt
+++ b/orte/mca/rml/oob/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/routed/base/owner.txt
+++ b/orte/mca/routed/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/routed/binomial/owner.txt
+++ b/orte/mca/routed/binomial/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/routed/debruijn/owner.txt
+++ b/orte/mca/routed/debruijn/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL?
+status: unmaintained

--- a/orte/mca/routed/direct/owner.txt
+++ b/orte/mca/routed/direct/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/rtc/base/owner.txt
+++ b/orte/mca/rtc/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rtc/freq/owner.txt
+++ b/orte/mca/rtc/freq/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/rtc/hwloc/owner.txt
+++ b/orte/mca/rtc/hwloc/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: maintenance

--- a/orte/mca/schizo/base/owner.txt
+++ b/orte/mca/schizo/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/schizo/ompi/owner.txt
+++ b/orte/mca/schizo/ompi/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/snapc/base/owner.txt
+++ b/orte/mca/snapc/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/orte/mca/snapc/full/owner.txt
+++ b/orte/mca/snapc/full/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/orte/mca/sstore/base/owner.txt
+++ b/orte/mca/sstore/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/orte/mca/sstore/central/owner.txt
+++ b/orte/mca/sstore/central/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/orte/mca/sstore/stage/owner.txt
+++ b/orte/mca/sstore/stage/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IU?
+status: unmaintained

--- a/orte/mca/state/app/owner.txt
+++ b/orte/mca/state/app/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/base/owner.txt
+++ b/orte/mca/state/base/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/dvm/owner.txt
+++ b/orte/mca/state/dvm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/hnp/owner.txt
+++ b/orte/mca/state/hnp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/novm/owner.txt
+++ b/orte/mca/state/novm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/orted/owner.txt
+++ b/orte/mca/state/orted/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/staged_hnp/owner.txt
+++ b/orte/mca/state/staged_hnp/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/staged_orted/owner.txt
+++ b/orte/mca/state/staged_orted/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active

--- a/orte/mca/state/tool/owner.txt
+++ b/orte/mca/state/tool/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: INTEL
+status: active


### PR DESCRIPTION
This commit adds an owner file in each of the component directories
for each framework.  This allows for a simple script to parse
the contents of the files and generate, among other things, tables
to be used on the project's wiki page.  Currently there are two
"fields" in the file, an owner and a status.  A tool to parse
the files and generate tables for the wiki page will be added
in a subsequent commit.