### PR TITLE
Fix the no-disconnect test by resolving a segfault on free - opal_dss…

### DIFF
--- a/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_ops.c
+++ b/opal/mca/pmix/pmix1xx/pmix/src/server/pmix_server_ops.c
@@ -857,7 +857,10 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
         kp->key = strdup("modex");
         PMIX_VALUE_CREATE(kp->value, 1);
         kp->value->type = PMIX_BYTE_OBJECT;
-        kp->value->data.bo.bytes = (char*)caddy->data;
+        /* we don't know if the host is going to save this data
+         * or not, so we have to copy it */
+        kp->value->data.bo.bytes = (char*)malloc(caddy->ndata);
+        memcpy(kp->value->data.bo.bytes, caddy->data, caddy->ndata);
         kp->value->data.bo.size = caddy->ndata;
         /* store it in the appropriate hash */
         if (PMIX_SUCCESS != (rc = pmix_hash_store(&nptr->server->remote, caddy->lcd->proc.rank, kp))) {

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -537,7 +537,10 @@ static void pmix_server_dmdx_resp(int status, orte_process_name_t* sender,
     }
 
     /* unload the remainder of the buffer */
-    opal_dss.unload(buffer, (void**)&data, &ndata);
+    if (OPAL_SUCCESS != (rc = opal_dss.unload(buffer, (void**)&data, &ndata))) {
+        ORTE_ERROR_LOG(rc);
+        return;
+    }
 
     /* if we got something, store the blobs locally so we can
      * meet any further requests without doing a remote fetch.
@@ -564,9 +567,6 @@ static void pmix_server_dmdx_resp(int status, orte_process_name_t* sender,
             req->mdxcbfunc(ret, (char*)data, ndata, req->cbdata, relcbfunc, data);
         }
         OBJ_RELEASE(req);
-    }
-    if (NULL != data) {
-        free(data);
     }
 }
 


### PR DESCRIPTION
….unload will return the remaining unpacked portion of a buffer. As such, it cannot return the pointer to that info as it might be partway inside of a malloc'd region. So copy the data out of the buffer.