### PR TITLE
mca/base: provide functions to determine if a framework is registered/open

### DIFF
--- a/ompi/mca/topo/base/topo_base_lazy_init.c
+++ b/ompi/mca/topo/base/topo_base_lazy_init.c
@@ -35,12 +35,11 @@ int mca_topo_base_lazy_init(void)
 {
     int err;
 
-    if (0 == opal_list_get_size(&ompi_topo_base_framework.framework_components)) {
-        ompi_topo_base_framework.framework_open(MCA_BASE_OPEN_FIND_COMPONENTS);
+    if (!mca_base_framework_is_open (&ompi_topo_base_framework)) {
         /**
-         * Register all available components, giving them a chance to access the MCA parameters.
+         * Register and open all available components, giving them a chance to access the MCA parameters.
          */
-        mca_base_framework_register(&ompi_topo_base_framework, MCA_BASE_REGISTER_DEFAULT);
+        mca_base_framework_open (&ompi_topo_base_framework, MCA_BASE_REGISTER_DEFAULT);
         if (OMPI_SUCCESS !=
             (err = mca_topo_base_find_available(OPAL_ENABLE_PROGRESS_THREADS,
                                                 OMPI_ENABLE_THREAD_MULTIPLE))) {

--- a/opal/mca/base/mca_base_framework.c
+++ b/opal/mca/base/mca_base_framework.c
@@ -19,12 +19,12 @@
 #include "mca_base_var.h"
 #include "opal/mca/base/base.h"
 
-static bool framework_is_registered (struct mca_base_framework_t *framework)
+bool mca_base_framework_is_registered (struct mca_base_framework_t *framework)
 {
     return !!(framework->framework_flags & MCA_BASE_FRAMEWORK_FLAG_REGISTERED);
 }
 
-static bool framework_is_open (struct mca_base_framework_t *framework)
+bool mca_base_framework_is_open (struct mca_base_framework_t *framework)
 {
     return !!(framework->framework_flags & MCA_BASE_FRAMEWORK_FLAG_OPEN);
 }
@@ -61,7 +61,7 @@ int mca_base_framework_register (struct mca_base_framework_t *framework,
 
     framework->framework_refcnt++;
 
-    if (framework_is_registered (framework)) {
+    if (mca_base_framework_is_registered (framework)) {
         return OPAL_SUCCESS;
     }
 
@@ -143,7 +143,7 @@ int mca_base_framework_open (struct mca_base_framework_t *framework,
     }
 
     /* check if this framework is already open */
-    if (framework_is_open (framework)) {
+    if (mca_base_framework_is_open (framework)) {
         return OPAL_SUCCESS;
     }
 
@@ -180,8 +180,8 @@ int mca_base_framework_open (struct mca_base_framework_t *framework,
 }
 
 int mca_base_framework_close (struct mca_base_framework_t *framework) {
-    bool is_open = framework_is_open (framework);
-    bool is_registered = framework_is_registered (framework);
+    bool is_open = mca_base_framework_is_open (framework);
+    bool is_registered = mca_base_framework_is_registered (framework);
     int ret, group_id;
 
     assert (NULL != framework);

--- a/opal/mca/base/mca_base_framework.h
+++ b/opal/mca/base/mca_base_framework.h
@@ -195,6 +195,29 @@ OPAL_DECLSPEC int mca_base_framework_open (mca_base_framework_t *framework,
  */
 OPAL_DECLSPEC int mca_base_framework_close (mca_base_framework_t *framework);
 
+
+/**
+ * Check if a framework is already registered
+ *
+ * @param[in] framework framework to query
+ *
+ * @retval true if the framework's mca variables are registered
+ * @retval false if not
+ */
+OPAL_DECLSPEC bool mca_base_framework_is_registered (struct mca_base_framework_t *framework);
+
+
+/**
+ * Check if a framework is already open
+ *
+ * @param[in] framework framework to query
+ *
+ * @retval true if the framework is open
+ * @retval false if not
+ */
+OPAL_DECLSPEC bool mca_base_framework_is_open (struct mca_base_framework_t *framework);
+
+
 /**
  * Macro to declare an MCA framework
  *


### PR DESCRIPTION
This commit also fixes a problem with the lazy opening of topo
components. The topo framework incorrectly: 1) checked if the topo
framework was open by checking the length of the components list, and
2) called the framework open directly instead of using
mca_base_framework_open.

fixes #544

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>