### PR TITLE
btl/openib: remove OFED version runtime check when XRC is used

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -1011,10 +1011,6 @@ static void device_destruct(mca_btl_openib_device_t *device)
 
 #if HAVE_XRC
 
-    if (!mca_btl_openib_xrc_check_api()) {
-        return;
-    }
-
     if (MCA_BTL_XRC_ENABLED) {
         if (OPAL_SUCCESS != mca_btl_openib_close_xrc_domain(device)) {
             BTL_VERBOSE(("XRC Internal error. Failed to close xrc domain"));

--- a/opal/mca/btl/openib/btl_openib_xrc.c
+++ b/opal/mca/btl/openib/btl_openib_xrc.c
@@ -39,29 +39,6 @@ OBJ_CLASS_INSTANCE(ib_address_t,
                    ib_address_constructor,
                    ib_address_destructor);
 
-/* run-time check for which libibverbs XRC API we really have underneath */
-bool mca_btl_openib_xrc_check_api()
-{
-    void *lib = dlopen(NULL, RTLD_NOW); /* current program */
-    if (!lib) {
-        BTL_ERROR(("XRC error: could not find XRC API version"));
-        return false;
-    }
-
-#if OPAL_HAVE_CONNECTX_XRC_DOMAINS
-    if (NULL != dlsym(lib, "ibv_open_xrcd")) {
-        BTL_ERROR(("XRC error: bad XRC API (require XRC from OFED 3.12+)"));
-        return false;
-    }
-#else
-    if (NULL != dlsym(lib, "ibv_create_xrc_rcv_qp")) {
-        BTL_ERROR(("XRC error: bad XRC API (require XRC from OFED pre 3.12)."));
-        return false;
-    }
-#endif
-    return true;
-}
-
 /* This func. opens XRC domain */
 int mca_btl_openib_open_xrc_domain(struct mca_btl_openib_device_t *device)
 {

--- a/opal/mca/btl/openib/btl_openib_xrc.h
+++ b/opal/mca/btl/openib/btl_openib_xrc.h
@@ -51,6 +51,4 @@ int mca_btl_openib_close_xrc_domain(struct mca_btl_openib_device_t *device);
 int mca_btl_openib_ib_address_add_new (uint16_t lid, uint64_t s_id,
         opal_jobid_t ep_jobid, mca_btl_openib_endpoint_t *ep);
 
-bool mca_btl_openib_xrc_check_api(void);
-
 #endif


### PR DESCRIPTION
this test seems broken :
 - some false positive were reported
 - it fails to detect some OFED version mismatch
this commit simply removes this test, which means the application
will likely fail if XRC is used ad OFED version is different
between compile time and runtime