### PR TITLE
libfabric/embedded: add missing psmx_eq.c

### DIFF
--- a/opal/mca/common/libfabric/Makefile.am
+++ b/opal/mca/common/libfabric/Makefile.am
@@ -178,6 +178,7 @@ libfabric_psm_sources = \
 	libfabric/prov/psm/src/psmx_init.c \
 	libfabric/prov/psm/src/psmx_domain.c \
 	libfabric/prov/psm/src/psmx_cq.c \
+	libfabric/prov/psm/src/psmx_eq.c \
 	libfabric/prov/psm/src/psmx_cntr.c \
 	libfabric/prov/psm/src/psmx_av.c \
 	libfabric/prov/psm/src/psmx_ep.c \


### PR DESCRIPTION
The ompi libfabric/Makefile.am to build the libmca_component_libfabric
lib was missing a recently added psmx_eq.c in the list of source
files for the psm provider.

Fixes #569

@yburette 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>