### PR TITLE
Additional java bindings

### DIFF
--- a/ompi/mpi/java/c/mpi_Op.c
+++ b/ompi/mpi/java/c/mpi_Op.c
@@ -69,7 +69,7 @@ JNIEXPORT void JNICALL Java_mpi_Op_getOp(JNIEnv *env, jobject jthis, jint type)
     static MPI_Op Ops[] = {
         MPI_OP_NULL, MPI_MAX, MPI_MIN, MPI_SUM,
         MPI_PROD, MPI_LAND, MPI_BAND, MPI_LOR, MPI_BOR, MPI_LXOR,
-        MPI_BXOR, MPI_MINLOC, MPI_MAXLOC
+        MPI_BXOR, MPI_MINLOC, MPI_MAXLOC, MPI_REPLACE, MPI_NO_OP
     };
     (*env)->SetLongField(env,jthis, ompi_java.OpHandle, (jlong)Ops[type]);
 }

--- a/ompi/mpi/java/c/mpi_Op.c
+++ b/ompi/mpi/java/c/mpi_Op.c
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/java/c/mpi_Win.c
+++ b/ompi/mpi/java/c/mpi_Win.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/java/c/mpi_Win.c
+++ b/ompi/mpi/java/c/mpi_Win.c
@@ -329,3 +329,106 @@ JNIEXPORT jlong JNICALL Java_mpi_Win_rGet(JNIEnv *env, jobject jthis, jlong win,
     return (jlong)request;
 }
 
+JNIEXPORT jlong JNICALL Java_mpi_Win_rAccumulate(JNIEnv *env, jobject jthis, jlong win,
+    jobject origin, jint orgCount, jlong orgType, jint targetRank, jint targetDisp,
+    jint targetCount, jlong targetType, jobject jOp, jlong hOp, jint baseType)
+{
+    void *orgPtr = (*env)->GetDirectBufferAddress(env, origin);
+    MPI_Op op = ompi_java_op_getHandle(env, jOp, hOp, baseType);
+    MPI_Request request;
+    
+    int rc = MPI_Raccumulate(orgPtr, orgCount, (MPI_Datatype)orgType,
+                            targetRank, (MPI_Aint)targetDisp, targetCount,
+                            (MPI_Datatype)targetType, op, (MPI_Win)win, &request);
+    
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)request;
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_getAccumulate(JNIEnv *env, jobject jthis, jlong win,
+                            jobject origin, jint orgCount, jlong orgType, jobject resultBuff, jint resultCount,
+                                                  jlong resultType, jint targetRank, jint targetDisp, jint targetCount, jlong targetType,
+                                                  jobject jOp, jlong hOp, jint baseType)
+{
+    void *orgPtr = (*env)->GetDirectBufferAddress(env, origin);
+    void *resultPtr = (*env)->GetDirectBufferAddress(env, resultBuff);
+    MPI_Op op = ompi_java_op_getHandle(env, jOp, hOp, baseType);
+    
+    int rc = MPI_Get_accumulate(orgPtr, orgCount, (MPI_Datatype)orgType,
+                                resultPtr, resultCount, (MPI_Datatype)resultType,
+                                targetRank, (MPI_Aint)targetDisp, targetCount,
+                                (MPI_Datatype)targetType, op, (MPI_Win)win);
+    
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Win_rGetAccumulate(JNIEnv *env, jobject jthis, jlong win,
+                                                    jobject origin, jint orgCount, jlong orgType, jobject resultBuff, jint resultCount,
+                                                    jlong resultType, jint targetRank, jint targetDisp, jint targetCount, jlong targetType,
+                                                    jobject jOp, jlong hOp, jint baseType)
+{
+    void *orgPtr = (*env)->GetDirectBufferAddress(env, origin);
+    void *resultPtr = (*env)->GetDirectBufferAddress(env, resultBuff);
+    MPI_Op op = ompi_java_op_getHandle(env, jOp, hOp, baseType);
+    MPI_Request request;
+    
+    int rc = MPI_Rget_accumulate(orgPtr, orgCount, (MPI_Datatype)orgType,
+                                 resultPtr, resultCount, (MPI_Datatype)resultType,
+                                 targetRank, (MPI_Aint)targetDisp, targetCount,
+                                 (MPI_Datatype)targetType, op, (MPI_Win)win, &request);
+    
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)request;
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_lockAll(JNIEnv *env, jobject jthis, jlong win, jint assertion)
+{
+    int rc = MPI_Win_lock_all(assertion, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_unlockAll(JNIEnv *env, jobject jthis, jlong win)
+{
+    int rc = MPI_Win_unlock_all((MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_sync(JNIEnv *env, jobject jthis, jlong win)
+{
+    int rc = MPI_Win_sync((MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_flush(JNIEnv *env, jobject jthis, jlong win, jint targetRank)
+{
+    int rc = MPI_Win_flush(targetRank, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_flushAll(JNIEnv *env, jobject jthis, jlong win)
+{
+    int rc = MPI_Win_flush_all((MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_compareAndSwap (JNIEnv *env, jobject jthis, jlong win, jobject origin,
+                                                    jobject compareAddr, jobject resultAddr, jlong dataType, jint targetRank, jint targetDisp)
+{
+    void *orgPtr = (*env)->GetDirectBufferAddress(env, origin);
+    void *compPtr = (*env)->GetDirectBufferAddress(env, compareAddr);
+    void *resultPtr = (*env)->GetDirectBufferAddress(env, resultAddr);
+    
+    int rc = MPI_Compare_and_swap(orgPtr, compPtr, resultPtr, dataType, targetRank, targetDisp, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_fetchAndOp(JNIEnv *env, jobject jthis, jlong win, jobject origin,
+                                               jobject resultAddr, jlong dataType, jint targetRank, jint targetDisp, jobject jOp, jlong hOp, jint baseType)
+{
+    void *orgPtr = (*env)->GetDirectBufferAddress(env, origin);
+    void *resultPtr = (*env)->GetDirectBufferAddress(env, resultAddr);
+    MPI_Op op = ompi_java_op_getHandle(env, jOp, hOp, baseType);
+    
+    int rc = MPI_Fetch_and_op(orgPtr, resultPtr, dataType, targetRank, targetDisp, op, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}

--- a/ompi/mpi/java/java/MPI.java
+++ b/ompi/mpi/java/java/MPI.java
@@ -68,7 +68,7 @@ public static final int GRAPH, DIST_GRAPH, CART;
 public static final int ANY_SOURCE, ANY_TAG;
 
 public static final Op MAX, MIN, SUM, PROD, LAND, BAND,
-                       LOR, BOR, LXOR, BXOR;
+                       LOR, BOR, LXOR, BXOR, REPLACE, NO_OP;
 
 /**
  * Global minimum operator.
@@ -241,6 +241,8 @@ static
     BXOR   = new Op(10);
     MINLOC = new Op(11);
     MAXLOC = new Op(12);
+    REPLACE = new Op(13);
+    NO_OP = new Op(14);
 
     GROUP_EMPTY  = new Group(Group.getEmpty());
     REQUEST_NULL = new Request(Request.getNull());

--- a/ompi/mpi/java/java/MPI.java
+++ b/ompi/mpi/java/java/MPI.java
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/java/java/Win.java
+++ b/ompi/mpi/java/java/Win.java
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/java/java/Win.java
+++ b/ompi/mpi/java/java/Win.java
@@ -558,4 +558,235 @@ private native long rGet(
         int targetRank, int targetDisp, int targetCount, long targetType,
         int baseType) throws MPIException;
 
+/**
+ * Java binding of {@code MPI_RACCUMULATE}.
+ * @param origin      origin buffer
+ * @param orgCount    number of entries in origin buffer
+ * @param orgType     datatype of each entry in origin buffer
+ * @param targetRank  rank of target
+ * @param targetDisp  displacement from start of window to target buffer
+ * @param targetCount number of entries in target buffer
+ * @param targetType  datatype of each entry in target buffer
+ * @param op          reduce operation
+ * @return RMA request
+ * @throws MPIException
+ */
+public Request rAccumulate(Buffer origin, int orgCount, Datatype orgType,
+                       int targetRank, int targetDisp, int targetCount,
+                       Datatype targetType, Op op)
+    throws MPIException
+{
+    MPI.check();
+
+    if(!origin.isDirect())
+        throw new IllegalArgumentException("The origin must be direct buffer.");
+
+    return new Request(rAccumulate(handle, origin, orgCount, orgType.handle,
+               targetRank, targetDisp, targetCount, targetType.handle,
+               op, op.handle, getBaseType(orgType, targetType)));
+}
+
+private native long rAccumulate(
+        long win, Buffer origin, int orgCount, long orgType,
+        int targetRank, int targetDisp, int targetCount, long targetType,
+        Op jOp, long hOp, int baseType) throws MPIException;
+
+/**
+ * Java binding of {@code MPI_GET_ACCUMULATE}.
+ * @param origin      	origin buffer
+ * @param orgCount    	number of entries in origin buffer
+ * @param orgType		datatype of each entry in origin buffer
+ * @param resultAddr   	result buffer
+ * @param resultCount	number of entries in result buffer
+ * @param resultType   	datatype of each entry in result buffer
+ * @param targetRank  	rank of target
+ * @param targetDisp  	displacement from start of window to target buffer
+ * @param targetCount 	number of entries in target buffer
+ * @param targetType  	datatype of each entry in target buffer
+ * @param op          	reduce operation
+ * @throws MPIException
+ */
+
+public void getAccumulate(Buffer origin, int orgCount, Datatype orgType,
+					Buffer resultAddr, int resultCount, Datatype resultType,
+                    int targetRank, int targetDisp, int targetCount,
+                    Datatype targetType, Op op)
+    throws MPIException
+{
+	MPI.check();
+
+    if(!origin.isDirect())
+        throw new IllegalArgumentException("The origin must be direct buffer.");
+
+    getAccumulate(handle, origin, orgCount, orgType.handle,
+    			resultAddr, resultCount, resultType.handle,
+               	targetRank, targetDisp, targetCount, targetType.handle,
+               	op, op.handle, getBaseType(orgType, targetType));
+}
+
+private native void getAccumulate(
+        long win, Buffer origin, int orgCount, long orgType,
+        Buffer resultAddr, int resultCount, long resultType,
+        int targetRank, int targetDisp, int targetCount, long targetType,
+        Op jOp, long hOp, int baseType) throws MPIException;
+
+/**
+ * Java binding of {@code MPI_RGET_ACCUMULATE}.
+ * @param origin      	origin buffer
+ * @param orgCount    	number of entries in origin buffer
+ * @param orgType		datatype of each entry in origin buffer
+ * @param resultAddr   	result buffer
+ * @param resultCount	number of entries in result buffer
+ * @param resultType   	datatype of each entry in result buffer
+ * @param targetRank  	rank of target
+ * @param targetDisp  	displacement from start of window to target buffer
+ * @param targetCount 	number of entries in target buffer
+ * @param targetType  	datatype of each entry in target buffer
+ * @param op          	reduce operation
+ * @return RMA request
+ * @throws MPIException
+ */
+
+public Request rGetAccumulate(Buffer origin, int orgCount, Datatype orgType,
+					Buffer resultAddr, int resultCount, Datatype resultType,
+                    int targetRank, int targetDisp, int targetCount,
+                    Datatype targetType, Op op)
+    throws MPIException
+{
+	MPI.check();
+
+    if(!origin.isDirect())
+        throw new IllegalArgumentException("The origin must be direct buffer.");
+
+    return new Request(rGetAccumulate(handle, origin, orgCount, orgType.handle,
+    			resultAddr, resultCount, resultType.handle,
+               	targetRank, targetDisp, targetCount, targetType.handle,
+               	op, op.handle, getBaseType(orgType, targetType)));
+}
+
+private native long rGetAccumulate(
+        long win, Buffer origin, int orgCount, long orgType,
+        Buffer resultAddr, int resultCount, long resultType,
+        int targetRank, int targetDisp, int targetCount, long targetType,
+        Op jOp, long hOp, int baseType) throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_LOCK_ALL}.
+ * @param assertion program assertion
+ * @throws MPIException 
+ */
+public void lockAll(int assertion) throws MPIException
+{
+    MPI.check();
+    lockAll(handle, assertion);
+}
+
+private native void lockAll(long win, int assertion)
+        throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_UNLOCK_ALL}.
+ * @throws MPIException 
+ */
+public void unlockAll() throws MPIException
+{
+    MPI.check();
+    unlockAll(handle);
+}
+
+private native void unlockAll(long win) throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_SYNC}.
+ * @throws MPIException 
+ */
+public void sync() throws MPIException
+{
+    MPI.check();
+    sync(handle);
+}
+
+private native void sync(long win) throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_FLUSH}.
+ * @param targetRank	rank of target window
+ * @throws MPIException 
+ */
+public void flush(int targetRank) throws MPIException
+{
+    MPI.check();
+    flush(handle, targetRank);
+}
+
+private native void flush(long win, int targetRank) throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_FLUSH_ALL}.
+ * @throws MPIException 
+ */
+public void flushAll() throws MPIException
+{
+    MPI.check();
+    flushAll(handle);
+}
+
+private native void flushAll(long win) throws MPIException;
+
+/**
+ * Java binding of {@code MPI_COMPARE_AND_SWAP}.
+ * @param origin      	origin buffer
+ * @param compareAddr   compare buffer
+ * @param resultAddr   	result buffer
+ * @param targetType  	datatype of each entry in target buffer
+ * @param targetRank  	rank of target
+ * @param targetDisp  	displacement from start of window to target buffer
+ * @throws MPIException
+ */
+
+public void compareAndSwap(Buffer origin, Buffer compareAddr, Buffer resultAddr,
+					Datatype targetType, int targetRank, int targetDisp)
+    throws MPIException
+{
+	MPI.check();
+
+    if(!origin.isDirect())
+        throw new IllegalArgumentException("The origin must be direct buffer.");
+
+    compareAndSwap(handle, origin, compareAddr, resultAddr,
+			targetType.handle, targetRank, targetDisp);
+}
+
+private native void compareAndSwap(
+        long win, Buffer origin, Buffer compareAddr, Buffer resultAddr,
+        long targetType, int targetRank, int targetDisp) throws MPIException;
+
+/**
+ * Java binding of {@code MPI_FETCH_AND_OP}.
+ * @param origin      	origin buffer
+ * @param resultAddr   	result buffer
+ * @param dataType  	datatype of entry in origin, result, and target buffers
+ * @param targetRank  	rank of target
+ * @param targetDisp  	displacement from start of window to target buffer
+ * @param op          	reduce operation
+ * @throws MPIException
+ */
+
+public void fetchAndOp(Buffer origin, Buffer resultAddr, Datatype dataType, 
+					int targetRank, int targetDisp, Op op)
+    throws MPIException
+{
+	MPI.check();
+
+    if(!origin.isDirect())
+        throw new IllegalArgumentException("The origin must be direct buffer.");
+
+    fetchAndOp(handle, origin, resultAddr, dataType.handle, targetRank, 
+    		targetDisp, op, op.handle, getBaseType(dataType, dataType));  //neccessary?
+}
+
+private native void fetchAndOp(
+        long win, Buffer origin, Buffer resultAddr, long targetType, int targetRank, 
+        int targetDisp, Op jOp, long hOp, int baseType) throws MPIException;
+
 } // Win


### PR DESCRIPTION
@jsquyres more java bindings

Java bindings for the following functions: MPI_RACCUMULATE, MPI_GET_ACCUMULATE, MPI_RGET_ACCUMULATE, MPI_WIN_LOCK_ALL, MPI_WIN_UNLOCK_ALL, MPI_WIN_SYNC, MPI_WIN_FLUSH, MPI_WIN_FLUSH_ALL, MPI_COMPARE_AND_SWAP, and MPI_FETCH_AND_OP.  Also includes Java bindings for the Operations MPI_REPLACE and MPI_NO_OP.

Signed-off-by: Nathaniel Graham <ngraham@lanl.gov>