### PR TITLE
Per the discussion on the telecon, change the -host behavior yet again

### DIFF
--- a/orte/mca/plm/base/base.h
+++ b/orte/mca/plm/base/base.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,6 +53,7 @@ ORTE_DECLSPEC int orte_plm_base_select(void);
 ORTE_DECLSPEC void orte_plm_base_app_report_launch(int fd, short event, void *data);
 ORTE_DECLSPEC void orte_plm_base_receive_process_msg(int fd, short event, void *data);
 
+ORTE_DECLSPEC void orte_plm_base_set_slots(orte_node_t *node);
 ORTE_DECLSPEC void orte_plm_base_setup_job(int fd, short args, void *cbdata);
 ORTE_DECLSPEC void orte_plm_base_setup_job_complete(int fd, short args, void *cbdata);
 ORTE_DECLSPEC void orte_plm_base_complete_setup(int fd, short args, void *cbdata);

--- a/orte/mca/ras/base/ras_base_allocate.c
+++ b/orte/mca/ras/base/ras_base_allocate.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,8 +77,8 @@ void orte_ras_base_display_alloc(void)
                      (NULL == alloc->name) ? "UNKNOWN" : alloc->name,
                      (int)alloc->slots, (int)alloc->slots_max, (int)alloc->slots_inuse);
         } else {
-            asprintf(&tmp2, "\t%s: slots=%d max_slots=%d slots_inuse=%d state=%s\n",
-                     (NULL == alloc->name) ? "UNKNOWN" : alloc->name,
+            asprintf(&tmp2, "\t%s: flags=0x%02x slots=%d max_slots=%d slots_inuse=%d state=%s\n",
+                     (NULL == alloc->name) ? "UNKNOWN" : alloc->name, alloc->flags,
                      (int)alloc->slots, (int)alloc->slots_max, (int)alloc->slots_inuse,
                      orte_node_state_to_str(alloc->state));
         }

--- a/orte/mca/ras/base/ras_base_node.c
+++ b/orte/mca/ras/base/ras_base_node.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$

--- a/orte/mca/rmaps/base/help-orte-rmaps-base.txt
+++ b/orte/mca/rmaps/base/help-orte-rmaps-base.txt
@@ -404,3 +404,9 @@ or provide more node locations in the file.
 The request to map processes by distance could not be completed
 because device to map near by was not specified. Please, use
 rmaps_dist_device mca parameter to set it.
+#
+[num-procs-not-specified]
+Either the -host or -hostfile options were given, but the number
+of processes to start was omitted. This combination is not supported.
+
+Please specify the number of processes to run and try again.

--- a/orte/runtime/data_type_support/orte_dt_print_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_print_fns.c
@@ -345,8 +345,8 @@ int orte_dt_print_node(char **output, char *prefix, orte_node_t *src, opal_data_
         goto PRINT_PROCS;
     }
 
-    asprintf(&tmp, "\n%sData for node: %s\tState: %0x",
-             pfx2, (NULL == src->name) ? "UNKNOWN" : src->name, src->state);
+    asprintf(&tmp, "\n%sData for node: %s\tState: %0x\tFlags: %02x",
+             pfx2, (NULL == src->name) ? "UNKNOWN" : src->name, src->state, src->flags);
     /* does this node have any aliases? */
     tmp3 = NULL;
     if (orte_get_attribute(&src->attributes, ORTE_NODE_ALIAS, (void**)&tmp3, OPAL_STRING)) {

--- a/orte/util/attr.h
+++ b/orte/util/attr.h
@@ -29,22 +29,22 @@ typedef uint8_t orte_app_context_flags_t;
 
 
 /* APP_CONTEXT ATTRIBUTE KEYS */
-#define ORTE_APP_HOSTFILE         1    // string  - hostfile
-#define ORTE_APP_ADD_HOSTFILE     2    // string  - hostfile to be added
-#define ORTE_APP_DASH_HOST        3    // string  - hosts specified with -host option
-#define ORTE_APP_ADD_HOST         4    // string  - hosts to be added
-#define ORTE_APP_USER_CWD         5    // bool  - user specified cwd
-#define ORTE_APP_SSNDIR_CWD       6    // bool  - use session dir as cwd
-#define ORTE_APP_PRELOAD_BIN      7    // bool  - move binaries to remote nodes prior to exec
-#define ORTE_APP_PRELOAD_FILES    8    // string  - files to be moved to remote nodes prior to exec
-#define ORTE_APP_SSTORE_LOAD      9    // string
-#define ORTE_APP_RECOV_DEF       10    // bool  - whether or not a recovery policy was defined
-#define ORTE_APP_MAX_RESTARTS    11    // int32 - max number of times a process can be restarted
-#define ORTE_APP_MIN_NODES       12    // int64 - min number of nodes required
-#define ORTE_APP_MANDATORY       13    // bool - flag if nodes requested in -host are "mandatory" vs "optional"
-#define ORTE_APP_MAX_PPN         14    // uint32 - maximum number of procs/node for this app
-#define ORTE_APP_PREFIX_DIR      15    // string - prefix directory for this app, if override necessary
-#define ORTE_APP_NO_CACHEDIR     16    // bool - flag that a cache dir is not to be specified for a Singularity container
+#define ORTE_APP_HOSTFILE            1    // string  - hostfile
+#define ORTE_APP_ADD_HOSTFILE        2    // string  - hostfile to be added
+#define ORTE_APP_DASH_HOST           3    // string  - hosts specified with -host option
+#define ORTE_APP_ADD_HOST            4    // string  - hosts to be added
+#define ORTE_APP_USER_CWD            5    // bool  - user specified cwd
+#define ORTE_APP_SSNDIR_CWD          6    // bool  - use session dir as cwd
+#define ORTE_APP_PRELOAD_BIN         7    // bool  - move binaries to remote nodes prior to exec
+#define ORTE_APP_PRELOAD_FILES       8    // string  - files to be moved to remote nodes prior to exec
+#define ORTE_APP_SSTORE_LOAD         9    // string
+#define ORTE_APP_RECOV_DEF          10    // bool  - whether or not a recovery policy was defined
+#define ORTE_APP_MAX_RESTARTS       11    // int32 - max number of times a process can be restarted
+#define ORTE_APP_MIN_NODES          12    // int64 - min number of nodes required
+#define ORTE_APP_MANDATORY          13    // bool - flag if nodes requested in -host are "mandatory" vs "optional"
+#define ORTE_APP_MAX_PPN            14    // uint32 - maximum number of procs/node for this app
+#define ORTE_APP_PREFIX_DIR         15    // string - prefix directory for this app, if override necessary
+#define ORTE_APP_NO_CACHEDIR        16    // bool - flag that a cache dir is not to be specified for a Singularity container
 
 #define ORTE_APP_MAX_KEY        100
 

--- a/orte/util/dash_host/dash_host.c
+++ b/orte/util/dash_host/dash_host.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -249,7 +249,6 @@ int orte_util_add_dash_host_nodes(opal_list_t *nodes,
                 }
             } else {
                 node->slots = 1;
-                ORTE_FLAG_SET(node, ORTE_NODE_FLAG_SLOTS_GIVEN);
             }
             opal_list_append(&adds, &node->super);
         }


### PR DESCRIPTION
 Per the discussion on the telecon, change the -host behavior so we only run one instance if no slots were provided and the user didn't specify #procs to run. However, if no slots are given and the user does specify #procs, then let the number of slots default to the #found processing elements

Ensure the returned exit status is non-zero if we fail to map

If no -np is given, but either -host and/or -hostfile was given, then error out with a message telling the user that this combination is not supported.

If -np is given, and -host is given with only one instance of each host, then default the #slots to the detected #pe's and enforce oversubscription rules.

If -np is given, and -host is given with more than one instance of a given host, then set the #slots for that host to the number of times it was given and enforce oversubscription rules. Alternatively, the #slots can be specified via "-host foo:N". I therefore believe that row #7 on Jeff's spreadsheet is incorrect.

With that one correction, this now passes all the given use-cases on that spreadsheet.

Make things behave under unmanaged allocations more like their managed cousins - if the #slots is given, then no-np shall fill things up.

Fixes #1344