### PR TITLE
Fix vader resource leak.

### DIFF
--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -263,6 +263,14 @@ mca_btl_base_descriptor_t* mca_btl_vader_alloc (struct mca_btl_base_module_t* bt
                                                 struct mca_btl_base_endpoint_t* endpoint,
                                                 uint8_t order, size_t size, uint32_t flags);
 
+/**
+ * Return a segment allocated by this BTL.
+ *
+ * @param btl (IN)      BTL module
+ * @param segment (IN)  Allocated segment.
+ */
+int mca_btl_vader_free (struct mca_btl_base_module_t *btl, mca_btl_base_descriptor_t *des);
+
 
 END_C_DECLS
 

--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -43,8 +43,6 @@ static int vader_register_error_cb (struct mca_btl_base_module_t* btl,
 
 static int vader_finalize (struct mca_btl_base_module_t* btl);
 
-static int vader_free (struct mca_btl_base_module_t* btl, mca_btl_base_descriptor_t* des);
-
 static struct mca_btl_base_descriptor_t *vader_prepare_src (
                                                             struct mca_btl_base_module_t *btl,
                                                             struct mca_btl_base_endpoint_t *endpoint,
@@ -69,7 +67,7 @@ mca_btl_vader_t mca_btl_vader = {
         .btl_del_procs = vader_del_procs,
         .btl_finalize = vader_finalize,
         .btl_alloc = mca_btl_vader_alloc,
-        .btl_free = vader_free,
+        .btl_free = mca_btl_vader_free,
         .btl_prepare_src = vader_prepare_src,
         .btl_send = mca_btl_vader_send,
         .btl_sendi = mca_btl_vader_sendi,
@@ -411,7 +409,7 @@ mca_btl_base_descriptor_t *mca_btl_vader_alloc(struct mca_btl_base_module_t *btl
  * @param btl (IN)      BTL module
  * @param segment (IN)  Allocated segment.
  */
-static int vader_free (struct mca_btl_base_module_t *btl, mca_btl_base_descriptor_t *des)
+int mca_btl_vader_free (struct mca_btl_base_module_t *btl, mca_btl_base_descriptor_t *des)
 {
     MCA_BTL_VADER_FRAG_RETURN((mca_btl_vader_frag_t *) des);
 

--- a/opal/mca/btl/vader/btl_vader_sendi.c
+++ b/opal/mca/btl/vader/btl_vader_sendi.c
@@ -105,6 +105,8 @@ int mca_btl_vader_sendi (struct mca_btl_base_module_t *btl,
     if (!vader_fifo_write_ep (frag->hdr, endpoint)) {
         if (descriptor) {
             *descriptor = &frag->base;
+        } else {
+            mca_btl_vader_free (btl, &frag->base);
         }
         return OPAL_ERR_OUT_OF_RESOURCE;
     }


### PR DESCRIPTION
This nasty bug was nicely masked. It was causing `mca_btl_vader_component.vader_frags_user`
overflow and as the result rear hangs of ompi-test-suite.

@hjelmn, please review.