### PR TITLE
mca/base: fix source file name bug for synonyms

### DIFF
--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved. 
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
@@ -251,9 +251,6 @@ int ompi_mpi_register_params(void)
     mca_base_var_register_synonym(value, "ompi", "mpi", NULL, "preconnect_all",
                                   MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    mca_base_var_register_synonym(value, "opal", "opal", NULL, "cuda_support",
-                                  MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
-
     /* Sparse group storage support */
     (void) mca_base_var_register("ompi", "mpi", NULL, "have_sparse_group_storage",
                                  "Whether this Open MPI installation supports storing of data in MPI groups in \"sparse\" formats (good for extremely large process count MPI jobs that create many communicators/groups)",
@@ -278,31 +275,22 @@ int ompi_mpi_register_params(void)
         ompi_use_sparse_group_storage = false;
     }
 
-    (void) mca_base_var_register("ompi", "mpi", NULL, "built_with_cuda_support",
-                                 "Whether CUDA GPU buffer support is built into library or not",
-                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
-                                 MCA_BASE_VAR_FLAG_DEFAULT_ONLY,
-                                 OPAL_INFO_LVL_4,
-                                 MCA_BASE_VAR_SCOPE_CONSTANT,
-                                 &opal_built_with_cuda_support);
+    value = mca_base_var_find ("opal", "opal", NULL, "cuda_support");
+    if (0 <= value) {
+        mca_base_var_register_synonym(value, "ompi", "mpi", NULL, "cuda_support",
+                                      MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    }
 
-    /* Current default is to enable CUDA support if it is built into library */
-    opal_cuda_support = opal_built_with_cuda_support;
+    value = mca_base_var_find ("opal", "opal", NULL, "built_with_cuda_support");
+    if (0 <= value) {
+        mca_base_var_register_synonym(value, "ompi", "mpi", NULL, "built_with_cuda_support", 0);
+    }
 
-    (void) mca_base_var_register("ompi", "mpi", NULL, "cuda_support",
-                                 "Whether CUDA GPU buffer support is enabled or not",
-                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                 OPAL_INFO_LVL_4,
-                                 MCA_BASE_VAR_SCOPE_READONLY,
-                                 &opal_cuda_support);
     if (opal_cuda_support && !opal_built_with_cuda_support) {
         opal_show_help("help-mpi-runtime.txt", "no cuda support",
                        true);
         ompi_rte_abort(1, NULL);
     }
-    mca_base_var_register_synonym(value, "opal", "opal", NULL, "cuda_support",
-                                  MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
-
 
     return OMPI_SUCCESS;
 }

--- a/opal/mca/base/mca_base_parse_paramfile.c
+++ b/opal/mca/base/mca_base_parse_paramfile.c
@@ -80,4 +80,5 @@ static void save_value(const char *name, const char *value)
 
     fv->mbvfv_value = value ? strdup(value) : NULL;
     fv->mbvfv_file  = file_being_read;
+    fv->mbvfv_lineno = opal_util_keyval_parse_lineno;
 }

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -131,7 +131,7 @@ static const char *info_lvl_strings[] = {
 static int fixup_files(char **file_list, char * path, bool rel_path_search, char sep);
 static int read_files (char *file_list, opal_list_t *file_values, char sep);
 static int mca_base_var_cache_files (bool rel_path_search);
-static int var_set_initial (mca_base_var_t *var);
+static int var_set_initial (mca_base_var_t *var, mca_base_var_t *original);
 static int var_get (int vari, mca_base_var_t **var_out, bool original);
 static int var_value_string (mca_base_var_t *var, char **value_string);
 
@@ -147,6 +147,21 @@ static void fv_constructor (mca_base_var_file_value_t *p);
 static void fv_destructor (mca_base_var_file_value_t *p);
 OBJ_CLASS_INSTANCE(mca_base_var_file_value_t, opal_list_item_t,
                    fv_constructor, fv_destructor);
+
+static const char *mca_base_var_source_file (const mca_base_var_t *var)
+{
+    mca_base_var_file_value_t *fv = (mca_base_var_file_value_t *) var->mbv_file_value;
+
+    if (NULL != var->mbv_source_file) {
+        return var->mbv_source_file;
+    }
+
+    if (fv) {
+        return fv->mbvfv_file;
+    }
+
+    return NULL;
+}
 
 /*
  * Generate a full name from three names
@@ -577,7 +592,7 @@ int mca_base_var_get_value (int vari, const void *value,
     }
 
     if (NULL != source_file) {
-        *source_file = var->mbv_source_file;
+        *source_file = mca_base_var_source_file (var);
     }
 
     return OPAL_SUCCESS;
@@ -794,6 +809,7 @@ int mca_base_var_set_value (int vari, const void *value, size_t size, mca_base_v
     var->mbv_source = source;
 
     if (MCA_BASE_VAR_SOURCE_FILE == source && NULL != source_file) {
+        var->mbv_file_value = NULL;
         var->mbv_source_file = append_filename_to_list(source_file);
     }
 
@@ -1051,7 +1067,7 @@ int mca_base_var_build_env(char ***env, int *num_env, bool internal)
         case MCA_BASE_VAR_SOURCE_FILE:
         case MCA_BASE_VAR_SOURCE_OVERRIDE:
             asprintf (&str, "%sSOURCE_%s=FILE:%s", mca_prefix, var->mbv_full_name,
-                      var->mbv_source_file);
+                      mca_base_var_source_file (var));
             break;
         case MCA_BASE_VAR_SOURCE_COMMAND_LINE:
             asprintf (&str, "%sSOURCE_%s=COMMAND_LINE", mca_prefix, var->mbv_full_name);
@@ -1256,29 +1272,18 @@ static int read_files(char *file_list, opal_list_t *file_values, char sep)
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
-    if (mca_base_var_file_list) {
-        count = opal_argv_count (mca_base_var_file_list);
-        ret = opal_argv_insert (&mca_base_var_file_list, count, tmp);
-        if (OPAL_SUCCESS != ret) {
-            return ret;
-        }
-
-        opal_argv_free (tmp);
-    } else {
-        mca_base_var_file_list = tmp;
-    }
-
-    count = opal_argv_count(mca_base_var_file_list);
+    count = opal_argv_count(tmp);
 
     /* Iterate through all the files passed in -- read them in reverse
        order so that we preserve unix/shell path-like semantics (i.e.,
        the entries farthest to the left get precedence) */
 
     for (i = count - 1; i >= 0; --i) {
-        mca_base_parse_paramfile(mca_base_var_file_list[i], file_values);
+        char *file_name = append_filename_to_list (tmp[i]);
+        mca_base_parse_paramfile(file_name, file_values);
     }
-    opal_argv_free(mca_base_var_file_list);
-    mca_base_var_file_list = NULL;
+
+    opal_argv_free (tmp);
 
     mca_base_internal_env_store();
 
@@ -1296,7 +1301,7 @@ static int register_variable (const char *project_name, const char *framework_na
 {
     int ret, var_index, group_index, tmp;
     mca_base_var_group_t *group;
-    mca_base_var_t *var;
+    mca_base_var_t *var, *original = NULL;
 
     /* Developer error. Storage can not be NULL and type must exist */
     assert (((flags & MCA_BASE_VAR_FLAG_SYNONYM) || NULL != storage) && type >= 0 && type < MCA_BASE_VAR_TYPE_MAX);
@@ -1490,7 +1495,7 @@ static int register_variable (const char *project_name, const char *framework_na
     var->mbv_enumerator = enumerator;
 
     if (flags & MCA_BASE_VAR_FLAG_SYNONYM) {
-        mca_base_var_t *original = opal_pointer_array_get_item (&mca_base_vars, synonym_for);
+        original = opal_pointer_array_get_item (&mca_base_vars, synonym_for);
 
         opal_value_array_append_item(&original->mbv_synonyms, &var_index);
     } else {
@@ -1505,7 +1510,7 @@ static int register_variable (const char *project_name, const char *framework_na
     /* go ahead and mark this variable as valid */
     var->mbv_flags |= MCA_BASE_VAR_FLAG_VALID;
 
-    ret = var_set_initial (var);
+    ret = var_set_initial (var, original);
     if (OPAL_SUCCESS != ret) {
         return ret;
     }
@@ -1618,7 +1623,7 @@ static int var_get_env (mca_base_var_t *var, const char *name, char **source, ch
 /*
  * Lookup a param in the environment
  */
-static int var_set_from_env (mca_base_var_t *var)
+static int var_set_from_env (mca_base_var_t *var, mca_base_var_t *original)
 {
     const char *var_full_name = var->mbv_full_name;
     const char *var_long_name = var->mbv_long_name;
@@ -1626,17 +1631,6 @@ static int var_set_from_env (mca_base_var_t *var)
     bool is_synonym = VAR_IS_SYNONYM(var[0]);
     char *source_env, *value_env;
     int ret;
-
-    if (is_synonym) {
-        ret = var_get (var->mbv_synonym_for, &var, true);
-        if (OPAL_SUCCESS != ret) {
-            return OPAL_ERROR;
-        }
-
-        if (var->mbv_source >= MCA_BASE_VAR_SOURCE_ENV) {
-            return OPAL_SUCCESS;
-        }
-    }
 
     ret = var_get_env (var, var_long_name, &source_env, &value_env);
     if (OPAL_SUCCESS != ret) {
@@ -1649,14 +1643,14 @@ static int var_set_from_env (mca_base_var_t *var)
 
     /* we found an environment variable but this variable is default-only. print
        a warning. */
-    if (VAR_IS_DEFAULT_ONLY(var[0])) {
+    if (VAR_IS_DEFAULT_ONLY(original[0])) {
         opal_show_help("help-mca-var.txt", "default-only-param-set",
                        true, var_full_name);
 
         return OPAL_ERR_NOT_FOUND;
     }
 
-    if (MCA_BASE_VAR_SOURCE_OVERRIDE == var->mbv_source) {
+    if (MCA_BASE_VAR_SOURCE_OVERRIDE == original->mbv_source) {
         if (!mca_base_var_suppress_override_warning) {
             opal_show_help("help-mca-var.txt", "overridden-param-set",
                            true, var_full_name);
@@ -1665,15 +1659,15 @@ static int var_set_from_env (mca_base_var_t *var)
         return OPAL_ERR_NOT_FOUND;
     }
 
-    var->mbv_source = MCA_BASE_VAR_SOURCE_ENV;
+    original->mbv_source = MCA_BASE_VAR_SOURCE_ENV;
 
     if (NULL != source_env) {
         if (0 == strncasecmp (source_env, "file:", 5)) {
-            var->mbv_source_file = append_filename_to_list(source_env + 5);
+            original->mbv_source_file = append_filename_to_list(source_env + 5);
             if (0 == strcmp (var->mbv_source_file, mca_base_var_override_file)) {
-                var->mbv_source = MCA_BASE_VAR_SOURCE_OVERRIDE;
+                original->mbv_source = MCA_BASE_VAR_SOURCE_OVERRIDE;
             } else {
-                var->mbv_source = MCA_BASE_VAR_SOURCE_FILE;
+                original->mbv_source = MCA_BASE_VAR_SOURCE_FILE;
             }
         } else if (0 == strcasecmp (source_env, "command")) {
             var->mbv_source = MCA_BASE_VAR_SOURCE_COMMAND_LINE;
@@ -1699,7 +1693,7 @@ static int var_set_from_env (mca_base_var_t *var)
         case MCA_BASE_VAR_SOURCE_FILE:
         case MCA_BASE_VAR_SOURCE_OVERRIDE:
             opal_show_help("help-mca-var.txt", "deprecated-mca-file",
-                           true, var_full_name, var->mbv_source_file,
+                           true, var_full_name, mca_base_var_source_file (var),
                            new_variable);
             break;
 
@@ -1711,13 +1705,13 @@ static int var_set_from_env (mca_base_var_t *var)
         }
     }
 
-    return var_set_from_string (var, value_env);
+    return var_set_from_string (original, value_env);
 }
 
 /*
  * Lookup a param in the files
  */
-static int var_set_from_file (mca_base_var_t *var, opal_list_t *file_values)
+static int var_set_from_file (mca_base_var_t *var, mca_base_var_t *original, opal_list_t *file_values)
 {
     const char *var_full_name = var->mbv_full_name;
     const char *var_long_name = var->mbv_long_name;
@@ -1725,17 +1719,6 @@ static int var_set_from_file (mca_base_var_t *var, opal_list_t *file_values)
     bool is_synonym = VAR_IS_SYNONYM(var[0]);
     mca_base_var_file_value_t *fv;
     int ret;
-
-    if (is_synonym) {
-        ret = var_get (var->mbv_synonym_for, &var, true);
-        if (OPAL_SUCCESS != ret) {
-            return OPAL_ERROR;
-        }
-
-        if (var->mbv_source >= MCA_BASE_VAR_SOURCE_FILE) {
-            return OPAL_SUCCESS;
-        }
-    }
 
     /* Scan through the list of values read in from files and try to
        find a match.  If we do, cache it on the param (for future
@@ -1755,7 +1738,7 @@ static int var_set_from_file (mca_base_var_t *var, opal_list_t *file_values)
             return OPAL_ERR_NOT_FOUND;
         }
 
-        if (MCA_BASE_VAR_FLAG_ENVIRONMENT_ONLY & var->mbv_flags) {
+        if (MCA_BASE_VAR_FLAG_ENVIRONMENT_ONLY & original->mbv_flags) {
             opal_show_help("help-mca-var.txt", "environment-only-param",
                            true, var_full_name, fv->mbvfv_value,
                            fv->mbvfv_file);
@@ -1763,7 +1746,7 @@ static int var_set_from_file (mca_base_var_t *var, opal_list_t *file_values)
             return OPAL_ERR_NOT_FOUND;
         }
 
-        if (MCA_BASE_VAR_SOURCE_OVERRIDE == var->mbv_source) {
+        if (MCA_BASE_VAR_SOURCE_OVERRIDE == original->mbv_source) {
             if (!mca_base_var_suppress_override_warning) {
                 opal_show_help("help-mca-var.txt", "overridden-param-set",
                                true, var_full_name);
@@ -1776,7 +1759,7 @@ static int var_set_from_file (mca_base_var_t *var, opal_list_t *file_values)
             const char *new_variable = "None (going away)";
 
             if (is_synonym) {
-                new_variable = var->mbv_full_name;
+                new_variable = original->mbv_full_name;
             }
 
             opal_show_help("help-mca-var.txt", "deprecated-mca-file",
@@ -1784,16 +1767,14 @@ static int var_set_from_file (mca_base_var_t *var, opal_list_t *file_values)
                            new_variable);
         }
 
-        if (NULL != fv->mbvfv_file) {
-            var->mbv_source_file = fv->mbvfv_file;
-            if (NULL == var->mbv_source_file) {
-                return OPAL_ERR_OUT_OF_RESOURCE;
-            }
+        original->mbv_file_value = (void *) fv;
+        original->mbv_source = MCA_BASE_VAR_SOURCE_FILE;
+        if (is_synonym) {
+            var->mbv_file_value = (void *) fv;
+            var->mbv_source = MCA_BASE_VAR_SOURCE_FILE;
         }
 
-        var->mbv_source = MCA_BASE_VAR_SOURCE_FILE;
-
-        return var_set_from_string (var, fv->mbvfv_value);
+        return var_set_from_string (original, fv->mbvfv_value);
     }
 
     return OPAL_ERR_NOT_FOUND;
@@ -1802,33 +1783,41 @@ static int var_set_from_file (mca_base_var_t *var, opal_list_t *file_values)
 /*
  * Lookup the initial value for a parameter
  */
-static int var_set_initial (mca_base_var_t *var)
+static int var_set_initial (mca_base_var_t *var, mca_base_var_t *original)
 {
     int ret;
 
-    var->mbv_source = MCA_BASE_VAR_SOURCE_DEFAULT;
+    if (original) {
+        /* synonym */
+        var->mbv_source = original->mbv_source;
+        var->mbv_file_value = original->mbv_file_value;
+        var->mbv_source_file = original->mbv_source_file;
+    } else {
+        var->mbv_source = MCA_BASE_VAR_SOURCE_DEFAULT;
+        original = var;
+    }
 
     /* Check all the places that the param may be hiding, in priority
        order. If the default only flag is set the user will get a
        warning if they try to set a value from the environment or a
        file. */
-    ret = var_set_from_file (var, &mca_base_var_override_values);
+    ret = var_set_from_file (var, original, &mca_base_var_override_values);
     if (OPAL_SUCCESS == ret) {
         var->mbv_flags = ~MCA_BASE_VAR_FLAG_SETTABLE & (var->mbv_flags | MCA_BASE_VAR_FLAG_OVERRIDE);
         var->mbv_source = MCA_BASE_VAR_SOURCE_OVERRIDE;
     }
 
-    ret = var_set_from_env (var);
+    ret = var_set_from_env (var, original);
     if (OPAL_ERR_NOT_FOUND != ret) {
         return ret;
     }
 
-    ret = var_set_from_file (var, &mca_base_envar_file_values);
+    ret = var_set_from_file (var, original, &mca_base_envar_file_values);
     if (OPAL_ERR_NOT_FOUND != ret) {
         return ret;
     }
 
-    ret = var_set_from_file (var, &mca_base_var_file_values);
+    ret = var_set_from_file (var, original, &mca_base_var_file_values);
     if (OPAL_ERR_NOT_FOUND != ret) {
         return ret;
     }
@@ -1916,7 +1905,15 @@ static char *source_name(mca_base_var_t *var)
     char *ret;
 
     if (MCA_BASE_VAR_SOURCE_FILE == var->mbv_source || MCA_BASE_VAR_SOURCE_OVERRIDE == var->mbv_source) {
-        int rc = asprintf(&ret, "file (%s)", var->mbv_source_file);
+        struct mca_base_var_file_value_t *fv = var->mbv_file_value;
+        int rc;
+
+        if (fv) {
+            rc = asprintf(&ret, "file (%s:%d)", fv->mbvfv_file, fv->mbvfv_lineno);
+        } else {
+            rc = asprintf(&ret, "file (%s)", var->mbv_source_file);
+        }
+
         /* some compilers will warn if the return code of asprintf is not checked (even if it is cast to void) */
         if (0 > rc) {
             return NULL;

--- a/opal/mca/base/mca_base_var.h
+++ b/opal/mca/base/mca_base_var.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  * 
@@ -279,6 +279,9 @@ struct mca_base_var_t {
 
     /** Storage for this variable */
     mca_base_var_storage_t *mbv_storage;
+
+    /** File value structure */
+    void *mbv_file_value;
 };
 /**
  * Convenience typedef.

--- a/opal/mca/base/mca_base_vari.h
+++ b/opal/mca/base/mca_base_vari.h
@@ -90,6 +90,8 @@ struct mca_base_var_file_value_t {
     char *mbvfv_value;
     /** File it came from */
     char *mbvfv_file;
+    /** Line it came from */
+    int mbvfv_lineno;
 };
 
 /**

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -198,11 +198,25 @@ int opal_register_params(void)
         return ret;
     }
 
+    ret = mca_base_var_register("opal", "opal", NULL, "built_with_cuda_support",
+                                "Whether CUDA GPU buffer support is built into library or not",
+                                MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_DEFAULT_ONLY,
+                                OPAL_INFO_LVL_4, MCA_BASE_VAR_SCOPE_CONSTANT,
+                                &opal_built_with_cuda_support);
+    if (0 > ret) {
+        return ret;
+    }
+
+    /* Current default is to enable CUDA support if it is built into library */
+    opal_cuda_support = opal_built_with_cuda_support;
     ret = mca_base_var_register ("opal", "opal", NULL, "cuda_support",
                                  "Whether CUDA GPU buffer support is enabled or not",
                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                  OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_ALL_EQ,
                                  &opal_cuda_support);
+    if (0 > ret) {
+        return ret;
+    }
 
     /* Leave pinned parameter */
     opal_leave_pinned = -1;

--- a/opal/util/keyval/keyval_lex.h
+++ b/opal/util/keyval/keyval_lex.h
@@ -42,6 +42,7 @@ extern FILE *opal_util_keyval_yyin;
 extern bool opal_util_keyval_parse_done;
 extern char *opal_util_keyval_yytext;
 extern int opal_util_keyval_yynewlines;
+extern int opal_util_keyval_yylineno;
 
 /*
  * Make lex-generated files not issue compiler warnings

--- a/opal/util/keyval/keyval_lex.l
+++ b/opal/util/keyval/keyval_lex.l
@@ -1,5 +1,6 @@
 %option nounput
 %option noinput
+%option yylineno
 
 %{ /* -*- C -*- */
 /*

--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #endif  /* HAVE_STRING_H */
 
+int opal_util_keyval_parse_lineno = 0;
+
 static const char *keyval_filename;
 static opal_keyval_parse_fn_t keyval_callback;
 static char *key_buffer = NULL;
@@ -104,6 +106,8 @@ cleanup:
 static int parse_line(void)
 {
     int val;
+
+    opal_util_keyval_parse_lineno = opal_util_keyval_yylineno;
 
     /* Save the name name */
     if (key_buffer_len < strlen(opal_util_keyval_yytext) + 1) {

--- a/opal/util/keyval_parse.h
+++ b/opal/util/keyval_parse.h
@@ -25,6 +25,8 @@
 
 BEGIN_C_DECLS
 
+extern int opal_util_keyval_parse_lineno;
+
 /**
  * Callback triggered for each key = value pair
  *


### PR DESCRIPTION
This commit fixes synonyms so the source file is correctly printed out
by ompi_info. This commit also adds support for printing out the line
number where the variable is set.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>