### PR TITLE
ddt: do not explicitly check parameter datatype is not MPI_DATATYPE_N…

### DIFF
--- a/ompi/mpi/c/bindings.h
+++ b/ompi/mpi/c/bindings.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,38 +39,39 @@ BEGIN_C_DECLS
    doesn't work to simply list all of the pragmas in a top-level
    header file. */
 
-/* These macros have to be used to check the corectness of the datatype depending on the
+/* These macros have to be used to check the correctness of the datatype depending on the
  * operations that we have to do with them. They can be used on all functions, not only
  * on the top level MPI functions, as they does not trigger the error handler. Is the user
  * responsability to do it.
+ * Since MPI_DATATYPE_NULL is not a committed type, there is no need for an adhoc test.
  */
 #define OMPI_CHECK_DATATYPE_FOR_SEND( RC, DDT, COUNT )                  \
     do {                                                                \
         /* (RC) = MPI_SUCCESS; */                                       \
-        if( NULL == (DDT) || MPI_DATATYPE_NULL == (DDT) ) (RC) = MPI_ERR_TYPE; \
+        if( NULL == (DDT) ||                                            \
+            !opal_datatype_is_committed(&((DDT)->super)) ||             \
+            !opal_datatype_is_valid(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE;       \
         else if( (COUNT) < 0 ) (RC) = MPI_ERR_COUNT;                    \
-        else if( !opal_datatype_is_committed(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE; \
-        else if( !opal_datatype_is_valid(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE;       \
     } while (0)
 
 #define OMPI_CHECK_DATATYPE_FOR_RECV( RC, DDT, COUNT )                  \
     do {                                                                \
-        /* (RC) = MPI_SUCCESS; */                                        \
-        if( NULL == (DDT) || MPI_DATATYPE_NULL == (DDT) ) (RC) = MPI_ERR_TYPE; \
+        /* (RC) = MPI_SUCCESS; */                                       \
+        if( NULL == (DDT) ||                                            \
+            !opal_datatype_is_committed(&((DDT)->super)) ||             \
+            /* XXX Fix flags ompi_datatype_is_overlapped((DDT)) || */   \
+            !opal_datatype_is_valid(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE;       \
         else if( (COUNT) < 0 ) (RC) = MPI_ERR_COUNT;                    \
-        else if( !opal_datatype_is_committed(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE;   \
-        /* XXX Fix flags else if( ompi_datatype_is_overlapped((DDT)) ) (RC) = MPI_ERR_TYPE; */ \
-        else if( !opal_datatype_is_valid(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE;       \
     } while (0)
 
 #define OMPI_CHECK_DATATYPE_FOR_ONE_SIDED( RC, DDT, COUNT )                          \
     do {                                                                             \
         /*(RC) = MPI_SUCCESS; */                                                     \
-        if( NULL == (DDT) || MPI_DATATYPE_NULL == (DDT) ) (RC) = MPI_ERR_TYPE;       \
+        if( NULL == (DDT) ||                                                         \
+            !opal_datatype_is_committed(&((DDT)->super)) ||                          \
+            opal_datatype_is_overlapped(&((DDT)->super)) ||                          \
+            !opal_datatype_is_valid(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE;          \
         else if( (COUNT) < 0 ) (RC) = MPI_ERR_COUNT;                                 \
-        else if( !opal_datatype_is_committed(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE; \
-        else if( opal_datatype_is_overlapped(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE; \
-        else if( !opal_datatype_is_valid(&((DDT)->super)) ) (RC) = MPI_ERR_TYPE;     \
     } while(0)
 
 

--- a/test/datatype/ddt_test.c
+++ b/test/datatype/ddt_test.c
@@ -11,6 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Sun Microsystems Inc. All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -394,6 +396,14 @@ int main( int argc, char* argv[] )
     printf( "\n\n#\n * TEST CONTIGUOUS\n #\n\n" );
     pdt = test_contiguous();
     OBJ_RELEASE( pdt ); assert( pdt == NULL );
+
+    printf( "\n\n#\n * TEST MPI_DATATYPE_NULL\n #\n\n" );
+    /*
+     * MPI_DATATYPE_NULL cannot be a committed datatype,
+     * see comment in ompi/mpi/c/bindings.h
+     */
+    assert(! opal_datatype_is_committed(&ompi_mpi_datatype_null.dt.super));
+
     printf( "\n\n#\n * TEST STRUCT\n #\n\n" );
     pdt = test_struct();
     OBJ_RELEASE( pdt ); assert( pdt == NULL );


### PR DESCRIPTION
…ULL.

Since MPI_DATATYPE_NULL is not a committed datatype, it cannot be
a valid parameter and there is no need for an ad-hoc test.