### PR TITLE
opal: fix various coverity errors

### DIFF
--- a/opal/class/opal_free_list.c
+++ b/opal/class/opal_free_list.c
@@ -225,11 +225,7 @@ int opal_free_list_grow_st (opal_free_list_t* flist, size_t num_elements)
                                                     flist->fl_rcache_reg_flags, MCA_RCACHE_ACCESS_ANY, &reg);
             if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
                 free (alloc_ptr);
-                if (flist->fl_mpool) {
-                    flist->fl_mpool->mpool_free (flist->fl_mpool, payload_ptr);
-                } else {
-                    free (payload_ptr);
-                }
+                flist->fl_mpool->mpool_free (flist->fl_mpool, payload_ptr);
 
                 return rc;
             }

--- a/opal/mca/mpool/hugepage/mpool_hugepage_component.c
+++ b/opal/mca/mpool/hugepage/mpool_hugepage_component.c
@@ -227,7 +227,7 @@ static void mca_mpool_hugepage_find_hugepages (void) {
             page_size = info.f_bsize;
 #endif
         } else {
-            sscanf (tok, "pagesize=%lu", &page_size);
+            (void) sscanf (tok, "pagesize=%lu", &page_size);
         }
 
         if (0 == page_size) {
@@ -294,20 +294,23 @@ static int mca_mpool_hugepage_query (const char *hints, int *priority_out,
                     my_priority = 0;
                     opal_output_verbose (MCA_BASE_VERBOSE_INFO, opal_mpool_base_framework.framework_output,
                                          "hugepage mpool does not match hint: %s=%s", key, value);
+                    opal_argv_free (hints_array);
                     return OPAL_ERR_NOT_FOUND;
                 }
             }
 
-            if (0 == strcasecmp ("page_size", key)) {
+            if (0 == strcasecmp ("page_size", key) && value) {
                 page_size = strtoul (value, &tmp, 0);
                 if (*tmp) {
                     switch (*tmp) {
                     case 'g':
                     case 'G':
                         page_size *= 1024;
+                        /* fall through */
                     case 'm':
                     case 'M':
                         page_size *= 1024;
+                        /* fall through */
                     case 'k':
                     case 'K':
                         page_size *= 1024;

--- a/opal/mca/mpool/hugepage/mpool_hugepage_module.c
+++ b/opal/mca/mpool/hugepage/mpool_hugepage_module.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2006      Voltaire. All rights reserved.
  * Copyright (c) 2007      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -159,8 +159,8 @@ void *mca_mpool_hugepage_seg_alloc (void *ctx, size_t *sizep)
     }
 
     base = mmap (NULL, size, PROT_READ | PROT_WRITE, flags | huge_page->mmap_flags, fd, 0);
+    close (fd);
     if (path) {
-        close (fd);
         unlink (path);
         free (path);
     }


### PR DESCRIPTION
Fix CID 1356358:  Null pointer dereferences  (REVERSE_INULL):

flist->fl_mpool can no longer be NULL. Removed the conditional.

Fix CID 1356357:  Resource leaks  (RESOURCE_LEAK):

Added the call to free the hints array.

Fix CID 1356356:  Resource leaks  (RESOURCE_LEAK):

This is a false error but it is safe to call close (-1) so just always
call close.

Fix CID 1356354:  Control flow issues  (MISSING_BREAK):
Fix CID 1356353:  Control flow issues  (MISSING_BREAK):

Add comments that indicate the fall-through is intentional.

Fix CID 1356351:  Null pointer dereferences  (FORWARD_NULL):

Fix potential SEGV if the page_size key is malformed.

Fix CID 1356350:  Error handling issues  (CHECKED_RETURN):

Add (void) to indicate that we do not care about the return code of
sscanf in this case.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>