### PR TITLE
more c99 updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -592,18 +592,17 @@ AC_CACHE_SAVE
 opal_show_title "Header file tests"
 
 AC_CHECK_HEADERS([alloca.h aio.h arpa/inet.h dirent.h \
-    dlfcn.h execinfo.h err.h fcntl.h grp.h inttypes.h libgen.h \
+    dlfcn.h execinfo.h err.h fcntl.h grp.h libgen.h \
     libutil.h memory.h netdb.h netinet/in.h netinet/tcp.h \
-    poll.h pthread.h pty.h pwd.h sched.h stdint.h stddef.h \
-    stdlib.h string.h strings.h stropts.h sys/fcntl.h sys/ipc.h sys/shm.h \
+    poll.h pthread.h pty.h pwd.h sched.h \
+    strings.h stropts.h sys/fcntl.h sys/ipc.h sys/shm.h \
     sys/ioctl.h sys/mman.h sys/param.h sys/queue.h \
     sys/resource.h sys/select.h sys/socket.h sys/sockio.h \
-    stdarg.h sys/stat.h sys/statfs.h sys/statvfs.h sys/time.h sys/tree.h \
+    sys/stat.h sys/statfs.h sys/statvfs.h sys/time.h sys/tree.h \
     sys/types.h sys/uio.h sys/un.h net/uio.h sys/utsname.h sys/vfs.h sys/wait.h syslog.h \
-    time.h termios.h ulimit.h unistd.h util.h utmp.h malloc.h \
-    ifaddrs.h crt_externs.h regex.h signal.h \
-    mntent.h paths.h \
-    ioLib.h sockLib.h hostLib.h shlwapi.h sys/synch.h limits.h db.h ndbm.h])
+    termios.h ulimit.h unistd.h util.h utmp.h malloc.h \
+    ifaddrs.h crt_externs.h regex.h mntent.h paths.h \
+    ioLib.h sockLib.h hostLib.h shlwapi.h sys/synch.h db.h ndbm.h])
 
 AC_CHECK_HEADERS([sys/mount.h], [], [],
 [AC_INCLUDES_DEFAULT

--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -81,9 +81,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #include "mpi.h"
 

--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -28,15 +28,9 @@
 #include "ompi_config.h"
 
 #include <stddef.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #include "ompi/constants.h"
 #include "opal/datatype/opal_convertor.h"

--- a/ompi/datatype/ompi_datatype_create.c
+++ b/ompi/datatype/ompi_datatype_create.c
@@ -20,9 +20,7 @@
 #include "ompi_config.h"
 
 #include <stddef.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/class/opal_pointer_array.h"
 #include "ompi/datatype/ompi_datatype.h"

--- a/ompi/debuggers/ompi_mpihandles_dll.c
+++ b/ompi/debuggers/ompi_mpihandles_dll.c
@@ -36,12 +36,8 @@
 
 #include "ompi_config.h"
 
-#if defined(HAVE_STRING_H)
 #include <string.h>
-#endif  /* defined(HAVE_STRING_H) */
-#if defined(HAVE_STDLIB_H)
 #include <stdlib.h>
-#endif  /* defined(HAVE_STDLIB_H) */
 
 #include "ompi/mca/pml/base/pml_base_request.h"
 #include "mpihandles_interface.h"

--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -71,12 +71,8 @@
 #ifdef HAVE_NO_C_CONST
 #define const
 #endif
-#if defined(HAVE_STRING_H)
 #include <string.h>
-#endif  /* defined(HAVE_STRING_H) */
-#if defined(HAVE_STDLIB_H)
 #include <stdlib.h>
-#endif  /* defined(HAVE_STDLIB_H) */
 
 /* Notice to developers!!!!
  * The following include files with _dbg.h suffixes contains definitions

--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -26,9 +26,7 @@
 #include "ompi_config.h"
 
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "mpi.h"
 

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -23,9 +23,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "ompi/communicator/communicator.h"
 #include "ompi/win/win.h"

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -26,13 +26,9 @@
 #include "ompi_config.h"
 #include "ompi/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <errno.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/ompi/mca/coll/cuda/coll_cuda_module.c
+++ b/ompi/mca/coll/cuda/coll_cuda_module.c
@@ -12,9 +12,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdio.h>
 
 #include "coll_cuda.h"

--- a/ompi/mca/coll/ml/coll_ml_allocation.c
+++ b/ompi/mca/coll/ml/coll_ml_allocation.c
@@ -11,9 +11,7 @@
 
 
 #include "ompi_config.h"
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 
 #include "coll_ml.h"
 #include "coll_ml_inlines.h"

--- a/ompi/mca/coll/sm/coll_sm_bcast.c
+++ b/ompi/mca/coll/sm/coll_sm_bcast.c
@@ -19,9 +19,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/constants.h"

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -34,9 +34,7 @@
 #include "ompi_config.h"
 
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SCHED_H
 #include <sched.h>
 #endif

--- a/ompi/mca/coll/sm/coll_sm_reduce.c
+++ b/ompi/mca/coll/sm/coll_sm_reduce.c
@@ -19,9 +19,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/datatype/opal_convertor.h"
 #include "opal/sys/atomic.h"

--- a/ompi/mca/dpm/base/base.h
+++ b/ompi/mca/dpm/base/base.h
@@ -25,9 +25,7 @@
 #include "ompi_config.h"
 #include "ompi/constants.h"
 
-#if HAVE_TIME_H
 #include <time.h>
-#endif
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/ompi/mca/dpm/base/dpm_base_null_fns.c
+++ b/ompi/mca/dpm/base/dpm_base_null_fns.c
@@ -26,9 +26,7 @@
 #include "ompi_config.h"
 #include <string.h>
 #include <stdio.h>
-#if HAVE_TIME_H
 #include <time.h>
-#endif
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/ompi/mca/dpm/dpm.h
+++ b/ompi/mca/dpm/dpm.h
@@ -31,9 +31,7 @@
 
 #include "ompi_config.h"
 
-#if HAVE_TIME_H
 #include <time.h>
-#endif
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/ompi/mca/dpm/orte/dpm_orte.c
+++ b/ompi/mca/dpm/orte/dpm_orte.c
@@ -31,9 +31,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
-#if HAVE_TIME_H
 #include <time.h>
-#endif
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/ompi/mca/io/romio314/romio/adio/ad_xfs/ad_xfs_open.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_xfs/ad_xfs_open.c
@@ -9,9 +9,7 @@
 
 #include "ad_xfs.h"
 #include <sys/ioctl.h>
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #ifndef HAVE_LSEEK64
 #define lseek64 lseek

--- a/ompi/mca/io/romio314/romio/adio/common/system_hints.c
+++ b/ompi/mca/io/romio314/romio/adio/common/system_hints.c
@@ -15,12 +15,8 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/ompi/mca/op/base/op_base_frame.c
+++ b/ompi/mca/op/base/op_base_frame.c
@@ -20,9 +20,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 #include "ompi/mca/mca.h"

--- a/ompi/mca/osc/osc.h
+++ b/ompi/mca/osc/osc.h
@@ -32,9 +32,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #include "ompi/mca/mca.h"
 

--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -26,9 +26,7 @@
 #include "ompi_config.h"
 #include <stdio.h>
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNIST_H */

--- a/ompi/mca/pml/base/pml_base_select.c
+++ b/ompi/mca/pml/base/pml_base_select.c
@@ -23,9 +23,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/class/opal_list.h"
 #include "opal/util/output.h"

--- a/ompi/mca/pml/v/pml_v_output.c
+++ b/ompi/mca/pml/v/pml_v_output.c
@@ -17,9 +17,7 @@
 #if defined(HAVE_UNISTD_H)
 #include <unistd.h>
 #endif
-#if defined(HAVE_STRING_H)
 #include <string.h>
-#endif
 
 int pml_v_output_open(char *output, int verbosity) {
     opal_output_stream_t lds;

--- a/ompi/mca/topo/base/topo_base_cart_get.c
+++ b/ompi/mca/topo/base/topo_base_cart_get.c
@@ -20,9 +20,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "ompi/mca/topo/base/base.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mca/vprotocol/base/vprotocol_base_select.c
+++ b/ompi/mca/vprotocol/base/vprotocol_base_select.c
@@ -13,9 +13,7 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "base.h"
 #include "ompi/mca/mca.h"

--- a/ompi/mpi/java/c/mpi_Intracomm.c
+++ b/ompi/mpi/java/c/mpi_Intracomm.c
@@ -47,9 +47,7 @@
 #include "ompi_config.h"
 
 #include <stdlib.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_TARGETCONDITIONALS_H
 #include <TargetConditionals.h>
 #endif

--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -54,12 +54,8 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_TARGETCONDITIONALS_H
 #include <TargetConditionals.h>
 #endif

--- a/ompi/peruse/peruse.c
+++ b/ompi/peruse/peruse.c
@@ -12,9 +12,7 @@
  */
 
 #include "ompi_config.h"
-#ifdef HAVE_STRING_H
 #  include <string.h>
-#endif
 #include "mpi.h"
 #include "ompi/peruse/peruse.h"
 #include "ompi/peruse/peruse-internal.h"

--- a/ompi/peruse/peruse_module.c
+++ b/ompi/peruse/peruse_module.c
@@ -13,9 +13,7 @@
  */
 
 #include "ompi_config.h"
-#ifdef HAVE_STDLIB_H
 #  include <stdlib.h>
-#endif
 #include "mpi.h"
 #include "ompi/peruse/peruse.h"
 #include "ompi/peruse/peruse-internal.h"

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -24,12 +24,8 @@
 
 #include "ompi_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif  /* HAVE_TIME_H */
 
 #include "ompi/constants.h"
 #include "ompi/datatype/ompi_datatype.h"

--- a/ompi/tools/ompi_info/ompi_info.c
+++ b/ompi/tools/ompi_info/ompi_info.c
@@ -36,9 +36,7 @@
 #include <sys/param.h>
 #endif
 #include <errno.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/version.h"
 #include "opal/mca/installdirs/installdirs.h"

--- a/opal/class/opal_hash_table.h
+++ b/opal/class/opal_hash_table.h
@@ -37,9 +37,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include "opal/class/opal_list.h"
 #include "opal/util/proc.h"
 

--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -116,9 +116,7 @@
 
 #include "opal_config.h"
 #include <assert.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 
 #include "opal/sys/atomic.h"
 

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -25,10 +25,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
-
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 #include "opal/prefetch.h"
 #include "opal/util/arch.h"

--- a/opal/datatype/opal_copy_functions_heterogeneous.c
+++ b/opal/datatype/opal_copy_functions_heterogeneous.c
@@ -16,9 +16,7 @@
 #include "opal_config.h"
 
 #include <stddef.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 #include "opal/util/arch.h"
 

--- a/opal/datatype/opal_datatype_internal.h
+++ b/opal/datatype/opal_datatype_internal.h
@@ -26,12 +26,8 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #if defined(VERBOSE)
 #include "opal/util/output.h"

--- a/opal/dss/dss_internal.h
+++ b/opal/dss/dss_internal.h
@@ -36,12 +36,10 @@
 #include "opal/dss/dss.h"
 #include "opal/util/proc.h"
 
-#ifdef HAVE_STRING_H
-#    if !defined(STDC_HEADERS) && HAVE_MEMORY_H
-#        include <memory.h>
-#    endif
-#    include <string.h>
+#if !defined(STDC_HEADERS) && HAVE_MEMORY_H
+#    include <memory.h>
 #endif
+#include <string.h>
 
 BEGIN_C_DECLS
 

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -22,9 +22,7 @@
 
 /* Inline C implementation of the functions defined in atomic.h */
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 /**********************************************************************
  *

--- a/opal/include/opal/types.h
+++ b/opal/include/opal/types.h
@@ -22,9 +22,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -241,10 +241,6 @@
 #    define OPAL_MODULE_DECLSPEC
 #  endif
 
-/*
- * Do we have <stdint.h>?
- */
-#ifdef HAVE_STDINT_H
 #if !defined(__STDC_LIMIT_MACROS) && (defined(c_plusplus) || defined (__cplusplus))
 /* When using a C++ compiler, the max / min value #defines for std
    types are only included if __STDC_LIMIT_MACROS is set before
@@ -252,10 +248,7 @@
 #define __STDC_LIMIT_MACROS
 #endif
 #include "opal_config.h"
-#include <stdint.h>
-#else
 #include "opal_stdint.h"
-#endif
 
 /***********************************************************************
  *

--- a/opal/include/opal_stdint.h
+++ b/opal/include/opal_stdint.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,111 +30,10 @@
  * Include what we can and define what is missing.
  */
 #include <limits.h>
+#include <stdint.h>
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
-
-/* 8-bit */
-
-#if SIZEOF_CHAR == 1
-
-#ifndef HAVE_INT8_T
-typedef signed char int8_t;
-#endif
-
-#ifndef HAVE_UINT8_T
-typedef unsigned char uint8_t;
-#endif
-
-#else
-
-#error Failed to define 8-bit types
-
-#endif
-
-/* 16-bit */
-
-#if SIZEOF_SHORT == 2
-
-#ifndef HAVE_INT16_T
-typedef signed short int16_t;
-#endif
-
-#ifndef HAVE_UINT16_T
-typedef unsigned short uint16_t;
-#endif
-
-#else
-
-#error Failed to define 16-bit types
-
-#endif
-
-/* 32-bit */
-
-#if SIZEOF_INT == 4
-
-#ifndef HAVE_INT32_T
-typedef signed int int32_t;
-#endif
-
-#ifndef HAVE_UINT32_T
-typedef unsigned int uint32_t;
-#endif
-
-#elif SIZEOF_LONG == 4
-
-#ifndef HAVE_INT32_T
-typedef signed long int32_t;
-#endif
-
-#ifndef HAVE_UINT32_T
-typedef unsigned long uint32_t;
-#endif
-
-#else
-
-#error Failed to define 32-bit types
-
-#endif
-
-/* 64-bit */
-
-#if SIZEOF_INT == 8
-
-#ifndef HAVE_INT64_T
-typedef signed int int64_t;
-#endif
-
-#ifndef HAVE_UINT64_T
-typedef unsigned int uint64_t;
-#endif
-
-#elif SIZEOF_LONG == 8
-
-#ifndef HAVE_INT64_T
-typedef signed long int64_t;
-#endif
-
-#ifndef HAVE_UINT64_T
-typedef unsigned long uint64_t;
-#endif
-
-#elif HAVE_LONG_LONG && SIZEOF_LONG_LONG == 8
-
-#ifndef HAVE_INT64_T
-typedef signed long long int64_t;
-#endif
-
-#ifndef HAVE_UINT64_T
-typedef unsigned long long uint64_t;
-#endif
-
-#else
-
-#error Failed to define 64-bit types
-
 #endif
 
 /* 128-bit */
@@ -204,143 +106,8 @@ typedef unsigned long long uintptr_t;
 
 #endif
 
-/* fix up some constants that may be missing */
-#ifndef SIZE_MAX
-# if SIZEOF_VOID_P == SIZEOF_INT
-#   define SIZE_MAX UINT_MAX
-# elif SIZEOF_VOID_P == SIZEOF_LONG
-#   define SIZE_MAX ULONG_MAX
-# else
-#   error Failed to find value for SIZE_MAX
-# endif
-#endif /* ifndef SIZE_MAX */
-
-
 /* inttypes.h printf specifiers */
-#ifdef HAVE_INTTYPES_H
 # include <inttypes.h>
-#else
-
-# if SIZEOF_LONG == 8
-#  define __PRI64_PREFIX	"l"
-#  define __PRIPTR_PREFIX	"l"
-# else
-#  define __PRI64_PREFIX	"ll"
-#  define __PRIPTR_PREFIX
-# endif
-
-/* Decimal notation.  */
-# define PRId8		"d"
-# define PRId16		"d"
-# define PRId32		"d"
-# define PRId64		__PRI64_PREFIX "d"
-
-# define PRIdLEAST8	"d"
-# define PRIdLEAST16	"d"
-# define PRIdLEAST32	"d"
-# define PRIdLEAST64	__PRI64_PREFIX "d"
-
-# define PRIdFAST8	"d"
-# define PRIdFAST16	__PRIPTR_PREFIX "d"
-# define PRIdFAST32	__PRIPTR_PREFIX "d"
-# define PRIdFAST64	__PRI64_PREFIX "d"
-
-# define PRIi8		"i"
-# define PRIi16		"i"
-# define PRIi32		"i"
-# define PRIi64		__PRI64_PREFIX "i"
-
-# define PRIiLEAST8	"i"
-# define PRIiLEAST16	"i"
-# define PRIiLEAST32	"i"
-# define PRIiLEAST64	__PRI64_PREFIX "i"
-
-# define PRIiFAST8	"i"
-# define PRIiFAST16	__PRIPTR_PREFIX "i"
-# define PRIiFAST32	__PRIPTR_PREFIX "i"
-# define PRIiFAST64	__PRI64_PREFIX "i"
-
-/* Octal notation.  */
-# define PRIo8		"o"
-# define PRIo16		"o"
-# define PRIo32		"o"
-# define PRIo64		__PRI64_PREFIX "o"
-
-# define PRIoLEAST8	"o"
-# define PRIoLEAST16	"o"
-# define PRIoLEAST32	"o"
-# define PRIoLEAST64	__PRI64_PREFIX "o"
-
-# define PRIoFAST8	"o"
-# define PRIoFAST16	__PRIPTR_PREFIX "o"
-# define PRIoFAST32	__PRIPTR_PREFIX "o"
-# define PRIoFAST64	__PRI64_PREFIX "o"
-
-/* Unsigned integers.  */
-# define PRIu8		"u"
-# define PRIu16		"u"
-# define PRIu32		"u"
-# define PRIu64		__PRI64_PREFIX "u"
-
-# define PRIuLEAST8	"u"
-# define PRIuLEAST16	"u"
-# define PRIuLEAST32	"u"
-# define PRIuLEAST64	__PRI64_PREFIX "u"
-
-# define PRIuFAST8	"u"
-# define PRIuFAST16	__PRIPTR_PREFIX "u"
-# define PRIuFAST32	__PRIPTR_PREFIX "u"
-# define PRIuFAST64	__PRI64_PREFIX "u"
-
-/* lowercase hexadecimal notation.  */
-# define PRIx8		"x"
-# define PRIx16		"x"
-# define PRIx32		"x"
-# define PRIx64		__PRI64_PREFIX "x"
-
-# define PRIxLEAST8	"x"
-# define PRIxLEAST16	"x"
-# define PRIxLEAST32	"x"
-# define PRIxLEAST64	__PRI64_PREFIX "x"
-
-# define PRIxFAST8	"x"
-# define PRIxFAST16	__PRIPTR_PREFIX "x"
-# define PRIxFAST32	__PRIPTR_PREFIX "x"
-# define PRIxFAST64	__PRI64_PREFIX "x"
-
-/* UPPERCASE hexadecimal notation.  */
-# define PRIX8		"X"
-# define PRIX16		"X"
-# define PRIX32		"X"
-# define PRIX64		__PRI64_PREFIX "X"
-
-# define PRIXLEAST8	"X"
-# define PRIXLEAST16	"X"
-# define PRIXLEAST32	"X"
-# define PRIXLEAST64	__PRI64_PREFIX "X"
-
-# define PRIXFAST8	"X"
-# define PRIXFAST16	__PRIPTR_PREFIX "X"
-# define PRIXFAST32	__PRIPTR_PREFIX "X"
-# define PRIXFAST64	__PRI64_PREFIX "X"
-
-/* Macros for printing `intmax_t' and `uintmax_t'.  */
-# define PRIdMAX	__PRI64_PREFIX "d"
-# define PRIiMAX	__PRI64_PREFIX "i"
-# define PRIoMAX	__PRI64_PREFIX "o"
-# define PRIuMAX	__PRI64_PREFIX "u"
-# define PRIxMAX	__PRI64_PREFIX "x"
-# define PRIXMAX	__PRI64_PREFIX "X"
-
-/* Macros for printing `intptr_t' and `uintptr_t'.  */
-# define PRIdPTR	__PRIPTR_PREFIX "d"
-# define PRIiPTR	__PRIPTR_PREFIX "i"
-# define PRIoPTR	__PRIPTR_PREFIX "o"
-# define PRIuPTR	__PRIPTR_PREFIX "u"
-# define PRIxPTR	__PRIPTR_PREFIX "x"
-# define PRIXPTR	__PRIPTR_PREFIX "X"
-
-#endif
 
 #ifndef PRIsize_t
 # if defined(ACCEPT_C99)

--- a/opal/mca/allocator/base/allocator_base_frame.c
+++ b/opal/mca/allocator/base/allocator_base_frame.c
@@ -19,9 +19,7 @@
 
 #include "opal_config.h"
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/mca/mca.h"
 #include "opal/mca/base/base.h"

--- a/opal/mca/btl/self/btl_self.h
+++ b/opal/mca/btl/self/btl_self.h
@@ -26,9 +26,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif  /* HAVE_SYS_TYPES_H */

--- a/opal/mca/btl/self/btl_self_component.c
+++ b/opal/mca/btl/self/btl_self_component.c
@@ -23,9 +23,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif  /* HAVE_SYS_TYPES_H */

--- a/opal/mca/btl/sm/btl_sm.h
+++ b/opal/mca/btl/sm/btl_sm.h
@@ -31,9 +31,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif  /* HAVE_STDINT_H */
 #ifdef HAVE_SCHED_H
 #include <sched.h>
 #endif  /* HAVE_SCHED_H */

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -30,9 +30,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif  /* HAVE_FCNTL_H */

--- a/opal/mca/btl/smcuda/btl_smcuda.h
+++ b/opal/mca/btl/smcuda/btl_smcuda.h
@@ -31,9 +31,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif  /* HAVE_STDINT_H */
 #ifdef HAVE_SCHED_H
 #include <sched.h>
 #endif  /* HAVE_SCHED_H */

--- a/opal/mca/btl/smcuda/btl_smcuda_component.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_component.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif  /* HAVE_FCNTL_H */

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -48,9 +48,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif  /* HAVE_SYS_TIME_H */
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif  /* HAVE_TIME_H */
 
 #include "opal/mca/event/event.h"
 #include "opal/util/net.h"

--- a/opal/mca/btl/usnic/btl_usnic_mca.c
+++ b/opal/mca/btl/usnic/btl_usnic_mca.c
@@ -23,9 +23,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <errno.h>
 
 #include "opal/mca/base/mca_base_var.h"

--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -32,9 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef HAVE_STDINT_H
 # include <stdint.h>
-#endif  /* HAVE_STDINT_H */
 #ifdef HAVE_SCHED_H
 # include <sched.h>
 #endif  /* HAVE_SCHED_H */

--- a/opal/mca/common/verbs/common_verbs_qp_type.c
+++ b/opal/mca/common/verbs/common_verbs_qp_type.c
@@ -12,9 +12,7 @@
 #include "opal/constants.h"
 
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <infiniband/verbs.h>
 
 #include "common_verbs.h"

--- a/opal/mca/crs/base/crs_base_fns.c
+++ b/opal/mca/crs/base/crs_base_fns.c
@@ -23,9 +23,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/opal/mca/crs/none/crs_none_module.c
+++ b/opal/mca/crs/none/crs_none_module.c
@@ -15,9 +15,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <sys/types.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/opal/mca/crs/self/crs_self_module.c
+++ b/opal/mca/crs/self/crs_self_module.c
@@ -24,9 +24,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_DLFCN_H
 #include <dlfcn.h>
 #endif

--- a/opal/mca/event/event.h
+++ b/opal/mca/event/event.h
@@ -22,12 +22,8 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
 
 #include "opal/class/opal_pointer_array.h"
 

--- a/opal/mca/hwloc/hwloc.h
+++ b/opal/mca/hwloc/hwloc.h
@@ -21,12 +21,8 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
 
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_value_array.h"

--- a/opal/mca/hwloc/hwloc1110/hwloc/include/private/private.h
+++ b/opal/mca/hwloc/hwloc1110/hwloc/include/private/private.h
@@ -31,9 +31,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #ifdef HAVE_SYS_UTSNAME_H
 #include <sys/utsname.h>
 #endif

--- a/opal/mca/mpool/base/mpool_base_alloc.c
+++ b/opal/mca/mpool/base/mpool_base_alloc.c
@@ -22,12 +22,8 @@
  */
 
 #include "opal_config.h"
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include "opal/mca/mpool/mpool.h"
 #include "base.h"
 #include "mpool_base_tree.h"

--- a/opal/mca/mpool/sm/mpool_sm_component.c
+++ b/opal/mca/mpool/sm/mpool_sm_component.c
@@ -26,9 +26,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H*/
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 #include <errno.h>
 #include "opal/mca/base/base.h"
 

--- a/opal/mca/pmix/native/pmix_native.c
+++ b/opal/mca/pmix/native/pmix_native.c
@@ -18,9 +18,7 @@
 #include "opal/constants.h"
 #include "opal/types.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/opal/mca/pstat/linux/pstat_linux_module.c
+++ b/opal/mca/pstat/linux/pstat_linux_module.c
@@ -34,9 +34,7 @@
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/opal/mca/pstat/test/pstat_test.c
+++ b/opal/mca/pstat/test/pstat_test.c
@@ -25,9 +25,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/opal/mca/reachable/weighted/reachable_weighted.c
+++ b/opal/mca/reachable/weighted/reachable_weighted.c
@@ -16,9 +16,7 @@
 #include "opal/constants.h"
 #include "opal/types.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/opal/mca/sec/basic/sec_basic.c
+++ b/opal/mca/sec/basic/sec_basic.c
@@ -11,9 +11,7 @@
 #include "opal_config.h"
 #include "opal/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal_stdint.h"
 #include "opal/dss/dss_types.h"

--- a/opal/mca/sec/keystone/sec_keystone.c
+++ b/opal/mca/sec/keystone/sec_keystone.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <stdio.h>
 #include <curl/curl.h>
 

--- a/opal/mca/sec/munge/sec_munge.c
+++ b/opal/mca/sec/munge/sec_munge.c
@@ -13,9 +13,7 @@
 #include "opal_config.h"
 #include "opal/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <munge.h>
 
 #include "opal_stdint.h"

--- a/opal/mca/shmem/base/shmem_base_select.c
+++ b/opal/mca/shmem/base/shmem_base_select.c
@@ -21,9 +21,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
 #include "opal/constants.h"
 #include "opal/util/output.h"

--- a/opal/mca/shmem/mmap/shmem_mmap_module.c
+++ b/opal/mca/shmem/mmap/shmem_mmap_module.c
@@ -37,15 +37,11 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif /* HAVE_SYS_TYPES_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif /* HAVE_NETDB_H */
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif /* HAVE_NETDB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */

--- a/opal/mca/shmem/posix/shmem_posix_common_utils.c
+++ b/opal/mca/shmem/posix/shmem_posix_common_utils.c
@@ -29,9 +29,7 @@
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif  /* HAVE_FCNTL_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #if OPAL_HAVE_SOLARIS && !defined(_POSIX_C_SOURCE)
   #define _POSIX_C_SOURCE 200112L /* Required for shm_{open,unlink} decls */
   #include <sys/mman.h>

--- a/opal/mca/shmem/posix/shmem_posix_component.c
+++ b/opal/mca/shmem/posix/shmem_posix_component.c
@@ -31,9 +31,7 @@
 
 
 #include <errno.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */

--- a/opal/mca/shmem/posix/shmem_posix_module.c
+++ b/opal/mca/shmem/posix/shmem_posix_module.c
@@ -42,9 +42,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif /* HAVE_SYS_TYPES_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif /* HAVE_NETDB_H */

--- a/opal/mca/shmem/shmem_types.h
+++ b/opal/mca/shmem/shmem_types.h
@@ -33,12 +33,8 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif /* HAVE_STDDEF_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
 BEGIN_C_DECLS
 

--- a/opal/mca/shmem/sysv/shmem_sysv_component.c
+++ b/opal/mca/shmem/sysv/shmem_sysv_component.c
@@ -34,9 +34,7 @@
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */

--- a/opal/mca/shmem/sysv/shmem_sysv_module.c
+++ b/opal/mca/shmem/sysv/shmem_sysv_module.c
@@ -45,9 +45,7 @@
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif /* HAVE_NETDB_H */

--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -24,9 +24,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/mca/timer/timer.h"
 #include "opal/mca/timer/base/base.h"

--- a/opal/runtime/opal_cr.c
+++ b/opal/runtime/opal_cr.c
@@ -30,9 +30,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <errno.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -46,9 +44,7 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>  /* for mkfifo */
 #endif  /* HAVE_SYS_STAT_H */
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/class/opal_object.h"
 #include "opal/util/opal_environ.h"

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -29,9 +29,7 @@
 #include "opal_config.h"
 
 #include <time.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/constants.h"
 #include "opal/runtime/opal.h"

--- a/opal/threads/condition.h
+++ b/opal/threads/condition.h
@@ -26,9 +26,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 #include <pthread.h>
 
 #include "opal/threads/mutex.h"

--- a/opal/threads/threads.h
+++ b/opal/threads/threads.h
@@ -26,9 +26,7 @@
 #include "opal_config.h"
 
 #include <pthread.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/class/opal_object.h"
 #if OPAL_ENABLE_DEBUG

--- a/opal/tools/opal-checkpoint/opal-checkpoint.c
+++ b/opal/tools/opal-checkpoint/opal-checkpoint.c
@@ -31,9 +31,7 @@
 
 #include <stdio.h>
 #include <errno.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
@@ -49,12 +47,8 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/constants.h"
 

--- a/opal/tools/opal-restart/opal-restart.c
+++ b/opal/tools/opal-restart/opal-restart.c
@@ -38,9 +38,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
@@ -53,9 +51,7 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/constants.h"
 

--- a/opal/tools/wrappers/opal_wrapper.c
+++ b/opal/tools/wrappers/opal_wrapper.c
@@ -24,9 +24,7 @@
 
 #include <stdio.h>
 #include <errno.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif  /* HAVE_SYS_STAT_H */
@@ -39,9 +37,7 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif  /* HAVE_SYS_WAIT_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/mca/installdirs/installdirs.h"
 #include "opal/runtime/opal.h"

--- a/opal/util/argv.c
+++ b/opal/util/argv.c
@@ -22,12 +22,8 @@
  */
 
 #include "opal_config.h"
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/util/argv.h"
 #include "opal/constants.h"

--- a/opal/util/basename.c
+++ b/opal/util/basename.c
@@ -23,9 +23,7 @@
 #include "opal_config.h"
 
 #include <stdlib.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_LIBGEN_H
 #include <libgen.h>
 #endif  /* HAVE_LIBGEN_H */

--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -24,9 +24,7 @@
 #include "opal_config.h"
 
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <ctype.h>
 
 #include "opal/class/opal_object.h"

--- a/opal/util/crc.c
+++ b/opal/util/crc.c
@@ -22,15 +22,11 @@
 #ifdef HAVE_STDIO_H
 #include <stdio.h>
 #endif /* HAVE_STDIO_H */
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif  /* HAVE_STRINGS_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */

--- a/opal/util/error.c
+++ b/opal/util/error.c
@@ -23,14 +23,10 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <errno.h>
 #include <stdio.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 #include "opal/util/error.h"
 #include "opal/constants.h"

--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -26,9 +26,7 @@
 #include "opal/util/keyval/keyval_lex.h"
 #include "opal/util/output.h"
 #include "opal/threads/mutex.h"
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 int opal_util_keyval_parse_lineno = 0;
 

--- a/opal/util/opal_getcwd.c
+++ b/opal/util/opal_getcwd.c
@@ -20,9 +20,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/basename.h"
 #include "opal/util/opal_getcwd.h"

--- a/opal/util/opal_pty.c
+++ b/opal/util/opal_pty.c
@@ -71,9 +71,7 @@
 # include <unistd.h>
 #endif
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 # include <string.h>
-#endif
 #ifdef HAVE_GRP_H
 #include <grp.h>
 #endif

--- a/opal/util/output.h
+++ b/opal/util/output.h
@@ -65,9 +65,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
 
 #include "opal/class/opal_object.h"
 

--- a/opal/util/stacktrace.c
+++ b/opal/util/stacktrace.c
@@ -25,13 +25,8 @@
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/util/stacktrace.h"
 #include "opal/mca/backtrace/backtrace.h"

--- a/opal/util/sys_limits.c
+++ b/opal/util/sys_limits.c
@@ -25,9 +25,7 @@
 
 #include "opal_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include <errno.h>
 #ifdef HAVE_SYS_TYPES_H

--- a/opal/util/timings.c
+++ b/opal/util/timings.c
@@ -15,9 +15,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include <errno.h>
 #ifdef HAVE_SYS_TYPES_H

--- a/opal/win32/win_compat.h
+++ b/opal/win32/win_compat.h
@@ -72,9 +72,7 @@
 #include <signal.h>
 #include <conio.h>
 #include <fcntl.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 /**
  * For all file io operations

--- a/orte/mca/dfs/app/dfs_app.c
+++ b/orte/mca/dfs/app/dfs_app.c
@@ -17,9 +17,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif

--- a/orte/mca/dfs/base/dfs_base_frame.c
+++ b/orte/mca/dfs/base/dfs_base_frame.c
@@ -14,9 +14,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/orte/mca/dfs/base/dfs_base_select.c
+++ b/orte/mca/dfs/base/dfs_base_select.c
@@ -11,9 +11,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/mca/base/base.h"

--- a/orte/mca/dfs/orted/dfs_orted.c
+++ b/orte/mca/dfs/orted/dfs_orted.c
@@ -18,9 +18,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif

--- a/orte/mca/dfs/test/dfs_test.c
+++ b/orte/mca/dfs/test/dfs_test.c
@@ -17,9 +17,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif

--- a/orte/mca/errmgr/base/errmgr_base_fns.c
+++ b/orte/mca/errmgr/base/errmgr_base_fns.c
@@ -27,9 +27,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #if HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif  /* HAVE_SYS_TYPES_H */

--- a/orte/mca/errmgr/base/errmgr_base_frame.c
+++ b/orte/mca/errmgr/base/errmgr_base_frame.c
@@ -26,9 +26,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/orte/mca/errmgr/base/errmgr_base_select.c
+++ b/orte/mca/errmgr/base/errmgr_base_select.c
@@ -22,9 +22,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/mca/base/base.h"

--- a/orte/mca/errmgr/base/errmgr_base_tool.c
+++ b/orte/mca/errmgr/base/errmgr_base_tool.c
@@ -14,9 +14,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #if HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif  /* HAVE_SYS_TYPES_H */

--- a/orte/mca/errmgr/default_app/errmgr_default_app.c
+++ b/orte/mca/errmgr/default_app/errmgr_default_app.c
@@ -22,9 +22,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 #include "opal/dss/dss.h"

--- a/orte/mca/errmgr/default_hnp/errmgr_default_hnp.c
+++ b/orte/mca/errmgr/default_hnp/errmgr_default_hnp.c
@@ -23,9 +23,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif

--- a/orte/mca/errmgr/default_orted/errmgr_default_orted.c
+++ b/orte/mca/errmgr/default_orted/errmgr_default_orted.c
@@ -22,9 +22,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 #include "opal/dss/dss.h"

--- a/orte/mca/errmgr/default_tool/errmgr_default_tool.c
+++ b/orte/mca/errmgr/default_tool/errmgr_default_tool.c
@@ -23,9 +23,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 #include "opal/dss/dss.h"

--- a/orte/mca/ess/lsf/ess_lsf_module.c
+++ b/orte/mca/ess/lsf/ess_lsf_module.c
@@ -25,9 +25,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <ctype.h>
 
 #include <lsf/lsbatch.h>

--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <ctype.h>
 #ifdef HAVE_NETDB_H
 #include <netdb.h>

--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -26,9 +26,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/ess/slurm/ess_slurm_module.c
+++ b/orte/mca/ess/slurm/ess_slurm_module.c
@@ -25,9 +25,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <ctype.h>
 
 

--- a/orte/mca/ess/tm/ess_tm_module.c
+++ b/orte/mca/ess/tm/ess_tm_module.c
@@ -24,9 +24,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <ctype.h>
 
 

--- a/orte/mca/filem/base/filem_base_fns.c
+++ b/orte/mca/filem/base/filem_base_fns.c
@@ -18,9 +18,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/filem/base/filem_base_receive.c
+++ b/orte/mca/filem/base/filem_base_receive.c
@@ -27,9 +27,7 @@
  */
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/filem/base/filem_base_select.c
+++ b/orte/mca/filem/base/filem_base_select.c
@@ -18,9 +18,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 

--- a/orte/mca/filem/raw/filem_raw_module.c
+++ b/orte/mca/filem/raw/filem_raw_module.c
@@ -19,9 +19,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/iof/base/base.h
+++ b/orte/mca/iof/base/base.h
@@ -41,9 +41,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_bitmap.h"

--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -25,9 +25,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdio.h>
 
 #include "orte/mca/mca.h"

--- a/orte/mca/iof/base/iof_base_output.c
+++ b/orte/mca/iof/base/iof_base_output.c
@@ -26,16 +26,12 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 #include <errno.h>
 
 #include "opal/util/output.h"

--- a/orte/mca/iof/hnp/iof_hnp.c
+++ b/orte/mca/iof/hnp/iof_hnp.c
@@ -29,9 +29,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/orte/mca/iof/hnp/iof_hnp_read.c
+++ b/orte/mca/iof/hnp/iof_hnp_read.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/iof/hnp/iof_hnp_receive.c
+++ b/orte/mca/iof/hnp/iof_hnp_receive.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #else

--- a/orte/mca/iof/hnp/iof_hnp_send.c
+++ b/orte/mca/iof/hnp/iof_hnp_send.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/iof/mr_hnp/iof_mrhnp.c
+++ b/orte/mca/iof/mr_hnp/iof_mrhnp.c
@@ -16,9 +16,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/orte/mca/iof/mr_hnp/iof_mrhnp_read.c
+++ b/orte/mca/iof/mr_hnp/iof_mrhnp_read.c
@@ -16,9 +16,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/iof/mr_hnp/iof_mrhnp_receive.c
+++ b/orte/mca/iof/mr_hnp/iof_mrhnp_receive.c
@@ -16,9 +16,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #else

--- a/orte/mca/iof/mr_orted/iof_mrorted.c
+++ b/orte/mca/iof/mr_orted/iof_mrorted.c
@@ -18,9 +18,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/orte/mca/iof/mr_orted/iof_mrorted_read.c
+++ b/orte/mca/iof/mr_orted/iof_mrorted_read.c
@@ -17,9 +17,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/iof/mr_orted/iof_mrorted_receive.c
+++ b/orte/mca/iof/mr_orted/iof_mrorted_receive.c
@@ -17,9 +17,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/iof/orted/iof_orted.c
+++ b/orte/mca/iof/orted/iof_orted.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/orte/mca/iof/orted/iof_orted_read.c
+++ b/orte/mca/iof/orted/iof_orted_read.c
@@ -26,9 +26,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/iof/orted/iof_orted_receive.c
+++ b/orte/mca/iof/orted/iof_orted_receive.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/iof/tool/iof_tool.c
+++ b/orte/mca/iof/tool/iof_tool.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "orte/mca/rml/rml.h"
 #include "orte/mca/rml/rml_types.h"

--- a/orte/mca/iof/tool/iof_tool_receive.c
+++ b/orte/mca/iof/tool/iof_tool_receive.c
@@ -27,9 +27,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/dss/dss.h"
 

--- a/orte/mca/notifier/base/notifier_base_frame.c
+++ b/orte/mca/notifier/base/notifier_base_frame.c
@@ -24,9 +24,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/util/argv.h"

--- a/orte/mca/notifier/base/notifier_base_select.c
+++ b/orte/mca/notifier/base/notifier_base_select.c
@@ -21,9 +21,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/mca/base/base.h"

--- a/orte/mca/notifier/notifier.h
+++ b/orte/mca/notifier/notifier.h
@@ -39,12 +39,8 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 #ifdef HAVE_SYSLOG_H
 #include <syslog.h>
 #endif

--- a/orte/mca/notifier/smtp/notifier_smtp_module.c
+++ b/orte/mca/notifier/smtp/notifier_smtp_module.c
@@ -27,15 +27,11 @@
 
 #include <stdio.h>
 #include <string.h>
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/util/show_help.h"
 #include "opal/util/argv.h"

--- a/orte/mca/notifier/syslog/notifier_syslog_module.c
+++ b/orte/mca/notifier/syslog/notifier_syslog_module.c
@@ -28,9 +28,7 @@
 #ifdef HAVE_SYSLOG_H
 #include <syslog.h>
 #endif
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
 
 #include "opal/util/show_help.h"
 

--- a/orte/mca/odls/alps/odls_alps_module.c
+++ b/orte/mca/odls/alps/odls_alps_module.c
@@ -68,9 +68,7 @@
 #include "orte/constants.h"
 #include "orte/types.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -95,15 +93,11 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif  /* HAVE_SYS_STAT_H */
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -39,9 +39,7 @@
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 
 #include <signal.h>
 

--- a/orte/mca/odls/base/odls_base_frame.c
+++ b/orte/mca/odls/base/odls_base_frame.c
@@ -26,9 +26,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/class/opal_ring_buffer.h"
 #include "orte/mca/mca.h"

--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -68,9 +68,7 @@
 #include "orte/constants.h"
 #include "orte/types.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -95,15 +93,11 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif  /* HAVE_SYS_STAT_H */
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif

--- a/orte/mca/plm/alps/plm_alps_module.c
+++ b/orte/mca/plm/alps/plm_alps_module.c
@@ -36,12 +36,8 @@
 #include <unistd.h>
 #endif
 #include <signal.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/plm/base/plm_base_orted_cmds.c
+++ b/orte/mca/plm/base/plm_base_orted_cmds.c
@@ -23,9 +23,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/orte/mca/plm/base/plm_base_receive.c
+++ b/orte/mca/plm/base/plm_base_receive.c
@@ -28,9 +28,7 @@
  */
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/orte/mca/plm/lsf/plm_lsf_module.c
+++ b/orte/mca/plm/lsf/plm_lsf_module.c
@@ -37,9 +37,7 @@
 #include <unistd.h>
 #endif
 #include <signal.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/plm/rsh/plm_rsh.h
+++ b/orte/mca/plm/rsh/plm_rsh.h
@@ -33,9 +33,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#if HAVE_TIME_H
 #include <time.h>
-#endif
 
 #include "opal/threads/condition.h"
 #include "orte/mca/mca.h"

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -48,9 +48,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/plm/slurm/plm_slurm_module.c
+++ b/orte/mca/plm/slurm/plm_slurm_module.c
@@ -28,17 +28,13 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <sys/types.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #include <signal.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/plm/tm/plm_tm_module.c
+++ b/orte/mca/plm/tm/plm_tm_module.c
@@ -30,9 +30,7 @@
 #include "orte/constants.h"
 #include "orte/types.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/orte/mca/qos/base/qos_base_channel_handlers.c
+++ b/orte/mca/qos/base/qos_base_channel_handlers.c
@@ -16,9 +16,7 @@
  */
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"

--- a/orte/mca/qos/noop/qos_noop_channel_handlers.c
+++ b/orte/mca/qos/noop/qos_noop_channel_handlers.c
@@ -16,9 +16,7 @@
  */
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"

--- a/orte/mca/ras/base/ras_base_allocate.c
+++ b/orte/mca/ras/base/ras_base_allocate.c
@@ -21,9 +21,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"

--- a/orte/mca/rmaps/base/rmaps_base_frame.c
+++ b/orte/mca/rmaps/base/rmaps_base_frame.c
@@ -25,9 +25,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/util/argv.h"

--- a/orte/mca/rmaps/lama/rmaps_lama_module.c
+++ b/orte/mca/rmaps/lama/rmaps_lama_module.c
@@ -20,9 +20,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/mca/hwloc/hwloc.h"
 

--- a/orte/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/orte/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -30,9 +30,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/mca/base/mca_base_var.h"
 

--- a/orte/mca/rmaps/ppr/rmaps_ppr.c
+++ b/orte/mca/rmaps/ppr/rmaps_ppr.c
@@ -18,9 +18,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/util/argv.h"

--- a/orte/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/orte/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -33,9 +33,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/util/argv.h"
 #include "opal/util/if.h"

--- a/orte/mca/rmaps/rank_file/rmaps_rank_file_component.c
+++ b/orte/mca/rmaps/rank_file/rmaps_rank_file_component.c
@@ -25,9 +25,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/mca/base/base.h"
 #include "opal/mca/hwloc/base/base.h"

--- a/orte/mca/rmaps/resilient/rmaps_resilient.c
+++ b/orte/mca/rmaps/resilient/rmaps_resilient.c
@@ -22,9 +22,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <stdio.h>
 
 #include "opal/util/argv.h"

--- a/orte/mca/rmaps/round_robin/rmaps_rr.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr.c
@@ -28,9 +28,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "orte/util/show_help.h"
 #include "orte/mca/errmgr/errmgr.h"

--- a/orte/mca/rmaps/seq/rmaps_seq.c
+++ b/orte/mca/rmaps/seq/rmaps_seq.c
@@ -30,9 +30,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #include <ctype.h>
 
 #include "opal/util/if.h"

--- a/orte/mca/rmaps/staged/rmaps_staged.c
+++ b/orte/mca/rmaps/staged/rmaps_staged.c
@@ -17,9 +17,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/dss/dss.h"

--- a/orte/mca/rml/base/rml_base_channel_handlers.c
+++ b/orte/mca/rml/base/rml_base_channel_handlers.c
@@ -17,9 +17,7 @@
  */
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"

--- a/orte/mca/rml/base/rml_base_frame.c
+++ b/orte/mca/rml/base/rml_base_frame.c
@@ -17,9 +17,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/dss/dss.h"
 #include "orte/mca/mca.h"

--- a/orte/mca/rml/base/rml_base_msg_handlers.c
+++ b/orte/mca/rml/base/rml_base_msg_handlers.c
@@ -28,9 +28,7 @@
  */
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"

--- a/orte/mca/rml/base/rml_base_receive.c
+++ b/orte/mca/rml/base/rml_base_receive.c
@@ -27,9 +27,7 @@
  */
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"

--- a/orte/mca/rtc/base/rtc_base_frame.c
+++ b/orte/mca/rtc/base/rtc_base_frame.c
@@ -12,9 +12,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/class/opal_list.h"

--- a/orte/mca/rtc/freq/rtc_freq.c
+++ b/orte/mca/rtc/freq/rtc_freq.c
@@ -17,9 +17,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif  /* HAVE_DIRENT_H */

--- a/orte/mca/rtc/hwloc/rtc_hwloc.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/mca/hwloc/hwloc.h"
 #include "opal/util/argv.h"

--- a/orte/mca/schizo/base/schizo_base_frame.c
+++ b/orte/mca/schizo/base/schizo_base_frame.c
@@ -12,9 +12,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/util/argv.h"

--- a/orte/mca/snapc/base/snapc_base_fns.c
+++ b/orte/mca/snapc/base/snapc_base_fns.c
@@ -19,9 +19,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif  /* HAVE_SYS_TYPES_H */

--- a/orte/mca/snapc/base/snapc_base_frame.c
+++ b/orte/mca/snapc/base/snapc_base_frame.c
@@ -21,9 +21,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/orte/mca/snapc/base/snapc_base_select.c
+++ b/orte/mca/snapc/base/snapc_base_select.c
@@ -17,9 +17,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 

--- a/orte/mca/snapc/full/snapc_full_app.c
+++ b/orte/mca/snapc/full/snapc_full_app.c
@@ -30,12 +30,8 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>  /* for mkfifo */
 #endif  /* HAVE_SYS_STAT_H */
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/runtime/orte_cr.h"
 #include "orte/runtime/orte_globals.h"

--- a/orte/mca/snapc/full/snapc_full_global.c
+++ b/orte/mca/snapc/full/snapc_full_global.c
@@ -21,9 +21,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/include/opal/prefetch.h"
 #include "opal/util/output.h"

--- a/orte/mca/snapc/full/snapc_full_local.c
+++ b/orte/mca/snapc/full/snapc_full_local.c
@@ -22,9 +22,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif  /* HAVE_FCNTL_H */
@@ -37,9 +35,7 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/runtime/opal_progress.h"
 #include "opal/runtime/opal_cr.h"

--- a/orte/mca/sstore/base/sstore_base_fns.c
+++ b/orte/mca/sstore/base/sstore_base_fns.c
@@ -13,9 +13,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/mca/sstore/base/sstore_base_select.c
+++ b/orte/mca/sstore/base/sstore_base_select.c
@@ -10,9 +10,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 

--- a/orte/mca/sstore/central/sstore_central_app.c
+++ b/orte/mca/sstore/central/sstore_central_app.c
@@ -14,9 +14,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/sstore/central/sstore_central_global.c
+++ b/orte/mca/sstore/central/sstore_central_global.c
@@ -17,9 +17,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/sstore/central/sstore_central_local.c
+++ b/orte/mca/sstore/central/sstore_central_local.c
@@ -17,9 +17,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/sstore/central/sstore_central_module.c
+++ b/orte/mca/sstore/central/sstore_central_module.c
@@ -14,9 +14,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/sstore/stage/sstore_stage_app.c
+++ b/orte/mca/sstore/stage/sstore_stage_app.c
@@ -14,9 +14,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/sstore/stage/sstore_stage_global.c
+++ b/orte/mca/sstore/stage/sstore_stage_global.c
@@ -17,9 +17,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/sstore/stage/sstore_stage_local.c
+++ b/orte/mca/sstore/stage/sstore_stage_local.c
@@ -17,9 +17,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/sstore/stage/sstore_stage_module.c
+++ b/orte/mca/sstore/stage/sstore_stage_module.c
@@ -14,9 +14,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/orte/mca/state/app/state_app.c
+++ b/orte/mca/state/app/state_app.c
@@ -14,9 +14,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 

--- a/orte/mca/state/base/state_base_frame.c
+++ b/orte/mca/state/base/state_base_frame.c
@@ -15,9 +15,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/orte/mca/state/base/state_base_select.c
+++ b/orte/mca/state/base/state_base_select.c
@@ -12,9 +12,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/mca/mca.h"
 #include "opal/mca/base/base.h"

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -13,9 +13,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 

--- a/orte/mca/state/hnp/state_hnp.c
+++ b/orte/mca/state/hnp/state_hnp.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 

--- a/orte/mca/state/novm/state_novm.c
+++ b/orte/mca/state/novm/state_novm.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 

--- a/orte/mca/state/orted/state_orted.c
+++ b/orte/mca/state/orted/state_orted.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 #include "opal/dss/dss.h"

--- a/orte/mca/state/staged_hnp/state_staged_hnp.c
+++ b/orte/mca/state/staged_hnp/state_staged_hnp.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 

--- a/orte/mca/state/staged_orted/state_staged_orted.c
+++ b/orte/mca/state/staged_orted/state_staged_orted.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 #include "opal/dss/dss.h"

--- a/orte/mca/state/tool/state_tool.c
+++ b/orte/mca/state/tool/state_tool.c
@@ -15,9 +15,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/output.h"
 

--- a/orte/orted/orted.h
+++ b/orte/orted/orted.h
@@ -22,9 +22,7 @@
 #include "orte_config.h"
 #include "orte/types.h"
 
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 
 #include "opal/dss/dss_types.h"
 #include "opal/class/opal_pointer_array.h"

--- a/orte/orted/orted_comm.c
+++ b/orte/orted/orted_comm.c
@@ -40,9 +40,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <signal.h>
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 
 
 #include "opal/mca/event/event.h"

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -28,9 +28,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include <stdio.h>
 #include <ctype.h>

--- a/orte/runtime/data_type_support/orte_dt_compare_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_compare_fns.c
@@ -19,9 +19,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include <sys/types.h>
 

--- a/orte/runtime/data_type_support/orte_dt_copy_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_copy_fns.c
@@ -25,9 +25,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/argv.h"
 #include "opal/dss/dss.h"

--- a/orte/runtime/orte_data_server.c
+++ b/orte/runtime/orte_data_server.c
@@ -23,9 +23,7 @@
 #include "orte/constants.h"
 #include "orte/types.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>

--- a/orte/runtime/orte_quit.c
+++ b/orte/runtime/orte_quit.c
@@ -26,9 +26,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/orte/runtime/orte_wait.c
+++ b/orte/runtime/orte_wait.c
@@ -24,9 +24,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <assert.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/orte/runtime/orte_wait.h
+++ b/orte/runtime/orte_wait.h
@@ -35,9 +35,7 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#if HAVE_TIME_H
 #include <time.h>
-#endif
 #if HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif

--- a/orte/tools/orte-checkpoint/orte-checkpoint.c
+++ b/orte/tools/orte-checkpoint/orte-checkpoint.c
@@ -31,9 +31,7 @@
 
 #include <stdio.h>
 #include <errno.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
@@ -49,9 +47,7 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif  /* HAVE_SYS_WAIT_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 
 #include "opal/util/cmd_line.h"

--- a/orte/tools/orte-clean/orte-clean.c
+++ b/orte/tools/orte-clean/orte-clean.c
@@ -30,9 +30,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif  /* HAVE_SYS_STAT_H */
@@ -45,9 +43,7 @@
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif  /* HAVE_SYS_PARAM_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif  /* HAVE_DIRENT_H */

--- a/orte/tools/orte-dvm/orte-dvm.c
+++ b/orte/tools/orte-dvm/orte-dvm.c
@@ -25,13 +25,9 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdio.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif  /* HAVE_STRINGS_H */

--- a/orte/tools/orte-info/orte-info.c
+++ b/orte/tools/orte-info/orte-info.c
@@ -37,9 +37,7 @@
 #include <sys/param.h>
 #endif
 #include <errno.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/mca/installdirs/installdirs.h"
 #include "opal/class/opal_object.h"

--- a/orte/tools/orte-info/output.c
+++ b/orte/tools/orte-info/output.c
@@ -24,9 +24,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #ifdef HAVE_TERMIOS_H
 #include <termios.h>
 #endif

--- a/orte/tools/orte-migrate/orte-migrate.c
+++ b/orte/tools/orte-migrate/orte-migrate.c
@@ -22,9 +22,7 @@
 
 #include <stdio.h>
 #include <errno.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
@@ -40,9 +38,7 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif  /* HAVE_SYS_WAIT_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 
 #include "opal/util/cmd_line.h"

--- a/orte/tools/orte-ps/orte-ps.c
+++ b/orte/tools/orte-ps/orte-ps.c
@@ -38,9 +38,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif  /* HAVE_SYS_STAT_H */
@@ -50,9 +48,7 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif  /* HAVE_SYS_WAIT_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif  /* HAVE_DIRENT_H */

--- a/orte/tools/orte-restart/orte-restart.c
+++ b/orte/tools/orte-restart/orte-restart.c
@@ -34,9 +34,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /*  HAVE_STDLIB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif  /* HAVE_SYS_STAT_H */
@@ -46,9 +44,7 @@
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif  /* HAVE_SYS_WAIT_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif  /* HAVE_STRING_H */
 
 #include "opal/runtime/opal.h"
 #include "opal/runtime/opal_cr.h"

--- a/orte/tools/orte-server/orte-server.c
+++ b/orte/tools/orte-server/orte-server.c
@@ -23,9 +23,7 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include <stdio.h>
 #include <ctype.h>

--- a/orte/tools/orte-submit/orte-submit.c
+++ b/orte/tools/orte-submit/orte-submit.c
@@ -27,13 +27,9 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdio.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif  /* HAVE_STRINGS_H */

--- a/orte/tools/orted/orted.c
+++ b/orte/tools/orted/orted.c
@@ -22,9 +22,7 @@
 #include "orte_config.h"
 
 #include <stdlib.h>
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -27,13 +27,9 @@
 #include "orte_config.h"
 #include "orte/constants.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #include <stdio.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif  /* HAVE_STDLIB_H */
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif  /* HAVE_STRINGS_H */

--- a/orte/util/dash_host/dash_host.c
+++ b/orte/util/dash_host/dash_host.c
@@ -22,9 +22,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"

--- a/orte/util/error_strings.c
+++ b/orte/util/error_strings.c
@@ -29,9 +29,7 @@
 #ifdef HAVE_SYS_SIGNAL_H
 #include <sys/signal.h>
 #else
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 #endif
 
 #include "orte/mca/plm/plm_types.h"

--- a/orte/util/pre_condition_transports.c
+++ b/orte/util/pre_condition_transports.c
@@ -21,9 +21,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -36,9 +34,7 @@
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
 
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/util/alfg.h"

--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -31,9 +31,7 @@
 
 #include "orte_config.h"
 
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/oshmem/mca/spml/base/spml_base_frame.c
+++ b/oshmem/mca/spml/base/spml_base_frame.c
@@ -16,9 +16,7 @@
 #include "oshmem_config.h"
 #include <stdio.h>
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNIST_H */

--- a/oshmem/mca/spml/base/spml_base_select.c
+++ b/oshmem/mca/spml/base/spml_base_select.c
@@ -12,9 +12,7 @@
 
 #include "oshmem_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include "opal/util/show_help.h"
 #include "opal/mca/base/base.h"

--- a/oshmem/mca/sshmem/base/sshmem_base_select.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_select.c
@@ -10,9 +10,7 @@
 
 #include "oshmem_config.h"
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 
 #include "opal/constants.h"
 #include "opal/util/output.h"

--- a/oshmem/mca/sshmem/mmap/sshmem_mmap_module.c
+++ b/oshmem/mca/sshmem/mmap/sshmem_mmap_module.c
@@ -23,15 +23,11 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif /* HAVE_SYS_TYPES_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif /* HAVE_NETDB_H */
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif /* HAVE_NETDB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */

--- a/oshmem/mca/sshmem/sysv/sshmem_sysv_component.c
+++ b/oshmem/mca/sshmem/sysv/sshmem_sysv_component.c
@@ -18,9 +18,7 @@
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */

--- a/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
+++ b/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
@@ -33,9 +33,7 @@
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif /* HAVE_NETDB_H */

--- a/oshmem/mca/sshmem/verbs/sshmem_verbs_module.c
+++ b/oshmem/mca/sshmem/verbs/sshmem_verbs_module.c
@@ -23,15 +23,11 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif /* HAVE_SYS_TYPES_H */
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif /* HAVE_STRING_H */
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif /* HAVE_NETDB_H */
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif /* HAVE_NETDB_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */

--- a/oshmem/tools/oshmem_info/oshmem_info.c
+++ b/oshmem/tools/oshmem_info/oshmem_info.c
@@ -25,9 +25,7 @@
 #include <sys/param.h>
 #endif
 #include <errno.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-#endif
 
 #include "opal/version.h"
 #include "opal/mca/installdirs/installdirs.h"

--- a/test/class/ompi_rb_tree.c
+++ b/test/class/ompi_rb_tree.c
@@ -21,9 +21,7 @@
  */
 
 #include "opal_config.h"
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #else

--- a/test/class/opal_hash_table.c
+++ b/test/class/opal_hash_table.c
@@ -22,9 +22,7 @@
  */
 
 #include "opal_config.h"
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <string.h>
 #include "support.h"
 #include "opal/class/opal_object.h"

--- a/test/class/opal_proc_table.c
+++ b/test/class/opal_proc_table.c
@@ -24,9 +24,7 @@
  */
 
 #include "opal_config.h"
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <string.h>
 #include "support.h"
 #include "opal/class/opal_object.h"

--- a/test/datatype/ddt_pack.c
+++ b/test/datatype/ddt_pack.c
@@ -25,12 +25,8 @@
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/proc/proc.h"
 
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include <poll.h>
 

--- a/test/datatype/opal_ddt_lib.c
+++ b/test/datatype/opal_ddt_lib.c
@@ -14,12 +14,9 @@
 #include "opal_config.h"
 
 #include <stdio.h>
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
-#ifdef HAVE_TIME_H
 #include <time.h>
-#endif
+
 #include "opal_ddt_lib.h"
 
 #include "opal/constants.h"


### PR DESCRIPTION
This commit does two things. It removes checks for C99 required
headers (stdlib.h, string.h, signal.h, etc). Additionally it removes
definitions for required C99 types (intptr_t, int64_t, int32_t, etc).

Signed-off-by: Nathan Hjelm <hjelmn@me.com>