### PR TITLE
portals4: add support for dynamic add_procs() to all Portals4 components

### DIFF
--- a/ompi/mca/coll/portals4/coll_portals4.h
+++ b/ompi/mca/coll/portals4/coll_portals4.h
@@ -29,6 +29,8 @@
 #include "ompi/communicator/communicator.h"
 #include "ompi/mca/coll/base/base.h"
 
+#include "ompi/mca/mtl/portals4/mtl_portals4.h"
+
 BEGIN_C_DECLS
 
 #define COLL_PORTALS4_NO_OP ((ptl_op_t)-1)
@@ -178,11 +180,7 @@ ompi_coll_portals4_iallreduce_intra_fini(struct ompi_coll_portals4_request_t *re
 static inline ptl_process_t
 ompi_coll_portals4_get_peer(struct ompi_communicator_t *comm, int rank)
 {
-    ompi_proc_t *proc = ompi_comm_peer_lookup(comm, rank);
-    if (proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4] == NULL) {
-        printf("ompi_coll_portals4_get_peer failure\n");
-    }
-    return *((ptl_process_t*) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
+    return ompi_mtl_portals4_get_peer(comm, rank);
 }
 
 

--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -26,8 +26,11 @@
 #include "opal/class/opal_free_list.h"
 #include "opal/class/opal_list.h"
 #include "opal/datatype/opal_convertor.h"
+#include "ompi/proc/proc.h"
 #include "ompi/mca/mtl/mtl.h"
 #include "ompi/mca/mtl/base/base.h"
+
+#include "ompi/communicator/communicator.h"
 
 #include "mtl_portals4_flowctl.h"
 
@@ -40,6 +43,13 @@ struct mca_mtl_portals4_module_t {
 
     /* Use the logical to physical table to accelerate portals4 adressing: 1 (true) : 0 (false) */
     int use_logical;
+    int maptable_created;
+    int need_init;
+
+    int use_flowctl;
+
+    ompi_proc_t   **world_procs;
+    size_t          world_nprocs;
 
     /** Eager limit; messages greater than this use a rendezvous protocol */
     unsigned long long eager_limit;
@@ -208,6 +218,29 @@ extern mca_mtl_portals4_module_t ompi_mtl_portals4;
 #define MTL_PORTALS4_GET_LENGTH(hdr_data) ((size_t)(hdr_data & 0xFFFFFFFFFFFFULL))
 #define MTL_PORTALS4_IS_SYNC_MSG(hdr_data)            \
     (0 != (MTL_PORTALS4_SYNC_MSG & hdr_data))
+
+/* mtl-portals4 helpers */
+OMPI_DECLSPEC ompi_proc_t *
+ompi_mtl_portals4_get_proc_group(struct ompi_group_t *group, int rank);
+
+static inline ptl_process_t
+ompi_mtl_portals4_get_peer_group(struct ompi_group_t *group, int rank)
+{
+    return *((ptl_process_t*)ompi_mtl_portals4_get_proc_group(group, rank));
+}
+
+static inline ompi_proc_t *
+ompi_mtl_portals4_get_proc(struct ompi_communicator_t *comm, int rank)
+{
+    return ompi_mtl_portals4_get_proc_group(comm->c_remote_group, rank);
+}
+
+static inline ptl_process_t
+ompi_mtl_portals4_get_peer(struct ompi_communicator_t *comm, int rank)
+{
+    return *((ptl_process_t*)ompi_mtl_portals4_get_proc(comm, rank));
+}
+
 
 /* MTL interface functions */
 extern int ompi_mtl_portals4_finalize(struct mca_mtl_base_module_t *mtl);

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -229,6 +229,18 @@ ompi_mtl_portals4_component_open(void)
     ompi_mtl_portals4.recv_idx = (ptl_pt_index_t) ~0UL;
     ompi_mtl_portals4.read_idx = (ptl_pt_index_t) ~0UL;
 
+    ompi_mtl_portals4.maptable_created=0;
+    ompi_mtl_portals4.need_init=1;
+
+#if OMPI_MTL_PORTALS4_FLOW_CONTROL
+    ompi_mtl_portals4.use_flowctl=1;
+#else
+    ompi_mtl_portals4.use_flowctl=0;
+#endif
+
+    ompi_mtl_portals4.world_nprocs=0;
+    ompi_mtl_portals4.world_procs=NULL;
+
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
@@ -25,4 +25,14 @@ struct mca_mtl_base_endpoint_t {
 };
 typedef struct mca_mtl_base_endpoint_t mca_mtl_base_endpoint_t;
 
+static inline mca_mtl_base_endpoint_t *
+ompi_mtl_portals4_get_endpoint (struct mca_mtl_base_module_t* mtl, ompi_proc_t *ompi_proc)
+{
+    if (OPAL_UNLIKELY(NULL == ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4])) {
+        ompi_mtl_portals4_add_procs (mtl, 1, &ompi_proc);
+    }
+
+    return ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4];
+}
+
 #endif

--- a/ompi/mca/mtl/portals4/mtl_portals4_probe.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_probe.c
@@ -22,6 +22,7 @@
 #include "ompi/message/message.h"
 
 #include "mtl_portals4.h"
+#include "mtl_portals4_endpoint.h"
 #include "mtl_portals4_request.h"
 #include "mtl_portals4_message.h"
 
@@ -78,7 +79,7 @@ ompi_mtl_portals4_iprobe(struct mca_mtl_base_module_t* mtl,
         remote_proc.rank = src;
     } else {
         ompi_proc_t* ompi_proc = ompi_comm_peer_lookup( comm, src );
-        remote_proc = *((ptl_process_t*) ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
+        remote_proc = *((ptl_process_t*) ompi_mtl_portals4_get_endpoint (mtl, ompi_proc));
     }
 
     MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits, comm->c_contextid,
@@ -156,7 +157,7 @@ ompi_mtl_portals4_improbe(struct mca_mtl_base_module_t *mtl,
         remote_proc.rank = src;
     } else {
         ompi_proc_t* ompi_proc = ompi_comm_peer_lookup( comm, src );
-        remote_proc = *((ptl_process_t*) ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
+        remote_proc = *((ptl_process_t*) ompi_mtl_portals4_get_endpoint (mtl, ompi_proc));
     }
 
     MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits, comm->c_contextid,

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv.c
@@ -29,6 +29,7 @@
 #include "ompi/message/message.h"
 
 #include "mtl_portals4.h"
+#include "mtl_portals4_endpoint.h"
 #include "mtl_portals4_request.h"
 #include "mtl_portals4_recv_short.h"
 #include "mtl_portals4_message.h"
@@ -367,7 +368,7 @@ ompi_mtl_portals4_irecv(struct mca_mtl_base_module_t* mtl,
         remote_proc.rank = src;
     } else {
         ompi_proc_t* ompi_proc = ompi_comm_peer_lookup( comm, src );
-        remote_proc = *((ptl_process_t*) ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
+        remote_proc = *((ptl_process_t*) ompi_mtl_portals4_get_endpoint (mtl, ompi_proc));
     }
 
     MTL_PORTALS4_SET_RECV_BITS(match_bits, ignore_bits, comm->c_contextid,

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -28,6 +28,7 @@
 #include "ompi/mca/mtl/base/mtl_base_datatype.h"
 
 #include "mtl_portals4.h"
+#include "mtl_portals4_endpoint.h"
 #include "mtl_portals4_request.h"
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
 #include "mtl_portals4_flowctl.h"
@@ -405,7 +406,7 @@ ompi_mtl_portals4_send_start(struct mca_mtl_base_module_t* mtl,
         ptl_proc.rank = dest;
     } else {
         ompi_proc_t *ompi_proc = ompi_comm_peer_lookup(comm, dest);
-        ptl_proc = *((ptl_process_t*) ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
+        ptl_proc = *((ptl_process_t*) ompi_mtl_portals4_get_endpoint (mtl, ompi_proc));
     }
 
     ret = ompi_mtl_datatype_pack(convertor, &start, &length, &free_after);

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -19,6 +19,8 @@
 #include "ompi/group/group.h"
 #include "ompi/communicator/communicator.h"
 
+#include "ompi/mca/mtl/portals4/mtl_portals4.h"
+
 #define OSC_PORTALS4_MB_DATA    0x0000000000000000ULL
 #define OSC_PORTALS4_MB_CONTROL 0x1000000000000000ULL
 
@@ -290,17 +292,15 @@ ompi_osc_portals4_complete_all(ompi_osc_portals4_module_t *module)
 }
 
 static inline ptl_process_t
-ompi_osc_portals4_get_peer(ompi_osc_portals4_module_t *module, int rank)
+ompi_osc_portals4_get_peer_group(struct ompi_group_t *group, int rank)
 {
-    ompi_proc_t *proc = ompi_comm_peer_lookup(module->comm, rank);
-    return *((ptl_process_t*) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
+    return ompi_mtl_portals4_get_peer_group(group, rank);
 }
 
 static inline ptl_process_t
-ompi_osc_portals4_get_peer_group(struct ompi_group_t *group, int rank)
+ompi_osc_portals4_get_peer(ompi_osc_portals4_module_t *module, int rank)
 {
-    ompi_proc_t *proc = ompi_group_get_proc_ptr(group, rank, true);
-    return *((ptl_process_t*) proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]);
+    return ompi_osc_portals4_get_peer_group(module->comm->c_remote_group, rank);
 }
 
 #endif

--- a/ompi/mca/osc/portals4/osc_portals4_active_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_active_target.c
@@ -15,8 +15,6 @@
 
 #include "osc_portals4.h"
 
-#include "ompi/mca/mtl/portals4/mtl_portals4_endpoint.h"
-
 
 int
 ompi_osc_portals4_fence(int assert, struct ompi_win_t *win)

--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -21,8 +21,6 @@
 #include "osc_portals4.h"
 #include "osc_portals4_request.h"
 
-#include "ompi/mca/mtl/portals4/mtl_portals4_endpoint.h"
-
 
 static int
 ompi_osc_portals4_get_op(struct ompi_op_t *op, ptl_op_t *ptl_op)

--- a/ompi/mca/osc/portals4/osc_portals4_passive_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_passive_target.c
@@ -18,8 +18,6 @@
 
 #include "osc_portals4.h"
 
-#include "ompi/mca/mtl/portals4/mtl_portals4_endpoint.h"
-
 enum locktype_t {
     lock_nocheck,
     lock_exclusive,

--- a/opal/mca/btl/portals4/btl_portals4.h
+++ b/opal/mca/btl/portals4/btl_portals4.h
@@ -50,6 +50,14 @@ struct mca_btl_portals4_component_t {
 
     /* Use the logical to physical table to accelerate portals4 adressing: 1 (true) : 0 (false) */
     int use_logical;
+    int maptable_created;
+    int need_init;
+
+    int use_flowctl;
+
+    opal_proc_t                    **world_procs;
+    size_t                           world_nprocs;
+    struct mca_btl_base_endpoint_t **world_peer_data;
 
     /* initial size of free lists */
     int portals_free_list_init_num;

--- a/opal/mca/btl/portals4/btl_portals4_component.c
+++ b/opal/mca/btl/portals4/btl_portals4_component.c
@@ -304,6 +304,19 @@ static mca_btl_base_module_t** mca_btl_portals4_component_init(int *num_btls,
     }
     OPAL_OUTPUT_VERBOSE((90, opal_btl_base_framework.framework_output, "PtlInit OK\n"));
 
+    mca_btl_portals4_component.maptable_created = 0;
+    mca_btl_portals4_component.need_init        = 1;
+
+#if OMPI_BTL_PORTALS4_FLOW_CONTROL
+    mca_btl_portals4_component.use_flowctl = 1;
+#else
+    mca_btl_portals4_component.use_flowctl = 0;
+#endif
+
+    mca_btl_portals4_component.world_nprocs    = 0;
+    mca_btl_portals4_component.world_procs     = NULL;
+    mca_btl_portals4_component.world_peer_data = NULL;
+
     /*
      * Initialize the network interfaces (try to open the interfaces 0 to (max_btls-1) )
      */


### PR DESCRIPTION
In the default mode of operation, the Portals4 components support
dynamic add_procs().

The Portals4 components have two alternate modes (flow control and
logical-to-physical) that require knowledge of all procs at startup.
In these modes, mtl-portals4 or btl-portals4 iterates through all
the procs in MPI_COMM_WORLD to allocate them and create the
endpoints.

@hjelmn - Please review the use of ompi_group_get_proc_ptr_raw() 
and ompi_proc_for_name() in mtl_portals4.c.
