### PR TITLE
OSX tempdir too long for sun_path

### DIFF
--- a/opal/mca/pmix/pmix120/pmix/src/server/pmix_server_listener.c
+++ b/opal/mca/pmix/pmix120/pmix/src/server/pmix_server_listener.c
@@ -72,19 +72,20 @@ pmix_status_t pmix_start_listening(struct sockaddr_un *address)
 {
     int flags;
     pmix_status_t rc;
-    unsigned int addrlen;
+    socklen_t addrlen;
     char *ptr;
 
     /* create a listen socket for incoming connection attempts */
     pmix_server_globals.listen_socket = socket(PF_UNIX, SOCK_STREAM, 0);
     if (pmix_server_globals.listen_socket < 0) {
-        printf("%s:%d socket() failed", __FILE__, __LINE__);
+        printf("%s:%d socket() failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
 
     addrlen = sizeof(struct sockaddr_un);
     if (bind(pmix_server_globals.listen_socket, (struct sockaddr*)address, addrlen) < 0) {
-        printf("%s:%d bind() failed", __FILE__, __LINE__);
+        printf("%s:%d bind() failed error:%s\n", __FILE__, __LINE__,
+                strerror(errno));
         return PMIX_ERROR;
     }
     /* set the mode as required */
@@ -95,18 +96,18 @@ pmix_status_t pmix_start_listening(struct sockaddr_un *address)
 
     /* setup listen backlog to maximum allowed by kernel */
     if (listen(pmix_server_globals.listen_socket, SOMAXCONN) < 0) {
-        printf("%s:%d listen() failed", __FILE__, __LINE__);
+        printf("%s:%d listen() failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
 
     /* set socket up to be non-blocking, otherwise accept could block */
     if ((flags = fcntl(pmix_server_globals.listen_socket, F_GETFL, 0)) < 0) {
-        printf("%s:%d fcntl(F_GETFL) failed", __FILE__, __LINE__);
+        printf("%s:%d fcntl(F_GETFL) failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
     flags |= O_NONBLOCK;
     if (fcntl(pmix_server_globals.listen_socket, F_SETFL, flags) < 0) {
-        printf("%s:%d fcntl(F_SETFL) failed", __FILE__, __LINE__);
+        printf("%s:%d fcntl(F_SETFL) failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
 

--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -515,7 +515,7 @@ int orte_ess_base_orted_setup(char **hosts)
     /* setup the PMIx server */
     if (ORTE_SUCCESS != (ret = pmix_server_init())) {
         ORTE_ERROR_LOG(ret);
-        error = "pmix server init";
+        error = "Try a shorter TMPDIR var. or change your computer's name (see uname -n), since pmix_server_init";
         goto error;
     }
 

--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -634,7 +634,7 @@ static int rte_init(void)
     /* setup the PMIx server */
     if (ORTE_SUCCESS != (ret = pmix_server_init())) {
         ORTE_ERROR_LOG(ret);
-        error = "pmix server init";
+        error = "Try a shorter TMPDIR var. or change your computer's name (see uname -n), since pmix_server_init";
         goto error;
     }
 

--- a/orte/orted/help-orted.txt
+++ b/orte/orted/help-orted.txt
@@ -43,6 +43,15 @@ a core that does not exist on this node:
 The MCA param directing this behavior is orte_daemon_cores.
 Please correct the request and try again.
 #
+[orterun:pmix-failed]
+The call to pmix_init_server() failed. This may be due to your
+system's restriction for Unix's socket's path-length.
+
+   orte_proc_session_dir: %s
+
+Please try to set TMPDIR to something short (like /tmp) or change
+Your computer's name (see uname -n).
+#
 [cwd]
 A dynamic operation (%s) was requested that requires us to obtain
 the current working directory. Unfortunately, an error was returned

--- a/orte/orted/help-orted.txt
+++ b/orte/orted/help-orted.txt
@@ -43,15 +43,6 @@ a core that does not exist on this node:
 The MCA param directing this behavior is orte_daemon_cores.
 Please correct the request and try again.
 #
-[orterun:pmix-failed]
-The call to pmix_init_server() failed. This may be due to your
-system's restriction for Unix's socket's path-length.
-
-   orte_proc_session_dir: %s
-
-Please try to set TMPDIR to something short (like /tmp) or change
-Your computer's name (see uname -n).
-#
 [cwd]
 A dynamic operation (%s) was requested that requires us to obtain
 the current working directory. Unfortunately, an error was returned

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -246,6 +246,9 @@ int pmix_server_init(void)
     if (ORTE_SUCCESS != (rc = opal_pmix.server_init(&pmix_server, &info))) {
         ORTE_ERROR_LOG(rc);
         /* memory cleanup will occur when finalize is called */
+        orte_show_help("help-orterun.txt", "orterun:pmix-failed", true,
+                       orte_process_info.proc_session_dir);
+        return rc;
     }
     OPAL_LIST_DESTRUCT(&info);
 

--- a/orte/tools/orterun/help-orterun.txt
+++ b/orte/tools/orterun/help-orterun.txt
@@ -660,3 +660,12 @@ method and try launching your job again.
 
 Your job will now abort.
 #
+[orterun:pmix-failed]
+The call to pmix_init_server() failed. This may be due to your
+system's restriction for Unix's socket's path-length.
+
+   orte_proc_session_dir: %s
+
+Please try to set TMPDIR to something short (like /tmp) or change
+Your computer's name (see uname -n).
+#


### PR DESCRIPTION
Per the discussion in the pull request in [pmix/master#71](https://github.com/pmix/master/pull/71) on Mac OSX, the temporary directory can get too long for the socket's sun_path (which is on LINUX 108 chars, on Mac OSX 103 chars), making Open MPI fail with cryptic: "bind() failed"...

Ralph suggested moving the pull request to OMPI.

So, now fail gracefully and have OMPI nicely complain to the user:

    USER@SUPER-MacBook-Pro:~/C/MPI_TESTS> ./mpi_wtick
    [SUPER-MacBook-Pro.local:28645] [[46320,0],0] bind() failed on error Address already in use (48)
    --------------------------------------------------------------------------
    The call to pmix_init_server() failed. This may be due to your
    system's restriction for Unix's socket's path-length.
    
    orte_proc_session_dir: /var/folders/30/c1t3_6m546n62qrckq5fs_wc0000gp/T/openmpi-sessions-502@USER-SUPER-MacBook-Pro_0/46320/0/0
    
    Please try to set TMPDIR to something short (like /tmp) or change
    Your computer's name (see uname -n).