### PR TITLE
Resolve the naming issue when direct-launched by PMIx-enabled RMs usi…

### DIFF
--- a/opal/mca/pmix/pmix_types.h
+++ b/opal/mca/pmix/pmix_types.h
@@ -44,7 +44,7 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_PROCDIR               "pmix.pdir"         // (char*) sub-nsdir assigned to proc
 
 /* information about relative ranks as assigned by the RM */
-#define OPAL_PMIX_JOBID                 "pmix.jobid"        // (char*) jobid assigned by scheduler
+#define OPAL_PMIX_JOBID                 "pmix.jobid"        // (uint32_t) jobid assigned by scheduler
 #define OPAL_PMIX_APPNUM                "pmix.appnum"       // (uint32_t) app number within the job
 #define OPAL_PMIX_RANK                  "pmix.rank"         // (uint32_t) process rank within the job
 #define OPAL_PMIX_GLOBAL_RANK           "pmix.grank"        // (uint32_t) rank spanning across all jobs in this session

--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -233,8 +233,8 @@ static int s1_init(void)
 
     OBJ_CONSTRUCT(&kv, opal_value_t);
     kv.key = strdup(OPAL_PMIX_JOBID);
-    kv.type = OPAL_STRING;
-    kv.data.string = pmix_id;
+    kv.type = OPAL_UINT32;
+    kv.data.uint32 = s1_pname.jobid;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
         OPAL_ERROR_LOG(ret);
         OBJ_DESTRUCT(&kv);

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -242,8 +242,8 @@ static int s2_init(void)
      */
     OBJ_CONSTRUCT(&kv, opal_value_t);
     kv.key = strdup(OPAL_PMIX_JOBID);
-    kv.type = OPAL_STRING;
-    kv.data.string = pmix_kvs_name;
+    kv.type = OPAL_UINT32;
+    kv.data.uint32 = s2_pname.jobid;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
         OPAL_ERROR_LOG(ret);
         OBJ_DESTRUCT(&kv);

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -861,6 +861,8 @@ void orte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                 ORTE_ERROR_LOG(rc);
                 continue;
             }
+            /* tell the child that it is being launched via ORTE */
+            opal_setenv(OPAL_MCA_PREFIX"orte_launch", "1", true, &app->env);
 
             /* ensure we clear any prior info regarding state or exit status in
              * case this is a restart


### PR DESCRIPTION
…ng a minimal-impact approach. Detect if we were launched via ORTE - if so, then use our standard methods for computing the jobid. If not, then just hash the nspace to create the jobid, and track the jobid <-> nspace correspondece down in the opal/mca/pmix/pmix1xx component. We then do the translation any time a function that passes process names is invoked.