### PR TITLE
Fix intercommunicator split (was triggered by MPICH/icsend test)

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -180,7 +180,7 @@ int ompi_comm_set_nb ( ompi_communicator_t **ncomm,
     if (0 < remote_size) {
         ompi_communicator_t *old_localcomm;
 
-        if (NULL == remote_group || &ompi_mpi_group_null.group == remote_group) {
+        if (NULL == remote_group) {
             ret = ompi_group_incl(oldcomm->c_remote_group, remote_size,
                                   remote_ranks, &newcomm->c_remote_group);
             if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
@@ -432,7 +432,7 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
     int rc=OMPI_SUCCESS;
     ompi_communicator_t *newcomp = NULL;
     int *lranks=NULL, *rranks=NULL;
-    ompi_group_t * local_group=NULL, * remote_group=NULL;
+    ompi_group_t * local_group=NULL;
 
     ompi_comm_allgatherfct *allgatherfct=NULL;
 
@@ -508,7 +508,6 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
     /* Step 2: determine all the information for the remote group */
     /* --------------------------------------------------------- */
     if ( inter ) {
-        remote_group = &ompi_mpi_group_null.group;
         rsize    = comm->c_remote_group->grp_proc_count;
         rresults = (int *) malloc ( rsize * 2 * sizeof(int));
         if ( NULL == rresults ) {
@@ -592,7 +591,7 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
                          comm->error_handler,/* error handler */
                          pass_on_topo,
                          local_group,       /* local group */
-                         remote_group);     /* remote group */
+                         NULL);             /* remote group */
 
     if ( NULL == newcomp ) {
         rc =  MPI_ERR_INTERN;


### PR DESCRIPTION
@hjelmn 
Nathan, it seems that you've introduced remote_group in `ompi_comm_split()` in a88b24ce. Could you review this fix?
With current master I see failures with `icsend` MPICH test. This test does `MPI_Comm_split` of inter-communicator.
In this case `remote_group` is set to `&ompi_mpi_group_null.group`:
https://github.com/open-mpi/ompi/blob/master/ompi/communicator/comm.c#L511
This leads this condition to trigger since `NULL != &ompi_mpi_group_null.group`:
https://github.com/open-mpi/ompi/blob/master/ompi/communicator/comm.c#L151:L153
and this drops `remote_size` that has useful value and was passed through the function arguments.

I may be missing your point in a88b24ce but it seems that some changes introduced there either:
(a) was later removed; or
(b) seems consistent with this change.