### PR TITLE
type_hindexed: fix compiler warnings

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1794,8 +1794,8 @@ OMPI_DECLSPEC  int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *tru
                                             MPI_Aint *true_extent);
 OMPI_DECLSPEC  int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb,
                                               MPI_Count *true_extent);
-OMPI_DECLSPEC  int MPI_Type_hindexed(int count, int array_of_blocklengths[],
-                                     MPI_Aint array_of_displacements[],
+OMPI_DECLSPEC  int MPI_Type_hindexed(int count, const int array_of_blocklengths[],
+                                     const MPI_Aint array_of_displacements[],
                                      MPI_Datatype oldtype, MPI_Datatype *newtype)
                                      __mpi_interface_deprecated__("MPI_Type_hindexed is superseded by MPI_Type_create_hindexed in MPI-2.0");
 OMPI_DECLSPEC  int MPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
@@ -2495,8 +2495,8 @@ OMPI_DECLSPEC  int PMPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *tr
                                              MPI_Aint *true_extent);
 OMPI_DECLSPEC  int PMPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb,
                                                MPI_Count *true_extent);
-OMPI_DECLSPEC  int PMPI_Type_hindexed(int count, int array_of_blocklengths[],
-                                      MPI_Aint array_of_displacements[],
+OMPI_DECLSPEC  int PMPI_Type_hindexed(int count, const int array_of_blocklengths[],
+                                      const MPI_Aint array_of_displacements[],
                                       MPI_Datatype oldtype, MPI_Datatype *newtype)
                                       __mpi_interface_deprecated__("MPI_Type_hindexed is superseded by MPI_Type_create_hindexed in MPI-2.0");
 OMPI_DECLSPEC  int PMPI_Type_hvector(int count, int blocklength, MPI_Aint stride,

--- a/ompi/mpi/c/type_hindexed.c
+++ b/ompi/mpi/c/type_hindexed.c
@@ -37,8 +37,8 @@ static const char FUNC_NAME[] = "MPI_Type_hindexed";
 
 
 int MPI_Type_hindexed(int count,
-                      int array_of_blocklengths[],
-                      MPI_Aint array_of_displacements[],
+                      const int array_of_blocklengths[],
+                      const MPI_Aint array_of_displacements[],
                       MPI_Datatype oldtype,
                       MPI_Datatype *newtype)
 {


### PR DESCRIPTION
Specifically:
    adio/common/utils.c: In function ‘ADIOI_Type_create_hindexed_x’:
    adio/common/utils.c:97:3: warning: passing argument 3 of
    ‘PMPI_Type_hindexed’ discards ‘const’ qualifier from pointer target
    type  [-Wdiscarded-qualifiers]

Signed-off-by: Karol Mroz <mroz.karol@gmail.com>