### PR TITLE
btl/openib: add check for IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG

### DIFF
--- a/config/opal_check_openfabrics.m4
+++ b/config/opal_check_openfabrics.m4
@@ -398,7 +398,7 @@ AC_DEFUN([OPAL_CHECK_EXP_VERBS],[
                     AC_MSG_RESULT([no])])
 
     AC_DEFINE_UNQUOTED([HAVE_EXP_VERBS], [$have_struct_ibv_exp_send_wr], [Experimental verbs])
-    AC_CHECK_DECLS([IBV_EXP_ATOMIC_HCA_REPLY_BE, IBV_EXP_QP_CREATE_ATOMIC_BE_REPLY, ibv_exp_create_qp, ibv_exp_query_device],
+    AC_CHECK_DECLS([IBV_EXP_ATOMIC_HCA_REPLY_BE, IBV_EXP_QP_CREATE_ATOMIC_BE_REPLY, ibv_exp_create_qp, ibv_exp_query_device, IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG],
                    [], [], [#include <infiniband/verbs_exp.h>])
     AS_IF([test '$have_struct_ibv_exp_send_wr' = 1], [$1], [$2])
     OPAL_VAR_SCOPE_POP

--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -1337,8 +1337,10 @@ static int udcm_rc_qp_create_one(udcm_module_t *m, mca_btl_base_endpoint_t* lcl_
     init_attr.comp_mask = IBV_EXP_QP_INIT_ATTR_PD;
     init_attr.pd = m->btl->device->ib_pd;
 
+#if HAVE_DECL_IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG
     init_attr.comp_mask |= IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG;
     init_attr.max_atomic_arg = sizeof (int64_t);
+#endif
 
 #if HAVE_DECL_IBV_EXP_ATOMIC_HCA_REPLY_BE
     if (IBV_EXP_ATOMIC_HCA_REPLY_BE == m->btl->device->ib_dev_attr.atomic_cap) {


### PR DESCRIPTION
Mofed 2.2 does not have the IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG attribute
flag. Add a check to fix compilation for mofed 2.2. This commit only
fixes complilation with the older mofed. It will not allow an Open MPI
compiled with mofed 2.3 or newer to work on a machine with mofed 2.2.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>