### PR TITLE
java/Prequest: keep a pointer to the buffer

### DIFF
--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -769,7 +769,7 @@ public class Comm implements Freeable, Cloneable
 	{
 		MPI.check();
 		assertDirectBuffer(buf);
-		return new Prequest(sendInit(handle, buf, count, type.handle, dest, tag));
+		return new Prequest(sendInit(handle, buf, count, type.handle, dest, tag), buf);
 	}
 
 	private native long sendInit(
@@ -794,7 +794,7 @@ public class Comm implements Freeable, Cloneable
 	{
 		MPI.check();
 		assertDirectBuffer(buf);
-		return new Prequest(bSendInit(handle, buf, count, type.handle, dest, tag));
+		return new Prequest(bSendInit(handle, buf, count, type.handle, dest, tag), buf);
 	}
 
 	private native long bSendInit(
@@ -819,7 +819,7 @@ public class Comm implements Freeable, Cloneable
 	{
 		MPI.check();
 		assertDirectBuffer(buf);
-		return new Prequest(sSendInit(handle, buf, count, type.handle, dest, tag));
+		return new Prequest(sSendInit(handle, buf, count, type.handle, dest, tag), buf);
 	}
 
 	private native long sSendInit(
@@ -844,7 +844,7 @@ public class Comm implements Freeable, Cloneable
 	{
 		MPI.check();
 		assertDirectBuffer(buf);
-		return new Prequest(rSendInit(handle, buf, count, type.handle, dest, tag));
+		return new Prequest(rSendInit(handle, buf, count, type.handle, dest, tag), buf);
 	}
 
 	private native long rSendInit(
@@ -869,7 +869,7 @@ public class Comm implements Freeable, Cloneable
 	{
 		MPI.check();
 		assertDirectBuffer(buf);
-		return new Prequest(recvInit(handle, buf, count, type.handle, source, tag));
+		return new Prequest(recvInit(handle, buf, count, type.handle, source, tag), buf);
 	}
 
 	private native long recvInit(

--- a/ompi/mpi/java/java/Prequest.java
+++ b/ompi/mpi/java/java/Prequest.java
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,18 +49,28 @@
 
 package mpi;
 
+import java.nio.Buffer;
+
 /**
  * Persistent request object.
  */
 public final class Prequest extends Request
 {
 	/**
+	 * Buffer used internally by the persistent request
+	 * maintain a pointer to the buffer to ensure it
+	 * cannot be free'd by the garbage collector
+	 */
+	private Buffer buffer;
+
+	/**
 	 * Constructor used by {@code sendInit}, etc.
 	 * @param handle	Handle for the Prequest object
 	 */
-	protected Prequest(long handle)
+	protected Prequest(long handle, Buffer buffer)
 	{
 		super(handle);
+		this.buffer = buffer;
 	}
 
 	/**


### PR DESCRIPTION
this prevents garbage collector from freeing the buffer

Refs open-mpi/ompi#369