### PR TITLE
oshmem: Enable force output for error messages

### DIFF
--- a/oshmem/mca/atomic/base/atomic_base_frame.c
+++ b/oshmem/mca/atomic/base/atomic_base_frame.c
@@ -18,6 +18,7 @@
 #include "opal/util/output.h"
 #include "opal/mca/base/base.h"
 
+#include "oshmem/util/oshmem_util.h"
 #include "oshmem/mca/atomic/atomic.h"
 #include "oshmem/mca/atomic/base/base.h"
 
@@ -73,6 +74,8 @@ static int mca_atomic_base_close(void)
 
 static int mca_atomic_base_open(mca_base_open_flag_t flags)
 {
+    oshmem_framework_open_output(&oshmem_atomic_base_framework);
+
     /* Open up all available components */
     if (OPAL_SUCCESS !=
         mca_base_framework_components_open(&oshmem_atomic_base_framework, flags)) {

--- a/oshmem/mca/memheap/base/memheap_base_frame.c
+++ b/oshmem/mca/memheap/base/memheap_base_frame.c
@@ -18,6 +18,7 @@
 #include "opal/util/output.h"
 #include "opal/mca/base/base.h"
 
+#include "oshmem/util/oshmem_util.h"
 #include "oshmem/mca/memheap/memheap.h"
 #include "oshmem/mca/memheap/base/base.h"
 
@@ -41,7 +42,6 @@ mca_memheap_map_t mca_memheap_base_map = {{{0}}};
 
 static int mca_memheap_base_register(mca_base_register_flag_t flags)
 {
-
     (void) mca_base_var_register("oshmem",
                                  "memheap",
                                  "base",
@@ -123,6 +123,8 @@ static int mca_memheap_base_open(mca_base_open_flag_t flags)
     memset(&mca_memheap_base_map, 0, sizeof(mca_memheap_base_map));
     mca_memheap_base_map.n_segments = 0;
     mca_memheap_base_map.num_transports = 0;
+
+    oshmem_framework_open_output(&oshmem_memheap_base_framework);
 
     /* Open up all available components */
     if (OPAL_SUCCESS !=

--- a/oshmem/mca/scoll/base/scoll_base_frame.c
+++ b/oshmem/mca/scoll/base/scoll_base_frame.c
@@ -18,6 +18,7 @@
 #include "opal/util/output.h"
 #include "opal/mca/base/base.h"
 
+#include "oshmem/util/oshmem_util.h"
 #include "oshmem/mca/scoll/scoll.h"
 #include "oshmem/mca/scoll/base/base.h"
 
@@ -100,6 +101,8 @@ static int mca_scoll_base_close(void)
 
 static int mca_scoll_base_open(mca_base_open_flag_t flags)
 {
+    oshmem_framework_open_output(&oshmem_scoll_base_framework);
+
     /* Open up all available components */
     if (OPAL_SUCCESS !=
             mca_base_framework_components_open(&oshmem_scoll_base_framework, flags)) {

--- a/oshmem/mca/spml/base/spml_base_frame.c
+++ b/oshmem/mca/spml/base/spml_base_frame.c
@@ -25,6 +25,7 @@
 #include "opal/mca/base/base.h"
 
 #include "oshmem/constants.h"
+#include "oshmem/util/oshmem_util.h"
 #include "oshmem/mca/spml/spml.h"
 #include "oshmem/mca/spml/base/base.h"
 #include "oshmem/mca/spml/base/spml_base_request.h"
@@ -107,6 +108,8 @@ static int mca_spml_base_open(mca_base_open_flag_t flags)
     OBJ_CONSTRUCT(&mca_spml_base_get_requests, opal_free_list_t);
 
     OBJ_CONSTRUCT(&mca_spml_base_spml, opal_pointer_array_t);
+
+    oshmem_framework_open_output(&oshmem_spml_base_framework);
 
     /* Open up all available components */
     if (OPAL_SUCCESS !=

--- a/oshmem/mca/sshmem/base/sshmem_base_open.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_open.c
@@ -16,6 +16,7 @@
 #include "opal/mca/base/base.h"
 #include "opal/mca/base/mca_base_var.h"
 
+#include "oshmem/util/oshmem_util.h"
 #include "oshmem/mca/sshmem/sshmem.h"
 #include "oshmem/mca/sshmem/base/base.h"
 
@@ -86,6 +87,8 @@ mca_sshmem_base_register (mca_base_register_flag_t flags)
 
 static int mca_sshmem_base_open(mca_base_open_flag_t flags)
 {
+    oshmem_framework_open_output(&oshmem_sshmem_base_framework);
+
     /* Open up all available components */
     if (OPAL_SUCCESS !=
         mca_base_framework_components_open(&oshmem_sshmem_base_framework, flags)) {

--- a/oshmem/util/oshmem_util.c
+++ b/oshmem/util/oshmem_util.c
@@ -13,8 +13,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#include "opal/util/output.h"
-
 #include "oshmem/constants.h"
 #include "oshmem/util/oshmem_util.h"
 
@@ -44,6 +42,7 @@ void oshmem_output_verbose(int level, int output_id, const char* prefix,
         free(str);
     }
 }
+
 
 void oshmem_output(int output_id, const char* prefix, const char* file,
     int line, const char* function, const char* format, ...)

--- a/oshmem/util/oshmem_util.h
+++ b/oshmem/util/oshmem_util.h
@@ -13,6 +13,10 @@
 
 #include "oshmem_config.h"
 
+#include "opal/util/output.h"
+#include "opal/mca/base/base.h"
+#include "opal/mca/base/mca_base_framework.h"
+
 /*
  * Environment variables
  */
@@ -31,5 +35,19 @@ void oshmem_output_verbose(int level, int output_id, const char* prefix,
  */
 void oshmem_output(int output_id, const char* prefix, const char* file,
     int line, const char* function, const char* format, ...);
+
+
+/* Force opening output for framework
+ * We would like to display error messages in any case (debug/release mode,
+ * set/unset verbose level)
+ * Setting verbose level is not a way because it enables non error messages
+ */
+static inline void oshmem_framework_open_output(struct mca_base_framework_t *framework)
+{
+    if (-1 == framework->framework_output) {
+        framework->framework_output = opal_output_open(NULL);
+    }
+}
+
 
 #endif /* OSHMEM_UTIL_H */


### PR DESCRIPTION
This change fixes issue when oshmem related error messages are not
visible for an user.

@miked-mellanox could you look at one