### PR TITLE
common/verbs: improve check for presence of HCAs

### DIFF
--- a/orte/mca/oob/ud/oob_ud_component.c
+++ b/orte/mca/oob/ud/oob_ud_component.c
@@ -173,15 +173,25 @@ static int mca_oob_ud_component_register (void)
 }
 
 static int  mca_oob_ud_component_available(void) {
+    int ret;
 
     opal_output_verbose(5, orte_oob_base_framework.framework_output,
                     "oob:ud: component_available called");
 
-    /* set the module event base - this is where we would spin off a separate
-     * progress thread if so desired */
-    mca_oob_ud_module.ev_base = orte_event_base;
+    /*
+     * check if we actually have HCAs on this node,
+     * if not, no way we can use ud.
+     */
+    if (opal_common_verbs_check_basics()) {
+        /* set the module event base - this is where we would spin off a separate
+         * progress thread if so desired */
+        mca_oob_ud_module.ev_base = orte_event_base;
+        ret = ORTE_SUCCESS;
+    } else {
+        ret = ORTE_ERR_NOT_AVAILABLE;
+    }
 
-    return ORTE_SUCCESS;
+    return ret;
 }
 
 static int port_mtus[] = {0, 256, 512, 1024, 2048, 4096};


### PR DESCRIPTION
Improve the check done in ```opal_common_verbs_check_basics```
to actually check if there really are HCAs under the
directory returned by ibv_get_sysfs_path()/class/infiniband.

@jsquyres - your commit to fake out ibverbs causes a melt-down in certain cases for the cray ib verbs simulation stuff and I don't want to have cray users have to specify --with-verbs=no on the config line.  I think if you're wanting to fake out ibverbs, I'm equally justified to avoid being faked out by cray ibverbs simulation layer. 

Fixes #575

Signed-off-by: Howard Pritchard <howardp@lanl.gov>