### PR TITLE
mpi-f: link the opal-pal.la library directly

### DIFF
--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2013 Inria.  All rights reserved.
 # Copyright (c) 2011-2013 Universite Bordeaux 1
 # Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
@@ -55,7 +55,14 @@ AM_CPPFLAGS = -DOMPI_PROFILE_LAYER=0 -DOMPI_COMPILING_FORTRAN_WRAPPERS=1
 
 lib_LTLIBRARIES =
 CLEANFILES =
-libmpi_mpifh_la_LIBADD = $(top_builddir)/ompi/libmpi.la $(OMPI_MPIEXT_MPIFH_LIBS)
+# Note that we invoke some OPAL functions directly in libmpi_mpifh.la,
+# so we need to link in the OPAL library directly (pulling it in
+# indirectly via libmpi.la does not work on all platforms).
+libmpi_mpifh_la_LIBADD = \
+        $(top_builddir)/ompi/libmpi.la \
+        $(OMPI_MPIEXT_MPIFH_LIBS) \
+        $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
+
 libmpi_mpifh_la_LDFLAGS = -version-info $(libmpi_mpifh_so_version)
 
 # Are we building the mpif.h bindings at all?


### PR DESCRIPTION
libmpi_mpifh.la makes some direct calls to libopen-pal.la.  In many (most?) cases, having libmpi_mpifh link against libmpi is sufficient (because libmpi pulls in libopen-pal).  But when building RPMs on SLES, some compiler/linker flags are used that seem to make this implicit linking not sufficient -- we get missing opal symbols when creating libmpi_mpifh.la.  So link in open-pal directly (vs. indirectly), which solves the problem.

@rhc54 This is not worth holding up v1.8.6.  I'm just putting that milestone on it because it's the next logical release.

@miked-mellanox Please review.

@miked-mellanox Also, I'd like to see the full output of "make V=1" from your rpmbuild without this PR (you'll need to insert that "V=1" in the "make all" of the rpm build somehow).  I'd like to see what gcc/linker flags are being used that is triggering this kind of behavior.  Can you send that output?