### PR TITLE
Initialize convertor in pml-cm-send/recv

### DIFF
--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -148,6 +148,7 @@ mca_pml_cm_recv(void *addr,
     mca_mtl_request_t *req_mtl =
             alloca(sizeof(mca_mtl_request_t) + ompi_mtl->mtl_request_size);
 
+    OBJ_CONSTRUCT(&convertor, opal_convertor_t);
     req_mtl->ompi_req = &req.req_ompi;
     req_mtl->completion_callback = mca_pml_cm_recv_fast_completion;
 
@@ -191,6 +192,7 @@ mca_pml_cm_recv(void *addr,
                               &convertor,
                               req_mtl));
     if( OPAL_UNLIKELY(OMPI_SUCCESS != ret) ) {
+	OBJ_DESTRUCT(&convertor);
         return ret;
     }
 
@@ -200,7 +202,7 @@ mca_pml_cm_recv(void *addr,
         *status = req.req_ompi.req_status;
     }
     ret = req.req_ompi.req_status.MPI_ERROR;
-
+    OBJ_DESTRUCT(&convertor);
     return ret;
 }
 
@@ -339,7 +341,7 @@ mca_pml_cm_send(void *buf,
         ompi_request_free( (ompi_request_t**)&sendreq );
     } else { 
         opal_convertor_t convertor;
-
+	OBJ_CONSTRUCT(&convertor, opal_convertor_t);
 #if !(OPAL_ENABLE_HETEROGENEOUS_SUPPORT)
 	if (opal_datatype_is_contiguous_memory_layout(&datatype->super, count)) {
 		
@@ -367,6 +369,7 @@ mca_pml_cm_send(void *buf,
                                  tag,  
                                  &convertor,
                                  sendmode));
+	OBJ_DESTRUCT(&convertor);
     }
     
     return ret;


### PR DESCRIPTION
Initialize convertor in pml-cm-send/recv
 - Fix assertion error in MPI_Allreduce_loc test.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>