### PR TITLE
Make explicit call to initalize MCA parameters in common CUDA code.

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -16,7 +16,7 @@
  *                         reserved.
  * Copyright (c) 2006-2007 Voltaire All rights reserved.
  * Copyright (c) 2009-2012 Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2011-2014 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2011-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Laboratory.  All rights reserved
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
  * Copyright (c) 2014-2015 Research Organization for Information Science
@@ -199,6 +199,10 @@ static int btl_openib_component_register(void)
            "open" failing is not printed */
         return OPAL_ERR_NOT_AVAILABLE;
     }
+
+#if OPAL_CUDA_SUPPORT
+    mca_common_cuda_register_mca_variables();
+#endif
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/smcuda/btl_smcuda_component.c
+++ b/opal/mca/btl/smcuda/btl_smcuda_component.c
@@ -195,6 +195,7 @@ static int smcuda_register(void)
     if (0 == mca_btl_smcuda.super.btl_cuda_eager_limit) {
         mca_btl_smcuda.super.btl_cuda_eager_limit = SIZE_MAX; /* magic number */
     }
+    mca_common_cuda_register_mca_variables();
 #endif /* OPAL_CUDA_SUPPORT */
     return mca_btl_smcuda_component_verify();
 }

--- a/opal/mca/common/cuda/common_cuda.h
+++ b/opal/mca/common/cuda/common_cuda.h
@@ -44,7 +44,7 @@ struct mca_mpool_common_cuda_reg_t {
 typedef struct mca_mpool_common_cuda_reg_t mca_mpool_common_cuda_reg_t;
 extern bool mca_common_cuda_enabled;
 
-OPAL_DECLSPEC int mca_common_cuda_register_mca_variables(void);
+OPAL_DECLSPEC void mca_common_cuda_register_mca_variables(void);
 
 OPAL_DECLSPEC void mca_common_cuda_register(void *ptr, size_t amount, char *msg);
 


### PR DESCRIPTION
This has bugged me forever that I could not see the MCA parameters from the common CUDA code.  Discussions with Nathan showed me how to fix this.  No functional changes, just refactoring and adding a new function to be called when parameters of registered.

Assigning @bosilca for this one too.

