### PR TITLE
Remove internal bool type definitions

### DIFF
--- a/config/c_get_alignment.m4
+++ b/config/c_get_alignment.m4
@@ -26,7 +26,8 @@ dnl
 AC_DEFUN([OPAL_C_GET_ALIGNMENT],[
     AC_CACHE_CHECK([alignment of $1],
                    [AS_TR_SH([opal_cv_c_align_$1])],
-		   [AC_RUN_IFELSE([AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT],
+		   [AC_RUN_IFELSE([AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT
+                                                    #include <stdbool.h> ],
 [[
     struct foo { char c; $1 x; };
     struct foo *p = (struct foo *) malloc(sizeof(struct foo));

--- a/config/c_get_alignment.m4
+++ b/config/c_get_alignment.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
-dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
 dnl $COPYRIGHT$
 dnl 
 dnl Additional copyrights may follow
@@ -23,6 +23,13 @@ dnl
 # ----------------------------------
 # Determine datatype alignment. 
 # First arg is type, 2nd arg is config var to define.
+# Now that we require C99 compilers, we include stdbool.h
+# in the alignment test so that we can find the definition
+# of "bool" when we test for its alignment. We might be able
+# to avoid this if we test for alignemtn of _Bool, but
+# since we use "bool" in the code, let's be safe and check
+# what we use. Yes, they should be the same - but "should" and
+# "are" frequently differ
 AC_DEFUN([OPAL_C_GET_ALIGNMENT],[
     AC_CACHE_CHECK([alignment of $1],
                    [AS_TR_SH([opal_cv_c_align_$1])],

--- a/configure.ac
+++ b/configure.ac
@@ -419,7 +419,7 @@ AC_CHECK_SIZEOF(pid_t)
 # Check for type alignments
 #
 
-OPAL_C_GET_ALIGNMENT(_Bool, OPAL_ALIGNMENT_BOOL)
+OPAL_C_GET_ALIGNMENT(bool, OPAL_ALIGNMENT_BOOL)
 OPAL_C_GET_ALIGNMENT(int8_t, OPAL_ALIGNMENT_INT8)
 OPAL_C_GET_ALIGNMENT(int16_t, OPAL_ALIGNMENT_INT16)
 OPAL_C_GET_ALIGNMENT(int32_t, OPAL_ALIGNMENT_INT32)
@@ -459,23 +459,6 @@ fi
 
 OPAL_C_GET_ALIGNMENT(void *, OPAL_ALIGNMENT_VOID_P)
 OPAL_C_GET_ALIGNMENT(size_t, OPAL_ALIGNMENT_SIZE_T)
-
-#
-# Does the C compiler native support "bool"? (i.e., without
-# <stdbool.h> or any other help)
-#
-
-OPAL_VAR_SCOPE_PUSH([MSG])
-AC_MSG_CHECKING(for C bool type)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-AC_INCLUDES_DEFAULT],
-[[bool bar, foo = true; bar = foo;]])],
-[OPAL_NEED_C_BOOL=0 MSG=yes],[OPAL_NEED_C_BOOL=1 MSG=no])
-AC_DEFINE_UNQUOTED(OPAL_NEED_C_BOOL, $OPAL_NEED_C_BOOL,
-    [Whether the C compiler supports "bool" without any other help (such as <stdbool.h>)])
-AC_MSG_RESULT([$MSG])
-AC_CHECK_SIZEOF(_Bool)
-OPAL_VAR_SCOPE_POP
 
 #
 # Check for other compiler characteristics
@@ -635,37 +618,6 @@ AC_CHECK_HEADERS([net/if.h], [], [],
 # include <sys/socket.h>
 #endif
 ])
-
-# Note that sometimes we have <stdbool.h>, but it doesn't work (e.g.,
-# have both Portland and GNU installed; using pgcc will find GNU's
-# <stdbool.h>, which all it does -- by standard -- is define "bool" to
-# "_Bool" [see
-# http://www.opengroup.org/onlinepubs/009695399/basedefs/stdbool.h.html],
-# and Portland has no idea what to do with _Bool).
-
-# So first figure out if we have <stdbool.h> (i.e., check the value of
-# the macro HAVE_STDBOOL_H from the result of AC_CHECK_HEADERS,
-# above).  If we do have it, then check to see if it actually works.
-# Define OPAL_USE_STDBOOL_H as approrpaite.
-AC_CHECK_HEADERS([stdbool.h], [have_stdbool_h=1], [have_stdbool_h=0])
-OPAL_VAR_SCOPE_PUSH([MSG])
-AC_MSG_CHECKING([if <stdbool.h> works])
-if test "$have_stdbool_h" = "1"; then
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-AC_INCLUDES_DEFAULT[
-#if HAVE_STDBOOL_H
-#include <stdbool.h>
-#endif]],
-[[bool bar, foo = true; bar = foo;]])],
-[OPAL_USE_STDBOOL_H=1 MSG=yes],[OPAL_USE_STDBOOL_H=0 MSG=no])
-else
-    OPAL_USE_STDBOOL_H=0
-    MSG="no (do not have <stdbool.h>)"
-fi
-AC_DEFINE_UNQUOTED(OPAL_USE_STDBOOL_H, $OPAL_USE_STDBOOL_H,
-    [Whether to use <stdbool.h> or not])
-AC_MSG_RESULT([$MSG])
-OPAL_VAR_SCOPE_POP
 
 # checkpoint results
 AC_CACHE_SAVE

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -15,6 +15,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -271,61 +272,6 @@ typedef OPAL_PTRDIFF_TYPE ptrdiff_t;
 #endif
 
 /*
- * If we're in C, we may need to bring in the bool type and true/false
- * constants.  OPAL_NEED_C_BOOL will be true if the compiler either
- * needs <stdbool.h> or doesn't define the bool type at all.
- */
-#if !(defined(c_plusplus) || defined(__cplusplus))
-#    if OPAL_NEED_C_BOOL
-#        if OPAL_USE_STDBOOL_H
-             /* If we're using <stdbool.h>, there is an implicit
-                assumption that the C++ bool is the same size and has
-                the same alignment.  However, configure may have
-                disabled the MPI C++ bindings, so if "_Bool" exists,
-                then use that sizeof. */
-#            include <stdbool.h>
-             /* This section exists because AC_SIZEOF(bool) may not be
-                run in configure if we're not building the MPI C++
-                bindings. */
-#            undef SIZEOF_BOOL
-#            if SIZEOF__BOOL > 0
-#                define SIZEOF_BOOL SIZEOF__BOOL
-#            else
-                 /* If all else fails, assume it's 1 */
-#                define SIZEOF_BOOL 1
-#            endif
-#        else
-             /* We need to create a bool type and ensure that it's the
-                same size / alignment as the C++ bool size /
-                alignment */
-#            define false 0
-#            define true 1
-#            if SIZEOF_BOOL == SIZEOF_CHAR && OPAL_ALIGNMENT_CXX_BOOL == OPAL_ALIGNMENT_CHAR
-typedef unsigned char bool;
-#            elif SIZEOF_BOOL == SIZEOF_SHORT && OPAL_ALIGNMENT_CXX_BOOL == OPAL_ALIGNMENT_SHORT
-typedef short bool;
-#            elif SIZEOF_BOOL == SIZEOF_INT && OPAL_ALIGNMENT_CXX_BOOL == OPAL_ALIGNMENT_INT
-typedef int bool;
-#            elif SIZEOF_BOOL == SIZEOF_LONG && OPAL_ALIGNMENT_CXX_BOOL == OPAL_ALIGNMENT_LONG
-typedef long bool;
-#            elif defined(SIZEOF_LONG_LONG) && defined(OPAL_ALIGNMENT_LONG) && SIZEOF_BOOL == SIZEOF_LONG && OPAL_ALIGNMENT_CXX_BOOL == OPAL_ALIGNMENT_LONG
-typedef long long bool;
-             /* If we have _Bool, use that */
-#            elif SIZEOF__BOOL > 0
-#                undef SIZEOF_BOOL
-#                define bool _Bool
-#                define SIZEOF_BOOL SIZEOF__BOOL
-#            else
-             /* If all else fails, just make bool be an unsigned char
-                and size of 1 */
-typedef unsigned char bool;
-#                define SIZEOF_BOOL 1
-#            endif
-#        endif  /* OPAL_USE_STDBOOL_H */
-#    endif  /* OPAL_NEED_C_BOOL */
-#endif
-
-/*
  * Maximum size of a filename path.
  */
 #include <limits.h>
@@ -467,6 +413,9 @@ static inline uint16_t ntohs(uint16_t netvar) { return netvar; }
 #endif
 
 #define IOVBASE_TYPE  void
+
+/* ensure the bool type is defined as it is used everywhere */
+#include <stdbool.h>
 
 /**
  * If we generate our own bool type, we need a special way to cast the result

--- a/test/datatype/position.c
+++ b/test/datatype/position.c
@@ -4,7 +4,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -15,9 +15,6 @@
 #include "ompi_config.h"
 #include <stdio.h>
 #include <string.h>
-#if OPAL_USE_STDBOOL_H
-#include <stdbool.h>
-#endif
 
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/datatype/ompi_datatype.h"

--- a/test/datatype/position_noncontig.c
+++ b/test/datatype/position_noncontig.c
@@ -4,7 +4,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,9 +15,6 @@
 #include "ompi_config.h"
 #include <stdio.h>
 #include <string.h>
-#if OPAL_USE_STDBOOL_H
-#include <stdbool.h>
-#endif
 
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/datatype/ompi_datatype.h"


### PR DESCRIPTION
Now that we require C99, and stdbool.h is part of C99, we no longer need to define our own bool types. Since bool is commonly used in a lot of places, just include stdbool.h in opal_config_bottom.h

@jsquyres please review