### PR TITLE
Patches for portable open-mpi packages from PathScale

### DIFF
--- a/opal/tools/wrappers/opal_wrapper.c
+++ b/opal/tools/wrappers/opal_wrapper.c
@@ -252,7 +252,8 @@ data_callback(const char *key, const char *value)
     } else if (0 == strcmp(key, "language")) {
         if (NULL != value) options_data[parse_options_idx].language = strdup(value);
     } else if (0 == strcmp(key, "compiler")) {
-        if (NULL != value) options_data[parse_options_idx].compiler = strdup(value);
+        if (NULL != value) options_data[parse_options_idx].compiler =
+            opal_install_dirs_expand(value);
     } else if (0 == strcmp(key, "project")) {
         if (NULL != value) options_data[parse_options_idx].project = strdup(value);
     } else if (0 == strcmp(key, "version")) {


### PR DESCRIPTION
04e30d4 commit adds support for auto-detecting install dir for open-mpi. If path specified at build time does not exist then openmpi uses path relative to executable.

04e30d4 adds support for ${} variables in paths to compiler in config files. With that patch we can set path to compiler relative to open-mpi install dir.