### PR TITLE
MXM: avoid disconnecting from a process which is still doing communication

### DIFF
--- a/ompi/mca/mtl/mxm/mtl_mxm.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm.c
@@ -599,6 +599,8 @@ int ompi_mtl_mxm_del_procs(struct mca_mtl_base_module_t *mtl, size_t nprocs,
 
 #if MXM_API >= MXM_VERSION(3,1)
     if (ompi_mtl_mxm.bulk_disconnect && nprocs == ompi_proc_world_size ()) {
+        /* avoid disconnecting from a process which is still doing communication */
+        opal_pmix.fence(NULL, 0);
         mxm_ep_powerdown(ompi_mtl_mxm.ep);
     }
 #endif

--- a/ompi/mca/pml/yalla/pml_yalla.c
+++ b/ompi/mca/pml/yalla/pml_yalla.c
@@ -257,6 +257,8 @@ int mca_pml_yalla_del_procs(struct ompi_proc_t **procs, size_t nprocs)
 
     if (ompi_mpi_finalized) {
         PML_YALLA_VERBOSE(3, "using bulk powerdown");
+        /* avoid disconnecting from a process which is still doing communication */
+        opal_pmix.fence(NULL, 0);
         mxm_ep_powerdown(ompi_pml_yalla.mxm_ep);
     }
 


### PR DESCRIPTION
master way to address this:
https://github.com/open-mpi/ompi-release/pull/632

