### PR TITLE
fortran/mpif-h: Insert missing weak symbols & Fix incorrect symbol names.

### DIFF
--- a/ompi/mpi/fortran/mpif-h/improbe_f.c
+++ b/ompi/mpi/fortran/mpif-h/improbe_f.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +34,9 @@
 #pragma weak pmpi_improbe = ompi_improbe_f
 #pragma weak pmpi_improbe_ = ompi_improbe_f
 #pragma weak pmpi_improbe__ = ompi_improbe_f
+
+#pragma weak PMPI_Improbe_f = ompi_improbe_f
+#pragma weak PMPI_Improbe_f08 = ompi_improbe_f
 #else
 OMPI_GENERATE_F77_BINDINGS (PMPI_IMPROBE,
                             pmpi_improbe,
@@ -50,6 +54,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_IMPROBE,
 #pragma weak mpi_improbe = ompi_improbe_f
 #pragma weak mpi_improbe_ = ompi_improbe_f
 #pragma weak mpi_improbe__ = ompi_improbe_f
+
+#pragma weak MPI_Improbe_f = ompi_improbe_f
+#pragma weak MPI_Improbe_f08 = ompi_improbe_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
 OMPI_GENERATE_F77_BINDINGS (MPI_IMPROBE,

--- a/ompi/mpi/fortran/mpif-h/imrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/imrecv_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,9 @@
 #pragma weak pmpi_imrecv = ompi_imrecv_f
 #pragma weak pmpi_imrecv_ = ompi_imrecv_f
 #pragma weak pmpi_imrecv__ = ompi_imrecv_f
+
+#pragma weak PMPI_Imrecv_f = ompi_imrecv_f
+#pragma weak PMPI_Imrecv_f08 = ompi_imrecv_f
 #else
 OMPI_GENERATE_F77_BINDINGS (PMPI_IMRECV,
                             pmpi_imrecv,
@@ -47,6 +51,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_IMRECV,
 #pragma weak mpi_imrecv = ompi_imrecv_f
 #pragma weak mpi_imrecv_ = ompi_imrecv_f
 #pragma weak mpi_imrecv__ = ompi_imrecv_f
+
+#pragma weak MPI_Imrecv_f = ompi_imrecv_f
+#pragma weak MPI_Imrecv_f08 = ompi_imrecv_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
 OMPI_GENERATE_F77_BINDINGS (MPI_IMRECV,

--- a/ompi/mpi/fortran/mpif-h/mprobe_f.c
+++ b/ompi/mpi/fortran/mpif-h/mprobe_f.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +55,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_MPROBE,
 #pragma weak mpi_mprobe = ompi_mprobe_f
 #pragma weak mpi_mprobe_ = ompi_mprobe_f
 #pragma weak mpi_mprobe__ = ompi_mprobe_f
+
+#pragma weak MPI_Mprobe_f = ompi_mprobe_f
+#pragma weak MPI_Mprobe_f08 = ompi_mprobe_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
 OMPI_GENERATE_F77_BINDINGS (MPI_MPROBE,

--- a/ompi/mpi/fortran/mpif-h/mrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/mrecv_f.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +34,9 @@
 #pragma weak pmpi_mrecv = ompi_mrecv_f
 #pragma weak pmpi_mrecv_ = ompi_mrecv_f
 #pragma weak pmpi_mrecv__ = ompi_mrecv_f
+
+#pragma weak PMPI_Mrecv_f = ompi_mrecv_f
+#pragma weak PMPI_Mrecv_f08 = ompi_mrecv_f
 #else
 OMPI_GENERATE_F77_BINDINGS (PMPI_MRECV,
                             pmpi_mrecv,
@@ -50,6 +54,9 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_MRECV,
 #pragma weak mpi_mrecv = ompi_mrecv_f
 #pragma weak mpi_mrecv_ = ompi_mrecv_f
 #pragma weak mpi_mrecv__ = ompi_mrecv_f
+
+#pragma weak MPI_Mrecv_f = ompi_mrecv_f
+#pragma weak MPI_Mrecv_f08 = ompi_mrecv_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
 OMPI_GENERATE_F77_BINDINGS (MPI_MRECV,

--- a/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,8 +36,8 @@
 #pragma weak pmpi_rget_accumulate_ = ompi_rget_accumulate_f
 #pragma weak pmpi_rget_accumulate__ = ompi_rget_accumulate_f
 
-#pragma weak PMPI_Get_accumulate_f = ompi_rget_accumulate_f
-#pragma weak PMPI_Get_accumulate_f08 = ompi_rget_accumulate_f
+#pragma weak PMPI_Rget_accumulate_f = ompi_rget_accumulate_f
+#pragma weak PMPI_Rget_accumulate_f08 = ompi_rget_accumulate_f
 #else
 OMPI_GENERATE_F77_BINDINGS (PMPI_RGET_ACCUMULATE,
                             pmpi_rget_accumulate,
@@ -54,8 +55,8 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_RGET_ACCUMULATE,
 #pragma weak mpi_rget_accumulate_ = ompi_rget_accumulate_f
 #pragma weak mpi_rget_accumulate__ = ompi_rget_accumulate_f
 
-#pragma weak MPI_Get_accumulate_f = ompi_rget_accumulate_f
-#pragma weak MPI_Get_accumulate_f08 = ompi_rget_accumulate_f
+#pragma weak MPI_Rget_accumulate_f = ompi_rget_accumulate_f
+#pragma weak MPI_Rget_accumulate_f08 = ompi_rget_accumulate_f
 #else
 #if ! OMPI_BUILD_MPI_PROFILING
 OMPI_GENERATE_F77_BINDINGS (MPI_RGET_ACCUMULATE,


### PR DESCRIPTION
fortran/mpif-h: Insert missing weak symbols & Fix incorrect symbol names.