### PR TITLE
Pr/mpi testsome man page update

### DIFF
--- a/ompi/mpi/man/man3/MPI_Testsome.3in
+++ b/ompi/mpi/man/man3/MPI_Testsome.3in
@@ -13,7 +13,8 @@
 .nf
 #include <mpi.h>
 int MPI_Testsome(int \fIincount\fP, MPI_Request \fIarray_of_requests[]\fP,
-	int\fI *outcount\fP, int\fI array_of_indices[]\fP, MPI_Status\fI array_of_statuses[]\fP)
+	int\fI *outcount\fP, int\fI array_of_indices[]\fP,
+	MPI_Status\fI array_of_statuses[]\fP)
 
 .fi
 .SH Fortran Syntax
@@ -43,7 +44,8 @@ MPI_Testsome(\fIincount\fP, \fIarray_of_requests\fP, \fIoutcount\fP, \fIarray_of
 .nf
 #include <mpi.h>
 static int Request::Testsome(int \fIincount\fP, Request
-	\fIarray_of_requests\fP[], int \fIarray_of_indices\fP[], Status \fIarray_of_statuses\fP[])
+	\fIarray_of_requests\fP[], int \fIarray_of_indices\fP[],
+	Status \fIarray_of_statuses\fP[])
 
 static int Request::Testsome(int \fIincount\fP, Request
 	\fIarray_of_requests\fP[], int \fIarray_of_indices\fP[])

--- a/ompi/mpi/man/man3/MPI_Testsome.3in
+++ b/ompi/mpi/man/man3/MPI_Testsome.3in
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
-.\" Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2011-2015 Cisco Systems, Inc.  All rights reserved.
 .\" $COPYRIGHT$
 .TH MPI_Testsome 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -76,7 +76,20 @@ Fortran only: Error status (integer).
 
 .SH DESCRIPTION
 .ft R
-Behaves like MPI_Waitsome, except that it returns immediately. If no operation has completed it returns outcount = 0. If there is no active handle in the list, it returns outcount = MPI_UNDEFINED.
+Behaves like MPI_Waitsome, except that it returns immediately.
+.sp
+Returns in outcount the number of requests from the list
+array_of_requests that have completed. Returns in the first outcount
+locations of the array array_of_indices the indices of these
+operations (index within the array array_of_requests; the array is
+indexed from 0 in C and from 1 in Fortran). Returns in the first
+outcount locations of the array array_of_status the status for these
+completed operations. If a request that completed was allocated by a
+nonblocking communication call, then it is deallocated, and the
+associated handle is set to MPI_REQUEST_NULL.
+.sp
+If no operation has completed it returns outcount = 0. If there is no
+active handle in the list, it returns outcount = MPI_UNDEFINED.
 .sp
 MPI_Testsome is a local operation, which returns immediately, whereas MPI_Waitsome blocks until a communication completes, if it was passed a list that contains at least one active handle. Both calls fulfill a fairness requirement: If a request for a receive repeatedly appears in a list of requests passed to MPI_Waitsome or MPI_Testsome, and a matching send has been posted, then the receive will eventually succeed unless the send is satisfied by another receive; send requests also fulfill this fairness requirement.
 .sp


### PR DESCRIPTION
Instead of solely relying on the out value definitions in MPI_Waitsome.3, explicitly copy this text here.

Note that the original text in this man page was copied verbatim from the MPI spec; we've now added a bit more text (copied from MPI_Waitsome.3in) that explains the out values so that users don't have to cross-reference to another man page.

Thanks to @eschnett for the suggestion.

Fixes open-mpi/ompi#1153