### PR TITLE
Fix macro return value when not CUDA-aware

### DIFF
--- a/ompi/mpiext/cuda/c/mpiext_cuda_c.h.in
+++ b/ompi/mpiext/cuda/c/mpiext_cuda_c.h.in
@@ -12,5 +12,5 @@
  *
  */
 
-#define MPIX_CUDA_AWARE_SUPPORT 1
+#define MPIX_CUDA_AWARE_SUPPORT @MPIX_CUDA_AWARE_SUPPORT@
 OMPI_DECLSPEC int MPIX_Query_cuda_support(void);

--- a/ompi/mpiext/cuda/configure.m4
+++ b/ompi/mpiext/cuda/configure.m4
@@ -17,6 +17,10 @@
 AC_DEFUN([OMPI_MPIEXT_cuda_CONFIG],[
     AC_CONFIG_FILES([ompi/mpiext/cuda/Makefile])
     AC_CONFIG_FILES([ompi/mpiext/cuda/c/Makefile])
+    AC_CONFIG_HEADER([ompi/mpiext/cuda/c/mpiext_cuda_c.h])
+
+    AC_DEFINE_UNQUOTED([MPIX_CUDA_AWARE_SUPPORT],[$CUDA_SUPPORT],
+                       [Macro that is set to 1 when CUDA-aware support is configured in and 0 when it is not])
 
     # We compile this whether CUDA support was requested or not. It allows
     # us to to detect if we have CUDA support.


### PR DESCRIPTION
This is to fix things so we set the macro to 0 when no CUDA-aware.  Otherwise, the macro is always set to 1 which is obviously wrong.

@jsquyres can you look at this one?

I still may try and change it so things are undefined, but that is still under discussion and I would like it to at least work as it was originally intended.  