### PR TITLE
Standardize verbosity levels

### DIFF
--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -284,7 +284,7 @@ static int mca_bml_r2_add_procs( size_t nprocs,
                     /* skip this btl if the exclusivity is less than the previous only if the btl does not provide full rdma (for one-sided) */
                     if(bml_btl->btl->btl_exclusivity > btl->btl_exclusivity  && ((btl_flags & MCA_BTL_FLAGS_RDMA) != MCA_BTL_FLAGS_RDMA)) {
                         btl->btl_del_procs(btl, 1, (opal_proc_t**)&proc, &btl_endpoints[p]);
-                        opal_output_verbose(20, opal_btl_base_framework.framework_output,
+                        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_bml_base_framework.framework_output,
                                             "mca: bml: Not using %s btl to %s on node %s "
                                             "because %s btl has higher exclusivity (%d > %d)",
                                             btl->btl_component->btl_version.mca_component_name,
@@ -295,7 +295,7 @@ static int mca_bml_r2_add_procs( size_t nprocs,
                         continue;
                     }
                 }
-                opal_output_verbose(1, opal_btl_base_framework.framework_output,
+                opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_bml_base_framework.framework_output,
                                     "mca: bml: Using %s btl to %s on node %s",
                                     btl->btl_component->btl_version.mca_component_name,
                                     OMPI_NAME_PRINT(&proc->super.proc_name),

--- a/opal/mca/base/base.h
+++ b/opal/mca/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -68,6 +68,30 @@ OPAL_DECLSPEC extern bool mca_base_component_show_load_errors;
 OPAL_DECLSPEC extern bool mca_base_component_disable_dlopen;
 OPAL_DECLSPEC extern char *mca_base_system_default_path;
 OPAL_DECLSPEC extern char *mca_base_user_default_path;
+
+/*
+ * Standard verbosity levels
+ */
+enum {
+    /** total silence */
+    MCA_BASE_VERBOSE_NONE  = -1,
+    /** only errors are printed */
+    MCA_BASE_VERBOSE_ERROR = 0,
+    /** emit messages about component selection, open, and unloading */
+    MCA_BASE_VERBOSE_COMPONENT = 10,
+    /** also emit warnings */
+    MCA_BASE_VERBOSE_WARN  = 20,
+    /** also emit general, user-relevant information, such as rationale as to why certain choices
+     * or code paths were taken, information gleaned from probing the local system, etc. */
+    MCA_BASE_VERBOSE_INFO  = 40,
+    /** also emit relevant tracing information (e.g., which functions were invoked /
+     * call stack entry/exit info) */
+    MCA_BASE_VERBOSE_TRACE = 60,
+    /** also emit Open MPI-developer-level (i.e,. highly detailed) information */
+    MCA_BASE_VERBOSE_DEBUG = 80,
+    /** also output anything else that might be useful */
+    MCA_BASE_VERBOSE_MAX   = 100,
+};
 
 /*
  * Public functions

--- a/opal/mca/base/mca_base_component_find.c
+++ b/opal/mca/base/mca_base_component_find.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -133,7 +135,7 @@ int mca_base_component_find (const char *directory, mca_base_framework_t *framew
         find_dyn_components(directory, framework, (const char**)requested_component_names,
                             include_mode);
     } else {
-        opal_output_verbose(40, 0,
+        opal_output_verbose (MCA_BASE_VERBOSE_INFO, 0,
                             "mca: base: component_find: dso loading for %s MCA components disabled",
                             framework->framework_name);
     }
@@ -193,11 +195,11 @@ int mca_base_components_filter (mca_base_framework_t *framework, uint32_t filter
         if (!can_use || (filter_flags & dummy->data.param_field) != filter_flags) {
             if (can_use && (filter_flags & MCA_BASE_METADATA_PARAM_CHECKPOINT) &&
                 !(MCA_BASE_METADATA_PARAM_CHECKPOINT & dummy->data.param_field)) {
-                opal_output_verbose(10, output_id,
-                                    "mca: base: components_filter: "
-                                    "(%s) Component %s is *NOT* Checkpointable - Disabled",
-                                    component->reserved,
-                                    component->mca_component_name);
+                opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                     "mca: base: components_filter: "
+                                     "(%s) Component %s is *NOT* Checkpointable - Disabled",
+                                     component->reserved,
+                                     component->mca_component_name);
             }
 
             opal_list_remove_item (components, &cli->super);
@@ -206,11 +208,11 @@ int mca_base_components_filter (mca_base_framework_t *framework, uint32_t filter
 
             OBJ_RELEASE(cli);
         } else if (filter_flags & MCA_BASE_METADATA_PARAM_CHECKPOINT) {
-            opal_output_verbose(10, output_id,
-                                "mca: base: components_filter: "
-                                "(%s) Component %s is Checkpointable",
-                                component->reserved,
-                                component->mca_component_name);
+            opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                 "mca: base: components_filter: "
+                                 "(%s) Component %s is Checkpointable",
+                                 component->reserved,
+                                 component->mca_component_name);
         }
     }
 

--- a/opal/mca/base/mca_base_component_repository.c
+++ b/opal/mca/base/mca_base_component_repository.c
@@ -314,10 +314,10 @@ int mca_base_component_repository_open (mca_base_framework_t *framework,
     char *struct_name = NULL;
     int vl, ret;
 
-    opal_output_verbose(40, 0, "mca_base_component_repository_open: examining dynamic %s MCA component \"%s\" at path %s",
-                        ri->ri_type, ri->ri_name, ri->ri_path);
+    opal_output_verbose(MCA_BASE_VERBOSE_INFO, 0, "mca_base_component_repository_open: examining dynamic "
+                        "%s MCA component \"%s\" at path %s", ri->ri_type, ri->ri_name, ri->ri_path);
 
-    vl = mca_base_component_show_load_errors ? 0 : 40;
+    vl = mca_base_component_show_load_errors ? MCA_BASE_VERBOSE_ERROR : MCA_BASE_VERBOSE_INFO;
 
     /* Ensure that this component is not already loaded (should only happen
        if it was statically loaded).  It's an error if it's already
@@ -327,7 +327,7 @@ int mca_base_component_repository_open (mca_base_framework_t *framework,
 
     OPAL_LIST_FOREACH(mitem, &framework->framework_components, mca_base_component_list_item_t) {
         if (0 == strcmp(mitem->cli_component->mca_component_name, ri->ri_name)) {
-            opal_output_verbose(40, 0, "mca_base_component_repository_open: already loaded (ignored)");
+            opal_output_verbose (MCA_BASE_VERBOSE_INFO, 0, "mca_base_component_repository_open: already loaded (ignored)");
             return OPAL_ERR_BAD_PARAM;
         }
     }
@@ -336,7 +336,7 @@ int mca_base_component_repository_open (mca_base_framework_t *framework,
     mitem = NULL;
 
     if (NULL != ri->ri_dlhandle) {
-        opal_output_verbose(40, 0, "mca_base_component_repository_open: already loaded. returning cached component");
+        opal_output_verbose (MCA_BASE_VERBOSE_INFO, 0, "mca_base_component_repository_open: already loaded. returning cached component");
         mitem = OBJ_NEW(mca_base_component_list_item_t);
         if (NULL == mitem) {
             return OPAL_ERR_OUT_OF_RESOURCE;
@@ -445,8 +445,8 @@ int mca_base_component_repository_open (mca_base_framework_t *framework,
         ri->ri_component_struct = mitem->cli_component = component_struct;
         opal_list_append(&framework->framework_components, &mitem->super);
 
-        opal_output_verbose(40, 0, "mca_base_component_repository_open: opened dynamic %s MCA component \"%s\"",
-                            ri->ri_type, ri->ri_name);
+        opal_output_verbose (MCA_BASE_VERBOSE_INFO, 0, "mca_base_component_repository_open: opened dynamic %s MCA "
+                             "component \"%s\"", ri->ri_type, ri->ri_name);
 
         return OPAL_SUCCESS;
     } while (0);

--- a/opal/mca/base/mca_base_components_close.c
+++ b/opal/mca/base/mca_base_components_close.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -33,9 +33,9 @@ void mca_base_component_unload (const mca_base_component_t *component, int outpu
     int ret;
 
     /* Unload */
-    opal_output_verbose(10, output_id,
-                        "mca: base: close: unloading component %s",
-                        component->mca_component_name);
+    opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                         "mca: base: close: unloading component %s",
+                         component->mca_component_name);
 
     ret = mca_base_var_group_find (component->mca_project_name, component->mca_type_name,
                                    component->mca_component_name);
@@ -51,9 +51,9 @@ void mca_base_component_close (const mca_base_component_t *component, int output
     /* Close */
     if (NULL != component->mca_close_component) {
         component->mca_close_component();
-        opal_output_verbose(10, output_id,
-                            "mca: base: close: component %s closed",
-                            component->mca_component_name);
+        opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                             "mca: base: close: component %s closed",
+                             component->mca_component_name);
     }
 
     mca_base_component_unload (component, output_id);

--- a/opal/mca/base/mca_base_components_open.c
+++ b/opal/mca/base/mca_base_components_open.c
@@ -109,26 +109,26 @@ static int open_components(mca_base_framework_t *framework)
     }
 
     /* Announce */
-    opal_output_verbose(10, output_id, "mca: base: components_open: opening %s components",
-                        framework->framework_name);
+    opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id, "mca: base: components_open: opening %s components",
+                         framework->framework_name);
 
     /* Traverse the list of components */
     OPAL_LIST_FOREACH_SAFE(cli, next, components, mca_base_component_list_item_t) {
         const mca_base_component_t *component = cli->cli_component;
 
-        opal_output_verbose(10, output_id,
-                            "mca: base: components_open: found loaded component %s",
-                            component->mca_component_name);
+        opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                             "mca: base: components_open: found loaded component %s",
+                             component->mca_component_name);
 
 	if (NULL != component->mca_open_component) {
 	    /* Call open if register didn't call it already */
             ret = component->mca_open_component();
 
             if (OPAL_SUCCESS == ret) {
-                opal_output_verbose(10, output_id,
-                                    "mca: base: components_open: "
-                                    "component %s open function successful",
-                                    component->mca_component_name);
+                opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                     "mca: base: components_open: "
+                                     "component %s open function successful",
+                                     component->mca_component_name);
             } else {
 		if (OPAL_ERR_NOT_AVAILABLE != ret) {
 		    /* If the component returns OPAL_ERR_NOT_AVAILABLE,
@@ -143,15 +143,16 @@ static int open_components(mca_base_framework_t *framework)
 		       expected. */
 
 		    if (mca_base_component_show_load_errors) {
-			opal_output(0, "mca: base: components_open: "
-				    "component %s / %s open function failed",
-				    component->mca_type_name,
-				    component->mca_component_name);
+			opal_output_verbose (MCA_BASE_VERBOSE_ERROR, output_id,
+                                             "mca: base: components_open: component %s "
+                                             "/ %s open function failed",
+                                             component->mca_type_name,
+                                             component->mca_component_name);
 		    }
-		    opal_output_verbose(10, output_id,
-					"mca: base: components_open: "
-					"component %s open function failed",
-					component->mca_component_name);
+		    opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                         "mca: base: components_open: "
+                                         "component %s open function failed",
+                                         component->mca_component_name);
 		}
 
                 mca_base_component_close (component, output_id);

--- a/opal/mca/base/mca_base_components_register.c
+++ b/opal/mca/base/mca_base_components_register.c
@@ -76,25 +76,25 @@ static int register_components(mca_base_framework_t *framework)
     int output_id = framework->framework_output;
 
     /* Announce */
-    opal_output_verbose(10, output_id,
-                        "mca: base: components_register: registering framework %s components",
-                        framework->framework_name);
+    opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                         "mca: base: components_register: registering framework %s components",
+                         framework->framework_name);
 
     /* Traverse the list of found components */
 
     OPAL_LIST_FOREACH_SAFE(cli, next, &framework->framework_components, mca_base_component_list_item_t) {
         component = (mca_base_component_t *)cli->cli_component;
 
-        opal_output_verbose(10, output_id,
+        opal_output_verbose(MCA_BASE_VERBOSE_COMPONENT, output_id,
                             "mca: base: components_register: found loaded component %s",
                             component->mca_component_name);
 
         /* Call the component's MCA parameter registration function (or open if register doesn't exist) */
         if (NULL == component->mca_register_component_params) {
-            opal_output_verbose(10, output_id,
-                                "mca: base: components_register: "
-                                "component %s has no register or open function",
-                                component->mca_component_name);
+            opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                 "mca: base: components_register: "
+                                 "component %s has no register or open function",
+                                 component->mca_component_name);
             ret = OPAL_SUCCESS;
         } else {
             ret = component->mca_register_component_params();
@@ -114,16 +114,17 @@ static int register_components(mca_base_framework_t *framework)
                    expected. */
 
                 if (mca_base_component_show_load_errors) {
-                    opal_output(0, "mca: base: components_register: "
-                                "component %s / %s register function failed",
-                                component->mca_type_name,
-                                component->mca_component_name);
+                    opal_output_verbose (MCA_BASE_VERBOSE_ERROR, output_id,
+                                         "mca: base: components_register: component %s "
+                                         "/ %s register function failed",
+                                         component->mca_type_name,
+                                         component->mca_component_name);
                 }
 
-                opal_output_verbose(10, output_id,
-                                    "mca: base: components_register: "
-                                    "component %s register function failed",
-                                    component->mca_component_name);
+                opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                     "mca: base: components_register: "
+                                     "component %s register function failed",
+                                     component->mca_component_name);
             }
 
             opal_list_remove_item (&framework->framework_components, &cli->super);
@@ -134,7 +135,7 @@ static int register_components(mca_base_framework_t *framework)
         }
 
         if (NULL != component->mca_register_component_params) {
-            opal_output_verbose (10, output_id, "mca: base: components_register: "
+            opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id, "mca: base: components_register: "
                                  "component %s register function successful",
                                  component->mca_component_name);
         }

--- a/opal/mca/base/mca_base_components_select.c
+++ b/opal/mca/base/mca_base_components_select.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,9 +42,9 @@ int mca_base_select(const char *type_name, int output_id,
     *best_module = NULL;
     *best_component = NULL;
 
-    opal_output_verbose(10, output_id,
-                        "mca:base:select: Auto-selecting %s components",
-                        type_name);
+    opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                         "mca:base:select: Auto-selecting %s components",
+                         type_name);
 
     /*
      * Traverse the list of available components.
@@ -55,18 +57,18 @@ int mca_base_select(const char *type_name, int output_id,
          * If there is a query function then use it.
          */
         if (NULL == component->mca_query_component) {
-            opal_output_verbose(5, output_id,
-                                "mca:base:select:(%5s) Skipping component [%s]. It does not implement a query function",
-                                type_name, component->mca_component_name );
+            opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                 "mca:base:select:(%5s) Skipping component [%s]. It does not implement a query function",
+                                 type_name, component->mca_component_name );
             continue;
         }
 
         /*
          * Query this component for the module and priority
          */
-        opal_output_verbose(5, output_id,
-                            "mca:base:select:(%5s) Querying component [%s]",
-                            type_name, component->mca_component_name);
+        opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                             "mca:base:select:(%5s) Querying component [%s]",
+                             type_name, component->mca_component_name);
 
         component->mca_query_component(&module, &priority);
 
@@ -74,18 +76,18 @@ int mca_base_select(const char *type_name, int output_id,
          * If no module was returned, then skip component
          */
         if (NULL == module) {
-            opal_output_verbose(5, output_id,
-                                "mca:base:select:(%5s) Skipping component [%s]. Query failed to return a module",
-                                type_name, component->mca_component_name );
+            opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                 "mca:base:select:(%5s) Skipping component [%s]. Query failed to return a module",
+                                 type_name, component->mca_component_name );
             continue;
         }
 
         /*
          * Determine if this is the best module we have seen by looking the priority
          */
-        opal_output_verbose(5, output_id,
-                            "mca:base:select:(%5s) Query of component [%s] set priority to %d",
-                            type_name, component->mca_component_name, priority);
+        opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                             "mca:base:select:(%5s) Query of component [%s] set priority to %d",
+                             type_name, component->mca_component_name, priority);
         if (priority > best_priority) {
             best_priority  = priority;
             *best_component = component;
@@ -99,7 +101,7 @@ int mca_base_select(const char *type_name, int output_id,
      * Make sure we found something in the process.
      */
     if (NULL == *best_component) {
-        opal_output_verbose(5, output_id,
+        opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
                             "mca:base:select:(%5s) No component selected!",
                             type_name);
         /*
@@ -111,9 +113,9 @@ int mca_base_select(const char *type_name, int output_id,
         return OPAL_ERR_NOT_FOUND;
     }
 
-    opal_output_verbose(5, output_id,
-                        "mca:base:select:(%5s) Selected component [%s]",
-                        type_name, (*best_component)->mca_component_name);
+    opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                         "mca:base:select:(%5s) Selected component [%s]",
+                         type_name, (*best_component)->mca_component_name);
 
     /*
      * Close the non-selected components

--- a/opal/mca/base/mca_base_framework.c
+++ b/opal/mca/base/mca_base_framework.c
@@ -92,10 +92,16 @@ int mca_base_framework_register (struct mca_base_framework_t *framework,
         }
 
         /* register a verbosity variable for this framework */
-        asprintf (&desc, "Verbosity level for the %s framework (0 = no verbosity)",
-                  framework->framework_name);
+        ret = asprintf (&desc, "Verbosity level for the %s framework (default: 0)",
+                        framework->framework_name);
+        if (0 > ret) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        framework->framework_verbose = MCA_BASE_VERBOSE_ERROR;
         ret = mca_base_framework_var_register (framework, "verbose", desc,
-                                               MCA_BASE_VAR_TYPE_INT, NULL, 0,
+                                               MCA_BASE_VAR_TYPE_INT,
+                                               &mca_base_var_enum_verbose, 0,
                                                MCA_BASE_VAR_FLAG_SETTABLE,
                                                OPAL_INFO_LVL_8,
                                                MCA_BASE_VAR_SCOPE_LOCAL,

--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -140,7 +140,7 @@ int mca_base_open(void)
     gethostname(hostname, 64);
     asprintf(&lds.lds_prefix, "[%s:%05d] ", hostname, getpid());
     opal_output_reopen(0, &lds);
-    opal_output_verbose(5, 0, "mca: base: opening components");
+    opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, 0, "mca: base: opening components");
     free(lds.lds_prefix);
 
     /* Open up the component repository */

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -852,7 +852,7 @@ int mca_base_var_deregister(int vari)
         var->mbv_storage->stringval) {
         free (var->mbv_storage->stringval);
         var->mbv_storage->stringval = NULL;
-    } else if (MCA_BASE_VAR_TYPE_BOOL != var->mbv_type && NULL != var->mbv_enumerator) {
+    } else if (var->mbv_enumerator && !var->mbv_enumerator->enum_is_static) {
         OBJ_RELEASE(var->mbv_enumerator);
     }
 
@@ -1486,7 +1486,9 @@ static int register_variable (const char *project_name, const char *framework_na
             OBJ_RELEASE (var->mbv_enumerator);
         }
 
-        OBJ_RETAIN(enumerator);
+        if (!enumerator->enum_is_static) {
+            OBJ_RETAIN(enumerator);
+        }
     }
 
     var->mbv_enumerator = enumerator;
@@ -1847,7 +1849,7 @@ static void var_destructor(mca_base_var_t *var)
     }
 
     /* don't release the boolean enumerator */
-    if (MCA_BASE_VAR_TYPE_BOOL != var->mbv_type && NULL != var->mbv_enumerator) {
+    if (var->mbv_enumerator && !var->mbv_enumerator->enum_is_static) {
         OBJ_RELEASE(var->mbv_enumerator);
     }
 
@@ -1860,6 +1862,7 @@ static void var_destructor(mca_base_var_t *var)
     if (NULL != var->mbv_long_name) {
         free(var->mbv_long_name);
     }
+
     if (NULL != var->mbv_description) {
         free(var->mbv_description);
     }

--- a/opal/mca/base/mca_base_var_enum.h
+++ b/opal/mca/base/mca_base_var_enum.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -106,6 +106,9 @@ typedef struct mca_base_var_enum_value_t mca_base_var_enum_value_t;
 struct mca_base_var_enum_t {
     opal_object_t super;
 
+    /** Is the enumerator statically allocated */
+    bool enum_is_static;
+
     /** Name of this enumerator. This value is duplicated from the argument provided to
         mca_base_var_enum_create() */
     char *enum_name;
@@ -176,5 +179,9 @@ OPAL_DECLSPEC int mca_base_var_enum_create (const char *name, const mca_base_var
  */
 extern mca_base_var_enum_t mca_base_var_enum_bool;
 
+/**
+ * Verbosity level enumerator
+ */
+extern mca_base_var_enum_t mca_base_var_enum_verbose;
 
 #endif /* !defined(MCA_BASE_VAR_ENUM_H) */


### PR DESCRIPTION
This is a RFC for defining standard verbosity levels for Open MPI components. The first cut defines the following levels:

```
enum {
    MCA_BASE_VERBOSE_NONE  = 0,
    MCA_BASE_VERBOSE_ERROR = 1,
    MCA_BASE_VERBOSE_WARN  = 10,
    MCA_BASE_VERBOSE_INFO  = 20,
    MCA_BASE_VERBOSE_DEBUG = 40,
    MCA_BASE_VERBOSE_TRACE = 60,
    MCA_BASE_VERBOSE_MAX   = 100,
};
```

Please let me know if I should add/remove any levels or change the mapping between the levels and the corresponding integer value.

I have not made an effort to enforce these levels. Component owners would be expected to modify the verbose output in their components to fit these levels.

For the original RFC please see:

http://www.open-mpi.org/community/lists/devel/2015/05/17468.php