### PR TITLE
When using btls always consider the self component

### DIFF
--- a/opal/mca/base/help-mca-base.txt
+++ b/opal/mca/base/help-mca-base.txt
@@ -59,3 +59,9 @@ all components *except* a and b", while "c,d" specifies the inclusive
 behavior and means "use *only* components c and d."
 
 You cannot mix inclusive and exclusive behavior.
+[framework-param:exclude-always-component]
+A request was made to exclude a component from consideration that
+must always be considered.
+
+Framework: %s
+Component: %s

--- a/opal/mca/base/mca_base_component_find.c
+++ b/opal/mca/base/mca_base_component_find.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -115,8 +115,8 @@ int mca_base_component_find (const char *directory, mca_base_framework_t *framew
     /* Find all the components that were statically linked in */
     if (static_components) {
         for (int i = 0 ; NULL != static_components[i]; ++i) {
-            if ( use_component(include_mode,
-                               (const char**)requested_component_names,
+            if ( (static_components[i]->mca_component_flags & MCA_BASE_COMPONENT_FLAG_ALWAYS_CONSIDER) ||
+                 use_component(include_mode, (const char**)requested_component_names,
                                static_components[i]->mca_component_name) ) {
                 cli = OBJ_NEW(mca_base_component_list_item_t);
                 if (NULL == cli) {
@@ -189,8 +189,9 @@ int mca_base_components_filter (mca_base_framework_t *framework, uint32_t filter
         mca_base_open_only_dummy_component_t *dummy =
             (mca_base_open_only_dummy_component_t *) cli->cli_component;
 
-        can_use = use_component (include_mode, (const char **) requested_component_names,
-                                 cli->cli_component->mca_component_name);
+        can_use = (cli->cli_component->mca_component_flags & MCA_BASE_COMPONENT_FLAG_ALWAYS_CONSIDER) ||
+            use_component (include_mode, (const char **) requested_component_names,
+                           cli->cli_component->mca_component_name);
 
         if (!can_use || (filter_flags & dummy->data.param_field) != filter_flags) {
             if (can_use && (filter_flags & MCA_BASE_METADATA_PARAM_CHECKPOINT) &&

--- a/opal/mca/btl/self/Makefile.am
+++ b/opal/mca/btl/self/Makefile.am
@@ -10,6 +10,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -17,30 +19,13 @@
 # $HEADER$
 #
 
-libmca_btl_self_la_sources = \
+# Make self component always static
+noinst_LTLIBRARIES = libmca_btl_self.la
+
+libmca_btl_self_la_SOURCES = \
     btl_self.c \
     btl_self.h \
     btl_self_component.c \
     btl_self_frag.c \
     btl_self_frag.h
 
-# Make the output library in this directory, and name it either
-# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
-# (for static builds).
-
-if MCA_BUILD_opal_btl_self_DSO
-component_noinst =
-component_install = mca_btl_self.la
-else
-component_noinst = libmca_btl_self.la
-component_install =
-endif
-
-mcacomponentdir = $(opallibdir)
-mcacomponent_LTLIBRARIES = $(component_install)
-mca_btl_self_la_SOURCES = $(libmca_btl_self_la_sources)
-mca_btl_self_la_LDFLAGS = -module -avoid-version
-
-noinst_LTLIBRARIES = $(component_noinst)
-libmca_btl_self_la_SOURCES = $(libmca_btl_self_la_sources)
-libmca_btl_self_la_LDFLAGS = -module -avoid-version

--- a/opal/mca/btl/self/btl_self_component.c
+++ b/opal/mca/btl/self/btl_self_component.c
@@ -48,6 +48,7 @@ mca_btl_self_component_t mca_btl_self_component = {
             .mca_open_component = mca_btl_self_component_open,
             .mca_close_component = mca_btl_self_component_close,
             .mca_register_component_params = mca_btl_self_component_register,
+            .mca_component_flags = MCA_BASE_COMPONENT_FLAG_ALWAYS_CONSIDER,
         },
         .btl_data = {
             /* The component is checkpoint ready */

--- a/opal/mca/btl/self/configure.m4
+++ b/opal/mca/btl/self/configure.m4
@@ -1,0 +1,19 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AC_DEFUN([MCA_opal_btl_self_COMPILE_MODE], [
+    AC_MSG_CHECKING([for MCA component btl:self compile mode])
+    $4=static
+    AC_MSG_RESULT([static])
+])
+
+AC_DEFUN([MCA_opal_btl_self_CONFIG], [
+    AC_CONFIG_FILES([opal/mca/btl/self/Makefile])
+])

--- a/opal/mca/mca.h
+++ b/opal/mca/mca.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -257,6 +257,15 @@ typedef int (*mca_base_register_component_params_2_0_0_fn_t)(void);
 #define MCA_BASE_MAX_COMPONENT_NAME_LEN 63
 
 /**
+ * Component flags (mca_component_flags field)
+ */
+enum {
+    /** Always consider this component for selection. For this flag to
+     * work properly the component must always be built statically. */
+    MCA_BASE_COMPONENT_FLAG_ALWAYS_CONSIDER = 1,
+};
+
+/**
  * Common type for all MCA components.
  *
  * An instance of this type is always the first element in MCA
@@ -315,9 +324,13 @@ struct mca_base_component_2_1_0_t {
   mca_base_register_component_params_2_0_0_fn_t mca_register_component_params;
   /**< Method for registering the component's MCA parameters */
 
+  int32_t mca_component_flags;
+  /**< flags for this component */
+
   /** Extra space to allow for expansion in the future without
-      breaking older components. */
-  char reserved[32];
+      breaking older components. NTH: reduced by 4 bytes for
+      mca_component_flags*/
+  char reserved[28];
 };
 /** Unversioned convenience typedef; use this name in
     frameworks/components to stay forward source-compatible */


### PR DESCRIPTION
This PR also contains the necessary infrastructure to support this new feature. This PR reflects the reality that btl/self is always needed when using btls for communication.
