### PR TITLE
fcoll/two_phase: fix coverity errors

### DIFF
--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -186,7 +189,7 @@ mca_fcoll_two_phase_file_read_all (mca_io_ompio_file_t *fh,
 					  two_phase_num_io_procs,
 					  max_data);
 	if (OMPI_SUCCESS != ret){
-	    return ret;
+            goto exit;
 	}
 
 	two_phase_num_io_procs = fh->f_final_num_aggrs;
@@ -497,21 +500,19 @@ exit:
 	if (flat_buf->indices != NULL){
 	    free (flat_buf->indices);
 	}
-	free(flat_buf);
 	flat_buf = NULL;
     }
-    if (start_offsets != NULL){
-	free(start_offsets);
-	start_offsets = NULL;
-    }
-    if (end_offsets != NULL){
-	free(end_offsets);
-	end_offsets = NULL;
-    }
-    if (aggregator_list != NULL){
-	free(aggregator_list);
-	aggregator_list = NULL;
-    }
+
+    free (start_offsets);
+    free (end_offsets);
+    free (aggregator_list);
+    free (fd_start);
+    free (decoded_iov);
+    free (buf_indices);
+    free (count_my_req_per_proc);
+    free (my_req);
+    free (others_req);
+    free (fd_end);
 
     return ret;
 }
@@ -634,8 +635,8 @@ static int two_phase_read_and_exch(mca_io_ompio_file_t *fh,
 
     start_pos = (int *) calloc(fh->f_size, sizeof(int));
     if ( NULL == start_pos ){
-	ret = OMPI_ERR_OUT_OF_RESOURCE;
-	return ret;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     done = 0;
@@ -717,7 +718,8 @@ static int two_phase_read_and_exch(mca_io_ompio_file_t *fh,
 		(1,sizeof(mca_io_ompio_io_array_t));
 	    if (NULL == fh->f_io_array) {
 		opal_output(1, "OUT OF MEMORY\n");
-		return OMPI_ERR_OUT_OF_RESOURCE;
+                ret = OMPI_ERR_OUT_OF_RESOURCE;
+                goto exit;
 	    }
 	    fh->f_io_array[0].offset = (IOVBASE_TYPE *)(intptr_t)off;
 	    fh->f_io_array[0].length = len;
@@ -728,7 +730,8 @@ static int two_phase_read_and_exch(mca_io_ompio_file_t *fh,
 	    if (fh->f_num_of_io_entries){
 		if ( 0 > fh->f_fbtl->fbtl_preadv (fh)) {
 		    opal_output(1, "READ FAILED\n");
-		    return OMPI_ERROR;
+                    ret = OMPI_ERROR;
+                    goto exit;
 		}
 	    }
 
@@ -797,40 +800,17 @@ static int two_phase_read_and_exch(mca_io_ompio_file_t *fh,
 				flat_buf, others_req, m, buf_idx,
 				buftype_extent, striping_unit, two_phase_num_io_procs,
 				aggregator_list);
-    if (ntimes){
-	free(read_buf);
-	read_buf = NULL;
-    }
-    if (NULL != curr_offlen_ptr){
-	free(curr_offlen_ptr);
-	curr_offlen_ptr = NULL;
-    }
-    if (NULL != count){
-	free(count);
-	count = NULL;
-    }
-    if (NULL != partial_send){
-	free(partial_send);
-	partial_send = NULL;
-    }
-    if (NULL != send_size){
-	free(send_size);
-	send_size = NULL;
-    }
-    if (NULL != recv_size){
-	free(recv_size);
-	recv_size = NULL;
-    }
-    if (NULL != recd_from_proc){
-	free(recd_from_proc);
-	recd_from_proc = NULL;
-    }
-    if (NULL != start_pos){
-	free(start_pos);
-	start_pos = NULL;
-    }
 
 exit:
+    free (read_buf);
+    free (curr_offlen_ptr);
+    free (count);
+    free (partial_send);
+    free (send_size);
+    free (recv_size);
+    free (recd_from_proc);
+    free (start_pos);
+
     return ret;
 
 }
@@ -919,7 +899,7 @@ static int two_phase_exchange_data(mca_io_ompio_file_t *fh,
     }
     else{
 
-	recv_buf = (char **)malloc(fh->f_size * sizeof(char *));
+	recv_buf = (char **) calloc (fh->f_size, sizeof(char *));
 	if (NULL == recv_buf){
 	    ret = OMPI_ERR_OUT_OF_RESOURCE;
 	    goto exit;
@@ -983,7 +963,9 @@ static int two_phase_exchange_data(mca_io_ompio_file_t *fh,
 	ret = ompi_request_wait_all(nprocs_recv,
 				    requests,
 				    MPI_STATUS_IGNORE);
-
+        if (OMPI_SUCCESS != ret) {
+            goto exit;
+        }
 
 	if (! (fh->f_flags & OMPIO_CONTIGUOUS_MEMORY)) {
 
@@ -1001,26 +983,23 @@ static int two_phase_exchange_data(mca_io_ompio_file_t *fh,
 				requests+nprocs_recv,
 				MPI_STATUS_IGNORE);
 
-    if (NULL != requests){
-	free(requests);
-	requests = NULL;
-    }
-
-    if (! (fh->f_flags & OMPIO_CONTIGUOUS_MEMORY)){
-	for (i=0; i< fh->f_size; i++){
-	    if (recv_size[i]){
-		free(recv_buf[i]);
-	    }
-	}
-	free(recv_buf);
-    }
-
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     end_rcomm_time = MPI_Wtime();
     rcomm_time += (end_rcomm_time - start_rcomm_time);
 #endif
 
 exit:
+
+    if (recv_buf) {
+	for (i=0; i< fh->f_size; i++){
+            free(recv_buf[i]);
+	}
+
+	free(recv_buf);
+    }
+
+    free(requests);
+
     return ret;
 
 }

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -220,7 +223,7 @@ mca_fcoll_two_phase_file_write_all (mca_io_ompio_file_t *fh,
 					  two_phase_num_io_procs,
 					  max_data);
 	if ( OMPI_SUCCESS != ret){
-	    return  ret;
+            goto exit;
 	}
 
 	two_phase_num_io_procs = fh->f_final_num_aggrs;
@@ -237,7 +240,8 @@ mca_fcoll_two_phase_file_write_all (mca_io_ompio_file_t *fh,
 
     aggregator_list = (int *) malloc (two_phase_num_io_procs *sizeof(int));
     if ( NULL == aggregator_list ) {
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     for (i =0; i< two_phase_num_io_procs; i++){
@@ -271,7 +275,8 @@ mca_fcoll_two_phase_file_write_all (mca_io_ompio_file_t *fh,
 
     if ( 0 == total_bytes ) {
         free(aggregator_list);
-	return OMPI_SUCCESS;
+        ret = OMPI_SUCCESS;
+        goto exit;
     }
 
     if (!(fh->f_flags & OMPIO_CONTIGUOUS_MEMORY)) {
@@ -560,17 +565,16 @@ exit :
     }
 
 
-
-    if (start_offsets != NULL) {
-	free(start_offsets);
-    }
-
-    if (end_offsets != NULL){
-	free(end_offsets);
-    }
-    if (aggregator_list != NULL){
-	free(aggregator_list);
-    }
+    free (start_offsets);
+    free (end_offsets);
+    free (aggregator_list);
+    free (decoded_iov);
+    free (fd_start);
+    free (fd_end);
+    free (others_req);
+    free (my_req);
+    free (buf_indices);
+    free (count_my_req_per_proc);
 
     return ret;
 }
@@ -657,61 +661,71 @@ static int two_phase_exch_and_write(mca_io_ompio_file_t *fh,
     curr_offlen_ptr = (int *) calloc(fh->f_size, sizeof(int));
 
     if ( NULL == curr_offlen_ptr ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     count = (int *) malloc(fh->f_size*sizeof(int));
 
     if ( NULL == count ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     partial_recv = (int *)calloc(fh->f_size, sizeof(int));
 
     if ( NULL == partial_recv ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     send_size = (int *) calloc(fh->f_size,sizeof(int));
 
     if ( NULL == send_size ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     recv_size = (int *) calloc(fh->f_size,sizeof(int));
 
     if ( NULL == recv_size ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     send_buf_idx = (int *) malloc(fh->f_size*sizeof(int));
 
     if ( NULL == send_buf_idx ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     sent_to_proc = (int *) calloc(fh->f_size, sizeof(int));
 
     if ( NULL == sent_to_proc){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     curr_to_proc = (int *) malloc(fh->f_size*sizeof(int));
 
     if ( NULL == curr_to_proc ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     done_to_proc = (int *) malloc(fh->f_size*sizeof(int));
 
     if ( NULL == done_to_proc ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     start_pos = (int *) malloc(fh->f_size*sizeof(int));
 
     if ( NULL == start_pos ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+      ret = OMPI_ERR_OUT_OF_RESOURCE;
+      goto exit;
     }
 
 
@@ -818,7 +832,8 @@ static int two_phase_exch_and_write(mca_io_ompio_file_t *fh,
 		(sizeof(mca_io_ompio_io_array_t));
 	    if (NULL == fh->f_io_array) {
 		opal_output(1, "OUT OF MEMORY\n");
-		return OMPI_ERR_OUT_OF_RESOURCE;
+		ret = OMPI_ERR_OUT_OF_RESOURCE;
+                goto exit;
 	    }
 
 	    fh->f_io_array[0].offset  =(IOVBASE_TYPE *)(intptr_t) off;
@@ -839,7 +854,8 @@ static int two_phase_exch_and_write(mca_io_ompio_file_t *fh,
 	    if (fh->f_num_of_io_entries){
 		if ( 0 > fh->f_fbtl->fbtl_pwritev (fh)) {
 		    opal_output(1, "WRITE FAILED\n");
-		    return OMPI_ERROR;
+                    ret = OMPI_ERROR;
+                    goto exit;
 		}
 	    }
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
@@ -883,41 +899,17 @@ static int two_phase_exch_and_write(mca_io_ompio_file_t *fh,
 
 exit:
 
-    if (ntimes){
-	if ( NULL != write_buf ){
-	    free(write_buf);
-	}
-    }
-    if ( NULL != curr_offlen_ptr ){
-	free(curr_offlen_ptr);
-    }
-    if ( NULL != count ){
-	free(count);
-    }
-    if ( NULL != partial_recv ){
-	free(partial_recv);
-    }
-    if ( NULL != send_size ){
-	free(send_size);
-    }
-    if ( NULL != recv_size ){
-	free(recv_size);
-    }
-    if ( NULL != sent_to_proc ){
-	free(sent_to_proc);
-    }
-    if ( NULL != start_pos ){
-	free(start_pos);
-    }
-    if ( NULL != send_buf_idx ){
-	free(send_buf_idx);
-    }
-    if ( NULL != curr_to_proc ){
-	free(curr_to_proc);
-    }
-    if ( NULL != done_to_proc ){
-	free(done_to_proc);
-    }
+    free (write_buf);
+    free (curr_offlen_ptr);
+    free (count);
+    free (partial_recv);
+    free (send_size);
+    free (recv_size);
+    free (sent_to_proc);
+    free (start_pos);
+    free (send_buf_idx);
+    free (curr_to_proc);
+    free (done_to_proc);
 
     return ret;
 }
@@ -986,7 +978,8 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
     tmp_len = (int *) malloc(fh->f_size*sizeof(int));
 
     if ( NULL == tmp_len ) {
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     j = 0;
@@ -1076,7 +1069,8 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
 		if (fh->f_num_of_io_entries){
 		    if ( 0 >  fh->f_fbtl->fbtl_preadv (fh)) {
 			opal_output(1, "READ FAILED\n");
-			return OMPI_ERROR;
+                        ret = OMPI_ERROR;
+                        goto exit;
 		    }
 		}
 
@@ -1100,7 +1094,8 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
 	malloc((nprocs_send+nprocs_recv+1)*sizeof(MPI_Request));
 
     if ( NULL == requests ){
-	return OMPI_ERR_OUT_OF_RESOURCE;
+        ret = OMPI_ERR_OUT_OF_RESOURCE;
+        goto exit;
     }
 
     j = 0;
@@ -1145,7 +1140,7 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
 	    }
     }
     else if(nprocs_send && (!(fh->f_flags & OMPIO_CONTIGUOUS_MEMORY))){
-	send_buf = (char **) malloc(fh->f_size*sizeof(char*));
+	send_buf = (char **) calloc (fh->f_size, sizeof(char*));
 	if ( NULL == send_buf ){
 	    ret = OMPI_ERR_OUT_OF_RESOURCE;
 	    goto exit;
@@ -1177,20 +1172,10 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
     }
 
 
-    for (i=0; i<nprocs_recv; i++) ompi_datatype_destroy(recv_types+i);
-    if (NULL != recv_types){
-	free(recv_types);
-	recv_types = NULL;
-    }
-
     ret = ompi_request_wait_all (nprocs_send+nprocs_recv,
 				 requests,
 				 MPI_STATUS_IGNORE);
 
-
-    if ( NULL != requests ){
-	free(requests);
-    }
 
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     end_comm_time = MPI_Wtime();
@@ -1198,6 +1183,18 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
 #endif
 
 exit:
+    for (i=0; i<nprocs_recv; i++) ompi_datatype_destroy(recv_types+i);
+    free (recv_types);
+
+    free (requests);
+    if (send_buf) {
+        for (i=0; i < fh->f_size; i++){
+            free (send_buf[i]);
+        }
+
+        free (send_buf);
+    }
+
     return ret;
 }
 

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_support_fns.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_support_fns.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -369,7 +372,7 @@ int mca_fcoll_two_phase_calc_my_requests (mca_io_ompio_file_t *fh,
 
     *count_my_req_per_proc_ptr = (int*)malloc(fh->f_size*sizeof(int));
 
-    if ( NULL == count_my_req_per_proc_ptr ){
+    if ( NULL == *count_my_req_per_proc_ptr ){
 	return OMPI_ERR_OUT_OF_RESOURCE;
     }
 


### PR DESCRIPTION
Fixes CIDs 72300, 72344, 1196764-1196768, 72300: Resource leaks

Mulitple allocated arrays are going out of scope at the end of
mca_fcoll_two_phase_file_write_all. Free these arrays. Also removed
the extraneous NULL checks since free (NULL) is safe in C.

Change returns to goto exit where the allocated resources are freed.

Fixes CIDs 72285-72292, 72297, 72298: Resource leaks

Change all appropriate return statements to goto exit to ensure that
all resources are freed. Also removed the NULL checks since free
(NULL) is safe in C.

Fixes CIDs 72295, 72296: Resource leaks

Moved free of requests and recv_types to after exit label. This will
ensure these are freed on error.

Also added a loop and statement to free send_buf which is going out of
scope at the end of the function.

Fixes CIDs 72336-72240, 735197, 735198: Resource leaks

Moved the exit label before to before the resources are released and
changed all appropriate return statements to goto exit. Also removed
extraneous NULL checks because free (NULL) is safe in C.

Fixes CIDs 72341, 72343, 1196805-1196809: Resource leaks

Free all resources after exit label and change return statements to
goto exit to ensure all resources are freed on error.

Fixes CID 1269973: Unused value

Check return code of ompi_request_wait_all. If it fails jump to the
exit.

Fixes CID 714119: Dereference before NULL check

Wrong value checked in conditional.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>