### PR TITLE
OMPI/MXM: add out of band barrier at the end of del_procs

### DIFF
--- a/ompi/mca/mtl/mxm/mtl_mxm.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm.c
@@ -617,6 +617,7 @@ int ompi_mtl_mxm_del_procs(struct mca_mtl_base_module_t *mtl, size_t nprocs,
             OBJ_RELEASE(endpoint);
         }
     }
+    opal_pmix.fence(NULL, 0);
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/pml/yalla/pml_yalla.c
+++ b/ompi/mca/pml/yalla/pml_yalla.c
@@ -240,6 +240,7 @@ int mca_pml_yalla_del_procs(struct ompi_proc_t **procs, size_t nprocs)
         PML_YALLA_VERBOSE(2, "disconnected from rank %ld", procs[i]->super.proc_name);
         procs[i]->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PML] = NULL;
     }
+    opal_pmix.fence(NULL, 0);
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
@yosefe @miked-mellanox @jladd-mlnx  please take a look
mxm shutdown requires out of band barrier
