### PR TITLE
orterun: allow DDT if options contain :'s

### DIFF
--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -1,5 +1,5 @@
-/* -*- C -*-
- *
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
- * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -2111,7 +2111,7 @@ static int process(char *orig_line, char *basename, opal_cmd_line_t *cmd_line,
         }
 
         /* Some debuggers do not support launching MPMD */
-        else if (single_app && NULL != strchr(tmp, ':')) {
+        else if (single_app && NULL != strstr(tmp, " : ")) {
             orte_show_help("help-orterun.txt",
                            "debugger only accepts single app", true,
                            (*new_argv)[0], (*new_argv)[0]);


### PR DESCRIPTION
There is a bug in MPMD detection that disables totalview if a : is
found anywhere on the command line. This includes inside an argument
option or MCA variable value. This commit changes the check to look
for the string " : " instead of the character : which should eliminate
the issue in most cases.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>