### PR TITLE
Cleanup the output-filename options so they work as expected.

### DIFF
--- a/orte/mca/iof/base/base.h
+++ b/orte/mca/iof/base/base.h
@@ -113,7 +113,7 @@ ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_iof_read_event_t);
 typedef struct {
     opal_list_item_t super;
     orte_process_name_t name;
-    orte_iof_sink_t *stdin;
+    orte_iof_sink_t *stdinev;
     orte_iof_read_event_t *revstdout;
     orte_iof_read_event_t *revstderr;
     orte_iof_read_event_t *revstddiag;
@@ -202,6 +202,7 @@ ORTE_DECLSPEC extern orte_iof_base_t orte_iof_base;
 ORTE_DECLSPEC int orte_iof_base_write_output(orte_process_name_t *name, orte_iof_tag_t stream,
                                              unsigned char *data, int numbytes,
                                              orte_iof_write_event_t *channel);
+ORTE_DECLSPEC void orte_iof_base_static_dump_output(orte_iof_read_event_t *rev);
 ORTE_DECLSPEC void orte_iof_base_write_handler(int fd, short event, void *cbdata);
 
 END_C_DECLS

--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -72,7 +72,7 @@ OBJ_CLASS_INSTANCE(orte_iof_job_t,
 
 static void orte_iof_base_proc_construct(orte_iof_proc_t* ptr)
 {
-    ptr->stdin = NULL;
+    ptr->stdinev = NULL;
     ptr->revstdout = NULL;
     ptr->revstderr = NULL;
     ptr->revstddiag = NULL;
@@ -81,8 +81,8 @@ static void orte_iof_base_proc_construct(orte_iof_proc_t* ptr)
 }
 static void orte_iof_base_proc_destruct(orte_iof_proc_t* ptr)
 {
-    if (NULL != ptr->stdin) {
-        OBJ_RELEASE(ptr->stdin);
+    if (NULL != ptr->stdinev) {
+        OBJ_RELEASE(ptr->stdinev);
     }
     if (NULL != ptr->revstdout) {
         OBJ_RELEASE(ptr->revstdout);

--- a/orte/mca/iof/hnp/iof_hnp_receive.c
+++ b/orte/mca/iof/hnp/iof_hnp_receive.c
@@ -254,6 +254,10 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
             }
         }
     }
+    /* if the user doesn't want a copy written to the screen, then we are done */
+    if (!proct->copy) {
+        return;
+    }
 
     /* output this to our local output unless one of the sinks was exclusive */
     if (!exclusive) {

--- a/orte/mca/iof/orted/iof_orted_read.c
+++ b/orte/mca/iof/orted/iof_orted_read.c
@@ -109,7 +109,11 @@ void orte_iof_orted_read_handler(int fd, short event, void *cbdata)
     if (NULL != rev->sink) {
         /* output to the corresponding file */
         orte_iof_base_write_output(&proct->name, rev->tag, data, numbytes, rev->sink->wev);
-        goto RESTART;
+    }
+    if (!proct->copy) {
+        /* re-add the event */
+        opal_event_add(rev->ev, 0);
+        return;
     }
 
     /* prep the buffer */
@@ -143,7 +147,6 @@ void orte_iof_orted_read_handler(int fd, short event, void *cbdata)
     orte_rml.send_buffer_nb(ORTE_PROC_MY_HNP, buf, ORTE_RML_TAG_IOF_HNP,
                             send_cb, NULL);
 
- RESTART:
     /* re-add the event */
     opal_event_add(rev->ev, 0);
 
@@ -156,14 +159,17 @@ void orte_iof_orted_read_handler(int fd, short event, void *cbdata)
      * the file descriptor */
     if (rev->tag & ORTE_IOF_STDOUT) {
         if( NULL != proct->revstdout ) {
+            orte_iof_base_static_dump_output(proct->revstdout);
             OBJ_RELEASE(proct->revstdout);
         }
     } else if (rev->tag & ORTE_IOF_STDERR) {
         if( NULL != proct->revstderr ) {
+            orte_iof_base_static_dump_output(proct->revstderr);
             OBJ_RELEASE(proct->revstderr);
         }
     } else if (rev->tag & ORTE_IOF_STDDIAG) {
         if( NULL != proct->revstddiag ) {
+            orte_iof_base_static_dump_output(proct->revstddiag);
             OBJ_RELEASE(proct->revstddiag);
         }
     }

--- a/orte/mca/iof/orted/iof_orted_receive.c
+++ b/orte/mca/iof/orted/iof_orted_receive.c
@@ -141,14 +141,14 @@ void orte_iof_orted_recv(int status, orte_process_name_t* sender,
                                      "%s writing data to local proc %s",
                                      ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                                      ORTE_NAME_PRINT(&proct->name)));
-                if (NULL == proct->stdin) {
+                if (NULL == proct->stdinev) {
                     continue;
                 }
                 /* send the bytes down the pipe - we even send 0 byte events
                  * down the pipe so it forces out any preceding data before
                  * closing the output stream
                  */
-                if (ORTE_IOF_MAX_INPUT_BUFFERS < orte_iof_base_write_output(&target, stream, data, numbytes, proct->stdin->wev)) {
+                if (ORTE_IOF_MAX_INPUT_BUFFERS < orte_iof_base_write_output(&target, stream, data, numbytes, proct->stdinev->wev)) {
                     /* getting too backed up - tell the HNP to hold off any more input if we
                      * haven't already told it
                      */


### PR DESCRIPTION
Have the remote nodes output locally to the files instead of sending it all back to the HNP.