### PR TITLE
fortran configiry: test for USE...ONLY support

### DIFF
--- a/config/ompi_fortran_check_use_only.m4
+++ b/config/ompi_fortran_check_use_only.m4
@@ -1,0 +1,61 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl
+dnl Check whether Fortran compiler supports the "only" clause properly
+dnl when using modules.  Specifically, if we "use a :: only foo" and "use
+dnl b :: only bar", and modules a and b have a conflicting "yow"
+dnl definition, it *should* be ignored because of the "only" clauses.  PGI
+dnl 15.7 (and probably prior versions) does not -- but only when
+dnl compiling with -g (!).
+dnl
+
+dnl OMPI_FORTRAN_CHECK_USE_ONLY([action if supported],
+dnl                                [action if not supported])
+dnl ----------------------------------------------------
+AC_DEFUN([OMPI_FORTRAN_CHECK_USE_ONLY],[
+    AS_VAR_PUSHDEF([use_only_var], [ompi_cv_fortran_use_only])
+
+    AC_CACHE_CHECK([if Fortran compiler supports USE...ONLY], use_only_var,
+       [AC_LANG_PUSH([Fortran])
+        AC_COMPILE_IFELSE([AC_LANG_SOURCE([[MODULE aaa
+INTEGER :: aaa_unique
+COMMON/common_to_both/COMMON_NAME_TO_BOTH
+END MODULE aaa
+
+MODULE bbb
+INTEGER :: bbb_unique
+INTEGER, BIND(C, name="common_to_both_") :: COMMON_NAME_TO_BOTH
+END MODULE bbb
+
+PROGRAM test_proc
+  USE :: aaa, ONLY: aaa_unique
+  USE :: bbb, ONLY: bbb_unique
+END PROGRAM]])],
+             [AS_VAR_SET(use_only_var, yes)],
+             [AS_VAR_SET(use_only_var, no)])
+        touch conftest_foo.mod
+        rm -rf *.mod 2>/dev/null
+        AC_LANG_POP([Fortran])
+       ])
+
+    AS_VAR_IF(use_only_var, [yes], [$1], [$2])
+    AS_VAR_POPDEF([use_only_var])dnl
+])

--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -438,6 +438,18 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
                [OMPI_FORTRAN_HAVE_PROCEDURE=0
                 OMPI_BUILD_FORTRAN_BINDINGS=$OMPI_FORTRAN_USEMPI_BINDINGS])])
 
+    # Per https://github.com/open-mpi/ompi/issues/857, if the Fortran
+    # compiler doesn't properly support "USE ... ONLY" notation,
+    # disable the mpi_f08 module.
+    OMPI_FORTRAN_HAVE_USE_ONLY=0
+    AS_IF([test $OMPI_TRY_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS && \
+           test $OMPI_BUILD_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS],
+          [ # Does the compiler support "USE ... ONLY"
+           OMPI_FORTRAN_CHECK_USE_ONLY(
+               [OMPI_FORTRAN_HAVE_USE_ONLY=1],
+               [OMPI_FORTRAN_HAVE_USE_ONLY=0
+                OMPI_BUILD_FORTRAN_BINDINGS=$OMPI_FORTRAN_USEMPI_BINDINGS])])
+
     OMPI_FORTRAN_HAVE_OPTIONAL_ARGS=0
     AS_IF([test $OMPI_TRY_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS && \
            test $OMPI_BUILD_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS],
@@ -780,6 +792,13 @@ end type test_mpi_handle],
     AC_DEFINE_UNQUOTED([OMPI_FORTRAN_HAVE_PROCEDURE],
                        [$OMPI_FORTRAN_HAVE_PROCEDURE],
                        [For ompi/mpi/fortran/use-mpi-f08/blah.F90 and blah.h and ompi_info: whether the compiler supports the "procedure" keyword or not])
+
+    # For configure-fortran-output.h, various files in
+    # ompi/mpi/fortran/use-mpi-f08/*.F90 and *.h files (and ompi_info)
+    AC_SUBST([OMPI_FORTRAN_HAVE_USE_ONLY])
+    AC_DEFINE_UNQUOTED([OMPI_FORTRAN_HAVE_USE_ONLY],
+                       [$OMPI_FORTRAN_HAVE_USE_ONLY],
+                       [For ompi/mpi/fortran/use-mpi-f08/blah.F90 and blah.h and ompi_info: whether the compiler supports "USE ... ONLY" notation properly or not])
 
     # For configure-fortran-output.h, various files in
     # ompi/mpi/fortran/use-mpi-f08/*.F90 and *.h files (and ompi_info)

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -102,6 +102,7 @@ void ompi_info_do_config(bool want_all)
     char *fortran_have_abstract;
     char *fortran_have_asynchronous;
     char *fortran_have_procedure;
+    char *fortran_have_use_only;
     char *fortran_have_c_funloc;
     char *fortran_08_using_wrappers_for_choice_buffer_functions;
     char *fortran_build_sizeof;
@@ -188,6 +189,7 @@ void ompi_info_do_config(bool want_all)
     fortran_have_abstract = OMPI_FORTRAN_HAVE_ABSTRACT ? "yes" : "no";
     fortran_have_asynchronous = OMPI_FORTRAN_HAVE_ASYNCHRONOUS ? "yes" : "no";
     fortran_have_procedure = OMPI_FORTRAN_HAVE_PROCEDURE ? "yes" : "no";
+    fortran_have_use_only = OMPI_FORTRAN_HAVE_USE_ONLY ? "yes" : "no";
     fortran_have_c_funloc = OMPI_FORTRAN_HAVE_C_FUNLOC ? "yes" : "no";
     fortran_08_using_wrappers_for_choice_buffer_functions =
         OMPI_FORTRAN_NEED_WRAPPER_ROUTINES ? "yes" : "no";
@@ -207,6 +209,7 @@ void ompi_info_do_config(bool want_all)
             OMPI_FORTRAN_HAVE_ABSTRACT &&
             OMPI_FORTRAN_HAVE_ASYNCHRONOUS &&
             OMPI_FORTRAN_HAVE_PROCEDURE &&
+            OMPI_FORTRAN_HAVE_USE_ONLY &&
             OMPI_FORTRAN_HAVE_C_FUNLOC &&
             OMPI_FORTRAN_NEED_WRAPPER_ROUTINES) {
             fortran_usempif08_compliance = "The mpi_f08 module is available, and is fully compliant.  w00t!";
@@ -232,6 +235,9 @@ void ompi_info_do_config(bool want_all)
             }
             if (!OMPI_FORTRAN_HAVE_PROCEDURE) {
                 append(f08_msg, sizeof(f08_msg), &first, "PROCEDUREs");
+            }
+            if (!OMPI_FORTRAN_HAVE_USE_ONLY) {
+                append(f08_msg, sizeof(f08_msg), &first, "USE_ONLY");
             }
             if (!OMPI_FORTRAN_HAVE_C_FUNLOC) {
                 append(f08_msg, sizeof(f08_msg), &first, "C_FUNLOCs");
@@ -428,6 +434,9 @@ void ompi_info_do_config(bool want_all)
     opal_info_out("Fort PROCEDURE",
                   "compiler:fortran:procedure",
                   fortran_have_procedure);
+    opal_info_out("Fort USE...ONLY",
+                  "compiler:fortran:use_only",
+                  fortran_have_use_only);
     opal_info_out("Fort C_FUNLOC",
                   "compiler:fortran:c_funloc",
                   fortran_have_c_funloc);


### PR DESCRIPTION
As of v15.7, the PGI Fortran compiler does not properly support how Open MPI uses the `USE ... ONLY` Fortran syntax to include modules with conflicting symbol definitions (interestingly, pgfortran only has a problem with this when compiling with `-g`).

In short, OMPI uses `USE :: module_aaa, ONLY: foo` and `USE :: module_bbb, ONLY: bar` to use modules aaa and bbb, even though they contain conflicting definitions for some symbols.  However, the use of the ONLY clause should preclude the inclusion of the conflicting symbols -- as the word implies, it should direct the compiler to *only* use the symbols identified by the clause (i.e., foo and bar, in this example).

This commit adds a configure test for this capability.  If the compiler fails to build a simple test that mimics this behavior, then disable the mpi_f08 bindings.

Fixes open-mpi/ompi#857

@rolfv please verify
@PHHargrove FYI