### PR TITLE
java: try do dlopen libmpi with the full path

### DIFF
--- a/config/ompi_setup_java.m4
+++ b/config/ompi_setup_java.m4
@@ -74,6 +74,9 @@ AC_DEFUN([OMPI_SETUP_JAVA_BINDINGS],[
         # header file needs this file, so we need to check for
         # it/include it in our sources when compiling on Mac).
         AC_CHECK_HEADERS([TargetConditionals.h])
+
+        # dladdr and Dl_info are required to build the full path to libmpi on OS X 10.11 aka El Capitan
+        AC_CHECK_TYPES([Dl_info], [], [], [[#include <dlfcn.h>]])
     else
         AC_MSG_RESULT([no])
         WANT_MPI_JAVA_SUPPORT=0

--- a/ompi/mpi/java/c/Makefile.am
+++ b/ompi/mpi/java/c/Makefile.am
@@ -1,9 +1,11 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2012	Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,7 +46,7 @@ libmpi_java_la_SOURCES = \
 	mpi_Status.c \
 	mpi_Win.c
 
-libmpi_java_la_LIBADD = $(top_builddir)/ompi/libmpi.la
+libmpi_java_la_LIBADD = -ldl $(top_builddir)/ompi/libmpi.la
 libmpi_java_la_LDFLAGS = -version-info $(libmpi_java_so_version)
 
 endif

--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -14,6 +14,8 @@
  *                         reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,8 +64,13 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
+#ifdef HAVE_DLFCN_H
 #include <dlfcn.h>
+#endif
 #include <poll.h>
+#ifdef HAVE_LIBGEN_H
+#include <libgen.h>
+#endif
 
 #include "opal/util/output.h"
 #include "opal/datatype/opal_convertor.h"
@@ -126,7 +133,27 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
 {
     libmpi = dlopen("libmpi." OPAL_DYN_LIB_SUFFIX, RTLD_NOW | RTLD_GLOBAL);
 
-    if(libmpi == NULL)
+#if defined(HAVE_DL_INFO) && defined(HAVE_LIBGEN_H)
+    /*
+     * OS X El Capitan does not propagate DYLD_LIBRARY_PATH to children any more
+     * so if previous dlopen failed, try to open libmpi in the same directory
+     * than the current libmpi_java
+     */
+    if(NULL == libmpi) {
+        Dl_info info;
+        if(0 != dladdr((void *)JNI_OnLoad, &info)) {
+            char libmpipath[OPAL_PATH_MAX];
+            char *libmpijavapath = strdup(info.dli_fname);
+            if (NULL != libmpijavapath) {
+                snprintf(libmpipath, OPAL_PATH_MAX-1, "%s/libmpi." OPAL_DYN_LIB_SUFFIX, dirname(libmpijavapath));
+                free(libmpijavapath);
+                libmpi = dlopen(libmpipath, RTLD_NOW | RTLD_GLOBAL);
+            }
+        }
+    }
+#endif
+
+    if(NULL == libmpi)
     {
         fprintf(stderr, "Java bindings failed to load libmpi: %s\n",dlerror());
         exit(1);


### PR DESCRIPTION
Since OS X 10.11 (aka El Capitan) DYLD_LIBRARY_PATH is no more
propagated to children, so try to dlopen libmpi with the full path
(set at configure time)

Fixes open-mpi/ompi#1220

Thanks Alexander Daryin for reporting this