### PR TITLE
plm/alps: fix orted based launch failures.

### DIFF
--- a/orte/mca/plm/alps/plm_alps_module.c
+++ b/orte/mca/plm/alps/plm_alps_module.c
@@ -288,6 +288,17 @@ static void launch_daemons(int fd, short args, void *cbdata)
     opal_argv_append(&argc, &argv, "1");
     opal_argv_append(&argc, &argv, "-cc");
     opal_argv_append(&argc, &argv, "none");
+    /*
+     * stuff below is necessary in the event that we've sadly configured Open MPI with --disable-dlopen,
+     * which results in the orted's being linked against all kinds of unnecessary cray libraries, including
+     * the cray pmi, which has a ctor that cause bad things if run when using mpirun/orted based launch.
+     *
+     * Code below adds env. variables for aprun to forward which suppresses the action of the Cray PMI ctor.
+     */
+    opal_argv_append(&argc, &argv, "-e");
+    opal_argv_append(&argc, &argv, "PMI_NO_PREINITIALIZE=1");
+    opal_argv_append(&argc, &argv, "-e");
+    opal_argv_append(&argc, &argv, "PMI_NO_FORK=1");
 
     /* create nodelist */
     nodelist_argv = NULL;


### PR DESCRIPTION
Turns out that when one builds Open MPI with --disable-dlopen
for Cray, a whole bunch of cray specific libraries get linked
in to the orted executable.  One of these is Cray PMI.  The
Cray PMI has a ctor which, if run, causes job launches using
mpirun to fail.  This commit suppresses the running of the
ctor and thus prevents failure to launch.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>