### PR TITLE
Correct the wrong "Name Binding" of functions 

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_detach.c
@@ -32,6 +32,9 @@
 OMPI_DECLSPEC void ompi_buffer_detach_f08(char *buffer, MPI_Fint *size,
                                           MPI_Fint *ierr);
 
+OMPI_DECLSPEC void pompi_buffer_detach_f08(char *buffer, MPI_Fint *size,
+                                          MPI_Fint *ierr);
+
 /* (this comment is repeated in ompi/mpi/fortran/mpif-h/buffer_detach_f.c)
  *
  * MPI-3.1 section 3.6, page 45, states that the mpif.h and mpi module
@@ -64,4 +67,9 @@ void ompi_buffer_detach_f08(char *buffer, MPI_Fint *size, MPI_Fint *ierr)
         OMPI_SINGLE_INT_2_FINT(size);
         *(void **)buffer = dummy;
     }
+}
+
+void pompi_buffer_detach_f08(char *buffer, MPI_Fint *size, MPI_Fint *ierr)
+{
+    ompi_buffer_detach_f08(buffer, size, ierr);
 }

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
@@ -1368,7 +1368,7 @@ subroutine ompi_comm_set_attr_f(comm,comm_keyval,attribute_val,ierror) &
 end subroutine ompi_comm_set_attr_f
 
 subroutine ompi_comm_set_info_f(comm,info,ierror) &
-   BIND(C, name="ompi_comm_get_info_f")
+   BIND(C, name="ompi_comm_set_info_f")
    implicit none
    INTEGER, INTENT(IN) :: comm
    INTEGER, INTENT(IN) :: info

--- a/ompi/mpi/fortran/use-mpi-f08/pmpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/pmpi-f-interfaces-bind.h
@@ -95,12 +95,11 @@ end subroutine pompi_buffer_attach_f
 ! PMPI_BUFFER_DETACH (i.e., it is different than the mpif.h / mpi
 ! module C implementation function).
 !
-! Note, too, we don't need a "p" version of the C implementation
-! function -- Fortran's interfaces provide MPI_ and PMPI_ names for
-! us; they can just both be bound to the same back-end
+! Note, too, the "p" version of the C implementation
+! function is a 1-line routine. It calls
 ! ompi_buffer_detach_f08 C function.
 subroutine pompi_buffer_detach_f(buffer_addr,size,ierror) &
-   BIND(C, name="ompi_buffer_detach_f08")
+   BIND(C, name="pompi_buffer_detach_f08")
    implicit none
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buffer_addr
    INTEGER, INTENT(OUT) :: size
@@ -1418,7 +1417,7 @@ subroutine pompi_type_set_name_f(type,type_name,ierror,type_name_len) &
 end subroutine pompi_type_set_name_f
 
 subroutine pompi_win_allocate_f(size, disp_unit, info, comm, &
-      baseptr, win, ierror) BIND(C, name="ompi_win_allocate_f")
+      baseptr, win, ierror) BIND(C, name="pompi_win_allocate_f")
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
   INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(IN) ::  size
@@ -1431,7 +1430,7 @@ subroutine pompi_win_allocate_f(size, disp_unit, info, comm, &
 end subroutine pompi_win_allocate_f
 
 subroutine pompi_win_allocate_shared_f(size, disp_unit, info, comm, &
-      baseptr, win, ierror) BIND(C, name="ompi_win_allocate_shared_f")
+      baseptr, win, ierror) BIND(C, name="pompi_win_allocate_shared_f")
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
   use :: mpi_f08_types, only : MPI_ADDRESS_KIND
   INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(IN) ::  size

--- a/ompi/mpi/fortran/use-mpi-f08/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pmpi-f08-interfaces.F90
@@ -2415,7 +2415,7 @@ end interface  PMPI_Topo_test
 ! MPI_Wtick is not a wrapper function
 !
 interface PMPI_Wtick
-function  PMPI_Wtick_f08( ) BIND(C,name="MPI_Wtick")
+function  PMPI_Wtick_f08( ) BIND(C,name="PMPI_Wtick")
    use, intrinsic :: ISO_C_BINDING
    implicit none
    DOUBLE PRECISION :: PMPI_Wtick_f08
@@ -2425,7 +2425,7 @@ end interface PMPI_Wtick
 ! MPI_Wtime is not a wrapper function
 !
 interface PMPI_Wtime
-function  PMPI_Wtime_f08( ) BIND(C,name="MPI_Wtime")
+function  PMPI_Wtime_f08( ) BIND(C,name="PMPI_Wtime")
    use, intrinsic :: ISO_C_BINDING
    implicit none
    DOUBLE PRECISION :: PMPI_Wtime_f08


### PR DESCRIPTION
There are several spelling mistakes. It is failed when building by IBM XL Fortran. I corrected them.