### PR TITLE
oob_tcp: fix peer->state wrong check

### DIFF
--- a/orte/mca/oob/tcp/oob_tcp.c
+++ b/orte/mca/oob/tcp/oob_tcp.c
@@ -361,7 +361,7 @@ static void process_ping(int fd, short args, void *cbdata)
     }
 
     /* if we are already connecting, there is nothing to do */
-    if (MCA_OOB_TCP_CONNECTING == peer->state &&
+    if (MCA_OOB_TCP_CONNECTING == peer->state ||
         MCA_OOB_TCP_CONNECT_ACK == peer->state) {
         opal_output_verbose(2, orte_oob_base_framework.framework_output,
                             "%s:[%s:%d] already connecting to peer %s",


### PR DESCRIPTION
Hi! I think I have found a small bug in process_ping function, see the commit.