### PR TITLE
mca/base: fix coverity issues and enable project name in MCA groups

### DIFF
--- a/opal/mca/base/mca_base_component_repository.c
+++ b/opal/mca/base/mca_base_component_repository.c
@@ -125,6 +125,7 @@ static int process_repository_item (const char *filename, void *data)
 
     ri = OBJ_NEW(mca_base_component_repository_item_t);
     if (NULL == ri) {
+        free (base);
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
@@ -227,14 +228,14 @@ int mca_base_component_repository_init(void)
     OBJ_CONSTRUCT(&mca_base_component_repository, opal_hash_table_t);
     ret = opal_hash_table_init (&mca_base_component_repository, 128);
     if (OPAL_SUCCESS != ret) {
-        mca_base_framework_close (&opal_dl_base_framework);
+        (void) mca_base_framework_close (&opal_dl_base_framework);
         return ret;
     }
 
     ret = mca_base_component_repository_add (mca_base_component_path);
     if (OPAL_SUCCESS != ret) {
         OBJ_DESTRUCT(&mca_base_component_repository);
-        mca_base_framework_close (&opal_dl_base_framework);
+        (void) mca_base_framework_close (&opal_dl_base_framework);
         return ret;
     }
 #endif
@@ -325,6 +326,9 @@ int mca_base_component_repository_open (mca_base_framework_t *framework,
             return OPAL_ERR_BAD_PARAM;
         }
     }
+
+    /* silence coverity issue (invalid free) */
+    mitem = NULL;
 
     if (NULL != ri->ri_dlhandle) {
         opal_output_verbose(40, 0, "mca_base_component_repository_open: already loaded. returning cached component");

--- a/opal/mca/base/mca_base_components_close.c
+++ b/opal/mca/base/mca_base_components_close.c
@@ -37,8 +37,7 @@ void mca_base_component_unload (const mca_base_component_t *component, int outpu
                         "mca: base: close: unloading component %s",
                         component->mca_component_name);
 
-    /* XXX -- TODO -- Replace reserved by mca_project_name for 1.9 */
-    ret = mca_base_var_group_find (component->reserved, component->mca_type_name,
+    ret = mca_base_var_group_find (component->mca_project_name, component->mca_type_name,
                                    component->mca_component_name);
     if (0 <= ret) {
         mca_base_var_group_deregister (ret);

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -260,8 +260,8 @@ int mca_base_pvar_register (const char *project, const char *framework, const ch
 
         do {
             /* generate the variable's full name */
-            mca_base_var_generate_full_name4 (NULL, framework, component, name, &pvar->name);
-            if (NULL == pvar->name) {
+            ret = mca_base_var_generate_full_name4 (NULL, framework, component, name, &pvar->name);
+            if (OPAL_SUCCESS != ret) {
                 ret = OPAL_ERR_OUT_OF_RESOURCE;
                 break;
             }


### PR DESCRIPTION
CID 1047278 Unchecked return value

Updated check for mca_base_var_generate_full_name4 to match other
checks. Logically equivalent to the old check. Not a bug.

CID 1196685 Dereference null return

Added check for NULL when looking up the original variable for a
synonym.

CID 1269705 Logically dead code

Removed code that set the project to NULL. Code was intended to be
removed with an earlier commit that added the project name into the
component structure. Added code to actually support searching for a
group with a wildcard ('*').

CID 1292739 Dereference null return
CID 1269819 Dereference null return

Removed unnecessary string duplication and strchr.

CID 1287030 Logically dead code

Refactored fixup_files code and confirmed that the code in question is
not reachable. Removed the dead code.

CID 1292740 Use of untrusted string

Use strdup to silence coverity warning.

CID 1294413 Free of address-of expression

Reset mitem to NULL after the OPAL_LIST_FOREACH loop to ensure we
never try to free the list sentinel.

CID 1294414 Unchecked return value

Use (void) to indicate we do not care about the return code in this
instance.

CID 1294415 Resource leak

On error free all the base pointer.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>