### PR TITLE
Improving robustness in opal_check_package header checking.

### DIFF
--- a/config/opal_check_package.m4
+++ b/config/opal_check_package.m4
@@ -44,15 +44,27 @@ AC_DEFUN([_OPAL_CHECK_PACKAGE_HEADER], [
             AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])
             AS_IF([test "$opal_check_package_header_happy" = "no"],
                   [# no go on the as is - reset the cache and try again
-                   unset opal_Header])],
-           [AS_IF([test "$3" != ""],
-                 AS_IF([test -e $3/$2],
-                       [$1_CPPFLAGS="$$1_CPPFLAGS -I$3"
-                        CPPFLAGS="$CPPFLAGS -I$3"],
-                       AS_IF([test -e $3/include/$2],
-                             [$1_CPPFLAGS="$$1_CPPFLAGS -I$3/include"
-                              CPPFLAGS="$CPPFLAGS -I$3/include"])))
-            AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])])
+                   unset opal_Header])])
+
+    AS_IF([test "$opal_check_package_header_happy" = "no" && \
+           test "$3" != ""],
+          [$1_CPPFLAGS="$$1_CPPFLAGS -I$3/include"
+           CPPFLAGS="$CPPFLAGS -I$3/include"
+           AC_VERBOSE([looking for header in "$3/include"])
+           AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])
+           AS_IF([test "$opal_check_package_header_happy" = "no"],
+                 [# still no... - reset the cache and try again
+                  unset opal_Header])])
+
+    AS_IF([test "$opal_check_package_header_happy" = "no" && \
+           test "$3" != ""],
+          [$1_CPPFLAGS="$$1_CPPFLAGS -I$3"
+           CPPFLAGS="$CPPFLAGS -I$3"
+           AC_VERBOSE([looking for header in "$3"])
+           AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])
+           AS_IF([test "$opal_check_package_header_happy" = "no"],
+                 [# still no...
+                  unset opal_Header])])
 
     AS_IF([test "$opal_check_package_header_happy" = "yes"], [$4], [$5])
 

--- a/config/opal_check_package.m4
+++ b/config/opal_check_package.m4
@@ -36,24 +36,27 @@ AC_DEFUN([_OPAL_CHECK_PACKAGE_HEADER], [
     unset opal_Header
 
     opal_check_package_header_happy="no"
-    AS_IF([test "$3" = "/usr" || \
+    AS_IF([test "$3" = "" || \
+           test "$3" = "/usr" || \
            test "$3" = "/usr/local"],
            [ # try as is...
             AC_VERBOSE([looking for header without includes])
-            AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [])
+            AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])
             AS_IF([test "$opal_check_package_header_happy" = "no"],
                   [# no go on the as is - reset the cache and try again
-                   unset opal_Header])])
+                   unset opal_Header])],
+           [AS_IF([test "$3" != ""],
+                 AS_IF([test -e $3/$2],
+                       [$1_CPPFLAGS="$$1_CPPFLAGS -I$3"
+                        CPPFLAGS="$CPPFLAGS -I$3"],
+                       AS_IF([test -e $3/include/$2],
+                             [$1_CPPFLAGS="$$1_CPPFLAGS -I$3/include"
+                              CPPFLAGS="$CPPFLAGS -I$3/include"])))
+            AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])])
 
-    AS_IF([test "$opal_check_package_header_happy" = "no"],
-          [AS_IF([test "$3" != ""],
-                 [$1_CPPFLAGS="$$1_CPPFLAGS -I$3/include"
-                  CPPFLAGS="$CPPFLAGS -I$3/include"])
-          AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])
-	  AS_IF([test "$opal_check_package_header_happy" = "yes"], [$4], [$5])],
-          [$4])
+    AS_IF([test "$opal_check_package_header_happy" = "yes"], [$4], [$5])
+
     unset opal_check_package_header_happy
-
     AS_VAR_POPDEF([opal_Header])dnl
 ])
 


### PR DESCRIPTION
This is to make the header checking in the opal_check_package macro a little bit more robust (specifically in "_OPAL_CHECK_PACKAGE_HEADER").  Basically, in addition to looking in \<provided path\>/include, it also tries looking in the provided path directly.