### PR TITLE
Use the low instead of the high bit to indicate a proc is a sentinel

### DIFF
--- a/ompi/group/group.c
+++ b/ompi/group/group.c
@@ -562,7 +562,7 @@ bool ompi_group_have_remote_peers (ompi_group_t *group)
 #if OMPI_GROUP_SPARSE
         proc = ompi_group_peer_lookup (group, i);
 #else
-        if ((intptr_t) group->grp_proc_pointers[i] < 0) {
+        if (ompi_proc_is_sentinel (group->grp_proc_pointers[i])) {
             return true;
         }
         proc = group->grp_proc_pointers[i];

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -340,7 +340,7 @@ static inline struct ompi_proc_t *ompi_group_dense_lookup (ompi_group_t *group, 
     }
 #endif
 
-    if (OPAL_UNLIKELY((intptr_t) group->grp_proc_pointers[peer_id] < 0)) {
+    if (OPAL_UNLIKELY(ompi_proc_is_sentinel (group->grp_proc_pointers[peer_id]))) {
         if (!allocate) {
             return NULL;
         }
@@ -386,7 +386,7 @@ ompi_proc_t *ompi_group_get_proc_ptr_raw (ompi_group_t *group, int rank);
 static inline opal_process_name_t ompi_group_get_proc_name (ompi_group_t *group, int rank)
 {
     ompi_proc_t *proc = ompi_group_get_proc_ptr_raw (group, rank);
-    if ((intptr_t) proc < 0) {
+    if (ompi_proc_is_sentinel (proc)) {
         return ompi_proc_sentinel_to_name ((intptr_t) proc);
     }
 

--- a/ompi/group/group_plist.c
+++ b/ompi/group/group_plist.c
@@ -59,7 +59,7 @@ static int ompi_group_dense_overlap (ompi_group_t *group1, ompi_group_t *group2,
 
 static struct ompi_proc_t *ompi_group_dense_lookup_raw (ompi_group_t *group, const int peer_id)
 {
-    if (OPAL_UNLIKELY((intptr_t) group->grp_proc_pointers[peer_id] < 0)) {
+    if (OPAL_UNLIKELY(ompi_proc_is_sentinel (group->grp_proc_pointers[peer_id]))) {
         ompi_proc_t *proc =
             (ompi_proc_t *) ompi_proc_lookup (ompi_proc_sentinel_to_name ((intptr_t) group->grp_proc_pointers[peer_id]));
         if (NULL != proc) {

--- a/ompi/proc/proc.h
+++ b/ompi/proc/proc.h
@@ -324,13 +324,22 @@ OMPI_DECLSPEC opal_proc_t *ompi_proc_for_name (const opal_process_name_t proc_na
 
 OMPI_DECLSPEC opal_proc_t *ompi_proc_lookup (const opal_process_name_t proc_name);
 
-
-static inline intptr_t ompi_proc_name_to_sentinel (opal_process_name_t name) {
-  return -*((intptr_t *) &name);
+/**
+ * Check if an ompi_proc_t is a sentinel
+ */
+static inline bool ompi_proc_is_sentinel (ompi_proc_t *proc)
+{
+    return (intptr_t) proc & 0x1;
 }
 
-static inline opal_process_name_t ompi_proc_sentinel_to_name (intptr_t sentinel) {
-  sentinel = -sentinel;
+static inline intptr_t ompi_proc_name_to_sentinel (opal_process_name_t name)
+{
+  return (*((intptr_t *) &name) << 1) & 0x1;
+}
+
+static inline opal_process_name_t ompi_proc_sentinel_to_name (intptr_t sentinel)
+{
+  sentinel >>= 1;;
   return *((opal_process_name_t *) &sentinel);
 }
 


### PR DESCRIPTION
The assumption that the high bit is not in use in pointers on any of our
supported platforms was incorrect. A better assumption is that all
ompi_proc_t pointers will be at least 2-byte aligned. This allows us
to use the low bit. To do this we drop the highest bit of the
opal_process_name_t jobid (hope this is ok) and use the low bit to
indicate the proc is really a sentinel.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>