### PR TITLE
fortran: add missing MPI_xxx_DUP_FN bindings

### DIFF
--- a/ompi/mpi/fortran/base/attr-fn-int-callback-interfaces.h
+++ b/ompi/mpi/fortran/base/attr-fn-int-callback-interfaces.h
@@ -4,6 +4,8 @@
 ! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 !                         reserved.
+! Copyright (c) 2015      Research Organization for Information Science
+!                         and Technology (RIST). All rights reserved.
 ! $COPYRIGHT$
 !
 ! Additional copyrights may follow
@@ -60,7 +62,30 @@ interface
      integer :: ierr
   end subroutine MPI_COMM_NULL_DELETE_FN
 
+  subroutine MPI_COMM_DUP_FN(oldcomm, comm_keyval, extra_state, attribute_val_in, &
+                             attribute_val_out, flag, ierr )
+     implicit none
+     include 'mpif-config.h'
+     integer :: oldcomm
+     integer :: comm_keyval
+     integer(kind=MPI_ADDRESS_KIND) :: extra_state, attribute_val_in, attribute_val_out
+     logical :: flag
+     integer :: ierr
+  end subroutine MPI_COMM_DUP_FN
+     
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  subroutine MPI_TYPE_DUP_FN( oldtype, type_keyval, extra_state, &
+                              attribute_val_in, attribute_val_out, &
+                              flag, ierr )
+     implicit none
+     include 'mpif-config.h'
+     integer :: oldtype
+     integer :: type_keyval
+     integer(KIND=MPI_ADDRESS_KIND) :: extra_state, attribute_val_in, attribute_val_out
+     logical :: flag
+     integer :: ierr
+  end subroutine MPI_TYPE_DUP_FN
 
   subroutine MPI_TYPE_NULL_COPY_FN( type, type_keyval, extra_state, &
                                     attribute_val_in, attribute_val_out, &
@@ -85,6 +110,18 @@ interface
   end subroutine MPI_TYPE_NULL_DELETE_FN
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  subroutine MPI_WIN_DUP_FN( oldwin, win_keyval, extra_state, &
+                             attribute_val_in, attribute_val_out, &
+                             flag, ierr)
+     implicit none
+     include 'mpif-config.h'
+     integer :: oldwin
+     integer :: win_keyval
+     integer(kind=MPI_ADDRESS_KIND) :: extra_state, attribute_val_in, attribute_val_out
+     logical :: flag
+     integer :: ierr
+  end subroutine MPI_WIN_DUP_FN
 
   subroutine MPI_WIN_NULL_COPY_FN( window, win_keyval, extra_state, &
                                    attribute_val_in, attribute_val_out, &


### PR DESCRIPTION
- MPI_COMM_DUP_FN
- MPI_TYPE_DUP_FN
- MPI_WIN_DUP_FN