### PR TITLE
Rename internal error code variables in errcode-internal.c

### DIFF
--- a/ompi/errhandler/errcode-internal.c
+++ b/ompi/errhandler/errcode-internal.c
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ *                         reseved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -30,27 +32,27 @@ opal_pointer_array_t ompi_errcodes_intern;
 int ompi_errcode_intern_lastused=0;
 
 static ompi_errcode_intern_t ompi_success_intern;
-static ompi_errcode_intern_t ompi_error;
-static ompi_errcode_intern_t ompi_err_out_of_resource;
-static ompi_errcode_intern_t ompi_err_temp_out_of_resource;
-static ompi_errcode_intern_t ompi_err_resource_busy;
-static ompi_errcode_intern_t ompi_err_bad_param;
-static ompi_errcode_intern_t ompi_err_fatal;
-static ompi_errcode_intern_t ompi_err_not_implemented;
-static ompi_errcode_intern_t ompi_err_not_supported;
-static ompi_errcode_intern_t ompi_err_interupted;
-static ompi_errcode_intern_t ompi_err_would_block;
-static ompi_errcode_intern_t ompi_err_in_errno;
-static ompi_errcode_intern_t ompi_err_unreach;
-static ompi_errcode_intern_t ompi_err_not_found;
-static ompi_errcode_intern_t ompi_err_request;
-static ompi_errcode_intern_t ompi_err_buffer;
-static ompi_errcode_intern_t ompi_err_rma_sync;
-static ompi_errcode_intern_t ompi_err_rma_shared;
-static ompi_errcode_intern_t ompi_err_rma_attach;
-static ompi_errcode_intern_t ompi_err_rma_range;
-static ompi_errcode_intern_t ompi_err_rma_conflict;
-static ompi_errcode_intern_t ompi_err_win;
+static ompi_errcode_intern_t ompi_error_intern;
+static ompi_errcode_intern_t ompi_err_out_of_resource_intern;
+static ompi_errcode_intern_t ompi_err_temp_out_of_resource_intern;
+static ompi_errcode_intern_t ompi_err_resource_busy_intern;
+static ompi_errcode_intern_t ompi_err_bad_param_intern;
+static ompi_errcode_intern_t ompi_err_fatal_intern;
+static ompi_errcode_intern_t ompi_err_not_implemented_intern;
+static ompi_errcode_intern_t ompi_err_not_supported_intern;
+static ompi_errcode_intern_t ompi_err_interupted_intern;
+static ompi_errcode_intern_t ompi_err_would_block_intern;
+static ompi_errcode_intern_t ompi_err_in_errno_intern;
+static ompi_errcode_intern_t ompi_err_unreach_intern;
+static ompi_errcode_intern_t ompi_err_not_found_intern;
+static ompi_errcode_intern_t ompi_err_request_intern;
+static ompi_errcode_intern_t ompi_err_buffer_intern;
+static ompi_errcode_intern_t ompi_err_rma_sync_intern;
+static ompi_errcode_intern_t ompi_err_rma_shared_intern;
+static ompi_errcode_intern_t ompi_err_rma_attach_intern;
+static ompi_errcode_intern_t ompi_err_rma_range_intern;
+static ompi_errcode_intern_t ompi_err_rma_conflict_intern;
+static ompi_errcode_intern_t ompi_err_win_intern;
 
 static void ompi_errcode_intern_construct(ompi_errcode_intern_t* errcode);
 static void ompi_errcode_intern_destruct(ompi_errcode_intern_t* errcode);
@@ -78,173 +80,173 @@ int ompi_errcode_intern_init (void)
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_success_intern.index,  
                                 &ompi_success_intern);
 
-    OBJ_CONSTRUCT(&ompi_error, ompi_errcode_intern_t);
-    ompi_error.code = OMPI_ERROR;
-    ompi_error.mpi_code = MPI_ERR_OTHER;
-    ompi_error.index = pos++;
-    strncpy(ompi_error.errstring, "OMPI_ERROR", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_error.index, 
-                                &ompi_error);
+    OBJ_CONSTRUCT(&ompi_error_intern, ompi_errcode_intern_t);
+    ompi_error_intern.code = OMPI_ERROR;
+    ompi_error_intern.mpi_code = MPI_ERR_OTHER;
+    ompi_error_intern.index = pos++;
+    strncpy(ompi_error_intern.errstring, "OMPI_ERROR", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_error_intern.index,
+                                &ompi_error_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_out_of_resource, ompi_errcode_intern_t);
-    ompi_err_out_of_resource.code = OMPI_ERR_OUT_OF_RESOURCE;
-    ompi_err_out_of_resource.mpi_code = MPI_ERR_INTERN;
-    ompi_err_out_of_resource.index = pos++;
-    strncpy(ompi_err_out_of_resource.errstring, "OMPI_ERR_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_out_of_resource.index, 
-                                &ompi_err_out_of_resource);
+    OBJ_CONSTRUCT(&ompi_err_out_of_resource_intern, ompi_errcode_intern_t);
+    ompi_err_out_of_resource_intern.code = OMPI_ERR_OUT_OF_RESOURCE;
+    ompi_err_out_of_resource_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_out_of_resource_intern.index = pos++;
+    strncpy(ompi_err_out_of_resource_intern.errstring, "OMPI_ERR_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_out_of_resource_intern.index,
+                                &ompi_err_out_of_resource_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_temp_out_of_resource, ompi_errcode_intern_t);
-    ompi_err_temp_out_of_resource.code = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-    ompi_err_temp_out_of_resource.mpi_code = MPI_ERR_INTERN;
-    ompi_err_temp_out_of_resource.index = pos++;
-    strncpy(ompi_err_temp_out_of_resource.errstring, "OMPI_ERR_TEMP_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_temp_out_of_resource.index, 
-                                &ompi_err_temp_out_of_resource);
+    OBJ_CONSTRUCT(&ompi_err_temp_out_of_resource_intern, ompi_errcode_intern_t);
+    ompi_err_temp_out_of_resource_intern.code = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
+    ompi_err_temp_out_of_resource_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_temp_out_of_resource_intern.index = pos++;
+    strncpy(ompi_err_temp_out_of_resource_intern.errstring, "OMPI_ERR_TEMP_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_temp_out_of_resource_intern.index,
+                                &ompi_err_temp_out_of_resource_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_resource_busy, ompi_errcode_intern_t);
-    ompi_err_resource_busy.code = OMPI_ERR_RESOURCE_BUSY;
-    ompi_err_resource_busy.mpi_code = MPI_ERR_INTERN;
-    ompi_err_resource_busy.index = pos++;
-    strncpy(ompi_err_resource_busy.errstring, "OMPI_ERR_RESOURCE_BUSY", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_resource_busy.index, 
-                                &ompi_err_resource_busy);
+    OBJ_CONSTRUCT(&ompi_err_resource_busy_intern, ompi_errcode_intern_t);
+    ompi_err_resource_busy_intern.code = OMPI_ERR_RESOURCE_BUSY;
+    ompi_err_resource_busy_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_resource_busy_intern.index = pos++;
+    strncpy(ompi_err_resource_busy_intern.errstring, "OMPI_ERR_RESOURCE_BUSY", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_resource_busy_intern.index,
+                                &ompi_err_resource_busy_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_bad_param, ompi_errcode_intern_t);
-    ompi_err_bad_param.code = OMPI_ERR_BAD_PARAM;
-    ompi_err_bad_param.mpi_code = MPI_ERR_ARG;
-    ompi_err_bad_param.index = pos++;
-    strncpy(ompi_err_bad_param.errstring, "OMPI_ERR_BAD_PARAM", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_bad_param.index, 
-                                &ompi_err_bad_param);
+    OBJ_CONSTRUCT(&ompi_err_bad_param_intern, ompi_errcode_intern_t);
+    ompi_err_bad_param_intern.code = OMPI_ERR_BAD_PARAM;
+    ompi_err_bad_param_intern.mpi_code = MPI_ERR_ARG;
+    ompi_err_bad_param_intern.index = pos++;
+    strncpy(ompi_err_bad_param_intern.errstring, "OMPI_ERR_BAD_PARAM", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_bad_param_intern.index,
+                                &ompi_err_bad_param_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_fatal, ompi_errcode_intern_t);
-    ompi_err_fatal.code = OMPI_ERR_FATAL;
-    ompi_err_fatal.mpi_code = MPI_ERR_INTERN;
-    ompi_err_fatal.index = pos++;
-    strncpy(ompi_err_fatal.errstring, "OMPI_ERR_FATAL", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_fatal.index, 
-                                &ompi_err_fatal);
+    OBJ_CONSTRUCT(&ompi_err_fatal_intern, ompi_errcode_intern_t);
+    ompi_err_fatal_intern.code = OMPI_ERR_FATAL;
+    ompi_err_fatal_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_fatal_intern.index = pos++;
+    strncpy(ompi_err_fatal_intern.errstring, "OMPI_ERR_FATAL", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_fatal_intern.index,
+                                &ompi_err_fatal_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_not_implemented, ompi_errcode_intern_t);
-    ompi_err_not_implemented.code = OMPI_ERR_NOT_IMPLEMENTED;
-    ompi_err_not_implemented.mpi_code = MPI_ERR_INTERN;
-    ompi_err_not_implemented.index = pos++;
-    strncpy(ompi_err_not_implemented.errstring, "OMPI_ERR_NOT_IMPLEMENTED", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_implemented.index, 
-                                &ompi_err_not_implemented);
+    OBJ_CONSTRUCT(&ompi_err_not_implemented_intern, ompi_errcode_intern_t);
+    ompi_err_not_implemented_intern.code = OMPI_ERR_NOT_IMPLEMENTED;
+    ompi_err_not_implemented_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_not_implemented_intern.index = pos++;
+    strncpy(ompi_err_not_implemented_intern.errstring, "OMPI_ERR_NOT_IMPLEMENTED", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_implemented_intern.index,
+                                &ompi_err_not_implemented_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_not_supported, ompi_errcode_intern_t);
-    ompi_err_not_supported.code = OMPI_ERR_NOT_SUPPORTED;
-    ompi_err_not_supported.mpi_code = MPI_ERR_INTERN;
-    ompi_err_not_supported.index = pos++;
-    strncpy(ompi_err_not_supported.errstring, "OMPI_ERR_NOT_SUPPORTED", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_supported.index, 
-                                &ompi_err_not_supported);
+    OBJ_CONSTRUCT(&ompi_err_not_supported_intern, ompi_errcode_intern_t);
+    ompi_err_not_supported_intern.code = OMPI_ERR_NOT_SUPPORTED;
+    ompi_err_not_supported_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_not_supported_intern.index = pos++;
+    strncpy(ompi_err_not_supported_intern.errstring, "OMPI_ERR_NOT_SUPPORTED", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_supported_intern.index,
+                                &ompi_err_not_supported_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_interupted, ompi_errcode_intern_t);
-    ompi_err_interupted.code = OMPI_ERR_INTERUPTED;
-    ompi_err_interupted.mpi_code = MPI_ERR_INTERN;
-    ompi_err_interupted.index = pos++;
-    strncpy(ompi_err_interupted.errstring, "OMPI_ERR_INTERUPTED", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_interupted.index, 
-                                &ompi_err_interupted);
+    OBJ_CONSTRUCT(&ompi_err_interupted_intern, ompi_errcode_intern_t);
+    ompi_err_interupted_intern.code = OMPI_ERR_INTERUPTED;
+    ompi_err_interupted_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_interupted_intern.index = pos++;
+    strncpy(ompi_err_interupted_intern.errstring, "OMPI_ERR_INTERUPTED", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_interupted_intern.index,
+                                &ompi_err_interupted_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_would_block, ompi_errcode_intern_t);
-    ompi_err_would_block.code = OMPI_ERR_WOULD_BLOCK;
-    ompi_err_would_block.mpi_code = MPI_ERR_INTERN;
-    ompi_err_would_block.index = pos++;
-    strncpy(ompi_err_would_block.errstring, "OMPI_ERR_WOULD_BLOCK", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_would_block.index, 
-                                &ompi_err_would_block);
+    OBJ_CONSTRUCT(&ompi_err_would_block_intern, ompi_errcode_intern_t);
+    ompi_err_would_block_intern.code = OMPI_ERR_WOULD_BLOCK;
+    ompi_err_would_block_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_would_block_intern.index = pos++;
+    strncpy(ompi_err_would_block_intern.errstring, "OMPI_ERR_WOULD_BLOCK", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_would_block_intern.index,
+                                &ompi_err_would_block_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_in_errno, ompi_errcode_intern_t);
-    ompi_err_in_errno.code = OMPI_ERR_IN_ERRNO;
-    ompi_err_in_errno.mpi_code = MPI_ERR_INTERN;
-    ompi_err_in_errno.index = pos++;
-    strncpy(ompi_err_in_errno.errstring, "OMPI_ERR_IN_ERRNO", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_in_errno.index, 
-                                &ompi_err_in_errno);
+    OBJ_CONSTRUCT(&ompi_err_in_errno_intern, ompi_errcode_intern_t);
+    ompi_err_in_errno_intern.code = OMPI_ERR_IN_ERRNO;
+    ompi_err_in_errno_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_in_errno_intern.index = pos++;
+    strncpy(ompi_err_in_errno_intern.errstring, "OMPI_ERR_IN_ERRNO", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_in_errno_intern.index,
+                                &ompi_err_in_errno_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_unreach, ompi_errcode_intern_t);
-    ompi_err_unreach.code = OMPI_ERR_UNREACH;
-    ompi_err_unreach.mpi_code = MPI_ERR_INTERN;
-    ompi_err_unreach.index = pos++;
-    strncpy(ompi_err_unreach.errstring, "OMPI_ERR_UNREACH", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_unreach.index, 
-                                &ompi_err_unreach);
+    OBJ_CONSTRUCT(&ompi_err_unreach_intern, ompi_errcode_intern_t);
+    ompi_err_unreach_intern.code = OMPI_ERR_UNREACH;
+    ompi_err_unreach_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_unreach_intern.index = pos++;
+    strncpy(ompi_err_unreach_intern.errstring, "OMPI_ERR_UNREACH", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_unreach_intern.index,
+                                &ompi_err_unreach_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_not_found, ompi_errcode_intern_t);
-    ompi_err_not_found.code = OMPI_ERR_NOT_FOUND;
-    ompi_err_not_found.mpi_code = MPI_ERR_INTERN;
-    ompi_err_not_found.index = pos++;
-    strncpy(ompi_err_not_found.errstring, "OMPI_ERR_NOT_FOUND", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_found.index, 
-                                &ompi_err_not_found);
+    OBJ_CONSTRUCT(&ompi_err_not_found_intern, ompi_errcode_intern_t);
+    ompi_err_not_found_intern.code = OMPI_ERR_NOT_FOUND;
+    ompi_err_not_found_intern.mpi_code = MPI_ERR_INTERN;
+    ompi_err_not_found_intern.index = pos++;
+    strncpy(ompi_err_not_found_intern.errstring, "OMPI_ERR_NOT_FOUND", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_found_intern.index,
+                                &ompi_err_not_found_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_buffer, ompi_errcode_intern_t);
-    ompi_err_buffer.code = OMPI_ERR_BUFFER;
-    ompi_err_buffer.mpi_code = MPI_ERR_BUFFER;
-    ompi_err_buffer.index = pos++;
-    strncpy(ompi_err_buffer.errstring, "OMPI_ERR_BUFFER", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_buffer.index, 
-                                &ompi_err_buffer);
+    OBJ_CONSTRUCT(&ompi_err_buffer_intern, ompi_errcode_intern_t);
+    ompi_err_buffer_intern.code = OMPI_ERR_BUFFER;
+    ompi_err_buffer_intern.mpi_code = MPI_ERR_BUFFER;
+    ompi_err_buffer_intern.index = pos++;
+    strncpy(ompi_err_buffer_intern.errstring, "OMPI_ERR_BUFFER", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_buffer_intern.index,
+                                &ompi_err_buffer_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_request, ompi_errcode_intern_t);
-    ompi_err_request.code = OMPI_ERR_REQUEST;
-    ompi_err_request.mpi_code = MPI_ERR_REQUEST;
-    ompi_err_request.index = pos++;
-    strncpy(ompi_err_request.errstring, "OMPI_ERR_REQUEST", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_request.index, 
-                                &ompi_err_request);
+    OBJ_CONSTRUCT(&ompi_err_request_intern, ompi_errcode_intern_t);
+    ompi_err_request_intern.code = OMPI_ERR_REQUEST;
+    ompi_err_request_intern.mpi_code = MPI_ERR_REQUEST;
+    ompi_err_request_intern.index = pos++;
+    strncpy(ompi_err_request_intern.errstring, "OMPI_ERR_REQUEST", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_request_intern.index,
+                                &ompi_err_request_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_rma_sync, ompi_errcode_intern_t);
-    ompi_err_rma_sync.code = OMPI_ERR_RMA_SYNC;
-    ompi_err_rma_sync.mpi_code = MPI_ERR_RMA_SYNC;
-    ompi_err_rma_sync.index = pos++;
-    strncpy(ompi_err_rma_sync.errstring, "OMPI_ERR_RMA_SYNC", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_sync.index,
-                                &ompi_err_rma_sync);
+    OBJ_CONSTRUCT(&ompi_err_rma_sync_intern, ompi_errcode_intern_t);
+    ompi_err_rma_sync_intern.code = OMPI_ERR_RMA_SYNC;
+    ompi_err_rma_sync_intern.mpi_code = MPI_ERR_RMA_SYNC;
+    ompi_err_rma_sync_intern.index = pos++;
+    strncpy(ompi_err_rma_sync_intern.errstring, "OMPI_ERR_RMA_SYNC", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_sync_intern.index,
+                                &ompi_err_rma_sync_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_rma_shared, ompi_errcode_intern_t);
-    ompi_err_rma_shared.code = OMPI_ERR_RMA_SHARED;
-    ompi_err_rma_shared.mpi_code = MPI_ERR_RMA_SHARED;
-    ompi_err_rma_shared.index = pos++;
-    strncpy(ompi_err_rma_shared.errstring, "OMPI_ERR_RMA_SHARED", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_shared.index,
-                                &ompi_err_rma_shared);
+    OBJ_CONSTRUCT(&ompi_err_rma_shared_intern, ompi_errcode_intern_t);
+    ompi_err_rma_shared_intern.code = OMPI_ERR_RMA_SHARED;
+    ompi_err_rma_shared_intern.mpi_code = MPI_ERR_RMA_SHARED;
+    ompi_err_rma_shared_intern.index = pos++;
+    strncpy(ompi_err_rma_shared_intern.errstring, "OMPI_ERR_RMA_SHARED", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_shared_intern.index,
+                                &ompi_err_rma_shared_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_rma_attach, ompi_errcode_intern_t);
-    ompi_err_rma_attach.code = OMPI_ERR_RMA_ATTACH;
-    ompi_err_rma_attach.mpi_code = MPI_ERR_RMA_ATTACH;
-    ompi_err_rma_attach.index = pos++;
-    strncpy(ompi_err_rma_attach.errstring, "OMPI_ERR_RMA_ATTACH", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_attach.index,
-                                &ompi_err_rma_attach);
+    OBJ_CONSTRUCT(&ompi_err_rma_attach_intern, ompi_errcode_intern_t);
+    ompi_err_rma_attach_intern.code = OMPI_ERR_RMA_ATTACH;
+    ompi_err_rma_attach_intern.mpi_code = MPI_ERR_RMA_ATTACH;
+    ompi_err_rma_attach_intern.index = pos++;
+    strncpy(ompi_err_rma_attach_intern.errstring, "OMPI_ERR_RMA_ATTACH", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_attach_intern.index,
+                                &ompi_err_rma_attach_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_rma_range, ompi_errcode_intern_t);
-    ompi_err_rma_range.code = OMPI_ERR_RMA_RANGE;
-    ompi_err_rma_range.mpi_code = MPI_ERR_RMA_RANGE;
-    ompi_err_rma_range.index = pos++;
-    strncpy(ompi_err_rma_range.errstring, "OMPI_ERR_RMA_RANGE", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_range.index,
-                                &ompi_err_rma_range);
+    OBJ_CONSTRUCT(&ompi_err_rma_range_intern, ompi_errcode_intern_t);
+    ompi_err_rma_range_intern.code = OMPI_ERR_RMA_RANGE;
+    ompi_err_rma_range_intern.mpi_code = MPI_ERR_RMA_RANGE;
+    ompi_err_rma_range_intern.index = pos++;
+    strncpy(ompi_err_rma_range_intern.errstring, "OMPI_ERR_RMA_RANGE", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_range_intern.index,
+                                &ompi_err_rma_range_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_rma_conflict, ompi_errcode_intern_t);
-    ompi_err_rma_conflict.code = OMPI_ERR_RMA_CONFLICT;
-    ompi_err_rma_conflict.mpi_code = MPI_ERR_RMA_CONFLICT;
-    ompi_err_rma_conflict.index = pos++;
-    strncpy(ompi_err_rma_conflict.errstring, "OMPI_ERR_RMA_CONFLICT", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_conflict.index,
-                                &ompi_err_rma_conflict);
+    OBJ_CONSTRUCT(&ompi_err_rma_conflict_intern, ompi_errcode_intern_t);
+    ompi_err_rma_conflict_intern.code = OMPI_ERR_RMA_CONFLICT;
+    ompi_err_rma_conflict_intern.mpi_code = MPI_ERR_RMA_CONFLICT;
+    ompi_err_rma_conflict_intern.index = pos++;
+    strncpy(ompi_err_rma_conflict_intern.errstring, "OMPI_ERR_RMA_CONFLICT", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_conflict_intern.index,
+                                &ompi_err_rma_conflict_intern);
 
-    OBJ_CONSTRUCT(&ompi_err_win, ompi_errcode_intern_t);
-    ompi_err_win.code = OMPI_ERR_WIN;
-    ompi_err_win.mpi_code = MPI_ERR_WIN;
-    ompi_err_win.index = pos++;
-    strncpy(ompi_err_win.errstring, "OMPI_ERR_WIN", OMPI_MAX_ERROR_STRING);
-    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_win.index,
-                                &ompi_err_win);
+    OBJ_CONSTRUCT(&ompi_err_win_intern, ompi_errcode_intern_t);
+    ompi_err_win_intern.code = OMPI_ERR_WIN;
+    ompi_err_win_intern.mpi_code = MPI_ERR_WIN;
+    ompi_err_win_intern.index = pos++;
+    strncpy(ompi_err_win_intern.errstring, "OMPI_ERR_WIN", OMPI_MAX_ERROR_STRING);
+    opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_win_intern.index,
+                                &ompi_err_win_intern);
 
     ompi_errcode_intern_lastused=pos;
     return OMPI_SUCCESS;
@@ -254,27 +256,27 @@ int ompi_errcode_intern_finalize(void)
 {
 
     OBJ_DESTRUCT(&ompi_success_intern);
-    OBJ_DESTRUCT(&ompi_error);
-    OBJ_DESTRUCT(&ompi_err_out_of_resource);
-    OBJ_DESTRUCT(&ompi_err_temp_out_of_resource);
-    OBJ_DESTRUCT(&ompi_err_resource_busy);
-    OBJ_DESTRUCT(&ompi_err_bad_param);
-    OBJ_DESTRUCT(&ompi_err_fatal);
-    OBJ_DESTRUCT(&ompi_err_not_implemented);
-    OBJ_DESTRUCT(&ompi_err_not_supported);
-    OBJ_DESTRUCT(&ompi_err_interupted);
-    OBJ_DESTRUCT(&ompi_err_would_block);
-    OBJ_DESTRUCT(&ompi_err_in_errno);
-    OBJ_DESTRUCT(&ompi_err_unreach);
-    OBJ_DESTRUCT(&ompi_err_not_found);
-    OBJ_DESTRUCT(&ompi_err_buffer);
-    OBJ_DESTRUCT(&ompi_err_request);
-    OBJ_DESTRUCT(&ompi_err_rma_sync);
-    OBJ_DESTRUCT(&ompi_err_rma_shared);
-    OBJ_DESTRUCT(&ompi_err_rma_attach);
-    OBJ_DESTRUCT(&ompi_err_rma_range);
-    OBJ_DESTRUCT(&ompi_err_rma_conflict);
-    OBJ_DESTRUCT(&ompi_err_win);
+    OBJ_DESTRUCT(&ompi_error_intern);
+    OBJ_DESTRUCT(&ompi_err_out_of_resource_intern);
+    OBJ_DESTRUCT(&ompi_err_temp_out_of_resource_intern);
+    OBJ_DESTRUCT(&ompi_err_resource_busy_intern);
+    OBJ_DESTRUCT(&ompi_err_bad_param_intern);
+    OBJ_DESTRUCT(&ompi_err_fatal_intern);
+    OBJ_DESTRUCT(&ompi_err_not_implemented_intern);
+    OBJ_DESTRUCT(&ompi_err_not_supported_intern);
+    OBJ_DESTRUCT(&ompi_err_interupted_intern);
+    OBJ_DESTRUCT(&ompi_err_would_block_intern);
+    OBJ_DESTRUCT(&ompi_err_in_errno_intern);
+    OBJ_DESTRUCT(&ompi_err_unreach_intern);
+    OBJ_DESTRUCT(&ompi_err_not_found_intern);
+    OBJ_DESTRUCT(&ompi_err_buffer_intern);
+    OBJ_DESTRUCT(&ompi_err_request_intern);
+    OBJ_DESTRUCT(&ompi_err_rma_sync_intern);
+    OBJ_DESTRUCT(&ompi_err_rma_shared_intern);
+    OBJ_DESTRUCT(&ompi_err_rma_attach_intern);
+    OBJ_DESTRUCT(&ompi_err_rma_range_intern);
+    OBJ_DESTRUCT(&ompi_err_rma_conflict_intern);
+    OBJ_DESTRUCT(&ompi_err_win_intern);
 
     OBJ_DESTRUCT(&ompi_errcodes_intern);
     return OMPI_SUCCESS;


### PR DESCRIPTION
The renamed variables used the same identifiers as variables in
errcode.c. To avoid confusion rename the variables to end in _intern.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>