### PR TITLE
Ensure that we completely register an nspace prior to launching local…

### DIFF
--- a/orte/orted/pmix/pmix_server_register_fns.c
+++ b/orte/orted/pmix/pmix_server_register_fns.c
@@ -42,15 +42,22 @@
 
 #include "orte/util/name_fns.h"
 #include "orte/runtime/orte_globals.h"
+#include "orte/runtime/orte_wait.h"
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/mca/rmaps/rmaps_types.h"
 
 #include "pmix_server_internal.h"
 #include "pmix_server.h"
 
+typedef struct {
+    volatile bool active;
+    opal_list_t *info;
+} myxfer_t;
+
 static void opcbfunc(int status, void *cbdata)
 {
-    opal_list_t *lt = (opal_list_t*)cbdata;
+    myxfer_t *p = (myxfer_t*)cbdata;
+    opal_list_t *lt = p->info;
     opal_value_t *k1, *k2;
     opal_list_t *pmap;
 
@@ -65,6 +72,7 @@ static void opcbfunc(int status, void *cbdata)
         }
         OBJ_RELEASE(lt);
     }
+    p->active = false;
 }
 
 /* stuff proc attributes for sending back to a proc */
@@ -83,6 +91,7 @@ int orte_pmix_server_register_nspace(orte_job_t *jdata)
     orte_app_context_t *app;
     uid_t uid;
     gid_t gid;
+    myxfer_t *p;
 
     opal_output_verbose(2, orte_pmix_server_globals.output,
                         "%s register nspace for %s",
@@ -406,11 +415,17 @@ int orte_pmix_server_register_nspace(orte_job_t *jdata)
     orte_set_attribute(&jdata->attributes, ORTE_JOB_NSPACE_REGISTERED, ORTE_ATTR_LOCAL, NULL, OPAL_BOOL);
 
     /* pass it down */
+    p = (myxfer_t*)malloc(sizeof(myxfer_t));
+    p->active = true;
+    p->info = info;
     if (OPAL_SUCCESS != opal_pmix.server_register_nspace(jdata->jobid,
                                                          jdata->num_local_procs,
-                                                         info, opcbfunc, (void*)info)) {
-        rc = ORTE_ERROR;
+                                                         info, opcbfunc, (void*)p)) {
+        OPAL_LIST_RELEASE(info);
+        return ORTE_ERROR;
     }
+    ORTE_WAIT_FOR_COMPLETION(p->active);
+    free(p);
 
-    return rc;
+    return ORTE_SUCCESS;
 }


### PR DESCRIPTION
… procs as otherwise we may attempt to send it down before it is registered, leading to data corruption