### PR TITLE
event/libevent2022: fix coverity issue

### DIFF
--- a/opal/mca/crs/none/crs_none_module.c
+++ b/opal/mca/crs/none/crs_none_module.c
@@ -1,8 +1,11 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2010 The Trustees of Indiana University.
  *                         All rights reserved.
  *
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -101,8 +104,7 @@ int opal_crs_none_restart(opal_crs_base_snapshot_t *base_snapshot, bool spawn_ch
             opal_output(0,
                         "crs:none: checkpoint(): Error: Unable to open the file (%s)",
                         base_snapshot->metadata_filename);
-            exit_status = OPAL_ERROR;
-            goto cleanup;
+            return OPAL_ERROR;
         }
     }
 
@@ -131,10 +133,9 @@ int opal_crs_none_restart(opal_crs_base_snapshot_t *base_snapshot, bool spawn_ch
     if( !spawn_child ) {
         opal_output_verbose(10, opal_crs_base_framework.framework_output,
                             "crs:none: none_restart: exec :(%s, %s):",
-                            strdup(cr_argv[0]),
-                            opal_argv_join(cr_argv, ' '));
+                            cr_argv[0], tmp_argv[0]);
 
-        status = execvp(strdup(cr_argv[0]), cr_argv);
+        status = execvp(cr_argv[0], cr_argv);
 
         if(status < 0) {
             opal_output(opal_crs_base_framework.framework_output,
@@ -152,10 +153,11 @@ int opal_crs_none_restart(opal_crs_base_snapshot_t *base_snapshot, bool spawn_ch
     }
 
  cleanup:
-    if (NULL != base_snapshot->metadata) {
-        fclose(base_snapshot->metadata);
+    if (cr_argv) {
+        opal_argv_free (cr_argv);
     }
-    base_snapshot->metadata = NULL;
+
+    fclose(base_snapshot->metadata);
     
     return exit_status;
 }

--- a/opal/mca/event/libevent2022/libevent2022_component.c
+++ b/opal/mca/event/libevent2022/libevent2022_component.c
@@ -125,7 +125,7 @@ static int libevent2022_register (void)
     const struct eventop** _eventop = eventops;
     char available_eventops[1024] = "none";
     char *help_msg = NULL;
-    int ret, len = 1024;
+    int ret;
 
     /* Retrieve the upper level specified event system, if any.
      * Default to select() on OS X and poll() everywhere else because
@@ -153,17 +153,15 @@ static int libevent2022_register (void)
      */
 
     if (NULL != (*_eventop)) {
-        available_eventops[0] = '\0';
-    }
+        const int len = sizeof (available_eventops);
+        int cur_len = snprintf (available_eventops, len, "%s", (*(_eventop++))->name);
 
-    while( NULL != (*_eventop) ) {
-        if( available_eventops[0] != '\0' ) {
-            (void) strncat (available_eventops, ", ", len);
+        for (int i = 1 ; eventops[i] && cur_len < len ; ++i) {
+            cur_len += snprintf (available_eventops + cur_len, len - cur_len, ", %s",
+                                 eventops[i]->name);
         }
-        (void) strncat (available_eventops, (*_eventop)->name,
-                        len);
-        _eventop++;  /* go to the next available eventop */
-        len = 1024 - strlen(available_eventops);
+        /* ensure the available_eventops string is always NULL-terminated  */
+        available_eventops[len - 1] = '\0';
     }
 
 #ifdef __APPLE__


### PR DESCRIPTION
CID 1269841 Out-of-bounds access (OVERRUN)

Correct issue. If the string being concatingated fills the remaining
buffer then a \0 is written past the end of the string. In practice
this should never happen but it should be fixed. I re-organized the
code a bit to clear this error.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>