### PR TITLE
plm/alps: remove unneded env. variable setting

### DIFF
--- a/orte/mca/plm/alps/plm_alps_module.c
+++ b/orte/mca/plm/alps/plm_alps_module.c
@@ -151,20 +151,6 @@ static int plm_alps_init(void)
  */
 static int plm_alps_launch_job(orte_job_t *jdata)
 {
-    orte_app_context_t *app;
-
-    for (int i = 0 ; i < jdata->apps->size ; ++i) {
-        int env_count;
-
-        if (NULL == (app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, i))) {
-            continue;
-        }
-
-        for (env_count = 0 ; app->env && app->env[env_count] ; ++env_count);
-        /* disable PMI for the application. this will prevent the pmi library from printing useless warnings */
-        opal_argv_append (&env_count, &app->env, "PMI_NO_FORK=1");
-        opal_argv_append (&env_count, &app->env, "PMI_NO_PREINITIALIZE=1");
-    }
 
     if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_RESTART)) {
         /* this is a restart situation - skip to the mapping stage */


### PR DESCRIPTION
In order to address issue #741, the orted's now are
always launched with the Cray PMI environment variables

PMI_NO_FORK
PMI_NO_PREINITIALIZE

set to disable running of the library's ctor.
So there's no longer a need to set these for the
application(s) being launched by the orted's.

@hjelmn  please review when you have a chance

Signed-off-by: Howard Pritchard <howardp@lanl.gov>