### PR TITLE
Fixing MXM Yalla and MTL add procs behavior. MXM cannot support dynam…

### DIFF
--- a/ompi/mca/mtl/mxm/mtl_mxm.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm.c
@@ -389,6 +389,9 @@ int ompi_mtl_mxm_module_init(void)
 
     /* Register the MXM progress function */
     opal_progress_register(ompi_mtl_mxm_progress);
+    
+    ompi_mtl_mxm.super.mtl_flags |= MCA_MTL_BASE_FLAG_REQUIRE_WORLD;
+
 
 #if MXM_API >= MXM_VERSION(2,0)
     if (ompi_mtl_mxm.using_mem_hooks) {

--- a/ompi/mca/pml/yalla/pml_yalla.c
+++ b/ompi/mca/pml/yalla/pml_yalla.c
@@ -184,6 +184,8 @@ int mca_pml_yalla_init(void)
     OBJ_CONSTRUCT(&ompi_pml_yalla.convs, mca_pml_yalla_freelist_t);
 
     opal_progress_register(mca_pml_yalla_progress);
+    
+    ompi_pml_yalla.super.pml_flags |= MCA_PML_BASE_FLAG_REQUIRE_WORLD;
 
     PML_YALLA_VERBOSE(2, "created mxm context %p ep %p", (void *)ompi_pml_yalla.mxm_context,
                       (void *)ompi_pml_yalla.mxm_ep);


### PR DESCRIPTION
…ic add procs, so propaget this info to the MTL and PML layers.