### PR TITLE
pml: fix commit open-mpi/ompi@6e6a3e965cf41d2686c79c01316ee8f5c52d37cf

### DIFF
--- a/ompi/mca/coll/base/coll_base_gather.c
+++ b/ompi/mca/coll/base/coll_base_gather.c
@@ -237,7 +237,7 @@ ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
         COLL_BASE_COMPUTED_SEGCOUNT( (size_t) first_segment_size, typelng,
                                       first_segment_count );
 
-        ret = MCA_PML_CALL(recv(sbuf, 0, MPI_BYTE, root,
+        ret = MCA_PML_CALL(recv(rbuf, 0, MPI_BYTE, root,
                                 MCA_COLL_BASE_TAG_GATHER,
                                 comm, MPI_STATUS_IGNORE));
         if (ret != MPI_SUCCESS) { line = __LINE__; goto error_hndl; }

--- a/ompi/mca/pml/base/pml_base_bsend.c
+++ b/ompi/mca/pml/base/pml_base_bsend.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -373,7 +375,7 @@ int mca_pml_base_bsend_request_fini(ompi_request_t* request)
     OPAL_THREAD_LOCK(&mca_pml_bsend_mutex);
 
     /* free buffer */
-    mca_pml_bsend_allocator->alc_free(mca_pml_bsend_allocator, sendreq->req_addr);
+    mca_pml_bsend_allocator->alc_free(mca_pml_bsend_allocator, (void *)sendreq->req_addr);
     sendreq->req_addr = sendreq->req_base.req_addr;
 
     /* decrement count of buffered requests */

--- a/ompi/mca/pml/base/pml_base_request.h
+++ b/ompi/mca/pml/base/pml_base_request.h
@@ -70,7 +70,7 @@ struct mca_pml_base_request_t {
     opal_convertor_t req_convertor;       /**< always need the convertor */
 /* END: These field have to match the definition of the mca_pml_cm_request_t */
 
-    const void *req_addr;                 /**< pointer to application buffer */
+    void *req_addr;                       /**< pointer to application buffer */
     size_t req_count;                     /**< count of user datatype elements */
     int32_t req_peer;                     /**< peer process - rank w/in this communicator */
     int32_t req_tag;                      /**< user defined tag */

--- a/ompi/mca/pml/base/pml_base_sendreq.h
+++ b/ompi/mca/pml/base/pml_base_sendreq.h
@@ -81,7 +81,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION( mca_pml_base_send_request_t );
       (request)->req_base.req_ompi.req_mpi_object.comm = comm;            \
       (request)->req_addr = addr;                                         \
       (request)->req_send_mode = mode;                                    \
-      (request)->req_base.req_addr = addr;                                \
+      (request)->req_base.req_addr = (void *)addr;                        \
       (request)->req_base.req_count = count;                              \
       (request)->req_base.req_datatype = datatype;                        \
       (request)->req_base.req_peer = (int32_t)peer;                       \

--- a/ompi/mca/pml/cm/pml_cm.h
+++ b/ompi/mca/pml/cm/pml_cm.h
@@ -67,7 +67,7 @@ OMPI_DECLSPEC extern int mca_pml_cm_del_comm(struct ompi_communicator_t* comm);
 
 
 __opal_attribute_always_inline__ static inline int
-mca_pml_cm_irecv_init(const void *addr,
+mca_pml_cm_irecv_init(void *addr,
                       size_t count,
                       ompi_datatype_t * datatype,
                       int src,
@@ -92,7 +92,7 @@ mca_pml_cm_irecv_init(const void *addr,
 }
 
 __opal_attribute_always_inline__ static inline int
-mca_pml_cm_irecv(const void *addr,
+mca_pml_cm_irecv(void *addr,
                  size_t count,
                  ompi_datatype_t * datatype,
                  int src,
@@ -133,7 +133,7 @@ mca_pml_cm_recv_fast_completion(struct mca_mtl_request_t *mtl_request)
 }
 
 __opal_attribute_always_inline__ static inline int
-mca_pml_cm_recv(const void *addr,
+mca_pml_cm_recv(void *addr,
                 size_t count,
                 ompi_datatype_t * datatype,
                 int src,

--- a/ompi/mca/pml/cm/pml_cm_recvreq.h
+++ b/ompi/mca/pml/cm/pml_cm_recvreq.h
@@ -13,8 +13,6 @@
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +36,7 @@ OBJ_CLASS_DECLARATION(mca_pml_cm_thin_recv_request_t);
 
 struct mca_pml_cm_hvy_recv_request_t {
     mca_pml_cm_request_t req_base;
-    const void *req_addr;                 /**< pointer to application buffer */
+    void *req_addr;                       /**< pointer to application buffer */
     size_t req_count;                     /**< count of user datatype elements */
     int32_t req_peer;                     /**< peer process - rank w/in this communicator */
     int32_t req_tag;                      /**< user defined tag */

--- a/ompi/mca/pml/ob1/pml_ob1.h
+++ b/ompi/mca/pml/ob1/pml_ob1.h
@@ -166,7 +166,7 @@ extern int mca_pml_ob1_send( const void *buf,
                              mca_pml_base_send_mode_t mode,
                              struct ompi_communicator_t* comm );
 
-extern int mca_pml_ob1_irecv_init( const void *buf,
+extern int mca_pml_ob1_irecv_init( void *buf,
                                    size_t count,
                                    ompi_datatype_t *datatype,
                                    int src,
@@ -174,7 +174,7 @@ extern int mca_pml_ob1_irecv_init( const void *buf,
                                    struct ompi_communicator_t* comm,
                                    struct ompi_request_t **request );
 
-extern int mca_pml_ob1_irecv( const void *buf,
+extern int mca_pml_ob1_irecv( void *buf,
                               size_t count,
                               ompi_datatype_t *datatype,
                               int src,
@@ -182,7 +182,7 @@ extern int mca_pml_ob1_irecv( const void *buf,
                               struct ompi_communicator_t* comm,
                               struct ompi_request_t **request );
 
-extern int mca_pml_ob1_recv( const void *buf,
+extern int mca_pml_ob1_recv( void *buf,
                              size_t count,
                              ompi_datatype_t *datatype,
                              int src,

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -15,8 +15,6 @@
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +31,7 @@
 
 mca_pml_ob1_recv_request_t *mca_pml_ob1_recvreq = NULL;
 
-int mca_pml_ob1_irecv_init(const void *addr,
+int mca_pml_ob1_irecv_init(void *addr,
                            size_t count,
                            ompi_datatype_t * datatype,
                            int src,
@@ -58,7 +56,7 @@ int mca_pml_ob1_irecv_init(const void *addr,
     return OMPI_SUCCESS;
 }
 
-int mca_pml_ob1_irecv(const void *addr,
+int mca_pml_ob1_irecv(void *addr,
                       size_t count,
                       ompi_datatype_t * datatype,
                       int src,
@@ -85,7 +83,7 @@ int mca_pml_ob1_irecv(const void *addr,
 }
 
 
-int mca_pml_ob1_recv(const void *addr,
+int mca_pml_ob1_recv(void *addr,
                      size_t count,
                      ompi_datatype_t * datatype,
                      int src,

--- a/ompi/mca/pml/pml.h
+++ b/ompi/mca/pml/pml.h
@@ -208,7 +208,7 @@ typedef int (*mca_pml_base_module_del_comm_fn_t)(struct ompi_communicator_t* com
  *  @return                 OMPI_SUCCESS or failure status.
  */
 typedef int (*mca_pml_base_module_irecv_init_fn_t)(
-    const void *buf,
+    void *buf,
     size_t count,
     struct ompi_datatype_t *datatype,
     int src,
@@ -230,7 +230,7 @@ typedef int (*mca_pml_base_module_irecv_init_fn_t)(
  *  @return                 OMPI_SUCCESS or failure status.
  */
 typedef int (*mca_pml_base_module_irecv_fn_t)(
-    const void *buf,
+    void *buf,
     size_t count,
     struct ompi_datatype_t *datatype,
     int src,
@@ -259,7 +259,7 @@ typedef int (*mca_pml_base_module_imrecv_fn_t)(
  *  @return                 OMPI_SUCCESS or failure status.
  */
 typedef int (*mca_pml_base_module_recv_fn_t)(
-    const void *buf,
+    void *buf,
     size_t count,
     struct ompi_datatype_t *datatype,
     int src,

--- a/ompi/mca/pml/yalla/pml_yalla.c
+++ b/ompi/mca/pml/yalla/pml_yalla.c
@@ -313,7 +313,7 @@ int mca_pml_yalla_del_comm(struct ompi_communicator_t* comm)
     return OMPI_SUCCESS;
 }
 
-int mca_pml_yalla_irecv_init(const void *buf, size_t count, ompi_datatype_t *datatype,
+int mca_pml_yalla_irecv_init(void *buf, size_t count, ompi_datatype_t *datatype,
                              int src, int tag, struct ompi_communicator_t* comm,
                              struct ompi_request_t **request)
 {
@@ -329,7 +329,7 @@ int mca_pml_yalla_irecv_init(const void *buf, size_t count, ompi_datatype_t *dat
     return OMPI_SUCCESS;
 }
 
-int mca_pml_yalla_irecv(const void *buf, size_t count, ompi_datatype_t *datatype,
+int mca_pml_yalla_irecv(void *buf, size_t count, ompi_datatype_t *datatype,
                         int src, int tag, struct ompi_communicator_t* comm,
                         struct ompi_request_t **request)
 {
@@ -353,7 +353,7 @@ int mca_pml_yalla_irecv(const void *buf, size_t count, ompi_datatype_t *datatype
     return OMPI_SUCCESS;
 }
 
-int mca_pml_yalla_recv(const void *buf, size_t count, ompi_datatype_t *datatype, int src,
+int mca_pml_yalla_recv(void *buf, size_t count, ompi_datatype_t *datatype, int src,
                        int tag, struct ompi_communicator_t* comm,
                        ompi_status_public_t* status)
 {

--- a/ompi/mca/pml/yalla/pml_yalla.h
+++ b/ompi/mca/pml/yalla/pml_yalla.h
@@ -1,7 +1,5 @@
 /*
  * Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -97,15 +95,15 @@ int mca_pml_yalla_progress(void);
 int mca_pml_yalla_add_comm(struct ompi_communicator_t* comm);
 int mca_pml_yalla_del_comm(struct ompi_communicator_t* comm);
 
-int mca_pml_yalla_irecv_init(const void *buf, size_t count, ompi_datatype_t *datatype,
+int mca_pml_yalla_irecv_init(void *buf, size_t count, ompi_datatype_t *datatype,
                              int src, int tag, struct ompi_communicator_t* comm,
                              struct ompi_request_t **request);
 
-int mca_pml_yalla_irecv(const void *buf, size_t count, ompi_datatype_t *datatype,
+int mca_pml_yalla_irecv(void *buf, size_t count, ompi_datatype_t *datatype,
                         int src, int tag, struct ompi_communicator_t* comm,
                         struct ompi_request_t **request);
 
-int mca_pml_yalla_recv(const void *buf, size_t count, ompi_datatype_t *datatype, int src,
+int mca_pml_yalla_recv(void *buf, size_t count, ompi_datatype_t *datatype, int src,
                        int tag, struct ompi_communicator_t* comm,
                        ompi_status_public_t* status);
 

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist.h
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist.h
@@ -64,14 +64,14 @@ int mca_vprotocol_pessimist_progress(void);
 int mca_vprotocol_pessimist_add_comm(struct ompi_communicator_t* comm);
 int mca_vprotocol_pessimist_del_comm(struct ompi_communicator_t* comm);
 
-int mca_vprotocol_pessimist_irecv(const void *addr,
+int mca_vprotocol_pessimist_irecv(void *addr,
                                   size_t count,
                                   ompi_datatype_t * datatype,
                                   int src,
                                   int tag,
                                   struct ompi_communicator_t *comm,
                                   struct ompi_request_t **request );
-int mca_vprotocol_pessimist_recv(const void *addr,
+int mca_vprotocol_pessimist_recv(void *addr,
                                  size_t count,
                                  ompi_datatype_t * datatype,
                                  int src,

--- a/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_recv.c
+++ b/ompi/mca/vprotocol/pessimist/vprotocol_pessimist_recv.c
@@ -1,8 +1,6 @@
 /*
  * Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +17,7 @@
 
 
 
-int mca_vprotocol_pessimist_irecv(const void *addr,
+int mca_vprotocol_pessimist_irecv(void *addr,
                      size_t count,
                      ompi_datatype_t * datatype,
                      int src,
@@ -45,7 +43,7 @@ int mca_vprotocol_pessimist_irecv(const void *addr,
 
 
 
-int mca_vprotocol_pessimist_recv(const void *addr,
+int mca_vprotocol_pessimist_recv(void *addr,
                       size_t count,
                       ompi_datatype_t * datatype,
                       int src,

--- a/opal/mca/allocator/allocator.h
+++ b/opal/mca/allocator/allocator.h
@@ -12,8 +12,6 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +55,7 @@ typedef void* (*mca_allocator_base_module_realloc_fn_t)(
   * Free function typedef
   */
 typedef void(*mca_allocator_base_module_free_fn_t)(
-    struct mca_allocator_base_module_t*, const void *);
+    struct mca_allocator_base_module_t*, void *);
 
 
 /**

--- a/opal/mca/allocator/basic/allocator_basic.c
+++ b/opal/mca/allocator/basic/allocator_basic.c
@@ -15,8 +15,6 @@
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -269,7 +267,7 @@ void * mca_allocator_basic_realloc(
   */
 void mca_allocator_basic_free(
     mca_allocator_base_module_t * base,
-    const void * ptr)
+    void * ptr)
 {
     mca_allocator_basic_module_t* module = (mca_allocator_basic_module_t*)base;
     mca_allocator_basic_segment_t* seg;

--- a/opal/mca/allocator/basic/allocator_basic.h
+++ b/opal/mca/allocator/basic/allocator_basic.h
@@ -12,8 +12,6 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -131,7 +129,7 @@ mca_allocator_base_module_t* mca_allocator_basic_component_init(
    */
     void mca_allocator_basic_free(
         mca_allocator_base_module_t * mem,
-        const void * ptr);
+        void * ptr);
 
 /**
    * Frees all the memory from all the basics back to the system. Note that

--- a/opal/mca/allocator/bucket/allocator_bucket_alloc.c
+++ b/opal/mca/allocator/bucket/allocator_bucket_alloc.c
@@ -10,8 +10,6 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      IBM Corp.,  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -280,7 +278,7 @@ void * mca_allocator_bucket_realloc(
    * Frees the passed region of memory
    *
    */
-void mca_allocator_bucket_free(mca_allocator_base_module_t * mem, const void * ptr)
+void mca_allocator_bucket_free(mca_allocator_base_module_t * mem, void * ptr)
 {
     mca_allocator_bucket_t * mem_options = (mca_allocator_bucket_t *) mem;
     mca_allocator_bucket_chunk_header_t * chunk  = (mca_allocator_bucket_chunk_header_t *) ptr - 1;

--- a/opal/mca/allocator/bucket/allocator_bucket_alloc.h
+++ b/opal/mca/allocator/bucket/allocator_bucket_alloc.h
@@ -9,8 +9,6 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -188,7 +186,7 @@ typedef struct mca_allocator_bucket_t mca_allocator_bucket_t;
    *
    */
     void mca_allocator_bucket_free(mca_allocator_base_module_t * mem,
-                                   const void * ptr);
+                                   void * ptr);
 
 /**
    * Frees all the memory from all the buckets back to the system. Note that


### PR DESCRIPTION
do not use the const modifier for allocator nor recv buffers