### PR TITLE
MPI extensions: build extensions by default

### DIFF
--- a/config/ompi_ext.m4
+++ b/config/ompi_ext.m4
@@ -45,8 +45,11 @@ AC_DEFUN([OMPI_EXT],[
     AC_MSG_RESULT([ompi_mpiext_list])
 
     AC_MSG_CHECKING([which MPI extension should be enabled])
-    if test "$enable_mpi_ext" = "yes" || test "$enable_mpi_ext" = "all"; then
-        msg="All Extensions"
+    if test "$enable_mpi_ext" = "" || \
+       test "$enable_mpi_ext" = "yes" || \
+       test "$enable_mpi_ext" = "all"; then
+        enable_mpi_ext=all
+        msg="All Available Extensions"
         str="`echo ENABLE_EXT_ALL=1`"
         eval $str
     else

--- a/ompi/mpiext/affinity/configure.m4
+++ b/ompi/mpiext/affinity/configure.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2004-2009 The Trustees of Indiana University.
 #                         All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -16,6 +16,10 @@ AC_DEFUN([OMPI_MPIEXT_affinity_CONFIG], [
     AC_CONFIG_FILES([ompi/mpiext/affinity/Makefile])
     AC_CONFIG_FILES([ompi/mpiext/affinity/c/Makefile])
 
-    # This example can always build, so we just execute $1.
-    $1
+    # This example can always build, so we just execute $1 if it was
+    # requested.
+    AS_IF([test "$ENABLE_affinity" = "1" || \
+           test "$ENABLE_EXT_ALL" = "1"],
+          [$1],
+          [$2])
 ])

--- a/ompi/mpiext/cr/configure.m4
+++ b/ompi/mpiext/cr/configure.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2004-2010 The Trustees of Indiana University.
 #                         All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -16,8 +16,25 @@ AC_DEFUN([OMPI_MPIEXT_cr_CONFIG],[
     AC_CONFIG_FILES([ompi/mpiext/cr/Makefile])
     AC_CONFIG_FILES([ompi/mpiext/cr/c/Makefile])
 
-    # If we don't want FT, don't compile this component
-    AS_IF([test "$opal_want_ft_cr" = "1"],
-        [$1],
-        [$2])
+    OPAL_VAR_SCOPE_PUSH([ompi_mpi_ext_cr_happy])
+
+    # If we don't want FT, don't compile this extention
+    AS_IF([test "$ENABLE_cr" = "1" || \
+           test "$ENABLE_EXT_ALL" = "1"],
+          [ompi_mpi_ext_cr_happy=1],
+          [ompi_mpi_ext_cr_happy=0])
+
+    AS_IF([test "$ompi_mpi_ext_cr_happy" = "1" && \
+           test "$opal_want_ft_cr" = "1"],
+          [$1],
+          [ # Error if the user specifically asked for this extension,
+            # but we can't build it.
+           AS_IF([test "$ENABLE_cr" = "1"],
+                 [AC_MSG_WARN([Requested "cr" MPI extension, but cannot build it])
+                  AC_MSG_WARN([because fault tolerance is not enabled.])
+                  AC_MSG_WARN([Try again with --enable-ft])
+                  AC_MSG_ERROR([Cannot continue])])
+           $2])
+
+    OPAL_VAR_SCOPE_POP
 ])

--- a/ompi/mpiext/example/configure.m4
+++ b/ompi/mpiext/example/configure.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2004-2009 The Trustees of Indiana University.
 #                         All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,8 +20,14 @@ AC_DEFUN([OMPI_MPIEXT_example_CONFIG],[
     AC_CONFIG_FILES([ompi/mpiext/example/use-mpi/Makefile])
     AC_CONFIG_FILES([ompi/mpiext/example/use-mpi-f08/Makefile])
 
-    # This example can always build, so we just execute $1.
-    $1
+    # If your extension can build, run $1.  Otherwise, run $2.  For
+    # the purposes of this example, we don't want it to build in most
+    # cases.  So only build if someone specifies an --enable-mpi-ext
+    # value that contains the token "example".
+    AS_IF([test "$ENABLE_example" = "1" || \
+           test "$ENABLE_EXT_ALL" = "1"],
+          [$1],
+          [$2])
 ])
 
 # only need to set this if the component needs init/finalize hooks


### PR DESCRIPTION
* affinity: will build unless disabled.
* cr: will build if FT is enabled, unless it is disabled.  It will   also complain/abort if you --with-mpi-ext=cr, but FT is disabled.
* example: will only build if --with-mpi-ext=example (and .ompi_ignore is removed)

This is for @rolfv.  :smile: 

@rhc54 Look good?