### PR TITLE
Add volatile to workaround GCC optimization bug in 4.9.2 and greater.

### DIFF
--- a/opal/mca/memory/linux/memory_linux.h
+++ b/opal/mca/memory/linux/memory_linux.h
@@ -32,12 +32,20 @@ typedef struct opal_memory_linux_component_t {
 #endif
 
 #if MEMORY_LINUX_PTMALLOC2
-    /* Ptmalloc2-specific data */
-    bool free_invoked;
-    bool malloc_invoked;
-    bool realloc_invoked;
-    bool memalign_invoked;
-    bool munmap_invoked;
+    /* Ptmalloc2-specific data. Note that these variables are all marked as volatile.
+     * This is needed because of what may be a buggy optimization in the GCC 4.9.2
+     * compilers and later. These variables are used in different code paths which the
+     * compiler is not aware of.
+     * Extra details located at these URLs:
+     * Open MPI User List: http://www.open-mpi.org/community/lists/users/2015/06/27039.php
+     * Bug Discussion: https://github.com/open-mpi/ompi/pull/625
+     * GCC Discussion: https://gcc.gnu.org/ml/gcc-bugs/2015-06/msg00757.html
+     */
+    volatile bool free_invoked;
+    volatile bool malloc_invoked;
+    volatile bool realloc_invoked;
+    volatile bool memalign_invoked;
+    volatile bool munmap_invoked;
 #endif
 } opal_memory_linux_component_t;
 


### PR DESCRIPTION
This pull request is for #988 and is a modified version from #650. I added in some comments about the issue that was being fixed as requested by @jsquyres. However, the fix itself is identical to that outlined in #650. I am hoping to get this through into 1.10.1 but if there are still enough questions about this fix, then I will give that up for now and we can try and work through the issues.

I will add @jsquyres , @goodell , @ggouaillardet to review this. 

