### PR TITLE
m4: rename OMPI_SUMMARY_* macros to OPAL_SUMMARY_*

### DIFF
--- a/config/ompi_check_mxm.m4
+++ b/config/ompi_check_mxm.m4
@@ -5,6 +5,7 @@ dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -78,7 +79,7 @@ AC_DEFUN([OMPI_CHECK_MXM],[
 
 	AS_IF([test "$ompi_mxm_version_ok" = "no"], [ompi_check_mxm_happy="no"])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Mellanox MXM]],[$1],[$ompi_check_mxm_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Mellanox MXM]],[$1],[$ompi_check_mxm_happy])
     fi
 
     AS_IF([test "$ompi_check_mxm_happy" = "yes"],

--- a/config/ompi_check_psm.m4
+++ b/config/ompi_check_psm.m4
@@ -68,7 +68,7 @@ AC_DEFUN([OMPI_CHECK_PSM],[
               [AC_MSG_WARN([PSM driver does not currently support progress threads.  Disabling BTL.])
                ompi_check_psm_happy="no"])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Intel TrueScale (PSM)]],[$1],[$ompi_check_psm_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Intel TrueScale (PSM)]],[$1],[$ompi_check_psm_happy])
     fi
 
     AS_IF([test "$ompi_check_psm_happy" = "yes"],

--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2006 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006      QLogic Corp. All rights reserved.
-# Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel Corporation. All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
@@ -69,7 +69,7 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
               [AC_MSG_WARN([PSM2 driver does not currently support progress threads.  Disabling MTL.])
                ompi_check_psm2_happy="no"])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Intel Omnipath (PSM2)]],[$1],[$ompi_check_psm2_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Intel Omnipath (PSM2)]],[$1],[$ompi_check_psm2_happy])
     fi
 
     AS_IF([test "$ompi_check_psm2_happy" = "yes"],

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -5,6 +5,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -76,7 +77,7 @@ AC_DEFUN([OMPI_CHECK_UCX],[
 
 	AS_IF([test "$ompi_ucx_version_ok" = "no"], [ompi_check_ucx_happy="no"])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])
     fi
 
 

--- a/config/opal_check_cma.m4
+++ b/config/opal_check_cma.m4
@@ -41,7 +41,7 @@ AC_DEFUN([OPAL_CHECK_CMA],[
 
 	OPAL_VAR_SCOPE_POP
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/Linux CMA]],[$1],[$ompi_check_cma_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/Linux CMA]],[$1],[$ompi_check_cma_happy])
     fi
 
     AS_IF([test "$ompi_check_cma_happy" = "yes"], [$2], [$3])

--- a/config/opal_check_cuda.m4
+++ b/config/opal_check_cuda.m4
@@ -124,7 +124,7 @@ else
     CUDA_SUPPORT=0
 fi
 
-OMPI_SUMMARY_ADD([[Miscellaneous]],[[CUDA support]],[opal_cuda], [$opal_check_cuda_happy])
+OPAL_SUMMARY_ADD([[Miscellaneous]],[[CUDA support]],[opal_cuda], [$opal_check_cuda_happy])
 
 AM_CONDITIONAL([OPAL_cuda_support], [test "x$CUDA_SUPPORT" = "x1"])
 AC_DEFINE_UNQUOTED([OPAL_CUDA_SUPPORT],$CUDA_SUPPORT,

--- a/config/opal_check_knem.m4
+++ b/config/opal_check_knem.m4
@@ -61,7 +61,7 @@ AC_DEFUN([OPAL_CHECK_KNEM],[
 
 	CPPFLAGS="$opal_check_knem_$1_save_CPPFLAGS"
 
-        OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/Linux KNEM]],[$1],[$opal_check_knem_happy])
+        OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/Linux KNEM]],[$1],[$opal_check_knem_happy])
 	OPAL_VAR_SCOPE_POP
     fi
 

--- a/config/opal_check_libfabric.m4
+++ b/config/opal_check_libfabric.m4
@@ -71,7 +71,7 @@ AC_DEFUN([OPAL_CHECK_LIBFABRIC],[
 	LDFLAGS=$opal_check_libfabric_$1_save_LDFLAGS
 	LIBS=$opal_check_libfabric_$1_save_LIBS
 
-	OMPI_SUMMARY_ADD([[Transports]],[[OpenFabrics Libfabric]],[$1],[$opal_check_libfabric_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[OpenFabrics Libfabric]],[$1],[$opal_check_libfabric_happy])
 
 	OPAL_VAR_SCOPE_POP
     fi

--- a/config/opal_check_openfabrics.m4
+++ b/config/opal_check_openfabrics.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2006-2016 Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2006-2009 Mellanox Technologies. All rights reserved.
@@ -277,7 +277,7 @@ AC_DEFUN([OPAL_CHECK_OPENFABRICS],[
 	LDFLAGS="$ompi_check_openib_$1_save_LDFLAGS"
 	LIBS="$ompi_check_openib_$1_save_LIBS"
 
-	OMPI_SUMMARY_ADD([[Transports]],[[OpenFabrics Verbs]],[$1],[$opal_check_openib_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[OpenFabrics Verbs]],[$1],[$opal_check_openib_happy])
 
         OPAL_VAR_SCOPE_POP
     fi

--- a/config/opal_check_portals4.m4
+++ b/config/opal_check_portals4.m4
@@ -94,7 +94,7 @@ AC_DEFUN([OPAL_CHECK_PORTALS4],[
 	AS_IF([test $max_md_size -ne 0 && test $max_va_size -ne 0],
               [AC_MSG_NOTICE([Portals 4 address space size: $max_md_size, $max_va_size])])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Portals4]],[$1],[$ompi_check_portals4_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Portals4]],[$1],[$ompi_check_portals4_happy])
     fi
 
     AS_IF([test "$ompi_check_portals4_happy" = "yes"],

--- a/config/opal_check_ugni.m4
+++ b/config/opal_check_ugni.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2006      QLogic Corp. All rights reserved.
-dnl Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved
@@ -68,7 +68,7 @@ AC_DEFUN([OPAL_CHECK_UGNI], [
               [AC_MSG_WARN([GNI driver does not currently support progress threads.  Disabling.])
                opal_check_ugni_happy="no"])
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Cray uGNI (Gemini/Aries)]],[$1],[$opal_check_ugni_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Cray uGNI (Gemini/Aries)]],[$1],[$opal_check_ugni_happy])
     fi
 
     AS_IF([test "$opal_check_ugni_happy" = "yes"],

--- a/config/opal_check_xpmem.m4
+++ b/config/opal_check_xpmem.m4
@@ -101,7 +101,7 @@ AC_DEFUN([OPAL_CHECK_XPMEM], [
 	    fi
 	fi
 
-	OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/XPMEM]],[$1],[$opal_check_cray_xpmem_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/XPMEM]],[$1],[$opal_check_cray_xpmem_happy])
     fi
 
     AS_IF([test "$opal_check_xpmem_happy" = "yes"], [

--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -9,7 +9,7 @@ dnl Additional copyrights may follow
 dnl
 dnl $HEADER$
 dnl
-AC_DEFUN([OMPI_SUMMARY_ADD],[
+AC_DEFUN([OPAL_SUMMARY_ADD],[
     OPAL_VAR_SCOPE_PUSH([ompi_summary_section ompi_summary_line ompi_summary_section_current])
 
     dnl need to replace spaces in the section name with somethis else. _ seems like a reasonable
@@ -32,7 +32,7 @@ AC_DEFUN([OMPI_SUMMARY_ADD],[
     OPAL_VAR_SCOPE_POP
 ])
 
-AC_DEFUN([OMPI_SUMMARY_PRINT],[
+AC_DEFUN([OPAL_SUMMARY_PRINT],[
     OPAL_VAR_SCOPE_PUSH([ompi_summary_section ompi_summary_section_name])
     cat <<EOF
 

--- a/config/orte_check_alps.m4
+++ b/config/orte_check_alps.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -157,7 +157,7 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
                CRAY_ALPSUTIL_LIBS = $CRAY_ALPSUTIL_STATIC_LIBS],
               [])
 
-	OMPI_SUMMARY_ADD([[Resource Managers]],[[Cray Alps]],[$1],[$orte_check_cray_alps_happy])
+	OPAL_SUMMARY_ADD([[Resource Managers]],[[Cray Alps]],[$1],[$orte_check_cray_alps_happy])
     fi
 
     AS_IF([test "$orte_check_cray_alps_happy" = "yes"],

--- a/config/orte_check_lsf.m4
+++ b/config/orte_check_lsf.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -122,7 +122,7 @@ AC_DEFUN([ORTE_CHECK_LSF],[
 	LDFLAGS="$orte_check_lsf_$1_save_LDFLAGS"
 	LIBS="$orte_check_lsf_$1_save_LIBS"
 
-	OMPI_SUMMARY_ADD([[Resource Managers]],[[LSF]],[$1],[$orte_check_lsf_happy])
+	OPAL_SUMMARY_ADD([[Resource Managers]],[[LSF]],[$1],[$orte_check_lsf_happy])
     fi
 
     AS_IF([test "$orte_check_lsf_happy" = "yes"],

--- a/config/orte_check_sge.m4
+++ b/config/orte_check_sge.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2009 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -50,7 +50,7 @@ AC_DEFUN([ORTE_CHECK_GRIDENGINE],[
                                     orte_gridengine_build=yes],
 				   [AC_MSG_RESULT([not found])])])])])
 
-	OMPI_SUMMARY_ADD([[Resource Managers]],[[Grid Engine]],[$1],[$orte_gridengine_build])
+	OPAL_SUMMARY_ADD([[Resource Managers]],[[Grid Engine]],[$1],[$orte_gridengine_build])
     fi
 
     AS_IF([test "$orte_gridengine_build" = "yes"],

--- a/config/orte_check_slurm.m4
+++ b/config/orte_check_slurm.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -68,7 +68,7 @@ AC_DEFUN([ORTE_CHECK_SLURM],[
                              [orte_check_slurm_happy="yes"],
                              [orte_check_slurm_happy="no"])])
 
-        OMPI_SUMMARY_ADD([[Resource Managers]],[[Slurm]],[$1],[$orte_check_slurm_happy])
+        OPAL_SUMMARY_ADD([[Resource Managers]],[[Slurm]],[$1],[$orte_check_slurm_happy])
     fi
 
     AS_IF([test "$orte_check_slurm_happy" = "yes"],

--- a/config/orte_check_tm.m4
+++ b/config/orte_check_tm.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -145,7 +145,7 @@ AC_DEFUN([ORTE_CHECK_TM],[
 	    orte_check_tm_happy=no
 	fi
 
-	OMPI_SUMMARY_ADD([[Resource Managers]],[[Torque]],[$1],[$orte_check_tm_happy])
+	OPAL_SUMMARY_ADD([[Resource Managers]],[[Torque]],[$1],[$orte_check_tm_happy])
 
 	OPAL_VAR_SCOPE_POP
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2006-2011 Los Alamos National Security, LLC.  All rights
 #                         reserved.
@@ -1392,4 +1392,4 @@ m4_ifdef([project_oshmem], [OSHMEM_CONFIG_FILES])
 
 AC_OUTPUT
 
-OMPI_SUMMARY_PRINT
+OPAL_SUMMARY_PRINT

--- a/opal/mca/btl/scif/configure.m4
+++ b/opal/mca/btl/scif/configure.m4
@@ -37,7 +37,7 @@ AC_DEFUN([MCA_opal_btl_scif_CONFIG],[
 
     AS_IF([test "$opal_btl_scif_happy" = "yes"], [$1], [$2])
 
-    OMPI_SUMMARY_ADD([[Transports]],[[Intel SCIF]],[[btl_scif]],[$opal_btl_scif_happy])
+    OPAL_SUMMARY_ADD([[Transports]],[[Intel SCIF]],[[btl_scif]],[$opal_btl_scif_happy])
 
     # substitute in the things needed to build scif
     AC_SUBST([btl_scif_CPPFLAGS])

--- a/opal/mca/btl/tcp/configure.m4
+++ b/opal/mca/btl/tcp/configure.m4
@@ -36,5 +36,5 @@ AC_DEFUN([MCA_opal_btl_tcp_CONFIG],[
 #include <netinet/in.h>
 #endif
 		   ])
-    OMPI_SUMMARY_ADD([[Transports]],[[TCP]],[[btl_tcp]],[$opal_btl_tcp_happy])
+    OPAL_SUMMARY_ADD([[Transports]],[[TCP]],[[btl_tcp]],[$opal_btl_tcp_happy])
 ])dnl

--- a/opal/mca/btl/vader/configure.m4
+++ b/opal/mca/btl/vader/configure.m4
@@ -43,7 +43,7 @@ AC_DEFUN([MCA_opal_btl_vader_CONFIG],[
     # always happy
     [$1]
 
-    OMPI_SUMMARY_ADD([[Transports]],[[Shared memory/copy in+copy out]],[$1],[yes])
+    OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/copy in+copy out]],[$1],[yes])
 
 # substitute in the things needed to build with XPMEM support
     AC_SUBST([btl_vader_CFLAGS])

--- a/orte/mca/plm/rsh/configure.m4
+++ b/orte/mca/plm/rsh/configure.m4
@@ -27,6 +27,6 @@ AC_DEFUN([MCA_orte_plm_rsh_CONFIG],[
 
     AC_CHECK_FUNC([fork], [plm_rsh_happy="yes"], [plm_rsh_happy="no"])
 
-    OMPI_SUMMARY_ADD([[Resource Managers]],[[ssh/rsh]],[$1],[$plm_rsh_happy])
+    OPAL_SUMMARY_ADD([[Resource Managers]],[[ssh/rsh]],[$1],[$plm_rsh_happy])
     AS_IF([test "$plm_rsh_happy" = "yes"], [$1], [$2])
 ])dnl


### PR DESCRIPTION
These macros should really be named OPAL_SUMMARY_*; they're used in
all projects, and therefore should be in the lowest later project (OPAL).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>