### PR TITLE
Fix a potential race condition in recv cancel

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -103,13 +103,14 @@ static int mca_pml_ob1_recv_request_cancel(struct ompi_request_t* ompi_request, 
     ompi_communicator_t *comm = request->req_recv.req_base.req_comm;
     mca_pml_ob1_comm_t *ob1_comm = comm->c_pml_comm;
 
+    /* The rest should be protected behind the match logic lock */
+    OPAL_THREAD_LOCK(&ob1_comm->matching_lock);
     if( true == request->req_match_received ) { /* way to late to cancel this one */
+        OPAL_THREAD_UNLOCK(&ob1_comm->matching_lock);
         assert( OMPI_ANY_TAG != ompi_request->req_status.MPI_TAG ); /* not matched isn't it */
         return OMPI_SUCCESS;
     }
 
-    /* The rest should be protected behind the match logic lock */
-    OPAL_THREAD_LOCK(&ob1_comm->matching_lock);
     if( request->req_recv.req_base.req_peer == OMPI_ANY_SOURCE ) {
         opal_list_remove_item( &ob1_comm->wild_receives, (opal_list_item_t*)request );
     } else {


### PR DESCRIPTION
The access to request->req_match_received is safe, however, when we read it false, we may unsafely assume that the request is not matched and go on and cancel it. As the matching lock is taken late, the request may actually get matched in the meantime, and we end-up cancelling a matched request. 