### PR TITLE
Allow for different security domains.

### DIFF
--- a/opal/mca/pmix/native/usock.c
+++ b/opal/mca/pmix/native/usock.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -359,15 +359,15 @@ int usock_send_connect_ack(void)
     hdr.type = PMIX_USOCK_IDENT;
 
     /* get our security credential */
-    if (OPAL_SUCCESS != (rc = opal_sec.get_my_credential(opal_dstore_internal, &OPAL_PROC_MY_NAME, &cred))) {
+    if (OPAL_SUCCESS != (rc = opal_sec.get_my_credential(NULL, opal_dstore_internal, &OPAL_PROC_MY_NAME, &cred))) {
         return rc;
     }
 
     /* set the number of bytes to be read beyond the header */
-    hdr.nbytes = strlen(opal_version_string) + 1 + cred->size;
+    hdr.nbytes = strlen(opal_version_string) + 1 + strlen(cred->method) + 1 + cred->size;
 
     /* create a space for our message */
-    sdsize = (sizeof(hdr) + strlen(opal_version_string) + 1 + cred->size);
+    sdsize = (sizeof(hdr) + strlen(opal_version_string) + 1 + strlen(cred->method) + 1 + cred->size);
     if (NULL == (msg = (char*)malloc(sdsize))) {
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
@@ -376,7 +376,8 @@ int usock_send_connect_ack(void)
     /* load the message */
     memcpy(msg, &hdr, sizeof(hdr));
     memcpy(msg+sizeof(hdr), opal_version_string, strlen(opal_version_string));
-    memcpy(msg+sizeof(hdr)+strlen(opal_version_string)+1, cred->credential, cred->size);
+    memcpy(msg+sizeof(hdr)+strlen(opal_version_string)+1, cred->method, strlen(cred->method));
+    memcpy(msg+sizeof(hdr)+strlen(opal_version_string)+1+strlen(cred->method)+1, cred->credential, cred->size);
 
 
     if (OPAL_SUCCESS != usock_send_blocking(msg, sdsize)) {

--- a/opal/mca/pmix/native/usock_sendrecv.c
+++ b/opal/mca/pmix/native/usock_sendrecv.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -632,8 +632,9 @@ static int usock_recv_connect_ack(void)
                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
 
     /* check security token */
-    creds.credential = (char*)(msg + strlen(version) + 1);
-    creds.size = hdr.nbytes - strlen(version) - 1;
+    creds.method = (char*)(msg + strlen(version) + 1);
+    creds.credential = (char*)(msg + strlen(version) + 1 + strlen(creds.method) + 1);
+    creds.size = hdr.nbytes - strlen(version) - 1 - strlen(creds.method) - 1;
     if (OPAL_SUCCESS != (rc = opal_sec.authenticate(&creds))) {
         OPAL_ERROR_LOG(rc);
     }

--- a/opal/mca/sec/base/Makefile.am
+++ b/opal/mca/sec/base/Makefile.am
@@ -1,6 +1,6 @@
 #
-# Copyright (c) 2014      Intel, Inc. All rights reserved.
-# Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+# Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -13,4 +13,5 @@ headers += \
 
 libmca_sec_la_SOURCES += \
 	base/sec_base_frame.c \
-	base/sec_base_select.c
+	base/sec_base_select.c \
+        base/sec_base_stubs.c

--- a/opal/mca/sec/base/base.h
+++ b/opal/mca/sec/base/base.h
@@ -25,11 +25,29 @@
 BEGIN_C_DECLS
 
 OPAL_DECLSPEC extern mca_base_framework_t opal_sec_base_framework;
+OPAL_DECLSPEC extern opal_list_t opal_sec_base_actives;
+
+/* object for storing active components */
+typedef struct {
+    opal_list_item_t super;
+    int pri;
+    opal_sec_base_module_t *module;
+    mca_base_component_t *component;
+} opal_sec_handle_t;
+OBJ_CLASS_DECLARATION(opal_sec_handle_t);
 
 /**
  * Select a sec module
  */
 OPAL_DECLSPEC int opal_sec_base_select(void);
+
+/* base stubs */
+OPAL_DECLSPEC int opal_sec_base_get_cred(char *method,
+                                         int dstorehandle,
+                                         opal_process_name_t *my_id,
+                                         opal_sec_cred_t **cred);
+
+OPAL_DECLSPEC int opal_sec_base_validate(opal_sec_cred_t *cred);
 
 END_C_DECLS
 

--- a/opal/mca/sec/base/sec_base_frame.c
+++ b/opal/mca/sec/base/sec_base_frame.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -27,23 +27,45 @@
 
 #include "opal/mca/sec/base/static-components.h"
 
-opal_sec_base_module_t opal_sec;
+opal_sec_API_module_t opal_sec = {
+    opal_sec_base_get_cred,
+    opal_sec_base_validate
+};
+opal_list_t opal_sec_base_actives;
 
 static int opal_sec_base_close(void)
 {
-    /* let the selected module finalize */
-    if (NULL != opal_sec.finalize) {
-            opal_sec.finalize();
+    opal_sec_handle_t *hdl;
+    
+    /* let the selected modules finalize */
+    OPAL_LIST_FOREACH(hdl, &opal_sec_base_actives, opal_sec_handle_t) {
+        if (NULL != hdl->module->finalize) {
+            hdl->module->finalize();
+        }
     }
 
+    OPAL_LIST_DESTRUCT(&opal_sec_base_actives);
+    
     return mca_base_framework_components_close(&opal_sec_base_framework, NULL);
 }
 
 static int opal_sec_base_open(mca_base_open_flag_t flags)
 {
+    OBJ_CONSTRUCT(&opal_sec_base_actives, opal_list_t);
+    
     /* Open up all available components */
     return mca_base_framework_components_open(&opal_sec_base_framework, flags);
 }
 
 MCA_BASE_FRAMEWORK_DECLARE(opal, sec, NULL, NULL, opal_sec_base_open, opal_sec_base_close,
                            mca_sec_base_static_components, 0);
+
+static void hcon(opal_sec_handle_t *p)
+{
+    p->pri = 0;
+    p->module = NULL;
+    p->component = NULL;
+}
+OBJ_CLASS_INSTANCE(opal_sec_handle_t,
+                   opal_list_item_t,
+                   hcon, NULL);

--- a/opal/mca/sec/base/sec_base_stubs.c
+++ b/opal/mca/sec/base/sec_base_stubs.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ * 
+ * Additional copyrights may follow
+ * 
+ * $HEADER$
+ */
+
+
+#include "opal_config.h"
+#include "opal/constants.h"
+
+#include "opal/mca/mca.h"
+#include "opal/util/output.h"
+#include "opal/mca/base/base.h"
+#include "opal/dss/dss_types.h"
+
+#include "opal/mca/sec/base/base.h"
+
+int opal_sec_base_get_cred(char *method,
+                           int dstorehandle,
+                           opal_process_name_t *my_id,
+                           opal_sec_cred_t **cred)
+{
+    opal_sec_handle_t *hdl;
+
+    opal_output_verbose(5, opal_sec_base_framework.framework_output,
+                        "Requesting credential from source %s",
+                        (NULL == method) ? "ANY" : method);
+    
+    OPAL_LIST_FOREACH(hdl, &opal_sec_base_actives, opal_sec_handle_t) {
+        if (NULL != method && 0 != strcmp(method, hdl->component->mca_component_name)) {
+            continue;
+        }
+        if (OPAL_SUCCESS == hdl->module->get_my_credential(dstorehandle, my_id, cred)) {
+            opal_output_verbose(5, opal_sec_base_framework.framework_output,
+                                "Created credential from source %s", hdl->component->mca_component_name);
+            /* record the source */
+            (*cred)->method = strdup(hdl->component->mca_component_name);
+            return OPAL_SUCCESS;
+        }
+    }
+    return OPAL_ERROR;
+}
+
+
+int opal_sec_base_validate(opal_sec_cred_t *cred)
+{
+    opal_sec_handle_t *hdl;
+
+    opal_output_verbose(5, opal_sec_base_framework.framework_output,
+                        "Received credential %s from source %s",
+                        (NULL == cred->credential) ? "NULL" : cred->credential,
+                        (NULL == cred->method) ? "NULL" : cred->method);
+    
+    OPAL_LIST_FOREACH(hdl, &opal_sec_base_actives, opal_sec_handle_t) {
+        if (NULL != cred->method &&
+            0 != strcmp(cred->method, hdl->component->mca_component_name)) {
+            continue;
+        }
+        if (OPAL_SUCCESS == hdl->module->authenticate(cred)) {
+            return OPAL_SUCCESS;
+        }
+    }
+    return OPAL_ERROR;
+}
+
+

--- a/opal/mca/sec/sec.h
+++ b/opal/mca/sec/sec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -42,6 +42,7 @@
 BEGIN_C_DECLS
 
 typedef struct {
+    char *method;
     char *credential;
     size_t size;
 } opal_sec_cred_t;
@@ -80,6 +81,10 @@ typedef int (*opal_sec_base_module_get_my_cred_fn_t)(int dstorehandle,
                                                      opal_process_name_t *my_id,
                                                      opal_sec_cred_t **cred);
 
+typedef int (*opal_sec_API_module_get_my_cred_fn_t)(char *method,
+                                                    int dstorehandle,
+                                                    opal_process_name_t *my_id,
+                                                    opal_sec_cred_t **cred);
 /*
  * Authenticate a security credential - given a security credential,
  * determine if the credential is valid. The credential is passed in
@@ -102,6 +107,12 @@ struct opal_sec_base_module_1_0_0_t {
 typedef struct opal_sec_base_module_1_0_0_t opal_sec_base_module_1_0_0_t;
 typedef struct opal_sec_base_module_1_0_0_t opal_sec_base_module_t;
 
+/* the API structure */
+typedef struct {
+    opal_sec_API_module_get_my_cred_fn_t    get_my_credential;
+    opal_sec_base_module_auth_fn_t          authenticate;
+} opal_sec_API_module_t;
+
 /*
  * the standard component data structure
  */
@@ -120,7 +131,7 @@ typedef struct opal_sec_base_component_1_0_0_t opal_sec_base_component_t;
   "sec", 1, 0, 0
 
 /* Global structure for accessing SEC functions */
-OPAL_DECLSPEC extern opal_sec_base_module_t opal_sec;  /* holds base function pointers */
+OPAL_DECLSPEC extern opal_sec_API_module_t opal_sec;  /* holds base function pointers */
 
 END_C_DECLS
 

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -1199,6 +1199,7 @@ static char **split_and_resolve(char **orig_str, char *name)
 
 static void peer_cons(mca_oob_tcp_peer_t *peer)
 {
+    peer->auth_method = NULL;
     peer->sd = -1;
     OBJ_CONSTRUCT(&peer->addrs, opal_list_t);
     peer->active_addr = NULL;
@@ -1212,6 +1213,9 @@ static void peer_cons(mca_oob_tcp_peer_t *peer)
 }
 static void peer_des(mca_oob_tcp_peer_t *peer)
 {
+    if (NULL != peer->auth_method) {
+        free(peer->auth_method);
+    }
     if (peer->send_ev_active) {
         opal_event_del(&peer->send_event);
     }

--- a/orte/mca/oob/tcp/oob_tcp_connection.c
+++ b/orte/mca/oob/tcp/oob_tcp_connection.c
@@ -367,18 +367,19 @@ static int tcp_peer_send_connect_ack(mca_oob_tcp_peer_t* peer)
     hdr.tag = 0;
 
     /* get our security credential*/
-    if (OPAL_SUCCESS != (rc = opal_sec.get_my_credential(opal_dstore_internal,
+    if (OPAL_SUCCESS != (rc = opal_sec.get_my_credential(peer->auth_method,
+                                                         opal_dstore_internal,
                                                          ORTE_PROC_MY_NAME, &cred))) {
         ORTE_ERROR_LOG(rc);
         return rc;
     }
 
     /* set the number of bytes to be read beyond the header */
-    hdr.nbytes = strlen(orte_version_string) + 1 + cred->size;
+    hdr.nbytes = strlen(orte_version_string) + 1 + strlen(cred->method) + 1 + cred->size;
     MCA_OOB_TCP_HDR_HTON(&hdr);
 
     /* create a space for our message */
-    sdsize = (sizeof(hdr) + strlen(orte_version_string) + 1 + cred->size);
+    sdsize = (sizeof(hdr) + strlen(orte_version_string) + 1 + strlen(cred->method) + 1 + cred->size);
     if (NULL == (msg = (char*)malloc(sdsize))) {
         return ORTE_ERR_OUT_OF_RESOURCE;
     }
@@ -387,7 +388,8 @@ static int tcp_peer_send_connect_ack(mca_oob_tcp_peer_t* peer)
     /* load the message */
     memcpy(msg, &hdr, sizeof(hdr));
     memcpy(msg+sizeof(hdr), orte_version_string, strlen(orte_version_string));
-    memcpy(msg+sizeof(hdr)+strlen(orte_version_string)+1, cred->credential, cred->size);
+    memcpy(msg+sizeof(hdr)+strlen(orte_version_string)+1, cred->method, strlen(cred->method));
+    memcpy(msg+sizeof(hdr)+strlen(orte_version_string)+1+strlen(cred->method)+1, cred->credential, cred->size);
 
     /* send it */
     if (ORTE_SUCCESS != tcp_peer_send_blocking(peer->sd, msg, sdsize)) {
@@ -797,12 +799,17 @@ int mca_oob_tcp_peer_recv_connect_ack(mca_oob_tcp_peer_t* pr,
                         ORTE_NAME_PRINT(&peer->name));
 
     /* check security token */
-    creds.credential = (char*)(msg + strlen(version) + 1);
-    creds.size = hdr.nbytes - strlen(version) - 1;
+    creds.method = (char*)(msg + strlen(version) + 1);
+    creds.credential = (char*)(msg + strlen(version) + 1 + strlen(creds.method) + 1);
+    creds.size = hdr.nbytes - strlen(version) - 1 - strlen(creds.method) - 1;
     if (OPAL_SUCCESS != (rc = opal_sec.authenticate(&creds))) {
         ORTE_ERROR_LOG(rc);
         free(msg);
         return ORTE_ERR_CONNECTION_REFUSED;
+    }
+    /* record the method they used so we can reciprocate */
+    if (NULL == peer->auth_method) {
+        peer->auth_method = strdup(creds.method);
     }
     free(msg);
 

--- a/orte/mca/oob/tcp/oob_tcp_peer.h
+++ b/orte/mca/oob/tcp/oob_tcp_peer.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC. 
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -42,6 +43,7 @@ typedef struct {
      * value that retaining the name makes sense
      */
     orte_process_name_t name;
+    char *auth_method;  // method they used to authenticate
     int sd;
     opal_list_t addrs;
     mca_oob_tcp_addr_t *active_addr;

--- a/orte/mca/oob/usock/oob_usock_component.c
+++ b/orte/mca/oob/usock/oob_usock_component.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -538,6 +538,7 @@ mca_oob_usock_peer_t* mca_oob_usock_peer_lookup(const orte_process_name_t *name)
 
 static void peer_cons(mca_oob_usock_peer_t *peer)
 {
+    peer->auth_method = NULL;
     peer->sd = -1;
     peer->state = MCA_OOB_USOCK_UNCONNECTED;
     peer->retries = 0;
@@ -550,6 +551,9 @@ static void peer_cons(mca_oob_usock_peer_t *peer)
 }
 static void peer_des(mca_oob_usock_peer_t *peer)
 {
+    if (NULL != peer->auth_method) {
+        free(peer->auth_method);
+    }
     if (0 <= peer->sd) {
         CLOSE_THE_SOCKET(peer->sd);
     }

--- a/orte/mca/oob/usock/oob_usock_peer.h
+++ b/orte/mca/oob/usock/oob_usock_peer.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC. 
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -35,6 +35,7 @@ typedef struct {
      * value that retaining the name makes sense
      */
     orte_process_name_t name;
+    char *auth_method;     // how the peer authenticated themselves to use
     int sd;
     int retries;                  // number of times we have tried to connect to this address
     mca_oob_usock_state_t state;

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
@@ -1396,6 +1396,7 @@ OBJ_CLASS_INSTANCE(pmix_server_recv_t,
 
 static void pcon(pmix_server_peer_t *p)
 {
+    p->auth_method = NULL;
     p->sd = -1;
     p->retries = 0;
     p->state = PMIX_SERVER_UNCONNECTED;
@@ -1408,6 +1409,9 @@ static void pcon(pmix_server_peer_t *p)
 }
 static void pdes(pmix_server_peer_t *p)
 {
+    if (NULL != p->auth_method) {
+        free(p->auth_method);
+    }
     OPAL_LIST_DESTRUCT(&p->send_queue);
 }
 OBJ_CLASS_INSTANCE(pmix_server_peer_t,

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC. 
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc.  All rights reserved. 
+ * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved. 
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
@@ -117,6 +117,7 @@ typedef struct {
     opal_object_t super;
     int sd;
     orte_process_name_t name;
+    char *auth_method;         // method used by peer to authenticate
     int retries;                  // number of times we have tried to connect to this address
     pmix_server_state_t state;
     opal_event_t op_event;      // used for connecting and operations other than read/write


### PR DESCRIPTION
Let the initiator of the connection determine the method to be used - if the receiver cannot support it, then that's an error that will cause the connection attempt to fail.