### PR TITLE
pmix/s1: fixes for s1 to work with pmix1x

### DIFF
--- a/opal/mca/pmix/s1/pmix_s1_component.c
+++ b/opal/mca/pmix/s1/pmix_s1_component.c
@@ -20,6 +20,7 @@
 
 #include "opal/constants.h"
 #include "opal/mca/pmix/pmix.h"
+#include "orte/util/proc_info.h"
 #include "pmix_s1.h"
 
 /*
@@ -91,6 +92,16 @@ static int pmix_s1_component_query(mca_base_module_t **module, int *priority)
 {
     /* disqualify ourselves if we are not under slurm */
     if (NULL == getenv("SLURM_JOBID")) {
+        *priority = 0;
+        *module = NULL;
+        return OPAL_ERROR;
+    }
+
+    /*
+     * Only APP procs should use pmi s1/s2/cray
+     */
+
+    if (!ORTE_PROC_IS_APP) {
         *priority = 0;
         *module = NULL;
         return OPAL_ERROR;


### PR DESCRIPTION
Discovered while trying to use master on
a truescale/psm system that recent pmix1x
work broke support for s1.  If master was
built with --with-pmi option, mpirun would
segfault almost immediately as it tried to
use pmix/s1 rather than the pmix/pmix1x.

Other fixes to handle kvs query with keys
which had not yet been stored.  Otherwise
when using srun, users see warning messages
which confuse them.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>