### PR TITLE
Status x java bindings

### DIFF
--- a/ompi/mpi/java/c/Makefile.am
+++ b/ompi/mpi/java/c/Makefile.am
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012	Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,23 +24,24 @@ ompi_HEADERS = \
 
 lib_LTLIBRARIES = libmpi_java.la
 libmpi_java_la_SOURCES = \
-        mpi_CartComm.c \
-        mpi_Comm.c \
+	mpi_CartComm.c \
+	mpi_Comm.c \
 	mpi_Constant.c \
-        mpi_Datatype.c \
-        mpi_Errhandler.c \
+	mpi_Count.c   \
+	mpi_Datatype.c \
+	mpi_Errhandler.c \
 	mpi_File.c \
-        mpi_GraphComm.c \
-        mpi_Group.c \
+	mpi_GraphComm.c \
+	mpi_Group.c \
 	mpi_Info.c \
-        mpi_Intercomm.c \
-        mpi_Intracomm.c \
+	mpi_Intercomm.c \
+	mpi_Intracomm.c \
 	mpi_Message.c \
-        mpi_MPI.c \
-        mpi_Op.c \
-        mpi_Request.c \
-        mpi_Prequest.c \
-        mpi_Status.c \
+	mpi_MPI.c \
+	mpi_Op.c \
+	mpi_Request.c \
+	mpi_Prequest.c \
+	mpi_Status.c \
 	mpi_Win.c
 
 libmpi_java_la_LIBADD = $(top_builddir)/ompi/libmpi.la

--- a/ompi/mpi/java/c/mpiJava.h
+++ b/ompi/mpi/java/c/mpiJava.h
@@ -33,6 +33,8 @@ typedef struct {
     jmethodID ShiftParmsInit;
     jclass    VersionClass;
     jmethodID VersionInit;
+    jclass    CountClass;
+    jmethodID CountInit;
     jclass    GraphParmsClass;
     jmethodID GraphParmsInit;
     jclass    DistGraphNeighborsClass;

--- a/ompi/mpi/java/c/mpi_Count.c
+++ b/ompi/mpi/java/c/mpi_Count.c
@@ -45,8 +45,8 @@
 JNIEXPORT void JNICALL Java_mpi_Count_initCount(JNIEnv *env, jclass jthis)
 {
 	jclass c = (*env)->FindClass(env, "mpi/Count");
-    ompi_java.CountClass = (*env)->NewGlobalRef(env, c);
-    ompi_java.CountInit = (*env)->GetMethodID(env, ompi_java.CountClass, "<init>", "(J)V");
+	ompi_java.CountClass = (*env)->NewGlobalRef(env, c);
+	ompi_java.CountInit = (*env)->GetMethodID(env, ompi_java.CountClass, "<init>", "(J)V");
 
-    (*env)->DeleteLocalRef(env, c);
+	(*env)->DeleteLocalRef(env, c);
 }

--- a/ompi/mpi/java/c/mpi_Count.c
+++ b/ompi/mpi/java/c/mpi_Count.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ *
+ * This file is almost a complete re-write for Open MPI compared to the
+ * original mpiJava package. Its license and copyright are listed below.
+ * See <path to ompi/mpi/java/README> for more information.
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ * File         : Version.java
+ * Author       : Nathaniel Graham
+ * Created      : Thu Jul  30 09:34 2015
+ */
+
+#include "ompi_config.h"
+
+#include <stdlib.h>
+#ifdef HAVE_TARGETCONDITIONALS_H
+#include <TargetConditionals.h>
+#endif
+
+#include "mpi.h"
+#include "mpi_Count.h"
+#include "mpiJava.h"
+
+JNIEXPORT void JNICALL Java_mpi_Count_initCount(JNIEnv *env, jclass jthis)
+{
+	jclass c = (*env)->FindClass(env, "mpi/Count");
+    ompi_java.CountClass = (*env)->NewGlobalRef(env, c);
+    ompi_java.CountInit = (*env)->GetMethodID(env, ompi_java.CountClass, "<init>", "(J)V");
+
+    (*env)->DeleteLocalRef(env, c);
+}

--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -205,6 +205,7 @@ static void deleteClasses(JNIEnv *env)
     (*env)->DeleteGlobalRef(env, ompi_java.CartParmsClass);
     (*env)->DeleteGlobalRef(env, ompi_java.ShiftParmsClass);
     (*env)->DeleteGlobalRef(env, ompi_java.VersionClass);
+    (*env)->DeleteGlobalRef(env, ompi_java.CountClass);
     (*env)->DeleteGlobalRef(env, ompi_java.GraphParmsClass);
     (*env)->DeleteGlobalRef(env, ompi_java.DistGraphNeighborsClass);
     (*env)->DeleteGlobalRef(env, ompi_java.StatusClass);

--- a/ompi/mpi/java/c/mpi_Status.c
+++ b/ompi/mpi/java/c/mpi_Status.c
@@ -121,7 +121,7 @@ JNIEXPORT jobject JNICALL Java_mpi_Status_getElementsX(
     ompi_java_exceptionCheck(env, rc);
 
 	return (*env)->NewObject(env, ompi_java.CountClass,
-		                             ompi_java.CountInit, (jlong)count);
+				ompi_java.CountInit, (jlong)count);
 }
 
 JNIEXPORT jint JNICALL Java_mpi_Status_setElements(

--- a/ompi/mpi/java/c/mpi_Status.c
+++ b/ompi/mpi/java/c/mpi_Status.c
@@ -109,6 +109,21 @@ JNIEXPORT jint JNICALL Java_mpi_Status_getElements(
     return count;
 }
 
+JNIEXPORT jobject JNICALL Java_mpi_Status_getElementsX(
+        JNIEnv *env, jobject jthis, jint source, jint tag,
+        jint error, jint cancelled, jlong ucount, jlong jType)
+{
+    MPI_Count count;
+    MPI_Status stat;
+    getStatus(&stat, source, tag, error, cancelled, ucount);
+    MPI_Datatype datatype = (MPI_Datatype)jType;
+    int rc = MPI_Get_elements_x(&stat, datatype, &count);
+    ompi_java_exceptionCheck(env, rc);
+
+	return (*env)->NewObject(env, ompi_java.CountClass,
+		                             ompi_java.CountInit, (jlong)count);
+}
+
 JNIEXPORT jint JNICALL Java_mpi_Status_setElements(
         JNIEnv *env, jobject jthis, jint source, jint tag,
         jint error, jint cancelled, jlong ucount, jlong jType, int count)
@@ -119,6 +134,19 @@ JNIEXPORT jint JNICALL Java_mpi_Status_setElements(
     int rc = MPI_Status_set_elements(&stat, datatype, count);
     ompi_java_exceptionCheck(env, rc);
     return stat._ucount;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Status_setElementsX(
+        JNIEnv *env, jobject jthis, jint source, jint tag,
+        jint error, jint cancelled, jlong ucount, jlong jType, jlong jcount)
+{
+    MPI_Status stat;
+    MPI_Count count = (long)jcount;
+    getStatus(&stat, source, tag, error, cancelled, ucount);
+    MPI_Datatype datatype = (MPI_Datatype)jType;
+    int rc = MPI_Status_set_elements_x(&stat, datatype, count);
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)stat._ucount;
 }
 
 JNIEXPORT void JNICALL Java_mpi_Status_setCancelled(

--- a/ompi/mpi/java/java/Count.java
+++ b/ompi/mpi/java/java/Count.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ *
+ * This file is almost a complete re-write for Open MPI compared to the
+ * original mpiJava package. Its license and copyright are listed below.
+ * See <path to ompi/mpi/java/README> for more information.
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ * File         : Count.java
+ * Author       : Nathaniel Graham
+ * Created      : Thu Jul  29 17:13 2015
+ */
+
+package mpi;
+
+/**
+ * This class represents {@code MPI_Count}.
+ */
+public final class Count implements Comparable
+{
+	private long count;
+
+	static
+	{
+		System.loadLibrary("mpi_java");
+		initCount();
+	}
+
+	private static native void initCount();
+
+	public Count(long count)
+	{
+		this.count = count;
+	}
+
+	/**
+	 * Gets value associated with this Count object.
+	 * @return Count value
+	 */
+	public long getCount()
+	{
+		return this.count;
+	}
+
+	/**
+	 * Sets the value associated with this Count object.
+	 * @param count	the value to set for this count object
+	 */
+	public void setCount(long count)
+	{
+		this.count = count;
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		if(obj instanceof Count) {
+			if(this.count == ((Count)obj).getCount()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public int compareTo(Object obj) 
+	{
+		if(obj instanceof Count) {
+			if(this.count - ((Count)obj).getCount() > 0) {
+				return 1;
+			} else if(this.count - ((Count)obj).getCount() == 0) {
+				return 0;
+			}
+		}
+		return -1;
+	}
+} // Count

--- a/ompi/mpi/java/java/Makefile.am
+++ b/ompi/mpi/java/java/Makefile.am
@@ -25,37 +25,38 @@ include $(top_srcdir)/Makefile.ompi-rules
 # just list them here in EXTRA_DIST so that they get picked up by
 # "make dist".
 JAVA_SRC_FILES = \
-        CartComm.java     \
-        CartParms.java    \
-        Comm.java         \
+	CartComm.java     \
+	CartParms.java    \
+	Comm.java         \
 	Constant.java     \
-        Datatype.java     \
+	Count.java	  \
+	Datatype.java     \
 	DistGraphNeighbors.java \
 	DoubleInt.java    \
 	DoubleComplex.java \
-        Errhandler.java   \
+	Errhandler.java   \
 	FloatComplex.java \
 	FloatInt.java     \
 	File.java         \
 	FileView.java     \
-        Freeable.java     \
-        GraphComm.java    \
-        GraphParms.java   \
-        Group.java        \
+	Freeable.java     \
+	GraphComm.java    \
+	GraphParms.java   \
+	Group.java        \
 	Info.java	  \
 	Int2.java         \
-        Intercomm.java    \
-        Intracomm.java    \
+	Intercomm.java    \
+	Intracomm.java    \
 	LongInt.java      \
 	Message.java      \
-        MPI.java          \
-        MPIException.java \
-        Op.java           \
-        Prequest.java     \
-        Request.java      \
-        ShiftParms.java   \
+	MPI.java          \
+	MPIException.java \
+	Op.java           \
+	Prequest.java     \
+	Request.java      \
+	ShiftParms.java   \
 	ShortInt.java     \
-        Status.java       \
+	Status.java       \
 	Struct.java       \
 	UserFunction.java \
 	Version.java	  \
@@ -71,26 +72,27 @@ if OMPI_WANT_JAVA_BINDINGS
 # we have a specific list of files here, as opposed to deriving them
 # from JAVA_SRC_FILES.
 JAVA_H = \
-        mpi_MPI.h          \
-        mpi_CartParms.h    \
-        mpi_CartComm.h     \
-        mpi_Comm.h         \
+	mpi_MPI.h          \
+	mpi_CartParms.h    \
+	mpi_CartComm.h     \
+	mpi_Comm.h         \
 	mpi_Constant.h     \
-        mpi_Datatype.h     \
-        mpi_Errhandler.h   \
+	mpi_Count.h        \
+	mpi_Datatype.h     \
+	mpi_Errhandler.h   \
 	mpi_File.h         \
-        mpi_GraphParms.h   \
-        mpi_GraphComm.h    \
-        mpi_Group.h        \
+	mpi_GraphParms.h   \
+	mpi_GraphComm.h    \
+	mpi_Group.h        \
 	mpi_Info.h         \
-        mpi_Intercomm.h    \
-        mpi_Intracomm.h    \
+	mpi_Intercomm.h    \
+	mpi_Intracomm.h    \
 	mpi_Message.h      \
-        mpi_Op.h           \
-        mpi_Prequest.h     \
-        mpi_Request.h      \
-        mpi_ShiftParms.h   \
-        mpi_Status.h       \
+	mpi_Op.h           \
+	mpi_Prequest.h     \
+	mpi_Request.h      \
+	mpi_ShiftParms.h   \
+	mpi_Status.h       \
 	mpi_Version.h	   \
 	mpi_Win.h
 

--- a/ompi/mpi/java/java/Status.java
+++ b/ompi/mpi/java/java/Status.java
@@ -138,6 +138,29 @@ public final class Status
 			int cancelled, long ucount, long datatype) throws MPIException;
 
 	/**
+	 * Retrieves the number of basic elements from status.
+	 * <p>Java binding of the MPI operation {@code MPI_GET_ELEMENTS_X}.
+	 * @param datatype datatype used by receive operation
+	 * @return number of received basic elements
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Count getElementsX(Datatype datatype) throws MPIException
+	{
+		MPI.check();
+		int  i = 0;
+		int  source    = (int)data[i++];
+		int  tag       = (int)data[i++];
+		int  error     = (int)data[i++];
+		int  cancelled = (int)data[i++];
+		long ucount    = data[i++];
+		return getElementsX(source, tag, error, cancelled, ucount, datatype.handle);
+	}
+
+	private native Count getElementsX(
+			int source, int tag, int error,
+			int cancelled, long ucount, long datatype) throws MPIException;
+	
+	/**
 	 * Sets the number of basic elements for this status object.
 	 * <p>Java binding of the MPI operation {@code MPI_STATUS_SET_ELEMENTS}.
 	 * @param datatype 	datatype used by receive operation
@@ -159,6 +182,29 @@ public final class Status
 	private native int setElements(
 			int source, int tag, int error,
 			int cancelled, long ucount, long datatype, int count) throws MPIException;
+	
+	/**
+	 * Sets the number of basic elements for this status object.
+	 * <p>Java binding of the MPI operation {@code MPI_STATUS_SET_ELEMENTS_X}.
+	 * @param datatype 	datatype used by receive operation
+	 * @param count		number of elements to associate with the status
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public void setElementsX(Datatype datatype, Count count) throws MPIException
+	{
+		MPI.check();
+		int  i = 0;
+		int  source    = (int)data[i++];
+		int  tag       = (int)data[i++];
+		int  error     = (int)data[i++];
+		int  cancelled = (int)data[i++];
+		long ucount    = data[i++];
+		data[4] = setElementsX(source, tag, error, cancelled, ucount, datatype.handle, count.getCount());
+	}
+
+	private native long setElementsX(
+			int source, int tag, int error,
+			int cancelled, long ucount, long datatype, long count) throws MPIException;
 	
 	/**
 	 * Sets the cancelled flag.


### PR DESCRIPTION
Includes java bindings for MPI_GET_ELEMENTS_X and
MPI_STATUS_SET_ELEMENTS_X.  This PR also adds the
Count object which represents MPI_Count.

Signed-off-by: Nathaniel Graham <ngraham@lanl.gov>

@hppritcha  @jsquyres 