### PR TITLE
mtl-portals4: fix bug in the Portals4 get_peer family

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -224,7 +224,7 @@ ompi_mtl_portals4_get_proc_group(struct ompi_group_t *group, int rank);
 static inline ptl_process_t
 ompi_mtl_portals4_get_peer_group(struct ompi_group_t *group, int rank)
 {
-    return *((ptl_process_t*)ompi_mtl_portals4_get_proc_group(group, rank));
+    return *((ptl_process_t*)(ompi_mtl_portals4_get_proc_group(group, rank)->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]));
 }
 
 static inline ompi_proc_t *
@@ -236,7 +236,7 @@ ompi_mtl_portals4_get_proc(struct ompi_communicator_t *comm, int rank)
 static inline ptl_process_t
 ompi_mtl_portals4_get_peer(struct ompi_communicator_t *comm, int rank)
 {
-    return *((ptl_process_t*)ompi_mtl_portals4_get_proc(comm, rank));
+    return *((ptl_process_t*)(ompi_mtl_portals4_get_proc(comm, rank)->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4]));
 }
 
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
@@ -20,6 +20,8 @@
 #ifndef OMPI_MTL_PORTALS_ENDPOINT_H
 #define OMPI_MTL_PORTALS_ENDPOINT_H
 
+#include "ompi/mca/mtl/portals4/mtl_portals4.h"
+
 struct mca_mtl_base_endpoint_t {
     ptl_process_t ptl_proc;
 };


### PR DESCRIPTION
The Portals4 get_peer family incorrectly cast the ompi_proc_t to
ptl_process_t and returned that as the peer.  The ptl_process_t is
actually found in the endpoint array.  This commit fixes the
Portals4 get_peer family to return the dereferenced endpoint
pointer.

@regrant - please review
