### PR TITLE
RELEASE the list only when list HEAD reference count is 1

### DIFF
--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -164,7 +164,12 @@ typedef struct opal_list_t opal_list_t;
  *
  * The opal_list_t destructor doesn't release the items on the
  * list - so provide two convenience macros that do so and then
- * destruct/release the list object itself
+ * destruct/release the list object itself. Destruct is for static
+ * lists and doesn't have to consider the reference count. Release
+ * function will release the entire list only when the list HEAD's
+ * reference count is 1. OBJ_RELEASE will decrement object's reference
+ * count. As List HEAD's release is done at the end, we compare the
+ * list HEAD's reference count to 1 instead of 0.
  *
  * @param[in] list List to destruct or release
  */

--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -177,13 +177,15 @@ typedef struct opal_list_t opal_list_t;
         OBJ_DESTRUCT(list);                                     \
     } while(0);
 
-#define OPAL_LIST_RELEASE(list)                                 \
-    do {                                                        \
-        opal_list_item_t *it;                                   \
-        while (NULL != (it = opal_list_remove_first(list))) {   \
-            OBJ_RELEASE(it);                                    \
-        }                                                       \
-        OBJ_RELEASE(list);                                      \
+#define OPAL_LIST_RELEASE(list)                                         \
+    do {                                                                \
+        if (1 == ((opal_object_t *) (list))->obj_reference_count ) {    \
+            opal_list_item_t *it;                                       \
+            while (NULL != (it = opal_list_remove_first(list))) {       \
+                OBJ_RELEASE(it);                                        \
+            }                                                           \
+        }                                                               \
+        OBJ_RELEASE(list);                                              \
     } while(0);
 
 


### PR DESCRIPTION
To enhance the OPAL_LIST_RELEASE API functionality, we will release the LIST HEAD and it's objects only if the List HEAD's reference count is 1. This helps us to retain the list by increasing the LIST HEAD's reference count in multiple places in code and ultimately release the LIST completely when the LIST HEAD's reference count is 1