### PR TITLE
orte/ess: Fix issue in pmi:pmix1xx initialization

### DIFF
--- a/orte/mca/ess/pmi/ess_pmi_component.c
+++ b/orte/mca/ess/pmi/ess_pmi_component.c
@@ -71,22 +71,24 @@ static int pmi_component_query(mca_base_module_t **module, int *priority)
 
     /* all APPS must use pmix */
     if (ORTE_PROC_IS_APP) {
-        /* open and setup pmix */
-        if (OPAL_SUCCESS != (ret = mca_base_framework_open(&opal_pmix_base_framework, 0))) {
-            ORTE_ERROR_LOG(ret);
-            *priority = -1;
-            *module = NULL;
-            return ret;
-        }
-        if (OPAL_SUCCESS != (ret = opal_pmix_base_select())) {
-            /* don't error log this as it might not be an error at all */
-            *priority = -1;
-            *module = NULL;
-            (void) mca_base_framework_close(&opal_pmix_base_framework);
-            return ret;
+        if (NULL == opal_pmix.initialized) {
+            /* open and setup pmix */
+            if (OPAL_SUCCESS != (ret = mca_base_framework_open(&opal_pmix_base_framework, 0))) {
+                ORTE_ERROR_LOG(ret);
+                *priority = -1;
+                *module = NULL;
+                return ret;
+            }
+            if (OPAL_SUCCESS != (ret = opal_pmix_base_select())) {
+                /* don't error log this as it might not be an error at all */
+                *priority = -1;
+                *module = NULL;
+                (void) mca_base_framework_close(&opal_pmix_base_framework);
+                return ret;
+            }
         }
         /* initialize the selected module */
-        if (OPAL_SUCCESS != (ret = opal_pmix.init())) {
+        if (!opal_pmix.initialized() && (OPAL_SUCCESS != (ret = opal_pmix.init()))) {
             /* cannot run */
             *priority = -1;
             *module = NULL;


### PR DESCRIPTION
There is an issue with attemption of double pmix1xx intialization
in case ess selection order is singleton,pmi.
In case an order is pmi,singleton it is not happened.

@rhc54, @jladd-mlnx  could you look at

It was observed in simple hello application running using srun:
env PMIX_VERBOSE=100 OMPI_MCA_opal_pmix_base_verbose=100 OMPI_MCA_orte_ess_base_verbose=100 srun -n2 ./hello.out
and selection logic looks as following:
mca:base:select:(  ess) Querying component [singleton]
mca:base:select:(  ess) Query of component [singleton] set priority to 25
mca:base:select:(  ess) Querying component [env]
mca:base:select:(  ess) Querying component [pmi]

This order is ok:
mca:base:select:(  ess) Querying component [env]
mca:base:select:(  ess) Querying component [hnp]
mca:base:select:(  ess) Querying component [pmi]
mca:base:select:(  ess) Query of component [singleton] set priority to 25

:bot:assign: @rhc54 
:bot:label:bug