### PR TITLE
bool: use SIZEOF__BOOL, not SIZEOF_BOOL

### DIFF
--- a/opal/datatype/opal_copy_functions.c
+++ b/opal/datatype/opal_copy_functions.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -224,13 +225,13 @@ COPY_TYPE ( long_double_complex, long double _Complex, 1)
 #define copy_long_double_complex NULL
 #endif
 
-#if SIZEOF_BOOL == SIZEOF_CHAR
+#if SIZEOF__BOOL == SIZEOF_CHAR
 COPY_TYPE (bool, char, 1)
-#elif SIZEOF_BOOL == SIZEOF_SHORT
+#elif SIZEOF__BOOL == SIZEOF_SHORT
 COPY_TYPE (bool, short, 1)
-#elif SIZEOF_BOOL == SIZEOF_INT
+#elif SIZEOF__BOOL == SIZEOF_INT
 COPY_TYPE (bool, int, 1)
-#elif SIZEOF_BOOL == SIZEOF_LONG
+#elif SIZEOF__BOOL == SIZEOF_LONG
 COPY_TYPE (bool, long, 1)
 #else
 #error No basic type for copy function for opal_datatype_bool found

--- a/opal/dss/dss_internal.h
+++ b/opal/dss/dss_internal.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,13 +74,13 @@ BEGIN_C_DECLS
  * Internal type corresponding to bool.  Do not use this in interface
  * calls - use OPAL_BOOL instead.
  */
-#if SIZEOF_BOOL == 1
+#if SIZEOF__BOOL == 1
 #define DSS_TYPE_BOOL OPAL_UINT8
-#elif SIZEOF_BOOL == 2
+#elif SIZEOF__BOOL == 2
 #define DSS_TYPE_BOOL OPAL_UINT16
-#elif SIZEOF_BOOL == 4
+#elif SIZEOF__BOOL == 4
 #define DSS_TYPE_BOOL OPAL_UINT32
-#elif SIZEOF_BOOL == 8
+#elif SIZEOF__BOOL == 8
 #define DSS_TYPE_BOOL OPAL_UINT64
 #else
 #error Unsupported bool size!


### PR DESCRIPTION
When you "autogen.pl --no-ompi", the AC_SIZEOF(bool) test is not run. But we *do* run AC_SIZEOF(_Bool), which is the equivalent.  So switch the uses of SIZEOF_BOOL in the code base to be SIZEOF__BOOL, and it's all good.

@rhc54 Did the bool improvements come over to v2.x yet?  If not, this patch will need to be included in the PR to v2.x.