### PR TITLE
Update PMIx support

### DIFF
--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_eventlog.c
@@ -30,7 +30,7 @@ int vprotocol_pessimist_event_logger_connect(int el_rank, ompi_communicator_t **
     asprintf(&pdat->value.key, VPROTOCOL_EVENT_LOGGER_NAME_FMT, el_rank);
     opal_list_append(&results, &pdat->super);
 
-    rc = opal_pmix.lookup(OPAL_PMIX_NAMESPACE, &results);
+    rc = opal_pmix.lookup(&results, NULL);
     if (OPAL_SUCCESS != rc ||
         OPAL_STRING != pdat->value.type ||
         NULL == pdat->value.data.string) {

--- a/ompi/mpi/c/lookup_name.c
+++ b/ompi/mpi/c/lookup_name.c
@@ -46,9 +46,8 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
 {
     char range[OPAL_MAX_INFO_VAL];
     int flag=0, ret;
-    opal_pmix_data_range_t rng;
-    bool range_given = false;
-    opal_list_t results;
+    opal_value_t *rng;
+    opal_list_t results, pinfo;
     opal_pmix_pdata_t *pdat;
 
     if ( MPI_PARAM_CHECK ) {
@@ -70,26 +69,32 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
 
     OPAL_CR_ENTER_LIBRARY();
 
+    OBJ_CONSTRUCT(&pinfo, opal_list_t);
+
     /* OMPI supports info keys to pass the range to
      * be searched for the given key */
     if (MPI_INFO_NULL != info) {
         ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
         if (flag) {
-            range_given = true;
             if (0 == strcmp(range, "nspace")) {
-                rng = OPAL_PMIX_NAMESPACE;  // share only with procs in same nspace
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_RANGE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_NAMESPACE;  // share only with procs in same nspace
+                opal_list_append(&pinfo, &rng->super);
             } else if (0 == strcmp(range, "session")) {
-                rng = OPAL_PMIX_SESSION; // share only with procs in same session
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_RANGE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_SESSION; // share only with procs in same session
+                opal_list_append(&pinfo, &rng->super);
             } else {
                 /* unrecognized scope */
+                OPAL_LIST_DESTRUCT(&pinfo);
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                             FUNC_NAME);
             }
         }
-    }
-    if (!range_given) {
-        /* default to nspace */
-        rng = OPAL_PMIX_NAMESPACE;
     }
 
     /* collect the findings */
@@ -98,7 +103,8 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
     pdat->value.key = strdup(service_name);
     opal_list_append(&results, &pdat->super);
 
-    ret = opal_pmix.lookup(rng, &results);
+    ret = opal_pmix.lookup(&results, &pinfo);
+    OPAL_LIST_DESTRUCT(&pinfo);
     if (OPAL_SUCCESS != ret ||
         OPAL_STRING != pdat->value.type ||
         NULL == pdat->value.data.string) {

--- a/ompi/mpi/c/publish_name.c
+++ b/ompi/mpi/c/publish_name.c
@@ -48,12 +48,8 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
     int rc;
     char range[OPAL_MAX_INFO_VAL];
     int flag=0;
-    opal_pmix_data_range_t rng;
-    bool range_given = false;
-    opal_pmix_persistence_t persist;
-    bool persistence_given = false;
+    opal_value_t *rng;
     opal_list_t values;
-    opal_value_t *pinfo;
 
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
@@ -73,58 +69,75 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
     }
 
     OPAL_CR_ENTER_LIBRARY();
+    OBJ_CONSTRUCT(&values, opal_list_t);
 
     /* OMPI supports info keys to pass the range and persistence to
      * be used for the given key */
     if (MPI_INFO_NULL != info) {
         ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
         if (flag) {
-            range_given = true;
             if (0 == strcmp(range, "nspace")) {
-                rng = OPAL_PMIX_NAMESPACE;  // share only with procs in same nspace
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_RANGE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_NAMESPACE;  // share only with procs in same nspace
+                opal_list_append(&values, &rng->super);
             } else if (0 == strcmp(range, "session")) {
-                rng = OPAL_PMIX_SESSION; // share only with procs in same session
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_RANGE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_SESSION; // share only with procs in same session
+                opal_list_append(&values, &rng->super);
             } else {
-                /* unrecognized range */
+                /* unrecognized scope */
+                OPAL_LIST_DESTRUCT(&values);
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                             FUNC_NAME);
             }
         }
         ompi_info_get (info, "persistence", sizeof(range) - 1, range, &flag);
         if (flag) {
-            persistence_given = true;
             if (0 == strcmp(range, "indef")) {
-                persist = OPAL_PMIX_PERSIST_INDEF;   // retain until specifically deleted
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_PERSISTENCE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_PERSIST_INDEF;   // retain until specifically deleted
+                opal_list_append(&values, &rng->super);
             } else if (0 == strcmp(range, "proc")) {
-                persist = OPAL_PMIX_PERSIST_PROC;    // retain until publishing process terminates
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_PERSISTENCE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_PERSIST_PROC;    // retain until publishing process terminates
+                opal_list_append(&values, &rng->super);
             } else if (0 == strcmp(range, "app")) {
-                persist = OPAL_PMIX_PERSIST_APP;     // retain until application terminates
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_PERSISTENCE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_PERSIST_APP;     // retain until application terminates
+                opal_list_append(&values, &rng->super);
             } else if (0 == strcmp(range, "session")) {
-                persist = OPAL_PMIX_PERSIST_SESSION; // retain until session/allocation terminates
+                rng = OBJ_NEW(opal_value_t);
+                rng->key = strdup(OPAL_PMIX_PERSISTENCE);
+                rng->type = OPAL_INT;
+                rng->data.integer = OPAL_PMIX_PERSIST_SESSION; // retain until session/allocation terminates
+                opal_list_append(&values, &rng->super);
             } else {
                 /* unrecognized persistence */
+                OPAL_LIST_DESTRUCT(&values);
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                             FUNC_NAME);
             }
         }
     }
-    if (!range_given) {
-        /* default to nspace */
-        rng = OPAL_PMIX_NAMESPACE;
-    }
-    if (!persistence_given) {
-        persist = OPAL_PMIX_PERSIST_APP;
-    }
 
-    /* publish the values */
-    OBJ_CONSTRUCT(&values, opal_list_t);
-    pinfo = OBJ_NEW(opal_value_t);
-    pinfo->key = strdup(service_name);
-    pinfo->type = OPAL_STRING;
-    pinfo->data.string = strdup(port_name);
-    opal_list_append(&values, &pinfo->super);
+    /* publish the service name */
+    rng = OBJ_NEW(opal_value_t);
+    rng->key = strdup(service_name);
+    rng->type = OPAL_STRING;
+    rng->data.string = strdup(port_name);
+    opal_list_append(&values, &rng->super);
 
-    rc = opal_pmix.publish(rng, persist, &values);
+    rc = opal_pmix.publish(&values);
     OPAL_LIST_DESTRUCT(&values);
 
     OPAL_CR_EXIT_LIBRARY();

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -325,12 +325,8 @@ typedef int (*opal_pmix_base_module_get_nb_fn_t)(const opal_process_name_t *proc
  * data has been posted and is available. The non-blocking form will
  * return immediately, executing the callback when the server confirms
  * availability of the data */
-typedef int (*opal_pmix_base_module_publish_fn_t)(opal_pmix_data_range_t scope,
-                                                  opal_pmix_persistence_t persist,
-                                                  opal_list_t *info);
-typedef int (*opal_pmix_base_module_publish_nb_fn_t)(opal_pmix_data_range_t scope,
-                                                     opal_pmix_persistence_t persist,
-                                                     opal_list_t *info,
+typedef int (*opal_pmix_base_module_publish_fn_t)(opal_list_t *info);
+typedef int (*opal_pmix_base_module_publish_nb_fn_t)(opal_list_t *info,
                                                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Lookup information published by another process within the
@@ -352,8 +348,8 @@ typedef int (*opal_pmix_base_module_publish_nb_fn_t)(opal_pmix_data_range_t scop
  * and return any found items. Thus, the caller is responsible for
  * ensuring that data is published prior to executing a lookup, or
  * for retrying until the requested data is found */
-typedef int (*opal_pmix_base_module_lookup_fn_t)(opal_pmix_data_range_t scope,
-                                                 opal_list_t *data);
+typedef int (*opal_pmix_base_module_lookup_fn_t)(opal_list_t *data,
+                                                 opal_list_t *info);
 
 /* Non-blocking form of the _PMIx_Lookup_ function. Data for
  * the provided NULL-terminated keys array will be returned
@@ -362,7 +358,7 @@ typedef int (*opal_pmix_base_module_lookup_fn_t)(opal_pmix_data_range_t scope,
  * wait for _all_ requested data before executing the callback
  * (_true_), or to callback once the server returns whatever
  * data is immediately available (_false_) */
-typedef int (*opal_pmix_base_module_lookup_nb_fn_t)(opal_pmix_data_range_t scope, int wait, char **keys,
+typedef int (*opal_pmix_base_module_lookup_nb_fn_t)(char **keys, opal_list_t *info,
                                                     opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 
 /* Unpublish data posted by this process using the given keys
@@ -370,14 +366,14 @@ typedef int (*opal_pmix_base_module_lookup_nb_fn_t)(opal_pmix_data_range_t scope
  * the data has been removed by the server. A value of _NULL_
  * for the keys parameter instructs the server to remove
  * _all_ data published by this process within the given scope */
-typedef int (*opal_pmix_base_module_unpublish_fn_t)(opal_pmix_data_range_t scope, char **keys);
+typedef int (*opal_pmix_base_module_unpublish_fn_t)(char **keys, opal_list_t *info);
 
 /* Non-blocking form of the _PMIx_Unpublish_ function. The
  * callback function will be executed once the server confirms
  * removal of the specified data. A value of _NULL_
  * for the keys parameter instructs the server to remove
  * _all_ data published by this process within the given scope  */
-typedef int (*opal_pmix_base_module_unpublish_nb_fn_t)(opal_pmix_data_range_t scope, char **keys,
+typedef int (*opal_pmix_base_module_unpublish_nb_fn_t)(char **keys, opal_list_t *info,
                                                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Spawn a new job. The spawned applications are automatically

--- a/opal/mca/pmix/pmix1xx/pmix/VERSION
+++ b/opal/mca/pmix/pmix1xx/pmix/VERSION
@@ -30,7 +30,7 @@ greek=a1
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=git51479b0
+repo_rev=git6afbc98
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Sep 01, 2015"
+date="Sep 04, 2015"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/opal/mca/pmix/pmix1xx/pmix/examples/pub.c
+++ b/opal/mca/pmix/pmix1xx/pmix/examples/pub.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
         (void)strncpy(info[1].key, "PANDA", PMIX_MAX_KEYLEN);
         info[1].value.type = PMIX_SIZE;
         info[1].value.data.size = 123456;
-        if (PMIX_SUCCESS != (rc = PMIx_Publish(PMIX_NAMESPACE, PMIX_PERSIST_APP, info, 2))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Publish(info, 2))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Publish failed: %d\n", myproc.nspace, myproc.rank, rc);
             goto done;
         }
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
     if (0 != myproc.rank) {
         PMIX_PDATA_CREATE(pdata, 1);
         (void)strncpy(pdata[0].key, "FOOBAR", PMIX_MAX_KEYLEN);
-        if (PMIX_SUCCESS != (rc = PMIx_Lookup(PMIX_NAMESPACE, NULL, 0, pdata, 1))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Lookup(pdata, 1, NULL, 0))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Lookup failed: %d\n", myproc.nspace, myproc.rank, rc);
             goto done;
         }
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
         keys[1] = "PANDA";
         keys[2] = NULL;
 
-        if (PMIX_SUCCESS != (rc = PMIx_Unpublish(PMIX_NAMESPACE, keys))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Unpublish(keys, NULL, 0))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Unpublish failed: %d\n", myproc.nspace, myproc.rank, rc);
             free(keys);
             goto done;

--- a/opal/mca/pmix/pmix1xx/pmix/examples/server.c
+++ b/opal/mca/pmix/pmix1xx/pmix/examples/server.c
@@ -52,15 +52,13 @@ static int dmodex_fn(const pmix_proc_t *proc,
                      const pmix_info_t info[], size_t ninfo,
                      pmix_modex_cbfunc_t cbfunc, void *cbdata);
 static int publish_fn(const pmix_proc_t *proc,
-                      pmix_data_range_t scope, pmix_persistence_t persist,
                       const pmix_info_t info[], size_t ninfo,
                       pmix_op_cbfunc_t cbfunc, void *cbdata);
-static int lookup_fn(const pmix_proc_t *proc,
-                     pmix_data_range_t scope,
-                     const pmix_info_t info[], size_t ninfo, char **keys,
+static int lookup_fn(const pmix_proc_t *proc, char **keys,
+                     const pmix_info_t info[], size_t ninfo,
                      pmix_lookup_cbfunc_t cbfunc, void *cbdata);
-static int unpublish_fn(const pmix_proc_t *proc,
-                        pmix_data_range_t scope, char **keys,
+static int unpublish_fn(const pmix_proc_t *proc, char **keys,
+                        const pmix_info_t info[], size_t ninfo,
                         pmix_op_cbfunc_t cbfunc, void *cbdata);
 static int spawn_fn(const pmix_proc_t *proc,
                     const pmix_info_t job_info[], size_t ninfo,
@@ -443,7 +441,6 @@ static int dmodex_fn(const pmix_proc_t *proc,
 
 
 static int publish_fn(const pmix_proc_t *proc,
-                      pmix_data_range_t scope, pmix_persistence_t persist,
                       const pmix_info_t info[], size_t ninfo,
                       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -467,9 +464,8 @@ static int publish_fn(const pmix_proc_t *proc,
 }
 
 
-static int lookup_fn(const pmix_proc_t *proc,
-                     pmix_data_range_t scope,
-                     const pmix_info_t info[], size_t ninfo, char **keys,
+static int lookup_fn(const pmix_proc_t *proc, char **keys,
+                     const pmix_info_t info[], size_t ninfo,
                      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_locdat_t *p, *p2;
@@ -517,8 +513,8 @@ static int lookup_fn(const pmix_proc_t *proc,
 }
 
 
-static int unpublish_fn(const pmix_proc_t *proc,
-                        pmix_data_range_t scope, char **keys,
+static int unpublish_fn(const pmix_proc_t *proc, char **keys,
+                        const pmix_info_t info[], size_t ninfo,
                         pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_locdat_t *p, *p2;

--- a/opal/mca/pmix/pmix1xx/pmix/include/pmix/pmix_common.h.in
+++ b/opal/mca/pmix/pmix1xx/pmix/include/pmix/pmix_common.h.in
@@ -163,6 +163,9 @@ BEGIN_C_DECLS
 #define PMIX_WAIT                  "pmix.wait"         // (int) caller requests that the server wait until the specified #values are found
 #define PMIX_COLLECTIVE_ALGO       "pmix.calgo"        // (char*) comma-delimited list of algorithms to use for collective
 #define PMIX_COLLECTIVE_ALGO_REQD  "pmix.calreqd"      // (bool) if true, indicates that the requested choice of algo is mandatory
+#define PMIX_NOTIFY_COMPLETION     "pmix.notecomp"     // (bool) notify parent process upon termination of child job
+#define PMIX_RANGE                 "pmix.range"        // (int) pmix_data_range_t value for calls to publish/lookup/unpublish
+#define PMIX_PERSISTENCE           "pmix.persist"      // (int) pmix_persistence_t value for calls to publish
 
 /* attributes used by host server to pass data to the server convenience library - the
  * data will then be parsed and provided to the local clients */

--- a/opal/mca/pmix/pmix1xx/pmix/include/pmix_server.h
+++ b/opal/mca/pmix/pmix1xx/pmix/include/pmix_server.h
@@ -103,7 +103,7 @@ BEGIN_C_DECLS
 typedef int (*pmix_server_client_connected_fn_t)(const pmix_proc_t *proc,
                                                  void* server_object);
 
-/* Notify the host server that a client called PMIx_Finalize- note
+/* Notify the host server that a client called PMIx_Finalize - note
  * that the client will be in a blocked state until the host server
  * executes the callback function, thus allowing the PMIx server support
  * library to release the client */
@@ -158,49 +158,46 @@ typedef pmix_status_t (*pmix_server_dmodex_req_fn_t)(const pmix_proc_t *proc,
 
 
 /* Publish data per the PMIx API specification. The callback is to be executed
- * upon completion of the operation. The host server is not required to guarantee
- * support for the requested range - i.e., the server does not need to return an
- * error if the data store doesn't support range-based isolation. However, the
- * server must return an error (a) if the key is duplicative within the storage
- * range, and (b) if the server does not allow overwriting of published info by
- * the original publisher - it is left to the discretion of the host server to
- * allow info-key-based flags to modify this behavior. The persist flag indicates
- * how long the server should retain the data. The nspace/rank of the publishing
- * process is also provided and is expected to be returned on any subsequent
- * lookup request */
+ * upon completion of the operation. The default data range is expected to be
+ * PMIX_SESSION, and the default persistence PMIX_PERSIST_SESSION. These values
+ * can be modified by including the respective pmix_info_t struct in the
+ * provided array.
+ *
+ * Note that the host server is not required to guarantee support for any specific
+ * range - i.e., the server does not need to return an error if the data store
+ * doesn't support range-based isolation. However, the server must return an error
+ * (a) if the key is duplicative within the storage range, and (b) if the server
+ * does not allow overwriting of published info by the original publisher - it is
+ * left to the discretion of the host server to allow info-key-based flags to modify
+ * this behavior.
+ *
+ * The persistence indicates how long the server should retain the data.
+ *
+ * The identifier of the publishing process is also provided and is expected to
+ * be returned on any subsequent lookup request */
 typedef pmix_status_t (*pmix_server_publish_fn_t)(const pmix_proc_t *proc,
-                                                  pmix_data_range_t range, pmix_persistence_t persist,
                                                   const pmix_info_t info[], size_t ninfo,
                                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Lookup published data. The host server will be passed a NULL-terminated array
- * of string keys along with the range within which the data is expected to have
- * been published. The host server is not required to guarantee support for all
- * PMIx-defined ranges, but should only search data stores within the specified
- * range within the context of the corresponding "publish" API.
+ * of string keys.
  *
  * The array of info structs is used to pass user-requested options to the server.
  * This can include a wait flag to indicate that the server should wait for all
  * data to become available before executing the callback function, or should
  * immediately callback with whatever data is available. In addition, a timeout
  * can be specified on the wait to preclude an indefinite wait for data that
- * may never be published. The directives are optional _unless_ the _mandatory_ flag
- * has been set - in such cases, the host RM is required to return an error
- * if the directive cannot be met. */
-typedef pmix_status_t (*pmix_server_lookup_fn_t)(const pmix_proc_t *proc,
-                                                 pmix_data_range_t range,
+ * may never be published. */
+typedef pmix_status_t (*pmix_server_lookup_fn_t)(const pmix_proc_t *proc, char **keys,
                                                  const pmix_info_t info[], size_t ninfo,
-                                                 char **keys,
                                                  pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 
 /* Delete data from the data store. The host server will be passed a NULL-terminated array
- * of string keys along with the range within which the data is expected to have
- * been published. The callback is to be executed upon completion of the delete
+ * of string keys, plus potential directives such as the data range within which the
+ * keys should be deleted. The callback is to be executed upon completion of the delete
  * procedure */
-typedef pmix_status_t (*pmix_server_unpublish_fn_t)(const pmix_proc_t *proc,
-                                                    pmix_data_range_t range,
+typedef pmix_status_t (*pmix_server_unpublish_fn_t)(const pmix_proc_t *proc, char **keys,
                                                     const pmix_info_t info[], size_t ninfo,
-                                                    char **keys,
                                                     pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Spawn a set of applications/processes as per the PMIx API. Note that

--- a/opal/mca/pmix/pmix1xx/pmix/src/client/pmi1.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/client/pmi1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -190,7 +190,7 @@ int PMI_Publish_name(const char service_name[], const char port[])
 
     /* publish the info - PMI-1 doesn't support
      * any scope other than inside our own nspace */
-    rc = PMIx_Publish(PMIX_NAMESPACE, PMIX_PERSIST_APP, &info, 1);
+    rc = PMIx_Publish(&info, 1);
 
     return convert_err(rc);
 }
@@ -204,7 +204,7 @@ int PMI_Unpublish_name(const char service_name[])
     keys[0] = (char*)service_name;
     keys[1] = NULL;
 
-    rc = PMIx_Unpublish(PMIX_NAMESPACE, keys);
+    rc = PMIx_Unpublish(keys, NULL, 0);
     return convert_err(rc);
 }
 
@@ -219,7 +219,7 @@ int PMI_Lookup_name(const char service_name[], char port[])
     (void)strncpy(pdata.key, service_name, PMIX_MAX_KEYLEN);
 
     /* PMI-1 doesn't want the nspace back */
-    if (PMIX_SUCCESS != (rc = PMIx_Lookup(PMIX_NAMESPACE, NULL, 0, &pdata, 1))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, NULL, 0))) {
         return convert_err(rc);
     }
 

--- a/opal/mca/pmix/pmix1xx/pmix/src/client/pmi2.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/client/pmi2.c
@@ -240,7 +240,7 @@ int PMI2_Nameserv_publish(const char service_name[], const PMI_keyval_t *info_pt
     }
     /* publish the info - PMI-2 doesn't support
      * any scope other than inside our own nspace */
-    rc = PMIx_Publish(PMIX_NAMESPACE, PMIX_PERSIST_APP, info, nvals);
+    rc = PMIx_Publish(info, nvals);
 
     return convert_err(rc);
 }
@@ -261,7 +261,7 @@ int PMI2_Nameserv_unpublish(const char service_name[],
         keys[1] = info_ptr->key;
     }
 
-    rc = PMIx_Unpublish(PMIX_NAMESPACE, keys);
+    rc = PMIx_Unpublish(keys, NULL, 0);
     return convert_err(rc);
 }
 
@@ -288,7 +288,7 @@ int PMI2_Nameserv_lookup(const char service_name[], const PMI_keyval_t *info_ptr
     }
 
     /* lookup the info */
-    if (PMIX_SUCCESS != (rc = PMIx_Lookup(PMIX_NAMESPACE, NULL, 0, pdata, nvals))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Lookup(pdata, nvals, NULL, 0))) {
         PMIX_PDATA_DESTRUCT(&pdata[0]);
         PMIX_PDATA_DESTRUCT(&pdata[1]);
         return convert_err(rc);

--- a/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server.c
@@ -246,13 +246,16 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     security_mode = strdup(pmix_sec.name);
 
     /* find the temp dir */
-    if (NULL == (tdir = getenv("TMPDIR"))) {
-        if (NULL == (tdir = getenv("TEMP"))) {
-            if (NULL == (tdir = getenv("TMP"))) {
-                tdir = "/tmp";
+    if (NULL == (tdir = getenv("PMIX_SERVER_TMPDIR"))) {
+        if (NULL == (tdir = getenv("TMPDIR"))) {
+            if (NULL == (tdir = getenv("TEMP"))) {
+                if (NULL == (tdir = getenv("TMP"))) {
+                    tdir = "/tmp";
+                }
             }
         }
     }
+
     /* now set the address - we use the pid here to reduce collisions */
     memset(&myaddress, 0, sizeof(struct sockaddr_un));
     myaddress.sun_family = AF_UNIX;
@@ -1879,7 +1882,7 @@ static void cnct_cbfunc(int status, void *cbdata)
     scd = PMIX_NEW(pmix_shift_caddy_t);
     scd->status = status;
     scd->tracker = tracker;
-    PMIX_THREADSHIFT(scd, _mdxcbfunc);
+    PMIX_THREADSHIFT(scd, _cnct);
 }
 
 

--- a/opal/mca/pmix/pmix1xx/pmix/test/server_callbacks.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/server_callbacks.c
@@ -151,7 +151,6 @@ int dmodex_fn(const pmix_proc_t *proc,
 }
 
 int publish_fn(const pmix_proc_t *proc,
-               pmix_data_range_t scope, pmix_persistence_t persist,
                const pmix_info_t info[], size_t ninfo,
                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -184,8 +183,8 @@ int publish_fn(const pmix_proc_t *proc,
     return PMIX_SUCCESS;
 }
 
-int lookup_fn(const pmix_proc_t *proc, pmix_data_range_t scope,
-              const pmix_info_t info[], size_t ninfo, char **keys,
+int lookup_fn(const pmix_proc_t *proc, char **keys,
+              const pmix_info_t info[], size_t ninfo,
               pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     size_t i, ndata, ret;
@@ -216,26 +215,26 @@ int lookup_fn(const pmix_proc_t *proc, pmix_data_range_t scope,
     return PMIX_SUCCESS;
 }
 
-int unpublish_fn(const pmix_proc_t *proc,
-                 pmix_data_range_t scope, char **keys,
+int unpublish_fn(const pmix_proc_t *proc, char **keys,
+                 const pmix_info_t info[], size_t ninfo,
                  pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    size_t i, ninfo;
-    pmix_test_info_t *info, *next;
+    size_t i;
+    pmix_test_info_t *iptr, *next;
     if (NULL == pmix_test_published_list) {
         return PMIX_ERR_NOT_FOUND;
     }
-    PMIX_LIST_FOREACH_SAFE(info, next, pmix_test_published_list, pmix_test_info_t) {
-        if (1) {// if data posted by this process
+    PMIX_LIST_FOREACH_SAFE(iptr, next, pmix_test_published_list, pmix_test_info_t) {
+        if (1) {  // if data posted by this process
             if (NULL == keys) {
-                pmix_list_remove_item(pmix_test_published_list, &info->super);
-                PMIX_RELEASE(info);
+                pmix_list_remove_item(pmix_test_published_list, &iptr->super);
+                PMIX_RELEASE(iptr);
             } else {
                 ninfo = pmix_argv_count(keys);
                 for (i = 0; i < ninfo; i++) {
-                    if (!strcmp(info->data.key, keys[i])) {
-                        pmix_list_remove_item(pmix_test_published_list, &info->super);
-                        PMIX_RELEASE(info);
+                    if (!strcmp(iptr->data.key, keys[i])) {
+                        pmix_list_remove_item(pmix_test_published_list, &iptr->super);
+                        PMIX_RELEASE(iptr);
                         break;
                     }
                 }

--- a/opal/mca/pmix/pmix1xx/pmix/test/server_callbacks.h
+++ b/opal/mca/pmix/pmix1xx/pmix/test/server_callbacks.h
@@ -29,14 +29,13 @@ pmix_status_t dmodex_fn(const pmix_proc_t *proc,
                         const pmix_info_t info[], size_t ninfo,
                         pmix_modex_cbfunc_t cbfunc, void *cbdata);
 pmix_status_t publish_fn(const pmix_proc_t *proc,
-                         pmix_data_range_t scope, pmix_persistence_t persist,
                          const pmix_info_t info[], size_t ninfo,
                          pmix_op_cbfunc_t cbfunc, void *cbdata);
-pmix_status_t lookup_fn(const pmix_proc_t *proc, pmix_data_range_t scope,
-                        const pmix_info_t info[], size_t ninfo, char **keys,
+pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
+                        const pmix_info_t info[], size_t ninfo,
                         pmix_lookup_cbfunc_t cbfunc, void *cbdata);
-pmix_status_t unpublish_fn(const pmix_proc_t *proc,
-                           pmix_data_range_t scope, char **keys,
+pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
+                           const pmix_info_t info[], size_t ninfo,
                            pmix_op_cbfunc_t cbfunc, void *cbdata);
 pmix_status_t spawn_fn(const pmix_proc_t *proc,
                        const pmix_info_t job_info[], size_t ninfo,

--- a/opal/mca/pmix/pmix1xx/pmix/test/simple/simpclient.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/simple/simpclient.c
@@ -44,11 +44,11 @@ int main(int argc, char **argv)
     char *tmp;
     pmix_proc_t proc, myproc;
     uint32_t nprocs, n;
-    
+
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank, rc);
-        exit(0);
+        exit(rc);
     }
     pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
 
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
     pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
-    
+
     /* put a few values */
     (void)asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
     value.type = PMIX_UINT32;
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
         pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
         goto done;
     }
-    
+
     /* check the returned data */
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     for (n=0; n < nprocs; n++) {
@@ -156,5 +156,5 @@ int main(int argc, char **argv)
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
     }
     fflush(stderr);
-    return(0);
+    return(rc);
 }

--- a/opal/mca/pmix/pmix1xx/pmix/test/simple/simppub.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/simple/simppub.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
     pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
-    
+
     /* call fence to ensure the data is received */
     PMIX_PROC_CONSTRUCT(&proc);
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
         pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
         goto done;
     }
-    
+
     /* publish something */
     if (0 == myproc.rank) {
         PMIX_INFO_CREATE(info, 2);
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
         (void)strncpy(info[1].key, "PANDA", PMIX_MAX_KEYLEN);
         info[1].value.type = PMIX_SIZE;
         info[1].value.data.size = 123456;
-        if (PMIX_SUCCESS != (rc = PMIx_Publish(PMIX_GLOBAL, PMIX_PERSIST_APP, info, 2))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Publish(info, 2))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Publish failed: %d", myproc.nspace, myproc.rank, rc);
             goto done;
         }
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
     if (0 != myproc.rank) {
         PMIX_PDATA_CREATE(pdata, 1);
         (void)strncpy(pdata[0].key, "FOOBAR", PMIX_MAX_KEYLEN);
-        if (PMIX_SUCCESS != (rc = PMIx_Lookup(PMIX_GLOBAL, NULL, 0, pdata, 1))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Lookup(pdata, 1, NULL, 0))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Lookup failed: %d", myproc.nspace, myproc.rank, rc);
             goto done;
         }
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
         pmix_argv_append_nosize(&keys, "FOOBAR");
         pmix_argv_append_nosize(&keys, "PANDA");
 
-        if (PMIX_SUCCESS != (rc = PMIx_Unpublish(PMIX_GLOBAL, keys))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Unpublish(keys, NULL, 0))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Unpublish failed: %d", myproc.nspace, myproc.rank, rc);
             goto done;
         }

--- a/opal/mca/pmix/pmix1xx/pmix/test/simple/simptest.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/simple/simptest.c
@@ -24,17 +24,24 @@
 
 #include <private/autogen/config.h>
 #include <pmix_server.h>
+#include <private/types.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <signal.h>
+#include PMIX_EVENT_HEADER
 
 #include "src/util/pmix_environ.h"
 #include "src/util/output.h"
 #include "src/util/printf.h"
 #include "src/util/argv.h"
 #include "src/buffer_ops/buffer_ops.h"
+#include "src/usock/usock.h"
 
 static pmix_status_t connected(const pmix_proc_t *proc, void *server_object);
 static pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
@@ -51,14 +58,13 @@ static pmix_status_t dmodex_fn(const pmix_proc_t *proc,
                                const pmix_info_t info[], size_t ninfo,
                                pmix_modex_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t publish_fn(const pmix_proc_t *proc,
-                                pmix_data_range_t scope, pmix_persistence_t persist,
                                 const pmix_info_t info[], size_t ninfo,
                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t lookup_fn(const pmix_proc_t *proc, pmix_data_range_t scope,
-                               const pmix_info_t info[], size_t ninfo, char **keys,
+static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
+                               const pmix_info_t info[], size_t ninfo,
                                pmix_lookup_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t unpublish_fn(const pmix_proc_t *proc,
-                                  pmix_data_range_t scope, char **keys,
+static pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
+                                  const pmix_info_t info[], size_t ninfo,
                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t spawn_fn(const pmix_proc_t *proc,
                               const pmix_info_t job_info[], size_t ninfo,
@@ -72,8 +78,6 @@ static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t register_event_fn(const pmix_info_t info[], size_t ninfo,
                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t listener_fn(int listening_sd,
-                                 pmix_connection_cbfunc_t cbfunc);
 
 static pmix_server_module_t mymodule = {
     connected,
@@ -88,7 +92,7 @@ static pmix_server_module_t mymodule = {
     connect_fn,
     disconnect_fn,
     register_event_fn,
-    listener_fn
+    NULL
 };
 
 typedef struct {
@@ -101,7 +105,7 @@ PMIX_CLASS_INSTANCE(pmix_locdat_t,
 
 typedef struct {
     pmix_object_t super;
-    volatile bool completed;
+    volatile bool active;
     pmix_proc_t caller;
     pmix_info_t *info;
     size_t ninfo;
@@ -113,7 +117,7 @@ static void xfcon(myxfer_t *p)
 {
     p->info = NULL;
     p->ninfo = 0;
-    p->completed = false;
+    p->active = true;
     p->cbfunc = NULL;
     p->spcbfunc = NULL;
     p->cbdata = NULL;
@@ -128,26 +132,35 @@ PMIX_CLASS_INSTANCE(myxfer_t,
                     pmix_object_t,
                     xfcon, xfdes);
 
+typedef struct {
+    pmix_list_item_t super;
+    pid_t pid;
+} wait_tracker_t;
+PMIX_CLASS_INSTANCE(wait_tracker_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
 static volatile int wakeup;
 static pmix_list_t pubdata;
+static pmix_event_t handler;
+static pmix_list_t children;
 
 static void set_namespace(int nprocs, char *ranks, char *nspace,
                           pmix_op_cbfunc_t cbfunc, myxfer_t *x);
 static void errhandler(pmix_status_t status,
                        pmix_proc_t procs[], size_t nprocs,
                        pmix_info_t info[], size_t ninfo);
+static void wait_signal_callback(int fd, short event, void *arg);
 
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {
     myxfer_t *x = (myxfer_t*)cbdata;
 
-    x->completed = true;
-    /* release the caller, if necessary - note that
-     * this may result in release of x, so this must
-     * be the last thing we do with it here */
+    /* release the caller, if necessary */
     if (NULL != x->cbfunc) {
         x->cbfunc(PMIX_SUCCESS, x->cbdata);
     }
+    x->active = false;
 }
 
 int main(int argc, char **argv)
@@ -161,6 +174,7 @@ int main(int argc, char **argv)
     pid_t pid;
     myxfer_t *x;
     pmix_proc_t proc;
+    wait_tracker_t *child;
 
     /* smoke test */
     if (PMIX_SUCCESS != 0) {
@@ -180,6 +194,12 @@ int main(int argc, char **argv)
 
     /* setup the pub data, in case it is used */
     PMIX_CONSTRUCT(&pubdata, pmix_list_t);
+
+    /* setup to see sigchld on the forked tests */
+    PMIX_CONSTRUCT(&children, pmix_list_t);
+    event_assign(&handler, pmix_globals.evbase, SIGCHLD,
+                 EV_SIGNAL|EV_PERSIST,wait_signal_callback, &handler);
+    event_add(&handler, NULL);
 
     /* see if we were passed the number of procs to run or
      * the executable to use */
@@ -208,7 +228,6 @@ int main(int argc, char **argv)
     tmp = pmix_argv_join(atmp, ',');
     x = PMIX_NEW(myxfer_t);
     set_namespace(nprocs, tmp, "foobar", opcbfunc, x);
-    free(tmp);
 
     /* set common argv and env */
     client_env = pmix_argv_copy(environ);
@@ -220,12 +239,8 @@ int main(int argc, char **argv)
 
     /* if the nspace registration hasn't completed yet,
      * wait for it here */
-    while (!x->completed) {
-        struct timespec ts;
-        ts.tv_sec = 0;
-        ts.tv_nsec = 100000;
-        nanosleep(&ts, NULL);
-    }
+    PMIX_WAIT_FOR_COMPLETION(x->active);
+    free(tmp);
     PMIX_RELEASE(x);
 
     /* fork/exec the test */
@@ -246,12 +261,7 @@ int main(int argc, char **argv)
         }
         /* don't fork/exec the client until we know it is registered
          * so we avoid a potential race condition in the server */
-        while (!x->completed) {
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100000;
-            nanosleep(&ts, NULL);
-        }
+        PMIX_WAIT_FOR_COMPLETION(x->active);
         PMIX_RELEASE(x);
         pid = fork();
         if (pid < 0) {
@@ -259,6 +269,9 @@ int main(int argc, char **argv)
             PMIx_server_finalize();
             return -1;
         }
+        child = PMIX_NEW(wait_tracker_t);
+        child->pid = pid;
+        pmix_list_append(&children, &child->super);
 
         if (pid == 0) {
             execve(executable, client_argv, client_env);
@@ -438,7 +451,6 @@ static int dmodex_fn(const pmix_proc_t *proc,
 
 
 static int publish_fn(const pmix_proc_t *proc,
-                      pmix_data_range_t scope, pmix_persistence_t persist,
                       const pmix_info_t info[], size_t ninfo,
                       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -462,9 +474,8 @@ static int publish_fn(const pmix_proc_t *proc,
 }
 
 
-static int lookup_fn(const pmix_proc_t *proc,
-                     pmix_data_range_t scope,
-                     const pmix_info_t info[], size_t ninfo, char **keys,
+static int lookup_fn(const pmix_proc_t *proc, char **keys,
+                     const pmix_info_t info[], size_t ninfo,
                      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_locdat_t *p, *p2;
@@ -512,8 +523,8 @@ static int lookup_fn(const pmix_proc_t *proc,
 }
 
 
-static int unpublish_fn(const pmix_proc_t *proc,
-                        pmix_data_range_t scope, char **keys,
+static int unpublish_fn(const pmix_proc_t *proc, char **keys,
+                        const pmix_info_t info[], size_t ninfo,
                         pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_locdat_t *p, *p2;
@@ -610,10 +621,39 @@ static pmix_status_t register_event_fn(const pmix_info_t info[], size_t ninfo,
     return PMIX_SUCCESS;
 }
 
-static int listener_fn(int listening_sd,
-                       pmix_connection_cbfunc_t cbfunc)
+static void wait_signal_callback(int fd, short event, void *arg)
 {
-    return PMIX_SUCCESS;
-}
+    pmix_event_t *sig = (pmix_event_t*) arg;
+    int status;
+    pid_t pid;
+    wait_tracker_t *t2;
 
+    if (SIGCHLD != event_get_signal(sig)) {
+        return;
+    }
+
+    /* we can have multiple children leave but only get one
+     * sigchild callback, so reap all the waitpids until we
+     * don't get anything valid back */
+    while (1) {
+        pid = waitpid(-1, &status, WNOHANG);
+        if (-1 == pid && EINTR == errno) {
+            /* try it again */
+            continue;
+        }
+        /* if we got garbage, then nothing we can do */
+        if (pid <= 0) {
+            return;
+        }
+
+        /* we are already in an event, so it is safe to access the list */
+        PMIX_LIST_FOREACH(t2, &children, wait_tracker_t) {
+            if (pid == t2->pid) {
+                /* found it! */
+                --wakeup;
+                break;
+            }
+        }
+    }
+}
 

--- a/opal/mca/pmix/pmix1xx/pmix/test/test_fence.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/test_fence.c
@@ -86,11 +86,11 @@ static void add_noise(char *noise_param, char *my_nspace, int my_rank)
     SET_KEY(key, fence_num, ind, use_same_keys);                                                                    \
     (void)strncpy(foobar.nspace, ns, PMIX_MAX_NSLEN); \
     foobar.rank = r; \
-    TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, key));                     \
+    TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, key));                          \
     if (blocking) {                                                                                                 \
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&foobar, key, NULL, 0, &val))) {                                                 \
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&foobar, key, NULL, 0, &val))) {                                         \
             if( !( rc == PMIX_ERR_NOT_FOUND && ok_notfnd ) ){                                                       \
-                TEST_ERROR(("%s:%d: PMIx_Get failed: %d from %s:%d", my_nspace, my_rank, rc, ns, r));            \
+                TEST_ERROR(("%s:%d: PMIx_Get failed: %d from %s:%d, key %s", my_nspace, my_rank, rc, ns, r, key));  \
             }                                                                                                       \
             rc = PMIX_ERROR;                                                                                        \
         }                                                                                                           \
@@ -99,8 +99,8 @@ static void add_noise(char *noise_param, char *my_nspace, int my_rank)
         cbdata.in_progress = 1;                                                                                     \
         PMIX_VALUE_CREATE(val, 1);                                                                                  \
         cbdata.kv = val;                                                                                            \
-        if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&foobar, key, NULL, 0, get_cb, (void*)&cbdata))) {                            \
-            TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d", my_nspace, my_rank, rc, ns, r));           \
+        if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&foobar, key, NULL, 0, get_cb, (void*)&cbdata))) {                    \
+            TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d, key=%s", my_nspace, my_rank, rc, ns, r, key)); \
             rc = PMIX_ERROR;                                                                                        \
         } else {                                                                                                    \
             count = 0;                                                                                              \
@@ -116,7 +116,8 @@ static void add_noise(char *noise_param, char *my_nspace, int my_rank)
     if (PMIX_SUCCESS == rc) {                                                                                       \
         if( PMIX_SUCCESS != cbdata.status ){                                                                        \
             if( !( rc == PMIX_ERR_NOT_FOUND && ok_notfnd ) ){                                                       \
-                TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d", my_nspace, my_rank, rc, my_nspace, r));\
+                TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d, key=%s",                                   \
+                            my_nspace, my_rank, rc, my_nspace, r));                                                 \
             }                                                                                                       \
             rc = PMIX_ERROR;                                                                                        \
         } else if (NULL == val) {                                                                                   \

--- a/opal/mca/pmix/pmix1xx/pmix/test/test_publish.c
+++ b/opal/mca/pmix/pmix1xx/pmix/test/test_publish.c
@@ -59,10 +59,10 @@ static int test_publish(char *my_nspace, int my_rank, int blocking)
     info.value.type = PMIX_STRING;
     info.value.data.string = strdup(data);
     if (blocking) {
-        rc = PMIx_Publish(PMIX_NAMESPACE, PMIX_PERSIST_INDEF, &info, 1);
+        rc = PMIx_Publish(&info, 1);
     } else {
         int in_progress = 1;
-        rc = PMIx_Publish_nb(PMIX_NAMESPACE, PMIX_PERSIST_INDEF, &info, 1, release_cb, &in_progress);
+        rc = PMIx_Publish_nb(&info, 1, release_cb, &in_progress);
         if (PMIX_SUCCESS == rc) {
             PMIX_WAIT_FOR_COMPLETION(in_progress);
         }
@@ -83,7 +83,7 @@ static int test_lookup(char *my_nspace, int my_rank, int blocking)
     (void)snprintf(data, 512, "data from proc %s:%d", my_nspace, my_rank);
 
     if (blocking) {
-        if (PMIX_SUCCESS != (rc = PMIx_Lookup(PMIX_NAMESPACE, NULL, 0, &pdata, 1))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, NULL, 0))) {
             PMIX_PDATA_DESTRUCT(&pdata);
             return rc;
         }
@@ -98,7 +98,7 @@ static int test_lookup(char *my_nspace, int my_rank, int blocking)
         cbdata.pdata = &pdata;
         /* copy the key across */
         (void)strncpy(pdata.key, keys[0], PMIX_MAX_KEYLEN);
-        rc = PMIx_Lookup_nb(PMIX_NAMESPACE, keys, NULL, 0, lookup_cb, (void*)&cbdata);
+        rc = PMIx_Lookup_nb(keys, NULL, 0, lookup_cb, (void*)&cbdata);
         if (PMIX_SUCCESS != rc) {
             PMIX_PDATA_DESTRUCT(&pdata);
             return rc;
@@ -130,10 +130,10 @@ static int test_unpublish(char *my_nspace, int my_rank, int blocking)
     keys[1] = NULL;
 
     if (blocking) {
-        rc = PMIx_Unpublish(PMIX_NAMESPACE, keys);
+        rc = PMIx_Unpublish(keys, NULL, 0);
     } else {
         int in_progress = 1;
-        rc = PMIx_Unpublish_nb(PMIX_NAMESPACE, keys, release_cb, &in_progress);
+        rc = PMIx_Unpublish_nb(keys, NULL, 0, release_cb, &in_progress);
         if (PMIX_SUCCESS == rc) {
             PMIX_WAIT_FOR_COMPLETION(in_progress);
         }

--- a/opal/mca/pmix/pmix1xx/pmix1.h
+++ b/opal/mca/pmix/pmix1xx/pmix1.h
@@ -89,20 +89,15 @@ OPAL_MODULE_DECLSPEC int pmix1_get(const opal_process_name_t *proc,
 OPAL_MODULE_DECLSPEC int pmix1_getnb(const opal_process_name_t *proc,
                                        const char *key,
                                        opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_publish(opal_pmix_data_range_t scope,
-                                         opal_pmix_persistence_t persist,
-                                         opal_list_t *info);
-OPAL_MODULE_DECLSPEC int pmix1_publishnb(opal_pmix_data_range_t scope,
-                                           opal_pmix_persistence_t persist,
-                                           opal_list_t *info,
+OPAL_MODULE_DECLSPEC int pmix1_publish(opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix1_publishnb(opal_list_t *info,
+                                         opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_lookup(opal_list_t *data, opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix1_lookupnb(char **keys, opal_list_t *info,
+                                        opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_unpublish(char **keys, opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix1_unpublishnb(char **keys, opal_list_t *info,
                                            opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_lookup(opal_pmix_data_range_t scope,
-                                        opal_list_t *data);
-OPAL_MODULE_DECLSPEC int pmix1_lookupnb(opal_pmix_data_range_t scope, int wait, char **keys,
-                                          opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_unpublish(opal_pmix_data_range_t scope, char **keys);
-OPAL_MODULE_DECLSPEC int pmix1_unpublishnb(opal_pmix_data_range_t scope, char **keys,
-                                             opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix1_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid);
 OPAL_MODULE_DECLSPEC int pmix1_spawnnb(opal_list_t *job_info, opal_list_t *apps,
                                          opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata);
@@ -119,8 +114,6 @@ OPAL_MODULE_DECLSPEC int pmix1_resolve_peers(const char *nodename, opal_jobid_t 
 OPAL_MODULE_DECLSPEC int pmix1_resolve_nodes(opal_jobid_t jobid, char **nodelist);
 
 /****  COMMON FUNCTIONS  ****/
-OPAL_MODULE_DECLSPEC void pmix1_register_errhandler(opal_pmix_errhandler_fn_t errhandler);
-OPAL_MODULE_DECLSPEC void pmix1_deregister_errhandler(void);
 OPAL_MODULE_DECLSPEC int pmix1_store_local(const opal_process_name_t *proc,
                                              opal_value_t *val);
 

--- a/opal/mca/pmix/pmix1xx/pmix_pmix1.c
+++ b/opal/mca/pmix/pmix1xx/pmix_pmix1.c
@@ -35,6 +35,7 @@
 #include "opal/util/show_help.h"
 
 #include "pmix1.h"
+#include "opal/mca/pmix/base/base.h"
 
 #include "opal/mca/pmix/pmix1xx/pmix/include/pmix/pmix_common.h"
 
@@ -82,36 +83,10 @@ const opal_pmix_base_module_t opal_pmix_pmix1xx_module = {
     pmix1_server_notify_error,
     /* utility APIs */
     PMIx_Get_version,
-    pmix1_register_errhandler,
-    pmix1_deregister_errhandler,
+    opal_pmix_base_register_handler,
+    opal_pmix_base_deregister_handler,
     pmix1_store_local
 };
-
-static pmix_notification_fn_t errhandler = NULL;
-
-static void notification_fn(int status,
-                            opal_list_t *procs,
-                            opal_list_t *info)
-{
-    /* convert the status */
-
-    /* convert the list of procs to an array of pmix_proc_t */
-
-    /* convert the list of info to an array of pmix_info_t */
-
-    /* pass this down to the notification function
-     * we were given */
-}
-
-void pmix1_register_errhandler(opal_pmix_errhandler_fn_t errhandler)
-{
-    return;
-}
-
-void pmix1_deregister_errhandler(void)
-{
-    return;
-}
 
 int pmix1_store_local(const opal_process_name_t *proc,
                      opal_value_t *val)

--- a/opal/mca/pmix/pmix_server.h
+++ b/opal/mca/pmix/pmix_server.h
@@ -92,8 +92,6 @@ typedef int (*opal_pmix_server_dmodex_req_fn_t)(opal_process_name_t *proc, opal_
  * process is also provided and is expected to be returned on any subsequent
  * lookup request */
 typedef int (*opal_pmix_server_publish_fn_t)(opal_process_name_t *proc,
-                                             opal_pmix_data_range_t range,
-                                             opal_pmix_persistence_t persist,
                                              opal_list_t *info,
                                              opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
@@ -110,18 +108,16 @@ typedef int (*opal_pmix_server_publish_fn_t)(opal_process_name_t *proc,
  * how the operation is to be executed (e.g., timeout limits, whether the
  * lookup should wait until data appears).
  */
-typedef int (*opal_pmix_server_lookup_fn_t)(opal_process_name_t *proc,
-                                            opal_pmix_data_range_t range,
-                                            opal_list_t *info, char **keys,
+typedef int (*opal_pmix_server_lookup_fn_t)(opal_process_name_t *proc, char **keys,
+                                            opal_list_t *info,
                                             opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 
 /* Delete data from the data store. The host server will be passed a NULL-terminated array
  * of string keys along with the scope within which the data is expected to have
  * been published. The callback is to be executed upon completion of the delete
  * procedure */
-typedef int (*opal_pmix_server_unpublish_fn_t)(opal_process_name_t *proc,
-                                               opal_pmix_data_range_t range,
-                                               opal_list_t *info,  char **keys,
+typedef int (*opal_pmix_server_unpublish_fn_t)(opal_process_name_t *proc, char **keys,
+                                               opal_list_t *info,
                                                opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Spawn a set of applications/processes as per the PMIx API. Note that

--- a/opal/mca/pmix/pmix_types.h
+++ b/opal/mca/pmix/pmix_types.h
@@ -32,14 +32,17 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_USERID                "pmix.euid"         // (uint32_t) effective user id
 #define OPAL_PMIX_GRPID                 "pmix.egid"         // (uint32_t) effective group id
 
+/* general proc-level attributes */
 #define OPAL_PMIX_CPUSET                "pmix.cpuset"       // (char*) hwloc bitmap applied to proc upon launch
 #define OPAL_PMIX_CREDENTIAL            "pmix.cred"         // (char*) security credential assigned to proc
 #define OPAL_PMIX_SPAWNED               "pmix.spawned"      // (bool) true if this proc resulted from a call to PMIx_Spawn
 #define OPAL_PMIX_ARCH                  "pmix.arch"         // (uint32_t) datatype architecture flag
+
 /* scratch directory locations for use by applications */
 #define OPAL_PMIX_TMPDIR                "pmix.tmpdir"       // (char*) top-level tmp dir assigned to session
 #define OPAL_PMIX_NSDIR                 "pmix.nsdir"        // (char*) sub-tmpdir assigned to namespace
 #define OPAL_PMIX_PROCDIR               "pmix.pdir"         // (char*) sub-nsdir assigned to proc
+
 /* information about relative ranks as assigned by the RM */
 #define OPAL_PMIX_JOBID                 "pmix.jobid"        // (char*) jobid assigned by scheduler
 #define OPAL_PMIX_APPNUM                "pmix.appnum"       // (uint32_t) app number within the job
@@ -71,17 +74,20 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_LOCAL_PEERS           "pmix.lpeers"       // (char*) comma-delimited string of ranks on this node within the specified nspace
 #define OPAL_PMIX_LOCAL_CPUSETS         "pmix.lcpus"        // (char*) colon-delimited cpusets of local peers within the specified nspace
 #define OPAL_PMIX_PROC_URI              "pmix.puri"         // (char*) URI containing contact info for proc
+
 /* size info */
 #define OPAL_PMIX_UNIV_SIZE             "pmix.univ.size"    // (uint32_t) #procs in this nspace
 #define OPAL_PMIX_JOB_SIZE              "pmix.job.size"     // (uint32_t) #procs in this job
 #define OPAL_PMIX_LOCAL_SIZE            "pmix.local.size"   // (uint32_t) #procs in this job on this node
 #define OPAL_PMIX_NODE_SIZE             "pmix.node.size"    // (uint32_t) #procs across all jobs on this node
 #define OPAL_PMIX_MAX_PROCS             "pmix.max.size"     // (uint32_t) max #procs for this job
+
 /* topology info */
 #define OPAL_PMIX_NET_TOPO              "pmix.ntopo"        // (char*) xml-representation of network topology
 #define OPAL_PMIX_LOCAL_TOPO            "pmix.ltopo"        // (char*) xml-representation of local node topology
 #define OPAL_PMIX_NODE_LIST             "pmix.nlist"        // (char*) comma-delimited list of nodes running procs for this job
 #define OPAL_PMIX_TOPOLOGY              "pmix.topo"         // (hwloc_topology_t) pointer to the PMIx client's internal topology object
+
 /* fault tolerance-related info */
 #define OPAL_PMIX_TERMINATE_SESSION     "pmix.term.sess"    // (bool) RM intends to terminate session
 #define OPAL_PMIX_TERMINATE_JOB         "pmix.term.job"     // (bool) RM intends to terminate this job
@@ -95,6 +101,9 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_WAIT                  "pmix.wait"         // (int) caller requests that the server wait until the specified #values are found
 #define OPAL_PMIX_COLLECTIVE_ALGO       "pmix.calgo"        // (char*) comma-delimited list of algorithms to use for collective
 #define OPAL_PMIX_COLLECTIVE_ALGO_REQD  "pmix.calreqd"      // (bool) if true, indicates that the requested choice of algo is mandatory
+#define OPAL_PMIX_NOTIFY_COMPLETION     "pmix.notecomp"     // (bool) notify parent process upon termination of child job
+#define OPAL_PMIX_RANGE                 "pmix.range"        // (int) opal_pmix_data_range_t value for calls to publish/lookup/unpublish
+#define OPAL_PMIX_PERSISTENCE           "pmix.persist"      // (int) opal_pmix_persistence_t value for calls to publish
 
 /* attribute used by host server to pass data to the server convenience library - the
  * data will then be parsed and provided to the local clients */
@@ -126,7 +135,8 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_STDIN_TGT             "pmix.stdin"        // (uint32_t) spawned proc rank that is to receive stdin
 
 
-/* define a scope for data "put" by PMI per the following:
+/* define a scope for data "put" by PMI per the following - maintain
+ * consistent order with the PMIx distro :
  *
  * OPAL_PMI_LOCAL - the data is intended only for other application
  *                  processes on the same node. Data marked in this way
@@ -137,7 +147,7 @@ BEGIN_C_DECLS
  * OPAL_PMI_GLOBAL - the data is to be shared with all other requesting processes,
  *                   regardless of location
  */
-#define OPAL_PMIX_SCOPE PMIX_UINT32
+#define OPAL_PMIX_SCOPE PMIX_UINT
 typedef enum {
     OPAL_PMIX_SCOPE_UNDEF = 0,
     OPAL_PMIX_LOCAL,           // share to procs also on this node
@@ -145,15 +155,17 @@ typedef enum {
     OPAL_PMIX_GLOBAL
 } opal_pmix_scope_t;
 
-/* define a range for data "published" by PMI */
-#define OPAL_PMIX_DATA_RANGE OPAL_UINT8
+/* define a range for data "published" by PMI  - maintain
+ * consistent order with the PMIx distro */
+#define OPAL_PMIX_DATA_RANGE OPAL_UINT
 typedef enum {
     OPAL_PMIX_DATA_RANGE_UNDEF = 0,
     OPAL_PMIX_NAMESPACE,       // data is available to procs in the same nspace only
     OPAL_PMIX_SESSION          // data available to all jobs in this session
 } opal_pmix_data_range_t;
 
-/* define a "persistence" policy for data published by clients */
+/* define a "persistence" policy for data published by clients - maintain
+ * consistent order with the PMIx distro */
 typedef enum {
     OPAL_PMIX_PERSIST_INDEF = 0,   // retain until specifically deleted
     OPAL_PMIX_PERSIST_PROC,        // retain until publishing process terminates

--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -351,6 +351,14 @@ int orte_ess_base_orted_setup(char **hosts)
         error = "orte_routed_base_select";
         goto error;
     }
+    /* setup the routed info - the selected routed component
+     * will know what to do.
+     */
+    if (ORTE_SUCCESS != (ret = orte_routed.init_routes(ORTE_PROC_MY_NAME->jobid, NULL))) {
+        ORTE_ERROR_LOG(ret);
+        error = "orte_routed.init_routes";
+        goto error;
+    }
     /*
      * Group communications
      */
@@ -645,7 +653,7 @@ int orte_ess_base_orted_finalize(void)
     /* shutdown the pmix server */
     pmix_server_finalize();
     (void) mca_base_framework_close(&opal_pmix_base_framework);
-    
+
     /* close frameworks */
     (void) mca_base_framework_close(&orte_schizo_base_framework);
     (void) mca_base_framework_close(&orte_filem_base_framework);

--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -647,12 +647,6 @@ static int rte_init(void)
         error = "opal_pmix_base_select";
         goto error;
     }
-    /* setup the PMIx server */
-    if (ORTE_SUCCESS != (ret = pmix_server_init())) {
-        ORTE_ERROR_LOG(ret);
-        error = "pmix server init";
-        goto error;
-    }
 
     /* setup the routed info - the selected routed component
      * will know what to do.
@@ -662,6 +656,14 @@ static int rte_init(void)
         error = "orte_routed.init_routes";
         goto error;
     }
+
+    /* setup the PMIx server */
+    if (ORTE_SUCCESS != (ret = pmix_server_init())) {
+        ORTE_ERROR_LOG(ret);
+        error = "pmix server init";
+        goto error;
+    }
+
     /* setup I/O forwarding system - must come after we init routes */
     if (ORTE_SUCCESS != (ret = mca_base_framework_open(&orte_iof_base_framework, 0))) {
         ORTE_ERROR_LOG(ret);

--- a/orte/mca/schizo/base/base.h
+++ b/orte/mca/schizo/base/base.h
@@ -65,7 +65,6 @@ ORTE_DECLSPEC int orte_schizo_base_parse_cli(char *personality,
 ORTE_DECLSPEC int orte_schizo_base_parse_env(char *personality,
                                              char *path,
                                              opal_cmd_line_t *cmd_line,
-                                             char *server,
                                              char **srcenv,
                                              char ***dstenv);
 ORTE_DECLSPEC int orte_schizo_base_setup_fork(orte_job_t *jdata,

--- a/orte/mca/schizo/base/schizo_base_stubs.c
+++ b/orte/mca/schizo/base/schizo_base_stubs.c
@@ -40,7 +40,6 @@ int orte_schizo_base_parse_cli(char *personality,
 int orte_schizo_base_parse_env(char *personality,
                                char *path,
                                opal_cmd_line_t *cmd_line,
-                               char *server,
                                char **srcenv,
                                char ***dstenv)
 {
@@ -50,7 +49,7 @@ int orte_schizo_base_parse_env(char *personality,
     OPAL_LIST_FOREACH(mod, &orte_schizo_base.active_modules, orte_schizo_base_active_module_t) {
         if (0 == strcmp(personality, mod->component->mca_component_name)) {
             if (NULL != mod->module->parse_env) {
-                rc = mod->module->parse_env(personality, path, cmd_line, server, srcenv, dstenv);
+                rc = mod->module->parse_env(personality, path, cmd_line, srcenv, dstenv);
                 return rc;
             }
         }

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -54,7 +54,6 @@ static int parse_cli(char *personality,
 static int parse_env(char *personality,
                      char *path,
                      opal_cmd_line_t *cmd_line,
-                     char *server,
                      char **srcenv,
                      char ***dstenv);
 static int setup_fork(orte_job_t *jdata,
@@ -154,7 +153,6 @@ static int parse_cli(char *personality,
 static int parse_env(char *personality,
                      char *path,
                      opal_cmd_line_t *cmd_line,
-                     char *ompi_server,
                      char **srcenv,
                      char ***dstenv)
 {
@@ -179,11 +177,6 @@ static int parse_env(char *personality,
             opal_setenv(param, value, false, dstenv);
             free(param);
         }
-    }
-
-    /* add the ompi-server, if provided */
-    if (NULL != ompi_server) {
-        opal_setenv("OMPI_MCA_pubsub_orte_server", ompi_server, true, dstenv);
     }
 
     /* set necessary env variables for external usage from tune conf file*/

--- a/orte/mca/schizo/schizo.h
+++ b/orte/mca/schizo/schizo.h
@@ -46,7 +46,6 @@ typedef int (*orte_schizo_base_module_parse_cli_fn_t)(char *personality,
 typedef int (*orte_schizo_base_module_parse_env_fn_t)(char *personality,
                                                       char *path,
                                                       opal_cmd_line_t *cmd_line,
-                                                      char *server,
                                                       char **srcenv,
                                                       char ***dstenv);
 

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -53,6 +53,7 @@
  typedef struct {
     opal_object_t super;
     opal_event_t ev;
+    int timeout;
     int room_num;
     int remote_room_num;
     orte_process_name_t proxy;
@@ -146,17 +147,13 @@ extern int pmix_server_fencenb_fn(opal_list_t *procs, opal_list_t *info,
 extern int pmix_server_dmodex_req_fn(opal_process_name_t *proc, opal_list_t *info,
                                      opal_pmix_modex_cbfunc_t cbfunc, void *cbdata);
 extern int pmix_server_publish_fn(opal_process_name_t *proc,
-                                  opal_pmix_data_range_t range,
-                                  opal_pmix_persistence_t persist,
                                   opal_list_t *info,
                                   opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
-extern int pmix_server_lookup_fn(opal_process_name_t *proc,
-                                 opal_pmix_data_range_t range,
-                                 opal_list_t *info, char **keys,
+extern int pmix_server_lookup_fn(opal_process_name_t *proc, char **keys,
+                                 opal_list_t *info,
                                  opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
-extern int pmix_server_unpublish_fn(opal_process_name_t *proc,
-                                    opal_pmix_data_range_t range,
-                                    opal_list_t *info, char **keys,
+extern int pmix_server_unpublish_fn(opal_process_name_t *proc, char **keys,
+                                    opal_list_t *info,
                                     opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 extern int pmix_server_spawn_fn(opal_process_name_t *requestor,
                                 opal_list_t *job_info, opal_list_t *apps,
@@ -186,6 +183,8 @@ typedef struct {
     opal_hotel_t reqs;
     int num_rooms;
     int timeout;
+    char *server_uri;
+    bool wait_for_server;
     orte_process_name_t server;
 } pmix_server_globals_t;
 

--- a/orte/tools/orte-submit/orte-submit.c
+++ b/orte/tools/orte-submit/orte-submit.c
@@ -1046,7 +1046,7 @@ static int create_app(int argc, char* argv[],
     app->env = opal_argv_copy(*app_env);
     if (ORTE_SUCCESS != (rc = orte_schizo.parse_env(myglobals.personality,
                                                     myglobals.path,
-                                                    &cmd_line, NULL,
+                                                    &cmd_line,
                                                     environ, &app->env))) {
         goto cleanup;
     }

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -158,7 +158,6 @@ void* MPIR_Breakpoint(void)
 static char **global_mca_env = NULL;
 static orte_std_cntr_t total_num_apps = 0;
 static bool want_prefix_by_default = (bool) ORTE_WANT_ORTERUN_PREFIX_BY_DEFAULT;
-static char *ompi_server=NULL;
 
 /*
  * Globals
@@ -284,16 +283,10 @@ static opal_cmd_line_init_t cmd_line_init[] = {
       NULL, OPAL_CMD_LINE_TYPE_BOOL,
       "Do not attempt to resolve interfaces" },
 
-    /* uri of Open MPI server, or at least where to get it */
-    { NULL, '\0', "ompi-server", "ompi-server", 1,
-      &orterun_globals.ompi_server, OPAL_CMD_LINE_TYPE_STRING,
-      "Specify the URI of the Open MPI server, or the name of the file (specified as file:filename) that contains that info" },
-    { NULL, '\0', "wait-for-server", "wait-for-server", 0,
-      &orterun_globals.wait_for_server, OPAL_CMD_LINE_TYPE_BOOL,
-      "If ompi-server is not already running, wait until it is detected (default: false)" },
-    { NULL, '\0', "server-wait-time", "server-wait-time", 1,
-      &orterun_globals.server_wait_timeout, OPAL_CMD_LINE_TYPE_INT,
-      "Time in seconds to wait for ompi-server (default: 10 sec)" },
+    /* uri of PMIx publish/lookup server, or at least where to get it */
+    { "pmix_server_uri", '\0', "ompi-server", "ompi-server", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Specify the URI of the publish/lookup server, or the name of the file (specified as file:filename) that contains that info" },
 
     { "carto_file_path", '\0', "cf", "cartofile", 1,
       NULL, OPAL_CMD_LINE_TYPE_STRING,
@@ -1041,42 +1034,6 @@ int orterun(int argc, char *argv[])
         goto DONE;
     }
 
-    /* if an uri for the ompi-server was provided, set the route */
-    if (NULL != ompi_server) {
-        opal_buffer_t buf;
-        /* setup our route to the server */
-        OBJ_CONSTRUCT(&buf, opal_buffer_t);
-        opal_dss.pack(&buf, &ompi_server, 1, OPAL_STRING);
-        if (ORTE_SUCCESS != (rc = orte_rml_base_update_contact_info(&buf))) {
-            ORTE_ERROR_LOG(rc);
-            ORTE_UPDATE_EXIT_STATUS(ORTE_ERROR_DEFAULT_EXIT_CODE);
-            goto DONE;
-        }
-        OBJ_DESTRUCT(&buf);
-        /* check if we are to wait for the server to start - resolves
-         * a race condition that can occur when the server is run
-         * as a background job - e.g., in scripts
-         */
-        if (orterun_globals.wait_for_server) {
-            /* ping the server */
-            struct timeval timeout;
-            timeout.tv_sec = orterun_globals.server_wait_timeout;
-            timeout.tv_usec = 0;
-            if (ORTE_SUCCESS != (rc = orte_rml.ping(ompi_server, &timeout))) {
-                /* try it one more time */
-                if (ORTE_SUCCESS != (rc = orte_rml.ping(ompi_server, &timeout))) {
-                    /* okay give up */
-                    orte_show_help("help-orterun.txt", "orterun:server-not-found", true,
-                                   orte_basename, ompi_server,
-                                   (long)orterun_globals.server_wait_timeout,
-                                   ORTE_ERROR_NAME(rc));
-                    ORTE_UPDATE_EXIT_STATUS(ORTE_ERROR_DEFAULT_EXIT_CODE);
-                    goto DONE;
-                }
-            }
-        }
-    }
-
     /* setup for debugging */
     orte_debugger_init_before_spawn(jdata);
     orte_state.add_job_state(ORTE_JOB_STATE_READY_FOR_DEBUGGERS,
@@ -1175,9 +1132,6 @@ static int init_globals(void)
         orterun_globals.appfile =     NULL;
         orterun_globals.wdir =        NULL;
         orterun_globals.path =        NULL;
-        orterun_globals.ompi_server = NULL;
-        orterun_globals.wait_for_server = false;
-        orterun_globals.server_wait_timeout = 10;
         orterun_globals.stdin_target = "0";
         orterun_globals.report_pid        = NULL;
         orterun_globals.report_uri        = NULL;
@@ -1270,132 +1224,7 @@ static int parse_locals(orte_job_t *jdata, int argc, char* argv[])
     bool made_app;
     orte_std_cntr_t j, size1;
 
-    /* if the ompi-server was given, then set it up here */
-    if (NULL != orterun_globals.ompi_server) {
-        /* someone could have passed us a file instead of a uri, so
-         * we need to first check to see what we have - if it starts
-         * with "file", then we know it is a file. Otherwise, we assume
-         * it is a uri as provided by the ompi-server's output
-         * of an ORTE-standard string. Note that this is NOT a standard
-         * uri as it starts with the process name!
-         */
-        if (0 == strncmp(orterun_globals.ompi_server, "file", strlen("file")) ||
-            0 == strncmp(orterun_globals.ompi_server, "FILE", strlen("FILE"))) {
-            char input[1024], *filename;
-            FILE *fp;
-
-            /* it is a file - get the filename */
-            filename = strchr(orterun_globals.ompi_server, ':');
-            if (NULL == filename) {
-                /* filename is not correctly formatted */
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-bad", true,
-                               orte_basename, orterun_globals.ompi_server);
-                exit(1);
-            }
-            ++filename; /* space past the : */
-
-            if (0 >= strlen(filename)) {
-                /* they forgot to give us the name! */
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-missing", true,
-                               orte_basename, orterun_globals.ompi_server);
-                exit(1);
-            }
-
-            /* open the file and extract the uri */
-            fp = fopen(filename, "r");
-            if (NULL == fp) { /* can't find or read file! */
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-access", true,
-                               orte_basename, orterun_globals.ompi_server);
-                exit(1);
-            }
-            if (NULL == fgets(input, 1024, fp)) {
-                /* something malformed about file */
-                fclose(fp);
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-file-bad", true,
-                               orte_basename, orterun_globals.ompi_server,
-                               orte_basename);
-                exit(1);
-            }
-            fclose(fp);
-            input[strlen(input)-1] = '\0';  /* remove newline */
-            ompi_server = strdup(input);
-        } else if (0 == strncmp(orterun_globals.ompi_server, "pid", strlen("pid")) ||
-                   0 == strncmp(orterun_globals.ompi_server, "PID", strlen("PID"))) {
-            opal_list_t hnp_list;
-            opal_list_item_t *item;
-            orte_hnp_contact_t *hnp;
-            char *ptr;
-            pid_t pid;
-
-            ptr = strchr(orterun_globals.ompi_server, ':');
-            if (NULL == ptr) {
-                /* pid is not correctly formatted */
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-pid-bad", true,
-                               orte_basename, orte_basename,
-                               orterun_globals.ompi_server, orte_basename);
-                exit(1);
-            }
-            ++ptr; /* space past the : */
-
-            if (0 >= strlen(ptr)) {
-                /* they forgot to give us the pid! */
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-pid-bad", true,
-                               orte_basename, orte_basename,
-                               orterun_globals.ompi_server, orte_basename);
-                exit(1);
-            }
-
-            pid = strtoul(ptr, NULL, 10);
-
-            /* to search the local mpirun's, we have to partially initialize the
-             * orte_process_info structure. This won't fully be setup until orte_init,
-             * but we finagle a little bit of it here
-             */
-            if (ORTE_SUCCESS != (rc = orte_session_dir_get_name(NULL, &orte_process_info.tmpdir_base,
-                                                                &orte_process_info.top_session_dir,
-                                                                NULL, NULL, NULL))) {
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-could-not-get-hnp-list", true,
-                               orte_basename, orte_basename);
-                exit(1);
-            }
-
-            OBJ_CONSTRUCT(&hnp_list, opal_list_t);
-
-            /* get the list of HNPs, but do -not- setup contact info to them in the RML */
-            if (ORTE_SUCCESS != (rc = orte_list_local_hnps(&hnp_list, false))) {
-                orte_show_help("help-orterun.txt", "orterun:ompi-server-could-not-get-hnp-list", true,
-                               orte_basename, orte_basename);
-                exit(1);
-            }
-
-            /* search the list for the desired pid */
-            while (NULL != (item = opal_list_remove_first(&hnp_list))) {
-                hnp = (orte_hnp_contact_t*)item;
-                if (pid == hnp->pid) {
-                    ompi_server = strdup(hnp->rml_uri);
-                    goto hnp_found;
-                }
-                OBJ_RELEASE(item);
-            }
-            /* if we got here, it wasn't found */
-            orte_show_help("help-orterun.txt", "orterun:ompi-server-pid-not-found", true,
-                           orte_basename, orte_basename, pid, orterun_globals.ompi_server,
-                           orte_basename);
-            OBJ_DESTRUCT(&hnp_list);
-            exit(1);
-        hnp_found:
-            /* cleanup rest of list */
-            while (NULL != (item = opal_list_remove_first(&hnp_list))) {
-                OBJ_RELEASE(item);
-            }
-            OBJ_DESTRUCT(&hnp_list);
-        } else {
-            ompi_server = strdup(orterun_globals.ompi_server);
-        }
-    }
-
     /* Make the apps */
-
     temp_argc = 0;
     temp_argv = NULL;
     opal_argv_append(&temp_argc, &temp_argv, argv[0]);
@@ -1640,7 +1469,7 @@ static int create_app(int argc, char* argv[],
     app->env = opal_argv_copy(*app_env);
     if (ORTE_SUCCESS != (rc = orte_schizo.parse_env(orterun_globals.personality,
                                                     orterun_globals.path,
-                                                    &cmd_line, ompi_server,
+                                                    &cmd_line,
                                                     environ, &app->env))) {
         goto cleanup;
     }

--- a/orte/tools/orterun/orterun.h
+++ b/orte/tools/orterun/orterun.h
@@ -51,9 +51,6 @@ struct orterun_globals_t {
     char *path;
     char *preload_files;
     bool sleep;
-    char *ompi_server;
-    bool wait_for_server;
-    int server_wait_timeout;
     char *stdin_target;
     char *prefix;
     char *path_to_mpirun;


### PR DESCRIPTION
This updates PMIx to open-mpi/pmix@43e45c3. It includes a fix to prevent "stalls" when the connection fails to complete, allowing the client to gracefully exit in such cases. Still working to prevent the stall in the first place. Also includes fixes to the publish/lookup/unpublish operations, and a slight streamlining of the APIs.
