### PR TITLE
use the actual preadv and pwritev functions if available. That's what…

### DIFF
--- a/ompi/mca/fbtl/posix/configure.m4
+++ b/ompi/mca/fbtl/posix/configure.m4
@@ -32,6 +32,9 @@ AC_DEFUN([MCA_ompi_fbtl_posix_CONFIG],[
                                     [aio_write], [rt],
                                     [fbtl_posix_happy="yes"])])
 
+    AC_CHECK_FUNCS([pwritev],[],[])
+    AC_CHECK_FUNCS([preadv],[],[])
+
     AS_IF([test "$fbtl_posix_happy" = "yes"],
           [$1],
           [$2])

--- a/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_preadv.c
@@ -80,6 +80,12 @@ ssize_t mca_fbtl_posix_preadv (mca_io_ompio_file_t *fh )
 	    }
 	}
 
+#if defined(HAVE_PREADV)
+	ret_code = preadv (fh->fd, iov, iov_count, iov_offset);
+	if ( 0 < ret_code ) {
+	    bytes_read+=ret_code;
+	}
+#else
 	if (-1 == lseek (fh->fd, iov_offset, SEEK_SET)) {
             opal_output(1, "lseek:%s", strerror(errno));
             free(iov);
@@ -89,6 +95,7 @@ ssize_t mca_fbtl_posix_preadv (mca_io_ompio_file_t *fh )
 	if ( 0 < ret_code ) {
 	    bytes_read+=ret_code;
 	}
+#endif
 	else if ( ret_code == -1 ) {
             opal_output(1, "readv:%s", strerror(errno));
             free(iov);

--- a/ompi/mca/fbtl/posix/fbtl_posix_pwritev.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_pwritev.c
@@ -93,6 +93,13 @@ ssize_t  mca_fbtl_posix_pwritev(mca_io_ompio_file_t *fh )
 	  }
 
 	*/
+#if defined (HAVE_PWRITEV) 
+	ret_code = pwritev (fh->fd, iov, iov_count, iov_offset);
+	if ( 0 < ret_code ) {
+	    bytes_written += ret_code;
+	}
+
+#else
 	if (-1 == lseek (fh->fd, iov_offset, SEEK_SET)) {
 	    opal_output(1, "lseek:%s", strerror(errno));
             free(iov);
@@ -102,6 +109,7 @@ ssize_t  mca_fbtl_posix_pwritev(mca_io_ompio_file_t *fh )
 	if ( 0 < ret_code ) {
 	    bytes_written += ret_code;
 	}
+#endif
 	else if (-1 == ret_code ) {
 	    opal_output(1, "writev:%s", strerror(errno));
             free (iov);


### PR DESCRIPTION
… the fbtl interfaces have been designed for.