### PR TITLE
don't try to bind tasks when direct launched by an external launcher that did no binding

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -166,7 +166,7 @@ static int opal_hwloc_base_register(mca_base_register_flag_t flags)
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY, &opal_hwloc_base_topo_file);
 
-    opal_hwloc_base_bind_direct_launched = false;
+    opal_hwloc_base_bind_direct_launched = true;
     (void) mca_base_var_register("opal", "hwloc", "base", "bind_direct_launched",
                                  "bind processes when direct launched ",
                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_9,

--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -42,6 +42,7 @@ hwloc_cpuset_t opal_hwloc_base_given_cpus=NULL;
 opal_hwloc_base_map_t opal_hwloc_base_map = OPAL_HWLOC_BASE_MAP_NONE;
 opal_hwloc_base_mbfa_t opal_hwloc_base_mbfa = OPAL_HWLOC_BASE_MBFA_WARN;
 opal_binding_policy_t opal_hwloc_binding_policy=0;
+bool opal_hwloc_base_bind_direct_launched = false;
 char *opal_hwloc_base_slot_list=NULL;
 char *opal_hwloc_base_cpu_set=NULL;
 bool opal_hwloc_report_bindings=false;
@@ -164,6 +165,12 @@ static int opal_hwloc_base_register(mca_base_register_flag_t flags)
                                  "Read local topology from file instead of directly sensing it",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY, &opal_hwloc_base_topo_file);
+
+    opal_hwloc_base_bind_direct_launched = false;
+    (void) mca_base_var_register("opal", "hwloc", "base", "bind_direct_launched",
+                                 "bind processes when direct launched ",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY, &opal_hwloc_base_bind_direct_launched);
 
     /* register parameters */
     return OPAL_SUCCESS;

--- a/opal/mca/hwloc/hwloc.h
+++ b/opal/mca/hwloc/hwloc.h
@@ -217,6 +217,7 @@ OPAL_DECLSPEC extern hwloc_cpuset_t opal_hwloc_my_cpuset;
 OPAL_DECLSPEC extern bool opal_hwloc_report_bindings;
 OPAL_DECLSPEC extern hwloc_obj_type_t opal_hwloc_levels[];
 OPAL_DECLSPEC extern bool opal_hwloc_use_hwthreads_as_cpus;
+OPAL_DECLSPEC extern bool opal_hwloc_base_bind_direct_launched;
 
 END_C_DECLS
 

--- a/orte/mca/ess/base/ess_base_fns.c
+++ b/orte/mca/ess/base/ess_base_fns.c
@@ -69,7 +69,7 @@ int orte_ess_base_proc_binding(void)
     }
 
     /* direct launched: use whatever the extarnal launcher has set */
-    if (NULL == orte_process_info.my_daemon_uri) {
+    if ((NULL == orte_process_info.my_daemon_uri) && !opal_hwloc_base_bind_direct_launched) {
         OPAL_OUTPUT_VERBOSE((5, orte_ess_base_framework.framework_output,
                              "%s Process externally launched -- use their binding",
                              ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));

--- a/orte/mca/ess/base/ess_base_fns.c
+++ b/orte/mca/ess/base/ess_base_fns.c
@@ -68,6 +68,14 @@ int orte_ess_base_proc_binding(void)
         }
     }
 
+    /* direct launched: use whatever the extarnal launcher has set */
+    if (NULL == orte_process_info.my_daemon_uri) {
+        OPAL_OUTPUT_VERBOSE((5, orte_ess_base_framework.framework_output,
+                             "%s Process externally launched -- use their binding",
+                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+        goto MOVEON;
+    }
+
     /* see if we were bound when launched */
     if (!orte_proc_is_bound) {
         OPAL_OUTPUT_VERBOSE((5, orte_ess_base_framework.framework_output,


### PR DESCRIPTION
When using an external launcher like srun, srun handles the
binding. Sometimes it does intentionnaly not bind, like for a hybrid
job.

If we set a binding policy in ompi (I like to have mpirun bind by
default) it is usually not applied in srun because there is a check to
see if processes were externally bound. But when they were
intentionally left unbound by srun, the check says they are unbound,
so we bind them.

I find this behaviour doesn't follow least suprise, and that by
default we should rather keep what the external launcher did.

So what I propose here is to not apply the binding policy for direct
launched jobs.
If we really want to enforce the binding policy when the launcher did
nothing, I propose a mca flag hwloc_base_bind_direct_launched=true


So for an unbound openmp job, with the original behaviour (or the new
mca param) we get:

```
   $ env OMPI_MCA_hwloc_base_binding_policy=core OMPI_MCA_hwloc_base_report_bindings=1 OMPI_MCA_hwloc_base_bind_direct_launched=true srun --exclusive -p bulldozer --label  -N1 -n1 --cpu_bind=none,verbose  omp_hybrid_hello
   0: [btp3:08632] MCW rank 0 bound to socket 0[core 0[hwt 0]]: [B/././././././././././././././.][./././././././././././././././.]
   0: 0.13 on btp3.8632.8654 bound to Core#0 (pu: {0}) running on 0; details: '[Socket#0(32GB)].Core{0}.PU{0}'
   0: 0.19 on btp3.8632.8660 bound to Core#0 (pu: {0}) running on 0; details: '[Socket#0(32GB)].Core{0}.PU{0}'
   0: 0.14 on btp3.8632.8655 bound to Core#0 (pu: {0}) running on 0; details: '[Socket#0(32GB)].Core{0}.PU{0}'

```

With the new behaviour, we maintain what srun did:

```
   $ env OMPI_MCA_hwloc_base_binding_policy=core OMPI_MCA_hwloc_base_report_bindings=1 srun --exclusive -p bulldozer --label  -N1 -n1 --cpu_bind=none,verbose  omp_hybrid_hello
   0: [btp3:08703] MCW rank 0 is not bound (or bound to all available processors)
   0: 0.24 on btp3.8703.8736 bound to Machine#0(64GB) (pu: {0-31}) running on 31; details: 'Socket{0-1}.Core{0-7}.PU{0-31}'
   0: 0.9 on btp3.8703.8721 bound to Machine#0(64GB) (pu: {0-31}) running on 31; details: 'Socket{0-1}.Core{0-7}.PU{0-31}'
   0: 0.0 on btp3.8703.8703 bound to Machine#0(64GB) (pu: {0-31}) running on 24; details: 'Socket{0-1}.Core{0-7}.PU{0-31}'
   [...]

```

What do you think of this ?