### PR TITLE
Revert the changes to the opal_list_t destructor

### DIFF
--- a/opal/class/opal_list.c
+++ b/opal/class/opal_list.c
@@ -97,17 +97,11 @@ static void opal_list_construct(opal_list_t *list)
 
 
 /*
- * Release the list items in the list.
- * Reset list pointers to be NULL
+ * Reset all the pointers to be NULL -- do not actually destroy
+ * anything.
  */
 static void opal_list_destruct(opal_list_t *list)
 {
-    opal_list_item_t *it;
-
-    while (NULL != (it = opal_list_remove_first(list))) {
-        OBJ_RELEASE(it);
-    }
-
     opal_list_construct(list);
 }
 

--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -168,22 +168,26 @@ typedef struct opal_list_t opal_list_t;
  *
  * @param[in] list List to destruct or release
  */
-#define OPAL_LIST_DESTRUCT(list)                                \
-    do {                                                        \
-        opal_list_item_t *it;                                   \
-        while (NULL != (it = opal_list_remove_first(list))) {   \
-            OBJ_RELEASE(it);                                    \
-        }                                                       \
-        OBJ_DESTRUCT(list);                                     \
+#define OPAL_LIST_DESTRUCT(list)                                  \
+    do {                                                          \
+        opal_list_item_t *it;                                     \
+        if (1 == ((opal_object_t*)(list))->obj_reference_count) { \
+          while (NULL != (it = opal_list_remove_first(list))) {   \
+              OBJ_RELEASE(it);                                    \
+          }                                                       \
+        }                                                         \
+        OBJ_DESTRUCT(list);                                       \
     } while(0);
 
-#define OPAL_LIST_RELEASE(list)                                 \
-    do {                                                        \
-        opal_list_item_t *it;                                   \
-        while (NULL != (it = opal_list_remove_first(list))) {   \
-            OBJ_RELEASE(it);                                    \
-        }                                                       \
-        OBJ_RELEASE(list);                                      \
+#define OPAL_LIST_RELEASE(list)                                   \
+    do {                                                          \
+        opal_list_item_t *it;                                     \
+        if (1 == ((opal_object_t*)(list))->obj_reference_count) { \
+          while (NULL != (it = opal_list_remove_first(list))) {   \
+              OBJ_RELEASE(it);                                    \
+          }                                                       \
+        }                                                         \
+        OBJ_RELEASE(list);                                        \
     } while(0);
 
 

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -452,11 +452,6 @@ void memheap_oob_destruct(void)
         PMPI_Request_free(&r->recv_req);
     }
 
-    /*clear these list object as they don't belong here */
-    while (NULL != opal_list_remove_first(&memheap_oob.req_list)) {
-        continue;
-    }
-
     OBJ_DESTRUCT(&memheap_oob.req_list);
     OBJ_DESTRUCT(&memheap_oob.lck);
     OBJ_DESTRUCT(&memheap_oob.cond);


### PR DESCRIPTION
Several places in the MPI layer are still attaching static objects to opal_list_t structures. This is causing random segfaults in the code. So, until we have a more complete solution, revert the changes to the opal_list_t destructor, and go back to the original patch that modified only the OPAL_LIST_RELEASE and OPAL_LIST_DESTRUCT macros
