### PR TITLE
More one sided bindings

### DIFF
--- a/ompi/mpi/java/c/mpi_Intracomm.c
+++ b/ompi/mpi/java/c/mpi_Intracomm.c
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,6 +64,15 @@ JNIEXPORT jlong JNICALL Java_mpi_Intracomm_split(
 {
     MPI_Comm newcomm;
     int rc = MPI_Comm_split((MPI_Comm)comm, colour, key, &newcomm);
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)newcomm;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Intracomm_splitType(
+        JNIEnv *env, jobject jthis, jlong comm, jint splitType, jint key, jlong info)
+{
+    MPI_Comm newcomm;
+    int rc = MPI_Comm_split_type((MPI_Comm)comm, splitType, key, (MPI_Info)info, &newcomm);
     ompi_java_exceptionCheck(env, rc);
     return (jlong)newcomm;
 }

--- a/ompi/mpi/java/c/mpi_Win.c
+++ b/ompi/mpi/java/c/mpi_Win.c
@@ -45,6 +45,32 @@ JNIEXPORT jlong JNICALL Java_mpi_Win_createWin(
     return (jlong)win;
 }
 
+JNIEXPORT jlong JNICALL Java_mpi_Win_allocateWin(JNIEnv *env, jobject jthis,
+                                                 jint size, jint dispUnit, jlong info, jlong comm, jobject jBase)
+{
+    void *basePtr = (*env)->GetDirectBufferAddress(env, jBase);
+    MPI_Win win;
+    
+    int rc = MPI_Win_allocate((MPI_Aint)size, dispUnit,
+                              (MPI_Info)info, (MPI_Comm)comm, basePtr, &win);
+    
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)win;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Win_allocateSharedWin(JNIEnv *env, jobject jthis,
+                                                       jint size, jint dispUnit, jlong info, jlong comm, jobject jBase)
+{
+    void *basePtr = (*env)->GetDirectBufferAddress(env, jBase);
+    MPI_Win win;
+    
+    int rc = MPI_Win_allocate_shared((MPI_Aint)size, dispUnit,
+                                     (MPI_Info)info, (MPI_Comm)comm, basePtr, &win);
+    
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)win;
+}
+
 JNIEXPORT jlong JNICALL Java_mpi_Win_createDynamicWin(
         JNIEnv *env, jobject jthis,
         jlong info, jlong comm)
@@ -432,5 +458,17 @@ JNIEXPORT void JNICALL Java_mpi_Win_fetchAndOp(JNIEnv *env, jobject jthis, jlong
     MPI_Op op = ompi_java_op_getHandle(env, jOp, hOp, baseType);
     
     int rc = MPI_Fetch_and_op(orgPtr, resultPtr, dataType, targetRank, targetDisp, op, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_flushLocal(JNIEnv *env, jobject jthis, jlong win, jint targetRank)
+{
+    int rc = MPI_Win_flush_local(targetRank, (MPI_Win)win);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_Win_flushLocalAll(JNIEnv *env, jobject jthis, jlong win)
+{
+    int rc = MPI_Win_flush_local_all((MPI_Win)win);
     ompi_java_exceptionCheck(env, rc);
 }

--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,6 +67,7 @@ import static mpi.MPI.assertDirectBuffer;
  */
 public class Comm implements Freeable
 {
+public final static int TYPE_SHARED = 0;
 protected final static int SELF  = 1;
 protected final static int WORLD = 2;
 protected long handle;

--- a/ompi/mpi/java/java/Intracomm.java
+++ b/ompi/mpi/java/java/Intracomm.java
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -138,6 +140,24 @@ public final Intracomm split(int colour, int key) throws MPIException
 }
 
 private native long split(long comm, int colour, int key) throws MPIException;
+
+/**
+ * Partition the group associated with this communicator and create
+ * a new communicator within each subgroup.
+ * <p>Java binding of the MPI operation {@code MPI_COMM_SPLIT_TYPE}.
+ * @param splitType	type of processes to be grouped together
+ * @param key	    control of rank assignment
+ * @param info		info argument
+ * @return new communicator
+ * @throws MPIException
+ */
+public final Intracomm splitType(int splitType, int key, Info info) throws MPIException
+{
+    MPI.check();
+    return new Intracomm(splitType(handle, splitType, key, info.handle));
+}
+
+private native long splitType(long comm, int colour, int key, long info) throws MPIException;
 
 /**
  * Create a new communicator.


### PR DESCRIPTION
Bindings for the MPI_WIN_FLUSH_LOCAL, MPI_WIN_FLUSH_LOCAL_ALL, MPI_WIN_ALLOCATE, MPI_WIN_ALLOCATE_SHARED, and MPI_COMM_SPLIT_TYPE.  Also added several necessary constants.

@jsquyres  @hppritcha 

Signed-off-by: Nathaniel Graham ngraham@lanl.gov