### PR TITLE
btl/tcp: ignore IPv6 link-local addresses

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -78,6 +78,7 @@ struct mca_btl_tcp_component_t {
     unsigned short tcp6_listen_port;        /**< IPv6 listen port */
     int tcp6_port_min;                      /**< IPv4 minimum port */
     int tcp6_port_range;                    /**< IPv4 port range */
+    bool tcp6_ignore_link_local;            /**< ignore IPv6 link-local addresses */
 #endif
     /* Port range restriction */
 

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -279,6 +279,16 @@ static int mca_btl_tcp_component_register(void)
 
     mca_btl_tcp_param_register_int ("disable_family", NULL, 0, OPAL_INFO_LVL_2,  &mca_btl_tcp_component.tcp_disable_family);
 
+#if OPAL_ENABLE_IPV6
+    mca_btl_tcp_component.tcp6_ignore_link_local = true;
+    (void) mca_base_component_var_register(&mca_btl_tcp_component.super.btl_version,
+                                           "ignore_ipv6_link_local",
+                                           "ignore IPv6 link-local addresses",
+                                           MCA_BASE_VAR_TYPE_BOOL,
+                                           NULL, 0, 0, OPAL_INFO_LVL_2,
+                                           MCA_BASE_VAR_SCOPE_READONLY, &mca_btl_tcp_component.tcp6_ignore_link_local);
+#endif
+
     return mca_btl_tcp_component_verify();
 }
 

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -350,12 +350,19 @@ static mca_btl_tcp_interface_t** mca_btl_tcp_retrieve_local_interfaces(void)
                                &local_interfaces[local_kindex_to_index[kindex]]->ipv4_netmask, 
                                sizeof(int));
             break;
+#if OPAL_ENABLE_IPV6
         case AF_INET6:
             /* if AF is disabled, skip it completely */
             if (6 == mca_btl_tcp_component.tcp_disable_family) {
                 continue;
             }
-
+            if (mca_btl_tcp_component.tcp6_ignore_link_local) {
+                struct sockaddr_in6 * sin6 = (struct sockaddr_in6 *)&local_addr;
+                if (IN6_IS_ADDR_LINKLOCAL(&(sin6->sin6_addr))) {
+                    continue;
+                }
+            }
+            
             local_interfaces[local_kindex_to_index[kindex]]->ipv6_address 
                 = (struct sockaddr_storage*) malloc(sizeof(local_addr));
             memcpy(local_interfaces[local_kindex_to_index[kindex]]->ipv6_address, 
@@ -364,6 +371,7 @@ static mca_btl_tcp_interface_t** mca_btl_tcp_retrieve_local_interfaces(void)
                                &local_interfaces[local_kindex_to_index[kindex]]->ipv6_netmask, 
                                sizeof(int));
             break;
+#endif
         default:
             opal_output(0, "unknown address family for tcp: %d\n",
                         local_addr.ss_family);


### PR DESCRIPTION
add the tcp_ignore_ipv6_link_local MCA param (bool) with a 'true' default value