### PR TITLE
examples: update ompi_info bindings checks

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -84,19 +84,19 @@ all: hello_c ring_c connectivity_c
 # MPI examples
 
 mpi:
-	@ if ompi_info --parsable | grep bindings:cxx:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:cxx:yes >/dev/null; then \
 	    $(MAKE) hello_cxx ring_cxx; \
 	fi
-	@ if ompi_info --parsable | grep bindings:mpif.h:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:mpif.h:yes >/dev/null; then \
 	    $(MAKE) hello_mpifh ring_mpifh; \
 	fi
-	@ if ompi_info --parsable | grep bindings:use_mpi:\"yes >/dev/null; then \
+	@ if ompi_info --parsable | egrep -q bindings:use_mpi:\"\?yes >/dev/null; then \
 	    $(MAKE) hello_usempi ring_usempi; \
 	fi
-	@ if ompi_info --parsable | grep bindings:use_mpi_f08:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:use_mpi_f08:yes >/dev/null; then \
 	    $(MAKE) hello_usempif08 ring_usempif08; \
 	fi
-	@ if ompi_info --parsable | grep bindings:java:yes >/dev/null; then \
+	@ if ompi_info --parsable | grep -q bindings:java:yes >/dev/null; then \
 	    $(MAKE) Hello.class Ring.class; \
 	fi
 


### PR DESCRIPTION
Use `-q` option to grep/egrep to suppress output (we only need the exit status).  Also, use egrep for the "use mpi" check, because some versions of ompi_info say `bindings:use_mpi:yes` and others say `bindings:use_mpi:"yes` (i.e., with the double quote).  This regexp will work with both versions.

@ggouaillardet Please review.  If acceptable, I'll add this to open-mpi/ompi-release#993 and open-mpi/ompi-release#994.