### PR TITLE
Ensure we always set sizeof_bool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -375,6 +375,7 @@ AC_CHECK_TYPES(ptrdiff_t)
 # Check for type sizes
 #
 
+AC_CHECK_SIZEOF(_Bool)
 AC_CHECK_SIZEOF(char)
 AC_CHECK_SIZEOF(short)
 AC_CHECK_SIZEOF(int)


### PR DESCRIPTION
When building --no-ompi, we don't run setup_cxx and hence sizeof_bool never gets set. So set it in configure.ac so everyone always has it

Check for sizeof(_Bool) so we don't need the C++ compiler

@jsquyres This should make you happy! We may also need this in 2.x as I think (but don't clearly recall) we moved the stdbool.h changes over there.