### PR TITLE
Don't be so prescriptive about the ess component to be used

### DIFF
--- a/orte/mca/ess/lsf/ess_lsf_component.c
+++ b/orte/mca/ess/lsf/ess_lsf_component.c
@@ -71,7 +71,8 @@ int orte_ess_lsf_component_query(mca_base_module_t **module, int *priority)
      * by mpirun in an LSF world
      */
 
-    if (NULL != getenv("LSB_JOBID") &&
+    if (ORTE_PROC_IS_DAEMON &&
+        NULL != getenv("LSB_JOBID") &&
         NULL != orte_process_info.my_hnp_uri) {
         *priority = 40;
         *module = (mca_base_module_t *)&orte_ess_lsf_module;

--- a/orte/mca/ess/tm/ess_tm_component.c
+++ b/orte/mca/ess/tm/ess_tm_component.c
@@ -75,7 +75,8 @@ int orte_ess_tm_component_query(mca_base_module_t **module, int *priority)
      * by mpirun in a tm world
      */
 
-    if (NULL != getenv("PBS_JOBID") &&
+    if (ORTE_PROC_IS_DAEMON &&
+        NULL != getenv("PBS_JOBID") &&
         NULL != orte_process_info.my_hnp_uri) {
         *priority = 30;
         *module = (mca_base_module_t *)&orte_ess_tm_module;

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -420,10 +420,10 @@ static int setup_fork(orte_job_t *jdata,
      */
     opal_setenv("OMPI_MCA_orte_bound_at_launch", "1", true, &app->env);
 
-    /* tell the ESS to select the pmi component - but don't override
+    /* tell the ESS to avoid the singleton component - but don't override
      * anything that may have been provided elsewhere
      */
-    opal_setenv("OMPI_MCA_ess", "pmi", false, &app->env);
+    opal_setenv("OMPI_MCA_ess", "^singleton", false, &app->env);
 
     /* ensure that the spawned process ignores direct launch components */
     opal_setenv("OMPI_MCA_pmix", "^s1,s2,cray", true, &app->env);


### PR DESCRIPTION
We just need to protect against the proc incorrectly taking the singleton component, so rule that one out. Ensure that the other components understand that they are only for use by daemons.