### PR TITLE
Topic/coll requests

### DIFF
--- a/ompi/mca/coll/base/base.h
+++ b/ompi/mca/coll/base/base.h
@@ -23,7 +23,7 @@
  * These functions are normally invoked by the back-ends of:
  *
  * - The back-ends of MPI_Init() and MPI_Finalize()
- * - Communuicactor constructors (e.g., MPI_Comm_split()) and
+ * - Communicator constructors (e.g., MPI_Comm_split()) and
  *   destructors (e.g., MPI_Comm_free())
  * - The laminfo command
  */

--- a/ompi/mca/coll/base/coll_base_alltoall.c
+++ b/ompi/mca/coll/base/coll_base_alltoall.c
@@ -650,9 +650,9 @@ int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, int scount,
     if( MPI_SUCCESS != err ) {
         OPAL_OUTPUT( (ompi_coll_base_framework.framework_output,"%s:%4d\tError occurred %d, rank %2d",
                       __FILE__, line, err, rank) );
-        /* Free the reqs */
-        ompi_coll_base_free_reqs(req, nreqs);
     }
+    /* Free the reqs in all cases as they are persistent requests */
+    ompi_coll_base_free_reqs(req, nreqs);
 
     /* All done */
     return err;

--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -123,9 +123,11 @@ mca_coll_base_alltoallv_intra_basic_inplace(const void *rbuf, const int *rcounts
  error_hndl:
     /* Free the temporary buffer */
     free (tmp_buffer);
+    if( MPI_SUCCESS != err ) {
+        ompi_coll_base_free_reqs(base_module->base_data->mcct_reqs, 2 );
+    }
 
     /* All done */
-
     return err;
 }
 
@@ -253,8 +255,7 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
                                       preq++));
         ++nreqs;
         if (MPI_SUCCESS != err) {
-            ompi_coll_base_free_reqs(data->mcct_reqs, nreqs);
-            return err;
+            goto err_hndl;
         }
     }
 
@@ -271,8 +272,7 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
                                       preq++));
         ++nreqs;
         if (MPI_SUCCESS != err) {
-            ompi_coll_base_free_reqs(data->mcct_reqs, nreqs);
-            return err;
+            goto err_hndl;
         }
     }
 
@@ -287,9 +287,10 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
      * error after we free everything. */
     err = ompi_request_wait_all(nreqs, data->mcct_reqs,
                                 MPI_STATUSES_IGNORE);
-
-    /* Free the requests. */
-    ompi_coll_base_free_reqs(data->mcct_reqs, nreqs);
+ err_hndl:
+    if( MPI_SUCCESS != err ) {  /* Free the requests. */
+        ompi_coll_base_free_reqs(data->mcct_reqs, nreqs);
+    }
 
     return err;
 }

--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -288,9 +288,8 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
     err = ompi_request_wait_all(nreqs, data->mcct_reqs,
                                 MPI_STATUSES_IGNORE);
  err_hndl:
-    if( MPI_SUCCESS != err ) {  /* Free the requests. */
-        ompi_coll_base_free_reqs(data->mcct_reqs, nreqs);
-    }
+    /* Free the requests in all cases as they are persistent */
+    ompi_coll_base_free_reqs(data->mcct_reqs, nreqs);
 
     return err;
 }

--- a/ompi/mca/coll/base/coll_base_barrier.c
+++ b/ompi/mca/coll/base/coll_base_barrier.c
@@ -324,7 +324,8 @@ int ompi_coll_base_barrier_intra_two_procs(struct ompi_communicator_t *comm,
 int ompi_coll_base_barrier_intra_basic_linear(struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
 {
-    int i, err, rank, size;
+    int i, err, rank, size, line;
+    ompi_request_t** requests = NULL;
 
     rank = ompi_comm_rank(comm);
     size = ompi_comm_size(comm);
@@ -334,50 +335,43 @@ int ompi_coll_base_barrier_intra_basic_linear(struct ompi_communicator_t *comm,
         err = MCA_PML_CALL(send (NULL, 0, MPI_BYTE, 0,
                                  MCA_COLL_BASE_TAG_BARRIER,
                                  MCA_PML_BASE_SEND_STANDARD, comm));
-        if (MPI_SUCCESS != err) {
-            return err;
-        }
+        if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
         err = MCA_PML_CALL(recv (NULL, 0, MPI_BYTE, 0,
                                  MCA_COLL_BASE_TAG_BARRIER,
                                  comm, MPI_STATUS_IGNORE));
-        if (MPI_SUCCESS != err) {
-            return err;
-        }
+        if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
     }
 
     /* The root collects and broadcasts the messages. */
 
     else {
-        ompi_request_t** requests;
-
-        requests = (ompi_request_t**)malloc( size * sizeof(ompi_request_t*) );
+        requests = coll_base_comm_get_reqs(module->base_data, size);
         for (i = 1; i < size; ++i) {
             err = MCA_PML_CALL(irecv(NULL, 0, MPI_BYTE, MPI_ANY_SOURCE,
                                      MCA_COLL_BASE_TAG_BARRIER, comm,
                                      &(requests[i])));
-            if (MPI_SUCCESS != err) {
-                return err;
-            }
+            if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
         }
         ompi_request_wait_all( size-1, requests+1, MPI_STATUSES_IGNORE );
+        requests = NULL;  /* we're done the requests array is clean */
 
         for (i = 1; i < size; ++i) {
             err = MCA_PML_CALL(send(NULL, 0, MPI_BYTE, i,
                                     MCA_COLL_BASE_TAG_BARRIER,
                                     MCA_PML_BASE_SEND_STANDARD, comm));
-            if (MPI_SUCCESS != err) {
-                return err;
-            }
+            if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
         }
-
-        free( requests );
     }
 
     /* All done */
-
     return MPI_SUCCESS;
-
+ err_hndl:
+    OPAL_OUTPUT( (ompi_coll_base_framework.framework_output,"%s:%4d\tError occurred %d, rank %2d",
+                  __FILE__, line, err, rank) );
+    if( NULL != requests )
+        ompi_coll_base_free_reqs(requests, size-1);
+    return err;
 }
 /* copied function (with appropriate renaming) ends here */
 

--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -143,7 +143,7 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
 
             /* wait for and forward the previous segment to children */
             err = ompi_request_wait( &recv_reqs[req_index ^ 0x1],
-                                     MPI_STATUSES_IGNORE );
+                                     MPI_STATUS_IGNORE );
             if (err != MPI_SUCCESS) { line = __LINE__; goto error_hndl; }
 
             for( i = 0; i < tree->tree_nextsize; i++ ) {
@@ -175,7 +175,7 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
         }
 
         /* Process the last segment */
-        err = ompi_request_wait( &recv_reqs[req_index], MPI_STATUSES_IGNORE );
+        err = ompi_request_wait( &recv_reqs[req_index], MPI_STATUS_IGNORE );
         if (err != MPI_SUCCESS) { line = __LINE__; goto error_hndl; }
         sendcount = original_count - (ptrdiff_t)(num_segments - 1) * count_by_segment;
         for( i = 0; i < tree->tree_nextsize; i++ ) {
@@ -240,8 +240,11 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
  error_hndl:
     OPAL_OUTPUT( (ompi_coll_base_framework.framework_output,"%s:%4d\tError occurred %d, rank %2d",
                   __FILE__, line, err, rank) );
-    if( (MPI_SUCCESS != err) && (NULL != send_reqs) ) {
-        ompi_coll_base_free_reqs( send_reqs, tree->tree_nextsize);
+    if( MPI_SUCCESS != err ) {
+        ompi_coll_base_free_reqs( recv_reqs, 2);
+        if( NULL != send_reqs ) {
+            ompi_coll_base_free_reqs( send_reqs, tree->tree_nextsize);
+        }
     }
 
     return err;
@@ -378,7 +381,6 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
     ptrdiff_t type_extent, lb;
     ompi_request_t *base_req, *new_req;
     ompi_coll_tree_t *tree;
-    mca_coll_base_comm_t *data = module->base_data;
 
     size = ompi_comm_size(comm);
     rank = ompi_comm_rank(comm);
@@ -391,7 +393,7 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
 
     /* setup the binary tree topology. */
     COLL_BASE_UPDATE_BINTREE( comm, module, root );
-    tree = data->cached_bintree;
+    tree = module->base_data->cached_bintree;
 
     err = ompi_datatype_type_size( datatype, &type_size );
 
@@ -501,8 +503,8 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
                                       comm, &new_req));
             if (err != MPI_SUCCESS) { line = __LINE__; goto error_hndl; }
 
-            /* wait for and forward current segment */
-            err = ompi_request_wait_all( 1, &base_req, MPI_STATUSES_IGNORE );
+            /* wait for and forward the previous segment */
+            err = ompi_request_wait( &base_req, MPI_STATUS_IGNORE );
             for( i = 0; i < tree->tree_nextsize; i++ ) {  /* send data to children (segcount[lr]) */
                 err = MCA_PML_CALL(send( tmpbuf[lr], segcount[lr], datatype,
                                          tree->tree_next[i], MCA_COLL_BASE_TAG_BCAST,
@@ -517,7 +519,7 @@ ompi_coll_base_bcast_intra_split_bintree ( void* buffer,
         } /* end of for segindex */
 
         /* wait for the last segment and forward current segment */
-        err = ompi_request_wait_all( 1, &base_req, MPI_STATUSES_IGNORE );
+        err = ompi_request_wait( &base_req, MPI_STATUS_IGNORE );
         for( i = 0; i < tree->tree_nextsize; i++ ) {  /* send data to children */
             err = MCA_PML_CALL(send(tmpbuf[lr], sendcount[lr], datatype,
                                     tree->tree_next[i], MCA_COLL_BASE_TAG_BCAST,
@@ -633,9 +635,7 @@ ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
                                         mca_coll_base_module_t *module)
 {
     int i, size, rank, err;
-    mca_coll_base_comm_t *data = module->base_data;
     ompi_request_t **preq, **reqs;
-
 
     size = ompi_comm_size(comm);
     rank = ompi_comm_rank(comm);
@@ -651,23 +651,19 @@ ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
     }
 
     /* Root sends data to all others. */
-    preq = reqs = coll_base_comm_get_reqs(data, size-1);
+    preq = reqs = coll_base_comm_get_reqs(module->base_data, size-1);
     for (i = 0; i < size; ++i) {
         if (i == rank) {
             continue;
         }
 
-        err = MCA_PML_CALL(isend_init(buff, count, datatype, i,
-                                      MCA_COLL_BASE_TAG_BCAST,
-                                      MCA_PML_BASE_SEND_STANDARD,
-                                      comm, preq++));
+        err = MCA_PML_CALL(isend(buff, count, datatype, i,
+                                 MCA_COLL_BASE_TAG_BCAST,
+                                 MCA_PML_BASE_SEND_STANDARD,
+                                 comm, preq++));
         if (MPI_SUCCESS != err) { goto err_hndl; }
     }
     --i;
-
-    /* Start your engines.  This will never return an error. */
-
-    MCA_PML_CALL(start(i, reqs));
 
     /* Wait for them all.  If there's an error, note that we don't
      * care what the error was -- just that there *was* an error.  The

--- a/ompi/mca/coll/base/coll_base_frame.c
+++ b/ompi/mca/coll/base/coll_base_frame.c
@@ -68,15 +68,7 @@ OBJ_CLASS_INSTANCE(mca_coll_base_module_t, opal_object_t,
 static void
 coll_base_comm_construct(mca_coll_base_comm_t *data)
 {
-    data->mcct_reqs = NULL;
-    data->mcct_num_reqs = 0;
-    data->cached_ntree = NULL;
-    data->cached_bintree = NULL;
-    data->cached_bmtree = NULL;
-    data->cached_in_order_bmtree = NULL;
-    data->cached_chain = NULL;
-    data->cached_pipeline = NULL;
-    data->cached_in_order_bintree = NULL;
+    memset ((char *) data + sizeof (data->super), 0, sizeof (*data) - sizeof (data->super));
 }
 
 static void

--- a/ompi/mca/coll/base/coll_base_frame.c
+++ b/ompi/mca/coll/base/coll_base_frame.c
@@ -119,9 +119,11 @@ OBJ_CLASS_INSTANCE(mca_coll_base_comm_t, opal_object_t,
 
 ompi_request_t** coll_base_comm_get_reqs(mca_coll_base_comm_t* data, int nreqs)
 {
-    if( data->mcct_num_reqs <= nreqs ) {
+    if( 0 == nreqs ) return NULL;
+
+    if( data->mcct_num_reqs <= nreqs )
         data->mcct_reqs = (ompi_request_t**)realloc(data->mcct_reqs, sizeof(ompi_request_t*) * nreqs);
-    }
+
     if( NULL != data->mcct_reqs ) {
         for( int i = data->mcct_num_reqs; i < nreqs; i++ )
             data->mcct_reqs[i] = MPI_REQUEST_NULL;

--- a/ompi/mca/coll/base/coll_base_frame.c
+++ b/ompi/mca/coll/base/coll_base_frame.c
@@ -83,10 +83,7 @@ static void
 coll_base_comm_destruct(mca_coll_base_comm_t *data)
 {
     if( NULL != data->mcct_reqs ) {
-        for( int i = 0; i < data->mcct_num_reqs; ++i ) {
-            if( MPI_REQUEST_NULL != data->mcct_reqs[i] )
-                ompi_request_free(&data->mcct_reqs[i]);
-        }
+        ompi_coll_base_free_reqs( data->mcct_reqs, data->mcct_num_reqs );
         free(data->mcct_reqs);
         data->mcct_reqs = NULL;
         data->mcct_num_reqs = 0;
@@ -122,18 +119,13 @@ OBJ_CLASS_INSTANCE(mca_coll_base_comm_t, opal_object_t,
 
 ompi_request_t** coll_base_comm_get_reqs(mca_coll_base_comm_t* data, int nreqs)
 {
-    int startfrom = data->mcct_num_reqs;
-
-    if( NULL == data->mcct_reqs ) {
-        assert(0 == data->mcct_num_reqs);
-        data->mcct_reqs = (ompi_request_t**)malloc(sizeof(ompi_request_t*) * nreqs);
-    } else if( data->mcct_num_reqs <= nreqs ) {
+    if( data->mcct_num_reqs <= nreqs ) {
         data->mcct_reqs = (ompi_request_t**)realloc(data->mcct_reqs, sizeof(ompi_request_t*) * nreqs);
     }
     if( NULL != data->mcct_reqs ) {
-        data->mcct_num_reqs = nreqs;
-        for( int i = startfrom; i < data->mcct_num_reqs; i++ )
+        for( int i = data->mcct_num_reqs; i < nreqs; i++ )
             data->mcct_reqs[i] = MPI_REQUEST_NULL;
+        data->mcct_num_reqs = nreqs;
     } else
         data->mcct_num_reqs = 0;  /* nothing to return */
     return data->mcct_reqs;

--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -353,9 +353,11 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_comm_t);
 static inline void ompi_coll_base_free_reqs(ompi_request_t **reqs, int count)
 {
     int i;
-    for (i = 0; i < count; ++i)
-        if( MPI_REQUEST_NULL != reqs[i] )
+    for (i = 0; i < count; ++i) {
+        if( MPI_REQUEST_NULL != reqs[i] ) {
             ompi_request_free(&reqs[i]);
+        }
+    }
 }
 
 /**

--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -343,11 +343,19 @@ struct mca_coll_base_comm_t {
 typedef struct mca_coll_base_comm_t mca_coll_base_comm_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_base_comm_t);
 
+/**
+ * Free all requests in an array. As these requests are usually used during
+ * collective communications, and as on a succesful collective they are
+ * expected to be released during the corresponding wait, the array should
+ * generally be empty. However, this function might be used on error conditions
+ * where it will allow a correct cleanup.
+ */
 static inline void ompi_coll_base_free_reqs(ompi_request_t **reqs, int count)
 {
     int i;
     for (i = 0; i < count; ++i)
-        ompi_request_free(&reqs[i]);
+        if( MPI_REQUEST_NULL != reqs[i] )
+            ompi_request_free(&reqs[i]);
 }
 
 /**

--- a/ompi/mca/coll/base/coll_base_gather.c
+++ b/ompi/mca/coll/base/coll_base_gather.c
@@ -266,7 +266,7 @@ ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
         */
         char *ptmp;
         ompi_request_t *first_segment_req;
-        reqs = (ompi_request_t**) calloc(size, sizeof(ompi_request_t*));
+        reqs = coll_base_comm_get_reqs(module->base_data, size);
         if (NULL == reqs) { ret = -1; line = __LINE__; goto error_hndl; }
 
         ompi_datatype_type_size(rdtype, &typelng);
@@ -319,16 +319,13 @@ ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
         /* wait all second segments to complete */
         ret = ompi_request_wait_all(size, reqs, MPI_STATUSES_IGNORE);
         if (ret != MPI_SUCCESS) { line = __LINE__; goto error_hndl; }
-
-        free(reqs);
     }
 
     /* All done */
-
     return MPI_SUCCESS;
  error_hndl:
     if (NULL != reqs) {
-        free(reqs);
+        ompi_coll_base_free_reqs(reqs, size);
     }
     OPAL_OUTPUT (( ompi_coll_base_framework.framework_output,
                    "ERROR_HNDL: node %d file %s line %d error %d\n",
@@ -405,7 +402,6 @@ ompi_coll_base_gather_intra_basic_linear(const void *sbuf, int scount,
     }
 
     /* All done */
-
     return MPI_SUCCESS;
 }
 

--- a/ompi/mca/coll/basic/coll_basic.h
+++ b/ompi/mca/coll/basic/coll_basic.h
@@ -283,17 +283,6 @@ BEGIN_C_DECLS
     int mca_coll_basic_ft_event(int status);
 
 
-/* Utility functions */
-
-    static inline void mca_coll_basic_free_reqs(ompi_request_t ** reqs,
-                                                int count)
-    {
-        int i;
-        for (i = 0; i < count; ++i)
-             ompi_request_free(&reqs[i]);
-    }
-
-
 struct mca_coll_basic_module_t {
     mca_coll_base_module_t super;
 
@@ -302,6 +291,23 @@ struct mca_coll_basic_module_t {
 };
 typedef struct mca_coll_basic_module_t mca_coll_basic_module_t;
 OBJ_CLASS_DECLARATION(mca_coll_basic_module_t);
+
+/* Utility functions */
+
+static inline void mca_coll_basic_free_reqs(ompi_request_t ** reqs, int count)
+{
+    int i;
+    for (i = 0; i < count; ++i)
+        if( MPI_REQUEST_NULL != reqs[i] ) {
+            ompi_request_free(&reqs[i]);
+        }
+}
+
+/**
+ * Return the array of requests on the data. If the array was not initialized
+ * or if it's size was too small, allocate it to fit the requested size.
+ */
+ompi_request_t** mca_coll_basic_get_reqs(mca_coll_basic_module_t* data, int nreqs);
 
 END_C_DECLS
 

--- a/ompi/mca/coll/basic/coll_basic.h
+++ b/ompi/mca/coll/basic/coll_basic.h
@@ -285,29 +285,12 @@ BEGIN_C_DECLS
 
 struct mca_coll_basic_module_t {
     mca_coll_base_module_t super;
-
-    ompi_request_t **mccb_reqs;
-    int mccb_num_reqs;
 };
 typedef struct mca_coll_basic_module_t mca_coll_basic_module_t;
-OBJ_CLASS_DECLARATION(mca_coll_basic_module_t);
+OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_basic_module_t);
 
-/* Utility functions */
-
-static inline void mca_coll_basic_free_reqs(ompi_request_t ** reqs, int count)
-{
-    int i;
-    for (i = 0; i < count; ++i)
-        if( MPI_REQUEST_NULL != reqs[i] ) {
-            ompi_request_free(&reqs[i]);
-        }
-}
-
-/**
- * Return the array of requests on the data. If the array was not initialized
- * or if it's size was too small, allocate it to fit the requested size.
- */
-ompi_request_t** mca_coll_basic_get_reqs(mca_coll_basic_module_t* data, int nreqs);
+typedef mca_coll_base_comm_t mca_coll_basic_comm_t;
+OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_basic_comm_t);
 
 END_C_DECLS
 

--- a/ompi/mca/coll/basic/coll_basic_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_allgather.c
@@ -51,7 +51,6 @@ mca_coll_basic_allgather_inter(const void *sbuf, int scount,
     char *tmpbuf = NULL, *ptmp;
     ptrdiff_t rlb, slb, rextent, sextent, incr;
     ompi_request_t *req;
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t*) module;
     ompi_request_t **reqs = NULL;
 
     rank = ompi_comm_rank(comm);
@@ -80,7 +79,7 @@ mca_coll_basic_allgather_inter(const void *sbuf, int scount,
         if (OMPI_SUCCESS != err) { line = __LINE__; goto exit; }
 
         /* Get a requests arrays of the right size */
-        reqs = mca_coll_basic_get_reqs(basic_module, rsize + 1);
+        reqs = coll_base_comm_get_reqs(module->base_data, rsize + 1);
         if( NULL == reqs ) { line = __LINE__; goto exit; }
 
         /* Do a send-recv between the two root procs. to avoid deadlock */
@@ -156,7 +155,7 @@ mca_coll_basic_allgather_inter(const void *sbuf, int scount,
     if( MPI_SUCCESS != err ) {
         OPAL_OUTPUT( (ompi_coll_base_framework.framework_output,"%s:%4d\tError occurred %d, rank %2d",
                       __FILE__, line, err, rank) );
-        if( NULL != reqs ) mca_coll_basic_free_reqs(reqs, rsize+1);
+        if( NULL != reqs ) ompi_coll_base_free_reqs(reqs, rsize+1);
     }
     if (NULL != tmpbuf) {
         free(tmpbuf);

--- a/ompi/mca/coll/basic/coll_basic_allreduce.c
+++ b/ompi/mca/coll/basic/coll_basic_allreduce.c
@@ -85,7 +85,6 @@ mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
     ptrdiff_t true_lb, true_extent;
     char *tmpbuf = NULL, *pml_buffer = NULL;
     ompi_request_t *req[2];
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t*) module;
     ompi_request_t **reqs = NULL;
 
     rank = ompi_comm_rank(comm);
@@ -114,7 +113,7 @@ mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
         if (NULL == tmpbuf) { err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto exit; }
         pml_buffer = tmpbuf - true_lb;
 
-        reqs = mca_coll_basic_get_reqs(basic_module, rsize - 1);
+        reqs = coll_base_comm_get_reqs(module->base_data, rsize - 1);
         if( NULL == reqs ) { err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto exit; }
 
         /* Do a send-recv between the two root procs. to avoid deadlock */
@@ -201,7 +200,7 @@ mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
     if( MPI_SUCCESS != err ) {
         OPAL_OUTPUT((ompi_coll_base_framework.framework_output,"%s:%4d\tError occurred %d, rank %2d", __FILE__,
                      line, err, rank));
-        mca_coll_basic_free_reqs(reqs, rsize - 1);
+        ompi_coll_base_free_reqs(reqs, rsize - 1);
     }
     if (NULL != tmpbuf) {
         free(tmpbuf);

--- a/ompi/mca/coll/basic/coll_basic_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoall.c
@@ -77,7 +77,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
 
     /* Initiate all send/recv to/from others. */
     nreqs = size * 2;
-    req = rreq = mca_coll_basic_get_reqs( (mca_coll_basic_module_t*) module, nreqs);
+    req = rreq = coll_base_comm_get_reqs( module->base_data, nreqs);
     sreq = rreq + size;
 
     prcv = (char *) rbuf;
@@ -88,7 +88,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
         err = MCA_PML_CALL(irecv(prcv + (i * rcvinc), rcount, rdtype, i,
                                  MCA_COLL_BASE_TAG_ALLTOALL, comm, rreq));
         if (OMPI_SUCCESS != err) {
-            mca_coll_basic_free_reqs(req, nreqs);
+            ompi_coll_base_free_reqs(req, nreqs);
             return err;
         }
     }
@@ -99,7 +99,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
                                  MCA_COLL_BASE_TAG_ALLTOALL,
                                  MCA_PML_BASE_SEND_STANDARD, comm, sreq));
         if (OMPI_SUCCESS != err) {
-            mca_coll_basic_free_reqs(req, nreqs);
+            ompi_coll_base_free_reqs(req, nreqs);
             return err;
         }
     }
@@ -112,7 +112,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
      * the error after we free everything. */
     err = ompi_request_wait_all(nreqs, req, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != err) {
-        mca_coll_basic_free_reqs(req, nreqs);
+        ompi_coll_base_free_reqs(req, nreqs);
     }
 
     /* All done */

--- a/ompi/mca/coll/basic/coll_basic_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoall.c
@@ -57,11 +57,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
     MPI_Aint sndinc;
     MPI_Aint rcvinc;
 
-    ompi_request_t **req;
-    ompi_request_t **sreq;
-    ompi_request_t **rreq;
-
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t*) module;
+    ompi_request_t **req, **sreq, **rreq;
 
     /* Initialize. */
 
@@ -81,7 +77,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
 
     /* Initiate all send/recv to/from others. */
     nreqs = size * 2;
-    req = rreq = basic_module->mccb_reqs;
+    req = rreq = mca_coll_basic_get_reqs( (mca_coll_basic_module_t*) module, nreqs);
     sreq = rreq + size;
 
     prcv = (char *) rbuf;
@@ -92,6 +88,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
         err = MCA_PML_CALL(irecv(prcv + (i * rcvinc), rcount, rdtype, i,
                                  MCA_COLL_BASE_TAG_ALLTOALL, comm, rreq));
         if (OMPI_SUCCESS != err) {
+            mca_coll_basic_free_reqs(req, nreqs);
             return err;
         }
     }
@@ -102,6 +99,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
                                  MCA_COLL_BASE_TAG_ALLTOALL,
                                  MCA_PML_BASE_SEND_STANDARD, comm, sreq));
         if (OMPI_SUCCESS != err) {
+            mca_coll_basic_free_reqs(req, nreqs);
             return err;
         }
     }
@@ -113,6 +111,9 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
      * So free them anyway -- even if there was an error, and return
      * the error after we free everything. */
     err = ompi_request_wait_all(nreqs, req, MPI_STATUSES_IGNORE);
+    if (OMPI_SUCCESS != err) {
+        mca_coll_basic_free_reqs(req, nreqs);
+    }
 
     /* All done */
     return err;

--- a/ompi/mca/coll/basic/coll_basic_alltoallv.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoallv.c
@@ -68,7 +68,7 @@ mca_coll_basic_alltoallv_inter(const void *sbuf, const int *scounts, const int *
 
     /* Initiate all send/recv to/from others. */
     nreqs = rsize * 2;
-    preq = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, nreqs);
+    preq = coll_base_comm_get_reqs(module->base_data, nreqs);
 
     /* Post all receives first  */
     /* A simple optimization: do not send and recv msgs of length zero */
@@ -79,7 +79,7 @@ mca_coll_basic_alltoallv_inter(const void *sbuf, const int *scounts, const int *
                                      i, MCA_COLL_BASE_TAG_ALLTOALLV, comm,
                                      &preq[i]));
             if (MPI_SUCCESS != err) {
-                mca_coll_basic_free_reqs(preq, i);
+                ompi_coll_base_free_reqs(preq, i);
                 return err;
             }
         }
@@ -94,7 +94,7 @@ mca_coll_basic_alltoallv_inter(const void *sbuf, const int *scounts, const int *
                                      MCA_PML_BASE_SEND_STANDARD, comm,
                                      &preq[rsize + i]));
             if (MPI_SUCCESS != err) {
-                mca_coll_basic_free_reqs(preq, rsize + i);
+                ompi_coll_base_free_reqs(preq, rsize + i);
                 return err;
             }
         }
@@ -102,7 +102,7 @@ mca_coll_basic_alltoallv_inter(const void *sbuf, const int *scounts, const int *
 
     err = ompi_request_wait_all(nreqs, preq, MPI_STATUSES_IGNORE);
     if (MPI_SUCCESS != err) {
-        mca_coll_basic_free_reqs(preq, nreqs);
+        ompi_coll_base_free_reqs(preq, nreqs);
     }
 
     /* All done */

--- a/ompi/mca/coll/basic/coll_basic_bcast.c
+++ b/ompi/mca/coll/basic/coll_basic_bcast.c
@@ -81,7 +81,7 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
 
     /* Send data to the children. */
 
-    reqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, size);
+    reqs = coll_base_comm_get_reqs(module->base_data, size);
 
     err = MPI_SUCCESS;
     preq = reqs;
@@ -92,12 +92,12 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
             peer = (peer + root) % size;
             ++nreqs;
 
-            err = MCA_PML_CALL(isend_init(buff, count, datatype, peer,
-                                          MCA_COLL_BASE_TAG_BCAST,
-                                          MCA_PML_BASE_SEND_STANDARD,
-                                          comm, preq++));
+            err = MCA_PML_CALL(isend(buff, count, datatype, peer,
+                                     MCA_COLL_BASE_TAG_BCAST,
+                                     MCA_PML_BASE_SEND_STANDARD,
+                                     comm, preq++));
             if (MPI_SUCCESS != err) {
-                mca_coll_basic_free_reqs(reqs, nreqs);
+                ompi_coll_base_free_reqs(reqs, nreqs);
                 return err;
             }
         }
@@ -107,10 +107,6 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
 
     if (nreqs > 0) {
 
-        /* Start your engines.  This will never return an error. */
-
-        MCA_PML_CALL(start(nreqs, reqs));
-
         /* Wait for them all.  If there's an error, note that we don't
          * care what the error was -- just that there *was* an error.
          * The PML will finish all requests, even if one or more of them
@@ -119,11 +115,11 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
          * error, and return the error after we free everything. */
 
         err = ompi_request_wait_all(nreqs, reqs, MPI_STATUSES_IGNORE);
+        if( MPI_SUCCESS != err ) {
+            ompi_coll_base_free_reqs(reqs, nreqs);
+        }
     }
 
-    if( MPI_SUCCESS != err ) {
-        mca_coll_basic_free_reqs(reqs, nreqs);
-    }
     /* All done */
 
     return err;
@@ -159,7 +155,7 @@ mca_coll_basic_bcast_lin_inter(void *buff, int count,
                                 MCA_COLL_BASE_TAG_BCAST, comm,
                                 MPI_STATUS_IGNORE));
     } else {
-        reqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, rsize);
+        reqs = coll_base_comm_get_reqs(module->base_data, rsize);
         /* root section */
         for (i = 0; i < rsize; i++) {
             err = MCA_PML_CALL(isend(buff, count, datatype, i,
@@ -167,13 +163,13 @@ mca_coll_basic_bcast_lin_inter(void *buff, int count,
                                      MCA_PML_BASE_SEND_STANDARD,
                                      comm, &(reqs[i])));
             if (OMPI_SUCCESS != err) {
-                mca_coll_basic_free_reqs(reqs, rsize);
+                ompi_coll_base_free_reqs(reqs, rsize);
                 return err;
             }
         }
         err = ompi_request_wait_all(rsize, reqs, MPI_STATUSES_IGNORE);
         if (OMPI_SUCCESS != err) {
-            mca_coll_basic_free_reqs(reqs, rsize);
+            ompi_coll_base_free_reqs(reqs, rsize);
         }
     }
 

--- a/ompi/mca/coll/basic/coll_basic_component.c
+++ b/ompi/mca/coll/basic/coll_basic_component.c
@@ -106,22 +106,10 @@ basic_register(void)
     return OMPI_SUCCESS;
 }
 
-
-static void
-mca_coll_basic_module_construct(mca_coll_basic_module_t *module)
-{
-    module->mccb_reqs = NULL;
-    module->mccb_num_reqs = 0;
-}
-
-static void
-mca_coll_basic_module_destruct(mca_coll_basic_module_t *module)
-{
-    if (NULL != module->mccb_reqs) free(module->mccb_reqs);
-}
-
-
 OBJ_CLASS_INSTANCE(mca_coll_basic_module_t,
                    mca_coll_base_module_t,
-                   mca_coll_basic_module_construct,
-                   mca_coll_basic_module_destruct);
+                   NULL,
+                   NULL);
+
+OBJ_CLASS_INSTANCE(mca_coll_basic_comm_t, mca_coll_base_comm_t,
+                   NULL, NULL);

--- a/ompi/mca/coll/basic/coll_basic_gatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_gatherv.c
@@ -142,21 +142,21 @@ mca_coll_basic_gatherv_inter(const void *sbuf, int scount,
             return OMPI_ERROR;
         }
 
-        reqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, size);
+        reqs = coll_base_comm_get_reqs(module->base_data, size);
         for (i = 0; i < size; ++i) {
             ptmp = ((char *) rbuf) + (extent * disps[i]);
             err = MCA_PML_CALL(irecv(ptmp, rcounts[i], rdtype, i,
                                      MCA_COLL_BASE_TAG_GATHERV,
                                      comm, &reqs[i]));
             if (OMPI_SUCCESS != err) {
-                mca_coll_basic_free_reqs(reqs, size);
+                ompi_coll_base_free_reqs(reqs, size);
                 return err;
             }
         }
 
         err = ompi_request_wait_all(size, reqs, MPI_STATUSES_IGNORE);
         if (OMPI_SUCCESS != err) {
-            mca_coll_basic_free_reqs(reqs, size);
+            ompi_coll_base_free_reqs(reqs, size);
         }
     }
 

--- a/ompi/mca/coll/basic/coll_basic_module.c
+++ b/ompi/mca/coll/basic/coll_basic_module.c
@@ -101,9 +101,6 @@ mca_coll_basic_comm_query(struct ompi_communicator_t *comm,
             size = dist_graph_size;
         }
     }
-    basic_module->mccb_num_reqs = size;
-    basic_module->mccb_reqs = (ompi_request_t**)
-        malloc(sizeof(ompi_request_t *) * basic_module->mccb_num_reqs);
 
     /* Choose whether to use [intra|inter], and [linear|log]-based
      * algorithms. */

--- a/ompi/mca/coll/basic/coll_basic_module.c
+++ b/ompi/mca/coll/basic/coll_basic_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2012      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -30,8 +30,6 @@
 #include "mpi.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/mca/coll/base/base.h"
-#include "ompi/mca/topo/topo.h"
-#include "ompi/mca/topo/base/base.h"
 #include "coll_basic.h"
 
 
@@ -59,50 +57,12 @@ mca_coll_base_module_t *
 mca_coll_basic_comm_query(struct ompi_communicator_t *comm,
                           int *priority)
 {
-    int size;
     mca_coll_basic_module_t *basic_module;
 
     basic_module = OBJ_NEW(mca_coll_basic_module_t);
     if (NULL == basic_module) return NULL;
 
     *priority = mca_coll_basic_priority;
-
-    /* Allocate the data that hangs off the communicator */
-
-    if (OMPI_COMM_IS_INTER(comm)) {
-        size = ompi_comm_remote_size(comm);
-    } else {
-        size = ompi_comm_size(comm);
-    }
-    size *= 2;
-    if (OMPI_COMM_IS_CART(comm)) {
-        int cart_size;
-        mca_topo_base_comm_cart_2_2_0_t *cart;
-        assert (NULL != comm->c_topo);
-        cart = comm->c_topo->mtc.cart;
-        cart_size = cart->ndims * 4;
-        if (cart_size > size) {
-            size = cart_size;
-        }
-    } else if (OMPI_COMM_IS_GRAPH(comm)) {
-        int rank, degree;
-        assert (NULL != comm->c_topo);
-        rank = ompi_comm_rank (comm);
-        mca_topo_base_graph_neighbors_count (comm, rank, &degree);
-        degree *= 2;
-        if (degree > size) {
-            size = degree;
-        }
-    } else if (OMPI_COMM_IS_DIST_GRAPH(comm)) {
-        int dist_graph_size;
-        mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph;
-        assert (NULL != comm->c_topo);
-        dist_graph = comm->c_topo->mtc.dist_graph;
-        dist_graph_size = dist_graph->indegree + dist_graph->outdegree;
-        if (dist_graph_size > size) {
-            size = dist_graph_size;
-        }
-    }
 
     /* Choose whether to use [intra|inter], and [linear|log]-based
      * algorithms. */

--- a/ompi/mca/coll/basic/coll_basic_module.c
+++ b/ompi/mca/coll/basic/coll_basic_module.c
@@ -76,10 +76,11 @@ mca_coll_basic_comm_query(struct ompi_communicator_t *comm,
     }
     size *= 2;
     if (OMPI_COMM_IS_CART(comm)) {
-        int cart_size, ndims;
+        int cart_size;
+        mca_topo_base_comm_cart_2_2_0_t *cart;
         assert (NULL != comm->c_topo);
-        comm->c_topo->topo.cart.cartdim_get(comm, &ndims);
-        cart_size = ndims * 4;
+        cart = comm->c_topo->mtc.cart;
+        cart_size = cart->ndims * 4;
         if (cart_size > size) {
             size = cart_size;
         }
@@ -87,16 +88,17 @@ mca_coll_basic_comm_query(struct ompi_communicator_t *comm,
         int rank, degree;
         assert (NULL != comm->c_topo);
         rank = ompi_comm_rank (comm);
-        comm->c_topo->topo.graph.graph_neighbors_count (comm, rank, &degree);
+        mca_topo_base_graph_neighbors_count (comm, rank, &degree);
         degree *= 2;
         if (degree > size) {
             size = degree;
         }
     } else if (OMPI_COMM_IS_DIST_GRAPH(comm)) {
-        int dist_graph_size, inneighbors, outneighbors, weighted;
+        int dist_graph_size;
+        mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph;
         assert (NULL != comm->c_topo);
-        comm->c_topo->topo.dist_graph.dist_graph_neighbors_count(comm, &inneighbors, &outneighbors, &weighted);
-        dist_graph_size = inneighbors + outneighbors;
+        dist_graph = comm->c_topo->mtc.dist_graph;
+        dist_graph_size = dist_graph->indegree + dist_graph->outdegree;
         if (dist_graph_size > size) {
             size = dist_graph_size;
         }

--- a/ompi/mca/coll/basic/coll_basic_module.c
+++ b/ompi/mca/coll/basic/coll_basic_module.c
@@ -181,10 +181,15 @@ int
 mca_coll_basic_module_enable(mca_coll_base_module_t *module,
                              struct ompi_communicator_t *comm)
 {
+    /* prepare the placeholder for the array of request* */
+    module->base_data = OBJ_NEW(mca_coll_basic_comm_t);
+    if (NULL == module->base_data) {
+        return OMPI_ERROR;
+    }
+
     /* All done */
     return OMPI_SUCCESS;
 }
-
 
 int
 mca_coll_basic_ft_event(int state) {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
@@ -50,7 +50,7 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
 
-    reqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 4 * cart->ndims );
+    reqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
     /* The ordering is defined as -1 then +1 in each dimension in
      * order of dimension. */
     for (dim = 0, nreqs = 0 ; dim < cart->ndims ; ++dim) {
@@ -99,13 +99,13 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, nreqs);
+        ompi_coll_base_free_reqs(reqs, nreqs);
         return rc;
     }
 
     rc = ompi_request_wait_all (nreqs, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, nreqs);
+        ompi_coll_base_free_reqs(reqs, nreqs);
     }
     return rc;
 }
@@ -133,7 +133,7 @@ mca_coll_basic_neighbor_allgather_graph(const void *sbuf, int scount,
     }
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t *) module, 2 * degree);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree);
 
     for (neighbor = 0; neighbor < degree ; ++neighbor) {
         rc = MCA_PML_CALL(irecv(rbuf, rcount, rdtype, edges[neighbor], MCA_COLL_BASE_TAG_ALLGATHER,
@@ -150,13 +150,13 @@ mca_coll_basic_neighbor_allgather_graph(const void *sbuf, int scount,
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, (2 * neighbor + 1));
+        ompi_coll_base_free_reqs( reqs, (2 * neighbor + 1));
         return rc;
     }
 
     rc = ompi_request_wait_all (degree * 2, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, degree * 2);
+        ompi_coll_base_free_reqs( reqs, degree * 2);
     }
     return rc;
 }
@@ -182,7 +182,7 @@ mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
     outedges = dist_graph->out;
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t *) module, indegree + outdegree);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
 
     for (neighbor = 0; neighbor < indegree ; ++neighbor) {
         rc = MCA_PML_CALL(irecv(rbuf, rcount, rdtype, inedges[neighbor],
@@ -193,7 +193,7 @@ mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, neighbor);
+        ompi_coll_base_free_reqs(reqs, neighbor);
         return rc;
     }
 
@@ -208,13 +208,13 @@ mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, indegree + neighbor);
+        ompi_coll_base_free_reqs(reqs, indegree + neighbor);
         return rc;
     }
 
     rc = ompi_request_wait_all (indegree + outdegree, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, indegree + outdegree);
+        ompi_coll_base_free_reqs(reqs, indegree + outdegree);
     }
     return rc;
 }

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
@@ -44,13 +44,13 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
 {
     const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
     const int rank = ompi_comm_rank (comm);
-    ompi_request_t **reqs;
+    ompi_request_t **reqs, **preqs;
     ptrdiff_t lb, extent;
     int rc = MPI_SUCCESS, dim, nreqs;
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
 
-    reqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
     /* The ordering is defined as -1 then +1 in each dimension in
      * order of dimension. */
     for (dim = 0, nreqs = 0 ; dim < cart->ndims ; ++dim) {
@@ -66,7 +66,7 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
             nreqs += 2;
             rc = MCA_PML_CALL(irecv(rbuf, rcount, rdtype, srank,
                                     MCA_COLL_BASE_TAG_ALLGATHER,
-                                    comm, reqs++));
+                                    comm, preqs++));
             if (OMPI_SUCCESS != rc) break;
 
             /* remove cast from const when the pml layer is updated to take
@@ -74,7 +74,7 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
             rc = MCA_PML_CALL(isend((void *) sbuf, scount, sdtype, srank,
                                     MCA_COLL_BASE_TAG_ALLGATHER,
                                     MCA_PML_BASE_SEND_STANDARD,
-                                    comm, reqs++));
+                                    comm, preqs++));
             if (OMPI_SUCCESS != rc) break;
         }
 
@@ -84,14 +84,14 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
             nreqs += 2;
             rc = MCA_PML_CALL(irecv(rbuf, rcount, rdtype, drank,
                                     MCA_COLL_BASE_TAG_ALLGATHER,
-                                    comm, reqs++));
+                                    comm, preqs++));
             if (OMPI_SUCCESS != rc) break;
 
 
             rc = MCA_PML_CALL(isend((void *) sbuf, scount, sdtype, drank,
                                     MCA_COLL_BASE_TAG_ALLGATHER,
                                     MCA_PML_BASE_SEND_STANDARD,
-                                    comm, reqs++));
+                                    comm, preqs++));
             if (OMPI_SUCCESS != rc) break;
         }
 

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgatherv.c
@@ -49,7 +49,7 @@ mca_coll_basic_neighbor_allgatherv_cart(const void *sbuf, int scount, struct omp
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
 
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 4 * cart->ndims);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims);
 
     /* The ordering is defined as -1 then +1 in each dimension in
      * order of dimension. */
@@ -88,13 +88,13 @@ mca_coll_basic_neighbor_allgatherv_cart(const void *sbuf, int scount, struct omp
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
         return rc;
     }
 
     rc = ompi_request_wait_all (nreqs, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
     }
     return rc;
 }
@@ -120,7 +120,7 @@ mca_coll_basic_neighbor_allgatherv_graph(const void *sbuf, int scount, struct om
     }
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 2 * degree);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree);
 
     for (neighbor = 0; neighbor < degree ; ++neighbor) {
         rc = MCA_PML_CALL(irecv((char *) rbuf + disps[neighbor] * extent, rcounts[neighbor],
@@ -136,13 +136,13 @@ mca_coll_basic_neighbor_allgatherv_graph(const void *sbuf, int scount, struct om
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, 2 * (neighbor + 1) );
+        ompi_coll_base_free_reqs( reqs, 2 * (neighbor + 1) );
         return rc;
     }
 
     rc = ompi_request_wait_all (degree * 2, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, 2 * degree );
+        ompi_coll_base_free_reqs( reqs, 2 * degree );
     }
     return rc;
 }
@@ -167,7 +167,7 @@ mca_coll_basic_neighbor_allgatherv_dist_graph(const void *sbuf, int scount, stru
     outedges = dist_graph->out;
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, indegree + outdegree);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
 
     for (neighbor = 0; neighbor < indegree ; ++neighbor) {
         rc = MCA_PML_CALL(irecv((char *) rbuf + disps[neighbor] * extent, rcounts[neighbor], rdtype,
@@ -176,7 +176,7 @@ mca_coll_basic_neighbor_allgatherv_dist_graph(const void *sbuf, int scount, stru
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, neighbor);
+        ompi_coll_base_free_reqs(reqs, neighbor);
         return rc;
     }
 
@@ -190,13 +190,13 @@ mca_coll_basic_neighbor_allgatherv_dist_graph(const void *sbuf, int scount, stru
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, indegree + neighbor);
+        ompi_coll_base_free_reqs(reqs, indegree + neighbor);
         return rc;
     }
 
     rc = ompi_request_wait_all (indegree + outdegree, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, indegree + outdegree);
+        ompi_coll_base_free_reqs(reqs, indegree + outdegree);
     }
     return rc;
 }

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
@@ -48,7 +48,7 @@ mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 4 * cart->ndims);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims);
 
     /* post receives first */
     for (dim = 0, nreqs = 0; dim < cart->ndims ; ++dim) {
@@ -82,7 +82,7 @@ mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs);
+        ompi_coll_base_free_reqs( reqs, nreqs);
         return rc;
     }
 
@@ -121,13 +121,13 @@ mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs);
+        ompi_coll_base_free_reqs( reqs, nreqs);
         return rc;
     }
 
     rc = ompi_request_wait_all (nreqs, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs);
+        ompi_coll_base_free_reqs( reqs, nreqs);
     }
     return rc;
 }
@@ -153,7 +153,7 @@ mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 2 * degree);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree);
 
     /* post receives first */
     for (neighbor = 0; neighbor < degree ; ++neighbor) {
@@ -163,7 +163,7 @@ mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi
         rbuf = (char *) rbuf + rdextent * rcount;
     }
     if( MPI_SUCCESS != rc ) {
-        mca_coll_basic_free_reqs( reqs, neighbor );
+        ompi_coll_base_free_reqs( reqs, neighbor );
         return rc;
     }
 
@@ -178,13 +178,13 @@ mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi
     }
 
     if( MPI_SUCCESS != rc ) {
-        mca_coll_basic_free_reqs( reqs, degree + neighbor );
+        ompi_coll_base_free_reqs( reqs, degree + neighbor );
         return rc;
     }
 
     rc = ompi_request_wait_all (degree * 2, reqs, MPI_STATUSES_IGNORE);
     if( MPI_SUCCESS != rc ) {
-        mca_coll_basic_free_reqs( reqs, 2 * degree );
+        ompi_coll_base_free_reqs( reqs, 2 * degree );
     }
     return rc;
 }
@@ -209,7 +209,7 @@ mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct 
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, indegree + outdegree);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
 
     /* post receives first */
     for (neighbor = 0; neighbor < indegree ; ++neighbor) {
@@ -221,7 +221,7 @@ mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct 
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, neighbor);
+        ompi_coll_base_free_reqs(reqs, neighbor);
         return rc;
     }
 
@@ -235,13 +235,13 @@ mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct 
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, indegree + neighbor);
+        ompi_coll_base_free_reqs(reqs, indegree + neighbor);
         return rc;
     }
 
     rc = ompi_request_wait_all (indegree + outdegree, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs(reqs, indegree + outdegree);
+        ompi_coll_base_free_reqs(reqs, indegree + outdegree);
     }
     return rc;
 }

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallv.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallv.c
@@ -49,7 +49,7 @@ mca_coll_basic_neighbor_alltoallv_cart(const void *sbuf, const int scounts[], co
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 4 * cart->ndims );
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
 
     /* post receives first */
     for (dim = 0, nreqs = 0, i = 0; dim < cart->ndims ; ++dim, i += 2) {
@@ -77,7 +77,7 @@ mca_coll_basic_neighbor_alltoallv_cart(const void *sbuf, const int scounts[], co
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
         return rc;
     }
 
@@ -107,13 +107,13 @@ mca_coll_basic_neighbor_alltoallv_cart(const void *sbuf, const int scounts[], co
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
         return rc;
     }
 
     rc = ompi_request_wait_all (nreqs, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
     }
     return rc;
 }
@@ -140,7 +140,7 @@ mca_coll_basic_neighbor_alltoallv_graph(const void *sbuf, const int scounts[], c
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 2 * degree );
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree );
 
     /* post all receives first */
     for (neighbor = 0; neighbor < degree ; ++neighbor) {
@@ -150,7 +150,7 @@ mca_coll_basic_neighbor_alltoallv_graph(const void *sbuf, const int scounts[], c
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, neighbor );
+        ompi_coll_base_free_reqs( reqs, neighbor );
         return rc;
     }
 
@@ -163,13 +163,13 @@ mca_coll_basic_neighbor_alltoallv_graph(const void *sbuf, const int scounts[], c
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, degree + neighbor );
+        ompi_coll_base_free_reqs( reqs, degree + neighbor );
         return rc;
     }
 
     rc = ompi_request_wait_all (degree * 2, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, degree * 2);
+        ompi_coll_base_free_reqs( reqs, degree * 2);
     }
     return rc;
 }
@@ -195,7 +195,7 @@ mca_coll_basic_neighbor_alltoallv_dist_graph(const void *sbuf, const int scounts
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t *) module, indegree + outdegree);
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
 
     /* post all receives first */
     for (neighbor = 0; neighbor < indegree ; ++neighbor) {
@@ -205,7 +205,7 @@ mca_coll_basic_neighbor_alltoallv_dist_graph(const void *sbuf, const int scounts
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, neighbor );
+        ompi_coll_base_free_reqs( reqs, neighbor );
         return rc;
     }
 
@@ -218,13 +218,13 @@ mca_coll_basic_neighbor_alltoallv_dist_graph(const void *sbuf, const int scounts
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, indegree + neighbor );
+        ompi_coll_base_free_reqs( reqs, indegree + neighbor );
         return rc;
     }
 
     rc = ompi_request_wait_all (indegree + outdegree, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, indegree + outdegree );
+        ompi_coll_base_free_reqs( reqs, indegree + outdegree );
     }
     return rc;
 }

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
@@ -46,7 +46,7 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
     int rc = MPI_SUCCESS, dim, i, nreqs;
     ompi_request_t **reqs, **preqs;
 
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 4 * cart->ndims );
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
 
     /* post receives first */
     for (dim = 0, i = 0, nreqs = 0; dim < cart->ndims ; ++dim, i += 2) {
@@ -74,7 +74,7 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
         return rc;
     }
 
@@ -104,13 +104,13 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
         return rc;
     }
 
     rc = ompi_request_wait_all (nreqs, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, nreqs );
+        ompi_coll_base_free_reqs( reqs, nreqs );
     }
     return rc;
 }
@@ -128,7 +128,7 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
     const int *edges;
 
     mca_topo_base_graph_neighbors_count (comm, rank, &degree);
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 2 * degree );
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree );
 
     edges = graph->edges;
     if (rank > 0) {
@@ -143,7 +143,7 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, neighbor );
+        ompi_coll_base_free_reqs( reqs, neighbor );
         return rc;
     }
 
@@ -156,13 +156,13 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, neighbor + degree );
+        ompi_coll_base_free_reqs( reqs, neighbor + degree );
         return rc;
     }
 
     rc = ompi_request_wait_all (degree * 2, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, degree * 2 );
+        ompi_coll_base_free_reqs( reqs, degree * 2 );
     }
     return rc;
 }
@@ -185,7 +185,7 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
     inedges = dist_graph->in;
     outedges = dist_graph->out;
 
-    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, indegree + outdegree );
+    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree );
     /* post all receives first */
     for (neighbor = 0; neighbor < indegree ; ++neighbor) {
         rc = MCA_PML_CALL(irecv((char *) rbuf + rdisps[neighbor], rcounts[neighbor], rdtypes[neighbor],
@@ -194,7 +194,7 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, neighbor );
+        ompi_coll_base_free_reqs( reqs, neighbor );
         return rc;
     }
 
@@ -207,13 +207,13 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
     }
 
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, indegree + neighbor );
+        ompi_coll_base_free_reqs( reqs, indegree + neighbor );
         return rc;
     }
 
     rc = ompi_request_wait_all (indegree + outdegree, reqs, MPI_STATUSES_IGNORE);
     if (OMPI_SUCCESS != rc) {
-        mca_coll_basic_free_reqs( reqs, indegree + outdegree );
+        ompi_coll_base_free_reqs( reqs, indegree + outdegree );
     }
     return rc;
 }

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2015 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -41,15 +41,15 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
                                        const MPI_Aint rdisps[], struct ompi_datatype_t * const *rdtypes,
                                        struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t *) module;
     const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
     const int rank = ompi_comm_rank (comm);
     int rc = MPI_SUCCESS, dim, i, nreqs;
-    ompi_request_t **reqs;
+    ompi_request_t **reqs, **preqs;
 
+    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 4 * cart->ndims );
 
     /* post receives first */
-    for (dim = 0, i = 0, nreqs = 0, reqs = basic_module->mccb_reqs ; dim < cart->ndims ; ++dim, i += 2) {
+    for (dim = 0, i = 0, nreqs = 0; dim < cart->ndims ; ++dim, i += 2) {
         int srank = MPI_PROC_NULL, drank = MPI_PROC_NULL;
 
         if (cart->dims[dim] > 1) {
@@ -59,22 +59,22 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
         }
 
         if (MPI_PROC_NULL != srank) {
-            rc = MCA_PML_CALL(irecv((char *) rbuf + rdisps[i], rcounts[i], rdtypes[i], srank,
-                                    MCA_COLL_BASE_TAG_ALLTOALL, comm, reqs++));
-            if (OMPI_SUCCESS != rc) break;
             nreqs++;
+            rc = MCA_PML_CALL(irecv((char *) rbuf + rdisps[i], rcounts[i], rdtypes[i], srank,
+                                    MCA_COLL_BASE_TAG_ALLTOALL, comm, preqs++));
+            if (OMPI_SUCCESS != rc) break;
         }
 
         if (MPI_PROC_NULL != drank) {
-            rc = MCA_PML_CALL(irecv((char *) rbuf + rdisps[i+1], rcounts[i+1], rdtypes[i+1], drank,
-                                    MCA_COLL_BASE_TAG_ALLTOALL, comm, reqs++));
-            if (OMPI_SUCCESS != rc) break;
             nreqs++;
+            rc = MCA_PML_CALL(irecv((char *) rbuf + rdisps[i+1], rcounts[i+1], rdtypes[i+1], drank,
+                                    MCA_COLL_BASE_TAG_ALLTOALL, comm, preqs++));
+            if (OMPI_SUCCESS != rc) break;
         }
     }
 
     if (OMPI_SUCCESS != rc) {
-        /* should probably try to clean up here */
+        mca_coll_basic_free_reqs( reqs, nreqs );
         return rc;
     }
 
@@ -88,27 +88,31 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
         }
 
         if (MPI_PROC_NULL != srank) {
+            nreqs++;
             /* remove cast from const when the pml layer is updated to take a const for the send buffer */
             rc = MCA_PML_CALL(isend((char *) sbuf + sdisps[i], scounts[i], sdtypes[i], srank,
-                                    MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD, comm, reqs++));
+                                    MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD, comm, preqs++));
             if (OMPI_SUCCESS != rc) break;
-            nreqs++;
         }
 
         if (MPI_PROC_NULL != drank) {
-            rc = MCA_PML_CALL(isend((char *) sbuf + sdisps[i+1], scounts[i+1], sdtypes[i+1], drank,
-                                    MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD, comm, reqs++));
-            if (OMPI_SUCCESS != rc) break;
             nreqs++;
+            rc = MCA_PML_CALL(isend((char *) sbuf + sdisps[i+1], scounts[i+1], sdtypes[i+1], drank,
+                                    MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD, comm, preqs++));
+            if (OMPI_SUCCESS != rc) break;
         }
     }
 
     if (OMPI_SUCCESS != rc) {
-        /* should probably try to clean up here */
+        mca_coll_basic_free_reqs( reqs, nreqs );
         return rc;
     }
 
-    return ompi_request_wait_all (nreqs, basic_module->mccb_reqs, MPI_STATUSES_IGNORE);
+    rc = ompi_request_wait_all (nreqs, reqs, MPI_STATUSES_IGNORE);
+    if (OMPI_SUCCESS != rc) {
+        mca_coll_basic_free_reqs( reqs, nreqs );
+    }
+    return rc;
 }
 
 static int
@@ -117,14 +121,14 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
                                         const MPI_Aint rdisps[], struct ompi_datatype_t * const rdtypes[],
                                         struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t *) module;
     const mca_topo_base_comm_graph_2_2_0_t *graph = comm->c_topo->mtc.graph;
     int rc = MPI_SUCCESS, neighbor, degree;
     const int rank = ompi_comm_rank (comm);
-    ompi_request_t **reqs;
+    ompi_request_t **reqs, **preqs;
     const int *edges;
 
     mca_topo_base_graph_neighbors_count (comm, rank, &degree);
+    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, 2 * degree );
 
     edges = graph->edges;
     if (rank > 0) {
@@ -132,14 +136,14 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
     }
 
     /* post all receives first */
-    for (neighbor = 0, reqs = basic_module->mccb_reqs ; neighbor < degree ; ++neighbor) {
+    for (neighbor = 0; neighbor < degree ; ++neighbor) {
         rc = MCA_PML_CALL(irecv((char *) rbuf + rdisps[neighbor], rcounts[neighbor], rdtypes[neighbor],
-                                edges[neighbor], MCA_COLL_BASE_TAG_ALLTOALL, comm, reqs++));
+                                edges[neighbor], MCA_COLL_BASE_TAG_ALLTOALL, comm, preqs++));
         if (OMPI_SUCCESS != rc) break;
     }
 
     if (OMPI_SUCCESS != rc) {
-        /* should probably try to clean up here */
+        mca_coll_basic_free_reqs( reqs, neighbor );
         return rc;
     }
 
@@ -147,16 +151,20 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
         /* remove cast from const when the pml layer is updated to take a const for the send buffer */
         rc = MCA_PML_CALL(isend((char *) sbuf + sdisps[neighbor], scounts[neighbor], sdtypes[neighbor],
                                 edges[neighbor], MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD,
-                                comm, reqs++));
+                                comm, preqs++));
         if (OMPI_SUCCESS != rc) break;
     }
 
     if (OMPI_SUCCESS != rc) {
-        /* should probably try to clean up here */
+        mca_coll_basic_free_reqs( reqs, neighbor + degree );
         return rc;
     }
 
-    return ompi_request_wait_all (degree * 2, basic_module->mccb_reqs, MPI_STATUSES_IGNORE);
+    rc = ompi_request_wait_all (degree * 2, reqs, MPI_STATUSES_IGNORE);
+    if (OMPI_SUCCESS != rc) {
+        mca_coll_basic_free_reqs( reqs, degree * 2 );
+    }
+    return rc;
 }
 
 static int
@@ -165,12 +173,11 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
                                              const MPI_Aint rdisps[], struct ompi_datatype_t * const *rdtypes,
                                              struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
 {
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t *) module;
     const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
     int rc = MPI_SUCCESS, neighbor;
     const int *inedges, *outedges;
     int indegree, outdegree;
-    ompi_request_t **reqs;
+    ompi_request_t **reqs, **preqs;
 
     indegree = dist_graph->indegree;
     outdegree = dist_graph->outdegree;
@@ -178,15 +185,16 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
     inedges = dist_graph->in;
     outedges = dist_graph->out;
 
+    reqs = preqs = mca_coll_basic_get_reqs( (mca_coll_basic_module_t *) module, indegree + outdegree );
     /* post all receives first */
-    for (neighbor = 0, reqs = basic_module->mccb_reqs ; neighbor < indegree ; ++neighbor) {
+    for (neighbor = 0; neighbor < indegree ; ++neighbor) {
         rc = MCA_PML_CALL(irecv((char *) rbuf + rdisps[neighbor], rcounts[neighbor], rdtypes[neighbor],
-                                inedges[neighbor], MCA_COLL_BASE_TAG_ALLTOALL, comm, reqs++));
+                                inedges[neighbor], MCA_COLL_BASE_TAG_ALLTOALL, comm, preqs++));
         if (OMPI_SUCCESS != rc) break;
     }
 
     if (OMPI_SUCCESS != rc) {
-        /* should probably try to clean up here */
+        mca_coll_basic_free_reqs( reqs, neighbor );
         return rc;
     }
 
@@ -194,16 +202,20 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
         /* remove cast from const when the pml layer is updated to take a const for the send buffer */
         rc = MCA_PML_CALL(isend((char *) sbuf + sdisps[neighbor], scounts[neighbor], sdtypes[neighbor],
                                 outedges[neighbor], MCA_COLL_BASE_TAG_ALLTOALL, MCA_PML_BASE_SEND_STANDARD,
-                                comm, reqs++));
+                                comm, preqs++));
         if (OMPI_SUCCESS != rc) break;
     }
 
     if (OMPI_SUCCESS != rc) {
-        /* should probably try to clean up here */
+        mca_coll_basic_free_reqs( reqs, indegree + neighbor );
         return rc;
     }
 
-    return ompi_request_wait_all (indegree + outdegree, basic_module->mccb_reqs, MPI_STATUSES_IGNORE);
+    rc = ompi_request_wait_all (indegree + outdegree, reqs, MPI_STATUSES_IGNORE);
+    if (OMPI_SUCCESS != rc) {
+        mca_coll_basic_free_reqs( reqs, indegree + outdegree );
+    }
+    return rc;
 }
 
 int mca_coll_basic_neighbor_alltoallw(const void *sbuf, const int scounts[], const MPI_Aint sdisps[],

--- a/ompi/mca/coll/basic/coll_basic_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_scatter.c
@@ -48,8 +48,7 @@ mca_coll_basic_scatter_inter(const void *sbuf, int scount,
     int i, size, err;
     char *ptmp;
     ptrdiff_t lb, incr;
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t*) module;
-    ompi_request_t **reqs = basic_module->mccb_reqs;
+    ompi_request_t **reqs;
 
     /* Initialize */
     size = ompi_comm_remote_size(comm);
@@ -69,6 +68,8 @@ mca_coll_basic_scatter_inter(const void *sbuf, int scount,
             return OMPI_ERROR;
         }
 
+        reqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, size);
+
         incr *= scount;
         for (i = 0, ptmp = (char *) sbuf; i < size; ++i, ptmp += incr) {
             err = MCA_PML_CALL(isend(ptmp, scount, sdtype, i,
@@ -76,13 +77,15 @@ mca_coll_basic_scatter_inter(const void *sbuf, int scount,
                                      MCA_PML_BASE_SEND_STANDARD, comm,
                                      reqs++));
             if (OMPI_SUCCESS != err) {
+                mca_coll_basic_free_reqs(reqs, i);
                 return err;
             }
         }
 
-        err =
-            ompi_request_wait_all(size, basic_module->mccb_reqs,
-                                  MPI_STATUSES_IGNORE);
+        err = ompi_request_wait_all(size, reqs, MPI_STATUSES_IGNORE);
+        if (OMPI_SUCCESS != err) {
+            mca_coll_basic_free_reqs(reqs, size);
+        }
     }
 
     return err;

--- a/ompi/mca/coll/basic/coll_basic_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_scatter.c
@@ -68,7 +68,7 @@ mca_coll_basic_scatter_inter(const void *sbuf, int scount,
             return OMPI_ERROR;
         }
 
-        reqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, size);
+        reqs = coll_base_comm_get_reqs(module->base_data, size);
 
         incr *= scount;
         for (i = 0, ptmp = (char *) sbuf; i < size; ++i, ptmp += incr) {
@@ -77,14 +77,14 @@ mca_coll_basic_scatter_inter(const void *sbuf, int scount,
                                      MCA_PML_BASE_SEND_STANDARD, comm,
                                      reqs++));
             if (OMPI_SUCCESS != err) {
-                mca_coll_basic_free_reqs(reqs, i);
+                ompi_coll_base_free_reqs(reqs, i);
                 return err;
             }
         }
 
         err = ompi_request_wait_all(size, reqs, MPI_STATUSES_IGNORE);
         if (OMPI_SUCCESS != err) {
-            mca_coll_basic_free_reqs(reqs, size);
+            ompi_coll_base_free_reqs(reqs, size);
         }
     }
 

--- a/ompi/mca/coll/basic/coll_basic_scatterv.c
+++ b/ompi/mca/coll/basic/coll_basic_scatterv.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2015 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -121,8 +121,7 @@ mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts,
     int i, size, err;
     char *ptmp;
     ptrdiff_t lb, extent;
-    mca_coll_basic_module_t *basic_module = (mca_coll_basic_module_t*) module;
-    ompi_request_t **reqs = basic_module->mccb_reqs;
+    ompi_request_t **reqs;
 
     /* Initialize */
     size = ompi_comm_remote_size(comm);
@@ -145,6 +144,7 @@ mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts,
             return OMPI_ERROR;
         }
 
+        reqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, size);
         for (i = 0; i < size; ++i) {
             ptmp = ((char *) sbuf) + (extent * disps[i]);
             err = MCA_PML_CALL(isend(ptmp, scounts[i], sdtype, i,
@@ -152,11 +152,15 @@ mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts,
                                      MCA_PML_BASE_SEND_STANDARD, comm,
                                      &(reqs[i])));
             if (OMPI_SUCCESS != err) {
+                mca_coll_basic_free_reqs(reqs, i);
                 return err;
             }
         }
 
         err = ompi_request_wait_all(size, reqs, MPI_STATUSES_IGNORE);
+        if (OMPI_SUCCESS != err) {
+            mca_coll_basic_free_reqs(reqs, size);
+        }
     }
 
     /* All done */

--- a/ompi/mca/coll/basic/coll_basic_scatterv.c
+++ b/ompi/mca/coll/basic/coll_basic_scatterv.c
@@ -144,7 +144,7 @@ mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts,
             return OMPI_ERROR;
         }
 
-        reqs = mca_coll_basic_get_reqs((mca_coll_basic_module_t*) module, size);
+        reqs = coll_base_comm_get_reqs(module->base_data, size);
         for (i = 0; i < size; ++i) {
             ptmp = ((char *) sbuf) + (extent * disps[i]);
             err = MCA_PML_CALL(isend(ptmp, scounts[i], sdtype, i,
@@ -152,14 +152,14 @@ mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts,
                                      MCA_PML_BASE_SEND_STANDARD, comm,
                                      &(reqs[i])));
             if (OMPI_SUCCESS != err) {
-                mca_coll_basic_free_reqs(reqs, i);
+                ompi_coll_base_free_reqs(reqs, i);
                 return err;
             }
         }
 
         err = ompi_request_wait_all(size, reqs, MPI_STATUSES_IGNORE);
         if (OMPI_SUCCESS != err) {
-            mca_coll_basic_free_reqs(reqs, size);
+            ompi_coll_base_free_reqs(reqs, size);
         }
     }
 

--- a/ompi/mca/coll/self/coll_self.h
+++ b/ompi/mca/coll/self/coll_self.h
@@ -145,9 +145,6 @@ int mca_coll_self_ft_event(int state);
 
 struct mca_coll_self_module_t {
     mca_coll_base_module_t super;
-
-    ompi_request_t **mccb_reqs;
-    int mccb_num_reqs;
 };
 typedef struct mca_coll_self_module_t mca_coll_self_module_t;
 OBJ_CLASS_DECLARATION(mca_coll_self_module_t);

--- a/ompi/mca/coll/tuned/coll_tuned_module.c
+++ b/ompi/mca/coll/tuned/coll_tuned_module.c
@@ -200,7 +200,7 @@ tuned_module_enable( mca_coll_base_module_t *module,
      * The default is set very high
      */
 
-    /* if we within the memory/size limit, allow preallocated data */
+    /* prepare the placeholder for the array of request* */
     data = OBJ_NEW(mca_coll_base_comm_t);
     if (NULL == data) {
         return OMPI_ERROR;

--- a/ompi/mca/topo/base/topo_base_cart_create.c
+++ b/ompi/mca/topo/base/topo_base_cart_create.c
@@ -160,12 +160,6 @@ int mca_topo_base_cart_create(mca_topo_base_module_t *topo,
         return MPI_ERR_INTERN;
     }
 
-    assert(NULL == new_comm->c_topo);
-    assert(!(new_comm->c_flags & OMPI_COMM_CART));
-    new_comm->c_topo           = topo;
-    new_comm->c_topo->mtc.cart = cart;
-    new_comm->c_topo->reorder  = reorder;
-    new_comm->c_flags         |= OMPI_COMM_CART;
     ret = ompi_comm_enable(old_comm, new_comm,
                            new_rank, num_procs, topo_procs);
     if (OMPI_SUCCESS != ret) {
@@ -180,6 +174,10 @@ int mca_topo_base_cart_create(mca_topo_base_module_t *topo,
         return ret;
     }
 
+    new_comm->c_topo           = topo;
+    new_comm->c_topo->mtc.cart = cart;
+    new_comm->c_topo->reorder  = reorder;
+    new_comm->c_flags         |= OMPI_COMM_CART;
     *comm_topo = new_comm;
 
     if( MPI_UNDEFINED == new_rank ) {

--- a/ompi/mca/topo/base/topo_base_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_graph_create.c
@@ -123,11 +123,6 @@ int mca_topo_base_graph_create(mca_topo_base_module_t *topo,
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    new_comm->c_topo            = topo;
-    new_comm->c_topo->mtc.graph = graph;
-    new_comm->c_flags          |= OMPI_COMM_GRAPH;
-    new_comm->c_topo->reorder   = reorder;
-
     ret = ompi_comm_enable(old_comm, new_comm,
                            new_rank, num_procs, topo_procs);
     if (OMPI_SUCCESS != ret) {
@@ -140,7 +135,11 @@ int mca_topo_base_graph_create(mca_topo_base_module_t *topo,
         }
         return ret;
     }
-
+    
+    new_comm->c_topo            = topo;
+    new_comm->c_topo->mtc.graph = graph;
+    new_comm->c_flags          |= OMPI_COMM_GRAPH;
+    new_comm->c_topo->reorder   = reorder;
     *comm_topo = new_comm;
 
     if( MPI_UNDEFINED == new_rank ) {


### PR DESCRIPTION
This patch fixes the issues identified by Gilles with the ibm tests (collectives and topologies). In addition it improves the memory usage of OMPI, a communicator without collective communications will never allocate the array of requests used to coordinate the basic collective algorithms.

This ticket is supposed to replace #790. @ggouaillardet and @hjelmn please review.