### PR TITLE
Print friendly message when dynamics disabled

### DIFF
--- a/ompi/mca/mtl/mxm/mtl_mxm_component.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm_component.c
@@ -3,6 +3,7 @@
  * Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -265,6 +266,8 @@ static int ompi_mtl_mxm_component_query(mca_base_module_t **module, int *priorit
     /*
      * if we get here it means that mxm is available so give high priority
      */
+
+    ompi_mpi_dynamics_disable("the MXM MTL does not support MPI dynamic process functionality");
 
     *priority = param_priority;
     *module = (mca_base_module_t *)&ompi_mtl_mxm.super;

--- a/ompi/mca/pml/yalla/pml_yalla_component.c
+++ b/ompi/mca/pml/yalla/pml_yalla_component.c
@@ -3,6 +3,7 @@
  * Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,6 +12,8 @@
  */
 
 #include "pml_yalla.h"
+
+#include "ompi/runtime/mpiruntime.h"
 
 
 static int mca_pml_yalla_component_register(void);
@@ -95,6 +98,8 @@ mca_pml_yalla_component_init(int* priority, bool enable_progress_threads,
     if ( (ret = mca_pml_yalla_init()) != 0) {
         return NULL;
     }
+
+    ompi_mpi_dynamics_disable("the Yalla (MXM) PML does not support MPI dynamic process functionality");
 
     *priority = ompi_pml_yalla.priority;
     return &ompi_pml_yalla.super;

--- a/ompi/mpi/c/comm_accept.c
+++ b/ompi/mpi/c/comm_accept.c
@@ -26,8 +26,11 @@
 #include "ompi_config.h"
 #include <stdio.h>
 
+#include "opal/util/show_help.h"
+
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
+#include "ompi/runtime/mpiruntime.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/info/info.h"
@@ -89,6 +92,10 @@ int MPI_Comm_accept(const char *port_name, MPI_Info info, int root,
         }
     }
 
+    if (!ompi_mpi_dynamics_is_enabled(FUNC_NAME)) {
+        return OMPI_ERRHANDLER_INVOKE(comm, OMPI_ERR_NOT_SUPPORTED, FUNC_NAME);
+    }
+
     /* parse info object. no prefedined values for this function in MPI-2
      * so lets ignore it for the moment.
      * if ( rank == root && MPI_INFO_NULL != info ) {
@@ -106,6 +113,14 @@ int MPI_Comm_accept(const char *port_name, MPI_Info info, int root,
     }
 
     OPAL_CR_EXIT_LIBRARY();
+
+    if (OPAL_ERR_NOT_SUPPORTED == rc) {
+        opal_show_help("help-mpi-api.txt",
+                       "MPI function not supported",
+                       true,
+                       FUNC_NAME,
+                       "Underlying runtime environment does not support accept/connect functionality");
+    }
 
     *newcomm = newcomp;
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME );

--- a/ompi/mpi/c/comm_connect.c
+++ b/ompi/mpi/c/comm_connect.c
@@ -26,8 +26,11 @@
 #include "ompi_config.h"
 #include <stdio.h>
 
+#include "opal/util/show_help.h"
+
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
+#include "ompi/runtime/mpiruntime.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/info/info.h"
@@ -89,6 +92,10 @@ int MPI_Comm_connect(const char *port_name, MPI_Info info, int root,
         }
     }
 
+    if (!ompi_mpi_dynamics_is_enabled(FUNC_NAME)) {
+        return OMPI_ERRHANDLER_INVOKE(comm, OMPI_ERR_NOT_SUPPORTED, FUNC_NAME);
+    }
+
     /* parse info object. No prefedined values for this function in MPI-2,
      * so lets ignore it for the moment.
      *
@@ -108,6 +115,14 @@ int MPI_Comm_connect(const char *port_name, MPI_Info info, int root,
     }
 
     OPAL_CR_EXIT_LIBRARY();
+
+    if (OPAL_ERR_NOT_SUPPORTED == rc) {
+        opal_show_help("help-mpi-api.txt",
+                       "MPI function not supported",
+                       true,
+                       FUNC_NAME,
+                       "Underlying runtime environment does not support accept/connect functionality");
+    }
 
     *newcomm = newcomp;
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);

--- a/ompi/mpi/help-mpi-api.txt
+++ b/ompi/mpi/help-mpi-api.txt
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2006      High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
-# Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -12,8 +12,10 @@
 # This is the US/English general help file for Open MPI.
 #
 [mpi-function-after-finalize]
-Calling any MPI-function after calling MPI_Finalize is erroneous.
-The only exceptions are MPI_Initialized, MPI_Finalized and MPI_Get_version.
+Calling most MPI functions after calling MPI_Finalize is erroneous.
+
+There are a small number of exceptions, such as MPI_Initialized,
+MPI_Finalized, and MPI_Get_version.
 #
 [mpi-initialize-twice]
 Calling MPI_Init or MPI_Init_thread twice is erroneous.
@@ -25,3 +27,10 @@ with errorcode %d.
 NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
 You may or may not see output from other processes, depending on
 exactly when Open MPI kills them.
+#
+[MPI function not supported]
+Your application has invoked an MPI function that is not supported in
+this environment.
+
+  MPI function: %s
+  Reason:       %s

--- a/ompi/runtime/Makefile.am
+++ b/ompi/runtime/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
@@ -30,6 +30,7 @@ headers += \
 
 libmpi_la_SOURCES += \
         runtime/ompi_mpi_abort.c \
+        runtime/ompi_mpi_dynamics.c \
         runtime/ompi_mpi_init.c \
         runtime/ompi_mpi_finalize.c \
         runtime/ompi_mpi_params.c \

--- a/ompi/runtime/mpiruntime.h
+++ b/ompi/runtime/mpiruntime.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
@@ -190,6 +190,37 @@ OMPI_DECLSPEC int ompi_mpi_abort(struct ompi_communicator_t* comm,
  * be made if they will be made).
  */
 int ompi_init_preconnect_mpi(void);
+
+/**
+ * Called to disable MPI dynamic process support.  It should be called
+ * by transports and/or environments where MPI dynamic process
+ * functionality cannot be supported, and provide a string indicating
+ * why the functionality is disabled (because it will be shown in a
+ * user help message).  For example, "<TRANSPORT> does not support MPI
+ * dynamic process functionality."
+ *
+ * This first-order functionality is fairly coarse-grained and simple:
+ * it presents a friendly show-help message to tell users why their
+ * MPI dynamic process functionality failed (vs. a potentially-cryptic
+ * network or hardware failure message).
+ *
+ * Someone may choose to implement a more fine-grained approach in the
+ * future.
+ */
+void ompi_mpi_dynamics_disable(const char *msg);
+
+/**
+ * Called by the MPI dynamic process functions (e.g., MPI_Comm_spawn)
+ * to see if MPI dynamic process support is enabled.  If it's not,
+ * this function will opal_show_help() a message and return false.
+ */
+bool ompi_mpi_dynamics_is_enabled(const char *function);
+
+/**
+ * Clean up memory / resources by the MPI dynamics process
+ * functionality checker
+ */
+void ompi_mpi_dynamics_finalize(void);
 
 END_C_DECLS
 

--- a/ompi/runtime/ompi_mpi_dynamics.c
+++ b/ompi/runtime/ompi_mpi_dynamics.c
@@ -1,0 +1,64 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "opal/util/show_help.h"
+
+#include "ompi/runtime/params.h"
+#include "ompi/runtime/mpiruntime.h"
+
+static char *ompi_mpi_dynamics_disabled_msg = "Enabled";
+
+
+void ompi_mpi_dynamics_disable(const char *msg)
+{
+    assert(msg);
+
+    ompi_mpi_dynamics_enabled = false;
+    ompi_mpi_dynamics_disabled_msg = strdup(msg);
+}
+
+bool ompi_mpi_dynamics_is_enabled(const char *function)
+{
+    if (ompi_mpi_dynamics_enabled) {
+        return true;
+    }
+
+    opal_show_help("help-mpi-api.txt",
+                   "MPI function not supported",
+                   true,
+                   function,
+                   ompi_mpi_dynamics_disabled_msg);
+    return false;
+}
+
+void ompi_mpi_dynamics_finalize(void)
+{
+    // If dynamics were disabled, then we have a message to free
+    if (!ompi_mpi_dynamics_enabled) {
+        free(ompi_mpi_dynamics_disabled_msg);
+        ompi_mpi_dynamics_disabled_msg = NULL;
+    }
+}

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2006-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
@@ -422,6 +422,10 @@ int ompi_mpi_finalize(void)
         OBJ_RELEASE(ompi_mpi_main_thread);
         ompi_mpi_main_thread = NULL;
     }
+
+    /* Clean up memory/resources from the MPI dynamic process
+       functionality checker */
+    ompi_mpi_dynamics_finalize();
 
     /* Leave the RTE */
 

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
@@ -65,6 +65,7 @@ char *ompi_mpi_show_mca_params_string = NULL;
 bool ompi_mpi_have_sparse_group_storage = !!(OMPI_GROUP_SPARSE);
 bool ompi_mpi_preconnect_mpi = false;
 uint32_t ompi_add_procs_cutoff = 1024;
+bool ompi_mpi_dynamics_enabled = true;
 
 static bool show_default_mca_params = false;
 static bool show_file_mca_params = false;
@@ -298,6 +299,14 @@ int ompi_mpi_register_params(void)
                                   0, 0, OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
                                   &ompi_add_procs_cutoff);
 
+
+    ompi_mpi_dynamics_enabled = true;
+    (void) mca_base_var_register("ompi", "mpi", NULL, "dynamics_enabled",
+                                 "Is the MPI dynamic process functionality enabled (e.g., MPI_COMM_SPAWN)?  Default is yes, but certain transports and/or environments may disable it.",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                 OPAL_INFO_LVL_4,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &ompi_mpi_dynamics_enabled);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/runtime/params.h
+++ b/ompi/runtime/params.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2013      Intel, Inc. All rights reserved
  * $COPYRIGHT$
@@ -133,6 +133,12 @@ OMPI_DECLSPEC extern uint32_t ompi_direct_modex_cutoff;
  * Cutoff point for calling add_procs for all processes
  */
 OMPI_DECLSPEC extern uint32_t ompi_add_procs_cutoff;
+
+/**
+ * Whether anything in the code base has disabled MPI dynamic process
+ * functionality or not
+ */
+OMPI_DECLSPEC extern bool ompi_mpi_dynamics_enabled;
 
 /**
  * Register MCA parameters used by the MPI layer.


### PR DESCRIPTION
Two commits:

1. New infrastructure to gracefully disable MPI dynamic process functionality
1. Have the MXM MTL and Yalla PML use this functionality

If merged, this will close #984.