### PR TITLE
Enable the PMIx notification callback system and fix debugger attach

### DIFF
--- a/ompi/mca/rte/orte/rte_orte.h
+++ b/ompi/mca/rte/orte/rte_orte.h
@@ -91,7 +91,7 @@ OMPI_DECLSPEC void __opal_attribute_noreturn__
 #define OMPI_ERROR_LOG ORTE_ERROR_LOG
 
 /* Init and finalize objects and operations */
-#define ompi_rte_init(a, b) orte_init(a, b, ORTE_PROC_MPI)
+OMPI_DECLSPEC int ompi_rte_init(int *pargc, char ***pargv);
 #define ompi_rte_finalize() orte_finalize()
 OMPI_DECLSPEC void ompi_rte_wait_for_debugger(void);
 

--- a/ompi/mca/rte/orte/rte_orte_module.c
+++ b/ompi/mca/rte/orte/rte_orte_module.c
@@ -52,6 +52,79 @@
 
 extern ompi_rte_orte_component_t mca_rte_orte_component;
 
+typedef struct {
+    volatile bool active;
+    int status;
+    int errhandler;
+} errhandler_t;
+
+static void register_cbfunc(int status, int errhndler, void *cbdata)
+{
+    errhandler_t *cd = (errhandler_t*)cbdata;
+    cd->status = status;
+    cd->errhandler = errhndler;
+    cd->active = false;
+}
+
+static volatile bool wait_for_release = true;
+static int errhandler = -1;
+
+static void notify_cbfunc(int status,
+                          opal_list_t *procs,
+                          opal_list_t *info,
+                          opal_pmix_release_cbfunc_t cbfunc,
+                          void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(cbdata);
+    }
+    wait_for_release = false;
+}
+
+
+int ompi_rte_init(int *pargc, char ***pargv)
+{
+    int rc;
+    opal_list_t info;
+    opal_value_t val;
+    errhandler_t cd;
+
+    if (ORTE_SUCCESS != (rc = orte_init(pargc, pargv, ORTE_PROC_MPI))) {
+        return rc;
+    }
+
+    if (!orte_standalone_operation) {
+        /* register to receive any debugger release */
+        OBJ_CONSTRUCT(&info, opal_list_t);
+        OBJ_CONSTRUCT(&val, opal_value_t);
+        val.key = strdup(OPAL_PMIX_ERROR_NAME);
+        val.type = OPAL_INT;
+        val.data.integer = OPAL_ERR_DEBUGGER_RELEASE;
+        opal_list_append(&info, &val.super);
+        cd.status = ORTE_ERROR;
+        cd.errhandler = -1;
+        cd.active = true;
+
+        opal_pmix.register_errhandler(&info, notify_cbfunc, register_cbfunc, &cd);
+
+        /* let the MPI progress engine run while we wait for
+         * registration to complete */
+        OMPI_WAIT_FOR_COMPLETION(cd.active);
+        /* safely deconstruct the list */
+        opal_list_remove_first(&info);
+        OBJ_DESTRUCT(&val);
+        OBJ_DESTRUCT(&info);
+        if (OPAL_SUCCESS != cd.status) {
+            /* ouch - we are doomed */
+            ORTE_ERROR_LOG(cd.status);
+            return OMPI_ERROR;
+        }
+        errhandler = cd.errhandler;
+    }
+
+    return OMPI_SUCCESS;
+}
+
 void ompi_rte_abort(int error_code, char *fmt, ...)
 {
     va_list arglist;
@@ -100,10 +173,10 @@ void ompi_rte_abort(int error_code, char *fmt, ...)
  * attaching debuggers -- see big comment in
  * orte/tools/orterun/debuggers.c explaining the two scenarios.
  */
+
 void ompi_rte_wait_for_debugger(void)
 {
     int debugger;
-    orte_rml_recv_cb_t xfer;
 
     /* See lengthy comment in orte/tools/orterun/debuggers.c about
        orte_in_parallel_debugger */
@@ -117,12 +190,12 @@ void ompi_rte_wait_for_debugger(void)
         /* if not, just return */
         return;
     }
-
     /* if we are being debugged, then we need to find
      * the correct plug-ins
      */
     ompi_debugger_setup_dlls();
 
+    /* wait for the debugger to attach */
     if (orte_standalone_operation) {
         /* spin until debugger attaches and releases us */
         while (MPIR_debug_gate == 0) {
@@ -133,23 +206,9 @@ void ompi_rte_wait_for_debugger(void)
 #endif
         }
     } else {
-        /* only the rank=0 proc waits for either a message from the
-         * HNP or for the debugger to attach - everyone else will just
-         * spin in * the grpcomm barrier in ompi_mpi_init until rank=0
-         * joins them.
-         */
-        if (0 != ORTE_PROC_MY_NAME->vpid) {
-            return;
-        }
-
-        /* VPID 0 waits for a message from the HNP */
-        OBJ_CONSTRUCT(&xfer, orte_rml_recv_cb_t);
-        xfer.active = true;
-        orte_rml.recv_buffer_nb(OMPI_NAME_WILDCARD,
-                                ORTE_RML_TAG_DEBUGGER_RELEASE,
-                                ORTE_RML_NON_PERSISTENT,
-                                orte_rml_recv_callback, &xfer);
-        /* let the MPI progress engine run while we wait */
-        OMPI_WAIT_FOR_COMPLETION(xfer.active);
+        /* now wait for the notification to occur */
+        OMPI_WAIT_FOR_COMPLETION(wait_for_release);
+        /* deregister the errhandler */
+        opal_pmix.deregister_errhandler(errhandler, NULL, NULL);
     }
 }

--- a/opal/dss/dss_compare.c
+++ b/opal/dss/dss_compare.c
@@ -10,9 +10,9 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -442,6 +442,15 @@ int opal_dss_compare_jobid(opal_jobid_t *value1,
     if (*value1 == OPAL_JOBID_WILDCARD ||
         *value2 == OPAL_JOBID_WILDCARD) return OPAL_EQUAL;
 
+    if (*value1 > *value2) return OPAL_VALUE1_GREATER;
+
+    if (*value2 > *value1) return OPAL_VALUE2_GREATER;
+
+    return OPAL_EQUAL;
+}
+
+int opal_dss_compare_status(int *value1, int *value2, opal_data_type_t type)
+{
     if (*value1 > *value2) return OPAL_VALUE1_GREATER;
 
     if (*value2 > *value1) return OPAL_VALUE2_GREATER;

--- a/opal/dss/dss_copy.c
+++ b/opal/dss/dss_copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -61,6 +61,7 @@ int opal_dss_std_copy(void **dest, void *src, opal_data_type_t type)
 
     case OPAL_INT:
     case OPAL_UINT:
+    case OPAL_STATUS:
         datasize = sizeof(int);
         break;
 

--- a/opal/dss/dss_internal.h
+++ b/opal/dss/dss_internal.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
@@ -332,6 +332,9 @@ int opal_dss_pack_jobid(opal_buffer_t *buffer, const void *src,
 int opal_dss_pack_vpid(opal_buffer_t *buffer, const void *src,
                       int32_t num_vals, opal_data_type_t type);
 
+int opal_dss_pack_status(opal_buffer_t *buffer, const void *src,
+                         int32_t num_vals, opal_data_type_t type);
+
 /*
  * Internal unpack functions
  */
@@ -401,6 +404,8 @@ int opal_dss_unpack_jobid(opal_buffer_t *buffer, void *dest,
 int opal_dss_unpack_vpid(opal_buffer_t *buffer, void *dest,
                         int32_t *num_vals, opal_data_type_t type);
 
+int opal_dss_unpack_status(opal_buffer_t *buffer, void *dest,
+                           int32_t *num_vals, opal_data_type_t type);
 
 /*
  * Internal copy functions
@@ -497,6 +502,8 @@ int opal_dss_compare_jobid(opal_jobid_t *value1,
                            opal_jobid_t *value2,
                            opal_data_type_t type);
 
+int opal_dss_compare_status(int *value1, int *value2, opal_data_type_t type);
+
 /*
  * Internal print functions
  */
@@ -536,6 +543,7 @@ int opal_dss_print_time(char **output, char *prefix, time_t *src, opal_data_type
 int opal_dss_print_name(char **output, char *prefix, opal_process_name_t *name, opal_data_type_t type);
 int opal_dss_print_jobid(char **output, char *prefix, opal_process_name_t *src, opal_data_type_t type);
 int opal_dss_print_vpid(char **output, char *prefix, opal_process_name_t *src, opal_data_type_t type);
+int opal_dss_print_status(char **output, char *prefix, int *src, opal_data_type_t type);
 
 
 /*

--- a/opal/dss/dss_open_close.c
+++ b/opal/dss/dss_open_close.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -611,6 +611,17 @@ int opal_dss_open(void)
         return rc;
     }
 
+
+    tmp = OPAL_STATUS;
+    if (OPAL_SUCCESS != (rc = opal_dss.register_type(opal_dss_pack_status,
+                                          opal_dss_unpack_status,
+                                          (opal_dss_copy_fn_t)opal_dss_std_copy,
+                                          (opal_dss_compare_fn_t)opal_dss_compare_status,
+                                          (opal_dss_print_fn_t)opal_dss_print_status,
+                                          OPAL_DSS_UNSTRUCTURED,
+                                          "OPAL_STATUS", &tmp))) {
+        return rc;
+    }
     /* All done */
 
     opal_dss_initialized = true;

--- a/opal/dss/dss_pack.c
+++ b/opal/dss/dss_pack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -1234,6 +1234,23 @@ int opal_dss_pack_vpid(opal_buffer_t *buffer, const void *src,
     /* Turn around and pack the real type */
     if (OPAL_SUCCESS != (
                          ret = opal_dss_pack_buffer(buffer, src, num_vals, OPAL_VPID_T))) {
+        OPAL_ERROR_LOG(ret);
+    }
+
+    return ret;
+}
+
+/*
+ * STATUS
+ */
+int opal_dss_pack_status(opal_buffer_t *buffer, const void *src,
+                         int32_t num_vals, opal_data_type_t type)
+{
+    int ret;
+
+    /* Turn around and pack the real type */
+    ret = opal_dss_pack_buffer(buffer, src, num_vals, OPAL_INT);
+    if (OPAL_SUCCESS != ret) {
         OPAL_ERROR_LOG(ret);
     }
 

--- a/opal/dss/dss_print.c
+++ b/opal/dss/dss_print.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -25,6 +25,7 @@
 #include "opal_stdint.h"
 #include <stdio.h>
 
+#include "opal/util/error.h"
 #include "opal/dss/dss_internal.h"
 
 int opal_dss_print(char **output, char *prefix, void *src, opal_data_type_t type)
@@ -1054,6 +1055,32 @@ int opal_dss_print_vpid(char **output, char *prefix,
     }
 
     asprintf(output, "%sData type: OPAL_VPID\tValue: %s", prefx, opal_vpid_print(src->vpid));
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return OPAL_SUCCESS;
+}
+
+int opal_dss_print_status(char **output, char *prefix,
+                          int *src, opal_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) asprintf(&prefx, " ");
+    else prefx = prefix;
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        asprintf(output, "%sData type: OPAL_STATUS\tValue: NULL pointer", prefx);
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return OPAL_SUCCESS;
+    }
+
+    asprintf(output, "%sData type: OPAL_STATUS\tValue: %s", prefx, opal_strerror(*src));
     if (prefx != prefix) {
         free(prefx);
     }

--- a/opal/dss/dss_types.h
+++ b/opal/dss/dss_types.h
@@ -13,9 +13,9 @@
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights
  *                         reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -120,6 +120,8 @@ typedef struct {
 #define    OPAL_NAME                (opal_data_type_t)   50
 #define    OPAL_JOBID               (opal_data_type_t)   51
 #define    OPAL_VPID                (opal_data_type_t)   52
+#define    OPAL_STATUS              (opal_data_type_t)   53
+
     /* OPAL Dynamic */
 #define    OPAL_DSS_ID_DYNAMIC      (opal_data_type_t)  100
 
@@ -245,6 +247,7 @@ typedef struct {
         float fval;
         double dval;
         struct timeval tv;
+        int status;
         opal_process_name_t name;
         opal_bool_array_t flag_array;
         opal_uint8_array_t byte_array;

--- a/opal/dss/dss_unpack.c
+++ b/opal/dss/dss_unpack.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -1514,6 +1514,23 @@ int opal_dss_unpack_vpid(opal_buffer_t *buffer, void *dest,
 
     /* Turn around and unpack the real type */
     if (OPAL_SUCCESS != (ret = opal_dss_unpack_buffer(buffer, dest, num_vals, OPAL_VPID_T))) {
+        OPAL_ERROR_LOG(ret);
+    }
+
+    return ret;
+}
+
+/*
+ * STATUS
+ */
+int opal_dss_unpack_status(opal_buffer_t *buffer, void *dest,
+                           int32_t *num_vals, opal_data_type_t type)
+{
+    int ret;
+
+    /* Turn around and unpack the real type */
+    ret = opal_dss_unpack_buffer(buffer, dest, num_vals, OPAL_INT);
+    if (OPAL_SUCCESS != ret) {
         OPAL_ERROR_LOG(ret);
     }
 

--- a/opal/include/opal/constants.h
+++ b/opal/include/opal/constants.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,7 +80,8 @@ enum {
     OPAL_ERR_AUTHENTICATION_FAILED          = (OPAL_ERR_BASE - 50),
     OPAL_ERR_COMM_FAILURE                   = (OPAL_ERR_BASE - 51),
     OPAL_ERR_SERVER_NOT_AVAIL               = (OPAL_ERR_BASE - 52),
-    OPAL_ERR_IN_PROCESS                     = (OPAL_ERR_BASE - 53)
+    OPAL_ERR_IN_PROCESS                     = (OPAL_ERR_BASE - 53),
+    OPAL_ERR_DEBUGGER_RELEASE               = (OPAL_ERR_BASE - 54)
 };
 
 #define OPAL_ERR_MAX                (OPAL_ERR_BASE - 100)

--- a/opal/mca/pmix/pmix112/Makefile.am
+++ b/opal/mca/pmix/pmix112/Makefile.am
@@ -42,6 +42,7 @@ mca_pmix_pmix112_la_CPPFLAGS = \
         -I$(srcdir)/pmix/include $(opal_pmix_pmix112_CPPFLAGS)
 mca_pmix_pmix112_la_LDFLAGS = -module -avoid-version $(opal_pmix_pmix112_LDFLAGS)
 mca_pmix_pmix112_la_LIBADD = $(opal_pmix_pmix112_LIBS)
+mca_pmix_pmix112_la_DEPENDENCIES = $(mca_pmix_pmix112_la_LIBADD)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_pmix112_la_SOURCES =$(sources)
@@ -49,3 +50,4 @@ libmca_pmix_pmix112_la_CFLAGS = $(opal_pmix_pmix112_CFLAGS)
 libmca_pmix_pmix112_la_CPPFLAGS = -I$(srcdir)/pmix/include $(opal_pmix_pmix112_CPPFLAGS)
 libmca_pmix_pmix112_la_LDFLAGS = -module -avoid-version $(opal_pmix_pmix112_LDFLAGS)
 libmca_pmix_pmix112_la_LIBADD = $(opal_pmix_pmix112_LIBS)
+libmca_pmix_pmix112_la_DEPENDENCIES = $(mca_pmix_pmix112_la_LIBADD)

--- a/opal/mca/pmix/pmix112/pmix1_server_south.c
+++ b/opal/mca/pmix/pmix112/pmix1_server_south.c
@@ -431,6 +431,7 @@ int pmix1_server_notify_error(int status,
     op->cbdata = cbdata;
 
     rc = pmix1_convert_opalrc(status);
+    opal_output(0, "CALLING NOTIFY ERROR");
     rc = PMIx_Notify_error(rc, ps, psz, eps, esz,
                            pinfo, sz, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {

--- a/opal/mca/pmix/pmix120/Makefile.am
+++ b/opal/mca/pmix/pmix120/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
@@ -42,6 +42,7 @@ mca_pmix_pmix120_la_CPPFLAGS = \
         -I$(srcdir)/pmix/include $(opal_pmix_pmix120_CPPFLAGS)
 mca_pmix_pmix120_la_LDFLAGS = -module -avoid-version $(opal_pmix_pmix120_LDFLAGS)
 mca_pmix_pmix120_la_LIBADD = $(opal_pmix_pmix120_LIBS)
+mca_pmix_pmix120_la_DEPENDENCIES = $(mca_pmix_pmix120_la_LIBADD)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_pmix120_la_SOURCES =$(sources)
@@ -49,3 +50,4 @@ libmca_pmix_pmix120_la_CFLAGS = $(opal_pmix_pmix120_CFLAGS)
 libmca_pmix_pmix120_la_CPPFLAGS = -I$(srcdir)/pmix/include $(opal_pmix_pmix120_CPPFLAGS)
 libmca_pmix_pmix120_la_LDFLAGS = -module -avoid-version $(opal_pmix_pmix120_LDFLAGS)
 libmca_pmix_pmix120_la_LIBADD = $(opal_pmix_pmix120_LIBS)
+libmca_pmix_pmix120_la_DEPENDENCIES = $(libmca_pmix_pmix120_la_LIBADD)

--- a/opal/mca/pmix/pmix120/pmix/src/buffer_ops/copy.c
+++ b/opal/mca/pmix/pmix120/pmix/src/buffer_ops/copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -136,6 +136,10 @@ int pmix_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type)
         datasize = sizeof(time_t);
         break;
 
+    case PMIX_STATUS:
+        datasize = sizeof(pmix_status_t);
+        break;
+
     default:
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
     }
@@ -166,7 +170,7 @@ int pmix_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
 
     return PMIX_SUCCESS;
 }
-/* compare function for pmix_value_t*/
+/* compare function for pmix_value_t */
 bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1)
 {
     bool rc = false;
@@ -212,6 +216,9 @@ bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1)
             break;
         case PMIX_STRING:
             rc = strcmp(p->data.string, p1->data.string);
+            break;
+        case PMIX_STATUS:
+            rc = (p->data.status == p1->data.status);
             break;
         default:
             pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)p->type);
@@ -293,6 +300,9 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
         p->data.tv.tv_sec = src->data.tv.tv_sec;
         p->data.tv.tv_usec = src->data.tv.tv_usec;
         break;
+    case PMIX_STATUS:
+        memcpy(&p->data.status, &src->data.status, sizeof(pmix_status_t));
+        break;
     case PMIX_INFO_ARRAY:
         p->data.array.size = src->data.array.size;
         if (0 < src->data.array.size) {
@@ -343,6 +353,7 @@ int pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
 {
     *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
     (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    (*dest)->required = src->required;
     return pmix_value_xfer(&(*dest)->value, &src->value);
 }
 

--- a/opal/mca/pmix/pmix120/pmix/src/buffer_ops/internal.h
+++ b/opal/mca/pmix/pmix120/pmix/src/buffer_ops/internal.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -275,6 +275,8 @@ int pmix_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
                             int32_t num_vals, pmix_data_type_t type);
 int pmix_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
+int pmix_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
+                           int32_t num_vals, pmix_data_type_t type);
 
 #if PMIX_HAVE_HWLOC
 int pmix_bfrop_pack_topo(pmix_buffer_t *buffer, const void *src,
@@ -337,6 +339,8 @@ int pmix_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
                               int32_t *num_vals, pmix_data_type_t type);
 int pmix_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type);
+int pmix_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
+                             int32_t *num_vals, pmix_data_type_t type);
 
 #if PMIX_HAVE_HWLOC
 int pmix_bfrop_unpack_topo(pmix_buffer_t *buffer, void *dest,
@@ -427,6 +431,7 @@ int pmix_bfrop_print_double(char **output, char *prefix, double *src, pmix_data_
 
 int pmix_bfrop_print_timeval(char **output, char *prefix, struct timeval *src, pmix_data_type_t type);
 int pmix_bfrop_print_time(char **output, char *prefix, time_t *src, pmix_data_type_t type);
+int pmix_bfrop_print_status(char **output, char *prefix, pmix_status_t *src, pmix_data_type_t type);
 
 #if PMIX_HAVE_HWLOC
 int pmix_bfrop_print_topo(char **output, char *prefix,

--- a/opal/mca/pmix/pmix120/pmix/src/buffer_ops/open_close.c
+++ b/opal/mca/pmix/pmix120/pmix/src/buffer_ops/open_close.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -289,6 +289,12 @@ pmix_status_t pmix_bfrop_open(void)
                        pmix_bfrop_std_copy,
                        pmix_bfrop_print_time);
 
+    PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS,
+                       pmix_bfrop_pack_status,
+                       pmix_bfrop_unpack_status,
+                       pmix_bfrop_std_copy,
+                       pmix_bfrop_print_status);
+
 #if PMIX_HAVE_HWLOC
     PMIX_REGISTER_TYPE("PMIX_HWLOC_TOPO", PMIX_HWLOC_TOPO,
                        pmix_bfrop_pack_topo,
@@ -395,6 +401,8 @@ pmix_status_t pmix_bfrop_close(void)
 void pmix_value_load(pmix_value_t *v, void *data,
                      pmix_data_type_t type)
 {
+    pmix_byte_object_t *bo;
+
     v->type = type;
     if (NULL == data) {
         /* just set the fields to zero */
@@ -457,9 +465,13 @@ void pmix_value_load(pmix_value_t *v, void *data,
         case PMIX_TIMEVAL:
             memcpy(&(v->data.tv), data, sizeof(struct timeval));
             break;
+        case PMIX_STATUS:
+            memcpy(&(v->data.status), data, sizeof(pmix_status_t));
+            break;
         case PMIX_BYTE_OBJECT:
-            v->data.bo.bytes = data;
-            memcpy(&(v->data.bo.size), data, sizeof(size_t));
+            bo = (pmix_byte_object_t*)data;
+            v->data.bo.bytes = bo->bytes;
+            memcpy(&(v->data.bo.size), &bo->size, sizeof(size_t));
             break;
         case PMIX_TIME:
         case PMIX_HWLOC_TOPO:
@@ -568,6 +580,10 @@ pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data,
         case PMIX_TIMEVAL:
             memcpy(*data, &(kv->data.tv), sizeof(struct timeval));
             *sz = sizeof(struct timeval);
+            break;
+        case PMIX_STATUS:
+            memcpy(*data, &(kv->data.status), sizeof(pmix_status_t));
+            *sz = sizeof(pmix_status_t);
             break;
         case PMIX_BYTE_OBJECT:
             if (NULL != kv->data.bo.bytes && 0 < kv->data.bo.size) {

--- a/opal/mca/pmix/pmix120/pmix/src/buffer_ops/pack.c
+++ b/opal/mca/pmix/pmix120/pmix/src/buffer_ops/pack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -406,6 +406,26 @@ int pmix_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
 }
 
 
+/* STATUS */
+int pmix_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
+                           int32_t num_vals, pmix_data_type_t type)
+{
+    int ret = PMIX_SUCCESS;
+    int32_t i;
+    pmix_status_t *ssrc = (pmix_status_t *)src;
+    int32_t status;
+
+    for (i = 0; i < num_vals; ++i) {
+        status = (int32_t)ssrc[i];
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_int32(buffer, &status, 1, PMIX_INT32))) {
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
 /* PACK FUNCTIONS FOR GENERIC PMIX TYPES */
 static int pack_val(pmix_buffer_t *buffer,
                     pmix_value_t *p)
@@ -503,6 +523,11 @@ static int pack_val(pmix_buffer_t *buffer,
             return ret;
         }
         break;
+    case PMIX_STATUS:
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.status, 1, PMIX_STATUS))) {
+            return ret;
+        }
+        break;
     case PMIX_INFO_ARRAY:
         if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.array, 1, PMIX_INFO_ARRAY))) {
             return ret;
@@ -561,6 +586,10 @@ int pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
         /* pack key */
         foo = info[i].key;
         if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* pack required flag */
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_bool(buffer, &info[i].required, 1, PMIX_BOOL))) {
             return ret;
         }
         /* pack the type */

--- a/opal/mca/pmix/pmix120/pmix/src/buffer_ops/unpack.c
+++ b/opal/mca/pmix/pmix120/pmix/src/buffer_ops/unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -500,6 +500,20 @@ int pmix_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
 }
 
 
+int pmix_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
+                             int32_t *num_vals, pmix_data_type_t type)
+{
+     pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrop_unpack_status * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(pmix_status_t)))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    return pmix_bfrop_unpack_int32(buffer, dest, num_vals, PMIX_INT32);
+}
+
+
 /* UNPACK FUNCTIONS FOR GENERIC PMIX TYPES */
 
 /*
@@ -672,6 +686,11 @@ int pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         }
         (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
+        /* unpack the required flag */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_bool(buffer, &ptr[i].required, &m, PMIX_BOOL))) {
+            return ret;
+        }
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */

--- a/opal/mca/pmix/pmix120/pmix/src/class/Makefile.am
+++ b/opal/mca/pmix/pmix120/pmix/src/class/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,10 +26,14 @@ headers += \
         src/class/pmix_object.h \
         src/class/pmix_list.h \
         src/class/pmix_pointer_array.h \
-        src/class/pmix_hash_table.h
+        src/class/pmix_hash_table.h \
+        src/class/pmix_hotel.h \
+        src/class/pmix_ring_buffer.h
 
 sources += \
         src/class/pmix_object.c \
         src/class/pmix_list.c \
         src/class/pmix_pointer_array.c \
-        src/class/pmix_hash_table.c
+        src/class/pmix_hash_table.c \
+        src/class/pmix_hotel.c \
+        src/class/pmix_ring_buffer.c

--- a/opal/mca/pmix/pmix120/pmix/src/class/pmix_hotel.c
+++ b/opal/mca/pmix/pmix120/pmix/src/class/pmix_hotel.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
+ * Copyright (c) 2015-2016 Intel, Inc. All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <private/autogen/config.h>
+
+#include <stdio.h>
+#include <stddef.h>
+
+#include PMIX_EVENT_HEADER
+#include "src/class/pmix_hotel.h"
+
+
+static void local_eviction_callback(int fd, short flags, void *arg)
+{
+    pmix_hotel_room_eviction_callback_arg_t *eargs =
+        (pmix_hotel_room_eviction_callback_arg_t*) arg;
+    void *occupant = eargs->hotel->rooms[eargs->room_num].occupant;
+
+    /* Remove the occurpant from the room.
+
+       Do not change this logic without also changing the same logic
+       in pmix_hotel_checkout() and
+       pmix_hotel_checkout_and_return_occupant(). */
+    pmix_hotel_t *hotel = eargs->hotel;
+    pmix_hotel_room_t *room = &(hotel->rooms[eargs->room_num]);
+    room->occupant = NULL;
+    hotel->last_unoccupied_room++;
+    assert(hotel->last_unoccupied_room < hotel->num_rooms);
+    hotel->unoccupied_rooms[hotel->last_unoccupied_room] = eargs->room_num;
+
+    /* Invoke the user callback to tell them that they were evicted */
+    hotel->evict_callback_fn(hotel,
+                             eargs->room_num,
+                             occupant);
+}
+
+
+int pmix_hotel_init(pmix_hotel_t *h, int num_rooms,
+                    pmix_event_base_t *evbase,
+                    uint32_t eviction_timeout,
+                    int eviction_event_priority,
+                    pmix_hotel_eviction_callback_fn_t evict_callback_fn)
+{
+    int i;
+
+    /* Bozo check */
+    if (num_rooms <= 0 ||
+        NULL == evict_callback_fn) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    h->num_rooms = num_rooms;
+    h->evbase = evbase;
+    h->eviction_timeout.tv_usec = eviction_timeout % 1000000;
+    h->eviction_timeout.tv_sec = eviction_timeout / 1000000;
+    h->evict_callback_fn = evict_callback_fn;
+    h->rooms = (pmix_hotel_room_t*)malloc(num_rooms * sizeof(pmix_hotel_room_t));
+    if (NULL != evict_callback_fn) {
+        h->eviction_args =
+            (pmix_hotel_room_eviction_callback_arg_t*)malloc(num_rooms * sizeof(pmix_hotel_room_eviction_callback_arg_t));
+    }
+    h->unoccupied_rooms = (int*) malloc(num_rooms * sizeof(int));
+    h->last_unoccupied_room = num_rooms - 1;
+
+    for (i = 0; i < num_rooms; ++i) {
+        /* Mark this room as unoccupied */
+        h->rooms[i].occupant = NULL;
+
+        /* Setup this room in the unoccupied index array */
+        h->unoccupied_rooms[i] = i;
+
+        /* Setup the eviction callback args */
+        h->eviction_args[i].hotel = h;
+        h->eviction_args[i].room_num = i;
+
+        /* Create this room's event (but don't add it) */
+        if (NULL != h->evbase) {
+            event_assign(&(h->rooms[i].eviction_timer_event),
+                         h->evbase,
+                         -1, 0, local_eviction_callback,
+                         &(h->eviction_args[i]));
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static void constructor(pmix_hotel_t *h)
+{
+    h->num_rooms = 0;
+    h->evbase = NULL;
+    h->eviction_timeout.tv_sec = 0;
+    h->eviction_timeout.tv_usec = 0;
+    h->evict_callback_fn = NULL;
+    h->rooms = NULL;
+    h->eviction_args = NULL;
+    h->unoccupied_rooms = NULL;
+    h->last_unoccupied_room = -1;
+}
+
+static void destructor(pmix_hotel_t *h)
+{
+    int i;
+
+    /* Go through all occupied rooms and destroy their events */
+    if (NULL != h->evbase) {
+        for (i = 0; i < h->num_rooms; ++i) {
+            if (NULL != h->rooms[i].occupant) {
+                event_del(&(h->rooms[i].eviction_timer_event));
+            }
+        }
+    }
+
+    if (NULL != h->rooms) {
+        free(h->rooms);
+    }
+    if (NULL != h->eviction_args) {
+        free(h->eviction_args);
+    }
+    if (NULL != h->unoccupied_rooms) {
+        free(h->unoccupied_rooms);
+    }
+}
+
+PMIX_CLASS_INSTANCE(pmix_hotel_t,
+                    pmix_object_t,
+                    constructor,
+                    destructor);

--- a/opal/mca/pmix/pmix120/pmix/src/class/pmix_hotel.h
+++ b/opal/mca/pmix/pmix120/pmix/src/class/pmix_hotel.h
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
+ * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file
+ *
+ * This file provides a "hotel" class:
+ *
+ * - A hotel has a fixed number of rooms (i.e., storage slots)
+ * - An arbitrary data pointer can check into an empty room at any time
+ * - The occupant of a room can check out at any time
+ * - Optionally, the occupant of a room can be forcibly evicted at a
+ *   given time (i.e., when an pmix timer event expires).
+ * - The hotel has finite occupancy; if you try to checkin a new
+ *   occupant and the hotel is already full, it will gracefully fail
+ *   to checkin.
+ *
+ * One use case for this class is for ACK-based network retransmission
+ * schemes (NACK-based retransmission schemes probably can use
+ * pmix_ring_buffer).
+ *
+ * For ACK-based retransmission schemes, a hotel might be used
+ * something like this:
+ *
+ * - when a message is sent, check it in to a hotel with a timer
+ * - if an ACK is received, check it out of the hotel (which also cancels
+ *   the timer)
+ * - if an ACK isn't received in time, the timer will expire and the
+ *   upper layer will get a callback with the message
+ * - if an ACK is received late (i.e., after its timer has expired),
+ *   then checkout will gracefully fail
+ *
+ * Note that this class intentionally provides pretty minimal
+ * functionality.  It is intended to be used in performance-critical
+ * code paths -- extra functionality would simply add latency.
+ *
+ * There is an pmix_hotel_init() function to create a hotel, but no
+ * corresponding finalize; the destructor will handle all finalization
+ * issues.  Note that when a hotel is destroyed, it will delete all
+ * pending events from the event base (i.e., all pending eviction
+ * callbacks); no further eviction callbacks will be invoked.
+ */
+
+#ifndef PMIX_HOTEL_H
+#define PMIX_HOTEL_H
+
+#include <private/autogen/config.h>
+#include "private/types.h"
+#include "private/prefetch.h"
+#include "pmix/pmix_common.h"
+#include "src/class/pmix_object.h"
+#include PMIX_EVENT_HEADER
+#include <pmix/rename.h>
+#include "src/util/output.h"
+
+BEGIN_C_DECLS
+
+struct pmix_hotel_t;
+
+/* User-supplied function to be invoked when an occupant is evicted. */
+typedef void (*pmix_hotel_eviction_callback_fn_t)(struct pmix_hotel_t *hotel,
+                                                  int room_num,
+                                                  void *occupant);
+
+/* Note that this is an internal data structure; it is not part of the
+   public pmix_hotel interface.  Public consumers of pmix_hotel
+   shouldn't need to use this struct at all (we only have it here in
+   this .h file because some functions are inlined for speed, and need
+   to get to the internals of this struct).
+
+   The room struct should be as small as possible to be cache
+   friendly.  Specifically: it would be great if multiple rooms could
+   fit in a single cache line because we'll always allocate a
+   contiguous set of rooms in an array. */
+typedef struct {
+    void *occupant;
+    pmix_event_t eviction_timer_event;
+} pmix_hotel_room_t;
+
+/* Note that this is an internal data structure; it is not part of the
+   public pmix_hotel interface.  Public consumers of pmix_hotel
+   shouldn't need to use this struct at all (we only have it here in
+   this .h file because some functions are inlined for speed, and need
+   to get to the internals of this struct).
+
+   Use a unique struct for holding the arguments for eviction
+   callbacks.  We *could* make the to-be-evicted pmix_hotel_room_t
+   instance as the argument, but we don't, for 2 reasons:
+
+   1. We want as many pmix_hotel_room_t's to fit in a cache line as
+      possible (i.e., to be as cache-friendly as possible).  The
+      common/fast code path only needs to access the data in the
+      pmix_hotel_room_t (and not the callback argument data).
+
+   2. Evictions will be uncommon, so we don't mind penalizing them a
+      bit by making the data be in a separate cache line.
+*/
+typedef struct {
+    struct pmix_hotel_t *hotel;
+    int room_num;
+} pmix_hotel_room_eviction_callback_arg_t;
+
+typedef struct pmix_hotel_t {
+    /* make this an object */
+    pmix_object_t super;
+
+    /* Max number of rooms in the hotel */
+    int num_rooms;
+
+    /* event base to be used for eviction timeout */
+    pmix_event_base_t *evbase;
+    struct timeval eviction_timeout;
+    pmix_hotel_eviction_callback_fn_t evict_callback_fn;
+
+    /* All rooms in this hotel */
+    pmix_hotel_room_t *rooms;
+
+    /* Separate array for all the eviction callback arguments (see
+       rationale above for why this is a separate array) */
+    pmix_hotel_room_eviction_callback_arg_t *eviction_args;
+
+    /* All currently unoccupied rooms in this hotel (not necessarily
+       in any particular order) */
+    int *unoccupied_rooms;
+    int last_unoccupied_room;
+} pmix_hotel_t;
+PMIX_CLASS_DECLARATION(pmix_hotel_t);
+
+/**
+ * Initialize the hotel.
+ *
+ * @param hotel Pointer to a hotel (IN)
+ * @param num_rooms The total number of rooms in the hotel (IN)
+ * @param evbase Pointer to event base used for eviction timeout
+ * @param eviction_timeout Max length of a stay at the hotel before
+ * the eviction callback is invoked (in microseconds)
+ * @param eviction_event_priority Event lib priority for the eviction timeout
+ * @param evict_callback_fn Callback function invoked if an occupant
+ * does not check out before the eviction_timeout.
+ *
+ * NOTE: If the callback function is NULL, then no eviction timer
+ * will be set - occupants will remain checked into the hotel until
+ * explicitly checked out.
+ *
+ * Also note: the eviction_callback_fn should absolutely not call any
+ * of the hotel checkout functions.  Specifically: the occupant has
+ * already been ("forcibly") checked out *before* the
+ * eviction_callback_fn is invoked.
+ *
+ * @return PMIX_SUCCESS if all initializations were succesful. Otherwise,
+ *  the error indicate what went wrong in the function.
+ */
+PMIX_DECLSPEC int pmix_hotel_init(pmix_hotel_t *hotel, int num_rooms,
+                                  pmix_event_base_t *evbase,
+                                  uint32_t eviction_timeout,
+                                  int eviction_event_priority,
+                                  pmix_hotel_eviction_callback_fn_t evict_callback_fn);
+
+/**
+ * Check in an occupant to the hotel.
+ *
+ * @param hotel Pointer to hotel (IN)
+ * @param occupant Occupant to check in (opaque to the hotel) (IN)
+ * @param room The room number that identifies this occupant in the
+ * hotel (OUT).
+ *
+ * If there is room in the hotel, the occupant is checked in and the
+ * timer for that occupant is started.  The occupant's room is
+ * returned in the "room" param.
+ *
+ * Note that once a room's checkout_expire timer expires, the occupant
+ * is forcibly checked out, and then the eviction callback is invoked.
+ *
+ * @return PMIX_SUCCESS if the occupant is successfully checked in,
+ * and the room parameter will contain a valid value.
+ * @return PMIX_ERR_TEMP_OUT_OF_RESOURCE is the hotel is full.  Try
+ * again later.
+ */
+static inline int pmix_hotel_checkin(pmix_hotel_t *hotel,
+                                     void *occupant,
+                                     int *room_num)
+{
+    pmix_hotel_room_t *room;
+
+    /* Do we have any rooms available? */
+    if (PMIX_UNLIKELY(hotel->last_unoccupied_room < 0)) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* Put this occupant into the first empty room that we have */
+    *room_num = hotel->unoccupied_rooms[hotel->last_unoccupied_room--];
+    room = &(hotel->rooms[*room_num]);
+    room->occupant = occupant;
+
+    /* Assign the event and make it pending */
+    if (NULL != hotel->evbase) {
+        event_add(&(room->eviction_timer_event),
+                  &(hotel->eviction_timeout));
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/**
+ * Same as pmix_hotel_checkin(), but slightly optimized for when the
+ * caller *knows* that there is a room available.
+ */
+static inline void pmix_hotel_checkin_with_res(pmix_hotel_t *hotel,
+                                     void *occupant,
+                                     int *room_num)
+{
+    pmix_hotel_room_t *room;
+
+    /* Put this occupant into the first empty room that we have */
+    *room_num = hotel->unoccupied_rooms[hotel->last_unoccupied_room--];
+    room = &(hotel->rooms[*room_num]);
+    assert(room->occupant == NULL);
+    room->occupant = occupant;
+
+    /* Assign the event and make it pending */
+    if (NULL != hotel->evbase) {
+        event_add(&(room->eviction_timer_event),
+                  &(hotel->eviction_timeout));
+    }
+}
+
+/**
+ * Check the specified occupant out of the hotel.
+ *
+ * @param hotel Pointer to hotel (IN)
+ * @param room Room number to checkout (IN)
+ *
+ * If there is an occupant in the room, their timer is canceled and
+ * they are checked out.
+ *
+ * Nothing is returned (as a minor optimization).
+ */
+static inline void pmix_hotel_checkout(pmix_hotel_t *hotel, int room_num)
+{
+    pmix_hotel_room_t *room;
+
+    /* Bozo check */
+    assert(room_num < hotel->num_rooms);
+
+    /* If there's an occupant in the room, check them out */
+    room = &(hotel->rooms[room_num]);
+    if (PMIX_LIKELY(NULL != room->occupant)) {
+        /* Do not change this logic without also changing the same
+           logic in pmix_hotel_checkout_and_return_occupant() and
+           pmix_hotel.c:local_eviction_callback(). */
+        room->occupant = NULL;
+        if (NULL != hotel->evbase) {
+            event_del(&(room->eviction_timer_event));
+        }
+        hotel->last_unoccupied_room++;
+        assert(hotel->last_unoccupied_room < hotel->num_rooms);
+        hotel->unoccupied_rooms[hotel->last_unoccupied_room] = room_num;
+    }
+
+    /* Don't bother returning whether we actually checked someone out
+       or not (because this is in the critical performance path) --
+       assume the upper layer knows what it's doing. */
+}
+
+/**
+ * Check the specified occupant out of the hotel and return the occupant.
+ *
+ * @param hotel Pointer to hotel (IN)
+ * @param room Room number to checkout (IN)
+ * @param void * occupant (OUT)
+ * If there is an occupant in the room, their timer is canceled and
+ * they are checked out.
+ *
+ * Use this checkout and when caller needs the occupant
+ */
+static inline void pmix_hotel_checkout_and_return_occupant(pmix_hotel_t *hotel, int room_num, void **occupant)
+{
+    pmix_hotel_room_t *room;
+
+    /* Bozo check */
+    assert(room_num < hotel->num_rooms);
+
+    /* If there's an occupant in the room, check them out */
+    room = &(hotel->rooms[room_num]);
+    if (PMIX_LIKELY(NULL != room->occupant)) {
+        pmix_output (10, "checking out occupant %p from room num %d", room->occupant, room_num);
+        /* Do not change this logic without also changing the same
+           logic in pmix_hotel_checkout() and
+           pmix_hotel.c:local_eviction_callback(). */
+        *occupant = room->occupant;
+        room->occupant = NULL;
+        if (NULL != hotel->evbase) {
+            event_del(&(room->eviction_timer_event));
+        }
+        hotel->last_unoccupied_room++;
+        assert(hotel->last_unoccupied_room < hotel->num_rooms);
+        hotel->unoccupied_rooms[hotel->last_unoccupied_room] = room_num;
+    }
+    else {
+        *occupant = NULL;
+    }
+}
+
+/**
+ * Returns true if the hotel is empty (no occupant)
+ * @param hotel Pointer to hotel (IN)
+ * @return bool true if empty false if there is a occupant(s)
+ *
+ */
+static inline bool pmix_hotel_is_empty (pmix_hotel_t *hotel)
+{
+    if (hotel->last_unoccupied_room == hotel->num_rooms - 1)
+        return true;
+    else
+        return false;
+}
+
+/**
+ * Access the occupant of a room, but leave them checked into their room.
+ *
+ * @param hotel Pointer to hotel (IN)
+ * @param room Room number to checkout (IN)
+ * @param void * occupant (OUT)
+ *
+ * This accessor function is typically used to cycle across the occupants
+ * to check for someone already present that matches a description.
+ */
+static inline void pmix_hotel_knock(pmix_hotel_t *hotel, int room_num, void **occupant)
+{
+    pmix_hotel_room_t *room;
+
+    /* Bozo check */
+    assert(room_num < hotel->num_rooms);
+
+    *occupant = NULL;
+
+    /* If there's an occupant in the room, have them come to the door */
+    room = &(hotel->rooms[room_num]);
+    if (PMIX_LIKELY(NULL != room->occupant)) {
+        pmix_output (10, "occupant %p in room num %d responded to knock", room->occupant, room_num);
+        *occupant = room->occupant;
+    }
+}
+
+END_C_DECLS
+
+#endif /* PMIX_HOTEL_H */

--- a/opal/mca/pmix/pmix120/pmix/src/class/pmix_ring_buffer.c
+++ b/opal/mca/pmix/pmix120/pmix/src/class/pmix_ring_buffer.c
@@ -1,0 +1,154 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <private/autogen/config.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "pmix/pmix_common.h"
+#include "src/class/pmix_ring_buffer.h"
+#include "src/util/output.h"
+
+static void pmix_ring_buffer_construct(pmix_ring_buffer_t *);
+static void pmix_ring_buffer_destruct(pmix_ring_buffer_t *);
+
+PMIX_CLASS_INSTANCE(pmix_ring_buffer_t, pmix_object_t,
+                    pmix_ring_buffer_construct,
+                    pmix_ring_buffer_destruct);
+
+/*
+ * pmix_ring_buffer constructor
+ */
+static void pmix_ring_buffer_construct(pmix_ring_buffer_t *ring)
+{
+    ring->head = 0;
+    ring->tail = -1;
+    ring->size = 0;
+    ring->addr = NULL;
+}
+
+/*
+ * pmix_ring_buffer destructor
+ */
+static void pmix_ring_buffer_destruct(pmix_ring_buffer_t *ring)
+{
+    if( NULL != ring->addr) {
+        free(ring->addr);
+        ring->addr = NULL;
+    }
+
+    ring->size = 0;
+}
+
+/**
+ * initialize a ring object
+ */
+int pmix_ring_buffer_init(pmix_ring_buffer_t* ring, int size)
+{
+    /* check for errors */
+    if (NULL == ring) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Allocate and set the ring to NULL */
+    ring->addr = (char **)calloc(size * sizeof(char*), 1);
+    if (NULL == ring->addr) { /* out of memory */
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    ring->size = size;
+
+    return PMIX_SUCCESS;
+}
+
+void* pmix_ring_buffer_push(pmix_ring_buffer_t *ring, void *ptr)
+{
+    char *p=NULL;
+
+    if (NULL != ring->addr[ring->head]) {
+        p = (char*)ring->addr[ring->head];
+        if (ring->tail == ring->size - 1) {
+            ring->tail = 0;
+        } else {
+            ring->tail = ring->head + 1;
+        }
+    }
+    ring->addr[ring->head] = (char*)ptr;
+    if (ring->tail < 0) {
+        ring->tail = ring->head;
+    }
+    if (ring->head == ring->size - 1) {
+        ring->head = 0;
+    } else {
+        ring->head++;
+    }
+    return (void*)p;
+}
+
+void* pmix_ring_buffer_pop(pmix_ring_buffer_t *ring)
+{
+    char *p=NULL;
+
+    if (-1 == ring->tail) {
+        /* nothing has been put on the ring yet */
+        p = NULL;
+    } else {
+        p = (char*)ring->addr[ring->tail];
+        ring->addr[ring->tail] = NULL;
+        if (ring->tail == ring->size-1) {
+            ring->tail = 0;
+        } else {
+            ring->tail++;
+        }
+        /* see if the ring is empty */
+        if (ring->tail == ring->head) {
+            ring->tail = -1;
+        }
+    }
+    return (void*)p;
+}
+
+ void* pmix_ring_buffer_poke(pmix_ring_buffer_t *ring, int i)
+ {
+    char *p=NULL;
+    int offset;
+
+    if (ring->size <= i || -1 == ring->tail) {
+        p = NULL;
+    } else if (i < 0) {
+        /* return the value at the head of the ring */
+        if (ring->head == 0) {
+            p = ring->addr[ring->size - 1];
+        } else {
+            p = ring->addr[ring->head - 1];
+        }
+    } else {
+        /* calculate the offset of the tail in the ring */
+        offset = ring->tail + i;
+        /* correct for wrap-around */
+        if (ring->size <= offset) {
+            offset -= ring->size;
+        }
+        p = ring->addr[offset];
+    }
+    return (void*)p;
+}

--- a/opal/mca/pmix/pmix120/pmix/src/class/pmix_ring_buffer.h
+++ b/opal/mca/pmix/pmix120/pmix/src/class/pmix_ring_buffer.h
@@ -1,0 +1,102 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2008 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file
+ *
+ */
+
+#ifndef PMIX_RING_BUFFER_H
+#define PMIX_RING_BUFFER_H
+
+#include <private/autogen/config.h>
+
+#include "src/class/pmix_object.h"
+#include "src/util/output.h"
+
+BEGIN_C_DECLS
+
+/**
+ * dynamic pointer ring
+ */
+struct pmix_ring_buffer_t {
+    /** base class */
+    pmix_object_t super;
+    /* head/tail indices */
+    int head;
+    int tail;
+    /** size of list, i.e. number of elements in addr */
+    int size;
+    /** pointer to ring */
+    char **addr;
+};
+/**
+ * Convenience typedef
+ */
+typedef struct pmix_ring_buffer_t pmix_ring_buffer_t;
+/**
+ * Class declaration
+ */
+PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_ring_buffer_t);
+
+/**
+ * Initialize the ring buffer, defining its size.
+ *
+ * @param ring Pointer to a ring buffer (IN/OUT)
+ * @param size The number of elements in the ring (IN)
+ *
+ * @return PMIX_SUCCESS if all initializations were succesful. Otherwise,
+ *  the error indicate what went wrong in the function.
+ */
+PMIX_DECLSPEC int pmix_ring_buffer_init(pmix_ring_buffer_t* ring, int size);
+
+/**
+ * Push an item onto the ring buffer, displacing the oldest
+ * item on the ring if the ring is full
+ *
+ * @param ring Pointer to ring (IN)
+ * @param ptr Pointer value (IN)
+ *
+ * @return Pointer to displaced item, NULL if ring
+ *         is not yet full
+ */
+PMIX_DECLSPEC void* pmix_ring_buffer_push(pmix_ring_buffer_t *ring, void *ptr);
+
+
+/**
+ * Pop an item off of the ring. The oldest entry on the ring will be
+ * returned. If nothing on the ring, NULL is returned.
+ *
+ * @param ring          Pointer to ring (IN)
+ *
+ * @return Error code.  NULL indicates an error.
+ */
+
+PMIX_DECLSPEC void* pmix_ring_buffer_pop(pmix_ring_buffer_t *ring);
+
+/*
+ * Access an element of the ring, without removing it, indexed
+ * starting at the tail - a value of -1 will return the element
+ * at the head of the ring
+ */
+PMIX_DECLSPEC void* pmix_ring_buffer_poke(pmix_ring_buffer_t *ring, int i);
+
+END_C_DECLS
+
+#endif /* PMIX_RING_BUFFER_H */

--- a/opal/mca/pmix/pmix120/pmix/src/client/pmix_client_get.c
+++ b/opal/mca/pmix/pmix120/pmix/src/client/pmix_client_get.c
@@ -56,16 +56,16 @@
 
 #include "pmix_client_ops.h"
 
-static pmix_buffer_t* pack_get(char *nspace, int rank,
+static pmix_buffer_t* _pack_get(char *nspace, int rank,
                                const pmix_info_t info[], size_t ninfo,
                                pmix_cmd_t cmd);
 
 static void _getnbfn(int sd, short args, void *cbdata);
 
-static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
+static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata);
 
-static void value_cbfunc(int status, pmix_value_t *kv, void *cbdata);
+static void _value_cbfunc(int status, pmix_value_t *kv, void *cbdata);
 
 int PMIx_Get(const pmix_proc_t *proc, const char key[],
              const pmix_info_t info[], size_t ninfo,
@@ -73,16 +73,6 @@ int PMIx_Get(const pmix_proc_t *proc, const char key[],
 {
     pmix_cb_t *cb;
     int rc;
-
-    if (NULL == proc) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix: %s:%d getting value for proc %s:%d key %s",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                        proc->nspace, proc->rank,
-                        (NULL == key) ? "NULL" : key);
 
     if (pmix_globals.init_cntr <= 0) {
         return PMIX_ERR_INIT;
@@ -93,7 +83,7 @@ int PMIx_Get(const pmix_proc_t *proc, const char key[],
      * the return message is recvd */
     cb = PMIX_NEW(pmix_cb_t);
     cb->active = true;
-    if (PMIX_SUCCESS != (rc = PMIx_Get_nb(proc, key, info, ninfo, value_cbfunc, cb))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Get_nb(proc, key, info, ninfo, _value_cbfunc, cb))) {
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -115,30 +105,60 @@ pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char *key,
                           pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_cb_t *cb;
-
-    if (NULL == proc) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix: get_nb value for proc %s:%d key %s",
-                        proc->nspace, proc->rank,
-                        (NULL == key) ? "NULL" : key);
+    int rank;
+    char *nm;
 
     if (pmix_globals.init_cntr <= 0) {
         return PMIX_ERR_INIT;
     }
 
-    /* protect against bozo input */
-    if (NULL == key) {
+    /* if the proc is NULL, then the caller is assuming
+     * that the key is universally unique within the caller's
+     * own nspace. This most likely indicates that the code
+     * was originally written for a legacy version of PMI.
+     *
+     * If the key is NULL, then the caller wants all
+     * data from the specified proc. Again, this likely
+     * indicates use of a legacy version of PMI.
+     *
+     * Either case is supported. However, we don't currently
+     * support the case where -both- values are NULL */
+    if (NULL == proc && NULL == key) {
         return PMIX_ERR_BAD_PARAM;
     }
+
+    /* if the key is NULL, the rank cannot be WILDCARD as
+     * we cannot return all info from every rank */
+    if (NULL != proc && PMIX_RANK_WILDCARD == proc->rank && NULL == key) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* if the given proc param is NULL, or the nspace is
+     * empty, then the caller is referencing our own nspace */
+    if (NULL == proc || 0 == strlen(proc->nspace)) {
+        nm = pmix_globals.myid.nspace;
+    } else {
+        nm = (char*)proc->nspace;
+    }
+
+    /* if the proc param is NULL, then we are seeking a key that
+     * must be globally unique, so communicate this to the hash
+     * functions with the UNDEF rank */
+    if (NULL == proc) {
+        rank = PMIX_RANK_UNDEF;
+    } else {
+        rank = proc->rank;
+    }
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: get_nb value for proc %s:%d key %s",
+                        nm, rank, (NULL == key) ? "NULL" : key);
 
     /* thread-shift so we can check global objects */
     cb = PMIX_NEW(pmix_cb_t);
     cb->active = true;
-    (void)strncpy(cb->nspace, proc->nspace, PMIX_MAX_NSLEN);
-    cb->rank = proc->rank;
+    (void)strncpy(cb->nspace, nm, PMIX_MAX_NSLEN);
+    cb->rank = rank;
     cb->key = (char*)key;
     cb->info = (pmix_info_t*)info;
     cb->ninfo = ninfo;
@@ -149,7 +169,7 @@ pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char *key,
     return PMIX_SUCCESS;
 }
 
-static void value_cbfunc(int status, pmix_value_t *kv, void *cbdata)
+static void _value_cbfunc(int status, pmix_value_t *kv, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
     pmix_status_t rc;
@@ -163,7 +183,7 @@ static void value_cbfunc(int status, pmix_value_t *kv, void *cbdata)
     cb->active = false;
 }
 
-static pmix_buffer_t* pack_get(char *nspace, int rank,
+static pmix_buffer_t* _pack_get(char *nspace, int rank,
                                const pmix_info_t info[], size_t ninfo,
                                pmix_cmd_t cmd)
 {
@@ -209,7 +229,7 @@ static pmix_buffer_t* pack_get(char *nspace, int rank,
 /* this callback is coming from the usock recv, and thus
  * is occurring inside of our progress thread - hence, no
  * need to thread shift */
-static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
+static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
@@ -218,18 +238,19 @@ static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     pmix_value_t *val = NULL;
     int32_t cnt;
     pmix_buffer_t *bptr;
-    pmix_kval_t *kp;
     pmix_nspace_t *ns, *nptr;
     int rank;
+    int cur_rank;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: get_nb callback recvd");
+
     if (NULL == cb) {
         /* nothing we can do */
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return;
     }
-    // cache the rank
+    /* cache the rank */
     rank = cb->rank;
 
     /* unpack the status */
@@ -262,31 +283,36 @@ static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
      * unpack and store it in the modex - this could consist
      * of buffers from multiple scopes */
     cnt = 1;
-    while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(buf, &bptr, &cnt, PMIX_BUFFER))) {
+    while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(buf, &cur_rank, &cnt, PMIX_INT))) {
+        pmix_kval_t *cur_kval;
+
         cnt = 1;
-        kp = PMIX_NEW(pmix_kval_t);
-        while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(bptr, kp, &cnt, PMIX_KVAL))) {
-            pmix_output_verbose(2, pmix_globals.debug_output,
-                                "pmix: unpacked key %s", kp->key);
-            if (PMIX_SUCCESS != (rc = pmix_hash_store(&nptr->modex, cb->rank, kp))) {
-                PMIX_ERROR_LOG(rc);
-            }
-            if (NULL != cb->key && 0 == strcmp(cb->key, kp->key)) {
-                pmix_output_verbose(2, pmix_globals.debug_output,
-                                    "pmix: found requested value");
-                if (PMIX_SUCCESS != (rc = pmix_bfrop.copy((void**)&val, kp->value, PMIX_VALUE))) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(kp);
-                    val = NULL;
-                    goto done;
-                }
-            }
-            PMIX_RELEASE(kp); // maintain acctg - hash_store does a retain
+        if (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(buf, &bptr, &cnt, PMIX_BUFFER))) {
             cnt = 1;
-            kp = PMIX_NEW(pmix_kval_t);
+            cur_kval = PMIX_NEW(pmix_kval_t);
+            while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(bptr, cur_kval, &cnt, PMIX_KVAL))) {
+                pmix_output_verbose(2, pmix_globals.debug_output,
+                                    "pmix: unpacked key %s", cur_kval->key);
+                if (PMIX_SUCCESS != (rc = pmix_hash_store(&nptr->modex, cur_rank, cur_kval))) {
+                    PMIX_ERROR_LOG(rc);
+                }
+                if (NULL != cb->key && 0 == strcmp(cb->key, cur_kval->key)) {
+                    pmix_output_verbose(2, pmix_globals.debug_output,
+                                        "pmix: found requested value");
+                    if (PMIX_SUCCESS != (rc = pmix_bfrop.copy((void**)&val, cur_kval->value, PMIX_VALUE))) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_RELEASE(cur_kval);
+                        val = NULL;
+                        goto done;
+                    }
+                }
+                PMIX_RELEASE(cur_kval); // maintain acctg - hash_store does a retain
+                cnt = 1;
+                cur_kval = PMIX_NEW(pmix_kval_t);
+            }
+            cnt = 1;
+            PMIX_RELEASE(cur_kval);
         }
-        cnt = 1;
-        PMIX_RELEASE(kp);
         PMIX_RELEASE(bptr);  // free's the data region
         if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
             PMIX_ERROR_LOG(rc);
@@ -338,28 +364,21 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     pmix_cb_t *cbret;
     pmix_buffer_t *msg;
     pmix_value_t *val;
+    pmix_info_t *info, *iptr;
+    pmix_pointer_array_t results;
     pmix_status_t rc;
-    char *nm;
     pmix_nspace_t *ns, *nptr;
-    size_t n;
+    size_t n, nvals;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: getnbfn value for proc %s:%d key %s",
                         cb->nspace, cb->rank,
                         (NULL == cb->key) ? "NULL" : cb->key);
 
-    /* if the nspace is empty, then the caller is referencing
-     * our own nspace */
-    if (0 == strlen(cb->nspace)) {
-        nm = pmix_globals.myid.nspace;
-    } else {
-        nm = (char*)cb->nspace;
-    }
-
     /* find the nspace object */
     nptr = NULL;
     PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_nspace_t) {
-        if (0 == strcmp(nm, ns->nspace)) {
+        if (0 == strcmp(cb->nspace, ns->nspace)) {
             nptr = ns;
             break;
         }
@@ -370,11 +389,103 @@ static void _getnbfn(int fd, short flags, void *cbdata)
          * server has never heard of it, the server will return
          * an error */
          nptr = PMIX_NEW(pmix_nspace_t);
-         (void)strncpy(nptr->nspace, nm, PMIX_MAX_NSLEN);
+         (void)strncpy(nptr->nspace, cb->nspace, PMIX_MAX_NSLEN);
          pmix_list_append(&pmix_globals.nspaces, &nptr->super);
          /* there is no point in looking for data in this nspace
           * object, so let's just go generate the request */
          goto request;
+    }
+
+    /* if the key is NULL, then we have to check both the job-data
+     * and the modex tables. If we don't yet have the modex data,
+     * then we are going to have to go get it. So let's check that
+     * case first */
+     if (NULL == cb->key) {
+        PMIX_CONSTRUCT(&results, pmix_pointer_array_t);
+        pmix_pointer_array_init(&results, 2, INT_MAX, 1);
+        nvals = 0;
+        /* if the rank is WILDCARD, then they want all the job-level info,
+         * so no need to check the modex */
+        if (PMIX_RANK_WILDCARD != cb->rank) {
+            if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->modex, cb->rank, NULL, &val))) {
+                pmix_output_verbose(2, pmix_globals.debug_output,
+                                    "pmix: value retrieved from dstore");
+                /* since we didn't provide them with a key, the hash function
+                 * must return the results in the pmix_info_array field of the
+                 * value */
+                if (NULL == val || PMIX_INFO_ARRAY != val->type) {
+                    /* this is an error */
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                    cb->value_cbfunc(PMIX_ERR_BAD_PARAM, NULL, cb->cbdata);
+                    PMIX_RELEASE(cb);
+                    return;
+                }
+                /* save the results */
+                info = (pmix_info_t*)val->data.array.array;
+                for (n=0; n < val->data.array.size; n++) {
+                    pmix_pointer_array_add(&results, &info[n]);
+                    ++nvals;
+                }
+                val->data.array.array = NULL;  // protect the data
+                val->data.array.size = 0;
+                /* cleanup */
+                if (NULL != val) {
+                    PMIX_VALUE_RELEASE(val);
+                }
+            } else {
+                /* if we didn't find a modex for this rank, then we need
+                 * to go get it. Recall that the NULL==key scenario only
+                 * pertains to cases where legacy PMI methods are being
+                 * employed. Thus, the caller wants -all- information for
+                 * the specified rank, not just the job-level info. */
+                 goto request;
+            }
+        }
+        /* now get any data from the job-level info */
+        if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, PMIX_RANK_WILDCARD, NULL, &val))) {
+            /* since we didn't provide them with a key, the hash function
+             * must return the results in the pmix_info_array field of the
+             * value */
+            if (NULL == val || PMIX_INFO_ARRAY != val->type) {
+                /* this is an error */
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                cb->value_cbfunc(PMIX_ERR_BAD_PARAM, NULL, cb->cbdata);
+                PMIX_RELEASE(cb);
+                return;
+            }
+            /* save the results */
+            info = (pmix_info_t*)val->data.array.array;
+            for (n=0; n < val->data.array.size; n++) {
+                pmix_pointer_array_add(&results, &info[n]);
+                ++nvals;
+            }
+            val->data.array.array = NULL;  // protect the data
+            val->data.array.size = 0;
+            /* cleanup */
+            if (NULL != val) {
+                PMIX_VALUE_RELEASE(val);
+            }
+        }
+        /* now let's package up the results */
+        PMIX_VALUE_CREATE(val, 1);
+        val->type = PMIX_INFO_ARRAY;
+        val->data.array.size = nvals;
+        PMIX_INFO_CREATE(iptr, nvals);
+        val->data.array.array = (struct pmix_info_t*)iptr;
+        for (n=0; n < (size_t)results.size && n < nvals; n++) {
+            if (NULL != (info = (pmix_info_t*)pmix_pointer_array_get_item(&results, n))) {
+                (void)strncpy(iptr[n].key, info->key, PMIX_MAX_KEYLEN);
+                pmix_value_xfer(&iptr[n].value, &info->value);
+                PMIX_INFO_FREE(info, 1);
+            }
+        }
+        /* done with results array */
+        PMIX_DESTRUCT(&results);
+        /* return the result to the caller */
+        cb->value_cbfunc(PMIX_SUCCESS, val, cb->cbdata);
+        PMIX_VALUE_FREE(val, 1);
+        PMIX_RELEASE(cb);
+        return;
     }
 
     /* the requested data could be in the job-data table, so let's
@@ -433,7 +544,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
          * the error */
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "Error requesting key=%s for rank = %d, namespace = %s",
-                            cb->key, cb->rank, nm);
+                            cb->key, cb->rank, cb->nspace);
         cb->value_cbfunc(rc, NULL, cb->cbdata);
         /* protect the data */
         cb->procs = NULL;
@@ -461,7 +572,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
             /* they don't want us to try and retrieve it */
             pmix_output_verbose(2, pmix_globals.debug_output,
                                 "PMIx_Get key=%s for rank = %d, namespace = %s was not found - request was optional",
-                                cb->key, cb->rank, nm);
+                                cb->key, cb->rank, cb->nspace);
             cb->value_cbfunc(PMIX_ERR_NOT_FOUND, NULL, cb->cbdata);
             PMIX_RELEASE(cb);
             return;
@@ -472,7 +583,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
      * this nspace:rank. If we do, then no need to ask again as the
      * request will return _all_ data from that proc */
     PMIX_LIST_FOREACH(cbret, &pmix_client_globals.pending_requests, pmix_cb_t) {
-        if (0 == strncmp(cbret->nspace, nm, PMIX_MAX_NSLEN) &&
+        if (0 == strncmp(cbret->nspace, cb->nspace, PMIX_MAX_NSLEN) &&
             cbret->rank == cb->rank) {
             /* we do have a pending request, but we still need to track this
              * outstanding request so we can satisfy it once the data is returned */
@@ -483,7 +594,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
 
     /* we don't have a pending request, so let's create one - don't worry
      * about packing the key as we return everything from that proc */
-    msg = pack_get(nm, cb->rank, cb->info, cb->ninfo, PMIX_GETNB_CMD);
+    msg = _pack_get(cb->nspace, cb->rank, cb->info, cb->ninfo, PMIX_GETNB_CMD);
     if (NULL == msg) {
         cb->value_cbfunc(PMIX_ERROR, NULL, cb->cbdata);
         PMIX_RELEASE(cb);
@@ -496,5 +607,5 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);
 
     /* push the message into our event base to send to the server */
-    PMIX_ACTIVATE_SEND_RECV(&pmix_client_globals.myserver, msg, getnb_cbfunc, cb);
+    PMIX_ACTIVATE_SEND_RECV(&pmix_client_globals.myserver, msg, _getnb_cbfunc, cb);
 }

--- a/opal/mca/pmix/pmix120/pmix/src/client/pmix_client_spawn.c
+++ b/opal/mca/pmix/pmix120/pmix/src/client/pmix_client_spawn.c
@@ -150,10 +150,12 @@ pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t ninfo,
         PMIX_RELEASE(msg);
         return rc;
     }
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, apps, napps, PMIX_APP))) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(msg);
-        return rc;
+    if (0 < napps) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, apps, napps, PMIX_APP))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
     }
 
     /* create a callback object as we need to pass it to the

--- a/opal/mca/pmix/pmix120/pmix/src/common/pmix_common.c
+++ b/opal/mca/pmix/pmix120/pmix/src/common/pmix_common.c
@@ -43,10 +43,10 @@ void PMIx_Register_errhandler(pmix_info_t info[], size_t ninfo,
          * call pmix_server_register_for_events, and call cbfunc with
          * reference to the errhandler */
          pmix_output_verbose(2, pmix_globals.debug_output,
-                             "registering client err handler");
+                             "registering client err handler with %d info", (int)ninfo);
          pmix_client_register_errhandler(info, ninfo,
-                                        errhandler,
-                                        cbfunc, cbdata);
+                                         errhandler,
+                                         cbfunc, cbdata);
     }
 }
 
@@ -80,17 +80,17 @@ pmix_status_t PMIx_Notify_error(pmix_status_t status,
     int rc;
 
     if (pmix_globals.server) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix_server_notify_error error =%d, rc=%d", status, rc);
         rc = pmix_server_notify_error(status, procs, nprocs, error_procs,
                                       error_nprocs, info, ninfo,
-                                       cbfunc, cbdata);
-        pmix_output_verbose(0, pmix_globals.debug_output,
-                            "pmix_server_notify_error error =%d, rc=%d", status, rc);
+                                      cbfunc, cbdata);
     } else {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix_client_notify_error error =%d, rc=%d", status, rc);
         rc = pmix_client_notify_error(status, procs, nprocs, error_procs,
                                       error_nprocs, info, ninfo,
                                       cbfunc, cbdata);
-        pmix_output_verbose(0, pmix_globals.debug_output,
-                            "pmix_client_notify_error error =%d, rc=%d", status, rc);
     }
     return rc;
 }

--- a/opal/mca/pmix/pmix120/pmix/src/include/pmix_globals.h
+++ b/opal/mca/pmix/pmix120/pmix/src/include/pmix_globals.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,6 +44,7 @@ BEGIN_C_DECLS
 /* define a structure for tracking error registrations */
 typedef struct {
     pmix_object_t super;
+    bool sglhdlr;                      // registers a specific error status handler
     pmix_notification_fn_t errhandler; /* registered err handler callback fn */
     pmix_info_t *info;                 /* error info keys registered with the handler */
     size_t ninfo;                      /* size of info */

--- a/opal/mca/pmix/pmix120/pmix/src/server/pmix_server_ops.h
+++ b/opal/mca/pmix/pmix120/pmix/src/server/pmix_server_ops.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2016 Intel, Inc. All rights reserved
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -15,6 +15,7 @@
 #include <private/autogen/config.h>
 #include <pmix/rename.h>
 #include <pmix/pmix_common.h>
+#include <src/class/pmix_ring_buffer.h>
 #include <pmix_server.h>
 #include "src/usock/usock.h"
 #include "src/util/hash.h"
@@ -157,6 +158,7 @@ typedef struct {
     int stop_thread[2];                     // pipe used to stop listener thread
     pmix_buffer_t gdata;                    // cache of data given to me for passing to all clients
     pmix_list_t client_eventregs;           // list of registered events per client.
+    pmix_ring_buffer_t notifications;       // ring buffer of pending notifications
 } pmix_server_globals_t;
 
 #define PMIX_PEER_CADDY(c, p, t)                \
@@ -272,6 +274,8 @@ pmix_status_t pmix_server_notify_error_client(pmix_peer_t *peer,
                                               pmix_buffer_t *buf,
                                               pmix_op_cbfunc_t cbfunc,
                                               void *cbdata);
+void pmix_server_check_notifications(pmix_regevents_info_t *reginfo,
+                                     pmix_notify_caddy_t *cd);
 
 void regevents_cbfunc (pmix_status_t status, void *cbdata);
 

--- a/opal/mca/pmix/pmix120/pmix/src/util/error.h
+++ b/opal/mca/pmix/pmix120/pmix/src/util/error.h
@@ -42,11 +42,19 @@ BEGIN_C_DECLS
         pmix_errhandler_invoke(e, NULL, 0, NULL, 0);    \
     } while(0);
 
+/* invoke the error handler that is registered against the given
+ * status, passing it the provided info on the procs that were
+ * affected, plus any additional info provided by the server */
 PMIX_DECLSPEC void pmix_errhandler_invoke(pmix_status_t status,
                                           pmix_proc_t procs[], size_t nprocs,
                                           pmix_info_t info[], size_t ninfo);
 
-PMIX_DECLSPEC pmix_status_t pmix_lookup_errhandler(pmix_notification_fn_t err,
+/* lookup the errhandler registered against the given status. If there
+ * is none, but an errhandler has been registered against the group
+ * that this status belongs to, then return that errhandler. If neither
+ * of those is true, but a general errhandler has been registered, then
+ * return that errhandler. Otherwise, return NOT_FOUND */
+PMIX_DECLSPEC pmix_status_t pmix_lookup_errhandler(pmix_info_t info[], size_t ninfo,
                                                    int *index);
 
 PMIX_DECLSPEC pmix_status_t pmix_add_errhandler(pmix_notification_fn_t err,

--- a/opal/mca/pmix/pmix120/pmix/src/util/hash.h
+++ b/opal/mca/pmix/pmix120/pmix/src/util/hash.h
@@ -27,10 +27,18 @@ BEGIN_C_DECLS
 pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
                               int rank, pmix_kval_t *kv);
 
-/* Fetch the value for a specified key from within
+/* Fetch the value for a specified key and rank from within
  * the given hash_table */
 pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, int rank,
                               const char *key, pmix_value_t **kvs);
+
+/* Fetch the value for a specified key from within
+ * the given hash_table
+ * It gets the next portion of data from table, where matching key.
+ * To get the first data from table, function is called with key parameter as string.
+ * Remaining data from table are obtained by calling function with a null pointer for the key parameter.*/
+pmix_status_t pmix_hash_fetch_by_key(pmix_hash_table_t *table, const char *key,
+                                     int *rank, pmix_value_t **kvs, void **last);
 
 /* remove the specified key-value from the given hash_table.
  * A NULL key will result in removal of all data for the

--- a/opal/mca/pmix/pmix120/pmix/src/util/output.h
+++ b/opal/mca/pmix/pmix120/pmix/src/util/output.h
@@ -507,6 +507,12 @@ struct pmix_output_stream_t {
                                                         char **olddir,
                                                         char **oldprefix);
 
+    /**
+     * Same as pmix_output_verbose(), but pointer to buffer and size.
+     */
+    PMIX_DECLSPEC void pmix_output_hexdump(int verbose_level, int output_id,
+                                           void *ptr, int buflen);
+
 #if PMIX_ENABLE_DEBUG
     /**
      * Main macro for use in sending debugging output to output streams;

--- a/opal/mca/pmix/pmix120/pmix120_server_north.c
+++ b/opal/mca/pmix/pmix120/pmix120_server_north.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc.

--- a/opal/mca/pmix/pmix120/pmix_pmix120.c
+++ b/opal/mca/pmix/pmix120/pmix_pmix120.c
@@ -211,6 +211,11 @@ static void reg_thread(int sd, short args, void *cbdata)
     int rc;
     opal_pmix120_etracker_t *trk;
 
+    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+                        "%s register complete with status %d",
+                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+                        cd->status);
+
     /* convert the status */
     rc = pmix120_convert_rc(cd->status);
 
@@ -251,6 +256,11 @@ static void pmix120_register_errhandler(opal_list_t *info,
     size_t n;
     opal_value_t *ival;
 
+    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+                        "%s REGISTER ERRHDNLR INFO %s",
+                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+                        (NULL == info) ? "NULL" : "NOT-NULL");
+
     /* setup a caddy for the operation so we can free
      * the array when done */
     cd = OBJ_NEW(pmix120_opcaddy_t);
@@ -266,7 +276,8 @@ static void pmix120_register_errhandler(opal_list_t *info,
             n=0;
             OPAL_LIST_FOREACH(ival, info, opal_value_t) {
                 (void)strncpy(cd->info[n].key, ival->key, PMIX_MAX_KEYLEN);
-                pmix120_value_load(&cd->info[n].value, ival);
+                cd->info[n].value.type = PMIX_INT;
+                cd->info[n].value.data.status = pmix120_convert_opalrc(ival->data.integer);
             }
         }
     }

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -248,8 +248,14 @@ opal_err2str(int errnum, const char **errmsg)
     case OPAL_ERR_SERVER_NOT_AVAIL:
         retval = "Server not available";
         break;
+    case OPAL_ERR_IN_PROCESS:
+        retval = "Operation in process";
+        break;
+    case OPAL_ERR_DEBUGGER_RELEASE:
+        retval = "Release debugger";
+        break;
     default:
-        retval = NULL;
+        retval = "UNRECOGNIZED";
     }
 
     *errmsg = retval;

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -540,6 +540,7 @@ void orte_plm_base_launch_apps(int fd, short args, void *cbdata)
     sig->signature = (orte_process_name_t*)malloc(sizeof(orte_process_name_t));
     sig->signature[0].jobid = ORTE_PROC_MY_NAME->jobid;
     sig->signature[0].vpid = ORTE_VPID_WILDCARD;
+    sig->sz = 1;
     if (ORTE_SUCCESS != (rc = orte_grpcomm.xcast(sig, ORTE_RML_TAG_DAEMON, buffer))) {
         ORTE_ERROR_LOG(rc);
         OBJ_RELEASE(buffer);
@@ -693,9 +694,6 @@ void orte_plm_base_post_launch(int fd, short args, void *cbdata)
     }
 
  cleanup:
-    /* need to init_after_spawn for debuggers */
-    ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_READY_FOR_DEBUGGERS);
-
     /* cleanup */
     OBJ_RELEASE(caddy);
 }

--- a/orte/mca/rml/rml_types.h
+++ b/orte/mca/rml/rml_types.h
@@ -110,8 +110,8 @@ BEGIN_C_DECLS
 /* show help */
 #define ORTE_RML_TAG_SHOW_HELP              36
 
-/* debugger release */
-#define ORTE_RML_TAG_DEBUGGER_RELEASE       37
+/* error notifications */
+#define ORTE_RML_TAG_NOTIFICATION           37
 
 /* bootstrap */
 #define ORTE_RML_TAG_BOOTSTRAP              38

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -75,6 +75,7 @@ typedef struct {
     opal_object_t super;
     opal_event_t ev;
     opal_list_t *procs;
+    opal_list_t *eprocs;
     opal_list_t *info;
     opal_pmix_op_cbfunc_t cbfunc;
     void *cbdata;
@@ -175,6 +176,10 @@ extern void pmix_server_keyval_client(int status, orte_process_name_t* sender,
                                       opal_buffer_t *buffer,
                                       orte_rml_tag_t tg, void *cbdata);
 
+extern void pmix_server_notify(int status, orte_process_name_t* sender,
+                               opal_buffer_t *buffer,
+                               orte_rml_tag_t tg, void *cbdata);
+
 /* exposed shared variables */
 typedef struct {
     bool initialized;
@@ -186,6 +191,7 @@ typedef struct {
     char *server_uri;
     bool wait_for_server;
     orte_process_name_t server;
+    opal_list_t notifications;
 } pmix_server_globals_t;
 
 extern pmix_server_globals_t orte_pmix_server_globals;


### PR DESCRIPTION
This currently is only supported by the pmix120 component, which is not selected by default. All other components will ignore error registration requests, and thus do not support debugger attach when launched via mpirun. Note that direct launched applications will support such attachment, but may not do so in a scalable fashion.

Fixes ##1225