### PR TITLE
configure: only enable sync builtin atomics if they link

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -13,6 +13,8 @@ dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -86,7 +88,7 @@ AC_DEFUN([OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128], [
 AC_DEFUN([OPAL_CHECK_SYNC_BUILTINS], [
   AC_MSG_CHECKING([for __sync builtin atomics])
 
-  AC_TRY_COMPILE([], [__sync_synchronize()],
+  AC_TRY_LINK([], [__sync_synchronize()],
     [AC_MSG_RESULT([yes])
      $1],
     [AC_MSG_RESULT([no])


### PR DESCRIPTION
This commit fixes the check for sync builtin atomics.
AC_COMPILE_IFELSE is insufficient to check for the builtins. Need to
use AC_LINK_IFELSE.

Fixes open-mpi/ompi#1487

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>