### PR TITLE
 If an executable isn't found, it's possible for the state machine to…

### DIFF
--- a/orte/mca/grpcomm/base/grpcomm_base_stubs.c
+++ b/orte/mca/grpcomm/base/grpcomm_base_stubs.c
@@ -311,6 +311,11 @@ static int create_dmns(orte_grpcomm_signature_t *sig,
             return ORTE_ERR_NOT_FOUND;
         }
         /* get the array */
+        if (0 == jdata->map->num_nodes) {
+            ORTE_UPDATE_EXIT_STATUS(ORTE_ERROR_DEFAULT_EXIT_CODE);
+            ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+            return ORTE_ERR_SILENT;
+        }
         dns = (orte_vpid_t*)malloc(jdata->map->num_nodes * sizeof(vpid));
         nds = 0;
         for (i=0; i < jdata->map->nodes->size && (int)nds < jdata->map->num_nodes; i++) {

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1652,6 +1652,7 @@ int orte_plm_base_setup_virtual_machine(orte_job_t *jdata)
                                      "%s plm:base:setup_vm only HNP in use",
                                      ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
                 OBJ_DESTRUCT(&nodes);
+                map->num_nodes = 1;
                 /* mark that the daemons have reported so we can proceed */
                 daemons->state = ORTE_JOB_STATE_DAEMONS_REPORTED;
                 return ORTE_SUCCESS;


### PR DESCRIPTION
… hit the grpcomm with a zero-node map before we actually terminate with error. Silence the annoying malloc warning about zero-byte requests.