### PR TITLE
ompi/comm: fix bug in ompi_comm_set

### DIFF
--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -535,6 +535,18 @@ int ompi_comm_finalize (void);
 /**
  * This is THE routine, where all the communicator stuff
  * is really set.
+ *
+ * @param[out] newcomm            new ompi communicator object
+ * @param[in]  oldcomm            old communicator
+ * @param[in]  local_size         size of local_ranks array
+ * @param[in]  local_ranks        local ranks (not used if local_group != NULL)
+ * @param[in]  remote_size        size of remote_ranks array
+ * @param[in]  remote_ranks       remote ranks (intercomm) (not used if remote_group != NULL)
+ * @param[in]  attr               attributes (can be NULL)
+ * @param[in]  errh               error handler
+ * @param[in]  copy_topocomponent whether to copy the topology
+ * @param[in]  local_group        local process group (may be NULL if local_ranks array supplied)
+ * @param[in]  remote_group       remote process group (may be NULL)
  */
 OMPI_DECLSPEC int ompi_comm_set ( ompi_communicator_t** newcomm,
                                   ompi_communicator_t* oldcomm,
@@ -548,6 +560,23 @@ OMPI_DECLSPEC int ompi_comm_set ( ompi_communicator_t** newcomm,
                                   ompi_group_t *local_group,
                                   ompi_group_t *remote_group   );
 
+/**
+ * This is THE routine, where all the communicator stuff
+ * is really set. Non-blocking version.
+ *
+ * @param[out] newcomm            new ompi communicator object
+ * @param[in]  oldcomm            old communicator
+ * @param[in]  local_size         size of local_ranks array
+ * @param[in]  local_ranks        local ranks (not used if local_group != NULL)
+ * @param[in]  remote_size        size of remote_ranks array
+ * @param[in]  remote_ranks       remote ranks (intercomm) (not used if remote_group != NULL)
+ * @param[in]  attr               attributes (can be NULL)
+ * @param[in]  errh               error handler
+ * @param[in]  copy_topocomponent whether to copy the topology
+ * @param[in]  local_group        local process group (may be NULL if local_ranks array supplied)
+ * @param[in]  remote_group       remote process group (may be NULL)
+ * @param[out] req                ompi_request_t object for tracking completion
+ */
 OMPI_DECLSPEC int ompi_comm_set_nb ( ompi_communicator_t **ncomm,
                                      ompi_communicator_t *oldcomm,
                                      int local_size,

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -1297,7 +1297,7 @@ static bool ompi_dpm_group_is_dyn (ompi_group_t *group, ompi_jobid_t thisjobid)
 {
     int size = group ? ompi_group_size (group) : 0;
 
-    for (int i = 1 ; i < size ; ++i) {
+    for (int i = 0 ; i < size ; ++i) {
         opal_process_name_t name = ompi_group_get_proc_name (group, i);
 
         if (thisjobid != ((ompi_process_name_t *) &name)->jobid) {


### PR DESCRIPTION
This commit updates the behavior of ompi_comm_set to explicitly take
either local/remote group(s) OR local/remote array(s). If array(s) are
in use the sizes will be taken from the appropriate group(s).

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>