### PR TITLE
osc/pt2pt: fix synchronization bugs

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
@@ -49,9 +49,7 @@ static int frag_send_cb (ompi_request_t *request)
     return OMPI_SUCCESS;
 }
 
-static int
-frag_send(ompi_osc_pt2pt_module_t *module,
-            ompi_osc_pt2pt_frag_t *frag)
+static int frag_send (ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_frag_t *frag)
 {
     int count;
 
@@ -61,31 +59,35 @@ frag_send(ompi_osc_pt2pt_module_t *module,
                          "osc pt2pt: frag_send called to %d, frag = %p, count = %d",
                          frag->target, (void *) frag, count));
 
-    /* we need to signal now that a frag is outgoing to ensure the count sent
-     * with the unlock message is correct */
-    ompi_osc_signal_outgoing (module, frag->target, 1);
-
     return ompi_osc_pt2pt_isend_w_cb (frag->buffer, count, MPI_BYTE, frag->target, OSC_PT2PT_FRAG_TAG,
                                      module->comm, frag_send_cb, frag);
 }
 
 
-int
-ompi_osc_pt2pt_frag_start(ompi_osc_pt2pt_module_t *module,
-                          ompi_osc_pt2pt_frag_t *frag)
+int ompi_osc_pt2pt_frag_start (ompi_osc_pt2pt_module_t *module,
+                               ompi_osc_pt2pt_frag_t *frag)
 {
     ompi_osc_pt2pt_peer_t *peer = module->peers + frag->target;
     int ret;
 
     assert(0 == frag->pending && peer->active_frag != frag);
 
+    /* we need to signal now that a frag is outgoing to ensure the count sent
+     * with the unlock message is correct */
+    ompi_osc_signal_outgoing (module, frag->target, 1);
+
     /* if eager sends are not active, can't send yet, so buffer and
        get out... */
-    if (!(peer->eager_send_active || module->all_access_epoch)) {
-        OPAL_THREAD_SCOPED_LOCK(&module->queued_frags_lock,
-                                opal_list_append(&module->queued_frags, (opal_list_item_t *) frag));
+    if (!(peer->eager_send_active || module->all_access_epoch) || opal_list_get_size (&peer->queued_frags)) {
+        OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output, "queuing fragment to peer %d",
+                             frag->target));
+        OPAL_THREAD_SCOPED_LOCK(&peer->lock,
+                                opal_list_append(&peer->queued_frags, (opal_list_item_t *) frag));
         return OMPI_SUCCESS;
     }
+
+    OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output, "sending fragment to peer %d",
+                         frag->target));
 
     ret = frag_send(module, frag);
 
@@ -94,105 +96,103 @@ ompi_osc_pt2pt_frag_start(ompi_osc_pt2pt_module_t *module,
     return ret;
 }
 
-
-int
-ompi_osc_pt2pt_frag_flush_target(ompi_osc_pt2pt_module_t *module, int target)
+static int ompi_osc_pt2pt_flush_active_frag (ompi_osc_pt2pt_module_t *module, int target)
 {
-    ompi_osc_pt2pt_frag_t *next, *frag = module->peers[target].active_frag;
+    ompi_osc_pt2pt_frag_t *active_frag = module->peers[target].active_frag;
     int ret = OMPI_SUCCESS;
 
-    OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: frag flush target begin"));
+    if (NULL == active_frag) {
+        /* nothing to do */
+        return OMPI_SUCCESS;
+    }
 
-    /* flush the active frag */
-    if (NULL != frag) {
-        if (1 != frag->pending) {
+    OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
+                         "osc pt2pt: flushing active fragment to target. pending: %d", target,
+                         active_frag->pending));
+
+    if (opal_atomic_cmpset (&module->peers[target].active_frag, active_frag, NULL)) {
+        if (0 != OPAL_THREAD_ADD32(&active_frag->pending, -1)) {
             /* communication going on while synchronizing; this is an rma usage bug */
             return OMPI_ERR_RMA_SYNC;
         }
 
-        if (opal_atomic_cmpset (&module->peers[target].active_frag, frag, NULL)) {
-            OPAL_THREAD_ADD32(&frag->pending, -1);
-            ret = ompi_osc_pt2pt_frag_start(module, frag);
-            if (OMPI_SUCCESS != ret) {
-                return ret;
-            }
-        }
+        ompi_osc_signal_outgoing (module, target, 1);
+        ret = frag_send (module, active_frag);
     }
 
+    return ret;
+}
+
+int ompi_osc_pt2pt_frag_flush_target (ompi_osc_pt2pt_module_t *module, int target)
+{
+    ompi_osc_pt2pt_peer_t *peer = module->peers + target;
+    ompi_osc_pt2pt_frag_t *next, *frag;
+    int ret = OMPI_SUCCESS;
+
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: frag flush target finished active frag"));
+                         "osc pt2pt: frag flush to target target %d. queue fragments: %u",
+                         target, opal_list_get_size (&peer->queued_frags)));
 
     /* walk through the pending list and send */
-    OPAL_THREAD_LOCK(&module->queued_frags_lock);
-    if (opal_list_get_size (&module->queued_frags)) {
-        OPAL_LIST_FOREACH_SAFE(frag, next, &module->queued_frags, ompi_osc_pt2pt_frag_t) {
-            if (frag->target == target) {
-                opal_list_remove_item(&module->queued_frags, (opal_list_item_t *) frag);
-                ret = frag_send(module, frag);
-                if (OPAL_UNLIKELY(OMPI_SUCCESS != frag)) {
-                    break;
-                }
-            }
+    OPAL_THREAD_LOCK(&peer->lock);
+    while (NULL != (frag = ((ompi_osc_pt2pt_frag_t *) opal_list_remove_first (&peer->queued_frags)))) {
+        ret = frag_send(module, frag);
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+            break;
         }
     }
-    OPAL_THREAD_UNLOCK(&module->queued_frags_lock);
+    OPAL_THREAD_UNLOCK(&peer->lock);
+
+    /* XXX -- TODO -- better error handling */
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
+    /* flush the active frag */
+    ret = ompi_osc_pt2pt_flush_active_frag (module, target);
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: frag flush target finished"));
+                         "osc pt2pt: frag flush target %d finished", target));
 
     return ret;
 }
 
 
-int
-ompi_osc_pt2pt_frag_flush_all(ompi_osc_pt2pt_module_t *module)
+int ompi_osc_pt2pt_frag_flush_all (ompi_osc_pt2pt_module_t *module)
 {
     int ret = OMPI_SUCCESS;
-    int i;
     ompi_osc_pt2pt_frag_t *frag, *next;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "osc pt2pt: frag flush all begin"));
 
-    /* flush the active frag */
-    for (i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
-        ompi_osc_pt2pt_frag_t *frag = module->peers[i].active_frag;
-
-        if (NULL != frag) {
-            if (1 != frag->pending) {
-                OPAL_THREAD_UNLOCK(&module->lock);
-                /* communication going on while synchronizing; this is a bug */
-                return OMPI_ERR_RMA_SYNC;
-            }
-
-            if (!opal_atomic_cmpset_ptr (&module->peers[i].active_frag, frag, NULL)) {
-                continue;
-            }
-
-            OPAL_THREAD_ADD32(&frag->pending, -1);
-            ret = ompi_osc_pt2pt_frag_start(module, frag);
-            if (OMPI_SUCCESS != ret) {
-                return ret;
-            }
-        }
-    }
-
-    OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: frag flush all finished active frag"));
-
     /* try to start all the queued frags */
-    OPAL_THREAD_LOCK(&module->queued_frags_lock);
-    if (opal_list_get_size (&module->queued_frags)) {
-        OPAL_LIST_FOREACH_SAFE(frag, next, &module->queued_frags, ompi_osc_pt2pt_frag_t) {
-            opal_list_remove_item(&module->queued_frags, (opal_list_item_t *) frag);
+    for (int i = 0 ; i < ompi_comm_size (module->comm) ; ++i) {
+        ompi_osc_pt2pt_peer_t *peer = module->peers + i;
+
+        while (NULL != (frag = ((ompi_osc_pt2pt_frag_t *) opal_list_remove_first (&peer->queued_frags)))) {
             ret = frag_send(module, frag);
             if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
                 break;
             }
         }
+
+        /* XXX -- TODO -- better error handling */
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
     }
-    OPAL_THREAD_UNLOCK(&module->queued_frags_lock);
+
+    OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
+                         "osc pt2pt: flushing all active fragments"));
+
+    /* flush the active frag */
+    for (int i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
+        ret = ompi_osc_pt2pt_flush_active_frag (module, i);
+        if (OMPI_SUCCESS != ret) {
+            return ret;
+        }
+    }
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "osc pt2pt: frag flush all done"));

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
@@ -44,15 +44,14 @@ extern int ompi_osc_pt2pt_frag_start(ompi_osc_pt2pt_module_t *module, ompi_osc_p
 extern int ompi_osc_pt2pt_frag_flush_target(ompi_osc_pt2pt_module_t *module, int target);
 extern int ompi_osc_pt2pt_frag_flush_all(ompi_osc_pt2pt_module_t *module);
 
-
 /*
  * Note: module lock must be held during this operation
  */
-static inline int ompi_osc_pt2pt_frag_alloc(ompi_osc_pt2pt_module_t *module, int target,
-                                           size_t request_len, ompi_osc_pt2pt_frag_t **buffer,
-                                           char **ptr)
+static inline int ompi_osc_pt2pt_frag_alloc (ompi_osc_pt2pt_module_t *module, int target,
+                                             size_t request_len, ompi_osc_pt2pt_frag_t **buffer,
+                                             char **ptr)
 {
-    ompi_osc_pt2pt_frag_t *curr = module->peers[target].active_frag;
+    ompi_osc_pt2pt_frag_t *curr;
     int ret;
 
     /* osc pt2pt headers can have 64-bit values. these will need to be aligned
@@ -65,6 +64,7 @@ static inline int ompi_osc_pt2pt_frag_alloc(ompi_osc_pt2pt_module_t *module, int
     }
 
     OPAL_THREAD_LOCK(&module->lock);
+    curr = module->peers[target].active_frag;
     if (NULL == curr || curr->remain_len < request_len) {
         opal_free_list_item_t *item = NULL;
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
@@ -84,8 +84,6 @@ ompi_osc_pt2pt_free(ompi_win_t *win)
      * probably produce an error here instead of cleaning up */
     OPAL_LIST_DESTRUCT(&module->pending_acc);
     OPAL_LIST_DESTRUCT(&module->pending_posts);
-    OPAL_LIST_DESTRUCT(&module->queued_frags);
-    OBJ_DESTRUCT(&module->queued_frags_lock);
 
     osc_pt2pt_gc_clean (module);
     OPAL_LIST_DESTRUCT(&module->request_gc);
@@ -93,6 +91,10 @@ ompi_osc_pt2pt_free(ompi_win_t *win)
     OBJ_DESTRUCT(&module->gc_lock);
 
     if (NULL != module->peers) {
+        for (int i = 0 ; i < ompi_comm_size (module->comm) ; ++i) {
+            OBJ_DESTRUCT(module->peers + i);
+        }
+
         free(module->peers);
     }
 


### PR DESCRIPTION
The fragment flush code tries to send the active fragment before
sending any queued fragments. This could cause osc messages to arrive
out-of-order at the target (bad). Ensure ordering by alway sending
the active fragment after sending queued fragments.

This commit also fixes a bug when a synchronization message (unlock,
flush, complete) can not be packed at the end of an existing active
fragment. In this case the source process will end up sending 1 more
fragment than claimed in the synchronization message. To fix the issue
a check has been added that fixes the fragment count if this situation
is detected.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>