### PR TITLE
man pages: fix problem with MPI_Win_lock_all

### DIFF
--- a/ompi/mpi/man/man3/MPI_Win_lock_all.3in
+++ b/ompi/mpi/man/man3/MPI_Win_lock_all.3in
@@ -19,7 +19,7 @@ int MPI_Win_lock_all(int \fIassert\fP, MPI_Win \fIwin\fP)
 .SH Fortran Syntax
 .nf
 INCLUDE 'mpif.h'
-MPI_WIN_LOCK(\fIASSERT, WIN, IERROR\fP)
+MPI_WIN_LOCK_ALL(\fIASSERT, WIN, IERROR\fP)
 	INTEGER \fIASSERT, WIN, IERROR\fP
 
 .fi


### PR DESCRIPTION
thanks to Thomas Jahns for pointing this out -

http://www.open-mpi.org/community/lists/users/2015/04/26633.php

Signed-off-by: Howard Pritchard <howardp@lanl.gov>