### PR TITLE
cm: fix selection priority

### DIFF
--- a/ompi/mca/pml/cm/pml_cm_component.c
+++ b/ompi/mca/pml/cm/pml_cm_component.c
@@ -143,11 +143,6 @@ mca_pml_cm_component_init(int* priority,
 {
     int ret;
 
-    if((*priority) > ompi_pml_cm.default_priority) {
-        *priority = ompi_pml_cm.default_priority;
-        return NULL;
-    }
-    *priority = ompi_pml_cm.default_priority;
     opal_output_verbose( 10, 0,
                          "in cm pml priority is %d\n", *priority);
     /* find a useable MTL */
@@ -166,8 +161,9 @@ mca_pml_cm_component_init(int* priority,
          * may still select PML/ob1 (BTLs) or PML/cm (MTLs) if preferable for the app/site.
          */
         *priority = 30;
+    } else {
+        *priority = ompi_pml_cm.default_priority;
     }
-
 
     if (ompi_mtl->mtl_flags & MCA_MTL_BASE_FLAG_REQUIRE_WORLD) {
         ompi_pml_cm.super.pml_flags |= MCA_PML_BASE_FLAG_REQUIRE_WORLD;

--- a/ompi/mca/pml/ob1/pml_ob1_component.c
+++ b/ompi/mca/pml/ob1/pml_ob1_component.c
@@ -254,10 +254,6 @@ mca_pml_ob1_component_init( int* priority,
     opal_output_verbose( 10, mca_pml_ob1_output,
                          "in ob1, my priority is %d\n", mca_pml_ob1.priority);
 
-    if((*priority) > mca_pml_ob1.priority) {
-        *priority = mca_pml_ob1.priority;
-        return NULL;
-    }
     *priority = mca_pml_ob1.priority;
 
     allocator_component = mca_allocator_component_lookup( mca_pml_ob1.allocator_name );


### PR DESCRIPTION
This patch removes a priority check that disables cm if the previous
pml had higher priority. The check was incorrect as coded and is
unnecessary as we finalize all but one pml anyway.

Fixes #1035

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>