### PR TITLE
coll/libnbc: fix coverity errors

### DIFF
--- a/ompi/mca/coll/libnbc/nbc.c
+++ b/ompi/mca/coll/libnbc/nbc.c
@@ -510,7 +510,7 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
         if(unpackargs.tmpinbuf) {
           buf1=(char*)handle->tmpbuf+(long)unpackargs.inbuf;
         } else {
-          buf1=unpackargs.outbuf;
+          buf1=unpackargs.inbuf;
         }
         if(unpackargs.tmpoutbuf) {
           buf2=(char*)handle->tmpbuf+(long)unpackargs.outbuf;

--- a/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ineighbor_alltoallw.c
@@ -85,6 +85,7 @@ int ompi_coll_libnbc_ineighbor_alltoallw(const void *sbuf, const int *scounts, c
     free (srcs);
 
     if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
+      free (dsts);
       OBJ_RELEASE(schedule);
       return res;
     }


### PR DESCRIPTION
Fix CID 1196812: Resource Leak

dsts array was leaked on error.

Fix CID 710565: Copy-paste error

The line in question (nbc:513) is indeed a copy-paste error.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>