### PR TITLE
Cleanup the temporary memory allocation in collectives

### DIFF
--- a/ompi/datatype/ompi_datatype_create_darray.c
+++ b/ompi/datatype/ompi_datatype_create_darray.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2015 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -247,32 +247,28 @@ int32_t ompi_datatype_create_darray(int size,
     }
 
 
-    /* set displacement and UB correctly. Please read the comment in subarray */
+    /**
+     * We need to shift the content (useful data) of the datatype, so
+     * we need to force the displacement to be moved. Therefore, we
+     * cannot use resize as it will only set the soft lb and ub
+     * markers without moving the data. Instead, we have to create a
+     * new data, and insert the last_Type with the correct
+     * displacement.
+     */
     {
-        ptrdiff_t displs[3], tmp_size;
-        ompi_datatype_t *types[3];
-        int blength[3] = { 1, 1, 1};
+        ptrdiff_t displs[2], tmp_size = 1;
 
-        displs[1] = st_offsets[start_loop];
-        tmp_size = 1;
-        for (i = start_loop + step ; i != end_loop ; i += step) {
+        displs[0] = st_offsets[start_loop];
+        displs[1] = orig_extent;
+        for (i = start_loop + step; i != end_loop; i += step) {
             tmp_size *= gsize_array[i - step];
-            displs[1] += tmp_size * st_offsets[i];
+            displs[0] += tmp_size * st_offsets[i];
+            displs[1] *= gsize_array[i];
         }
+        displs[0] *= orig_extent;
 
-        displs[0] = 0;
-        displs[1] *= orig_extent;
-        displs[2] = orig_extent;
-        for (i = 0 ; i < ndims ; i++) {
-            displs[2] *= gsize_array[i];
-        }
-        if(oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
-            types[0] = MPI_LB; types[1] = lastType; types[2] = MPI_UB;
-
-            rc = ompi_datatype_create_struct(3, blength, displs, types, newtype);
-        } else {
-            ompi_datatype_create_resized(lastType, displs[1], displs[2], newtype);
-        }
+        *newtype = ompi_datatype_create(lastType->super.desc.used);
+        ompi_datatype_add(*newtype, lastType, 1, displs[0], displs[1]);
         ompi_datatype_destroy(&lastType);
         /* need to destroy the old type even in error condition, so
            don't check return code from above until after cleanup. */

--- a/ompi/datatype/ompi_datatype_create_subarray.c
+++ b/ompi/datatype/ompi_datatype_create_subarray.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2015 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -91,29 +91,16 @@ int32_t ompi_datatype_create_subarray(int ndims,
     }
 
  replace_subarray_type:
-    /*
-     * Resized will only set the soft lb and ub markers without moving the real
-     * data inside. Thus, in case the original data contains the hard markers
-     * (MPI_LB or MPI_UB) we must force the displacement of the data upward to
-     * the right position AND set the hard markers LB and UB.
-     *
-     * NTH: ompi_datatype_create_resized() does not do enough for the general
-     * pack/unpack functions to work correctly. Until this is fixed always use
-     * ompi_datatype_create_struct(). Once this is fixed remove 1 || below. To
-     * verify that the regression is fixed run the subarray test in the Open MPI
-     * ibm testsuite.
-     */
-    if(1 || oldtype->super.flags & (OPAL_DATATYPE_FLAG_USER_LB | OPAL_DATATYPE_FLAG_USER_UB) ) {
-        MPI_Aint displs[3];
-        MPI_Datatype types[3];
-        int blength[3] = { 1, 1, 1 };
-
-        displs[0] = 0; displs[1] = displ * extent; displs[2] = size * extent;
-        types[0] = MPI_LB; types[1] = last_type; types[2] = MPI_UB;
-        ompi_datatype_create_struct( 3, blength, displs, types, newtype );
-    } else {
-        ompi_datatype_create_resized(last_type, displ * extent, size * extent, newtype);
-    }
+    /**
+      * We need to shift the content (useful data) of the datatype, so
+      * we need to force the displacement to be moved. Therefore, we
+      * cannot use resize as it will only set the soft lb and ub
+      * markers without moving the data. Instead, we have to create a
+      * new data, and insert the last_Type with the correct
+      * displacement.
+      */
+    *newtype = ompi_datatype_create( last_type->super.desc.used );
+    ompi_datatype_add( *newtype, last_type, 1, displ * extent, size * extent);
     ompi_datatype_destroy( &last_type );
 
     return OMPI_SUCCESS;

--- a/opal/datatype/opal_datatype_resize.c
+++ b/opal/datatype/opal_datatype_resize.c
@@ -4,6 +4,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +22,6 @@ int32_t opal_datatype_resize( opal_datatype_t* type, OPAL_PTRDIFF_TYPE lb, OPAL_
 {
     type->lb = lb;
     type->ub = lb + extent;
-
-    type->true_lb += lb;
-    type->true_ub += lb;
 
     type->flags &= ~OPAL_DATATYPE_FLAG_NO_GAPS;
     if( (extent == (OPAL_PTRDIFF_TYPE)type->size) &&


### PR DESCRIPTION
Cleanup the memory handling for temporary buffers in some of the collective modules. Added a new function opal_datatype_span, to compute the memory span of count number of datatype, excluding the gaps in the beginning and at the end. If a memory allocation is made using the returned value, the gap (also returned) should be removed from the allocated pointer.