### PR TITLE
oob/config: if --with-verbs=no, no ud

### DIFF
--- a/orte/mca/oob/ud/configure.m4
+++ b/orte/mca/oob/ud/configure.m4
@@ -47,7 +47,7 @@ AC_DEFUN([MCA_orte_oob_ud_CONFIG],[
     LDFLAGS=$orte_oob_ud_check_save_LDFLAGS
     LIBS=$orte_oob_ud_check_save_LIBS
 
-    AS_IF([test "$orte_oob_ud_check_happy" = "yes"],
+    AS_IF([test "$orte_oob_ud_check_happy" = "yes" && test "$opal_want_verbs" != "no"],
           [$1],
           [AS_IF([test "$opal_want_verbs" = "yes"],
                  [AC_MSG_WARN([--with-verbs specified, but cannot build this component])


### PR DESCRIPTION
The oob/ud configure was not honoring the case
if the ompi is configured with --with-verbs=no.
This fixes that problem.

Fixes #522

Signed-off-by: Howard Pritchard <howardp@lanl.gov>