### PR TITLE
ompi/opal/orte/oshmem/test: max hostname length cleanup

### DIFF
--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -95,7 +95,7 @@ opal_pointer_array_t ompi_info_f_to_c_table = {{0}};
  */
 int ompi_info_init(void)
 {
-    char val[MPI_MAX_INFO_VAL];
+    char val[OPAL_MAXHOSTNAMELEN];
     char *cptr;
 
     /* initialize table */
@@ -134,7 +134,7 @@ int ompi_info_init(void)
     }
 
     /* local host name */
-    gethostname(val, MPI_MAX_INFO_VAL);
+    gethostname(val, sizeof(val));
     ompi_info_set(&ompi_mpi_info_env.info, "host", val);
 
     /* architecture name */

--- a/ompi/mca/pml/v/pml_v_output.c
+++ b/ompi/mca/pml/v/pml_v_output.c
@@ -21,7 +21,7 @@
 
 int pml_v_output_open(char *output, int verbosity) {
     opal_output_stream_t lds;
-    char hostname[32] = "NA";
+    char hostname[OPAL_MAXHOSTNAMELEN] = "NA";
 
     OBJ_CONSTRUCT(&lds, opal_output_stream_t);
     if(!output) {
@@ -40,7 +40,7 @@ int pml_v_output_open(char *output, int verbosity) {
             lds.lds_file_suffix = output;
         }
         lds.lds_is_debugging = true;
-        gethostname(hostname, 32);
+        gethostname(hostname, sizeof(hostname));
         asprintf(&lds.lds_prefix, "[%s:%05d] pml_v: ", hostname, getpid());
         lds.lds_verbose_level = verbosity;
         mca_pml_v.output = opal_output_open(&lds);

--- a/ompi/mpi/c/get_processor_name.c
+++ b/ompi/mpi/c/get_processor_name.c
@@ -66,7 +66,7 @@ int MPI_Get_processor_name(char *name, int *resultlen)
        Guard against gethostname() returning a *really long* hostname
        and not null-terminating the string.  The Fortran API version
        will pad to the right if necessary. */
-    gethostname(name, MPI_MAX_PROCESSOR_NAME - 1);
+    gethostname(name, (MPI_MAX_PROCESSOR_NAME - 1));
     name[MPI_MAX_PROCESSOR_NAME - 1] = '\0';
     *resultlen = (int) strlen(name);
 

--- a/ompi/runtime/ompi_mpi_abort.c
+++ b/ompi/runtime/ompi_mpi_abort.c
@@ -119,7 +119,7 @@ int
 ompi_mpi_abort(struct ompi_communicator_t* comm,
                int errcode)
 {
-    char *msg, *host, hostname[MAXHOSTNAMELEN];
+    char *msg, *host, hostname[OPAL_MAXHOSTNAMELEN];
     pid_t pid = 0;
 
     /* Protection for recursive invocation */

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -113,7 +113,7 @@ int ompi_mpi_finalize(void)
         /* Note that if we're not initialized or already finalized, we
            cannot raise an MPI exception.  The best that we can do is
            write something to stderr. */
-        char hostname[MAXHOSTNAMELEN];
+        char hostname[OPAL_MAXHOSTNAMELEN];
         pid_t pid = getpid();
         gethostname(hostname, sizeof(hostname));
 

--- a/ompi/tools/mpisync/sync.c
+++ b/ompi/tools/mpisync/sync.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
     MPI_Comm comm = MPI_COMM_WORLD;
     int rank, commsize;
     double offs = 0, rtt = 0;
-    char hname[1024];
+    char hname[OPAL_MAXHOSTNAMELEN];
 
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &commsize);
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    if( gethostname(hname, 1024) ){
+    if( gethostname(hname, sizeof(hname)) ){
         perror("Cannot get hostname. Abort");
         MPI_Abort(MPI_COMM_WORLD, 1);
     }
@@ -129,13 +129,13 @@ int main(int argc, char **argv)
              fprintf(stderr, "Fail to allocate memory. Abort\n");
              MPI_Abort(MPI_COMM_WORLD, 1);
         }
-        char *hnames = malloc(1024*commsize);
+        char *hnames = malloc(OPAL_MAXHOSTNAMELEN * commsize);
         if( hnames == NULL ){
              fprintf(stderr, "Fail to allocate memory. Abort\n");
              MPI_Abort(MPI_COMM_WORLD, 1);
         }
 
-        MPI_Gather(hname,1024,MPI_CHAR,hnames,1024,MPI_CHAR, 0, MPI_COMM_WORLD);
+        MPI_Gather(hname,sizeof(hname),MPI_CHAR,hnames,sizeof(hname),MPI_CHAR, 0, MPI_COMM_WORLD);
         MPI_Gather(send,2,MPI_DOUBLE,measure,2, MPI_DOUBLE, 0, MPI_COMM_WORLD);
         char tmpname[128];
         FILE *fp = fopen(filename,"w");
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
              MPI_Abort(MPI_COMM_WORLD, 1);
         }
         double (*m)[2] = (void*)measure;
-        char (*h)[1024] = (void*)hnames;
+        char (*h)[OPAL_MAXHOSTNAMELEN] = (void*)hnames;
         int i;
         fprintf(fp, "# Used algorithm: %s\n", (alg ? "binary tree" : "linear"));
         for(i=0; i<commsize;i++){
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
         }
         fclose(fp);
     } else {
-        MPI_Gather(hname,1024, MPI_CHAR, NULL, 1024, MPI_CHAR, 0, MPI_COMM_WORLD);
+        MPI_Gather(hname, sizeof(hname), MPI_CHAR, NULL, sizeof(hname), MPI_CHAR, 0, MPI_COMM_WORLD);
         MPI_Gather(send,2, MPI_DOUBLE, NULL, 2, MPI_DOUBLE, 0, MPI_COMM_WORLD);
     }
 

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -285,6 +285,14 @@ typedef OPAL_PTRDIFF_TYPE ptrdiff_t;
 #define OPAL_PATH_SEP "/"
 #define OPAL_ENV_SEP  ':'
 
+#if defined(MAXHOSTNAMELEN)
+#define OPAL_MAXHOSTNAMELEN (MAXHOSTNAMELEN + 1)
+#elif defined(HOST_NAME_MAX)
+#define OPAL_MAXHOSTNAMELEN (HOST_NAME_MAX + 1)
+#else
+/* SUSv2 guarantees that "Host names are limited to 255 bytes". */
+#define OPAL_MAXHOSTNAMELEN (255 + 1)
+#endif
 
 /*
  * Do we want memory debugging?
@@ -489,12 +497,7 @@ static inline uint16_t ntohs(uint16_t netvar) { return netvar; }
 #ifdef HAVE_HOSTLIB_H
 /* gethostname() */
 #include <hostLib.h>
-
-#ifndef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN 64
 #endif
-#endif
-
 #endif
 
 /* If we're in C++, then just undefine restrict and then define it to

--- a/opal/mca/base/mca_base_component_find.c
+++ b/opal/mca/base/mca_base_component_find.c
@@ -330,7 +330,7 @@ static int component_find_check (mca_base_framework_t *framework, char **request
         }
 
         if (!found) {
-            char h[MAXHOSTNAMELEN];
+            char h[OPAL_MAXHOSTNAMELEN];
             gethostname(h, sizeof(h));
             opal_show_help("help-mca-base.txt",
                            "find-available:not-valid", true,

--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -66,7 +66,7 @@ int mca_base_open(void)
 {
     char *value;
     opal_output_stream_t lds;
-    char hostname[64];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     int var_id;
 
     if (mca_base_opened++) {
@@ -137,7 +137,7 @@ int mca_base_open(void)
     } else {
         set_defaults(&lds);
     }
-    gethostname(hostname, 64);
+    gethostname(hostname, sizeof(hostname));
     asprintf(&lds.lds_prefix, "[%s:%05d] ", hostname, getpid());
     opal_output_reopen(0, &lds);
     opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, 0, "mca: base: opening components");

--- a/opal/mca/event/libevent2022/libevent/evdns.c
+++ b/opal/mca/event/libevent2022/libevent/evdns.c
@@ -48,6 +48,8 @@
  * Version: 0.1b
  */
 
+#include "opal_config.h"
+
 #include <sys/types.h>
 #include "event2/event-config.h"
 
@@ -120,10 +122,6 @@
 #define EVDNS_LOG_DEBUG 0
 #define EVDNS_LOG_WARN 1
 #define EVDNS_LOG_MSG 2
-
-#ifndef HOST_NAME_MAX
-#define HOST_NAME_MAX 255
-#endif
 
 #include <stdio.h>
 
@@ -3108,7 +3106,7 @@ evdns_search_ndots_set(const int ndots) {
 
 static void
 search_set_from_hostname(struct evdns_base *base) {
-	char hostname[HOST_NAME_MAX + 1], *domainname;
+	char hostname[OPAL_MAXHOSTNAMELEN], *domainname;
 
 	ASSERT_LOCKED(base);
 	search_postfix_clear(base);

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -399,7 +399,7 @@ int opal_hwloc_base_report_bind_failure(const char *file,
 
     if (!already_reported &&
         OPAL_HWLOC_BASE_MBFA_SILENT != opal_hwloc_base_mbfa) {
-        char hostname[64];
+        char hostname[OPAL_MAXHOSTNAMELEN];
         gethostname(hostname, sizeof(hostname));
 
         opal_show_help("help-opal-hwloc-base.txt", "mbind failure", true,

--- a/opal/mca/pmix/pmix114/pmix/examples/dynamic.c
+++ b/opal/mca/pmix/pmix114/pmix/examples/dynamic.c
@@ -45,12 +45,12 @@ int main(int argc, char **argv)
     uint32_t nprocs;
     char nsp2[PMIX_MAX_NSLEN+1];
     pmix_app_t *app;
-    char hostname[1024], dir[1024];
+    char hostname[PMIX_MAXHOSTNAMELEN], dir[1024];
     pmix_proc_t *peers;
     size_t npeers, ntmp=0;
     char *nodelist;
 
-    gethostname(hostname, 1024);
+    gethostname(hostname, sizeof(hostname));
     getcwd(dir, 1024);
 
     /* init us */

--- a/opal/mca/pmix/pmix114/pmix/include/pmix/autogen/pmix_config_bottom.h
+++ b/opal/mca/pmix/pmix114/pmix/include/pmix/autogen/pmix_config_bottom.h
@@ -258,6 +258,15 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 #define PMIX_PATH_MAX	256
 #endif
 
+#if defined(MAXHOSTNAMELEN)
+#define PMIX_MAXHOSTNAMELEN (MAXHOSTNAMELEN + 1)
+#elif defined(HOST_NAME_MAX)
+#define PMIX_MAXHOSTNAMELEN (HOST_NAME_MAX + 1)
+#else
+/* SUSv2 guarantees that "Host names are limited to 255 bytes". */
+#define PMIX_MAXHOSTNAMELEN (255 + 1)
+#endif
+
 /*
  * Set the compile-time path-separator on this system and variable separator
  */
@@ -387,12 +396,7 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 #ifdef HAVE_HOSTLIB_H
 /* gethostname() */
 #include <hostLib.h>
-
-#ifndef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN 64
 #endif
-#endif
-
 #endif
 
 /* If we're in C++, then just undefine restrict and then define it to

--- a/opal/mca/pmix/pmix114/pmix/src/util/output.c
+++ b/opal/mca/pmix/pmix114/pmix/src/util/output.c
@@ -125,7 +125,7 @@ PMIX_CLASS_INSTANCE(pmix_output_stream_t, pmix_object_t, construct, NULL);
 bool pmix_output_init(void)
 {
     int i;
-    char hostname[32];
+    char hostname[PMIX_MAXHOSTNAMELEN];
     char *str;
 
     if (initialized) {
@@ -250,7 +250,7 @@ bool pmix_output_switch(int output_id, bool enable)
 void pmix_output_reopen_all(void)
 {
     char *str;
-    char hostname[32];
+    char hostname[PMIX_MAXHOSTNAMELEN];
 
     str = getenv("PMIX_OUTPUT_STDERR_FD");
     if (NULL != str) {

--- a/opal/mca/pmix/pmix114/pmix/test/simple/simpdyn.c
+++ b/opal/mca/pmix/pmix114/pmix/test/simple/simpdyn.c
@@ -49,12 +49,12 @@ int main(int argc, char **argv)
     uint32_t nprocs;
     char nsp2[PMIX_MAX_NSLEN+1];
     pmix_app_t *app;
-    char hostname[1024];
+    char hostname[PMIX_MAXHOSTNAMELEN];
     pmix_proc_t *peers;
     size_t npeers, ntmp=0;
     char *nodelist;
     
-    gethostname(hostname, 1024);
+    gethostname(hostname, sizeof(hostname));
     
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {

--- a/opal/mca/pmix/pmix114/pmix/test/simple/simptest.c
+++ b/opal/mca/pmix/pmix114/pmix/test/simple/simptest.c
@@ -316,9 +316,9 @@ static void set_namespace(int nprocs, char *ranks, char *nspace,
                           pmix_op_cbfunc_t cbfunc, myxfer_t *x)
 {
     char *regex, *ppn;
-    char hostname[1024];
+    char hostname[PMIX_MAXHOSTNAMELEN];
 
-    gethostname(hostname, 1024);
+    gethostname(hostname, sizeof(hostname));
     x->ninfo = 6;
 
     PMIX_INFO_CREATE(x->info, x->ninfo);

--- a/opal/mca/pstat/test/pstat_test.c
+++ b/opal/mca/pstat/test/pstat_test.c
@@ -65,7 +65,7 @@ static int query(pid_t pid,
                  opal_node_stats_t *nstats)
 {
     double dtime;
-    char hostname[128];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     if (NULL != stats) {
         /* record the time of this sample */
@@ -83,7 +83,7 @@ static int query(pid_t pid,
     }
 
     if (NULL != stats) {
-        gethostname(hostname, 128);
+        gethostname(hostname, sizeof(hostname));
         strncpy(stats->node, hostname, OPAL_PSTAT_MAX_STRING_LEN);
 
         stats->pid = pid;

--- a/opal/mca/shmem/mmap/shmem_mmap_module.c
+++ b/opal/mca/shmem/mmap/shmem_mmap_module.c
@@ -365,9 +365,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
      * a network filesystem, the user may see a shared memory performance hit.
      */
     if (opal_shmem_mmap_nfs_warning && opal_path_nfs(real_file_name, NULL)) {
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-mmap.txt", "mmap on nfs", 1, hn,
                        real_file_name);
     }
@@ -382,9 +381,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
         goto out;
     }
     if (!space_available) {
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         rc = OPAL_ERR_OUT_OF_RESOURCE;
         opal_show_help("help-opal-shmem-mmap.txt", "target full", 1,
                        real_file_name, hn, (unsigned long)real_size,
@@ -394,9 +392,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
     /* enough space is available, so create the segment */
     if (-1 == (ds_buf->seg_id = open(real_file_name, O_CREAT | O_RDWR, 0600))) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                        "open(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -405,9 +402,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
     /* size backing file - note the use of real_size here */
     if (0 != ftruncate(ds_buf->seg_id, real_size)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                        "ftruncate(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -418,9 +414,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
                                        PROT_READ | PROT_WRITE, MAP_SHARED,
                                        ds_buf->seg_id, 0))) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                        "mmap(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -466,9 +461,8 @@ out:
     if (-1 != ds_buf->seg_id) {
         if (0 != close(ds_buf->seg_id)) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                            "close(2)", "", strerror(err), err);
             rc = OPAL_ERROR;
@@ -500,9 +494,8 @@ segment_attach(opal_shmem_ds_t *ds_buf)
     if (my_pid != ds_buf->seg_cpid) {
         if (-1 == (ds_buf->seg_id = open(ds_buf->seg_name, O_RDWR))) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                            "open(2)", "", strerror(err), err);
             return NULL;
@@ -512,9 +505,8 @@ segment_attach(opal_shmem_ds_t *ds_buf)
                                    PROT_READ | PROT_WRITE, MAP_SHARED,
                                    ds_buf->seg_id, 0))) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                            "mmap(2)", "", strerror(err), err);
             /* mmap failed, so close the file and return NULL - no error check
@@ -529,9 +521,8 @@ segment_attach(opal_shmem_ds_t *ds_buf)
          */
         if (0 != close(ds_buf->seg_id)) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1,
                            hn, "close(2)", "", strerror(err), err);
         }
@@ -570,9 +561,8 @@ segment_detach(opal_shmem_ds_t *ds_buf)
 
     if (0 != munmap((void *)ds_buf->seg_base_addr, ds_buf->seg_size)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                        "munmap(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -599,9 +589,8 @@ segment_unlink(opal_shmem_ds_t *ds_buf)
 
     if (-1 == unlink(ds_buf->seg_name)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                        "unlink(2)", ds_buf->seg_name, strerror(err), err);
         return OPAL_ERROR;

--- a/opal/mca/shmem/posix/shmem_posix_common_utils.c
+++ b/opal/mca/shmem/posix/shmem_posix_common_utils.c
@@ -88,9 +88,8 @@ shmem_posix_shm_open(char *posix_file_name_buff, size_t size)
              * of here. we can't be selected :-(.
              */
             else {
-                char hn[MAXHOSTNAMELEN];
-                gethostname(hn, MAXHOSTNAMELEN - 1);
-                hn[MAXHOSTNAMELEN - 1] = '\0';
+                char hn[OPAL_MAXHOSTNAMELEN];
+                gethostname(hn, sizeof(hn));
                 opal_output_verbose(10, opal_shmem_base_framework.framework_output,
                      "shmem_posix_shm_open: disqualifying posix because "
                      "shm_open(2) failed with error: %s (errno %d)\n",

--- a/opal/mca/shmem/posix/shmem_posix_component.c
+++ b/opal/mca/shmem/posix/shmem_posix_component.c
@@ -178,9 +178,8 @@ posix_runtime_query(mca_base_module_t **module,
         /* free up allocated resources before we return */
         if (0 != shm_unlink(tmp_buff)) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1,
                            hn, "shm_unlink(2)", "", strerror(err), err);
             /* something strange happened, so consider this a run-time test

--- a/opal/mca/shmem/posix/shmem_posix_module.c
+++ b/opal/mca/shmem/posix/shmem_posix_module.c
@@ -203,9 +203,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
     /* size backing file - note the use of real_size here */
     else if (0 != ftruncate(ds_buf->seg_id, real_size)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1, hn,
                        "ftruncate(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -215,9 +214,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
                                                                    PROT_READ | PROT_WRITE, MAP_SHARED,
                                                                    ds_buf->seg_id, 0))) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1, hn,
                        "mmap(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -267,9 +265,8 @@ out:
     if (-1 != ds_buf->seg_id) {
         if (0 != close(ds_buf->seg_id)) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1, hn,
                            "close(2)", "", strerror(err), err);
             rc = OPAL_ERROR;
@@ -307,9 +304,8 @@ segment_attach(opal_shmem_ds_t *ds_buf)
     if (my_pid != ds_buf->seg_cpid) {
         if (-1 == (ds_buf->seg_id = shm_open(ds_buf->seg_name, O_RDWR, 0600))) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1, hn,
                            "open(2)", "", strerror(err), err);
             return NULL;
@@ -319,9 +315,8 @@ segment_attach(opal_shmem_ds_t *ds_buf)
                                                      PROT_READ | PROT_WRITE, MAP_SHARED,
                                                      ds_buf->seg_id, 0))) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1, hn,
                            "mmap(2)", "", strerror(err), err);
             /* mmap failed, so shm_unlink and return NULL - no error check here
@@ -337,9 +332,8 @@ segment_attach(opal_shmem_ds_t *ds_buf)
              */
             if (0 != close(ds_buf->seg_id)) {
                 int err = errno;
-                char hn[MAXHOSTNAMELEN];
-                gethostname(hn, MAXHOSTNAMELEN - 1);
-                hn[MAXHOSTNAMELEN - 1] = '\0';
+                char hn[OPAL_MAXHOSTNAMELEN];
+                gethostname(hn, sizeof(hn));
                 opal_show_help("help-opal-shmem-mmap.txt", "sys call fail", 1,
                                hn, "close(2)", "", strerror(err), err);
              }
@@ -379,9 +373,8 @@ segment_detach(opal_shmem_ds_t *ds_buf)
 
     if (0 != munmap((void*)ds_buf->seg_base_addr, ds_buf->seg_size)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1, hn,
                        "munmap(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -408,9 +401,8 @@ segment_unlink(opal_shmem_ds_t *ds_buf)
 
     if (-1 == shm_unlink(ds_buf->seg_name)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-posix.txt", "sys call fail", 1, hn,
                        "shm_unlink(2)", ds_buf->seg_name, strerror(err), err);
         return OPAL_ERROR;

--- a/opal/mca/shmem/sysv/shmem_sysv_module.c
+++ b/opal/mca/shmem/sysv/shmem_sysv_module.c
@@ -195,9 +195,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
     if (-1 == (ds_buf->seg_id = shmget(IPC_PRIVATE, real_size,
                                        IPC_CREAT | IPC_EXCL | S_IRWXU))) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-sysv.txt", "sys call fail", 1, hn,
                        "shmget(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -206,9 +205,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
     /* attach to the sement */
     else if ((void *)-1 == (seg_hdrp = shmat(ds_buf->seg_id, NULL, 0))) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-sysv.txt", "sys call fail", 1, hn,
                        "shmat(2)", "", strerror(err), err);
         shmctl(ds_buf->seg_id, IPC_RMID, NULL);
@@ -221,9 +219,8 @@ segment_create(opal_shmem_ds_t *ds_buf,
      */
     else if (0 != shmctl(ds_buf->seg_id, IPC_RMID, NULL)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-sysv.txt", "sys call fail", 1, hn,
                        "shmctl(2)", "", strerror(err), err);
         rc = OPAL_ERROR;
@@ -294,9 +291,8 @@ segment_attach(opal_shmem_ds_t *ds_buf)
         if ((void *)-1 == (ds_buf->seg_base_addr = shmat(ds_buf->seg_id, NULL,
                                                          0))) {
             int err = errno;
-            char hn[MAXHOSTNAMELEN];
-            gethostname(hn, MAXHOSTNAMELEN - 1);
-            hn[MAXHOSTNAMELEN - 1] = '\0';
+            char hn[OPAL_MAXHOSTNAMELEN];
+            gethostname(hn, sizeof(hn));
             opal_show_help("help-opal-shmem-sysv.txt", "sys call fail", 1, hn,
                            "shmat(2)", "", strerror(err), err);
             shmctl(ds_buf->seg_id, IPC_RMID, NULL);
@@ -337,9 +333,8 @@ segment_detach(opal_shmem_ds_t *ds_buf)
 
     if (0 != shmdt((char*)ds_buf->seg_base_addr)) {
         int err = errno;
-        char hn[MAXHOSTNAMELEN];
-        gethostname(hn, MAXHOSTNAMELEN - 1);
-        hn[MAXHOSTNAMELEN - 1] = '\0';
+        char hn[OPAL_MAXHOSTNAMELEN];
+        gethostname(hn, sizeof(hn));
         opal_show_help("help-opal-shmem-sysv.txt", "sys call fail", 1, hn,
                        "shmdt(2)", "", strerror(err), err);
         rc = OPAL_ERROR;

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -269,7 +269,7 @@ opal_init_util(int* pargc, char*** pargv)
 {
     int ret;
     char *error = NULL;
-    char hostname[512];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     if( ++opal_util_initialized != 1 ) {
         if( opal_util_initialized < 1 ) {
@@ -294,7 +294,7 @@ opal_init_util(int* pargc, char*** pargv)
      * that we don't bother with fqdn and prefix issues here - we let
      * the RTE later replace this with a modified name if the user
      * requests it */
-    gethostname(hostname, 512);
+    gethostname(hostname, sizeof(hostname));
     opal_process_info.nodename = strdup(hostname);
 
     /* initialize the memory allocator */

--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -127,7 +127,7 @@ OBJ_CLASS_INSTANCE(opal_output_stream_t, opal_object_t, construct, NULL);
 bool opal_output_init(void)
 {
     int i;
-    char hostname[32];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     char *str;
 
     if (initialized) {
@@ -177,7 +177,6 @@ bool opal_output_init(void)
         verbose.lds_want_stderr = true;
     }
     gethostname(hostname, sizeof(hostname));
-    hostname[sizeof(hostname)-1] = '\0';
     asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid());
 
     for (i = 0; i < OPAL_OUTPUT_MAX_STREAMS; ++i) {
@@ -254,7 +253,7 @@ bool opal_output_switch(int output_id, bool enable)
 void opal_output_reopen_all(void)
 {
     char *str;
-    char hostname[32];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     str = getenv("OPAL_OUTPUT_STDERR_FD");
     if (NULL != str) {

--- a/opal/util/stacktrace.c
+++ b/opal/util/stacktrace.c
@@ -42,7 +42,7 @@
 
 #define HOSTFORMAT "[%s:%05d] "
 
-static char stacktrace_hostname[64];
+static char stacktrace_hostname[OPAL_MAXHOSTNAMELEN];
 static char *unable_to_print_msg = "Unable to print stack trace!\n";
 
 /**
@@ -427,7 +427,6 @@ int opal_util_register_stackhandlers (void)
     bool complain, showed_help = false;
 
     gethostname(stacktrace_hostname, sizeof(stacktrace_hostname));
-    stacktrace_hostname[sizeof(stacktrace_hostname) - 1] = '\0';
     /* to keep these somewhat readable, only print the machine name */
     for (i = 0 ; i < (int)strlen(stacktrace_hostname) ; ++i) {
         if (stacktrace_hostname[i] == '.') {

--- a/opal/util/timings.c
+++ b/opal/util/timings.c
@@ -75,8 +75,8 @@ int opal_timing_clocksync_read(char *fname)
     bool found = false;
     char *ptr = NULL;
 
-    char hname[1024] = "NA";
-    if( gethostname(hname, 1024) ){
+    char hname[OPAL_MAXHOSTNAMELEN] = "NA";
+    if( gethostname(hname, sizeof(hname)) ){
         opal_output(0, "opal_timing_clocksync_read(%s): Cannot gethostname",
                     fname);
     }

--- a/opal/win32/win_compat.h
+++ b/opal/win32/win_compat.h
@@ -176,6 +176,7 @@ typedef unsigned int uint;
 
 #define MAXPATHLEN _MAX_PATH
 #define MAXHOSTNAMELEN _MAX_PATH
+#define OPAL_MAXHOSTNAMELEN (MAXHOSTNAMELEN + 1)
 #define PATH_MAX _MAX_PATH
 #define WTERMSIG(EXIT_CODE)    (1)
 #define WIFEXITED(EXIT_CODE)   (1)

--- a/orte/mca/oob/alps/oob_alps_component.c
+++ b/orte/mca/oob/alps/oob_alps_component.c
@@ -194,15 +194,14 @@ static int component_send(orte_rml_send_t *msg)
 static char* component_get_addr(void)
 {
     int len;
-    char hn[MAXHOSTNAMELEN], *cptr;
+    char hn[OPAL_MAXHOSTNAMELEN], *cptr;
 
     /*
      * TODO: for aries want to plug in GNI addr here instead to
      * eventually be able to support connect/accept using aprun.
      */
 
-    len = gethostname(hn, MAXHOSTNAMELEN - 1);
-    hn[len]='\0';
+    len = gethostname(hn, sizeof(hn));
 
     asprintf(&cptr, "gni://%s:%d", hn, getpid());
 

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -230,7 +230,7 @@ int orte_daemon(int argc, char *argv[])
     char *rml_uri;
     int i;
     opal_buffer_t *buffer;
-    char hostname[100];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 #if OPAL_ENABLE_FT_CR == 1
     char *tmp_env_var = NULL;
 #endif
@@ -297,7 +297,7 @@ int orte_daemon(int argc, char *argv[])
      * away just in case we have a problem along the way
      */
     if (orted_globals.debug) {
-        gethostname(hostname, 100);
+        gethostname(hostname, sizeof(hostname));
         fprintf(stderr, "Daemon was launched on %s - beginning to initialize\n", hostname);
     }
 
@@ -725,12 +725,12 @@ int orte_daemon(int argc, char *argv[])
         if (orte_retain_aliases) {
             char **aliases=NULL;
             uint8_t naliases, ni;
-            char hostname[ORTE_MAX_HOSTNAME_SIZE];
+            char hostname[OPAL_MAXHOSTNAMELEN];
 
             /* if we stripped the prefix or removed the fqdn,
              * include full hostname as an alias
              */
-            gethostname(hostname, ORTE_MAX_HOSTNAME_SIZE);
+            gethostname(hostname, sizeof(hostname));
             if (strlen(orte_process_info.nodename) < strlen(hostname)) {
                 opal_argv_append_nosize(&aliases, hostname);
             }

--- a/orte/test/mpi/concurrent_spawn.c
+++ b/orte/test/mpi/concurrent_spawn.c
@@ -1,4 +1,6 @@
 #define _GNU_SOURCE
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -13,7 +15,7 @@ int main(int argc, char* argv[])
     int msg;
     MPI_Comm parent, children[NUM_CHILDREN];
     int rank, size, i;
-    char hostname[512];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     pid_t pid;
     char *child_argv[2] = { "", NULL };
 
@@ -54,7 +56,7 @@ int main(int argc, char* argv[])
     }
     /* Otherwise, we're the child */
     else {
-        gethostname(hostname, 512);
+        gethostname(hostname, sizeof(hostname));
         if (argc == 1) {
             printf("ERROR: child did not receive exepcted argv!\n");
             i = -1;

--- a/orte/test/mpi/delayed_abort.c
+++ b/orte/test/mpi/delayed_abort.c
@@ -5,6 +5,8 @@
  * The most basic of MPI applications
  */
 
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 #include "mpi.h"
@@ -12,13 +14,13 @@
 int main(int argc, char* argv[])
 {
     int rank, size;
-    char hostname[512];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    gethostname(hostname, 512);
+    gethostname(hostname, sizeof(hostname));
     printf("%s: I am %d of %d. pid=%d\n", hostname, rank, size, getpid());
 
     if (rank%3 == 0) {

--- a/orte/test/mpi/hello_nodename.c
+++ b/orte/test/mpi/hello_nodename.c
@@ -6,6 +6,9 @@
  */
 
 #define _GNU_SOURCE
+
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -15,7 +18,7 @@
 int main(int argc, char* argv[])
 {
     int rank, size;
-    char hostname[512];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     void *appnum;
     void *univ_size;
     char *appstr, *unistr;
@@ -40,7 +43,7 @@ int main(int argc, char* argv[])
         asprintf(&unistr, "%d", *(int*)univ_size);
     }
 
-    gethostname(hostname, 512);
+    gethostname(hostname, sizeof(hostname));
     printf("Hello, World, I am %d of %d on host %s from app number %s universe size %s universe envar %s\n",
            rank, size, hostname, appstr, unistr, (NULL == envar) ? "NULL" : envar);
 

--- a/orte/test/mpi/info_spawn.c
+++ b/orte/test/mpi/info_spawn.c
@@ -1,3 +1,5 @@
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -11,7 +13,7 @@ int main(int argc, char* argv[])
     int msg, rc, i;
     MPI_Comm parent, child;
     int rank, size;
-    char hostname[512];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     pid_t pid;
     MPI_Info info;
     char *keyval, *tmp;
@@ -63,7 +65,7 @@ int main(int argc, char* argv[])
     else {
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
         MPI_Comm_size(MPI_COMM_WORLD, &size);
-        gethostname(hostname, 512);
+        gethostname(hostname, sizeof(hostname));
         pid = getpid();
         printf("Hello from the child %d of %d on host %s pid %ld\n", rank, 3, hostname, (long)pid);
         if (0 == rank) {

--- a/orte/test/mpi/simple_spawn.c
+++ b/orte/test/mpi/simple_spawn.c
@@ -1,3 +1,5 @@
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -9,7 +11,7 @@ int main(int argc, char* argv[])
     int msg, rc;
     MPI_Comm parent, child;
     int rank, size;
-    char hostname[512];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     pid_t pid;
 
     pid = getpid();
@@ -41,7 +43,7 @@ int main(int argc, char* argv[])
     else {
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
         MPI_Comm_size(MPI_COMM_WORLD, &size);
-        gethostname(hostname, 512);
+        gethostname(hostname, sizeof(hostname));
         pid = getpid();
         printf("Hello from the child %d of %d on host %s pid %ld\n", rank, 3, hostname, (long)pid);
         if (0 == rank) {

--- a/orte/test/mpi/singleton_client_server.c
+++ b/orte/test/mpi/singleton_client_server.c
@@ -1,3 +1,4 @@
+#include "orte_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -44,7 +45,7 @@
 
 int main(int argc, char *argv[])
 {
-  char hostname[255] ;
+  char hostname[OPAL_MAXHOSTNAMELEN] ;
   char buff[255] ;
 
   int role ;
@@ -80,7 +81,7 @@ int main(int argc, char *argv[])
 
   /* get the node name */
   {
-    int retval = gethostname(hostname, 255) ;
+    int retval = gethostname(hostname, sizeof(hostname));
     if(retval == -1)
     {
       fprintf(stderr, "gethostname failed: %s\n", strerror(errno)) ;

--- a/orte/test/mpi/spawn_multiple.c
+++ b/orte/test/mpi/spawn_multiple.c
@@ -1,3 +1,5 @@
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -9,7 +11,7 @@ int main(int argc, char* argv[])
     int msg;
     MPI_Comm parent, child;
     int rank, size;
-    char hostname[512];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     pid_t pid;
     int i;
     char *cmds[2];
@@ -48,7 +50,7 @@ int main(int argc, char* argv[])
     else {
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
         MPI_Comm_size(MPI_COMM_WORLD, &size);
-        gethostname(hostname, 512);
+        gethostname(hostname, sizeof(hostname));
         pid = getpid();
         printf("Hello from the child %d of %d on host %s pid %ld: argv[1] = %s\n", rank, size, hostname, (long)pid, argv[1]);
         MPI_Recv(&msg, 1, MPI_INT, 0, 1, parent, MPI_STATUS_IGNORE);

--- a/orte/test/mpi/spawn_tree.c
+++ b/orte/test/mpi/spawn_tree.c
@@ -1,3 +1,5 @@
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -9,7 +11,7 @@ int main(int argc, char ** argv){
 
     int i;
     int rank, size, child_rank;
-    char nomehost[20];
+    char nomehost[OPAL_MAXHOSTNAMELEN];
     MPI_Comm parent, intercomm1, intercomm2;
     int erro;
     int level, curr_level;
@@ -60,7 +62,7 @@ int main(int argc, char ** argv){
 
     }
 
-    gethostname(nomehost, 20);
+    gethostname(nomehost, sizeof(nomehost));
     printf("(%d) in %s\n", rank, nomehost);
 
     MPI_Finalize();

--- a/orte/test/system/orte_abort.c
+++ b/orte/test/system/orte_abort.c
@@ -6,6 +6,8 @@
  * abnormal program termination
  */
 
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 
@@ -21,14 +23,14 @@ int main(int argc, char* argv[])
     int i, rc;
     double pi;
     pid_t pid;
-    char hostname[500];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     if (0 > (rc = orte_init(&argc, &argv, ORTE_PROC_NON_MPI))) {
         fprintf(stderr, "orte_abort: couldn't init orte - error code %d\n", rc);
         return rc;
     }
     pid = getpid();
-    gethostname(hostname, 500);
+    gethostname(hostname, sizeof(hostname));
 
     if (1 < argc) {
         rc = strtol(argv[1], NULL, 10);

--- a/orte/test/system/orte_exit.c
+++ b/orte/test/system/orte_exit.c
@@ -6,6 +6,8 @@
  * abnormal program termination
  */
 
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 
@@ -21,14 +23,14 @@ int main(int argc, char* argv[])
     int i, rc;
     double pi;
     pid_t pid;
-    char hostname[500];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     if (0 > (rc = orte_init(&argc, &argv, ORTE_PROC_NON_MPI))) {
         fprintf(stderr, "orte_abort: couldn't init orte - error code %d\n", rc);
         return rc;
     }
     pid = getpid();
-    gethostname(hostname, 500);
+    gethostname(hostname, sizeof(hostname));
 
     printf("orte_abort: Name %s Host: %s Pid %ld\n", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
            hostname, (long)pid);

--- a/orte/test/system/orte_nodename.c
+++ b/orte/test/system/orte_nodename.c
@@ -5,6 +5,8 @@
  * The most basic of MPI applications
  */
 
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 
@@ -20,7 +22,7 @@
 int main(int argc, char* argv[])
 {
     int rc, i, restart=-1;
-    char hostname[512], *rstrt;
+    char hostname[OPAL_MAXHOSTNAMELEN], *rstrt;
     pid_t pid;
 
     if (0 > (rc = orte_init(&argc, &argv, ORTE_PROC_NON_MPI))) {
@@ -32,7 +34,7 @@ int main(int argc, char* argv[])
         restart = strtol(rstrt, NULL, 10);
     }
 
-    gethostname(hostname, 512);
+    gethostname(hostname, sizeof(hostname));
     pid = getpid();
 
     printf("orte_nodename: Node %s Name %s Pid %ld Restarts: %d\n",

--- a/orte/test/system/ulfm.c
+++ b/orte/test/system/ulfm.c
@@ -1,6 +1,8 @@
 /* -*- C -*-
  */
 
+#include "orte_config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -19,14 +21,14 @@ int main(int argc, char* argv[])
     int i, rc;
     double pi;
     pid_t pid;
-    char hostname[500];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     if (0 > (rc = orte_init(&argc, &argv, ORTE_PROC_NON_MPI))) {
         fprintf(stderr, "orte_abort: couldn't init orte - error code %d\n", rc);
         return rc;
     }
     pid = getpid();
-    gethostname(hostname, 500);
+    gethostname(hostname, sizeof(hostname));
 
     if (1 < argc) {
         rc = strtol(argv[1], NULL, 10);

--- a/orte/util/proc_info.c
+++ b/orte/util/proc_info.c
@@ -99,7 +99,7 @@ int orte_proc_info(void)
 
     int idx, i;
     char *ptr;
-    char hostname[ORTE_MAX_HOSTNAME_SIZE];
+    char hostname[OPAL_MAXHOSTNAMELEN];
     char **prefixes;
     bool match;
     struct in_addr buf;
@@ -168,7 +168,7 @@ int orte_proc_info(void)
     orte_process_info.pid = getpid();
 
     /* get the nodename */
-    gethostname(hostname, ORTE_MAX_HOSTNAME_SIZE);
+    gethostname(hostname, sizeof(hostname));
     /* add this to our list of aliases */
     opal_argv_append_nosize(&orte_process_info.aliases, hostname);
 

--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -45,8 +45,6 @@
 
 BEGIN_C_DECLS
 
-#define ORTE_MAX_HOSTNAME_SIZE  512
-
 typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_TYPE_NONE     0x0000
 #define ORTE_PROC_SINGLETON     0x0001

--- a/oshmem/runtime/oshmem_shmem_abort.c
+++ b/oshmem/runtime/oshmem_shmem_abort.c
@@ -42,7 +42,7 @@ static bool have_been_invoked = false;
 
 int oshmem_shmem_abort(int errcode)
 {
-    char *host, hostname[MAXHOSTNAMELEN];
+    char *host, hostname[OPAL_MAXHOSTNAMELEN];
     pid_t pid = 0;
 
     /* Protection for recursive invocation */

--- a/test/util/opal_if.c
+++ b/test/util/opal_if.c
@@ -59,7 +59,7 @@ test_ifaddrtoname(char *addr)
 int
 main(int argc, char *argv[])
 {
-    char hostname[MAXHOSTNAMELEN];
+    char hostname[OPAL_MAXHOSTNAMELEN];
 
     opal_init(&argc, &argv);
     test_init("opal_if");
@@ -117,7 +117,7 @@ main(int argc, char *argv[])
     }
 
     /* local host name */
-    gethostname(hostname, MAXHOSTNAMELEN);
+    gethostname(hostname, sizeof(hostname));
     if (test_ifaddrtoname(hostname)) {
         test_success();
     } else {


### PR DESCRIPTION
Trying to standardize from where max hostname length is derived and how gethostname() called. This is low priority/cleanup, but touches a fair number of files.

I've left MPI_Get_processor_name() to continue using MPI_MAX_PROCESSOR_NAME, as the variable to which it writes the hostname is passed into the function. If for some reason hostname max lengths ever exceed MPI_MAX_PROCESSOR_NAME, we could segfault.

Also, programs in orte/test/ are not configured to build, and further, they have various build failures. I've added the hostname max len fixups to these files as well, knowing they don't build. Perhaps a future TODO :)

Fixes: https://github.com/open-mpi/ompi/issues/1551