### PR TITLE
SPML/IKRIT: opal_progress and ud_only fixes

### DIFF
--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -105,8 +105,13 @@ static inline mxm_mem_key_t *to_mxm_mkey(sshmem_mkey_t *mkey) {
 
 static inline void mca_spml_irkit_req_wait(mxm_req_base_t *req)
 {
-    while (!mxm_req_test(req))
+    do {
+        /* do at least one progress since
+         * with some TLs (self, shm) request
+         * can be completed immediately
+         */
         opal_progress();
+    } while (!mxm_req_test(req));
 }
 
 static int mca_spml_ikrit_put_request_free(struct oshmem_request_t** request)

--- a/oshmem/mca/spml/ikrit/spml_ikrit_component.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit_component.c
@@ -127,7 +127,6 @@ static inline int check_mxm_hw_tls(char *v, char *tls)
         if (strstr(tls, "ud") &&
             (NULL == strstr(tls, "rc") && NULL == strstr(tls, "dc") &&
              NULL == strstr(tls, "shm"))) {
-            mca_spml_ikrit.ud_only = 1;
             return OSHMEM_SUCCESS;
         }
 	}


### PR DESCRIPTION
Fixes two problems found during testing of https://github.com/open-mpi/ompi/pull/1126

Some MXM tls such as self, shm can comlete requests immediately.
Make sure that opal_progress() is called before before request
is completed.

fix ud_only logic when hw rdma channel is using ud and main
transport is rc or dc.

https://github.com/open-mpi/ompi/pull/1126

@miked-mellanox @yosefe 
