### PR TITLE
Do not push child processes into separate process groups so that any …

### DIFF
--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -786,10 +786,8 @@ static int rte_finalize(void)
         /** Remove the USR signal handlers */
         opal_event_signal_del(&sigusr1_handler);
         opal_event_signal_del(&sigusr2_handler);
-        if (orte_forward_job_control) {
-            opal_event_signal_del(&sigtstp_handler);
-            opal_event_signal_del(&sigcont_handler);
-        }
+        opal_event_signal_del(&sigtstp_handler);
+        opal_event_signal_del(&sigcont_handler);
         signals_set = false;
     }
 

--- a/orte/mca/odls/alps/odls_alps_module.c
+++ b/orte/mca/odls/alps/odls_alps_module.c
@@ -416,13 +416,6 @@ static int do_child(orte_app_context_t* context,
     sigset_t sigs;
     char *param, *msg;
 
-    if (orte_forward_job_control) {
-        /* Set a new process group for this child, so that a
-           SIGSTOP can be sent to it without being sent to the
-           orted. */
-        setpgid(0, 0);
-    }
-
     /* Setup the pipe to be close-on-exec */
     opal_fd_set_cloexec(write_fd);
 
@@ -798,11 +791,6 @@ static int send_signal(pid_t pid, int signal)
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                          signal, (long)pid));
 
-    if (orte_forward_job_control) {
-	/* Send the signal to the process group rather than the
-	   process.  The child is the leader of its process group. */
-	pid = -pid;
-    }
     if (kill(pid, signal) != 0) {
         switch(errno) {
             case EINVAL:

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -143,9 +143,6 @@ char *orte_output_filename = NULL;
 /* generate new xterm windows to display output from specified ranks */
 char *orte_xterm = NULL;
 
-/* whether or not to forward SIGTSTP and SIGCONT signals */
-bool orte_forward_job_control = false;
-
 /* report launch progress */
 bool orte_report_launch_progress = false;
 

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -521,9 +521,6 @@ ORTE_DECLSPEC extern opal_pointer_array_t *orte_node_topologies;
 ORTE_DECLSPEC extern opal_pointer_array_t *orte_local_children;
 ORTE_DECLSPEC extern orte_vpid_t orte_total_procs;
 
-/* whether or not to forward SIGTSTP and SIGCONT signals */
-ORTE_DECLSPEC extern bool orte_forward_job_control;
-
 /* IOF controls */
 ORTE_DECLSPEC extern bool orte_tag_output;
 ORTE_DECLSPEC extern bool orte_timestamp_output;

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -543,14 +543,6 @@ int orte_register_params(void)
         orte_map_stddiag_to_stderr = true;
     }
 
-    /* whether or not to forward SIGTSTP and SIGCONT signals */
-    orte_forward_job_control = false;
-    (void) mca_base_var_register ("orte", "orte", NULL, "forward_job_control",
-                                  "Forward SIGTSTP (after converting to SIGSTOP) and SIGCONT signals to the application procs [default: no]",
-                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-                                  &orte_forward_job_control);
-
     /* whether or not to report launch progress */
     orte_report_launch_progress = false;
     (void) mca_base_var_register ("orte", "orte", NULL, "report_launch_progress",

--- a/orte/tools/orte-submit/orte-submit.1in
+++ b/orte/tools/orte-submit/orte-submit.1in
@@ -1133,9 +1133,7 @@ SIGUSR1 and SIGUSR2 signals received by orte-submit are propagated to
 all processes in the job.
 .
 .PP
-One can turn on forwarding of SIGSTOP and SIGCONT to the program executed
-by ompi-submit by setting the MCA parameter orte_forward_job_control to 1.
-A SIGTSTOP signal to ompi-submit will then cause a SIGSTOP signal to be sent
+A SIGTSTOP signal to ompi-submit will cause a SIGSTOP signal to be sent
 to all of the programs started by ompi-submit and likewise a SIGCONT signal
 to ompi-submit will cause a SIGCONT sent.
 .

--- a/orte/tools/orterun/orterun.1in
+++ b/orte/tools/orterun/orterun.1in
@@ -1240,9 +1240,7 @@ SIGUSR1 and SIGUSR2 signals received by orterun are propagated to
 all processes in the job.
 .
 .PP
-One can turn on forwarding of SIGSTOP and SIGCONT to the program executed
-by mpirun by setting the MCA parameter orte_forward_job_control to 1.
-A SIGTSTOP signal to mpirun will then cause a SIGSTOP signal to be sent
+A SIGTSTOP signal to mpirun will cause a SIGSTOP signal to be sent
 to all of the programs started by mpirun and likewise a SIGCONT signal
 to mpirun will cause a SIGCONT sent.
 .


### PR DESCRIPTION
…host RM can still "see" them, and ensure that any signal sent to the orted's themselves will be provided to all child processes. Forward all signals from mpirun to the child processes, removing the old MCA parameter required to turn that behavior "on".

Refs #1419 