### PR TITLE
RFC: ompi_mpi_params.c: set mpi_add_procs_cutoff default to 0

### DIFF
--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
@@ -64,7 +64,9 @@ int ompi_mpi_event_tick_rate = -1;
 char *ompi_mpi_show_mca_params_string = NULL;
 bool ompi_mpi_have_sparse_group_storage = !!(OMPI_GROUP_SPARSE);
 bool ompi_mpi_preconnect_mpi = false;
-uint32_t ompi_add_procs_cutoff = 1024;
+
+#define OMPI_ADD_PROCS_CUTOFF_DEFAULT 0
+uint32_t ompi_add_procs_cutoff = OMPI_ADD_PROCS_CUTOFF_DEFAULT;
 bool ompi_mpi_dynamics_enabled = true;
 
 static bool show_default_mca_params = false;
@@ -263,12 +265,12 @@ int ompi_mpi_register_params(void)
         ompi_rte_abort(1, NULL);
     }
 
-    ompi_add_procs_cutoff = 1024;
+    ompi_add_procs_cutoff = OMPI_ADD_PROCS_CUTOFF_DEFAULT;
     (void) mca_base_var_register ("ompi", "mpi", NULL, "add_procs_cutoff",
                                   "Maximum world size for pre-allocating resources for all "
                                   "remote processes. Increasing this limit may improve "
-                                  "communication performance at the cost of memory usage "
-                                  "(default: 1024)", MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
+                                  "communication performance at the cost of memory usage",
+                                  MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL,
                                   0, 0, OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
                                   &ompi_add_procs_cutoff);
 


### PR DESCRIPTION
Decrease the default value of the "mpi_add_procs_cutoff" MCA param from 1024 to 32.

@hppritcha Setting the milestone to v2.0.0 because the "partial add procs" behavior was supposed to be a key feature of v2.0.0.  Setting that to only happen at 1024 procs seems a little high.  Do you agree?

RFC for the rest of the community: does anyone have a concern about setting this value to 32? 