### PR TITLE
topo/treematch: fix segmentation fault in neighborhood dist_graph create

### DIFF
--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -114,15 +114,38 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
 
     if(!reorder) {  /* No reorder. Create a new communicator, then   */
                     /* jump out to attach the dist_graph and return */
+        int num_procs, rank, i;
+        ompi_proc_t **topo_procs = NULL;
+        ompi_communicator_t * new_comm;
     fallback:
-
-        if( OMPI_SUCCESS == (err = ompi_comm_create(comm_old,
-                                                    comm_old->c_local_group,
-                                                    newcomm))){
-            /* Attach the dist_graph to the newly created communicator */
-            (*newcomm)->c_flags        |= OMPI_COMM_DIST_GRAPH;
-            (*newcomm)->c_topo          = topo_module;
-            (*newcomm)->c_topo->reorder = reorder;
+        num_procs = ompi_comm_size(comm_old);
+        rank = ompi_comm_rank(comm_old);
+        topo_procs = (ompi_proc_t**)malloc(num_procs * sizeof(ompi_proc_t *));
+        if(OMPI_GROUP_IS_DENSE(comm_old->c_local_group)) {
+            memcpy(topo_procs, 
+                   comm_old->c_local_group->grp_proc_pointers,
+                   num_procs * sizeof(ompi_proc_t *));
+        } else {
+            for(i = 0 ; i < num_procs; i++) {
+                topo_procs[i] = ompi_group_peer_lookup(comm_old->c_local_group,i);
+            }
+        }
+        new_comm = ompi_comm_allocate(num_procs, 0);
+        if (NULL == new_comm) {
+            free(topo_procs);
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        /* Attach the dist_graph to the newly created communicator */
+        new_comm->c_flags        |= OMPI_COMM_DIST_GRAPH;
+        new_comm->c_topo          = topo_module;
+        new_comm->c_topo->reorder = reorder;
+        err = ompi_comm_enable(comm_old, new_comm,
+                               rank, num_procs, topo_procs);
+        if (OMPI_SUCCESS == err) {
+            *newcomm = new_comm;
+        } else {
+            free(topo_procs);
+            ompi_comm_free(&new_comm);
         }
         return err;
     }  /* reorder == yes */

--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -259,10 +259,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
     /* Then, we need to know if the processes are bound */
     /* We make the hypothesis that all processes are in  */
     /* the same state : all bound or none bound */
-    hwloc_err = hwloc_topology_init(&opal_hwloc_topology);
-    if (-1 == hwloc_err) goto fallback;
-    hwloc_err = hwloc_topology_load(opal_hwloc_topology);
-    if (-1 == hwloc_err) goto fallback;
+    assert(NULL != opal_hwloc_topology);
     root_obj = hwloc_get_root_obj(opal_hwloc_topology);
     if (NULL == root_obj) goto fallback;
 


### PR DESCRIPTION
if the degree of the topology size is higher than the communicator size
(inspired by commit open-mpi/ompi@76204dfafe48c2859fe3c8250e2d9f3c23799a76)