### PR TITLE
btl/openib/udcm: fix local XRC connections

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -557,6 +557,7 @@ static int udcm_endpoint_init_self_xrc (struct mca_btl_base_endpoint_t *lcl_ep)
         recv_qpn = lcl_ep->xrc_recv_qp_num;
 #endif
 
+        lcl_ep->ib_addr->remote_xrc_rcv_qp_num = recv_qpn;
         lcl_ep->rem_info.rem_qps[0].rem_psn = lcl_ep->xrc_recv_psn;
         lcl_ep->rem_info.rem_qps[0].rem_qp_num = recv_qpn;
 


### PR DESCRIPTION
This commit ensures ib_addr->remote_xrc_rcv_qp_num value is set when
creating the loopback queue pair. This is needed when communicating
with any other local peer.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>