### PR TITLE
pml-cm bug fixes

### DIFF
--- a/ompi/mca/mtl/base/mtl_base_datatype.h
+++ b/ompi/mca/mtl/base/mtl_base_datatype.h
@@ -40,6 +40,7 @@ ompi_mtl_datatype_pack(struct opal_convertor_t *convertor,
 
 #if !(OPAL_ENABLE_HETEROGENEOUS_SUPPORT)
     if (convertor->pDesc && 
+	!(convertor->flags & CONVERTOR_COMPLETED) &&
 	opal_datatype_is_contiguous_memory_layout(convertor->pDesc,
 						  convertor->count)) {
 	    *freeAfter = false;

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -116,6 +116,66 @@ do {                                                                    \
 #endif
 
 #if (OPAL_ENABLE_HETEROGENEOUS_SUPPORT)
+#define MCA_PML_CM_HVY_SEND_REQUEST_INIT_COMMON(req_send,               \
+                                            ompi_proc,                  \
+                                            comm,                       \
+                                            tag,                        \
+                                            datatype,                   \
+                                            sendmode,                   \
+                                            buf,                        \
+                                            count)                      \
+{                                                                       \
+    OBJ_RETAIN(comm);                                                   \
+    OBJ_RETAIN(datatype);                                               \
+    (req_send)->req_base.req_comm = comm;                               \
+    (req_send)->req_base.req_datatype = datatype;                       \
+    opal_convertor_copy_and_prepare_for_send(                           \
+                                             ompi_proc->super.proc_convertor, \
+                                             &(datatype->super),        \
+                                             count,                     \
+                                             buf,                       \
+                                             0,                         \
+                                             &(req_send)->req_base.req_convertor ); \
+    (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
+    (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =               \
+        comm->c_my_rank;                                                \
+    (req_send)->req_base.req_ompi.req_status.MPI_TAG = tag;             \
+    (req_send)->req_base.req_ompi.req_status._ucount = count;           \
+    (req_send)->req_send_mode = sendmode;                               \
+    (req_send)->req_base.req_free_called = false;                       \
+}
+#else
+#define MCA_PML_CM_HVY_SEND_REQUEST_INIT_COMMON(req_send,               \
+                                            ompi_proc,                  \
+                                            comm,                       \
+                                            tag,                        \
+                                            datatype,                   \
+                                            sendmode,                   \
+                                            buf,                        \
+                                            count)                      \
+{                                                                       \
+    OBJ_RETAIN(comm);                                                   \
+    OBJ_RETAIN(datatype);                                               \
+    (req_send)->req_base.req_comm = comm;                               \
+    (req_send)->req_base.req_datatype = datatype;                       \
+    opal_convertor_copy_and_prepare_for_send(                           \
+        ompi_mpi_local_convertor,                                       \
+        &(datatype->super),                                             \
+        count,                                                          \
+        buf,                                                            \
+        0,                                                              \
+        &(req_send)->req_base.req_convertor );                          \
+    (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
+    (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =               \
+        comm->c_my_rank;                                                \
+    (req_send)->req_base.req_ompi.req_status.MPI_TAG = tag;             \
+    (req_send)->req_base.req_ompi.req_status._ucount = count;           \
+    (req_send)->req_send_mode = sendmode;                               \
+    (req_send)->req_base.req_free_called = false;                       \
+}
+#endif
+
+#if (OPAL_ENABLE_HETEROGENEOUS_SUPPORT)
 #define MCA_PML_CM_SEND_REQUEST_INIT_COMMON(req_send,                   \
                                             ompi_proc,                  \
                                             comm,                       \
@@ -209,7 +269,7 @@ do {                                                                    \
         sendreq->req_peer = dst;                                        \
         sendreq->req_addr = buf;                                        \
         sendreq->req_count = count;                                     \
-        MCA_PML_CM_SEND_REQUEST_INIT_COMMON( (&sendreq->req_send),      \
+        MCA_PML_CM_HVY_SEND_REQUEST_INIT_COMMON( (&sendreq->req_send),  \
                                              ompi_proc,                 \
                                              comm,                      \
                                              tag,                       \

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -495,6 +495,8 @@ int32_t opal_convertor_set_position_nocheck( opal_convertor_t* convertor,
          * completed. With this flag set the pack and unpack functions  \
          * will not do anything.                                        \
          */                                                             \
+        convertor->pDesc      = (opal_datatype_t*)datatype;             \
+        convertor->count      = count;                                  \
         if( OPAL_UNLIKELY((0 == count) || (0 == datatype->size)) ) {    \
             convertor->flags |= OPAL_DATATYPE_FLAG_NO_GAPS | CONVERTOR_COMPLETED;  \
             convertor->local_size = convertor->remote_size = 0;         \
@@ -503,13 +505,11 @@ int32_t opal_convertor_set_position_nocheck( opal_convertor_t* convertor,
         /* Compute the local in advance */                              \
         convertor->local_size = count * datatype->size;                 \
         convertor->pBaseBuf   = (unsigned char*)pUserBuf;               \
-        convertor->count      = count;                                  \
                                                                         \
         /* Grab the datatype part of the flags */                       \
         convertor->flags     &= CONVERTOR_TYPE_MASK;                    \
         convertor->flags     |= (CONVERTOR_DATATYPE_MASK & datatype->flags); \
         convertor->flags     |= (CONVERTOR_NO_OP | CONVERTOR_HOMOGENEOUS); \
-        convertor->pDesc      = (opal_datatype_t*)datatype;             \
         convertor->bConverted = 0;                                      \
         /* By default consider the optimized description */             \
         convertor->use_desc = &(datatype->opt_desc);                    \

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -495,8 +495,6 @@ int32_t opal_convertor_set_position_nocheck( opal_convertor_t* convertor,
          * completed. With this flag set the pack and unpack functions  \
          * will not do anything.                                        \
          */                                                             \
-        convertor->pDesc      = (opal_datatype_t*)datatype;             \
-        convertor->count      = count;                                  \
         if( OPAL_UNLIKELY((0 == count) || (0 == datatype->size)) ) {    \
             convertor->flags |= OPAL_DATATYPE_FLAG_NO_GAPS | CONVERTOR_COMPLETED;  \
             convertor->local_size = convertor->remote_size = 0;         \
@@ -505,11 +503,13 @@ int32_t opal_convertor_set_position_nocheck( opal_convertor_t* convertor,
         /* Compute the local in advance */                              \
         convertor->local_size = count * datatype->size;                 \
         convertor->pBaseBuf   = (unsigned char*)pUserBuf;               \
+        convertor->count      = count;                                  \
                                                                         \
         /* Grab the datatype part of the flags */                       \
         convertor->flags     &= CONVERTOR_TYPE_MASK;                    \
         convertor->flags     |= (CONVERTOR_DATATYPE_MASK & datatype->flags); \
         convertor->flags     |= (CONVERTOR_NO_OP | CONVERTOR_HOMOGENEOUS); \
+        convertor->pDesc      = (opal_datatype_t*)datatype;             \
         convertor->bConverted = 0;                                      \
         /* By default consider the optimized description */             \
         convertor->use_desc = &(datatype->opt_desc);                    \


### PR DESCRIPTION
- Set convertor pDesc and count in OPAL_CONVERTOR_PREPARE (including cases where count = 0)
- Do opal_convertor_copy_and_prepare_for_send for buffered send mode as MCA_PML_CM_HVY_SEND_REQUEST_BSEND_ALLOC calls opal_convertor_pack directly

@bosilca  - Please review.