### PR TITLE
Solaris statfs fix

### DIFF
--- a/ompi/mca/fs/base/base.h
+++ b/ompi/mca/fs/base/base.h
@@ -48,6 +48,7 @@ OMPI_DECLSPEC int mca_fs_base_init_file (struct mca_io_ompio_file_t *file);
 
 OMPI_DECLSPEC int mca_fs_base_get_param (struct mca_io_ompio_file_t *file, int keyval);
 OMPI_DECLSPEC void mca_fs_base_get_parent_dir (char *filename, char **dirnamep);
+OMPI_DECLSPEC int  mca_fs_base_get_fstype(char *fname);
 /*
  * Globals
  */

--- a/ompi/mca/fs/base/fs_base_get_parent_dir.c
+++ b/ompi/mca/fs/base/fs_base_get_parent_dir.c
@@ -103,7 +103,12 @@ int  mca_fs_base_get_fstype(char *fname )
     bool ret = opal_path_nfs ( fname, &fstype );
 
     if ( false == ret ) {
-        return ompio_type;
+        char *dir;
+        mca_fs_base_get_parent_dir (fname, &dir );
+        ret = opal_path_nfs (dir, &fstype);
+        if ( false == ret ) {
+            return ompio_type;
+        }
     }
     if ( 0 == strncasecmp(fstype, "lustre", sizeof("lustre")) ) {
         ompio_type = LUSTRE;

--- a/ompi/mca/fs/base/fs_base_get_parent_dir.c
+++ b/ompi/mca/fs/base/fs_base_get_parent_dir.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -25,9 +25,11 @@
 
 #include "ompi/mca/mca.h"
 #include "opal/mca/base/base.h"
+#include "opal/util/path.h"
 
 #include "ompi/mca/fs/fs.h"
 #include "ompi/mca/fs/base/base.h"
+#include "ompi/mca/io/ompio/io_ompio.h"
 
 #ifdef HAVE_SYS_STATFS_H
 #include <sys/statfs.h> /* or <sys/vfs.h> */
@@ -93,3 +95,24 @@ void mca_fs_base_get_parent_dir ( char *filename, char **dirnamep)
     *dirnamep = dir;
     return;
 }
+
+int  mca_fs_base_get_fstype(char *fname )
+{
+    int ompio_type = UFS;
+    char *fstype=NULL;
+    bool ret = opal_path_nfs ( fname, &fstype );
+
+    if ( false == ret ) {
+        return ompio_type;
+    }
+    if ( 0 == strncasecmp(fstype, "lustre", sizeof("lustre")) ) {
+        ompio_type = LUSTRE;
+    }
+    else if ( 0 == strncasecmp(fstype, "pvfs2", sizeof("pvfs2"))) {
+        ompio_type = PVFS2;
+    }
+
+    free (fstype);
+    return ompio_type;
+}
+

--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2015 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -93,22 +93,8 @@ mca_fs_lustre_component_file_query (mca_io_ompio_file_t *fh, int *priority)
     tmp = strchr (fh->f_filename, ':');
     if (!tmp) {
         if (OMPIO_ROOT == fh->f_rank) {
-            do {
-                err = statfs (fh->f_filename, &fsbuf);
-            } while (err && (errno == ESTALE));
-
-            if (err && (errno == ENOENT)) {
-                mca_fs_base_get_parent_dir (fh->f_filename, &dir);
-                err = statfs (dir, &fsbuf);
-                free (dir);
-            }
-#ifndef LL_SUPER_MAGIC
-#define LL_SUPER_MAGIC 0x0BD00BD0
-#endif
-            if (fsbuf.f_type == LL_SUPER_MAGIC) {
-                fh->f_fstype = LUSTRE;
-            }
-	}
+            fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
+        }
 	fh->f_comm->c_coll.coll_bcast (&(fh->f_fstype),
 				       1,
 				       MPI_INT,

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2015 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -96,18 +96,7 @@ mca_fs_pvfs2_component_file_query (mca_io_ompio_file_t *fh, int *priority)
     tmp = strchr (fh->f_filename, ':');
     if (!tmp) {
         if (OMPIO_ROOT == fh->f_rank) {
-            do {
-                err = statfs (fh->f_filename, &fsbuf);
-            } while (err && (errno == ESTALE));
-
-            if (err && (errno == ENOENT)) {
-                mca_fs_base_get_parent_dir (fh->f_filename, &dir);
-                err = statfs (dir, &fsbuf);
-                free (dir);
-            }
-            if (fsbuf.f_type == PVFS2_SUPER_MAGIC) {
-                fh->f_fstype = PVFS2;
-            }
+            fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
 	}
 	fh->f_comm->c_coll.coll_bcast (&(fh->f_fstype),
 				       1,

--- a/opal/mca/shmem/mmap/shmem_mmap_module.c
+++ b/opal/mca/shmem/mmap/shmem_mmap_module.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2014 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2016      University of Houston. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -363,7 +364,7 @@ segment_create(opal_shmem_ds_t *ds_buf,
      * this is an important check because if the backing store is located on
      * a network filesystem, the user may see a shared memory performance hit.
      */
-    if (opal_shmem_mmap_nfs_warning && opal_path_nfs(real_file_name)) {
+    if (opal_shmem_mmap_nfs_warning && opal_path_nfs(real_file_name, NULL)) {
         char hn[MAXHOSTNAMELEN];
         gethostname(hn, MAXHOSTNAMELEN - 1);
         hn[MAXHOSTNAMELEN - 1] = '\0';

--- a/opal/util/path.h
+++ b/opal/util/path.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2016      University of Houston. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,19 +127,22 @@ OPAL_DECLSPEC char *opal_path_access(char *fname, char *path, int mode) __opal_a
 
 /**
  * @brief Figure out, whether fname is on network file system
+ * and return fstype if known
  *
  * Try to figure out, whether the file name specified through fname is
- * on any network file system (currently NFS, Lustre and Panasas).
+ * on any network file system (currently NFS, Lustre, GPFS,  Panasas
+ * and PVFS2 ).
  *
  * If the file is not created, the parent directory is checked.
  * This allows checking for NFS prior to opening the file.
  *
- * @param[in]     fname        File name to check
+ * @fname[in]     File name to check
+ * @fstype[out]   File system type if retval is true
  *
  * @retval true                If fname is on NFS, Lustre or Panasas
  * @retval false               otherwise
  */
-OPAL_DECLSPEC bool opal_path_nfs(char *fname) __opal_attribute_warn_unused_result__;
+OPAL_DECLSPEC bool opal_path_nfs(char *fname, char **fstype) __opal_attribute_warn_unused_result__;
 
 /**
  * @brief Returns the disk usage of path.

--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
         printf("Interactive opal_path_nfs() test:\n");
         for (i = 1; i < argc; i++) {
             printf ("Is dir[%d]:%s one of the detected network file systems? %s\n",
-                    i, argv[i], opal_path_nfs (argv[i]) ? "Yes": "No");
+                    i, argv[i], opal_path_nfs (argv[i], NULL) ? "Yes": "No");
         }
 
         return 0;
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
         int i;
         for (i = 1; i < argc; i++)
             printf ("Is dir[%d]:%s one of the detected network file systems? %s\n",
-                    i, argv[i], opal_path_nfs (argv[i]) ? "Yes": "No");
+                    i, argv[i], opal_path_nfs (argv[i], NULL) ? "Yes": "No");
     }
 
     get_mounts (&num_dirs, &dirs, &nfs);
@@ -119,7 +119,7 @@ void test(char* file, bool expect)
     printf ("test(): file:%s bool:%d\n",
             file, expect);
 #endif
-    if (expect == opal_path_nfs (file)) {
+    if (expect == opal_path_nfs (file, NULL)) {
         test_success();
     } else {
         char * msg;


### PR DESCRIPTION
This is part 1 of the fix to make ompio compile on solaris correctly.

@rhc54 would you mind having a look especially at the modifications in opal_path_nfs that I made? Basically I added an additional argument, which is however only set if the user does not pass NULL as an input pointer.

Part 2 of the fix will have to occur based on this modification on the release branch only (that code section does not exist in master)