### PR TITLE
contrib/lanl: update Makefile

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -59,6 +59,12 @@ EXTRA_DIST = \
         platform/lanl/cray_xe6/optimized-common \
         platform/lanl/cray_xe6/optimized-lustre \
         platform/lanl/cray_xe6/optimized-lustre.conf \
+        platform/lanl/cray_xc_cle5.2/debug-common \
+        platform/lanl/cray_xc_cle5.2/debug-lustre \
+        platform/lanl/cray_xc_cle5.2/debug-lustre.conf \
+        platform/lanl/cray_xc_cle5.2/optimized-common \
+        platform/lanl/cray_xc_cle5.2/optimized-lustre \
+        platform/lanl/cray_xc_cle5.2/optimized-lustre.conf \
         platform/lanl/toss/debug-common \
         platform/lanl/toss/debug-nopanasas \
         platform/lanl/toss/debug-nopanasas.conf \


### PR DESCRIPTION
update Makefile to get new LANL platform files into the distcheck tarballs.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>