### PR TITLE
Cleanup some valgrind complaints about jumps with uninitialized values.

### DIFF
--- a/opal/mca/pmix/pmix112/pmix1_server_south.c
+++ b/opal/mca/pmix/pmix112/pmix1_server_south.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc.
@@ -431,7 +431,6 @@ int pmix1_server_notify_error(int status,
     op->cbdata = cbdata;
 
     rc = pmix1_convert_opalrc(status);
-    opal_output(0, "CALLING NOTIFY ERROR");
     rc = PMIx_Notify_error(rc, ps, psz, eps, esz,
                            pinfo, sz, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {

--- a/orte/mca/iof/base/base.h
+++ b/orte/mca/iof/base/base.h
@@ -117,7 +117,8 @@ typedef struct {
     orte_iof_read_event_t *revstdout;
     orte_iof_read_event_t *revstderr;
     orte_iof_read_event_t *revstddiag;
-    opal_list_t subscribers;
+    opal_list_t *subscribers;
+    bool copy;
 } orte_iof_proc_t;
 ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_iof_proc_t);
 

--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -76,7 +76,8 @@ static void orte_iof_base_proc_construct(orte_iof_proc_t* ptr)
     ptr->revstdout = NULL;
     ptr->revstderr = NULL;
     ptr->revstddiag = NULL;
-    OBJ_CONSTRUCT(&ptr->subscribers, opal_list_t);
+    ptr->subscribers = NULL;
+    ptr->copy = true;
 }
 static void orte_iof_base_proc_destruct(orte_iof_proc_t* ptr)
 {
@@ -92,7 +93,9 @@ static void orte_iof_base_proc_destruct(orte_iof_proc_t* ptr)
     if (NULL != ptr->revstddiag) {
         OBJ_RELEASE(ptr->revstddiag);
     }
-    OPAL_LIST_DESTRUCT(&ptr->subscribers);
+    if (NULL != ptr->subscribers) {
+        OPAL_LIST_RELEASE(ptr->subscribers);
+    }
 }
 OBJ_CLASS_INSTANCE(orte_iof_proc_t,
                    opal_list_item_t,

--- a/orte/mca/iof/hnp/iof_hnp_component.c
+++ b/orte/mca/iof/hnp/iof_hnp_component.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,7 +91,7 @@ static int orte_iof_hnp_close(void)
 static int orte_iof_hnp_query(mca_base_module_t **module, int *priority)
 {
     /* if we are not the HNP, then don't use this module */
-    if (!ORTE_PROC_IS_HNP) {
+    if (!ORTE_PROC_IS_HNP && !ORTE_PROC_IS_MASTER) {
         *priority = -1;
         *module = NULL;
         return ORTE_ERROR;

--- a/orte/mca/iof/hnp/iof_hnp_receive.c
+++ b/orte/mca/iof/hnp/iof_hnp_receive.c
@@ -61,7 +61,7 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
     int rc;
     bool exclusive;
     orte_iof_proc_t *proct;
-    orte_ns_cmp_bitmask_t mask=ORTE_NS_CMP_ALL;
+    orte_ns_cmp_bitmask_t mask=ORTE_NS_CMP_ALL | ORTE_NS_CMP_WILD;
 
     OPAL_OUTPUT_VERBOSE((1, orte_iof_base_framework.framework_output,
                          "%s received IOF from proc %s",
@@ -102,9 +102,8 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
     }
 
     OPAL_OUTPUT_VERBOSE((1, orte_iof_base_framework.framework_output,
-                         "%s received IOF cmd from sender %s for source %s",
+                         "%s received IOF cmd for source %s",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                         ORTE_NAME_PRINT(&requestor),
                          ORTE_NAME_PRINT(&origin)));
 
     /* check to see if a tool has requested something */
@@ -144,26 +143,29 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
         /* a tool is requesting that we send it a copy of the specified stream(s)
          * from the specified process(es), so create a sink for it
          */
+        if (NULL == proct->subscribers) {
+            proct->subscribers = OBJ_NEW(opal_list_t);
+        }
         if (ORTE_IOF_STDOUT & stream) {
             ORTE_IOF_SINK_DEFINE(&sink, &origin, -1, ORTE_IOF_STDOUT, NULL);
             sink->daemon.jobid = requestor.jobid;
             sink->daemon.vpid = requestor.vpid;
             sink->exclusive = exclusive;
-            opal_list_append(&proct->subscribers, &sink->super);
+            opal_list_append(proct->subscribers, &sink->super);
         }
         if (ORTE_IOF_STDERR & stream) {
             ORTE_IOF_SINK_DEFINE(&sink, &origin, -1, ORTE_IOF_STDERR, NULL);
             sink->daemon.jobid = requestor.jobid;
             sink->daemon.vpid = requestor.vpid;
             sink->exclusive = exclusive;
-            opal_list_append(&proct->subscribers, &sink->super);
+            opal_list_append(proct->subscribers, &sink->super);
         }
         if (ORTE_IOF_STDDIAG & stream) {
             ORTE_IOF_SINK_DEFINE(&sink, &origin, -1, ORTE_IOF_STDDIAG, NULL);
             sink->daemon.jobid = requestor.jobid;
             sink->daemon.vpid = requestor.vpid;
             sink->exclusive = exclusive;
-            opal_list_append(&proct->subscribers, &sink->super);
+            opal_list_append(proct->subscribers, &sink->super);
         }
         goto CLEAN_RETURN;
     }
@@ -181,7 +183,7 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
             if (OPAL_EQUAL != orte_util_compare_name_fields(mask, &proct->name, &origin)) {
                 continue;
             }
-            OPAL_LIST_FOREACH_SAFE(sink, next, &proct->subscribers, orte_iof_sink_t) {
+            OPAL_LIST_FOREACH_SAFE(sink, next, proct->subscribers, orte_iof_sink_t) {
                  /* if the target isn't set, then this sink is for another purpose - ignore it */
                 if (ORTE_JOBID_INVALID == sink->daemon.jobid) {
                     continue;
@@ -196,7 +198,7 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
                      * completed sending anything to that requestor before it exits
                      */
                     orte_iof_hnp_send_data_to_endpoint(&sink->daemon, &origin, ORTE_IOF_CLOSE, NULL, 0);
-                    opal_list_remove_item(&proct->subscribers, &sink->super);
+                    opal_list_remove_item(proct->subscribers, &sink->super);
                     OBJ_RELEASE(sink);
                 }
             }
@@ -233,20 +235,22 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
   NSTEP:
     /* cycle through the endpoints to see if someone else wants a copy */
     exclusive = false;
-    OPAL_LIST_FOREACH(sink, &proct->subscribers, orte_iof_sink_t) {
-        /* if the target isn't set, then this sink is for another purpose - ignore it */
-        if (ORTE_JOBID_INVALID == sink->daemon.jobid) {
-            continue;
-        }
-        if ((stream & sink->tag) &&
-            sink->name.jobid == origin.jobid &&
-            (ORTE_VPID_WILDCARD == sink->name.vpid ||
-             ORTE_VPID_WILDCARD == origin.vpid ||
-             sink->name.vpid == origin.vpid)) {
-            /* send the data to the tool */
-            orte_iof_hnp_send_data_to_endpoint(&sink->daemon, &origin, stream, data, numbytes);
-            if (sink->exclusive) {
-                exclusive = true;
+    if (NULL != proct->subscribers) {
+        OPAL_LIST_FOREACH(sink, proct->subscribers, orte_iof_sink_t) {
+            /* if the target isn't set, then this sink is for another purpose - ignore it */
+            if (ORTE_JOBID_INVALID == sink->daemon.jobid) {
+                continue;
+            }
+            if ((stream & sink->tag) &&
+                sink->name.jobid == origin.jobid &&
+                (ORTE_VPID_WILDCARD == sink->name.vpid ||
+                 ORTE_VPID_WILDCARD == origin.vpid ||
+                 sink->name.vpid == origin.vpid)) {
+                /* send the data to the tool */
+                orte_iof_hnp_send_data_to_endpoint(&sink->daemon, &origin, stream, data, numbytes);
+                if (sink->exclusive) {
+                    exclusive = true;
+                }
             }
         }
     }

--- a/orte/mca/iof/orted/iof_orted_component.c
+++ b/orte/mca/iof/orted/iof_orted_component.c
@@ -88,7 +88,7 @@ static int orte_iof_orted_query(mca_base_module_t **module, int *priority)
         return ORTE_ERROR;
     }
 
-    *priority = 100;
+    *priority = 80;
     *module = (mca_base_module_t *) &orte_iof_orted_module;
 
     return ORTE_SUCCESS;

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1726,6 +1726,7 @@ int orte_plm_base_setup_virtual_machine(orte_job_t *jdata)
             /* if the app provided a dash-host, and we are not treating
              * them as requested or "soft" locations, then use those nodes
              */
+            hosts = NULL;
             if (!orte_soft_locations &&
                 orte_get_attribute(&app->attributes, ORTE_APP_DASH_HOST, (void**)&hosts, OPAL_STRING)) {
                 OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,

--- a/orte/mca/ras/base/ras_base_allocate.c
+++ b/orte/mca/ras/base/ras_base_allocate.c
@@ -113,7 +113,7 @@ void orte_ras_base_allocate(int fd, short args, void *cbdata)
     orte_std_cntr_t i;
     orte_app_context_t *app;
     orte_state_caddy_t *caddy = (orte_state_caddy_t*)cbdata;
-    char *hosts;
+    char *hosts=NULL;
 
     OPAL_OUTPUT_VERBOSE((5, orte_ras_base_framework.framework_output,
                          "%s ras:base:allocate",

--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -484,6 +484,7 @@ static int bind_in_place(orte_job_t *jdata,
                 continue;
             }
             /* bozo check */
+            locale = NULL;
             if (!orte_get_attribute(&proc->attributes, ORTE_PROC_HWLOC_LOCALE, (void**)&locale, OPAL_PTR)) {
                 orte_show_help("help-orte-rmaps-base.txt", "rmaps:no-locale", true, ORTE_NAME_PRINT(&proc->name));
                 return ORTE_ERR_SILENT;

--- a/orte/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/orte/mca/rmaps/base/rmaps_base_support_fns.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -166,6 +166,7 @@ int orte_rmaps_base_get_target_nodes(opal_list_t *allocated_nodes, orte_std_cntr
         /* if the app provided a dash-host, and we are not treating
          * them as requested or "soft" locations, then use those nodes
          */
+        hosts = NULL;
         if (!orte_soft_locations &&
             orte_get_attribute(&app->attributes, ORTE_APP_DASH_HOST, (void**)&hosts, OPAL_STRING)) {
             OPAL_OUTPUT_VERBOSE((5, orte_rmaps_base_framework.framework_output,

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -436,13 +436,11 @@ static void check_complete(int fd, short args, void *cbdata)
 
     if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
         /* this was a debugger daemon. notify that a debugger has detached */
-        OBJ_RETAIN(jdata);
         ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_DEBUGGER_DETACH);
     } else if (jdata->state != ORTE_JOB_STATE_NOTIFIED) {
         OPAL_OUTPUT_VERBOSE((2, orte_state_base_framework.framework_output,
                              "%s state:dvm:check_job_completed state is terminated - activating notify",
                              ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
-        OBJ_RETAIN(jdata);
         ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_NOTIFY_COMPLETED);
         /* mark the job as notified */
         jdata->state = ORTE_JOB_STATE_NOTIFIED;


### PR DESCRIPTION
Fix a few IOF issues reported by Mark Santcroos when submitting jobs from tools. Add the ability to pass directives to the --output-filename option that tell ORTE to (a) not include the jobid in the path to the output files, and (b) not to copy the output to the tool (i.e., just store it in the files).

Remove stale debug

Fix a segfault if no subscribers are present