### PR TITLE
odls/alps: fix busted build for cray.

### DIFF
--- a/orte/mca/odls/alps/odls_alps_module.c
+++ b/orte/mca/odls/alps/odls_alps_module.c
@@ -752,11 +752,6 @@ int orte_odls_alps_launch_local_procs(opal_buffer_t *data)
     /* launch the local procs */
     ORTE_ACTIVATE_LOCAL_LAUNCH(job, odls_alps_fork_local_proc);
     
-    opal_dstore_attr_t *attr;
-    attr = pmix_server_create_shared_segment(job);
-    if (NULL != attr) {
-        opal_setenv("PMIX_SEG_INFO", attr->connection_info, true, &orte_launch_environ);
-    }
     return ORTE_SUCCESS;
 }
 


### PR DESCRIPTION
This commit fixes things broken by commit
ea35e47.

Fixes #616

For some reason this commit wasn't picked up in previous PR #616.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>