### PR TITLE
Correct the binding for the --map-by node case

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -110,7 +110,8 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
         opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                             "mca:rmaps: nprocs %s",
                             ORTE_VPID_PRINT(nprocs));
-        if (ORTE_MAPPING_GIVEN & ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping)) {
+        if (ORTE_MAPPING_GIVEN & ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping) &&
+            ORTE_MAPPING_BYNODE != ORTE_GET_MAPPING_POLICY(orte_rmaps_base.mapping)) {
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                 "mca:rmaps mapping given - using default");
             map->mapping = orte_rmaps_base.mapping;


### PR DESCRIPTION
We should still use our default binding algorithms. Thanks to @artpol84 for pointing it out.
