### PR TITLE
opal_info_support: fix memory leak and refactor for pvars

### DIFF
--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -648,6 +648,8 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
 
     const mca_base_var_group_t *curr_group = NULL;
     char *component_msg = NULL;
+    asprintf(&component_msg, " %s", group_component);
+
     for (i = 0 ; i < count ; ++i) {
         ret = mca_base_var_get(variables[i], &var);
         if (OPAL_SUCCESS != ret || ((var->mbv_flags & MCA_BASE_VAR_FLAG_INTERNAL) &&
@@ -657,8 +659,6 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
         }
 
         if (opal_info_pretty && curr_group != group) {
-            free(component_msg);
-            asprintf(&component_msg, " %s", group_component);
             asprintf(&message, "MCA%s %s%s", requested ? "" : " (disabled)",
                      group->group_framework,
                      component_msg ? component_msg : "");
@@ -704,6 +704,15 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
             continue;
         }
 
+        if (opal_info_pretty && curr_group != group) {
+            asprintf(&message, "MCA%s %s%s", requested ? "" : " (disabled)",
+                     group->group_framework,
+                     component_msg ? component_msg : "");
+            opal_info_out(message, message, "---------------------------------------------------");
+            free(message);
+            curr_group = group;
+        }
+
         ret = mca_base_pvar_dump (variables[i], &strings, !opal_info_pretty ? MCA_BASE_VAR_DUMP_PARSABLE : MCA_BASE_VAR_DUMP_READABLE);
         if (OPAL_SUCCESS != ret) {
             continue;
@@ -711,7 +720,9 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
 
         for (j = 0 ; strings[j] ; ++j) {
             if (0 == j && opal_info_pretty) {
-                asprintf (&message, "MCA%s %s", requested ? "" : " (disabled)", group->group_framework);
+                asprintf (&message, "MCA%s %s%s", requested ? "" : " (disabled)",
+                          group->group_framework,
+                          component_msg ? component_msg : "");
                 opal_info_out(message, message, strings[j]);
                 free(message);
             } else {

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -740,6 +740,7 @@ static void opal_info_show_mca_group_params(const mca_base_var_group_t *group, m
         }
         opal_info_show_mca_group_params(group, max_level, want_internal);
     }
+    free(component_msg);
 }
 
 void opal_info_show_mca_params(const char *type, const char *component,


### PR DESCRIPTION
https://github.com/open-mpi/ompi/commit/43254391a8088abd1ee5d009e5b41fa14b751cf7 Fixes a memory leak I introduced with the addition of "component_msg".
https://github.com/open-mpi/ompi/commit/13979f559fac4f85aa080df50d497c24f3a833fd Adds the same kind of component output and separation to group_pvars as we have for group_vars.

A gist of the full output: https://gist.github.com/kmroz/45a01e1dd3d7b8c0fc2e9c62e5edd6ce