### PR TITLE
Fix "autogen.pl --no-ompi"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1379,8 +1379,9 @@ AC_CONFIG_FILES([
     test/support/Makefile
     test/threads/Makefile
     test/util/Makefile
-    test/monitoring/Makefile
 ])
+m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile])])
+
 AC_CONFIG_FILES([contrib/dist/mofed/debian/rules],
                 [chmod +x contrib/dist/mofed/debian/rules])
 AC_CONFIG_FILES([contrib/dist/mofed/compile_debian_mlnx_example],

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -11,6 +11,8 @@
 #                         All rights reserved.
 # Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -19,5 +21,8 @@
 #
 
 # support needs to be first for dependencies
-SUBDIRS = support asm class threads datatype util monitoring
+SUBDIRS = support asm class threads datatype util
+if PROJECT_OMPI
+SUBDIRS += monitoring
+endif
 DIST_SUBDIRS = event $(SUBDIRS)


### PR DESCRIPTION
This was broken due to inclusion of a conditional (MCA_BUILD_ompi_pml_monitoring_DSO) in the test/monitoring Makefile.am that is only defined if OMPI is built.

@jsquyres @bosilca I suspect this isn't the right way to fix the build, but I've tried everything I can think of to resolve it with no luck. This seems to work, but looks ugly. Could you guys please look at this?
