### PR TITLE
osc/pt2pt: fix bugs that caused incorrect fragment counting

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -171,8 +171,8 @@ struct ompi_osc_pt2pt_module_t {
        received. */
     uint64_t flush_ack_received_count;
 
-    /** True if the access epoch is a passive target access epoch */
-    bool passive_target_access_epoch;
+    /** Number of targets locked/being locked */
+    unsigned int passive_target_access_epoch;
 
     /** start sending data eagerly */
     bool active_eager_send_active;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -497,13 +497,13 @@ ompi_osc_pt2pt_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used)
 
 OBJ_CLASS_INSTANCE(ompi_osc_pt2pt_pending_t, opal_list_item_t, NULL, NULL);
 
-void ompi_osc_pt2pt_peer_construct (ompi_osc_pt2pt_peer_t *peer)
+static void ompi_osc_pt2pt_peer_construct (ompi_osc_pt2pt_peer_t *peer)
 {
     OBJ_CONSTRUCT(&peer->queued_frags, opal_list_t);
     OBJ_CONSTRUCT(&peer->lock, opal_mutex_t);
 }
 
-void ompi_osc_pt2pt_peer_destruct (ompi_osc_pt2pt_peer_t *peer)
+static void ompi_osc_pt2pt_peer_destruct (ompi_osc_pt2pt_peer_t *peer)
 {
     OBJ_DESTRUCT(&peer->queued_frags);
     OBJ_DESTRUCT(&peer->lock);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -1633,6 +1633,9 @@ static int ompi_osc_pt2pt_callback (ompi_request_t *request)
     switch (base_header->type) {
     case OMPI_OSC_PT2PT_HDR_TYPE_FRAG:
         process_frag(module, (ompi_osc_pt2pt_frag_header_t *) base_header);
+
+        /* only data fragments should be included in the completion counters */
+        mark_incoming_completion (module, (base_header->flags & OMPI_OSC_PT2PT_HDR_FLAG_PASSIVE_TARGET) ? source : MPI_PROC_NULL);
         break;
     case OMPI_OSC_PT2PT_HDR_TYPE_POST:
         (void) osc_pt2pt_incoming_post (module, source);
@@ -1654,12 +1657,6 @@ static int ompi_osc_pt2pt_callback (ompi_request_t *request)
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "finished processing incoming messages"));
-    /* post messages come unbuffered and should NOT increment the incoming completion
-     * counters */
-    if (OMPI_OSC_PT2PT_HDR_TYPE_POST != base_header->type) {
-        mark_incoming_completion (module, (base_header->flags & OMPI_OSC_PT2PT_HDR_FLAG_PASSIVE_TARGET) ?
-                                  source : MPI_PROC_NULL);
-    }
 
     osc_pt2pt_gc_clean (module);
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
@@ -107,7 +107,7 @@ static int ompi_osc_pt2pt_flush_active_frag (ompi_osc_pt2pt_module_t *module, in
     }
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: flushing active fragment to target. pending: %d", target,
+                         "osc pt2pt: flushing active fragment to target %d. pending: %d", target,
                          active_frag->pending));
 
     if (opal_atomic_cmpset (&module->peers[target].active_frag, active_frag, NULL)) {
@@ -126,12 +126,12 @@ static int ompi_osc_pt2pt_flush_active_frag (ompi_osc_pt2pt_module_t *module, in
 int ompi_osc_pt2pt_frag_flush_target (ompi_osc_pt2pt_module_t *module, int target)
 {
     ompi_osc_pt2pt_peer_t *peer = module->peers + target;
-    ompi_osc_pt2pt_frag_t *next, *frag;
+    ompi_osc_pt2pt_frag_t *frag;
     int ret = OMPI_SUCCESS;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: frag flush to target target %d. queue fragments: %u",
-                         target, opal_list_get_size (&peer->queued_frags)));
+                         "osc pt2pt: frag flush to target target %d. queue fragments: %lu",
+                         target, (unsigned long) opal_list_get_size (&peer->queued_frags)));
 
     /* walk through the pending list and send */
     OPAL_THREAD_LOCK(&peer->lock);
@@ -161,7 +161,7 @@ int ompi_osc_pt2pt_frag_flush_target (ompi_osc_pt2pt_module_t *module, int targe
 int ompi_osc_pt2pt_frag_flush_all (ompi_osc_pt2pt_module_t *module)
 {
     int ret = OMPI_SUCCESS;
-    ompi_osc_pt2pt_frag_t *frag, *next;
+    ompi_osc_pt2pt_frag_t *frag;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "osc pt2pt: frag flush all begin"));


### PR DESCRIPTION
This commit fixes a bug identified by MTT that occurred when mixing
passive and active target synchronization. The bugs fixed in this
commit are:

 - Do not update incoming fragment counts for any type of unbuffered
   control message. These messages are out-of-band and should not be
   considered towards the signal counts.

 - Complete a change from using received counts to expected counts for
   lock, unlock, and flush acks. Part of the change made it into
   master before the rest was ready. This was preventing wakeups in
   some cases.

 - Turn the passive_target_access_epoch module member into a
   counter. As long as at least one peer is locked we are in a
   passive-target epoch and not an active target one. This fix will
   ensure that fragment flags are set appropriately.

fixes #538

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>