### PR TITLE
remove a erroneous parenthesis which prevents the compilation of the …

### DIFF
--- a/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_open.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_open.c
@@ -50,7 +50,6 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
 
     amode_direct = amode | O_DIRECT;
 
-    }
     /* odd length here because lov_user_md contains some fixed data and
      * then a list of 'lmm_objects' representing stripe */
     lumlen = sizeof(struct lov_user_md) +


### PR DESCRIPTION
…lustre adio
@roblatham00 would you mind confirming that this is really correct? Not sure how the parenthesis got in in the first place, but it didn't compile on the Stuttgart Cray originally, but does now.