### PR TITLE
osc/sm: fix remaining coverity issues

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_active_target.c
+++ b/ompi/mca/osc/sm/osc_sm_active_target.c
@@ -150,7 +150,7 @@ ompi_osc_sm_start(struct ompi_group_t *group,
 
         for (int i = 0 ; i < size ; ++i) {
             int rank_byte = ranks[i] >> 6;
-            uint64_t old, rank_bit = 1 << (ranks[i] & 0x3f);
+            uint64_t old, rank_bit = ((uint64_t) 1) << (ranks[i] & 0x3f);
 
             /* wait for rank to post */
             while (!(module->posts[my_rank][rank_byte] & rank_bit)) {
@@ -219,7 +219,7 @@ ompi_osc_sm_post(struct ompi_group_t *group,
         (ompi_osc_sm_module_t*) win->w_osc_module;
     int my_rank = ompi_comm_rank (module->comm);
     int my_byte = my_rank >> 6;
-    uint64_t my_bit = 1 << (my_rank & 0x3f);
+    uint64_t my_bit = ((uint64_t) 1) << (my_rank & 0x3f);
     int gsize;
 
     OPAL_THREAD_LOCK(&module->lock);

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -477,9 +477,10 @@ ompi_osc_sm_free(struct ompi_win_t *win)
 
     /* cleanup */
     ompi_comm_free(&module->comm);
-    free(module);
 
     OBJ_DESTRUCT(&module->lock);
+
+    free(module);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
Fixes CID 1324870: Memory - illegal accesses (USE_AFTER_FREE)

Free osc module after calling destruct on the lock.

Fixes CID 1324868: Integer handling issues (OVERFLOW_BEFORE_WIDEN)
Fixes CID 1324867: Integer handling issues (OVERFLOW_BEFORE_WIDEN)

Explicitly cast to uint64_t to ensure the widen happens before an overflow
can occur.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>