### PR TITLE
New add_procs behavior

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -109,12 +109,13 @@ int ompi_comm_init(void)
 
     for (size_t i = 0 ; i < size ; ++i) {
         opal_process_name_t name = {.vpid = i, .jobid = OMPI_PROC_MY_NAME->jobid};
+        /* look for existing ompi_proc_t that matches this name */
         group->grp_proc_pointers[i] = (ompi_proc_t *) ompi_proc_lookup (name);
         if (NULL == group->grp_proc_pointers[i]) {
             /* set sentinel value */
-            group->grp_proc_pointers[i] = (ompi_proc_t *)(-*((intptr_t *) &name));
+            group->grp_proc_pointers[i] = (ompi_proc_t *) ompi_proc_name_to_sentinel (name);
         } else {
-            OBJ_RETAIN (ompi_proc_local_proc);
+            OBJ_RETAIN (group->grp_proc_pointers[i]);
         }
     }
 

--- a/ompi/group/group.c
+++ b/ompi/group/group.c
@@ -568,3 +568,23 @@ int ompi_group_compare(ompi_group_t *group1,
 
     return return_value;
 }
+
+bool ompi_group_have_remote_peers (ompi_group_t *group)
+{
+    for (size_t i = 0 ; i < group->grp_proc_count ; ++i) {
+        ompi_proc_t *proc = NULL;
+#if OMPI_GROUP_SPARSE
+        proc = ompi_group_peer_lookup (group, i);
+#else
+        if ((intptr_t) group->grp_proc_pointers[i] < 0) {
+            return true;
+        }
+        proc = group->grp_proc_pointers[i];
+#endif
+        if (!OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/ompi/group/group.c
+++ b/ompi/group/group.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2007      Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
- * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -49,16 +49,14 @@ int ompi_group_translate_ranks ( ompi_group_t *group1,
                                  ompi_group_t *group2,
                                  int *ranks2)
 {
-    int rank, proc, proc2;
-    struct ompi_proc_t *proc1_pointer, *proc2_pointer;
-
     if ( MPI_GROUP_EMPTY == group1 || MPI_GROUP_EMPTY == group2 ) {
-        for (proc = 0; proc < n_ranks ; proc++) {
+        for (int proc = 0; proc < n_ranks ; ++proc) {
             ranks2[proc] = MPI_UNDEFINED;
         }
         return MPI_SUCCESS;
     }
 
+#if OMPI_GROUP_SPARSE
     /*
      * If we are translating from a parent to a child that uses the sparse format
      * or vice versa, we use the translate ranks function corresponding to the
@@ -80,8 +78,11 @@ int ompi_group_translate_ranks ( ompi_group_t *group1,
                 (group1,n_ranks,ranks1,group2,ranks2);
         }
 
+        /* unknown sparse group type */
+        assert (0);
     }
-    else if( group2->grp_parent_group_ptr == group1 ) { /* from parent to child*/
+
+    if( group2->grp_parent_group_ptr == group1 ) { /* from parent to child*/
         if(OMPI_GROUP_IS_SPORADIC(group2)) {
             return ompi_group_translate_ranks_sporadic
                 (group1,n_ranks,ranks1,group2,ranks2);
@@ -95,28 +96,32 @@ int ompi_group_translate_ranks ( ompi_group_t *group1,
                 (group1,n_ranks,ranks1,group2,ranks2);
         }
 
+        /* unknown sparse group type */
+        assert (0);
     }
-    else {
-        /* loop over all ranks */
-        for (proc = 0; proc < n_ranks; proc++) {
-            rank=ranks1[proc];
-            if ( MPI_PROC_NULL == rank) {
-                ranks2[proc] = MPI_PROC_NULL;
-            }
-            else {
-                proc1_pointer = ompi_group_peer_lookup(group1 ,rank);
-                /* initialize to no "match" */
-                ranks2[proc] = MPI_UNDEFINED;
-                for (proc2 = 0; proc2 < group2->grp_proc_count; proc2++) {
-                    proc2_pointer= ompi_group_peer_lookup(group2, proc2);
-                    if ( proc1_pointer == proc2_pointer) {
-                        ranks2[proc] = proc2;
-                        break;
-                    }
-                }  /* end proc2 loop */
-            } /* end proc loop */
+#endif
+
+    /* loop over all ranks */
+    for (int proc = 0; proc < n_ranks; ++proc) {
+        struct ompi_proc_t *proc1_pointer, *proc2_pointer;
+        int rank = ranks1[proc];
+
+        if ( MPI_PROC_NULL == rank) {
+            ranks2[proc] = MPI_PROC_NULL;
+            continue;
         }
-    }
+
+        proc1_pointer = ompi_group_get_proc_ptr_raw (group1, rank);
+        /* initialize to no "match" */
+        ranks2[proc] = MPI_UNDEFINED;
+        for (int proc2 = 0; proc2 < group2->grp_proc_count; ++proc2) {
+            proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
+            if ( proc1_pointer == proc2_pointer) {
+                ranks2[proc] = proc2;
+                break;
+            }
+        }  /* end proc2 loop */
+    } /* end proc loop */
 
     return MPI_SUCCESS;
 }
@@ -166,25 +171,6 @@ int ompi_group_dump (ompi_group_t* group)
     }
     printf("*********************************************************\n");
     return OMPI_SUCCESS;
-}
-
-/*
- * This is the function that iterates through the sparse groups to the dense group
- * to reach the process pointer
- */
-ompi_proc_t* ompi_group_get_proc_ptr (ompi_group_t* group , int rank)
-{
-    int ranks1,ranks2;
-    do {
-        if(OMPI_GROUP_IS_DENSE(group)) {
-            return group->grp_proc_pointers[rank];
-        }
-        ranks1 = rank;
-        ompi_group_translate_ranks( group, 1, &ranks1,
-                                    group->grp_parent_group_ptr,&ranks2);
-        rank = ranks2;
-        group = group->grp_parent_group_ptr;
-    } while (1);
 }
 
 int ompi_group_minloc ( int list[] , int length )

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -210,14 +210,13 @@ ompi_group_t *ompi_group_allocate_bmap(int orig_group_size , int group_size)
  */
 void ompi_group_increment_proc_count(ompi_group_t *group)
 {
-    int proc;
     ompi_proc_t * proc_pointer;
-    for (proc = 0; proc < group->grp_proc_count; proc++) {
-        proc_pointer = ompi_group_peer_lookup(group,proc);
-        OBJ_RETAIN(proc_pointer);
+    for (int proc = 0 ; proc < group->grp_proc_count ; ++proc) {
+	proc_pointer = ompi_group_peer_lookup_existing (group, proc);
+	if (proc_pointer) {
+	    OBJ_RETAIN(proc_pointer);
+	}
     }
-
-    return;
 }
 
 /*
@@ -226,14 +225,13 @@ void ompi_group_increment_proc_count(ompi_group_t *group)
 
 void ompi_group_decrement_proc_count(ompi_group_t *group)
 {
-    int proc;
     ompi_proc_t * proc_pointer;
-    for (proc = 0; proc < group->grp_proc_count; proc++) {
-        proc_pointer = ompi_group_peer_lookup(group,proc);
-        OBJ_RELEASE(proc_pointer);
+    for (int proc = 0 ; proc < group->grp_proc_count ; ++proc) {
+	proc_pointer = ompi_group_peer_lookup_existing (group, proc);
+	if (proc_pointer) {
+	    OBJ_RELEASE(proc_pointer);
+	}
     }
-
-    return;
 }
 
 /*

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -253,9 +253,6 @@ static void ompi_group_construct(ompi_group_t *new_group)
 
     /* default the sparse values for groups */
     new_group->grp_parent_group_ptr = NULL;
-
-    /* return */
-    return;
 }
 
 
@@ -298,9 +295,6 @@ static void ompi_group_destruct(ompi_group_t *group)
         opal_pointer_array_set_item(&ompi_group_f_to_c_table,
                                     group->grp_f_to_c_index, NULL);
     }
-
-    /* return */
-    return;
 }
 
 

--- a/ompi/group/group_plist.c
+++ b/ompi/group/group_plist.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 University of Houston. All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc. All rights reserved.
- * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -29,6 +29,38 @@
 
 #include <math.h>
 
+static struct ompi_proc_t *ompi_group_dense_lookup_raw (ompi_group_t *group, const int peer_id)
+{
+    if (OPAL_UNLIKELY((intptr_t) group->grp_proc_pointers[peer_id] < 0)) {
+        ompi_proc_t *proc =
+            (ompi_proc_t *) ompi_proc_lookup (ompi_proc_sentinel_to_name ((intptr_t) group->grp_proc_pointers[peer_id]));
+        if (NULL != proc) {
+            /* replace sentinel value with an actual ompi_proc_t */
+            group->grp_proc_pointers[peer_id] = proc;
+            /* retain the proc */
+            OBJ_RETAIN(group->grp_proc_pointers[peer_id]);
+        }
+    }
+
+    return group->grp_proc_pointers[peer_id];
+}
+
+ompi_proc_t *ompi_group_get_proc_ptr_raw (ompi_group_t *group, int rank)
+{
+#if OMPI_GROUP_SPARSE
+    do {
+        if (OMPI_GROUP_IS_DENSE(group)) {
+            return ompi_group_dense_lookup_raw (group, peer_id);
+        }
+        int ranks1 = rank;
+        ompi_group_translate_ranks (group, 1, &ranks1, group->grp_parent_group_ptr, &rank);
+        group = group->grp_parent_group_ptr;
+    } while (1);
+#else
+    return ompi_group_dense_lookup_raw (group, rank);
+#endif
+}
+
 int ompi_group_calc_plist ( int n , const int *ranks ) {
     return sizeof(char *) * n ;
 }
@@ -37,7 +69,7 @@ int ompi_group_incl_plist(ompi_group_t* group, int n, const int *ranks,
                           ompi_group_t **new_group)
 {
     /* local variables */
-    int proc,my_group_rank;
+    int my_group_rank;
     ompi_group_t *group_pointer, *new_group_pointer;
     ompi_proc_t *my_proc_pointer;
 
@@ -56,9 +88,9 @@ int ompi_group_incl_plist(ompi_group_t* group, int n, const int *ranks,
     }
 
     /* put group elements in the list */
-    for (proc = 0; proc < n; proc++) {
+    for (int proc = 0; proc < n; proc++) {
         new_group_pointer->grp_proc_pointers[proc] =
-            ompi_group_peer_lookup(group_pointer,ranks[proc]);
+            ompi_group_get_proc_ptr_raw (group_pointer, ranks[proc]);
     }                           /* end proc loop */
 
     /* increment proc reference counters */
@@ -87,33 +119,30 @@ int ompi_group_union (ompi_group_t* group1, ompi_group_t* group2,
                       ompi_group_t **new_group)
 {
     /* local variables */
-    int new_group_size, proc1, proc2, found_in_group;
-    int my_group_rank, cnt;
-    ompi_group_t *group1_pointer, *group2_pointer, *new_group_pointer;
+    int new_group_size, my_group_rank, cnt;
+    ompi_group_t *new_group_pointer;
     ompi_proc_t *proc1_pointer, *proc2_pointer, *my_proc_pointer = NULL;
-
-    group1_pointer = (ompi_group_t *) group1;
-    group2_pointer = (ompi_group_t *) group2;
 
     /*
      * form union
      */
 
     /* get new group size */
-    new_group_size = group1_pointer->grp_proc_count;
+    new_group_size = group1->grp_proc_count;
 
     /* check group2 elements to see if they need to be included in the list */
-    for (proc2 = 0; proc2 < group2_pointer->grp_proc_count; proc2++) {
-        proc2_pointer = ompi_group_peer_lookup(group2_pointer,proc2);
+    for (int proc2 = 0; proc2 < group2->grp_proc_count; ++proc2) {
+        bool found_in_group = false;
+
+        proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
 
         /* check to see if this proc2 is alread in the group */
-        found_in_group = 0;
-        for (proc1 = 0; proc1 < group1_pointer->grp_proc_count; proc1++) {
-            proc1_pointer = ompi_group_peer_lookup(group1_pointer,proc1);
+        for (int proc1 = 0; proc1 < group1->grp_proc_count; ++proc1) {
+            proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
 
             if (proc1_pointer == proc2_pointer) {
                 /* proc2 is in group1 - don't double count */
-                found_in_group = 1;
+                found_in_group = true;
                 break;
             }
         }                       /* end proc1 loop */
@@ -140,24 +169,25 @@ int ompi_group_union (ompi_group_t* group1, ompi_group_t* group2,
     /* fill in the new group list */
 
     /* put group1 elements in the list */
-    for (proc1 = 0; proc1 < group1_pointer->grp_proc_count; proc1++) {
+    for (int proc1 = 0; proc1 < group1->grp_proc_count; ++proc1) {
         new_group_pointer->grp_proc_pointers[proc1] =
-            ompi_group_peer_lookup(group1_pointer,proc1);
+            ompi_group_get_proc_ptr_raw (group1, proc1);
     }
-    cnt = group1_pointer->grp_proc_count;
+    cnt = group1->grp_proc_count;
 
     /* check group2 elements to see if they need to be included in the list */
-    for (proc2 = 0; proc2 < group2_pointer->grp_proc_count; proc2++) {
-        proc2_pointer = ompi_group_peer_lookup(group2_pointer,proc2);
+    for (int proc2 = 0; proc2 < group2->grp_proc_count; ++proc2) {
+        bool found_in_group = false;
+
+        proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
 
         /* check to see if this proc2 is alread in the group */
-        found_in_group = 0;
-        for (proc1 = 0; proc1 < group1_pointer->grp_proc_count; proc1++) {
-            proc1_pointer = ompi_group_peer_lookup(group1_pointer,proc1);
+        for (int proc1 = 0; proc1 < group1->grp_proc_count; ++proc1) {
+            proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
 
             if (proc1_pointer == proc2_pointer) {
                 /* proc2 is in group1 - don't double count */
-                found_in_group = 1;
+                found_in_group = true;
                 break;
             }
         }                       /* end proc1 loop */
@@ -166,23 +196,21 @@ int ompi_group_union (ompi_group_t* group1, ompi_group_t* group2,
             continue;
         }
 
-        new_group_pointer->grp_proc_pointers[cnt] =
-            ompi_group_peer_lookup(group2_pointer,proc2);
-        cnt++;
+        new_group_pointer->grp_proc_pointers[cnt++] = proc2_pointer;
     }                           /* end proc loop */
 
     /* increment proc reference counters */
     ompi_group_increment_proc_count(new_group_pointer);
 
     /* find my rank */
-    my_group_rank = group1_pointer->grp_my_rank;
+    my_group_rank = group1->grp_my_rank;
     if (MPI_UNDEFINED == my_group_rank) {
-        my_group_rank = group2_pointer->grp_my_rank;
+        my_group_rank = group2->grp_my_rank;
         if ( MPI_UNDEFINED != my_group_rank) {
-            my_proc_pointer = ompi_group_peer_lookup(group2_pointer,my_group_rank);
+            my_proc_pointer = ompi_group_peer_lookup(group2,my_group_rank);
         }
     } else {
-        my_proc_pointer = ompi_group_peer_lookup(group1_pointer,my_group_rank);
+        my_proc_pointer = ompi_group_peer_lookup(group1,my_group_rank);
     }
 
     if ( MPI_UNDEFINED == my_group_rank ) {
@@ -206,38 +234,29 @@ int ompi_group_difference(ompi_group_t* group1, ompi_group_t* group2,
                           ompi_group_t **new_group) {
 
     /* local varibles */
-    int new_group_size, proc1, proc2, found_in_group2, cnt;
-    int my_group_rank;
-    ompi_group_t *group1_pointer, *group2_pointer, *new_group_pointer;
+    int new_group_size, my_group_rank;
+    ompi_group_t *new_group_pointer;
     ompi_proc_t *proc1_pointer, *proc2_pointer, *my_proc_pointer = NULL;
-
-
-    group1_pointer=(ompi_group_t *)group1;
-    group2_pointer=(ompi_group_t *)group2;
 
     /*
      * form union
      */
 
     /* get new group size */
-    new_group_size=0;
+    new_group_size = group1->grp_proc_count;
 
     /* loop over group1 members */
-    for( proc1=0; proc1 < group1_pointer->grp_proc_count; proc1++ ) {
-        proc1_pointer = ompi_group_peer_lookup(group1_pointer,proc1);
+    for (int proc1 = 0 ; proc1 < group1->grp_proc_count ; ++proc1) {
+        proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
+
         /* check to see if this proc is in group2 */
-        found_in_group2=0;
-        for( proc2=0 ; proc2 < group2_pointer->grp_proc_count ; proc2++ ) {
-            proc2_pointer = ompi_group_peer_lookup(group2_pointer,proc2);
+        for (int proc2 = 0 ; proc2 < group2->grp_proc_count ; ++proc2) {
+            proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
             if( proc1_pointer == proc2_pointer ) {
-                found_in_group2=true;
+                --new_group_size;
                 break;
             }
         }  /* end proc1 loop */
-        if(found_in_group2) {
-            continue;
-        }
-        new_group_size++;
     }  /* end proc loop */
 
     if ( 0 == new_group_size ) {
@@ -253,41 +272,39 @@ int ompi_group_difference(ompi_group_t* group1, ompi_group_t* group2,
     }
 
     /* fill in group list */
-    cnt=0;
     /* loop over group1 members */
-    for( proc1=0; proc1 < group1_pointer->grp_proc_count; proc1++ ) {
-        proc1_pointer = ompi_group_peer_lookup(group1_pointer,proc1);
+    for (int proc1 = 0, cnt = 0 ; proc1 < group1->grp_proc_count ; ++proc1) {
+        bool found_in_group2 = false;
+
+        proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
         /* check to see if this proc is in group2 */
-        found_in_group2=0;
-        for( proc2=0 ; proc2 < group2_pointer->grp_proc_count ; proc2++ ) {
-            proc2_pointer = ompi_group_peer_lookup(group2_pointer,proc2);
+        for (int proc2 = 0 ; proc2 < group2->grp_proc_count ; ++proc2) {
+            proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
             if( proc1_pointer == proc2_pointer ) {
-                found_in_group2=true;
+                found_in_group2 = true;
                 break;
             }
         }  /* end proc1 loop */
-        if(found_in_group2) {
+
+        if (found_in_group2) {
             continue;
         }
 
-        new_group_pointer->grp_proc_pointers[cnt] =
-            ompi_group_peer_lookup(group1_pointer,proc1);
-
-        cnt++;
+        new_group_pointer->grp_proc_pointers[cnt++] = proc1_pointer;
     }  /* end proc loop */
 
     /* increment proc reference counters */
     ompi_group_increment_proc_count(new_group_pointer);
 
     /* find my rank */
-    my_group_rank=group1_pointer->grp_my_rank;
+    my_group_rank=group1->grp_my_rank;
     if ( MPI_UNDEFINED != my_group_rank ) {
-        my_proc_pointer = ompi_group_peer_lookup(group1_pointer,my_group_rank);
+        my_proc_pointer = ompi_group_peer_lookup(group1,my_group_rank);
     }
     else {
-        my_group_rank=group2_pointer->grp_my_rank;
+        my_group_rank=group2->grp_my_rank;
         if ( MPI_UNDEFINED != my_group_rank ) {
-            my_proc_pointer = ompi_group_peer_lookup(group2_pointer,my_group_rank);
+            my_proc_pointer = ompi_group_peer_lookup(group2,my_group_rank);
         }
     }
 

--- a/ompi/group/group_plist.c
+++ b/ompi/group/group_plist.c
@@ -29,6 +29,34 @@
 
 #include <math.h>
 
+static int ompi_group_dense_overlap (ompi_group_t *group1, ompi_group_t *group2, opal_bitmap_t *bitmap)
+{
+    ompi_proc_t *proc1_pointer, *proc2_pointer;
+    int rc, overlap_count;
+
+    overlap_count = 0;
+
+    for (int proc1 = 0 ; proc1 < group1->grp_proc_count ; ++proc1) {
+        proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
+
+        /* check to see if this proc is in group2 */
+        for (int proc2 = 0 ; proc2 < group2->grp_proc_count ; ++proc2) {
+            proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
+            if( proc1_pointer == proc2_pointer ) {
+                rc = opal_bitmap_set_bit (bitmap, proc2);
+                if (OPAL_SUCCESS != rc) {
+                    return rc;
+                }
+                ++overlap_count;
+
+                break;
+            }
+        }  /* end proc1 loop */
+    }  /* end proc loop */
+
+    return overlap_count;
+}
+
 static struct ompi_proc_t *ompi_group_dense_lookup_raw (ompi_group_t *group, const int peer_id)
 {
     if (OPAL_UNLIKELY((intptr_t) group->grp_proc_pointers[peer_id] < 0)) {
@@ -71,7 +99,6 @@ int ompi_group_incl_plist(ompi_group_t* group, int n, const int *ranks,
     /* local variables */
     int my_group_rank;
     ompi_group_t *group_pointer, *new_group_pointer;
-    ompi_proc_t *my_proc_pointer;
 
     group_pointer = (ompi_group_t *)group;
 
@@ -99,10 +126,8 @@ int ompi_group_incl_plist(ompi_group_t* group, int n, const int *ranks,
     /* find my rank */
     my_group_rank=group_pointer->grp_my_rank;
     if (MPI_UNDEFINED != my_group_rank) {
-        my_proc_pointer=ompi_group_peer_lookup (group_pointer,my_group_rank);
-        ompi_set_group_rank(new_group_pointer,my_proc_pointer);
-    }
-    else {
+        ompi_set_group_rank(new_group_pointer, ompi_proc_local_proc);
+    } else {
         new_group_pointer->grp_my_rank = MPI_UNDEFINED;
     }
 
@@ -119,50 +144,41 @@ int ompi_group_union (ompi_group_t* group1, ompi_group_t* group2,
                       ompi_group_t **new_group)
 {
     /* local variables */
-    int new_group_size, my_group_rank, cnt;
+    int new_group_size, cnt, rc, overlap_count;
     ompi_group_t *new_group_pointer;
-    ompi_proc_t *proc1_pointer, *proc2_pointer, *my_proc_pointer = NULL;
+    ompi_proc_t *proc2_pointer;
+    opal_bitmap_t bitmap;
 
     /*
      * form union
      */
 
     /* get new group size */
-    new_group_size = group1->grp_proc_count;
+    OBJ_CONSTRUCT(&bitmap, opal_bitmap_t);
+    rc = opal_bitmap_init (&bitmap, 32);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
 
     /* check group2 elements to see if they need to be included in the list */
-    for (int proc2 = 0; proc2 < group2->grp_proc_count; ++proc2) {
-        bool found_in_group = false;
+    overlap_count = ompi_group_dense_overlap (group1, group2, &bitmap);
+    if (0 > overlap_count) {
+        OBJ_DESTRUCT(&bitmap);
+        return overlap_count;
+    }
 
-        proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
-
-        /* check to see if this proc2 is alread in the group */
-        for (int proc1 = 0; proc1 < group1->grp_proc_count; ++proc1) {
-            proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
-
-            if (proc1_pointer == proc2_pointer) {
-                /* proc2 is in group1 - don't double count */
-                found_in_group = true;
-                break;
-            }
-        }                       /* end proc1 loop */
-
-        if (found_in_group) {
-            continue;
-        }
-
-        new_group_size++;
-    }                           /* end proc loop */
-
+    new_group_size = group1->grp_proc_count + group2->grp_proc_count - overlap_count;
     if ( 0 == new_group_size ) {
         *new_group = MPI_GROUP_EMPTY;
         OBJ_RETAIN(MPI_GROUP_EMPTY);
+        OBJ_DESTRUCT(&bitmap);
         return MPI_SUCCESS;
     }
 
     /* get new group struct */
     new_group_pointer = ompi_group_allocate(new_group_size);
     if (NULL == new_group_pointer) {
+        OBJ_DESTRUCT(&bitmap);
         return MPI_ERR_GROUP;
     }
 
@@ -177,51 +193,27 @@ int ompi_group_union (ompi_group_t* group1, ompi_group_t* group2,
 
     /* check group2 elements to see if they need to be included in the list */
     for (int proc2 = 0; proc2 < group2->grp_proc_count; ++proc2) {
-        bool found_in_group = false;
-
-        proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
-
-        /* check to see if this proc2 is alread in the group */
-        for (int proc1 = 0; proc1 < group1->grp_proc_count; ++proc1) {
-            proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
-
-            if (proc1_pointer == proc2_pointer) {
-                /* proc2 is in group1 - don't double count */
-                found_in_group = true;
-                break;
-            }
-        }                       /* end proc1 loop */
-
-        if (found_in_group) {
+        if (opal_bitmap_is_set_bit (&bitmap, proc2)) {
             continue;
         }
 
+        proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
         new_group_pointer->grp_proc_pointers[cnt++] = proc2_pointer;
     }                           /* end proc loop */
+
+    OBJ_DESTRUCT(&bitmap);
 
     /* increment proc reference counters */
     ompi_group_increment_proc_count(new_group_pointer);
 
     /* find my rank */
-    my_group_rank = group1->grp_my_rank;
-    if (MPI_UNDEFINED == my_group_rank) {
-        my_group_rank = group2->grp_my_rank;
-        if ( MPI_UNDEFINED != my_group_rank) {
-            my_proc_pointer = ompi_group_peer_lookup(group2,my_group_rank);
-        }
+    if (MPI_UNDEFINED != group1->grp_my_rank || MPI_UNDEFINED != group2->grp_my_rank) {
+        ompi_set_group_rank(new_group_pointer, ompi_proc_local_proc);
     } else {
-        my_proc_pointer = ompi_group_peer_lookup(group1,my_group_rank);
-    }
-
-    if ( MPI_UNDEFINED == my_group_rank ) {
         new_group_pointer->grp_my_rank = MPI_UNDEFINED;
-    }
-    else {
-        ompi_set_group_rank(new_group_pointer, my_proc_pointer);
     }
 
     *new_group = (MPI_Group) new_group_pointer;
-
 
     return OMPI_SUCCESS;
 }
@@ -234,85 +226,65 @@ int ompi_group_difference(ompi_group_t* group1, ompi_group_t* group2,
                           ompi_group_t **new_group) {
 
     /* local varibles */
-    int new_group_size, my_group_rank;
+    int new_group_size, overlap_count, rc;
     ompi_group_t *new_group_pointer;
-    ompi_proc_t *proc1_pointer, *proc2_pointer, *my_proc_pointer = NULL;
+    ompi_proc_t *proc1_pointer;
+    opal_bitmap_t bitmap;
 
     /*
      * form union
      */
 
     /* get new group size */
-    new_group_size = group1->grp_proc_count;
+    OBJ_CONSTRUCT(&bitmap, opal_bitmap_t);
+    rc = opal_bitmap_init (&bitmap, 32);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
 
-    /* loop over group1 members */
-    for (int proc1 = 0 ; proc1 < group1->grp_proc_count ; ++proc1) {
-        proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
+    /* check group2 elements to see if they need to be included in the list */
+    overlap_count = ompi_group_dense_overlap (group2, group1, &bitmap);
+    if (0 > overlap_count) {
+        OBJ_DESTRUCT(&bitmap);
+        return overlap_count;
+    }
 
-        /* check to see if this proc is in group2 */
-        for (int proc2 = 0 ; proc2 < group2->grp_proc_count ; ++proc2) {
-            proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
-            if( proc1_pointer == proc2_pointer ) {
-                --new_group_size;
-                break;
-            }
-        }  /* end proc1 loop */
-    }  /* end proc loop */
-
+    new_group_size = group1->grp_proc_count - overlap_count;
     if ( 0 == new_group_size ) {
         *new_group = MPI_GROUP_EMPTY;
         OBJ_RETAIN(MPI_GROUP_EMPTY);
+        OBJ_DESTRUCT(&bitmap);
         return MPI_SUCCESS;
     }
 
     /* allocate a new ompi_group_t structure */
-    new_group_pointer=ompi_group_allocate(new_group_size);
+    new_group_pointer = ompi_group_allocate(new_group_size);
     if( NULL == new_group_pointer ) {
+        OBJ_DESTRUCT(&bitmap);
         return MPI_ERR_GROUP;
     }
 
     /* fill in group list */
     /* loop over group1 members */
     for (int proc1 = 0, cnt = 0 ; proc1 < group1->grp_proc_count ; ++proc1) {
-        bool found_in_group2 = false;
-
-        proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
-        /* check to see if this proc is in group2 */
-        for (int proc2 = 0 ; proc2 < group2->grp_proc_count ; ++proc2) {
-            proc2_pointer = ompi_group_get_proc_ptr_raw (group2, proc2);
-            if( proc1_pointer == proc2_pointer ) {
-                found_in_group2 = true;
-                break;
-            }
-        }  /* end proc1 loop */
-
-        if (found_in_group2) {
+        if (opal_bitmap_is_set_bit (&bitmap, proc1)) {
             continue;
         }
 
+        proc1_pointer = ompi_group_get_proc_ptr_raw (group1, proc1);
         new_group_pointer->grp_proc_pointers[cnt++] = proc1_pointer;
     }  /* end proc loop */
+
+    OBJ_DESTRUCT(&bitmap);
 
     /* increment proc reference counters */
     ompi_group_increment_proc_count(new_group_pointer);
 
     /* find my rank */
-    my_group_rank=group1->grp_my_rank;
-    if ( MPI_UNDEFINED != my_group_rank ) {
-        my_proc_pointer = ompi_group_peer_lookup(group1,my_group_rank);
-    }
-    else {
-        my_group_rank=group2->grp_my_rank;
-        if ( MPI_UNDEFINED != my_group_rank ) {
-            my_proc_pointer = ompi_group_peer_lookup(group2,my_group_rank);
-        }
-    }
-
-    if ( MPI_UNDEFINED == my_group_rank ) {
+    if (MPI_UNDEFINED == group1->grp_my_rank || MPI_UNDEFINED != group2->grp_my_rank) {
         new_group_pointer->grp_my_rank = MPI_UNDEFINED;
-    }
-    else {
-        ompi_set_group_rank(new_group_pointer,my_proc_pointer);
+    } else {
+        ompi_set_group_rank(new_group_pointer, ompi_proc_local_proc);
     }
 
     *new_group = (MPI_Group)new_group_pointer;

--- a/ompi/group/group_set_rank.c
+++ b/ompi/group/group_set_rank.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2007 University of Houston. All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,12 +41,10 @@ void ompi_set_group_rank(ompi_group_t *group, struct ompi_proc_t *proc_pointer)
         for (proc = 0; proc < group->grp_proc_count; proc++) {
             /* check and see if this proc pointer matches proc_pointer
              */
-            if (ompi_group_peer_lookup(group,proc) == proc_pointer) {
+	    if (ompi_group_peer_lookup_existing (group, proc) == proc_pointer) {
                 group->grp_my_rank = proc;
-            }
+		break;
+	    }
         }                       /* end proc loop */
     }
-
-    /* return */
-    return;
 }

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -17,6 +17,8 @@
  *                         reserved.
  * Copyright (c) 2011-2013 INRIA.  All rights reserved.
  * Copyright (c) 2015      University of Houston. All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1333,7 +1335,7 @@ OMPI_DECLSPEC  int MPI_Comm_spawn_multiple(int count, char *array_of_commands[],
 OMPI_DECLSPEC  int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm);
 OMPI_DECLSPEC  int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, MPI_Comm *newcomm);
 OMPI_DECLSPEC  int MPI_Comm_test_inter(MPI_Comm comm, int *flag);
-OMPI_DECLSPEC  int MPI_Compare_and_swap(void *origin_addr, void *compare_addr,
+OMPI_DECLSPEC  int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr,
                                         void *result_addr, MPI_Datatype datatype, int target_rank,
                                         MPI_Aint target_disp, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Dims_create(int nnodes, int ndims, int dims[]);
@@ -1351,7 +1353,7 @@ OMPI_DECLSPEC  int MPI_Error_class(int errorcode, int *errorclass);
 OMPI_DECLSPEC  int MPI_Error_string(int errorcode, char *string, int *resultlen);
 OMPI_DECLSPEC  int MPI_Exscan(const void *sendbuf, void *recvbuf, int count,
                               MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-OMPI_DECLSPEC  int MPI_Fetch_and_op(void *origin_addr, void *result_addr, MPI_Datatype datatype,
+OMPI_DECLSPEC  int MPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype datatype,
                                     int target_rank, MPI_Aint target_disp, MPI_Op op, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count,
                               MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
@@ -1627,7 +1629,7 @@ OMPI_DECLSPEC  int MPI_Put(const void *origin_addr, int origin_count, MPI_Dataty
                            int target_rank, MPI_Aint target_disp, int target_count,
                            MPI_Datatype target_datatype, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Query_thread(int *provided);
-OMPI_DECLSPEC  int MPI_Raccumulate(void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
+OMPI_DECLSPEC  int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
                                    int target_rank, MPI_Aint target_disp, int target_count,
                                    MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
 OMPI_DECLSPEC  int MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source,
@@ -1851,7 +1853,7 @@ OMPI_DECLSPEC  int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_at
                                          MPI_Win_delete_attr_function *win_delete_attr_fn,
                                          int *win_keyval, void *extra_state);
 OMPI_DECLSPEC  int MPI_Win_delete_attr(MPI_Win win, int win_keyval);
-OMPI_DECLSPEC  int MPI_Win_detach(MPI_Win win, void *base);
+OMPI_DECLSPEC  int MPI_Win_detach(MPI_Win win, const void *base);
 OMPI_DECLSPEC  MPI_Win MPI_Win_f2c(MPI_Fint win);
 OMPI_DECLSPEC  int MPI_Win_fence(int assert, MPI_Win win);
 OMPI_DECLSPEC  int MPI_Win_flush(int rank, MPI_Win win);
@@ -2033,7 +2035,7 @@ OMPI_DECLSPEC  int PMPI_Comm_spawn_multiple(int count, char *array_of_commands[]
 OMPI_DECLSPEC  int PMPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm);
 OMPI_DECLSPEC  int PMPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, MPI_Comm *newcomm);
 OMPI_DECLSPEC  int PMPI_Comm_test_inter(MPI_Comm comm, int *flag);
-OMPI_DECLSPEC  int PMPI_Compare_and_swap(void *origin_addr, void *compare_addr,
+OMPI_DECLSPEC  int PMPI_Compare_and_swap(const void *origin_addr, const void *compare_addr,
                                          void *result_addr, MPI_Datatype datatype, int target_rank,
                                          MPI_Aint target_disp, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Dims_create(int nnodes, int ndims, int dims[]);
@@ -2051,7 +2053,7 @@ OMPI_DECLSPEC  int PMPI_Error_class(int errorcode, int *errorclass);
 OMPI_DECLSPEC  int PMPI_Error_string(int errorcode, char *string, int *resultlen);
 OMPI_DECLSPEC  int PMPI_Exscan(const void *sendbuf, void *recvbuf, int count,
                                MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-OMPI_DECLSPEC  int PMPI_Fetch_and_op(void *origin_addr, void *result_addr, MPI_Datatype datatype,
+OMPI_DECLSPEC  int PMPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype datatype,
                                      int target_rank, MPI_Aint target_disp, MPI_Op op, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Iexscan(const void *sendbuf, void *recvbuf, int count,
                                MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
@@ -2329,7 +2331,7 @@ OMPI_DECLSPEC  int PMPI_Put(const void *origin_addr, int origin_count, MPI_Datat
                             int target_rank, MPI_Aint target_disp, int target_count,
                             MPI_Datatype target_datatype, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Query_thread(int *provided);
-OMPI_DECLSPEC  int PMPI_Raccumulate(void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
+OMPI_DECLSPEC  int PMPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
                                     int target_rank, MPI_Aint target_disp, int target_count,
                                     MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
 OMPI_DECLSPEC  int PMPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source,
@@ -2553,7 +2555,7 @@ OMPI_DECLSPEC  int PMPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_a
                                           MPI_Win_delete_attr_function *win_delete_attr_fn,
                                           int *win_keyval, void *extra_state);
 OMPI_DECLSPEC  int PMPI_Win_delete_attr(MPI_Win win, int win_keyval);
-OMPI_DECLSPEC  int PMPI_Win_detach(MPI_Win win, void *base);
+OMPI_DECLSPEC  int PMPI_Win_detach(MPI_Win win, const void *base);
 OMPI_DECLSPEC  MPI_Win PMPI_Win_f2c(MPI_Fint win);
 OMPI_DECLSPEC  int PMPI_Win_fence(int assert, MPI_Win win);
 OMPI_DECLSPEC  int PMPI_Win_flush(int rank, MPI_Win win);

--- a/ompi/mca/bml/base/base.h
+++ b/ompi/mca/bml/base/base.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,6 +28,7 @@
 #include "ompi/mca/mca.h"
 #include "opal/mca/base/mca_base_framework.h"
 #include "ompi/mca/bml/bml.h"
+#include "ompi/proc/proc.h"
 
 
 /*
@@ -59,6 +63,14 @@ OMPI_DECLSPEC  int mca_bml_base_ft_event(int state);
 OMPI_DECLSPEC extern mca_bml_base_component_t mca_bml_component;
 OMPI_DECLSPEC extern mca_bml_base_module_t mca_bml;
 OMPI_DECLSPEC extern mca_base_framework_t ompi_bml_base_framework;
+
+static inline struct mca_bml_base_endpoint_t *mca_bml_base_get_endpoint (struct ompi_proc_t *proc) {
+    if (OPAL_UNLIKELY(NULL == proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML])) {
+        mca_bml.bml_add_proc (proc);
+    }
+
+    return (struct mca_bml_base_endpoint_t *) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
+}
 
 
 END_C_DECLS

--- a/ompi/mca/bml/r2/bml_r2.c
+++ b/ompi/mca/bml/r2/bml_r2.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2014 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Intel, Inc. All rights reserved
@@ -144,6 +144,293 @@ static void mca_bml_r2_calculate_bandwidth_latency (mca_bml_base_btl_array_t *bt
     }
 }
 
+static mca_bml_base_endpoint_t *mca_bml_r2_allocate_endpoint (ompi_proc_t *proc) {
+    mca_bml_base_endpoint_t *bml_endpoint;
+
+    /* allocate bml specific proc data */
+    bml_endpoint = OBJ_NEW(mca_bml_base_endpoint_t);
+    if (NULL == bml_endpoint) {
+        opal_output(0, "mca_bml_r2_add_procs: unable to allocate resources");
+        return NULL;
+    }
+
+    /* preallocate space in array for max number of r2s */
+    mca_bml_base_btl_array_reserve(&bml_endpoint->btl_eager, mca_bml_r2.num_btl_modules);
+    mca_bml_base_btl_array_reserve(&bml_endpoint->btl_send,  mca_bml_r2.num_btl_modules);
+    mca_bml_base_btl_array_reserve(&bml_endpoint->btl_rdma,  mca_bml_r2.num_btl_modules);
+    bml_endpoint->btl_max_send_size = -1;
+    bml_endpoint->btl_proc = proc;
+    proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML] = bml_endpoint;
+
+    bml_endpoint->btl_flags_or = 0;
+    return bml_endpoint;
+}
+
+static void mca_bml_r2_register_progress (mca_btl_base_module_t *btl)
+{
+    if (NULL != btl->btl_component->btl_progress) {
+        bool found = false;
+
+        for (size_t p = 0 ; p < mca_bml_r2.num_btl_progress ; ++p) {
+            if(mca_bml_r2.btl_progress[p] == btl->btl_component->btl_progress) {
+                found = true;
+                break;
+            }
+        }
+
+        if (found == false) {
+            mca_bml_r2.btl_progress[mca_bml_r2.num_btl_progress++] =
+                btl->btl_component->btl_progress;
+            opal_progress_register (btl->btl_component->btl_progress);
+        }
+    }
+}
+
+static int mca_bml_r2_endpoint_add_btl (struct ompi_proc_t *proc, mca_bml_base_endpoint_t *bml_endpoint,
+                                        mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *btl_endpoint)
+{
+    mca_bml_base_btl_t* bml_btl = NULL;
+    int btl_flags = btl->btl_flags;
+    bool btl_in_use = false;
+    size_t size;
+
+    /* NTH: these flags should have been sanitized by the btl. Once that is verified these
+     * checks can be safely removed. */
+    if ((btl_flags & MCA_BTL_FLAGS_PUT) && (NULL == btl->btl_put)) {
+        opal_output(0, "mca_bml_r2_add_procs: The PUT flag is specified for"
+                    " the %s BTL without any PUT function attached. Discard the flag !",
+                    btl->btl_component->btl_version.mca_component_name);
+        btl_flags ^= MCA_BTL_FLAGS_PUT;
+    }
+    if ((btl_flags & MCA_BTL_FLAGS_GET) && (NULL == btl->btl_get)) {
+        opal_output(0, "mca_bml_r2_add_procs: The GET flag is specified for"
+                    " the %s BTL without any GET function attached. Discard the flag !",
+                    btl->btl_component->btl_version.mca_component_name);
+        btl_flags ^= MCA_BTL_FLAGS_GET;
+    }
+
+    if ((btl_flags & (MCA_BTL_FLAGS_PUT | MCA_BTL_FLAGS_GET | MCA_BTL_FLAGS_SEND)) == 0) {
+        /* If no protocol specified, we have 2 choices: we ignore the BTL
+         * as we don't know which protocl to use, or we suppose that all
+         * BTLs support the send protocol. This is really a btl error as
+         * these flags should have been sanitized by the btl. */
+        btl_flags |= MCA_BTL_FLAGS_SEND;
+    }
+
+    if (btl_flags & MCA_BTL_FLAGS_SEND) {
+        /* dont allow an additional BTL with a lower exclusivity ranking */
+        bml_btl = mca_bml_base_btl_array_get_index (&bml_endpoint->btl_send, size - 1);
+        size = mca_bml_base_btl_array_get_size (&bml_endpoint->btl_send);
+
+        if (!bml_btl || bml_btl->btl->btl_exclusivity < btl->btl_exclusivity) {
+            /* this btl has higher exclusivity than an existing btl or none exists */
+
+            opal_output_verbose(1, opal_btl_base_framework.framework_output,
+                                "mca: bml: Using %s btl for send to %s on node %s",
+                                btl->btl_component->btl_version.mca_component_name,
+                                OMPI_NAME_PRINT(&proc->super.proc_name),
+                                proc->super.proc_hostname);
+
+            /* cache the endpoint on the proc */
+            if (NULL == bml_btl || (bml_btl->btl->btl_exclusivity <= btl->btl_exclusivity)) {
+                bml_btl = mca_bml_base_btl_array_insert (&bml_endpoint->btl_send);
+                bml_btl->btl = btl;
+                bml_btl->btl_endpoint = btl_endpoint;
+                bml_btl->btl_weight = 0;
+                bml_btl->btl_flags = btl_flags;
+
+                /**
+                 * calculate the bitwise OR of the btl flags
+                 */
+                bml_endpoint->btl_flags_or |= bml_btl->btl_flags;
+            } else {
+                opal_output_verbose(20, opal_btl_base_framework.framework_output,
+                                    "mca: bml: Not using %s btl for send to %s on node %s "
+                                    "because %s btl has higher exclusivity (%d > %d)",
+                                    btl->btl_component->btl_version.mca_component_name,
+                                    OMPI_NAME_PRINT(&proc->super.proc_name), proc->super.proc_hostname,
+                                    bml_btl->btl->btl_component->btl_version.mca_component_name,
+                                    bml_btl->btl->btl_exclusivity,
+                                    btl->btl_exclusivity);
+            }
+
+            btl_in_use = true;
+        }
+    }
+
+    /* always add rdma endpoints */
+    if ((btl_flags & MCA_BTL_FLAGS_RDMA) &&
+        !((proc->super.proc_arch != ompi_proc_local_proc->super.proc_arch) &&
+          (0 == (btl->btl_flags & MCA_BTL_FLAGS_HETEROGENEOUS_RDMA)))) {
+        mca_bml_base_btl_t *bml_btl_rdma = mca_bml_base_btl_array_insert(&bml_endpoint->btl_rdma);
+
+        bml_btl_rdma->btl = btl;
+        bml_btl_rdma->btl_endpoint = btl_endpoint;
+        bml_btl_rdma->btl_weight = 0;
+        bml_btl_rdma->btl_flags = btl_flags;
+
+        if (bml_endpoint->btl_pipeline_send_length < btl->btl_rdma_pipeline_send_length) {
+            bml_endpoint->btl_pipeline_send_length = btl->btl_rdma_pipeline_send_length;
+        }
+
+        if (bml_endpoint->btl_send_limit < btl->btl_min_rdma_pipeline_size) {
+            bml_endpoint->btl_send_limit = btl->btl_min_rdma_pipeline_size;
+        }
+
+        btl_in_use = true;
+    }
+
+    return btl_in_use ? OMPI_SUCCESS : OMPI_ERR_NOT_AVAILABLE;
+}
+
+static void mca_bml_r2_compute_endpoint_metrics (mca_bml_base_endpoint_t *bml_endpoint)
+{
+    double total_bandwidth = 0;
+    uint32_t latency;
+    size_t n_send, n_rdma;
+
+    /* (1) determine the total bandwidth available across all btls
+     *     note that we need to do this here, as we may already have btls configured
+     * (2) determine the highest priority ranking for latency
+     * (3) compute the maximum amount of bytes that can be send without any
+     *     weighting. Once the left over is smaller than this number we will
+     *     start using the weight to compute the correct amount.
+     */
+    n_send = mca_bml_base_btl_array_get_size (&bml_endpoint->btl_send);
+    n_rdma = mca_bml_base_btl_array_get_size (&bml_endpoint->btl_rdma);
+
+    /* sort BTLs in descending order according to bandwidth value */
+    qsort (bml_endpoint->btl_send.bml_btls, n_send,
+           sizeof(mca_bml_base_btl_t), btl_bandwidth_compare);
+
+    bml_endpoint->btl_rdma_index = 0;
+
+    mca_bml_r2_calculate_bandwidth_latency (&bml_endpoint->btl_send, &total_bandwidth, &latency);
+
+    /* (1) set the weight of each btl as a percentage of overall bandwidth
+     * (2) copy all btl instances at the highest priority ranking into the
+     *     list of btls used for first fragments
+     */
+    for (size_t n_index = 0 ; n_index < n_send ; ++n_index) {
+        mca_bml_base_btl_t *bml_btl =
+            mca_bml_base_btl_array_get_index(&bml_endpoint->btl_send, n_index);
+        mca_btl_base_module_t *btl = bml_btl->btl;
+
+        /* compute weighting factor for this r2 */
+        if(btl->btl_bandwidth > 0) {
+            bml_btl->btl_weight = (float)(btl->btl_bandwidth / total_bandwidth);
+        } else {
+            bml_btl->btl_weight = (float)(1.0 / n_send);
+        }
+
+        /* check to see if this r2 is already in the array of r2s
+         * used for first fragments - if not add it.
+         */
+        if(btl->btl_latency == latency) {
+            mca_bml_base_btl_t* bml_btl_new =
+                mca_bml_base_btl_array_insert(&bml_endpoint->btl_eager);
+            *bml_btl_new = *bml_btl;
+        }
+
+        /* set endpoint max send size as min of available btls */
+        if (bml_endpoint->btl_max_send_size > btl->btl_max_send_size)
+            bml_endpoint->btl_max_send_size = btl->btl_max_send_size;
+    }
+
+    /* sort BTLs in descending order according to bandwidth value */
+    qsort(bml_endpoint->btl_rdma.bml_btls, n_rdma,
+          sizeof(mca_bml_base_btl_t), btl_bandwidth_compare);
+
+    mca_bml_r2_calculate_bandwidth_latency (&bml_endpoint->btl_rdma, &total_bandwidth, &latency);
+
+    /* set rdma btl weights */
+    for (size_t n_index = 0 ; n_index < n_rdma ; ++n_index) {
+        mca_bml_base_btl_t *bml_btl =
+            mca_bml_base_btl_array_get_index(&bml_endpoint->btl_rdma, n_index);
+
+        /* compute weighting factor for this r2 */
+        if (bml_btl->btl->btl_bandwidth > 0.0) {
+            bml_btl->btl_weight = (float)(bml_btl->btl->btl_bandwidth / total_bandwidth);
+        } else {
+            bml_btl->btl_weight = (float)(1.0 / n_rdma);
+        }
+    }
+}
+
+static int mca_bml_r2_add_proc (struct ompi_proc_t *proc)
+{
+    mca_bml_base_endpoint_t *bml_endpoint;
+    /* at least one btl is in use */
+    bool btl_in_use;
+    int rc;
+
+    if (OPAL_UNLIKELY(NULL == proc)) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+
+    /* check if this endpoint is already set up */
+    if (NULL != proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML]) {
+        OBJ_RETAIN(proc);
+        return OMPI_SUCCESS;
+    }
+
+    /* add btls if not already done */
+    if (OMPI_SUCCESS != (rc = mca_bml_r2_add_btls())) {
+        return rc;
+    }
+
+    bml_endpoint = mca_bml_r2_allocate_endpoint (proc);
+    if (OPAL_UNLIKELY(NULL == bml_endpoint)) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (int p_index = 0 ; p_index < mca_bml_r2.num_btl_modules ; ++p_index) {
+        mca_btl_base_module_t *btl = mca_bml_r2.btl_modules[p_index];
+        struct mca_btl_base_endpoint_t *btl_endpoint = NULL;
+
+        /* if the r2 can reach the destination proc it sets the
+         * corresponding bit (proc index) in the reachable bitmap
+         * and can return addressing information for each proc
+         * that is passed back to the r2 on data transfer calls
+         */
+        rc = btl->btl_add_procs (btl, 1, (opal_proc_t **) &proc, &btl_endpoint, NULL);
+        if (OMPI_SUCCESS != rc || NULL == btl_endpoint) {
+            /* This BTL has troubles adding the nodes. Let's continue maybe some other BTL
+             * can take care of this task. */
+            continue;
+        }
+
+        rc = mca_bml_r2_endpoint_add_btl (proc, bml_endpoint, btl, btl_endpoint);
+        if (OMPI_SUCCESS != rc) {
+            btl->btl_del_procs (btl, 1, (opal_proc_t **) &proc, &btl_endpoint);
+        } else {
+            mca_bml_r2_register_progress (btl);
+            btl_in_use = true;
+        }
+    }
+
+    if (!btl_in_use) {
+        /* no btl is available for this proc */
+        if (mca_bml_r2.show_unreach_errors) {
+            opal_show_help ("help-mca-bml-r2.txt", "unreachable proc", true,
+                            OMPI_NAME_PRINT(&(ompi_proc_local_proc->super.proc_name)),
+                            (NULL != ompi_proc_local_proc->super.proc_hostname ?
+                             ompi_proc_local_proc->super.proc_hostname : "unknown!"),
+                            OMPI_NAME_PRINT(&(proc->super.proc_name)),
+                            (NULL != proc->super.proc_hostname ?
+                             proc->super.proc_hostname : "unknown!"),
+                            btl_names);
+        }
+
+        return OMPI_ERR_UNREACH;
+    }
+
+    /* compute metrics for registered btls */
+    mca_bml_r2_compute_endpoint_metrics (bml_endpoint);
+
+    return OMPI_SUCCESS;
+}
+
 /*
  *   For each proc setup a datastructure that indicates the BTLs
  *   that can be used to reach the destination.
@@ -154,7 +441,7 @@ static int mca_bml_r2_add_procs( size_t nprocs,
                                  struct ompi_proc_t** procs,
                                  struct opal_bitmap_t* reachable )
 {
-    size_t p, p_index, n_new_procs = 0;
+    size_t n_new_procs = 0;
     struct mca_btl_base_endpoint_t ** btl_endpoints = NULL;
     struct ompi_proc_t** new_procs = NULL;
     int rc, ret = OMPI_SUCCESS;
@@ -170,7 +457,7 @@ static int mca_bml_r2_add_procs( size_t nprocs,
     /* Select only the procs that don't yet have the BML proc struct. This prevent
      * us from calling btl->add_procs several times on the same destination proc.
      */
-    for(p_index = 0; p_index < nprocs; p_index++) {
+    for (size_t p_index = 0 ; p_index < nprocs ; ++p_index) {
         struct ompi_proc_t* proc = procs[p_index];
 
         if(NULL !=  proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML]) {
@@ -203,10 +490,9 @@ static int mca_bml_r2_add_procs( size_t nprocs,
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    for(p_index = 0; p_index < mca_bml_r2.num_btl_modules; p_index++) {
-        mca_btl_base_module_t* btl = mca_bml_r2.btl_modules[p_index];
+    for (size_t p_index = 0 ; p_index < mca_bml_r2.num_btl_modules ; ++p_index) {
+        mca_btl_base_module_t *btl = mca_bml_r2.btl_modules[p_index];
         int btl_inuse = 0;
-        int btl_flags;
 
         /* if the r2 can reach the destination proc it sets the
          * corresponding bit (proc index) in the reachable bitmap
@@ -217,240 +503,69 @@ static int mca_bml_r2_add_procs( size_t nprocs,
         memset(btl_endpoints, 0, nprocs *sizeof(struct mca_btl_base_endpoint_t*));
 
         rc = btl->btl_add_procs(btl, n_new_procs, (opal_proc_t**)new_procs, btl_endpoints, reachable);
-        if(OMPI_SUCCESS != rc) {
-            /* This BTL has troubles adding the nodes. Let's continue maybe some other BTL
-             * can take care of this task.
-             */
+        if (OMPI_SUCCESS != rc) {
+            /* This BTL encountered an error while adding procs. Continue in case some other
+             * BTL(s) can be used. */
             continue;
         }
 
         /* for each proc that is reachable */
-        for( p = 0; p < n_new_procs; p++ ) {
-            if(opal_bitmap_is_set_bit(reachable, p)) {
-                ompi_proc_t *proc = new_procs[p];
-                mca_bml_base_endpoint_t * bml_endpoint =
-                    (mca_bml_base_endpoint_t*) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
-                mca_bml_base_btl_t* bml_btl = NULL;
-                size_t size;
-
-                if(NULL == bml_endpoint) {
-                    /* allocate bml specific proc data */
-                    bml_endpoint = OBJ_NEW(mca_bml_base_endpoint_t);
-                    if (NULL == bml_endpoint) {
-                        opal_output(0, "mca_bml_r2_add_procs: unable to allocate resources");
-                        free(btl_endpoints);
-                        free(new_procs);
-                        return OMPI_ERR_OUT_OF_RESOURCE;
-                    }
-
-                    /* preallocate space in array for max number of r2s */
-                    mca_bml_base_btl_array_reserve(&bml_endpoint->btl_eager, mca_bml_r2.num_btl_modules);
-                    mca_bml_base_btl_array_reserve(&bml_endpoint->btl_send,  mca_bml_r2.num_btl_modules);
-                    mca_bml_base_btl_array_reserve(&bml_endpoint->btl_rdma,  mca_bml_r2.num_btl_modules);
-                    bml_endpoint->btl_max_send_size = -1;
-                    bml_endpoint->btl_proc = proc;
-                    proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML] = bml_endpoint;
-
-                    bml_endpoint->btl_flags_or = 0;
-                }
-
-                btl_flags = btl->btl_flags;
-                if( (btl_flags & MCA_BTL_FLAGS_PUT) && (NULL == btl->btl_put) ) {
-                    opal_output(0, "mca_bml_r2_add_procs: The PUT flag is specified for"
-                                " the %s BTL without any PUT function attached. Discard the flag !",
-                                btl->btl_component->btl_version.mca_component_name);
-                    btl_flags ^= MCA_BTL_FLAGS_PUT;
-                }
-                if( (btl_flags & MCA_BTL_FLAGS_GET) && (NULL == btl->btl_get) ) {
-                    opal_output(0, "mca_bml_r2_add_procs: The GET flag is specified for"
-                                " the %s BTL without any GET function attached. Discard the flag !",
-                                btl->btl_component->btl_version.mca_component_name);
-                    btl_flags ^= MCA_BTL_FLAGS_GET;
-                }
-
-                if( (btl_flags & (MCA_BTL_FLAGS_PUT | MCA_BTL_FLAGS_GET | MCA_BTL_FLAGS_SEND)) == 0 ) {
-                    /**
-                     * If no protocol specified, we have 2 choices: we ignore the BTL
-                     * as we don't know which protocl to use, or we suppose that all
-                     * BTLs support the send protocol.
-                     */
-                    btl_flags |= MCA_BTL_FLAGS_SEND;
-                }
-
-                /* dont allow an additional BTL with a lower exclusivity ranking */
-                size = mca_bml_base_btl_array_get_size(&bml_endpoint->btl_send);
-                if(size > 0) {
-                    bml_btl = mca_bml_base_btl_array_get_index(&bml_endpoint->btl_send, size-1);
-                    /* skip this btl if the exclusivity is less than the previous only if the btl does not provide full rdma (for one-sided) */
-                    if(bml_btl->btl->btl_exclusivity > btl->btl_exclusivity  && ((btl_flags & MCA_BTL_FLAGS_RDMA) != MCA_BTL_FLAGS_RDMA)) {
-                        btl->btl_del_procs(btl, 1, (opal_proc_t**)&proc, &btl_endpoints[p]);
-                        opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_bml_base_framework.framework_output,
-                                            "mca: bml: Not using %s btl to %s on node %s "
-                                            "because %s btl has higher exclusivity (%d > %d)",
-                                            btl->btl_component->btl_version.mca_component_name,
-                                            OMPI_NAME_PRINT(&proc->super.proc_name), proc->super.proc_hostname,
-                                            bml_btl->btl->btl_component->btl_version.mca_component_name,
-                                            bml_btl->btl->btl_exclusivity,
-                                            btl->btl_exclusivity);
-                        continue;
-                    }
-                }
-                opal_output_verbose(MCA_BASE_VERBOSE_INFO, ompi_bml_base_framework.framework_output,
-                                    "mca: bml: Using %s btl to %s on node %s",
-                                    btl->btl_component->btl_version.mca_component_name,
-                                    OMPI_NAME_PRINT(&proc->super.proc_name),
-                                    proc->super.proc_hostname);
-
-                /* cache the endpoint on the proc */
-                if (NULL == bml_btl || (bml_btl->btl->btl_exclusivity <= btl->btl_exclusivity)) {
-                    bml_btl = mca_bml_base_btl_array_insert(&bml_endpoint->btl_send);
-                    bml_btl->btl = btl;
-                    bml_btl->btl_endpoint = btl_endpoints[p];
-                    bml_btl->btl_weight = 0;
-                    bml_btl->btl_flags = btl_flags;
-
-                    /**
-                     * calculate the bitwise OR of the btl flags
-                     */
-                    bml_endpoint->btl_flags_or |= bml_btl->btl_flags;
-                }
-
-                /* always add rdma endpoints */
-                if ((btl_flags & MCA_BTL_FLAGS_RDMA) &&
-                    !((proc->super.proc_arch != ompi_proc_local_proc->super.proc_arch) &&
-                      (0 == (btl->btl_flags & MCA_BTL_FLAGS_HETEROGENEOUS_RDMA)))) {
-                    mca_bml_base_btl_t *bml_btl_rdma = mca_bml_base_btl_array_insert(&bml_endpoint->btl_rdma);
-
-                    bml_btl_rdma->btl = btl;
-                    bml_btl_rdma->btl_endpoint = btl_endpoints[p];
-                    bml_btl_rdma->btl_weight = 0;
-                    bml_btl_rdma->btl_flags = btl_flags;
-
-                    if (bml_endpoint->btl_pipeline_send_length < btl->btl_rdma_pipeline_send_length) {
-                        bml_endpoint->btl_pipeline_send_length = btl->btl_rdma_pipeline_send_length;
-                    }
-
-                    if (bml_endpoint->btl_send_limit < btl->btl_min_rdma_pipeline_size) {
-                        bml_endpoint->btl_send_limit = btl->btl_min_rdma_pipeline_size;
-                    }
-                }
-
-                /* This BTL is in use, allow the progress registration */
-                btl_inuse++;
+        for (size_t p = 0 ; p < n_new_procs ; ++p) {
+            if (!opal_bitmap_is_set_bit(reachable, p)) {
+                continue;
             }
+
+            ompi_proc_t *proc = new_procs[p];
+            mca_bml_base_endpoint_t *bml_endpoint =
+                (mca_bml_base_endpoint_t *) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
+            mca_bml_base_btl_t *bml_btl = NULL;
+            size_t size;
+
+            if (NULL == bml_endpoint) {
+                bml_endpoint = mca_bml_r2_allocate_endpoint (proc);
+                if (NULL == bml_endpoint) {
+                    free(btl_endpoints);
+                    free(new_procs);
+                    return OPAL_ERR_OUT_OF_RESOURCE;
+                }
+            }
+
+            rc = mca_bml_r2_endpoint_add_btl (proc, bml_endpoint, btl, btl_endpoints[p]);
+            if (OMPI_SUCCESS != rc) {
+                btl->btl_del_procs(btl, 1, (opal_proc_t**)&proc, &btl_endpoints[p]);
+                continue;
+            }
+
+            /* This BTL is in use, allow the progress registration */
+            btl_inuse++;
         }
 
-        if(btl_inuse > 0 && NULL != btl->btl_component->btl_progress) {
-            size_t p;
-            bool found = false;
-            for( p = 0; p < mca_bml_r2.num_btl_progress; p++ ) {
-                if(mca_bml_r2.btl_progress[p] == btl->btl_component->btl_progress) {
-                    found = true;
-                    break;
-                }
-            }
-            if(found == false) {
-                mca_bml_r2.btl_progress[mca_bml_r2.num_btl_progress] =
-                    btl->btl_component->btl_progress;
-                mca_bml_r2.num_btl_progress++;
-                opal_progress_register( btl->btl_component->btl_progress );
-            }
+        if (btl_inuse) {
+            mca_bml_r2_register_progress (btl);
         }
     }
+
     free(btl_endpoints);
 
     /* iterate back through procs and compute metrics for registered r2s */
-    for(p=0; p<n_new_procs; p++) {
-        ompi_proc_t *proc = new_procs[p];
-        mca_bml_base_endpoint_t* bml_endpoint =
-            (mca_bml_base_endpoint_t*) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
-        double total_bandwidth = 0;
-        uint32_t latency;
-        size_t n_send, n_rdma;
+    for (size_t p = 0; p < n_new_procs ; ++p) {
+        mca_bml_base_endpoint_t *bml_endpoint =
+            (mca_bml_base_endpoint_t *) new_procs[p]->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
 
         /* skip over procs w/ no btl's registered */
-        if(NULL == bml_endpoint) {
-            continue;
-        }
-
-        /* (1) determine the total bandwidth available across all btls
-         *     note that we need to do this here, as we may already have btls configured
-         * (2) determine the highest priority ranking for latency
-         * (3) compute the maximum amount of bytes that can be send without any
-         *     weighting. Once the left over is smaller than this number we will
-         *     start using the weight to compute the correct amount.
-         */
-        n_send = mca_bml_base_btl_array_get_size(&bml_endpoint->btl_send);
-        n_rdma = mca_bml_base_btl_array_get_size(&bml_endpoint->btl_rdma);
-
-        /* sort BTLs in descending order according to bandwidth value */
-        qsort(bml_endpoint->btl_send.bml_btls, n_send,
-                sizeof(mca_bml_base_btl_t), btl_bandwidth_compare);
-
-        bml_endpoint->btl_rdma_index = 0;
-
-        mca_bml_r2_calculate_bandwidth_latency (&bml_endpoint->btl_send, &total_bandwidth, &latency);
-
-        /* (1) set the weight of each btl as a percentage of overall bandwidth
-         * (2) copy all btl instances at the highest priority ranking into the
-         *     list of btls used for first fragments
-         */
-        for (size_t n_index = 0 ; n_index < n_send ; ++n_index) {
-            mca_bml_base_btl_t* bml_btl =
-                mca_bml_base_btl_array_get_index(&bml_endpoint->btl_send, n_index);
-            mca_btl_base_module_t *btl = bml_btl->btl;
-
-            /* compute weighting factor for this r2 */
-            if(btl->btl_bandwidth > 0) {
-                bml_btl->btl_weight = (float)(btl->btl_bandwidth / total_bandwidth);
-            } else {
-                bml_btl->btl_weight = (float)(1.0 / n_send);
-            }
-
-            /* check to see if this r2 is already in the array of r2s
-             * used for first fragments - if not add it.
-             */
-            if(btl->btl_latency == latency) {
-                mca_bml_base_btl_t* bml_btl_new =
-                    mca_bml_base_btl_array_insert(&bml_endpoint->btl_eager);
-                *bml_btl_new = *bml_btl;
-            }
-
-            /* set endpoint max send size as min of available btls */
-            if(bml_endpoint->btl_max_send_size > btl->btl_max_send_size)
-               bml_endpoint->btl_max_send_size = btl->btl_max_send_size;
-        }
-
-        /* sort BTLs in descending order according to bandwidth value */
-        qsort(bml_endpoint->btl_rdma.bml_btls, n_rdma,
-                sizeof(mca_bml_base_btl_t), btl_bandwidth_compare);
-
-        mca_bml_r2_calculate_bandwidth_latency (&bml_endpoint->btl_rdma, &total_bandwidth, &latency);
-
-        /* set rdma btl weights */
-        for (size_t n_index = 0 ; n_index < n_rdma ; ++n_index) {
-            mca_bml_base_btl_t *bml_btl =
-                mca_bml_base_btl_array_get_index(&bml_endpoint->btl_rdma, n_index);
-
-            /* compute weighting factor for this r2 */
-            if (bml_btl->btl->btl_bandwidth > 0.0) {
-                bml_btl->btl_weight = (float)(bml_btl->btl->btl_bandwidth / total_bandwidth);
-            } else {
-                bml_btl->btl_weight = (float)(1.0 / n_rdma);
-            }
+        if (NULL != bml_endpoint) {
+            mca_bml_r2_compute_endpoint_metrics (bml_endpoint);
         }
     }
 
     /* see if we have a connection to everyone else */
-    for(p = 0; p < n_new_procs; p++) {
+    for(size_t p = 0; p < n_new_procs ; ++p) {
         ompi_proc_t *proc = new_procs[p];
 
         if (NULL == proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML]) {
             ret = OMPI_ERR_UNREACH;
             if (mca_bml_r2.show_unreach_errors) {
-                opal_show_help("help-mca-bml-r2.txt",
-                               "unreachable proc",
-                               true,
+                opal_show_help("help-mca-bml-r2.txt", "unreachable proc", true,
                                OMPI_NAME_PRINT(&(ompi_proc_local_proc->super.proc_name)),
                                (NULL != ompi_proc_local_proc->super.proc_hostname ?
                                 ompi_proc_local_proc->super.proc_hostname : "unknown!"),
@@ -459,6 +574,7 @@ static int mca_bml_r2_add_procs( size_t nprocs,
                                 proc->super.proc_hostname : "unknown!"),
                                btl_names);
             }
+
             break;
         }
     }
@@ -476,7 +592,6 @@ static int mca_bml_r2_add_procs( size_t nprocs,
 static int mca_bml_r2_del_procs(size_t nprocs,
                                 struct ompi_proc_t** procs)
 {
-    size_t p;
     int rc;
     struct ompi_proc_t** del_procs = (struct ompi_proc_t**)
         malloc(nprocs * sizeof(struct ompi_proc_t*));
@@ -486,26 +601,27 @@ static int mca_bml_r2_del_procs(size_t nprocs,
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    for(p = 0; p < nprocs; p++) {
+    for (size_t p = 0 ; p < nprocs ; ++p) {
         ompi_proc_t *proc = procs[p];
         /* We much check that there are 2 references to the proc (not 1). The
          * first reference belongs to ompi/proc the second belongs to the bml
          * since we retained it. We will release that reference at the end of
          * the loop below. */
-        if(((opal_object_t*)proc)->obj_reference_count == 2) {
+        if (((opal_object_t*)proc)->obj_reference_count == 2 &&
+            NULL != proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML]) {
             del_procs[n_del_procs++] = proc;
         }
     }
 
-    for(p = 0; p < n_del_procs; p++) {
+    for (size_t p = 0 ; p < n_del_procs ; ++p) {
         ompi_proc_t *proc = del_procs[p];
         mca_bml_base_endpoint_t* bml_endpoint =
             (mca_bml_base_endpoint_t*) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
-        size_t f_index, f_size;
+        size_t f_size;
 
         /* notify each btl that the proc is going away */
         f_size = mca_bml_base_btl_array_get_size(&bml_endpoint->btl_send);
-        for(f_index = 0; f_index < f_size; f_index++) {
+        for (size_t f_index = 0 ; f_index < f_size ; ++f_index) {
             mca_bml_base_btl_t* bml_btl = mca_bml_base_btl_array_get_index(&bml_endpoint->btl_send, f_index);
             mca_btl_base_module_t* btl = bml_btl->btl;
 
@@ -521,10 +637,12 @@ static int mca_bml_r2_del_procs(size_t nprocs,
              */
         }
 
+        proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML] = NULL;
+
         OBJ_RELEASE(proc);
+
         /* do any required cleanup */
         OBJ_RELEASE(bml_endpoint);
-        proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML] = NULL;
     }
     free(del_procs);
 
@@ -835,6 +953,7 @@ int mca_bml_r2_component_fini(void)
 mca_bml_r2_module_t mca_bml_r2 = {
     .super = {
         .bml_component = &mca_bml_r2_component,
+        .bml_add_proc = mca_bml_r2_add_proc,
         .bml_add_procs = mca_bml_r2_add_procs,
         .bml_del_procs = mca_bml_r2_del_procs,
         .bml_add_btl = mca_bml_r2_add_btl,
@@ -843,8 +962,7 @@ mca_bml_r2_module_t mca_bml_r2 = {
         .bml_register = mca_bml_r2_register,
         .bml_register_error = mca_bml_r2_register_error,
         .bml_finalize = mca_bml_r2_finalize,
-        .bml_ft_event = mca_bml_r2_ft_event
-    }
-
+        .bml_ft_event = mca_bml_r2_ft_event,
+    },
 };
 

--- a/ompi/mca/coll/fca/coll_fca_module.c
+++ b/ompi/mca/coll/fca/coll_fca_module.c
@@ -35,25 +35,6 @@ int mca_coll_fca_init_query(bool enable_progress_threads,
     return OMPI_SUCCESS;
 }
 
-static int have_remote_peers(ompi_group_t *group, size_t size, int *local_peers)
-{
-    ompi_proc_t *proc;
-    size_t i;
-    int ret;
-
-    *local_peers = 0;
-    ret = 0;
-    for (i = 0; i < size; ++i) {
-        proc = ompi_group_peer_lookup(group, i);
-        if (OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
-            ++*local_peers;
-        } else {
-            ret = 1;
-        }
-    }
-    return ret;
-}
-
 static inline ompi_proc_t* __local_rank_lookup(ompi_communicator_t *comm, int rank)
 {
     return ompi_group_peer_lookup(comm->c_local_group, rank);
@@ -618,7 +599,7 @@ mca_coll_fca_comm_query(struct ompi_communicator_t *comm, int *priority)
     if (size < mca_coll_fca_component.fca_np)
         goto exit;
 
-    if (!have_remote_peers(comm->c_local_group, size, &local_peers) || OMPI_COMM_IS_INTER(comm))
+    if (!ompi_group_have_remote_peers(comm->c_local_group), || OMPI_COMM_IS_INTER(comm))
         goto exit;
 
     fca_module = OBJ_NEW(mca_coll_fca_module_t);

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -73,7 +73,6 @@ uint32_t mca_coll_sm_one = 1;
  */
 static int sm_module_enable(mca_coll_base_module_t *module,
                           struct ompi_communicator_t *comm);
-static bool have_local_peers(ompi_group_t *group, size_t size);
 static int bootstrap_comm(ompi_communicator_t *comm,
                           mca_coll_sm_module_t *module);
 static int mca_coll_sm_module_disable(mca_coll_base_module_t *module,
@@ -171,8 +170,7 @@ mca_coll_sm_comm_query(struct ompi_communicator_t *comm, int *priority)
     /* If we're intercomm, or if there's only one process in the
        communicator, or if not all the processes in the communicator
        are not on this node, then we don't want to run */
-    if (OMPI_COMM_IS_INTER(comm) || 1 == ompi_comm_size(comm) ||
-        !have_local_peers(comm->c_local_group, ompi_comm_size(comm))) {
+    if (OMPI_COMM_IS_INTER(comm) || 1 == ompi_comm_size(comm) || ompi_group_have_remote_peers (comm->c_local_group)) {
         opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                             "coll:sm:comm_query (%d/%s): intercomm, comm is too small, or not all peers local; disqualifying myself", comm->c_contextid, comm->c_name);
 	return NULL;
@@ -502,23 +500,6 @@ int ompi_coll_sm_lazy_enable(mca_coll_base_module_t *module,
                         comm->c_contextid, comm->c_name);
     return OMPI_SUCCESS;
 }
-
-
-static bool have_local_peers(ompi_group_t *group, size_t size)
-{
-    size_t i;
-    ompi_proc_t *proc;
-
-    for (i = 0; i < size; ++i) {
-        proc = ompi_group_peer_lookup(group,i);
-        if (!OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 
 static int bootstrap_comm(ompi_communicator_t *comm,
                           mca_coll_sm_module_t *module)

--- a/ompi/mca/mtl/psm/mtl_psm.h
+++ b/ompi/mca/mtl/psm/mtl_psm.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      QLogic Corporation. All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,6 +26,7 @@
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/mtl/mtl.h"
 #include "ompi/mca/mtl/base/base.h"
+#include "ompi/proc/proc.h"
 #include "opal/datatype/opal_convertor.h"
 #include <psm.h>
 #include <psm_mq.h>

--- a/ompi/mca/mtl/psm/mtl_psm_endpoint.h
+++ b/ompi/mca/mtl/psm/mtl_psm_endpoint.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      QLogic Corporation. All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,6 +56,15 @@ struct mca_mtl_psm_endpoint_t {
 
 typedef struct mca_mtl_psm_endpoint_t  mca_mtl_psm_endpoint_t;
 OBJ_CLASS_DECLARATION(mca_mtl_psm_endpoint);
+
+static inline mca_mtl_psm_endpoint_t *ompi_mtl_psm_get_endpoint (struct mca_mtl_base_module_t* mtl, ompi_proc_t *ompi_proc)
+{
+    if (OPAL_UNLIKELY(NULL == ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL])) {
+	ompi_mtl_psm_add_procs (mtl, 1, &ompi_proc);
+    }
+
+    return ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];
+}
 
 END_C_DECLS
 #endif

--- a/ompi/mca/mtl/psm/mtl_psm_send.c
+++ b/ompi/mca/mtl/psm/mtl_psm_send.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      QLogic Corporation. All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +45,7 @@ ompi_mtl_psm_send(struct mca_mtl_base_module_t* mtl,
     int ret;
     size_t length;
     ompi_proc_t* ompi_proc = ompi_comm_peer_lookup( comm, dest );
-    mca_mtl_psm_endpoint_t* psm_endpoint = (mca_mtl_psm_endpoint_t*) ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];
+    mca_mtl_psm_endpoint_t* psm_endpoint = ompi_mtl_psm_get_endpoint (mtl, ompi_proc);
 
     assert(mtl == &ompi_mtl_psm.super);
 
@@ -94,7 +97,7 @@ ompi_mtl_psm_isend(struct mca_mtl_base_module_t* mtl,
     mca_mtl_psm_request_t * mtl_psm_request = (mca_mtl_psm_request_t*) mtl_request;
     size_t length;
     ompi_proc_t* ompi_proc = ompi_comm_peer_lookup( comm, dest );
-    mca_mtl_psm_endpoint_t* psm_endpoint = (mca_mtl_psm_endpoint_t*)ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];
+    mca_mtl_psm_endpoint_t* psm_endpoint = ompi_mtl_psm_get_endpoint (mtl, ompi_proc);
 
     assert(mtl == &ompi_mtl_psm.super);
 

--- a/ompi/mca/mtl/psm2/mtl_psm2.h
+++ b/ompi/mca/mtl/psm2/mtl_psm2.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006      QLogic Corporation. All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +27,7 @@
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/mtl/mtl.h"
 #include "ompi/mca/mtl/base/base.h"
+#include "ompi/proc/proc.h"
 #include "opal/datatype/opal_convertor.h"
 #include <psm2.h>
 #include <psm2_mq.h>

--- a/ompi/mca/mtl/psm2/mtl_psm2_endpoint.h
+++ b/ompi/mca/mtl/psm2/mtl_psm2_endpoint.h
@@ -55,5 +55,14 @@ struct mca_mtl_psm2_endpoint_t {
 typedef struct mca_mtl_psm2_endpoint_t  mca_mtl_psm2_endpoint_t;
 OBJ_CLASS_DECLARATION(mca_mtl_psm2_endpoint);
 
+static inline mca_mtl_psm_endpoint_t *ompi_mtl_psm2_get_endpoint (struct mca_mtl_base_module_t* mtl, ompi_proc_t *ompi_proc)
+{
+    if (OPAL_UNLIKELY(NULL == ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL])) {
+	ompi_mtl_psm2_add_procs (mtl, 1, &ompi_proc);
+    }
+
+    return ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];
+}
+
 END_C_DECLS
 #endif

--- a/ompi/mca/mtl/psm2/mtl_psm2_send.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_send.c
@@ -43,7 +43,7 @@ ompi_mtl_psm2_send(struct mca_mtl_base_module_t* mtl,
     int ret;
     size_t length;
     ompi_proc_t* ompi_proc = ompi_comm_peer_lookup( comm, dest );
-    mca_mtl_psm2_endpoint_t* psm_endpoint = (mca_mtl_psm2_endpoint_t*) ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];
+    mca_mtl_psm2_endpoint_t* psm_endpoint = ompi_mtl_psm2_get_endpoint (mtl, ompi_proc);
 
     assert(mtl == &ompi_mtl_psm2.super);
 
@@ -95,7 +95,7 @@ ompi_mtl_psm2_isend(struct mca_mtl_base_module_t* mtl,
     mca_mtl_psm2_request_t * mtl_psm2_request = (mca_mtl_psm2_request_t*) mtl_request;
     size_t length;
     ompi_proc_t* ompi_proc = ompi_comm_peer_lookup( comm, dest );
-    mca_mtl_psm2_endpoint_t* psm_endpoint = (mca_mtl_psm2_endpoint_t*)ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];
+    mca_mtl_psm2_endpoint_t* psm_endpoint = ompi_mtl_psm2_get_endpoint (mtl, ompi_proc);
 
     assert(mtl == &ompi_mtl_psm2.super);
 

--- a/ompi/mca/osc/base/osc_base_obj_convert.c
+++ b/ompi/mca/osc/base/osc_base_obj_convert.c
@@ -134,7 +134,7 @@ int ompi_osc_base_process_op (void *outbuf, void *inbuf, size_t inbuflen,
     return OMPI_SUCCESS;
 }
 
-int ompi_osc_base_sndrcv_op (void *origin, int32_t origin_count,
+int ompi_osc_base_sndrcv_op (const void *origin, int32_t origin_count,
                              struct ompi_datatype_t *origin_dt,
                              void *target, int32_t target_count,
                              struct ompi_datatype_t *target_dt,
@@ -152,7 +152,7 @@ int ompi_osc_base_sndrcv_op (void *origin, int32_t origin_count,
     bool done;
 
     if (ompi_datatype_is_predefined(origin_dt) && origin_dt == target_dt) {
-        ompi_op_reduce(op, origin, target, origin_count, origin_dt);
+        ompi_op_reduce(op, (void *)origin, target, origin_count, origin_dt);
 
         return OMPI_SUCCESS;
     }

--- a/ompi/mca/osc/base/osc_base_obj_convert.h
+++ b/ompi/mca/osc/base/osc_base_obj_convert.h
@@ -7,6 +7,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -117,7 +119,7 @@ OMPI_DECLSPEC int ompi_osc_base_process_op(void *outbuf,
                                            int count,
                                            ompi_op_t *op);
 
-OMPI_DECLSPEC int ompi_osc_base_sndrcv_op(void *origin,
+OMPI_DECLSPEC int ompi_osc_base_sndrcv_op(const void *origin,
                                           int32_t origin_count,
                                           struct ompi_datatype_t *origin_dt,
                                           void *target,

--- a/ompi/mca/osc/osc.h
+++ b/ompi/mca/osc/osc.h
@@ -11,6 +11,8 @@
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -181,7 +183,7 @@ typedef int (*ompi_osc_base_module_win_shared_query_fn_t)(struct ompi_win_t *win
                                                           size_t *size, int *disp_unit, void *baseptr);
 
 typedef int (*ompi_osc_base_module_win_attach_fn_t)(struct ompi_win_t *win, void *base, size_t size);
-typedef int (*ompi_osc_base_module_win_detach_fn_t)(struct ompi_win_t *win, void *base);
+typedef int (*ompi_osc_base_module_win_detach_fn_t)(struct ompi_win_t *win, const void *base);
 
 /**
  * Free resources associated with win
@@ -231,15 +233,15 @@ typedef int (*ompi_osc_base_module_accumulate_fn_t)(void *origin_addr,
                                                    struct ompi_op_t *op,
                                                    struct ompi_win_t *win);
 
-typedef int (*ompi_osc_base_module_compare_and_swap_fn_t)(void *origin_addr,
-                                                          void *compare_addr,
+typedef int (*ompi_osc_base_module_compare_and_swap_fn_t)(const void *origin_addr,
+                                                          const void *compare_addr,
                                                           void *result_addr,
                                                           struct ompi_datatype_t *dt,
                                                           int target,
                                                           OPAL_PTRDIFF_TYPE target_disp,
                                                           struct ompi_win_t *win);
 
-typedef int (*ompi_osc_base_module_fetch_and_op_fn_t)(void *origin_addr,
+typedef int (*ompi_osc_base_module_fetch_and_op_fn_t)(const void *origin_addr,
                                                       void *result_addr,
                                                       struct ompi_datatype_t *dt,
                                                       int target,
@@ -247,7 +249,7 @@ typedef int (*ompi_osc_base_module_fetch_and_op_fn_t)(void *origin_addr,
                                                       struct ompi_op_t *op,
                                                       struct ompi_win_t *win);
 
-typedef int (*ompi_osc_base_module_get_accumulate_fn_t)(void *origin_addr,
+typedef int (*ompi_osc_base_module_get_accumulate_fn_t)(const void *origin_addr,
                                                         int origin_count,
                                                         struct ompi_datatype_t *origin_datatype,
                                                         void *result_addr,
@@ -281,7 +283,7 @@ typedef int (*ompi_osc_base_module_rget_fn_t)(void *origin_addr,
                                               struct ompi_request_t **request);
 
 
-typedef int (*ompi_osc_base_module_raccumulate_fn_t)(void *origin_addr,
+typedef int (*ompi_osc_base_module_raccumulate_fn_t)(const void *origin_addr,
                                                      int origin_count,
                                                      struct ompi_datatype_t *origin_dt,
                                                      int target,

--- a/ompi/mca/osc/osc.h
+++ b/ompi/mca/osc/osc.h
@@ -203,7 +203,7 @@ typedef int (*ompi_osc_base_module_win_detach_fn_t)(struct ompi_win_t *win, cons
 typedef int (*ompi_osc_base_module_free_fn_t)(struct ompi_win_t *win);
 
 
-typedef int (*ompi_osc_base_module_put_fn_t)(void *origin_addr,
+typedef int (*ompi_osc_base_module_put_fn_t)(const void *origin_addr,
                                             int origin_count,
                                             struct ompi_datatype_t *origin_dt,
                                             int target,
@@ -223,7 +223,7 @@ typedef int (*ompi_osc_base_module_get_fn_t)(void *origin_addr,
                                             struct ompi_win_t *win);
 
 
-typedef int (*ompi_osc_base_module_accumulate_fn_t)(void *origin_addr,
+typedef int (*ompi_osc_base_module_accumulate_fn_t)(const void *origin_addr,
                                                    int origin_count,
                                                    struct ompi_datatype_t *origin_dt,
                                                    int target,
@@ -262,7 +262,7 @@ typedef int (*ompi_osc_base_module_get_accumulate_fn_t)(const void *origin_addr,
                                                         struct ompi_op_t *op,
                                                         struct ompi_win_t *win);
 
-typedef int (*ompi_osc_base_module_rput_fn_t)(void *origin_addr,
+typedef int (*ompi_osc_base_module_rput_fn_t)(const void *origin_addr,
                                               int origin_count,
                                               struct ompi_datatype_t *origin_dt,
                                               int target,
@@ -294,7 +294,7 @@ typedef int (*ompi_osc_base_module_raccumulate_fn_t)(const void *origin_addr,
                                                      struct ompi_win_t *win,
                                                      struct ompi_request_t **request);
 
-typedef int (*ompi_osc_base_module_rget_accumulate_fn_t)(void *origin_addr,
+typedef int (*ompi_osc_base_module_rget_accumulate_fn_t)(const void *origin_addr,
                                                          int origin_count,
                                                          struct ompi_datatype_t *origin_datatype,
                                                          void *result_addr,

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -122,7 +122,7 @@ int ompi_osc_portals4_detach(struct ompi_win_t *win, const void *base);
 
 int ompi_osc_portals4_free(struct ompi_win_t *win);
 
-int ompi_osc_portals4_put(void *origin_addr,
+int ompi_osc_portals4_put(const void *origin_addr,
                           int origin_count,
                           struct ompi_datatype_t *origin_dt,
                           int target,
@@ -140,7 +140,7 @@ int ompi_osc_portals4_get(void *origin_addr,
                           struct ompi_datatype_t *target_dt,
                           struct ompi_win_t *win);
 
-int ompi_osc_portals4_accumulate(void *origin_addr,
+int ompi_osc_portals4_accumulate(const void *origin_addr,
                                  int origin_count,
                                  struct ompi_datatype_t *origin_dt,
                                  int target,
@@ -179,7 +179,7 @@ int ompi_osc_portals4_get_accumulate(const void *origin_addr,
                                      struct ompi_op_t *op,
                                      struct ompi_win_t *win);
 
-int ompi_osc_portals4_rput(void *origin_addr,
+int ompi_osc_portals4_rput(const void *origin_addr,
                            int origin_count,
                            struct ompi_datatype_t *origin_dt,
                            int target,
@@ -210,7 +210,7 @@ int ompi_osc_portals4_raccumulate(const void *origin_addr,
                                   struct ompi_win_t *win,
                                   struct ompi_request_t **request);
 
-int ompi_osc_portals4_rget_accumulate(void *origin_addr,
+int ompi_osc_portals4_rget_accumulate(const void *origin_addr,
                                       int origin_count,
                                       struct ompi_datatype_t *origin_datatype,
                                       void *result_addr,

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2011-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -116,7 +118,7 @@ get_displacement(ompi_osc_portals4_module_t *module,
 
 
 int ompi_osc_portals4_attach(struct ompi_win_t *win, void *base, size_t len);
-int ompi_osc_portals4_detach(struct ompi_win_t *win, void *base);
+int ompi_osc_portals4_detach(struct ompi_win_t *win, const void *base);
 
 int ompi_osc_portals4_free(struct ompi_win_t *win);
 
@@ -148,15 +150,15 @@ int ompi_osc_portals4_accumulate(void *origin_addr,
                                  struct ompi_op_t *op,
                                  struct ompi_win_t *win);
 
-int ompi_osc_portals4_compare_and_swap(void *origin_addr,
-                                       void *compare_addr,
+int ompi_osc_portals4_compare_and_swap(const void *origin_addr,
+                                       const void *compare_addr,
                                        void *result_addr,
                                        struct ompi_datatype_t *dt,
                                        int target,
                                        OPAL_PTRDIFF_TYPE target_disp,
                                        struct ompi_win_t *win);
 
-int ompi_osc_portals4_fetch_and_op(void *origin_addr,
+int ompi_osc_portals4_fetch_and_op(const void *origin_addr,
                                    void *result_addr,
                                    struct ompi_datatype_t *dt,
                                    int target,
@@ -164,7 +166,7 @@ int ompi_osc_portals4_fetch_and_op(void *origin_addr,
                                    struct ompi_op_t *op,
                                    struct ompi_win_t *win);
 
-int ompi_osc_portals4_get_accumulate(void *origin_addr,
+int ompi_osc_portals4_get_accumulate(const void *origin_addr,
                                      int origin_count,
                                      struct ompi_datatype_t *origin_datatype,
                                      void *result_addr,
@@ -197,7 +199,7 @@ int ompi_osc_portals4_rget(void *origin_addr,
                            struct ompi_win_t *win,
                            struct ompi_request_t **request);
 
-int ompi_osc_portals4_raccumulate(void *origin_addr,
+int ompi_osc_portals4_raccumulate(const void *origin_addr,
                                   int origin_count,
                                   struct ompi_datatype_t *origin_dt,
                                   int target,

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -299,7 +299,7 @@ ompi_osc_portals4_get_peer(ompi_osc_portals4_module_t *module, int rank)
 static inline ptl_process_t
 ompi_osc_portals4_get_peer_group(struct ompi_group_t *group, int rank)
 {
-    ompi_proc_t *proc = ompi_group_get_proc_ptr(group, rank);
+    ompi_proc_t *proc = ompi_group_get_proc_ptr(group, rank, true);
     return *((ptl_process_t*) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
 }
 

--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -182,7 +182,7 @@ ompi_osc_portals4_get_dt(struct ompi_datatype_t *dt, ptl_datatype_t *ptl_dt)
 
 
 int
-ompi_osc_portals4_rput(void *origin_addr,
+ompi_osc_portals4_rput(const void *origin_addr,
                        int origin_count,
                        struct ompi_datatype_t *origin_dt,
                        int target,
@@ -417,7 +417,7 @@ ompi_osc_portals4_raccumulate(const void *origin_addr,
 
 
 int
-ompi_osc_portals4_rget_accumulate(void *origin_addr,
+ompi_osc_portals4_rget_accumulate(const void *origin_addr,
                                   int origin_count,
                                   struct ompi_datatype_t *origin_dt,
                                   void *result_addr,
@@ -582,7 +582,7 @@ ompi_osc_portals4_rget_accumulate(void *origin_addr,
 
 
 int
-ompi_osc_portals4_put(void *origin_addr,
+ompi_osc_portals4_put(const void *origin_addr,
                       int origin_count,
                       struct ompi_datatype_t *origin_dt,
                       int target,
@@ -694,7 +694,7 @@ ompi_osc_portals4_get(void *origin_addr,
 
 
 int
-ompi_osc_portals4_accumulate(void *origin_addr,
+ompi_osc_portals4_accumulate(const void *origin_addr,
                              int origin_count,
                              struct ompi_datatype_t *origin_dt,
                              int target,

--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2014      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -312,7 +314,7 @@ ompi_osc_portals4_rget(void *origin_addr,
 
 
 int
-ompi_osc_portals4_raccumulate(void *origin_addr,
+ompi_osc_portals4_raccumulate(const void *origin_addr,
                               int origin_count,
                               struct ompi_datatype_t *origin_dt,
                               int target,
@@ -785,7 +787,7 @@ ompi_osc_portals4_accumulate(void *origin_addr,
 
 
 int
-ompi_osc_portals4_get_accumulate(void *origin_addr,
+ompi_osc_portals4_get_accumulate(const void *origin_addr,
                                  int origin_count,
                                  struct ompi_datatype_t *origin_dt,
                                  void *result_addr,
@@ -937,8 +939,8 @@ ompi_osc_portals4_get_accumulate(void *origin_addr,
 
 
 int
-ompi_osc_portals4_compare_and_swap(void *origin_addr,
-                                   void *compare_addr,
+ompi_osc_portals4_compare_and_swap(const void *origin_addr,
+                                   const void *compare_addr,
                                    void *result_addr,
                                    struct ompi_datatype_t *dt,
                                    int target,
@@ -1000,7 +1002,7 @@ ompi_osc_portals4_compare_and_swap(void *origin_addr,
 
 
 int
-ompi_osc_portals4_fetch_and_op(void *origin_addr,
+ompi_osc_portals4_fetch_and_op(const void *origin_addr,
                                void *result_addr,
                                struct ompi_datatype_t *dt,
                                int target,

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2011-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -583,7 +585,7 @@ ompi_osc_portals4_attach(struct ompi_win_t *win, void *base, size_t len)
 
 
 int
-ompi_osc_portals4_detach(struct ompi_win_t *win, void *base)
+ompi_osc_portals4_detach(struct ompi_win_t *win, const void *base)
 {
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -12,6 +12,8 @@
  *                         reserved.
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -246,7 +248,7 @@ OBJ_CLASS_DECLARATION(ompi_osc_pt2pt_pending_t);
 extern bool ompi_osc_pt2pt_no_locks;
 
 int ompi_osc_pt2pt_attach(struct ompi_win_t *win, void *base, size_t len);
-int ompi_osc_pt2pt_detach(struct ompi_win_t *win, void *base);
+int ompi_osc_pt2pt_detach(struct ompi_win_t *win, const void *base);
 
 int ompi_osc_pt2pt_free(struct ompi_win_t *win);
 
@@ -278,15 +280,15 @@ int ompi_osc_pt2pt_get(void *origin_addr,
                              struct ompi_datatype_t *target_dt,
                              struct ompi_win_t *win);
 
-int ompi_osc_pt2pt_compare_and_swap(void *origin_addr,
-                                   void *compare_addr,
+int ompi_osc_pt2pt_compare_and_swap(const void *origin_addr,
+                                   const void *compare_addr,
                                    void *result_addr,
                                    struct ompi_datatype_t *dt,
                                    int target,
                                    OPAL_PTRDIFF_TYPE target_disp,
                                    struct ompi_win_t *win);
 
-int ompi_osc_pt2pt_fetch_and_op(void *origin_addr,
+int ompi_osc_pt2pt_fetch_and_op(const void *origin_addr,
                                void *result_addr,
                                struct ompi_datatype_t *dt,
                                int target,
@@ -294,7 +296,7 @@ int ompi_osc_pt2pt_fetch_and_op(void *origin_addr,
                                struct ompi_op_t *op,
                                struct ompi_win_t *win);
 
-int ompi_osc_pt2pt_get_accumulate(void *origin_addr,
+int ompi_osc_pt2pt_get_accumulate(const void *origin_addr,
                                  int origin_count,
                                  struct ompi_datatype_t *origin_datatype,
                                  void *result_addr,
@@ -327,7 +329,7 @@ int ompi_osc_pt2pt_rget(void *origin_addr,
                        struct ompi_win_t *win,
                        struct ompi_request_t **request);
 
-int ompi_osc_pt2pt_raccumulate(void *origin_addr,
+int ompi_osc_pt2pt_raccumulate(const void *origin_addr,
                               int origin_count,
                               struct ompi_datatype_t *origin_dt,
                               int target,
@@ -405,7 +407,7 @@ int ompi_osc_pt2pt_component_irecv(ompi_osc_pt2pt_module_t *module,
                                   struct ompi_communicator_t *comm);
 
 int ompi_osc_pt2pt_component_isend(ompi_osc_pt2pt_module_t *module,
-                                  void *buf,
+                                  const void *buf,
                                   size_t count,
                                   struct ompi_datatype_t *datatype,
                                   int dest,
@@ -565,7 +567,7 @@ static inline void osc_pt2pt_copy_on_recv (void *target, void *source, size_t so
  *       buffer. The copy is done with a convertor generated from proc,
  *       datatype, and count.
  */
-static inline void osc_pt2pt_copy_for_send (void *target, size_t target_len, void *source, ompi_proc_t *proc,
+static inline void osc_pt2pt_copy_for_send (void *target, size_t target_len, const void *source, ompi_proc_t *proc,
                                            int count, ompi_datatype_t *datatype)
 {
     opal_convertor_t convertor;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -252,7 +252,7 @@ int ompi_osc_pt2pt_detach(struct ompi_win_t *win, const void *base);
 
 int ompi_osc_pt2pt_free(struct ompi_win_t *win);
 
-int ompi_osc_pt2pt_put(void *origin_addr,
+int ompi_osc_pt2pt_put(const void *origin_addr,
                              int origin_count,
                              struct ompi_datatype_t *origin_dt,
                              int target,
@@ -261,7 +261,7 @@ int ompi_osc_pt2pt_put(void *origin_addr,
                              struct ompi_datatype_t *target_dt,
                              struct ompi_win_t *win);
 
-int ompi_osc_pt2pt_accumulate(void *origin_addr,
+int ompi_osc_pt2pt_accumulate(const void *origin_addr,
                                     int origin_count,
                                     struct ompi_datatype_t *origin_dt,
                                     int target,
@@ -309,7 +309,7 @@ int ompi_osc_pt2pt_get_accumulate(const void *origin_addr,
                                  struct ompi_op_t *op,
                                  struct ompi_win_t *win);
 
-int ompi_osc_pt2pt_rput(void *origin_addr,
+int ompi_osc_pt2pt_rput(const void *origin_addr,
                        int origin_count,
                        struct ompi_datatype_t *origin_dt,
                        int target,
@@ -340,7 +340,7 @@ int ompi_osc_pt2pt_raccumulate(const void *origin_addr,
                               struct ompi_win_t *win,
                               struct ompi_request_t **request);
 
-int ompi_osc_pt2pt_rget_accumulate(void *origin_addr,
+int ompi_osc_pt2pt_rget_accumulate(const void *origin_addr,
                                   int origin_count,
                                   struct ompi_datatype_t *origin_datatype,
                                   void *result_addr,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
@@ -150,7 +150,7 @@ static inline int ompi_osc_pt2pt_get_self (void *target, int target_count, ompi_
     return OMPI_SUCCESS;
 }
 
-static inline int ompi_osc_pt2pt_cas_self (void *source, void *compare, void *result, ompi_datatype_t *datatype,
+static inline int ompi_osc_pt2pt_cas_self (const void *source, const void *compare, void *result, ompi_datatype_t *datatype,
                                           OPAL_PTRDIFF_TYPE target_disp, ompi_osc_pt2pt_module_t *module)
 {
     void *target = (unsigned char*) module->baseptr +
@@ -182,7 +182,7 @@ static inline int ompi_osc_pt2pt_cas_self (void *source, void *compare, void *re
     return OMPI_SUCCESS;
 }
 
-static inline int ompi_osc_pt2pt_acc_self (void *source, int source_count, ompi_datatype_t *source_datatype,
+static inline int ompi_osc_pt2pt_acc_self (const void *source, int source_count, ompi_datatype_t *source_datatype,
                                           OPAL_PTRDIFF_TYPE target_disp, int target_count, ompi_datatype_t *target_datatype,
                                           ompi_op_t *op, ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_request_t *request)
 {
@@ -208,7 +208,7 @@ static inline int ompi_osc_pt2pt_acc_self (void *source, int source_count, ompi_
     if (&ompi_mpi_op_replace.op != op) {
         ret = ompi_osc_base_sndrcv_op (source, source_count, source_datatype, target, target_count, target_datatype, op);
     } else {
-        ret = ompi_datatype_sndrcv (source, source_count, source_datatype, target, target_count, target_datatype);
+        ret = ompi_datatype_sndrcv ((void *)source, source_count, source_datatype, target, target_count, target_datatype);
     }
 
     ompi_osc_pt2pt_accumulate_unlock (module);
@@ -226,7 +226,7 @@ static inline int ompi_osc_pt2pt_acc_self (void *source, int source_count, ompi_
     return OMPI_SUCCESS;
 }
 
-static inline int ompi_osc_pt2pt_gacc_self (void *source, int source_count, ompi_datatype_t *source_datatype,
+static inline int ompi_osc_pt2pt_gacc_self (const void *source, int source_count, ompi_datatype_t *source_datatype,
                                            void *result, int result_count, ompi_datatype_t *result_datatype,
                                            OPAL_PTRDIFF_TYPE target_disp, int target_count, ompi_datatype_t *target_datatype,
                                            ompi_op_t *op, ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_request_t *request)
@@ -264,7 +264,7 @@ static inline int ompi_osc_pt2pt_gacc_self (void *source, int source_count, ompi
             if (&ompi_mpi_op_replace.op != op) {
                 ret = ompi_osc_base_sndrcv_op (source, source_count, source_datatype, target, target_count, target_datatype, op);
             } else {
-                ret = ompi_datatype_sndrcv (source, source_count, source_datatype, target, target_count, target_datatype);
+                ret = ompi_datatype_sndrcv ((void *)source, source_count, source_datatype, target, target_count, target_datatype);
             }
         }
 
@@ -463,7 +463,7 @@ ompi_osc_pt2pt_put(void *origin_addr, int origin_count,
 
 
 static int
-ompi_osc_pt2pt_accumulate_w_req (void *origin_addr, int origin_count,
+ompi_osc_pt2pt_accumulate_w_req (const void *origin_addr, int origin_count,
                                 struct ompi_datatype_t *origin_dt,
                                 int target, OPAL_PTRDIFF_TYPE target_disp,
                                 int target_count,
@@ -647,7 +647,7 @@ ompi_osc_pt2pt_accumulate(void *origin_addr, int origin_count,
                                            target_dt, op, win, NULL);
 }
 
-int ompi_osc_pt2pt_compare_and_swap (void *origin_addr, void *compare_addr,
+int ompi_osc_pt2pt_compare_and_swap (const void *origin_addr, const void *compare_addr,
                                     void *result_addr, struct ompi_datatype_t *dt,
                                     int target, OPAL_PTRDIFF_TYPE target_disp,
                                     struct ompi_win_t *win)
@@ -737,7 +737,7 @@ int ompi_osc_pt2pt_compare_and_swap (void *origin_addr, void *compare_addr,
 }
 
 
-int ompi_osc_pt2pt_fetch_and_op(void *origin_addr, void *result_addr,
+int ompi_osc_pt2pt_fetch_and_op(const void *origin_addr, void *result_addr,
                                struct ompi_datatype_t *dt, int target,
                                OPAL_PTRDIFF_TYPE target_disp, struct ompi_op_t *op,
                                struct ompi_win_t *win)
@@ -956,7 +956,7 @@ int ompi_osc_pt2pt_get (void *origin_addr, int origin_count, struct ompi_datatyp
                                         target_count, target_dt, win, true, &request);
 }
 
-int ompi_osc_pt2pt_raccumulate(void *origin_addr, int origin_count,
+int ompi_osc_pt2pt_raccumulate(const void *origin_addr, int origin_count,
                               struct ompi_datatype_t *origin_dt, int target,
                               OPAL_PTRDIFF_TYPE target_disp, int target_count,
                               struct ompi_datatype_t *target_dt, struct ompi_op_t *op,
@@ -1001,7 +1001,7 @@ int ompi_osc_pt2pt_raccumulate(void *origin_addr, int origin_count,
 
 
 static inline
-int ompi_osc_pt2pt_rget_accumulate_internal (void *origin_addr, int origin_count,
+int ompi_osc_pt2pt_rget_accumulate_internal (const void *origin_addr, int origin_count,
                                             struct ompi_datatype_t *origin_datatype,
                                             void *result_addr, int result_count,
                                             struct ompi_datatype_t *result_datatype,
@@ -1188,7 +1188,7 @@ int ompi_osc_pt2pt_rget_accumulate_internal (void *origin_addr, int origin_count
     return ret;
 }
 
-int ompi_osc_pt2pt_get_accumulate(void *origin_addr, int origin_count,
+int ompi_osc_pt2pt_get_accumulate(const void *origin_addr, int origin_count,
                                  struct ompi_datatype_t *origin_dt,
                                  void *result_addr, int result_count,
                                  struct ompi_datatype_t *result_dt,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
@@ -82,7 +82,7 @@ static int ompi_osc_pt2pt_dt_send_complete (ompi_request_t *request)
 }
 
 /* self communication optimizations */
-static inline int ompi_osc_pt2pt_put_self (void *source, int source_count, ompi_datatype_t *source_datatype,
+static inline int ompi_osc_pt2pt_put_self (const void *source, int source_count, ompi_datatype_t *source_datatype,
                                           OPAL_PTRDIFF_TYPE target_disp, int target_count, ompi_datatype_t *target_datatype,
                                           ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_request_t *request)
 {
@@ -103,7 +103,7 @@ static inline int ompi_osc_pt2pt_put_self (void *source, int source_count, ompi_
         return OMPI_ERR_RMA_SYNC;
     }
 
-    ret = ompi_datatype_sndrcv (source, source_count, source_datatype,
+    ret = ompi_datatype_sndrcv ((void *)source, source_count, source_datatype,
                                 target, target_count, target_datatype);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
         return ret;
@@ -286,7 +286,7 @@ static inline int ompi_osc_pt2pt_gacc_self (const void *source, int source_count
 }
 /* end: self communication optimizations */
 
-static inline int ompi_osc_pt2pt_put_w_req (void *origin_addr, int origin_count,
+static inline int ompi_osc_pt2pt_put_w_req (const void *origin_addr, int origin_count,
                                            struct ompi_datatype_t *origin_dt,
                                            int target, OPAL_PTRDIFF_TYPE target_disp,
                                            int target_count, struct ompi_datatype_t *target_dt,
@@ -450,7 +450,7 @@ static inline int ompi_osc_pt2pt_put_w_req (void *origin_addr, int origin_count,
 }
 
 int
-ompi_osc_pt2pt_put(void *origin_addr, int origin_count,
+ompi_osc_pt2pt_put(const void *origin_addr, int origin_count,
                   struct ompi_datatype_t *origin_dt,
                   int target, OPAL_PTRDIFF_TYPE target_disp,
                   int target_count,
@@ -635,7 +635,7 @@ ompi_osc_pt2pt_accumulate_w_req (const void *origin_addr, int origin_count,
 }
 
 int
-ompi_osc_pt2pt_accumulate(void *origin_addr, int origin_count,
+ompi_osc_pt2pt_accumulate(const void *origin_addr, int origin_count,
                          struct ompi_datatype_t *origin_dt,
                          int target, OPAL_PTRDIFF_TYPE target_disp,
                          int target_count,
@@ -746,7 +746,7 @@ int ompi_osc_pt2pt_fetch_and_op(const void *origin_addr, void *result_addr,
                                         target, target_disp, 1, dt, op, win);
 }
 
-int ompi_osc_pt2pt_rput(void *origin_addr, int origin_count,
+int ompi_osc_pt2pt_rput(const void *origin_addr, int origin_count,
                        struct ompi_datatype_t *origin_dt,
                        int target, OPAL_PTRDIFF_TYPE target_disp,
                        int target_count, struct ompi_datatype_t *target_dt,
@@ -1205,7 +1205,7 @@ int ompi_osc_pt2pt_get_accumulate(const void *origin_addr, int origin_count,
 }
 
 
-int ompi_osc_pt2pt_rget_accumulate(void *origin_addr, int origin_count,
+int ompi_osc_pt2pt_rget_accumulate(const void *origin_addr, int origin_count,
                                   struct ompi_datatype_t *origin_dt,
                                   void *result_addr, int result_count,
                                   struct ompi_datatype_t *result_dt,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -1724,7 +1724,7 @@ isend_completion_cb(ompi_request_t *request)
 }
 
 
-int ompi_osc_pt2pt_component_isend (ompi_osc_pt2pt_module_t *module, void *buf,
+int ompi_osc_pt2pt_component_isend (ompi_osc_pt2pt_module_t *module, const void *buf,
                                     size_t count, struct ompi_datatype_t *datatype,
                                     int dest, int tag, struct ompi_communicator_t *comm)
 {
@@ -1732,7 +1732,7 @@ int ompi_osc_pt2pt_component_isend (ompi_osc_pt2pt_module_t *module, void *buf,
                                      isend_completion_cb, module);
 }
 
-int ompi_osc_pt2pt_isend_w_cb (void *ptr, int count, ompi_datatype_t *datatype, int target, int tag,
+int ompi_osc_pt2pt_isend_w_cb (const void *ptr, int count, ompi_datatype_t *datatype, int target, int tag,
                               ompi_communicator_t *comm, ompi_request_complete_fn_t cb, void *ctx)
 {
     ompi_request_t *request;
@@ -1742,7 +1742,7 @@ int ompi_osc_pt2pt_isend_w_cb (void *ptr, int count, ompi_datatype_t *datatype, 
                          "osc pt2pt: ompi_osc_pt2pt_isend_w_cb sending %d bytes to %d with tag %d",
                          count, target, tag));
 
-    ret = MCA_PML_CALL(isend_init(ptr, count, datatype, target, tag,
+    ret = MCA_PML_CALL(isend_init((void *)ptr, count, datatype, target, tag,
                                   MCA_PML_BASE_SEND_STANDARD, comm, &request));
     if (OMPI_SUCCESS != ret) {
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.h
@@ -11,6 +11,8 @@
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,7 +68,7 @@ int ompi_osc_pt2pt_control_send_unbuffered (ompi_osc_pt2pt_module_t *module,
  * be called with the associated request. The context specified in ctx will be stored in
  * the req_completion_cb_data member of the ompi_request_t for use by the callback.
  */
-int ompi_osc_pt2pt_isend_w_cb (void *ptr, int count, ompi_datatype_t *datatype, int target, int tag,
+int ompi_osc_pt2pt_isend_w_cb (const void *ptr, int count, ompi_datatype_t *datatype, int target, int tag,
                               ompi_communicator_t *comm, ompi_request_complete_fn_t cb, void *ctx);
 
 /**

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
@@ -11,6 +11,8 @@
  * Copyright (c) 2007-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +40,7 @@ ompi_osc_pt2pt_attach(struct ompi_win_t *win, void *base, size_t len)
 
 
 int
-ompi_osc_pt2pt_detach(struct ompi_win_t *win, void *base)
+ompi_osc_pt2pt_detach(struct ompi_win_t *win, const void *base)
 {
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_request.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_request.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +24,7 @@ struct ompi_osc_pt2pt_request_t {
     ompi_request_t super;
 
     int type;
-    void *origin_addr;
+    const void *origin_addr;
     int origin_count;
     struct ompi_datatype_t *origin_dt;
     ompi_osc_pt2pt_module_t* module;

--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -91,7 +91,7 @@ int ompi_osc_sm_detach(struct ompi_win_t *win, const void *base);
 
 int ompi_osc_sm_free(struct ompi_win_t *win);
 
-int ompi_osc_sm_put(void *origin_addr,
+int ompi_osc_sm_put(const void *origin_addr,
                           int origin_count,
                           struct ompi_datatype_t *origin_dt,
                           int target,
@@ -109,7 +109,7 @@ int ompi_osc_sm_get(void *origin_addr,
                           struct ompi_datatype_t *target_dt,
                           struct ompi_win_t *win);
 
-int ompi_osc_sm_accumulate(void *origin_addr,
+int ompi_osc_sm_accumulate(const void *origin_addr,
                                  int origin_count,
                                  struct ompi_datatype_t *origin_dt,
                                  int target,
@@ -148,7 +148,7 @@ int ompi_osc_sm_get_accumulate(const void *origin_addr,
                                      struct ompi_op_t *op,
                                      struct ompi_win_t *win);
 
-int ompi_osc_sm_rput(void *origin_addr,
+int ompi_osc_sm_rput(const void *origin_addr,
                            int origin_count,
                            struct ompi_datatype_t *origin_dt,
                            int target,
@@ -179,7 +179,7 @@ int ompi_osc_sm_raccumulate(const void *origin_addr,
                                   struct ompi_win_t *win,
                                   struct ompi_request_t **request);
 
-int ompi_osc_sm_rget_accumulate(void *origin_addr,
+int ompi_osc_sm_rget_accumulate(const void *origin_addr,
                                       int origin_count,
                                       struct ompi_datatype_t *origin_datatype,
                                       void *result_addr,

--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -87,7 +87,7 @@ typedef struct ompi_osc_sm_module_t ompi_osc_sm_module_t;
 int ompi_osc_sm_shared_query(struct ompi_win_t *win, int rank, size_t *size, int *disp_unit, void *baseptr);
 
 int ompi_osc_sm_attach(struct ompi_win_t *win, void *base, size_t len);
-int ompi_osc_sm_detach(struct ompi_win_t *win, void *base);
+int ompi_osc_sm_detach(struct ompi_win_t *win, const void *base);
 
 int ompi_osc_sm_free(struct ompi_win_t *win);
 
@@ -119,15 +119,15 @@ int ompi_osc_sm_accumulate(void *origin_addr,
                                  struct ompi_op_t *op,
                                  struct ompi_win_t *win);
 
-int ompi_osc_sm_compare_and_swap(void *origin_addr,
-                                       void *compare_addr,
+int ompi_osc_sm_compare_and_swap(const void *origin_addr,
+                                       const void *compare_addr,
                                        void *result_addr,
                                        struct ompi_datatype_t *dt,
                                        int target,
                                        OPAL_PTRDIFF_TYPE target_disp,
                                        struct ompi_win_t *win);
 
-int ompi_osc_sm_fetch_and_op(void *origin_addr,
+int ompi_osc_sm_fetch_and_op(const void *origin_addr,
                                    void *result_addr,
                                    struct ompi_datatype_t *dt,
                                    int target,
@@ -135,7 +135,7 @@ int ompi_osc_sm_fetch_and_op(void *origin_addr,
                                    struct ompi_op_t *op,
                                    struct ompi_win_t *win);
 
-int ompi_osc_sm_get_accumulate(void *origin_addr,
+int ompi_osc_sm_get_accumulate(const void *origin_addr,
                                      int origin_count,
                                      struct ompi_datatype_t *origin_datatype,
                                      void *result_addr,
@@ -168,7 +168,7 @@ int ompi_osc_sm_rget(void *origin_addr,
                            struct ompi_win_t *win,
                            struct ompi_request_t **request);
 
-int ompi_osc_sm_raccumulate(void *origin_addr,
+int ompi_osc_sm_raccumulate(const void *origin_addr,
                                   int origin_count,
                                   struct ompi_datatype_t *origin_dt,
                                   int target,

--- a/ompi/mca/osc/sm/osc_sm_comm.c
+++ b/ompi/mca/osc/sm/osc_sm_comm.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2011      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,7 +101,7 @@ ompi_osc_sm_rget(void *origin_addr,
 
 
 int
-ompi_osc_sm_raccumulate(void *origin_addr,
+ompi_osc_sm_raccumulate(const void *origin_addr,
                         int origin_count,
                         struct ompi_datatype_t *origin_dt,
                         int target,
@@ -127,7 +129,7 @@ ompi_osc_sm_raccumulate(void *origin_addr,
 
     opal_atomic_lock(&module->node_states[target].accumulate_lock);
     if (op == &ompi_mpi_op_replace.op) {
-        ret = ompi_datatype_sndrcv(origin_addr, origin_count, origin_dt,
+        ret = ompi_datatype_sndrcv((void *)origin_addr, origin_count, origin_dt,
                                     remote_address, target_count, target_dt);
     } else {
         ret = ompi_osc_base_sndrcv_op(origin_addr, origin_count, origin_dt,
@@ -307,7 +309,7 @@ ompi_osc_sm_accumulate(void *origin_addr,
 
 
 int
-ompi_osc_sm_get_accumulate(void *origin_addr,
+ompi_osc_sm_get_accumulate(const void *origin_addr,
                            int origin_count,
                            struct ompi_datatype_t *origin_dt,
                            void *result_addr,
@@ -342,7 +344,7 @@ ompi_osc_sm_get_accumulate(void *origin_addr,
     if (OMPI_SUCCESS != ret || op == &ompi_mpi_op_no_op.op) goto done;
 
     if (op == &ompi_mpi_op_replace.op) {
-        ret = ompi_datatype_sndrcv(origin_addr, origin_count, origin_dt,
+        ret = ompi_datatype_sndrcv((void *)origin_addr, origin_count, origin_dt,
                                    remote_address, target_count, target_dt);
     } else {
         ret = ompi_osc_base_sndrcv_op(origin_addr, origin_count, origin_dt,
@@ -358,8 +360,8 @@ ompi_osc_sm_get_accumulate(void *origin_addr,
 
 
 int
-ompi_osc_sm_compare_and_swap(void *origin_addr,
-                             void *compare_addr,
+ompi_osc_sm_compare_and_swap(const void *origin_addr,
+                             const void *compare_addr,
                              void *result_addr,
                              struct ompi_datatype_t *dt,
                              int target,
@@ -398,7 +400,7 @@ ompi_osc_sm_compare_and_swap(void *origin_addr,
 
 
 int
-ompi_osc_sm_fetch_and_op(void *origin_addr,
+ompi_osc_sm_fetch_and_op(const void *origin_addr,
                          void *result_addr,
                          struct ompi_datatype_t *dt,
                          int target,
@@ -429,7 +431,7 @@ ompi_osc_sm_fetch_and_op(void *origin_addr,
     if (op == &ompi_mpi_op_replace.op) {
         ompi_datatype_copy_content_same_ddt(dt, 1, (char*) remote_address, (char*) origin_addr);
     } else {
-        ompi_op_reduce(op, origin_addr, remote_address, 1, dt);
+        ompi_op_reduce(op, (void *)origin_addr, remote_address, 1, dt);
     }
 
  done:

--- a/ompi/mca/osc/sm/osc_sm_comm.c
+++ b/ompi/mca/osc/sm/osc_sm_comm.c
@@ -21,7 +21,7 @@
 #include "osc_sm.h"
 
 int
-ompi_osc_sm_rput(void *origin_addr,
+ompi_osc_sm_rput(const void *origin_addr,
                  int origin_count,
                  struct ompi_datatype_t *origin_dt,
                  int target,
@@ -45,7 +45,7 @@ ompi_osc_sm_rput(void *origin_addr,
 
     remote_address = ((char*) (module->bases[target])) + module->disp_units[target] * target_disp;
 
-    ret = ompi_datatype_sndrcv(origin_addr, origin_count, origin_dt,
+    ret = ompi_datatype_sndrcv((void *)origin_addr, origin_count, origin_dt,
                                remote_address, target_count, target_dt);
     if (OMPI_SUCCESS != ret) {
         return ret;
@@ -149,7 +149,7 @@ ompi_osc_sm_raccumulate(const void *origin_addr,
 
 
 int
-ompi_osc_sm_rget_accumulate(void *origin_addr,
+ompi_osc_sm_rget_accumulate(const void *origin_addr,
                                   int origin_count,
                                   struct ompi_datatype_t *origin_dt,
                                   void *result_addr,
@@ -185,7 +185,7 @@ ompi_osc_sm_rget_accumulate(void *origin_addr,
     if (OMPI_SUCCESS != ret || op == &ompi_mpi_op_no_op.op) goto done;
 
     if (op == &ompi_mpi_op_replace.op) {
-        ret = ompi_datatype_sndrcv(origin_addr, origin_count, origin_dt,
+        ret = ompi_datatype_sndrcv((void *)origin_addr, origin_count, origin_dt,
                                    remote_address, target_count, target_dt);
     } else {
         ret = ompi_osc_base_sndrcv_op(origin_addr, origin_count, origin_dt,
@@ -206,7 +206,7 @@ ompi_osc_sm_rget_accumulate(void *origin_addr,
 
 
 int
-ompi_osc_sm_put(void *origin_addr,
+ompi_osc_sm_put(const void *origin_addr,
                       int origin_count,
                       struct ompi_datatype_t *origin_dt,
                       int target,
@@ -229,7 +229,7 @@ ompi_osc_sm_put(void *origin_addr,
 
     remote_address = ((char*) (module->bases[target])) + module->disp_units[target] * target_disp;
 
-    ret = ompi_datatype_sndrcv(origin_addr, origin_count, origin_dt,
+    ret = ompi_datatype_sndrcv((void *)origin_addr, origin_count, origin_dt,
                                remote_address, target_count, target_dt);
 
     return ret;
@@ -268,7 +268,7 @@ ompi_osc_sm_get(void *origin_addr,
 
 
 int
-ompi_osc_sm_accumulate(void *origin_addr,
+ompi_osc_sm_accumulate(const void *origin_addr,
                        int origin_count,
                        struct ompi_datatype_t *origin_dt,
                        int target,
@@ -295,7 +295,7 @@ ompi_osc_sm_accumulate(void *origin_addr,
 
     opal_atomic_lock(&module->node_states[target].accumulate_lock);
     if (op == &ompi_mpi_op_replace.op) {
-        ret = ompi_datatype_sndrcv(origin_addr, origin_count, origin_dt,
+        ret = ompi_datatype_sndrcv((void *)origin_addr, origin_count, origin_dt,
                                     remote_address, target_count, target_dt);
     } else {
         ret = ompi_osc_base_sndrcv_op(origin_addr, origin_count, origin_dt,

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -4,7 +4,9 @@
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -424,7 +426,7 @@ ompi_osc_sm_attach(struct ompi_win_t *win, void *base, size_t len)
 
 
 int
-ompi_osc_sm_detach(struct ompi_win_t *win, void *base)
+ompi_osc_sm_detach(struct ompi_win_t *win, const void *base)
 {
     ompi_osc_sm_module_t *module =
         (ompi_osc_sm_module_t*) win->w_osc_module;

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -134,10 +134,8 @@ check_win_ok(ompi_communicator_t *comm, int flavor)
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
-    for (i = 0 ; i < ompi_comm_size(comm) ; ++i) {
-        if (!OPAL_PROC_ON_LOCAL_NODE(ompi_comm_peer_lookup(comm, i)->super.proc_flags)) {
-            return OMPI_ERR_RMA_SHARED;
-        }
+    if (ompi_group_have_remote_peers (comm->c_local_group)) {
+        return OMPI_ERR_RMA_SHARED;
     }
 
     return OMPI_SUCCESS;

--- a/ompi/mca/pml/ob1/pml_ob1_comm.c
+++ b/ompi/mca/pml/ob1/pml_ob1_comm.c
@@ -40,14 +40,15 @@ static void mca_pml_ob1_comm_proc_destruct(mca_pml_ob1_comm_proc_t* proc)
     OBJ_DESTRUCT(&proc->frags_cant_match);
     OBJ_DESTRUCT(&proc->specific_receives);
     OBJ_DESTRUCT(&proc->unexpected_frags);
+    if (proc->ompi_proc) {
+        OBJ_RELEASE(proc->ompi_proc);
+    }
 }
 
 
-static OBJ_CLASS_INSTANCE(
-    mca_pml_ob1_comm_proc_t,
-    opal_object_t,
-    mca_pml_ob1_comm_proc_construct,
-    mca_pml_ob1_comm_proc_destruct);
+OBJ_CLASS_INSTANCE(mca_pml_ob1_comm_proc_t, opal_object_t,
+                   mca_pml_ob1_comm_proc_construct,
+                   mca_pml_ob1_comm_proc_destruct);
 
 
 static void mca_pml_ob1_comm_construct(mca_pml_ob1_comm_t* comm)
@@ -63,11 +64,16 @@ static void mca_pml_ob1_comm_construct(mca_pml_ob1_comm_t* comm)
 
 static void mca_pml_ob1_comm_destruct(mca_pml_ob1_comm_t* comm)
 {
-    size_t i;
-    for(i=0; i<comm->num_procs; i++)
-        OBJ_DESTRUCT((&comm->procs[i]));
-    if(NULL != comm->procs)
+    if (NULL != comm->procs) {
+        for (size_t i = 0; i < comm->num_procs; ++i) {
+            if (comm->procs[i]) {
+                OBJ_RELEASE(comm->procs[i]);
+            }
+        }
+
         free(comm->procs);
+    }
+
     OBJ_DESTRUCT(&comm->wild_receives);
     OBJ_DESTRUCT(&comm->matching_lock);
 }
@@ -80,17 +86,12 @@ OBJ_CLASS_INSTANCE(
     mca_pml_ob1_comm_destruct);
 
 
-int mca_pml_ob1_comm_init_size(mca_pml_ob1_comm_t* comm, size_t size)
+int mca_pml_ob1_comm_init_size (mca_pml_ob1_comm_t* comm, size_t size)
 {
-    size_t i;
-
     /* send message sequence-number support - sender side */
-    comm->procs = (mca_pml_ob1_comm_proc_t*)malloc(sizeof(mca_pml_ob1_comm_proc_t)*size);
+    comm->procs = (mca_pml_ob1_comm_proc_t **) calloc(size, sizeof (mca_pml_ob1_comm_proc_t *));
     if(NULL == comm->procs) {
         return OMPI_ERR_OUT_OF_RESOURCE;
-    }
-    for(i=0; i<size; i++) {
-        OBJ_CONSTRUCT(comm->procs+i, mca_pml_ob1_comm_proc_t);
     }
     comm->num_procs = size;
     return OMPI_SUCCESS;

--- a/ompi/mca/pml/ob1/pml_ob1_component.c
+++ b/ompi/mca/pml/ob1/pml_ob1_component.c
@@ -144,9 +144,12 @@ static int mca_pml_ob1_get_unex_msgq_size (const struct mca_base_pvar_t *pvar, v
     int i;
 
     for (i = 0 ; i < comm_size ; ++i) {
-        pml_proc = pml_comm->procs + i;
-
-        values[i] = opal_list_get_size (&pml_proc->unexpected_frags);
+        pml_proc = pml_comm->procs[i];
+        if (pml_proc) {
+            values[i] = opal_list_get_size (&pml_proc->unexpected_frags);
+        } else {
+            values[i] = 0;
+        }
     }
 
     return OMPI_SUCCESS;
@@ -162,9 +165,13 @@ static int mca_pml_ob1_get_posted_recvq_size (const struct mca_base_pvar_t *pvar
     int i;
 
     for (i = 0 ; i < comm_size ; ++i) {
-        pml_proc = pml_comm->procs + i;
+        pml_proc = pml_comm->procs[i];
 
-        values[i] = opal_list_get_size (&pml_proc->specific_receives);
+        if (pml_proc) {
+            values[i] = opal_list_get_size (&pml_proc->specific_receives);
+        } else {
+            values[i] = 0;
+        }
     }
 
     return OMPI_SUCCESS;

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -146,7 +146,6 @@ mca_pml_ob1_imrecv( void *buf,
     int src, tag;
     ompi_communicator_t *comm;
     mca_pml_ob1_comm_proc_t* proc;
-    mca_pml_ob1_comm_t* ob1_comm;
     uint64_t seq;
 
     /* get the request from the message and the frag from the request
@@ -156,7 +155,6 @@ mca_pml_ob1_imrecv( void *buf,
     src = recvreq->req_recv.req_base.req_ompi.req_status.MPI_SOURCE;
     tag = recvreq->req_recv.req_base.req_ompi.req_status.MPI_TAG;
     comm = (*message)->comm;
-    ob1_comm = recvreq->req_recv.req_base.req_comm->c_pml_comm;
     seq = recvreq->req_recv.req_base.req_sequence;
 
     /* make the request a recv request again */
@@ -194,7 +192,7 @@ mca_pml_ob1_imrecv( void *buf,
     /* Note - sequence number already assigned */
     recvreq->req_recv.req_base.req_sequence = seq;
 
-    proc = &ob1_comm->procs[recvreq->req_recv.req_base.req_peer];
+    proc = mca_pml_ob1_peer_lookup (comm, recvreq->req_recv.req_base.req_peer);
     recvreq->req_recv.req_base.req_proc = proc->ompi_proc;
     prepare_recv_req_converter(recvreq);
 
@@ -241,7 +239,6 @@ mca_pml_ob1_mrecv( void *buf,
     int src, tag, rc;
     ompi_communicator_t *comm;
     mca_pml_ob1_comm_proc_t* proc;
-    mca_pml_ob1_comm_t* ob1_comm;
     uint64_t seq;
 
     /* get the request from the message and the frag from the request
@@ -252,7 +249,6 @@ mca_pml_ob1_mrecv( void *buf,
     src = recvreq->req_recv.req_base.req_ompi.req_status.MPI_SOURCE;
     tag = recvreq->req_recv.req_base.req_ompi.req_status.MPI_TAG;
     seq = recvreq->req_recv.req_base.req_sequence;
-    ob1_comm = recvreq->req_recv.req_base.req_comm->c_pml_comm;
 
     /* make the request a recv request again */
     /* The old request kept pointers to comm and the char datatype.
@@ -288,7 +284,7 @@ mca_pml_ob1_mrecv( void *buf,
     /* Note - sequence number already assigned */
     recvreq->req_recv.req_base.req_sequence = seq;
 
-    proc = &ob1_comm->procs[recvreq->req_recv.req_base.req_peer];
+    proc = mca_pml_ob1_peer_lookup (comm, recvreq->req_recv.req_base.req_peer);
     recvreq->req_recv.req_base.req_proc = proc->ompi_proc;
     prepare_recv_req_converter(recvreq);
 

--- a/ompi/mca/pml/ob1/pml_ob1_isend.c
+++ b/ompi/mca/pml/ob1/pml_ob1_isend.c
@@ -126,15 +126,14 @@ int mca_pml_ob1_isend(void *buf,
                       ompi_communicator_t * comm,
                       ompi_request_t ** request)
 {
-    mca_pml_ob1_comm_t* ob1_comm = comm->c_pml_comm;
+    mca_pml_ob1_comm_proc_t *ob1_proc = mca_pml_ob1_peer_lookup (comm, dst);
     mca_pml_ob1_send_request_t *sendreq = NULL;
-    ompi_proc_t *dst_proc = ompi_comm_peer_lookup (comm, dst);
-    mca_bml_base_endpoint_t* endpoint = (mca_bml_base_endpoint_t*)
-                                        dst_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
+    ompi_proc_t *dst_proc = ob1_proc->ompi_proc;
+    mca_bml_base_endpoint_t* endpoint = mca_bml_base_get_endpoint (dst_proc);
     int16_t seqn;
     int rc;
 
-    seqn = (uint16_t) OPAL_THREAD_ADD32(&ob1_comm->procs[dst].send_sequence, 1);
+    seqn = (uint16_t) OPAL_THREAD_ADD32(&ob1_proc->send_sequence, 1);
 
     if (MCA_PML_BASE_SEND_SYNCHRONOUS != sendmode) {
         rc = mca_pml_ob1_send_inline (buf, count, datatype, dst, tag, seqn, dst_proc,
@@ -176,10 +175,9 @@ int mca_pml_ob1_send(void *buf,
                      mca_pml_base_send_mode_t sendmode,
                      ompi_communicator_t * comm)
 {
-    mca_pml_ob1_comm_t* ob1_comm = comm->c_pml_comm;
-    ompi_proc_t *dst_proc = ompi_comm_peer_lookup (comm, dst);
-    mca_bml_base_endpoint_t* endpoint = (mca_bml_base_endpoint_t*)
-                                        dst_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
+    mca_pml_ob1_comm_proc_t *ob1_proc = mca_pml_ob1_peer_lookup (comm, dst);
+    ompi_proc_t *dst_proc = ob1_proc->ompi_proc;
+    mca_bml_base_endpoint_t* endpoint = mca_bml_base_get_endpoint (dst_proc);
     mca_pml_ob1_send_request_t *sendreq = NULL;
     int16_t seqn;
     int rc;
@@ -202,7 +200,7 @@ int mca_pml_ob1_send(void *buf,
         return OMPI_ERR_UNREACH;
     }
 
-    seqn = (uint16_t) OPAL_THREAD_ADD32(&ob1_comm->procs[dst].send_sequence, 1);
+    seqn = (uint16_t) OPAL_THREAD_ADD32(&ob1_proc->send_sequence, 1);
 
     /**
      * The immediate send will not have a request, so they are

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -143,7 +143,7 @@ void mca_pml_ob1_recv_frag_callback_match(mca_btl_base_module_t* btl,
     comm = (mca_pml_ob1_comm_t *)comm_ptr->c_pml_comm;
 
     /* source sequence number */
-    proc = &comm->procs[hdr->hdr_src];
+    proc = mca_pml_ob1_peer_lookup (comm_ptr, hdr->hdr_src);
 
     /* We generate the MSG_ARRIVED event as soon as the PML is aware
      * of a matching fragment arrival. Independing if it is received
@@ -650,7 +650,7 @@ static int mca_pml_ob1_recv_frag_match( mca_btl_base_module_t *btl,
 
     /* source sequence number */
     frag_msg_seq = hdr->hdr_seq;
-    proc = &comm->procs[hdr->hdr_src];
+    proc = mca_pml_ob1_peer_lookup (comm_ptr, hdr->hdr_src);
 
     /**
      * We generate the MSG_ARRIVED event as soon as the PML is aware of a matching

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -433,8 +433,7 @@ static inline int mca_pml_ob1_recv_request_ack_send(ompi_proc_t* proc,
 {
     size_t i;
     mca_bml_base_btl_t* bml_btl;
-    mca_bml_base_endpoint_t* endpoint =
-        (mca_bml_base_endpoint_t*)proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
+    mca_bml_base_endpoint_t* endpoint = mca_bml_base_get_endpoint (proc);
 
     for(i = 0; i < mca_bml_base_btl_array_get_size(&endpoint->btl_eager); i++) {
         bml_btl = mca_bml_base_btl_array_get_next(&endpoint->btl_eager);

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -480,16 +480,16 @@ mca_pml_ob1_send_request_start_seq (mca_pml_ob1_send_request_t* sendreq, mca_bml
 static inline int
 mca_pml_ob1_send_request_start( mca_pml_ob1_send_request_t* sendreq )
 {
-    mca_bml_base_endpoint_t* endpoint = (mca_bml_base_endpoint_t*)
-                                        sendreq->req_send.req_base.req_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_BML];
-    mca_pml_ob1_comm_t* comm = sendreq->req_send.req_base.req_comm->c_pml_comm;
+    mca_bml_base_endpoint_t *endpoint = mca_bml_base_get_endpoint (sendreq->req_send.req_base.req_proc);
+    ompi_communicator_t *comm = sendreq->req_send.req_base.req_comm;
+    mca_pml_ob1_comm_proc_t *ob1_proc = mca_pml_ob1_peer_lookup (comm, sendreq->req_send.req_base.req_peer);
     int32_t seqn;
 
     if (OPAL_UNLIKELY(NULL == endpoint)) {
         return OMPI_ERR_UNREACH;
     }
 
-    seqn = OPAL_THREAD_ADD32(&comm->procs[sendreq->req_send.req_base.req_peer].send_sequence, 1);
+    seqn = OPAL_THREAD_ADD32(&ob1_proc->send_sequence, 1);
 
     return mca_pml_ob1_send_request_start_seq (sendreq, endpoint, seqn);
 }

--- a/ompi/mpi/c/accumulate.c
+++ b/ompi/mpi/c/accumulate.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2009      Sun Microsystmes, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,8 +128,7 @@ int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origi
 
     OPAL_CR_ENTER_LIBRARY();
 
-    /* XXX -- CONST -- do not cast away const -- update mca/osc */
-    rc = ompi_win->w_osc_module->osc_accumulate((void *) origin_addr,
+    rc = ompi_win->w_osc_module->osc_accumulate(origin_addr,
                                                 origin_count,
                                                 origin_datatype,
                                                 target_rank,

--- a/ompi/mpi/c/compare_and_swap.c
+++ b/ompi/mpi/c/compare_and_swap.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +41,7 @@
 static const char FUNC_NAME[] = "MPI_Compare_and_swap";
 
 
-int MPI_Compare_and_swap(void *origin_addr, void *compare_addr, void *result_addr,
+int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr, void *result_addr,
                          MPI_Datatype datatype, int target_rank, MPI_Aint target_disp, MPI_Win win)
 {
     int rc;

--- a/ompi/mpi/c/fetch_and_op.c
+++ b/ompi/mpi/c/fetch_and_op.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +41,7 @@
 static const char FUNC_NAME[] = "MPI_Fetch_and_op";
 
 
-int MPI_Fetch_and_op(void *origin_addr, void *result_addr, MPI_Datatype datatype,
+int MPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype datatype,
                      int target_rank, MPI_Aint target_disp, MPI_Op op, MPI_Win win)
 {
     int rc;

--- a/ompi/mpi/c/get_accumulate.c
+++ b/ompi/mpi/c/get_accumulate.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -133,8 +135,7 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype o
 
     OPAL_CR_ENTER_LIBRARY();
 
-    /* XXX -- TODO: do not cast away the const */
-    rc = ompi_win->w_osc_module->osc_get_accumulate((void *) origin_addr,
+    rc = ompi_win->w_osc_module->osc_get_accumulate(origin_addr,
                                                     origin_count,
                                                     origin_datatype,
                                                     result_addr,

--- a/ompi/mpi/c/put.c
+++ b/ompi/mpi/c/put.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,8 +79,7 @@ int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype origin_datat
 
     OPAL_CR_ENTER_LIBRARY();
 
-    /* XXX -- CONST -- do not cast away const -- update mca/osc */
-    rc = win->w_osc_module->osc_put((void *) origin_addr, origin_count, origin_datatype,
+    rc = win->w_osc_module->osc_put(origin_addr, origin_count, origin_datatype,
                                     target_rank, target_disp, target_count,
                                     target_datatype, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);

--- a/ompi/mpi/c/raccumulate.c
+++ b/ompi/mpi/c/raccumulate.c
@@ -130,8 +130,7 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype orig
 
     OPAL_CR_ENTER_LIBRARY();
 
-    /* TODO: don't cast away the const */
-    rc = ompi_win->w_osc_module->osc_raccumulate((void*) origin_addr,
+    rc = ompi_win->w_osc_module->osc_raccumulate(origin_addr,
                                                 origin_count,
                                                 origin_datatype,
                                                 target_rank,

--- a/ompi/mpi/c/raccumulate.c
+++ b/ompi/mpi/c/raccumulate.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +45,7 @@
 
 static const char FUNC_NAME[] = "MPI_Raccumulate";
 
-int MPI_Raccumulate(void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
+int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype,
                    int target_rank, MPI_Aint target_disp, int target_count,
                    MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request)
 {

--- a/ompi/mpi/c/rget_accumulate.c
+++ b/ompi/mpi/c/rget_accumulate.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All right
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,8 +137,7 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype 
 
     OPAL_CR_ENTER_LIBRARY();
 
-    /* TODO: do not cast away the const */
-    rc = ompi_win->w_osc_module->osc_rget_accumulate((void *) origin_addr,
+    rc = ompi_win->w_osc_module->osc_rget_accumulate(origin_addr,
                                                     origin_count,
                                                     origin_datatype,
                                                     result_addr,

--- a/ompi/mpi/c/rput.c
+++ b/ompi/mpi/c/rput.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,9 +82,8 @@ int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype origin_data
 
     OPAL_CR_ENTER_LIBRARY();
 
-    /* TODO: do not cast away the const */
-    rc = win->w_osc_module->osc_rput((void *) origin_addr, origin_count, origin_datatype,
-                                    target_rank, target_disp, target_count,
+    rc = win->w_osc_module->osc_rput(origin_addr, origin_count, origin_datatype,
+                                     target_rank, target_disp, target_count,
                                      target_datatype, win, request);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/win_detach.c
+++ b/ompi/mpi/c/win_detach.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +40,7 @@
 
 static const char FUNC_NAME[] = "MPI_Win_detach";
 
-int MPI_Win_detach(MPI_Win win, void *base)
+int MPI_Win_detach(MPI_Win win, const void *base)
 {
     int ret = MPI_SUCCESS;
 

--- a/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/mpi-f-interfaces-bind.h
@@ -124,6 +124,7 @@
 ! Wasn't that simple?  Here's the list of subroutines that are not
 ! prototyped in this file because they fall into case #1 or #2, above.
 !
+! Case #1:
 ! MPI_Cart_create
 ! MPI_Cart_get
 ! MPI_Cart_map
@@ -137,15 +138,20 @@
 ! MPI_File_set_atomicity
 ! MPI_Finalized
 ! MPI_Graph_create
-! MPI_Improbe
 ! MPI_Info_get
 ! MPI_Info_get_valuelen
 ! MPI_Initialized
 ! MPI_Intercomm_merge
-! MPI_Iprobe
 ! MPI_Is_thread_main
 ! MPI_Op_commutative
 ! MPI_Op_create
+! MPI_Type_get_attr
+! MPI_Win_get_attr
+! MPI_Win_test
+!
+! Case #2:
+! MPI_Iprobe
+! MPI_Improbe
 ! MPI_Request_get_status
 ! MPI_Status_set_cancelled
 ! MPI_Test
@@ -153,9 +159,6 @@
 ! MPI_Testany
 ! MPI_Testsome
 ! MPI_Test_cancelled
-! MPI_Type_get_attr
-! MPI_Win_get_attr
-! MPI_Win_test
 !
 
 interface

--- a/ompi/proc/proc.h
+++ b/ompi/proc/proc.h
@@ -304,6 +304,25 @@ OMPI_DECLSPEC int ompi_proc_unpack(opal_buffer_t *buf,
  */
 OMPI_DECLSPEC int ompi_proc_refresh(void);
 
+/**
+ * Get the ompi_proc_t for a given process name
+ *
+ * @param[in] proc_name opal process name
+ *
+ * @returns cached or new ompi_proc_t for the given process name
+ *
+ * This function looks up the given process name in the hash of existing
+ * ompi_proc_t structures. If no ompi_proc_t structure exists matching the
+ * given name a new ompi_proc_t is allocated, initialized, and returned.
+ *
+ * @note The ompi_proc_t is added to the local list of processes but is not
+ * added to any communicator. ompi_comm_peer_lookup is responsible for caching
+ * the ompi_proc_t on a communicator.
+ */
+OMPI_DECLSPEC opal_proc_t *ompi_proc_for_name (const opal_process_name_t proc_name);
+
+
+OMPI_DECLSPEC opal_proc_t *ompi_proc_lookup (const opal_process_name_t proc_name);
 
 END_C_DECLS
 

--- a/ompi/proc/proc.h
+++ b/ompi/proc/proc.h
@@ -324,6 +324,16 @@ OMPI_DECLSPEC opal_proc_t *ompi_proc_for_name (const opal_process_name_t proc_na
 
 OMPI_DECLSPEC opal_proc_t *ompi_proc_lookup (const opal_process_name_t proc_name);
 
+
+static inline intptr_t ompi_proc_name_to_sentinel (opal_process_name_t name) {
+  return -*((intptr_t *) &name);
+}
+
+static inline opal_process_name_t ompi_proc_sentinel_to_name (intptr_t sentinel) {
+  sentinel = -sentinel;
+  return *((opal_process_name_t *) &sentinel);
+}
+
 END_C_DECLS
 
 #endif /* OMPI_PROC_PROC_H */

--- a/ompi/runtime/ompi_mpi_abort.c
+++ b/ompi/runtime/ompi_mpi_abort.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,7 +91,7 @@ static void try_kill_peers(ompi_communicator_t *comm,
         } else {
             assert(count <= nprocs);
             procs[count++] =
-                *OMPI_CAST_RTE_NAME(&ompi_group_get_proc_ptr(comm->c_remote_group, i)->super.proc_name);
+                *OMPI_CAST_RTE_NAME(&ompi_group_get_proc_ptr(comm->c_remote_group, i, true)->super.proc_name);
         }
     }
 
@@ -96,7 +99,7 @@ static void try_kill_peers(ompi_communicator_t *comm,
     for (i = 0; i < ompi_comm_remote_size(comm); ++i) {
         assert(count <= nprocs);
         procs[count++] =
-            *OMPI_CAST_RTE_NAME(&ompi_group_get_proc_ptr(comm->c_remote_group, i)->super.proc_name);
+            *OMPI_CAST_RTE_NAME(&ompi_group_get_proc_ptr(comm->c_remote_group, i, true)->super.proc_name);
     }
 
     if (nprocs > 0) {

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -400,6 +400,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
     opal_compare_proc = _process_name_compare;
     opal_convert_string_to_process_name = _convert_string_to_process_name;
     opal_convert_process_name_to_string = _convert_process_name_to_string;
+    opal_proc_for_name = ompi_proc_for_name;
 
     /* Register MCA variables */
     if (OPAL_SUCCESS != (ret = ompi_register_mca_variables())) {

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -64,6 +64,7 @@ int ompi_mpi_event_tick_rate = -1;
 char *ompi_mpi_show_mca_params_string = NULL;
 bool ompi_mpi_have_sparse_group_storage = !!(OMPI_GROUP_SPARSE);
 bool ompi_mpi_preconnect_mpi = false;
+uint32_t ompi_add_procs_cutoff = 1024;
 
 static bool show_default_mca_params = false;
 static bool show_file_mca_params = false;
@@ -287,6 +288,16 @@ int ompi_mpi_register_params(void)
                        true);
         ompi_rte_abort(1, NULL);
     }
+
+    ompi_add_procs_cutoff = 1024;
+    (void) mca_base_var_register ("ompi", "mpi", NULL, "add_procs_cutoff",
+                                  "Maximum world size for pre-allocating resources for all "
+                                  "remote processes. Increasing this limit may improve "
+                                  "communication performance at the cost of memory usage "
+                                  "(default: 1024)", MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
+                                  0, 0, OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
+                                  &ompi_add_procs_cutoff);
+
 
     return OMPI_SUCCESS;
 }

--- a/ompi/runtime/params.h
+++ b/ompi/runtime/params.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
@@ -123,10 +124,15 @@ OMPI_DECLSPEC extern bool ompi_have_sparse_group_storage;
  */
 OMPI_DECLSPEC extern bool ompi_use_sparse_group_storage;
 
-/*
+/**
  * Cutoff point for retrieving hostnames
  */
 OMPI_DECLSPEC extern uint32_t ompi_direct_modex_cutoff;
+
+/**
+ * Cutoff point for calling add_procs for all processes
+ */
+OMPI_DECLSPEC extern uint32_t ompi_add_procs_cutoff;
 
 /**
  * Register MCA parameters used by the MPI layer.

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -605,12 +605,15 @@ typedef int (*mca_btl_base_module_finalize_fn_t)(
  * modex_recv() function. The BTL may utilize this information to
  * determine reachability of each peer process.
  *
- * For each process that is reachable by the BTL, the bit corresponding to the index
- * into the proc array (nprocs) should be set in the reachable bitmask. The BTL
- * will return an array of pointers to a data structure defined
- * by the BTL that is then returned to the BTL on subsequent calls to the BTL data
- * transfer functions (e.g btl_send). This may be used by the BTL to cache any addressing
- * or connection information (e.g. TCP socket, IB queue pair).
+ * The caller may pass a "reachable" bitmap pointer.  If it is not
+ * NULL, for each process that is reachable by the BTL, the bit
+ * corresponding to the index into the proc array (nprocs) should be
+ * set in the reachable bitmask. The BTL will return an array of
+ * pointers to a data structure defined by the BTL that is then
+ * returned to the BTL on subsequent calls to the BTL data transfer
+ * functions (e.g btl_send). This may be used by the BTL to cache any
+ * addressing or connection information (e.g. TCP socket, IB queue
+ * pair).
  */
 typedef int (*mca_btl_base_module_add_procs_fn_t)(
     struct mca_btl_base_module_t* btl,

--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -873,6 +873,7 @@ int mca_btl_openib_add_procs(
     for (i = 0, local_procs = 0 ; i < (int) nprocs; i++) {
         struct opal_proc_t* proc = procs[i];
         mca_btl_openib_proc_t* ib_proc;
+        bool found_existing = false;
         int remote_matching_port;
 
         opal_output(-1, "add procs: adding proc %d", i);
@@ -897,6 +898,24 @@ int mca_btl_openib_add_procs(
             /* if we don't have connection info for this process, it's
              * okay because some other method might be able to reach it,
              * so just mark it as unreachable by us */
+            continue;
+        }
+
+        OPAL_THREAD_LOCK(&ib_proc->proc_lock);
+        for (j = 0 ; j < (int) ib_proc->proc_endpoint_count ; ++j) {
+            endpoint = ib_proc->proc_endpoints[j];
+            if (endpoint->endpoint_btl == openib_btl) {
+                found_existing = true;
+                break;
+            }
+        }
+        OPAL_THREAD_UNLOCK(&ib_proc->proc_lock);
+
+        if (found_existing) {
+            if (reachable) {
+                opal_bitmap_set_bit(reachable, i);
+            }
+            peers[i] = endpoint;
             continue;
         }
 
@@ -1048,6 +1067,37 @@ int mca_btl_openib_add_procs(
     openib_btl->device->mem_reg_max /= openib_btl->local_procs;
 
     return OPAL_SUCCESS;
+}
+
+struct mca_btl_base_endpoint_t *mca_btl_openib_get_ep (struct mca_btl_base_module_t *btl, struct opal_proc_t *proc)
+{
+    mca_btl_openib_module_t *openib_btl = (mca_btl_openib_module_t *) btl;
+    mca_btl_base_endpoint_t *endpoint;
+    mca_btl_openib_proc_t *ib_proc;
+
+    if (NULL == (ib_proc = mca_btl_openib_proc_create(proc))) {
+        /* if we don't have connection info for this process, it's
+         * okay because some other method might be able to reach it,
+         * so just mark it as unreachable by us */
+        return NULL;
+    }
+
+    OPAL_THREAD_LOCK(&ib_proc->proc_lock);
+    for (size_t j = 0 ; j < ib_proc->proc_endpoint_count ; ++j) {
+        endpoint = ib_proc->proc_endpoints[j];
+        if (endpoint->endpoint_btl == openib_btl) {
+            OPAL_THREAD_UNLOCK(&ib_proc->proc_lock);
+            return endpoint;
+        }
+    }
+    OPAL_THREAD_UNLOCK(&ib_proc->proc_lock);
+
+    BTL_VERBOSE(("creating new endpoint for remote process {.jobid = 0x%x, .vpid = 0x%x}",
+                 proc->proc_name.jobid, proc->proc_name.vpid));
+
+    endpoint = NULL;
+    (void) mca_btl_openib_add_procs (btl, 1, &proc, &endpoint, NULL);
+    return endpoint;
 }
 
 /*

--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -875,6 +875,18 @@ int mca_btl_openib_post_srr(mca_btl_openib_module_t* openib_btl, const int qp);
 const char* btl_openib_get_transport_name(mca_btl_openib_transport_type_t transport_type);
 
 /**
+ * Get an endpoint for a process
+ *
+ * @param btl (IN)    BTL module
+ * @param proc (IN)   opal process object
+ *
+ * This function will return an existing endpoint if one exists otherwise it will allocate
+ * a new endpoint and return it.
+ */
+struct mca_btl_base_endpoint_t *mca_btl_openib_get_ep (struct mca_btl_base_module_t *btl,
+                                                       struct opal_proc_t *proc);
+
+/**
  * Get a transport type of btl.
  */
 

--- a/opal/mca/btl/openib/btl_openib_mca.c
+++ b/opal/mca/btl/openib/btl_openib_mca.c
@@ -565,7 +565,8 @@ int btl_openib_register_mca_params(void)
     mca_btl_openib_module.super.btl_rdma_pipeline_frag_size = 1024 * 1024;
     mca_btl_openib_module.super.btl_min_rdma_pipeline_size = 256 * 1024;
     mca_btl_openib_module.super.btl_flags = MCA_BTL_FLAGS_RDMA |
-	MCA_BTL_FLAGS_NEED_ACK | MCA_BTL_FLAGS_NEED_CSUM | MCA_BTL_FLAGS_HETEROGENEOUS_RDMA;
+	MCA_BTL_FLAGS_NEED_ACK | MCA_BTL_FLAGS_NEED_CSUM | MCA_BTL_FLAGS_HETEROGENEOUS_RDMA |
+        MCA_BTL_FLAGS_SEND;
 #if BTL_OPENIB_FAILOVER_ENABLED
     mca_btl_openib_module.super.btl_flags |= MCA_BTL_FLAGS_FAILOVER_SUPPORT;
 #endif

--- a/opal/mca/btl/portals4/btl_portals4_component.c
+++ b/opal/mca/btl/portals4/btl_portals4_component.c
@@ -221,7 +221,8 @@ mca_btl_portals4_component_open(void)
     mca_btl_portals4_module.super.btl_min_rdma_pipeline_size = 0;
     mca_btl_portals4_module.super.btl_flags =
         MCA_BTL_FLAGS_RDMA |
-        MCA_BTL_FLAGS_RDMA_MATCHED;
+        MCA_BTL_FLAGS_RDMA_MATCHED |
+        MCA_BTL_FLAGS_SEND;
 
     mca_btl_portals4_module.super.btl_registration_handle_size = sizeof (mca_btl_base_registration_handle_t);
 

--- a/opal/mca/btl/self/btl_self_component.c
+++ b/opal/mca/btl/self/btl_self_component.c
@@ -98,7 +98,7 @@ static int mca_btl_self_component_register(void)
     mca_btl_self.btl_rdma_pipeline_send_length = INT_MAX;
     mca_btl_self.btl_rdma_pipeline_frag_size = INT_MAX;
     mca_btl_self.btl_min_rdma_pipeline_size = 0;
-    mca_btl_self.btl_flags = MCA_BTL_FLAGS_PUT | MCA_BTL_FLAGS_SEND_INPLACE;
+    mca_btl_self.btl_flags = MCA_BTL_FLAGS_PUT | MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_SEND;
     mca_btl_self.btl_bandwidth = 100;
     mca_btl_self.btl_latency = 0;
     mca_btl_base_param_register(&mca_btl_self_component.super.btl_version,

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -269,7 +269,8 @@ static int mca_btl_tcp_component_register(void)
                                        MCA_BTL_FLAGS_SEND_INPLACE |
                                        MCA_BTL_FLAGS_NEED_CSUM |
                                        MCA_BTL_FLAGS_NEED_ACK |
-                                       MCA_BTL_FLAGS_HETEROGENEOUS_RDMA;
+                                       MCA_BTL_FLAGS_HETEROGENEOUS_RDMA |
+                                       MCA_BTL_FLAGS_SEND;
 
     mca_btl_tcp_module.super.btl_bandwidth = 100;
     mca_btl_tcp_module.super.btl_latency = 100;

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -14,7 +14,9 @@
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -738,6 +740,31 @@ mca_btl_tcp_proc_t* mca_btl_tcp_proc_lookup(const opal_process_name_t *name)
     opal_proc_table_get_value(&mca_btl_tcp_component.tcp_procs,
                               *name, (void**)&proc);
     OPAL_THREAD_UNLOCK(&mca_btl_tcp_component.tcp_lock);
+    if (OPAL_UNLIKELY(NULL == proc)) {
+        mca_btl_base_endpoint_t *endpoint;
+        opal_proc_t *opal_proc;
+        int rc;
+
+        BTL_VERBOSE(("adding tcp proc for unknown peer {.jobid = 0x%x, .vpid = 0x%x}",
+                     name->jobid, name->vpid));
+
+        opal_proc = opal_proc_for_name (*name);
+        if (NULL == opal_proc) {
+            return NULL;
+        }
+
+        /* try adding this proc to each btl until */
+        for (int i = 0 ; i < mca_btl_tcp_component.tcp_num_btls ; ++i) {
+            endpoint = NULL;
+            (void) mca_btl_tcp_add_procs (&mca_btl_tcp_component.tcp_btls[i]->super, 1, &opal_proc,
+                                          &endpoint, NULL);
+            if (NULL != endpoint && NULL == proc) {
+                /* get the proc and continue on (could probably just break here) */
+                proc = endpoint->endpoint_proc;
+            }
+        }
+    }
+
     return proc;
 }
 

--- a/opal/mca/btl/ugni/btl_ugni.h
+++ b/opal/mca/btl/ugni/btl_ugni.h
@@ -49,7 +49,7 @@
 
 /* ompi and smsg endpoint attributes */
 typedef struct mca_btl_ugni_endpoint_attr_t {
-    uint64_t proc_id;
+    opal_process_name_t proc_name;
     uint32_t index;
     gni_smsg_attr_t smsg_attr;
     gni_mem_handle_t rmt_irq_mem_hndl;
@@ -67,6 +67,7 @@ typedef struct mca_btl_ugni_module_t {
 
     opal_common_ugni_device_t *device;
 
+    opal_mutex_t endpoint_lock;
     size_t endpoint_count;
     opal_pointer_array_t endpoints;
     opal_hash_table_t id_to_endpoint;
@@ -228,6 +229,8 @@ mca_btl_ugni_del_procs (struct mca_btl_base_module_t *btl,
                         size_t nprocs,
                         struct opal_proc_t **procs,
                         struct mca_btl_base_endpoint_t **peers);
+
+struct mca_btl_base_endpoint_t *mca_btl_ugni_get_ep (struct mca_btl_base_module_t *module, opal_proc_t *proc);
 
 /**
  * Initiate an asynchronous send.

--- a/opal/mca/btl/ugni/btl_ugni_component.c
+++ b/opal/mca/btl/ugni/btl_ugni_component.c
@@ -386,8 +386,8 @@ mca_btl_ugni_component_init (int *num_btl_modules,
 static inline int
 mca_btl_ugni_progress_datagram (mca_btl_ugni_module_t *ugni_module)
 {
+    uint64_t datagram_id, data, proc_id;
     uint32_t remote_addr, remote_id;
-    uint64_t datagram_id, data;
     mca_btl_base_endpoint_t *ep;
     gni_post_state_t post_state;
     gni_ep_handle_t handle;
@@ -425,15 +425,24 @@ mca_btl_ugni_progress_datagram (mca_btl_ugni_module_t *ugni_module)
 
     /* if this is a wildcard endpoint lookup the remote peer by the proc id we received */
     if (handle == ugni_module->wildcard_ep) {
-        BTL_VERBOSE(("received connection attempt on wildcard endpoint from proc id: %" PRIx64, ugni_module->wc_remote_attr.proc_id));
-        rc = opal_hash_table_get_value_uint64 (&ugni_module->id_to_endpoint,
-                                               ugni_module->wc_remote_attr.proc_id,
-                                               (void *) &ep);
+        proc_id = mca_btl_ugni_proc_name_to_id (ugni_module->wc_remote_attr.proc_name);
+
+        BTL_VERBOSE(("received connection attempt on wildcard endpoint from proc id: %" PRIx64,
+                     proc_id));
+
+        OPAL_THREAD_LOCK(&ugni_module->endpoint_lock);
+        rc = opal_hash_table_get_value_uint64 (&ugni_module->id_to_endpoint, proc_id, (void **) &ep);
+        OPAL_THREAD_UNLOCK(&ugni_module->endpoint_lock);
+
         /* check if the endpoint is known */
         if (OPAL_UNLIKELY(OPAL_SUCCESS != rc || NULL == ep)) {
-            BTL_ERROR(("received connection attempt from an unknown peer. rc: %d, ep: %p, id: 0x%" PRIx64,
-                       rc, (void *) ep, ugni_module->wc_remote_attr.proc_id));
-            return OPAL_ERR_NOT_FOUND;
+            struct opal_proc_t *remote_proc = opal_proc_for_name (ugni_module->wc_remote_attr.proc_name);
+            BTL_VERBOSE(("Got connection request from an unknown peer {jobid = 0x%x, vid = 0x%x}",
+                         ugni_module->wc_remote_attr.proc_name.jobid, ugni_module->wc_remote_attr.proc_name.vpid));
+            ep = mca_btl_ugni_get_ep (&ugni_module->super, remote_proc);
+            if (OPAL_UNLIKELY(NULL == ep)) {
+                return rc;
+            }
         }
     } else {
         BTL_VERBOSE(("directed datagram complete for endpoint %p", (void *) ep));

--- a/opal/mca/btl/ugni/btl_ugni_module.c
+++ b/opal/mca/btl/ugni/btl_ugni_module.c
@@ -91,6 +91,7 @@ mca_btl_ugni_module_init (mca_btl_ugni_module_t *ugni_module,
     OBJ_CONSTRUCT(&ugni_module->pending_smsg_frags_bb, opal_pointer_array_t);
     OBJ_CONSTRUCT(&ugni_module->ep_wait_list_lock,opal_mutex_t);
     OBJ_CONSTRUCT(&ugni_module->ep_wait_list, opal_list_t);
+    OBJ_CONSTRUCT(&ugni_module->endpoint_lock, opal_mutex_t);
     OBJ_CONSTRUCT(&ugni_module->endpoints, opal_pointer_array_t);
     OBJ_CONSTRUCT(&ugni_module->id_to_endpoint, opal_hash_table_t);
     OBJ_CONSTRUCT(&ugni_module->smsg_mboxes, opal_free_list_t);
@@ -208,6 +209,7 @@ mca_btl_ugni_module_finalize (struct mca_btl_base_module_t *btl)
     OBJ_DESTRUCT(&ugni_module->smsg_mboxes);
     OBJ_DESTRUCT(&ugni_module->pending_smsg_frags_bb);
     OBJ_DESTRUCT(&ugni_module->id_to_endpoint);
+    OBJ_DESTRUCT(&ugni_module->endpoint_lock);
     OBJ_DESTRUCT(&ugni_module->endpoints);
 
     OBJ_DESTRUCT(&ugni_module->eager_get_pending);

--- a/opal/mca/btl/ugni/btl_ugni_smsg.c
+++ b/opal/mca/btl/ugni/btl_ugni_smsg.c
@@ -27,7 +27,7 @@ static void mca_btl_ugni_smsg_mbox_construct (mca_btl_ugni_smsg_mbox_t *mbox) {
     mbox->attr.smsg_attr.msg_buffer     = base_reg->base;
     mbox->attr.smsg_attr.buff_size      = mca_btl_ugni_component.smsg_mbox_size;
     mbox->attr.smsg_attr.mem_hndl       = ugni_reg->handle.gni_handle;
-    mbox->attr.proc_id = mca_btl_ugni_proc_name_to_id (OPAL_PROC_MY_NAME);
+    mbox->attr.proc_name = OPAL_PROC_MY_NAME;
     mbox->attr.rmt_irq_mem_hndl = mca_btl_ugni_component.modules[0].device->smsg_irq_mhndl;
 }
 

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -427,7 +427,7 @@ static int usnic_add_procs(struct mca_btl_base_module_t* base_module,
 
     /* Find all the endpoints with a complete set of USD destinations
        and mark them as reachable */
-    for (size_t i = 0; i < nprocs; ++i) {
+    for (size_t i = 0; NULL != reachable && i < nprocs; ++i) {
         if (NULL != endpoints[i]) {
             bool happy = true;
             for (int channel = 0; channel < USNIC_NUM_CHANNELS; ++channel) {

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -239,8 +239,10 @@ static int mca_btl_vader_component_register (void)
     mca_btl_vader.super.btl_rdma_pipeline_send_length = mca_btl_vader.super.btl_eager_limit;
     mca_btl_vader.super.btl_rdma_pipeline_frag_size   = mca_btl_vader.super.btl_eager_limit;
 
+    mca_btl_vader.super.btl_flags = MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_SEND;
+
     if (MCA_BTL_VADER_NONE != mca_btl_vader_component.single_copy_mechanism) {
-        mca_btl_vader.super.btl_flags     = MCA_BTL_FLAGS_RDMA | MCA_BTL_FLAGS_SEND_INPLACE;
+        mca_btl_vader.super.btl_flags    |= MCA_BTL_FLAGS_RDMA;
         /* Single copy mechanisms should provide better bandwidth */
         mca_btl_vader.super.btl_bandwidth = 40000; /* Mbs */
 
@@ -248,7 +250,6 @@ static int mca_btl_vader_component_register (void)
         mca_btl_vader.super.btl_get = (mca_btl_base_module_get_fn_t) mca_btl_vader_dummy_rdma;
         mca_btl_vader.super.btl_put = (mca_btl_base_module_get_fn_t) mca_btl_vader_dummy_rdma;
     } else {
-        mca_btl_vader.super.btl_flags     = MCA_BTL_FLAGS_SEND_INPLACE;
         mca_btl_vader.super.btl_bandwidth = 10000; /* Mbs */
     }
 

--- a/opal/mca/pmix/pmix1xx/pmix/VERSION
+++ b/opal/mca/pmix/pmix1xx/pmix/VERSION
@@ -30,7 +30,7 @@ greek=a1
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=gitebb9a6a
+repo_rev=git11e7b06
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Aug 28, 2015"
+date="Aug 30, 2015"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/opal/mca/pmix/pmix1xx/pmix/config/Makefile.am
+++ b/opal/mca/pmix/pmix1xx/pmix/config/Makefile.am
@@ -1,5 +1,5 @@
 # PMIx copyrights:
-# Copyright (c) 2013      Intel, Inc. All rights reserved
+# Copyright (c) 2013-2015 Intel, Inc. All rights reserved
 #
 #########################
 #
@@ -9,22 +9,23 @@
 # Copyright (c) 2004-2005 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2010      Oracle and/or its affiliates.  All rights 
+# Copyright (c) 2010      Oracle and/or its affiliates.  All rights
 #                         reserved.
 #########################
 # $COPYRIGHT$
-# 
+#
 # Additional copyrights may follow
-# 
+#
 # $HEADER$
 #
 
 EXTRA_DIST += \
+	config/c_get_alignment.m4 \
 	config/pmix_get_version.sh \
 	config/distscript.sh \
 	config/pmix_check_attributes.m4 \

--- a/opal/mca/pmix/pmix1xx/pmix/config/c_get_alignment.m4
+++ b/opal/mca/pmix/pmix1xx/pmix/config/c_get_alignment.m4
@@ -1,0 +1,72 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# PMIX_C_GET_ALIGN(type, config_var)
+# ----------------------------------
+# Determine datatype alignment.
+# First arg is type, 2nd arg is config var to define.
+# Now that we require C99 compilers, we include stdbool.h
+# in the alignment test so that we can find the definition
+# of "bool" when we test for its alignment. We might be able
+# to avoid this if we test for alignment of _Bool, but
+# since we use "bool" in the code, let's be safe and check
+# what we use. Yes, they should be the same - but "should" and
+# "are" frequently differ
+AC_DEFUN([PMIX_C_GET_ALIGNMENT],[
+    AC_CACHE_CHECK([alignment of $1],
+                   [AS_TR_SH([pmix_cv_c_align_$1])],
+		   [AC_RUN_IFELSE([AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT
+                                                    #include <stdbool.h> ],
+[[
+    struct foo { char c; $1 x; };
+    struct foo *p = (struct foo *) malloc(sizeof(struct foo));
+    int diff;
+    FILE *f=fopen("conftestval", "w");
+    if (!f) exit(1);
+    diff = ((char *)&p->x) - ((char *)&p->c);
+    fprintf(f, "%d\n", (diff >= 0) ? diff : -diff);
+]])],                         [AS_TR_SH([pmix_cv_c_align_$1])=`cat conftestval`],
+                               [AC_MSG_WARN([*** Problem running configure test!])
+                                AC_MSG_WARN([*** See config.log for details.])
+                                AC_MSG_ERROR([*** Cannot continue.])],
+                               [ # cross compile - do a non-executable test.  Trick
+                                 # taken from the Autoconf 2.59c.  Switch to using
+                                 # AC_CHECK_ALIGNOF when we can require Autoconf 2.60.
+                                 _AC_COMPUTE_INT([(long int) offsetof (pmix__type_alignof_, y)],
+                                                 [AS_TR_SH([pmix_cv_c_align_$1])],
+                                                 [AC_INCLUDES_DEFAULT
+#include <stdbool.h>
+
+#ifndef offsetof
+# define offsetof(type, member) ((char *) &((type *) 0)->member - (char *) 0)
+#endif
+typedef struct { char x; $1 y; } pmix__type_alignof_;
+],
+                                                 [AC_MSG_WARN([*** Problem running configure test!])
+                                                  AC_MSG_WARN([*** See config.log for details.])
+                                                  AC_MSG_ERROR([*** Cannot continue.])])])])
+
+AC_DEFINE_UNQUOTED([$2], [$AS_TR_SH([pmix_cv_c_align_$1])], [Alignment of type $1])
+eval "$2=$AS_TR_SH([pmix_cv_c_align_$1])"
+
+rm -rf conftest* ]) dnl

--- a/opal/mca/pmix/pmix1xx/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix1xx/pmix/config/pmix.m4
@@ -146,7 +146,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     ##################################
     # Does the compiler support "ident"-like constructs?
     PMIX_CHECK_IDENT([CC], [CFLAGS], [c], [C])
-    PMIX_SETUP_CC
 
     #
     # Check for some types
@@ -192,6 +191,31 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CHECK_SIZEOF(wchar_t)
 
     AC_CHECK_SIZEOF(pid_t)
+
+    #
+    # Check for type alignments
+    #
+
+    PMIX_C_GET_ALIGNMENT(bool, PMIX_ALIGNMENT_BOOL)
+    PMIX_C_GET_ALIGNMENT(int8_t, PMIX_ALIGNMENT_INT8)
+    PMIX_C_GET_ALIGNMENT(int16_t, PMIX_ALIGNMENT_INT16)
+    PMIX_C_GET_ALIGNMENT(int32_t, PMIX_ALIGNMENT_INT32)
+    PMIX_C_GET_ALIGNMENT(int64_t, PMIX_ALIGNMENT_INT64)
+    PMIX_C_GET_ALIGNMENT(char, PMIX_ALIGNMENT_CHAR)
+    PMIX_C_GET_ALIGNMENT(short, PMIX_ALIGNMENT_SHORT)
+    PMIX_C_GET_ALIGNMENT(wchar_t, PMIX_ALIGNMENT_WCHAR)
+    PMIX_C_GET_ALIGNMENT(int, PMIX_ALIGNMENT_INT)
+    PMIX_C_GET_ALIGNMENT(long, PMIX_ALIGNMENT_LONG)
+    if test "$ac_cv_type_long_long" = yes; then
+        PMIX_C_GET_ALIGNMENT(long long, PMIX_ALIGNMENT_LONG_LONG)
+    fi
+    PMIX_C_GET_ALIGNMENT(float, PMIX_ALIGNMENT_FLOAT)
+    PMIX_C_GET_ALIGNMENT(double, PMIX_ALIGNMENT_DOUBLE)
+    if test "$ac_cv_type_long_double" = yes; then
+        PMIX_C_GET_ALIGNMENT(long double, PMIX_ALIGNMENT_LONG_DOUBLE)
+    fi
+    PMIX_C_GET_ALIGNMENT(void *, PMIX_ALIGNMENT_VOID_P)
+    PMIX_C_GET_ALIGNMENT(size_t, PMIX_ALIGNMENT_SIZE_T)
 
 
     #
@@ -265,18 +289,18 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     pmix_show_title "Header file tests"
 
     AC_CHECK_HEADERS([arpa/inet.h \
-                               fcntl.h inttypes.h libgen.h \
-                               netinet/in.h \
-                               stdint.h stddef.h \
-                               stdlib.h string.h strings.h \
-                               sys/param.h \
-                               sys/select.h sys/socket.h \
-                               stdarg.h sys/stat.h sys/time.h \
-                               sys/types.h sys/un.h sys/uio.h net/uio.h \
-                               sys/wait.h syslog.h \
-                               time.h unistd.h \
-                               crt_externs.h signal.h \
-                               ioLib.h sockLib.h hostLib.h limits.h])
+                      fcntl.h inttypes.h libgen.h \
+                      netinet/in.h \
+                      stdint.h stddef.h \
+                      stdlib.h string.h strings.h \
+                      sys/param.h \
+                      sys/select.h sys/socket.h \
+                      stdarg.h sys/stat.h sys/time.h \
+                      sys/types.h sys/un.h sys/uio.h net/uio.h \
+                      sys/wait.h syslog.h \
+                      time.h unistd.h \
+                      crt_externs.h signal.h \
+                      ioLib.h sockLib.h hostLib.h limits.h])
 
     # Note that sometimes we have <stdbool.h>, but it doesn't work (e.g.,
     # have both Portland and GNU installed; using pgcc will find GNU's
@@ -547,7 +571,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # final compiler config
     ############################################################################
 
-    pmix_show_subtitle "Compiler flags"
+    pmix_show_subtitle "Set path-related compiler flags"
 
     #
     # This is needed for VPATH builds, so that it will -I the appropriate
@@ -568,14 +592,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     else
         CPPFLAGS='-I$(PMIX_top_srcdir) -I$(PMIX_top_srcdir)/src -I$(PMIX_top_srcdir)/include'" $CPPFLAGS"
     fi
-
-    #
-    # Delayed the substitution of CFLAGS and CXXFLAGS until now because
-    # they may have been modified throughout the course of this script.
-    #
-
-    AC_SUBST(CFLAGS)
-    AC_SUBST(CPPFLAGS)
 
     # pmixdatadir, pmixlibdir, and pmixinclude are essentially the same as
     # pkg*dir, but will always be */pmix.
@@ -639,7 +655,7 @@ else
     WANT_PICKY_COMPILER=0
 fi
 #################### Early development override ####################
-if test "$WANT_PICKY_COMPILER" = "0" -a -z "$enable_picky" -a "$PMIX_DEVEL" = 1; then
+if test "$WANT_PICKY_COMPILER" = "0" -a -z "$enable_picky" -a "$PMIX_DEVEL" = "1"; then
     WANT_PICKY_COMPILER=1
     echo "--> developer override: enable picky compiler by default"
 fi

--- a/opal/mca/pmix/pmix1xx/pmix/config/pmix_setup_hwloc.m4
+++ b/opal/mca/pmix/pmix1xx/pmix/config/pmix_setup_hwloc.m4
@@ -39,7 +39,7 @@ AC_DEFUN([_PMIX_HWLOC_EMBEDDED_MODE],[
     AC_MSG_CHECKING([for hwloc])
     AC_MSG_RESULT([assumed available (embedded mode)])
 
-    PMIX_HWLOC_HEADER=$with_hwloc_header
+    PMIX_HWLOC_HEADER="$with_hwloc_header"
     PMIX_HWLOC_CPPFLAGS=
     PMIX_HWLOC_LIB=
     PMIX_HWLOC_LDFLAGS=

--- a/opal/mca/pmix/pmix1xx/pmix/config/pmix_setup_libevent.m4
+++ b/opal/mca/pmix/pmix1xx/pmix/config/pmix_setup_libevent.m4
@@ -39,12 +39,13 @@ AC_DEFUN([_PMIX_LIBEVENT_EMBEDDED_MODE],[
     AC_MSG_CHECKING([for libevent])
     AC_MSG_RESULT([assumed available (embedded mode)])
 
-    PMIX_EVENT_HEADER=$with_libevent_header
-    PMIX_EVENT2_THREAD_HEADER=$with_libevent_header
+    PMIX_EVENT_HEADER="$with_libevent_header"
+    PMIX_EVENT2_THREAD_HEADER="$with_libevent_header"
     PMIX_EVENT_CPPFLAGS=
     PMIX_EVENT_LIB=
     PMIX_EVENT_LDFLAGS=
-])
+
+ ])
 
 AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
     PMIX_VAR_SCOPE_PUSH([pmix_event_dir pmix_event_libdir])

--- a/opal/mca/pmix/pmix1xx/pmix/configure.ac
+++ b/opal/mca/pmix/pmix1xx/pmix/configure.ac
@@ -146,19 +146,6 @@ LT_INIT()
 LT_LANG([C])
 LT_LANG([C++])
 
-####################################################################
-# Setup C compiler
-####################################################################
-
-CFLAGS_save="$CFLAGS"
-AC_PROG_CC
-CFLAGS="$CFLAGS_save"
-
-AC_ARG_VAR(CC_FOR_BUILD,[build system C compiler])
-AS_IF([test -z "$CC_FOR_BUILD"],[
-    AC_SUBST([CC_FOR_BUILD], [$CC])
-])
-
 ############################################################################
 # Configuration options
 ############################################################################
@@ -183,6 +170,37 @@ PMIX_SETUP_CORE([])
 PMIX_DO_AM_CONDITIONALS
 
 ####################################################################
+# Setup C compiler
+####################################################################
+
+CFLAGS_save="$CFLAGS"
+AC_PROG_CC
+CFLAGS="$CFLAGS_save"
+
+AC_ARG_VAR(CC_FOR_BUILD,[build system C compiler])
+AS_IF([test -z "$CC_FOR_BUILD"],[
+    AC_SUBST([CC_FOR_BUILD], [$CC])
+])
+
+PMIX_SETUP_CC
+
+#
+# Delayed the substitution of CFLAGS and CXXFLAGS until now because
+# they may have been modified throughout the course of this script.
+#
+
+AC_SUBST(CFLAGS)
+AC_SUBST(CPPFLAGS)
+
+pmix_show_title "Final compiler flags"
+
+AC_MSG_CHECKING([final CPPFLAGS])
+AC_MSG_RESULT([$CPPFLAGS])
+
+AC_MSG_CHECKING([final CFLAGS])
+AC_MSG_RESULT([$CFLAGS])
+
+####################################################################
 # Version information
 ####################################################################
 
@@ -197,4 +215,7 @@ AC_SUBST([libpmix_so_version])
 AC_CONFIG_FILES(pmix_config_prefix[test/Makefile]
                 pmix_config_prefix[test/simple/Makefile]
                 pmix_config_prefix[examples/Makefile])
+
+pmix_show_title "Configuration complete"
+
 AC_OUTPUT

--- a/opal/mca/pmix/pmix1xx/pmix/examples/client.c
+++ b/opal/mca/pmix/pmix1xx/pmix/examples/client.c
@@ -24,6 +24,8 @@
  */
 
 #include <pmix/autogen/config.h>
+
+#define _GNU_SOURCE
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,26 +47,26 @@ int main(int argc, char **argv)
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank, rc);
         exit(0);
     }
-    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
 
     /* get our universe size */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get universe size failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
-    
+    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+
     /* put a few values */
     (void)asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Store_internal failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
 
@@ -72,7 +74,7 @@ int main(int argc, char **argv)
     value.type = PMIX_UINT64;
     value.data.uint64 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Put internal failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
 
@@ -80,12 +82,12 @@ int main(int argc, char **argv)
     value.type = PMIX_STRING;
     value.data.string = "1234";
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Put internal failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Commit failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Commit failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
 
@@ -96,7 +98,7 @@ int main(int argc, char **argv)
     PMIX_INFO_CREATE(info, 1);
     (void)strncpy(info->key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, info, 1))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
     PMIX_INFO_FREE(info, 1);
@@ -105,49 +107,49 @@ int main(int argc, char **argv)
     for (n=0; n < nprocs; n++) {
         (void)asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank);
         if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, tmp, NULL, 0, &val))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Get %s failed: %d", myproc.nspace, myproc.rank, tmp, rc);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, myproc.rank, tmp, rc);
             goto done;
         }
         if (PMIX_UINT64 != val->type) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Get %s returned wrong type: %d", myproc.nspace, myproc.rank, tmp, val->type);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s returned wrong type: %d\n", myproc.nspace, myproc.rank, tmp, val->type);
             PMIX_VALUE_RELEASE(val);
             free(tmp);
             goto done;
         }
         if (1234 != val->data.uint64) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Get %s returned wrong value: %d", myproc.nspace, myproc.rank, tmp, (int)val->data.uint64);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s returned wrong value: %d\n", myproc.nspace, myproc.rank, tmp, (int)val->data.uint64);
             PMIX_VALUE_RELEASE(val);
             free(tmp);
             goto done;
         }
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, tmp);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s returned correct\n", myproc.nspace, myproc.rank, tmp);
         PMIX_VALUE_RELEASE(val);
         free(tmp);
         (void)asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank);
         if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, tmp, NULL, 0, &val))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Get %s failed: %d", myproc.nspace, myproc.rank, tmp, rc);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, myproc.rank, tmp, rc);
             goto done;
         }
         if (PMIX_STRING != val->type) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Get %s returned wrong type: %d", myproc.nspace, myproc.rank, tmp, val->type);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s returned wrong type: %d\n", myproc.nspace, myproc.rank, tmp, val->type);
             PMIX_VALUE_RELEASE(val);
             free(tmp);
             goto done;
         }
         if (0 != strcmp(val->data.string, "1234")) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Get %s returned wrong value: %s", myproc.nspace, myproc.rank, tmp, val->data.string);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s returned wrong value: %s\n", myproc.nspace, myproc.rank, tmp, val->data.string);
             PMIX_VALUE_RELEASE(val);
             free(tmp);
             goto done;
         }
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, tmp);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s returned correct\n", myproc.nspace, myproc.rank, tmp);
         PMIX_VALUE_RELEASE(val);
         free(tmp);
     }
 
  done:
     /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize())) {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
     } else {

--- a/opal/mca/pmix/pmix1xx/pmix/examples/fault.c
+++ b/opal/mca/pmix/pmix1xx/pmix/examples/fault.c
@@ -39,7 +39,7 @@ static void notification_fn(pmix_status_t status,
                             pmix_proc_t procs[], size_t nprocs,
                             pmix_info_t info[], size_t ninfo)
 {
-    pmix_output(0, "Client %s:%d NOTIFIED with status %d", myproc.nspace, myproc.rank, status);
+    fprintf(stderr, "Client %s:%d NOTIFIED with status %d\n", myproc.nspace, myproc.rank, status);
     completed = true;
 }
 
@@ -50,41 +50,41 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     pmix_proc_t proc;
     uint32_t nprocs;
-    
+
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank, rc);
         exit(0);
     }
-    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
 
     /* get our universe size */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get universe size failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
     completed = false;
-    
+
     /* register our errhandler */
     PMIx_Register_errhandler(NULL, 0, notification_fn);
-    
+
     /* call fence to sync */
     PMIX_PROC_CONSTRUCT(&proc);
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
-    
+
     /* rank=0 calls abort */
     if (0 == myproc.rank) {
         PMIx_Abort(PMIX_ERR_OUT_OF_RESOURCE, "Eat rocks",
                    &proc, 1);
-        pmix_output(0, "Client ns %s rank %d: Abort called", myproc.nspace, myproc.rank);
+        fprintf(stderr, "Client ns %s rank %d: Abort called\n", myproc.nspace, myproc.rank);
     }
     /* everyone simply waits */
     while (!completed) {
@@ -96,9 +96,9 @@ int main(int argc, char **argv)
 
  done:
     /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
     PMIx_Deregister_errhandler();
-    
+
     if (PMIX_SUCCESS != (rc = PMIx_Finalize())) {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
     } else {

--- a/opal/mca/pmix/pmix1xx/pmix/examples/pub.c
+++ b/opal/mca/pmix/pmix1xx/pmix/examples/pub.c
@@ -45,29 +45,29 @@ int main(int argc, char **argv)
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank, rc);
         exit(0);
     }
-    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
 
     /* get our universe size */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get universe size failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
-    
+    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+
     /* call fence to ensure the data is received */
     PMIX_PROC_CONSTRUCT(&proc);
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
-    
+
     /* publish something */
     if (0 == myproc.rank) {
         PMIX_INFO_CREATE(info, 2);
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
         info[1].value.type = PMIX_SIZE;
         info[1].value.data.size = 123456;
         if (PMIX_SUCCESS != (rc = PMIx_Publish(PMIX_NAMESPACE, PMIX_PERSIST_APP, info, 2))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Publish failed: %d", myproc.nspace, myproc.rank, rc);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Publish failed: %d\n", myproc.nspace, myproc.rank, rc);
             goto done;
         }
         PMIX_INFO_FREE(info, 2);
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
     /* call fence again so all procs know the data
      * has been published */
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
 
@@ -96,61 +96,65 @@ int main(int argc, char **argv)
         PMIX_PDATA_CREATE(pdata, 1);
         (void)strncpy(pdata[0].key, "FOOBAR", PMIX_MAX_KEYLEN);
         if (PMIX_SUCCESS != (rc = PMIx_Lookup(PMIX_NAMESPACE, NULL, 0, pdata, 1))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Lookup failed: %d", myproc.nspace, myproc.rank, rc);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup failed: %d\n", myproc.nspace, myproc.rank, rc);
             goto done;
         }
         /* check the return for value and source */
         if (0 != strncmp(myproc.nspace, pdata[0].proc.nspace, PMIX_MAX_NSLEN)) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Lookup returned wrong nspace: %s",
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong nspace: %s\n",
                         myproc.nspace, myproc.rank, pdata[0].proc.nspace);
             goto done;
         }
         if (0 != pdata[0].proc.rank) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Lookup returned wrong rank: %d",
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong rank: %d\n",
                         myproc.nspace, myproc.rank, pdata[0].proc.rank);
             goto done;
         }
         if (PMIX_UINT8 != pdata[0].value.type) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Lookup returned wrong type: %d",
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong type: %d\n",
                         myproc.nspace, myproc.rank, pdata[0].value.type);
             goto done;
         }
         if (1 != pdata[0].value.data.uint8) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Lookup returned wrong value: %d",
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup returned wrong value: %d\n",
                         myproc.nspace, myproc.rank, (int)pdata[0].value.data.uint8);
             goto done;
         }
         PMIX_PDATA_FREE(pdata, 1);
-        pmix_output(0, "PUBLISH-LOOKUP SUCCEEDED");
+        fprintf(stderr, "PUBLISH-LOOKUP SUCCEEDED\n");
     }
 
     /* call fence again so rank 0 waits before leaving */
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
 
     if (0 == myproc.rank) {
-        char **keys = NULL;
-        pmix_argv_append_nosize(&keys, "FOOBAR");
-        pmix_argv_append_nosize(&keys, "PANDA");
+        char **keys;
+        keys = (char**)malloc(3 * sizeof(char*));
+        keys[0] = "FOOBAR";
+        keys[1] = "PANDA";
+        keys[2] = NULL;
 
         if (PMIX_SUCCESS != (rc = PMIx_Unpublish(PMIX_NAMESPACE, keys))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Unpublish failed: %d", myproc.nspace, myproc.rank, rc);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Unpublish failed: %d\n", myproc.nspace, myproc.rank, rc);
+            free(keys);
             goto done;
         }
-        pmix_output(0, "UNPUBLISH SUCCEEDED");
+        free(keys);
+        fprintf(stderr, "UNPUBLISH SUCCEEDED\n");
     }
 
     /* call fence again so everyone waits for rank 0 before leaving */
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
 
  done:
     /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize())) {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
     } else {

--- a/opal/mca/pmix/pmix1xx/pmix/examples/server.c
+++ b/opal/mca/pmix/pmix1xx/pmix/examples/server.c
@@ -300,7 +300,6 @@ int main(int argc, char **argv)
 static void set_namespace(int nprocs, char *ranks, char *nspace,
                           pmix_op_cbfunc_t cbfunc, myxfer_t *x)
 {
-    size_t ninfo = 6;
     char *regex, *ppn;
     char hostname[1024];
 

--- a/opal/mca/pmix/pmix1xx/pmix/include/pmix/pmix_common.h.in
+++ b/opal/mca/pmix/pmix1xx/pmix/include/pmix/pmix_common.h.in
@@ -119,7 +119,6 @@ BEGIN_C_DECLS
 #define PMIX_NODE_RANK             "pmix.nrank"        // (uint16_t) rank on this node spanning all jobs
 #define PMIX_LOCALLDR              "pmix.lldr"         // (uint64_t) opal_identifier of lowest rank on this node within this job
 #define PMIX_APPLDR                "pmix.aldr"         // (uint32_t) lowest rank in this app within this job
-#define PMIX_LOCALITY              "pmix.loc"          // (uint16_t) relative locality of two procs
 
 /* proc location-related info */
 /* For PMIX_HOSTNAME, three use-cases exist for PMIx_Get:

--- a/opal/mca/pmix/pmix1xx/pmix/src/buffer_ops/open_close.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/buffer_ops/open_close.c
@@ -409,6 +409,9 @@ void pmix_value_load(pmix_value_t *v, void *data,
         switch(type) {
         case PMIX_UNDEF:
             break;
+        case PMIX_BOOL:
+            memcpy(&(v->data.flag), data, 1);
+            break;
         case PMIX_BYTE:
             memcpy(&(v->data.byte), data, 1);
             break;
@@ -497,6 +500,10 @@ int pmix_value_unload(pmix_value_t *kv, void **data,
         switch(type) {
         case PMIX_UNDEF:
             rc = PMIX_ERR_UNKNOWN_DATA_TYPE;
+            break;
+        case PMIX_BOOL:
+            memcpy(*data, &(kv->data.flag), 1);
+            *sz = 1;
             break;
         case PMIX_BYTE:
             memcpy(*data, &(kv->data.byte), 1);

--- a/opal/mca/pmix/pmix1xx/pmix/src/buffer_ops/unpack.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/buffer_ops/unpack.c
@@ -146,7 +146,7 @@ int pmix_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32_t *num_vals
 int pmix_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type)
 {
-    int32_t i, k;
+    int32_t i;
     uint8_t *src;
     bool *dst;
 

--- a/opal/mca/pmix/pmix1xx/pmix/src/class/pmix_object.h
+++ b/opal/mca/pmix/pmix1xx/pmix/src/class/pmix_object.h
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -124,6 +126,8 @@
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif  /* HAVE_STDLIB_H */
+
+#include "include/pmix/rename.h"
 
 
 BEGIN_C_DECLS

--- a/opal/mca/pmix/pmix1xx/pmix/src/class/pmix_object.h
+++ b/opal/mca/pmix/pmix1xx/pmix/src/class/pmix_object.h
@@ -12,8 +12,6 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -128,7 +126,6 @@
 #endif  /* HAVE_STDLIB_H */
 
 #include "include/pmix/rename.h"
-
 
 BEGIN_C_DECLS
 

--- a/opal/mca/pmix/pmix1xx/pmix/src/client/pmix_client.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/client/pmix_client.c
@@ -856,7 +856,6 @@ void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
     pmix_nspace_t *nsptr, *nsptr2;
     pmix_nrec_t *nrec, *nr2;
     char **procs;
-    pmix_value_t *val;
 
     /* cycle across our known nspaces */
     nsptr = NULL;

--- a/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server.c
@@ -542,7 +542,6 @@ pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
                                           pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_setup_caddy_t *cd;
-    size_t i;
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
     (void)strncpy(cd->proc.nspace, nspace, PMIX_MAX_NSLEN);
@@ -552,7 +551,7 @@ pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
     /* copy across the info array, if given */
     if (0 < ninfo) {
         cd->ninfo = ninfo;
-	cd->info = info;
+        cd->info = info;
     }
 
     /* we have to push this into our event library to avoid
@@ -569,7 +568,7 @@ static void _execute_collective(int sd, short args, void *cbdata)
     pmix_server_trkr_t *trk = tcd->trk;
     char *data = NULL;
     size_t sz = 0;
-    pmix_buffer_t bucket, pbkt, xfer;
+    pmix_buffer_t bucket, xfer;
     pmix_rank_info_t *info;
     pmix_value_t *val;
 
@@ -653,8 +652,6 @@ static void _register_client(int sd, short args, void *cbdata)
     pmix_nspace_t *nptr, *tmp;
     pmix_server_trkr_t *trk;
     pmix_trkr_caddy_t *tcd;
-    bool found;
-    pmix_dmdx_local_t *lcd, *lcdnext;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:server _register_client for nspace %s rank %d",
@@ -781,7 +778,7 @@ static void _dmodex_req(int sd, short args, void *cbdata)
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_rank_info_t *info, *iptr;
     pmix_nspace_t *nptr, *ns;
-    pmix_buffer_t pbkt, xfer;
+    pmix_buffer_t pbkt;
     pmix_value_t *val;
     char *data = NULL;
     size_t sz = 0;
@@ -1567,7 +1564,6 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     pmix_buffer_t xfer, *bptr, *databuf, *bpscope, *reply;
     pmix_nspace_t *nptr, *ns;
     pmix_server_caddy_t *cd;
-    pmix_kval_t *kp;
     char *nspace;
     int rank, rc;
     int32_t cnt = 1;

--- a/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_listener.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_listener.c
@@ -362,7 +362,7 @@ static void connection_handler(int sd, short flags, void* cbdata)
 pmix_status_t pmix_server_authenticate(int sd, int *out_rank, pmix_peer_t **peer,
                                        pmix_buffer_t **reply)
 {
-    char *msg, *nspace, *version, *cred, *ptr;
+    char *msg, *nspace, *version, *cred;
     int rc, rank;
     pmix_usock_hdr_t hdr;
     pmix_nspace_t *nptr, *tmp;

--- a/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_listener.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_listener.c
@@ -415,12 +415,14 @@ pmix_status_t pmix_server_authenticate(int sd, int *out_rank, pmix_peer_t **peer
                         "connect-ack recvd from peer %s:%d",
                         nspace, rank);
 
-    /* check that this is from a matching version - for ABI
-     * compatibility, we only require that this match at the
-     * major and minor levels: not the release */
+    /* do not check the version - we only retain it at this
+     * time in case we need to check it at some future date.
+     * For now, our intent is to retain backward compatibility
+     * and so we will assume that all versions are compatible. */
     csize = strlen(nspace)+1+sizeof(int);
     version = (char*)(msg+csize);
     csize += strlen(version) + 1;  // position ourselves before modifiying version
+#if 0
     /* find the first '.' */
     ptr = strchr(version, '.');
     if (NULL != ptr) {
@@ -440,6 +442,7 @@ pmix_status_t pmix_server_authenticate(int sd, int *out_rank, pmix_peer_t **peer
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "connect-ack version from client matches ours");
+#endif
 
     /* see if we know this nspace */
     nptr = NULL;

--- a/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_ops.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_ops.c
@@ -292,7 +292,7 @@ pmix_status_t pmix_pending_resolve(pmix_nspace_t *nptr, int rank, pmix_dmdx_loca
     if( NULL == lcd ){
         PMIX_LIST_FOREACH(cd, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
             if (0 != strncmp(nptr->nspace, cd->proc.nspace, PMIX_MAX_NSLEN) ||
-                    rank != cd->proc.rank) {
+                rank != cd->proc.rank) {
                 continue;
             }
             lcd = cd;
@@ -913,7 +913,7 @@ static void dmdx_cbfunc(pmix_status_t status,
     caddy = PMIX_NEW(pmix_dmdx_reply_caddy_t);
     caddy->status = status;
     /* point to the callers cbfunc */
-    caddy->relcbfunc - release_fn;
+    caddy->relcbfunc = release_fn;
     caddy->cbdata = release_cbdata;
 
     caddy->data   = data;

--- a/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_ops.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_ops.c
@@ -80,8 +80,8 @@ static void relfn(void *cbdata)
     free(data);
 }
 
-pmix_status_t _satisfy_local_req(pmix_nspace_t *nptr, pmix_rank_info_t *info,
-                                 pmix_modex_cbfunc_t cbfunc, void *cbdata)
+static pmix_status_t _satisfy_local_req(pmix_nspace_t *nptr, pmix_rank_info_t *info,
+                                        pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix_buffer_t pbkt, xfer;
@@ -114,8 +114,8 @@ pmix_status_t _satisfy_local_req(pmix_nspace_t *nptr, pmix_rank_info_t *info,
     return PMIX_ERR_NOT_FOUND;
 }
 
-pmix_status_t _satisfy_remote_req(pmix_nspace_t *nptr, int rank,
-                                    pmix_modex_cbfunc_t cbfunc, void *cbdata)
+static pmix_status_t _satisfy_remote_req(pmix_nspace_t *nptr, int rank,
+                                         pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix_buffer_t pbkt, xfer;
@@ -152,10 +152,6 @@ pmix_status_t pmix_pending_request(pmix_nspace_t *nptr, int rank,
 {
     pmix_dmdx_local_t *lcd = NULL, *cd;
     pmix_rank_info_t *iptr, *rkinfo;
-    pmix_buffer_t pbkt, xfer;
-    pmix_value_t *val;
-    char *data;
-    size_t sz;
     int rc;
 
     /* 1. Try to satisfy the request right now */
@@ -292,7 +288,7 @@ pmix_status_t pmix_pending_resolve(pmix_nspace_t *nptr, int rank, pmix_dmdx_loca
     if( NULL == lcd ){
         PMIX_LIST_FOREACH(cd, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
             if (0 != strncmp(nptr->nspace, cd->proc.nspace, PMIX_MAX_NSLEN) ||
-                rank != cd->proc.rank) {
+                    rank != cd->proc.rank) {
                 continue;
             }
             lcd = cd;
@@ -510,10 +506,8 @@ static pmix_server_trkr_t* get_tracker(pmix_proc_t *procs,
                                        size_t nprocs, pmix_cmd_t type)
 {
     pmix_server_trkr_t *trk;
-    pmix_rank_info_t *iptr, *info;
     size_t i;
-    bool match, all_def;
-    pmix_nspace_t *nptr, *ns;
+    bool match;
 
     pmix_output_verbose(5, pmix_globals.debug_output,
                         "get_tracker called with %d procs", (int)nprocs);
@@ -578,7 +572,7 @@ static pmix_server_trkr_t* new_tracker(pmix_proc_t *procs,
     pmix_server_trkr_t *trk;
     pmix_rank_info_t *iptr, *info;
     size_t i;
-    bool match, all_def;
+    bool all_def;
     pmix_nspace_t *nptr, *ns;
 
     pmix_output_verbose(5, pmix_globals.debug_output,
@@ -878,7 +872,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
         PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
         caddy->status = PMIX_ERR_NOT_FOUND;
         PMIX_RELEASE(caddy);
-        return;
+        goto cleanup;
     }
 
     kp = PMIX_NEW(pmix_kval_t);

--- a/opal/mca/pmix/pmix1xx/pmix/src/util/timings.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/util/timings.c
@@ -33,7 +33,7 @@
 #endif
 
 
-#if PMIX_COMPILE_TIMING
+#if PMIX_ENABLE_TIMING
 
 #include "src/class/pmix_pointer_array.h"
 #include "src/class/pmix_list.h"

--- a/opal/mca/pmix/pmix1xx/pmix/test/pmix_client.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/pmix_client.c
@@ -41,8 +41,6 @@
 
 int main(int argc, char **argv)
 {
-    char nspace[PMIX_MAX_NSLEN+1];
-    int rank;
     int rc;
     pmix_value_t value;
     pmix_value_t *val = &value;
@@ -62,7 +60,7 @@ int main(int argc, char **argv)
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
-        TEST_ERROR(("Client ns %s rank %d: PMIx_Init failed: %d", params.nspace, rank, rc));
+        TEST_ERROR(("Client ns %s rank %d: PMIx_Init failed: %d", params.nspace, params.rank, rc));
         FREE_TEST_PARAMS(params);
         exit(0);
     }
@@ -73,7 +71,7 @@ int main(int argc, char **argv)
         exit(0);
     }
     if ( NULL != params.prefix && -1 != params.ns_id) {
-        TEST_SET_FILE(params.prefix, params.ns_id, rank);
+        TEST_SET_FILE(params.prefix, params.ns_id, params.rank);
     }
     TEST_VERBOSE((" Client ns %s rank %d: PMIx_Init success", myproc.nspace, myproc.rank));
 

--- a/opal/mca/pmix/pmix1xx/pmix/test/simple/simptest.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/simple/simptest.c
@@ -70,6 +70,8 @@ static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
 static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t register_event_fn(const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t listener_fn(int listening_sd,
                                  pmix_connection_cbfunc_t cbfunc);
 
@@ -85,7 +87,8 @@ static pmix_server_module_t mymodule = {
     spawn_fn,
     connect_fn,
     disconnect_fn,
-    NULL
+    register_event_fn,
+    listener_fn
 };
 
 typedef struct {
@@ -601,6 +604,11 @@ static int disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
     return PMIX_SUCCESS;
 }
 
+static pmix_status_t register_event_fn(const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_SUCCESS;
+}
 
 static int listener_fn(int listening_sd,
                        pmix_connection_cbfunc_t cbfunc)

--- a/opal/mca/pmix/pmix1xx/pmix/test/test_common.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/test_common.c
@@ -205,7 +205,7 @@ void parse_cmd(int argc, char **argv, test_params *params)
         char *rankno = getenv("SLURM_LOCALID");
         if( NULL != ranklist && NULL != rankno ){
             char **argv = pmix_argv_split(ranklist, ',');
-            int i, count = pmix_argv_count(argv);
+            int count = pmix_argv_count(argv);
             int rankidx = strtoul(rankno, NULL, 10);
             if( rankidx >= count ){
                 fprintf(stderr, "It feels like we are running under SLURM:\n\t"

--- a/opal/mca/rcache/vma/rcache_vma.c
+++ b/opal/mca/rcache/vma/rcache_vma.c
@@ -42,7 +42,7 @@ void mca_rcache_vma_module_init( mca_rcache_vma_module_t* rcache ) {
     rcache->base.rcache_clean = mca_rcache_vma_clean;
     rcache->base.rcache_finalize = mca_rcache_vma_finalize;
     rcache->base.rcache_dump_range = mca_rcache_vma_dump_range;
-    OBJ_CONSTRUCT(&rcache->base.lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&rcache->base.lock, opal_recursive_mutex_t);
     mca_rcache_vma_tree_init(rcache);
 }
 

--- a/opal/threads/mutex.c
+++ b/opal/threads/mutex.c
@@ -72,3 +72,29 @@ OBJ_CLASS_INSTANCE(opal_mutex_t,
                    opal_object_t,
                    opal_mutex_construct,
                    opal_mutex_destruct);
+
+static void opal_recursive_mutex_construct(opal_recursive_mutex_t *m)
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+
+#if OPAL_ENABLE_DEBUG
+    m->m_lock_debug = 0;
+    m->m_lock_file = NULL;
+    m->m_lock_line = 0;
+#endif
+
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+
+    pthread_mutex_init(&m->m_lock_pthread, &attr);
+    pthread_mutexattr_destroy(&attr);
+
+#if OPAL_HAVE_ATOMIC_SPINLOCKS
+    opal_atomic_init( &m->m_lock_atomic, OPAL_ATOMIC_UNLOCKED );
+#endif
+}
+
+OBJ_CLASS_INSTANCE(opal_recursive_mutex_t,
+                   opal_object_t,
+                   opal_recursive_mutex_construct,
+                   opal_mutex_destruct);

--- a/opal/threads/mutex.h
+++ b/opal/threads/mutex.h
@@ -50,7 +50,7 @@ OPAL_DECLSPEC extern bool opal_uses_threads;
  * Opaque mutex object
  */
 typedef struct opal_mutex_t opal_mutex_t;
-
+typedef struct opal_mutex_t opal_recursive_mutex_t;
 
 /**
  * Try to acquire a mutex.

--- a/opal/threads/mutex_unix.h
+++ b/opal/threads/mutex_unix.h
@@ -61,6 +61,7 @@ struct opal_mutex_t {
     opal_atomic_lock_t m_lock_atomic;
 };
 OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_mutex_t);
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_recursive_mutex_t);
 
 /************************************************************************
  *

--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
@@ -6,6 +7,8 @@
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,6 +167,11 @@ static int opal_convert_string_to_jobid_should_never_be_called(opal_jobid_t *job
     return OPAL_ERR_NOT_SUPPORTED;
 }
 
+static struct opal_proc_t *opal_proc_for_name_should_never_be_called (opal_process_name_t name)
+{
+    return NULL;
+}
+
 char* (*opal_process_name_print)(const opal_process_name_t) = opal_process_name_print_should_never_be_called;
 char* (*opal_vpid_print)(const opal_vpid_t) = opal_vpid_print_should_never_be_called;
 char* (*opal_jobid_print)(const opal_jobid_t) = opal_jobid_print_should_never_be_called;
@@ -171,6 +179,7 @@ int (*opal_convert_string_to_process_name)(opal_process_name_t *name, const char
 int (*opal_convert_process_name_to_string)(char** name_string, const opal_process_name_t *name) = opal_convert_process_name_to_string_should_never_be_called;
 char* (*opal_convert_jobid_to_string)(opal_jobid_t jobid) = opal_convert_jobid_to_string_should_never_be_called;
 int (*opal_convert_string_to_jobid)(opal_jobid_t *jobid, const char *jobid_string) = opal_convert_string_to_jobid_should_never_be_called;
+struct opal_proc_t *(*opal_proc_for_name) (const opal_process_name_t name) = opal_proc_for_name_should_never_be_called;
 
 char* opal_get_proc_hostname(const opal_proc_t *proc)
 {

--- a/opal/util/proc.h
+++ b/opal/util/proc.h
@@ -138,6 +138,13 @@ OPAL_DECLSPEC extern char* (*opal_jobid_print)(const opal_jobid_t);
 OPAL_DECLSPEC extern char* (*opal_convert_jobid_to_string)(opal_jobid_t jobid);
 OPAL_DECLSPEC extern int (*opal_convert_string_to_jobid)(opal_jobid_t *jobid, const char *jobid_string);
 
+/**
+ * Lookup an opal_proc_t by name
+ *
+ * @param name (IN) name to lookup
+ */
+OPAL_DECLSPEC extern struct opal_proc_t *(*opal_proc_for_name) (const opal_process_name_t name);
+
 #define OPAL_NAME_PRINT(OPAL_PN)    opal_process_name_print(OPAL_PN)
 #define OPAL_JOBID_PRINT(OPAL_PN)   opal_jobid_print(OPAL_PN)
 #define OPAL_VPID_PRINT(OPAL_PN)    opal_vpid_print(OPAL_PN)

--- a/orte/orted/pmix/pmix_server_register_fns.c
+++ b/orte/orted/pmix/pmix_server_register_fns.c
@@ -255,10 +255,7 @@ int orte_pmix_server_register_nspace(orte_job_t *jdata)
                 kv->key = strdup(OPAL_PMIX_CPUSET);
                 kv->type = OPAL_STRING;
                 if (orte_get_attribute(&pptr->attributes, ORTE_PROC_CPU_BITMAP, (void**)&tmp, OPAL_STRING)) {
-                    (void)asprintf(&kv->data.string, "%s:%s", ORTE_NAME_PRINT(&pptr->name), tmp);
-                    free(tmp);
-                } else {
-                    (void)asprintf(&kv->data.string, "%s", ORTE_NAME_PRINT(&pptr->name));
+                    kv->data.string = tmp;
                 }
                 opal_list_append(info, &kv->super);
                 /* go ahead and register this client */


### PR DESCRIPTION
This PR updates the behavior of add_procs in master. If the number of processes in the job exceeds mpi_add_procs_cutoff then ompi_proc_t objects will only be made/added for local processes. All other processes will be created dynamically as needed.

See the messages in the various commits for more information.

This PR will be pushed once all BTL authors have indicated that their BTLs are ready for the new behavior. So far the following are supported (or no changes were needed): openib, scif, self, sm, smcuda, tcp, ugni, and vader.