### PR TITLE
configury: add the --enable-static-runtime option

### DIFF
--- a/config/orte_configure_options.m4
+++ b/config/orte_configure_options.m4
@@ -16,6 +16,8 @@ dnl Copyright (c) 2009      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2009-2013 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -68,4 +70,10 @@ AC_DEFINE_UNQUOTED([ORTE_ENABLE_STATIC_PORTS],
                    [$orte_enable_static_ports],
 		   [Whether we want static ports enabled])
 
+AC_ARG_ENABLE(static-runtime,
+AC_HELP_STRING([--enable-static-runtime],
+               [Link orted with the static compiler runtime]))
+AS_IF([test "x$enable_static_runtime" = "xyes"],
+      [enable_static=yes])
+AM_CONDITIONAL([ORTE_STATIC_RUNTIME], [test "x$enable_static_runtime" = "xyes"])
 ])dnl

--- a/orte/tools/orted/Makefile.am
+++ b/orte/tools/orted/Makefile.am
@@ -11,6 +11,8 @@
 #                         All rights reserved.
 # Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,7 +45,11 @@ orted_SOURCES = orted.c
 #  nothing to -all-static in the Makefile.in
 #  nice for systems that don't have all the shared
 #  libraries on the computes
+if ORTE_STATIC_RUNTIME
+orted_LDFLAGS = -static
+else
 orted_LDFLAGS =
+endif # ORTE_STATIC_RUNTIME
 orted_LDADD = \
 	$(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
 	$(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la


### PR DESCRIPTION
with this option, static libraries are forced to be built, and
orted is linked with the --static libtool flag.
This is enough so orted does not need the intel compiler runtime
dynamic libraries when compiled with icc.