### PR TITLE
odls/alps: changes to accommodate Cray slurm

### DIFF
--- a/orte/mca/odls/alps/odls_alps_component.c
+++ b/orte/mca/odls/alps/odls_alps_component.c
@@ -81,13 +81,14 @@ int orte_odls_alps_component_query(mca_base_module_t **module, int *priority)
     bool flag;
 
     /*
-     * make sure we're in a daemon process
+     * make sure we're in a daemon process.  On systems using
+     * SLURM, can be the HNP process as well
      */
 
-    if (!ORTE_PROC_IS_DAEMON) {
+    if (!(ORTE_PROC_IS_DAEMON || ORTE_PROC_IS_HNP)) {
         *priority = 0;
         *module = NULL;
-        rc = ORTE_ERROR;
+        return rc;
     }
 
     /*

--- a/orte/mca/odls/alps/odls_alps_utils.c
+++ b/orte/mca/odls/alps/odls_alps_utils.c
@@ -72,7 +72,8 @@ int orte_odls_alps_get_rdma_creds(void)
      * application processes can actually use the HSN API (uGNI).
      */
 
-    if (ORTE_PROC_IS_DAEMON) {
+    if (ORTE_PROC_IS_DAEMON || ORTE_PROC_IS_HNP) {
+
 
         ret = alps_app_lli_lock();
 


### PR DESCRIPTION
It turns out on Cray systems running nativized
SLURM, that the ORTE HNP daemon actually launches
the MPI processes on the first node in the
allocation.  Changes to the odls/alps launcher
to account for this.

@hjelmn 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>