### PR TITLE
tests: fix library name

### DIFF
--- a/test/event/Makefile.am
+++ b/test/event/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,19 +29,19 @@ TESTS = $(check_PROGRAMS)
 signal_test_SOURCES = signal-test.c
 signal_test_LDFLAGS = $(OPAL_PKG_CONFIG_LDFLAGS)
 signal_test_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 signal_test_DEPENDENCIES = $(signal_test_LDADD)
 
 time_test_SOURCES = time-test.c
 time_test_LDFLAGS = $(OPAL_PKG_CONFIG_LDFLAGS)
 time_test_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 time_test_DEPENDENCIES = $(time_test_LDADD)
 
 event_test_SOURCES = event-test.c
 event_test_LDFLAGS = $(OPAL_PKG_CONFIG_LDFLAGS)
 event_test_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 event_test_DEPENDENCIES = $(event_test_LDADD)
 
 distclean:

--- a/test/memchecker/Makefile.am
+++ b/test/memchecker/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,33 +31,33 @@ TESTS = \
 access_buffer_test_SOURCES = access_buffer_test.c
 access_buffer_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 access_buffer_test_LDADD = \
-        $(top_builddir)/ompi/libmpi.la
+        $(top_builddir)/ompi/lib@OPAL_LIB_PREFIX@mpi.la
 access_buffer_test_DEPENDENCIES = $(access_buffer_test_LDADD)
 
 irecv_init_check_SOURCES = irecv_init_check.c
 irecv_init_check_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 irecv_init_check_LDADD = \
-        $(top_builddir)/ompi/libmpi.la
+        $(top_builddir)/ompi/lib@OPAL_LIB_PREFIX@mpi.la
 irecv_init_check_DEPENDENCIES = $(irecv_init_check_LDADD)
 
 
 irecv_uninit_check_SOURCES = irecv_uninit_check.c
 irecv_uninit_check_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 irecv_uninit_check_LDADD = \
-        $(top_builddir)/ompi/libmpi.la
+        $(top_builddir)/ompi/lib@OPAL_LIB_PREFIX@mpi.la
 irecv_uninit_check_DEPENDENCIES = $(irecv_uninit_check_LDADD)
 
 non_blocking_send_test_SOURCES = non_blocking_send_test.c
 non_blocking_send_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 non_blocking_send_test_LDADD = \
-        $(top_builddir)/ompi/libmpi.la
+        $(top_builddir)/ompi/lib@OPAL_LIB_PREFIX@mpi.la
 non_blocking_send_test_DEPENDENCIES = $(non_blocking_send_test_LDADD)
 
 
 non_blocking_recv_test_SOURCES = non_blocking_recv_test.c
 non_blocking_recv_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 non_blocking_recv_test_LDADD = \
-        $(top_builddir)/ompi/libmpi.la
+        $(top_builddir)/ompi/lib@OPAL_LIB_PREFIX@mpi.la
 non_blocking_recv_test_DEPENDENCIES = $(non_blocking_recv_test_LDADD)
 
 distclean:

--- a/test/runtime/Makefile.am
+++ b/test/runtime/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -51,7 +52,7 @@ orte_init_finalize_DEPENDENCIES = $(orte_init_finalize_LDADD)
 opal_init_finalize_SOURCES = \
     opal_init_finalize.c
 opal_init_finalize_LDADD = \
-	$(top_builddir)/opal/libopen-pal.la \
+	$(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(top_builddir)/test/support/libsupport.a
 opal_init_finalize_DEPENDENCIES = $(opal_init_finalize_LDADD)
 

--- a/test/threads/Makefile.am
+++ b/test/threads/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,13 +33,13 @@ TESTS =
 opal_thread_SOURCES = opal_thread.c
 opal_thread_LDADD = \
         $(top_builddir)/test/support/libsupport.a \
-        $(top_builddir)/opal/libopen-pal.la
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 opal_thread_DEPENDENCIES = $(opal_thread_LDADD)
 
 opal_condition_SOURCES = opal_condition.c
 opal_condition_LDADD = \
         $(top_builddir)/test/support/libsupport.a \
-        $(top_builddir)/opal/libopen-pal.la
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 opal_condition_DEPENDENCIES = $(opal_condition_LDADD)
 
 distclean:

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
 #                         reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -69,26 +70,26 @@ TESTS = \
 
 opal_bit_ops_SOURCES = opal_bit_ops.c
 opal_bit_ops_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_bit_ops_DEPENDENCIES = $(opal_path_nfs_LDADD)
 
 
 opal_path_nfs_SOURCES = opal_path_nfs.c
 opal_path_nfs_LDADD = \
-        $(top_builddir)/opal/libopen-pal.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_path_nfs_DEPENDENCIES = $(opal_path_nfs_LDADD)
 
 #opal_os_path_SOURCES = opal_os_path.c
 #opal_os_path_LDADD = \
-#        $(top_builddir)/opal/libopen-pal.la \
+#        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 #        $(top_builddir)/test/support/libsupport.a
 #opal_os_path_DEPENDENCIES = $(opal_os_path_LDADD)
 
 #opal_timer_SOURCES = opal_timer.c
 #opal_timer_LDADD = \
-#        $(top_builddir)/opal/libopen-pal.la \
+#        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 #        $(top_builddir)/test/support/libsupport.a
 #opal_timer_DEPENDENCIES = $(opal_timer_LDADD)
 
@@ -101,7 +102,7 @@ opal_path_nfs_DEPENDENCIES = $(opal_path_nfs_LDADD)
 
 #opal_os_create_dirpath_SOURCES = opal_os_create_dirpath.c
 #opal_os_create_dirpath_LDADD = \
-#        $(top_builddir)/opal/libopen-pal.la \
+#        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 #        $(top_builddir)/test/support/libsupport.a
 #opal_os_create_dirpath_DEPENDENCIES = $(opal_os_create_dirpath_LDADD)
 


### PR DESCRIPTION
Use @OPAL_LIB_PREFIX@ as appropriate in the library that we link against.