### PR TITLE
MPI C++ Datatypes: don't declare/define if no C++ support

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Rigde National Laboratory.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
@@ -941,6 +941,9 @@ OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_long_double;
 OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_wchar;
 OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_packed;
 
+/* Per MPI-3.1 A.1.1 p674, only define the C++ datatypes if we're
+   actually building C++ support */
+#if defined(OMPI_BUILD_CXX_BINDINGS) && OMPI_BUILD_CXX_BINDINGS
 /*
  * Following are the C++/C99 datatypes
  */
@@ -948,6 +951,7 @@ OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_cxx_bool;
 OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_cxx_cplex;
 OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_cxx_dblcplex;
 OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_cxx_ldblcplex;
+#endif
 
 /*
  * Following are the Fortran datatypes
@@ -1162,10 +1166,15 @@ OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUSES_IGNORE;
 #if HAVE_LONG_DOUBLE__COMPLEX
 #define MPI_C_LONG_DOUBLE_COMPLEX OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_c_long_double_complex)
 #endif
+
+/* Per MPI-3.1 A.1.1 p674, only define the C++ datatypes if we're
+   actually building C++ support */
+#if defined(OMPI_BUILD_CXX_BINDINGS) && OMPI_BUILD_CXX_BINDINGS
 #define MPI_CXX_BOOL              OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_cxx_bool)
 #define MPI_CXX_FLOAT_COMPLEX     OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_cxx_cplex)
 #define MPI_CXX_DOUBLE_COMPLEX    OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_cxx_dblcplex)
 #define MPI_CXX_LONG_DOUBLE_COMPLEX OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_cxx_ldblcplex)
+#endif
 
 /* New datatypes from the 3.0 standard */
 #define MPI_COUNT                 OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_count)


### PR DESCRIPTION
Per MPI-3.1 A.1.1 p674, only define the C++ datatypes if we're actually building C++ support.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

This consequence came out of the "should we define Fortran MPI datatypes in mpi.h if there's no Fortran support?" discussion.  In the MPI Fortran WG discussion, it turns out that MPI-3.1 _does_ say that the C++ datatypes should _not_ be available in mpi.h if there's no C++ bindings.  The spec unfortunately don't say anything about the Fortran datatypes -- so it'll be brought up [in the March 2016 MPI Forum meeting](http://meetings.mpi-forum.org/secretary/2016/03/agenda.php).

This commit removes the C++ MPI Datatypes from mpi.h when there's no C++ support.

@bosilca Please review.
