### PR TITLE
Java bindings for window name get and set

### DIFF
--- a/ompi/mpi/java/c/mpi_Win.c
+++ b/ompi/mpi/java/c/mpi_Win.c
@@ -472,3 +472,25 @@ JNIEXPORT void JNICALL Java_mpi_Win_flushLocalAll(JNIEnv *env, jobject jthis, jl
     int rc = MPI_Win_flush_local_all((MPI_Win)win);
     ompi_java_exceptionCheck(env, rc);
 }
+
+JNIEXPORT void JNICALL Java_mpi_Win_setName(
+        JNIEnv *env, jobject jthis, jlong handle, jstring jname)
+{
+    const char *name = (*env)->GetStringUTFChars(env, jname, NULL);
+    int rc = MPI_Win_set_name((MPI_Comm)handle, (char*)name);
+    ompi_java_exceptionCheck(env, rc);
+    (*env)->ReleaseStringUTFChars(env, jname, name);
+}
+
+JNIEXPORT jstring JNICALL Java_mpi_Win_getName(
+        JNIEnv *env, jobject jthis, jlong handle)
+{
+    char name[MPI_MAX_OBJECT_NAME];
+    int len;
+    int rc = MPI_Win_get_name((MPI_Comm)handle, name, &len);
+
+    if(ompi_java_exceptionCheck(env, rc))
+        return NULL;
+
+    return (*env)->NewStringUTF(env, name);
+}

--- a/ompi/mpi/java/java/Win.java
+++ b/ompi/mpi/java/java/Win.java
@@ -874,4 +874,30 @@ public void flushLocalAll() throws MPIException
 
 private native void flushLocalAll(long win) throws MPIException;
 
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_GET_NAME}.
+ * @return the name associated with this window
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
+ */
+public String getName() throws MPIException
+{
+	MPI.check();
+	return getName(handle);
+}
+
+private native String getName(long handle) throws MPIException;
+
+/**
+ * Java binding of the MPI operation {@code MPI_WIN_SET_NAME}.
+ * @param name	the name to associate with this window
+ * @throws MPIException Signals that an MPI exception of some sort has occurred.
+ */
+public void setName(String name) throws MPIException
+{
+	MPI.check();
+	setName(handle, name);
+}
+
+private native void setName(long handle, String name) throws MPIException;
+
 } // Win


### PR DESCRIPTION
Updated to call to the JNI

Includes bindings for MPI_WIN_GET_NAME and MPI_WIN_SET_NAME.

Signed-off-by: Nathaniel Graham <ngraham@lanl.gov>

@jsquyres  @hppritcha 