### PR TITLE
configury: fix autogen.pl --no-ompi

### DIFF
--- a/Makefile.ompi-rules
+++ b/Makefile.ompi-rules
@@ -1,5 +1,5 @@
 # -*- makefile -*-
-# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -9,13 +9,13 @@
 #
 
 TRIM_OPTIONS=
-if ! OMPI_BUILD_MPI_CXX_BINDINGS
+if ! MAN_PAGE_BUILD_MPI_CXX_BINDINGS
     TRIM_OPTIONS += --nocxx
 endif
-if ! OMPI_BUILD_FORTRAN_MPIFH_BINDINGS
+if ! MAN_PAGE_BUILD_MPIFH_BINDINGS
     TRIM_OPTIONS += --nofortran
 endif
-if ! OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS
+if ! MAN_PAGE_BUILD_USEMPIF08_BINDINGS
     TRIM_OPTIONS += --nof08
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -502,8 +502,12 @@ OPAL_CHECK_OFFSETOF
 # sets up the C++ MPI bindings, etc.).  Perhaps it was moved to OPAL
 # just on the rationale that all compiler setup should be done in
 # OPAL...?  Shrug.
+WANT_MPI_CXX_SUPPORT=0
 m4_ifdef([project_ompi], [OPAL_SETUP_CXX
                           OMPI_SETUP_CXX])
+# Used in Makefile.ompi-rules
+AM_CONDITIONAL(MAN_PAGE_BUILD_MPI_CXX_BINDINGS,
+               [test "$WANT_MPI_CXX_SUPPORT" = 1])
 
 ##################################
 # Only after setting up both
@@ -547,7 +551,15 @@ OPAL_CONFIG_ASM
 # Fortran
 ##################################
 
+OMPI_BUILD_FORTRAN_BINDINGS=0
+
 m4_ifdef([project_ompi], [OMPI_SETUP_MPI_FORTRAN], [ompi_fortran_happy=0])
+
+# Used in Makefile.ompi-rules
+AM_CONDITIONAL(MAN_PAGE_BUILD_MPIFH_BINDINGS,
+              [test $OMPI_BUILD_FORTRAN_BINDINGS -gt $OMPI_FORTRAN_NO_BINDINGS])
+AM_CONDITIONAL(MAN_PAGE_BUILD_USEMPIF08_BINDINGS,
+              [test $OMPI_BUILD_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS])
 
 AM_CONDITIONAL(OSHMEM_BUILD_FORTRAN_BINDINGS,
     [test "$enable_oshmem" = "yes" && \


### PR DESCRIPTION
The Makefile.ompi-rules trim options previously used AM_CONDITIONALs that were defined only when the OMPI project was configured.  Hence, if you ran "autogen.pl --no-ompi", autogen would fail with lots of messages about undefined AM_CONDITIONALs.

This commit makes new AM_CONDITIONALs outside of the project configuration that can be safely used elsewhere.

@ggouaillardet Please review.