### PR TITLE
Improving opal_pointer_array bounds checking.

### DIFF
--- a/opal/class/opal_pointer_array.c
+++ b/opal/class/opal_pointer_array.c
@@ -166,6 +166,10 @@ int opal_pointer_array_set_item(opal_pointer_array_t *table, int index,
 {
     assert(table != NULL);
 
+    if (OPAL_UNLIKELY(0 > index)) {
+        return OPAL_ERROR;
+    }
+
     /* expand table if required to set a specific index */
 
     OPAL_THREAD_LOCK(&(table->lock));

--- a/opal/class/opal_pointer_array.h
+++ b/opal/class/opal_pointer_array.h
@@ -33,6 +33,7 @@
 
 #include "opal/threads/mutex.h"
 #include "opal/class/opal_object.h"
+#include "opal/prefetch.h"
 
 BEGIN_C_DECLS
 
@@ -124,7 +125,7 @@ static inline void *opal_pointer_array_get_item(opal_pointer_array_t *table,
 {
     void *p;
 
-    if( table->size <= element_index ) {
+    if( OPAL_UNLIKELY(0 > element_index || table->size <= element_index) ) {
         return NULL;
     }
     OPAL_THREAD_LOCK(&(table->lock));


### PR DESCRIPTION
This is basically just guarding against negative indexes.

For opal_pointer_array_get_item(), the code documentation specifies that NULL should be returned on error, so I simply expanded the check in the initial "if" statement to check for a negative index.

For opal_pointer_array_set_item(), the code documentation specifies that (-1) should be returned on error, so I added an "if" statement to check for a negative index.  I noticed the assert instruction to guard against a NULL array and was wondering if this should be used to guard against a negative index instead, but figured returning an error was more consistent with the code documentation and more consistent with opal_array_get_item()'s behavior.

If this is not the appropriate fix, I would be more than happy to make the necessary changes.