### PR TITLE
osc/pt2pt: bug fixes

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -631,8 +631,8 @@ static inline void osc_pt2pt_add_pending (ompi_osc_pt2pt_pending_t *pending)
                             opal_list_append (&mca_osc_pt2pt_component.pending_operations, &pending->super));
 }
 
-#define OSC_PT2PT_FRAG_TAG   0x80000
-#define OSC_PT2PT_FRAG_MASK  0x7ffff
+#define OSC_PT2PT_FRAG_TAG   0x10000
+#define OSC_PT2PT_FRAG_MASK  0x0ffff
 
 /**
  * get_tag:

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
@@ -147,6 +147,7 @@ int ompi_osc_pt2pt_fence(int assert, ompi_win_t *win)
 
     /* short-circuit the noprecede case */
     if (0 != (assert & MPI_MODE_NOPRECEDE)) {
+        module->comm->c_coll.coll_barrier (module->comm,  module->comm->c_coll.coll_barrier);
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                              "osc pt2pt: fence end (short circuit)"));
         return ret;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -213,7 +213,7 @@ int ompi_osc_pt2pt_control_send (ompi_osc_pt2pt_module_t *module, int target,
     char *ptr;
     int ret;
 
-    ret = ompi_osc_pt2pt_frag_alloc(module, target, len, &frag, &ptr, false);
+    ret = ompi_osc_pt2pt_frag_alloc(module, target, len, &frag, &ptr, false, true);
     if (OPAL_LIKELY(OMPI_SUCCESS == ret)) {
         memcpy (ptr, data, len);
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
@@ -57,16 +57,62 @@ static inline int ompi_osc_pt2pt_frag_finish (ompi_osc_pt2pt_module_t *module,
     return OMPI_SUCCESS;
 }
 
+static inline ompi_osc_pt2pt_frag_t *ompi_osc_pt2pt_frag_alloc_non_buffered (ompi_osc_pt2pt_module_t *module,
+                                                                             ompi_osc_pt2pt_peer_t *peer,
+                                                                             size_t request_len)
+{
+    ompi_osc_pt2pt_frag_t *curr;
+
+    /* to ensure ordering flush the buffer on the peer */
+    curr = peer->active_frag;
+    if (NULL != curr && opal_atomic_cmpset (&peer->active_frag, curr, NULL)) {
+        /* If there's something pending, the pending finish will
+           start the buffer.  Otherwise, we need to start it now. */
+        int ret = ompi_osc_pt2pt_frag_finish (module, curr);
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+            return NULL;
+        }
+    }
+
+    curr = (ompi_osc_pt2pt_frag_t *) opal_free_list_get (&mca_osc_pt2pt_component.frags);
+    if (OPAL_UNLIKELY(NULL == curr)) {
+        return NULL;
+    }
+
+    curr->target = peer->rank;
+
+    curr->header = (ompi_osc_pt2pt_frag_header_t*) curr->buffer;
+    curr->top = (char*) (curr->header + 1);
+    curr->remain_len = mca_osc_pt2pt_component.buffer_size;
+    curr->module = module;
+    curr->pending = 1;
+
+    curr->header->base.type = OMPI_OSC_PT2PT_HDR_TYPE_FRAG;
+    curr->header->base.flags = OMPI_OSC_PT2PT_HDR_FLAG_VALID;
+    if (module->passive_target_access_epoch) {
+        curr->header->base.flags |= OMPI_OSC_PT2PT_HDR_FLAG_PASSIVE_TARGET;
+    }
+    curr->header->source = ompi_comm_rank(module->comm);
+    curr->header->num_ops = 1;
+
+    return curr;
+}
+
 /*
- * Note: module lock must be held during this operation
+ * Note: this function takes the module lock
+ *
+ * buffered sends will cache the fragment on the peer object associated with the
+ * target. unbuffered-sends will cause the target fragment to be flushed and
+ * will not be cached on the peer. this causes the fragment to be flushed as
+ * soon as it is sent. this allows request-based rma fragments to be completed
+ * so MPI_Test/MPI_Wait/etc will work as expected.
  */
 static inline int ompi_osc_pt2pt_frag_alloc (ompi_osc_pt2pt_module_t *module, int target,
                                              size_t request_len, ompi_osc_pt2pt_frag_t **buffer,
-                                             char **ptr, bool long_send)
+                                             char **ptr, bool long_send, bool buffered)
 {
     ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, target);
     ompi_osc_pt2pt_frag_t *curr;
-    int ret;
 
     /* osc pt2pt headers can have 64-bit values. these will need to be aligned
      * on an 8-byte boundary on some architectures so we up align the allocation
@@ -77,51 +123,34 @@ static inline int ompi_osc_pt2pt_frag_alloc (ompi_osc_pt2pt_module_t *module, in
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
+    OPAL_OUTPUT_VERBOSE((MCA_BASE_VERBOSE_TRACE, ompi_osc_base_framework.framework_output,
+                         "attempting to allocate buffer for %lu bytes to target %d. long send: %d, "
+                         "buffered: %d", (unsigned long) request_len, target, long_send, buffered));
+
     OPAL_THREAD_LOCK(&module->lock);
-    curr = peer->active_frag;
-    if (NULL == curr || curr->remain_len < request_len || (long_send && curr->pending_long_sends == 32)) {
-        if (NULL != curr && opal_atomic_cmpset (&peer->active_frag, curr, NULL)) {
-            /* If there's something pending, the pending finish will
-               start the buffer.  Otherwise, we need to start it now. */
-            ret = ompi_osc_pt2pt_frag_finish (module, curr);
-            if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+    if (buffered) {
+        curr = peer->active_frag;
+        if (NULL == curr || curr->remain_len < request_len || (long_send && curr->pending_long_sends == 32)) {
+            curr = ompi_osc_pt2pt_frag_alloc_non_buffered (module, peer, request_len);
+            if (OPAL_UNLIKELY(NULL == curr)) {
                 OPAL_THREAD_UNLOCK(&module->lock);
-                return ret;
+                return OMPI_ERR_OUT_OF_RESOURCE;
             }
+
+            curr->pending_long_sends = long_send;
+            peer->active_frag = curr;
+        } else {
+            OPAL_THREAD_ADD32(&curr->header->num_ops, 1);
+            curr->pending_long_sends += long_send;
         }
 
-        curr = (ompi_osc_pt2pt_frag_t *) opal_free_list_get (&mca_osc_pt2pt_component.frags);
+        OPAL_THREAD_ADD32(&curr->pending, 1);
+    } else {
+        curr = ompi_osc_pt2pt_frag_alloc_non_buffered (module, peer, request_len);
         if (OPAL_UNLIKELY(NULL == curr)) {
+            OPAL_THREAD_UNLOCK(&module->lock);
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
-
-        curr->target = target;
-
-        curr->header = (ompi_osc_pt2pt_frag_header_t*) curr->buffer;
-        curr->top = (char*) (curr->header + 1);
-        curr->remain_len = mca_osc_pt2pt_component.buffer_size;
-        curr->module = module;
-        curr->pending = 2;
-        curr->pending_long_sends = long_send;
-
-        curr->header->base.type = OMPI_OSC_PT2PT_HDR_TYPE_FRAG;
-        curr->header->base.flags = OMPI_OSC_PT2PT_HDR_FLAG_VALID;
-        if (module->passive_target_access_epoch) {
-            curr->header->base.flags |= OMPI_OSC_PT2PT_HDR_FLAG_PASSIVE_TARGET;
-        }
-        curr->header->source = ompi_comm_rank(module->comm);
-        curr->header->num_ops = 1;
-
-        if (curr->remain_len < request_len) {
-            OPAL_THREAD_UNLOCK(&module->lock);
-            return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-        }
-
-        peer->active_frag = curr;
-    } else {
-        OPAL_THREAD_ADD32(&curr->pending, 1);
-        OPAL_THREAD_ADD32(&curr->header->num_ops, 1);
-        curr->pending_long_sends += long_send;
     }
 
     *ptr = curr->top;


### PR DESCRIPTION
This commit fixes several bugs identified by @ggouaillardet and MTT:

 - Fix SEGV in long send completion caused by missing update to the
   request callback data.

 - Add an MPI_Barrier to the fence short-cut. This fixes potential
   semantic issues where messages may be received before fence is
   reached.

 - Ensure fragments are flushed when using request-based RMA. This
   allows MPI_Test/MPI_Wait/etc to work as expected.

 - Restore the tag space back to 16-bits. It was intended that the
   space be expanded to 32-bits but the required change to the
   fragment headers was not committed. The tag space may be expanded
   in a later commit.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>