### PR TITLE
create the opal_common_verbs_want_fork_support parameter.

### DIFF
--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -25,6 +25,7 @@ SUBDIRS = \
         etc \
         util \
 	mca/base \
+	mca/common/verbs \
 	$(MCA_opal_FRAMEWORKS_SUBDIRS) \
 	$(MCA_opal_FRAMEWORK_COMPONENT_STATIC_SUBDIRS) \
         . \
@@ -41,6 +42,7 @@ DIST_SUBDIRS = \
         etc \
 	util \
 	mca/base \
+	mca/common/verbs \
 	$(MCA_opal_FRAMEWORKS_SUBDIRS) \
 	$(MCA_opal_FRAMEWORK_COMPONENT_ALL_SUBDIRS)
 
@@ -54,6 +56,7 @@ lib@OPAL_LIB_PREFIX@open_pal_la_LIBADD = \
         datatype/libdatatype.la \
         mca/base/libmca_base.la \
         util/libopalutil.la \
+        mca/common/verbs/libmca_common_verbs.la \
 	$(MCA_opal_FRAMEWORK_LIBS)
 lib@OPAL_LIB_PREFIX@open_pal_la_DEPENDENCIES = $(lib@OPAL_LIB_PREFIX@open_pal_la_LIBADD)
 lib@OPAL_LIB_PREFIX@open_pal_la_LDFLAGS = -version-info $(libopen_pal_so_version)

--- a/opal/mca/btl/openib/btl_openib_mca.c
+++ b/opal/mca/btl/openib/btl_openib_mca.c
@@ -734,15 +734,6 @@ int btl_openib_verify_mca_params (void)
         mca_btl_openib_component.cq_poll_batch = MCA_BTL_OPENIB_CQ_POLL_BATCH_DEFAULT;
     }
 
-#if !HAVE_IBV_FORK_INIT
-    if (1 == mca_btl_openib_component.want_fork_support) {
-        opal_show_help("help-mpi-btl-openib.txt",
-                       "ibv_fork requested but not supported", true,
-                       opal_process_info.nodename);
-        return OPAL_ERR_BAD_PARAM;
-    }
-#endif
-
     mca_btl_openib_component.ib_pkey_val &= MCA_BTL_IB_PKEY_MASK;
 
     if (mca_btl_openib_component.ib_min_rnr_timer > 31) {

--- a/opal/mca/btl/openib/help-mpi-btl-openib.txt
+++ b/opal/mca/btl/openib/help-mpi-btl-openib.txt
@@ -267,16 +267,6 @@ Please see this FAQ entry for more details:
 NOTE: You can turn off this warning by setting the MCA parameter
       btl_openib_warn_default_gid_prefix to 0.
 #
-[ibv_fork requested but not supported]
-WARNING: fork() support was requested for the OpenFabrics (openib)
-BTL, but it is not supported on the host %s.  Deactivating the
-OpenFabrics BTL.
-#
-[ibv_fork_init fail]
-WARNING: fork() support was requested for the OpenFabrics (openib)
-BTL, but the library call ibv_fork_init() failed on the host %s.
-Deactivating the OpenFabrics BTL.
-#
 [wrong buffer alignment]
 Wrong buffer alignment %d configured on host '%s'. Should be bigger
 than zero and power of two. Use default %d instead.

--- a/opal/mca/common/verbs/common_verbs.h
+++ b/opal/mca/common/verbs/common_verbs.h
@@ -40,7 +40,7 @@ OPAL_DECLSPEC void opal_ibv_free_device_list(struct ibv_device **ib_devs);
  */
 extern bool opal_common_verbs_warn_nonexistent_if;
 extern int opal_common_verbs_want_fork_support;
-OPAL_DECLSPEC void opal_common_verbs_mca_register(mca_base_component_t *component);
+OPAL_DECLSPEC void opal_common_verbs_mca_register(void);
 
 /*
  * common_verbs_basics.c

--- a/opal/mca/common/verbs/common_verbs_mca.c
+++ b/opal/mca/common/verbs/common_verbs_mca.c
@@ -36,7 +36,7 @@ static void register_internal(void)
     mca_base_var_register_synonym(warn_nonexistent_if_index, "ompi", "ompi_common",
                                   "verbs", "warn_nonexistent_if", MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    mca_base_var_register("opal", "opal_common", "verbs", "want_fork_support",
+    mca_base_var_register("opal", "opal", NULL, "common_verbs_want_fork_support",
                           "Whether fork support is desired or not "
                           "(negative = try to enable fork support, but continue even "
                           "if it is not available, 0 = do not enable fork support, "
@@ -48,13 +48,9 @@ static void register_internal(void)
     registered = true;
 }
 
-void opal_common_verbs_mca_register(mca_base_component_t *component)
+void opal_common_verbs_mca_register(void)
 {
     if (!registered) {
         register_internal();
     }
-
-    /* Make synonym for the common_verbs MCA params. */
-    mca_base_var_register_synonym(warn_nonexistent_if_index, "ompi", component->mca_type_name,
-                                  component->mca_component_name, "warn_nonexistent_if", 0);
 }

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -40,6 +40,7 @@
 #include "opal/mca/shmem/base/base.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/runtime/opal_params.h"
+#include "opal/mca/common/verbs/common_verbs.h"
 #include "opal/dss/dss.h"
 #include "opal/util/show_help.h"
 #include "opal/util/timings.h"
@@ -274,6 +275,9 @@ int opal_register_params(void)
     if (OPAL_SUCCESS != ret) { 
         return ret; 
     }
+
+    /* register the common_verbs parameters */
+    opal_common_verbs_mca_register();
 
     return OPAL_SUCCESS;
 }


### PR DESCRIPTION
call the opal_common_verbs_mca_register function to make sure that
opal_common_verbs_want_fork_support mca parameter is created and therefore
can be used to control the fork support.

reviewed by @miked-mellanox 