### PR TITLE
Prevent GCC optimization on shared variables

### DIFF
--- a/opal/mca/memory/linux/memory_linux.h
+++ b/opal/mca/memory/linux/memory_linux.h
@@ -33,11 +33,11 @@ typedef struct opal_memory_linux_component_t {
 
 #if MEMORY_LINUX_PTMALLOC2
     /* Ptmalloc2-specific data */
-    bool free_invoked;
-    bool malloc_invoked;
-    bool realloc_invoked;
-    bool memalign_invoked;
-    bool munmap_invoked;
+    volatile bool free_invoked;
+    volatile bool malloc_invoked;
+    volatile bool realloc_invoked;
+    volatile bool memalign_invoked;
+    volatile bool munmap_invoked;
 #endif
 } opal_memory_linux_component_t;
 


### PR DESCRIPTION
The *_invoked variables are used in different code paths the compiler does not know about.
For detailed description see users mailing list “Bug: Disabled mpi_leave_pinned for GPUDirect and InfiniBand during run-time caused by GCC optimizations” http://www.open-mpi.org/community/lists/users/2015/06/27039.php.