### PR TITLE
Add a macro to indicate CUDA-aware support

### DIFF
--- a/ompi/mpiext/cuda/c/mpiext_cuda_c.h
+++ b/ompi/mpiext/cuda/c/mpiext_cuda_c.h
@@ -12,4 +12,5 @@
  *
  */
 
+#define MPIX_CUDA_AWARE_SUPPORT 1
 OMPI_DECLSPEC int MPIx_CUDA_SUPPORT(void);


### PR DESCRIPTION
Add macro to indicate CUDA-aware support has been built into the library.  This code is only built when the library was configued using --with-cuda.