### PR TITLE
oob ud: put call to ibv_fork_init() before *all* ibv calls

### DIFF
--- a/orte/mca/oob/ud/oob_ud_component.c
+++ b/orte/mca/oob/ud/oob_ud_component.c
@@ -6,6 +6,7 @@
  *                         and Technology (RIST). All rights reserved.
  *               2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -216,15 +217,6 @@ static inline int mca_oob_ud_device_setup (mca_oob_ud_device_t *device,
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), (void *) ib_device);
 
 
-    /* If fork support is requested, try to enable it */
-    rc = opal_common_verbs_fork_test();
-    if (OPAL_SUCCESS != rc) {
-        opal_output_verbose(5, orte_oob_base_framework.framework_output,
-                            "%s oob:ud:device_setup failed in ibv_fork_init. errno = %d",
-                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), errno);
-        return ORTE_ERROR;
-    }
-
     device->ib_context = ibv_open_device (ib_device);
     if (NULL == device->ib_context) {
         opal_output_verbose(5, orte_oob_base_framework.framework_output,
@@ -295,6 +287,15 @@ static int mca_oob_ud_component_startup(void)
     int num_devices, i, rc;
     opal_list_item_t *item, *item2;
     bool found_one = false;
+
+    /* If fork support is requested, try to enable it */
+    rc = opal_common_verbs_fork_test();
+    if (OPAL_SUCCESS != rc) {
+        opal_output_verbose(5, orte_oob_base_framework.framework_output,
+                            "%s oob:ud:device_setup failed in ibv_fork_init. errno = %d",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), errno);
+        return ORTE_ERROR;
+    }
 
     devices = ibv_get_device_list (&num_devices);
     if (NULL == devices || 0 == num_devices) {


### PR DESCRIPTION
I noticed today that the call to `ibv_fork_support()` is after the call to `ibv_get_device_list()` in the oob ud component.

Isn't this too late?

The call sequence of `ibv_get_device_list()` effectively calls `pthread_once(..., ibverbs_init)`, which ends up calling `ibv_fork_init()` if certain environment variables are set.  This means that libibvebrs, itself, thinks that `ibv_fork_init()` should be invoked even before the bulk of `ibv_get_device_list()` is invoked.

As such, this PR moves the call to `opal_common_verbs_fork_test()` to up before the call to `ibv_get_device_list()` (just curious -- why not use `opal_ibv_get_device_list()`?).  This ensures that the call to `ibv_fork_init()` is before *all* other ibv_* calls.

Please review: @miked-mellanox @hjelmn 