### PR TITLE
portals4: use a single Memory Descriptor to cover all of memory

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -76,12 +76,8 @@ struct mca_mtl_portals4_module_t {
     /** MD handle for sending ACKS */
     ptl_handle_md_t zero_md_h;
 
-    /** Send MD handle(s).  Use ompi_mtl_portals4_get_md() to get the right md */
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    ptl_handle_md_t *send_md_hs;
-#else
+    /** Send MD handle */
     ptl_handle_md_t send_md_h;
-#endif
 
     /** long message receive overflow ME.  Persistent ME, first in
         overflow list on the recv_idx portal table. */
@@ -211,64 +207,6 @@ extern mca_mtl_portals4_module_t ompi_mtl_portals4;
 #define MTL_PORTALS4_GET_LENGTH(hdr_data) ((size_t)(hdr_data & 0xFFFFFFFFFFFFULL))
 #define MTL_PORTALS4_IS_SYNC_MSG(hdr_data)            \
     (0 != (MTL_PORTALS4_SYNC_MSG & hdr_data))
-
-
-/*
- * Not all implementations of Portals 4 support binding a memory
- * descriptor which covers all of memory, but all support covering a
- * large fraction of memory.  Therefore, rather than working around
- * the issue by pinning per message, we use a number of memory
- * descriptors to cover all of memory.  As long as the maximum memory
- * descriptor is a large fraction of the user virtual address space
- * (like 46 bit MDs on a platform with 47 bits of user virtual address
- * space), this works fine.
- *
- * Our scheme is to create N memory descriptors which contiguously
- * cover the entire user address space, then another N-1 contiguous
- * memory descriptors offset by 1/2 the size of the MD, then a final
- * memory descriptor of 1/2 the size of the other MDs covering the top
- * of the memory space, to avoid if statements in the critical path.  This
- * scheme allows for a maximum message size of 1/2 the size of the MD
- * without ever crossing an MD boundary.  Also, because MD sizes are
- * always on a power of 2 in this scheme, computing the offsets and MD
- * selection are quick, using only bit shift and mask.q
- *
- * ompi_mtl_portals4_get_md() relies heavily on compiler constant folding.
- * "mask" can be constant folded into a constant.  "which" compiler folds 
- * into a bit shift of a register a constant number of times, then masked
- * by a constant (the input is, unfortunately, not constant).
- *
- * In the case where an MD can cover all of memory,
- * ompi_mtl_portals4_get_md() will be compiled into two assignments.
- * Assuming the function inlines (and it certainly should be), the two
- * assignments should be optimized into register assignments for the
- * Portals call relatively easily.
- */
-static inline void
-ompi_mtl_portals4_get_md(const void *ptr, ptl_handle_md_t *md_h, void **base_ptr)
-{
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    int mask = (1ULL << (OPAL_PORTALS4_MAX_VA_SIZE - OPAL_PORTALS4_MAX_MD_SIZE + 1)) - 1;
-    int which = (((uintptr_t) ptr) >> (OPAL_PORTALS4_MAX_MD_SIZE - 1)) & mask;
-    *md_h = ompi_mtl_portals4.send_md_hs[which];
-    *base_ptr = (void*) (which * (1ULL << (OPAL_PORTALS4_MAX_MD_SIZE - 1)));
-#else
-    *md_h = ompi_mtl_portals4.send_md_h;
-    *base_ptr = 0;
-#endif
-}
-
-
-static inline int
-ompi_mtl_portals4_get_num_mds(void)
-{
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    return (1 << (OPAL_PORTALS4_MAX_VA_SIZE - OPAL_PORTALS4_MAX_MD_SIZE + 1));
-#else
-    return 1;
-#endif
-}
-
 
 /* MTL interface functions */
 extern int ompi_mtl_portals4_finalize(struct mca_mtl_base_module_t *mtl);

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -225,12 +225,6 @@ ompi_mtl_portals4_component_open(void)
     ompi_mtl_portals4.recv_eq_h = PTL_INVALID_HANDLE;
     ompi_mtl_portals4.zero_md_h = PTL_INVALID_HANDLE;
 
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    ompi_mtl_portals4.send_md_hs = NULL;
-#else
-    ompi_mtl_portals4.send_md_h = PTL_INVALID_HANDLE;
-#endif
-
     ompi_mtl_portals4.long_overflow_me_h = PTL_INVALID_HANDLE;
     ompi_mtl_portals4.recv_idx = (ptl_pt_index_t) ~0UL;
     ompi_mtl_portals4.read_idx = (ptl_pt_index_t) ~0UL;
@@ -485,3 +479,4 @@ ompi_mtl_portals4_progress(void)
 
     return count;
 }
+

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -184,8 +184,6 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
     ptl_match_bits_t match_bits;
     ptl_me_t me;
     ptl_hdr_data_t hdr_data;
-    ptl_handle_md_t md_h;
-    void *base;
 
     MTL_PORTALS4_SET_SEND_BITS(match_bits, contextid, localrank, tag, 
                                MTL_PORTALS4_SHORT_MSG);
@@ -233,23 +231,20 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
                              ptl_request->opcount, hdr_data, match_bits));
     }
 
-    ompi_mtl_portals4_get_md(start, &md_h, &base);
-
     OPAL_OUTPUT_VERBOSE((50, ompi_mtl_base_framework.framework_output,
-                         "Send %lu, start: %p, base: %p, offset: %lx",
-                         ptl_request->opcount, start, base,
-                         (ptl_size_t) ((char*) start - (char*) base)));
+                         "Send %lu, start: %p",
+                         ptl_request->opcount, start));
 
-    ret = PtlPut(md_h,
-                 (ptl_size_t) ((char*) start - (char*) base),
+    ret = PtlPut(ompi_mtl_portals4.send_md_h,
+                 (ptl_size_t) start,
                  length,
-		 PTL_ACK_REQ,
-		 ptl_proc,
-		 ompi_mtl_portals4.recv_idx,
-		 match_bits,
-		 0,
+                 PTL_ACK_REQ,
+                 ptl_proc,
+                 ompi_mtl_portals4.recv_idx,
+                 match_bits,
+                 0,
                  ptl_request,
-		 hdr_data);
+                 hdr_data);
     if (OPAL_UNLIKELY(PTL_OK != ret)) {
         opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                             "%s:%d: PtlPut failed: %d",
@@ -274,8 +269,6 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
     ptl_me_t me;
     ptl_hdr_data_t hdr_data;
     ptl_size_t put_length;
-    ptl_handle_md_t md_h;
-    void *base;
 
     MTL_PORTALS4_SET_SEND_BITS(match_bits, contextid, localrank, tag, 
                                MTL_PORTALS4_LONG_MSG);
@@ -316,10 +309,8 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
     put_length = (rndv == ompi_mtl_portals4.protocol) ? 
         (ptl_size_t) ompi_mtl_portals4.eager_limit : (ptl_size_t) length;
 
-    ompi_mtl_portals4_get_md(start, &md_h, &base);
-
-    ret = PtlPut(md_h,
-                 (ptl_size_t) ((char*) start - (char*) base),
+    ret = PtlPut(ompi_mtl_portals4.send_md_h,
+                 (ptl_size_t) start,
                  put_length,
                  PTL_ACK_REQ,
                  ptl_proc,

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -76,13 +76,8 @@ struct ompi_osc_portals4_module_t {
     ptl_handle_ni_t ni_h; /* network interface used by this window */
     ptl_pt_index_t pt_idx; /* portal table index used by this window (this will be same across window) */
     ptl_handle_ct_t ct_h; /* Counting event handle used for completion in this window */
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    ptl_handle_md_t *md_h; /* memory descriptor describing all of memory used by this window */
-    ptl_handle_md_t *req_md_h; /* memory descriptor with event completion used by this window */
-#else
-    ptl_handle_md_t md_h[1]; /* memory descriptor describing all of memory used by this window */
-    ptl_handle_md_t req_md_h[1]; /* memory descriptor with event completion used by this window */
-#endif
+    ptl_handle_md_t md_h; /* memory descriptor describing all of memory used by this window */
+    ptl_handle_md_t req_md_h; /* memory descriptor with event completion used by this window */
     ptl_handle_me_t data_me_h; /* data match list entry (MB are CID | OSC_PORTALS4_MB_DATA) */
     ptl_handle_me_t control_me_h; /* match list entry for control data (node_state_t).  Match bits are (CID | OSC_PORTALS4_MB_CONTROL). */
     int64_t opcount;
@@ -118,39 +113,6 @@ get_displacement(ompi_osc_portals4_module_t *module,
         return module->disp_unit;
     }
 }
-
-
-/*
- * See note in ompi/mtl/portals4/mtl_portals4.h for how we deal with
- * platforms that don't allow us to crate an MD that covers all of
- * memory.
- */
-static inline void
-ompi_osc_portals4_get_md(const void *ptr, const ptl_handle_md_t *array,
-                         ptl_handle_md_t *md_h, void **base_ptr)
-{
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    int mask = (1ULL << (OPAL_PORTALS4_MAX_VA_SIZE - OPAL_PORTALS4_MAX_MD_SIZE + 1)) - 1;
-    int which = (((uintptr_t) ptr) >> (OPAL_PORTALS4_MAX_MD_SIZE - 1)) & mask;
-    *md_h = array[which];
-    *base_ptr = (void*) (which * (1ULL << (OPAL_PORTALS4_MAX_MD_SIZE - 1)));
-#else
-    *md_h = array[0];
-    *base_ptr = 0;
-#endif
-}
-
-
-static inline int
-ompi_osc_portals4_get_num_mds(void)
-{
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    return (1 << (OPAL_PORTALS4_MAX_VA_SIZE - OPAL_PORTALS4_MAX_MD_SIZE + 1));
-#else
-    return 1;
-#endif
-}
-
 
 
 int ompi_osc_portals4_attach(struct ompi_win_t *win, void *base, size_t len);

--- a/ompi/mca/osc/portals4/osc_portals4_active_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_active_target.c
@@ -74,8 +74,6 @@ ompi_osc_portals4_complete(struct ompi_win_t *win)
     ompi_osc_portals4_module_t *module =
         (ompi_osc_portals4_module_t*) win->w_osc_module;
     int ret, i, size;
-    ptl_handle_md_t md_h;
-    void *base;
 
     ret = ompi_osc_portals4_complete_all(module);
     if (ret != OMPI_SUCCESS) return ret;
@@ -84,13 +82,11 @@ ompi_osc_portals4_complete(struct ompi_win_t *win)
         module->state.post_count = 0;
         PtlAtomicSync();
 
-        ompi_osc_portals4_get_md(&module->one, module->md_h, &md_h, &base);
-
         size = ompi_group_size(module->start_group);
         for (i = 0 ; i < size ; ++i) {
 
-            ret = PtlAtomic(md_h,
-                            (ptl_size_t) ((char*) &module->one - (char*) base),
+            ret = PtlAtomic(module->md_h,
+                            (ptl_size_t) &module->one,
                             sizeof(module->one),
                             PTL_ACK_REQ,
                             ompi_osc_portals4_get_peer_group(module->start_group, i),
@@ -124,8 +120,6 @@ ompi_osc_portals4_post(struct ompi_group_t *group,
     ompi_osc_portals4_module_t *module =
         (ompi_osc_portals4_module_t*) win->w_osc_module;
     int ret, i, size;
-    ptl_handle_md_t md_h;
-    void *base;
 
     if (0 == (assert & MPI_MODE_NOCHECK)) {
         OBJ_RETAIN(group);
@@ -134,12 +128,10 @@ ompi_osc_portals4_post(struct ompi_group_t *group,
         module->state.complete_count = 0;
         PtlAtomicSync();
 
-        ompi_osc_portals4_get_md(&module->one, module->md_h, &md_h, &base);
-
         size = ompi_group_size(module->post_group);
         for (i = 0 ; i < size ; ++i) {
-            ret = PtlAtomic(md_h,
-                            (ptl_size_t) ((char*) &module->one - (char*) base),
+            ret = PtlAtomic(module->md_h,
+                            (ptl_size_t) &module->one,
                             sizeof(module->one),
                             PTL_ACK_REQ,
                             ompi_osc_portals4_get_peer_group(module->post_group, i),

--- a/ompi/mca/osc/portals4/osc_portals4_passive_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_passive_target.c
@@ -44,18 +44,13 @@ lk_cas64(ompi_osc_portals4_module_t *module,
 {
     int ret;
     size_t offset = offsetof(ompi_osc_portals4_node_state_t, lock);
-    ptl_handle_md_t result_md_h, write_md_h;
-    void *result_base, *write_base;
 
     (void)opal_atomic_add_64(&module->opcount, 1);
 
-    ompi_osc_portals4_get_md(result_val, module->md_h, &result_md_h, &result_base);
-    ompi_osc_portals4_get_md(&write_val, module->md_h, &write_md_h, &write_base);
-
-    ret = PtlSwap(result_md_h,
-                  (char*) result_val - (char*) result_base,
-                  write_md_h,
-                  (char*) &write_val - (char*) write_base,
+    ret = PtlSwap(module->md_h,
+                  (ptl_size_t) result_val,
+                  module->md_h,
+                  (ptl_size_t) &write_val,
                   sizeof(int64_t),
                   ompi_osc_portals4_get_peer(module, target),
                   module->pt_idx,
@@ -82,15 +77,11 @@ lk_write64(ompi_osc_portals4_module_t *module,
 {
     int ret;
     size_t offset = offsetof(ompi_osc_portals4_node_state_t, lock);
-    ptl_handle_md_t md_h;
-    void *base;
 
     (void)opal_atomic_add_64(&module->opcount, 1);
 
-    ompi_osc_portals4_get_md(&write_val, module->md_h, &md_h, &base);
-
-    ret = PtlPut(md_h,
-                 (char*) &write_val - (char*) base,
+    ret = PtlPut(module->md_h,
+                 (ptl_size_t) &write_val,
                  sizeof(int64_t),
                  PTL_ACK_REQ,
                  ompi_osc_portals4_get_peer(module, target),
@@ -116,18 +107,13 @@ lk_add64(ompi_osc_portals4_module_t *module,
 {
     int ret;
     size_t offset = offsetof(ompi_osc_portals4_node_state_t, lock);
-    ptl_handle_md_t result_md_h, write_md_h;
-    void *result_base, *write_base;
 
     (void)opal_atomic_add_64(&module->opcount, 1);
 
-    ompi_osc_portals4_get_md(result_val, module->md_h, &result_md_h, &result_base);
-    ompi_osc_portals4_get_md(&write_val, module->md_h, &write_md_h, &write_base);
-
-    ret = PtlFetchAtomic(result_md_h,
-                         (char*) result_val - (char*) result_base,
-                         write_md_h,
-                         (char*) &write_val - (char*) write_base,
+    ret = PtlFetchAtomic(module->md_h,
+                         (ptl_size_t) result_val,
+                         module->md_h,
+                         (ptl_size_t) &write_val,
                          sizeof(int64_t),
                          ompi_osc_portals4_get_peer(module, target),
                          module->pt_idx,

--- a/opal/mca/btl/portals4/btl_portals4.h
+++ b/opal/mca/btl/portals4/btl_portals4.h
@@ -120,12 +120,8 @@ struct mca_btl_portals4_module_t {
     /** MD handle for sending ACKS */
     ptl_handle_md_t zero_md_h;
 
-    /** Send MD handle(s).  Use opal_mtl_portals4_get_md() to get the right md */
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    ptl_handle_md_t *send_md_hs;
-#else
+    /** Send MD handle */
     ptl_handle_md_t send_md_h;
-#endif
 
     /** long message receive overflow ME.  Persistent ME, first in
         overflow list on the recv_idx portal table. */
@@ -176,36 +172,6 @@ typedef struct mca_btl_portals4_module_t mca_btl_portals4_module_t;
     }
 
 #define REQ_BTL_TABLE_ID	2
-
-/*
- * See note in ompi/mtl/portals4/mtl_portals4.h for how we deal with
- * platforms that don't allow us to crate an MD that covers all of
- * memory.
- */
-static inline void
-opal_btl_portals4_get_md(const void *ptr, ptl_handle_md_t *md_h, void **base_ptr, mca_btl_portals4_module_t *portals4_btl)
-{
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    int mask = (1ULL << (OPAL_PORTALS4_MAX_VA_SIZE - OPAL_PORTALS4_MAX_MD_SIZE + 1)) - 1;
-    int which = (((uintptr_t) ptr) >> (OPAL_PORTALS4_MAX_MD_SIZE - 1)) & mask;
-    *md_h = portals4_btl->send_md_hs[which];
-    *base_ptr = (void*) (which * (1ULL << (OPAL_PORTALS4_MAX_MD_SIZE - 1)));
-#else
-    *md_h = portals4_btl->send_md_h;
-    *base_ptr = 0;
-#endif
-}
-
-
-static inline int
-mca_btl_portals4_get_num_mds(void)
-{
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    return (1 << (OPAL_PORTALS4_MAX_VA_SIZE - OPAL_PORTALS4_MAX_MD_SIZE + 1));
-#else
-    return 1;
-#endif
-}
 
 int mca_btl_portals4_component_progress(void);
 void mca_btl_portals4_free_module(mca_btl_portals4_module_t *portals4_btl);

--- a/opal/mca/btl/portals4/btl_portals4_component.c
+++ b/opal/mca/btl/portals4/btl_portals4_component.c
@@ -242,11 +242,7 @@ mca_btl_portals4_component_open(void)
 
     mca_btl_portals4_module.recv_eq_h = PTL_EQ_NONE;
 
-#if OPAL_PORTALS4_MAX_MD_SIZE < OPAL_PORTALS4_MAX_VA_SIZE
-    mca_btl_portals4_module.send_md_hs = NULL;
-#else
     mca_btl_portals4_module.send_md_h = PTL_INVALID_HANDLE;
-#endif
 
     mca_btl_portals4_module.portals_ni_h = PTL_INVALID_HANDLE;
     mca_btl_portals4_module.zero_md_h = PTL_INVALID_HANDLE;


### PR DESCRIPTION
In days past, some implementations of Portals4 could not cover all
of memory with a single Memory Descriptor so multiple large
overlapping Memory Descriptors were created.  Because none of the
current implementations have this limitation (and no future
implementations should either), this commit removes the overlapping
Memory Descriptors code in the BTL, MTL and OSC components.

@regrant - please review
