### PR TITLE
Fix for openib btl mca command line parameter btl_openib_mtu being

### DIFF
--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -1720,7 +1720,11 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
     /* If we did find values for this device (or in the defaults
        section), handle them */
     merge_values(&values, &default_values);
-    if (values.mtu_set) {
+    /*  If MCA param was set, use it. If not, check the INI file
+        or default to IBV_MTU_1024 */
+    if (0 < mca_btl_openib_component.ib_mtu) {
+        device->mtu = mca_btl_openib_component.ib_mtu;
+    } else if (values.mtu_set) {
         switch (values.mtu) {
         case 256:
             device->mtu = IBV_MTU_256;
@@ -1739,11 +1743,11 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
             break;
         default:
             BTL_ERROR(("invalid MTU value specified in INI file (%d); ignored", values.mtu));
-            device->mtu = mca_btl_openib_component.ib_mtu;
+            device->mtu = IBV_MTU_1024 ;
             break;
         }
     } else {
-        device->mtu = mca_btl_openib_component.ib_mtu;
+        device->mtu = IBV_MTU_1024 ;
     }
 
     /* Allocate the protection domain for the device */

--- a/opal/mca/btl/openib/btl_openib_mca.c
+++ b/opal/mca/btl/openib/btl_openib_mca.c
@@ -368,7 +368,7 @@ int btl_openib_register_mca_params(void)
         /* Don't try to recover from this */
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-    mca_btl_openib_component.ib_mtu = IBV_MTU_1024;
+    mca_btl_openib_component.ib_mtu = 0;
     (void) mca_base_var_enum_create("btl_openib_mtus", ib_mtu_values, &new_enum);
     tmp = mca_base_component_var_register(&mca_btl_openib_component.super.btl_version,
                                           "mtu", msg, MCA_BASE_VAR_TYPE_INT, new_enum,


### PR DESCRIPTION
Openib btl command line parameter to set the mtu was being ignored, only the ini file values were being taken into account. With the fix the precedence order is: command line, ini file specifics, ini file defaults. 