### PR TITLE
Modify the way we get the local shell for rsh/ssh launch

### DIFF
--- a/orte/mca/plm/rsh/help-plm-rsh.txt
+++ b/orte/mca/plm/rsh/help-plm-rsh.txt
@@ -60,10 +60,9 @@ will cause the system to deadlock.
 To avoid deadlock, either increase the number of concurrent daemons, or
 remove the debug-daemons flag.
 
-[unknown-user]
-The user (%d) is unknown to the system (i.e. there is no corresponding
-entry in the password file). Please contact your system administrator
-for a fix.
+[popen-failed]
+We were unable to run a command to determine the shell being used - we
+are not able to continue.
 #
 [cannot-resolve-shell-with-prefix]
 The rsh launcher has been given a prefix to use, but could not determine

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -1520,25 +1520,43 @@ static int setup_shell(orte_plm_rsh_shell_t *rshell,
     orte_plm_rsh_shell_t remote_shell, local_shell;
     char *param;
     int rc;
+    FILE *fp;
+    char path[1035];
 
     /* What is our local shell? */
     local_shell = ORTE_PLM_RSH_SHELL_UNKNOWN;
 
-#if OPAL_ENABLE_GETPWUID
-    {
-        struct passwd *p;
 
-        p = getpwuid(getuid());
-        if( NULL == p ) {
-            /* This user is unknown to the system. Therefore, there is no reason we
-             * spawn whatsoever in his name. Give up with a HUGE error message.
-             */
-            orte_show_help( "help-plm-rsh.txt", "unknown-user", true, (int)getuid() );
-            return ORTE_ERR_FATAL;
-        }
-        param = p->pw_shell;
-        local_shell = find_shell(p->pw_shell);
+    /* Open the command for reading. */
+    fp = popen("ps -hp $$|awk '{echo $5}'", "r");
+    if (fp == NULL) {
+        orte_show_help( "help-plm-rsh.txt", "unknown-user", true, (int)getuid() );
+        printf("Failed to run command\n" );
+        return ORTE_ERR_OUT_OF_RESOURCE;
     }
+
+    /* Read the output a line at a time - output it. */
+    while (fgets(path, sizeof(path)-1, fp) != NULL) {
+        printf("%s", path);
+    }
+    /* close */
+    pclose(fp);
+
+#if OPAL_ENABLE_GETPWUID
+        {
+            struct passwd *p;
+
+            p = getpwuid(getuid());
+            if( NULL == p ) {
+                /* This user is unknown to the system. Therefore, there is no reason we
+                 * spawn whatsoever in his name. Give up with a HUGE error message.
+                 */
+                orte_show_help( "help-plm-rsh.txt", "unknown-user", true, (int)getuid() );
+                return ORTE_ERR_FATAL;
+            }
+            param = p->pw_shell;
+            local_shell = find_shell(p->pw_shell);
+        }
 #endif
 
     /* If we didn't find it in getpwuid(), try looking at the $SHELL

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -1518,58 +1518,38 @@ static int setup_shell(orte_plm_rsh_shell_t *rshell,
                        char *nodename, int *argc, char ***argv)
 {
     orte_plm_rsh_shell_t remote_shell, local_shell;
-    char *param;
     int rc;
     FILE *fp;
-    char path[1035];
-
+    char path[256];
+    bool skip;
+    
     /* What is our local shell? */
     local_shell = ORTE_PLM_RSH_SHELL_UNKNOWN;
 
 
     /* Open the command for reading. */
-    fp = popen("ps -hp $$|awk '{echo $5}'", "r");
+    fp = popen("ps -p $$ | awk '{print $4}'", "r");
     if (fp == NULL) {
-        orte_show_help( "help-plm-rsh.txt", "unknown-user", true, (int)getuid() );
-        printf("Failed to run command\n" );
+        orte_show_help("help-plm-rsh.txt", "popen-failed", true);
         return ORTE_ERR_OUT_OF_RESOURCE;
     }
 
     /* Read the output a line at a time - output it. */
+    skip = true;
     while (fgets(path, sizeof(path)-1, fp) != NULL) {
-        printf("%s", path);
+        /* skip the first line - the second contains the name of the shell */
+        if (skip) {
+            skip = false;
+            continue;
+        }
+        break;
     }
     /* close */
     pclose(fp);
+    local_shell = find_shell(path);
 
-#if OPAL_ENABLE_GETPWUID
-        {
-            struct passwd *p;
-
-            p = getpwuid(getuid());
-            if( NULL == p ) {
-                /* This user is unknown to the system. Therefore, there is no reason we
-                 * spawn whatsoever in his name. Give up with a HUGE error message.
-                 */
-                orte_show_help( "help-plm-rsh.txt", "unknown-user", true, (int)getuid() );
-                return ORTE_ERR_FATAL;
-            }
-            param = p->pw_shell;
-            local_shell = find_shell(p->pw_shell);
-        }
-#endif
-
-    /* If we didn't find it in getpwuid(), try looking at the $SHELL
-       environment variable (see https://svn.open-mpi.org/trac/ompi/ticket/1060)
-    */
-    if (ORTE_PLM_RSH_SHELL_UNKNOWN == local_shell && 
-        NULL != (param = getenv("SHELL"))) {
-        local_shell = find_shell(param);
-    }
-    
     if (ORTE_PLM_RSH_SHELL_UNKNOWN == local_shell) {
-        opal_output(0, "WARNING: local probe returned unhandled shell:%s assuming bash\n",
-                    (NULL != param) ? param : "unknown");
+        opal_output(0, "WARNING: local probe returned unhandled shell:%s assuming bash\n", path);
         local_shell = ORTE_PLM_RSH_SHELL_BASH;
     }
     


### PR DESCRIPTION
Don't look in the passwd file for the default shell because the user may have changed it. Instead, detect the currently effective shell and use it.

@jsquyres Please take a gander at this - I'll squash it once we get it right