### PR TITLE
opal/progress: added function to call a function as part of opal_progress

### DIFF
--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -373,3 +373,42 @@ opal_progress_unregister(opal_progress_callback_t cb)
 
     return ret;
 }
+
+struct opal_progress_event_t {
+    opal_event_t super;
+    void *(*fn)(void *);
+    void *arg;
+    opal_event_t *event;
+};
+
+typedef struct opal_progress_event_t opal_progress_event_t;
+
+static void *opal_progress_run_once_cb (int fd, int flags, void *context)
+{
+    opal_progress_event_t *event = (opal_progress_event_t *) context;
+    void *ret;
+
+    ret = event->fn (event->arg);
+    opal_event_del (&event->super);
+    free (event);
+    return ret;
+}
+
+int opal_progress_run_once (void *(*fn)(void *), void *arg)
+{
+    opal_progress_event_t *event = malloc (sizeof (opal_progress_event_t));
+
+    if (OPAL_UNLIKELY(NULL == event)) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    event->fn = fn;
+    event->arg = arg;
+
+    opal_event_set (opal_sync_event_base, &event->super, -1, OPAL_EV_READ,
+                    opal_progress_run_once_cb, event);
+
+    opal_event_active (&event->super, OPAL_EV_READ, 1);
+
+    return OPAL_SUCCESS;
+}

--- a/opal/runtime/opal_progress.h
+++ b/opal/runtime/opal_progress.h
@@ -53,6 +53,13 @@ OPAL_DECLSPEC int opal_progress_init(void);
  */
 OPAL_DECLSPEC int opal_progress_finalize(void);
 
+/**
+ * Run function as part of opal_progress()
+ *
+ * @param[in] fn    function to run
+ * @param[in] arg   function data
+ */
+OPAL_DECLSPEC int opal_progress_run_once (void *(*fn)(void *), void *arg);
 
 /**
  * Progress all pending events


### PR DESCRIPTION
This commit add the opal_progress_run_once function. This function
creates a new event that is put on the opal_sync_event_base that runs
the requested function as part of opal_progress().

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>