### PR TITLE
opal/hwloc: fix topology detection when socket is above numa

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -1349,7 +1350,7 @@ opal_hwloc_locality_t opal_hwloc_base_get_relative_locality(hwloc_topology_t top
      * NOTE: we may alter that latter part as hwloc's ability to
      * sense multi-cu, multi-cluster systems grows
      */
-    locality = OPAL_PROC_ON_NODE;
+    locality = OPAL_PROC_ON_NODE | OPAL_PROC_ON_HOST | OPAL_PROC_ON_CU | OPAL_PROC_ON_CLUSTER;
 
     /* if either cpuset is NULL, then that isn't bound */
     if (NULL == cpuset1 || NULL == cpuset2) {
@@ -1397,25 +1398,25 @@ opal_hwloc_locality_t opal_hwloc_base_get_relative_locality(hwloc_topology_t top
                 shared = true;
                 switch(obj->type) {
                 case HWLOC_OBJ_NODE:
-                    locality = OPAL_PROC_ON_NUMA;
+                    locality |= OPAL_PROC_ON_NUMA;
                     break;
                 case HWLOC_OBJ_SOCKET:
-                    locality = OPAL_PROC_ON_SOCKET;
+                    locality |= OPAL_PROC_ON_SOCKET;
                     break;
                 case HWLOC_OBJ_CACHE:
                     if (3 == obj->attr->cache.depth) {
-                        locality = OPAL_PROC_ON_L3CACHE;
+                        locality |= OPAL_PROC_ON_L3CACHE;
                     } else if (2 == obj->attr->cache.depth) {
-                        locality = OPAL_PROC_ON_L2CACHE;
+                        locality |= OPAL_PROC_ON_L2CACHE;
                     } else {
-                        locality = OPAL_PROC_ON_L1CACHE;
+                        locality |= OPAL_PROC_ON_L1CACHE;
                     }
                     break;
                 case HWLOC_OBJ_CORE:
-                    locality = OPAL_PROC_ON_CORE;
+                    locality |= OPAL_PROC_ON_CORE;
                     break;
                 case HWLOC_OBJ_PU:
-                    locality = OPAL_PROC_ON_HWTHREAD;
+                    locality |= OPAL_PROC_ON_HWTHREAD;
                     break;
                 default:
                     /* just ignore it */

--- a/opal/mca/hwloc/hwloc.h
+++ b/opal/mca/hwloc/hwloc.h
@@ -78,33 +78,33 @@ enum {
     OPAL_PROC_LOCALITY_UNKNOWN  = 0x0000,
     OPAL_PROC_NON_LOCAL         = 0x8000,
     OPAL_PROC_ON_CLUSTER        = 0x0001,
-    OPAL_PROC_ON_CU             = 0x0003,
-    OPAL_PROC_ON_HOST           = 0x0007,
-    OPAL_PROC_ON_BOARD          = 0x000f,
-    OPAL_PROC_ON_NODE           = 0x000f,   // same host and board
-    OPAL_PROC_ON_NUMA           = 0x001f,
-    OPAL_PROC_ON_SOCKET         = 0x003f,
-    OPAL_PROC_ON_L3CACHE        = 0x007f,
-    OPAL_PROC_ON_L2CACHE        = 0x00ff,
-    OPAL_PROC_ON_L1CACHE        = 0x01ff,
-    OPAL_PROC_ON_CORE           = 0x03ff,
-    OPAL_PROC_ON_HWTHREAD       = 0x07ff,
-    OPAL_PROC_ALL_LOCAL         = 0x0fff
+    OPAL_PROC_ON_CU             = 0x0002,
+    OPAL_PROC_ON_HOST           = 0x0004,
+    OPAL_PROC_ON_BOARD          = 0x0008,
+    OPAL_PROC_ON_NODE           = 0x000c,   // same host and board
+    OPAL_PROC_ON_NUMA           = 0x0010,
+    OPAL_PROC_ON_SOCKET         = 0x0020,
+    OPAL_PROC_ON_L3CACHE        = 0x0040,
+    OPAL_PROC_ON_L2CACHE        = 0x0080,
+    OPAL_PROC_ON_L1CACHE        = 0x0100,
+    OPAL_PROC_ON_CORE           = 0x0200,
+    OPAL_PROC_ON_HWTHREAD       = 0x0400,
+    OPAL_PROC_ALL_LOCAL         = 0x0fff,
 };
 
 /** Process locality macros */
-#define OPAL_PROC_ON_LOCAL_CLUSTER(n)   ((n) & OPAL_PROC_ON_CLUSTER)
-#define OPAL_PROC_ON_LOCAL_CU(n)        (!(((n) & OPAL_PROC_ON_CU) ^ OPAL_PROC_ON_CU))
-#define OPAL_PROC_ON_LOCAL_HOST(n)      (!(((n) & OPAL_PROC_ON_HOST) ^ OPAL_PROC_ON_HOST))
-#define OPAL_PROC_ON_LOCAL_BOARD(n)     (!(((n) & OPAL_PROC_ON_BOARD) ^ OPAL_PROC_ON_BOARD))
+#define OPAL_PROC_ON_LOCAL_CLUSTER(n)   (!!((n) & OPAL_PROC_ON_CLUSTER))
+#define OPAL_PROC_ON_LOCAL_CU(n)        (!!((n) & OPAL_PROC_ON_CU))
+#define OPAL_PROC_ON_LOCAL_HOST(n)      (!!((n) & OPAL_PROC_ON_HOST))
+#define OPAL_PROC_ON_LOCAL_BOARD(n)     (!!((n) & OPAL_PROC_ON_BOARD))
 #define OPAL_PROC_ON_LOCAL_NODE(n)      (OPAL_PROC_ON_LOCAL_HOST(n) && OPAL_PROC_ON_LOCAL_BOARD(n))
-#define OPAL_PROC_ON_LOCAL_NUMA(n)      (!(((n) & OPAL_PROC_ON_NUMA) ^ OPAL_PROC_ON_NUMA))
-#define OPAL_PROC_ON_LOCAL_SOCKET(n)    (!(((n) & OPAL_PROC_ON_SOCKET) ^ OPAL_PROC_ON_SOCKET))
-#define OPAL_PROC_ON_LOCAL_L3CACHE(n)   (!(((n) & OPAL_PROC_ON_L3CACHE) ^ OPAL_PROC_ON_L3CACHE))
-#define OPAL_PROC_ON_LOCAL_L2CACHE(n)   (!(((n) & OPAL_PROC_ON_L2CACHE) ^ OPAL_PROC_ON_L2CACHE))
-#define OPAL_PROC_ON_LOCAL_L1CACHE(n)   (!(((n) & OPAL_PROC_ON_L1CACHE) ^ OPAL_PROC_ON_L1CACHE))
-#define OPAL_PROC_ON_LOCAL_CORE(n)      (!(((n) & OPAL_PROC_ON_CORE) ^ OPAL_PROC_ON_CORE))
-#define OPAL_PROC_ON_LOCAL_HWTHREAD(n)  (!(((n) & OPAL_PROC_ON_HWTHREAD) ^ OPAL_PROC_ON_HWTHREAD))
+#define OPAL_PROC_ON_LOCAL_NUMA(n)      (!!((n) & OPAL_PROC_ON_NUMA))
+#define OPAL_PROC_ON_LOCAL_SOCKET(n)    (!!((n) & OPAL_PROC_ON_SOCKET))
+#define OPAL_PROC_ON_LOCAL_L3CACHE(n)   (!!((n) & OPAL_PROC_ON_L3CACHE))
+#define OPAL_PROC_ON_LOCAL_L2CACHE(n)   (!!((n) & OPAL_PROC_ON_L2CACHE))
+#define OPAL_PROC_ON_LOCAL_L1CACHE(n)   (!!((n) & OPAL_PROC_ON_L1CACHE))
+#define OPAL_PROC_ON_LOCAL_CORE(n)      (!!((n) & OPAL_PROC_ON_CORE))
+#define OPAL_PROC_ON_LOCAL_HWTHREAD(n)  (!!((n) & OPAL_PROC_ON_HWTHREAD))
 
 /* ******************************************************************** */
 


### PR DESCRIPTION
The OPAL_PROC_ON_* definitions have been changed from values to
flags. This should not cause any problems as these values were already
used as flags throughout the code base. Note, there will be a
difference between localities produced by the new code and the
old. For example, if a machine does not have a level-3 but two cores
share a level-1 or level-2 cache cache the level-3 bit will not be set
in the locality and OPAL_PROC_ON_LOCAL_L3CACHE will return 0. Before
this change it would have returned 1.

In addition the OPAL_PROC_ON_LOCAL_* macros have been simplified.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
