### PR TITLE
ompi/java: better error message if dlopen fails

### DIFF
--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -135,7 +135,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
     if(libmpi == NULL)
     {
-        fprintf(stderr, "Java bindings failed to load liboshmem.\n");
+        fprintf(stderr, "Java bindings failed to load libmpi: %s\n",dlerror());
         exit(1);
     }
 

--- a/oshmem/shmem/java/c/shmem_ShMem.c
+++ b/oshmem/shmem/java/c/shmem_ShMem.c
@@ -90,7 +90,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
     if(liboshmem == NULL)
     {
-        fprintf(stderr, "Java bindings failed to load liboshmem.\n");
+        fprintf(stderr, "Java bindings failed to load liboshmem: %s\n",dlerror());
         exit(1);
     }
 


### PR DESCRIPTION
The error message emitted by ompi/java when dlopen
fails is misleading and not very informative.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>