### PR TITLE
osc/sm: Fix a bug that `MPI_WIN_TEST` does not update `flag` to 0

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_active_target.c
+++ b/ompi/mca/osc/sm/osc_sm_active_target.c
@@ -315,6 +315,8 @@ ompi_osc_sm_test(struct ompi_win_t *win,
         OBJ_RELEASE(module->post_group);
         module->post_group = NULL;
         *flag = 1;
+    } else {
+        *flag = 0;
     }
 
     OPAL_THREAD_UNLOCK(&module->lock);


### PR DESCRIPTION
`MPI_WIN_TEST` must update the `flag` parameter to 0 when not all
origin processes called `MPI_WIN_COMPLETE`. But sm OSC doesn't.
If the caller initialize the `flag` argument to a non-0 value,
the caller will receive the non-0 `flag` value.

@hjelmn please review

I'll create PRs for v1.10 and v2.0.
