### PR TITLE
fcoll/two_phase: fix new coverity errors

### DIFF
--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
@@ -500,7 +500,7 @@ exit:
 	if (flat_buf->indices != NULL){
 	    free (flat_buf->indices);
 	}
-	flat_buf = NULL;
+        free (flat_buf);
     }
 
     free (start_offsets);

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
@@ -274,7 +274,6 @@ mca_fcoll_two_phase_file_write_all (mca_io_ompio_file_t *fh,
     total_bytes = (size_t) long_total_bytes;
 
     if ( 0 == total_bytes ) {
-        free(aggregator_list);
         ret = OMPI_SUCCESS;
         goto exit;
     }


### PR DESCRIPTION
Fix CID 1325467: use after free

Remove extra free of aggregator_list.

Fix CID 1325466: resource leak

Fix typo in prior coverity fix.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>