### PR TITLE
Add explicit implementation of Cloneable

### DIFF
--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -65,7 +65,7 @@ import static mpi.MPI.assertDirectBuffer;
 /**
  * The {@code Comm} class represents communicators.
  */
-public class Comm implements Freeable
+public class Comm implements Freeable, Cloneable
 {
 	public final static int TYPE_SHARED = 0;
 	protected final static int SELF  = 1;

--- a/ompi/mpi/java/java/Datatype.java
+++ b/ompi/mpi/java/java/Datatype.java
@@ -52,7 +52,7 @@ import java.nio.*;
 /**
  * The {@code Datatype} class represents {@code MPI_Datatype} handles.
  */
-public final class Datatype implements Freeable
+public final class Datatype implements Freeable, Cloneable
 {
 	protected long handle;
 	protected int baseType;

--- a/ompi/mpi/java/java/Info.java
+++ b/ompi/mpi/java/java/Info.java
@@ -23,7 +23,7 @@ package mpi;
 /**
  * This class represents {@code MPI_Info}.
  */
-public final class Info implements Freeable
+public final class Info implements Freeable, Cloneable
 {
 	protected long handle;
 	protected static final long NULL = getNull();


### PR DESCRIPTION
Added Cloneable to the implemented interface list as per
Coverity suggestion.  The required methods were already
implemented, but it was not explicitly stated.  This is
an intent revealing change.

Coverity pointed out this lapse.

Signed-off-by: Nathaniel Graham <ngraham@lanl.gov>

@hppritcha  @jsquyres 