### PR TITLE
Port the changes from #782 to the master.

### DIFF
--- a/ompi/mpi/c/finalized.c
+++ b/ompi/mpi/c/finalized.c
@@ -11,7 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,8 +39,6 @@ static const char FUNC_NAME[] = "MPI_Finalized";
 
 int MPI_Finalized(int *flag)
 {
-    MPI_Comm null = NULL;
-
     OPAL_CR_NOOP_PROGRESS();
 
     /* We must obtain the lock to guarnatee consistent values of
@@ -63,7 +62,10 @@ int MPI_Finalized(int *flag)
                                               FUNC_NAME);
             } else {
                 opal_mutex_unlock(&ompi_mpi_bootstrap_mutex);
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                 * directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(MPI_ERR_ARG),
                                               FUNC_NAME);
             }
         }

--- a/ompi/mpi/c/get_library_version.c
+++ b/ompi/mpi/c/get_library_version.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +40,6 @@ static const char FUNC_NAME[] = "MPI_Get_library_version";
 int MPI_Get_library_version(char *version, int *resultlen)
 {
     int len_left;
-    MPI_Comm null = MPI_COMM_NULL;
     char *ptr, tmp[MPI_MAX_LIBRARY_VERSION_STRING];
 
     OPAL_CR_NOOP_PROGRESS();
@@ -62,7 +62,10 @@ int MPI_Get_library_version(char *version, int *resultlen)
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                               FUNC_NAME);
             } else {
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                 * directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(MPI_ERR_ARG),
                                               FUNC_NAME);
             }
         }

--- a/ompi/mpi/c/get_version.c
+++ b/ompi/mpi/c/get_version.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,8 +38,6 @@ static const char FUNC_NAME[] = "MPI_Get_version";
 
 int MPI_Get_version(int *version, int *subversion)
 {
-    MPI_Comm null = NULL;
-
     OPAL_CR_NOOP_PROGRESS();
 
     if (MPI_PARAM_CHECK) {
@@ -59,7 +58,10 @@ int MPI_Get_version(int *version, int *subversion)
                 return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                               FUNC_NAME);
             } else {
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                 * directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(MPI_ERR_ARG),
                                               FUNC_NAME);
             }
         }

--- a/ompi/mpi/c/initialized.c
+++ b/ompi/mpi/c/initialized.c
@@ -11,7 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,8 +39,6 @@ static const char FUNC_NAME[] = "MPI_Initialized";
 
 int MPI_Initialized(int *flag)
 {
-    MPI_Comm null = NULL;
-
     OPAL_CR_NOOP_PROGRESS();
 
     /* We must obtain the lock to guarnatee consistent values of
@@ -63,7 +62,10 @@ int MPI_Initialized(int *flag)
                                               FUNC_NAME);
             } else {
                 opal_mutex_unlock(&ompi_mpi_bootstrap_mutex);
-                return OMPI_ERRHANDLER_INVOKE(null, MPI_ERR_ARG,
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                 * directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(MPI_ERR_ARG),
                                               FUNC_NAME);
             }
         }

--- a/opal/mca/event/libevent2022/libevent2022_component.c
+++ b/opal/mca/event/libevent2022/libevent2022_component.c
@@ -123,7 +123,7 @@ const opal_event_component_t mca_event_libevent2022_component = {
 static int libevent2022_register (void)
 {
     const struct eventop** _eventop = eventops;
-    char available_eventops[1024] = "none";
+    char available_eventops[BUFSIZ] = "none";
     char *help_msg = NULL;
     int ret;
 

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -2120,7 +2120,6 @@ static int process(char *orig_line, char *basename, opal_cmd_line_t *cmd_line,
         else {
             goto out;
         }
-        free(tmp);
     }
 
     /* All done -- didn't find it */


### PR DESCRIPTION
Not everything applies here as the code in the 1.10 series is a little different. In addition, we asked for a few changes (e.g., using MPI_ERR_ARG instead of "13") that are incorporated here.

Thanks to @jsharpe for the PR