### PR TITLE
configury: minor updates to config summary output

### DIFF
--- a/config/ompi_check_psm.m4
+++ b/config/ompi_check_psm.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006      QLogic Corp. All rights reserved.
-dnl Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -68,7 +68,7 @@ AC_DEFUN([OMPI_CHECK_PSM],[
               [AC_MSG_WARN([PSM driver does not currently support progress threads.  Disabling BTL.])
                ompi_check_psm_happy="no"])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[QLogic Infinipath (PSM)]],[$1],[$ompi_check_psm_happy])
+	OMPI_SUMMARY_ADD([[Transports]],[[Intel TrueScale (PSM)]],[$1],[$ompi_check_psm_happy])
     fi
 
     AS_IF([test "$ompi_check_psm_happy" = "yes"],

--- a/config/opal_check_cma.m4
+++ b/config/opal_check_cma.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009      The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
 # Copyright (c) 2013-2016 Los Alamos National Security, LLC. All rights
 #                         reserved.
@@ -41,7 +41,7 @@ AC_DEFUN([OPAL_CHECK_CMA],[
 
 	OPAL_VAR_SCOPE_POP
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Linux CMA IPC]],[$1],[$ompi_check_cma_happy])
+	OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/Linux CMA]],[$1],[$ompi_check_cma_happy])
     fi
 
     AS_IF([test "$ompi_check_cma_happy" = "yes"], [$2], [$3])

--- a/config/opal_check_cuda.m4
+++ b/config/opal_check_cuda.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
@@ -123,6 +123,8 @@ else
     AC_MSG_RESULT([no])
     CUDA_SUPPORT=0
 fi
+
+OMPI_SUMMARY_ADD([[Miscellaneous]],[[CUDA support]],[opal_cuda], [$opal_check_cuda_happy])
 
 AM_CONDITIONAL([OPAL_cuda_support], [test "x$CUDA_SUPPORT" = "x1"])
 AC_DEFINE_UNQUOTED([OPAL_CUDA_SUPPORT],$CUDA_SUPPORT,

--- a/config/opal_check_knem.m4
+++ b/config/opal_check_knem.m4
@@ -3,7 +3,7 @@ dnl
 dnl Copyright (c) 2009      The University of Tennessee and The University
 dnl                         of Tennessee Research Foundation.  All rights
 dnl                         reserved.
-dnl Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
@@ -61,7 +61,7 @@ AC_DEFUN([OPAL_CHECK_KNEM],[
 
 	CPPFLAGS="$opal_check_knem_$1_save_CPPFLAGS"
 
-        OMPI_SUMMARY_ADD([[Transports]],[[KNEM Shared Memory]],[$1],[$opal_check_knem_happy])
+        OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/Linux KNEM]],[$1],[$opal_check_knem_happy])
 	OPAL_VAR_SCOPE_POP
     fi
 

--- a/config/opal_check_libfabric.m4
+++ b/config/opal_check_libfabric.m4
@@ -1,6 +1,6 @@
 dnl -*- shell-script -*-
 dnl
-dnl Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl $COPYRIGHT$
@@ -71,7 +71,7 @@ AC_DEFUN([OPAL_CHECK_LIBFABRIC],[
 	LDFLAGS=$opal_check_libfabric_$1_save_LDFLAGS
 	LIBS=$opal_check_libfabric_$1_save_LIBS
 
-	OMPI_SUMMARY_ADD([[Transports]],[[OpenFabrics libfabric]],[$1],[$opal_check_libfabric_happy])
+	OMPI_SUMMARY_ADD([[Transports]],[[OpenFabrics Libfabric]],[$1],[$opal_check_libfabric_happy])
 
 	OPAL_VAR_SCOPE_POP
     fi

--- a/config/opal_check_portals4.m4
+++ b/config/opal_check_portals4.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006      QLogic Corp. All rights reserved.
-dnl Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -94,7 +94,7 @@ AC_DEFUN([OPAL_CHECK_PORTALS4],[
 	AS_IF([test $max_md_size -ne 0 && test $max_va_size -ne 0],
               [AC_MSG_NOTICE([Portals 4 address space size: $max_md_size, $max_va_size])])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[portals4]],[$1],[$ompi_check_portals4_happy])
+	OMPI_SUMMARY_ADD([[Transports]],[[Portals4]],[$1],[$ompi_check_portals4_happy])
     fi
 
     AS_IF([test "$ompi_check_portals4_happy" = "yes"],

--- a/config/opal_check_xpmem.m4
+++ b/config/opal_check_xpmem.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009-2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
@@ -101,7 +101,7 @@ AC_DEFUN([OPAL_CHECK_XPMEM], [
 	    fi
 	fi
 
-	OMPI_SUMMARY_ADD([[Transports]],[[XPMEM Shared Memory]],[$1],[$opal_check_cray_xpmem_happy])
+	OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/XPMEM]],[$1],[$opal_check_cray_xpmem_happy])
     fi
 
     AS_IF([test "$opal_check_xpmem_happy" = "yes"], [

--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -2,6 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -33,53 +34,48 @@ AC_DEFUN([OMPI_SUMMARY_ADD],[
 
 AC_DEFUN([OMPI_SUMMARY_PRINT],[
     OPAL_VAR_SCOPE_PUSH([ompi_summary_section ompi_summary_section_name])
-    echo "\nOpen MPI configuration:"
-    echo "-----------------------"
-    echo "Version: $OMPI_MAJOR_VERSION.$OMPI_MINOR_VERSION.$OMPI_RELEASE_VERSION $OMPI_GREEK_VERSION"
+    cat <<EOF
 
-    dnl Print out which projects will be built
-    echo "Build Open Platform Abstration project: yes"
-    if test "$project_orte_amc" = "true" ; then
-	echo "Build Open Runtime project: yes"
-    else
-	echo "Build Open Runtime project: no"
-    fi
+Open MPI configuration:
+-----------------------
+Version: $OMPI_MAJOR_VERSION.$OMPI_MINOR_VERSION.$OMPI_RELEASE_VERSION$OMPI_GREEK_VERSION
+EOF
 
     if test "$project_ompi_amc" = "true" ; then
-	echo "Build Open MPI project: yes"
+	echo "Build MPI C bindings: yes"
     else
-	echo "Build Open MPI project: no"
-    fi
-
-    if test "$project_shmem_amc" = "true" ; then
-	echo "Build Open SHMEM project: yes"
-    else
-	echo "Build Open SHMEM project: no"
+	echo "Build MPI C bindings: no"
     fi
 
     dnl Print out the bindings if we are building OMPI
     if test "$project_ompi_amc" = "true" ; then
 	if test x$enable_mpi_cxx = xyes ; then
-	    echo "MPI C++ bindings (deprecated): yes"
+	    echo "Build MPI C++ bindings (deprecated): yes"
 	else
-	    echo "MPI C++ bindings (deprecated): no"
+	    echo "Build MPI C++ bindings (deprecated): no"
 	fi
 
 	if test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_MPIFH_BINDINGS ; then
-	    echo "MPI Fortran bindings: mpif.h"
+	    echo "Build MPI Fortran bindings: mpif.h"
 	elif test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_USEMPI_BINDINGS ; then
-	    echo "MPI Fortran bindings: mpif.h, use mpi"
+	    echo "Build MPI Fortran bindings: mpif.h, use mpi"
 	elif test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_USEMPIF08_BINDINGS ; then
-	    echo "MPI Fortran bindings: mpif.h, use mpi, use mpi_f08"
+	    echo "Build MPI Fortran bindings: mpif.h, use mpi, use mpi_f08"
 	else
-	    echo "MPI Fortran bindings: no"
+	    echo "Build MPI Fortran bindings: no"
 	fi
 
         if test x$opal_java_happy = xyes ; then
-            echo "MPI Java bindings (experimental): yes"
+            echo "Build MPI Java bindings (experimental): yes"
         else
-            echo "MPI Java bindings (experimental): no"
+            echo "MPI Build Java bindings (experimental): no"
         fi
+    fi
+
+    if test "$project_shmem_amc" = "true" ; then
+	echo "Build Open SHMEM support: yes"
+    else
+	echo "Build Open SHMEM support: no"
     fi
 
     if test $WANT_DEBUG = 0 ; then
@@ -90,6 +86,8 @@ AC_DEFUN([OMPI_SUMMARY_PRINT],[
 
     if test ! -z $with_platform ; then
 	echo "Platform file: $with_platform"
+    else
+	echo "Platform file: (none)"
     fi
 
     echo
@@ -103,8 +101,13 @@ AC_DEFUN([OMPI_SUMMARY_PRINT],[
     done
 
     if test $WANT_DEBUG = 1 ; then
-	echo "INTERNAL DEBUGGING IS ENABLED. DO NOT USE THIS BUILD FOR PERFORMANCE MEASUREMENTS!\n"
+        cat <<EOF
+*****************************************************************************
+ THIS IS A DEBUG BUILD!  DO NOT USE THIS BUILD FOR PERFORMANCE MEASUREMENTS!
+*****************************************************************************
+EOF
     fi
+    echo " "
 
     OPAL_VAR_SCOPE_POP
 ])

--- a/opal/mca/btl/scif/configure.m4
+++ b/opal/mca/btl/scif/configure.m4
@@ -4,6 +4,7 @@
 #                         reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,6 +36,8 @@ AC_DEFUN([MCA_opal_btl_scif_CONFIG],[
     fi
 
     AS_IF([test "$opal_btl_scif_happy" = "yes"], [$1], [$2])
+
+    OMPI_SUMMARY_ADD([[Transports]],[[Intel SCIF]],[[btl_scif]],[$opal_btl_scif_happy])
 
     # substitute in the things needed to build scif
     AC_SUBST([btl_scif_CPPFLAGS])

--- a/opal/mca/btl/tcp/configure.m4
+++ b/opal/mca/btl/tcp/configure.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -36,5 +36,5 @@ AC_DEFUN([MCA_opal_btl_tcp_CONFIG],[
 #include <netinet/in.h>
 #endif
 		   ])
-    OMPI_SUMMARY_ADD([[Transports]],[[tcp]],[[btl_tcp]],[$opal_btl_tcp_happy])
+    OMPI_SUMMARY_ADD([[Transports]],[[TCP]],[[btl_tcp]],[$opal_btl_tcp_happy])
 ])dnl

--- a/opal/mca/btl/vader/configure.m4
+++ b/opal/mca/btl/vader/configure.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009      The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2015      Research Organization for Information Science
@@ -43,7 +43,9 @@ AC_DEFUN([MCA_opal_btl_vader_CONFIG],[
     # always happy
     [$1]
 
-    # substitute in the things needed to build with XPMEM support
+    OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/copy in+copy out]],[$1],[yes])
+
+# substitute in the things needed to build with XPMEM support
     AC_SUBST([btl_vader_CFLAGS])
     AC_SUBST([btl_vader_CPPFLAGS])
     AC_SUBST([btl_vader_LDFLAGS])

--- a/orte/mca/plm/rsh/configure.m4
+++ b/orte/mca/plm/rsh/configure.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
-# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,5 +27,6 @@ AC_DEFUN([MCA_orte_plm_rsh_CONFIG],[
 
     AC_CHECK_FUNC([fork], [plm_rsh_happy="yes"], [plm_rsh_happy="no"])
 
+    OMPI_SUMMARY_ADD([[Resource Managers]],[[ssh/rsh]],[$1],[$plm_rsh_happy])
     AS_IF([test "$plm_rsh_happy" = "yes"], [$1], [$2])
 ])dnl


### PR DESCRIPTION
This is an addendum to Nathan's original commit (d2f5fca82a44cbe27a068e08c3b69ae66cdf6e53).

Output now looks like this:

```
Open MPI configuration:
-----------------------
Version: 3.0.0a1
Build Open Platform Abstration project: yes
Build Open Runtime project: yes
Build Open MPI project: yes
Build Open SHMEM project: no
MPI C++ bindings (deprecated): no
MPI Fortran bindings: mpif.h, use mpi, use mpi_f08
MPI Java bindings (experimental): yes
Debug build: yes
Platform file: (none)

Transports
-----------------------
Cray uGNI (Gemini/Aries): no
Intel Omnipath (PSM2): no
Intel SCIF: no
Mellanox MXM: no
Open UCX: no
OpenFabrics Libfabric: yes
OpenFabrics Verbs: yes
Portals v4: no
QLogic Infinipath (PSM): no
Shared memory/Linux CMA: no
Shared Memory/Linux KNEM: no
Shared Memory/XPMEM: no
TCP: yes

Resource Managers
-----------------------
Cray Alps: no
Grid Engine: no
LSF: no
Slurm: yes
Torque: no

*****************************************************************************
 THIS IS A DEBUG BUILD!  DO NOT USE THIS BUILD FOR PERFORMANCE MEASUREMENTS!
*****************************************************************************
```

@hjelmn Opinions?