### PR TITLE
bml: always enable the bml

### DIFF
--- a/ompi/mca/bml/base/bml_base_init.c
+++ b/ompi/mca/bml/base/bml_base_init.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,18 +52,18 @@ mca_bml_base_inited(void)
 
 int mca_bml_base_init( bool enable_progress_threads,
                        bool enable_mpi_threads) {
-    opal_list_item_t *item = NULL;
     mca_bml_base_component_t *component = NULL, *best_component = NULL;
     mca_bml_base_module_t *module = NULL, *best_module = NULL;
     int priority = 0, best_priority = -1;
     mca_base_component_list_item_t *cli = NULL;
 
+    if (init_called) {
+        return OPAL_SUCCESS;
+    }
+
     init_called = true;
 
-    for (item = opal_list_get_first(&ompi_bml_base_framework.framework_components);
-         opal_list_get_end(&ompi_bml_base_framework.framework_components) != item;
-         item = opal_list_get_next(item)) {
-        cli = (mca_base_component_list_item_t*) item;
+    OPAL_LIST_FOREACH(cli, &ompi_bml_base_framework.framework_components, mca_base_component_list_item_t) {
         component = (mca_bml_base_component_t*) cli->cli_component;
         if(NULL == component->bml_init) {
             opal_output_verbose( 10, ompi_bml_base_framework.framework_output,

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -58,6 +58,7 @@
 #include "opal/mca/rcache/base/base.h"
 #include "opal/mca/rcache/rcache.h"
 #include "opal/mca/mpool/base/base.h"
+#include "opal/mca/btl/base/base.h"
 #include "opal/mca/pmix/pmix.h"
 #include "opal/util/timings.h"
 
@@ -597,6 +598,10 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
     }
     if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_bml_base_framework, 0))) {
         error = "mca_bml_base_open() failed";
+        goto error;
+    }
+    if (OMPI_SUCCESS != (ret = mca_bml_base_init (1, ompi_mpi_thread_multiple))) {
+        error = "mca_bml_base_init() failed";
         goto error;
     }
     if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_pml_base_framework, 0))) {


### PR DESCRIPTION
This commit ensures the bml is always enabled whether or not it will
be used. This ensures that any available btls communicate their modex
so that they can be used for one-sided communication.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>