### PR TITLE
oob/alps: swat compiler warning

### DIFF
--- a/orte/mca/ess/alps/ess_alps_module.c
+++ b/orte/mca/ess/alps/ess_alps_module.c
@@ -56,7 +56,7 @@ static orte_vpid_t starting_vpid = 0;
 
 static int rte_init(void)
 {
-    int ret, i;
+    int ret;
     char *error = NULL;
     char **hosts = NULL;
 

--- a/orte/mca/oob/alps/oob_alps_component.c
+++ b/orte/mca/oob/alps/oob_alps_component.c
@@ -74,7 +74,6 @@
 
 static int alps_component_open(void);
 static int alps_component_close(void);
-static int alps_component_register(void);
 static int component_available(void);
 static int component_startup(void);
 static void component_shutdown(void);


### PR DESCRIPTION
swat some alps related compiler warnings when using --enable-picky

Signed-off-by: Howard Pritchard <howardp@lanl.gov>