### PR TITLE
oshmem: Add Non-blocking Remote Memory Access Routines

### DIFF
--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -129,6 +129,24 @@ OSHMEM_DECLSPEC void pshmem_iput64(void* target, const void* source, ptrdiff_t t
 OSHMEM_DECLSPEC void pshmem_iput128(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 /*
+ * Nonblocking put routines
+ */
+OSHMEM_DECLSPEC  void pshmem_putmem_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_short_put_nbi(short *target, const short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int_put_nbi(int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_long_put_nbi(long *target, const long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_longlong_put_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_float_put_nbi(float *target, const float *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_double_put_nbi(double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_put8_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_put16_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_put32_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_put64_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_put128_nbi(void *target, const void *source, size_t len, int pe);
+
+/*
  * Elemental get routines
  */
 OSHMEM_DECLSPEC  char pshmem_char_g(char* addr, int pe);
@@ -168,6 +186,24 @@ OSHMEM_DECLSPEC void pshmem_long_iget(long* target, const long* source, ptrdiff_
 OSHMEM_DECLSPEC void pshmem_iget32(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_iget64(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_iget128(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+
+/*
+ * Nonblocking data get routines
+ */
+OSHMEM_DECLSPEC  void pshmem_getmem_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_char_get_nbi(char *target, const char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_short_get_nbi(short *target, const short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int_get_nbi(int *target, const int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_long_get_nbi(long *target, const long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_longlong_get_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_float_get_nbi(float *target, const float *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_get8_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_get16_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_get32_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_get64_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_get128_nbi(void *target, const void *source, size_t len, int pe);
 
 /*
  * Atomic operations

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -192,6 +192,24 @@ OSHMEM_DECLSPEC void shmem_iput64(void* target, const void* source, ptrdiff_t ts
 OSHMEM_DECLSPEC void shmem_iput128(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 /*
+ * Nonblocking put routines
+ */
+OSHMEM_DECLSPEC  void shmem_putmem_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_short_put_nbi(short *target, const short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int_put_nbi(int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_long_put_nbi(long *target, const long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_longlong_put_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_float_put_nbi(float *target, const float *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_double_put_nbi(double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_put8_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_put16_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_put32_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_put64_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_put128_nbi(void *target, const void *source, size_t len, int pe);
+
+/*
  * Elemental get routines
  */
 OSHMEM_DECLSPEC  char shmem_char_g(char* addr, int pe);
@@ -231,6 +249,24 @@ OSHMEM_DECLSPEC void shmem_long_iget(long* target, const long* source, ptrdiff_t
 OSHMEM_DECLSPEC void shmem_iget32(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_iget64(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_iget128(void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+
+/*
+ * Nonblocking data get routines
+ */
+OSHMEM_DECLSPEC  void shmem_getmem_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_char_get_nbi(char *target, const char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_short_get_nbi(short *target, const short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int_get_nbi(int *target, const int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_long_get_nbi(long *target, const long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_longlong_get_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_float_get_nbi(float *target, const float *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_get8_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_get16_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_get32_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_get64_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_get128_nbi(void *target, const void *source, size_t len, int pe);
 
 /*
  * Atomic operations

--- a/oshmem/mca/spml/base/base.h
+++ b/oshmem/mca/spml/base/base.h
@@ -71,6 +71,16 @@ OSHMEM_DECLSPEC int mca_spml_base_oob_get_mkeys(int pe,
 
 OSHMEM_DECLSPEC void mca_spml_base_rmkey_unpack(sshmem_mkey_t *mkey, int pe);
 OSHMEM_DECLSPEC void mca_spml_base_rmkey_free(sshmem_mkey_t *mkey);
+OSHMEM_DECLSPEC int mca_spml_base_put_nb(void *dst_addr,
+                                         size_t size,
+                                         void *src_addr,
+                                         int dst,
+                                         void **handle);
+OSHMEM_DECLSPEC int mca_spml_base_get_nb(void *dst_addr,
+                                         size_t size,
+                                         void *src_addr,
+                                         int src,
+                                         void **handle);
 
 /*
  * MCA framework

--- a/oshmem/mca/spml/base/spml_base.c
+++ b/oshmem/mca/spml/base/spml_base.c
@@ -165,3 +165,15 @@ void mca_spml_base_rmkey_unpack(sshmem_mkey_t *mkey, int pe)
 void mca_spml_base_rmkey_free(sshmem_mkey_t *mkey)
 {
 }
+
+int mca_spml_base_put_nb(void *dst_addr, size_t size,
+                         void *src_addr, int dst, void **handle)
+{
+    return OSHMEM_ERROR;
+}
+
+int mca_spml_base_get_nb(void *dst_addr, size_t size,
+                         void *src_addr, int src, void **handle)
+{
+    return OSHMEM_ERROR;
+}

--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -221,6 +221,7 @@ mca_spml_ikrit_t mca_spml_ikrit = {
         mca_spml_ikrit_put,
         mca_spml_ikrit_put_nb,
         mca_spml_ikrit_get,
+        mca_spml_base_get_nb, /* todo: mca_spml_ikrit_get_nb, */
         mca_spml_ikrit_recv,
         mca_spml_ikrit_send,
         mca_spml_base_wait,

--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -221,7 +221,7 @@ mca_spml_ikrit_t mca_spml_ikrit = {
         mca_spml_ikrit_put,
         mca_spml_ikrit_put_nb,
         mca_spml_ikrit_get,
-        mca_spml_base_get_nb, /* todo: mca_spml_ikrit_get_nb, */
+        mca_spml_ikrit_get_nb,
         mca_spml_ikrit_recv,
         mca_spml_ikrit_send,
         mca_spml_base_wait,
@@ -870,6 +870,15 @@ static inline int mca_spml_ikrit_get_shm(void *src_addr,
     memcpy(dst_addr, (void *) (unsigned long) rva, size);
     opal_progress();
     return OSHMEM_SUCCESS;
+}
+
+int mca_spml_ikrit_get_nb(void* src_addr,
+                          size_t size,
+                          void* dst_addr,
+                          int src,
+                          void **handle)
+{
+    return mca_spml_ikrit_get_async(src_addr, size, dst_addr, src);
 }
 
 int mca_spml_ikrit_get(void *src_addr, size_t size, void *dst_addr, int src)

--- a/oshmem/mca/spml/ikrit/spml_ikrit.h
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.h
@@ -130,6 +130,11 @@ extern int mca_spml_ikrit_get(void* dst_addr,
                               size_t size,
                               void* src_addr,
                               int src);
+extern int mca_spml_ikrit_get_nb(void* src_addr,
+                                 size_t size,
+                                 void* dst_addr,
+                                 int src,
+                                 void **handle);
 /* extension. used 4 fence implementation b4 fence was added to mxm */
 extern int mca_spml_ikrit_get_async(void *src_addr,
                                     size_t size,

--- a/oshmem/mca/spml/spml.h
+++ b/oshmem/mca/spml/spml.h
@@ -208,16 +208,34 @@ typedef int (*mca_spml_base_module_put_nb_fn_t)(void *dst_addr,
  * Blocking data transfer from remote PE.
  * Read data from remote PE.
  *
- * @param dst_addr - The address on the local PE, to write the result of the get operation to.
- * @param size     - The number of bytes to be read.
- * @param src_addr - The address on the remote PE, to read from.
- * @param src      - The ID of the remote PE.
- * @return         - OSHMEM_SUCCESS or failure status.
+ * @param dst_addr The address on the local PE, to write the result of the get operation to.
+ * @param size     The number of bytes to be read.
+ * @param src_addr The address on the remote PE, to read from.
+ * @param src      The ID of the remote PE.
+ * @return         OSHMEM_SUCCESS or failure status.
  */
 typedef int (*mca_spml_base_module_get_fn_t)(void *dst_addr,
                                              size_t size,
                                              void *src_addr,
                                              int src);
+
+/**
+ * Non-blocking data transfer from remote PE.
+ * Read data from remote PE.
+ *
+ * @param dst_addr The address on the local PE, to write the result of the get operation to.
+ * @param size     The number of bytes to be read.
+ * @param src_addr The address on the remote PE, to read from.
+ * @param src      The ID of the remote PE.
+ * @param handle   The address of a handle to be passed to shmem_wait_nb() or
+ *                 shmem_test_nb() to wait or poll for the completion of the transfer.
+ * @return         - OSHMEM_SUCCESS or failure status.
+ */
+typedef int (*mca_spml_base_module_get_nb_fn_t)(void *dst_addr,
+                                               size_t size,
+                                               void *src_addr,
+                                               int src,
+                                               void **handle);
 
 /**
  *  Post a receive and wait for completion.
@@ -255,7 +273,7 @@ typedef int (*mca_spml_base_module_fence_fn_t)(void);
  *
  * @return         - OSHMEM_SUCCESS or failure status.
  */
-typedef int (*mca_spml_base_module_wait_nb_fn_t)(void*);
+typedef int (*mca_spml_base_module_wait_nb_fn_t)(void *);
 
 /**
  *  SPML instance.
@@ -273,6 +291,7 @@ struct mca_spml_base_module_1_0_0_t {
     mca_spml_base_module_put_fn_t spml_put;
     mca_spml_base_module_put_nb_fn_t spml_put_nb;
     mca_spml_base_module_get_fn_t spml_get;
+    mca_spml_base_module_get_nb_fn_t spml_get_nb;
 
     mca_spml_base_module_recv_fn_t spml_recv;
     mca_spml_base_module_send_fn_t spml_send;

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -53,8 +53,9 @@ mca_spml_ucx_t mca_spml_ucx = {
         mca_spml_ucx_deregister,
         mca_spml_base_oob_get_mkeys,
         mca_spml_ucx_put,
-        NULL, /* todo: mca_spml_ucx_put_nb, */
+        mca_spml_base_put_nb, /* todo: mca_spml_ucx_put_nb, */
         mca_spml_ucx_get,
+        mca_spml_base_get_nb, /* todo: mca_spml_ucx_get_nb, */
         mca_spml_ucx_recv,
         mca_spml_ucx_send,
         mca_spml_base_wait,

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -53,9 +53,9 @@ mca_spml_ucx_t mca_spml_ucx = {
         mca_spml_ucx_deregister,
         mca_spml_base_oob_get_mkeys,
         mca_spml_ucx_put,
-        mca_spml_base_put_nb, /* todo: mca_spml_ucx_put_nb, */
+        mca_spml_ucx_put_nb,
         mca_spml_ucx_get,
-        mca_spml_base_get_nb, /* todo: mca_spml_ucx_get_nb, */
+        mca_spml_ucx_get_nb,
         mca_spml_ucx_recv,
         mca_spml_ucx_send,
         mca_spml_base_wait,
@@ -391,6 +391,19 @@ int mca_spml_ucx_get(void *src_addr, size_t size, void *dst_addr, int src)
     return ucx_status_to_oshmem(status);
 }
 
+int mca_spml_ucx_get_nb(void *src_addr, size_t size, void *dst_addr, int src, void **handle)
+{
+    void *rva;
+    ucs_status_t status;
+    spml_ucx_mkey_t *ucx_mkey;
+
+    ucx_mkey = mca_spml_ucx_get_mkey(src, src_addr, &rva);
+    status = ucp_get_nbi(mca_spml_ucx.ucp_peers[src].ucp_conn, dst_addr, size,
+                     (uint64_t)rva, ucx_mkey->rkey);
+
+    return ucx_status_to_oshmem(status);
+}
+
 int mca_spml_ucx_put(void* dst_addr, size_t size, void* src_addr, int dst)
 {
     void *rva;
@@ -399,6 +412,19 @@ int mca_spml_ucx_put(void* dst_addr, size_t size, void* src_addr, int dst)
 
     ucx_mkey = mca_spml_ucx_get_mkey(dst, dst_addr, &rva);
     status = ucp_put(mca_spml_ucx.ucp_peers[dst].ucp_conn, src_addr, size,
+                     (uint64_t)rva, ucx_mkey->rkey);
+
+    return ucx_status_to_oshmem(status);
+}
+
+int mca_spml_ucx_put_nb(void* dst_addr, size_t size, void* src_addr, int dst, void **handle)
+{
+    void *rva;
+    ucs_status_t status;
+    spml_ucx_mkey_t *ucx_mkey;
+
+    ucx_mkey = mca_spml_ucx_get_mkey(dst, dst_addr, &rva);
+    status = ucp_put_nbi(mca_spml_ucx.ucp_peers[dst].ucp_conn, src_addr, size,
                      (uint64_t)rva, ucx_mkey->rkey);
 
     return ucx_status_to_oshmem(status);

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -70,6 +70,11 @@ extern int mca_spml_ucx_get(void* dst_addr,
                               size_t size,
                               void* src_addr,
                               int src);
+extern int mca_spml_ucx_get_nb(void* dst_addr,
+                              size_t size,
+                              void* src_addr,
+                              int src,
+                              void **handle);
 
 extern int mca_spml_ucx_put(void* dst_addr,
                               size_t size,

--- a/oshmem/mca/spml/yoda/spml_yoda.c
+++ b/oshmem/mca/spml/yoda/spml_yoda.c
@@ -57,6 +57,7 @@ mca_spml_yoda_module_t mca_spml_yoda = {
         mca_spml_yoda_put,
         mca_spml_yoda_put_nb,
         mca_spml_yoda_get,
+        mca_spml_base_get_nb, /* todo: mca_spml_yoda_get_nb, */
         mca_spml_yoda_recv,
         mca_spml_yoda_send,
         mca_spml_base_wait,

--- a/oshmem/mca/spml/yoda/spml_yoda.c
+++ b/oshmem/mca/spml/yoda/spml_yoda.c
@@ -57,7 +57,7 @@ mca_spml_yoda_module_t mca_spml_yoda = {
         mca_spml_yoda_put,
         mca_spml_yoda_put_nb,
         mca_spml_yoda_get,
-        mca_spml_base_get_nb, /* todo: mca_spml_yoda_get_nb, */
+        mca_spml_yoda_get_nb,
         mca_spml_yoda_recv,
         mca_spml_yoda_send,
         mca_spml_base_wait,
@@ -901,6 +901,8 @@ int mca_spml_yoda_put_nb(void* dst_addr,
 {
     UNREFERENCED_PARAMETER(handle);
 
+    /* TODO: real nonblocking operation is needed
+     */
     return mca_spml_yoda_put_internal(dst_addr, size, src_addr, dst, 1);
 }
 
@@ -972,6 +974,17 @@ int mca_spml_yoda_enable(bool enable)
 #endif
 
     return OSHMEM_SUCCESS;
+}
+
+int mca_spml_yoda_get_nb(void* src_addr,
+                          size_t size,
+                          void* dst_addr,
+                          int src,
+                          void **handle)
+{
+    /* TODO: real nonblocking operation is needed
+     */
+    return mca_spml_yoda_get(src_addr, size, dst_addr, src);
 }
 
 /**

--- a/oshmem/mca/spml/yoda/spml_yoda.h
+++ b/oshmem/mca/spml/yoda/spml_yoda.h
@@ -102,6 +102,11 @@ extern int mca_spml_yoda_get(void* dst_addr,
                              size_t size,
                              void* src_addr,
                              int src);
+extern int mca_spml_yoda_get_nb(void* dst_addr,
+                                size_t size,
+                                void* src_addr,
+                                int dst,
+                                void **handle);
 extern int mca_spml_yoda_put(void* dst_addr,
                              size_t size,
                              void* src_addr,

--- a/oshmem/shmem/c/Makefile.am
+++ b/oshmem/shmem/c/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2015 Mellanox Technologies, Inc.
+# Copyright (c) 2013-2016 Mellanox Technologies, Inc.
 #                         All rights reserved
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
@@ -40,6 +40,8 @@ OSHMEM_API_SOURCES = \
 	shmem_wait.c \
 	shmem_iget.c \
 	shmem_iput.c \
+	shmem_get_nb.c \
+	shmem_put_nb.c \
 	shmem_udcflush.c \
 	shmem_udcflush_line.c \
 	shmem_set_cache_inv.c \

--- a/oshmem/shmem/c/profile/Makefile.am
+++ b/oshmem/shmem/c/profile/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013      Mellanox Technologies, Inc.
+# Copyright (c) 2013-2016 Mellanox Technologies, Inc.
 #                         All rights reserved
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
@@ -52,6 +52,8 @@ OSHMEM_API_SOURCES = \
 	pshmem_wait.c \
 	pshmem_iget.c \
 	pshmem_iput.c \
+	pshmem_get_nb.c \
+	pshmem_put_nb.c \
 	pshmem_udcflush.c \
 	pshmem_udcflush_line.c \
 	pshmem_set_cache_inv.c \

--- a/oshmem/shmem/c/profile/defines.h
+++ b/oshmem/shmem/c/profile/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Mellanox Technologies, Inc.
+ * Copyright (c) 2013-2016 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -108,6 +108,24 @@
 #define shmem_iput128                pshmem_iput128
 
 /*
+ * Non-block data put routines
+ */
+#define shmem_char_put_nbi           pshmem_char_put_nbi
+#define shmem_short_put_nbi          pshmem_short_put_nbi
+#define shmem_int_put_nbi            pshmem_int_put_nbi
+#define shmem_long_put_nbi           pshmem_long_put_nbi
+#define shmem_float_put_nbi          pshmem_float_put_nbi
+#define shmem_double_put_nbi         pshmem_double_put_nbi
+#define shmem_longlong_put_nbi       pshmem_longlong_put_nbi
+#define shmem_longdouble_put_nbi     pshmem_longdouble_put_nbi
+#define shmem_put8_nbi               pshmem_put8_nbi
+#define shmem_put16_nbi              pshmem_put16_nbi
+#define shmem_put32_nbi              pshmem_put32_nbi
+#define shmem_put64_nbi              pshmem_put64_nbi
+#define shmem_put128_nbi             pshmem_put128_nbi
+#define shmem_putmem_nbi             pshmem_putmem_nbi
+
+/*
  * Elemental get routines
  */
 #define shmem_char_g                 pshmem_char_g
@@ -153,6 +171,24 @@
 #define shmem_iget32                 pshmem_iget32
 #define shmem_iget64                 pshmem_iget64
 #define shmem_iget128                pshmem_iget128
+
+/*
+ * Non-block data get routines
+ */
+#define shmem_char_get_nbi           pshmem_char_get_nbi
+#define shmem_short_get_nbi          pshmem_short_get_nbi
+#define shmem_int_get_nbi            pshmem_int_get_nbi
+#define shmem_long_get_nbi           pshmem_long_get_nbi
+#define shmem_float_get_nbi          pshmem_float_get_nbi
+#define shmem_double_get_nbi         pshmem_double_get_nbi
+#define shmem_longlong_get_nbi       pshmem_longlong_get_nbi
+#define shmem_longdouble_get_nbi     pshmem_longdouble_get_nbi
+#define shmem_get8_nbi               pshmem_get8_nbi
+#define shmem_get16_nbi              pshmem_get16_nbi
+#define shmem_get32_nbi              pshmem_get32_nbi
+#define shmem_get64_nbi              pshmem_get64_nbi
+#define shmem_get128_nbi             pshmem_get128_nbi
+#define shmem_getmem_nbi             pshmem_getmem_nbi
 
 /*
  * Atomic operations

--- a/oshmem/shmem/c/shmem_get_nb.c
+++ b/oshmem/shmem/c/shmem_get_nb.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "oshmem_config.h"
+
+#include "oshmem/constants.h"
+#include "oshmem/include/shmem.h"
+
+#include "oshmem/runtime/runtime.h"
+
+#include "oshmem/mca/spml/spml.h"
+
+/*
+ * These routines retrieve data from a contiguous data object on a remote PE.
+ * The shmem_get() routines transfer nelems elements of the data object at address source
+ * on the remote PE (pe), to the data object at address target on the local PE. These routines
+ * return after the data has been copied to address target on the local pe.
+ */
+#define SHMEM_TYPE_GET_NB(type_name, type)    \
+    void shmem##type_name##_get_nbi(type *target, const type *source, size_t nelems, int pe) \
+    {                                                               \
+        int rc = OSHMEM_SUCCESS;                                    \
+        size_t size = 0;                                            \
+                                                                    \
+        RUNTIME_CHECK_INIT();                                       \
+        RUNTIME_CHECK_PE(pe);                                       \
+        RUNTIME_CHECK_ADDR(source);                                 \
+                                                                    \
+        size = nelems * sizeof(type);                               \
+        rc = MCA_SPML_CALL(get_nb(                                  \
+            (void *)source,                                         \
+            size,                                                   \
+            (void *)target,                                         \
+            pe, NULL));                                             \
+        RUNTIME_CHECK_RC(rc);                                       \
+                                                                    \
+        return ;                                                    \
+    }
+
+#if OSHMEM_PROFILING
+#include "oshmem/include/pshmem.h"
+#pragma weak shmem_char_get_nbi = pshmem_char_get_nbi
+#pragma weak shmem_short_get_nbi = pshmem_short_get_nbi
+#pragma weak shmem_int_get_nbi = pshmem_int_get_nbi
+#pragma weak shmem_long_get_nbi = pshmem_long_get_nbi
+#pragma weak shmem_longlong_get_nbi = pshmem_longlong_get_nbi
+#pragma weak shmem_float_get_nbi = pshmem_float_get_nbi
+#pragma weak shmem_double_get_nbi = pshmem_double_get_nbi
+#pragma weak shmem_longdouble_get_nbi = pshmem_longdouble_get_nbi
+#pragma weak shmem_get8_nbi = pshmem_get8_nbi
+#pragma weak shmem_get16_nbi = pshmem_get16_nbi
+#pragma weak shmem_get32_nbi = pshmem_get32_nbi
+#pragma weak shmem_get64_nbi = pshmem_get64_nbi
+#pragma weak shmem_get128_nbi = pshmem_get128_nbi
+#pragma weak shmem_getmem_nbi = pshmem_getmem_nbi
+#include "oshmem/shmem/c/profile/defines.h"
+#endif
+
+SHMEM_TYPE_GET_NB(_char, char)
+SHMEM_TYPE_GET_NB(_short, short)
+SHMEM_TYPE_GET_NB(_int, int)
+SHMEM_TYPE_GET_NB(_long, long)
+SHMEM_TYPE_GET_NB(_longlong, long long)
+SHMEM_TYPE_GET_NB(_float, float)
+SHMEM_TYPE_GET_NB(_double, double)
+SHMEM_TYPE_GET_NB(_longdouble, long double)
+
+#define SHMEM_TYPE_GETMEM_NB(name, element_size, prefix)    \
+    void prefix##name##_nbi(void *target, const void *source, size_t nelems, int pe) \
+    {                                                               \
+        int rc = OSHMEM_SUCCESS;                                    \
+        size_t size = 0;                                            \
+                                                                    \
+        RUNTIME_CHECK_INIT();                                       \
+        RUNTIME_CHECK_PE(pe);                                       \
+        RUNTIME_CHECK_ADDR(source);                                 \
+                                                                    \
+        size = nelems * element_size;                               \
+        rc = MCA_SPML_CALL(get_nb(                                  \
+            (void *)source,                                         \
+            size,                                                   \
+            (void *)target,                                         \
+            pe, NULL));                                             \
+       RUNTIME_CHECK_RC(rc);                                        \
+                                                                    \
+        return ;                                                    \
+    }
+
+SHMEM_TYPE_GETMEM_NB(_get8, 1, shmem)
+SHMEM_TYPE_GETMEM_NB(_get16, 2, shmem)
+SHMEM_TYPE_GETMEM_NB(_get32, 4, shmem)
+SHMEM_TYPE_GETMEM_NB(_get64, 8, shmem)
+SHMEM_TYPE_GETMEM_NB(_get128, 16, shmem)
+SHMEM_TYPE_GETMEM_NB(_getmem, 1, shmem)

--- a/oshmem/shmem/c/shmem_put_nb.c
+++ b/oshmem/shmem/c/shmem_put_nb.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "oshmem_config.h"
+
+#include "oshmem/constants.h"
+#include "oshmem/include/shmem.h"
+
+#include "oshmem/runtime/runtime.h"
+
+#include "oshmem/mca/spml/spml.h"
+
+/*
+ * The nonblocking put routines provide a method for copying data from a contiguous local data
+ * object to a data object on a specified PE.
+ * These routines transfer nelems elements of the data object at address source on the calling
+ * PE, to the data object at address target on the remote PE pe. These routines start the
+ * remote transfer and may return before the data is delivered to the remote PE. The delivery
+ * of data into the data object on the destination PE from different put calls may occur in any
+ * order. Because of this, two successive put operations may deliver data out of order unless a
+ * call to shmem_fence() is introduced between the two calls.
+ * The routines return after posting the operation. The operation is considered complete after a
+ * subsequent call to shmem_quiet. At the completion of shmem_quiet, the data has been copied
+ * into the dest array on the destination PE.
+ */
+#define SHMEM_TYPE_PUT_NB(type_name, type)    \
+    void shmem##type_name##_put_nbi(type *target, const type *source, size_t len, int pe) \
+    {                                                               \
+        int rc = OSHMEM_SUCCESS;                                    \
+        size_t size = 0;                                            \
+                                                                    \
+        RUNTIME_CHECK_INIT();                                       \
+        RUNTIME_CHECK_PE(pe);                                       \
+        RUNTIME_CHECK_ADDR(target);                                 \
+                                                                    \
+        size = len * sizeof(type);                                  \
+        rc = MCA_SPML_CALL(put_nb(                                  \
+            (void *)target,                                         \
+            size,                                                   \
+            (void *)source,                                         \
+            pe, NULL));                                             \
+        RUNTIME_CHECK_RC(rc);                                       \
+                                                                    \
+        return ;                                                    \
+    }
+
+#if OSHMEM_PROFILING
+#include "oshmem/include/pshmem.h"
+#pragma weak shmem_char_put_nbi = pshmem_char_put_nbi
+#pragma weak shmem_short_put_nbi = pshmem_short_put_nbi
+#pragma weak shmem_int_put_nbi = pshmem_int_put_nbi
+#pragma weak shmem_long_put_nbi = pshmem_long_put_nbi
+#pragma weak shmem_longlong_put_nbi = pshmem_longlong_put_nbi
+#pragma weak shmem_float_put_nbi = pshmem_float_put_nbi
+#pragma weak shmem_double_put_nbi = pshmem_double_put_nbi
+#pragma weak shmem_longdouble_put_nbi = pshmem_longdouble_put_nbi
+#pragma weak shmem_put8_nbi = pshmem_put8_nbi
+#pragma weak shmem_put16_nbi = pshmem_put16_nbi
+#pragma weak shmem_put32_nbi = pshmem_put32_nbi
+#pragma weak shmem_put64_nbi = pshmem_put64_nbi
+#pragma weak shmem_put128_nbi = pshmem_put128_nbi
+#pragma weak shmem_putmem_nbi = pshmem_putmem_nbi
+#include "oshmem/shmem/c/profile/defines.h"
+#endif
+
+SHMEM_TYPE_PUT_NB(_char, char)
+SHMEM_TYPE_PUT_NB(_short, short)
+SHMEM_TYPE_PUT_NB(_int, int)
+SHMEM_TYPE_PUT_NB(_long, long)
+SHMEM_TYPE_PUT_NB(_longlong, long long)
+SHMEM_TYPE_PUT_NB(_float, float)
+SHMEM_TYPE_PUT_NB(_double, double)
+SHMEM_TYPE_PUT_NB(_longdouble, long double)
+
+#define SHMEM_TYPE_PUTMEM_NB(name, element_size, prefix)    \
+    void prefix##name##_nbi(void *target, const void *source, size_t nelems, int pe) \
+    {                                                               \
+        int rc = OSHMEM_SUCCESS;                                    \
+        size_t size = 0;                                            \
+                                                                    \
+        RUNTIME_CHECK_INIT();                                       \
+        RUNTIME_CHECK_PE(pe);                                       \
+        RUNTIME_CHECK_ADDR(target);                                 \
+                                                                    \
+        size = nelems * element_size;                               \
+        rc = MCA_SPML_CALL(put_nb(                                  \
+            (void *)target,                                         \
+            size,                                                   \
+            (void *)source,                                         \
+            pe, NULL));                                             \
+        RUNTIME_CHECK_RC(rc);                                       \
+                                                                    \
+        return ;                                                    \
+    }
+
+SHMEM_TYPE_PUTMEM_NB(_put8, 1, shmem)
+SHMEM_TYPE_PUTMEM_NB(_put16, 2, shmem)
+SHMEM_TYPE_PUTMEM_NB(_put32, 4, shmem)
+SHMEM_TYPE_PUTMEM_NB(_put64, 8, shmem)
+SHMEM_TYPE_PUTMEM_NB(_put128, 16, shmem)
+SHMEM_TYPE_PUTMEM_NB(_putmem, 1, shmem)

--- a/oshmem/shmem/fortran/Makefile.am
+++ b/oshmem/shmem/fortran/Makefile.am
@@ -69,6 +69,7 @@ liboshmem_fortran_la_SOURCES += \
                     shmem_iput8_f.c \
                     shmem_logical_iput_f.c \
                     shmem_real_iput_f.c \
+                    shmem_put_nb_f.c \
                     shmem_character_get_f.c \
                     shmem_complex_get_f.c \
                     shmem_double_get_f.c \
@@ -91,6 +92,7 @@ liboshmem_fortran_la_SOURCES += \
                     shmem_integer_iget_f.c \
                     shmem_logical_iget_f.c \
                     shmem_real_iget_f.c \
+                    shmem_get_nb_f.c \
                     shmem_swap_f.c \
                     shmem_int4_swap_f.c \
                     shmem_int8_swap_f.c \

--- a/oshmem/shmem/fortran/profile/Makefile.am
+++ b/oshmem/shmem/fortran/profile/Makefile.am
@@ -61,6 +61,7 @@ nodist_liboshmem_fortran_pshmem_la_SOURCES = \
 	pshmem_iput8_f.c \
 	pshmem_logical_iput_f.c \
 	pshmem_real_iput_f.c \
+	pshmem_put_nb_f.c \
 	pshmem_character_get_f.c \
 	pshmem_complex_get_f.c \
 	pshmem_double_get_f.c \
@@ -83,6 +84,7 @@ nodist_liboshmem_fortran_pshmem_la_SOURCES = \
 	pshmem_integer_iget_f.c \
 	pshmem_logical_iget_f.c \
 	pshmem_real_iget_f.c \
+	pshmem_get_nb_f.c \
 	pshmem_swap_f.c \
 	pshmem_int4_swap_f.c \
 	pshmem_int8_swap_f.c \

--- a/oshmem/shmem/fortran/profile/defines.h
+++ b/oshmem/shmem/fortran/profile/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014      Mellanox Technologies, Inc.
+ * Copyright (c) 2014-2016 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -118,6 +118,10 @@
 #define shmem_character_put_ pshmem_character_put_
 #define shmem_character_put__ pshmem_character_put__
 
+#define SHMEM_CHARACTER_PUT_NBI PSHMEM_CHARACTER_PUT_NBI
+#define shmem_character_put_nbi_ pshmem_character_put_nbi_
+#define shmem_character_put_nbi__ pshmem_character_put_nbi__
+
 #define SHMEM_COLLECT4 PSHMEM_COLLECT4
 #define shmem_collect4_ pshmem_collect4_
 #define shmem_collect4__ pshmem_collect4__
@@ -166,6 +170,10 @@
 #define shmem_complex_put_ pshmem_complex_put_
 #define shmem_complex_put__ pshmem_complex_put__
 
+#define SHMEM_COMPLEX_PUT_NBI PSHMEM_COMPLEX_PUT_NBI
+#define shmem_complex_put_nbi_ pshmem_complex_put_nbi_
+#define shmem_complex_put_nbi__ pshmem_complex_put_nbi__
+
 #define SHMEM_DOUBLE_GET PSHMEM_DOUBLE_GET
 #define shmem_double_get_ pshmem_double_get_
 #define shmem_double_get__ pshmem_double_get__
@@ -181,6 +189,10 @@
 #define SHMEM_DOUBLE_PUT PSHMEM_DOUBLE_PUT
 #define shmem_double_put_ pshmem_double_put_
 #define shmem_double_put__ pshmem_double_put__
+
+#define SHMEM_DOUBLE_PUT_NBI PSHMEM_DOUBLE_PUT_NBI
+#define shmem_double_put_nbi_ pshmem_double_put_nbi_
+#define shmem_double_put_nbi__ pshmem_double_put_nbi__
 
 #define SHMEM_FENCE PSHMEM_FENCE
 #define shmem_fence_ pshmem_fence_
@@ -229,6 +241,102 @@
 #define SHMEM_IGET8 PSHMEM_IGET8
 #define shmem_iget8_ pshmem_iget8_
 #define shmem_iget8__ pshmem_iget8__
+
+#define SHMEM_GETMEM_NBI PSHMEM_GETMEM_NBI
+#define shmem_getmem_nbi_ pshmem_getmem_nbi_
+#define shmem_getmem_nbi__ pshmem_getmem_nbi__
+
+#define SHMEM_CHARACTER_GET_NBI PSHMEM_CHARACTER_GET_NBI
+#define shmem_character_get_nbi_ pshmem_character_get_nbi_
+#define shmem_character_get_nbi__ pshmem_character_get_nbi__
+
+#define SHMEM_COMPLEX_GET_NBI PSHMEM_COMPLEX_GET_NBI
+#define shmem_complex_get_nbi_ pshmem_complex_get_nbi_
+#define shmem_complex_get_nbi__ pshmem_complex_get_nbi__
+
+#define SHMEM_DOUBLE_GET_NBI PSHMEM_DOUBLE_GET_NBI
+#define shmem_double_get_nbi_ pshmem_double_get_nbi_
+#define shmem_double_get_nbi__ pshmem_double_get_nbi__
+
+#define SHMEM_INTEGER_GET_NBI PSHMEM_INTEGER_GET_NBI
+#define shmem_integer_get_nbi_ pshmem_integer_get_nbi_
+#define shmem_integer_get_nbi__ pshmem_integer_get_nbi__
+
+#define SHMEM_LOGICAL_GET_NBI PSHMEM_LOGICAL_GET_NBI
+#define shmem_logical_get_nbi_ pshmem_logical_get_nbi_
+#define shmem_logical_get_nbi__ pshmem_logical_get_nbi__
+
+#define SHMEM_REAL_GET_NBI PSHMEM_REAL_GET_NBI
+#define shmem_real_get_nbi_ pshmem_real_get_nbi_
+#define shmem_real_get_nbi__ pshmem_real_get_nbi__
+
+#define SHMEM_GET4_NBI PSHMEM_GET4_NBI
+#define shmem_get4_nbi_ pshmem_get4_nbi_
+#define shmem_get4_nbi__ pshmem_get4_nbi__
+
+#define SHMEM_GET8_NBI PSHMEM_GET8_NBI
+#define shmem_get8_nbi_ pshmem_get8_nbi_
+#define shmem_get8_nbi__ pshmem_get8_nbi__
+
+#define SHMEM_GET32_NBI PSHMEM_GET32_NBI
+#define shmem_get32_nbi_ pshmem_get32_nbi_
+#define shmem_get32_nbi__ pshmem_get32_nbi__
+
+#define SHMEM_GET64_NBI PSHMEM_GET64_NBI
+#define shmem_get64_nbi_ pshmem_get64_nbi_
+#define shmem_get64_nbi__ pshmem_get64_nbi__
+
+#define SHMEM_GET128_NBI PSHMEM_GET128_NBI
+#define shmem_get128_nbi_ pshmem_get128_nbi_
+#define shmem_get128_nbi__ pshmem_get128_nbi__
+
+#define SHMEM_PUTMEM_NBI PSHMEM_PUTMEM_NBI
+#define shmem_putmem_nbi_ pshmem_putmem_nbi_
+#define shmem_putmem_nbi__ pshmem_putmem_nbi__
+
+#define SHMEM_CHARACTER_PUT_NBI PSHMEM_CHARACTER_PUT_NBI
+#define shmem_character_put_nbi_ pshmem_character_put_nbi_
+#define shmem_character_put_nbi__ pshmem_character_put_nbi__
+
+#define SHMEM_COMPLEX_PUT_NBI PSHMEM_COMPLEX_PUT_NBI
+#define shmem_complex_put_nbi_ pshmem_complex_put_nbi_
+#define shmem_complex_put_nbi__ pshmem_complex_put_nbi__
+
+#define SHMEM_DOUBLE_PUT_NBI PSHMEM_DOUBLE_PUT_NBI
+#define shmem_double_put_nbi_ pshmem_double_put_nbi_
+#define shmem_double_put_nbi__ pshmem_double_put_nbi__
+
+#define SHMEM_INTEGER_PUT_NBI PSHMEM_INTEGER_PUT_NBI
+#define shmem_integer_put_nbi_ pshmem_integer_put_nbi_
+#define shmem_integer_put_nbi__ pshmem_integer_put_nbi__
+
+#define SHMEM_LOGICAL_PUT_NBI PSHMEM_LOGICAL_PUT_NBI
+#define shmem_logical_put_nbi_ pshmem_logical_put_nbi_
+#define shmem_logical_put_nbi__ pshmem_logical_put_nbi__
+
+#define SHMEM_REAL_PUT_NBI PSHMEM_REAL_PUT_NBI
+#define shmem_real_put_nbi_ pshmem_real_put_nbi_
+#define shmem_real_put_nbi__ pshmem_real_put_nbi__
+
+#define SHMEM_PUT4_NBI PSHMEM_PUT4_NBI
+#define shmem_put4_nbi_ pshmem_put4_nbi_
+#define shmem_put4_nbi__ pshmem_put4_nbi__
+
+#define SHMEM_PUT8_NBI PSHMEM_PUT8_NBI
+#define shmem_put8_nbi_ pshmem_put8_nbi_
+#define shmem_put8_nbi__ pshmem_put8_nbi__
+
+#define SHMEM_PUT32_NBI PSHMEM_PUT32_NBI
+#define shmem_put32_nbi_ pshmem_put32_nbi_
+#define shmem_put32_nbi__ pshmem_put32_nbi__
+
+#define SHMEM_PUT64_NBI PSHMEM_PUT64_NBI
+#define shmem_put64_nbi_ pshmem_put64_nbi_
+#define shmem_put64_nbi__ pshmem_put64_nbi__
+
+#define SHMEM_PUT128_NBI PSHMEM_PUT128_NBI
+#define shmem_put128_nbi_ pshmem_put128_nbi_
+#define shmem_put128_nbi__ pshmem_put128_nbi__
 
 #define SHMEM_INT4_ADD PSHMEM_INT4_ADD
 #define shmem_int4_add_ pshmem_int4_add_

--- a/oshmem/shmem/fortran/profile/prototypes_pshmem.h
+++ b/oshmem/shmem/fortran/profile/prototypes_pshmem.h
@@ -36,6 +36,7 @@ PN (void, pshpclmove, PSHPCLMOVE, (FORTRAN_POINTER_T *addr, MPI_Fint *length, MP
 PN (FORTRAN_POINTER_T*, pshmem_ptr, PSHMEM_PTR, (FORTRAN_POINTER_T target, MPI_Fint *pe));
 PN (ompi_fortran_logical_t, pshmem_pe_accessible, PSHMEM_PE_ACCESSIBLE, (MPI_Fint *pe));
 PN (MPI_Fint, pshmem_addr_accessible, PSHMEM_ADDR_ACCESSIBLE, (FORTRAN_POINTER_T addr, MPI_Fint *pe));
+
 PN (void, pshmem_put, PSHMEM_PUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, pshmem_character_put, PSHMEM_CHARACTER_PUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, pshmem_complex_put, PSHMEM_COMPLEX_PUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
@@ -49,6 +50,7 @@ PN (void, pshmem_put32, PSHMEM_PUT32, (FORTRAN_POINTER_T target, FORTRAN_POINTER
 PN (void, pshmem_put64, PSHMEM_PUT64, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, pshmem_put128, PSHMEM_PUT128, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, pshmem_putmem, PSHMEM_PUTMEM, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+
 PN (void, pshmem_iput4, PSHMEM_IPUT4, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_iput8, PSHMEM_IPUT8, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_iput32, PSHMEM_IPUT32, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
@@ -59,6 +61,20 @@ PN (void, pshmem_double_iput, PSHMEM_DOUBLE_IPUT, (FORTRAN_POINTER_T target, FOR
 PN (void, pshmem_integer_iput, PSHMEM_INTEGER_IPUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_logical_iput, PSHMEM_LOGICAL_IPUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_real_iput, PSHMEM_REAL_IPUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
+
+PN (void, pshmem_putmem_nbi, PSHMEM_PUTMEM_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_character_put_nbi, PSHMEM_CHARACTER_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_complex_put_nbi, PSHMEM_COMPLEX_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_double_put_nbi, PSHMEM_DOUBLE_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_integer_put_nbi, PSHMEM_INTEGER_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_logical_put_nbi, PSHMEM_LOGICAL_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_real_put_nbi, PSHMEM_REAL_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_put4_nbi, PSHMEM_PUT4_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_put8_nbi, PSHMEM_PUT8_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_put32_nbi, PSHMEM_PUT32_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_put64_nbi, PSHMEM_PUT64_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, pshmem_put128_nbi, PSHMEM_PUT128_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+
 PN (void, pshmem_character_get, PSHMEM_CHARACTER_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_complex_get, PSHMEM_COMPLEX_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_double_get, PSHMEM_DOUBLE_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
@@ -71,6 +87,7 @@ PN (void, pshmem_get128, PSHMEM_GET128, (FORTRAN_POINTER_T target, FORTRAN_POINT
 PN (void, pshmem_getmem, PSHMEM_GETMEM, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_logical_get, PSHMEM_LOGICAL_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_real_get, PSHMEM_REAL_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+
 PN (void, pshmem_iget4, PSHMEM_IGET4, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_iget8, PSHMEM_IGET8, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_iget32, PSHMEM_IGET32, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
@@ -81,6 +98,20 @@ PN (void, pshmem_double_iget, PSHMEM_DOUBLE_IGET, (FORTRAN_POINTER_T target, FOR
 PN (void, pshmem_integer_iget, PSHMEM_INTEGER_IGET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_logical_iget, PSHMEM_LOGICAL_IGET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, pshmem_real_iget, PSHMEM_REAL_IGET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
+
+PN (void, pshmem_getmem_nbi, PSHMEM_GETMEM_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_character_get_nbi, PSHMEM_CHARACTER_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_complex_get_nbi, PSHMEM_COMPLEX_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_double_get_nbi, PSHMEM_DOUBLE_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_integer_get_nbi, PSHMEM_INTEGER_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_logical_get_nbi, PSHMEM_LOGICAL_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_real_get_nbi, PSHMEM_REAL_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_get4_nbi, PSHMEM_GET4_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_get8_nbi, PSHMEM_GET8_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_get32_nbi, PSHMEM_GET32_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_get64_nbi, PSHMEM_GET64_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, pshmem_get128_nbi, PSHMEM_GET128_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+
 PN (MPI_Fint, pshmem_swap, PSHMEM_SWAP, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T value, MPI_Fint *pe));
 PN (ompi_fortran_integer4_t, pshmem_int4_swap, PSHMEM_INT4_SWAP, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T value, MPI_Fint *pe));
 PN (ompi_fortran_integer8_t, pshmem_int8_swap, PSHMEM_INT8_SWAP, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T value, MPI_Fint *pe));

--- a/oshmem/shmem/fortran/prototypes_shmem.h
+++ b/oshmem/shmem/fortran/prototypes_shmem.h
@@ -39,6 +39,7 @@ PN (void, shpclmove, SHPCLMOVE, (FORTRAN_POINTER_T *addr, MPI_Fint *length, MPI_
 PN (FORTRAN_POINTER_T*, shmem_ptr, SHMEM_PTR, (FORTRAN_POINTER_T target, MPI_Fint *pe));
 PN (ompi_fortran_logical_t, shmem_pe_accessible, SHMEM_PE_ACCESSIBLE, (MPI_Fint *pe));
 PN (MPI_Fint, shmem_addr_accessible, SHMEM_ADDR_ACCESSIBLE, (FORTRAN_POINTER_T addr, MPI_Fint *pe));
+
 PN (void, shmem_put, SHMEM_PUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, shmem_character_put, SHMEM_CHARACTER_PUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, shmem_complex_put, SHMEM_COMPLEX_PUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
@@ -52,6 +53,7 @@ PN (void, shmem_put32, SHMEM_PUT32, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T
 PN (void, shmem_put64, SHMEM_PUT64, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, shmem_put128, SHMEM_PUT128, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
 PN (void, shmem_putmem, SHMEM_PUTMEM, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+
 PN (void, shmem_iput4, SHMEM_IPUT4, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_iput8, SHMEM_IPUT8, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_iput32, SHMEM_IPUT32, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
@@ -62,6 +64,20 @@ PN (void, shmem_double_iput, SHMEM_DOUBLE_IPUT, (FORTRAN_POINTER_T target, FORTR
 PN (void, shmem_integer_iput, SHMEM_INTEGER_IPUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_logical_iput, SHMEM_LOGICAL_IPUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_real_iput, SHMEM_REAL_IPUT, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
+
+PN (void, shmem_putmem_nbi, SHMEM_PUTMEM_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_character_put_nbi, SHMEM_CHARACTER_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_complex_put_nbi, SHMEM_COMPLEX_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_double_put_nbi, SHMEM_DOUBLE_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_integer_put_nbi, SHMEM_INTEGER_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_logical_put_nbi, SHMEM_LOGICAL_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_real_put_nbi, SHMEM_REAL_PUT_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_put4_nbi, SHMEM_PUT4_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_put8_nbi, SHMEM_PUT8_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_put32_nbi, SHMEM_PUT32_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_put64_nbi, SHMEM_PUT64_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+PN (void, shmem_put128_nbi, SHMEM_PUT128_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe));
+
 PN (void, shmem_character_get, SHMEM_CHARACTER_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_complex_get, SHMEM_COMPLEX_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_double_get, SHMEM_DOUBLE_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
@@ -74,6 +90,7 @@ PN (void, shmem_get128, SHMEM_GET128, (FORTRAN_POINTER_T target, FORTRAN_POINTER
 PN (void, shmem_getmem, SHMEM_GETMEM, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_logical_get, SHMEM_LOGICAL_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_real_get, SHMEM_REAL_GET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+
 PN (void, shmem_iget4, SHMEM_IGET4, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_iget8, SHMEM_IGET8, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_iget32, SHMEM_IGET32, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
@@ -84,6 +101,21 @@ PN (void, shmem_double_iget, SHMEM_DOUBLE_IGET, (FORTRAN_POINTER_T target, FORTR
 PN (void, shmem_integer_iget, SHMEM_INTEGER_IGET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_logical_iget, SHMEM_LOGICAL_IGET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
 PN (void, shmem_real_iget, SHMEM_REAL_IGET, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *tst, MPI_Fint *sst, MPI_Fint *len, MPI_Fint *pe));
+
+PN (void, shmem_getmem_nbi, SHMEM_GETMEM_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_character_get_nbi, SHMEM_CHARACTER_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_complex_get_nbi, SHMEM_COMPLEX_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_double_get_nbi, SHMEM_DOUBLE_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_integer_get_nbi, SHMEM_INTEGER_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_logical_get_nbi, SHMEM_LOGICAL_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_real_get_nbi, SHMEM_REAL_GET_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_get4_nbi, SHMEM_GET4_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_get8_nbi, SHMEM_GET8_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_get32_nbi, SHMEM_GET32_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_get64_nbi, SHMEM_GET64_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+PN (void, shmem_get128_nbi, SHMEM_GET128_NBI, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe));
+
+
 PN (MPI_Fint, shmem_swap, SHMEM_SWAP, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T value, MPI_Fint *pe));
 PN (ompi_fortran_integer4_t, shmem_int4_swap, SHMEM_INT4_SWAP, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T value, MPI_Fint *pe));
 PN (ompi_fortran_integer8_t, shmem_int8_swap, SHMEM_INT8_SWAP, (FORTRAN_POINTER_T target, FORTRAN_POINTER_T value, MPI_Fint *pe));

--- a/oshmem/shmem/fortran/shmem_get_nb_f.c
+++ b/oshmem/shmem/fortran/shmem_get_nb_f.c
@@ -1,0 +1,250 @@
+   /*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "oshmem_config.h"
+#include "oshmem/shmem/fortran/bindings.h"
+#include "oshmem/include/shmem.h"
+#include "oshmem/shmem/shmem_api_logger.h"
+#include "oshmem/runtime/runtime.h"
+#include "oshmem/mca/spml/spml.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "stdio.h"
+
+#if OSHMEM_PROFILING
+#include "oshmem/shmem/fortran/profile/pbindings.h"
+
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_GETMEM_NBI, shmem_getmem_nbi)
+
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_CHARACTER_GET_NBI, shmem_character_get_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_COMPLEX_GET_NBI, shmem_complex_get_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_DOUBLE_GET_NBI, shmem_double_get_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_INTEGER_GET_NBI, shmem_integer_get_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_LOGICAL_GET_NBI, shmem_logical_get_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_REAL_GET_NBI, shmem_real_get_nbi)
+
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_GET4_NBI, shmem_get4_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_GET8_NBI, shmem_get8_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_GET32_NBI, shmem_get32_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_GET64_NBI, shmem_get64_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_GET128_NBI, shmem_get128_nbi)
+
+#include "oshmem/shmem/fortran/profile/defines.h"
+#endif
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_GETMEM_NBI,
+        shmem_getmem_nbi_,
+        shmem_getmem_nbi__,
+        shmem_getmem_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_getmem_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len),
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_CHARACTER_GET_NBI,
+        shmem_character_get_nbi_,
+        shmem_character_get_nbi__,
+        shmem_character_get_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe))
+
+void shmem_character_get_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    size_t character_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_character.dt, &character_type_size);
+
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * character_type_size,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_COMPLEX_GET_NBI,
+        shmem_complex_get_nbi_,
+        shmem_complex_get_nbi__,
+        shmem_complex_get_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_complex_get_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    size_t complex_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_cplex.dt, &complex_type_size);
+
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * complex_type_size,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_DOUBLE_GET_NBI,
+        shmem_double_get_nbi_,
+        shmem_double_get_nbi__,
+        shmem_double_get_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_double_get_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    size_t double_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_dblprec.dt, &double_type_size);
+
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * double_type_size,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_INTEGER_GET_NBI,
+        shmem_integer_get_nbi_,
+        shmem_integer_get_nbi__,
+        shmem_integer_get_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_integer_get_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    size_t integer_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_integer.dt, &integer_type_size);
+
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * integer_type_size,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_LOGICAL_GET_NBI,
+        shmem_logical_get_nbi_,
+        shmem_logical_get_nbi__,
+        shmem_logical_get_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_logical_get_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    size_t logical_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_logical.dt, &logical_type_size);
+
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * logical_type_size,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_REAL_GET_NBI,
+        shmem_real_get_nbi_,
+        shmem_real_get_nbi__,
+        shmem_real_get_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_real_get_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    size_t real_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_real.dt, &real_type_size);
+
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * real_type_size,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_GET4_NBI,
+        shmem_get4_nbi_,
+        shmem_get4_nbi__,
+        shmem_get4_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_get4_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * 4,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_GET8_NBI,
+        shmem_get8_nbi_,
+        shmem_get8_nbi__,
+        shmem_get8_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_get8_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * 8,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_GET32_NBI,
+        shmem_get32_nbi_,
+        shmem_get32_nbi__,
+        shmem_get32_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_get32_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * 4,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_GET64_NBI,
+        shmem_get64_nbi_,
+        shmem_get64_nbi__,
+        shmem_get64_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_get64_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * 8,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_GET128_NBI,
+        shmem_get128_nbi_,
+        shmem_get128_nbi__,
+        shmem_get128_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe),
+        (target,source,len,pe) )
+
+void shmem_get128_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *len, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(get_nb(FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*len) * 16,
+        FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*pe), NULL));
+}

--- a/oshmem/shmem/fortran/shmem_put_nb_f.c
+++ b/oshmem/shmem/fortran/shmem_put_nb_f.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "oshmem_config.h"
+#include "oshmem/shmem/fortran/bindings.h"
+#include "oshmem/include/shmem.h"
+#include "oshmem/shmem/shmem_api_logger.h"
+#include "oshmem/runtime/runtime.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "stdio.h"
+
+#if OSHMEM_PROFILING
+#include "oshmem/shmem/fortran/profile/pbindings.h"
+
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_PUTMEM_NBI, shmem_putmem_nbi)
+
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_CHARACTER_PUT_NBI, shmem_character_put_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_COMPLEX_PUT_NBI, shmem_complex_put_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_DOUBLE_PUT_NBI, shmem_double_put_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_INTEGER_PUT_NBI, shmem_integer_put_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_LOGICAL_PUT_NBI, shmem_logical_put_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_REAL_PUT_NBI, shmem_real_put_nbi)
+
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_PUT4_NBI, shmem_put4_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_PUT8_NBI, shmem_put8_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_PUT32_NBI, shmem_put32_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_PUT64_NBI, shmem_put64_nbi)
+SHMEM_GENERATE_WEAK_BINDINGS(SHMEM_PUT128_NBI, shmem_put128_nbi)
+
+#include "oshmem/shmem/fortran/profile/defines.h"
+#endif
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_PUTMEM_NBI,
+        shmem_putmem_nbi_,
+        shmem_putmem_nbi__,
+        shmem_putmem_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_putmem_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length),
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_CHARACTER_PUT_NBI,
+        shmem_character_put_nbi_,
+        shmem_character_put_nbi__,
+        shmem_character_put_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_character_put_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    size_t character_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_character.dt, &character_type_size);
+
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * character_type_size,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_COMPLEX_PUT_NBI,
+        shmem_complex_put_nbi_,
+        shmem_complex_put_nbi__,
+        shmem_complex_put_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_complex_put_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    size_t complex_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_cplex.dt, &complex_type_size);
+
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * complex_type_size,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_DOUBLE_PUT_NBI,
+        shmem_double_put_nbi_,
+        shmem_double_put_nbi__,
+        shmem_double_put_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_double_put_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    size_t double_precision_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_dblprec.dt, &double_precision_type_size);
+
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * double_precision_type_size,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_INTEGER_PUT_NBI,
+        shmem_integer_put_nbi_,
+        shmem_integer_put_nbi__,
+        shmem_integer_put_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_integer_put_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    size_t integer_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_integer.dt, &integer_type_size);
+
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * integer_type_size,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_LOGICAL_PUT_NBI,
+        shmem_logical_put_nbi_,
+        shmem_logical_put_nbi__,
+        shmem_logical_put_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_logical_put_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    size_t logical_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_logical.dt, &logical_type_size);
+
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * logical_type_size,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_REAL_PUT_NBI,
+        shmem_real_put_nbi_,
+        shmem_real_put_nbi__,
+        shmem_real_put_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_real_put_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    size_t real_type_size = 0;
+    ompi_datatype_type_size(&ompi_mpi_real.dt, &real_type_size);
+
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * real_type_size,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_PUT4_NBI,
+        shmem_put4_nbi_,
+        shmem_put4_nbi__,
+        shmem_put4_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_put4_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * 4,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_PUT8_NBI,
+        shmem_put8_nbi_,
+        shmem_put8_nbi__,
+        shmem_put8_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_put8_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * 8,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_PUT32_NBI,
+        shmem_put32_nbi_,
+        shmem_put32_nbi__,
+        shmem_put32_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_put32_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * 4,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_PUT64_NBI,
+        shmem_put64_nbi_,
+        shmem_put64_nbi__,
+        shmem_put64_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_put64_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * 8,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}
+
+SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
+        SHMEM_PUT128_NBI,
+        shmem_put128_nbi_,
+        shmem_put128_nbi__,
+        shmem_put128_nbi_f,
+        (FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe),
+        (target,source,length,pe) )
+
+void shmem_put128_nbi_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
+{
+    MCA_SPML_CALL(put_nb(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * 16,
+        FPTR_2_VOID_PTR(source),
+        OMPI_FINT_2_INT(*pe), NULL));
+}

--- a/oshmem/shmem/man/man3/Makefile.extra
+++ b/oshmem/shmem/man/man3/Makefile.extra
@@ -187,7 +187,38 @@ shmem_api_man_pages = \
         shmem/man/man3/shmem_clear_cache_line_inv.3 \
         shmem/man/man3/shmem_info_get_name.3 \
         shmem/man/man3/shmem_info_get_version.3 \
-        shmem/man/man3/shmem_global_exit.3
+        shmem/man/man3/shmem_global_exit.3 \
+\
+        shmem/man/man3/shmem_getmem_nbi.3 \
+        shmem/man/man3/shmem_char_get_nbi.3 \
+        shmem/man/man3/shmem_short_get_nbi.3 \
+        shmem/man/man3/shmem_int_get_nbi.3 \
+        shmem/man/man3/shmem_long_get_nbi.3 \
+        shmem/man/man3/shmem_longlong_get_nbi.3 \
+        shmem/man/man3/shmem_float_get_nbi.3 \
+        shmem/man/man3/shmem_double_get_nbi.3 \
+        shmem/man/man3/shmem_longdouble_get_nbi.3 \
+        shmem/man/man3/shmem_get8_nbi.3 \
+        shmem/man/man3/shmem_get16_nbi.3 \
+        shmem/man/man3/shmem_get32_nbi.3 \
+        shmem/man/man3/shmem_get64_nbi.3 \
+        shmem/man/man3/shmem_get128_nbi.3 \
+\
+        shmem/man/man3/shmem_putmem_nbi.3 \
+        shmem/man/man3/shmem_char_put_nbi.3 \
+        shmem/man/man3/shmem_short_put_nbi.3 \
+        shmem/man/man3/shmem_int_put_nbi.3 \
+        shmem/man/man3/shmem_long_put_nbi.3 \
+        shmem/man/man3/shmem_longlong_put_nbi.3 \
+        shmem/man/man3/shmem_float_put_nbi.3 \
+        shmem/man/man3/shmem_double_put_nbi.3 \
+        shmem/man/man3/shmem_longdouble_put_nbi.3 \
+        shmem/man/man3/shmem_put8_nbi.3 \
+        shmem/man/man3/shmem_put16_nbi.3 \
+        shmem/man/man3/shmem_put32_nbi.3 \
+        shmem/man/man3/shmem_put64_nbi.3 \
+        shmem/man/man3/shmem_put128_nbi.3
+
 
 if PROJECT_OSHMEM
 nodist_man_MANS += $(shmem_api_man_pages)

--- a/oshmem/shmem/man/man3/shmem_char_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_char_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_char_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_char_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_double_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_double_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_double_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_double_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_float_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_float_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_float_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_float_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_get128_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_get128_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_get16_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_get16_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_get32_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_get32_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_get64_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_get64_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_get8_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_get8_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_getmem_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_getmem_nbi.3in
@@ -1,0 +1,168 @@
+.\" -*- nroff -*-
+.\" Copyright (c) 2016      Mellanox Technologies, Inc.
+.\" $COPYRIGHT$
+.de Vb
+.ft CW
+.nf
+..
+.de Ve
+.ft R
+
+.fi
+..
+.TH "SHMEM\\_GET\\_NBI" "3" "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+
+\fIshmem_getmem_nbi\fP(3),
+\fIshmem_char_get_nbi\fP(3),
+\fIshmem_short_get_nbi\fP(3),
+\fIshmem_int_get_nbi\fP(3),
+\fIshmem_long_get_nbi\fP(3),
+\fIshmem_longlong_get_nbi\fP(3),
+\fIshmem_float_get_nbi\fP(3),
+\fIshmem_double_get_nbi\fP(3),
+\fIshmem_longdouble_get_nbi\fP(3),
+\fIshmem_get8_nbi\fP(3),
+\fIshmem_get16_nbi\fP(3),
+\fIshmem_get32_nbi\fP(3),
+\fIshmem_get64_nbi\fP(3),
+\fIshmem_get128_nbi\fP(3),
+\- The nonblocking get routines provide a method for copying data from a contiguous remote data object on the specified PE to the local data object.
+.SH SYNOPSIS
+
+C or C++:
+.Vb
+#include <mpp/shmem.h>
+
+void shmem_getmem_nbi(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_char_get(char *dest, const char *source,
+  size_t nelems, int pe);
+
+void shmem_short_get(short *dest, const short *source,
+  size_t nelems, int pe);
+
+void shmem_int_get(int *dest, const int *source,
+  size_t nelems, int pe);
+
+void shmem_long_get(long *dest, const long *source,
+  size_t nelems, int pe);
+
+void shmem_longlong_get(long long *dest, const long long *source,
+  size_t nelems, int pe);
+
+void shmem_float_get(float *dest, const float *source,
+  size_t nelems, int pe);
+
+void shmem_double_get(double *dest, const double *source,
+  size_t nelems, int pe);
+
+void shmem_longdouble_get(long double *dest, const long double *source,
+  size_t nelems, int pe);
+
+void shmem_get8(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_get16(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_get32(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_get64(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_get128(void *dest, const void *source,
+  size_t nelems, int pe);
+
+.Ve
+Fortran:
+.Vb
+INCLUDE "mpp/shmem.fh"
+
+INTEGER nelems, pe
+
+CALL SHMEM_GETMEM_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_CHARACTER_GET_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_COMPLEX_GET_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_DOUBLE_GET_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_INTEGER_GET_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_LOGICAL_GET_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_REAL_GET_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_GET4_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_GET8_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_GET32_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_GET64_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_GET128_NBI(dest, source, nelems, pe)
+
+.Ve
+.SH DESCRIPTION
+
+The get routines provide a method for copying a contiguous symmetric data
+object from a different PE to a contiguous data object on the local PE.
+The routines return after posting the operation. The operation is
+considered complete after a subsequent call to shmem_quiet. At the completion
+of shmem_quiet, the data has been delivered to the dest array on the local PE.
+.PP
+The arguments are as follows:
+.TP
+dest
+Local data object to be updated.
+.TP
+source
+Data object on the PE identified by pe that contains the data to be copied. This
+data object must be remotely accessible.
+.TP
+nelems
+Number of elements in the target and source arrays. len must be of type integer. If
+you are using Fortran, it must be a constant, variable, or array element of default
+integer type.
+.TP
+pe
+PE number of the remote PE. pe must be of type integer. If you are using Fortran, it
+must be a constant, variable, or array element of default integer type.
+.PP
+If you are using Fortran, data types must be of default size. For example, a real variable must
+be declared as REAL, REAL*4, or REAL(KIND=4).
+.SH NOTES
+
+See \fIintro_shmem\fP(3)
+for a definition of the term remotely accessible.
+.SH EXAMPLES
+
+Consider this simple example for Fortran.
+.Vb
+PROGRAM REDUCTION
+  REAL VALUES, SUM
+  COMMON /C/ VALUES
+  REAL WORK
+
+  CALL START_PES(0) ! ALLOW ANY NUMBER OF PES
+  VALUES = MY_PE() ! INITIALIZE IT TO SOMETHING
+  CALL SHMEM_BARRIER_ALL
+  SUM = 0.0
+  DO I = 0,NUM_PES()\-1
+    CALL SHMEM_REAL_GET_NBI(WORK, VALUES, 1, I)
+    CALL SHMEM_QUIET                ! wait for delivery
+    SUM = SUM + WORK
+  ENDDO
+  PRINT *, 'PE ', MY_PE(), ' COMPUTED SUM=', SUM
+  CALL SHMEM_BARRIER_ALL
+END
+.Ve
+.SH SEE ALSO
+
+\fIintro_shmem\fP(3),
+\fIshmem_quiet\fP(3)

--- a/oshmem/shmem/man/man3/shmem_int_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_int_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_int_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_int_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_long_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_long_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_long_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_long_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_longdouble_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_longdouble_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_longdouble_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_longdouble_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_longlong_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_longlong_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_longlong_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_longlong_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_put128_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_put128_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_put16_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_put16_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_put32_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_put32_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_put64_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_put64_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_put8_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_put8_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_putmem_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_putmem_nbi.3in
@@ -1,0 +1,171 @@
+.\" -*- nroff -*-
+.\" Copyright (c) 2016      Mellanox Technologies, Inc.
+.\" $COPYRIGHT$
+.de Vb
+.ft CW
+.nf
+..
+.de Ve
+.ft R
+
+.fi
+..
+.TH "SHMEM\\_PUT\\_NBI" "3" "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+
+\fIshmem_putmem_nbi\fP(3),
+\fIshmem_char_put_nbi\fP(3),
+\fIshmem_short_put_nbi\fP(3),
+\fIshmem_int_put_nbi\fP(3),
+\fIshmem_long_put_nbi\fP(3),
+\fIshmem_longlong_put_nbi\fP(3),
+\fIshmem_float_put_nbi\fP(3),
+\fIshmem_double_put_nbi\fP(3),
+\fIshmem_longdouble_put_nbi\fP(3),
+\fIshmem_put8_nbi\fP(3),
+\fIshmem_put16_nbi\fP(3),
+\fIshmem_put32_nbi\fP(3),
+\fIshmem_put64_nbi\fP(3),
+\fIshmem_put128_nbi\fP(3),
+\- The nonblocking put routines provide a method for copying data from a contiguous local data object to a data object on a specified PE.
+.SH SYNOPSIS
+
+C or C++:
+.Vb
+#include <mpp/shmem.h>
+
+void shmem_putmem_nbi(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_char_put(char *dest, const char *source,
+  size_t nelems, int pe);
+
+void shmem_short_put(short *dest, const short *source,
+  size_t nelems, int pe);
+
+void shmem_int_put(int *dest, const int *source,
+  size_t nelems, int pe);
+
+void shmem_long_put(long *dest, const long *source,
+  size_t nelems, int pe);
+
+void shmem_longlong_put(long long *dest, const long long *source,
+  size_t nelems, int pe);
+
+void shmem_float_put(float *dest, const float *source,
+  size_t nelems, int pe);
+
+void shmem_double_put(double *dest, const double *source,
+  size_t nelems, int pe);
+
+void shmem_longdouble_put(long double *dest, const long double *source,
+  size_t nelems, int pe);
+
+void shmem_put8(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_put16(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_put32(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_put64(void *dest, const void *source,
+  size_t nelems, int pe);
+
+void shmem_put128(void *dest, const void *source,
+  size_t nelems, int pe);
+
+.Ve
+Fortran:
+.Vb
+INCLUDE "mpp/shmem.fh"
+
+INTEGER nelems, pe
+
+CALL SHMEM_PUTMEM_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_CHARACTER_PUT_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_COMPLEX_PUT_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_DOUBLE_PUT_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_INTEGER_PUT_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_LOGICAL_PUT_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_REAL_PUT_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_PUT4_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_PUT8_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_PUT32_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_PUT64_NBI(dest, source, nelems, pe)
+
+CALL SHMEM_PUT128_NBI(dest, source, nelems, pe)
+
+.Ve
+.SH DESCRIPTION
+
+The routines return after posting the operation. The operation is considered
+complete after a subsequent call to shmem_quiet. At the completion of shmem_quiet,
+the data has been copied into the dest array on the destination PE.
+The delivery of data words into the data object on the destination PE may occur
+in any order. Furthermore, two successive put routines may deliver data out of
+order unless a call to shmem_fence is introduced between the two calls.
+.PP
+The arguments are as follows:
+.TP
+dest
+Data object to be updated on the remote PE. This data object must be
+remotely accessible.
+.TP
+source
+Data object containing the data to be copied.
+.TP
+nelems
+Number of elements in the dest and source arrays. nelems must be
+of type size_t for C. If you are using Fortran, it must be a constant,
+variable, or array element of default integer type.
+.TP
+pe
+PE number of the remote PE. pe must be of type integer. If you are using Fortran, it
+must be a constant, variable, or array element of default integer type.
+.PP
+If you are using Fortran, data types must be of default size. For example, a real variable must
+be declared as REAL, REAL*4, or REAL(KIND=4).
+.SH NOTES
+
+See \fIintro_shmem\fP(3)
+for a definition of the term remotely accessible.
+.SH EXAMPLES
+
+Consider this simple example for Fortran.
+.Vb
+#include <stdio.h>
+#include <mpp/shmem.h>
+
+main()
+{
+  long source[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+  static long target[10];
+  shmem_init();
+
+  if (shmem_my_pe() == 0) {
+    /* put 10 words into target on PE 1 */
+    shmem_long_put_nbi(target, source, 10, 1);
+    shmem_quiet();
+  }
+  shmem_barrier_all();  /* sync sender and receiver */
+  if (shmem_my_pe() == 1)
+    shmem_udcflush();  /* not required on Altix systems */
+  printf("target[0] on PE %d is %d\\n", shmem_my_pe(), target[0]);
+}
+.Ve
+.SH SEE ALSO
+
+\fIintro_shmem\fP(3),
+\fIshmem_quiet\fP(3)

--- a/oshmem/shmem/man/man3/shmem_short_get_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_short_get_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_getmem_nbi.3

--- a/oshmem/shmem/man/man3/shmem_short_put_nbi.3in
+++ b/oshmem/shmem/man/man3/shmem_short_put_nbi.3in
@@ -1,0 +1,1 @@
+.so man3/shmem_putmem_nbi.3


### PR DESCRIPTION
openshmem spec v1.3 decalres new api non-blocking functions
This PR adds support of these api.

@yosefe could you look at spml/ucx component
@alex-mikheev could you check spml/ikrit and spml/yoda component
@jsquyres please check in general
