### PR TITLE
usnic: use fi_getname in newer libfabric

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_module.h
+++ b/opal/mca/btl/usnic/btl_usnic_module.h
@@ -25,6 +25,7 @@
 #define OPAL_BTL_USNIC_MODULE_H
 
 #include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_errno.h>


### PR DESCRIPTION
When using an external libfabric (or really any libfabric newer than
libfabric commit 607e863), we must use fi_getname to determine the local
port of our endpoint.

@jsquyres please review (and propagate to other OMPI branches/instances as needed)