### PR TITLE
usnic fixes for differences between libfabric v1.0.0 and v1.1.0

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic.h
+++ b/opal/mca/btl/usnic/btl_usnic.h
@@ -220,6 +220,12 @@ typedef struct opal_btl_usnic_component_t {
         API >=v1.1, the usnic provider returned 1 upon success. */
     ssize_t cq_readerr_success_value;
     ssize_t cq_readerr_try_again_value;
+
+    /** Offset into the send buffer where the payload will go.  For
+        libfabric v1.0.0 / API v1.0, this is 0.  For libfabric >=v1.1
+        / API >=v1.1, this is the endpoint.msg_prefix_size (i.e.,
+        component.transport_header_len). */
+    uint32_t prefix_send_offset;
 } opal_btl_usnic_component_t;
 
 OPAL_MODULE_DECLSPEC extern opal_btl_usnic_component_t mca_btl_usnic_component;

--- a/opal/mca/btl/usnic/btl_usnic.h
+++ b/opal/mca/btl/usnic/btl_usnic.h
@@ -93,7 +93,7 @@ extern opal_rng_buff_t opal_btl_usnic_rand_buff;
 
 /* Set to >0 to randomly drop received frags.  The higher the number,
    the more frequent the drops. */
-#define WANT_RECV_FRAG_DROPS 0
+#define WANT_RECV_DROPS 0
 /* Set to >0 to randomly fail to send an ACK, mimicing a lost ACK.
    The higher the number, the more frequent the failed-to-send-ACK. */
 #define WANT_FAIL_TO_SEND_ACK 0
@@ -102,10 +102,10 @@ extern opal_rng_buff_t opal_btl_usnic_rand_buff;
    the failed-to-resend-frag. */
 #define WANT_FAIL_TO_RESEND_FRAG 0
 
-#if WANT_RECV_FRAG_DROPS > 0
-#define FAKE_RECV_FRAG_DROP (opal_rand(&opal_btl_usnic_rand_buff) < WANT_RECV_FRAG_DROPS)
+#if WANT_RECV_DROPS > 0
+#define FAKE_RECV_DROP (opal_rand(&opal_btl_usnic_rand_buff) < WANT_RECV_DROPS)
 #else
-#define FAKE_RECV_FRAG_DROP 0
+#define FAKE_RECV_DROP 0
 #endif
 
 #if WANT_FAIL_TO_SEND_ACK > 0

--- a/opal/mca/btl/usnic/btl_usnic.h
+++ b/opal/mca/btl/usnic/btl_usnic.h
@@ -213,6 +213,13 @@ typedef struct opal_btl_usnic_component_t {
     /* Prefix for the connectivity map filename (map will be output if
        the prefix is non-NULL) */
     char *connectivity_map_prefix;
+
+    /** Expected return value from fi_cq_readerr() upon success.  In
+        libfabric v1.0.0 / API v1.0, the usnic provider returned
+        sizeof(fi_cq_err_entry) upon success.  In libfabric >=v1.1 /
+        API >=v1.1, the usnic provider returned 1 upon success. */
+    ssize_t cq_readerr_success_value;
+    ssize_t cq_readerr_try_again_value;
 } opal_btl_usnic_component_t;
 
 OPAL_MODULE_DECLSPEC extern opal_btl_usnic_component_t mca_btl_usnic_component;

--- a/opal/mca/btl/usnic/btl_usnic_ack.c
+++ b/opal/mca/btl/usnic/btl_usnic_ack.c
@@ -252,6 +252,7 @@ opal_btl_usnic_ack_complete(opal_btl_usnic_module_t *module,
                                    opal_btl_usnic_ack_segment_t *ack)
 {
     opal_btl_usnic_ack_segment_return(module, ack);
+    ++module->mod_channels[ack->ss_channel].credits;
 }
 
 /*****************************************************************************/

--- a/opal/mca/btl/usnic/btl_usnic_ack.c
+++ b/opal/mca/btl/usnic/btl_usnic_ack.c
@@ -201,8 +201,7 @@ opal_btl_usnic_ack_send(
     /* Get an ACK frag.  If we don't get one, just discard this ACK. */
     ack = opal_btl_usnic_ack_segment_alloc(module);
     if (OPAL_UNLIKELY(NULL == ack)) {
-        opal_output(0, "====================== No frag for sending the ACK -- skipped");
-        abort();
+        return;
     }
 
     /* send the seq of the lowest item in the window that

--- a/opal/mca/btl/usnic/btl_usnic_compat.c
+++ b/opal/mca/btl/usnic/btl_usnic_compat.c
@@ -715,6 +715,25 @@ opal_btl_usnic_put(struct mca_btl_base_module_t *base_module,
     sfrag->sf_size = size;
     sfrag->sf_ack_bytes_left = size;
 
+
+
+    /* JMS NOTE: This is currently broken, and is deactivated by
+       removing the MCA_BTL_FLAGS_PUT from .btl_flags in btl_module.c.
+
+       Overwriting the uf_local_seg values is not a good idea, and
+       doesn't do anything to actually send the data in the
+       progression past finish_put_or_send().
+
+       The proper fix is to change the plumbing here to eventually
+       call fi_sendv() with an iov[0] = the internal buffer that's
+       already allocated, and iov[1] = the user's buffer.  The usnic
+       provider in fi_sendv() will be smart enough to figure out which
+       is more performance: memcpy'ing the 2 buffers together and
+       doing a single xfer down to the hardware, or actually doing a
+       SG list down to the hardware. */
+
+
+
     opal_btl_usnic_frag_t *frag;
     frag = &sfrag->sf_base;
     frag->uf_local_seg[0].seg_len = size;

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -1143,27 +1143,18 @@ static int usnic_handle_completion(
     case OPAL_BTL_USNIC_SEG_ACK:
         opal_btl_usnic_ack_complete(module,
                 (opal_btl_usnic_ack_segment_t *)seg);
-{ opal_btl_usnic_send_segment_t *sseg = (opal_btl_usnic_send_segment_t *)seg;
-++module->mod_channels[sseg->ss_channel].credits;
-}
         break;
 
     /**** Send of frag segment completion ****/
     case OPAL_BTL_USNIC_SEG_FRAG:
         opal_btl_usnic_frag_send_complete(module,
                 (opal_btl_usnic_frag_segment_t*)seg);
-{ opal_btl_usnic_send_segment_t *sseg = (opal_btl_usnic_send_segment_t *)seg;
-++module->mod_channels[sseg->ss_channel].credits;
-}
         break;
 
     /**** Send of chunk segment completion ****/
     case OPAL_BTL_USNIC_SEG_CHUNK:
         opal_btl_usnic_chunk_send_complete(module,
                 (opal_btl_usnic_chunk_segment_t*)seg);
-{ opal_btl_usnic_send_segment_t *sseg = (opal_btl_usnic_send_segment_t *)seg;
-++module->mod_channels[sseg->ss_channel].credits;
-}
         break;
 
     /**** Receive completions ****/

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -1109,6 +1109,9 @@ static int usnic_handle_completion(
     seg = (opal_btl_usnic_segment_t*)completion->op_context;
     rseg = (opal_btl_usnic_recv_segment_t*)seg;
 
+    /* Make the completion be Valgrind-defined */
+    opal_memchecker_base_mem_defined(seg, sizeof(*seg));
+
     /* Handle work completions */
     switch(seg->us_type) {
 

--- a/opal/mca/btl/usnic/btl_usnic_frag.c
+++ b/opal/mca/btl/usnic/btl_usnic_frag.c
@@ -175,12 +175,13 @@ send_frag_constructor(opal_btl_usnic_send_frag_t *frag)
 static void
 send_frag_destructor(opal_btl_usnic_send_frag_t *frag)
 {
-    mca_btl_base_descriptor_t *desc;
-
+#if OPAL_ENABLE_DEBUG
     /* make sure nobody twiddled these values after the constructor */
+    mca_btl_base_descriptor_t *desc;
     desc = &frag->sf_base.uf_base;
     assert(desc->USNIC_SEND_LOCAL == frag->sf_base.uf_local_seg);
     assert(0 == frag->sf_base.uf_local_seg[0].seg_len);
+#endif
 
     /* PML may change desc->des_remote to point elsewhere, cannot assert that it
      * still points to our embedded segment */

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -2125,7 +2125,7 @@ static void init_random_objects(opal_btl_usnic_module_t *module)
 
 static void init_freelists(opal_btl_usnic_module_t *module)
 {
-    int rc;
+    int rc __opal_attribute_unused__;
     uint32_t segsize;
 
     segsize = (module->local_modex.max_msg_size +

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1450,12 +1450,13 @@ static int create_ep(opal_btl_usnic_module_t* module,
         sa = (struct sockaddr *)channel->info->src_addr;
         assert(AF_INET == sa->sa_family);
     }
+#endif
+
     sin = (struct sockaddr_in *)channel->info->src_addr;
     assert(sizeof(struct sockaddr_in) == channel->info->src_addrlen);
 
     /* no matter the version of libfabric, this should hold */
     assert(0 == sin->sin_port);
-#endif
 
     rc = fi_endpoint(module->domain, channel->info, &channel->ep, NULL);
     if (0 != rc || NULL == channel->ep) {

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -2338,7 +2338,6 @@ opal_btl_usnic_module_t opal_btl_usnic_module_template = {
         .btl_exclusivity = MCA_BTL_EXCLUSIVITY_DEFAULT,
         .btl_flags =
             MCA_BTL_FLAGS_SEND |
-            MCA_BTL_FLAGS_PUT |
             MCA_BTL_FLAGS_SEND_INPLACE,
 
         .btl_add_procs = usnic_add_procs,

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1421,7 +1421,7 @@ static int create_ep(opal_btl_usnic_module_t* module,
             opal_process_info.my_local_rank);
     }
 
-    rc = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hint, &channel->info);
+    rc = fi_getinfo(FI_VERSION(1, 1), NULL, 0, 0, hint, &channel->info);
     fi_freeinfo(hint);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
@@ -1634,6 +1634,9 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
         goto error;
     }
 
+    assert(channel->info->ep_attr->msg_prefix_size ==
+           (uint32_t) mca_btl_usnic_component.transport_header_len);
+
     /*
      * Initialize pool of receive segments.  Round MTU up to cache
      * line size so that each segment is guaranteed to start on a
@@ -1777,6 +1780,33 @@ static void init_find_transport_header_len(opal_btl_usnic_module_t *module)
         module->fabric_info->ep_attr->msg_prefix_size;
     mca_btl_usnic_component.transport_protocol =
         module->fabric_info->ep_attr->protocol;
+
+    /* The usnic provider in libfabric v1.0.0 (i.e., API v1.0) treated
+       FI_MSG_PREFIX inconsistently between senders and receivers.  It
+       was corrected in libfabric v1.1.0 (i.e., API v1.1), meaning
+       that FI_MSG_PREFIX is treated consistently between senders and
+       receivers.
+
+       So check what version of the libfabric API we have, and setup
+       to use the "old" (inconsistent) MSG_PREFIX behavior, or the
+       "new" MSG_PREFIX (consistent) behavior.
+
+       NOTE: This is a little redundant; we're setting a
+       component-level attribute during each module's setup.  We do
+       this here (and not earlier, when we check fi_version() during
+       the component setup) because we can't obtain the value of the
+       endpoint msg_prefix_size until we setup the first module.
+       Also, it's safe because each module will set the component
+       attribute to the same value.  So it's ok. */
+    uint32_t libfabric_api;
+    libfabric_api = fi_version();
+    if (1 == FI_MAJOR(libfabric_api) &&
+        0 == FI_MINOR(libfabric_api)) {
+        mca_btl_usnic_component.prefix_send_offset = 0;
+    } else {
+        mca_btl_usnic_component.prefix_send_offset =
+            module->fabric_info->ep_attr->msg_prefix_size;
+    }
 }
 
 /*
@@ -1835,13 +1865,15 @@ static void init_payload_lengths(opal_btl_usnic_module_t *module)
     /* Find the max payload this port can handle */
     module->max_frag_payload =
         module->local_modex.max_msg_size - /* start with the MTU */
-        sizeof(opal_btl_usnic_btl_header_t); /* subtract size of
-                                                the BTL header */
+        sizeof(opal_btl_usnic_btl_header_t) - /* subtract size of
+                                                 the BTL header */
+        mca_btl_usnic_component.prefix_send_offset;
 
     /* same, but use chunk header */
     module->max_chunk_payload =
         module->local_modex.max_msg_size -
-        sizeof(opal_btl_usnic_btl_chunk_header_t);
+        sizeof(opal_btl_usnic_btl_chunk_header_t) -
+        mca_btl_usnic_component.prefix_send_offset;
 
     /* Priorirty queue MTU and max size */
     if (0 == module->max_tiny_msg_size) {
@@ -2097,7 +2129,6 @@ static void init_freelists(opal_btl_usnic_module_t *module)
     uint32_t segsize;
 
     segsize = (module->local_modex.max_msg_size +
-           module->fabric_info->ep_attr->msg_prefix_size +
            opal_cache_line_size - 1) &
         ~(opal_cache_line_size - 1);
 
@@ -2105,7 +2136,7 @@ static void init_freelists(opal_btl_usnic_module_t *module)
     OBJ_CONSTRUCT(&module->small_send_frags, opal_free_list_t);
     rc = usnic_compat_free_list_init(&module->small_send_frags,
                              sizeof(opal_btl_usnic_small_send_frag_t) +
-                             mca_btl_usnic_component.transport_header_len,
+                                 mca_btl_usnic_component.prefix_send_offset,
                              opal_cache_line_size,
                              OBJ_CLASS(opal_btl_usnic_small_send_frag_t),
                              segsize,
@@ -2123,7 +2154,7 @@ static void init_freelists(opal_btl_usnic_module_t *module)
     OBJ_CONSTRUCT(&module->large_send_frags, opal_free_list_t);
     rc = usnic_compat_free_list_init(&module->large_send_frags,
                              sizeof(opal_btl_usnic_large_send_frag_t) +
-                             mca_btl_usnic_component.transport_header_len,
+                                 mca_btl_usnic_component.prefix_send_offset,
                              opal_cache_line_size,
                              OBJ_CLASS(opal_btl_usnic_large_send_frag_t),
                              0,  /* payload size */
@@ -2141,7 +2172,7 @@ static void init_freelists(opal_btl_usnic_module_t *module)
     OBJ_CONSTRUCT(&module->put_dest_frags, opal_free_list_t);
     rc = usnic_compat_free_list_init(&module->put_dest_frags,
                              sizeof(opal_btl_usnic_put_dest_frag_t) +
-                             mca_btl_usnic_component.transport_header_len,
+                                 mca_btl_usnic_component.prefix_send_offset,
                              opal_cache_line_size,
                              OBJ_CLASS(opal_btl_usnic_put_dest_frag_t),
                              0,  /* payload size */
@@ -2160,7 +2191,7 @@ static void init_freelists(opal_btl_usnic_module_t *module)
     OBJ_CONSTRUCT(&module->chunk_segs, opal_free_list_t);
     rc = usnic_compat_free_list_init(&module->chunk_segs,
                              sizeof(opal_btl_usnic_chunk_segment_t) +
-                             mca_btl_usnic_component.transport_header_len,
+                                 mca_btl_usnic_component.prefix_send_offset,
                              opal_cache_line_size,
                              OBJ_CLASS(opal_btl_usnic_chunk_segment_t),
                              segsize,
@@ -2178,12 +2209,11 @@ static void init_freelists(opal_btl_usnic_module_t *module)
     /* ACK segments freelist */
     uint32_t ack_segment_len;
     ack_segment_len = (sizeof(opal_btl_usnic_btl_header_t) +
-           module->fabric_info->ep_attr->msg_prefix_size +
             opal_cache_line_size - 1) & ~(opal_cache_line_size - 1);
     OBJ_CONSTRUCT(&module->ack_segs, opal_free_list_t);
     rc = usnic_compat_free_list_init(&module->ack_segs,
                              sizeof(opal_btl_usnic_ack_segment_t) +
-                             mca_btl_usnic_component.transport_header_len,
+                                 mca_btl_usnic_component.prefix_send_offset,
                              opal_cache_line_size,
                              OBJ_CLASS(opal_btl_usnic_ack_segment_t),
                              ack_segment_len,

--- a/opal/mca/btl/usnic/btl_usnic_recv.c
+++ b/opal/mca/btl/usnic/btl_usnic_recv.c
@@ -77,7 +77,7 @@ void opal_btl_usnic_recv_call(opal_btl_usnic_module_t *module,
 
     /* Find out who sent this segment */
     endpoint = seg->rs_endpoint;
-    if (FAKE_RECV_FRAG_DROP || OPAL_UNLIKELY(NULL == endpoint)) {
+    if (FAKE_RECV_DROP || OPAL_UNLIKELY(NULL == endpoint)) {
         /* No idea who this was from, so drop it */
 #if MSGDEBUG1
         opal_output(0, "=== Unknown sender; dropped: seq %" UDSEQ,

--- a/opal/mca/btl/usnic/btl_usnic_recv.h
+++ b/opal/mca/btl/usnic/btl_usnic_recv.h
@@ -267,6 +267,9 @@ opal_btl_usnic_recv_fast(opal_btl_usnic_module_t *module,
     int delta;
     int i;
 
+    /* Make the whole payload Valgrind defined */
+    opal_memchecker_base_mem_defined(seg->rs_protocol_header, seg->rs_len);
+
     bseg = &seg->rs_base;
 
     /* Find out who sent this segment */
@@ -285,10 +288,6 @@ opal_btl_usnic_dump_hex(bseg->us_btl_header, bseg->us_btl_header->payload_len + 
             (OPAL_BTL_USNIC_PAYLOAD_TYPE_FRAG ==
                 bseg->us_btl_header->payload_type) &&
             seg->rs_base.us_btl_header->put_addr == NULL) {
-
-        /* Valgrind help */
-        opal_memchecker_base_mem_defined(
-                (void*)(seg->rs_protocol_header), seg->rs_len);
 
         seq = seg->rs_base.us_btl_header->pkt_seq;
         delta = SEQ_DIFF(seq, endpoint->endpoint_next_contig_seq_to_recv);
@@ -381,6 +380,9 @@ opal_btl_usnic_recv(opal_btl_usnic_module_t *module,
     mca_btl_active_message_callback_t* reg;
     opal_btl_usnic_endpoint_t *endpoint;
     int rc;
+
+    /* Make the whole payload Valgrind defined */
+    opal_memchecker_base_mem_defined(seg->rs_protocol_header, seg->rs_len);
 
     bseg = &seg->rs_base;
 

--- a/opal/mca/btl/usnic/btl_usnic_send.c
+++ b/opal/mca/btl/usnic/btl_usnic_send.c
@@ -66,6 +66,8 @@ opal_btl_usnic_frag_send_complete(opal_btl_usnic_module_t *module,
 
     /* see if this endpoint needs to be made ready-to-send */
     opal_btl_usnic_check_rts(frag->sf_endpoint);
+
+    ++module->mod_channels[sseg->ss_channel].credits;
 }
 
 /*
@@ -97,6 +99,8 @@ opal_btl_usnic_chunk_send_complete(opal_btl_usnic_module_t *module,
 
     /* see if this endpoint needs to be made ready-to-send */
     opal_btl_usnic_check_rts(frag->sf_endpoint);
+
+    ++module->mod_channels[sseg->ss_channel].credits;
 }
 
 /* Responsible for completing non-fastpath parts of a put or send operation,

--- a/opal/mca/btl/usnic/btl_usnic_send.h
+++ b/opal/mca/btl/usnic/btl_usnic_send.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -79,7 +79,7 @@ opal_btl_usnic_post_segment(
     /* Send the segment */
     ret = fi_send(channel->ep,
             sseg->ss_ptr,
-            sseg->ss_len,
+            sseg->ss_len + mca_btl_usnic_component.prefix_send_offset,
             NULL,
             endpoint->endpoint_remote_addrs[channel_id],
             sseg);
@@ -128,7 +128,7 @@ opal_btl_usnic_post_ack(
 
     ret = fi_send(channel->ep,
             sseg->ss_ptr,
-            sseg->ss_len,
+            sseg->ss_len + mca_btl_usnic_component.prefix_send_offset,
             NULL,
             endpoint->endpoint_remote_addrs[channel_id],
             sseg);


### PR DESCRIPTION
Two commits to handle differences between libfabric v1.0.0 and v1.1.0:

1. `fi_cq_readerr()` return value differences
1. FI_MSG_PREFIX behavior differences

@bturrubiates @goodell please review.  The `fi_cq_readerr()` thing is new -- I discovered that tonight.