### PR TITLE
btl-portals4: remove unnecessary PtlMDBind result check

### DIFF
--- a/opal/mca/btl/portals4/btl_portals4_rdma.c
+++ b/opal/mca/btl/portals4/btl_portals4_rdma.c
@@ -78,13 +78,6 @@ mca_btl_portals4_get(struct mca_btl_base_module_t* btl_base,
     frag->endpoint = btl_peer;
     frag->hdr.tag = MCA_BTL_TAG_MAX;
 
-    if (OPAL_UNLIKELY(PTL_OK != ret)) {
-        opal_output_verbose(1, opal_btl_base_framework.framework_output,
-                            "%s:%d: PtlMDBind failed: %d",
-                            __FILE__, __LINE__, ret);
-        return OPAL_ERROR;
-    }
-
     frag->match_bits = remote_handle->key;
     frag->addr = local_address;
     frag->length = size;


### PR DESCRIPTION
When PtlMDBind was removed, the result check was left in which
causes intermittent failures depending on the junk value found in
the 'ret' variable.  The commit removes the result check.

@regrant - please review
