### PR TITLE
opal/memory: Move Memory Allocation Hooks usage from openib

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -98,7 +98,7 @@
 #endif
 #include "ompi/runtime/ompi_cr.h"
 
-#if defined(MEMORY_LINUX_PTMALLOC2) && MEMORY_LINUX_PTMALLOC2
+#if MEMORY_LINUX_HAVE_MALLOC_HOOK_SUPPORT
 #include "opal/mca/memory/linux/memory_linux.h"
 /* So this sucks, but with OPAL in its own library that is brought in
    implicity from libmpi, there are times when the malloc initialize
@@ -106,7 +106,7 @@
    from here, since any MPI code is going to call MPI_Init... */
 OPAL_DECLSPEC void (*__malloc_initialize_hook) (void) =
     opal_memory_linux_malloc_init_hook;
-#endif
+#endif /* MEMORY_LINUX_HAVE_MALLOC_HOOK_SUPPORT */
 
 /* This is required for the boundaries of the hash tables used to store
  * the F90 types returned by the MPI_Type_create_f90_XXX functions.

--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -300,11 +300,6 @@ struct mca_btl_openib_component_t {
 #if BTL_OPENIB_FAILOVER_ENABLED
     int verbose_failover;
 #endif
-#if BTL_OPENIB_MALLOC_HOOKS_ENABLED
-    int use_memalign;
-    size_t memalign_threshold;
-    void* (*previous_malloc_hook)(size_t __size, const void*);
-#endif
 #if OPAL_CUDA_SUPPORT
     bool cuda_async_send;
     bool cuda_async_recv;

--- a/opal/mca/btl/openib/btl_openib_mca.c
+++ b/opal/mca/btl/openib/btl_openib_mca.c
@@ -703,26 +703,19 @@ int btl_openib_register_mca_params(void)
                   0, &mca_btl_openib_component.gid_index,
                   REGINT_GE_ZERO));
 
-#if BTL_OPENIB_MALLOC_HOOKS_ENABLED
-    CHECK(reg_int("memalign", NULL,
-                  "[64 | 32 | 0] - Enable (64bit or 32bit)/Disable(0) memory"
-                  "alignment for all malloc calls if btl openib is used.",
-                  32, &mca_btl_openib_component.use_memalign,
-                  REGINT_GE_ZERO));
+#if MEMORY_LINUX_MALLOC_ALIGN_ENABLED
+    tmp = mca_base_var_find ("opal", "memory", "linux", "memalign");
+    if (0 <= tmp) {
+        (void) mca_base_var_register_synonym(tmp, "opal", "btl", "openib", "memalign",
+                                             MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    }
 
-    mca_btl_openib_component.memalign_threshold =
-        mca_btl_openib_module.super.btl_eager_limit;
-    tmp = mca_base_component_var_register(&mca_btl_openib_component.super.btl_version,
-                                          "memalign_threshold",
-                                          "Allocating memory more than btl_openib_memalign_threshhold"
-                                          "bytes will automatically be algined to the value of btl_openib_memalign bytes."
-                                          "memalign_threshhold defaults to the same value as mca_btl_openib_eager_limit.",
-                                          MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9,
-                                          MCA_BASE_VAR_SCOPE_READONLY,
-                                          &mca_btl_openib_component.memalign_threshold);
-    if (0 > tmp) ret = tmp;
-#endif
+    tmp = mca_base_var_find ("opal", "memory", "linux", "memalign_threshold");
+    if (0 <= tmp) {
+        (void) mca_base_var_register_synonym(tmp, "opal", "btl", "openib", "memalign_threshold",
+                                             MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    }
+#endif /* MEMORY_LINUX_MALLOC_ALIGN_ENABLED */
 
     /* Register any MCA params for the connect pseudo-components */
     if (OPAL_SUCCESS == ret) {
@@ -820,17 +813,6 @@ int btl_openib_verify_mca_params (void)
         opal_show_help("help-mpi-btl-openib.txt", "do_not_set_openib_value",
                        true, opal_process_info.nodename);
         mca_btl_openib_module.super.btl_cuda_max_send_size = 0;
-    }
-#endif
-
-#if BTL_OPENIB_MALLOC_HOOKS_ENABLED
-    if (mca_btl_openib_component.use_memalign != 32
-        && mca_btl_openib_component.use_memalign != 64
-        && mca_btl_openib_component.use_memalign != 0){
-        opal_show_help("help-mpi-btl-openib.txt", "invalid mca param value",
-                       true, "Wrong btl_openib_memalign parameter value. Allowed values: 64, 32, 0.",
-                       "btl_openib_memalign is reset to 32");
-        mca_btl_openib_component.use_memalign = 32;
     }
 #endif
 

--- a/opal/mca/btl/openib/configure.m4
+++ b/opal/mca/btl/openib/configure.m4
@@ -120,28 +120,6 @@ AC_DEFUN([MCA_opal_btl_openib_CONFIG],[
                        [enable openib BTL failover])
     AM_CONDITIONAL([MCA_btl_openib_enable_failover], [test "x$btl_openib_failover_enabled" = "x1"])
 
-    # Check for __malloc_hook availability
-    AC_ARG_ENABLE(btl-openib-malloc-alignment,
-    	AC_HELP_STRING([--enable-btl-openib-malloc-alignment], [Enable support for allocated memory alignment. Default: enabled if supported, disabled otherwise.]))
-
-    btl_openib_malloc_hooks_enabled=0
-    AS_IF([test "$enable_btl_openib_malloc_alignment" != "no"],
-        [AC_CHECK_HEADER([malloc.h],
-             [AC_CHECK_FUNC([__malloc_hook],
-                  [AC_CHECK_FUNC([__realloc_hook],
-                       [AC_CHECK_FUNC([__free_hook],
-                            [btl_openib_malloc_hooks_enabled=1])])])])])
-
-    AS_IF([test "$enable_btl_openib_malloc_alignment" = "yes" && test "$btl_openib_malloc_hooks_enabled" = "0"],
-          [AC_MSG_ERROR([openib malloc alignment is requested but __malloc_hook is not available])])
-    AC_MSG_CHECKING([whether the openib BTL will use malloc hooks])
-    AS_IF([test "$btl_openib_malloc_hooks_enabled" = "0"],
-          [AC_MSG_RESULT([no])],
-          [AC_MSG_RESULT([yes])])
-
-    AC_DEFINE_UNQUOTED(BTL_OPENIB_MALLOC_HOOKS_ENABLED, [$btl_openib_malloc_hooks_enabled],
-                       [Whether the openib BTL malloc hooks are enabled])
-
     # make sure that CUDA-aware checks have been done
     AC_REQUIRE([OPAL_CHECK_CUDA])
 

--- a/opal/mca/memory/linux/configure.m4
+++ b/opal/mca/memory/linux/configure.m4
@@ -63,6 +63,42 @@ AC_DEFUN([MCA_opal_memory_linux_CONFIG],[
                  [memory_linux_ptmalloc2_happy=no
                   memory_linux_ummu_happy=no])])
 
+
+    ######################################################################
+    # if memory hook available
+    ######################################################################
+    memory_hook_found=1
+    AS_IF([test "$memory_hook_found" -eq 1],
+        [memory_hook_found=0 AC_CHECK_HEADER([malloc.h],
+             [AC_CHECK_FUNC([__malloc_initialize_hook],
+                 [AC_CHECK_FUNC([__malloc_hook],
+                     [AC_CHECK_FUNC([__realloc_hook],
+                         [AC_CHECK_FUNC([__free_hook],
+                            [memory_hook_found=1])])])])])])
+    AC_MSG_CHECKING([whether the system can use malloc hooks])
+    AS_IF([test "$memory_hook_found" = "0"],
+          [AC_MSG_RESULT([no])],
+          [AC_MSG_RESULT([yes])])
+    AC_DEFINE_UNQUOTED([MEMORY_LINUX_HAVE_MALLOC_HOOK_SUPPORT], [$memory_hook_found],
+                   	   [Whether the system has Memory Allocation Hooks])
+
+    AC_ARG_ENABLE(memory-linux-malloc-alignment,
+        AC_HELP_STRING([--enable-memory-linux-malloc-alignment], [Enable support for allocated memory alignment. Default: enabled if supported, disabled otherwise.]))
+
+    malloc_align_enabled=0
+    AS_IF([test "$enable_memory_linux_malloc_alignment" != "no"],
+        [malloc_align_enabled=$memory_hook_found])
+
+    AS_IF([test "$enable_memory_linux_malloc_alignment" = "yes" && test "$malloc_align_enabled" = "0"],
+          [AC_MSG_ERROR([memory linux malloc alignment is requested but __malloc_hook is not available])])
+    AC_MSG_CHECKING([whether the memory linux will use malloc alignment])
+    AS_IF([test "$malloc_align_enabled" = "0"],
+          [AC_MSG_RESULT([no])],
+          [AC_MSG_RESULT([yes])])
+
+    AC_DEFINE_UNQUOTED(MEMORY_LINUX_MALLOC_ALIGN_ENABLED, [$malloc_align_enabled],
+                       [Whether the memory linux malloc alignment is enabled])
+
     ######################################################################
     # ptmalloc2
     ######################################################################

--- a/opal/mca/memory/linux/help-opal-memory-linux.txt
+++ b/opal/mca/memory/linux/help-opal-memory-linux.txt
@@ -27,3 +27,10 @@ alternate memory hook manager *may* be used instead (if available).
   Local host:  %s
   UMMU device: %s
   Error:       %s (%d)
+#
+[invalid mca param value]
+WARNING: An invalid MCA parameter value was found for memory/linux
+component.
+
+  Problem:    %s
+  Resolution: %s

--- a/opal/mca/memory/linux/hooks.c
+++ b/opal/mca/memory/linux/hooks.c
@@ -33,6 +33,7 @@
 #include "opal/mca/mca.h"
 #include "opal/mca/memory/memory.h"
 #include "opal/constants.h"
+#include "opal/memoryhooks/memory.h"
 
 #include "opal/mca/memory/linux/memory_linux.h"
 
@@ -734,7 +735,10 @@ static check_result_t check(const char *name)
     }
 }
 
-/* OMPI's init function */
+
+/* This function is called on loading libmpi in case system has Memory Allocation Hooks
+ * (see ompi/runtime/ompi_mpi_init.c for details)
+ */
 void opal_memory_linux_malloc_init_hook(void)
 {
     check_result_t r1, lp, lpp;

--- a/opal/mca/memory/linux/memory_linux.h
+++ b/opal/mca/memory/linux/memory_linux.h
@@ -31,6 +31,11 @@ typedef struct opal_memory_linux_component_t {
     int ummunotify_fd;
 #endif
 
+#if MEMORY_LINUX_MALLOC_ALIGN_ENABLED
+    int use_memalign;
+    size_t memalign_threshold;
+#endif
+
 #if MEMORY_LINUX_PTMALLOC2
     /* Ptmalloc2-specific data. Note that these variables are all marked as volatile.
      * This is needed because of what may be a buggy optimization in the GCC 4.9.2
@@ -64,12 +69,19 @@ int opal_memory_linux_ummunotify_close(void);
 /* memory_linux_ptmalloc2.c */
 int opal_memory_linux_ptmalloc2_open(void);
 int opal_memory_linux_ptmalloc2_close(void);
-OPAL_DECLSPEC void opal_memory_linux_malloc_init_hook(void);
 
 /* memory_linux_munmap.c */
 OPAL_DECLSPEC int opal_memory_linux_free_ptmalloc2_munmap(void *start, size_t length, int from_alloc);
 OPAL_DECLSPEC int munmap(void* addr, size_t len);
 #endif /* !MEMORY_LINUX_PTMALLOC2 */
+
+#if MEMORY_LINUX_HAVE_MALLOC_HOOK_SUPPORT
+OPAL_DECLSPEC void opal_memory_linux_malloc_init_hook(void);
+#endif /* MEMORY_LINUX_HAVE_MALLOC_HOOK_SUPPORT */
+
+#if MEMORY_LINUX_MALLOC_ALIGN_ENABLED
+OPAL_DECLSPEC void opal_memory_linux_malloc_set_alignment(int use_memalign, size_t memalign_threshold);
+#endif /* MEMORY_LINUX_MALLOC_ALIGN_ENABLED */
 
 END_C_DECLS
 


### PR DESCRIPTION
These changes fix issue https://github.com/open-mpi/ompi/issues/1336

opal/memory/linux component should be single place that opeartes with
Memory Allocation Hooks. It is safe because it is linked statically.

@ggouaillardet @yosefe could you please look at it.