### PR TITLE
mtl-portals4: fix datatype overflow in ompi_mtl_portals4_long_isend()

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4_recv.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv.c
@@ -392,10 +392,10 @@ ompi_mtl_portals4_irecv(struct mca_mtl_base_module_t* mtl,
     ptl_request->super.super.ompi_req->req_status.MPI_ERROR = OMPI_SUCCESS;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_mtl_base_framework.framework_output,
-                         "Recv %lu from %x,%x of length %d (0x%lx, 0x%lx, 0x%lx)\n",
+                         "Recv %lu from %x,%x of length %ld (0x%lx, 0x%lx, 0x%lx)\n",
                          ptl_request->opcount,
                          remote_proc.phys.nid, remote_proc.phys.pid, 
-                         (int)length, match_bits, ignore_bits, (unsigned long) ptl_request));
+                         (int64_t)length, match_bits, ignore_bits, (unsigned long) ptl_request));
 
     me.start = start;
     me.length = length;
@@ -473,9 +473,9 @@ ompi_mtl_portals4_imrecv(struct mca_mtl_base_module_t* mtl,
     ptl_request->super.super.ompi_req->req_status.MPI_ERROR = OMPI_SUCCESS;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_mtl_base_framework.framework_output,
-                         "Mrecv %lu of length %d (0x%lx)\n",
+                         "Mrecv %lu of length %ld (0x%lx)\n",
                          ptl_request->opcount,
-                         (int)length, (unsigned long) ptl_request));
+                         (int64_t)length, (unsigned long) ptl_request));
 
     (*message) = MPI_MESSAGE_NULL;
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -264,7 +264,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
 }
 
 static inline int
-ompi_mtl_portals4_long_isend(void *start, int length, int contextid, int tag,
+ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
                              int localrank, 
                              ptl_process_t ptl_proc,
                              ompi_mtl_portals4_isend_request_t *ptl_request)
@@ -425,11 +425,11 @@ ompi_mtl_portals4_send_start(struct mca_mtl_base_module_t* mtl,
     ptl_request->event_count = 0;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_mtl_base_framework.framework_output,
-                         "Send %lu to %x,%x of length %d\n",
+                         "Send %lu to %x,%x of length %ld\n",
                          ptl_request->opcount,
                          ptl_proc.phys.nid,
                          ptl_proc.phys.pid,
-                         (int)length));
+                         (int64_t)length));
 
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
     item = opal_free_list_get (&ompi_mtl_portals4.flowctl.pending_fl);


### PR DESCRIPTION
The length parameter of ompi_mtl_portals4_long_isend() was declared
as "int", which may not be big enough depending on the platform and
compiler options used.  This commit changes the type to size_t to
prevent overflow.

@regrant - please review
