### PR TITLE
btl/tcp: ignore IPV6 link local addresses

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -355,6 +355,10 @@ static mca_btl_tcp_interface_t** mca_btl_tcp_retrieve_local_interfaces(void)
             if (6 == mca_btl_tcp_component.tcp_disable_family) {
                 continue;
             }
+            if (opal_net_islinklocal(&local_addr)) {
+                /* tcp/btl does not (yet) know how to handle ipv6 linklocal addresses, so skip them */
+                continue;
+            }
 
             local_interfaces[local_kindex_to_index[kindex]]->ipv6_address 
                 = (struct sockaddr_storage*) malloc(sizeof(local_addr));
@@ -561,7 +565,7 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
             }
 
             /* check state of ipv6 address pair - ipv6 is always public,
-             * since link-local addresses are skipped in opal_ifinit()
+             * since link-local addresses are skipped in mca_btl_tcp_retrieve_local_interfaces()
              */
             if(NULL != local_interfaces[i]->ipv6_address &&
                NULL != peer_interfaces[j]->ipv6_address) {

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -13,6 +13,8 @@
  *                         reserved. 
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -243,6 +245,19 @@ opal_net_islocalhost(const struct sockaddr *addr)
         return false;
         break;
     }
+}
+
+
+bool
+opal_net_islinklocal(const struct sockaddr_storage* addr)
+{
+    const struct sockaddr_sin6 *inaddr = (struct sockaddr*) addr;
+    assert(AF_INET6 == addr->ss_family);
+#if OPAL_ENABLE_IPV6
+    return IN6_IS_ADDR_LINKLOCAL (&inaddr->sin6_addr);
+#else
+    return false;
+#endif /* OPAL_ENABLE_IPV6 */
 }
 
 

--- a/opal/util/net.h
+++ b/opal/util/net.h
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
  *                         reserved. 
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -84,6 +86,18 @@ OPAL_DECLSPEC uint32_t opal_net_prefix2netmask(uint32_t prefixlen);
  *                         false otherwise.
  */
 OPAL_DECLSPEC bool opal_net_islocalhost(const struct sockaddr *addr);
+
+
+/**
+ * Determine if given address is an IPV6 local link address
+ *
+ * Determine if the given IP address is an IPV6 local link address
+ *
+ * @param addr             struct sockaddr_storage of IP address
+ * @return                 true if addr is an IPV6 local link address,
+ *                         false otherwise.
+ */
+OPAL_DECLSPEC bool opal_net_islinklocal(const struct sockaddr_storage *addr);
 
 
 /**


### PR DESCRIPTION
Refs open-mpi/ompi#585