### PR TITLE
Convert csh script distscript.csh into a POSIX sh script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2012-2015 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 # 
@@ -25,7 +25,7 @@ EXTRA_DIST = README INSTALL VERSION Doxyfile LICENSE autogen.pl README.JAVA.txt
 include examples/Makefile.include
 
 dist-hook:
-	env LS_COLORS= csh "$(top_srcdir)/config/distscript.csh" "$(top_srcdir)" "$(distdir)" "$(OMPI_VERSION)" "$(OMPI_REPO_REV)"
+	env LS_COLORS= sh "$(top_srcdir)/config/distscript.sh" "$(top_srcdir)" "$(distdir)" "$(OMPI_VERSION)" "$(OMPI_REPO_REV)"
 
 # Check for common symbols.  Use a "-hook" to increase the odds that a
 # developer will see it at the end of their installation process.

--- a/config/distscript.sh
+++ b/config/distscript.sh
@@ -22,16 +22,16 @@
 # $HEADER$
 #
 
-srcdir="$1"
+srcdir=$1
 builddir=$PWD
-distdir="$builddir/$2"
-OMPI_VERSION="$3"
-OMPI_REPO_REV="$4"
+distdir=$builddir/$2
+OMPI_VERSION=$3
+OMPI_REPO_REV=$4
 
 if test x"$2" = x ; then
     echo "Must supply relative distdir as argv[2] -- aborting"
     exit 1
-elif test x"$OMPI_VERSION" = x ; then
+elif test x$OMPI_VERSION = x ; then
     echo "Must supply version as argv[1] -- aborting"
     exit 1
 fi

--- a/config/distscript.sh
+++ b/config/distscript.sh
@@ -1,4 +1,4 @@
-#! /bin/csh -f
+#!/usr/bin/env sh
 #
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
@@ -13,6 +13,8 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,30 +22,30 @@
 # $HEADER$
 #
 
-set srcdir="$1"
-set builddir="`pwd`"
-set distdir="$builddir/$2"
-set OMPI_VERSION="$3"
-set OMPI_REPO_REV="$4"
+srcdir="$1"
+builddir=$PWD
+distdir="$builddir/$2"
+OMPI_VERSION="$3"
+OMPI_REPO_REV="$4"
 
-if ("$distdir" == "") then
+if test x"$2" = x ; then
     echo "Must supply relative distdir as argv[2] -- aborting"
     exit 1
-elif ("$OMPI_VERSION" == "") then
+elif test x"$OMPI_VERSION" = x ; then
     echo "Must supply version as argv[1] -- aborting"
     exit 1
-endif
+fi
 
 # we can catch some hard (but possible) to do mistakes by looking at
 # our repo's revision, but only if we are in the source tree.
 # Otherwise, use what configure told us, at the cost of allowing one
 # or two corner cases in (but otherwise VPATH builds won't work)
-set repo_rev=$OMPI_REPO_REV
-if (-d .git) then
-    set repo_rev="`config/opal_get_version.sh VERSION --repo-rev`"
-endif
+repo_rev=$OMPI_REPO_REV
+if test -d .git ; then
+    repo_rev=$(config/opal_get_version.sh VERSION --repo-rev)
+fi
 
-set start=`date`
+start=$(date)
 cat <<EOF
 
 Creating Open MPI distribution
@@ -57,15 +59,15 @@ umask 022
 
 # Some shell startup files alias cp, mv, and rm to have "-i"
 # (interactive).  Unalias here, just so that we don't use that option.
-unalias cp
-unalias rm
-unalias mv
+unalias cp &> /dev/null
+unalias rm &> /dev/null
+unalias mv &> /dev/null
 
-if (! -d "$distdir") then
+if test ! -d "$distdir" ; then
     echo "*** ERROR: dist dir does not exist"
     echo "*** ERROR:   $distdir"
     exit 1
-endif
+fi
 
 #
 # Update VERSION:repo_rev with the best value we have.
@@ -87,15 +89,15 @@ echo "*** Now in distdir: $distdir"
 # Put the release version number in the README and INSTALL files
 #
 
-set files="README INSTALL"
+files="README INSTALL"
 echo "*** Updating version number in $files..."
-foreach file ($files)
+for file in $(echo $files) ; do
     echo " - Setting $file"
-    if (-f $file) then
+    if test -f $file ; then
 	sed -e "s/OMPI_VERSION/$OMPI_VERSION/g" $file > bar
 	mv -f bar $file
-    endif
-end
+    fi
+done
 
 #
 # All done


### PR DESCRIPTION
This commit removes the only cshell script in the Open MPI
project.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>