### PR TITLE
Fix openib memory registration limit calculation if cutoff = 0.

### DIFF
--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1044,7 +1044,7 @@ int mca_btl_openib_add_procs(
     }
 
     openib_btl->local_procs += local_procs;
-    openib_btl->device->mem_reg_max /= openib_btl->local_procs;
+    openib_btl->device->mem_reg_max = openib_btl->device->mem_reg_max_total / openib_btl->local_procs;
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -409,7 +409,7 @@ typedef struct mca_btl_openib_device_t {
     /* Maximum value supported by this device for max_inline_data */
     uint32_t max_inline_data;
     /* Registration limit and current count */
-    uint64_t mem_reg_max, mem_reg_active;
+    uint64_t mem_reg_max, mem_reg_max_total, mem_reg_active;
     /* Device is ready for use */
     bool ready_for_use;
     /* Async event */

--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -1630,7 +1630,8 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
     }
 
     device->mem_reg_active = 0;
-    device->mem_reg_max    = calculate_max_reg(ibv_get_device_name(ib_dev));
+    device->mem_reg_max_total = calculate_max_reg(ibv_get_device_name(ib_dev));
+    device->mem_reg_max = device->mem_reg_max_total;
     if(( 0 == device->mem_reg_max) && mca_btl_openib_component.abort_not_enough_reg_mem) {
         return OPAL_ERROR;
     }


### PR DESCRIPTION
Avoid recursive decrease of `openib_btl->device->mem_reg_max`.

@hjelmn, please review