### PR TITLE
opal: fix coverity issues

### DIFF
--- a/opal/class/opal_graph.c
+++ b/opal/class/opal_graph.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -149,13 +152,7 @@ static void opal_graph_construct(opal_graph_t *graph)
 
 static void opal_graph_destruct(opal_graph_t *graph)
 {
-    opal_adjacency_list_t *aj_list;
-
-    while (false == opal_list_is_empty(graph->adjacency_list)) {
-        aj_list = (opal_adjacency_list_t *)opal_list_remove_first(graph->adjacency_list);
-        OBJ_RELEASE(aj_list);
-    }
-    OBJ_RELEASE(graph->adjacency_list);
+    OPAL_LIST_RELEASE(graph->adjacency_list);
     graph->number_of_vertices = 0;
     graph->number_of_edges = 0;
 }
@@ -174,15 +171,8 @@ static void opal_adjacency_list_construct(opal_adjacency_list_t *aj_list)
 
 static void opal_adjacency_list_destruct(opal_adjacency_list_t *aj_list)
 {
-   opal_graph_edge_t *edge;
-
    aj_list->vertex = NULL;
-   while (false == opal_list_is_empty(aj_list->edges)) {
-       edge = (opal_graph_edge_t *)opal_list_remove_first(aj_list->edges);
-       OBJ_RELEASE(edge);
-   }
-   OBJ_RELEASE(aj_list->edges);
-
+   OPAL_LIST_RELEASE(aj_list->edges);
 }
 
 /**
@@ -349,14 +339,9 @@ void opal_graph_remove_vertex(opal_graph_t *graph, opal_graph_vertex_t *vertex)
     opal_adjacency_list_t *adj_list;
     opal_graph_edge_t *edge;
 
-    /**
-     * remove all the edges of this vertex and destruct them.
-     */
+    /* do not need to remove all the edges of this vertex and destruct them as
+     * they will be released in the destructor for adj_list */
     adj_list = vertex->in_adj_list;
-    while (false == opal_list_is_empty(adj_list->edges)) {
-        edge = (opal_graph_edge_t *)opal_list_remove_first(adj_list->edges);
-        OBJ_RELEASE(edge);
-    }
     /**
      * remove the adjscency list of this vertex from the graph and
      * destruct it.

--- a/opal/mca/btl/openib/btl_openib_endpoint.c
+++ b/opal/mca/btl/openib/btl_openib_endpoint.c
@@ -632,8 +632,7 @@ void mca_btl_openib_endpoint_connected(mca_btl_openib_endpoint_t *endpoint)
     /* Process pending packet on the endpoint */
 
     /* While there are frags in the list, process them */
-    while (!opal_list_is_empty(&(endpoint->pending_lazy_frags))) {
-        frag_item = opal_list_remove_first(&(endpoint->pending_lazy_frags));
+    while (NULL != (frag_item = opal_list_remove_first(&(endpoint->pending_lazy_frags)))) {
         frag = to_send_frag(frag_item);
         /* We need to post this one */
 

--- a/opal/mca/btl/openib/btl_openib_proc.c
+++ b/opal/mca/btl/openib/btl_openib_proc.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -15,6 +16,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -184,6 +187,9 @@ mca_btl_openib_proc_t* mca_btl_openib_proc_get_locked(opal_proc_t* proc)
     /* First time, gotta create a new IB proc
      * out of the opal_proc ... */
     ib_proc = OBJ_NEW(mca_btl_openib_proc_t);
+    if (NULL == ib_proc) {
+      return NULL;
+    }
 
     /* Initialize number of peer */
     ib_proc->proc_endpoint_count = 0;
@@ -321,10 +327,9 @@ mca_btl_openib_proc_t* mca_btl_openib_proc_get_locked(opal_proc_t* proc)
 
 err_exit:
 
-    fprintf(stderr,"%d: error exit from mca_btl_openib_proc_create\n", OPAL_PROC_MY_NAME.vpid);
-    if( NULL != ib_proc ){
-        OBJ_RELEASE(ib_proc);
-    }
+    BTL_ERROR(("%d: error exit from mca_btl_openib_proc_create", OPAL_PROC_MY_NAME.vpid));
+
+    OBJ_RELEASE(ib_proc);
     return NULL;
 }
 

--- a/opal/mca/mpool/hugepage/mpool_hugepage_module.c
+++ b/opal/mca/mpool/hugepage/mpool_hugepage_module.c
@@ -159,10 +159,13 @@ void *mca_mpool_hugepage_seg_alloc (void *ctx, size_t *sizep)
     }
 
     base = mmap (NULL, size, PROT_READ | PROT_WRITE, flags | huge_page->mmap_flags, fd, 0);
-    close (fd);
     if (path) {
         unlink (path);
         free (path);
+    }
+
+    if (fd >= 0) {
+        close (fd);
     }
 
     if (MAP_FAILED == base) {


### PR DESCRIPTION
Fix CID 1345825 (1 of 1): Dereference before null check (REVERSE_INULL):

ib_proc should not be NULL in this case. Removed the check and added a
check for NULL after OBJ_NEW.

CID 1269821 (1 of 1): Dereference null return value (NULL_RETURNS):

I labeled this one as a false positive (which it is) but the code in
question could stand be be cleaned up.

Fix CID 1356424 (1 of 1): Argument cannot be negative (NEGATIVE_RETURNS):

While trying to silence another Coverity issue another was
flagged. Protect the close of fd with if (fd >= 0).

CID 70772 (1 of 1): Dereference null return value (NULL_RETURNS):
CID 70773 (1 of 1): Dereference null return value (NULL_RETURNS):
CID 70774 (1 of 1): Dereference null return value (NULL_RETURNS):

None of these are errors and are intentional but now that we have a
list release function use that to make these go away. The cleanup is
similar to CID 1269821.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>