### PR TITLE
limit the number of bytes used for the semaphore name depending on pl…

### DIFF
--- a/ompi/mca/io/ompio/io_ompio.c
+++ b/ompi/mca/io/ompio/io_ompio.c
@@ -189,8 +189,8 @@ int ompi_io_ompio_generate_current_file_view (struct mca_io_ompio_file_t *fh,
     int block = 1;
 
    /* allocate an initial iovec, will grow if needed */
-    iov = (struct iovec *) malloc
-        (OMPIO_IOVEC_INITIAL_SIZE * sizeof (struct iovec));
+    iov = (struct iovec *) calloc
+        (OMPIO_IOVEC_INITIAL_SIZE, sizeof (struct iovec));
     if (NULL == iov) {
         opal_output(1, "OUT OF MEMORY\n");
         return OMPI_ERR_OUT_OF_RESOURCE;

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -184,8 +184,14 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     /* the semaphore is shared by keeping it in the shared memory segment  */
 
 #if defined(HAVE_SEM_OPEN)
-    sm_data->sem_name = (char*) malloc( sizeof(char) * (strlen(filename_basename)+32) );
-    sprintf(sm_data->sem_name,"OMPIO_sharedfp_sem_%s",filename_basename);
+
+#if defined (__APPLE__)    
+    sm_data->sem_name = (char*) malloc( sizeof(char) * 32);
+    snprintf(sm_data->sem_name,31,"OMPIO_%s",filename_basename);
+#else
+    sm_data->sem_name = (char*) malloc( sizeof(char) * 253);
+    snprintf(sm_data->sem_name,252,"OMPIO_%s",filename_basename);
+#endif
 
     if( (sm_data->mutex = sem_open(sm_data->sem_name, O_CREAT, 0644, 1)) != SEM_FAILED ) {
 #elif defined(HAVE_SEM_INIT)


### PR DESCRIPTION
…atform (31 bytes for MacOS, 252 for Linux)