### PR TITLE
romio,java: cleanup deprecated hindexed call

### DIFF
--- a/ompi/mca/io/romio314/romio/adio/common/ad_coll_build_req_new.c
+++ b/ompi/mca/io/romio314/romio/adio/common/ad_coll_build_req_new.c
@@ -844,7 +844,7 @@ int ADIOI_Build_agg_reqs(ADIO_File fd, int rw_type, int nprocs,
     {
 	if (client_comm_sz_arr[i] > 0)
 	{
-	    MPI_Type_hindexed(client_ol_ct_arr[i], client_blk_arr[i],
+	    MPI_Type_create_hindexed(client_ol_ct_arr[i], client_blk_arr[i],
 			      client_disp_arr[i], MPI_BYTE,
 			      &(client_comm_dtype_arr[i]));
 	    MPI_Type_commit(&(client_comm_dtype_arr[i]));
@@ -863,7 +863,7 @@ int ADIOI_Build_agg_reqs(ADIO_File fd, int rw_type, int nprocs,
 	if (agg_ol_ct == 1)
 	    MPI_Type_contiguous (agg_blk_arr[0], MPI_BYTE, agg_dtype_p);
 	else if (agg_ol_ct > 1)
-	    MPI_Type_hindexed(agg_ol_ct, agg_blk_arr, agg_disp_arr, MPI_BYTE,
+	    MPI_Type_create_hindexed(agg_ol_ct, agg_blk_arr, agg_disp_arr, MPI_BYTE,
 			      agg_dtype_p);
 
 	MPI_Type_commit(agg_dtype_p);
@@ -1203,7 +1203,7 @@ int ADIOI_Build_client_reqs(ADIO_File fd,
     {
 	if (agg_comm_sz_arr[i] > 0)
 	{
-	    MPI_Type_hindexed(agg_ol_ct_arr[i], agg_blk_arr[i],
+	    MPI_Type_create_hindexed(agg_ol_ct_arr[i], agg_blk_arr[i],
                               agg_disp_arr[i], MPI_BYTE,
                               &(agg_comm_dtype_arr[i]));
             MPI_Type_commit(&(agg_comm_dtype_arr[i]));
@@ -2063,7 +2063,7 @@ int ADIOI_Build_client_req(ADIO_File fd,
     /* Create the aggregator MPI_Datatype */
     if (agg_comm_sz > 0)
     {
-	MPI_Type_hindexed(agg_ol_ct, agg_blk_arr, agg_disp_arr, MPI_BYTE,
+	MPI_Type_create_hindexed(agg_ol_ct, agg_blk_arr, agg_disp_arr, MPI_BYTE,
 			  agg_comm_dtype_p);
 	MPI_Type_commit(agg_comm_dtype_p);
     }

--- a/ompi/mca/io/romio314/romio/adio/common/utils.c
+++ b/ompi/mca/io/romio314/romio/adio/common/utils.c
@@ -93,7 +93,7 @@ int ADIOI_Type_create_hindexed_x(int count,
 	ret = MPI_Type_create_struct(count, blocklens, array_of_displacements,
 		types, newtype);
     } else {
-	ret = MPI_Type_hindexed(count, blocklens,
+	ret = MPI_Type_create_hindexed(count, blocklens,
 		array_of_displacements, oldtype, newtype);
     }
     for (i=0; i< count; i++)

--- a/ompi/mca/io/romio314/romio/test/types_with_zeros.c
+++ b/ompi/mca/io/romio314/romio/test/types_with_zeros.c
@@ -70,7 +70,7 @@ static int test_indexed_with_zeros(char *filename, int testcase)
 	    MPI_Type_indexed(num, blocklen, indices, MPI_INT, &filetype);
 	    break;
 	case HINDEXED:
-	    MPI_Type_hindexed(num, blocklen, addrs, MPI_INT, &filetype);
+	    MPI_Type_create_hindexed(num, blocklen, addrs, MPI_INT, &filetype);
 	    break;
 	case STRUCT:
 	    MPI_Type_create_struct(num, blocklen, addrs, types, &filetype);

--- a/ompi/mpi/java/c/mpi_Datatype.c
+++ b/ompi/mpi/java/c/mpi_Datatype.c
@@ -226,7 +226,7 @@ JNIEXPORT jlong JNICALL Java_mpi_Datatype_getHIndexed(
     for(i = 0; i < count; i++)
         cDisps[i] = jDisps[i];
 
-    int rc = MPI_Type_hindexed(count, cBlockLengths, cDisps,
+    int rc = MPI_Type_create_hindexed(count, cBlockLengths, cDisps,
                                (MPI_Datatype)oldType, &type);
 
     ompi_java_exceptionCheck(env, rc);


### PR DESCRIPTION
Following up on https://github.com/open-mpi/ompi/pull/1523.

I've left headers, makefiles and sources related to MPI_Type_hindexed() in place. Since I saw various other APIs marked as deprecated, I have no idea what you guys typically do in such cases?