### PR TITLE
hwloc_base_util.c: Remove newly unused variable 'i'.

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -541,7 +541,6 @@ unsigned int opal_hwloc_base_get_npus(hwloc_topology_t topo,
                                       hwloc_obj_t obj)
 {
     opal_hwloc_obj_data_t *data;
-    int i;
     unsigned int cnt = 0;
     hwloc_cpuset_t cpuset;
 


### PR DESCRIPTION
Missed removing the loop variable when I replaced the loop with a function call in pull request https://github.com/open-mpi/ompi/pull/1297