### PR TITLE
simplify use of sockaddr* structs to work around buffer overflow warning

### DIFF
--- a/orte/mca/oob/tcp/oob_tcp.c
+++ b/orte/mca/oob/tcp/oob_tcp.c
@@ -221,7 +221,7 @@ static void accept_connection(const int accepted_fd,
 static int parse_uri(const uint16_t af_family,
                      const char* host,
                      const char *port,
-                     struct sockaddr* inaddr)
+                     struct sockaddr_storage* inaddr)
 {
     struct sockaddr_in *in;
 
@@ -260,7 +260,6 @@ static int parse_uri(const uint16_t af_family,
 static void process_set_peer(int fd, short args, void *cbdata)
 {
     mca_oob_tcp_peer_op_t *pop = (mca_oob_tcp_peer_op_t*)cbdata;
-    struct sockaddr inaddr;
     mca_oob_tcp_peer_t *peer;
     int rc=ORTE_SUCCESS;
     uint64_t *ui64 = (uint64_t*)(&pop->peer);
@@ -290,7 +289,8 @@ static void process_set_peer(int fd, short args, void *cbdata)
         }
     }
 
-    if ((rc = parse_uri(pop->af_family, pop->net, pop->port, (struct sockaddr*) &inaddr)) != ORTE_SUCCESS) {
+    maddr = OBJ_NEW(mca_oob_tcp_addr_t);
+    if ((rc = parse_uri(pop->af_family, pop->net, pop->port, (struct sockaddr_storage*) &(maddr->addr))) != ORTE_SUCCESS) {
         ORTE_ERROR_LOG(rc);
         goto cleanup;
     }
@@ -301,8 +301,7 @@ static void process_set_peer(int fd, short args, void *cbdata)
                         ORTE_NAME_PRINT(&pop->peer),
                         (NULL == pop->net) ? "NULL" : pop->net,
                         (NULL == pop->port) ? "NULL" : pop->port);
-    maddr = OBJ_NEW(mca_oob_tcp_addr_t);
-    memcpy(&maddr->addr, &inaddr, sizeof(inaddr));
+    /* memcpy(&maddr->addr, &inaddr, sizeof(inaddr)); */
     opal_list_append(&peer->addrs, &maddr->super);
 
  cleanup:

--- a/orte/mca/oob/tcp/oob_tcp.c
+++ b/orte/mca/oob/tcp/oob_tcp.c
@@ -290,8 +290,9 @@ static void process_set_peer(int fd, short args, void *cbdata)
     }
 
     maddr = OBJ_NEW(mca_oob_tcp_addr_t);
-    if ((rc = parse_uri(pop->af_family, pop->net, pop->port, (struct sockaddr_storage*) &(maddr->addr))) != ORTE_SUCCESS) {
+    if (ORTE_SUCCESS != (rc = parse_uri(pop->af_family, pop->net, pop->port, (struct sockaddr_storage*) &(maddr->addr)))) {
         ORTE_ERROR_LOG(rc);
+        OBJ_RELEASE(maddr);
         goto cleanup;
     }
 
@@ -301,7 +302,6 @@ static void process_set_peer(int fd, short args, void *cbdata)
                         ORTE_NAME_PRINT(&pop->peer),
                         (NULL == pop->net) ? "NULL" : pop->net,
                         (NULL == pop->port) ? "NULL" : pop->port);
-    /* memcpy(&maddr->addr, &inaddr, sizeof(inaddr)); */
     opal_list_append(&peer->addrs, &maddr->super);
 
  cleanup:


### PR DESCRIPTION
The current method of moving around the sockaddr data causes compile time buffer overflow warnings:
> [  197s] /usr/include/bits/string3.h:84:3: warning: call to __builtin___memset_chk will always overflow destination buffer [enabled by default]
> [  197s]    return __builtin___memset_chk (__dest, __ch, __len, __bos0 (__dest));

by doing the following:
create a temp `sockaddr` struct pointer that is used in calling parse_uri
`memcpy` 0's over the struct using `sizeof `a `sockaddr_in` or `sockaddr_in6` (which is larger and causes the buffer overflow warning)
then upon return
create a `mca_oob_tcp_addr_t `object
`memcpy` the original `sockaddr` struct over `mca_oob_tcp_addr_t->addr` (which is a `sockaddr_storage` struct)

Instead this patch simplifies the process by creating the `mca_oob_tcp_addr` object first, then passes the pointer to its `sockaddr_storage` struct so the `parse_uri` copies in the data directly.