### PR TITLE
configure: re-enable built-in atomic support

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -879,8 +879,6 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
     if test "$opal_cv_asm_builtin" = "BUILTIN_NO" && test "$enable_osx_builtin_atomics" = "yes" ; then
        AC_CHECK_HEADER([libkern/OSAtomic.h],
                        [opal_cv_asm_builtin="BUILTIN_OSX"])
-    else
-       opal_cv_asm_builtin="BUILTIN_NO"
     fi
 
         OPAL_CHECK_ASM_PROC


### PR DESCRIPTION
This commit removes an erroneous else statement from the OSX built-in
atomics check. The else branch sets the built-in atomics support to
BUILTIN_NO if either opal_cv_asm_builtin is not BUILTIN_NO or OSX
atomics support is disabled.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>