### PR TITLE
mtl/psm2: do not set PSM2_DEVICES env variable

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -198,10 +198,6 @@ ompi_mtl_psm2_component_init(bool enable_progress_threads,
 	return NULL;
     }
 
-    if (num_local_procs == num_total_procs) {
-      setenv("PSM2_DEVICES", "self,shm", 0);
-    }
-
     err = psm2_init(&verno_major, &verno_minor);
     if (err) {
       opal_show_help("help-mtl-psm2.txt",


### PR DESCRIPTION
The PSM2 MTL was setting the PSM2_DEVICES environment
variable to self,shm for single node jobs.  This is
causing single node/single process jobs to fail on
some omnipath systems.  Not setting this environment
variable fixes these issues.

This fix is needed as part of bringup of omnipath
clusters at several customer sites.

Fixes issue #1559 

@matcabral 
@rhc54  (copying you just for fyi)

Signed-off-by: Howard Pritchard <howardp@lanl.gov>