### PR TITLE
opal: fix multiple bugs in MCA and opal

### DIFF
--- a/opal/mca/base/mca_base_close.c
+++ b/opal/mca/base/mca_base_close.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -25,34 +28,40 @@
 #include "opal/mca/base/mca_base_component_repository.h"
 #include "opal/constants.h"
 
+extern int mca_base_opened;
+
 /*
  * Main MCA shutdown.
  */
 int mca_base_close(void)
 {
-  extern bool mca_base_opened;
-  if (mca_base_opened) {
+    assert (mca_base_opened);
+    if (!--mca_base_opened) {
+        /* deregister all MCA base parameters */
+        int group_id = mca_base_var_group_find ("opal", "mca", "base");
 
-      /* release the default paths */
-      if (NULL != mca_base_system_default_path) {
-          free(mca_base_system_default_path);
-      }
-      if (NULL != mca_base_user_default_path) {
-          free(mca_base_user_default_path);
-      }
-      
-    /* Close down the component repository */
-    mca_base_component_repository_finalize();
+        if (-1 < group_id) {
+            mca_base_var_group_deregister (group_id);
+        }
 
-    /* Shut down the dynamic component finder */
-    mca_base_component_find_finalize();
+        /* release the default paths */
+        if (NULL != mca_base_system_default_path) {
+            free(mca_base_system_default_path);
+        }
+        if (NULL != mca_base_user_default_path) {
+            free(mca_base_user_default_path);
+        }
 
-    /* Close opal output stream 0 */
-    opal_output_close(0);
-  }
-  mca_base_opened = false;
+        /* Close down the component repository */
+        mca_base_component_repository_finalize();
 
-  /* All done */
+        /* Shut down the dynamic component finder */
+        mca_base_component_find_finalize();
 
-  return OPAL_SUCCESS;
+        /* Close opal output stream 0 */
+        opal_output_close(0);
+    }
+
+    /* All done */
+    return OPAL_SUCCESS;
 }

--- a/opal/mca/base/mca_base_component_repository.c
+++ b/opal/mca/base/mca_base_component_repository.c
@@ -105,16 +105,6 @@ int mca_base_component_repository_init(void)
     }
     opal_dl_base_select();
 
-    /* Bump the refcount to indicate that this framework is "special"
-       -- it can't be finalized until all other frameworks have been
-       finalized.  E.g., in opal/runtime/opal_info_support.c, there's
-       a loop calling mca_base_framework_close() on all OPAL
-       frameworks.  But that function simply decrements each
-       framework's refcount, and if it's zero, closes it.  This
-       additional increment ensures that the "dl" framework is not
-       closed as part of that loop. */
-    ++opal_dl_base_framework.framework_refcnt;
-
     OBJ_CONSTRUCT(&repository, opal_list_t);
 #endif
 
@@ -265,9 +255,6 @@ void mca_base_component_repository_finalize(void)
       }
     } while (opal_list_get_size(&repository) > 0);
 
-    /* Close the dl framework (see comment about refcnt in
-       mca_base_component_repository_init()) */
-    --opal_dl_base_framework.framework_refcnt;
     (void) mca_base_framework_close(&opal_dl_base_framework);
 #endif
 

--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -11,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -42,7 +44,7 @@
  * Public variables
  */
 char *mca_base_component_path = NULL;
-bool mca_base_opened = false;
+int mca_base_opened = 0;
 char *mca_base_system_default_path = NULL;
 char *mca_base_user_default_path = NULL;
 bool mca_base_component_show_load_errors = true;
@@ -67,9 +69,7 @@ int mca_base_open(void)
     char hostname[64];
     int var_id;
 
-    if (!mca_base_opened) {
-        mca_base_opened = true;
-    } else {
+    if (mca_base_opened++) {
         return OPAL_SUCCESS;
     }
 

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -114,6 +114,8 @@ int mca_base_pvar_finalize (void)
             }
         }
 
+        pvar_count = 0;
+
         OBJ_DESTRUCT(&registered_pvars);
         OBJ_DESTRUCT(&mca_base_pvar_index_hash);
     }

--- a/opal/mca/dl/dlopen/dl_dlopen_component.c
+++ b/opal/mca/dl/dlopen/dl_dlopen_component.c
@@ -67,10 +67,6 @@ opal_dl_dlopen_component_t mca_dl_dlopen_component = {
         /* The dl framework members */
         .priority = 80
     },
-
-    /* Now fill in the dlopen component-specific members */
-    .filename_suffixes_mca_storage = ".so,.dylib,.dll,.sl",
-    .filename_suffixes = NULL
 };
 
 
@@ -78,6 +74,7 @@ static int dlopen_component_register(void)
 {
     int ret;
 
+    mca_dl_dlopen_component.filename_suffixes_mca_storage = ".so,.dylib,.dll,.sl";
     ret =
         mca_base_component_var_register(&mca_dl_dlopen_component.base.base_version,
                                         "filename_suffixes",

--- a/opal/mca/shmem/base/shmem_base_close.c
+++ b/opal/mca/shmem/base/shmem_base_close.c
@@ -38,6 +38,10 @@ opal_shmem_base_close(void)
         opal_shmem_base_module->module_finalize();
     }
 
+    opal_shmem_base_selected = false;
+    opal_shmem_base_component = NULL;
+    opal_shmem_base_module = NULL;
+
     return mca_base_framework_components_close (&opal_shmem_base_framework,
                                                 NULL);
 }

--- a/opal/runtime/opal_finalize.c
+++ b/opal/runtime/opal_finalize.c
@@ -129,9 +129,6 @@ opal_finalize(void)
 #if OPAL_ENABLE_FT_CR    == 1
     (void) mca_base_framework_close(&opal_compress_base_framework);
 #endif
-    
-    /* close the shmem framework */
-    (void) mca_base_framework_close(&opal_shmem_base_framework);
 
     (void) mca_base_framework_close(&opal_event_base_framework);
 

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2013 Los Alamos National Security, LLC.
+ * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 University of Houston. All rights reserved.
  * $COPYRIGHT$
@@ -88,7 +88,7 @@ const char *opal_info_ver_mca = "mca";
 const char *opal_info_ver_type = "type";
 const char *opal_info_ver_component = "component";
 
-static bool opal_info_registered = false;
+static int opal_info_registered = 0;
 
 static void component_map_construct(opal_info_component_map_t *map)
 {
@@ -227,8 +227,6 @@ int opal_info_init(int argc, char **argv,
 
 void opal_info_finalize(void)
 {
-    opal_info_close_components ();
-    mca_base_close();
     opal_finalize_util();
 }
 
@@ -295,11 +293,9 @@ int opal_info_register_framework_params(opal_pointer_array_t *component_map)
 {
     int rc;
 
-    if (opal_info_registered) {
+    if (opal_info_registered++) {
         return OPAL_SUCCESS;
     }
-
-    opal_info_registered = true;
 
     /* Register mca/base parameters */
     if( OPAL_SUCCESS != mca_base_open() ) {
@@ -321,9 +317,17 @@ void opal_info_close_components(void)
 {
     int i;
 
+    assert(opal_info_registered);
+    if (--opal_info_registered) {
+        return;
+    }
+
     for (i=0; NULL != opal_frameworks[i]; i++) {
         (void) mca_base_framework_close(opal_frameworks[i]);
     }
+
+    /* release our reference to MCA */
+    mca_base_close ();
 }
 
 

--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -481,10 +484,16 @@ void opal_output_finalize(void)
             opal_output_close(verbose_stream);
         }
         free(verbose.lds_prefix);
+        verbose.lds_prefix = NULL;
+
         verbose_stream = -1;
 
         free (output_prefix);
+        output_prefix = NULL;
+
         free (output_dir);
+        output_dir = NULL;
+
         if(NULL != temp_str) {
 	    free(temp_str);
 	    temp_str = NULL;
@@ -493,6 +502,8 @@ void opal_output_finalize(void)
         OBJ_DESTRUCT(&verbose);
         OBJ_DESTRUCT(&mutex);
     }
+
+    initialized = false;
 }
 
 /************************************************************************/

--- a/orte/runtime/orte_info_support.c
+++ b/orte/runtime/orte_info_support.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2013 Los Alamos National Security, LLC.
+ * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 University of Houston. All rights reserved.
  * $COPYRIGHT$
@@ -38,7 +38,7 @@
 
 const char *orte_info_type_orte = "orte";
 
-static bool orte_info_registered = false;
+static int orte_info_registered = 0;
 
 void orte_info_register_types(opal_pointer_array_t *mca_types)
 {
@@ -57,11 +57,9 @@ int orte_info_register_framework_params(opal_pointer_array_t *component_map)
 {
     int rc;
 
-    if (orte_info_registered) {
+    if (orte_info_registered++) {
         return ORTE_SUCCESS;
     }
-
-    orte_info_registered = true;
 
     /* Register the ORTE layer's MCA parameters */
     
@@ -83,9 +81,16 @@ void orte_info_close_components(void)
 {
     int i;
 
+    assert (orte_info_registered);
+    if (--orte_info_registered) {
+        return;
+    }
+
     for (i=0; NULL != orte_frameworks[i]; i++) {
         (void) mca_base_framework_close(orte_frameworks[i]);
     }
+
+    opal_info_close_components ();
 }
 
 void orte_info_show_orte_version(const char *scope)


### PR DESCRIPTION
This commit fixes the following bugs:

 - opal_output_finalize did not properly set internal state. This
   caused problems when calling the sequence opal_output_init (),
   opal_output_finalize (), opal_output_init ().

 - opal_info support called mca_base_open () but never called the
   matching mca_base_close (). mca_base_open () and mca_base_close ()
   have been updated to use a open count instead of an open flag to
   allow mca_base_open to be called through multiple paths (as may be
   the case when MPI_T is in use).

 - orte_info support did not register opal variables. This can cause
   orte-info to not return opal variables.

 - opal_info, orte_info, and ompi_info support have been updated to
   use a register count.

 - When opening the dl framework the reference count was added to
   ensure the framework stuck around. The framework being closed
   prematurely was a bug in the MCA base that has since been
   corrected. The increment (and associated decrement) have been
   removed.

 - dl/dlopen did not set the value of
   mca_dl_dlopen_component.filename_suffixes_mca_storage on each call
   to register. Instead the value was set in the component
   structure. This caused the value to be lost when re-loading the
   component. Fixed by setting the default value in register.

 - Reset shmem framework state on close to avoid returning a stale
   component after reloading opal/shmem.

 - MCA base parameters were not properly deregistered when the MCA
   base was closed.

This commit may fix #374.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>