### PR TITLE
DNM opal_info: print a component even when it does not contain any parameters

### DIFF
--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -639,6 +639,23 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
         }
     }
 
+    /* Print the component before diving into it's paramters. This ensures that
+     * an enable component is mentioned even when it does not have any explicity
+     * parameters.
+     */
+    if (opal_info_pretty) {
+	asprintf (&message, "MCA%s %s %s", requested ? "" : " (disabled)",
+		  group->group_framework,
+		  group->group_component ? group->group_component : "");
+	opal_info_out(message, message, "---------------------------------------------------");
+	free(message);
+    } else {
+	asprintf (&message, "mca:%s:%s:disabled:%s", group->group_framework,
+		  group_component, requested ? "false" : "true");
+	opal_info_out("", "", message);
+	free (message);
+    }
+
     for (i = 0 ; i < count ; ++i) {
         ret = mca_base_var_get(variables[i], &var);
         if (OPAL_SUCCESS != ret || ((var->mbv_flags & MCA_BASE_VAR_FLAG_INTERNAL) &&
@@ -654,7 +671,7 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
 
         for (j = 0 ; strings[j] ; ++j) {
             if (0 == j && opal_info_pretty) {
-                asprintf (&message, "MCA%s %s", requested ? "" : " (disabled)", group->group_framework);
+		asprintf (&message, "MCA%s %s %s", requested ? "" : " (disabled)", group->group_framework, group->group_component ? group->group_component : "");
                 opal_info_out(message, message, strings[j]);
                 free(message);
             } else {
@@ -689,7 +706,7 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
 
         for (j = 0 ; strings[j] ; ++j) {
             if (0 == j && opal_info_pretty) {
-                asprintf (&message, "MCA%s %s", requested ? "" : " (disabled)", group->group_framework);
+		asprintf (&message, "MCA%s %s %s", requested ? "" : " (disabled)", group->group_framework, group->group_component ? group->group_component : "");
                 opal_info_out(message, message, strings[j]);
                 free(message);
             } else {


### PR DESCRIPTION
An attempt to 'fix' https://github.com/open-mpi/ompi/issues/1396. To test, I disabled all tcp btl parameter registration. Sure enough, ompi_info skips over the tcp btl in opal_info_show_mca_group_params(). With this patch, the parameter output is sectioned based on components. If a component does not contain any parameters, an empty section is displayed. Sample output below:

                MCA btl : ---------------------------------------------------
                MCA btl : parameter "btl" (current value: "", data source:
                          default, level: 2 user/detail, type: string)
                          Default selection set of components for the btl
                          framework (<none> means use all components that can
                          be found)
            MCA btl base: ---------------------------------------------------
            MCA btl base: parameter "btl_base_verbose" (current value:
                          "error", data source: default, level: 8 dev/detail,
                          type: int)
                          Verbosity level for the btl framework (default: 0)
                          Valid values: -1:"none", 0:"error", 10:"component",
                          20:"warn", 40:"info", 60:"trace", 80:"debug",
                          100:"max", 0 - 100
            MCA btl base: parameter "btl_base_include" (current value: "",
                          data source: default, level: 9 dev/all, type:
                          string)
            MCA btl base: parameter "btl_base_exclude" (current value: "",
                          data source: default, level: 9 dev/all, type:
                          string)
            MCA btl base: parameter "btl_base_warn_component_unused" (current
                          value: "1", data source: default, level: 9 dev/all,
                          type: int)
                          This parameter is used to turn on warning messages
                          when certain NICs are not used
             MCA btl tcp: ---------------------------------------------------

Note that despite the tcp btl not having any registered parameters, it still does show up in the listing. I've no idea if this even comes close to what @hppritcha had in mind :smile: We could drop the "------------------" from the output, for example.