### PR TITLE
pml/ob1: Fix a memory leak regarding pending FIN control messages.

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -16,7 +16,8 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -715,6 +716,7 @@ void mca_pml_ob1_process_pending_packets(mca_bml_base_btl_t* bml_btl)
                                           pckt->order,
                                           pckt->status);
                 if( OPAL_UNLIKELY(OMPI_ERR_OUT_OF_RESOURCE == rc) ) {
+                    MCA_PML_OB1_PCKT_PENDING_RETURN(pckt);
                     return;
                 }
                 break;


### PR DESCRIPTION
In the current ob1 PML implementation, once a FIN control message is appended to the pending list,
the ob1 PML attempts to send the FIN again in the `mca_pml_ob1_process_pending_packets` function. But if the PML failed to sent the FIN again, the `mca_pml_ob1_send_fin` function creates a new `mca_pml_ob1_pckt_pending_t` object and the old object is not retured to the free list.