### PR TITLE
monitoring lib: rename to ompi_monitoring_prof.so

### DIFF
--- a/test/monitoring/Makefile.am
+++ b/test/monitoring/Makefile.am
@@ -19,10 +19,10 @@
 if PROJECT_OMPI
     noinst_PROGRAMS = monitoring_test
     monitoring_test_SOURCES = monitoring_test.c
-    monitoring_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
+    monitoring_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
     monitoring_test_LDADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
-        $(top_builddir)/opal/libopen-pal.la
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 if MCA_BUILD_ompi_pml_monitoring_DSO
     lib_LTLIBRARIES = ompi_monitoring_prof.la
@@ -31,7 +31,7 @@ if MCA_BUILD_ompi_pml_monitoring_DSO
         -module -avoid-version -shared $(WRAPPER_EXTRA_LDFLAGS)
     ompi_monitoring_prof_la_LIBADD = \
         $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
-        $(top_builddir)/opal/libopen-pal.la
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 endif # MCA_BUILD_ompi_pml_monitoring_DSO
 
 endif # PROJECT_OMPI

--- a/test/monitoring/Makefile.am
+++ b/test/monitoring/Makefile.am
@@ -6,6 +6,7 @@
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -19,16 +20,18 @@ if PROJECT_OMPI
     noinst_PROGRAMS = monitoring_test
     monitoring_test_SOURCES = monitoring_test.c
     monitoring_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-    monitoring_test_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la $(top_builddir)/opal/libopen-pal.la
+    monitoring_test_LDADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/libopen-pal.la
 
 if MCA_BUILD_ompi_pml_monitoring_DSO
-    lib_LTLIBRARIES = monitoring_prof.la
-    monitoring_prof_la_SOURCES = monitoring_prof.c
-    monitoring_prof_la_LDFLAGS=-module -avoid-version -shared $(WRAPPER_EXTRA_LDFLAGS)
-    monitoring_prof_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la $(top_builddir)/opal/libopen-pal.la
-endif
+    lib_LTLIBRARIES = ompi_monitoring_prof.la
+    ompi_monitoring_prof_la_SOURCES = monitoring_prof.c
+    ompi_monitoring_prof_la_LDFLAGS= \
+        -module -avoid-version -shared $(WRAPPER_EXTRA_LDFLAGS)
+    ompi_monitoring_prof_la_LIBADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/libopen-pal.la
+endif # MCA_BUILD_ompi_pml_monitoring_DSO
 
-endif
-
-distclean:
-	rm -rf *.dSYM .deps .libs *.la *.lo monitoring_test *.log *.o *.trs Makefile
+endif # PROJECT_OMPI

--- a/test/monitoring/monitoring_prof.c
+++ b/test/monitoring/monitoring_prof.c
@@ -15,12 +15,19 @@
 /*
 pml monitoring PMPI profiler
 
-Designed by George Bosilca <bosilca@icl.utk.edu>, Emmanuel Jeannot <emmanuel.jeannot@inria.fr> and Guillaume Papauré <guillaume.papaure@bull.net>
+Designed by:
+  George Bosilca <bosilca@icl.utk.edu>
+  Emmanuel Jeannot <emmanuel.jeannot@inria.fr>
+  Guillaume Papauré <guillaume.papaure@bull.net>
+
 Contact the authors for questions.
 
 To be run as:
 
-mpirun -np 4 -x LD_PRELOAD=ompi_install_dir/lib/monitoring_prof.so --mca pml_monitoring_enable 1 ./my_app
+mpirun -np 4 \
+    --mca pml_monitoring_enable 1 \
+    -x LD_PRELOAD=ompi_install_dir/lib/ompi_monitoring_prof.so \
+    ./my_app
 
 ...
 ...


### PR DESCRIPTION
The library that is installed is specific to Open MPI, so put an "ompi_" prefix on it.

Also do some minor line wrappings and cleanups of text.

Signed-off-by: Jeff Squyres jsquyres@cisco.com

@bosilca I added an "ompi_" prefix to the library name so that it is clear that the installed library is specific to Open MPI, and did some other minor text cleanups.  Please review.  Did you have a milestone in mind for bringing this monitoring stuff over to the v2.x branch?
