### PR TITLE
asm/ia32: do not use the = constraint modifier for input/output operands

### DIFF
--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2007-2010 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -157,6 +160,25 @@ static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
 
 #if OPAL_GCC_INLINE_ASSEMBLY
 
+#define OPAL_HAVE_ATOMIC_SWAP_32 1
+
+static inline int32_t opal_atomic_swap_32( volatile int32_t *addr,
+					   int32_t newval)
+{
+    int32_t oldval;
+
+    __asm__ __volatile__("xchg %1, %0" :
+			 "=r" (oldval), "=m" (*addr) :
+			 "0" (newval), "m" (*addr) :
+			 "memory");
+    return oldval;
+}
+
+#endif /* OPAL_GCC_INLINE_ASSEMBLY */
+
+
+#if OPAL_GCC_INLINE_ASSEMBLY
+
 /**
  * atomic_add - add integer to atomic variable
  * @i: integer value to add
@@ -169,7 +191,7 @@ static inline int32_t opal_atomic_add_32(volatile int32_t* v, int i)
     int ret = i;
    __asm__ __volatile__(
                         SMPLOCK "xaddl %1,%0"
-                        :"=m" (*v), "+r" (ret)
+                        :"+m" (*v), "+r" (ret)
                         :
                         :"memory", "cc"
                         );
@@ -189,7 +211,7 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t* v, int i)
     int ret = -i;
    __asm__ __volatile__(
                         SMPLOCK "xaddl %1,%0"
-                        :"=m" (*v), "+r" (ret)
+                        :"+m" (*v), "+r" (ret)
                         :
                         :"memory", "cc"
                         );


### PR DESCRIPTION
Also added support for the xchg instruction. The instruction is
supported by ia32 and may benefit vader.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>