### PR TITLE
Create a separate OPAL event base

### DIFF
--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -428,7 +428,6 @@ int ompi_mpi_finalize(void)
     }
 
     /* Leave the RTE */
-
     if (OMPI_SUCCESS != (ret = ompi_rte_finalize())) {
         return ret;
     }
@@ -439,6 +438,9 @@ int ompi_mpi_finalize(void)
         OMPI_ERROR_LOG(ret);
         return ret;
     }
+
+    /* cleanup the progress engine */
+    opal_progress_finalize();
 
     if (OPAL_SUCCESS != (ret = opal_finalize_util())) {
         return ret;

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
@@ -482,6 +482,16 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
 
     /* check for timing request - get stop time and report elapsed time if so */
     OPAL_TIMING_MNEXT((&tm,"time from completion of rte_init to modex"));
+
+    /*
+     * Initialize the general progress engine
+     */
+    if (OPAL_SUCCESS != (ret = opal_progress_init())) {
+        error = "opal_progress_init";
+        goto error;
+    }
+    /* we want to tick the event library whenever possible */
+    opal_progress_event_users_increment();
 
 #if OPAL_HAVE_HWLOC
     /* if hwloc is available but didn't get setup for some

--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -75,6 +75,7 @@ nobase_opal_HEADERS = $(headers)
 endif
 
 include class/Makefile.am
+include errhandler/Makefile.am
 include memoryhooks/Makefile.am
 include runtime/Makefile.am
 include threads/Makefile.am

--- a/opal/errhandler/Makefile.am
+++ b/opal/errhandler/Makefile.am
@@ -1,0 +1,17 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2015      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This makefile.am does not stand on its own - it is included from opal/Makefile.am
+
+headers += \
+        errhandler/opal_errhandler.h
+
+lib@OPAL_LIB_PREFIX@open_pal_la_SOURCES += \
+        errhandler/opal_errhandler.c

--- a/opal/errhandler/opal_errhandler.c
+++ b/opal/errhandler/opal_errhandler.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "opal/errhandler/opal_errhandler.h"
+
+opal_errhandler_fn_t errhandler = NULL;
+void *cbdata = NULL;
+
+void opal_register_errhandler(opal_errhandler_fn_t newerr, void *cbd)
+{
+    errhandler = newerr;
+    cbdata = cbd;
+}
+
+void opal_deregister_errhandler(void)
+{
+    errhandler = NULL;
+    cbdata = NULL;
+}
+
+void opal_invoke_errhandler(int status, opal_proc_t *proc)
+{
+    if (NULL != errhandler) {
+        errhandler(status, proc, cbdata);
+    }
+}

--- a/opal/errhandler/opal_errhandler.h
+++ b/opal/errhandler/opal_errhandler.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_ERRHANDLER_H
+#define OPAL_ERRHANDLER_H
+
+#include "opal_config.h"
+
+#include "opal/util/proc.h"
+
+typedef void (*opal_errhandler_fn_t)(int status, opal_proc_t *proc, void *cbdata);
+
+OPAL_DECLSPEC void opal_register_errhandler(opal_errhandler_fn_t errhandler, void *cbdata);
+
+OPAL_DECLSPEC void opal_deregister_errhandler(void);
+
+OPAL_DECLSPEC void opal_invoke_errhandler(int status, opal_proc_t *proc);
+
+#endif

--- a/opal/mca/btl/openib/btl_openib_fd.c
+++ b/opal/mca/btl/openib/btl_openib_fd.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2009 Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  *
  * $COPYRIGHT$
  *

--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -7,7 +7,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Bull SAS.  All rights reserved.
  *
  * $COPYRIGHT$

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2015 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -818,7 +818,7 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
     /* register listen port */
 #if OPAL_ENABLE_IPV6
     if (AF_INET6 == af_family) {
-        opal_event_set(opal_event_base, &mca_btl_tcp_component.tcp6_recv_event,
+        opal_event_set(opal_progress_event_base, &mca_btl_tcp_component.tcp6_recv_event,
                         mca_btl_tcp_component.tcp6_listen_sd,
                         OPAL_EV_READ|OPAL_EV_PERSIST,
                         mca_btl_tcp_component_accept_handler,
@@ -827,7 +827,7 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
     } else
 #endif
     {
-        opal_event_set(opal_event_base, &mca_btl_tcp_component.tcp_recv_event,
+        opal_event_set(opal_progress_event_base, &mca_btl_tcp_component.tcp_recv_event,
                         mca_btl_tcp_component.tcp_listen_sd,
                         OPAL_EV_READ|OPAL_EV_PERSIST,
                         mca_btl_tcp_component_accept_handler,
@@ -1049,7 +1049,7 @@ static void mca_btl_tcp_component_accept_handler( int incoming_sd,
 
         /* wait for receipt of peers process identifier to complete this connection */
         event = OBJ_NEW(mca_btl_tcp_event_t);
-        opal_event_set(opal_event_base, &event->event, sd, OPAL_EV_READ, mca_btl_tcp_component_recv_handler, event);
+        opal_event_set(opal_progress_event_base, &event->event, sd, OPAL_EV_READ, mca_btl_tcp_component_recv_handler, event);
         opal_event_add(&event->event, 0);
     }
 }

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -309,7 +309,7 @@ static inline void mca_btl_tcp_endpoint_event_init(mca_btl_base_endpoint_t* btl_
     btl_endpoint->endpoint_cache_pos = btl_endpoint->endpoint_cache;
 #endif  /* MCA_BTL_TCP_ENDPOINT_CACHE */
 
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_recv_event,
+    opal_event_set(opal_progress_event_base, &btl_endpoint->endpoint_recv_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_READ|OPAL_EV_PERSIST,
                     mca_btl_tcp_endpoint_recv_handler,
@@ -320,7 +320,7 @@ static inline void mca_btl_tcp_endpoint_event_init(mca_btl_base_endpoint_t* btl_
      * will be fired only once, and when the endpoint is marked as
      * CONNECTED the event should be recreated with the correct flags.
      */
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_send_event,
+    opal_event_set(opal_progress_event_base, &btl_endpoint->endpoint_send_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_WRITE,
                     mca_btl_tcp_endpoint_send_handler,
@@ -509,7 +509,7 @@ void mca_btl_tcp_endpoint_accept(mca_btl_base_endpoint_t* btl_endpoint,
     assert(btl_endpoint->endpoint_sd_next == -1);
     btl_endpoint->endpoint_sd_next = sd;
 
-    opal_event_evtimer_set(opal_event_base, &btl_endpoint->endpoint_accept_event,
+    opal_event_evtimer_set(opal_progress_event_base, &btl_endpoint->endpoint_accept_event,
                            mca_btl_tcp_endpoint_complete_accept, btl_endpoint);
     opal_event_add(&btl_endpoint->endpoint_accept_event, &now);
 }
@@ -570,7 +570,7 @@ static void mca_btl_tcp_endpoint_connected(mca_btl_base_endpoint_t* btl_endpoint
     MCA_BTL_TCP_ENDPOINT_DUMP(1, btl_endpoint, true, "READY [endpoint_connected]");
 
     /* Create the send event in a persistent manner. */
-    opal_event_set(opal_event_base, &btl_endpoint->endpoint_send_event,
+    opal_event_set(opal_progress_event_base, &btl_endpoint->endpoint_send_event,
                     btl_endpoint->endpoint_sd,
                     OPAL_EV_WRITE | OPAL_EV_PERSIST,
                     mca_btl_tcp_endpoint_send_handler,

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -972,7 +972,7 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
     }
 
     /* start timer to guarantee synthetic clock advances */
-    opal_event_set(opal_event_base, &usnic_clock_timer_event,
+    opal_event_set(opal_progress_event_base, &usnic_clock_timer_event,
                    -1, 0, usnic_clock_callback,
                    &usnic_clock_timeout);
     usnic_clock_timer_event_set = true;

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -2068,7 +2068,7 @@ static void init_async_event(opal_btl_usnic_module_t *module)
     }
 
     /* Get the fd to receive events on this device */
-    opal_event_set(opal_event_base, &(module->device_async_event), fd,
+    opal_event_set(opal_progress_event_base, &(module->device_async_event), fd,
                    OPAL_EV_READ | OPAL_EV_PERSIST,
                    module_async_event_callback, module);
     opal_event_add(&(module->device_async_event), NULL);

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -212,7 +213,7 @@ int opal_btl_usnic_stats_init(opal_btl_usnic_module_t *module)
         module->stats.timeout.tv_sec = mca_btl_usnic_component.stats_frequency;
         module->stats.timeout.tv_usec = 0;
 
-        opal_event_set(opal_event_base, &(module->stats.timer_event),
+        opal_event_set(opal_progress_event_base, &(module->stats.timer_event),
                        -1, EV_TIMEOUT | EV_PERSIST,
                        &usnic_stats_callback, module);
         opal_event_add(&(module->stats.timer_event),

--- a/opal/mca/event/base/event_base_frame.c
+++ b/opal/mca/event/base/event_base_frame.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +15,7 @@
 #include "opal/util/output.h"
 #include "opal/mca/mca.h"
 #include "opal/mca/base/base.h"
+#include "opal/runtime/opal_progress_threads.h"
 
 #include "opal/mca/event/event.h"
 #include "opal/mca/event/base/base.h"
@@ -65,6 +66,7 @@ static int opal_event_base_close(void)
  * Globals
  */
 opal_event_base_t *opal_event_base=NULL;
+opal_event_base_t *opal_progress_event_base=NULL;
 
 static int opal_event_base_open(mca_base_open_flag_t flags)
 {
@@ -83,15 +85,5 @@ static int opal_event_base_open(mca_base_open_flag_t flags)
     /* Declare our intent to use threads */
     opal_event_use_threads();
 
-    /* get our event base */
-    if (NULL == (opal_event_base = opal_event_base_create())) {
-        return OPAL_ERROR;
-    }
-
-    /* set the number of priorities */
-    if (0 < OPAL_EVENT_NUM_PRI) {
-        opal_event_base_priority_init(opal_event_base, OPAL_EVENT_NUM_PRI);
-    }
-
-    return rc;
+    return OPAL_SUCCESS;
 }

--- a/opal/mca/event/event.h
+++ b/opal/mca/event/event.h
@@ -36,13 +36,15 @@ BEGIN_C_DECLS
 #define OPAL_EVENT_NUM_PRI   8
 
 #define OPAL_EV_ERROR_PRI         0
-#define OPAL_EV_MSG_HI_PRI        1
-#define OPAL_EV_SYS_HI_PRI        2
-#define OPAL_EV_MSG_LO_PRI        3
-#define OPAL_EV_SYS_LO_PRI        4
-#define OPAL_EV_INFO_HI_PRI       5
-#define OPAL_EV_INFO_LO_PRI       6
-#define OPAL_EV_LOWEST_PRI        7
+
+#define OPAL_EV_BTL_RED_PRI       1
+#define OPAL_EV_BTL_YEL_PRI       2
+#define OPAL_EV_BTL_GRN_PRI       3
+#define OPAL_EV_BTL_BLU_PRI       4
+
+#define OPAL_EV_RTE_HI_PRI        5
+#define OPAL_EV_RTE_MED_PRI       6
+#define OPAL_EV_RTE_LO_PRI        7
 
 #define OPAL_EVENT_SIGNAL(ev)	opal_event_get_signal(ev)
 

--- a/opal/mca/event/external/external.h
+++ b/opal/mca/event/external/external.h
@@ -28,6 +28,7 @@ typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
 OPAL_DECLSPEC extern opal_event_base_t *opal_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_progress_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/event/libevent2022/libevent2022.h
+++ b/opal/mca/event/libevent2022/libevent2022.h
@@ -68,6 +68,7 @@ typedef struct event_base opal_event_base_t;
 typedef struct event opal_event_t;
 
 OPAL_DECLSPEC extern opal_event_base_t *opal_event_base;
+OPAL_DECLSPEC extern opal_event_base_t *opal_progress_event_base;
 
 #define OPAL_EV_TIMEOUT EV_TIMEOUT
 #define OPAL_EV_READ    EV_READ

--- a/opal/mca/pmix/base/base.h
+++ b/opal/mca/pmix/base/base.h
@@ -33,7 +33,7 @@ OPAL_DECLSPEC extern bool opal_pmix_base_allow_delayed_server;
 
 OPAL_DECLSPEC void opal_pmix_base_register_handler(opal_pmix_errhandler_fn_t err);
 OPAL_DECLSPEC void opal_pmix_base_deregister_handler(void);
-OPAL_DECLSPEC void opal_pmix_base_errhandler(int error);
+OPAL_DECLSPEC void opal_pmix_base_errhandler(int error, opal_proc_t *proc);
 
 
 END_C_DECLS

--- a/opal/mca/pmix/base/pmix_base_fns.c
+++ b/opal/mca/pmix/base/pmix_base_fns.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -41,10 +41,10 @@ void opal_pmix_base_register_handler(opal_pmix_errhandler_fn_t err)
     errhandler = err;
 }
 
-void opal_pmix_base_errhandler(int error)
+void opal_pmix_base_errhandler(int error, opal_proc_t *proc)
 {
     if (NULL != errhandler) {
-        errhandler(error);
+        errhandler(error, proc);
     }
 }
 

--- a/opal/mca/pmix/native/pmix_native.h
+++ b/opal/mca/pmix/native/pmix_native.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,8 +44,10 @@ typedef enum {
 /* define a macro for abnormal termination */
 #define PMIX_NATIVE_ABNORMAL_TERM                               \
     do {                                                        \
+        opal_proc_t *me;                                        \
+        me = opal_proc_local_get();                             \
         mca_pmix_native_component.state = PMIX_USOCK_FAILED;    \
-        opal_pmix_base_errhandler(OPAL_ERR_COMM_FAILURE);       \
+        opal_pmix_base_errhandler(OPAL_ERR_COMM_FAILURE, me);   \
     } while(0);
 
 /* define a command type for communicating to the
@@ -140,7 +142,6 @@ typedef struct {
     opal_buffer_t *cache_local;
     opal_buffer_t *cache_remote;
     opal_buffer_t *cache_global;
-    opal_event_base_t *evbase;
     opal_process_name_t id;
     opal_process_name_t server;
     char *uri;
@@ -190,9 +191,9 @@ OPAL_MODULE_DECLSPEC int usock_send_connect_ack(void);
         ms->bfr = (b);                                                  \
         ms->cbfunc = (cb);                                              \
         ms->cbdata = (d);                                               \
-        opal_event_set(mca_pmix_native_component.evbase, &((ms)->ev), -1, \
-                       OPAL_EV_WRITE, pmix_usock_send_recv, (ms));   \
-        opal_event_set_priority(&((ms)->ev), OPAL_EV_MSG_LO_PRI);       \
+        opal_event_set(opal_event_base, &((ms)->ev), -1,                \
+                       OPAL_EV_WRITE, pmix_usock_send_recv, (ms));      \
+        opal_event_set_priority(&((ms)->ev), OPAL_EV_RTE_HI_PRI);       \
         opal_event_active(&((ms)->ev), OPAL_EV_WRITE, 1);               \
     } while(0);
 
@@ -202,10 +203,10 @@ OPAL_MODULE_DECLSPEC int usock_send_connect_ack(void);
                             "%s [%s:%d] post msg",                      \
                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),         \
                             __FILE__, __LINE__);                        \
-        opal_event_set(mca_pmix_native_component.evbase, &ms->ev, -1,   \
+        opal_event_set(opal_event_base, &ms->ev, -1,                    \
                        OPAL_EV_WRITE,                                   \
                        pmix_usock_process_msg, ms);                     \
-        opal_event_set_priority(&ms->ev, OPAL_EV_MSG_LO_PRI);           \
+        opal_event_set_priority(&ms->ev, OPAL_EV_RTE_HI_PRI);           \
         opal_event_active(&ms->ev, OPAL_EV_WRITE, 1);                   \
     } while(0);
 

--- a/opal/mca/pmix/native/pmix_native_component.c
+++ b/opal/mca/pmix/native/pmix_native_component.c
@@ -82,7 +82,6 @@ static int pmix_native_open(void)
     mca_pmix_native_component.cache_local = NULL;
     mca_pmix_native_component.cache_remote = NULL;
     mca_pmix_native_component.cache_global = NULL;
-    mca_pmix_native_component.evbase = NULL;
     mca_pmix_native_component.id = opal_name_invalid;
     mca_pmix_native_component.server = opal_name_invalid;
     mca_pmix_native_component.uri = NULL;

--- a/opal/mca/pmix/native/usock.c
+++ b/opal/mca/pmix/native/usock.c
@@ -68,14 +68,14 @@ static OBJ_CLASS_INSTANCE(pmix_usock_op_t,
                           opal_object_t,
                           NULL, NULL);
 
-#define PMIX_ACTIVATE_USOCK_STATE(cbfunc)                               \
-    do {                                                                \
-        pmix_usock_op_t *op;                                            \
-        op = OBJ_NEW(pmix_usock_op_t);                                  \
-        opal_event_set(mca_pmix_native_component.evbase, &op->ev, -1,   \
-                       OPAL_EV_WRITE, (cbfunc), op);                    \
-        opal_event_set_priority(&op->ev, OPAL_EV_MSG_LO_PRI);           \
-        opal_event_active(&op->ev, OPAL_EV_WRITE, 1);                    \
+#define PMIX_ACTIVATE_USOCK_STATE(cbfunc)                       \
+    do {                                                        \
+        pmix_usock_op_t *op;                                    \
+        op = OBJ_NEW(pmix_usock_op_t);                          \
+        opal_event_set(opal_event_base, &op->ev, -1,            \
+                       OPAL_EV_WRITE, (cbfunc), op);            \
+        opal_event_set_priority(&op->ev, OPAL_EV_RTE_HI_PRI);   \
+        opal_event_active(&op->ev, OPAL_EV_WRITE, 1);           \
     } while(0);
 
 void pmix_usock_send_recv(int fd, short args, void *cbdata)
@@ -275,20 +275,20 @@ static void pmix_usock_try_connect(int fd, short args, void *cbdata)
                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
 
     /* setup event callbacks */
-    opal_event_set(mca_pmix_native_component.evbase,
+    opal_event_set(opal_event_base,
                    &mca_pmix_native_component.recv_event,
                    mca_pmix_native_component.sd,
                    OPAL_EV_READ|OPAL_EV_PERSIST,
                    pmix_usock_recv_handler, NULL);
-    opal_event_set_priority(&mca_pmix_native_component.recv_event, OPAL_EV_MSG_LO_PRI);
+    opal_event_set_priority(&mca_pmix_native_component.recv_event, OPAL_EV_RTE_HI_PRI);
     mca_pmix_native_component.recv_ev_active = false;
 
-    opal_event_set(mca_pmix_native_component.evbase,
+    opal_event_set(opal_event_base,
                    &mca_pmix_native_component.send_event,
                    mca_pmix_native_component.sd,
                    OPAL_EV_WRITE|OPAL_EV_PERSIST,
                    pmix_usock_send_handler, NULL);
-    opal_event_set_priority(&mca_pmix_native_component.send_event, OPAL_EV_MSG_LO_PRI);
+    opal_event_set_priority(&mca_pmix_native_component.send_event, OPAL_EV_RTE_HI_PRI);
     mca_pmix_native_component.send_ev_active = false;
 
     /* setup the socket as non-blocking */

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -280,13 +280,11 @@ typedef void (*opal_pmix_cbfunc_t)(int status, opal_value_t *kv, void *cbdata);
  * that takes into account directives and availability of
  * non-blocking operations
  */
-#define OPAL_FENCE(p, s, cf, cd)                                        \
-    do {                                                                \
-        opal_pmix.fence((p), (s));                                      \
-    } while(0);
+#define OPAL_FENCE(p, s, cf, cd)                \
+        opal_pmix.fence((p), (s));
 
 /* callback handler for errors */
-typedef void (*opal_pmix_errhandler_fn_t)(int error);
+typedef void (*opal_pmix_errhandler_fn_t)(int error, opal_proc_t *proc);
 
 /****    DEFINE THE PUBLIC API'S                          ****
  ****    NOTE THAT WE DO NOT HAVE A 1:1 MAPPING OF APIs   ****

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -280,8 +280,10 @@ typedef void (*opal_pmix_cbfunc_t)(int status, opal_value_t *kv, void *cbdata);
  * that takes into account directives and availability of
  * non-blocking operations
  */
-#define OPAL_FENCE(p, s, cf, cd)        \
-        opal_pmix.fence((p), (s));
+#define OPAL_FENCE(p, s, cf, cd)                                        \
+    do {                                                                \
+        opal_pmix.fence((p), (s));                                      \
+    } while(0);
 
 /* callback handler for errors */
 typedef void (*opal_pmix_errhandler_fn_t)(int error);

--- a/opal/mca/sec/basic/sec_basic.c
+++ b/opal/mca/sec/basic/sec_basic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
   * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +37,7 @@ opal_sec_base_module_t opal_sec_basic_module = {
     authenticate
 };
 
-static opal_sec_cred_t my_cred;
+static opal_sec_cred_t my_cred = {NULL, NULL, 0};
 static bool initialized = false;
 
 static int init(void)
@@ -47,9 +47,16 @@ static int init(void)
 
 static void finalize(void)
 {
-    if (initialized) {
+    if (NULL != my_cred.credential) {
         free(my_cred.credential);
+        my_cred.credential = NULL;
     }
+    if (NULL != my_cred.method) {
+        free(my_cred.method);
+        my_cred.method = NULL;
+    }
+    my_cred.size = 0;
+    initialized = false;
 }
 
 static int get_my_cred(int dstorehandle,

--- a/opal/mca/sec/munge/sec_munge.c
+++ b/opal/mca/sec/munge/sec_munge.c
@@ -40,7 +40,7 @@ opal_sec_base_module_t opal_sec_munge_module = {
     authenticate
 };
 
-static opal_sec_cred_t my_cred;
+static opal_sec_cred_t my_cred = {NULL, NULL, 0};
 static bool initialized = false;
 static bool refresh = false;
 
@@ -70,9 +70,15 @@ static int init(void)
 
 static void finalize(void)
 {
-    if (initialized) {
+    if (NULL != my_cred.credential) {
         free(my_cred.credential);
+        my_cred.credential = NULL;
     }
+    if (NULL != my_cred.method) {
+        free(my_cred.method);
+        my_cred.method = NULL;
+    }
+    my_cred.size = 0;
 }
 
 static int get_my_cred(int dstorehandle,

--- a/opal/runtime/opal_finalize.c
+++ b/opal/runtime/opal_finalize.c
@@ -47,6 +47,7 @@
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/mca/event/base/base.h"
 #include "opal/runtime/opal_progress.h"
+#include "opal/runtime/opal_progress_threads.h"
 #include "opal/mca/shmem/base/base.h"
 #if OPAL_ENABLE_FT_CR    == 1
 #include "opal/mca/compress/base/base.h"
@@ -133,9 +134,7 @@ opal_finalize(void)
         }
         return OPAL_SUCCESS;
     }
-
-    opal_progress_finalize();
-
+    
     /* close the checkpoint and restart service */
     opal_cr_finalize();
 

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -470,16 +470,6 @@ opal_init(int* pargc, char*** pargv)
         goto return_error;
     }
 
-    /*
-     * Initialize the general progress engine
-     */
-    if (OPAL_SUCCESS != (ret = opal_progress_init())) {
-        error = "opal_progress_init";
-        goto return_error;
-    }
-    /* we want to tick the event library whenever possible */
-    opal_progress_event_users_increment();
-
     /* setup the shmem framework */
     if (OPAL_SUCCESS != (ret = mca_base_framework_open(&opal_shmem_base_framework, 0))) {
         error = "opal_shmem_base_open";

--- a/opal/runtime/opal_progress_threads.c
+++ b/opal/runtime/opal_progress_threads.c
@@ -175,11 +175,13 @@ void opal_stop_progress_thread(char *name, bool cleanup)
              * case the thread is blocked in a call to select for
              * a long time */
             if (trk->block_active) {
+                trk->block_active = false;
                 i=1;
                 write(trk->pipe[1], &i, sizeof(int));
             }
             /* wait for thread to exit */
             opal_thread_join(&trk->engine, NULL);
+            /* mark the block as inactive */
             /* cleanup, if they indicated they are done with this event base */
             if (cleanup) {
                 opal_list_remove_item(&tracking, &trk->super);

--- a/opal/runtime/opal_progress_threads.h
+++ b/opal/runtime/opal_progress_threads.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/orte/runtime/orte_finalize.c
+++ b/orte/runtime/orte_finalize.c
@@ -26,6 +26,7 @@
 #include "orte/constants.h"
 
 #include "opal/runtime/opal.h"
+#include "opal/runtime/opal_progress_threads.h"
 #include "opal/util/output.h"
 
 #include "orte/mca/ess/ess.h"
@@ -82,6 +83,11 @@ int orte_finalize(void)
     /* Close the general debug stream */
     opal_output_close(orte_debug_output);
 
+    /* shutdown the async progress thread, if we have one */
+    if (ORTE_PROC_IS_APP) {
+        opal_stop_progress_thread("opal", true);
+    }
+    
     /* finalize the opal utilities */
     rc = opal_finalize();
 

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -125,9 +125,9 @@ ORTE_DECLSPEC extern int orte_exit_status;
  * that overrides the need to process MPI messages
  */
 #define ORTE_ERROR_PRI  OPAL_EV_ERROR_PRI
-#define ORTE_MSG_PRI    OPAL_EV_MSG_LO_PRI
-#define ORTE_SYS_PRI    OPAL_EV_SYS_LO_PRI
-#define ORTE_INFO_PRI   OPAL_EV_INFO_LO_PRI
+#define ORTE_MSG_PRI    OPAL_EV_RTE_HI_PRI
+#define ORTE_SYS_PRI    OPAL_EV_RTE_MED_PRI
+#define ORTE_INFO_PRI   OPAL_EV_RTE_LO_PRI
 
 /* define some common keys used in ORTE */
 #define ORTE_DB_DAEMON_VPID  "orte.daemon.vpid"


### PR DESCRIPTION
Create a separate OPAL event base (opal_progress_event_base) that is progressed only via call to opal_progress. Move the opal_event_base into an async progress thread. Update all the BTLs to use the opal_progress_event_base so they retain their prior behavior - BTL authors may want to evaluate their events to see if any should move to the async thread.

This completes the Jan meeting deliverable

@jsquyres @hjelmn  please take a look
