### PR TITLE
Enable the ability to make tarballs on the Mac tarball

### DIFF
--- a/test/asm/Makefile.am
+++ b/test/asm/Makefile.am
@@ -87,3 +87,6 @@ maintainer-clean-local:
 	atomic_spinlock_noinline.c \
 	atomic_math_noinline.c \
 	atomic_cmpset_noinline.c
+
+distclean:
+	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -102,3 +102,6 @@ opal_fifo_DEPENDENCIES = $(opal_fifo_LDADD)
 
 clean-local:
 	rm -f opal_bitmap_test_out.txt opal_hash_table_test_out.txt opal_proc_table_test_out.txt
+
+distclean:
+	rm -rf *.dSYM .deps .libs *.log *.txt *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -71,3 +71,6 @@ opal_datatype_test_SOURCES = opal_datatype_test.c opal_ddt_lib.c opal_ddt_lib.h
 opal_datatype_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 opal_datatype_test_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
+
+distclean:
+	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/event/Makefile.am
+++ b/test/event/Makefile.am
@@ -43,3 +43,6 @@ event_test_LDFLAGS = $(OPAL_PKG_CONFIG_LDFLAGS)
 event_test_LDADD = \
         $(top_builddir)/opal/libopen-pal.la
 event_test_DEPENDENCIES = $(event_test_LDADD)
+
+distclean:
+	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/memchecker/Makefile.am
+++ b/test/memchecker/Makefile.am
@@ -59,3 +59,6 @@ non_blocking_recv_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 non_blocking_recv_test_LDADD = \
         $(top_builddir)/ompi/libmpi.la
 non_blocking_recv_test_DEPENDENCIES = $(non_blocking_recv_test_LDADD)
+
+distclean:
+	rm -rf *.dSYM .deps *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/monitoring/Makefile.am
+++ b/test/monitoring/Makefile.am
@@ -28,3 +28,6 @@ if MCA_BUILD_ompi_pml_monitoring_DSO
 endif
 
 endif
+
+distclean:
+	rm -rf *.dSYM .deps .libs *.la *.lo monitoring_test *.log *.o *.trs Makefile

--- a/test/mpi/environment/Makefile.am
+++ b/test/mpi/environment/Makefile.am
@@ -27,3 +27,6 @@ chello_LDADD = \
 	$(top_builddir)/src/libompi.la
 chello_DEPENDENCIES = $(chello_LDADD)
 
+
+distclean:
+	rm -rf *.dSYM .deps *.log *.o *.trs $(noinst_PROGRAMS) Makefile

--- a/test/runtime/Makefile.am
+++ b/test/runtime/Makefile.am
@@ -54,3 +54,6 @@ opal_init_finalize_LDADD = \
 	$(top_builddir)/opal/libopen-pal.la \
 	$(top_builddir)/test/support/libsupport.a
 opal_init_finalize_DEPENDENCIES = $(opal_init_finalize_LDADD)
+
+distclean:
+	rm -rf *.dSYM .deps *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/support/Makefile.am
+++ b/test/support/Makefile.am
@@ -31,3 +31,6 @@ check_LIBRARIES = libsupport.a
 libsupport_a_SOURCES = \
         support.c \
         support.h
+
+distclean:
+	rm -rf *.dSYM .deps *.log *.o *.trs $(check_LIBRARIES) Makefile

--- a/test/threads/Makefile.am
+++ b/test/threads/Makefile.am
@@ -41,3 +41,5 @@ opal_condition_LDADD = \
         $(top_builddir)/opal/libopen-pal.la
 opal_condition_DEPENDENCIES = $(opal_condition_LDADD)
 
+distclean:
+	rm -rf *.dSYM .deps .libs *.log *.o *.trs $(check_PROGRAMS) Makefile

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -119,3 +119,7 @@ opal_path_nfs_DEPENDENCIES = $(opal_path_nfs_LDADD)
 
 clean-local:
 	rm -f test_session_dir_out test-file opal_path_nfs.out
+
+distclean:
+	rm -rf *.dSYM .deps .libs *.out *.log *.o *.trs $(check_PROGRAMS) Makefile
+


### PR DESCRIPTION
 by ensuring that "make distclean" completely cleans up the test directories