### PR TITLE
romio: always set err_ status in MPIO_DATATYPE_ISCOMMITTED

### DIFF
--- a/ompi/mca/io/romio/romio/mpi-io/mpioimpl.h
+++ b/ompi/mca/io/romio/romio/mpi-io/mpioimpl.h
@@ -36,7 +36,7 @@
    of correct programs */
 #define MPIU_THREAD_CS_ENTER(x,y)
 #define MPIU_THREAD_CS_EXIT(x,y)
-#define MPIO_DATATYPE_ISCOMMITTED(dtype_, err_) do {} while (0)
+#define MPIO_DATATYPE_ISCOMMITTED(dtype_, err_) do { err_ = 0; } while (0)
 #ifdef HAVE_WINDOWS_H
 #define MPIU_UNREFERENCED_ARG(a) a
 #else


### PR DESCRIPTION
from the ROMIO sources :
/* Any MPI implementation that wishes to follow the thread-safety and
   error reporting features provided by MPICH must implement these
   four functions.  Defining these as empty should not change the behavior
   of correct programs */
the MPIO_DATATYPE_ISCOMMITTED macro now always set err_=0
this is an optimistic approach for Open MPI, but it is likely other upper
layers already checked the datatype was committed.
not setting err_ is incorrect since it can lead to some use of uninitialized
variable.

Fixes open-mpi/ompi#404