### PR TITLE
Enable by default the _sync version of atomic operations on OS X.

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -2,7 +2,7 @@ dnl
 dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 dnl                         University Research and Technology
 dnl                         Corporation.  All rights reserved.
-dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl Copyright (c) 2004-2015 The University of Tennessee and The University
 dnl                         of Tennessee Research Foundation.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -864,16 +864,26 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
 
     AC_ARG_ENABLE([builtin-atomics],
       [AC_HELP_STRING([--enable-builtin-atomics],
-         [Enable use of __sync builtin atomics (default: disabled)])])
-
+         [Enable use of __sync builtin atomics (default: enabled)])]
+         [], [enable_builtin_atomics="yes"])
     AC_ARG_ENABLE([osx-builtin-atomics],
       [AC_HELP_STRING([--enable-osx-builtin-atomics],
-         [Enable use of OSX builtin atomics (default: disabled)])])
+         [Enable use of OSX builtin atomics (default: enabled)])],
+         [], [enable_osx_builtin_atomics="yes"])
 
-    if test "$enable_builtin_atomics" = "yes" ; then
-       OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"],
-         [AC_MSG_ERROR([__sync builtin atomics requested but not found.])])
-       AC_DEFINE([OPAL_C_GCC_INLINE_ASSEMBLY], [1],
+    opal_cv_asm_builtin="BUILTIN_NO"
+    if test "$enable_osx_builtin_atomics" = "yes" ; then
+       AC_MSG_CHECKING([for OSX atomic support])
+       AC_CHECK_HEADER([libkern/OSAtomic.h],
+                       [opal_cv_asm_builtin="BUILTIN_OSX"
+                        AC_MSG_RESULT([yes])],
+                       [AC_MSG_RESULT([no])])
+    fi
+    if test "$opal_cv_asm_builtin" = "BUILTIN_NO" -a "$enable_builtin_atomics" = "yes" ; then
+       AC_MSG_CHECKING([for builtin atomic support])
+       OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"
+                                 AC_MSG_RESULT([yes])],
+                                [AC_MSG_RESULT([no])])AC_DEFINE([OPAL_C_GCC_INLINE_ASSEMBLY], [1],
          [Whether C compiler supports GCC style inline assembly])
        OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
     elif test "$enable_osx_builtin_atomics" = "yes" ; then

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -864,7 +864,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
 
     AC_ARG_ENABLE([builtin-atomics],
       [AC_HELP_STRING([--enable-builtin-atomics],
-         [Enable use of __sync builtin atomics (default: enabled)])]
+         [Enable use of __sync builtin atomics (default: enabled)])],
          [], [enable_builtin_atomics="yes"])
     AC_ARG_ENABLE([osx-builtin-atomics],
       [AC_HELP_STRING([--enable-osx-builtin-atomics],
@@ -873,20 +873,12 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
 
     opal_cv_asm_builtin="BUILTIN_NO"
     if test "$opal_cv_asm_builtin" = "BUILTIN_NO" -a "$enable_builtin_atomics" = "yes" ; then
-       AC_MSG_CHECKING([for builtin atomic support])
-       OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"
-                                 AC_MSG_RESULT([yes])],
-                                [AC_MSG_RESULT([no])])
-       AC_DEFINE([OPAL_C_GCC_INLINE_ASSEMBLY], [1],
-                 [Whether C compiler supports GCC style inline assembly])
+       OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"], [])
        OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
     fi
     if test "$opal_cv_asm_builtin" = "BUILTIN_NO" -a "$enable_osx_builtin_atomics" = "yes" ; then
-       AC_MSG_CHECKING([for OSX atomic support])
        AC_CHECK_HEADER([libkern/OSAtomic.h],
-                       [opal_cv_asm_builtin="BUILTIN_OSX"
-                        AC_MSG_RESULT([yes])],
-                       [AC_MSG_RESULT([no])])
+                       [opal_cv_asm_builtin="BUILTIN_OSX"])
     else
        opal_cv_asm_builtin="BUILTIN_NO"
     fi

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -872,23 +872,21 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
          [], [enable_osx_builtin_atomics="yes"])
 
     opal_cv_asm_builtin="BUILTIN_NO"
-    if test "$enable_osx_builtin_atomics" = "yes" ; then
+    if test "$opal_cv_asm_builtin" = "BUILTIN_NO" -a "$enable_builtin_atomics" = "yes" ; then
+       AC_MSG_CHECKING([for builtin atomic support])
+       OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"
+                                 AC_MSG_RESULT([yes])],
+                                [AC_MSG_RESULT([no])])
+       AC_DEFINE([OPAL_C_GCC_INLINE_ASSEMBLY], [1],
+                 [Whether C compiler supports GCC style inline assembly])
+       OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
+    fi
+    if test "$opal_cv_asm_builtin" = "BUILTIN_NO" -a "$enable_osx_builtin_atomics" = "yes" ; then
        AC_MSG_CHECKING([for OSX atomic support])
        AC_CHECK_HEADER([libkern/OSAtomic.h],
                        [opal_cv_asm_builtin="BUILTIN_OSX"
                         AC_MSG_RESULT([yes])],
                        [AC_MSG_RESULT([no])])
-    fi
-    if test "$opal_cv_asm_builtin" = "BUILTIN_NO" -a "$enable_builtin_atomics" = "yes" ; then
-       AC_MSG_CHECKING([for builtin atomic support])
-       OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"
-                                 AC_MSG_RESULT([yes])],
-                                [AC_MSG_RESULT([no])])AC_DEFINE([OPAL_C_GCC_INLINE_ASSEMBLY], [1],
-         [Whether C compiler supports GCC style inline assembly])
-       OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
-    elif test "$enable_osx_builtin_atomics" = "yes" ; then
-	   AC_CHECK_HEADER([libkern/OSAtomic.h],[opal_cv_asm_builtin="BUILTIN_OSX"],
-	    [AC_MSG_ERROR([OSX builtin atomics requested but not found.])])
     else
        opal_cv_asm_builtin="BUILTIN_NO"
     fi


### PR DESCRIPTION
As most compilers gain support for builtin atomics I propose to switch the default Open MPI behavior with regard to atomics. Instead of relying on our own atomics, we should leverage what the compiler, or the OS, is supporting. This patch change the default behavior for builds on OSX or with a compiler supporting gcc-type atomic builtins.

This is a replacement for the now defunct #288.

@goodell and @hjelmn please review.