### PR TITLE
Handle ompi error codes in java code

### DIFF
--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -479,7 +479,7 @@ int ompi_attr_init(void)
 
     keyval_hash = OBJ_NEW(opal_hash_table_t);
     if (NULL == keyval_hash) {
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
     key_bitmap = OBJ_NEW(opal_bitmap_t);
     /*
@@ -487,7 +487,7 @@ int ompi_attr_init(void)
      */
     opal_bitmap_set_max_size (key_bitmap, OMPI_FORTRAN_HANDLE_MAX);
     if (0 != opal_bitmap_init(key_bitmap, 32)) {
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
     for (int_pos = 0; int_pos < (sizeof(void*) / sizeof(MPI_Fint)); 
@@ -540,7 +540,7 @@ static int ompi_attr_create_keyval_impl(ompi_attribute_type_t type,
     /* Allocate space for the list item */
     keyval = OBJ_NEW(ompi_attribute_keyval_t);
     if (NULL == keyval) {
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
     /* Fill in the list item (must be done before we set the keyval
@@ -667,7 +667,7 @@ int ompi_attr_set_c(ompi_attribute_type_t type, void *object,
     int ret;
     attribute_value_t *new_attr = OBJ_NEW(attribute_value_t);
     if (NULL == new_attr) {
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
     OPAL_THREAD_LOCK(&attribute_lock);
@@ -698,7 +698,7 @@ int ompi_attr_set_fortran_mpi1(ompi_attribute_type_t type, void *object,
     int ret;
     attribute_value_t *new_attr = OBJ_NEW(attribute_value_t);
     if (NULL == new_attr) {
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
     OPAL_THREAD_LOCK(&attribute_lock);
@@ -730,7 +730,7 @@ int ompi_attr_set_fortran_mpi2(ompi_attribute_type_t type, void *object,
     int ret;
     attribute_value_t *new_attr = OBJ_NEW(attribute_value_t);
     if (NULL == new_attr) {
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
     OPAL_THREAD_LOCK(&attribute_lock);
@@ -1056,7 +1056,7 @@ int ompi_attr_delete_all(ompi_attribute_type_t type, void *object,
     attrs = malloc(sizeof(attribute_value_t *) * num_attrs);
     if (NULL == attrs) {
         OPAL_THREAD_UNLOCK(&attribute_lock);
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
     ret = opal_hash_table_get_first_key_uint32(attr_hash, &key, &attr, &node);

--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -189,10 +189,10 @@ int ompi_attr_hash_init(opal_hash_table_t **hash)
     *hash = OBJ_NEW(opal_hash_table_t);
     if (NULL == *hash) {
         fprintf(stderr, "Error while creating the local attribute list\n");
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
     if (OMPI_SUCCESS != opal_hash_table_init(*hash, ATTR_HASH_SIZE)) {
-        return MPI_ERR_SYSRESOURCE;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
   
     return MPI_SUCCESS;

--- a/ompi/errhandler/errcode.h
+++ b/ompi/errhandler/errcode.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -69,10 +71,13 @@ static inline bool ompi_mpi_errcode_is_invalid(int errcode)
  */
 static inline int ompi_mpi_errcode_get_class (int errcode)
 {
-    ompi_mpi_errcode_t *err;
+    ompi_mpi_errcode_t *err = NULL;
 
-    err = (ompi_mpi_errcode_t *)opal_pointer_array_get_item(&ompi_mpi_errcodes, errcode);
-    /* If we get a bogus errcode, return MPI_ERR_UNKNOWN */
+    if (errcode >= 0) {
+        err = (ompi_mpi_errcode_t *)opal_pointer_array_get_item(&ompi_mpi_errcodes, errcode);
+        /* If we get a bogus errcode, return MPI_ERR_UNKNOWN */
+    }
+
     if (NULL != err) {
 	if ( err->code != MPI_UNDEFINED ) { 
 	    return err->cls;
@@ -92,6 +97,10 @@ static inline int ompi_mpi_errcode_is_predefined ( int errcode )
 static inline int ompi_mpi_errnum_is_class ( int errnum ) 
 {
     ompi_mpi_errcode_t *err;
+
+    if (errno < 0) {
+        return false;
+    }
 
     if ( errnum <= ompi_mpi_errcode_lastpredefined ) {
 	/* Predefined error values represent an error code and 
@@ -117,11 +126,14 @@ static inline int ompi_mpi_errnum_is_class ( int errnum )
  */
 static inline char* ompi_mpi_errnum_get_string (int errnum)
 {
-    ompi_mpi_errcode_t *err;
-    
-    err = (ompi_mpi_errcode_t *)opal_pointer_array_get_item(&ompi_mpi_errcodes, errnum);
-    /* If we get a bogus errcode, return a string indicating that this
-       truly should not happen */
+    ompi_mpi_errcode_t *err = NULL;
+
+    if (errnum >= 0) {
+        err = (ompi_mpi_errcode_t *)opal_pointer_array_get_item(&ompi_mpi_errcodes, errnum);
+        /* If we get a bogus errcode, return a string indicating that this
+           truly should not happen */
+    }
+
     if (NULL != err) {
         return err->errstring;
     } else {

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -610,9 +610,6 @@ enum {
    error codes without breaking ABI. */
 #define MPI_ERR_LASTCODE              92
 
-#define MPI_ERR_SYSRESOURCE          -2
-
-
 /*
  * Comparison results.  Don't change the order of these, the group
  * comparison functions rely on it.

--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -328,8 +328,6 @@ $constants->{MPI_ERR_RMA_SHARED} = 71;
 $constants->{MPI_T_ERR_INVALID} = 72;
 $constants->{MPI_ERR_LASTCODE} = 92;
 
-$constants->{MPI_ERR_SYSRESOURCE} = -2;
-
 $constants->{MPI_IDENT} = 0;
 $constants->{MPI_CONGRUENT} = 1;
 $constants->{MPI_SIMILAR} = 2;

--- a/ompi/mpi/java/c/mpi_Constant.c
+++ b/ompi/mpi/java/c/mpi_Constant.c
@@ -176,5 +176,4 @@ JNIEXPORT void JNICALL Java_mpi_Constant_setConstant(JNIEnv *env, jobject obj)
 
     ompi_java_setIntField(env, c, obj, "ERR_WIN",          MPI_ERR_WIN);
     ompi_java_setIntField(env, c, obj, "ERR_LASTCODE",     MPI_ERR_LASTCODE);
-    ompi_java_setIntField(env, c, obj, "ERR_SYSRESOURCE",  MPI_ERR_SYSRESOURCE);
 }

--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -531,8 +531,11 @@ static void* getBuffer(JNIEnv *env, ompi_java_buffer_t **item, int size)
         opal_free_list_item_t *freeListItem;
         freeListItem = opal_free_list_get (&ompi_java_buffers);
 
-        ompi_java_exceptionCheck(env, NULL == freeListItem ? OMPI_ERROR :
-                                 OMPI_SUCCESS);
+        ompi_java_exceptionCheck(env, NULL == freeListItem ? MPI_ERR_NO_MEM :
+                                 MPI_SUCCESS);
+        if (NULL == freeListItem) {
+            return NULL;
+        }
 
         *item = (ompi_java_buffer_t*)freeListItem;
         return (*item)->buffer;
@@ -1049,6 +1052,14 @@ void ompi_java_releasePtrArray(JNIEnv *env, jlongArray array,
 
 jboolean ompi_java_exceptionCheck(JNIEnv *env, int rc)
 {
+    if (rc < 0) {
+        /* handle ompi error code */
+        rc = ompi_errcode_get_mpi_code (rc);
+        /* ompi_mpi_errcode_get_class CAN NOT handle negative error codes.
+         * all Open MPI MPI error codes should be > 0. */
+        assert (rc >= 0);
+    }
+
     if(MPI_SUCCESS == rc)
     {
         return JNI_FALSE;


### PR DESCRIPTION
This commit also adds protection against negative error codes in ompi
error code functions. There is one outstanding issue. There is a
negative MPI error code defined in mpi.h. This will need to be fixed
separetely.

This commit fixes coverity IDs 1271533 and 1270156.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>