### PR TITLE
RFC: Add support for flag enumerators for MCA variables

### DIFF
--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -275,7 +275,7 @@ int ompi_info_set (ompi_info_t *info, const char *key, const char *value)
 int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
                               mca_base_var_enum_t *var_enum)
 {
-    const char *string_value;
+    char *string_value;
     int ret;
 
     ret = var_enum->string_from_value (var_enum, value, &string_value);
@@ -283,7 +283,9 @@ int ompi_info_set_value_enum (ompi_info_t *info, const char *key, int value,
         return ret;
     }
 
-    return ompi_info_set (info, key, string_value);
+    ret = ompi_info_set (info, key, string_value);
+    free (string_value);
+    return ret;
 }
 
 

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -1526,7 +1526,7 @@ int mca_base_var_register (const char *project_name, const char *framework_name,
                            mca_base_var_scope_t scope, void *storage)
 {
     /* Only integer variables can have enumerator */
-    assert (NULL == enumerator || MCA_BASE_VAR_TYPE_INT == type);
+    assert (NULL == enumerator || (MCA_BASE_VAR_TYPE_INT == type || MCA_BASE_VAR_TYPE_UNSIGNED_INT == type));
 
     return register_variable (project_name, framework_name, component_name,
                               variable_name, description, type, enumerator,
@@ -1927,7 +1927,6 @@ static char *source_name(mca_base_var_t *var)
 static int var_value_string (mca_base_var_t *var, char **value_string)
 {
     const mca_base_var_storage_t *value;
-    const char *tmp;
     int ret;
 
     assert (MCA_BASE_VAR_TYPE_MAX > var->mbv_type);
@@ -1974,18 +1973,13 @@ static int var_value_string (mca_base_var_t *var, char **value_string)
     } else {
         /* we use an enumerator to handle string->bool and bool->string conversion */
         if (MCA_BASE_VAR_TYPE_BOOL == var->mbv_type) {
-            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->boolval, &tmp);
+            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->boolval, value_string);
         } else {
-            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->intval, &tmp);
+            ret = var->mbv_enumerator->string_from_value(var->mbv_enumerator, value->intval, value_string);
         }
 
         if (OPAL_SUCCESS != ret) {
             return ret;
-        }
-
-        *value_string = strdup (tmp);
-        if (NULL == *value_string) {
-            ret = OPAL_ERR_OUT_OF_RESOURCE;
         }
     }
 

--- a/opal/mca/btl/base/base.h
+++ b/opal/mca/btl/base/base.h
@@ -75,6 +75,9 @@ OPAL_DECLSPEC extern bool mca_btl_base_thread_multiple_override;
 
 OPAL_DECLSPEC extern mca_base_framework_t opal_btl_base_framework;
 
+extern mca_base_var_enum_flag_t *mca_btl_base_flag_enum;
+extern mca_base_var_enum_flag_t *mca_btl_base_atomic_enum;
+
 END_C_DECLS
 
 #endif /* MCA_BTL_BASE_H */

--- a/opal/mca/btl/base/btl_base_frame.c
+++ b/opal/mca/btl/base/btl_base_frame.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  * Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +32,39 @@
 #include "opal/mca/base/base.h"
 #include "opal/mca/btl/btl.h"
 #include "opal/mca/btl/base/base.h"
+
+mca_base_var_enum_flag_t *mca_btl_base_flag_enum = NULL;
+mca_base_var_enum_flag_t *mca_btl_base_atomic_enum = NULL;
+
+mca_base_var_enum_value_flag_t mca_btl_base_flag_enum_flags[] = {
+    {MCA_BTL_FLAGS_SEND, "send", 0},
+    {MCA_BTL_FLAGS_PUT, "put", 0},
+    {MCA_BTL_FLAGS_GET, "get", 0},
+    {MCA_BTL_FLAGS_SEND_INPLACE, "inplace", 0},
+    {MCA_BTL_FLAGS_SIGNALED, "signaled", 0},
+    {MCA_BTL_FLAGS_ATOMIC_OPS, "atomics", 0},
+    {MCA_BTL_FLAGS_ATOMIC_FOPS, "fetching-atomics", 0},
+    {MCA_BTL_FLAGS_SINGLE_ADD_PROCS, "static", 0},
+    {MCA_BTL_FLAGS_CUDA_PUT, "cuda-put", 0},
+    {MCA_BTL_FLAGS_CUDA_GET, "cuda-get", 0},
+    {MCA_BTL_FLAGS_CUDA_COPY_ASYNC_SEND, "cuda-async-send", 0},
+    {MCA_BTL_FLAGS_CUDA_COPY_ASYNC_RECV, "cuda-async-recv", 0},
+    {MCA_BTL_FLAGS_FAILOVER_SUPPORT, "failover", 0},
+    {MCA_BTL_FLAGS_NEED_ACK, "need-ack", 0},
+    {MCA_BTL_FLAGS_NEED_CSUM, "need-csum", 0},
+    {MCA_BTL_FLAGS_HETEROGENEOUS_RDMA, "hetero-rdma", 0},
+    {0, NULL, 0}
+};
+
+mca_base_var_enum_value_flag_t mca_btl_base_atomic_enum_flags[] = {
+  {MCA_BTL_ATOMIC_SUPPORTS_ADD, "add", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_AND, "and", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_OR, "or", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_XOR, "xor", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_CSWAP, "compare-and-swap", 0},
+  {MCA_BTL_ATOMIC_SUPPORTS_GLOB, "global"},
+  {0, NULL, 0}
+};
 
 mca_btl_active_message_callback_t mca_btl_base_active_message_trigger[MCA_BTL_TAG_MAX] = {{0}};
 
@@ -104,6 +140,9 @@ static int mca_btl_base_register(mca_base_register_flag_t flags)
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &mca_btl_base_warn_component_unused);
 
+    (void) mca_base_var_enum_create_flag ("btl_flags", mca_btl_base_flag_enum_flags, &mca_btl_base_flag_enum);
+    (void) mca_base_var_enum_create_flag ("btl_atomic_flags", mca_btl_base_atomic_enum_flags, &mca_btl_base_atomic_enum);
+
     return OPAL_SUCCESS;
 }
 
@@ -158,6 +197,14 @@ static int mca_btl_base_close(void)
     (void) mca_base_framework_components_close(&opal_btl_base_framework, NULL);
 
     OBJ_DESTRUCT(&mca_btl_base_modules_initialized);
+
+    if (mca_btl_base_flag_enum) {
+        OBJ_RELEASE(mca_btl_base_flag_enum);
+    }
+
+    if (mca_btl_base_atomic_enum) {
+        OBJ_RELEASE(mca_btl_base_atomic_enum);
+    }
 
 #if 0
     /* restore event processing */

--- a/opal/mca/btl/base/btl_base_mca.c
+++ b/opal/mca/btl/base/btl_base_mca.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -34,8 +36,6 @@
 int mca_btl_base_param_register(mca_base_component_t *version,
                                 mca_btl_base_module_t *module)
 {
-    char *msg;
-
     /* If this is ever triggered change the uint32_ts in mca_btl_base_module_t to unsigned ints */
     assert(sizeof(unsigned int) == sizeof(uint32_t));
 
@@ -46,33 +46,14 @@ int mca_btl_base_param_register(mca_base_component_t *version,
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &module->btl_exclusivity);
 
-    asprintf(&msg, "BTL bit flags (general flags: SEND=%d, PUT=%d, GET=%d, SEND_INPLACE=%d, HETEROGENEOUS_RDMA=%d, "
-             "ATOMIC_OPS=%d; flags only used by the \"dr\" PML (ignored by others): ACK=%d, CHECKSUM=%d, "
-             "RDMA_COMPLETION=%d; flags only used by the \"bfo\" PML (ignored by others): FAILOVER_SUPPORT=%d)",
-             MCA_BTL_FLAGS_SEND,
-             MCA_BTL_FLAGS_PUT,
-             MCA_BTL_FLAGS_GET,
-             MCA_BTL_FLAGS_SEND_INPLACE,
-             MCA_BTL_FLAGS_HETEROGENEOUS_RDMA,
-             MCA_BTL_FLAGS_ATOMIC_OPS,
-             MCA_BTL_FLAGS_NEED_ACK,
-             MCA_BTL_FLAGS_NEED_CSUM,
-             MCA_BTL_FLAGS_RDMA_COMPLETION,
-             MCA_BTL_FLAGS_FAILOVER_SUPPORT);
-    (void) mca_base_component_var_register(version, "flags", msg,
-                                           MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0,
-                                           OPAL_INFO_LVL_5,
-                                           MCA_BASE_VAR_SCOPE_READONLY,
-                                           &module->btl_flags);
-    free(msg);
+    (void) mca_base_component_var_register(version, "flags", "BTL bit flags (general flags: send, put, get, in-place, hetero-rdma, "
+                                           "atomics, fetching-atomics)", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+                                           &mca_btl_base_flag_enum->super, 0, 0, OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_READONLY, &module->btl_flags);
 
-    asprintf (&msg, "BTL atomic bit flags (general flags: ADD=%d, AND=%d, OR=%d, XOR=%d",
-              MCA_BTL_ATOMIC_SUPPORTS_ADD, MCA_BTL_ATOMIC_SUPPORTS_AND, MCA_BTL_ATOMIC_SUPPORTS_OR,
-              MCA_BTL_ATOMIC_SUPPORTS_XOR);
-    (void) mca_base_component_var_register(version, "atomic_flags", msg, MCA_BASE_VAR_TYPE_UNSIGNED_INT,
-                                           NULL, 0, MCA_BASE_VAR_FLAG_DEFAULT_ONLY, OPAL_INFO_LVL_5,
+    (void) mca_base_component_var_register(version, "atomic_flags", "BTL atomic support flags", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+                                           &mca_btl_base_atomic_enum->super, 0, MCA_BASE_VAR_FLAG_DEFAULT_ONLY, OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_CONSTANT, &module->btl_atomic_flags);
-    free(msg);
 
     (void) mca_base_component_var_register(version, "rndv_eager_limit", "Size (in bytes, including header) of \"phase 1\" fragment sent for all large messages (must be >= 0 and <= eager_limit)",
                                            MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0,

--- a/opal/mca/mpool/memkind/mpool_memkind_component.c
+++ b/opal/mca/mpool/memkind/mpool_memkind_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2010-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -148,13 +148,14 @@ static int mca_mpool_memkind_open (void)
     }
 
     if (memkind_check_available (default_kind)) {
-        const char *kind_string;
+        char *kind_string;
 
         mca_mpool_memkind_enum->string_from_value (mca_mpool_memkind_enum,
                                                    mca_mpool_memkind_component.default_partition,
                                                    &kind_string);
         opal_output_verbose (MCA_BASE_VERBOSE_WARN, mca_mpool_memkind_component.output,
                              "default kind %s not available", kind_string);
+        free (kind_string);
         return OPAL_ERR_NOT_AVAILABLE;
     }
 


### PR DESCRIPTION
This PR adds support for flag enumerators for MCA variables. A new function and types have been added to ```mca_base_var_enum.h``` to support these enumerators. Use ```mca_base_var_enum_create_flag``` to create a flag enumerator with a given set of flags and use the enumerator with ```mca_base_var_register()/mca_base_pvar_register()```.

Variables using a flag enumerator can take a comma-delimited list of flags. For example, instead of

```
# set put, get, send, and in-place
btl_vader_flags = 0xf
```

a user can can now use

```
# set put, get, send, and in-place
btl_vader_flags = send,put,get,in-place
```

The old value way of setting the flags will continue to work.