### PR TITLE
btl/openib: more coverity fixes

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -1544,8 +1544,8 @@ static uint64_t calculate_max_reg (const char *device_name)
 
     } else if (!strncmp(device_name, "mlx4", 4)) {
         if (0 == stat("/sys/module/mlx4_core/parameters/log_num_mtt", &statinfo)) {
-            mtts_per_seg = 1 << read_module_param("/sys/module/mlx4_core/parameters/log_mtts_per_seg", 1, 63);
-            num_mtt = 1 << read_module_param("/sys/module/mlx4_core/parameters/log_mtts_per_seg", 1, 63);
+            mtts_per_seg = 1ull << read_module_param("/sys/module/mlx4_core/parameters/log_mtts_per_seg", 1, 63);
+            num_mtt = 1ull << read_module_param("/sys/module/mlx4_core/parameters/log_mtts_per_seg", 1, 63);
             if (1 == num_mtt) {
                 /* NTH: is 19 a minimum? when log_num_mtt is set to 0 use 19 */
                 num_mtt = 1 << 19;
@@ -1557,7 +1557,7 @@ static uint64_t calculate_max_reg (const char *device_name)
 
     } else if (!strncmp(device_name, "mthca", 5)) {
         if (0 == stat("/sys/module/ib_mthca/parameters/num_mtt", &statinfo)) {
-            mtts_per_seg = 1 << read_module_param("/sys/module/ib_mthca/parameters/log_mtts_per_seg", 1, 63);
+            mtts_per_seg = 1ull << read_module_param("/sys/module/ib_mthca/parameters/log_mtts_per_seg", 1, 63);
             num_mtt = read_module_param("/sys/module/ib_mthca/parameters/num_mtt", 1 << 20, (uint64_t) -1);
             reserved_mtt = read_module_param("/sys/module/ib_mthca/parameters/fmr_reserved_mtts", 0, (uint64_t) -1);
 
@@ -3544,7 +3544,7 @@ static void handle_wc(mca_btl_openib_device_t* device, const uint32_t cq,
     return;
 
 error:
-    if(endpoint && endpoint->endpoint_proc && endpoint->endpoint_proc->proc_opal)
+    if(endpoint->endpoint_proc && endpoint->endpoint_proc->proc_opal)
         remote_proc = endpoint->endpoint_proc->proc_opal;
 
     /* For iWARP, the TCP connection is tied to the QP once the QP is

--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2007-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
- * Copyright (c) 2011-2014 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2011-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -1804,11 +1804,11 @@ static int udcm_handle_connect(mca_btl_openib_endpoint_t *lcl_ep,
     udcm_endpoint_t *udep = UDCM_ENDPOINT_DATA(lcl_ep);
     int rc = OPAL_ERROR;
 
-    do {
-        if (NULL == udep) {
-            break;
-        }
+    if (NULL == udep) {
+        return OPAL_ERROR;
+    }
 
+    do {
         opal_mutex_lock (&udep->udep_lock);
 
         if (true == udep->recv_req) {


### PR DESCRIPTION
CID 1301390 Dereference before null check (REVERSE_INULL)

endpoint can not be NULL here. Remove NULL check.

CID 1269836 Unintentional integer overflow (OVERFLOW_BEFORE_WIDEN)
CID 1301388 Bad bit shift operation (BAD_SHIFT)

Add ull to integer constants to ensure the math is done in 64-bits not
32.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>