### PR TITLE
Ensure that we cleanup the pmix peer info, including closing the sock…

### DIFF
--- a/orte/mca/state/base/state_base_fns.c
+++ b/orte/mca/state/base/state_base_fns.c
@@ -523,6 +523,8 @@ void orte_state_base_track_procs(int fd, short argc, void *cbdata)
         ORTE_FLAG_UNSET(pdata, ORTE_PROC_FLAG_ALIVE);
         pdata->state = state;
         if (ORTE_FLAG_TEST(pdata, ORTE_PROC_FLAG_LOCAL)) {
+            /* tell the PMIx subsystem to cleanup this client */
+            opal_pmix.server_deregister_client(proc);
             /* Clean up the session directory as if we were the process
              * itself.  This covers the case where the process died abnormally
              * and didn't cleanup its own session directory.

--- a/orte/test/mpi/loop_spawn.c
+++ b/orte/test/mpi/loop_spawn.c
@@ -12,17 +12,23 @@
 
 int main(int argc, char **argv)
 {
-    int iter, err, rank, size;
+    int iter, itermax, err, rank, size;
     MPI_Comm comm, merged;
 
-    /* MPI environnement */
+    /* MPI environment */
+
+    if (2 == argc) {
+        itermax = atoi(argv[1]);
+    } else {
+        itermax = 100;
+    }
 
     printf("parent*******************************\n");
     printf("parent: Launching MPI*\n");
 
     MPI_Init( &argc, &argv);
 
-    for (iter = 0; iter < 100; ++iter) {
+    for (iter = 0; iter < itermax; ++iter) {
         MPI_Comm_spawn(EXE_TEST, NULL, 1, MPI_INFO_NULL,
                        0, MPI_COMM_WORLD, &comm, &err);
         printf("parent: MPI_Comm_spawn #%d return : %d\n", iter, err);


### PR DESCRIPTION
…et, as local child procs complete and as the job completes

Fixes https://github.com/open-mpi/ompi/issues/1526

