### PR TITLE
initialize opal_common_verbs_want_fork_support to -1.

### DIFF
--- a/opal/mca/common/verbs/common_verbs_mca.c
+++ b/opal/mca/common/verbs/common_verbs_mca.c
@@ -20,7 +20,7 @@ static bool registered = false;
 static int warn_nonexistent_if_index = -1;
 
 bool opal_common_verbs_warn_nonexistent_if = true;
-int opal_common_verbs_want_fork_support = 1;
+int opal_common_verbs_want_fork_support = -1;
 
 static void register_internal(void)
 {


### PR DESCRIPTION
This way, if the call to ibv_fork_init() fails, the job will still
continue.