### PR TITLE
Build always and fix return value

### DIFF
--- a/ompi/mpiext/cuda/c/mpiext_cuda.c
+++ b/ompi/mpiext/cuda/c/mpiext_cuda.c
@@ -23,9 +23,9 @@
 #include "opal/constants.h"
 #include "ompi/mpiext/cuda/c/mpiext_cuda_c.h"
 
-/* The fact that this code is configured and compiled means that we have CUDA aware
-   support.  We may expand on this API to return more features in the future. */
+/* If CUDA-aware support is configured in, return 1. Otherwise, return 0.
+ * This API may be extended to return more features in the future. */
 int MPIX_Query_cuda_support(void)
 {
-    return OPAL_SUCCESS;
+    return OPAL_CUDA_SUPPORT;
 }

--- a/ompi/mpiext/cuda/configure.m4
+++ b/ompi/mpiext/cuda/configure.m4
@@ -18,25 +18,10 @@ AC_DEFUN([OMPI_MPIEXT_cuda_CONFIG],[
     AC_CONFIG_FILES([ompi/mpiext/cuda/Makefile])
     AC_CONFIG_FILES([ompi/mpiext/cuda/c/Makefile])
 
-    OPAL_VAR_SCOPE_PUSH([ompi_mpi_ext_cuda_happy])
-
-    # If we don't want CUDA, don't compile this extention
+    # We compile this whether CUDA support was requested or not. It allows
+    # us to to detect if we have CUDA support.
     AS_IF([test "$ENABLE_cuda" = "1" || \
            test "$ENABLE_EXT_ALL" = "1"],
-          [ompi_mpi_ext_cuda_happy=1],
-          [ompi_mpi_ext_cuda_happy=0])
-
-    AS_IF([test "$ompi_mpi_ext_cuda_happy" = "1" && \
-           test "$CUDA_SUPPORT" = "1"],
           [$1],
-          [ # Error if the user specifically asked for this extension,
-            # but we can't build it.
-           AS_IF([test "$ENABLE_cuda" = "1"],
-                 [AC_MSG_WARN([Requested "cuda" MPI extension, but cannot build it])
-                  AC_MSG_WARN([because cuda support is not enabled.])
-                  AC_MSG_WARN([Try again with --with-cuda])
-                  AC_MSG_ERROR([Cannot continue])])
-           $2])
-
-    OPAL_VAR_SCOPE_POP
+          [$2])
 ])


### PR DESCRIPTION
This change makes the CUDA extensions always build so they are always available whether we configure with CUDA support or not.  That is needed as this extension is being used to determine whether we have CUDA aware support or not.

@jsquyres Can you review?  This is fixing bug #776
