### PR TITLE
Search for lstat in sys/stat.h

### DIFF
--- a/ompi/mca/io/romio314/romio/configure.ac
+++ b/ompi/mca/io/romio314/romio/configure.ac
@@ -1720,7 +1720,8 @@ fi
 AC_CHECK_FUNCS(lstat)
 if test "$ac_cv_func_lstat" = "yes" ; then
     # Do we need to declare lstat?
-    PAC_FUNC_NEEDS_DECL([#include <unistd.h>],lstat)
+    PAC_FUNC_NEEDS_DECL([#include <unistd.h>
+                         #include <sys/stat.h>],lstat)
 fi
 AC_CHECK_FUNCS(readlink)
 if test "$ac_cv_func_readlink" = "yes" ; then


### PR DESCRIPTION
According to the Linux man page, both sys/stat.h and unistd.h are
supposed to be included before using lstat, and, at least on some
machines, sys/stat.h is actually the necessary one.

This fixes a strange linking failure on one of my systems for reasons that I'm not completely clear on.