### PR TITLE
Cleanup the code a bit by simply adding our nspace to the top of the …

### DIFF
--- a/opal/mca/pmix/cray/pmix_cray.c
+++ b/opal/mca/pmix/cray/pmix_cray.c
@@ -78,6 +78,9 @@ static int cray_unpublish_nb(char **keys, opal_list_t *info,
 static const char *cray_get_version(void);
 static int cray_store_local(const opal_process_name_t *proc,
                           opal_value_t *val);
+static const char *cray_get_nspace(opal_jobid_t jobid);
+static void cray_register_jobid(opal_jobid_t jobid, const char *nspace);
+
 #if 0
 static bool cray_get_attr(const char *attr, opal_value_t **kv);
 #endif
@@ -109,7 +112,9 @@ const opal_pmix_base_module_t opal_pmix_cray_module = {
     .get_version = cray_get_version,
     .register_errhandler = opal_pmix_base_register_handler,
     .deregister_errhandler = opal_pmix_base_deregister_handler,
-    .store_local = cray_store_local
+    .store_local = cray_store_local,
+    .get_nspace = cray_get_nspace,
+    .register_jobid = cray_register_jobid
 };
 
 // usage accounting
@@ -812,6 +817,16 @@ static int cray_store_local(const opal_process_name_t *proc,
     opal_pmix_base_store(proc, val);
 
     return OPAL_SUCCESS;
+}
+
+static const char *cray_get_nspace(opal_jobid_t jobid)
+{
+    return NULL;
+}
+
+static void cray_register_jobid(opal_jobid_t jobid, const char *nspace)
+{
+    return;
 }
 
 static char* pmix_error(int pmix_err)

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -701,6 +701,12 @@ typedef void (*opal_pmix_base_module_deregister_fn_t)(void);
 typedef int (*opal_pmix_base_module_store_fn_t)(const opal_process_name_t *proc,
                                                 opal_value_t *val);
 
+/* retrieve the nspace corresponding to a given jobid */
+typedef const char* (*opal_pmix_base_module_get_nspace_fn_t)(opal_jobid_t jobid);
+
+/* register a jobid-to-nspace pair */
+typedef void (*opal_pmix_base_module_register_jobid_fn_t)(opal_jobid_t jobid, const char *nspace);
+
 /*
  * the standard public API data structure
  */
@@ -745,6 +751,8 @@ typedef struct {
     opal_pmix_base_module_register_fn_t               register_errhandler;
     opal_pmix_base_module_deregister_fn_t             deregister_errhandler;
     opal_pmix_base_module_store_fn_t                  store_local;
+    opal_pmix_base_module_get_nspace_fn_t             get_nspace;
+    opal_pmix_base_module_register_jobid_fn_t         register_jobid;
 } opal_pmix_base_module_t;
 
 typedef struct {

--- a/opal/mca/pmix/pmix1xx/pmix1.h
+++ b/opal/mca/pmix/pmix1xx/pmix1.h
@@ -30,11 +30,24 @@
 
 BEGIN_C_DECLS
 
-OPAL_DECLSPEC extern opal_pmix_base_component_t mca_pmix_pmix1_component;
+typedef struct {
+  opal_pmix_base_component_t super;
+  opal_list_t jobids;
+  bool native_launch;
+} mca_pmix_pmix1_component_t;
+
+OPAL_DECLSPEC extern mca_pmix_pmix1_component_t mca_pmix_pmix1xx_component;
 
 OPAL_DECLSPEC extern const opal_pmix_base_module_t opal_pmix_pmix1xx_module;
 
 /****  INTERNAL OBJECTS  ****/
+typedef struct {
+    opal_list_item_t super;
+    opal_jobid_t jobid;
+    char nspace[PMIX_MAX_NSLEN + 1];
+} opal_pmix1_jobid_trkr_t;
+OBJ_CLASS_DECLARATION(opal_pmix1_jobid_trkr_t);
+
 typedef struct {
     opal_object_t super;
     pmix_proc_t p;

--- a/opal/mca/pmix/pmix1xx/pmix_pmix1.c
+++ b/opal/mca/pmix/pmix1xx/pmix_pmix1.c
@@ -44,6 +44,8 @@
 /* These are functions used by both client and server to
  * access common functions in the embedded PMIx library */
 
+static const char *pmix1_get_nspace(opal_jobid_t jobid);
+static void pmix1_register_jobid(opal_jobid_t jobid, const char *nspace);
 
 const opal_pmix_base_module_t opal_pmix_pmix1xx_module = {
     /* client APIs */
@@ -85,8 +87,38 @@ const opal_pmix_base_module_t opal_pmix_pmix1xx_module = {
     PMIx_Get_version,
     opal_pmix_base_register_handler,
     opal_pmix_base_deregister_handler,
-    pmix1_store_local
+    pmix1_store_local,
+    pmix1_get_nspace,
+    pmix1_register_jobid
 };
+
+static const char *pmix1_get_nspace(opal_jobid_t jobid)
+{
+    opal_pmix1_jobid_trkr_t *jptr;
+
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix1xx_component.jobids, opal_pmix1_jobid_trkr_t) {
+        if (jptr->jobid == jobid) {
+            return jptr->nspace;
+        }
+    }
+    return NULL;
+}
+
+static void pmix1_register_jobid(opal_jobid_t jobid, const char *nspace)
+{
+    opal_pmix1_jobid_trkr_t *jptr;
+
+    /* if we don't already have it, add this to our jobid tracker */
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix1xx_component.jobids, opal_pmix1_jobid_trkr_t) {
+        if (jptr->jobid == jobid) {
+            return;
+        }
+    }
+    jptr = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+    (void)strncpy(jptr->nspace, nspace, PMIX_MAX_NSLEN);
+    jptr->jobid = jobid;
+    opal_list_append(&mca_pmix_pmix1xx_component.jobids, &jptr->super);
+}
 
 pmix_status_t pmix1_convert_opalrc(int rc)
 {
@@ -436,6 +468,10 @@ int pmix1_value_unload(opal_value_t *kv,
 
 
 /****  INSTANTIATE INTERNAL CLASSES  ****/
+OBJ_CLASS_INSTANCE(opal_pmix1_jobid_trkr_t,
+                   opal_list_item_t,
+                   NULL, NULL);
+
 static void opcon(pmix1_opcaddy_t *p)
 {
     memset(&p->p, 0, sizeof(pmix_proc_t));

--- a/opal/mca/pmix/pmix1xx/pmix_pmix1_component.c
+++ b/opal/mca/pmix/pmix1xx/pmix_pmix1_component.c
@@ -18,6 +18,7 @@
 #include "opal_config.h"
 
 #include "opal/constants.h"
+#include "opal/class/opal_list.h"
 #include "opal/util/proc.h"
 #include "opal/mca/pmix/pmix.h"
 #include "pmix1.h"
@@ -41,43 +42,47 @@ static int pmix1xx_component_query(mca_base_module_t **module, int *priority);
  * and pointers to our public functions in it
  */
 
-opal_pmix_base_component_t mca_pmix_pmix1xx_component = {
+mca_pmix_pmix1_component_t mca_pmix_pmix1xx_component = {
+    {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
-    .base_version = {
+        .base_version = {
         /* Indicate that we are a pmix v1.1.0 component (which also
            implies a specific MCA version) */
 
-        OPAL_PMIX_BASE_VERSION_2_0_0,
+            OPAL_PMIX_BASE_VERSION_2_0_0,
 
         /* Component name and version */
 
-        .mca_component_name = "pmix1xx",
-        MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                              OPAL_RELEASE_VERSION),
+            .mca_component_name = "pmix1xx",
+            MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+                                  OPAL_RELEASE_VERSION),
 
         /* Component open and close functions */
 
-        .mca_open_component = pmix1xx_open,
-        .mca_close_component = pmix1xx_close,
-        .mca_query_component = pmix1xx_component_query,
-    },
-    /* Next the MCA v1.0.0 component meta data */
-    .base_data = {
+            .mca_open_component = pmix1xx_open,
+            .mca_close_component = pmix1xx_close,
+            .mca_query_component = pmix1xx_component_query,
+        },
+        /* Next the MCA v1.0.0 component meta data */
+        .base_data = {
         /* The component is checkpoint ready */
-        MCA_BASE_METADATA_PARAM_CHECKPOINT
-    }
+            MCA_BASE_METADATA_PARAM_CHECKPOINT
+        }
+    },
+    .native_launch = false
 };
 
 static int pmix1xx_open(void)
 {
-
+    OBJ_CONSTRUCT(&mca_pmix_pmix1xx_component.jobids, opal_list_t);
     return OPAL_SUCCESS;
 }
 
 static int pmix1xx_close(void)
 {
+    OPAL_LIST_DESTRUCT(&mca_pmix_pmix1xx_component.jobids);
     return OPAL_SUCCESS;
 }
 

--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -49,6 +49,8 @@ static int s1_job_connect(opal_list_t *procs);
 static int s1_job_disconnect(opal_list_t *procs);
 static int s1_store_local(const opal_process_name_t *proc,
                           opal_value_t *val);
+static const char *s1_get_nspace(opal_jobid_t jobid);
+static void s1_register_jobid(opal_jobid_t jobid, const char *nspace);
 
 const opal_pmix_base_module_t opal_pmix_s1_module = {
     s1_init,
@@ -89,7 +91,9 @@ const opal_pmix_base_module_t opal_pmix_s1_module = {
     NULL,
     opal_pmix_base_register_handler,
     opal_pmix_base_deregister_handler,
-    s1_store_local
+    s1_store_local,
+    s1_get_nspace,
+    s1_register_jobid
 };
 
 // usage accounting
@@ -644,6 +648,14 @@ static int s1_store_local(const opal_process_name_t *proc,
     return OPAL_SUCCESS;
 }
 
+static const char *s1_get_nspace(opal_jobid_t jobid)
+{
+    return NULL;
+}
+static void s1_register_jobid(opal_jobid_t jobid, const char *nspace)
+{
+    return;
+}
 
 static char* pmix_error(int pmix_err)
 {

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -56,6 +56,8 @@ static int s2_job_connect(opal_list_t *procs);
 static int s2_job_disconnect(opal_list_t *procs);
 static int s2_store_local(const opal_process_name_t *proc,
                           opal_value_t *val);
+static const char *s2_get_nspace(opal_jobid_t jobid);
+static void s2_register_jobid(opal_jobid_t jobid, const char *nspace);
 
 const opal_pmix_base_module_t opal_pmix_s2_module = {
     s2_init,
@@ -96,7 +98,9 @@ const opal_pmix_base_module_t opal_pmix_s2_module = {
     NULL,
     opal_pmix_base_register_handler,
     opal_pmix_base_deregister_handler,
-    s2_store_local
+    s2_store_local,
+    s2_get_nspace,
+    s2_register_jobid
 };
 
 // usage accounting
@@ -663,6 +667,14 @@ static int s2_store_local(const opal_process_name_t *proc,
     return OPAL_SUCCESS;
 }
 
+static const char *s2_get_nspace(opal_jobid_t jobid)
+{
+    return NULL;
+}
+static void s2_register_jobid(opal_jobid_t jobid, const char *nspace)
+{
+    return;
+}
 
 static char* pmix_error(int pmix_err)
 {


### PR DESCRIPTION
…list of jobid <-> nspace correlations. Add two new APIs to opal_pmix for registering new jobid/nspace pairs and retrieving an nspace given a jobid - these are required to support connect/accept. No impact on the PMIx library.