### PR TITLE
btl openib: only initialize CPCs if there are devices to use

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -2532,11 +2532,6 @@ btl_openib_component_init(int *num_btl_modules,
         goto no_btls;
     }
 
-    /* Init CPC components */
-    if (OPAL_SUCCESS != (ret = opal_btl_openib_connect_base_init())) {
-        goto no_btls;
-    }
-
     /* If we are using ptmalloc2 and there are no posix threads
        available, this will cause memory corruption.  Refuse to run.
        Right now, ptmalloc2 is the only memory manager that we have on
@@ -2789,6 +2784,12 @@ btl_openib_component_init(int *num_btl_modules,
                            "no active ports found", true, 
                            opal_process_info.nodename);
         }
+        goto no_btls;
+    }
+
+    /* Now that we know we have devices and ports that we want to use,
+       init CPC components */
+    if (OPAL_SUCCESS != (ret = opal_btl_openib_connect_base_init())) {
         goto no_btls;
     }
 


### PR DESCRIPTION
Defer initializing the CPCs until we know that we have devices/ports to use.  This both prevents some useless work at startup when there are no devices/ports to use, and also prevents librdmacm from complaining that there are no verbs-capable RDMA devices available (e.g., if a Cisco usNIC device is present, but does not present a verbs RDMA interface).

@hjelmn Can you please confirm that I didn't break anything?