### PR TITLE
powerpc: update mem barrier instructions

### DIFF
--- a/opal/include/opal/sys/alpha/atomic.h
+++ b/opal/include/opal/sys/alpha/atomic.h
@@ -63,6 +63,10 @@ static inline void opal_atomic_wmb(void)
     WMB();
 }
 
+static inline void opal_atomic_isync(void)
+{
+}
+
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
 

--- a/opal/include/opal/sys/amd64/atomic.h
+++ b/opal/include/opal/sys/amd64/atomic.h
@@ -66,6 +66,10 @@ static inline void opal_atomic_wmb(void)
     MB();
 }
 
+static inline void opal_atomic_isync(void)
+{
+}
+
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
 

--- a/opal/include/opal/sys/arm/atomic.h
+++ b/opal/include/opal/sys/arm/atomic.h
@@ -88,6 +88,11 @@ void opal_atomic_wmb(void)
     WMB();
 }
 
+static inline
+void opal_atomic_isync(void)
+{
+}
+
 #endif
 
 

--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -75,6 +75,10 @@ static inline void opal_atomic_wmb(void)
     MB();
 }
 
+static inline void opal_atomic_isync(void)
+{
+}
+
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
 

--- a/opal/include/opal/sys/ia64/atomic.h
+++ b/opal/include/opal/sys/ia64/atomic.h
@@ -61,6 +61,9 @@ static inline void opal_atomic_wmb(void)
     MB();
 }
 
+static inline void opal_atomic_isync(void)
+{
+}
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 

--- a/opal/include/opal/sys/mips/atomic.h
+++ b/opal/include/opal/sys/mips/atomic.h
@@ -74,6 +74,11 @@ void opal_atomic_wmb(void)
     WMB();
 }
 
+static inline
+void opal_atomic_isync(void)
+{
+}
+
 #endif
 
 /**********************************************************************

--- a/opal/include/opal/sys/osx/atomic.h
+++ b/opal/include/opal/sys/osx/atomic.h
@@ -67,6 +67,10 @@ static inline void opal_atomic_wmb(void)
     MB();
 }
 
+static inline void opal_atomic_isync(void)
+{
+}
+
 /**********************************************************************
  *
  * Atomic math operations

--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -27,6 +27,7 @@
 #define MB()  __asm__ __volatile__ ("sync" : : : "memory")
 #define RMB() __asm__ __volatile__ ("lwsync" : : : "memory")
 #define WMB() __asm__ __volatile__ ("eieio" : : : "memory")
+#define ISYNC() __asm__ __volatile__ ("isync" : : : "memory")
 #define SMP_SYNC  "sync \n\t"
 #define SMP_ISYNC "\n\tisync"
 
@@ -74,7 +75,13 @@ void opal_atomic_rmb(void)
 static inline
 void opal_atomic_wmb(void)
 {
-    WMB();
+    RMB();
+}
+
+static inline
+void opal_atomic_isync(void)
+{
+    ISYNC();
 }
 
 #elif OPAL_XLC_INLINE_ASSEMBLY /* end OPAL_GCC_INLINE_ASSEMBLY */

--- a/opal/include/opal/sys/sparcv9/atomic.h
+++ b/opal/include/opal/sys/sparcv9/atomic.h
@@ -65,6 +65,11 @@ static inline void opal_atomic_wmb(void)
     MEMBAR("#StoreStore");
 }
 
+static inline void opal_atomic_isync(void)
+{
+}
+
+
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
 


### PR DESCRIPTION
       - added isync interface.
       - define ocoms_atomic_wmb() to lwsync as it is recommend over eieio
         on cache enabled storage.
        (http://www.ibm.com/developerworks/systems/articles/powerpc.html).