### PR TITLE
Fix MPI_Alltoall to support inter-communicators.

### DIFF
--- a/ompi/mpi/c/alltoall.c
+++ b/ompi/mpi/c/alltoall.c
@@ -92,12 +92,10 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
-    /* Do we need to do anything? Per MPI standard the (v3.1 page 168 line 48)
-     * the amount of data sent must be equal to the amount of data received.
-     */
-    ompi_datatype_type_size(recvtype, &recvtype_size);
-    if( (0 == recvcount) || (0 == recvtype_size) ) {
-        return MPI_SUCCESS;
+    if( !OMPI_COMM_IS_INTER(comm) ){
+        if( (0 == recvcount) || (0 == recvtype_size) ) {
+            return MPI_SUCCESS;
+        }
     }
 
     OPAL_CR_ENTER_LIBRARY();


### PR DESCRIPTION
@bosilca @jsquyres @miked-mellanox @jladd-mlnx @hjelmn 
Hello, I'm seing hangs of the **icalltoall** MPICH/coll tests.

In **icalltoall** hang occured because in line 46:
http://git.mpich.org/mpich-mellanox.git/blob/master:/test/mpi/coll/icalltoall.c#l46
`Alltoall` is called with **zero** receive buffer. In ompi/master we immidiately exit:
https://github.com/open-mpi/ompi/blob/master/ompi/mpi/c/alltoall.c#L99
while in v1.10 we would continue:
https://github.com/open-mpi/ompi-release/blob/v1.10/ompi/mpi/c/alltoall.c#L101:L103

As you can see in https://github.com/open-mpi/ompi/blob/master/ompi/mpi/c/alltoall.c#L99 we will only exit if receive size is 0, we don't have this option for the send buffer.
As the result left side of the inter-communicator immidiately exits `Alltoall` and continues while the right side waits for the collective to complete.

Other collectives are not so strict about that, i.e. **ialltoall** doesn't have this check at all:
https://github.com/open-mpi/ompi/blob/master/ompi/mpi/c/ialltoall.c#L100
The same is for **alltoallv**:
https://github.com/open-mpi/ompi/blob/master/ompi/mpi/c/alltoallv.c#L123

the comment  before deleted piece of code references MPI standard:
```C
-    /* Do we need to do anything? Per MPI standard the (v3.1 page 168 line 48)
-     * the amount of data sent must be equal to the amount of data received.
-     */
-    ompi_datatype_type_size(recvtype, &recvtype_size);
-    if( (0 == recvcount) || (0 == recvtype_size) ) {
-        return MPI_SUCCESS;
-    }
```

Here is the snippet:
```
The type signature associated with sendcount, sendtype, at a process must be equal to the 
type signature associated with recvcount, recvtype at any other process. This implies that 
the amount of data sent must be equal to the amount of data received, pairwise between 
every pair of processes.
```

However I think that comment interprets this only for intra-communicators. In case of inter-communicators we don't know what did processes in other group specified as the sendbuffer/sendcount.
And there is already parameter check for the intra-communicator case in the code:
https://github.com/open-mpi/ompi/blob/master/ompi/mpi/c/alltoall.c#L85:L92

Other collectives seems to be consistent and pass MPICH/coll tests from this perspective.