### PR TITLE
memory/patcher: cast away const in shmdt hook

### DIFF
--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -344,7 +344,9 @@ static int intercept_shmdt (const void *shmaddr)
     OPAL_PATCHER_BEGIN;
     int result;
 
-    opal_mem_hooks_release_hook (shmaddr, memory_patcher_get_shm_seg_size (shmaddr), false);
+    /* opal_mem_hooks_release_hook should probably be updated to take a const void *.
+     * for now just cast away the const */
+    opal_mem_hooks_release_hook ((void *) shmaddr, memory_patcher_get_shm_seg_size (shmaddr), false);
 
     if (original_shmdt) {
         result = original_shmdt (shmaddr);


### PR DESCRIPTION
The opal_mem_hooks_release_hook does not have const on the pointer
(though it probably should). This commit eliminates a warning by
casting away the const until opal_mem_hooks_release_hook is updated to
use const.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>