### PR TITLE
opal/util/error: check for existing convertor for error range

### DIFF
--- a/opal/util/error.c
+++ b/opal/util/error.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,8 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2012 Los Alamos National Security, LLC. 
- *                         All rights reserved.
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -197,6 +198,11 @@ opal_error_register(const char *project, int err_base, int err_max,
             converters[i].project[MAX_CONVERTER_PROJECT_LEN-1] = '\0';
             converters[i].err_base = err_base;
             converters[i].err_max = err_max;
+            converters[i].converter = converter;
+            return OPAL_SUCCESS;
+        } else if (converters[i].err_base == err_base &&
+                   converters[i].err_max == err_max &&
+                   !strcmp (project, converters[i].project)) {
             converters[i].converter = converter;
             return OPAL_SUCCESS;
         }


### PR DESCRIPTION
This commit fixes a bug when opal_error_init is called with the same
values multiple times. If opal_error_init is called too many times it
will start failing with OPAL_ERR_OUT_OF_RESOURCE. To fix the problem
check if an existing convertor matching the requested one and return
that one instead.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>