### PR TITLE
monitor/test: allow static build of monitor tests

### DIFF
--- a/test/monitoring/Makefile.am
+++ b/test/monitoring/Makefile.am
@@ -21,6 +21,6 @@ if PROJECT_OMPI
     monitoring_test_LDADD = $(top_builddir)/ompi/libmpi.la $(top_builddir)/opal/libopen-pal.la
 
     monitoring_prof_la_SOURCES = monitoring_prof.c
-    monitoring_prof_la_LDFLAGS=-module -avoid-version -shared $(WRAPPER_EXTRA_LDFLAGS)
+    monitoring_prof_la_LDFLAGS=-module -avoid-version $(WRAPPER_EXTRA_LDFLAGS)
     monitoring_prof_la_LIBADD = $(top_builddir)/ompi/libmpi.la $(top_builddir)/opal/libopen-pal.la
 endif


### PR DESCRIPTION
this fixes a problem when configuring with:

./configure --enable-orterun-prefix-by-default --enable-static --disable-shared

Thanks to @marksantcroos for reporting this.

@jsquyres please double check

Signed-off-by: Howard Pritchard <howardp@lanl.gov>