### PR TITLE
ORTED: issue with libpath and Intel compilers.

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh.h
+++ b/orte/mca/plm/rsh/plm_rsh.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011      IBM Corporation.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Bull SAS.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,6 +64,7 @@ struct orte_plm_rsh_component_t {
     bool pass_environ_mca_params;
     char *ssh_args;
     char *pass_libpath;
+    bool propagate_libpath;
 };
 typedef struct orte_plm_rsh_component_t orte_plm_rsh_component_t;
 

--- a/orte/mca/plm/rsh/plm_rsh_component.c
+++ b/orte/mca/plm/rsh/plm_rsh_component.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      IBM Corporation.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Bull SAS.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -217,6 +218,14 @@ static int rsh_component_register(void)
                                             OPAL_INFO_LVL_2,
                                             MCA_BASE_VAR_SCOPE_READONLY,
                                             &mca_plm_rsh_component.pass_libpath);
+
+    mca_plm_rsh_component.propagate_libpath = false;
+    (void) mca_base_component_var_register (c, "propagate_libpath",
+                                            "Prepend the current LD_LIBRARY_PATH to the remote shell's LD_LIBRARY_PATH",
+                                            MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                            OPAL_INFO_LVL_9,
+                                            MCA_BASE_VAR_SCOPE_READONLY,
+                                            &mca_plm_rsh_component.propagate_libpath);
 
     return ORTE_SUCCESS;
 }

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2014-2015 Intel Corporation.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Bull SAS.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -340,6 +341,7 @@ static int setup_launch(int *argcptr, char ***argvptr,
     char *lib_base=NULL, *bin_base=NULL;
     char *opal_prefix = getenv("OPAL_PREFIX");
     char* full_orted_cmd = NULL;
+    char *ld_library_path, *oldstr;
 
     /* Figure out the basenames for the libdir and bindir.  This
        requires some explanation:
@@ -454,6 +456,29 @@ static int setup_launch(int *argcptr, char ***argvptr,
         asprintf(&lib_base, "%s/%s", prefix_dir, param);
     }
     free(param);
+
+    if (true == mca_plm_rsh_component.propagate_libpath) {
+        /* if the user requested we pass the current node's LD_LIBRARY_PATH to
+         * the ORTED's environment on the remote node, we append it. */
+        ld_library_path = getenv("LD_LIBRARY_PATH");
+
+        if (NULL != ld_library_path) {
+            /* the user actually has a LD_LIBRARY_PATH we need to pass */
+            oldstr = lib_base;
+            lib_base = NULL;
+
+            if (NULL == oldstr) {
+                /* if no previous lib_base were set, we just copy the current
+                 * LD_LIBRARY_PATH into lib_base. */
+                lib_base = strdup(ld_library_path);
+            } else {
+                /* In this case we concatenate the old lib_base (which is in
+                 * oldstr) to the current ld_library_path. */
+                asprintf(&lib_base, "%s:%s", ld_library_path, oldstr);
+                free(oldstr);
+            }
+        }
+    }
 
     /* we now need to assemble the actual cmd that will be executed - this depends
      * upon whether or not a prefix directory is being used


### PR DESCRIPTION
When compiled with Intel compiler suite, ORTED is linked against several Intel libraries. This causes ORTED to crash before being launched due to the lack of propagation of the current LD_LIBRARY_PATH over SSH.

This patch add an MCA option to orte's plm_rsh module,
mca_plm_rsh_propagate_libpath (bool). When set to true it automatically
prepends to the remote node's LD_LIBRARY_PATH the current LD_LIBRARY_PATH
before launching the ORTED daemon.