### PR TITLE
Java null handle bugfix

### DIFF
--- a/ompi/mpi/java/java/Request.java
+++ b/ompi/mpi/java/java/Request.java
@@ -471,8 +471,12 @@ public class Request implements Freeable
 	{
 		long[] h = new long[r.length];
 
-		for(int i = 0; i < r.length; i++)
-			h[i] = r[i].handle;
+		for(int i = 0; i < r.length; i++) {
+			if(r[i] != null)
+				h[i] = r[i].handle;
+			else
+				h[i] = 0;
+		}
 
 		return h;
 	}


### PR DESCRIPTION
A helper method in Request.java could cause a crash
if the request array that was passed contained nulls.

Signed-off-by: Nathaniel Graham <ngraham@lanl.gov>

@hppritcha @jsquyres 