### PR TITLE
ompi_comm_enable: always OBJ_RELEASE new_comm if an error occurs

### DIFF
--- a/ompi/mca/topo/base/topo_base_cart_create.c
+++ b/ompi/mca/topo/base/topo_base_cart_create.c
@@ -172,12 +172,6 @@ int mca_topo_base_cart_create(mca_topo_base_module_t *topo,
     if (OMPI_SUCCESS != ret) {
         /* something wrong happened during setting the communicator */
         free(topo_procs);
-        OBJ_RELEASE(cart);
-        if (MPI_COMM_NULL != new_comm) {
-            new_comm->c_topo = NULL;
-            new_comm->c_flags &= ~OMPI_COMM_CART;
-            ompi_comm_free (&new_comm);
-        }
         return ret;
     }
 

--- a/ompi/mca/topo/base/topo_base_dist_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create.c
@@ -335,25 +335,6 @@ int mca_topo_base_dist_graph_create(mca_topo_base_module_t* module,
     ret = ompi_comm_enable(comm_old, new_comm,
                            rank, num_procs, topo_procs);
     if (OMPI_SUCCESS != ret) {
-        if ( NULL != topo->in ) {
-            free(topo->in);
-        }
-        if ( NULL != topo->out ) {
-            free(topo->out);
-        }
-        if ( NULL != topo->inw ) {
-            free(topo->inw);
-        }
-        if ( NULL != topo->outw ) {
-            free(topo->outw);
-        }
-        if (MPI_COMM_NULL != new_comm) {
-            new_comm->c_topo->mtc.dist_graph = NULL;
-            new_comm->c_topo             = NULL;
-            new_comm->c_flags           &= ~OMPI_COMM_DIST_GRAPH;
-            ompi_comm_free (&new_comm);
-        }
-        free(topo);
         free(topo_procs);
         return ret;
     }

--- a/ompi/mca/topo/base/topo_base_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_graph_create.c
@@ -132,12 +132,6 @@ int mca_topo_base_graph_create(mca_topo_base_module_t *topo,
                            new_rank, num_procs, topo_procs);
     if (OMPI_SUCCESS != ret) {
         free(topo_procs);
-        OBJ_RELEASE(graph);
-        if (MPI_COMM_NULL != new_comm) {
-            new_comm->c_topo            = NULL;
-            new_comm->c_flags          &= ~OMPI_COMM_GRAPH;
-            ompi_comm_free (&new_comm);
-        }
         return ret;
     }
     


### PR DESCRIPTION
and simplify the error handling in topo/base upon ompi_comm_enable
invokation