### PR TITLE
opal_info_support: add component to param pretty output

### DIFF
--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -639,12 +639,20 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
         }
     }
 
+    const mca_base_var_group_t *curr_group = NULL;
+    char *component_msg = NULL;
     for (i = 0 ; i < count ; ++i) {
         ret = mca_base_var_get(variables[i], &var);
         if (OPAL_SUCCESS != ret || ((var->mbv_flags & MCA_BASE_VAR_FLAG_INTERNAL) &&
                                     !want_internal) ||
             max_level < var->mbv_info_lvl) {
             continue;
+        }
+
+        if (opal_info_pretty && curr_group != group) {
+            free(component_msg);
+            asprintf(&component_msg, " %s", group_component);
+            curr_group = group;
         }
 
         ret = mca_base_var_dump(variables[i], &strings, !opal_info_pretty ? MCA_BASE_VAR_DUMP_PARSABLE : MCA_BASE_VAR_DUMP_READABLE);
@@ -654,7 +662,9 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
 
         for (j = 0 ; strings[j] ; ++j) {
             if (0 == j && opal_info_pretty) {
-                asprintf (&message, "MCA%s %s", requested ? "" : " (disabled)", group->group_framework);
+                asprintf (&message, "MCA%s %s%s", requested ? "" : " (disabled)",
+                          group->group_framework,
+                          component_msg ? component_msg : "");
                 opal_info_out(message, message, strings[j]);
                 free(message);
             } else {

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -652,6 +652,11 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
         if (opal_info_pretty && curr_group != group) {
             free(component_msg);
             asprintf(&component_msg, " %s", group_component);
+            asprintf(&message, "MCA%s %s%s", requested ? "" : " (disabled)",
+                     group->group_framework,
+                     component_msg ? component_msg : "");
+            opal_info_out(message, message, "---------------------------------------------------");
+            free(message);
             curr_group = group;
         }
 


### PR DESCRIPTION
As a small supplement to https://github.com/open-mpi/ompi/pull/1515 I thought it would be nice to:

1. add component names to the parameter output
2. separate parameter sections with a dashed line according to component (  @rhc54 also liked the visual separation this offers.)

The result is something like:

    % ompi_info --params btl all --level 3
            [...]
            MCA btl base: ---------------------------------------------------
            MCA btl base: parameter "btl" (current value: "", data source:
                          default, level: 2 user/detail, type: string)
                          Default selection set of components for the btl
                          framework (<none> means use all components that can
                          be found)
           MCA btl vader: ---------------------------------------------------
           MCA btl vader: parameter "btl_vader_single_copy_mechanism"
                          (current value: "cma", data source: default, level:
                          3 user/all, type: int)
                          Single copy mechanism to use (defaults to best
                          available)
                          Valid values: 1:"cma", 3:"none"
             MCA btl tcp: ---------------------------------------------------
             MCA btl tcp: parameter "btl_tcp_if_include" (current value: "",
                          data source: default, level: 1 user/basic, type:
                          string)
                          Comma-delimited list of devices and/or CIDR
                          notation of networks to use for MPI communication
                          (e.g., "eth0,192.168.0.0/16").  Mutually exclusive
                          with btl_tcp_if_exclude.
             MCA btl tcp: parameter "btl_tcp_if_exclude" (current value:
                          "127.0.0.1/8,sppp", data source: default, level: 1
                          user/basic, type: string)
                          Comma-delimited list of devices and/or CIDR
                          notation of networks to NOT use for MPI
                          communication -- all devices not matching these
                          specifications will be used (e.g.,
                          "eth0,192.168.0.0/16").  If set to a non-default
                          value, it is mutually exclusive with
                          btl_tcp_if_include.
              [...]