### PR TITLE
ompi/group: do not decrement parent group proc pointers in destruct

### DIFF
--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -295,7 +295,6 @@ static void ompi_group_destruct(ompi_group_t *group)
     }
 
     if (NULL != group->grp_parent_group_ptr){
-        ompi_group_decrement_proc_count(group->grp_parent_group_ptr);
         OBJ_RELEASE(group->grp_parent_group_ptr);
     }
 


### PR DESCRIPTION
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>