### PR TITLE
Plug some memory leaks

### DIFF
--- a/orte/mca/grpcomm/direct/grpcomm_direct.c
+++ b/orte/mca/grpcomm/direct/grpcomm_direct.c
@@ -259,7 +259,7 @@ static void xcast_recv(int status, orte_process_name_t* sender,
     orte_namelist_t *nm;
     int ret, cnt;
     opal_buffer_t *relay, *rly;
-    orte_daemon_cmd_flag_t command;
+    orte_daemon_cmd_flag_t command = ORTE_DAEMON_NULL_CMD;
     opal_buffer_t wireup;
     opal_byte_object_t *bo;
     int8_t flag;
@@ -429,20 +429,24 @@ static void xcast_recv(int status, orte_process_name_t* sender,
             opal_output(0, "%s grpcomm:direct:send_relay proc %s not found - cannot relay",
                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), ORTE_NAME_PRINT(&nm->name));
             OBJ_RELEASE(rly);
+            OBJ_RELEASE(item);
             continue;
         }
         if (ORTE_PROC_STATE_RUNNING < rec->state) {
             opal_output(0, "%s grpcomm:direct:send_relay proc %s not running - cannot relay",
                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), ORTE_NAME_PRINT(&nm->name));
             OBJ_RELEASE(rly);
+            OBJ_RELEASE(item);
             continue;
         }
         if (ORTE_SUCCESS != (ret = orte_rml.send_buffer_nb(&nm->name, rly, ORTE_RML_TAG_XCAST,
                                                            orte_rml_send_callback, NULL))) {
             ORTE_ERROR_LOG(ret);
             OBJ_RELEASE(rly);
+            OBJ_RELEASE(item);
             continue;
         }
+        OBJ_RELEASE(item);
     }
     OBJ_RELEASE(rly);  // retain accounting
 

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -101,6 +101,7 @@ void orte_plm_base_daemons_reported(int fd, short args, void *cbdata)
             OBJ_RELEASE(caddy);
             return;
         }
+        t = NULL;
         if (NULL == (node = dmn1->node) ||
             NULL == (t = node->topology)) {
             /* something is wrong */

--- a/orte/mca/routed/radix/routed_radix.c
+++ b/orte/mca/routed/radix/routed_radix.c
@@ -835,6 +835,7 @@ static void radix_tree(int rank, int *num_children,
                 }
                 /* point to this relations */
                 relations = relatives;
+                OBJ_RELEASE(child);
             }
             /* search for this child's relatives */
             radix_tree(peer, NULL, NULL, relations);

--- a/orte/mca/state/base/state_base_fns.c
+++ b/orte/mca/state/base/state_base_fns.c
@@ -603,6 +603,11 @@ void orte_state_base_check_all_complete(int fd, short args, void *cbdata)
         orte_iof.complete(jdata);
     }
 
+    /* tell the PMIx server to release its data */
+    if (NULL != opal_pmix.server_deregister_nspace) {
+        opal_pmix.server_deregister_nspace(jdata->jobid);
+    }
+
     i32ptr = &i32;
     if (orte_get_attribute(&jdata->attributes, ORTE_JOB_NUM_NONZERO_EXIT, (void**)&i32ptr, OPAL_INT32) && !orte_abort_non_zero_exit) {
         if (!orte_report_child_jobs_separately || 1 == ORTE_LOCAL_JOBID(jdata->jobid)) {
@@ -710,10 +715,6 @@ void orte_state_base_check_all_complete(int fd, short args, void *cbdata)
         }
         OBJ_RELEASE(map);
         jdata->map = NULL;
-        /* tell the PMIx server to release its data */
-        if (NULL != opal_pmix.server_deregister_nspace) {
-            opal_pmix.server_deregister_nspace(jdata->jobid);
-        }
     }
 
  CHECK_ALIVE:

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -381,6 +381,11 @@ static void check_complete(int fd, short args, void *cbdata)
         orte_iof.complete(jdata);
     }
 
+    /* tell the PMIx subsystem the job is complete */
+    if (NULL != opal_pmix.server_deregister_nspace) {
+        opal_pmix.server_deregister_nspace(jdata->jobid);
+    }
+
     /* Release the resources used by this job. Since some errmgrs may want
      * to continue using resources allocated to the job as part of their
      * fault recovery procedure, we only do this once the job is "complete".
@@ -427,10 +432,6 @@ static void check_complete(int fd, short args, void *cbdata)
         }
         OBJ_RELEASE(map);
         jdata->map = NULL;
-        /* tell the PMIx server to release its data */
-        if (NULL != opal_pmix.server_deregister_nspace) {
-            opal_pmix.server_deregister_nspace(jdata->jobid);
-        }
     }
 
     if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -486,6 +486,9 @@ int orte_submit_init(int argc, char *argv[],
             orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-access", true, myglobals.hnp);
             exit(1);
         }
+        /* initialize the input to NULLs to ensure any input
+         * string is NULL-terminated */
+        memset(input, 0, 1024);
         if (NULL == fgets(input, 1024, fp)) {
             /* something malformed about file */
             fclose(fp);


### PR DESCRIPTION
Release child object when we are recording someone's relatives.
(Thanks to Mark Santcroos!)

Release routing list entries.
(Thanks to Mark Santcroos!)

Address some Coverity concerns