### PR TITLE
MPI_Info update (2nd / corrected PR)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ dgdimick@lnal.gov               Denis Dimick                LANL
 dgoodell@cisco.com              Dave Goodell                Cisco
 donald.kerr@oracle.com          Donald Kerr                 Sun, Oracle
 dorons@mellanox.com             Doron Shoham                Mellanox
+dsolt@us.ibm.com                David Solt                  IBM
 ethan.mallove@oracle.com        Ethan Mallove               Sun, Oracle
 eugene.loh@oracle.com           Eugene Loh                  Sun, Oracle
 gabriel@cs.uh.edu               Edgar Gabriel               HLRS, UH, UTK

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -22,6 +22,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,7 +87,7 @@ static int ompi_comm_copy_topo (ompi_communicator_t *oldcomm,
 
 /* idup with local group and info. the local group support is provided to support ompi_comm_set_nb */
 static int ompi_comm_idup_internal (ompi_communicator_t *comm, ompi_group_t *group, ompi_group_t *remote_group,
-                                    ompi_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req);
+                                    opal_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req);
 
 
 /**********************************************************************/
@@ -787,7 +788,7 @@ static int ompi_comm_split_type_get_part (ompi_group_t *group, int *results, int
 int
 ompi_comm_split_type(ompi_communicator_t *comm,
                      int split_type, int key,
-                     ompi_info_t *info,
+                     opal_info_t *info,
                      ompi_communicator_t** newcomm)
 {
     int myinfo[2];
@@ -998,7 +999,7 @@ int ompi_comm_dup ( ompi_communicator_t * comm, ompi_communicator_t **newcomm )
 /**********************************************************************/
 /**********************************************************************/
 /**********************************************************************/
-int ompi_comm_dup_with_info ( ompi_communicator_t * comm, ompi_info_t *info, ompi_communicator_t **newcomm )
+int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info, ompi_communicator_t **newcomm )
 {
     ompi_communicator_t *newcomp = NULL;
     ompi_group_t *remote_group = NULL;
@@ -1076,14 +1077,14 @@ int ompi_comm_idup (ompi_communicator_t *comm, ompi_communicator_t **newcomm, om
     return ompi_comm_idup_with_info (comm, NULL, newcomm, req);
 }
 
-int ompi_comm_idup_with_info (ompi_communicator_t *comm, ompi_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req)
+int ompi_comm_idup_with_info (ompi_communicator_t *comm, opal_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req)
 {
     return ompi_comm_idup_internal (comm, comm->c_local_group, comm->c_remote_group, info, newcomm, req);
 }
 
 /* NTH: we need a way to idup with a smaller local group so this function takes a local group */
 static int ompi_comm_idup_internal (ompi_communicator_t *comm, ompi_group_t *group, ompi_group_t *remote_group,
-                                    ompi_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req)
+                                    opal_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req)
 {
     struct ompi_comm_idup_with_info_context *context;
     ompi_comm_request_t *request;

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -21,6 +21,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +34,7 @@
 #include <stdio.h>
 
 #include "opal/util/bit_ops.h"
+#include "opal/util/info_subscriber.h"
 #include "ompi/constants.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/coll/base/base.h"
@@ -52,9 +54,9 @@
 opal_pointer_array_t ompi_mpi_communicators = {{0}};
 opal_pointer_array_t ompi_comm_f_to_c_table = {{0}};
 
-ompi_predefined_communicator_t  ompi_mpi_comm_world = {{{0}}};
-ompi_predefined_communicator_t  ompi_mpi_comm_self = {{{0}}};
-ompi_predefined_communicator_t  ompi_mpi_comm_null = {{{0}}};
+ompi_predefined_communicator_t  ompi_mpi_comm_world = {{{{0}}}};
+ompi_predefined_communicator_t  ompi_mpi_comm_self = {{{{0}}}};
+ompi_predefined_communicator_t  ompi_mpi_comm_null = {{{{0}}}};
 ompi_communicator_t  *ompi_mpi_comm_parent = NULL;
 
 ompi_predefined_communicator_t *ompi_mpi_comm_world_addr =
@@ -67,7 +69,7 @@ ompi_predefined_communicator_t *ompi_mpi_comm_null_addr =
 static void ompi_comm_construct(ompi_communicator_t* comm);
 static void ompi_comm_destruct(ompi_communicator_t* comm);
 
-OBJ_CLASS_INSTANCE(ompi_communicator_t, opal_object_t,
+OBJ_CLASS_INSTANCE(ompi_communicator_t, opal_infosubscriber_t,
                    ompi_comm_construct,
                    ompi_comm_destruct);
 

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -20,6 +20,7 @@
  * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 
 #include "ompi_config.h"
 #include "opal/class/opal_object.h"
+#include "opal/class/opal_hash_table.h"
+#include "opal/util/info_subscriber.h"
 #include "ompi/errhandler/errhandler.h"
 #include "opal/threads/mutex.h"
 #include "ompi/communicator/comm_request.h"
@@ -115,7 +118,7 @@ OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_communicators;
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_comm_f_to_c_table;
 
 struct ompi_communicator_t {
-    opal_object_t              c_base;
+    opal_infosubscriber_t      super;
     opal_mutex_t               c_lock; /* mutex for name and potentially
                                           attributes */
     char  c_name[MPI_MAX_OBJECT_NAME];
@@ -420,7 +423,7 @@ OMPI_DECLSPEC int ompi_comm_split (ompi_communicator_t *comm, int color, int key
  */
 OMPI_DECLSPEC int ompi_comm_split_type(ompi_communicator_t *comm,
                                        int split_type, int key,
-                                       struct ompi_info_t *info,
+                                       struct opal_info_t *info,
                                        ompi_communicator_t** newcomm);
 
 /**
@@ -451,7 +454,7 @@ OMPI_DECLSPEC int ompi_comm_idup (ompi_communicator_t *comm, ompi_communicator_t
  * @param comm:      input communicator
  * @param newcomm:   the new communicator or MPI_COMM_NULL if any error is detected.
  */
-OMPI_DECLSPEC int ompi_comm_dup_with_info (ompi_communicator_t *comm, ompi_info_t *info, ompi_communicator_t **newcomm);
+OMPI_DECLSPEC int ompi_comm_dup_with_info (ompi_communicator_t *comm, opal_info_t *info, ompi_communicator_t **newcomm);
 
 /**
  * dup a communicator (non-blocking) with info.
@@ -461,7 +464,7 @@ OMPI_DECLSPEC int ompi_comm_dup_with_info (ompi_communicator_t *comm, ompi_info_
  * @param comm:      input communicator
  * @param newcomm:   the new communicator or MPI_COMM_NULL if any error is detected.
  */
-OMPI_DECLSPEC int ompi_comm_idup_with_info (ompi_communicator_t *comm, ompi_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req);
+OMPI_DECLSPEC int ompi_comm_idup_with_info (ompi_communicator_t *comm, opal_info_t *info, ompi_communicator_t **newcomm, ompi_request_t **req);
 
 /**
  * compare two communicators.

--- a/ompi/debuggers/ompi_mpihandles_dll.c
+++ b/ompi/debuggers/ompi_mpihandles_dll.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -234,7 +235,7 @@ int mpidbg_init_per_image(mqs_image *image, const mqs_image_callbacks *icb,
         mqs_find_type(image, "ompi_file_t", mqs_lang_c);
     handle_types->hi_c_group = i_info->ompi_group_t.type;
     handle_types->hi_c_info =
-        mqs_find_type(image, "ompi_info_t", mqs_lang_c);
+        mqs_find_type(image, "opal_info_t", mqs_lang_c);
     /* JMS: "MPI_Offset" is a typedef (see comment about MPI_Aint above) */
     handle_types->hi_c_offset =
         mqs_find_type(image, "MPI_Offset", mqs_lang_c);

--- a/ompi/debuggers/predefined_gap_test.c
+++ b/ompi/debuggers/predefined_gap_test.c
@@ -5,6 +5,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,8 +53,8 @@ int main(int argc, char **argv) {
     /* Test Predefined communicator sizes */
     printf("ompi_predefined_communicator_t = %lu bytes\n", sizeof(ompi_predefined_communicator_t));
     printf("ompi_communicator_t = %lu bytes\n", sizeof(ompi_communicator_t));
-    GAP_CHECK("c_base", test_comm, c_base, c_base, 0);
-    GAP_CHECK("c_lock", test_comm, c_lock, c_base, 1);
+    GAP_CHECK("c_base", test_comm, super, super, 0);
+    GAP_CHECK("c_lock", test_comm, c_lock, super, 1);
     GAP_CHECK("c_name", test_comm, c_name, c_lock, 1);
     GAP_CHECK("c_contextid", test_comm, c_contextid, c_name, 1);
     GAP_CHECK("c_my_rank", test_comm, c_my_rank, c_contextid, 1);
@@ -120,8 +121,8 @@ int main(int argc, char **argv) {
     printf("=============================================\n");
     printf("ompi_predefined_win_t = %lu bytes\n", sizeof(ompi_predefined_win_t));
     printf("ompi_win_t = %lu bytes\n", sizeof(ompi_win_t));
-    GAP_CHECK("w_base", test_win, w_base, w_base, 0);
-    GAP_CHECK("w_lock", test_win, w_lock, w_base, 1);
+    GAP_CHECK("super", test_win, super, super, 0);
+    GAP_CHECK("w_lock", test_win, w_lock, super, 1);
     GAP_CHECK("w_name", test_win, w_name, w_lock, 1);
     GAP_CHECK("w_group", test_win, w_group, w_name, 1);
     GAP_CHECK("w_flags", test_win, w_flags, w_group, 1);
@@ -137,8 +138,7 @@ int main(int argc, char **argv) {
     printf("ompi_info_t = %lu bytes\n", sizeof(ompi_info_t));
     GAP_CHECK("super", test_info, super, super, 0);
     GAP_CHECK("i_f_to_c_index", test_info, i_f_to_c_index, super, 1);
-    GAP_CHECK("i_lock", test_info, i_lock, i_f_to_c_index, 1);
-    GAP_CHECK("i_freed", test_info, i_freed, i_lock, 1);
+    GAP_CHECK("i_freed", test_info, i_freed, i_f_to_c_index, 1);
 
     /* Test Predefined file sizes */
     printf("=============================================\n");
@@ -148,8 +148,7 @@ int main(int argc, char **argv) {
     GAP_CHECK("f_comm", test_file, f_comm, super, 1);
     GAP_CHECK("f_filename", test_file, f_filename, f_comm, 1);
     GAP_CHECK("f_amode", test_file, f_amode,  f_filename, 1);
-    GAP_CHECK("f_info", test_file, f_info, f_amode,  1);
-    GAP_CHECK("f_flags", test_file, f_flags, f_info,  1);
+    GAP_CHECK("f_flags", test_file, f_flags, f_amode,  1);
     GAP_CHECK("f_f_to_c_index", test_file, f_f_to_c_index, f_flags, 1);
     GAP_CHECK("error_handler", test_file, error_handler, f_f_to_c_index, 1);
     GAP_CHECK("errhandler_type", test_file, errhandler_type, error_handler, 1);

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -708,7 +709,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
         if ( array_of_info != NULL && array_of_info[i] != MPI_INFO_NULL ) {
 
             /* check for personality - this is a job-level key */
-            ompi_info_get (array_of_info[i], "personality", sizeof(host) - 1, host, &flag);
+            opal_info_get (array_of_info[i], "personality", sizeof(host) - 1, host, &flag);
             if ( flag ) {
                 personality = true;
                 info = OBJ_NEW(opal_value_t);
@@ -718,7 +719,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'host' */
-            ompi_info_get (array_of_info[i], "host", sizeof(host) - 1, host, &flag);
+            opal_info_get (array_of_info[i], "host", sizeof(host) - 1, host, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_HOST);
@@ -727,7 +728,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'hostfile' */
-            ompi_info_get (array_of_info[i], "hostfile", sizeof(host) - 1, host, &flag);
+            opal_info_get (array_of_info[i], "hostfile", sizeof(host) - 1, host, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_HOSTFILE);
@@ -736,7 +737,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'add-hostfile' */
-            ompi_info_get (array_of_info[i], "add-hostfile", sizeof(host) - 1, host, &flag);
+            opal_info_get (array_of_info[i], "add-hostfile", sizeof(host) - 1, host, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_ADD_HOSTFILE);
@@ -745,7 +746,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'add-host' */
-            ompi_info_get (array_of_info[i], "add-host", sizeof(host) - 1, host, &flag);
+            opal_info_get (array_of_info[i], "add-host", sizeof(host) - 1, host, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_ADD_HOST);
@@ -754,7 +755,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for env */
-            ompi_info_get (array_of_info[i], "env", sizeof(host)-1, host, &flag);
+            opal_info_get (array_of_info[i], "env", sizeof(host)-1, host, &flag);
             if ( flag ) {
                 envars = opal_argv_split(host, '\n');
                 for (j=0; NULL != envars[j]; j++) {
@@ -770,7 +771,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
              *
              * This is a job-level key
              */
-            ompi_info_get (array_of_info[i], "ompi_prefix", sizeof(prefix) - 1, prefix, &flag);
+            opal_info_get (array_of_info[i], "ompi_prefix", sizeof(prefix) - 1, prefix, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_PREFIX);
@@ -779,7 +780,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'wdir' */
-            ompi_info_get (array_of_info[i], "wdir", sizeof(cwd) - 1, cwd, &flag);
+            opal_info_get (array_of_info[i], "wdir", sizeof(cwd) - 1, cwd, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_WDIR);
@@ -789,7 +790,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'mapper' - a job-level key */
-            ompi_info_get(array_of_info[i], "mapper", sizeof(mapper) - 1, mapper, &flag);
+            opal_info_get(array_of_info[i], "mapper", sizeof(mapper) - 1, mapper, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_MAPPER);
@@ -798,7 +799,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'display_map' - a job-level key */
-            ompi_info_get_bool(array_of_info[i], "display_map", &local_spawn, &flag);
+            opal_info_get_bool(array_of_info[i], "display_map", &local_spawn, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_DISPLAY_MAP);
@@ -807,7 +808,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'npernode' and 'ppr' - job-level key */
-            ompi_info_get (array_of_info[i], "npernode", sizeof(slot_list) - 1, slot_list, &flag);
+            opal_info_get (array_of_info[i], "npernode", sizeof(slot_list) - 1, slot_list, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_PPR);
@@ -815,14 +816,14 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                 (void)asprintf(&(info->data.string), "%s:n", slot_list);
                 opal_list_append(&job_info, &info->super);
             }
-            ompi_info_get (array_of_info[i], "pernode", sizeof(slot_list) - 1, slot_list, &flag);
+            opal_info_get (array_of_info[i], "pernode", sizeof(slot_list) - 1, slot_list, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_PPR);
                 opal_value_load(info, "1:n", OPAL_STRING);
                 opal_list_append(&job_info, &info->super);
             }
-            ompi_info_get (array_of_info[i], "ppr", sizeof(slot_list) - 1, slot_list, &flag);
+            opal_info_get (array_of_info[i], "ppr", sizeof(slot_list) - 1, slot_list, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_PPR);
@@ -831,7 +832,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'map_by' - job-level key */
-            ompi_info_get(array_of_info[i], "map_by", sizeof(slot_list) - 1, slot_list, &flag);
+            opal_info_get(array_of_info[i], "map_by", sizeof(slot_list) - 1, slot_list, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_MAPBY);
@@ -840,7 +841,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'rank_by' - job-level key */
-            ompi_info_get(array_of_info[i], "rank_by", sizeof(slot_list) - 1, slot_list, &flag);
+            opal_info_get(array_of_info[i], "rank_by", sizeof(slot_list) - 1, slot_list, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_RANKBY);
@@ -849,7 +850,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'bind_to' - job-level key */
-            ompi_info_get(array_of_info[i], "bind_to", sizeof(slot_list) - 1, slot_list, &flag);
+            opal_info_get(array_of_info[i], "bind_to", sizeof(slot_list) - 1, slot_list, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_BINDTO);
@@ -858,7 +859,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'preload_binary' - job-level key */
-            ompi_info_get_bool(array_of_info[i], "ompi_preload_binary", &local_spawn, &flag);
+            opal_info_get_bool(array_of_info[i], "ompi_preload_binary", &local_spawn, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_PRELOAD_BIN);
@@ -867,7 +868,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* check for 'preload_files' - job-level key */
-            ompi_info_get (array_of_info[i], "ompi_preload_files", sizeof(cwd) - 1, cwd, &flag);
+            opal_info_get (array_of_info[i], "ompi_preload_files", sizeof(cwd) - 1, cwd, &flag);
             if ( flag ) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_PRELOAD_FILES);
@@ -878,7 +879,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             /* see if this is a non-mpi job - if so, then set the flag so ORTE
              * knows what to do - job-level key
              */
-            ompi_info_get_bool(array_of_info[i], "ompi_non_mpi", &non_mpi, &flag);
+            opal_info_get_bool(array_of_info[i], "ompi_non_mpi", &non_mpi, &flag);
             if (flag && non_mpi) {
                 info = OBJ_NEW(opal_value_t);
                 info->key = strdup(OPAL_PMIX_NON_PMI);
@@ -887,7 +888,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             }
 
             /* see if this is an MCA param that the user wants applied to the child job */
-            ompi_info_get (array_of_info[i], "ompi_param", sizeof(params) - 1, params, &flag);
+            opal_info_get (array_of_info[i], "ompi_param", sizeof(params) - 1, params, &flag);
             if ( flag ) {
                 opal_argv_append_unique_nosize(&app->env, params, true);
             }
@@ -895,7 +896,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             /* see if user specified what to do with stdin - defaults to
              * not forwarding stdin to child processes - job-level key
              */
-            ompi_info_get (array_of_info[i], "ompi_stdin_target", sizeof(stdin_target) - 1, stdin_target, &flag);
+            opal_info_get (array_of_info[i], "ompi_stdin_target", sizeof(stdin_target) - 1, stdin_target, &flag);
             if ( flag ) {
                 if (0 == strcmp(stdin_target, "all")) {
                     ui32 = ORTE_VPID_WILDCARD;

--- a/ompi/file/file.c
+++ b/ompi/file/file.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +40,7 @@ opal_pointer_array_t ompi_file_f_to_c_table = {{0}};
 /*
  * MPI_FILE_NULL (_addr flavor is for F03 bindings)
  */
-ompi_predefined_file_t  ompi_mpi_file_null = {{{0}}};
+ompi_predefined_file_t  ompi_mpi_file_null = {{{{0}}}};
 ompi_predefined_file_t  *ompi_mpi_file_null_addr = &ompi_mpi_file_null;
 
 
@@ -54,7 +55,7 @@ static void file_destructor(ompi_file_t *obj);
  * Class instance for ompi_file_t
  */
 OBJ_CLASS_INSTANCE(ompi_file_t,
-                   opal_object_t,
+                   opal_infosubscriber_t,
                    file_constructor,
                    file_destructor);
 
@@ -92,7 +93,7 @@ int ompi_file_init(void)
  * Back end to MPI_FILE_OPEN
  */
 int ompi_file_open(struct ompi_communicator_t *comm, const char *filename,
-                   int amode, struct ompi_info_t *info, ompi_file_t **fh)
+                   int amode, struct opal_info_t *info, ompi_file_t **fh)
 {
     int ret;
     ompi_file_t *file;
@@ -107,17 +108,11 @@ int ompi_file_open(struct ompi_communicator_t *comm, const char *filename,
     file->f_comm = comm;
     OBJ_RETAIN(comm);
 
-    if (MPI_INFO_NULL != info) {
-        if(NULL == file->f_info) {
-            file->f_info = OBJ_NEW(ompi_info_t);
-        }
-        if (OMPI_SUCCESS != (ret = ompi_info_dup(info, &file->f_info))) {
-            OBJ_RELEASE(file);
-            return ret;
-        }
-    } else {
-        file->f_info = MPI_INFO_NULL;
-        OBJ_RETAIN(MPI_INFO_NULL);
+    /* Present the info to the info layer */
+
+    if (OPAL_SUCCESS != opal_infosubscribe_change_info(&file->super, info)) {
+        OBJ_RELEASE(file);
+        return ret;
     }
 
     file->f_amode = amode;
@@ -224,7 +219,6 @@ static void file_constructor(ompi_file_t *file)
     file->f_comm = NULL;
     file->f_filename = NULL;
     file->f_amode = 0;
-    file->f_info = NULL;
 
     /* Initialize flags */
 
@@ -301,13 +295,6 @@ static void file_destructor(ompi_file_t *file)
         OBJ_RELEASE(file->error_handler);
 #if OPAL_ENABLE_DEBUG
         file->error_handler = NULL;
-#endif
-    }
-
-    if (NULL != file->f_info) {
-        OBJ_RELEASE(file->f_info);
-#if OPAL_ENABLE_DEBUG
-        file->f_info = NULL;
 #endif
     }
 

--- a/ompi/file/file.h
+++ b/ompi/file/file.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +30,7 @@
 #include "opal/class/opal_list.h"
 #include "ompi/errhandler/errhandler.h"
 #include "opal/threads/mutex.h"
+#include "opal/util/info_subscriber.h"
 #include "ompi/mca/io/io.h"
 
 /*
@@ -44,7 +46,7 @@ BEGIN_C_DECLS
  */
 struct ompi_file_t {
     /** Base of OBJ_* interface */
-    opal_object_t super;
+    opal_infosubscriber_t super;
 
     /** Communicator that this file was created with */
     struct ompi_communicator_t *f_comm;
@@ -54,10 +56,6 @@ struct ompi_file_t {
 
     /** Amode that this file was created with */
     int f_amode;
-
-    /** MPI_Info that this file was created with.  Note that this is
-        *NOT* what should be returned from OMPI_FILE_GET_INFO! */
-    struct ompi_info_t *f_info;
 
     /** Bit flags */
     int32_t f_flags;
@@ -148,7 +146,7 @@ int ompi_file_init(void);
  * handling as well.
  */
 int ompi_file_open(struct ompi_communicator_t *comm, const char *filename,
-                   int amode, struct ompi_info_t *info,
+                   int amode, struct opal_info_t *info,
                    ompi_file_t **fh);
 
 /**

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,45 +44,32 @@
 #include "opal/util/opal_getcwd.h"
 #include "opal/util/output.h"
 #include "opal/util/strncpy.h"
+#include "opal/util/info.h"
 
 #include "ompi/info/info.h"
 #include "ompi/runtime/mpiruntime.h"
 #include "ompi/runtime/params.h"
 
-
 /*
  * Global variables
  */
-ompi_predefined_info_t ompi_mpi_info_null = {{{{0}}}};
+ompi_predefined_info_t ompi_mpi_info_null;
 ompi_predefined_info_t *ompi_mpi_info_null_addr = &ompi_mpi_info_null;
-ompi_predefined_info_t ompi_mpi_info_env = {{{{0}}}};
-
+ompi_predefined_info_t ompi_mpi_info_env;
 
 /*
  * Local functions
  */
 static void info_constructor(ompi_info_t *info);
 static void info_destructor(ompi_info_t *info);
-static void info_entry_constructor(ompi_info_entry_t *entry);
-static void info_entry_destructor(ompi_info_entry_t *entry);
-static ompi_info_entry_t *info_find_key (ompi_info_t *info, const char *key);
-
 
 /*
  * ompi_info_t classes
  */
 OBJ_CLASS_INSTANCE(ompi_info_t,
-                   opal_list_t,
+                   opal_info_t,
                    info_constructor,
                    info_destructor);
-
-/*
- * ompi_info_entry_t classes
- */
-OBJ_CLASS_INSTANCE(ompi_info_entry_t,
-                   opal_list_item_t,
-                   info_entry_constructor,
-                   info_entry_destructor);
 
 /*
  * The global fortran <-> C translation table
@@ -93,7 +81,7 @@ opal_pointer_array_t ompi_info_f_to_c_table = {{0}};
  * fortran to C translation table. It also fills in the values
  * for the MPI_INFO_GET_ENV object
  */
-int ompi_info_init(void)
+int ompi_mpiinfo_init(void)
 {
     char val[MPI_MAX_INFO_VAL];
     char *cptr;
@@ -118,35 +106,35 @@ int ompi_info_init(void)
 
     /* command for this app_context */
     if (NULL != (cptr = getenv("OMPI_COMMAND"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "command", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "command", cptr);
     }
 
     /* space-separated list of argv for this command */
     if (NULL != (cptr = getenv("OMPI_ARGV"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "argv", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "argv", cptr);
     }
 
     /* max procs for the entire job */
     if (NULL != (cptr = getenv("OMPI_MCA_orte_ess_num_procs"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "maxprocs", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "maxprocs", cptr);
         /* Open MPI does not support the "soft" option, so set it to maxprocs */
-        ompi_info_set(&ompi_mpi_info_env.info, "soft", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "soft", cptr);
     }
 
     /* local host name */
     gethostname(val, MPI_MAX_INFO_VAL);
-    ompi_info_set(&ompi_mpi_info_env.info, "host", val);
+    opal_info_set(&ompi_mpi_info_env.info.super, "host", val);
 
     /* architecture name */
     if (NULL != (cptr = getenv("OMPI_MCA_orte_cpu_type"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "arch", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "arch", cptr);
     }
 #ifdef HAVE_SYS_UTSNAME_H
     else {
         struct utsname sysname;
         uname(&sysname);
         cptr = sysname.machine;
-        ompi_info_set(&ompi_mpi_info_env.info, "arch", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "arch", cptr);
     }
 #endif
 
@@ -155,7 +143,7 @@ int ompi_info_init(void)
      * of determining the value
      */
     if (NULL != (cptr = getenv("OMPI_MCA_initial_wdir"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "wdir", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "wdir", cptr);
     }
 
     /* provide the REQUESTED thread level - may be different
@@ -163,16 +151,16 @@ int ompi_info_init(void)
      * ugly, but have to do a switch to find the string representation */
     switch (ompi_mpi_thread_requested) {
     case MPI_THREAD_SINGLE:
-        ompi_info_set(&ompi_mpi_info_env.info, "thread_level", "MPI_THREAD_SINGLE");
+        opal_info_set(&ompi_mpi_info_env.info.super, "thread_level", "MPI_THREAD_SINGLE");
         break;
     case MPI_THREAD_FUNNELED:
-        ompi_info_set(&ompi_mpi_info_env.info, "thread_level", "MPI_THREAD_FUNNELED");
+        opal_info_set(&ompi_mpi_info_env.info.super, "thread_level", "MPI_THREAD_FUNNELED");
         break;
     case MPI_THREAD_SERIALIZED:
-        ompi_info_set(&ompi_mpi_info_env.info, "thread_level", "MPI_THREAD_SERIALIZED");
+        opal_info_set(&ompi_mpi_info_env.info.super, "thread_level", "MPI_THREAD_SERIALIZED");
         break;
     case MPI_THREAD_MULTIPLE:
-        ompi_info_set(&ompi_mpi_info_env.info, "thread_level", "MPI_THREAD_MULTIPLE");
+        opal_info_set(&ompi_mpi_info_env.info.super, "thread_level", "MPI_THREAD_MULTIPLE");
         break;
     default:
         /* do nothing - don't know the value */
@@ -183,24 +171,24 @@ int ompi_info_init(void)
 
     /* the number of app_contexts in this job */
     if (NULL != (cptr = getenv("OMPI_NUM_APP_CTX"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "ompi_num_apps", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "ompi_num_apps", cptr);
     }
 
     /* space-separated list of first MPI rank of each app_context */
     if (NULL != (cptr = getenv("OMPI_FIRST_RANKS"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "ompi_first_rank", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "ompi_first_rank", cptr);
     }
 
     /* space-separated list of num procs for each app_context */
     if (NULL != (cptr = getenv("OMPI_APP_CTX_NUM_PROCS"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "ompi_np", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "ompi_np", cptr);
     }
 
     /* location of the directory containing any prepositioned files
      * the user may have requested
      */
     if (NULL != (cptr = getenv("OMPI_FILE_LOCATION"))) {
-        ompi_info_set(&ompi_mpi_info_env.info, "ompi_positioned_file_dir", cptr);
+        opal_info_set(&ompi_mpi_info_env.info.super, "ompi_positioned_file_dir", cptr);
     }
 
     /* All done */
@@ -210,309 +198,15 @@ int ompi_info_init(void)
 
 
 /*
- * Duplicate an info
- */
-int ompi_info_dup (ompi_info_t *info, ompi_info_t **newinfo)
-{
-    int err;
-    opal_list_item_t *item;
-    ompi_info_entry_t *iterator;
-
-    OPAL_THREAD_LOCK(info->i_lock);
-    for (item = opal_list_get_first(&(info->super));
-         item != opal_list_get_end(&(info->super));
-         item = opal_list_get_next(iterator)) {
-         iterator = (ompi_info_entry_t *) item;
-         err = ompi_info_set(*newinfo, iterator->ie_key, iterator->ie_value);
-         if (MPI_SUCCESS != err) {
-            OPAL_THREAD_UNLOCK(info->i_lock);
-            return err;
-         }
-     }
-    OPAL_THREAD_UNLOCK(info->i_lock);
-     return MPI_SUCCESS;
-}
-
-
-/*
- * Set a value on the info
- */
-int ompi_info_set (ompi_info_t *info, const char *key, const char *value)
-{
-    char *new_value;
-    ompi_info_entry_t *new_info;
-    ompi_info_entry_t *old_info;
-
-    new_value = strdup(value);
-    if (NULL == new_value) {
-      return MPI_ERR_NO_MEM;
-    }
-
-    OPAL_THREAD_LOCK(info->i_lock);
-    old_info = info_find_key (info, key);
-    if (NULL != old_info) {
-        /*
-         * key already exists. remove the value associated with it
-         */
-        free(old_info->ie_value);
-        old_info->ie_value = new_value;
-    } else {
-        new_info = OBJ_NEW(ompi_info_entry_t);
-        if (NULL == new_info) {
-            free(new_value);
-            OPAL_THREAD_UNLOCK(info->i_lock);
-            return MPI_ERR_NO_MEM;
-        }
-        strncpy (new_info->ie_key, key, MPI_MAX_INFO_KEY);
-        new_info->ie_value = new_value;
-        opal_list_append (&(info->super), (opal_list_item_t *) new_info);
-    }
-    OPAL_THREAD_UNLOCK(info->i_lock);
-    return MPI_SUCCESS;
-}
-
-
-int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
-                              mca_base_var_enum_t *var_enum)
-{
-    const char *string_value;
-    int ret;
-
-    ret = var_enum->string_from_value (var_enum, value, &string_value);
-    if (OPAL_SUCCESS != ret) {
-        return ret;
-    }
-
-    return ompi_info_set (info, key, string_value);
-}
-
-
-
-/*
- * Free an info handle and all of its keys and values.
- */
-int ompi_info_free (ompi_info_t **info)
-{
-    (*info)->i_freed = true;
-    OBJ_RELEASE(*info);
-    *info = MPI_INFO_NULL;
-    return MPI_SUCCESS;
-}
-
-
-/*
- * Get a value from an info
- */
-int ompi_info_get (ompi_info_t *info, const char *key, int valuelen,
-                   char *value, int *flag)
-{
-    ompi_info_entry_t *search;
-    int value_length;
-
-    OPAL_THREAD_LOCK(info->i_lock);
-    search = info_find_key (info, key);
-    if (NULL == search){
-        *flag = 0;
-    } else {
-        /*
-         * We have found the element, so we can return the value
-         * Set the flag, value_length and value
-         */
-         *flag = 1;
-         value_length = strlen(search->ie_value);
-         /*
-          * If the stored value is shorter than valuelen, then
-          * we can copy the entire value out. Else, we have to
-          * copy ONLY valuelen bytes out
-          */
-          if (value_length < valuelen ) {
-               strcpy(value, search->ie_value);
-          } else {
-               opal_strncpy(value, search->ie_value, valuelen);
-               if (MPI_MAX_INFO_VAL == valuelen) {
-                   value[valuelen-1] = 0;
-               } else {
-                   value[valuelen] = 0;
-               }
-          }
-    }
-    OPAL_THREAD_UNLOCK(info->i_lock);
-    return MPI_SUCCESS;
-}
-
-int ompi_info_get_value_enum (ompi_info_t *info, const char *key, int *value,
-                              int default_value, mca_base_var_enum_t *var_enum,
-                              int *flag)
-{
-    ompi_info_entry_t *search;
-    int ret;
-
-    *value = default_value;
-
-    OPAL_THREAD_LOCK(info->i_lock);
-    search = info_find_key (info, key);
-    if (NULL == search){
-        OPAL_THREAD_UNLOCK(info->i_lock);
-        *flag = 0;
-        return MPI_SUCCESS;
-    }
-
-    /* we found a mathing key. pass the string value to the enumerator and
-     * return */
-    *flag = 1;
-
-    ret = var_enum->value_from_string (var_enum, search->ie_value, value);
-    OPAL_THREAD_UNLOCK(info->i_lock);
-
-    return ret;
-}
-
-
-/*
- * Similar to ompi_info_get(), but cast the result into a boolean
- * using some well-defined rules.
- */
-int ompi_info_get_bool(ompi_info_t *info, char *key, bool *value, int *flag)
-{
-    char *ptr;
-    char str[256];
-
-    str[sizeof(str) - 1] = '\0';
-    ompi_info_get(info, key, sizeof(str) - 1, str, flag);
-    if (*flag) {
-        *value = false;
-
-        /* Trim whitespace */
-        ptr = str + sizeof(str) - 1;
-        while (ptr >= str && isspace(*ptr)) {
-            *ptr = '\0';
-            --ptr;
-        }
-        ptr = str;
-        while (ptr < str + sizeof(str) - 1 && *ptr != '\0' &&
-               isspace(*ptr)) {
-            ++ptr;
-        }
-        if ('\0' != *ptr) {
-            if (isdigit(*ptr)) {
-                *value = (bool) atoi(ptr);
-            } else if (0 == strcasecmp(ptr, "yes") ||
-                       0 == strcasecmp(ptr, "true")) {
-                *value = true;
-            } else if (0 != strcasecmp(ptr, "no") &&
-                       0 != strcasecmp(ptr, "false")) {
-                /* RHC unrecognized value -- print a warning? */
-            }
-        }
-    }
-    return MPI_SUCCESS;
-}
-
-/*
- * Delete a key from an info
- */
-int ompi_info_delete (ompi_info_t *info, const char *key)
-{
-    ompi_info_entry_t *search;
-
-    OPAL_THREAD_LOCK(info->i_lock);
-    search = info_find_key (info, key);
-    if (NULL == search){
-         OPAL_THREAD_UNLOCK(info->i_lock);
-         return MPI_ERR_INFO_NOKEY;
-    } else {
-         /*
-          * An entry with this key value was found. Remove the item
-          * and free the memory allocated to it.
-          * As this key *must* be available, we do not check for errors.
-          */
-          opal_list_remove_item (&(info->super),
-                                 (opal_list_item_t *)search);
-          OBJ_RELEASE(search);
-    }
-    OPAL_THREAD_UNLOCK(info->i_lock);
-    return MPI_SUCCESS;
-}
-
-
-/*
- * Return the length of a value
- */
-int ompi_info_get_valuelen (ompi_info_t *info, const char *key, int *valuelen,
-                            int *flag)
-{
-    ompi_info_entry_t *search;
-
-    OPAL_THREAD_LOCK(info->i_lock);
-    search = info_find_key (info, key);
-    if (NULL == search){
-        *flag = 0;
-    } else {
-        /*
-         * We have found the element, so we can return the value
-         * Set the flag, value_length and value
-         */
-         *flag = 1;
-         *valuelen = strlen(search->ie_value);
-    }
-    OPAL_THREAD_UNLOCK(info->i_lock);
-    return MPI_SUCCESS;
-}
-
-
-/*
- * Get the nth key
- */
-int ompi_info_get_nthkey (ompi_info_t *info, int n, char *key)
-{
-    ompi_info_entry_t *iterator;
-
-    /*
-     * Iterate over and over till we get to the nth key
-     */
-    OPAL_THREAD_LOCK(info->i_lock);
-    for (iterator = (ompi_info_entry_t *)opal_list_get_first(&(info->super));
-         n > 0;
-         --n) {
-         iterator = (ompi_info_entry_t *)opal_list_get_next(iterator);
-         if (opal_list_get_end(&(info->super)) ==
-             (opal_list_item_t *) iterator) {
-             OPAL_THREAD_UNLOCK(info->i_lock);
-             return MPI_ERR_ARG;
-         }
-    }
-    /*
-     * iterator is of the type opal_list_item_t. We have to
-     * cast it to ompi_info_entry_t before we can use it to
-     * access the value
-     */
-    strncpy(key, iterator->ie_key, MPI_MAX_INFO_KEY);
-    OPAL_THREAD_UNLOCK(info->i_lock);
-    return MPI_SUCCESS;
-}
-
-
-/*
  * Shut down MPI_Info handling
  */
-int ompi_info_finalize(void)
+int ompi_mpiinfo_finalize(void)
 {
     size_t i, max;
     ompi_info_t *info;
     opal_list_item_t *item;
-    ompi_info_entry_t *entry;
+    opal_info_entry_t *entry;
     bool found = false;
-
-    /* Release MPI_INFO_NULL.  Do this so that we don't get a bogus
-       leak report on it.  Plus, it's statically allocated, so we
-       don't want to call OBJ_RELEASE on it. */
-
-    OBJ_DESTRUCT(&ompi_mpi_info_null.info);
-    opal_pointer_array_set_item(&ompi_info_f_to_c_table, 0, NULL);
-
-    /* ditto for MPI_INFO_GET_ENV */
-    OBJ_DESTRUCT(&ompi_mpi_info_env.info);
-    opal_pointer_array_set_item(&ompi_info_f_to_c_table, 1, NULL);
 
     /* Go through the f2c table and see if anything is left.  Free them
        all. */
@@ -542,10 +236,11 @@ int ompi_info_finalize(void)
             if (!info->i_freed && ompi_debug_show_handle_leaks) {
                 if (ompi_debug_show_handle_leaks) {
                     opal_output(0, "WARNING: MPI_Info still allocated at MPI_FINALIZE");
-                    for (item = opal_list_get_first(&(info->super));
-                         opal_list_get_end(&(info->super)) != item;
+
+                    for (item = opal_list_get_first(&info->super.super);
+                         opal_list_get_end(&(info->super.super)) != item;
                          item = opal_list_get_next(item)) {
-                        entry = (ompi_info_entry_t *) item;
+                        entry = (opal_info_entry_t *) item;
                         opal_output(0, "WARNING:   key=\"%s\", value=\"%s\"",
                                     entry->ie_key,
                                     NULL != entry->ie_value ? entry->ie_value : "(null)");
@@ -568,8 +263,9 @@ int ompi_info_finalize(void)
     /* All done -- destroy the table */
 
     OBJ_DESTRUCT(&ompi_info_f_to_c_table);
-    return OMPI_SUCCESS;
+    return OPAL_SUCCESS;
 }
+
 
 
 /*
@@ -580,39 +276,26 @@ static void info_constructor(ompi_info_t *info)
 {
     info->i_f_to_c_index = opal_pointer_array_add(&ompi_info_f_to_c_table,
                                                   info);
-    info->i_lock = OBJ_NEW(opal_mutex_t);
     info->i_freed = false;
 
-    /* If the user doesn't want us to ever free it, then add an extra
-       RETAIN here */
-
+/* 
+ * If the user doesn't want us to ever free it, then add an extra
+ * RETAIN here 
+ */
     if (ompi_debug_no_free_handles) {
         OBJ_RETAIN(&(info->super));
     }
 }
 
-
 /*
- * This function is called during OBJ_DESTRUCT of "info". When this
- * done, we need to remove the entry from the ompi fortran to C
- * translation table
- */
+ *  * This function is called during OBJ_DESTRUCT of "info". When this
+ *   * done, we need to remove the entry from the opal fortran to C
+ *    * translation table
+ *     */
 static void info_destructor(ompi_info_t *info)
 {
-    opal_list_item_t *item;
-    ompi_info_entry_t *iterator;
-
-    /* Remove every key in the list */
-
-    for (item = opal_list_remove_first(&(info->super));
-         NULL != item;
-         item = opal_list_remove_first(&(info->super))) {
-        iterator = (ompi_info_entry_t *) item;
-        OBJ_RELEASE(iterator);
-    }
-
-    /* reset the &ompi_info_f_to_c_table entry - make sure that the
-       entry is in the table */
+   /* reset the &ompi_info_f_to_c_table entry - make sure that the
+      entry is in the table */
 
     if (MPI_UNDEFINED != info->i_f_to_c_index &&
         NULL != opal_pointer_array_get_item(&ompi_info_f_to_c_table,
@@ -621,104 +304,16 @@ static void info_destructor(ompi_info_t *info)
                                     info->i_f_to_c_index, NULL);
     }
 
-    /* Release the lock */
-
-    OBJ_RELEASE(info->i_lock);
 }
 
 
 /*
- * ompi_info_entry_t interface functions
+ * Free an info handle and all of its keys and values.
  */
-static void info_entry_constructor(ompi_info_entry_t *entry)
+int ompi_info_free (ompi_info_t **info)
 {
-    memset(entry->ie_key, 0, sizeof(entry->ie_key));
-    entry->ie_key[MPI_MAX_INFO_KEY] = 0;
+    (*info)->i_freed = true;
+    OBJ_RELEASE(*info);
+    *info = MPI_INFO_NULL;
+    return MPI_SUCCESS;
 }
-
-
-static void info_entry_destructor(ompi_info_entry_t *entry)
-{
-    if (NULL != entry->ie_value) {
-        free(entry->ie_value);
-    }
-}
-
-
-/*
- * Find a key
- *
- * Do NOT thread lock in here -- the calling function is responsible
- * for that.
- */
-static ompi_info_entry_t *info_find_key (ompi_info_t *info, const char *key)
-{
-    ompi_info_entry_t *iterator;
-
-    /* No thread locking in here! */
-
-    /* Iterate over all the entries. If the key is found, then
-     * return immediately. Else, the loop will fall of the edge
-     * and NULL is returned
-     */
-    for (iterator = (ompi_info_entry_t *)opal_list_get_first(&(info->super));
-         opal_list_get_end(&(info->super)) != (opal_list_item_t*) iterator;
-         iterator = (ompi_info_entry_t *)opal_list_get_next(iterator)) {
-        if (0 == strcmp(key, iterator->ie_key)) {
-            return iterator;
-        }
-    }
-    return NULL;
-}
-
-
-int
-ompi_info_value_to_int(char *value, int *interp)
-{
-    long tmp;
-    char *endp;
-
-    if (NULL == value || '\0' == value[0]) return OMPI_ERR_BAD_PARAM;
-
-    errno = 0;
-    tmp = strtol(value, &endp, 10);
-    /* we found something not a number */
-    if (*endp != '\0') return OMPI_ERR_BAD_PARAM;
-    /* underflow */
-    if (tmp == 0 && errno == EINVAL) return OMPI_ERR_BAD_PARAM;
-
-    *interp = (int) tmp;
-
-    return OMPI_SUCCESS;
-}
-
-
-int
-ompi_info_value_to_bool(char *value, bool *interp)
-{
-    int tmp;
-
-    /* idiot case */
-    if (NULL == value || NULL == interp) return OMPI_ERR_BAD_PARAM;
-
-    /* is it true / false? */
-    if (0 == strcmp(value, "true")) {
-        *interp = true;
-        return OMPI_SUCCESS;
-    } else if (0 == strcmp(value, "false")) {
-        *interp = false;
-        return OMPI_SUCCESS;
-
-    /* is it a number? */
-    } else if (OMPI_SUCCESS == ompi_info_value_to_int(value, &tmp)) {
-        if (tmp == 0) {
-            *interp = false;
-        } else {
-            *interp = true;
-        }
-        return OMPI_SUCCESS;
-    }
-
-    return OMPI_ERR_BAD_PARAM;
-}
-

--- a/ompi/info/info.h
+++ b/ompi/info/info.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,32 +29,25 @@
 #include <string.h>
 
 #include "mpi.h"
+#include "opal/util/info.h"
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/threads/mutex.h"
 
 #include "opal/mca/base/mca_base_var_enum.h"
 
-/**
- * \internal
- * ompi_info_t structure. MPI_Info is a pointer to this structure
- */
+
 struct ompi_info_t {
-  opal_list_t super;
+    struct opal_info_t super;
   /**< generic list pointer which is the container for (key,value)
        pairs */
   int i_f_to_c_index;
   /**< fortran handle for info. This is needed for translation from
        fortran to C and vice versa */
-  opal_mutex_t *i_lock;
   /**< Mutex for thread safety */
   bool i_freed;
   /**< Whether this info has been freed or not */
 };
-/**
- * \internal
- * Convenience typedef
- */
 typedef struct ompi_info_t ompi_info_t;
 
 /**
@@ -69,32 +63,7 @@ struct ompi_predefined_info_t {
 };
 typedef struct ompi_predefined_info_t ompi_predefined_info_t;
 
-
-/**
- * \internal
- *
- * ompi_info_entry_t object. Each item in ompi_info_list is of this
- * type. It contains (key,value) pairs
- */
-struct ompi_info_entry_t {
-    opal_list_item_t super; /**< required for opal_list_t type */
-    char *ie_value; /**< value part of the (key, value) pair.
-                  * Maximum length is MPI_MAX_INFO_VAL */
-    char ie_key[MPI_MAX_INFO_KEY + 1]; /**< "key" part of the (key, value)
-                                     * pair */
-};
-/**
- * \internal
- * Convenience typedef
- */
-typedef struct ompi_info_entry_t ompi_info_entry_t;
-
 BEGIN_C_DECLS
-
-/**
- * Table for Fortran <-> C translation table
- */
-extern opal_pointer_array_t ompi_info_f_to_c_table;
 
 /**
  * Global instance for MPI_INFO_NULL
@@ -107,240 +76,41 @@ OMPI_DECLSPEC extern ompi_predefined_info_t ompi_mpi_info_null;
 OMPI_DECLSPEC extern ompi_predefined_info_t *ompi_mpi_info_null_addr;
 
 /**
- * Global instance for MPI_INFO_ENV
- */
-OMPI_DECLSPEC extern ompi_predefined_info_t ompi_mpi_info_env;
-
-/**
  * \internal
  * Some declarations needed to use OBJ_NEW and OBJ_DESTRUCT macros
  */
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_info_t);
 
 /**
- * \internal
- * Some declarations needed to use OBJ_NEW and OBJ_DESTRUCT macros
- */
-OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_info_entry_t);
-
-/**
  * This function is invoked during ompi_mpi_init() and sets up
  * MPI_Info handling.
  */
-int ompi_info_init(void);
+int ompi_mpiinfo_init(void);
+
+/**
+ * This function is used to free a ompi level info
+ */
+int ompi_info_free (ompi_info_t **info);
+
 
 /**
  * This functions is called during ompi_mpi_finalize() and shuts
  * down MPI_Info handling.
  */
-int ompi_info_finalize(void);
-
-/**
- *   ompi_info_dup - Duplicate an 'MPI_Info' object
- *
- *   @param info source info object (handle)
- *   @param newinfo pointer to the new info object (handle)
- *
- *   @retval MPI_SUCCESS upon success
- *   @retval MPI_ERR_NO_MEM if out of memory
- *
- *   Not only will the (key, value) pairs be duplicated, the order
- *   of keys will be the same in 'newinfo' as it is in 'info'.  When
- *   an info object is no longer being used, it should be freed with
- *   'MPI_Info_free'.
- */
-int ompi_info_dup (ompi_info_t *info, ompi_info_t **newinfo);
-
-/**
- * Set a new key,value pair on info.
- *
- * @param info pointer to ompi_info_t object
- * @param key pointer to the new key object
- * @param value pointer to the new value object
- *
- * @retval MPI_SUCCESS upon success
- * @retval MPI_ERR_NO_MEM if out of memory
- */
-OMPI_DECLSPEC int ompi_info_set (ompi_info_t *info, const char *key, const char *value);
-
-/**
- * Set a new key,value pair from a variable enumerator.
- *
- * @param info pointer to ompi_info_t object
- * @param key pointer to the new key object
- * @param value integer value of the info key (must be valid in var_enum)
- * @param var_enum variable enumerator
- *
- * @retval MPI_SUCCESS upon success
- * @retval MPI_ERR_NO_MEM if out of memory
- * @retval OPAL_ERR_VALUE_OUT_OF_BOUNDS if the value is not valid in the enumerator
- */
-OMPI_DECLSPEC int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
-                                            mca_base_var_enum_t *var_enum);
-
-/**
- * ompi_info_free - Free an 'MPI_Info' object.
- *
- *   @param info pointer to info (ompi_info_t *) object to be freed (handle)
- *
- *   @retval MPI_SUCCESS
- *   @retval MPI_ERR_ARG
- *
- *   Upon successful completion, 'info' will be set to
- *   'MPI_INFO_NULL'.  Free the info handle and all of its keys and
- *   values.
- */
-int ompi_info_free (ompi_info_t **info);
-
-  /**
-   *   Get a (key, value) pair from an 'MPI_Info' object and assign it
-   *   into a boolen output.
-   *
-   *   @param info Pointer to ompi_info_t object
-   *   @param key null-terminated character string of the index key
-   *   @param value Boolean output value
-   *   @param flag true (1) if 'key' defined on 'info', false (0) if not
-   *               (logical)
-   *
-   *   @retval MPI_SUCCESS
-   *
-   *   If found, the string value will be cast to the boolen output in
-   *   the following manner:
-   *
-   *   - If the string value is digits, the return value is "(bool)
-   *     atoi(value)"
-   *   - If the string value is (case-insensitive) "yes" or "true", the
-   *     result is true
-   *   - If the string value is (case-insensitive) "no" or "false", the
-   *     result is false
-   *   - All other values are false
-   */
-OMPI_DECLSPEC int ompi_info_get_bool (ompi_info_t *info, char *key, bool *value,
-                                      int *flag);
-
-/**
- *   Get a (key, value) pair from an 'MPI_Info' object and assign it
- *   into an integer output based on the enumerator value.
- *
- *   @param info Pointer to ompi_info_t object
- *   @param key null-terminated character string of the index key
- *   @param value integer output value
- *   @param default_value value to use if the string does not conform to the
- *          values accepted by the enumerator
- *   @param var_enum variable enumerator for the value
- *   @param flag true (1) if 'key' defined on 'info', false (0) if not
- *               (logical)
- *
- *   @retval MPI_SUCCESS
- */
-
-OMPI_DECLSPEC int ompi_info_get_value_enum (ompi_info_t *info, const char *key,
-                                            int *value, int default_value,
-                                            mca_base_var_enum_t *var_enum, int *flag);
-
-/**
- *   Get a (key, value) pair from an 'MPI_Info' object
- *
- *   @param info Pointer to ompi_info_t object
- *   @param key null-terminated character string of the index key
- *   @param valuelen maximum length of 'value' (integer)
- *   @param value null-terminated character string of the value
- *   @param flag true (1) if 'key' defined on 'info', false (0) if not
- *               (logical)
- *
- *   @retval MPI_SUCCESS
- *
- *   In C and C++, 'valuelen' should be one less than the allocated
- *   space to allow for for the null terminator.
- */
-OMPI_DECLSPEC int ompi_info_get (ompi_info_t *info, const char *key, int valuelen,
-                                 char *value, int *flag);
-
-/**
- * Delete a (key,value) pair from "info"
- *
- * @param info ompi_info_t pointer on which we need to operate
- * @param key The key portion of the (key,value) pair that
- *            needs to be deleted
- *
- * @retval MPI_SUCCESS
- * @retval MPI_ERR_NOKEY
- */
-int ompi_info_delete (ompi_info_t *info, const char *key);
-
-/**
- *   @param info - ompi_info_t pointer object (handle)
- *   @param key - null-terminated character string of the index key
- *   @param valuelen - length of the value associated with 'key' (integer)
- *   @param flag - true (1) if 'key' defined on 'info', false (0) if not
- *   (logical)
- *
- *   @retval MPI_SUCCESS
- *   @retval MPI_ERR_ARG
- *   @retval MPI_ERR_INFO_KEY
- *
- *   The length returned in C and C++ does not include the end-of-string
- *   character.  If the 'key' is not found on 'info', 'valuelen' is left
- *   alone.
- */
-OMPI_DECLSPEC int ompi_info_get_valuelen (ompi_info_t *info, const char *key, int *valuelen,
-                                          int *flag);
-
-/**
- *   ompi_info_get_nthkey - Get a key indexed by integer from an 'MPI_Info' o
- *
- *   @param info Pointer to ompi_info_t object
- *   @param n index of key to retrieve (integer)
- *   @param key character string of at least 'MPI_MAX_INFO_KEY' characters
- *
- *   @retval MPI_SUCCESS
- *   @retval MPI_ERR_ARG
- */
-int ompi_info_get_nthkey (ompi_info_t *info, int n, char *key);
-
-/**
- * Convert value string to boolean
- *
- * Convert value string \c value into a boolean, using the
- * interpretation rules specified in MPI-2 Section 4.10.  The
- * strings "true", "false", and integer numbers can be converted
- * into booleans.  All others will return \c OMPI_ERR_BAD_PARAM
- *
- * @param value Value string for info key to interpret
- * @param interp returned interpretation of the value key
- *
- * @retval OMPI_SUCCESS string was successfully interpreted
- * @retval OMPI_ERR_BAD_PARAM string was not able to be interpreted
- */
-OMPI_DECLSPEC int ompi_info_value_to_bool(char *value, bool *interp);
-
-/**
- * Convert value string to integer
- *
- * Convert value string \c value into a integer, using the
- * interpretation rules specified in MPI-2 Section 4.10.
- * All others will return \c OMPI_ERR_BAD_PARAM
- *
- * @param value Value string for info key to interpret
- * @param interp returned interpretation of the value key
- *
- * @retval OMPI_SUCCESS string was successfully interpreted
- * @retval OMPI_ERR_BAD_PARAM string was not able to be interpreted
- */
-int ompi_info_value_to_int(char *value, int *interp);
+int ompi_mpiinfo_finalize(void);
 
 END_C_DECLS
 
 /**
  * Return whether this info has been freed already or not.
  *
- * @param info Pointer to ompi_info_t object.
+ * @param info Pointer to opal_info_t object.
  *
  * @retval true If the info has already been freed
  * @retval false If the info has not yet been freed
  *
  * If the info has been freed, return true.  This will likely only
- * happen in a reliable manner if ompi_debug_handle_never_free is
+ * happen in a reliable manner if opal_debug_handle_never_free is
  * true, in which case an extra OBJ_RETAIN is set on the object during
  * OBJ_NEW, meaning that the user will never be able to actually free
  * the underlying object.  It's a good way to find out if a process is
@@ -352,18 +122,5 @@ static inline bool ompi_info_is_freed(ompi_info_t *info)
 }
 
 
-/**
- * Get the number of keys defined on on an MPI_Info object
- * @param info Pointer to ompi_info_t object.
- * @param nkeys Pointer to nkeys, which needs to be filled up.
- *
- * @retval The number of keys defined on info
- */
-static inline int
-ompi_info_get_nkeys(ompi_info_t *info, int *nkeys)
-{
-    *nkeys = (int) opal_list_get_size(&(info->super));
-    return MPI_SUCCESS;
-}
 
 #endif /* OMPI_INFO_H */

--- a/ompi/mca/fs/fs.h
+++ b/ompi/mca/fs/fs.h
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,10 +111,10 @@ typedef int (*mca_fs_base_module_finalize_1_0_0_fn_t)
 
 typedef int (*mca_fs_base_module_file_open_fn_t)(
     struct ompi_communicator_t *comm, const char *filename, int amode,
-    struct ompi_info_t *info, struct mca_io_ompio_file_t *fh);
+    struct opal_info_t *info, struct mca_io_ompio_file_t *fh);
 typedef int (*mca_fs_base_module_file_close_fn_t)(struct mca_io_ompio_file_t *fh);
 typedef int (*mca_fs_base_module_file_delete_fn_t)(
-    char *filename, struct ompi_info_t *info);
+    char *filename, struct opal_info_t *info);
 typedef int (*mca_fs_base_module_file_set_size_fn_t)
     (struct mca_io_ompio_file_t *fh, OMPI_MPI_OFFSET_TYPE size);
 typedef int (*mca_fs_base_module_file_get_size_fn_t)

--- a/ompi/mca/fs/lustre/fs_lustre.h
+++ b/ompi/mca/fs/lustre/fs_lustre.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,13 +61,13 @@ OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_lustre_componen
 int mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
                              const char *filename,
                              int amode,
-                             struct ompi_info_t *info,
+                             struct opal_info_t *info,
                              mca_io_ompio_file_t *fh);
 
 int mca_fs_lustre_file_close (mca_io_ompio_file_t *fh);
 
 int mca_fs_lustre_file_delete (char *filename,
-                               struct ompi_info_t *info);
+                               struct opal_info_t *info);
 
 int mca_fs_lustre_file_set_size (mca_io_ompio_file_t *fh,
                                  OMPI_MPI_OFFSET_TYPE size);

--- a/ompi/mca/fs/lustre/fs_lustre_file_delete.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_delete.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@
  */
 int
 mca_fs_lustre_file_delete (char* file_name,
-                       struct ompi_info_t *info)
+                       struct opal_info_t *info)
 {
     int ret;
 

--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,7 +60,7 @@ int
 mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
                      const char* filename,
                      int access_mode,
-                     struct ompi_info_t *info,
+                     struct opal_info_t *info,
                      mca_io_ompio_file_t *fh)
 {
     int amode;
@@ -94,12 +95,12 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
         amode = amode | O_EXCL;
 
 
-    ompi_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_size );
     }
 
-    ompi_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_width );
     }

--- a/ompi/mca/fs/plfs/fs_plfs.h
+++ b/ompi/mca/fs/plfs/fs_plfs.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,13 +53,13 @@ OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_plfs_component;
 int mca_fs_plfs_file_open (struct ompi_communicator_t *comm,
                              const char *filename,
                              int amode,
-                             struct ompi_info_t *info,
+                             struct opal_info_t *info,
                              mca_io_ompio_file_t *fh);
 
 int mca_fs_plfs_file_close (mca_io_ompio_file_t *fh);
 
 int mca_fs_plfs_file_delete (char *filename,
-                               struct ompi_info_t *info);
+                               struct opal_info_t *info);
 
 int mca_fs_plfs_file_set_size (mca_io_ompio_file_t *fh,
                                  OMPI_MPI_OFFSET_TYPE size);

--- a/ompi/mca/fs/plfs/fs_plfs_file_delete.c
+++ b/ompi/mca/fs/plfs/fs_plfs_file_delete.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@
  */
 int
 mca_fs_plfs_file_delete (char* file_name,
-                       struct ompi_info_t *info)
+                       struct opal_info_t *info)
 {
     plfs_error_t plfs_ret;
     char wpath[1024];

--- a/ompi/mca/fs/plfs/fs_plfs_file_open.c
+++ b/ompi/mca/fs/plfs/fs_plfs_file_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,7 +45,7 @@ int
 mca_fs_plfs_file_open (struct ompi_communicator_t *comm,
                      const char* filename,
                      int access_mode,
-                     struct ompi_info_t *info,
+                     struct opal_info_t *info,
                      mca_io_ompio_file_t *fh)
 {
     int rank;

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.h
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -70,13 +71,13 @@ OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_pvfs2_component
 int mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
                             const char *filename,
                             int amode,
-                            struct ompi_info_t *info,
+                            struct opal_info_t *info,
                             mca_io_ompio_file_t *fh);
 
 int mca_fs_pvfs2_file_close (mca_io_ompio_file_t *fh);
 
 int mca_fs_pvfs2_file_delete (char *filename,
-                              struct ompi_info_t *info);
+                              struct opal_info_t *info);
 
 int mca_fs_pvfs2_file_set_size (mca_io_ompio_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE size);

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_delete.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_delete.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +39,7 @@
  */
 int
 mca_fs_pvfs2_file_delete (char* file_name,
-                          struct ompi_info_t *info)
+                          struct opal_info_t *info)
 {
     PVFS_credentials credentials;
     PVFS_sysresp_getparent resp_getparent;

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,7 +61,7 @@ int
 mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
                         const char* filename,
                         int access_mode,
-                        struct ompi_info_t *info,
+                        struct opal_info_t *info,
                         mca_io_ompio_file_t *fh)
 {
     int ret;
@@ -108,12 +109,12 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
        update mca_fs_pvfs2_stripe_width and mca_fs_pvfs2_stripe_size
        before calling fake_an_open() */
 
-    ompi_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_size );
     }
 
-    ompi_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_width );
     }

--- a/ompi/mca/fs/ufs/fs_ufs.h
+++ b/ompi/mca/fs/ufs/fs_ufs.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,13 +51,13 @@ OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_ufs_component;
 int mca_fs_ufs_file_open (struct ompi_communicator_t *comm,
                           const char *filename,
                           int amode,
-                          struct ompi_info_t *info,
+                          struct opal_info_t *info,
                           mca_io_ompio_file_t *fh);
 
 int mca_fs_ufs_file_close (mca_io_ompio_file_t *fh);
 
 int mca_fs_ufs_file_delete (char *filename,
-                            struct ompi_info_t *info);
+                            struct opal_info_t *info);
 
 int mca_fs_ufs_file_set_size (mca_io_ompio_file_t *fh,
                               OMPI_MPI_OFFSET_TYPE size);

--- a/ompi/mca/fs/ufs/fs_ufs_file_delete.c
+++ b/ompi/mca/fs/ufs/fs_ufs_file_delete.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@
  */
 int
 mca_fs_ufs_file_delete (char* file_name,
-                       struct ompi_info_t *info)
+                       struct opal_info_t *info)
 {
     int ret;
 

--- a/ompi/mca/fs/ufs/fs_ufs_file_open.c
+++ b/ompi/mca/fs/ufs/fs_ufs_file_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2014 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +43,7 @@ int
 mca_fs_ufs_file_open (struct ompi_communicator_t *comm,
 		      const char* filename,
 		      int access_mode,
-		      struct ompi_info_t *info,
+		      struct opal_info_t *info,
 		      mca_io_ompio_file_t *fh)
 {
     int amode;

--- a/ompi/mca/io/base/base.h
+++ b/ompi/mca/io/base/base.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -157,7 +158,7 @@ BEGIN_C_DECLS
      * module).  See io.h for details.
      */
     OMPI_DECLSPEC int mca_io_base_delete(const char *filename,
-                                         struct ompi_info_t *info);
+                                         struct opal_info_t *info);
 
     OMPI_DECLSPEC int mca_io_base_register_datarep(const char *,
                                               MPI_Datarep_conversion_function*,

--- a/ompi/mca/io/base/io_base_delete.c
+++ b/ompi/mca/io/base/io_base_delete.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +30,7 @@
 #include "opal/class/opal_list.h"
 #include "opal/util/argv.h"
 #include "opal/util/output.h"
+#include "opal/util/info.h"
 #include "ompi/mca/mca.h"
 #include "opal/mca/base/base.h"
 #include "ompi/mca/io/io.h"
@@ -52,19 +54,19 @@ typedef struct avail_io_t avail_io_t;
  * Local functions
  */
 static opal_list_t *check_components(opal_list_t *components,
-                                     const char *filename, struct ompi_info_t *info,
+                                     const char *filename, struct opal_info_t *info,
                                      char **names, int num_names);
 static avail_io_t *check_one_component(const mca_base_component_t *component,
-                                       const char *filename, struct ompi_info_t *info);
+                                       const char *filename, struct opal_info_t *info);
 
 static avail_io_t *query(const mca_base_component_t *component,
-                         const char *filename, struct ompi_info_t *info);
+                         const char *filename, struct opal_info_t *info);
 static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *io_component,
-                               const char *filename, struct ompi_info_t *info);
+                               const char *filename, struct opal_info_t *info);
 
-static void unquery(avail_io_t *avail, const char *filename, struct ompi_info_t *info);
+static void unquery(avail_io_t *avail, const char *filename, struct opal_info_t *info);
 
-static int delete_file(avail_io_t *avail, const char *filename, struct ompi_info_t *info);
+static int delete_file(avail_io_t *avail, const char *filename, struct opal_info_t *info);
 
 
 /*
@@ -75,7 +77,7 @@ static OBJ_CLASS_INSTANCE(avail_io_t, opal_list_item_t, NULL, NULL);
 
 /*
  */
-int mca_io_base_delete(const char *filename, struct ompi_info_t *info)
+int mca_io_base_delete(const char *filename, struct opal_info_t *info)
 {
     int err;
     opal_list_t *selectable;
@@ -180,7 +182,7 @@ static int avail_io_compare (opal_list_item_t **itema,
  * priority order.
  */
 static opal_list_t *check_components(opal_list_t *components,
-                                     const char *filename, struct ompi_info_t *info,
+                                     const char *filename, struct opal_info_t *info,
                                      char **names, int num_names)
 {
     int i;
@@ -249,7 +251,7 @@ static opal_list_t *check_components(opal_list_t *components,
  * Check a single component
  */
 static avail_io_t *check_one_component(const mca_base_component_t *component,
-                                       const char *filename, struct ompi_info_t *info)
+                                       const char *filename, struct opal_info_t *info)
 {
     avail_io_t *avail;
 
@@ -282,7 +284,7 @@ static avail_io_t *check_one_component(const mca_base_component_t *component,
  * module struct
  */
 static avail_io_t *query(const mca_base_component_t *component,
-                         const char *filename, struct ompi_info_t *info)
+                         const char *filename, struct opal_info_t *info)
 {
     const mca_io_base_component_2_0_0_t *ioc_200;
 
@@ -303,7 +305,7 @@ static avail_io_t *query(const mca_base_component_t *component,
 
 
 static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
-                               const char *filename, struct ompi_info_t *info)
+                               const char *filename, struct opal_info_t *info)
 {
     bool usable;
     int priority, ret;
@@ -333,7 +335,7 @@ static avail_io_t *query_2_0_0(const mca_io_base_component_2_0_0_t *component,
  * Unquery functions
  **************************************************************************/
 
-static void unquery(avail_io_t *avail, const char *filename, struct ompi_info_t *info)
+static void unquery(avail_io_t *avail, const char *filename, struct opal_info_t *info)
 {
     const mca_io_base_component_2_0_0_t *ioc_200;
 
@@ -358,7 +360,7 @@ static void unquery(avail_io_t *avail, const char *filename, struct ompi_info_t 
 /*
  * Invoke the component's delete function
  */
-static int delete_file(avail_io_t *avail, const char *filename, struct ompi_info_t *info)
+static int delete_file(avail_io_t *avail, const char *filename, struct opal_info_t *info)
 {
     const mca_io_base_component_2_0_0_t *ioc_200;
 

--- a/ompi/mca/io/base/io_base_file_select.c
+++ b/ompi/mca/io/base/io_base_file_select.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,7 @@
 #include "ompi/file/file.h"
 #include "opal/util/argv.h"
 #include "opal/util/output.h"
+#include "opal/util/info.h"
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_object.h"
 #include "ompi/mca/mca.h"
@@ -455,7 +457,7 @@ static int module_init(ompi_file_t *file)
     case MCA_IO_BASE_V_2_0_0:
         iom_200 = &(file->f_io_selected_module.v2_0_0);
         return iom_200->io_module_file_open(file->f_comm, file->f_filename,
-                                            file->f_amode, file->f_info,
+                                            file->f_amode, file->super.s_info,
                                             file);
         break;
 

--- a/ompi/mca/io/io.h
+++ b/ompi/mca/io/io.h
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,14 +90,14 @@ typedef int (*mca_io_base_component_file_unquery_fn_t)
     (struct ompi_file_t *file, struct mca_io_base_file_t *private_data);
 
 typedef int (*mca_io_base_component_file_delete_query_fn_t)
-    (const char *filename, struct ompi_info_t *info,
+    (const char *filename, struct opal_info_t *info,
      struct mca_io_base_delete_t **private_data,
      bool *usable, int *priority);
 typedef int (*mca_io_base_component_file_delete_select_fn_t)
-    (const char *filename, struct ompi_info_t *info,
+    (const char *filename, struct opal_info_t *info,
      struct mca_io_base_delete_t *private_data);
 typedef int (*mca_io_base_component_file_delete_unselect_fn_t)
-    (const char *filename, struct ompi_info_t *info,
+    (const char *filename, struct opal_info_t *info,
      struct mca_io_base_delete_t *private_data);
 
 typedef int (*mca_io_base_component_register_datarep_fn_t)(
@@ -140,7 +141,7 @@ typedef union mca_io_base_components_t mca_io_base_components_t;
 
 typedef int (*mca_io_base_module_file_open_fn_t)
     (struct ompi_communicator_t *comm, const char *filename, int amode,
-     struct ompi_info_t *info, struct ompi_file_t *fh);
+     struct opal_info_t *info, struct ompi_file_t *fh);
 typedef int (*mca_io_base_module_file_close_fn_t)(struct ompi_file_t *fh);
 
 typedef int (*mca_io_base_module_file_set_size_fn_t)
@@ -151,15 +152,11 @@ typedef int (*mca_io_base_module_file_get_size_fn_t)
     (struct ompi_file_t *fh, MPI_Offset *size);
 typedef int (*mca_io_base_module_file_get_amode_fn_t)
     (struct ompi_file_t *fh, int *amode);
-typedef int (*mca_io_base_module_file_set_info_fn_t)
-    (struct ompi_file_t *fh, struct ompi_info_t *info);
-typedef int (*mca_io_base_module_file_get_info_fn_t)
-    (struct ompi_file_t *fh, struct ompi_info_t **info_used);
 
 typedef int (*mca_io_base_module_file_set_view_fn_t)
     (struct ompi_file_t *fh, MPI_Offset disp, struct ompi_datatype_t *etype,
      struct ompi_datatype_t *filetype, const char *datarep,
-     struct ompi_info_t *info);
+     struct opal_info_t *info);
 typedef int (*mca_io_base_module_file_get_view_fn_t)
     (struct ompi_file_t *fh, MPI_Offset *disp,
      struct ompi_datatype_t **etype, struct ompi_datatype_t **filetype,
@@ -309,8 +306,6 @@ struct mca_io_base_module_2_0_0_t {
     mca_io_base_module_file_preallocate_fn_t io_module_file_preallocate;
     mca_io_base_module_file_get_size_fn_t    io_module_file_get_size;
     mca_io_base_module_file_get_amode_fn_t   io_module_file_get_amode;
-    mca_io_base_module_file_set_info_fn_t    io_module_file_set_info;
-    mca_io_base_module_file_get_info_fn_t    io_module_file_get_info;
 
     mca_io_base_module_file_set_view_fn_t    io_module_file_set_view;
     mca_io_base_module_file_get_view_fn_t    io_module_file_get_view;

--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -301,7 +302,7 @@ struct mca_io_ompio_file_t {
     const char            *f_filename;
     char                  *f_datarep;
     opal_convertor_t      *f_convertor;
-    ompi_info_t           *f_info;
+    opal_info_t           *f_info;
     int32_t                f_flags;
     void                  *f_fs_ptr;
     int                    f_atomicity;
@@ -411,7 +412,7 @@ OMPI_DECLSPEC int ompi_io_ompio_set_file_defaults (mca_io_ompio_file_t *fh);
 OMPI_DECLSPEC int ompio_io_ompio_file_open (ompi_communicator_t *comm,
                                             const char *filename,
                                             int amode,
-                                            ompi_info_t *info,
+                                            opal_info_t *info,
                                             mca_io_ompio_file_t *fh,bool use_sharedfp);
 
 OMPI_DECLSPEC int ompio_io_ompio_file_write_at (mca_io_ompio_file_t *fh,
@@ -699,14 +700,14 @@ int mca_io_ompio_file_set_view (struct ompi_file_t *fh,
                                 struct ompi_datatype_t *etype,
                                 struct ompi_datatype_t *filetype,
                                 const char *datarep,
-                                struct ompi_info_t *info);
+                                struct opal_info_t *info);
 
 int mca_io_ompio_set_view_internal (struct mca_io_ompio_file_t *fh,
 				    OMPI_MPI_OFFSET_TYPE disp,
 				    struct ompi_datatype_t *etype,
 				    struct ompi_datatype_t *filetype,
 				    const char *datarep,
-				    struct ompi_info_t *info);
+				    struct opal_info_t *info);
 
 int mca_io_ompio_file_get_view (struct ompi_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE *disp,
@@ -716,7 +717,7 @@ int mca_io_ompio_file_get_view (struct ompi_file_t *fh,
 int mca_io_ompio_file_open (struct ompi_communicator_t *comm,
                             const char *filename,
                             int amode,
-                            struct ompi_info_t *info,
+                            struct opal_info_t *info,
                             struct ompi_file_t *fh);
 int mca_io_ompio_file_close (struct ompi_file_t *fh);
 int mca_io_ompio_file_delete (const char *filename,
@@ -729,10 +730,6 @@ int mca_io_ompio_file_get_size (struct ompi_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE * size);
 int mca_io_ompio_file_get_amode (struct ompi_file_t *fh,
                                  int *amode);
-int mca_io_ompio_file_set_info (struct ompi_file_t *fh,
-                                struct ompi_info_t *info);
-int mca_io_ompio_file_get_info (struct ompi_file_t *fh,
-                                struct ompi_info_t ** info_used);
 int mca_io_ompio_file_sync (struct ompi_file_t *fh);
 int mca_io_ompio_file_seek (struct ompi_file_t *fh,
                             OMPI_MPI_OFFSET_TYPE offet,
@@ -743,7 +740,7 @@ int mca_io_ompio_file_set_view (struct ompi_file_t *fh,
                                 struct ompi_datatype_t *etype,
                                 struct ompi_datatype_t *filetype,
                                 const char *datarep,
-                                struct ompi_info_t *info);
+                                struct opal_info_t *info);
 int mca_io_ompio_file_get_view (struct ompi_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE *disp,
                                 struct ompi_datatype_t **etype,

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,11 +56,11 @@ file_query (struct ompi_file_t *file,
 static int file_unquery(struct ompi_file_t *file,
                         struct mca_io_base_file_t *private_data);
 
-static int delete_query(const char *filename, struct ompi_info_t *info,
+static int delete_query(const char *filename, struct opal_info_t *info,
                         struct mca_io_base_delete_t **private_data,
                         bool *usable, int *priorty);
 
-static int delete_select(const char *filename, struct ompi_info_t *info,
+static int delete_select(const char *filename, struct opal_info_t *info,
                          struct mca_io_base_delete_t *private_data);
 
 static int register_datarep(const char *,
@@ -290,7 +291,7 @@ static int file_unquery(struct ompi_file_t *file,
 }
 
 
-static int delete_query(const char *filename, struct ompi_info_t *info,
+static int delete_query(const char *filename, struct opal_info_t *info,
                         struct mca_io_base_delete_t **private_data,
                         bool *usable, int *priority)
 {
@@ -301,7 +302,7 @@ static int delete_query(const char *filename, struct ompi_info_t *info,
     return OMPI_SUCCESS;
 }
 
-static int delete_select(const char *filename, struct ompi_info_t *info,
+static int delete_select(const char *filename, struct opal_info_t *info,
                          struct mca_io_base_delete_t *private_data)
 {
     int ret;

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +44,7 @@ int
 mca_io_ompio_file_open (ompi_communicator_t *comm,
                         const char *filename,
                         int amode,
-                        ompi_info_t *info,
+                        opal_info_t *info,
                         ompi_file_t *fh)
 {
     int ret = OMPI_SUCCESS;
@@ -75,7 +76,7 @@ int
 ompio_io_ompio_file_open (ompi_communicator_t *comm,
                         const char *filename,
                         int amode,
-                        ompi_info_t *info,
+                        opal_info_t *info,
                         mca_io_ompio_file_t *ompio_fh, bool use_sharedfp)
 {
     int ret = OMPI_SUCCESS;
@@ -575,42 +576,6 @@ mca_io_ompio_file_get_amode (ompi_file_t *fh,
     return OMPI_SUCCESS;
 }
 
-
-int mca_io_ompio_file_set_info (ompi_file_t *fh,
-				ompi_info_t *info)
-{
-    int ret = OMPI_SUCCESS;
-
-    if ( MPI_INFO_NULL == fh->f_info ) {
-	/* OBJ_RELEASE(MPI_INFO_NULL); */
-    }
-    else {
-	ompi_info_free ( &fh->f_info);
-	fh->f_info = OBJ_NEW(ompi_info_t);
-	ret = ompi_info_dup (info, &fh->f_info);
-    }
-
-    return ret;
-}
-
-
-int mca_io_ompio_file_get_info (ompi_file_t *fh,
-				ompi_info_t ** info_used)
-{
-    int ret = OMPI_SUCCESS;
-    ompi_info_t *info=NULL;
-
-    if ( MPI_INFO_NULL == fh->f_info  ) {
-	*info_used = MPI_INFO_NULL;
-    }
-    else {
-	info = OBJ_NEW(ompi_info_t);
-	ret = ompi_info_dup (fh->f_info, &info);
-	*info_used = info;
-    }
-
-    return ret;
-}
 
 int
 mca_io_ompio_file_get_type_extent (ompi_file_t *fh,

--- a/ompi/mca/io/ompio/io_ompio_file_set_view.c
+++ b/ompi/mca/io/ompio/io_ompio_file_set_view.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ *  Copyright (c) 2016 IBM Corp.  All rights reserved.
  *  $COPYRIGHT$
  *
  *  Additional copyrights may follow
@@ -46,7 +47,7 @@ int mca_io_ompio_set_view_internal(mca_io_ompio_file_t *fh,
 				   ompi_datatype_t *etype,
 				   ompi_datatype_t *filetype,
 				   const char *datarep,
-				   ompi_info_t *info)
+				   opal_info_t *info)
 {
 
     size_t max_data = 0;
@@ -198,7 +199,7 @@ int mca_io_ompio_file_set_view (ompi_file_t *fp,
                                 ompi_datatype_t *etype,
                                 ompi_datatype_t *filetype,
                                 const char *datarep,
-                                ompi_info_t *info)
+                                opal_info_t *info)
 {
     int ret=OMPI_SUCCESS;
     mca_io_ompio_data_t *data;

--- a/ompi/mca/io/ompio/io_ompio_module.c
+++ b/ompi/mca/io/ompio/io_ompio_module.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,8 +36,6 @@ mca_io_base_module_2_0_0_t mca_io_ompio_module = {
     mca_io_ompio_file_preallocate,
     mca_io_ompio_file_get_size,
     mca_io_ompio_file_get_amode,
-    mca_io_ompio_file_set_info,
-    mca_io_ompio_file_get_info,
 
     mca_io_ompio_file_set_view,
     mca_io_ompio_file_get_view,

--- a/ompi/mca/io/romio314/src/io_romio314.h
+++ b/ompi/mca/io/romio314/src/io_romio314.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,11 +67,11 @@ typedef struct mca_io_romio314_data_t mca_io_romio314_data_t;
 int mca_io_romio314_file_open (struct ompi_communicator_t *comm,
                             const char *filename,
                             int amode,
-                            struct ompi_info_t *info,
+                            struct opal_info_t *info,
                             ompi_file_t *fh);
 int mca_io_romio314_file_close (struct ompi_file_t *fh);
 int mca_io_romio314_file_delete (const char *filename,
-                              struct ompi_info_t *info);
+                              struct opal_info_t *info);
 int mca_io_romio314_file_set_size (struct ompi_file_t *fh,
                                 MPI_Offset size);
 int mca_io_romio314_file_preallocate (struct ompi_file_t *fh,
@@ -80,9 +81,9 @@ int mca_io_romio314_file_get_size (struct ompi_file_t *fh,
 int mca_io_romio314_file_get_amode (struct ompi_file_t *fh,
                                  int *amode);
 int mca_io_romio314_file_set_info (struct ompi_file_t *fh,
-                                struct ompi_info_t *info);
+                                struct opal_info_t *info);
 int mca_io_romio314_file_get_info (struct ompi_file_t *fh,
-                                struct ompi_info_t ** info_used);
+                                struct opal_info_t ** info_used);
 
 /* Section 9.3 */
 int mca_io_romio314_file_set_view (struct ompi_file_t *fh,
@@ -90,7 +91,7 @@ int mca_io_romio314_file_set_view (struct ompi_file_t *fh,
                                 struct ompi_datatype_t *etype,
                                 struct ompi_datatype_t *filetype,
                                 const char *datarep,
-                                struct ompi_info_t *info);
+                                struct opal_info_t *info);
 int mca_io_romio314_file_get_view (struct ompi_file_t *fh,
                                 MPI_Offset * disp,
                                 struct ompi_datatype_t ** etype,

--- a/ompi/mca/io/romio314/src/io_romio314_component.c
+++ b/ompi/mca/io/romio314/src/io_romio314_component.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,10 +49,10 @@ static const struct mca_io_base_module_2_0_0_t *
 static int file_unquery(struct ompi_file_t *file,
                         struct mca_io_base_file_t *private_data);
 
-static int delete_query(const char *filename, struct ompi_info_t *info,
+static int delete_query(const char *filename, struct opal_info_t *info,
                         struct mca_io_base_delete_t **private_data,
                         bool *usable, int *priorty);
-static int delete_select(const char *filename, struct ompi_info_t *info,
+static int delete_select(const char *filename, struct opal_info_t *info,
                          struct mca_io_base_delete_t *private_data);
 
 static int register_datarep(const char *,
@@ -222,7 +223,7 @@ static int file_unquery(struct ompi_file_t *file,
 }
 
 
-static int delete_query(const char *filename, struct ompi_info_t *info,
+static int delete_query(const char *filename, struct opal_info_t *info,
                         struct mca_io_base_delete_t **private_data,
                         bool *usable, int *priority)
 {
@@ -234,7 +235,7 @@ static int delete_query(const char *filename, struct ompi_info_t *info,
 }
 
 
-static int delete_select(const char *filename, struct ompi_info_t *info,
+static int delete_select(const char *filename, struct opal_info_t *info,
                          struct mca_io_base_delete_t *private_data)
 {
     int ret;

--- a/ompi/mca/io/romio314/src/io_romio314_file_open.c
+++ b/ompi/mca/io/romio314/src/io_romio314_file_open.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +32,7 @@ int
 mca_io_romio314_file_open (ompi_communicator_t *comm,
                         const char *filename,
                         int amode,
-                        ompi_info_t *info,
+                        opal_info_t *info,
                         ompi_file_t *fh)
 {
     int ret;
@@ -149,7 +150,7 @@ mca_io_romio314_file_get_amode (ompi_file_t *fh,
 
 int
 mca_io_romio314_file_set_info (ompi_file_t *fh,
-                            ompi_info_t *info)
+                            opal_info_t *info)
 {
     int ret;
     mca_io_romio314_data_t *data;
@@ -165,7 +166,7 @@ mca_io_romio314_file_set_info (ompi_file_t *fh,
 
 int
 mca_io_romio314_file_get_info (ompi_file_t *fh,
-                            ompi_info_t ** info_used)
+                            opal_info_t ** info_used)
 {
     int ret;
     mca_io_romio314_data_t *data;
@@ -185,7 +186,7 @@ mca_io_romio314_file_set_view (ompi_file_t *fh,
                             struct ompi_datatype_t *etype,
                             struct ompi_datatype_t *filetype,
                             const char *datarep,
-                            ompi_info_t *info)
+                            opal_info_t *info)
 {
     int ret;
     mca_io_romio314_data_t *data;

--- a/ompi/mca/osc/base/base.h
+++ b/ompi/mca/osc/base/base.h
@@ -7,6 +7,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +42,7 @@ int ompi_osc_base_select(ompi_win_t *win,
                          size_t size,
                          int disp_unit,
                          ompi_communicator_t *comm,
-                         ompi_info_t *info,
+                         opal_info_t *info,
                          int flavor,
                          int *model);
 

--- a/ompi/mca/osc/base/osc_base_init.c
+++ b/ompi/mca/osc/base/osc_base_init.c
@@ -10,6 +10,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +35,7 @@ ompi_osc_base_select(ompi_win_t *win,
                      size_t size,
                      int disp_unit,
                      ompi_communicator_t *comm,
-                     ompi_info_t *info,
+                     opal_info_t *info,
                      int flavor,
                      int *model)
 {

--- a/ompi/mca/osc/osc.h
+++ b/ompi/mca/osc/osc.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +46,7 @@ BEGIN_C_DECLS
 
 
 struct ompi_win_t;
-struct ompi_info_t;
+struct opal_info_t;
 struct ompi_communicator_t;
 struct ompi_group_t;
 struct ompi_datatype_t;
@@ -116,7 +117,7 @@ typedef int (*ompi_osc_base_component_query_fn_t)(struct ompi_win_t *win,
                                                   size_t size,
                                                   int disp_unit,
                                                   struct ompi_communicator_t *comm,
-                                                  struct ompi_info_t *info,
+                                                  struct opal_info_t *info,
                                                   int flavor);
 
 /**
@@ -148,7 +149,7 @@ typedef int (*ompi_osc_base_component_select_fn_t)(struct ompi_win_t *win,
                                                    size_t size,
                                                    int disp_unit,
                                                    struct ompi_communicator_t *comm,
-                                                   struct ompi_info_t *info,
+                                                   struct opal_info_t *info,
                                                    int flavor,
                                                    int *model);
 
@@ -352,9 +353,6 @@ typedef int (*ompi_osc_base_module_flush_local_fn_t)(int target,
                                                struct ompi_win_t *win);
 typedef int (*ompi_osc_base_module_flush_local_all_fn_t)(struct ompi_win_t *win);
 
-typedef int (*ompi_osc_base_module_set_info_fn_t)(struct ompi_win_t *win, struct ompi_info_t *info);
-typedef int (*ompi_osc_base_module_get_info_fn_t)(struct ompi_win_t *win, struct ompi_info_t **info_used);
-
 
 
 /* ******************************************************************** */
@@ -406,9 +404,6 @@ struct ompi_osc_base_module_3_0_0_t {
     ompi_osc_base_module_flush_all_fn_t osc_flush_all;
     ompi_osc_base_module_flush_local_fn_t osc_flush_local;
     ompi_osc_base_module_flush_local_all_fn_t osc_flush_local_all;
-
-    ompi_osc_base_module_set_info_fn_t osc_set_info;
-    ompi_osc_base_module_get_info_fn_t osc_get_info;
 };
 typedef struct ompi_osc_base_module_3_0_0_t ompi_osc_base_module_3_0_0_t;
 typedef ompi_osc_base_module_3_0_0_t ompi_osc_base_module_t;

--- a/ompi/mca/osc/portals4/osc_portals4.h
+++ b/ompi/mca/osc/portals4/osc_portals4.h
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -266,8 +267,8 @@ int ompi_osc_portals4_flush_local(int target,
                                   struct ompi_win_t *win);
 int ompi_osc_portals4_flush_local_all(struct ompi_win_t *win);
 
-int ompi_osc_portals4_set_info(struct ompi_win_t *win, struct ompi_info_t *info);
-int ompi_osc_portals4_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used);
+int ompi_osc_portals4_set_info(struct ompi_win_t *win, struct opal_info_t *info);
+int ompi_osc_portals4_get_info(struct ompi_win_t *win, struct opal_info_t **info_used);
 
 static inline int
 ompi_osc_portals4_complete_all(ompi_osc_portals4_module_t *module)

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,10 +28,10 @@ static int component_register(void);
 static int component_init(bool enable_progress_threads, bool enable_mpi_threads);
 static int component_finalize(void);
 static int component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                           struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                           struct ompi_communicator_t *comm, struct opal_info_t *info,
                            int flavor);
 static int component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                            struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                            struct ompi_communicator_t *comm, struct opal_info_t *info,
                             int flavor, int *model);
 
 
@@ -105,14 +106,14 @@ ompi_osc_portals4_module_t ompi_osc_portals4_module_template = {
    looks in the info structure passed by the user, then through mca
    parameters. */
 static bool
-check_config_value_bool(char *key, ompi_info_t *info)
+check_config_value_bool(char *key, opal_info_t *info)
 {
     char *value_string;
     int value_len, ret, flag, param;
     const bool *flag_value;
     bool result;
 
-    ret = ompi_info_get_valuelen(info, key, &value_len, &flag);
+    ret = opal_info_get_valuelen(info, key, &value_len, &flag);
     if (OMPI_SUCCESS != ret) goto info_not_found;
     if (flag == 0) goto info_not_found;
     value_len++;
@@ -120,13 +121,13 @@ check_config_value_bool(char *key, ompi_info_t *info)
     value_string = (char*)malloc(sizeof(char) * value_len + 1); /* Should malloc 1 char for NUL-termination */
     if (NULL == value_string) goto info_not_found;
 
-    ret = ompi_info_get(info, key, value_len, value_string, &flag);
+    ret = opal_info_get(info, key, value_len, value_string, &flag);
     if (OMPI_SUCCESS != ret) {
         free(value_string);
         goto info_not_found;
     }
     assert(flag != 0);
-    ret = ompi_info_value_to_bool(value_string, &result);
+    ret = opal_info_value_to_bool(value_string, &result);
     free(value_string);
     if (OMPI_SUCCESS != ret) goto info_not_found;
     return result;
@@ -143,14 +144,14 @@ check_config_value_bool(char *key, ompi_info_t *info)
 
 
 static bool
-check_config_value_equal(char *key, ompi_info_t *info, char *value)
+check_config_value_equal(char *key, opal_info_t *info, char *value)
 {
     char *value_string;
     int value_len, ret, flag, param;
     const bool *flag_value;
     bool result = false;
 
-    ret = ompi_info_get_valuelen(info, key, &value_len, &flag);
+    ret = opal_info_get_valuelen(info, key, &value_len, &flag);
     if (OMPI_SUCCESS != ret) goto info_not_found;
     if (flag == 0) goto info_not_found;
     value_len++;
@@ -158,7 +159,7 @@ check_config_value_equal(char *key, ompi_info_t *info, char *value)
     value_string = (char*)malloc(sizeof(char) * value_len + 1); /* Should malloc 1 char for NUL-termination */
     if (NULL == value_string) goto info_not_found;
 
-    ret = ompi_info_get(info, key, value_len, value_string, &flag);
+    ret = opal_info_get(info, key, value_len, value_string, &flag);
     if (OMPI_SUCCESS != ret) {
         free(value_string);
         goto info_not_found;
@@ -352,7 +353,7 @@ component_finalize(void)
 
 static int
 component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                struct ompi_communicator_t *comm, struct opal_info_t *info,
                 int flavor)
 {
     if (MPI_WIN_FLAVOR_SHARED == flavor) return -1;
@@ -363,7 +364,7 @@ component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
 
 static int
 component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                 struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                 struct ompi_communicator_t *comm, struct opal_info_t *info,
                  int flavor, int *model)
 {
     ompi_osc_portals4_module_t *module = NULL;
@@ -623,7 +624,7 @@ ompi_osc_portals4_free(struct ompi_win_t *win)
 
 
 int
-ompi_osc_portals4_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
+ompi_osc_portals4_set_info(struct ompi_win_t *win, struct opal_info_t *info)
 {
     ompi_osc_portals4_module_t *module =
         (ompi_osc_portals4_module_t*) win->w_osc_module;
@@ -635,19 +636,19 @@ ompi_osc_portals4_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
 
 
 int
-ompi_osc_portals4_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used)
+ompi_osc_portals4_get_info(struct ompi_win_t *win, struct opal_info_t **info_used)
 {
     ompi_osc_portals4_module_t *module =
         (ompi_osc_portals4_module_t*) win->w_osc_module;
 
-    ompi_info_t *info = OBJ_NEW(ompi_info_t);
+    opal_info_t *info = OBJ_NEW(opal_info_t);
     if (NULL == info) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
-    ompi_info_set(info, "no_locks",  (module->state.lock == LOCK_ILLEGAL) ? "true" : "false");
+    opal_info_set(info, "no_locks",  (module->state.lock == LOCK_ILLEGAL) ? "true" : "false");
     if (module->atomic_max < mca_osc_portals4_component.matching_atomic_max) {
-        ompi_info_set(info, "accumulate_ordering", "none");
+        opal_info_set(info, "accumulate_ordering", "none");
     } else {
-        ompi_info_set(info, "accumulate_ordering", "rar,war,raw,waw");
+        opal_info_set(info, "accumulate_ordering", "rar,war,raw,waw");
     }
 
     *info_used = info;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -398,8 +399,8 @@ int ompi_osc_pt2pt_flush_local(int target,
                               struct ompi_win_t *win);
 int ompi_osc_pt2pt_flush_local_all(struct ompi_win_t *win);
 
-int ompi_osc_pt2pt_set_info(struct ompi_win_t *win, struct ompi_info_t *info);
-int ompi_osc_pt2pt_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used);
+int ompi_osc_pt2pt_set_info(struct ompi_win_t *win, struct opal_info_t *info);
+int ompi_osc_pt2pt_get_info(struct ompi_win_t *win, struct opal_info_t **info_used);
 
 int ompi_osc_pt2pt_component_irecv(ompi_osc_pt2pt_module_t *module,
                                   void *buf,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,10 +39,10 @@ static int component_register(void);
 static int component_init(bool enable_progress_threads, bool enable_mpi_threads);
 static int component_finalize(void);
 static int component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                           struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                           struct ompi_communicator_t *comm, struct opal_info_t *info,
                            int flavor);
 static int component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                            struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                            struct ompi_communicator_t *comm, struct opal_info_t *info,
                             int flavor, int *model);
 
 ompi_osc_pt2pt_component_t mca_osc_pt2pt_component = {
@@ -114,11 +115,11 @@ bool ompi_osc_pt2pt_no_locks = false;
 /* look up parameters for configuring this window.  The code first
    looks in the info structure passed by the user, then through mca
    parameters. */
-static bool check_config_value_bool(char *key, ompi_info_t *info, bool result)
+static bool check_config_value_bool(char *key, opal_info_t *info, bool result)
 {
     int flag;
 
-    (void) ompi_info_get_bool (info, key, &result, &flag);
+    (void) opal_info_get_bool (info, key, &result, &flag);
     return result;
 }
 
@@ -260,7 +261,7 @@ component_finalize(void)
 
 static int
 component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                struct ompi_communicator_t *comm, struct opal_info_t *info,
                 int flavor)
 {
     if (MPI_WIN_FLAVOR_SHARED == flavor) return -1;
@@ -271,7 +272,7 @@ component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
 
 static int
 component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                 struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                 struct ompi_communicator_t *comm, struct opal_info_t *info,
                  int flavor, int *model)
 {
     ompi_osc_pt2pt_module_t *module = NULL;
@@ -426,7 +427,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 
 
 int
-ompi_osc_pt2pt_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
+ompi_osc_pt2pt_set_info(struct ompi_win_t *win, struct opal_info_t *info)
 {
     ompi_osc_pt2pt_module_t *module =
         (ompi_osc_pt2pt_module_t*) win->w_osc_module;
@@ -438,9 +439,9 @@ ompi_osc_pt2pt_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
 
 
 int
-ompi_osc_pt2pt_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used)
+ompi_osc_pt2pt_get_info(struct ompi_win_t *win, struct opal_info_t **info_used)
 {
-    ompi_info_t *info = OBJ_NEW(ompi_info_t);
+    opal_info_t *info = OBJ_NEW(opal_info_t);
     if (NULL == info) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
     *info_used = info;

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2012-2015 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,6 +44,7 @@
 #if OPAL_CUDA_SUPPORT
 #include "opal/datatype/opal_datatype_cuda.h"
 #endif /* OPAL_CUDA_SUPPORT */
+#include "opal/util/info_subscriber.h"
 
 #include "ompi/info/info.h"
 #include "ompi/communicator/communicator.h"
@@ -58,16 +60,18 @@ static int ompi_osc_rdma_component_register (void);
 static int ompi_osc_rdma_component_init (bool enable_progress_threads, bool enable_mpi_threads);
 static int ompi_osc_rdma_component_finalize (void);
 static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                                          struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                                          struct ompi_communicator_t *comm, struct opal_info_t *info,
                                           int flavor);
 static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                                           struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                                           struct ompi_communicator_t *comm, struct opal_info_t *info,
                                            int flavor, int *model);
 
-static int ompi_osc_rdma_set_info (struct ompi_win_t *win, struct ompi_info_t *info);
-static int ompi_osc_rdma_get_info (struct ompi_win_t *win, struct ompi_info_t **info_used);
+static int ompi_osc_rdma_set_info (struct ompi_win_t *win, struct opal_info_t *info);
+static int ompi_osc_rdma_get_info (struct ompi_win_t *win, struct opal_info_t **info_used);
 
 static int ompi_osc_rdma_query_btls (ompi_communicator_t *comm, struct mca_btl_base_module_t **btl);
+
+static char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, char *key, char *value);
 
 static char *ompi_osc_rdma_btl_names;
 
@@ -126,21 +130,18 @@ ompi_osc_base_module_t ompi_osc_rdma_module_rdma_template = {
     .osc_flush_all = ompi_osc_rdma_flush_all,
     .osc_flush_local = ompi_osc_rdma_flush_local,
     .osc_flush_local_all = ompi_osc_rdma_flush_local_all,
-
-    .osc_set_info = ompi_osc_rdma_set_info,
-    .osc_get_info = ompi_osc_rdma_get_info
 };
 
 /* look up parameters for configuring this window.  The code first
    looks in the info structure passed by the user, then it checks
    for a matching MCA variable. */
-static bool check_config_value_bool (char *key, ompi_info_t *info)
+static bool check_config_value_bool (char *key, opal_info_t *info)
 {
     int ret, flag, param;
     bool result = false;
     const bool *flag_value = &result;
 
-    ret = ompi_info_get_bool (info, key, &result, &flag);
+    ret = opal_info_get_bool (info, key, &result, &flag);
     if (OMPI_SUCCESS == ret && flag) {
         return result;
     }
@@ -308,7 +309,7 @@ int ompi_osc_rdma_component_finalize (void)
 
 
 static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                                          struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                                          struct ompi_communicator_t *comm, struct opal_info_t *info,
                                           int flavor)
 {
 
@@ -985,7 +986,7 @@ static int ompi_osc_rdma_check_parameters (ompi_osc_rdma_module_t *module, int d
 
 
 static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                                           struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                                           struct ompi_communicator_t *comm, struct opal_info_t *info,
                                            int flavor, int *model)
 {
     ompi_osc_rdma_module_t *module = NULL;
@@ -1094,6 +1095,15 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
     } else {
         module->state_size += mca_osc_rdma_component.max_attach * module->region_size;
     }
+/*
+ * These are the info's that this module is interested in
+ */
+    opal_infosubscribe_subscribe(&win->super, "no_locks", "false", ompi_osc_rdma_set_no_lock_info);
+
+/*
+ * TODO: same_size, same_disp_unit have w_flag entries, but do not appear
+ * to be used anywhere.  If that changes, they should be subscribed
+ */
 
     /* fill in the function pointer part */
     memcpy(&module->super, &ompi_osc_rdma_module_rdma_template, sizeof(module->super));
@@ -1190,7 +1200,42 @@ static int ompi_osc_rdma_component_select (struct ompi_win_t *win, void **base, 
 }
 
 
-static int ompi_osc_rdma_set_info (struct ompi_win_t *win, struct ompi_info_t *info)
+static char* ompi_osc_rdma_set_no_lock_info(opal_infosubscriber_t *obj, char *key, char *value)
+{
+
+    struct ompi_win_t *win = (struct ompi_win_t*) obj;
+    ompi_osc_rdma_module_t *module = GET_MODULE(win);
+    bool temp;
+
+    temp = opal_str_to_bool(value);
+    if (temp && !module->no_locks) {
+        /* clean up the lock hash. it is up to the user to ensure no lock is
+         * outstanding from this process when setting the info key */
+        OBJ_DESTRUCT(&module->outstanding_locks);
+        OBJ_CONSTRUCT(&module->outstanding_locks, opal_hash_table_t);
+
+        module->no_locks = true;
+    } else if (!temp && module->no_locks) {
+        int world_size = ompi_comm_size (module->comm);
+        int init_limit = world_size > 256 ? 256 : world_size;
+        int ret;
+
+        ret = opal_hash_table_init (&module->outstanding_locks, init_limit);
+        if (OPAL_SUCCESS != ret) {
+            module->no_locks = true;
+        }
+
+        module->no_locks = false;
+    }
+    /* enforce collectiveness... */
+    module->comm->c_coll.coll_barrier(module->comm, module->comm->c_coll.coll_barrier_module);
+/* 
+ * Accept any value
+ */
+    return module->no_locks ? "true" : "false";
+}
+
+static int ompi_osc_rdma_set_info (struct ompi_win_t *win, struct opal_info_t *info)
 {
     ompi_osc_rdma_module_t *module = GET_MODULE(win);
     bool temp;
@@ -1224,9 +1269,9 @@ static int ompi_osc_rdma_set_info (struct ompi_win_t *win, struct ompi_info_t *i
 }
 
 
-static int ompi_osc_rdma_get_info (struct ompi_win_t *win, struct ompi_info_t **info_used)
+static int ompi_osc_rdma_get_info (struct ompi_win_t *win, struct opal_info_t **info_used)
 {
-    ompi_info_t *info = OBJ_NEW(ompi_info_t);
+    opal_info_t *info = OBJ_NEW(opal_info_t);
 
     if (NULL == info) {
         return OMPI_ERR_TEMP_OUT_OF_RESOURCE;

--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -235,7 +236,7 @@ int ompi_osc_sm_flush_local(int target,
                                   struct ompi_win_t *win);
 int ompi_osc_sm_flush_local_all(struct ompi_win_t *win);
 
-int ompi_osc_sm_set_info(struct ompi_win_t *win, struct ompi_info_t *info);
-int ompi_osc_sm_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used);
+int ompi_osc_sm_set_info(struct ompi_win_t *win, struct opal_info_t *info);
+int ompi_osc_sm_get_info(struct ompi_win_t *win, struct opal_info_t **info_used);
 
 #endif

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,6 +22,7 @@
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
 #include "ompi/request/request.h"
 #include "opal/util/sys_limits.h"
+#include "opal/util/info_subscriber.h"
 
 #include "osc_sm.h"
 
@@ -28,11 +30,13 @@ static int component_open(void);
 static int component_init(bool enable_progress_threads, bool enable_mpi_threads);
 static int component_finalize(void);
 static int component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                           struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                           struct ompi_communicator_t *comm, struct opal_info_t *info,
                            int flavor);
 static int component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                            struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                            struct ompi_communicator_t *comm, struct opal_info_t *info,
                             int flavor, int *model);
+static char* component_set_blocking_fence_info(void *obj, char *key, char *val);
+static char* component_set_alloc_shared_noncontig_info(void *obj, char *key, char *val);
 
 
 ompi_osc_sm_component_t mca_osc_sm_component = {
@@ -94,9 +98,6 @@ ompi_osc_sm_module_t ompi_osc_sm_module_template = {
         .osc_flush_all = ompi_osc_sm_flush_all,
         .osc_flush_local = ompi_osc_sm_flush_local,
         .osc_flush_local_all = ompi_osc_sm_flush_local_all,
-
-        .osc_set_info = ompi_osc_sm_set_info,
-        .osc_get_info = ompi_osc_sm_get_info
     }
 };
 
@@ -142,7 +143,7 @@ check_win_ok(ompi_communicator_t *comm, int flavor)
 
 static int
 component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                struct ompi_communicator_t *comm, struct opal_info_t *info,
                 int flavor)
 {
     int ret;
@@ -159,7 +160,7 @@ component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
 
 static int
 component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
-                 struct ompi_communicator_t *comm, struct ompi_info_t *info,
+                 struct ompi_communicator_t *comm, struct opal_info_t *info,
                  int flavor, int *model)
 {
     ompi_osc_sm_module_t *module = NULL;
@@ -176,6 +177,17 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     if (NULL == module) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
     OBJ_CONSTRUCT(&module->lock, opal_mutex_t);
+
+    ret = opal_infosubscribe_subscribe(win, "blocking_fence", "false", 
+        component_set_blocking_fence_info);
+
+    module->global_state->use_barrier_for_fence = 1;
+
+    if (OPAL_SUCCESS != ret) goto error;
+
+    ret = opal_infosubscribe_subscribe(win, "alloc_shared_contig", "false", component_set_alloc_shared_noncontig_info);
+
+    if (OPAL_SUCCESS != ret) goto error;
 
     /* fill in the function pointer part */
     memcpy(module, &ompi_osc_sm_module_template,
@@ -224,7 +236,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         if (NULL == rbuf) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
         module->noncontig = false;
-        if (OMPI_SUCCESS != ompi_info_get_bool(info, "alloc_shared_noncontig",
+        if (OMPI_SUCCESS != opal_info_get_bool(info, "alloc_shared_noncontig",
                                                &module->noncontig, &flag)) {
             goto error;
         }
@@ -336,7 +348,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         bool blocking_fence=false;
         int flag;
 
-        if (OMPI_SUCCESS != ompi_info_get_bool(info, "blocking_fence",
+        if (OMPI_SUCCESS != opal_info_get_bool(info, "blocking_fence",
                                                &blocking_fence, &flag)) {
             goto error;
         }
@@ -487,7 +499,7 @@ ompi_osc_sm_free(struct ompi_win_t *win)
 
 
 int
-ompi_osc_sm_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
+ompi_osc_sm_set_info(struct ompi_win_t *win, struct opal_info_t *info)
 {
     ompi_osc_sm_module_t *module =
         (ompi_osc_sm_module_t*) win->w_osc_module;
@@ -498,19 +510,42 @@ ompi_osc_sm_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
 }
 
 
+static char*
+component_set_blocking_fence_info(void *obj, char *key, char *val)
+{
+    ompi_osc_sm_module_t *module = (ompi_osc_sm_module_t*) ((struct ompi_win_t*) obj)->w_osc_module;
+/*
+ * Assuming that you can't change the default.  
+ */
+    return module->global_state->use_barrier_for_fence ? "true" : "false";
+}
+
+
+static char*
+component_set_alloc_shared_noncontig_info(void *obj, char *key, char *val)
+{
+
+    ompi_osc_sm_module_t *module = (ompi_osc_sm_module_t*) ((struct ompi_win_t*) obj)->w_osc_module;
+/*
+ * Assuming that you can't change the default.  
+ */
+    return module->noncontig ? "true" : "false";
+}
+
+
 int
-ompi_osc_sm_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used)
+ompi_osc_sm_get_info(struct ompi_win_t *win, struct opal_info_t **info_used)
 {
     ompi_osc_sm_module_t *module =
         (ompi_osc_sm_module_t*) win->w_osc_module;
 
-    ompi_info_t *info = OBJ_NEW(ompi_info_t);
+    opal_info_t *info = OBJ_NEW(opal_info_t);
     if (NULL == info) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
     if (module->flavor == MPI_WIN_FLAVOR_SHARED) {
-        ompi_info_set(info, "blocking_fence",
+        opal_info_set(info, "blocking_fence",
                       (1 == module->global_state->use_barrier_for_fence) ? "true" : "false");
-        ompi_info_set(info, "alloc_shared_noncontig",
+        opal_info_set(info, "alloc_shared_noncontig",
                       (module->noncontig) ? "true" : "false");
     }
 

--- a/ompi/mca/rte/orte/rte_orte.h
+++ b/ompi/mca/rte/orte/rte_orte.h
@@ -6,6 +6,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +38,6 @@ struct opal_proc_t;
 #include "orte/util/name_fns.h"
 #include "orte/util/proc_info.h"
 
-#include "ompi/info/info.h"
 struct ompi_proc_t;
 struct ompi_communicator_t;
 

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc.h
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc.h
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015      University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,7 +59,7 @@ int mca_sharedfp_addproc_get_position (mca_io_ompio_file_t *fh,
 int mca_sharedfp_addproc_file_open (struct ompi_communicator_t *comm,
                                        const char* filename,
                                        int amode,
-                                       struct ompi_info_t *info,
+                                       struct opal_info_t *info,
                                        mca_io_ompio_file_t *fh);
 int mca_sharedfp_addproc_file_close (mca_io_ompio_file_t *fh);
 int mca_sharedfp_addproc_read (mca_io_ompio_file_t *fh,

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc_file_open.c
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc_file_open.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013-2015 University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +35,7 @@
 int mca_sharedfp_addproc_file_open (struct ompi_communicator_t *comm,
                                     const char* filename,
                                     int amode,
-                                    struct ompi_info_t *info,
+                                    struct opal_info_t *info,
                                     mca_io_ompio_file_t *fh)
 {
     int ret = OMPI_SUCCESS, err;

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013-2015 University of Houston. All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -103,7 +104,7 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_individual_component_file
     info = fh->f_info;
     if ( info != MPI_INFO_NULL ){
         valuelen = MPI_MAX_INFO_VAL;
-        ompi_info_get ( info,"OMPIO_SHAREDFP_RELAXED_ORDERING", valuelen, value, &flag);
+        opal_info_get ( info,"OMPIO_SHAREDFP_RELAXED_ORDERING", valuelen, value, &flag);
         if ( flag ) {
            if ( mca_sharedfp_individual_verbose ) {
                 opal_output(ompi_sharedfp_base_framework.framework_output,

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.h
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2013      University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +58,7 @@ int mca_sharedfp_individual_seek (mca_io_ompio_file_t *fh,
 int mca_sharedfp_individual_file_open (struct ompi_communicator_t *comm,
                                        const char* filename,
                                        int amode,
-                                       struct ompi_info_t *info,
+                                       struct opal_info_t *info,
                                        mca_io_ompio_file_t *fh);
 int mca_sharedfp_individual_file_close (mca_io_ompio_file_t *fh);
 int mca_sharedfp_individual_read (mca_io_ompio_file_t *fh,

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_file_open.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_file_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2013-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +34,7 @@
 int mca_sharedfp_individual_file_open (struct ompi_communicator_t *comm,
 				       const char* filename,
 				       int amode,
-				       struct ompi_info_t *info,
+				       struct opal_info_t *info,
 				       mca_io_ompio_file_t *fh)
 {
     int err = 0;

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2013      University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +58,7 @@ int mca_sharedfp_lockedfile_get_position (mca_io_ompio_file_t *fh,
 int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
                                        const char* filename,
                                        int amode,
-                                       struct ompi_info_t *info,
+                                       struct opal_info_t *info,
                                        mca_io_ompio_file_t *fh);
 int mca_sharedfp_lockedfile_file_close (mca_io_ompio_file_t *fh);
 int mca_sharedfp_lockedfile_read (mca_io_ompio_file_t *fh,

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2013-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +37,7 @@
 int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
 				       const char* filename,
 				       int amode,
-				       struct ompi_info_t *info,
+				       struct opal_info_t *info,
 				       mca_io_ompio_file_t *fh)
 {
     int err = MPI_SUCCESS;

--- a/ompi/mca/sharedfp/sharedfp.h
+++ b/ompi/mca/sharedfp/sharedfp.h
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -176,7 +177,7 @@ typedef int (*mca_sharedfp_base_module_read_ordered_end_fn_t)(
         ompi_status_public_t *status);
 typedef int (*mca_sharedfp_base_module_file_open_fn_t)(
         struct ompi_communicator_t *comm, const char *filename, int amode,
-        struct ompi_info_t *info, struct mca_io_ompio_file_t *fh);
+        struct opal_info_t *info, struct mca_io_ompio_file_t *fh);
 typedef int (*mca_sharedfp_base_module_file_close_fn_t)(struct mca_io_ompio_file_t *fh);
 
 

--- a/ompi/mca/sharedfp/sm/sharedfp_sm.h
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +58,7 @@ int mca_sharedfp_sm_get_position (mca_io_ompio_file_t *fh,
 int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
                                        const char* filename,
                                        int amode,
-                                       struct ompi_info_t *info,
+                                       struct opal_info_t *info,
                                        mca_io_ompio_file_t *fh);
 int mca_sharedfp_sm_file_close (mca_io_ompio_file_t *fh);
 int mca_sharedfp_sm_read (mca_io_ompio_file_t *fh,

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +47,7 @@
 int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
                                const char* filename,
                                int amode,
-                               struct ompi_info_t *info,
+                               struct opal_info_t *info,
                                mca_io_ompio_file_t *fh)
 {
     int err = OMPI_SUCCESS;

--- a/ompi/mca/topo/base/base.h
+++ b/ompi/mca/topo/base/base.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -171,7 +172,7 @@ mca_topo_base_dist_graph_create(mca_topo_base_module_t* module,
                                 ompi_communicator_t *old_comm,
                                 int n, const int nodes[],
                                 const int degrees[], const int targets[], const int weights[],
-                                ompi_info_t *info, int reorder,
+                                opal_info_t *info, int reorder,
                                 ompi_communicator_t **new_comm);
 
 OMPI_DECLSPEC int
@@ -180,7 +181,7 @@ mca_topo_base_dist_graph_create_adjacent(mca_topo_base_module_t* module,
                                          int indegree, const int sources[],
                                          const int sourceweights[], int outdegree,
                                          const int destinations[], const int destweights[],
-                                         ompi_info_t *info, int reorder,
+                                         opal_info_t *info, int reorder,
                                          ompi_communicator_t **comm_dist_graph);
 
 OMPI_DECLSPEC int

--- a/ompi/mca/topo/base/topo_base_dist_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create.c
@@ -283,7 +283,7 @@ int mca_topo_base_dist_graph_create(mca_topo_base_module_t* module,
                                     int n, const int nodes[],
                                     const int degrees[], const int targets[],
                                     const int weights[],
-                                    ompi_info_t *info, int reorder,
+                                    opal_info_t *info, int reorder,
                                     ompi_communicator_t **newcomm)
 {
     int err;

--- a/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
@@ -26,7 +26,7 @@ int mca_topo_base_dist_graph_create_adjacent(mca_topo_base_module_t* module,
                                              int outdegree,
                                              const int destinations[],
                                              const int destweights[],
-                                             ompi_info_t *info, int reorder,
+                                             opal_info_t *info, int reorder,
                                              ompi_communicator_t **newcomm)
 {
     mca_topo_base_comm_dist_graph_2_2_0_t *topo = NULL;

--- a/ompi/mca/topo/topo.h
+++ b/ompi/mca/topo/topo.h
@@ -16,6 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -252,7 +253,7 @@ typedef int (*mca_topo_base_module_dist_graph_create_fn_t)
                      struct ompi_communicator_t *old_comm,
                      int n, const int nodes[],
                      const int degrees[], const int targets[], const int weights[],
-                     struct ompi_info_t *info, int reorder,
+                     struct opal_info_t *info, int reorder,
                      struct ompi_communicator_t **new_comm);
 
 /* Back end for MPI_DIST_GRAPH_CREATE_ADJACENT */
@@ -264,7 +265,7 @@ typedef int (*mca_topo_base_module_dist_graph_create_adjacent_fn_t)
                      int outdegree,
                      const int destinations[],
                      const int destweights[],
-                     struct ompi_info_t *info, int reorder,
+                     struct opal_info_t *info, int reorder,
                      ompi_communicator_t **comm_dist_graph);
 
 /* Back end for MPI_DIST_GRAPH_NEIGHBORS */

--- a/ompi/mca/topo/treematch/topo_treematch.h
+++ b/ompi/mca/topo/treematch/topo_treematch.h
@@ -6,6 +6,7 @@
  * Copyright (c) 2011-2015 Bordeaux Polytechnic Institute
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,7 +70,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* module,
                                          int n, const int nodes[],
                                          const int degrees[], const int targets[],
                                          const int weights[],
-                                         struct ompi_info_t *info, int reorder,
+                                         struct opal_info_t *info, int reorder,
                                          ompi_communicator_t **newcomm);
 /*
  * ******************************************************************

--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -102,7 +103,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
                                          int n, const int nodes[],
                                          const int degrees[], const int targets[],
                                          const int weights[],
-                                         struct ompi_info_t *info, int reorder,
+                                         struct opal_info_t *info, int reorder,
                                          ompi_communicator_t **newcomm)
 {
     int err;

--- a/ompi/mpi/c/comm_dup_with_info.c
+++ b/ompi/mpi/c/comm_dup_with_info.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +68,7 @@ int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm)
 
     OPAL_CR_ENTER_LIBRARY();
 
-    rc = ompi_comm_dup_with_info (comm, info, newcomm);
+    rc = ompi_comm_dup_with_info (comm, &info->super, newcomm);
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/comm_get_info.c
+++ b/ompi/mpi/c/comm_get_info.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,13 +47,21 @@ int MPI_Comm_get_info(MPI_Comm comm, MPI_Info *info_used)
         }
     }
 
-    /* At the moment, we do not support any communicator hints.  So
-       just return a new, empty info obect handle. */
+    if (NULL == comm->super.s_info) {
+/*
+ * Setup any defaults if MPI_Win_set_info was never called
+ */
+        opal_infosubscribe_change_info(comm, &MPI_INFO_NULL->super);
+    }
+
+
     (*info_used) = OBJ_NEW(ompi_info_t);
     if (NULL == (*info_used)) {
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_NO_MEM,
+       return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_NO_MEM,
                                       FUNC_NAME);
     }
+
+    opal_info_dup(comm->super.s_info, &(*info_used)->super);
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/comm_set_info.c
+++ b/ompi/mpi/c/comm_set_info.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,7 +17,7 @@
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
-#include "ompi/info/info.h"
+#include "opal/util/info_subscriber.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -47,7 +48,9 @@ int MPI_Comm_set_info(MPI_Comm comm, MPI_Info info)
         }
     }
 
-    /* At the moment, we do not support any communicator hints.
-       So... do nothing */
+    OPAL_CR_ENTER_LIBRARY();
+
+    opal_infosubscribe_change_info(comm, info);
+
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/comm_spawn.c
+++ b/ompi/mpi/c/comm_spawn.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,7 +110,7 @@ int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info inf
 
     /* See if the info key "ompi_non_mpi" was set to true */
     if (rank == root) {
-        ompi_info_get_bool(info, "ompi_non_mpi", &non_mpi, &flag);
+        opal_info_get_bool(info, "ompi_non_mpi", &non_mpi, &flag);
     }
 
     OPAL_CR_ENTER_LIBRARY();

--- a/ompi/mpi/c/comm_spawn_multiple.c
+++ b/ompi/mpi/c/comm_spawn_multiple.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -105,7 +106,7 @@ int MPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_o
                    be set to true on all of them.  Note that not
                    setting ompi_non_mpi is the same as setting it to
                    false. */
-                ompi_info_get_bool(array_of_info[i], "ompi_non_mpi", &non_mpi,
+                opal_info_get_bool(array_of_info[i], "ompi_non_mpi", &non_mpi,
                                    &flag);
                 if (flag && 0 == i) {
                     /* If this is the first info, save its
@@ -141,7 +142,7 @@ int MPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_o
         if (MPI_INFO_NULL == array_of_info[0]) {
             non_mpi = false;
         } else {
-            ompi_info_get_bool(array_of_info[0], "ompi_non_mpi", &non_mpi,
+            opal_info_get_bool(array_of_info[0], "ompi_non_mpi", &non_mpi,
                                &flag);
             if (!flag) {
                 non_mpi = false;

--- a/ompi/mpi/c/file_set_info.c
+++ b/ompi/mpi/c/file_set_info.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,6 +26,8 @@
 #include "ompi/runtime/params.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/info/info.h"
+#include "ompi/communicator/communicator.h"
+#include "opal/util/info_subscriber.h"
 #include "ompi/file/file.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -39,34 +42,27 @@ static const char FUNC_NAME[] = "MPI_File_set_info";
 
 int MPI_File_set_info(MPI_File fh, MPI_Info info)
 {
-    int rc;
+    int ret; 
+
+    OPAL_CR_NOOP_PROGRESS();
 
     if (MPI_PARAM_CHECK) {
-        rc = MPI_SUCCESS;
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+
         if (ompi_file_invalid(fh)) {
-            fh = MPI_FILE_NULL;
-            rc = MPI_ERR_FILE;
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_FILE, FUNC_NAME);
         }
-        OMPI_ERRHANDLER_CHECK(rc, fh, rc, FUNC_NAME);
+
+	if (NULL == info || MPI_INFO_NULL == info ||
+            ompi_info_is_freed(info)) {
+            return OMPI_ERRHANDLER_INVOKE(fh, MPI_ERR_INFO,
+                                          FUNC_NAME);
+        }
     }
 
     OPAL_CR_ENTER_LIBRARY();
 
-    /* Call the back-end io component function */
+    ret = opal_infosubscribe_change_info(fh, &info->super);
 
-    switch (fh->f_io_version) {
-    case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
-            io_module_file_set_info(fh, info);
-        break;
-
-    default:
-        rc = MPI_ERR_INTERN;
-        break;
-    }
-
-    /* All done */
-
-    OMPI_ERRHANDLER_RETURN(rc, fh, rc, FUNC_NAME);
+    OMPI_ERRHANDLER_RETURN(ret, fh, ret, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_delete.c
+++ b/ompi/mpi/c/info_delete.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,6 +78,6 @@ int MPI_Info_delete(MPI_Info info, const char *key) {
 
     OPAL_CR_ENTER_LIBRARY();
 
-    err = ompi_info_delete (info, key);
+    err = opal_info_delete (info, key);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_dup.c
+++ b/ompi/mpi/c/info_dup.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,7 +74,7 @@ int MPI_Info_dup(MPI_Info info, MPI_Info *newinfo) {
         }
     }
 
-    *newinfo = OBJ_NEW(ompi_info_t);
+    *newinfo = OBJ_NEW(opal_info_t);
     if (NULL == *newinfo) {
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_NO_MEM,
                                       FUNC_NAME);
@@ -84,6 +85,6 @@ int MPI_Info_dup(MPI_Info info, MPI_Info *newinfo) {
     /*
      * Now to actually duplicate all the values
      */
-    err = ompi_info_dup (info, newinfo);
+    err = opal_info_dup (info, newinfo);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get.c
+++ b/ompi/mpi/c/info_get.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,6 +101,6 @@ int MPI_Info_get(MPI_Info info, const char *key, int valuelen,
 
     OPAL_CR_ENTER_LIBRARY();
 
-    err = ompi_info_get (info, key, valuelen, value, flag);
+    err = opal_info_get(info, key, valuelen, value, flag);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get_nkeys.c
+++ b/ompi/mpi/c/info_get_nkeys.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,6 +70,6 @@ int MPI_Info_get_nkeys(MPI_Info info, int *nkeys)
 
     OPAL_CR_ENTER_LIBRARY();
 
-    err = ompi_info_get_nkeys(info, nkeys);
+    err = opal_info_get_nkeys(info, nkeys);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get_nthkey.c
+++ b/ompi/mpi/c/info_get_nthkey.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -82,7 +83,7 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
        1 from the value returned by get_nkeys().  So be sure to
        compare appropriately. */
 
-    err = ompi_info_get_nkeys(info, &nkeys);
+    err = opal_info_get_nkeys(info, &nkeys);
     OMPI_ERRHANDLER_CHECK(err, MPI_COMM_WORLD, err, FUNC_NAME);
     if (n > (nkeys - 1)) {
         OPAL_CR_EXIT_LIBRARY();
@@ -92,6 +93,6 @@ int MPI_Info_get_nthkey(MPI_Info info, int n, char *key)
 
     /* Everything seems alright. Call the back end key copy */
 
-    err = ompi_info_get_nthkey (info, n, key);
+    err = opal_info_get_nthkey (info, n, key);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_get_valuelen.c
+++ b/ompi/mpi/c/info_get_valuelen.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,6 +91,6 @@ int MPI_Info_get_valuelen(MPI_Info info, const char *key, int *valuelen,
 
     OPAL_CR_ENTER_LIBRARY();
 
-    err = ompi_info_get_valuelen (info, key, valuelen, flag);
+    err = opal_info_get_valuelen (info, key, valuelen, flag);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/info_set.c
+++ b/ompi/mpi/c/info_set.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -104,6 +105,6 @@ int MPI_Info_set(MPI_Info info, const char *key, const char *value)
      * allocator.
      */
 
-    err = ompi_info_set (info, key, value);
+    err = opal_info_set (info, key, value);
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/lookup_name.c
+++ b/ompi/mpi/c/lookup_name.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,7 +89,7 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
     /* OMPI supports info keys to pass the range to
      * be searched for the given key */
     if (MPI_INFO_NULL != info) {
-        ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
+        opal_info_get (info, "range", sizeof(range) - 1, range, &flag);
         if (flag) {
             if (0 == strcmp(range, "nspace")) {
                 rng = OBJ_NEW(opal_value_t);

--- a/ompi/mpi/c/publish_name.c
+++ b/ompi/mpi/c/publish_name.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,7 +89,7 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
     /* OMPI supports info keys to pass the range and persistence to
      * be used for the given key */
     if (MPI_INFO_NULL != info) {
-        ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
+        opal_info_get (info, "range", sizeof(range) - 1, range, &flag);
         if (flag) {
             if (0 == strcmp(range, "nspace")) {
                 rng = OBJ_NEW(opal_value_t);
@@ -110,7 +111,7 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
                                             FUNC_NAME);
             }
         }
-        ompi_info_get (info, "persistence", sizeof(range) - 1, range, &flag);
+        opal_info_get (info, "persistence", sizeof(range) - 1, range, &flag);
         if (flag) {
             if (0 == strcmp(range, "indef")) {
                 rng = OBJ_NEW(opal_value_t);

--- a/ompi/mpi/c/unpublish_name.c
+++ b/ompi/mpi/c/unpublish_name.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,7 +91,7 @@ int MPI_Unpublish_name(const char *service_name, MPI_Info info,
     /* OMPI supports info keys to pass the range to
      * be searched for the given key */
     if (MPI_INFO_NULL != info) {
-        ompi_info_get (info, "range", sizeof(range) - 1, range, &flag);
+        opal_info_get (info, "range", sizeof(range) - 1, range, &flag);
         if (flag) {
             if (0 == strcmp(range, "nspace")) {
                 rng = OBJ_NEW(opal_value_t);

--- a/ompi/mpi/c/win_set_info.c
+++ b/ompi/mpi/c/win_set_info.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +16,8 @@
 #include "ompi/runtime/params.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/win/win.h"
+#include "ompi/communicator/communicator.h"
+#include "opal/util/info_subscriber.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -45,6 +48,7 @@ int MPI_Win_set_info(MPI_Win win, MPI_Info info)
 
     OPAL_CR_ENTER_LIBRARY();
 
-    ret = win->w_osc_module->osc_set_info(win, info);
+    ret = opal_infosubscribe_change_info(win, info);
+
     OMPI_ERRHANDLER_RETURN(ret, win, ret, FUNC_NAME);
 }

--- a/ompi/mpiext/cr/c/quiesce_start.c
+++ b/ompi/mpiext/cr/c/quiesce_start.c
@@ -6,6 +6,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +77,7 @@ int OMPI_CR_Quiesce_start(MPI_Comm commP, MPI_Info *info)
     /*
      * (Old) info logic
      */
-    /*ompi_info_set((ompi_info_t*)*info, "target", cur_datum.target_dir);*/
+    /*opal_info_set((opal_info_t*)*info, "target", cur_datum.target_dir);*/
 
     return ret;
 }
@@ -123,7 +124,7 @@ int OMPI_CR_Quiesce_start(MPI_Comm commP, MPI_Info *info)
  *   1 = Memory must be in user space (i.e., not on network card
  *
  */
-static int extract_info_into_datum(ompi_info_t *info, orte_snapc_base_quiesce_t *datum)
+static int extract_info_into_datum(opal_info_t *info, orte_snapc_base_quiesce_t *datum)
 {
     int info_flag = false;
     int max_crs_len = 32;
@@ -135,7 +136,7 @@ static int extract_info_into_datum(ompi_info_t *info, orte_snapc_base_quiesce_t 
     /*
      * Key: crs
      */
-    ompi_info_get(info, "crs", max_crs_len, info_char, &info_flag);
+    opal_info_get(info, "crs", max_crs_len, info_char, &info_flag);
     if( info_flag) {
         datum->crs_name = strdup(info_char);
     }
@@ -143,7 +144,7 @@ static int extract_info_into_datum(ompi_info_t *info, orte_snapc_base_quiesce_t 
     /*
      * Key: cmdline
      */
-    ompi_info_get(info, "cmdline", OPAL_PATH_MAX, info_char, &info_flag);
+    opal_info_get(info, "cmdline", OPAL_PATH_MAX, info_char, &info_flag);
     if( info_flag) {
         datum->cmdline = strdup(info_char);
     }
@@ -151,7 +152,7 @@ static int extract_info_into_datum(ompi_info_t *info, orte_snapc_base_quiesce_t 
     /*
      * Key: handle
      */
-    ompi_info_get(info, "handle", OPAL_PATH_MAX, info_char, &info_flag);
+    opal_info_get(info, "handle", OPAL_PATH_MAX, info_char, &info_flag);
     if( info_flag) {
         datum->handle = strdup(info_char);
     }
@@ -159,7 +160,7 @@ static int extract_info_into_datum(ompi_info_t *info, orte_snapc_base_quiesce_t 
     /*
      * Key: target
      */
-    ompi_info_get(info, "target", OPAL_PATH_MAX, info_char, &info_flag);
+    opal_info_get(info, "target", OPAL_PATH_MAX, info_char, &info_flag);
     if( info_flag) {
         datum->target_dir = strdup(info_char);
     }
@@ -167,7 +168,7 @@ static int extract_info_into_datum(ompi_info_t *info, orte_snapc_base_quiesce_t 
     /*
      * Key: restarting
      */
-    ompi_info_get_bool(info, "restarting", &info_bool, &info_flag);
+    opal_info_get_bool(info, "restarting", &info_bool, &info_flag);
     if( info_flag ) {
         datum->restarting = info_bool;
     } else {
@@ -177,7 +178,7 @@ static int extract_info_into_datum(ompi_info_t *info, orte_snapc_base_quiesce_t 
     /*
      * Key: checkpointing
      */
-    ompi_info_get_bool(info, "checkpointing", &info_bool, &info_flag);
+    opal_info_get_bool(info, "checkpointing", &info_bool, &info_flag);
     if( info_flag ) {
         datum->checkpointing = info_bool;
     } else {

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  *
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -389,7 +390,7 @@ int ompi_mpi_finalize(void)
     }
 
     /* free info resources */
-    if (OMPI_SUCCESS != (ret = ompi_info_finalize())) {
+    if (OMPI_SUCCESS != (ret = ompi_mpiinfo_finalize())) {
         goto done;
     }
 

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -21,6 +21,7 @@
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -697,7 +698,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
     }
 
     /* initialize info */
-    if (OMPI_SUCCESS != (ret = ompi_info_init())) {
+    if (OMPI_SUCCESS != (ret = ompi_mpiinfo_init())) {
         error = "ompi_info_init() failed";
         goto error;
     }

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +25,8 @@
  */
 
 #include "ompi_config.h"
+
+#include "opal/util/info_subscriber.h"
 
 #include "mpi.h"
 #include "ompi/win/win.h"
@@ -43,7 +46,7 @@
  */
 opal_pointer_array_t ompi_mpi_windows = {{0}};
 
-ompi_predefined_win_t ompi_mpi_win_null = {{{0}}};
+ompi_predefined_win_t ompi_mpi_win_null = {{{{0}}}};
 ompi_predefined_win_t *ompi_mpi_win_null_addr = &ompi_mpi_win_null;
 mca_base_var_enum_t *ompi_win_accumulate_ops = NULL;
 
@@ -56,7 +59,7 @@ static mca_base_var_enum_value_t accumulate_ops_values[] = {
 static void ompi_win_construct(ompi_win_t *win);
 static void ompi_win_destruct(ompi_win_t *win);
 
-OBJ_CLASS_INSTANCE(ompi_win_t, opal_object_t,
+OBJ_CLASS_INSTANCE(ompi_win_t, opal_infosubscriber_t,
                    ompi_win_construct, ompi_win_destruct);
 
 int
@@ -119,7 +122,7 @@ int ompi_win_finalize(void)
     return OMPI_SUCCESS;
 }
 
-static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int flavor, ompi_win_t **win_out)
+static int alloc_window(struct ompi_communicator_t *comm, opal_info_t *info, int flavor, ompi_win_t **win_out)
 {
     ompi_win_t *win;
     ompi_group_t *group;
@@ -131,7 +134,7 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = ompi_info_get_value_enum (info, "accumulate_ops", &acc_ops,
+    ret = opal_info_get_value_enum (info, "accumulate_ops", &acc_ops,
                                     OMPI_WIN_ACCUMULATE_OPS_SAME_OP_NO_OP,
                                     ompi_win_accumulate_ops, &flag);
     if (OMPI_SUCCESS != ret) {
@@ -192,7 +195,7 @@ config_window(void *base, size_t size, int disp_unit,
 int
 ompi_win_create(void *base, size_t size,
                 int disp_unit, ompi_communicator_t *comm,
-                ompi_info_t *info,
+                opal_info_t *info,
                 ompi_win_t** newwin)
 {
     ompi_win_t *win;
@@ -223,7 +226,7 @@ ompi_win_create(void *base, size_t size,
 
 
 int
-ompi_win_allocate(size_t size, int disp_unit, ompi_info_t *info,
+ompi_win_allocate(size_t size, int disp_unit, opal_info_t *info,
                   ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin)
 {
     ompi_win_t *win;
@@ -256,7 +259,7 @@ ompi_win_allocate(size_t size, int disp_unit, ompi_info_t *info,
 
 
 int
-ompi_win_allocate_shared(size_t size, int disp_unit, ompi_info_t *info,
+ompi_win_allocate_shared(size_t size, int disp_unit, opal_info_t *info,
                          ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin)
 {
     ompi_win_t *win;
@@ -289,7 +292,7 @@ ompi_win_allocate_shared(size_t size, int disp_unit, ompi_info_t *info,
 
 
 int
-ompi_win_create_dynamic(ompi_info_t *info, ompi_communicator_t *comm, ompi_win_t **newwin)
+ompi_win_create_dynamic(opal_info_t *info, ompi_communicator_t *comm, ompi_win_t **newwin)
 {
     ompi_win_t *win;
     int model;

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +30,7 @@
 
 #include "opal/class/opal_object.h"
 #include "opal/class/opal_hash_table.h"
+#include "opal/util/info_subscriber.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/info/info.h"
 #include "ompi/communicator/communicator.h"
@@ -55,12 +57,12 @@ OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_ops;
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_windows;
 
 struct ompi_win_t {
-    opal_object_t w_base;
+    opal_infosubscriber_t super;
 
     opal_mutex_t  w_lock;
 
     char w_name[MPI_MAX_OBJECT_NAME];
-
+  
     /* Group associated with this window. */
     ompi_group_t *w_group;
 
@@ -111,13 +113,13 @@ int ompi_win_init(void);
 int ompi_win_finalize(void);
 
 int ompi_win_create(void *base, size_t size, int disp_unit,
-                    ompi_communicator_t *comm, ompi_info_t *info,
+                    ompi_communicator_t *comm, opal_info_t *info,
                     ompi_win_t **newwin);
-int ompi_win_allocate(size_t size, int disp_unit, ompi_info_t *info,
+int ompi_win_allocate(size_t size, int disp_unit, opal_info_t *info,
                       ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin);
-int ompi_win_allocate_shared(size_t size, int disp_unit, ompi_info_t *info,
+int ompi_win_allocate_shared(size_t size, int disp_unit, opal_info_t *info,
                       ompi_communicator_t *comm, void *baseptr, ompi_win_t **newwin);
-int ompi_win_create_dynamic(ompi_info_t *info, ompi_communicator_t *comm, ompi_win_t **newwin);
+int ompi_win_create_dynamic(opal_info_t *info, ompi_communicator_t *comm, ompi_win_t **newwin);
 
 int ompi_win_free(ompi_win_t *win);
 

--- a/opal/mca/mpool/base/mpool_base_alloc.c
+++ b/opal/mca/mpool/base/mpool_base_alloc.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2010-2016 IBM Corp.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -29,20 +29,7 @@
 #include "mpool_base_tree.h"
 #include "mpool_base_mem_cb.h"
 #include "opal/threads/mutex.h"
-
-struct opal_info_t {
-  opal_list_t super;
-  /**< generic list pointer which is the container for (key,value)
-       pairs */
-  int i_f_to_c_index;
-  /**< fortran handle for info. This is needed for translation from
-       fortran to C and vice versa */
-  opal_mutex_t *i_lock;
-  /**< Mutex for thread safety */
-  bool i_freed;
-  /**< Whether this info has been freed or not */
-};
-typedef struct opal_info_t opal_info_t;
+#include "opal/util/info.h"
 
 /**
  * Memory Pool Registration
@@ -165,15 +152,15 @@ void *mca_mpool_base_alloc(size_t size, opal_info_t *info)
         char key[MPI_MAX_INFO_KEY + 1];
         char value[MPI_MAX_INFO_VAL + 1];
 
-        ompi_info_get_nkeys(info, &num_keys);
+        opal_info_get_nkeys(info, &num_keys);
         for(i = 0; i < num_keys; i++)
         {
-            ompi_info_get_nthkey(info, i, key);
+            opal_info_get_nthkey(info, i, key);
             if ( 0 != strcmp(key, "mpool") ) {
                 continue;
             }
             mpool_requested = true;
-            ompi_info_get(info, key, MPI_MAX_INFO_VAL, value, &flag);
+            opal_info_get(info, key, MPI_MAX_INFO_VAL, value, &flag);
             if ( !flag ) {
                 continue;
             }

--- a/opal/util/Makefile.am
+++ b/opal/util/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2013      Intel, Inc. All rights reserved
+# Copyright (c) 2016 IBM Corp.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -65,7 +66,9 @@ headers = \
         strncpy.h \
         sys_limits.h \
         timings.h \
-        uri.h
+        uri.h \
+        info_subscriber.h \
+	info.h
 
 libopalutil_la_SOURCES = \
         $(headers) \
@@ -99,7 +102,9 @@ libopalutil_la_SOURCES = \
         stacktrace.c \
         strncpy.c \
         sys_limits.c \
-        uri.c
+        uri.c \
+ 	info_subscriber.c \
+ 	info.c
 
 if OPAL_COMPILE_TIMING
 libopalutil_la_SOURCES += timings.c

--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -1,0 +1,487 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <limits.h>
+#include <ctype.h>
+#ifdef HAVE_SYS_UTSNAME_H
+#include <sys/utsname.h>
+#endif
+#include <assert.h>
+
+#include "opal/util/argv.h"
+#include "opal/util/opal_getcwd.h"
+#include "opal/util/output.h"
+#include "opal/util/strncpy.h"
+
+#include "opal/util/info.h"
+#ifdef XXX
+#include "ompi/runtime/mpiruntime.h"
+#include "ompi/runtime/params.h"
+#endif
+
+
+/*
+ * Local functions
+ */
+static void info_constructor(opal_info_t *info);
+static void info_destructor(opal_info_t *info);
+static void info_entry_constructor(opal_info_entry_t *entry);
+static void info_entry_destructor(opal_info_entry_t *entry);
+static opal_info_entry_t *info_find_key (opal_info_t *info, const char *key);
+
+
+/*
+ * opal_info_t classes
+ */
+OBJ_CLASS_INSTANCE(opal_info_t,
+                   opal_list_t,
+                   info_constructor,
+                   info_destructor);
+
+/*
+ * opal_info_entry_t classes
+ */
+OBJ_CLASS_INSTANCE(opal_info_entry_t,
+                   opal_list_item_t,
+                   info_entry_constructor,
+                   info_entry_destructor);
+
+
+
+/*
+ * Duplicate an info
+ */
+int opal_info_dup (opal_info_t *info, opal_info_t **newinfo)
+{
+    int err;
+    opal_list_item_t *item;
+    opal_info_entry_t *iterator;
+
+    OPAL_THREAD_LOCK(info->i_lock);
+    for (item = opal_list_get_first(&(info->super));
+         item != opal_list_get_end(&(info->super));
+         item = opal_list_get_next(iterator)) {
+         iterator = (opal_info_entry_t *) item;
+         err = opal_info_set(*newinfo, iterator->ie_key, iterator->ie_value);
+         if (MPI_SUCCESS != err) {
+            OPAL_THREAD_UNLOCK(info->i_lock);
+            return err;
+         }
+     }
+    OPAL_THREAD_UNLOCK(info->i_lock);
+     return MPI_SUCCESS;
+}
+
+
+/*
+ * Set a value on the info
+ */
+int opal_info_set (opal_info_t *info, const char *key, const char *value)
+{
+    char *new_value;
+    opal_info_entry_t *new_info;
+    opal_info_entry_t *old_info;
+
+    new_value = strdup(value);
+    if (NULL == new_value) {
+      return MPI_ERR_NO_MEM;
+    }
+
+    OPAL_THREAD_LOCK(info->i_lock);
+    old_info = info_find_key (info, key);
+    if (NULL != old_info) {
+        /*
+         * key already exists. remove the value associated with it
+         */
+        free(old_info->ie_value);
+        old_info->ie_value = new_value;
+    } else {
+        new_info = OBJ_NEW(opal_info_entry_t);
+        if (NULL == new_info) {
+            free(new_value);
+            OPAL_THREAD_UNLOCK(info->i_lock);
+            return MPI_ERR_NO_MEM;
+        }
+        strncpy (new_info->ie_key, key, MPI_MAX_INFO_KEY);
+        new_info->ie_value = new_value;
+        opal_list_append (&(info->super), (opal_list_item_t *) new_info);
+    }
+    OPAL_THREAD_UNLOCK(info->i_lock);
+    return MPI_SUCCESS;
+}
+
+
+int opal_info_set_value_enum (opal_info_t *info, const char *key, int value,
+                              mca_base_var_enum_t *var_enum)
+{
+    char *string_value;
+    int ret;
+
+    ret = var_enum->string_from_value (var_enum, value, &string_value);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    return opal_info_set (info, key, string_value);
+}
+
+
+/*
+ * Get a value from an info
+ */
+int opal_info_get (opal_info_t *info, const char *key, int valuelen,
+                   char *value, int *flag)
+{
+    opal_info_entry_t *search;
+    int value_length;
+
+    OPAL_THREAD_LOCK(info->i_lock);
+    search = info_find_key (info, key);
+    if (NULL == search){
+        *flag = 0;
+    } else {
+        /*
+         * We have found the element, so we can return the value
+         * Set the flag, value_length and value
+         */
+         *flag = 1;
+         value_length = strlen(search->ie_value);
+         /*
+          * If the stored value is shorter than valuelen, then
+          * we can copy the entire value out. Else, we have to
+          * copy ONLY valuelen bytes out
+          */
+          if (value_length < valuelen ) {
+               strcpy(value, search->ie_value);
+          } else {
+               opal_strncpy(value, search->ie_value, valuelen);
+               if (MPI_MAX_INFO_VAL == valuelen) {
+                   value[valuelen-1] = 0;
+               } else {
+                   value[valuelen] = 0;
+               }
+          }
+    }
+    OPAL_THREAD_UNLOCK(info->i_lock);
+    return MPI_SUCCESS;
+}
+
+int opal_info_get_value_enum (opal_info_t *info, const char *key, int *value,
+                              int default_value, mca_base_var_enum_t *var_enum,
+                              int *flag)
+{
+    opal_info_entry_t *search;
+    int ret;
+
+    *value = default_value;
+
+    OPAL_THREAD_LOCK(info->i_lock);
+    search = info_find_key (info, key);
+    if (NULL == search){
+        OPAL_THREAD_UNLOCK(info->i_lock);
+        *flag = 0;
+        return MPI_SUCCESS;
+    }
+
+    /* we found a mathing key. pass the string value to the enumerator and
+     * return */
+    *flag = 1;
+
+    ret = var_enum->value_from_string (var_enum, search->ie_value, value);
+    OPAL_THREAD_UNLOCK(info->i_lock);
+
+    return ret;
+}
+
+
+/*
+ * Similar to opal_info_get(), but cast the result into a boolean
+ * using some well-defined rules.
+ */
+int opal_info_get_bool(opal_info_t *info, char *key, bool *value, int *flag)
+{
+    char str[256];
+
+    str[sizeof(str) - 1] = '\0';
+    opal_info_get(info, key, sizeof(str) - 1, str, flag);
+    if (*flag) {
+	*value = opal_str_to_bool(str);
+    }
+
+    return MPI_SUCCESS;
+}
+
+
+bool
+opal_str_to_bool(char *str)
+{
+    bool result = false;
+    char *ptr;
+
+    /* Trim whitespace */
+    ptr = str + sizeof(str) - 1;
+    while (ptr >= str && isspace(*ptr)) {
+        *ptr = '\0';
+        --ptr;
+    }
+    ptr = str;
+    while (ptr < str + sizeof(str) - 1 && *ptr != '\0' &&
+           isspace(*ptr)) {
+        ++ptr;
+    }
+    if ('\0' != *ptr) {
+        if (isdigit(*ptr)) {
+            result = (bool) atoi(ptr);
+        } else if (0 == strcasecmp(ptr, "yes") ||
+                   0 == strcasecmp(ptr, "true")) {
+            result = true;
+        } else if (0 != strcasecmp(ptr, "no") &&
+                   0 != strcasecmp(ptr, "false")) {
+            /* RHC unrecognized value -- print a warning? */
+        }
+    }
+    return result;   
+}
+
+/*
+ * Delete a key from an info
+ */
+int opal_info_delete(opal_info_t *info, const char *key)
+{
+    opal_info_entry_t *search;
+
+    OPAL_THREAD_LOCK(info->i_lock);
+    search = info_find_key (info, key);
+    if (NULL == search){
+         OPAL_THREAD_UNLOCK(info->i_lock);
+         return MPI_ERR_INFO_NOKEY;
+    } else {
+         /*
+          * An entry with this key value was found. Remove the item
+          * and free the memory allocated to it.
+          * As this key *must* be available, we do not check for errors.
+          */
+          opal_list_remove_item (&(info->super),
+                                 (opal_list_item_t *)search);
+          OBJ_RELEASE(search);
+    }
+    OPAL_THREAD_UNLOCK(info->i_lock);
+    return MPI_SUCCESS;
+}
+
+
+/*
+ * Return the length of a value
+ */
+int opal_info_get_valuelen (opal_info_t *info, const char *key, int *valuelen,
+                            int *flag)
+{
+    opal_info_entry_t *search;
+
+    OPAL_THREAD_LOCK(info->i_lock);
+    search = info_find_key (info, key);
+    if (NULL == search){
+        *flag = 0;
+    } else {
+        /*
+         * We have found the element, so we can return the value
+         * Set the flag, value_length and value
+         */
+         *flag = 1;
+         *valuelen = strlen(search->ie_value);
+    }
+    OPAL_THREAD_UNLOCK(info->i_lock);
+    return MPI_SUCCESS;
+}
+
+
+/*
+ * Get the nth key
+ */
+int opal_info_get_nthkey (opal_info_t *info, int n, char *key)
+{
+    opal_info_entry_t *iterator;
+
+    /*
+     * Iterate over and over till we get to the nth key
+     */
+    OPAL_THREAD_LOCK(info->i_lock);
+    for (iterator = (opal_info_entry_t *)opal_list_get_first(&(info->super));
+         n > 0;
+         --n) {
+         iterator = (opal_info_entry_t *)opal_list_get_next(iterator);
+         if (opal_list_get_end(&(info->super)) ==
+             (opal_list_item_t *) iterator) {
+             OPAL_THREAD_UNLOCK(info->i_lock);
+             return MPI_ERR_ARG;
+         }
+    }
+    /*
+     * iterator is of the type opal_list_item_t. We have to
+     * cast it to opal_info_entry_t before we can use it to
+     * access the value
+     */
+    strncpy(key, iterator->ie_key, MPI_MAX_INFO_KEY);
+    OPAL_THREAD_UNLOCK(info->i_lock);
+    return MPI_SUCCESS;
+}
+
+
+
+/*
+ * This function is invoked when OBJ_NEW() is called. Here, we add this
+ * info pointer to the table and then store its index as the handle
+ */
+static void info_constructor(opal_info_t *info)
+{
+    info->i_lock = OBJ_NEW(opal_mutex_t);
+}
+
+/*
+ * This function is called during OBJ_DESTRUCT of "info". When this
+ * done, we need to remove the entry from the opal fortran to C
+ * translation table
+ */
+static void info_destructor(opal_info_t *info)
+{
+    opal_list_item_t *item;
+    opal_info_entry_t *iterator;
+
+    /* Remove every key in the list */
+
+    for (item = opal_list_remove_first(&(info->super));
+         NULL != item;
+         item = opal_list_remove_first(&(info->super))) {
+        iterator = (opal_info_entry_t *) item;
+        OBJ_RELEASE(iterator);
+    }
+
+    /* Release the lock */
+
+    OBJ_RELEASE(info->i_lock);
+}
+
+
+/*
+ * opal_info_entry_t interface functions
+ */
+static void info_entry_constructor(opal_info_entry_t *entry)
+{
+    memset(entry->ie_key, 0, sizeof(entry->ie_key));
+    entry->ie_key[MPI_MAX_INFO_KEY] = 0;
+}
+
+
+static void info_entry_destructor(opal_info_entry_t *entry)
+{
+    if (NULL != entry->ie_value) {
+        free(entry->ie_value);
+    }
+}
+
+
+/*
+ * Find a key
+ *
+ * Do NOT thread lock in here -- the calling function is responsible
+ * for that.
+ */
+static opal_info_entry_t *info_find_key (opal_info_t *info, const char *key)
+{
+    opal_info_entry_t *iterator;
+
+    /* No thread locking in here! */
+
+    /* Iterate over all the entries. If the key is found, then
+     * return immediately. Else, the loop will fall of the edge
+     * and NULL is returned
+     */
+    for (iterator = (opal_info_entry_t *)opal_list_get_first(&(info->super));
+         opal_list_get_end(&(info->super)) != (opal_list_item_t*) iterator;
+         iterator = (opal_info_entry_t *)opal_list_get_next(iterator)) {
+        if (0 == strcmp(key, iterator->ie_key)) {
+            return iterator;
+        }
+    }
+    return NULL;
+}
+
+
+int
+opal_info_value_to_int(char *value, int *interp)
+{
+    long tmp;
+    char *endp;
+
+    if (NULL == value || '\0' == value[0]) return OPAL_ERR_BAD_PARAM;
+
+    errno = 0;
+    tmp = strtol(value, &endp, 10);
+    /* we found something not a number */
+    if (*endp != '\0') return OPAL_ERR_BAD_PARAM;
+    /* underflow */
+    if (tmp == 0 && errno == EINVAL) return OPAL_ERR_BAD_PARAM;
+
+    *interp = (int) tmp;
+
+    return OPAL_SUCCESS;
+}
+
+
+int
+opal_info_value_to_bool(char *value, bool *interp)
+{
+    int tmp;
+
+    /* idiot case */
+    if (NULL == value || NULL == interp) return OPAL_ERR_BAD_PARAM;
+
+    /* is it true / false? */
+    if (0 == strcmp(value, "true")) {
+        *interp = true;
+        return OPAL_SUCCESS;
+    } else if (0 == strcmp(value, "false")) {
+        *interp = false;
+        return OPAL_SUCCESS;
+
+    /* is it a number? */
+    } else if (OPAL_SUCCESS == opal_info_value_to_int(value, &tmp)) {
+        if (tmp == 0) {
+            *interp = false;
+        } else {
+            *interp = true;
+        }
+        return OPAL_SUCCESS;
+    }
+
+    return OPAL_ERR_BAD_PARAM;
+}
+

--- a/opal/util/info.h
+++ b/opal/util/info.h
@@ -1,0 +1,306 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_INFO_H
+#define OPAL_INFO_H
+
+#include <string.h>
+
+#include "mpi.h"
+#include "opal/class/opal_list.h"
+#include "opal/class/opal_pointer_array.h"
+#include "opal/threads/mutex.h"
+#include "opal/mca/base/mca_base_var_enum.h"
+
+/**
+ * \internal
+ * opal_info_t structure. MPI_Info is a pointer to this structure
+ */
+
+struct opal_info_t {
+  opal_list_t   super;
+  opal_mutex_t	*i_lock;
+};
+
+/**
+ * \internal
+ * Convenience typedef
+ */
+typedef struct opal_info_t opal_info_t;
+
+
+/**
+ * Table for Fortran <-> C translation table
+ */
+extern opal_pointer_array_t ompi_info_f_to_c_table;
+
+
+/**
+ * \internal
+ *
+ * opal_info_entry_t object. Each item in opal_info_list is of this
+ * type. It contains (key,value) pairs
+ */
+struct opal_info_entry_t {
+    opal_list_item_t super; /**< required for opal_list_t type */
+    char *ie_value; /**< value part of the (key, value) pair.
+                  * Maximum length is MPI_MAX_INFO_VAL */
+    char ie_key[MPI_MAX_INFO_KEY + 1]; /**< "key" part of the (key, value)
+                                     * pair */
+};
+/**
+ * \internal
+ * Convenience typedef
+ */
+typedef struct opal_info_entry_t opal_info_entry_t;
+
+BEGIN_C_DECLS
+
+/**
+ * \internal
+ * Some declarations needed to use OBJ_NEW and OBJ_DESTRUCT macros
+ */
+OMPI_DECLSPEC OBJ_CLASS_DECLARATION(opal_info_t);
+
+/**
+ * \internal
+ * Some declarations needed to use OBJ_NEW and OBJ_DESTRUCT macros
+ */
+OMPI_DECLSPEC OBJ_CLASS_DECLARATION(opal_info_entry_t);
+
+
+int opal_mpiinfo_init(void*);
+
+/**
+ *   opal_info_dup - Duplicate an 'MPI_Info' object
+ *
+ *   @param info source info object (handle)
+ *   @param newinfo pointer to the new info object (handle)
+ *
+ *   @retval MPI_SUCCESS upon success
+ *   @retval MPI_ERR_NO_MEM if out of memory
+ *
+ *   Not only will the (key, value) pairs be duplicated, the order
+ *   of keys will be the same in 'newinfo' as it is in 'info'.  When
+ *   an info object is no longer being used, it should be freed with
+ *   'MPI_Info_free'.
+ */
+int opal_info_dup (opal_info_t *info, opal_info_t **newinfo);
+
+/**
+ * Set a new key,value pair on info.
+ *
+ * @param info pointer to opal_info_t object
+ * @param key pointer to the new key object
+ * @param value pointer to the new value object
+ *
+ * @retval MPI_SUCCESS upon success
+ * @retval MPI_ERR_NO_MEM if out of memory
+ */
+OMPI_DECLSPEC int opal_info_set (opal_info_t *info, const char *key, const char *value);
+
+/**
+ * Set a new key,value pair from a variable enumerator.
+ *
+ * @param info pointer to opal_info_t object
+ * @param key pointer to the new key object
+ * @param value integer value of the info key (must be valid in var_enum)
+ * @param var_enum variable enumerator
+ *
+ * @retval MPI_SUCCESS upon success
+ * @retval MPI_ERR_NO_MEM if out of memory
+ * @retval OPAL_ERR_VALUE_OUT_OF_BOUNDS if the value is not valid in the enumerator
+ */
+OMPI_DECLSPEC int opal_info_set_value_enum (opal_info_t *info, const char *key, int value,
+                                            mca_base_var_enum_t *var_enum);
+
+/**
+ * opal_info_free - Free an 'MPI_Info' object.
+ *
+ *   @param info pointer to info (opal_info_t *) object to be freed (handle)
+ *
+ *   @retval MPI_SUCCESS
+ *   @retval MPI_ERR_ARG
+ *
+ *   Upon successful completion, 'info' will be set to
+ *   'MPI_INFO_NULL'.  Free the info handle and all of its keys and
+ *   values.
+ */
+int opal_info_free (opal_info_t **info);
+
+  /**
+   *   Get a (key, value) pair from an 'MPI_Info' object and assign it
+   *   into a boolen output.
+   *
+   *   @param info Pointer to opal_info_t object
+   *   @param key null-terminated character string of the index key
+   *   @param value Boolean output value
+   *   @param flag true (1) if 'key' defined on 'info', false (0) if not
+   *               (logical)
+   *
+   *   @retval MPI_SUCCESS
+   *
+   *   If found, the string value will be cast to the boolen output in
+   *   the following manner:
+   *
+   *   - If the string value is digits, the return value is "(bool)
+   *     atoi(value)"
+   *   - If the string value is (case-insensitive) "yes" or "true", the
+   *     result is true
+   *   - If the string value is (case-insensitive) "no" or "false", the
+   *     result is false
+   *   - All other values are false
+   */
+OMPI_DECLSPEC int opal_info_get_bool (opal_info_t *info, char *key, bool *value,
+                                      int *flag);
+
+/**
+ *   Get a (key, value) pair from an 'MPI_Info' object and assign it
+ *   into an integer output based on the enumerator value.
+ *
+ *   @param info Pointer to opal_info_t object
+ *   @param key null-terminated character string of the index key
+ *   @param value integer output value
+ *   @param default_value value to use if the string does not conform to the
+ *          values accepted by the enumerator
+ *   @param var_enum variable enumerator for the value
+ *   @param flag true (1) if 'key' defined on 'info', false (0) if not
+ *               (logical)
+ *
+ *   @retval MPI_SUCCESS
+ */
+
+OMPI_DECLSPEC int opal_info_get_value_enum (opal_info_t *info, const char *key,
+                                            int *value, int default_value,
+                                            mca_base_var_enum_t *var_enum, int *flag);
+
+/**
+ *   Get a (key, value) pair from an 'MPI_Info' object
+ *
+ *   @param info Pointer to opal_info_t object
+ *   @param key null-terminated character string of the index key
+ *   @param valuelen maximum length of 'value' (integer)
+ *   @param value null-terminated character string of the value
+ *   @param flag true (1) if 'key' defined on 'info', false (0) if not
+ *               (logical)
+ *
+ *   @retval MPI_SUCCESS
+ *
+ *   In C and C++, 'valuelen' should be one less than the allocated
+ *   space to allow for for the null terminator.
+ */
+OMPI_DECLSPEC int opal_info_get (opal_info_t *info, const char *key, int valuelen,
+                                 char *value, int *flag);
+
+/**
+ * Delete a (key,value) pair from "info"
+ *
+ * @param info opal_info_t pointer on which we need to operate
+ * @param key The key portion of the (key,value) pair that
+ *            needs to be deleted
+ *
+ * @retval MPI_SUCCESS
+ * @retval MPI_ERR_NOKEY
+ */
+int opal_info_delete(opal_info_t *info, const char *key);
+
+/**
+ *   @param info - opal_info_t pointer object (handle)
+ *   @param key - null-terminated character string of the index key
+ *   @param valuelen - length of the value associated with 'key' (integer)
+ *   @param flag - true (1) if 'key' defined on 'info', false (0) if not
+ *   (logical)
+ *
+ *   @retval MPI_SUCCESS
+ *   @retval MPI_ERR_ARG
+ *   @retval MPI_ERR_INFO_KEY
+ *
+ *   The length returned in C and C++ does not include the end-of-string
+ *   character.  If the 'key' is not found on 'info', 'valuelen' is left
+ *   alone.
+ */
+OMPI_DECLSPEC int opal_info_get_valuelen (opal_info_t *info, const char *key, int *valuelen,
+                                          int *flag);
+
+/**
+ *   opal_info_get_nthkey - Get a key indexed by integer from an 'MPI_Info' o
+ *
+ *   @param info Pointer to opal_info_t object
+ *   @param n index of key to retrieve (integer)
+ *   @param key character string of at least 'MPI_MAX_INFO_KEY' characters
+ *
+ *   @retval MPI_SUCCESS
+ *   @retval MPI_ERR_ARG
+ */
+int opal_info_get_nthkey (opal_info_t *info, int n, char *key);
+
+/**
+ * Convert value string to boolean
+ *
+ * Convert value string \c value into a boolean, using the
+ * interpretation rules specified in MPI-2 Section 4.10.  The
+ * strings "true", "false", and integer numbers can be converted
+ * into booleans.  All others will return \c OMPI_ERR_BAD_PARAM
+ *
+ * @param value Value string for info key to interpret
+ * @param interp returned interpretation of the value key
+ *
+ * @retval OMPI_SUCCESS string was successfully interpreted
+ * @retval OMPI_ERR_BAD_PARAM string was not able to be interpreted
+ */
+OMPI_DECLSPEC int opal_info_value_to_bool(char *value, bool *interp);
+
+/**
+ * Convert value string to integer
+ *
+ * Convert value string \c value into a integer, using the
+ * interpretation rules specified in MPI-2 Section 4.10.
+ * All others will return \c OMPI_ERR_BAD_PARAM
+ *
+ * @param value Value string for info key to interpret
+ * @param interp returned interpretation of the value key
+ *
+ * @retval OMPI_SUCCESS string was successfully interpreted
+ * @retval OMPI_ERR_BAD_PARAM string was not able to be interpreted
+ */
+int opal_info_value_to_int(char *value, int *interp);
+
+END_C_DECLS
+
+/**
+ * Get the number of keys defined on on an MPI_Info object
+ * @param info Pointer to opal_info_t object.
+ * @param nkeys Pointer to nkeys, which needs to be filled up.
+ *
+ * @retval The number of keys defined on info
+ */
+static inline int
+opal_info_get_nkeys(opal_info_t *info, int *nkeys)
+{
+    *nkeys = (int) opal_list_get_size(&(info->super));
+    return MPI_SUCCESS;
+}
+
+bool opal_str_to_bool(char*);
+
+#endif /* OPAL_INFO_H */

--- a/opal/util/info_subscriber.c
+++ b/opal/util/info_subscriber.c
@@ -1,0 +1,250 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <limits.h>
+#include <ctype.h>
+#ifdef HAVE_SYS_UTSNAME_H
+#include <sys/utsname.h>
+#endif
+#include <assert.h>
+
+#include "opal/util/argv.h"
+#include "opal/util/opal_getcwd.h"
+#include "opal/util/output.h"
+#include "opal/util/strncpy.h"
+#include "opal/util/info_subscriber.h"
+
+static char* opal_infosubscribe_inform_subscribers(opal_infosubscriber_t * object, char *key, char *new_value);
+static void infosubscriber_construct(opal_infosubscriber_t *obj);
+static void infosubscriber_destruct(opal_infosubscriber_t *obj);
+
+/*
+ * Local structures
+ */
+
+typedef struct opal_callback_list_t opal_callback_list_t;
+
+struct opal_callback_list_item_t {
+    opal_list_item_t super;
+    char *default_value;
+    opal_key_interest_callback_t *callback;
+};
+typedef struct opal_callback_list_item_t opal_callback_list_item_t;
+
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_infosubscriber_t);
+OBJ_CLASS_INSTANCE(opal_infosubscriber_t, 
+                   opal_object_t, 
+                   infosubscriber_construct, 
+                   infosubscriber_destruct);
+
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_callback_list_item_t);
+OBJ_CLASS_INSTANCE(opal_callback_list_item_t, 
+                   opal_list_item_t, 
+                   NULL, 
+                   NULL);
+
+static void infosubscriber_construct(opal_infosubscriber_t *obj) {
+    OBJ_CONSTRUCT(&obj->s_subscriber_table, opal_hash_table_t);
+    opal_hash_table_init(&obj->s_subscriber_table, 10);
+}
+
+static void infosubscriber_destruct(opal_infosubscriber_t *obj) {
+    OBJ_DESTRUCT(&obj->s_subscriber_table);
+}
+
+static char* opal_infosubscribe_inform_subscribers(opal_infosubscriber_t *object, char *key, char *new_value)
+{
+    opal_hash_table_t *table = &object->s_subscriber_table;
+    opal_list_t *list = NULL;
+    opal_callback_list_item_t *item;
+    char *updated_value = NULL;
+
+/*
+ * Present the new value to each subscriber.  They can decide to accept it, ignore it, or 
+ * over-ride it with their own value (like ignore, but they specify what value they want it to have).
+ *
+ * Since multiple subscribers could set values, only the last setting is kept as the 
+ * returned value.
+ */
+    if (table) {
+        opal_hash_table_get_value_ptr(table, key, strlen(key), (void**) &list);
+
+        if (list) {
+            updated_value = new_value;
+            OPAL_LIST_FOREACH(item, list, opal_callback_list_item_t) {
+		updated_value = item->callback(object, key, updated_value);
+            }
+        }
+    }
+
+    return updated_value;
+}
+
+
+
+
+int
+opal_infosubscribe_change_info(opal_infosubscriber_t *object, opal_info_t *new_info)
+{
+    int err;
+    size_t key_size;
+    int flag;
+    opal_info_entry_t *iterator;
+    opal_info_t **old_info = &object->s_info;
+    opal_info_t *real_info;
+    char *updated_value;
+    void *node = NULL;
+    char *next_key;
+    opal_hash_table_t *table = &object->s_subscriber_table;
+    opal_callback_list_item_t *item;
+    opal_list_t *list = NULL;
+
+    /* for each key/value in new info, let subscribers know of new value */
+
+    real_info = OBJ_NEW(opal_info_t);
+ 
+    OPAL_LIST_FOREACH(iterator, &new_info->super, opal_info_entry_t) {
+      
+        if ((updated_value = opal_infosubscribe_inform_subscribers(object, iterator->ie_key, iterator->ie_value))) {
+            err = opal_info_set(real_info, iterator->ie_key, updated_value);    
+            if (MPI_SUCCESS != err) {
+              return err;
+            }
+        }
+    }
+
+/* 
+ * Now any values in the old_info that were not included in the new info we should 
+ * tell them that they are going away and give a chance to set them in the new info
+ * SOLT: TODO: This should be a compare with MPI_INFO_NULL??
+ */
+   if (NULL != *old_info) {
+   
+        /* let subscribers know it is going away, they may set a new value for it */
+
+        OPAL_LIST_FOREACH(iterator, &(*old_info)->super, opal_info_entry_t) {
+
+/*
+ * See if this is updated in the new_info.  If so, we don't need to tell them about it
+ * going away, we already told them about the value change.
+ */
+            err = opal_info_get (new_info, iterator->ie_key, 0, NULL, &flag);
+            if (MPI_SUCCESS != err) {
+                return err;
+            }
+   
+            if (!flag && (updated_value = opal_infosubscribe_inform_subscribers(object, iterator->ie_key, NULL))) {
+                err = opal_info_set(real_info, iterator->ie_key, updated_value);
+                if (MPI_SUCCESS != err) {
+                    return err;
+                }
+            }
+        }
+
+       /* Clear old info */
+       OBJ_DESTRUCT(old_info);
+
+    } else {
+/*
+ * If there is no old_info, then this is the first time that we are setting something and we should set all 
+ * defaults that were not changed in new_info
+ */
+        err = opal_hash_table_get_first_key_ptr(table, (void**) &next_key, &key_size, (void**) &list, &node);
+
+
+        while (list && err == OPAL_SUCCESS) {
+
+            err = opal_info_get (new_info, next_key, 0, NULL, &flag);
+            if (MPI_SUCCESS != err) {
+                return err;
+            }
+/*
+ * Figure out which subscriber's default value we will take.  (Psst, we are going to 
+ * take the first one we see)
+ */
+            updated_value = NULL;
+            OPAL_LIST_FOREACH(item, list, opal_callback_list_item_t) {
+                 if (item->default_value) {
+	             updated_value = item->default_value;
+                     break;
+                 }
+            }
+		
+            if (updated_value) {
+                err = opal_info_set(real_info, next_key, updated_value);
+            }
+        }
+
+        err = opal_hash_table_get_next_key_ptr(table, (void**) next_key, &key_size, (void**) &list, node, &node);
+    }
+
+   *old_info = real_info;
+   
+   return OPAL_SUCCESS;
+}
+
+int opal_infosubscribe_subscribe(opal_infosubscriber_t *object, char *key, char *value, opal_key_interest_callback_t *callback)
+{
+    opal_list_t *list = NULL;
+    opal_hash_table_t *table = &object->s_subscriber_table;
+    opal_callback_list_item_t *callback_list_item;
+
+    if (table) {
+        opal_hash_table_get_value_ptr(table, key, strlen(key), (void**) &list);
+
+        if (!list) {
+            list = OBJ_NEW(opal_list_t);
+            opal_hash_table_set_value_ptr(table, key, strlen(key), list);
+        }
+
+	callback_list_item = OBJ_NEW(opal_callback_list_item_t);
+        callback_list_item->callback = callback;
+	if (value) {
+            callback_list_item->default_value = strdup(value);
+        } else {
+            callback_list_item->default_value = NULL;
+        }
+
+        opal_list_append(list, (opal_list_item_t*) callback_list_item); 
+    } else {
+/*
+ * TODO: This should not happen
+ */ 
+    }
+
+    return OPAL_SUCCESS;
+}
+
+/*
+    OBJ_DESTRUCT(&opal_comm_info_hashtable);
+    OBJ_DESTRUCT(&opal_win_info_hashtable);
+    OBJ_DESTRUCT(&opal_file_info_hashtable);
+*/

--- a/opal/util/info_subscriber.h
+++ b/opal/util/info_subscriber.h
@@ -1,0 +1,83 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OMPI_INFOSUBSCRIBE_H
+#define OMPI_INFOSUBSCRIBE_H
+
+#include <string.h>
+
+#include "opal/class/opal_list.h"
+#include "opal/class/opal_pointer_array.h"
+#include "opal/class/opal_hash_table.h"
+#include "opal/threads/mutex.h"
+#include "opal/util/info.h"
+
+#include "opal/mca/base/mca_base_var_enum.h"
+
+
+#define INFO_SUBSCRIBER_SIZE 5
+
+struct opal_infosubscriber_t {
+    opal_object_t	s_base;
+    opal_hash_table_t 	s_subscriber_table;
+    opal_info_t 	*s_info;
+};
+typedef struct opal_infosubscriber_t opal_infosubscriber_t;
+
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_infosubscriber_t);
+
+typedef char*(opal_key_interest_callback_t)(opal_infosubscriber_t*, char*, char*);
+
+/**
+ *   opal_infosubscribe_change_info - Make changes to a Comm/Win/File Info
+ *
+ *   @param type Comm/Win/File
+ *   @param object corresponding Com/Win/File object
+ *   @param old_info previous info setting
+ *   @param new_info new info setting
+ *
+ *   @retval OPAL status
+ *
+ *   Notifies subscribers of info's that have gone away and new info settings
+ */
+int opal_infosubscribe_change_info(opal_infosubscriber_t*, opal_info_t *);
+
+
+/**
+ *   opal_infosubscribe_subscribe - Request to be updated about info changes to a Comm/Win/File Info
+ *
+ *   @param type Comm/Win/File of obj
+ *   @param obj either a comm, win or file
+ *   @param key info key being set
+ *   @param initial_value default value (or NULL if none)
+ *   @param callback callback to be called when key changes
+ *
+ *   @retval OPAL status
+ *
+ *   Notifies subscribers of info's that have gone away and new info settings
+ *   Does not try to optimize settings that are the same between old and new
+ *   info's.
+ */
+int opal_infosubscribe_subscribe(opal_infosubscriber_t*, char *, char *, opal_key_interest_callback_t);
+
+#endif /* OMPI_INFO_H */

--- a/oshmem/runtime/oshmem_info_support.c
+++ b/oshmem/runtime/oshmem_info_support.c
@@ -2,6 +2,7 @@
  *  Copyright (c) 2013      Mellanox Technologies, Inc.
  *                          All rights reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +58,7 @@ int oshmem_info_register_framework_params(opal_pointer_array_t *component_map)
     }
 
     /* Do OMPI interface call */
-    rc = ompi_info_register_framework_params(component_map);
+    rc = opal_info_register_framework_params(component_map);
     if (OMPI_SUCCESS != rc) {
         return rc;
     }
@@ -74,7 +75,7 @@ void oshmem_info_close_components(void)
     }
 
     /* Do OMPI interface call */
-    ompi_info_close_components();
+    opal_info_close_components();
 }
 
 void oshmem_info_show_oshmem_version(const char *scope)

--- a/oshmem/tools/oshmem_info/oshmem_info.c
+++ b/oshmem/tools/oshmem_info/oshmem_info.c
@@ -3,6 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  *
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -111,7 +112,7 @@ int main(int argc, char *argv[])
 #endif
 
     /* add in the ompi frameworks */
-    ompi_info_register_types(&mca_types);
+    opal_info_register_types(&mca_types);
 
     /* add in the oshmem frameworks */
     oshmem_info_register_types(&mca_types);

--- a/oshmem/tools/oshmem_info/param.c
+++ b/oshmem/tools/oshmem_info/param.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 IBM Corp.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +46,7 @@
 #include "oshmem/tools/oshmem_info/oshmem_info.h"
 
 
-const char *ompi_info_deprecated_value = "deprecated-ompi-info-value";
+const char *opal_info_deprecated_value = "deprecated-ompi-info-value";
 
 static void append(char *dest, size_t max, int *first, char *src)
 {
@@ -301,7 +302,7 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("Fort use mpi", "bindings:use_mpi",
                   fortran_usempi);
     opal_info_out("Fort use mpi size", "bindings:use_mpi:size",
-                  ompi_info_deprecated_value);
+                  opal_info_deprecated_value);
     opal_info_out("Fort use mpi_f08", "bindings:use_mpi_f08",
                   fortran_usempif08);
     opal_info_out("Fort mpi_f08 compliance", "bindings:use_mpi_f08:compliance",


### PR DESCRIPTION
This is my first pull request, please give careful review. Not sure if this should be on a branch first? This change is intended for 2.1 and is a new model of handling MPI_Info changes to communicators/windows/files. It moves much of the info handling to the opal layer, but retains a wrapper for info objects that are exposed to the user. This allows us to use the info keyvalue concept internally and also implement MPI_Info using this internal concept. 

The main driver for this change was to allow different components to see changes to MPI_Info (via MPI_Comm_set_info, etc) and have an opportunity to respond to those changes by either accepting the change and modifying their future behavior or modifying the proposed info change if they do not support it. 

There are some scenarios which are difficult for this model. Particularly if multiple components (called subscribers in the code) use the same key but conflict on the values they support. Currently the key is presented to each component in turn and each has a chance to modify the value. The ordering therefore matters. The key (no pun intended) is to not do this. Each module should either use its own keys or they should agree on what values they can accept. 

This code has received very minimal testing. I verified that no_locks values could be updated and the new value rejected when the underlying component does not support it. I can work on further testing, but would like some eyes on this as I do that to make sure the overall direction makes sense and that my approach to moving code around makes sense for the Open MPI architecture.

I would especially like @hjelmn to make sure that this will work for him.

@jsquyres @hjelmn @nysal @jjhursey @gpaulsen
