### PR TITLE
Ensure we properly commit suicide if/when we lose connection to the daemon.

### DIFF
--- a/opal/mca/pmix/native/usock_sendrecv.c
+++ b/opal/mca/pmix/native/usock_sendrecv.c
@@ -176,6 +176,8 @@ void pmix_usock_send_handler(int sd, short flags, void *cbdata)
                     mca_pmix_native_component.send_ev_active = false;
                     OBJ_RELEASE(msg);
                     mca_pmix_native_component.send_msg = NULL;
+                    CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+                    PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
                     return;
                 }
             }
@@ -208,6 +210,8 @@ void pmix_usock_send_handler(int sd, short flags, void *cbdata)
                     mca_pmix_native_component.send_ev_active = false;
                     OBJ_RELEASE(msg);
                     mca_pmix_native_component.send_msg = NULL;
+                    CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+                    PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
                     return;
                 }
             }
@@ -239,6 +243,8 @@ void pmix_usock_send_handler(int sd, short flags, void *cbdata)
             opal_event_del(&mca_pmix_native_component.send_event);
             mca_pmix_native_component.send_ev_active = false;
         }
+        CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+        PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
         break;
     }
 }
@@ -356,6 +362,8 @@ void pmix_usock_recv_handler(int sd, short flags, void *cbdata)
                                 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
             opal_event_del(&mca_pmix_native_component.recv_event);
             mca_pmix_native_component.recv_ev_active = false;
+            CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+            PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
             return;
         }
         break;
@@ -372,6 +380,8 @@ void pmix_usock_recv_handler(int sd, short flags, void *cbdata)
             if (NULL == mca_pmix_native_component.recv_msg) {
                 opal_output(0, "%s usock_recv_handler: unable to allocate recv message\n",
                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+                CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+                PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
                 return;
             }
             /* start by reading the header */
@@ -416,6 +426,7 @@ void pmix_usock_recv_handler(int sd, short flags, void *cbdata)
                                     "%s usock:recv:handler error reading bytes - closing connection",
                                     OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
                 CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+                PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
                 return;
             }
         }
@@ -447,6 +458,7 @@ void pmix_usock_recv_handler(int sd, short flags, void *cbdata)
                 opal_event_del(&mca_pmix_native_component.recv_event);
                 mca_pmix_native_component.recv_ev_active = false;
                 CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+                PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
                 return;
             }
         }
@@ -456,6 +468,7 @@ void pmix_usock_recv_handler(int sd, short flags, void *cbdata)
                     OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), 
                     mca_pmix_native_component.state);
         CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+        PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
         break;
     }
 }
@@ -689,6 +702,7 @@ static void usock_complete_connect(void)
                     opal_socket_errno);
         mca_pmix_native_component.state = PMIX_USOCK_FAILED;
         CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+        PMIX_NATIVE_ABNORMAL_TERM;
         return;
     }
 
@@ -703,8 +717,8 @@ static void usock_complete_connect(void)
                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
                             strerror(so_error),
                             so_error);
-        mca_pmix_native_component.state = PMIX_USOCK_FAILED;
         CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+        PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
         return;
     } else if (so_error != 0) {
         /* No need to worry about the return code here - we return regardless
@@ -715,8 +729,8 @@ static void usock_complete_connect(void)
                             "connection to server failed with error %d",
                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
                             so_error);
-        mca_pmix_native_component.state = PMIX_USOCK_FAILED;
         CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+        PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
         return;
     }
 
@@ -737,8 +751,8 @@ static void usock_complete_connect(void)
     } else {
         opal_output(0, "%s usock_complete_connect: unable to send connect ack to server",
                     OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-        mca_pmix_native_component.state = PMIX_USOCK_FAILED;
         CLOSE_THE_SOCKET(mca_pmix_native_component.sd);
+        PMIX_NATIVE_ABNORMAL_TERM;  // report the error upstream
     }
 }
 


### PR DESCRIPTION
There are multiple paths by which a lost daemon can be reported, and so a race condition exists in the pmix support. Our MPI layer wants the ability to determine the response to the failure, and so it will call down to the RTE with any abort request. This comes down to the pmix layer as a "pmix_abort" command, which involves communicating the request to the daemon - who is gone. Sadly, the pmix component may not know that just yet, and so we hang.

So add a brief timer event to kick us out of the communication. The precise amount of time we should wait is somewhat TBD, but set something short for now and we can adjust.