### PR TITLE
cxx: "rank" is now a function in C++11

### DIFF
--- a/ompi/mpi/cxx/comm_inln.h
+++ b/ompi/mpi/cxx/comm_inln.h
@@ -10,7 +10,7 @@
 //                         University of Stuttgart.  All rights reserved.
 // Copyright (c) 2004-2005 The Regents of the University of California.
 //                         All rights reserved.
-// Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+// Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
 // Copyright (c) 2011      FUJITSU LIMITED.  All rights reserved.
 // $COPYRIGHT$
 //
@@ -271,9 +271,9 @@ MPI::Comm::Get_size() const
 inline int
 MPI::Comm::Get_rank() const
 {
-  int rank;
-  (void)MPI_Comm_rank (mpi_comm, &rank);
-  return rank;
+  int myrank;
+  (void)MPI_Comm_rank (mpi_comm, &myrank);
+  return myrank;
 }
 
 inline int

--- a/ompi/mpi/cxx/group_inln.h
+++ b/ompi/mpi/cxx/group_inln.h
@@ -10,6 +10,7 @@
 //                         University of Stuttgart.  All rights reserved.
 // Copyright (c) 2004-2005 The Regents of the University of California.
 //                         All rights reserved.
+// Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 // $COPYRIGHT$
 //
 // Additional copyrights may follow
@@ -32,9 +33,9 @@ MPI::Group::Get_size() const
 inline int
 MPI::Group::Get_rank() const
 {
-  int rank;
-  (void)MPI_Group_rank(mpi_group, &rank);
-  return rank;
+  int myrank;
+  (void)MPI_Group_rank(mpi_group, &myrank);
+  return myrank;
 }
 
 inline void

--- a/ompi/mpi/cxx/topology_inln.h
+++ b/ompi/mpi/cxx/topology_inln.h
@@ -12,6 +12,7 @@
 //                         All rights reserved.
 // Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 // Copyright (c) 2011      FUJITSU LIMITED.  All rights reserved.
+// Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 // $COPYRIGHT$
 //
 // Additional copyrights may follow
@@ -81,9 +82,9 @@ MPI::Cartcomm::Get_topo(int maxdims, int dims[], bool periods[],
 inline int
 MPI::Cartcomm::Get_cart_rank(const int coords[]) const
 {
-  int rank;
-  (void)MPI_Cart_rank(mpi_comm, const_cast<int *>(coords), &rank);
-  return rank;
+  int myrank;
+  (void)MPI_Cart_rank(mpi_comm, const_cast<int *>(coords), &myrank);
+  return myrank;
 }
 
 inline void


### PR DESCRIPTION
Use "myrank" instead (I tried using ::rank, but had varied success... so I just renamed the variable).

@hppritcha Please review.  Could easily slip to v2.0.1, if you want.  I don't have a strong preference.