### PR TITLE
opal_timers: ASM update

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -389,7 +389,7 @@ foo$opal_cv_asm_label_suffix
     # test for both 16 and 10 (decimal and hex notations)
     echo "configure: .align test address offset is $opal_asm_addr" >&AC_FD_CC
     if test "$opal_asm_addr" = "16" || test "$opal_asm_addr" = "10" ; then
-       opal_cv_asm_align_log="yes"
+        opal_cv_asm_align_log="yes"
     else
         opal_cv_asm_align_log="no"
     fi])
@@ -401,7 +401,7 @@ foo$opal_cv_asm_label_suffix
     fi
 
     AC_DEFINE_UNQUOTED([OPAL_ASM_ALIGN_LOG],
-                       [$asm_align_log_result],
+                       [$opal_asm_align_log_result],
                        [Assembly align directive expects logarithmic value])
 
     unset omp_asm_addr asm_result
@@ -1068,17 +1068,18 @@ AC_MSG_ERROR([Can not continue.])
 
     # Check for RDTSCP support
     result=0
-    AS_IF([test "$opal_cv_asm_arch" = "OPAL_AMD64" || test "$opal_cv_asm_arch" = "OPAL_IA32"],
+    AS_IF([test "$opal_cv_asm_arch" = "AMD64" || test "$opal_cv_asm_arch" = "IA32"],
           [AC_MSG_CHECKING([for RDTSCP assembly support])
            AC_LANG_PUSH([C])
-           AC_TRY_RUN([[
+           AC_TRY_RUN([
+#include <stdint.h>
 int main(int argc, char* argv[])
 {
-  unsigned int rax, rdx;
-  __asm__ __volatile__ ("rdtscp\n": "=a" (rax), "=d" (rdx):: "%rax", "%rdx");
+  uint32_t eax, edx;
+  __asm__ __volatile__ ("rdtscp\n": "=a" (eax), "=d" (edx):: "ecx");
   return 0;
 }
-           ]],
+           ],
            [result=1
             AC_MSG_RESULT([yes])],
            [AC_MSG_RESULT([no])],

--- a/opal/asm/base/AMD64.asm
+++ b/opal/asm/base/AMD64.asm
@@ -46,7 +46,6 @@ END_FUNC(opal_atomic_cmpset_64)
 START_FUNC(opal_sys_timer_get_cycles)
         rdtsc
         salq    $32, %rdx
-        mov     %eax, %eax
         orq     %rdx, %rax
         ret
 END_FUNC(opal_sys_timer_get_cycles)

--- a/opal/asm/base/IA32.asm
+++ b/opal/asm/base/IA32.asm
@@ -102,9 +102,6 @@ END_FUNC(opal_atomic_sub_32)
 
 
 START_FUNC(opal_sys_timer_get_cycles)
-        pushl   %ebp
-        movl    %esp, %ebp
         rdtsc
-        popl    %ebp
         ret
 END_FUNC(opal_sys_timer_get_cycles)

--- a/opal/include/opal/sys/ia32/timer.h
+++ b/opal/include/opal/sys/ia32/timer.h
@@ -7,6 +7,8 @@
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2016      HfT Stuttgart, University of Applied Science.
+ *                         All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -32,15 +34,12 @@ static inline opal_timer_t
 opal_sys_timer_get_cycles(void)
 {
     opal_timer_t ret;
-    int tmp;
-
     __asm__ __volatile__(
-                         "xchg{l} {%%}ebx, %1\n"
-                         "cpuid\n"
-                         "xchg{l} {%%}ebx, %1\n"
-                         "rdtsc\n"
-                         : "=A"(ret), "=r"(tmp)
-                         :: "ecx");
+                         "cpuid\n\t"
+                         "rdtsc\n\t"
+                         : "=A" (ret)       // Output
+                         : "a" (0)          // Input
+                         : "ecx");          // Clobber
 
     return ret;
 }


### PR DESCRIPTION
This is from an email from @ hpcraink (Rainer Keller) -- @bosilca and @hjelmn -- can you have a look at Rainer's proposal?  (I can't easily find a Github ID for Rainer)

---

Over time OMPI’s opal_sys_timer_get_cycles was amended/changed.

It references Intel’s documentation “How to Benchmark Code Execution Times” — but the author’s inline asm has various errors.

Two drawbacks, it seems, we have copied:
- cpuid uses as input eax — and YES, the number of CPU cycles vary, esp. if You provide non-valid input values — like providing eax as outcome from rdtsc(p)… That is silly.
- having rtscp and cpuid in the same **asm** section requires us saving eax and edx to the outside variables. GCC’s register allocation (now) is smart… Leaving mov eax, eax which should be optimized away by GAS, which ISN’t smart ,-)

This is also the case in the “pre-processed” generated ASM. Furthermore, the opal_config_asm.m4 has a bug, which makes Configure never check/set OPAL_ASSEMBLY_SUPPORTS_RDTSCP. (also the asm was dodgy). (and there was a buglet to not set OPAL_ASM_ALIGN_LOG).

I’d like to check in the following patch to OMPI.

What do You think?

Good to apply?

Tested on:
- MacOSX with gcc (which does not activate this code) and two VMs:
- Linux/Debian8-i386 with gcc 
- Linux/Ubuntu-15.10-x86-64 with gcc

Thanks,
Rainer

PS: The difference e.g. with Linux/Debian8-i386 is:

OLD:

``` asm
00000000 <opal_sys_timer_get_cycles>:
  0:   55                      push   %ebp
  1:   89 e5                   mov    %esp,%ebp
  3:   56                      push   %esi
  4:   83 ec 14                sub    $0x14,%esp
  7:   87 de                   xchg   %ebx,%esi
  9:   0f a2                   cpuid  
  b:   87 de                   xchg   %ebx,%esi
  d:   0f 31                   rdtsc  
  f:   89 45 f0                mov    %eax,-0x10(%ebp)
 12:   89 55 f4                mov    %edx,-0xc(%ebp)
 15:   89 75 ec                mov    %esi,-0x14(%ebp)
 18:   8b 45 f0                mov    -0x10(%ebp),%eax
 1b:   8b 55 f4                mov    -0xc(%ebp),%edx
 1e:   83 c4 14                add    $0x14,%esp
 21:   5e                      pop    %esi
 22:   5d                      pop    %ebp
 23:   c3                      ret 
```

NEW: 

``` asm
00000000 <opal_sys_timer_get_cycles>:
  0:   55                      push   %ebp
  1:   89 e5                   mov    %esp,%ebp
  3:   83 ec 10                sub    $0x10,%esp
  6:   b8 00 00 00 00          mov    $0x0,%eax
  b:   0f a2                   cpuid  
  d:   0f 31                   rdtsc  
  f:   89 45 f8                mov    %eax,-0x8(%ebp)
 12:   89 55 fc                mov    %edx,-0x4(%ebp)
 15:   8b 45 f8                mov    -0x8(%ebp),%eax
 18:   8b 55 fc                mov    -0x4(%ebp),%edx
 1b:   c9                      leave  
 1c:   c3                      ret 
```
