### PR TITLE
Correct the datatype args to prevent valgrind memory corruption in MPI_Win_fence.

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -713,7 +713,7 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( int32_t* i, MPI_Aint* 
         ompi_datatype_create_indexed_block( i[0], i[1], &(i[2]), d[0], &datatype );
         {
             const int* a_i[3] = {&i[0], &i[1], &i[2]};
-            ompi_datatype_set_args( datatype, 2 * i[0], a_i, 0, NULL, 1, d, MPI_COMBINER_INDEXED_BLOCK );
+            ompi_datatype_set_args( datatype, 2 * i[0] + 1, a_i, 0, NULL, 1, d, MPI_COMBINER_INDEXED_BLOCK );
         }
         break;
         /******************************************************************/


### PR DESCRIPTION
Per Satish Balay

See http://www.open-mpi.org/community/lists/users/2015/04/26818.php

@bosilca @ggouaillardet Can you please review? This needs to go into 1.8.5 if correct
