### PR TITLE
display-devel-map: minor output tweak

### DIFF
--- a/orte/runtime/data_type_support/orte_dt_print_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_print_fns.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
@@ -544,7 +544,7 @@ int orte_dt_print_proc(char **output, char *prefix, orte_proc_t *src, opal_data_
                 strcpy(bind, "UNKNOWN");
             }
         }
-        asprintf(&tmp2, "%s\n%s\tState: %s\tApp_context: %ld\n%s\tLocale: %s\tBinding: %s", tmp, pfx2,
+        asprintf(&tmp2, "%s\n%s\tState: %s\tApp_context: %ld\n%s\tLocale:  %s\n\t\tBinding: %s", tmp, pfx2,
                  orte_proc_state_to_str(src->state), (long)src->app_idx, pfx2, locale, bind);
     }
 #else


### PR DESCRIPTION
hwloc output can get fairly long, especially on machines with lots of cores and/or hyperthreads.  So put the Locale and Binding output on separate lines.

Specifically, I just tweaked one line of code to make the output look like this:

```
 Data for node: ivy03	State: 3
 	Daemon: [[5246,0],1]	Daemon launched: True
 	Num slots: 1	Slots in use: 1	Oversubscribed: FALSE
 	Num slots allocated: 1	Max slots: 0
 	Num procs: 1	Next node_rank: 1
 	Data for proc: [[5246,1],0]
 		Pid: 0	Local rank: 0	Node rank: 0	App rank: 0
 		State: INITIALIZED	App_context: 0
 		Locale:  [B/././././././././.][./././././././././.]
		Binding: [B/././././././././.][./././././././././.]
```

instead of

```
 	Data for proc: [[21078,1],1]
 		Pid: 0	Local rank: 0	Node rank: 0	App rank: 1
 		State: INITIALIZED	App_context: 0
 		Locale: [B/././././././././.][./././././././././.]	Binding: [B/././././././././.][./././././././././.]
```

@rhc54 Is this ok?  If so, this PR can be merged, and this commit can be added to open-mpi/ompi-release#255