### PR TITLE
mtl-portals4: test for valid handle before releasing resources

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4.c
@@ -552,15 +552,31 @@ ompi_mtl_portals4_finalize(struct mca_mtl_base_module_t *mtl)
 #endif
     ompi_mtl_portals4_recv_short_fini();
 
-    PtlMEUnlink(ompi_mtl_portals4.long_overflow_me_h);
-    PtlMDRelease(ompi_mtl_portals4.zero_md_h);
-    PtlMDRelease(ompi_mtl_portals4.send_md_h);
+    if (!PtlHandleIsEqual(ompi_mtl_portals4.long_overflow_me_h, PTL_INVALID_HANDLE)) {
+        PtlMEUnlink(ompi_mtl_portals4.long_overflow_me_h);
+    }
+    if (!PtlHandleIsEqual(ompi_mtl_portals4.zero_md_h, PTL_INVALID_HANDLE)) {
+        PtlMDRelease(ompi_mtl_portals4.zero_md_h);
+    }
+    if (!PtlHandleIsEqual(ompi_mtl_portals4.send_md_h, PTL_INVALID_HANDLE)) {
+        PtlMDRelease(ompi_mtl_portals4.send_md_h);
+    }
+    if (ompi_mtl_portals4.read_idx != (ptl_pt_index_t) ~0UL) {
+        PtlPTFree(ompi_mtl_portals4.ni_h, ompi_mtl_portals4.read_idx);
+    }
+    if (ompi_mtl_portals4.recv_idx != (ptl_pt_index_t) ~0UL) {
+        PtlPTFree(ompi_mtl_portals4.ni_h, ompi_mtl_portals4.recv_idx);
+    }
+    if (!PtlHandleIsEqual(ompi_mtl_portals4.send_eq_h, PTL_INVALID_HANDLE)) {
+        PtlEQFree(ompi_mtl_portals4.send_eq_h);
+    }
+    if (!PtlHandleIsEqual(ompi_mtl_portals4.recv_eq_h, PTL_INVALID_HANDLE)) {
+        PtlEQFree(ompi_mtl_portals4.recv_eq_h);
+    }
+    if (!PtlHandleIsEqual(ompi_mtl_portals4.ni_h, PTL_INVALID_HANDLE)) {
+        PtlNIFini(ompi_mtl_portals4.ni_h);
+    }
 
-    PtlPTFree(ompi_mtl_portals4.ni_h, ompi_mtl_portals4.read_idx);
-    PtlPTFree(ompi_mtl_portals4.ni_h, ompi_mtl_portals4.recv_idx);
-    PtlEQFree(ompi_mtl_portals4.send_eq_h);
-    PtlEQFree(ompi_mtl_portals4.recv_eq_h);
-    PtlNIFini(ompi_mtl_portals4.ni_h);
     PtlFini();
 
     return OMPI_SUCCESS;


### PR DESCRIPTION
During component finalize, mtl-portals4 would blindly release
resources without testing if the handle was valid.  This was OK,
but resource allocation is now delayed until add_procs().  If
mtl-portals4 is deselected, it will be finalized without
add_procs() ever being called.  This commit ensures that invalid
handles are not released.

@regrant - please review
