### PR TITLE
Fix memory corruption in orte-ps

### DIFF
--- a/orte/tools/orte-ps/orte-ps.c
+++ b/orte/tools/orte-ps/orte-ps.c
@@ -651,7 +651,7 @@ static int pretty_print_vpids(orte_job_t *job) {
     char *snap_ref = NULL;
     char *snap_loc = NULL;
 #endif
-    char *nodename;
+    char **nodename;
 
     /*
      * Caculate segment lengths
@@ -672,6 +672,7 @@ static int pretty_print_vpids(orte_job_t *job) {
     len_ckpt_l      = -3;
 #endif
 
+    nodename = (char **) malloc(job->num_procs * sizeof(char *));
     for(v=0; v < job->num_procs; v++) {
         char *rankstr;
         vpid = (orte_proc_t*)job->procs->addr[v];
@@ -707,10 +708,10 @@ static int pretty_print_vpids(orte_job_t *job) {
             len_rank = strlen(rankstr);
         free(rankstr);
 
-        nodename = NULL;
-        if( orte_get_attribute(&vpid->attributes, ORTE_PROC_NODENAME, (void**)&nodename, OPAL_STRING) &&
-            (int)strlen(nodename) > len_node) {
-            len_node = strlen(nodename);
+        nodename[v] = NULL;
+        if( orte_get_attribute(&vpid->attributes, ORTE_PROC_NODENAME, (void**)&nodename[v], OPAL_STRING) &&
+            (int)strlen(nodename[v]) > len_node) {
+            len_node = strlen(nodename[v]);
         } else if ((int)strlen("Unknown") > len_node) {
             len_node = strlen("Unknown");
         }
@@ -793,12 +794,12 @@ static int pretty_print_vpids(orte_job_t *job) {
         printf("%*s | ",  len_o_proc_name, o_proc_name);
         printf("%*u | ",  len_rank       , (uint)vpid->local_rank);
         printf("%*d | ",  len_pid        , vpid->pid);
-        printf("%*s | ",  len_node       , (NULL == nodename) ? "Unknown" : nodename);
-        if (NULL != nodename) {
-            free(nodename);
-        }
+        printf("%*s | ",  len_node       , (NULL == nodename[v]) ? "Unknown" : nodename[v]);
         printf("%*s | ",  len_state      , orte_proc_state_to_str(vpid->state));
 
+        if (NULL != nodename[v]) {
+            free(nodename[v]);
+        }
 #if OPAL_ENABLE_FT_CR == 1
         printf("%*s | ",  len_ckpt_s, state_str);
         printf("%*s | ",  len_ckpt_r, (NULL == snap_ref ?  "" : snap_ref));


### PR DESCRIPTION
I was trying to get PADB to work, which uses orte-ps and glibc complained about double free's.
