### PR TITLE
opal_info_support: output component versions

### DIFF
--- a/ompi/tools/ompi_info/ompi_info.c
+++ b/ompi/tools/ompi_info/ompi_info.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
         if (OMPI_ERR_BAD_PARAM == ret) {
             /* output what we got */
             opal_info_do_params(true, opal_cmd_line_is_taken(ompi_info_cmd_line, "internal"),
-                                &mca_types, NULL);
+                                &mca_types, &component_map, NULL);
         }
         exit(1);
     }
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     if (want_all || opal_cmd_line_is_taken(ompi_info_cmd_line, "param") ||
         opal_cmd_line_is_taken(ompi_info_cmd_line, "params")) {
         opal_info_do_params(want_all, opal_cmd_line_is_taken(ompi_info_cmd_line, "internal"),
-                            &mca_types, ompi_info_cmd_line);
+                            &mca_types, &component_map, ompi_info_cmd_line);
         acted = true;
     }
     if (opal_cmd_line_is_taken(ompi_info_cmd_line, "type")) {

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -429,6 +429,7 @@ void opal_info_do_path(bool want_all, opal_cmd_line_t *cmd_line)
 
 void opal_info_do_params(bool want_all_in, bool want_internal,
                          opal_pointer_array_t *mca_types,
+                         opal_pointer_array_t *component_map,
                          opal_cmd_line_t *opal_info_cmd_line)
 {
     mca_base_var_info_lvl_t max_level = OPAL_INFO_LVL_1;

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -483,6 +483,9 @@ void opal_info_do_params(bool want_all_in, bool want_internal,
     /* Show the params */
 
     if (want_all) {
+        opal_info_show_component_version(mca_types, component_map, opal_info_type_all,
+                                         opal_info_component_all, opal_info_ver_full,
+                                         opal_info_ver_all);
         for (i = 0; i < mca_types->size; ++i) {
             if (NULL == (type = (char *)opal_pointer_array_get_item(mca_types, i))) {
                 continue;
@@ -511,6 +514,9 @@ void opal_info_do_params(bool want_all_in, bool want_internal,
                 exit(1);
             }
 
+            opal_info_show_component_version(mca_types, component_map, type,
+                                             component, opal_info_ver_full,
+                                             opal_info_ver_all);
             opal_info_show_mca_params(type, component, max_level, want_internal);
         }
     }

--- a/opal/runtime/opal_info_support.h
+++ b/opal/runtime/opal_info_support.h
@@ -68,6 +68,7 @@ OPAL_DECLSPEC void opal_info_err_params(opal_pointer_array_t *component_map);
 
 OPAL_DECLSPEC void opal_info_do_params(bool want_all_in, bool want_internal,
                                        opal_pointer_array_t *mca_type,
+                                       opal_pointer_array_t *component_map,
                                        opal_cmd_line_t *opal_info_cmd_line);
 
 OPAL_DECLSPEC void opal_info_show_path(const char *type, const char *value);

--- a/oshmem/tools/oshmem_info/oshmem_info.c
+++ b/oshmem/tools/oshmem_info/oshmem_info.c
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
         if (OSHMEM_ERR_BAD_PARAM == ret) {
             /* output what we got */
             opal_info_do_params(true, opal_cmd_line_is_taken(info_cmd_line, "internal"),
-                                &mca_types, NULL);
+                                &mca_types, &component_map, NULL);
         }
         exit(1);
     }
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
     if (want_all || opal_cmd_line_is_taken(info_cmd_line, "param") ||
         opal_cmd_line_is_taken(info_cmd_line, "params")) {
         opal_info_do_params(want_all, opal_cmd_line_is_taken(info_cmd_line, "internal"),
-                            &mca_types, info_cmd_line);
+                            &mca_types, &component_map, info_cmd_line);
         acted = true;
     }
 


### PR DESCRIPTION
Hopefully a better approach than https://github.com/open-mpi/ompi/pull/1514. Aims at fixing https://github.com/open-mpi/ompi/issues/1396.

Tests:

    % ompi_info --param btl all
                 MCA btl: vader (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: sm (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: self (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: tcp (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: parameter "btl_tcp_if_include" (current value: "",
                          data source: default, level: 1 user/basic, type:
                          string)
                          Comma-delimited list of devices and/or CIDR
                          notation of networks to use for MPI communication
                          (e.g., "eth0,192.168.0.0/16").  Mutually exclusive
                          with btl_tcp_if_exclude.
                 MCA btl: parameter "btl_tcp_if_exclude" (current value:
                          "127.0.0.1/8,sppp", data source: default, level: 1
                          user/basic, type: string)
                          Comma-delimited list of devices and/or CIDR
                          notation of networks to NOT use for MPI
                          communication -- all devices not matching these
                          specifications will be used (e.g.,
                          "eth0,192.168.0.0/16").  If set to a non-default
                          value, it is mutually exclusive with
                          btl_tcp_if_include.
                 MCA btl: parameter "btl_tcp_progress_thread" (current value:
                          "0", data source: default, level: 1 user/basic,
                          type: int)


    % ompi_info --param btl tcp
                 MCA btl: tcp (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: parameter "btl_tcp_if_include" (current value: "",
                          data source: default, level: 1 user/basic, type:
                          string)
                          Comma-delimited list of devices and/or CIDR
                          notation of networks to use for MPI communication
                          (e.g., "eth0,192.168.0.0/16").  Mutually exclusive
                          with btl_tcp_if_exclude.
                 MCA btl: parameter "btl_tcp_if_exclude" (current value:
                          "127.0.0.1/8,sppp", data source: default, level: 1
                          user/basic, type: string)
                          Comma-delimited list of devices and/or CIDR
                          notation of networks to NOT use for MPI
                          communication -- all devices not matching these
                          specifications will be used (e.g.,
                          "eth0,192.168.0.0/16").  If set to a non-default
                          value, it is mutually exclusive with
                          btl_tcp_if_include.
                 MCA btl: parameter "btl_tcp_progress_thread" (current value:
                          "0", data source: default, level: 1 user/basic,
                          type: int)


    % ompi_info -a
    [...]
     MPI_MAX_DATAREP_STRING: 128
           MCA allocator: basic (MCA v2.1.0, API v2.0.0, Component v3.0.0)
           MCA allocator: bucket (MCA v2.1.0, API v2.0.0, Component v3.0.0)
           MCA backtrace: execinfo (MCA v2.1.0, API v2.0.0, Component v3.0.0)
                 MCA btl: vader (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: sm (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: self (MCA v2.1.0, API v3.0.0, Component v3.0.0)
                 MCA btl: tcp (MCA v2.1.0, API v3.0.0, Component v3.0.0)
            MCA compress: bzip (MCA v2.1.0, API v2.0.0, Component v3.0.0)
    [...]
            MCA sharedfp: sm (MCA v2.1.0, API v2.0.0, Component v3.0.0)
            MCA sharedfp: lockedfile (MCA v2.1.0, API v2.0.0, Component v3.0.0)
            MCA sharedfp: individual (MCA v2.1.0, API v2.0.0, Component v3.0.0)
                MCA topo: treematch (MCA v2.1.0, API v2.2.0, Component v3.0.0)
                MCA topo: basic (MCA v2.1.0, API v2.2.0, Component v3.0.0)
           MCA vprotocol: pessimist (MCA v2.1.0, API v2.0.0, Component v3.0.0)
                 MCA mca: parameter "mca_param_files" (current value: "/home/kilo/.openmpi/mca-params.conf:/home/kilo/local/etc/openmpi-mca-params.conf", data source: default, level: 2 user/detail, type: string, deprecated, synonym of: mca_base_param_files)
                          Path for MCA configuration files containing variable values
    [...]

@jsquyres / @hjelmn - What are your thoughts, gents?