### PR TITLE
pmix/external114: External component supporting 1.1.4

### DIFF
--- a/config/opal_check_version.m4
+++ b/config/opal_check_version.m4
@@ -1,0 +1,79 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# Parameters: (use a version "1.1.4rc2" as the example)
+# * prefix
+#   Will export a variable $prefix_version_cmp
+#   - action_if_less         => "less"
+#   - action_if_equal        => "equal"
+#   - action_if_equal_series => "series"
+#   - action_if_greater      => "greater"
+# * version_actual
+#   Actual version string
+# * version_desired
+#   Desired version string to check against
+# * action_if_less
+#   Action to take if the version is strictly less than
+#   "1.1.3" < "1.1.4rc2"
+# * action_if_equal
+#   Action to take if the version matches exactly
+#   "1.1.4rc2" = "1.1.4rc2"
+# * action_if_equal_series
+#   Action to take if the version matches to this series
+#   "1.1.4rc1" ~=~ "1.1.4rc2"
+#   "1.1.4" ~=~ "1.1.4rc2"
+# * action_if_greater
+#   Action to take if the version is strictly greater than
+#   "1.1.5" > "1.1.4rc2"
+#   "2.0" > "1.1.4rc2"
+#
+# See documentation on m4_version_compare and AS_VERSION_COMPARE for more
+# precise definitions
+# OPAL_CHECK_VERSION(prefix, version_actual, version_desired,
+#                    action_if_less, action_if_equal, action_if_equal_series,
+#                    action_if_greater)
+# ----------------------------------------------------
+AC_DEFUN([OPAL_CHECK_VERSION],[
+    version_actual=$2
+    version_desired=$3
+    
+    AC_MSG_CHECKING([Checking library version is $version_desired])
+    # 
+    # Example: If version_desired=1.1.4 and
+    # version_actual=1.1.3    -> -1
+    # version_actual=1.1.4    ->  0
+    # version_actual=1.1.4rc1 ->  1
+    # version_actual=1.1.5    ->  1 (need further check)
+    #
+    AS_VERSION_COMPARE(["$version_actual"], [$version_desired],
+            [AC_MSG_RESULT([Earlier than expected ($version_actual < $$version_desired)])
+             $1_version_cmp="less"
+             $4],
+            [AC_MSG_RESULT([Equal])
+             $1_version_cmp="equal"
+             $5],
+            [
+             # Need further check to make sure we are < 1.1.5
+             # version_actual=1.1.4rc1 ->  -1
+             # version_actual=1.1.4    ->   0 (caught above)
+             # version_actual=1.1.5    ->   1
+             AS_VERSION_COMPARE(["$version_actual"], [$version_desired"zzzz"],
+                 [AC_MSG_RESULT([Within release series ($version_actual)])
+                  $1_version_cmp="series"
+                  $6],
+                 [AC_MSG_RESULT([Within release series ($version_actual)])
+                  $1_version_cmp="series"
+                  $6],
+                 [AC_MSG_RESULT([Later than expected ($version_actual > $$version_desired)])
+                  $1_version_cmp="greater"
+                  $7]
+             )]
+         )
+])dnl

--- a/opal/mca/pmix/external/configure.m4
+++ b/opal/mca/pmix/external/configure.m4
@@ -18,6 +18,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2014-2015 Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,7 +33,21 @@ AC_DEFUN([MCA_opal_pmix_external_CONFIG],[
 
     AC_REQUIRE([OPAL_CHECK_PMIX])
 
-    AS_IF([test "$opal_external_pmix_happy" = "yes"],
+    # We have a different external comment for the 1.1.4 series, so check that
+    AS_IF([test "$opal_external_pmix_happy" = "yes" ],
+          [
+           OPAL_CHECK_VERSION([opal_pmix_external],
+                              [$opal_external_pmix_version],
+                              ["1.1.4"],
+                              [opal_external_pmix_version_happy="yes"],
+                              [AC_MSG_WARN([Defer to the 1.1.4 external component])
+                               opal_external_pmix_version_happy="no"],
+                              [AC_MSG_WARN([Defer to the 1.1.4 external component])
+                               opal_external_pmix_version_happy="no"],
+                              [opal_external_pmix_version_happy="yes"])
+           ])
+
+    AS_IF([test "$opal_external_pmix_happy" = "yes" && test "$opal_external_pmix_version_happy" = "yes" ],
           [AS_IF([test "$opal_event_external_support" != "yes"],
                  [AC_MSG_WARN([EXTERNAL PMIX SUPPORT REQUIRES USE OF EXTERNAL LIBEVENT])
                   AC_MSG_WARN([LIBRARY. THIS LIBRARY MUST POINT TO THE SAME ONE USED])

--- a/opal/mca/pmix/external114/Makefile.am
+++ b/opal/mca/pmix/external114/Makefile.am
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2014-2015 Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        pmix_ext.h \
+        pmix_ext_component.c \
+        pmix_ext.c \
+        pmix_ext_client.c \
+        pmix_ext_server_south.c \
+        pmix_ext_server_north.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_opal_pmix_external114_DSO
+component_noinst =
+component_install = mca_pmix_external114.la
+else
+component_noinst = libmca_pmix_external114.la
+component_install =
+endif
+
+mcacomponentdir = $(opallibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_pmix_external114_la_SOURCES = $(sources)
+mca_pmix_external114_la_CFLAGS =
+mca_pmix_external114_la_CPPFLAGS = $(opal_pmix_ext_CPPFLAGS)
+mca_pmix_external114_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext_LDFLAGS)
+mca_pmix_external114_la_LIBADD = $(opal_pmix_ext_LIBS) \
+        $(OPAL_TOP_BUILDDIR)/opal/mca/event/lib@OPAL_LIB_PREFIX@mca_event.la \
+        $(OPAL_TOP_BUILDDIR)/opal/mca/hwloc/lib@OPAL_LIB_PREFIX@mca_hwloc.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_pmix_external114_la_SOURCES =$(sources)
+libmca_pmix_external114_la_CFLAGS =
+libmca_pmix_external114_la_CPPFLAGS = $(opal_pmix_ext_CPPFLAGS)
+libmca_pmix_external114_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext_LDFLAGS)
+libmca_pmix_external114_la_LIBADD = $(opal_pmix_ext_LIBS)

--- a/opal/mca/pmix/external114/configure.m4
+++ b/opal/mca/pmix/external114/configure.m4
@@ -1,0 +1,76 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2014-2015 Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pmix_external114_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_opal_pmix_external114_CONFIG],[
+    AC_CONFIG_FILES([opal/mca/pmix/external114/Makefile])
+
+    AC_REQUIRE([OPAL_CHECK_PMIX])
+
+    opal_pmix_external_114_happy="no"
+    opal_pmix_external_114_version_good="no"
+
+    AS_IF([test "$opal_external_pmix_happy" = "yes"],
+        [OPAL_CHECK_VERSION([opal_pmix_external_114],
+                            [$opal_external_pmix_version],
+                            ["1.1.4"],
+                            [opal_pmix_external_114_version_good="no"],
+                            [opal_pmix_external_114_version_good="yes"],
+                            [opal_pmix_external_114_version_good="yes"],
+                            [opal_pmix_external_114_version_good="no"])
+
+         AS_IF([test "$opal_pmix_external_114_version_good" = "no"],
+             [AC_MSG_WARN([External PMIx 1.1.4 component disabled. Incorrect library version ($opal_external_pmix_version)])
+              $2],
+             [
+              # Make sure we have an external libevent
+              AS_IF([test "$opal_event_external_support" != "yes"],
+                  [AC_MSG_WARN([EXTERNAL PMIX SUPPORT REQUIRES USE OF EXTERNAL LIBEVENT])
+                   AC_MSG_WARN([LIBRARY. THIS LIBRARY MUST POINT TO THE SAME ONE USED])
+                   AC_MSG_WARN([TO BUILD PMIX OR ELSE UNPREDICTABLE BEHAVIOR MAY RESULT])
+                   AC_MSG_ERROR([PLEASE CORRECT THE CONFIGURE COMMAND LINE AND REBUILD])])
+
+              # Make sure we have an external hwloc
+              AS_IF([test "$opal_hwloc_external_support" != "yes"],
+                  [AC_MSG_WARN([EXTERNAL PMIX SUPPORT REQUIRES USE OF EXTERNAL HWLOC])
+                   AC_MSG_WARN([LIBRARY THIS LIBRARY MUST POINT TO THE SAME ONE USED ])
+                   AC_MSG_WARN([TO BUILD PMIX OR ELSE UNPREDICTABLE BEHAVIOR MAY RESULT])
+                   AC_MSG_ERROR([PLEASE CORRECT THE CONFIGURE COMMAND LINE AND REBUILD])])
+             opal_pmix_external_114_happy="yes"
+             $1]
+        )
+        ],
+        [$2]
+    )
+
+    # External wrapper compiler flags
+    #external114_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}/openmpi/$opal_pmix_external114_basedir/pmix -I${includedir}/openmpi/$opal_pmix_external114_basedir/pmix/include'
+
+    OPAL_VAR_SCOPE_POP
+])dnl

--- a/opal/mca/pmix/external114/pmix_ext.c
+++ b/opal/mca/pmix/external114/pmix_ext.c
@@ -46,61 +46,61 @@
 /* These are functions used by both client and server to
  * access common functions in the embedded PMIx library */
 
-static const char *pmix1_get_nspace(opal_jobid_t jobid);
-static void pmix1_register_jobid(opal_jobid_t jobid, const char *nspace);
+static const char *pmix_ext114_get_nspace(opal_jobid_t jobid);
+static void pmix_ext114_register_jobid(opal_jobid_t jobid, const char *nspace);
 
-const opal_pmix_base_module_t opal_pmix_external_module = {
+const opal_pmix_base_module_t opal_pmix_external114_module = {
     /* client APIs */
-    .init = pmix1_client_init,
-    .finalize = pmix1_client_finalize,
-    .initialized = pmix1_initialized,
-    .abort = pmix1_abort,
-    .commit = pmix1_commit,
-    .fence = pmix1_fence,
-    .fence_nb = pmix1_fencenb,
-    .put = pmix1_put,
-    .get = pmix1_get,
-    .get_nb = pmix1_getnb,
-    .publish = pmix1_publish,
-    .publish_nb = pmix1_publishnb,
-    .lookup = pmix1_lookup,
-    .lookup_nb = pmix1_lookupnb,
-    .unpublish = pmix1_unpublish,
-    .unpublish_nb = pmix1_unpublishnb,
-    .spawn = pmix1_spawn,
-    .spawn_nb = pmix1_spawnnb,
-    .connect = pmix1_connect,
-    .connect_nb = pmix1_connectnb,
-    .disconnect = pmix1_disconnect,
-    .disconnect_nb = pmix1_disconnectnb,
-    .resolve_peers = pmix1_resolve_peers,
-    .resolve_nodes = pmix1_resolve_nodes,
+    .init = pmix_ext114_client_init,
+    .finalize = pmix_ext114_client_finalize,
+    .initialized = pmix_ext114_initialized,
+    .abort = pmix_ext114_abort,
+    .commit = pmix_ext114_commit,
+    .fence = pmix_ext114_fence,
+    .fence_nb = pmix_ext114_fencenb,
+    .put = pmix_ext114_put,
+    .get = pmix_ext114_get,
+    .get_nb = pmix_ext114_getnb,
+    .publish = pmix_ext114_publish,
+    .publish_nb = pmix_ext114_publishnb,
+    .lookup = pmix_ext114_lookup,
+    .lookup_nb = pmix_ext114_lookupnb,
+    .unpublish = pmix_ext114_unpublish,
+    .unpublish_nb = pmix_ext114_unpublishnb,
+    .spawn = pmix_ext114_spawn,
+    .spawn_nb = pmix_ext114_spawnnb,
+    .connect = pmix_ext114_connect,
+    .connect_nb = pmix_ext114_connectnb,
+    .disconnect = pmix_ext114_disconnect,
+    .disconnect_nb = pmix_ext114_disconnectnb,
+    .resolve_peers = pmix_ext114_resolve_peers,
+    .resolve_nodes = pmix_ext114_resolve_nodes,
     /* server APIs */
-    .server_init = pmix1_server_init,
-    .server_finalize = pmix1_server_finalize,
-    .generate_regex = pmix1_server_gen_regex,
-    .generate_ppn = pmix1_server_gen_ppn,
-    .server_register_nspace = pmix1_server_register_nspace,
-    .server_deregister_nspace = pmix1_server_deregister_nspace,
-    .server_register_client = pmix1_server_register_client,
-    .server_deregister_client = pmix1_server_deregister_client,
-    .server_setup_fork = pmix1_server_setup_fork,
-    .server_dmodex_request = pmix1_server_dmodex,
-    .server_notify_error = pmix1_server_notify_error,
+    .server_init = pmix_ext114_server_init,
+    .server_finalize = pmix_ext114_server_finalize,
+    .generate_regex = pmix_ext114_server_gen_regex,
+    .generate_ppn = pmix_ext114_server_gen_ppn,
+    .server_register_nspace = pmix_ext114_server_register_nspace,
+    .server_deregister_nspace = pmix_ext114_server_deregister_nspace,
+    .server_register_client = pmix_ext114_server_register_client,
+    .server_deregister_client = pmix_ext114_server_deregister_client,
+    .server_setup_fork = pmix_ext114_server_setup_fork,
+    .server_dmodex_request = pmix_ext114_server_dmodex,
+    .server_notify_error = pmix_ext114_server_notify_error,
     /* utility APIs */
     .get_version = PMIx_Get_version,
     .register_errhandler = opal_pmix_base_register_handler,
     .deregister_errhandler = opal_pmix_base_deregister_handler,
-    .store_local = pmix1_store_local,
-    .get_nspace = pmix1_get_nspace,
-    .register_jobid = pmix1_register_jobid
+    .store_local = pmix_ext114_store_local,
+    .get_nspace = pmix_ext114_get_nspace,
+    .register_jobid = pmix_ext114_register_jobid
 };
 
-static const char *pmix1_get_nspace(opal_jobid_t jobid)
+static const char *pmix_ext114_get_nspace(opal_jobid_t jobid)
 {
-    opal_pmix1_jobid_trkr_t *jptr;
+    opal_pmix_ext114_jobid_trkr_t *jptr;
 
-    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix_ext114_jobid_trkr_t) {
         if (jptr->jobid == jobid) {
             return jptr->nspace;
         }
@@ -108,23 +108,23 @@ static const char *pmix1_get_nspace(opal_jobid_t jobid)
     return NULL;
 }
 
-static void pmix1_register_jobid(opal_jobid_t jobid, const char *nspace)
+static void pmix_ext114_register_jobid(opal_jobid_t jobid, const char *nspace)
 {
-    opal_pmix1_jobid_trkr_t *jptr;
+    opal_pmix_ext114_jobid_trkr_t *jptr;
 
     /* if we don't already have it, add this to our jobid tracker */
-    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix_ext114_jobid_trkr_t) {
         if (jptr->jobid == jobid) {
             return;
         }
     }
-    jptr = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+    jptr = OBJ_NEW(opal_pmix_ext114_jobid_trkr_t);
     (void)strncpy(jptr->nspace, nspace, PMIX_MAX_NSLEN);
     jptr->jobid = jobid;
     opal_list_append(&mca_pmix_external114_component.jobids, &jptr->super);
 }
 
-pmix_status_t pmix1_convert_opalrc(int rc)
+pmix_status_t pmix_ext114_convert_opalrc(int rc)
 {
     switch (rc) {
     case OPAL_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
@@ -186,7 +186,7 @@ pmix_status_t pmix1_convert_opalrc(int rc)
     }
 }
 
-int pmix1_convert_rc(pmix_status_t rc)
+int pmix_ext114_convert_rc(pmix_status_t rc)
 {
     switch (rc) {
     case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
@@ -271,7 +271,7 @@ int pmix1_convert_rc(pmix_status_t rc)
     }
 }
 
-pmix_scope_t pmix1_convert_opalscope(opal_pmix_scope_t scope) {
+pmix_scope_t pmix_ext114_convert_opalscope(opal_pmix_scope_t scope) {
     switch(scope) {
     case OPAL_PMIX_LOCAL:
         return PMIX_LOCAL;
@@ -284,7 +284,7 @@ pmix_scope_t pmix1_convert_opalscope(opal_pmix_scope_t scope) {
     }
 }
 
-void pmix1_value_load(pmix_value_t *v,
+void pmix_ext114_value_load(pmix_value_t *v,
                       opal_value_t *kv)
 {
     switch(kv->type) {
@@ -385,7 +385,7 @@ void pmix1_value_load(pmix_value_t *v,
     }
 }
 
-int pmix1_value_unload(opal_value_t *kv,
+int pmix_ext114_value_unload(opal_value_t *kv,
                        const pmix_value_t *v)
 {
     int rc=OPAL_SUCCESS;
@@ -490,11 +490,11 @@ int pmix1_value_unload(opal_value_t *kv,
 
 
 /****  INSTANTIATE INTERNAL CLASSES  ****/
-OBJ_CLASS_INSTANCE(opal_pmix1_jobid_trkr_t,
+OBJ_CLASS_INSTANCE(opal_pmix_ext114_jobid_trkr_t,
                    opal_list_item_t,
                    NULL, NULL);
 
-static void opcon(pmix1_opcaddy_t *p)
+static void opcon(pmix_ext114_opcaddy_t *p)
 {
     memset(&p->p, 0, sizeof(pmix_proc_t));
     p->procs = NULL;
@@ -512,7 +512,7 @@ static void opcon(pmix1_opcaddy_t *p)
     p->spcbfunc = NULL;
     p->cbdata = NULL;
 }
-static void opdes(pmix1_opcaddy_t *p)
+static void opdes(pmix_ext114_opcaddy_t *p)
 {
     if (NULL != p->procs) {
         PMIX_PROC_FREE(p->procs, p->nprocs);
@@ -527,11 +527,11 @@ static void opdes(pmix1_opcaddy_t *p)
         PMIX_APP_FREE(p->apps, p->sz);
     }
 }
-OBJ_CLASS_INSTANCE(pmix1_opcaddy_t,
+OBJ_CLASS_INSTANCE(pmix_ext114_opcaddy_t,
                    opal_object_t,
                    opcon, opdes);
 
-static void ocadcon(pmix1_opalcaddy_t *p)
+static void ocadcon(pmix_ext114_opalcaddy_t *p)
 {
     OBJ_CONSTRUCT(&p->procs, opal_list_t);
     OBJ_CONSTRUCT(&p->info, opal_list_t);
@@ -545,12 +545,12 @@ static void ocadcon(pmix1_opalcaddy_t *p)
     p->odmdxfunc = NULL;
     p->ocbdata = NULL;
 }
-static void ocaddes(pmix1_opalcaddy_t *p)
+static void ocaddes(pmix_ext114_opalcaddy_t *p)
 {
     OPAL_LIST_DESTRUCT(&p->procs);
     OPAL_LIST_DESTRUCT(&p->info);
     OPAL_LIST_DESTRUCT(&p->apps);
 }
-OBJ_CLASS_INSTANCE(pmix1_opalcaddy_t,
+OBJ_CLASS_INSTANCE(pmix_ext114_opalcaddy_t,
                    opal_object_t,
                    ocadcon, ocaddes);

--- a/opal/mca/pmix/external114/pmix_ext.c
+++ b/opal/mca/pmix/external114/pmix_ext.c
@@ -1,0 +1,556 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+#include "opal/constants.h"
+#include "opal/types.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "opal/dss/dss.h"
+#include "opal/mca/event/event.h"
+#include "opal/mca/hwloc/base/base.h"
+#include "opal/runtime/opal.h"
+#include "opal/runtime/opal_progress_threads.h"
+#include "opal/util/argv.h"
+#include "opal/util/error.h"
+#include "opal/util/output.h"
+#include "opal/util/proc.h"
+#include "opal/util/show_help.h"
+
+#include "pmix_ext.h"
+#include "opal/mca/pmix/base/base.h"
+#include "opal/mca/pmix/pmix_types.h"
+
+#include <pmix/pmix_common.h>
+
+/****    C.O.M.M.O.N   I.N.T.E.R.F.A.C.E.S     ****/
+
+/* These are functions used by both client and server to
+ * access common functions in the embedded PMIx library */
+
+static const char *pmix1_get_nspace(opal_jobid_t jobid);
+static void pmix1_register_jobid(opal_jobid_t jobid, const char *nspace);
+
+const opal_pmix_base_module_t opal_pmix_external_module = {
+    /* client APIs */
+    .init = pmix1_client_init,
+    .finalize = pmix1_client_finalize,
+    .initialized = pmix1_initialized,
+    .abort = pmix1_abort,
+    .commit = pmix1_commit,
+    .fence = pmix1_fence,
+    .fence_nb = pmix1_fencenb,
+    .put = pmix1_put,
+    .get = pmix1_get,
+    .get_nb = pmix1_getnb,
+    .publish = pmix1_publish,
+    .publish_nb = pmix1_publishnb,
+    .lookup = pmix1_lookup,
+    .lookup_nb = pmix1_lookupnb,
+    .unpublish = pmix1_unpublish,
+    .unpublish_nb = pmix1_unpublishnb,
+    .spawn = pmix1_spawn,
+    .spawn_nb = pmix1_spawnnb,
+    .connect = pmix1_connect,
+    .connect_nb = pmix1_connectnb,
+    .disconnect = pmix1_disconnect,
+    .disconnect_nb = pmix1_disconnectnb,
+    .resolve_peers = pmix1_resolve_peers,
+    .resolve_nodes = pmix1_resolve_nodes,
+    /* server APIs */
+    .server_init = pmix1_server_init,
+    .server_finalize = pmix1_server_finalize,
+    .generate_regex = pmix1_server_gen_regex,
+    .generate_ppn = pmix1_server_gen_ppn,
+    .server_register_nspace = pmix1_server_register_nspace,
+    .server_deregister_nspace = pmix1_server_deregister_nspace,
+    .server_register_client = pmix1_server_register_client,
+    .server_deregister_client = pmix1_server_deregister_client,
+    .server_setup_fork = pmix1_server_setup_fork,
+    .server_dmodex_request = pmix1_server_dmodex,
+    .server_notify_error = pmix1_server_notify_error,
+    /* utility APIs */
+    .get_version = PMIx_Get_version,
+    .register_errhandler = opal_pmix_base_register_handler,
+    .deregister_errhandler = opal_pmix_base_deregister_handler,
+    .store_local = pmix1_store_local,
+    .get_nspace = pmix1_get_nspace,
+    .register_jobid = pmix1_register_jobid
+};
+
+static const char *pmix1_get_nspace(opal_jobid_t jobid)
+{
+    opal_pmix1_jobid_trkr_t *jptr;
+
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+        if (jptr->jobid == jobid) {
+            return jptr->nspace;
+        }
+    }
+    return NULL;
+}
+
+static void pmix1_register_jobid(opal_jobid_t jobid, const char *nspace)
+{
+    opal_pmix1_jobid_trkr_t *jptr;
+
+    /* if we don't already have it, add this to our jobid tracker */
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+        if (jptr->jobid == jobid) {
+            return;
+        }
+    }
+    jptr = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+    (void)strncpy(jptr->nspace, nspace, PMIX_MAX_NSLEN);
+    jptr->jobid = jobid;
+    opal_list_append(&mca_pmix_external114_component.jobids, &jptr->super);
+}
+
+pmix_status_t pmix1_convert_opalrc(int rc)
+{
+    switch (rc) {
+    case OPAL_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    case OPAL_ERR_COMM_FAILURE:
+        return PMIX_ERR_COMM_FAILURE;
+    case OPAL_ERR_NOT_IMPLEMENTED:
+        return PMIX_ERR_NOT_IMPLEMENTED;
+    case OPAL_ERR_NOT_SUPPORTED:
+        return PMIX_ERR_NOT_SUPPORTED;
+    case OPAL_ERR_NOT_FOUND:
+        return PMIX_ERR_NOT_FOUND;
+    case OPAL_ERR_SERVER_NOT_AVAIL:
+        return PMIX_ERR_SERVER_NOT_AVAIL;
+
+    case OPAL_ERR_BAD_PARAM:
+        return PMIX_ERR_BAD_PARAM;
+    case OPAL_ERR_OUT_OF_RESOURCE:
+        return PMIX_ERR_NOMEM;
+
+    case OPAL_ERR_DATA_VALUE_NOT_FOUND:
+        return PMIX_ERR_DATA_VALUE_NOT_FOUND;
+    case OPAL_ERR_IN_ERRNO:
+        return PMIX_ERR_IN_ERRNO;
+    case OPAL_ERR_UNREACH:
+        return PMIX_ERR_UNREACH;
+    case OPAL_ERR_TIMEOUT:
+        return PMIX_ERR_TIMEOUT;
+    case OPAL_ERR_PERM:
+        return PMIX_ERR_NO_PERMISSIONS;
+    case OPAL_ERR_PACK_MISMATCH:
+        return PMIX_ERR_PACK_MISMATCH;
+    case OPAL_ERR_PACK_FAILURE:
+        return PMIX_ERR_PACK_FAILURE;
+
+    case OPAL_ERR_UNPACK_FAILURE:
+        return PMIX_ERR_UNPACK_FAILURE;
+    case OPAL_ERR_UNPACK_INADEQUATE_SPACE:
+        return PMIX_ERR_UNPACK_INADEQUATE_SPACE;
+    case OPAL_ERR_TYPE_MISMATCH:
+        return PMIX_ERR_TYPE_MISMATCH;
+    case OPAL_ERR_PROC_ENTRY_NOT_FOUND:
+        return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+    case OPAL_ERR_UNKNOWN_DATA_TYPE:
+        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+    case OPAL_ERR_WOULD_BLOCK:
+        return PMIX_ERR_WOULD_BLOCK;
+    case OPAL_EXISTS:
+        return PMIX_EXISTS;
+
+    case OPAL_ERR_SILENT:
+        return PMIX_ERR_SILENT;
+    case OPAL_ERROR:
+        return PMIX_ERROR;
+    case OPAL_SUCCESS:
+        return PMIX_SUCCESS;
+    default:
+        return PMIX_ERROR;
+    }
+}
+
+int pmix1_convert_rc(pmix_status_t rc)
+{
+    switch (rc) {
+    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+        return OPAL_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    case PMIX_ERR_COMM_FAILURE:
+        return OPAL_ERR_COMM_FAILURE;
+    case PMIX_ERR_NOT_IMPLEMENTED:
+        return OPAL_ERR_NOT_IMPLEMENTED;
+    case PMIX_ERR_NOT_SUPPORTED:
+        return OPAL_ERR_NOT_SUPPORTED;
+    case PMIX_ERR_NOT_FOUND:
+        return OPAL_ERR_NOT_FOUND;
+    case PMIX_ERR_SERVER_NOT_AVAIL:
+        return OPAL_ERR_SERVER_NOT_AVAIL;
+
+    case PMIX_ERR_INVALID_NAMESPACE:
+    case PMIX_ERR_INVALID_SIZE:
+    case PMIX_ERR_INVALID_KEYVALP:
+    case PMIX_ERR_INVALID_NUM_PARSED:
+    case PMIX_ERR_INVALID_ARGS:
+    case PMIX_ERR_INVALID_NUM_ARGS:
+    case PMIX_ERR_INVALID_LENGTH:
+    case PMIX_ERR_INVALID_VAL_LENGTH:
+    case PMIX_ERR_INVALID_VAL:
+    case PMIX_ERR_INVALID_KEY_LENGTH:
+    case PMIX_ERR_INVALID_KEY:
+    case PMIX_ERR_INVALID_ARG:
+        return OPAL_ERR_BAD_PARAM;
+    case PMIX_ERR_NOMEM:
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    case PMIX_ERR_INIT:
+        return OPAL_ERROR;
+
+    case PMIX_ERR_DATA_VALUE_NOT_FOUND:
+        return OPAL_ERR_DATA_VALUE_NOT_FOUND;
+    case PMIX_ERR_OUT_OF_RESOURCE:
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    case PMIX_ERR_RESOURCE_BUSY:
+        return OPAL_ERR_TEMP_OUT_OF_RESOURCE;
+    case PMIX_ERR_BAD_PARAM:
+        return OPAL_ERR_BAD_PARAM;
+    case PMIX_ERR_IN_ERRNO:
+        return OPAL_ERR_IN_ERRNO;
+    case PMIX_ERR_UNREACH:
+        return OPAL_ERR_UNREACH;
+    case PMIX_ERR_TIMEOUT:
+        return OPAL_ERR_TIMEOUT;
+    case PMIX_ERR_NO_PERMISSIONS:
+        return OPAL_ERR_PERM;
+    case PMIX_ERR_PACK_MISMATCH:
+        return OPAL_ERR_PACK_MISMATCH;
+    case PMIX_ERR_PACK_FAILURE:
+        return OPAL_ERR_PACK_FAILURE;
+
+    case PMIX_ERR_UNPACK_FAILURE:
+        return OPAL_ERR_UNPACK_FAILURE;
+    case PMIX_ERR_UNPACK_INADEQUATE_SPACE:
+        return OPAL_ERR_UNPACK_INADEQUATE_SPACE;
+    case PMIX_ERR_TYPE_MISMATCH:
+        return OPAL_ERR_TYPE_MISMATCH;
+    case PMIX_ERR_PROC_ENTRY_NOT_FOUND:
+        return OPAL_ERR_PROC_ENTRY_NOT_FOUND;
+    case PMIX_ERR_UNKNOWN_DATA_TYPE:
+        return OPAL_ERR_UNKNOWN_DATA_TYPE;
+    case PMIX_ERR_WOULD_BLOCK:
+        return OPAL_ERR_WOULD_BLOCK;
+    case PMIX_ERR_READY_FOR_HANDSHAKE:
+    case PMIX_ERR_HANDSHAKE_FAILED:
+    case PMIX_ERR_INVALID_CRED:
+        return OPAL_ERR_COMM_FAILURE;
+    case PMIX_EXISTS:
+        return OPAL_EXISTS;
+
+    case PMIX_ERR_SILENT:
+        return OPAL_ERR_SILENT;
+    case PMIX_ERROR:
+        return OPAL_ERROR;
+    case PMIX_SUCCESS:
+        return OPAL_SUCCESS;
+    default:
+        return OPAL_ERROR;
+    }
+}
+
+pmix_scope_t pmix1_convert_opalscope(opal_pmix_scope_t scope) {
+    switch(scope) {
+    case OPAL_PMIX_LOCAL:
+        return PMIX_LOCAL;
+    case OPAL_PMIX_REMOTE:
+        return PMIX_REMOTE;
+    case OPAL_PMIX_GLOBAL:
+        return PMIX_GLOBAL;
+    default:
+        return PMIX_SCOPE_UNDEF;
+    }
+}
+
+void pmix1_value_load(pmix_value_t *v,
+                      opal_value_t *kv)
+{
+    switch(kv->type) {
+        case OPAL_UNDEF:
+            v->type = PMIX_UNDEF;
+            opal_output(0, "TYPE WAS UNDEF");
+            break;
+        case OPAL_BOOL:
+            v->type = PMIX_BOOL;
+            memcpy(&(v->data.flag), &kv->data.flag, 1);
+            break;
+        case OPAL_BYTE:
+            v->type = PMIX_BYTE;
+            memcpy(&(v->data.byte), &kv->data.byte, 1);
+            break;
+        case OPAL_STRING:
+            v->type = PMIX_STRING;
+            if (NULL != kv->data.string) {
+                v->data.string = strdup(kv->data.string);
+            } else {
+                v->data.string = NULL;
+            }
+            break;
+        case OPAL_SIZE:
+            v->type = PMIX_SIZE;
+            v->data.size = (size_t)kv->data.size;
+            break;
+        case OPAL_PID:
+            v->type = PMIX_PID;
+            memcpy(&(v->data.pid), &kv->data.pid, sizeof(pid_t));
+            break;
+        case OPAL_INT:
+            v->type = PMIX_INT;
+            memcpy(&(v->data.integer), &kv->data.integer, sizeof(int));
+            break;
+        case OPAL_INT8:
+            v->type = PMIX_INT8;
+            memcpy(&(v->data.int8), &kv->data.int8, 1);
+            break;
+        case OPAL_INT16:
+            v->type = PMIX_INT16;
+            memcpy(&(v->data.int16), &kv->data.int16, 2);
+            break;
+        case OPAL_INT32:
+            v->type = PMIX_INT32;
+            memcpy(&(v->data.int32), &kv->data.int32, 4);
+            break;
+        case OPAL_INT64:
+            v->type = PMIX_INT64;
+            memcpy(&(v->data.int64), &kv->data.int64, 8);
+            break;
+        case OPAL_UINT:
+            v->type = PMIX_UINT;
+            memcpy(&(v->data.uint), &kv->data.uint, sizeof(int));
+            break;
+        case OPAL_UINT8:
+            v->type = PMIX_UINT8;
+            memcpy(&(v->data.uint8), &kv->data.uint8, 1);
+            break;
+        case OPAL_UINT16:
+            v->type = PMIX_UINT16;
+            memcpy(&(v->data.uint16), &kv->data.uint16, 2);
+            break;
+        case OPAL_UINT32:
+            v->type = PMIX_UINT32;
+            memcpy(&(v->data.uint32), &kv->data.uint32, 4);
+            break;
+        case OPAL_UINT64:
+            v->type = PMIX_UINT64;
+            memcpy(&(v->data.uint64), &kv->data.uint64, 8);
+            break;
+        case OPAL_FLOAT:
+            v->type = PMIX_FLOAT;
+            memcpy(&(v->data.fval), &kv->data.fval, sizeof(float));
+            break;
+        case OPAL_DOUBLE:
+            v->type = PMIX_DOUBLE;
+            memcpy(&(v->data.dval), &kv->data.dval, sizeof(double));
+            break;
+        case OPAL_TIMEVAL:
+            v->type = PMIX_TIMEVAL;
+            memcpy(&(v->data.tv), &kv->data.tv, sizeof(struct timeval));
+            break;
+        case OPAL_BYTE_OBJECT:
+            v->type = PMIX_BYTE_OBJECT;
+            if (NULL != kv->data.bo.bytes) {
+                v->data.bo.bytes = (char*)malloc(kv->data.bo.size);
+                memcpy(v->data.bo.bytes, kv->data.bo.bytes, kv->data.bo.size);
+                v->data.bo.size = (size_t)kv->data.bo.size;
+            } else {
+                v->data.bo.bytes = NULL;
+                v->data.bo.size = 0;
+            }
+            break;
+        default:
+            /* silence warnings */
+            break;
+    }
+}
+
+int pmix1_value_unload(opal_value_t *kv,
+                       const pmix_value_t *v)
+{
+    int rc=OPAL_SUCCESS;
+
+
+    switch(v->type) {
+    case PMIX_UNDEF:
+        rc = OPAL_ERR_UNKNOWN_DATA_TYPE;
+        break;
+    case PMIX_BOOL:
+        kv->type = OPAL_BOOL;
+        memcpy(&kv->data.flag, &(v->data.flag), 1);
+        break;
+    case PMIX_BYTE:
+        kv->type = OPAL_BYTE;
+        memcpy(&kv->data.byte, &(v->data.byte), 1);
+        break;
+    case PMIX_STRING:
+        kv->type = OPAL_STRING;
+        if (NULL != v->data.string) {
+            kv->data.string = strdup(v->data.string);
+        }
+        break;
+    case PMIX_SIZE:
+        kv->type = OPAL_SIZE;
+        kv->data.size = (int)v->data.size;
+        break;
+    case PMIX_PID:
+        kv->type = OPAL_PID;
+        memcpy(&kv->data.pid, &(v->data.pid), sizeof(pid_t));
+        break;
+    case PMIX_INT:
+        kv->type = OPAL_INT;
+        memcpy(&kv->data.integer, &(v->data.integer), sizeof(int));
+        break;
+    case PMIX_INT8:
+        kv->type = OPAL_INT8;
+        memcpy(&kv->data.int8, &(v->data.int8), 1);
+        break;
+    case PMIX_INT16:
+        kv->type = OPAL_INT16;
+        memcpy(&kv->data.int16, &(v->data.int16), 2);
+        break;
+    case PMIX_INT32:
+        kv->type = OPAL_INT32;
+        memcpy(&kv->data.int32, &(v->data.int32), 4);
+        break;
+    case PMIX_INT64:
+        kv->type = OPAL_INT64;
+        memcpy(&kv->data, &(v->data.int64), 8);
+        break;
+    case PMIX_UINT:
+        kv->type = OPAL_UINT;
+        memcpy(&kv->data, &(v->data.uint), sizeof(int));
+        break;
+    case PMIX_UINT8:
+        kv->type = OPAL_UINT8;
+        memcpy(&kv->data, &(v->data.uint8), 1);
+        break;
+    case PMIX_UINT16:
+        kv->type = OPAL_UINT16;
+        memcpy(&kv->data, &(v->data.uint16), 2);
+        break;
+    case PMIX_UINT32:
+        kv->type = OPAL_UINT32;
+        memcpy(&kv->data, &(v->data.uint32), 4);
+        break;
+    case PMIX_UINT64:
+        kv->type = OPAL_UINT64;
+        memcpy(&kv->data, &(v->data.uint64), 8);
+        break;
+    case PMIX_FLOAT:
+        kv->type = OPAL_FLOAT;
+        memcpy(&kv->data, &(v->data.fval), sizeof(float));
+        break;
+    case PMIX_DOUBLE:
+        kv->type = OPAL_DOUBLE;
+        memcpy(&kv->data, &(v->data.dval), sizeof(double));
+        break;
+    case PMIX_TIMEVAL:
+        kv->type = OPAL_TIMEVAL;
+        memcpy(&kv->data, &(v->data.tv), sizeof(struct timeval));
+        break;
+    case PMIX_BYTE_OBJECT:
+        kv->type = OPAL_BYTE_OBJECT;
+        if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
+            kv->data.bo.bytes = (uint8_t*)malloc(v->data.bo.size);
+            memcpy(kv->data.bo.bytes, v->data.bo.bytes, v->data.bo.size);
+            kv->data.bo.size = (int)v->data.bo.size;
+        } else {
+            kv->data.bo.bytes = NULL;
+            kv->data.bo.size = 0;
+        }
+        break;
+    default:
+        /* silence warnings */
+        rc = OPAL_ERROR;
+        break;
+    }
+    return rc;
+}
+
+
+/****  INSTANTIATE INTERNAL CLASSES  ****/
+OBJ_CLASS_INSTANCE(opal_pmix1_jobid_trkr_t,
+                   opal_list_item_t,
+                   NULL, NULL);
+
+static void opcon(pmix1_opcaddy_t *p)
+{
+    memset(&p->p, 0, sizeof(pmix_proc_t));
+    p->procs = NULL;
+    p->nprocs = 0;
+    p->error_procs = NULL;
+    p->nerror_procs = 0;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->apps = NULL;
+    p->sz = 0;
+    p->opcbfunc = NULL;
+    p->mdxcbfunc = NULL;
+    p->valcbfunc = NULL;
+    p->lkcbfunc = NULL;
+    p->spcbfunc = NULL;
+    p->cbdata = NULL;
+}
+static void opdes(pmix1_opcaddy_t *p)
+{
+    if (NULL != p->procs) {
+        PMIX_PROC_FREE(p->procs, p->nprocs);
+    }
+    if (NULL != p->error_procs) {
+        PMIX_PROC_FREE(p->error_procs, p->nerror_procs);
+    }
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->sz);
+    }
+    if (NULL != p->apps) {
+        PMIX_APP_FREE(p->apps, p->sz);
+    }
+}
+OBJ_CLASS_INSTANCE(pmix1_opcaddy_t,
+                   opal_object_t,
+                   opcon, opdes);
+
+static void ocadcon(pmix1_opalcaddy_t *p)
+{
+    OBJ_CONSTRUCT(&p->procs, opal_list_t);
+    OBJ_CONSTRUCT(&p->info, opal_list_t);
+    OBJ_CONSTRUCT(&p->apps, opal_list_t);
+    p->opcbfunc = NULL;
+    p->dmdxfunc = NULL;
+    p->mdxcbfunc = NULL;
+    p->lkupcbfunc = NULL;
+    p->spwncbfunc = NULL;
+    p->cbdata = NULL;
+    p->odmdxfunc = NULL;
+    p->ocbdata = NULL;
+}
+static void ocaddes(pmix1_opalcaddy_t *p)
+{
+    OPAL_LIST_DESTRUCT(&p->procs);
+    OPAL_LIST_DESTRUCT(&p->info);
+    OPAL_LIST_DESTRUCT(&p->apps);
+}
+OBJ_CLASS_INSTANCE(pmix1_opalcaddy_t,
+                   opal_object_t,
+                   ocadcon, ocaddes);

--- a/opal/mca/pmix/external114/pmix_ext.h
+++ b/opal/mca/pmix/external114/pmix_ext.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef MCA_PMIX_PMIX1_H
+#define MCA_PMIX_PMIX1_H
+
+#include "opal_config.h"
+
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+#ifdef HAVE_SYS_UN_H
+#include <sys/un.h>
+#endif
+
+#include "opal/mca/mca.h"
+#include "opal/mca/event/event.h"
+#include "opal/util/proc.h"
+
+#include "opal/mca/pmix/pmix.h"
+#include "opal/mca/pmix/pmix_server.h"
+#include <pmix_server.h>
+#include <pmix/pmix_common.h>
+
+BEGIN_C_DECLS
+
+typedef struct {
+  opal_pmix_base_component_t super;
+  opal_list_t jobids;
+  bool native_launch;
+} mca_pmix_pmix1_component_t;
+
+OPAL_DECLSPEC extern mca_pmix_pmix1_component_t mca_pmix_external114_component;
+
+OPAL_DECLSPEC extern const opal_pmix_base_module_t opal_pmix_external_module;
+
+/****  INTERNAL OBJECTS  ****/
+typedef struct {
+    opal_list_item_t super;
+    opal_jobid_t jobid;
+    char nspace[PMIX_MAX_NSLEN + 1];
+} opal_pmix1_jobid_trkr_t;
+OBJ_CLASS_DECLARATION(opal_pmix1_jobid_trkr_t);
+
+typedef struct {
+    opal_object_t super;
+    pmix_proc_t p;
+    pmix_proc_t *procs;
+    size_t nprocs;
+    pmix_proc_t *error_procs;
+    size_t nerror_procs;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_app_t *apps;
+    size_t sz;
+    opal_pmix_op_cbfunc_t opcbfunc;
+    opal_pmix_modex_cbfunc_t mdxcbfunc;
+    opal_pmix_value_cbfunc_t valcbfunc;
+    opal_pmix_lookup_cbfunc_t lkcbfunc;
+    opal_pmix_spawn_cbfunc_t spcbfunc;
+    void *cbdata;
+} pmix1_opcaddy_t;
+OBJ_CLASS_DECLARATION(pmix1_opcaddy_t);
+
+typedef struct {
+    opal_object_t super;
+    opal_list_t procs;
+    opal_list_t info;
+    opal_list_t apps;
+    pmix_op_cbfunc_t opcbfunc;
+    pmix_dmodex_response_fn_t dmdxfunc;
+    pmix_modex_cbfunc_t mdxcbfunc;
+    pmix_lookup_cbfunc_t lkupcbfunc;
+    pmix_spawn_cbfunc_t spwncbfunc;
+    void *cbdata;
+    opal_pmix_release_cbfunc_t odmdxfunc;
+    void *ocbdata;
+} pmix1_opalcaddy_t;
+OBJ_CLASS_DECLARATION(pmix1_opalcaddy_t);
+
+
+/****  CLIENT FUNCTIONS  ****/
+OPAL_MODULE_DECLSPEC int pmix1_client_init(void);
+OPAL_MODULE_DECLSPEC int pmix1_client_finalize(void);
+OPAL_MODULE_DECLSPEC int pmix1_initialized(void);
+OPAL_MODULE_DECLSPEC int pmix1_abort(int flag, const char *msg,
+                                     opal_list_t *procs);
+OPAL_MODULE_DECLSPEC int pmix1_commit(void);
+OPAL_MODULE_DECLSPEC int pmix1_fence(opal_list_t *procs, int collect_data);
+OPAL_MODULE_DECLSPEC int pmix1_fencenb(opal_list_t *procs, int collect_data,
+                                       opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_put(opal_pmix_scope_t scope,
+                                     opal_value_t *val);
+OPAL_MODULE_DECLSPEC int pmix1_get(const opal_process_name_t *proc, const char *key,
+                                   opal_list_t *info, opal_value_t **val);
+OPAL_MODULE_DECLSPEC int pmix1_getnb(const opal_process_name_t *proc, const char *key,
+                                     opal_list_t *info,
+                                     opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_publish(opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix1_publishnb(opal_list_t *info,
+                                         opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_lookup(opal_list_t *data, opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix1_lookupnb(char **keys, opal_list_t *info,
+                                        opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_unpublish(char **keys, opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix1_unpublishnb(char **keys, opal_list_t *info,
+                                           opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid);
+OPAL_MODULE_DECLSPEC int pmix1_spawnnb(opal_list_t *job_info, opal_list_t *apps,
+                                       opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_connect(opal_list_t *procs);
+OPAL_MODULE_DECLSPEC int pmix1_connectnb(opal_list_t *procs,
+                                         opal_pmix_op_cbfunc_t cbfunc,
+                                         void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_disconnect(opal_list_t *procs);
+OPAL_MODULE_DECLSPEC int pmix1_disconnectnb(opal_list_t *procs,
+                                            opal_pmix_op_cbfunc_t cbfunc,
+                                            void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_resolve_peers(const char *nodename, opal_jobid_t jobid,
+                                             opal_list_t *procs);
+OPAL_MODULE_DECLSPEC int pmix1_resolve_nodes(opal_jobid_t jobid, char **nodelist);
+
+/****  COMMON FUNCTIONS  ****/
+OPAL_MODULE_DECLSPEC int pmix1_store_local(const opal_process_name_t *proc,
+                                             opal_value_t *val);
+
+/****  SERVER SOUTHBOUND FUNCTIONS  ****/
+OPAL_MODULE_DECLSPEC int pmix1_server_init(opal_pmix_server_module_t *module,
+                                           opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix1_server_finalize(void);
+OPAL_MODULE_DECLSPEC int pmix1_server_gen_regex(const char *input, char **regex);
+OPAL_MODULE_DECLSPEC int pmix1_server_gen_ppn(const char *input, char **ppn);
+OPAL_MODULE_DECLSPEC int pmix1_server_register_nspace(opal_jobid_t jobid,
+                                                      int nlocalprocs,
+                                                      opal_list_t *info,
+                                                      opal_pmix_op_cbfunc_t cbfunc,
+                                                      void *cbdata);
+OPAL_MODULE_DECLSPEC void pmix1_server_deregister_nspace(opal_jobid_t jobid);
+OPAL_MODULE_DECLSPEC int pmix1_server_register_client(const opal_process_name_t *proc,
+                                                      uid_t uid, gid_t gid,
+                                                      void *server_object,
+                                                      opal_pmix_op_cbfunc_t cbfunc,
+                                                      void *cbdata);
+OPAL_MODULE_DECLSPEC void pmix1_server_deregister_client(const opal_process_name_t *proc);
+OPAL_MODULE_DECLSPEC int pmix1_server_setup_fork(const opal_process_name_t *proc, char ***env);
+OPAL_MODULE_DECLSPEC int pmix1_server_dmodex(const opal_process_name_t *proc,
+                                             opal_pmix_modex_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix1_server_notify_error(int status,
+                                                   opal_list_t *procs,
+                                                   opal_list_t *error_procs,
+                                                   opal_list_t *info,
+                                                   opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
+/****  COMPONENT UTILITY FUNCTIONS  ****/
+OPAL_MODULE_DECLSPEC pmix_status_t pmix1_convert_opalrc(int rc);
+OPAL_MODULE_DECLSPEC int pmix1_convert_rc(pmix_status_t rc);
+OPAL_MODULE_DECLSPEC pmix_scope_t pmix1_convert_opalscope(opal_pmix_scope_t scope);
+OPAL_MODULE_DECLSPEC void pmix1_value_load(pmix_value_t *v,
+                                           opal_value_t *kv);
+OPAL_MODULE_DECLSPEC int pmix1_value_unload(opal_value_t *kv,
+                                            const pmix_value_t *v);
+
+END_C_DECLS
+
+#endif /* MCA_PMIX_PMIX1_H */

--- a/opal/mca/pmix/external114/pmix_ext.h
+++ b/opal/mca/pmix/external114/pmix_ext.h
@@ -10,8 +10,8 @@
  * $HEADER$
  */
 
-#ifndef MCA_PMIX_PMIX1_H
-#define MCA_PMIX_PMIX1_H
+#ifndef MCA_PMIX_EXT114_H
+#define MCA_PMIX_EXT114_H
 
 #include "opal_config.h"
 
@@ -28,6 +28,7 @@
 
 #include "opal/mca/pmix/pmix.h"
 #include "opal/mca/pmix/pmix_server.h"
+#include <pmix.h>
 #include <pmix_server.h>
 #include <pmix/pmix_common.h>
 
@@ -41,15 +42,15 @@ typedef struct {
 
 OPAL_DECLSPEC extern mca_pmix_pmix1_component_t mca_pmix_external114_component;
 
-OPAL_DECLSPEC extern const opal_pmix_base_module_t opal_pmix_external_module;
+OPAL_DECLSPEC extern const opal_pmix_base_module_t opal_pmix_external114_module;
 
 /****  INTERNAL OBJECTS  ****/
 typedef struct {
     opal_list_item_t super;
     opal_jobid_t jobid;
     char nspace[PMIX_MAX_NSLEN + 1];
-} opal_pmix1_jobid_trkr_t;
-OBJ_CLASS_DECLARATION(opal_pmix1_jobid_trkr_t);
+} opal_pmix_ext114_jobid_trkr_t;
+OBJ_CLASS_DECLARATION(opal_pmix_ext114_jobid_trkr_t);
 
 typedef struct {
     opal_object_t super;
@@ -68,8 +69,8 @@ typedef struct {
     opal_pmix_lookup_cbfunc_t lkcbfunc;
     opal_pmix_spawn_cbfunc_t spcbfunc;
     void *cbdata;
-} pmix1_opcaddy_t;
-OBJ_CLASS_DECLARATION(pmix1_opcaddy_t);
+} pmix_ext114_opcaddy_t;
+OBJ_CLASS_DECLARATION(pmix_ext114_opcaddy_t);
 
 typedef struct {
     opal_object_t super;
@@ -84,77 +85,77 @@ typedef struct {
     void *cbdata;
     opal_pmix_release_cbfunc_t odmdxfunc;
     void *ocbdata;
-} pmix1_opalcaddy_t;
-OBJ_CLASS_DECLARATION(pmix1_opalcaddy_t);
+} pmix_ext114_opalcaddy_t;
+OBJ_CLASS_DECLARATION(pmix_ext114_opalcaddy_t);
 
 
 /****  CLIENT FUNCTIONS  ****/
-OPAL_MODULE_DECLSPEC int pmix1_client_init(void);
-OPAL_MODULE_DECLSPEC int pmix1_client_finalize(void);
-OPAL_MODULE_DECLSPEC int pmix1_initialized(void);
-OPAL_MODULE_DECLSPEC int pmix1_abort(int flag, const char *msg,
+OPAL_MODULE_DECLSPEC int pmix_ext114_client_init(void);
+OPAL_MODULE_DECLSPEC int pmix_ext114_client_finalize(void);
+OPAL_MODULE_DECLSPEC int pmix_ext114_initialized(void);
+OPAL_MODULE_DECLSPEC int pmix_ext114_abort(int flag, const char *msg,
                                      opal_list_t *procs);
-OPAL_MODULE_DECLSPEC int pmix1_commit(void);
-OPAL_MODULE_DECLSPEC int pmix1_fence(opal_list_t *procs, int collect_data);
-OPAL_MODULE_DECLSPEC int pmix1_fencenb(opal_list_t *procs, int collect_data,
+OPAL_MODULE_DECLSPEC int pmix_ext114_commit(void);
+OPAL_MODULE_DECLSPEC int pmix_ext114_fence(opal_list_t *procs, int collect_data);
+OPAL_MODULE_DECLSPEC int pmix_ext114_fencenb(opal_list_t *procs, int collect_data,
                                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_put(opal_pmix_scope_t scope,
+OPAL_MODULE_DECLSPEC int pmix_ext114_put(opal_pmix_scope_t scope,
                                      opal_value_t *val);
-OPAL_MODULE_DECLSPEC int pmix1_get(const opal_process_name_t *proc, const char *key,
+OPAL_MODULE_DECLSPEC int pmix_ext114_get(const opal_process_name_t *proc, const char *key,
                                    opal_list_t *info, opal_value_t **val);
-OPAL_MODULE_DECLSPEC int pmix1_getnb(const opal_process_name_t *proc, const char *key,
+OPAL_MODULE_DECLSPEC int pmix_ext114_getnb(const opal_process_name_t *proc, const char *key,
                                      opal_list_t *info,
                                      opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_publish(opal_list_t *info);
-OPAL_MODULE_DECLSPEC int pmix1_publishnb(opal_list_t *info,
+OPAL_MODULE_DECLSPEC int pmix_ext114_publish(opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix_ext114_publishnb(opal_list_t *info,
                                          opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_lookup(opal_list_t *data, opal_list_t *info);
-OPAL_MODULE_DECLSPEC int pmix1_lookupnb(char **keys, opal_list_t *info,
+OPAL_MODULE_DECLSPEC int pmix_ext114_lookup(opal_list_t *data, opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix_ext114_lookupnb(char **keys, opal_list_t *info,
                                         opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_unpublish(char **keys, opal_list_t *info);
-OPAL_MODULE_DECLSPEC int pmix1_unpublishnb(char **keys, opal_list_t *info,
+OPAL_MODULE_DECLSPEC int pmix_ext114_unpublish(char **keys, opal_list_t *info);
+OPAL_MODULE_DECLSPEC int pmix_ext114_unpublishnb(char **keys, opal_list_t *info,
                                            opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid);
-OPAL_MODULE_DECLSPEC int pmix1_spawnnb(opal_list_t *job_info, opal_list_t *apps,
+OPAL_MODULE_DECLSPEC int pmix_ext114_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid);
+OPAL_MODULE_DECLSPEC int pmix_ext114_spawnnb(opal_list_t *job_info, opal_list_t *apps,
                                        opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_connect(opal_list_t *procs);
-OPAL_MODULE_DECLSPEC int pmix1_connectnb(opal_list_t *procs,
+OPAL_MODULE_DECLSPEC int pmix_ext114_connect(opal_list_t *procs);
+OPAL_MODULE_DECLSPEC int pmix_ext114_connectnb(opal_list_t *procs,
                                          opal_pmix_op_cbfunc_t cbfunc,
                                          void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_disconnect(opal_list_t *procs);
-OPAL_MODULE_DECLSPEC int pmix1_disconnectnb(opal_list_t *procs,
+OPAL_MODULE_DECLSPEC int pmix_ext114_disconnect(opal_list_t *procs);
+OPAL_MODULE_DECLSPEC int pmix_ext114_disconnectnb(opal_list_t *procs,
                                             opal_pmix_op_cbfunc_t cbfunc,
                                             void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_resolve_peers(const char *nodename, opal_jobid_t jobid,
+OPAL_MODULE_DECLSPEC int pmix_ext114_resolve_peers(const char *nodename, opal_jobid_t jobid,
                                              opal_list_t *procs);
-OPAL_MODULE_DECLSPEC int pmix1_resolve_nodes(opal_jobid_t jobid, char **nodelist);
+OPAL_MODULE_DECLSPEC int pmix_ext114_resolve_nodes(opal_jobid_t jobid, char **nodelist);
 
 /****  COMMON FUNCTIONS  ****/
-OPAL_MODULE_DECLSPEC int pmix1_store_local(const opal_process_name_t *proc,
+OPAL_MODULE_DECLSPEC int pmix_ext114_store_local(const opal_process_name_t *proc,
                                              opal_value_t *val);
 
 /****  SERVER SOUTHBOUND FUNCTIONS  ****/
-OPAL_MODULE_DECLSPEC int pmix1_server_init(opal_pmix_server_module_t *module,
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_init(opal_pmix_server_module_t *module,
                                            opal_list_t *info);
-OPAL_MODULE_DECLSPEC int pmix1_server_finalize(void);
-OPAL_MODULE_DECLSPEC int pmix1_server_gen_regex(const char *input, char **regex);
-OPAL_MODULE_DECLSPEC int pmix1_server_gen_ppn(const char *input, char **ppn);
-OPAL_MODULE_DECLSPEC int pmix1_server_register_nspace(opal_jobid_t jobid,
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_finalize(void);
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_gen_regex(const char *input, char **regex);
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_gen_ppn(const char *input, char **ppn);
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_register_nspace(opal_jobid_t jobid,
                                                       int nlocalprocs,
                                                       opal_list_t *info,
                                                       opal_pmix_op_cbfunc_t cbfunc,
                                                       void *cbdata);
-OPAL_MODULE_DECLSPEC void pmix1_server_deregister_nspace(opal_jobid_t jobid);
-OPAL_MODULE_DECLSPEC int pmix1_server_register_client(const opal_process_name_t *proc,
+OPAL_MODULE_DECLSPEC void pmix_ext114_server_deregister_nspace(opal_jobid_t jobid);
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_register_client(const opal_process_name_t *proc,
                                                       uid_t uid, gid_t gid,
                                                       void *server_object,
                                                       opal_pmix_op_cbfunc_t cbfunc,
                                                       void *cbdata);
-OPAL_MODULE_DECLSPEC void pmix1_server_deregister_client(const opal_process_name_t *proc);
-OPAL_MODULE_DECLSPEC int pmix1_server_setup_fork(const opal_process_name_t *proc, char ***env);
-OPAL_MODULE_DECLSPEC int pmix1_server_dmodex(const opal_process_name_t *proc,
+OPAL_MODULE_DECLSPEC void pmix_ext114_server_deregister_client(const opal_process_name_t *proc);
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_setup_fork(const opal_process_name_t *proc, char ***env);
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_dmodex(const opal_process_name_t *proc,
                                              opal_pmix_modex_cbfunc_t cbfunc, void *cbdata);
-OPAL_MODULE_DECLSPEC int pmix1_server_notify_error(int status,
+OPAL_MODULE_DECLSPEC int pmix_ext114_server_notify_error(int status,
                                                    opal_list_t *procs,
                                                    opal_list_t *error_procs,
                                                    opal_list_t *info,
@@ -162,14 +163,14 @@ OPAL_MODULE_DECLSPEC int pmix1_server_notify_error(int status,
 
 
 /****  COMPONENT UTILITY FUNCTIONS  ****/
-OPAL_MODULE_DECLSPEC pmix_status_t pmix1_convert_opalrc(int rc);
-OPAL_MODULE_DECLSPEC int pmix1_convert_rc(pmix_status_t rc);
-OPAL_MODULE_DECLSPEC pmix_scope_t pmix1_convert_opalscope(opal_pmix_scope_t scope);
-OPAL_MODULE_DECLSPEC void pmix1_value_load(pmix_value_t *v,
+OPAL_MODULE_DECLSPEC pmix_status_t pmix_ext114_convert_opalrc(int rc);
+OPAL_MODULE_DECLSPEC int pmix_ext114_convert_rc(pmix_status_t rc);
+OPAL_MODULE_DECLSPEC pmix_scope_t pmix_ext114_convert_opalscope(opal_pmix_scope_t scope);
+OPAL_MODULE_DECLSPEC void pmix_ext114_value_load(pmix_value_t *v,
                                            opal_value_t *kv);
-OPAL_MODULE_DECLSPEC int pmix1_value_unload(opal_value_t *kv,
+OPAL_MODULE_DECLSPEC int pmix_ext114_value_unload(opal_value_t *kv,
                                             const pmix_value_t *v);
 
 END_C_DECLS
 
-#endif /* MCA_PMIX_PMIX1_H */
+#endif /* MCA_PMIX_EXT114_H */

--- a/opal/mca/pmix/external114/pmix_ext_client.c
+++ b/opal/mca/pmix/external114/pmix_ext_client.c
@@ -1,0 +1,1308 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+#include "opal/constants.h"
+#include "opal/types.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "opal/hash_string.h"
+#include "opal/util/argv.h"
+#include "opal/util/proc.h"
+
+#include "opal/mca/pmix/base/base.h"
+#include "pmix_ext.h"
+#include <pmix.h>
+//#include <src/buffer_ops/buffer_ops.h>
+
+static pmix_proc_t my_proc;
+static char *dbgvalue=NULL;
+static int errhdler_ref = 0;
+
+static void release_cbfunc(void *cbdata)
+{
+    pmix1_opalcaddy_t *cd = (pmix1_opalcaddy_t*)cbdata;
+    OBJ_RELEASE(cd);
+}
+static void myerr(pmix_status_t status,
+                  pmix_proc_t procs[], size_t nprocs,
+                  pmix_info_t info[], size_t ninfo)
+{
+    int rc;
+    opal_namelist_t *nm;
+    opal_value_t *iptr;
+    size_t n;
+    pmix1_opalcaddy_t *cd;
+
+    /* convert the incoming status */
+    rc = pmix1_convert_rc(status);
+
+    /* setup the caddy */
+    cd = OBJ_NEW(pmix1_opalcaddy_t);
+
+    /* convert the array of procs */
+    for (n=0; n < nprocs; n++) {
+        nm = OBJ_NEW(opal_namelist_t);
+        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+            OPAL_ERROR_LOG(rc);
+            OBJ_RELEASE(cd);
+            return;
+        }
+        nm->name.vpid = procs[n].rank;
+        opal_list_append(&cd->procs, &nm->super);
+    }
+
+    /* convert the array of info */
+    for (n=0; n < ninfo; n++) {
+        iptr = OBJ_NEW(opal_value_t);
+        iptr->key = strdup(info[n].key);
+        pmix1_value_unload(iptr, &info[n].value);
+        opal_list_append(&cd->info, &iptr->super);
+    }
+
+    /* call the base errhandler */
+    opal_pmix_base_errhandler(rc, &cd->procs, &cd->info, release_cbfunc, cd);
+}
+
+static void errreg_cbfunc (pmix_status_t status,
+                          int errhandler_ref,
+                          void *cbdata)
+{
+    errhdler_ref = errhandler_ref;
+    opal_output_verbose(5, opal_pmix_base_framework.framework_output,
+                        "PMIX client errreg_cbfunc - error handler registered status=%d, reference=%d",
+                         status, errhandler_ref);
+}
+
+int pmix1_client_init(void)
+{
+    opal_process_name_t pname;
+    pmix_status_t rc;
+    int dbg;
+    opal_pmix1_jobid_trkr_t *job;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client init");
+
+    if (0 < (dbg = opal_output_get_verbosity(opal_pmix_base_framework.framework_output))) {
+        asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
+        putenv(dbgvalue);
+    }
+    rc = PMIx_Init(&my_proc);
+    if (PMIX_SUCCESS != rc) {
+        return pmix1_convert_rc(rc);
+    }
+
+    /* store our jobid and rank */
+   if (NULL != getenv(OPAL_MCA_PREFIX"orte_launch")) {
+        /* if we were launched by the OMPI RTE, then
+         * the jobid is in a special format - so get it */
+        mca_pmix_external114_component.native_launch = true;
+        opal_convert_string_to_jobid(&pname.jobid, my_proc.nspace);
+    } else {
+        /* we were launched by someone else, so make the
+         * jobid just be the hash of the nspace */
+        OPAL_HASH_STR(my_proc.nspace, pname.jobid);
+        /* keep it from being negative */
+        pname.jobid &= ~(0x8000);
+    }
+    /* insert this into our list of jobids - it will be the
+     * first, and so we'll check it first */
+    job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+    (void)strncpy(job->nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+    job->jobid = pname.jobid;
+    opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
+
+    pname.vpid = my_proc.rank;
+    opal_proc_set_name(&pname);
+
+    /* register the errhandler */
+    PMIx_Register_errhandler(NULL, 0, myerr, errreg_cbfunc, NULL );
+    return OPAL_SUCCESS;
+
+}
+
+int pmix1_client_finalize(void)
+{
+    pmix_status_t rc;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client finalize");
+
+    /* deregister the errhandler */
+    PMIx_Deregister_errhandler(errhdler_ref, NULL, NULL);
+
+    rc = PMIx_Finalize();
+
+    return pmix1_convert_rc(rc);
+}
+
+int pmix1_initialized(void)
+{
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client initialized");
+
+    return PMIx_Initialized();
+}
+
+int pmix1_abort(int flag, const char *msg,
+                  opal_list_t *procs)
+{
+    pmix_status_t rc;
+    pmix_proc_t *parray=NULL;
+    size_t n, cnt=0;
+    opal_namelist_t *ptr;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client abort");
+
+    /* convert the list of procs to an array
+     * of pmix_proc_t */
+    if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
+        PMIX_PROC_CREATE(parray, cnt);
+        n=0;
+        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+            /* look thru our list of jobids and find the
+             * corresponding nspace */
+            job = NULL;
+            OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+                if (jptr->jobid == ptr->name.jobid) {
+                    job = jptr;
+                    break;
+                }
+            }
+            if (NULL == job) {
+                return OPAL_ERR_NOT_FOUND;
+            }
+            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+            parray[n].rank = ptr->name.vpid;
+            ++n;
+        }
+    }
+
+    /* call the library abort */
+    rc = PMIx_Abort(flag, msg, parray, cnt);
+
+    /* release the array */
+    PMIX_PROC_FREE(parray, cnt);
+
+    return pmix1_convert_rc(rc);
+}
+
+int pmix1_store_local(const opal_process_name_t *proc, opal_value_t *val)
+{
+    pmix_value_t kv;
+    pmix_status_t rc;
+    pmix_proc_t p;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    if (NULL != proc) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        job = NULL;
+        OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (jptr->jobid == proc->jobid) {
+                job = jptr;
+                break;
+            }
+        }
+        if (NULL == job) {
+            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+            return OPAL_ERR_NOT_FOUND;
+        }
+        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+        p.rank = proc->vpid;
+    } else {
+        /* use our name */
+        (void)strncpy(p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+        p.rank = OPAL_PROC_MY_NAME.vpid;
+    }
+
+    PMIX_VALUE_CONSTRUCT(&kv);
+    pmix1_value_load(&kv, val);
+
+    rc = PMIx_Store_internal(&p, val->key, &kv);
+    PMIX_VALUE_DESTRUCT(&kv);
+
+    return pmix1_convert_rc(rc);
+}
+
+int pmix1_commit(void)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_Commit();
+    return pmix1_convert_rc(rc);
+}
+
+static void opcbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+
+    if (NULL != op->opcbfunc) {
+        op->opcbfunc(pmix1_convert_rc(status), op->cbdata);
+    }
+    OBJ_RELEASE(op);
+}
+
+int pmix1_fence(opal_list_t *procs, int collect_data)
+{
+    pmix_status_t rc;
+    pmix_proc_t *parray=NULL;
+    size_t n, cnt=0;
+    opal_namelist_t *ptr;
+    pmix_info_t info, *iptr;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client fence");
+
+    /* convert the list of procs to an array
+     * of pmix_proc_t */
+    if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
+        PMIX_PROC_CREATE(parray, cnt);
+        n=0;
+        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+            /* look thru our list of jobids and find the
+             * corresponding nspace */
+            job = NULL;
+            OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+                if (jptr->jobid == ptr->name.jobid) {
+                    job = jptr;
+                    break;
+                }
+            }
+            if (NULL == job) {
+                return OPAL_ERR_NOT_FOUND;
+            }
+            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+            parray[n].rank = ptr->name.vpid;
+            ++n;
+        }
+    }
+    if (collect_data) {
+        PMIX_INFO_CONSTRUCT(&info);
+        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+        info.value.type = PMIX_BOOL;
+        info.value.data.flag = true;
+        iptr = &info;
+        n = 1;
+    } else {
+        iptr = NULL;
+        n = 0;
+    }
+
+    /* call the library function */
+    rc = PMIx_Fence(parray, cnt, iptr, n);
+
+    /* release the array */
+    PMIX_PROC_FREE(parray, cnt);
+    if (NULL != iptr) {
+        PMIX_INFO_DESTRUCT(&info);
+    }
+
+    return pmix1_convert_rc(rc);
+
+}
+
+int pmix1_fencenb(opal_list_t *procs, int collect_data,
+                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_status_t rc;
+    pmix_proc_t *parray=NULL;
+    size_t n, cnt=0;
+    opal_namelist_t *ptr;
+    pmix1_opcaddy_t *op;
+    pmix_info_t info, *iptr;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client fence_nb");
+
+    /* convert the list of procs to an array
+     * of pmix_proc_t */
+    if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
+        PMIX_PROC_CREATE(parray, cnt);
+        n=0;
+        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+            /* look thru our list of jobids and find the
+             * corresponding nspace */
+            job = NULL;
+            OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+                if (jptr->jobid == ptr->name.jobid) {
+                    job = jptr;
+                    break;
+                }
+            }
+            if (NULL == job) {
+                return OPAL_ERR_NOT_FOUND;
+            }
+            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+            parray[n].rank = ptr->name.vpid;
+            ++n;
+        }
+    }
+
+    if (collect_data) {
+        PMIX_INFO_CONSTRUCT(&info);
+        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+        iptr = &info;
+        n = 1;
+    } else {
+        iptr = NULL;
+        n = 0;
+    }
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+    op->procs = parray;
+    op->nprocs = cnt;
+
+    /* call the library function */
+    rc = PMIx_Fence_nb(parray, cnt, iptr, n, opcbfunc, op);
+    if (PMIX_SUCCESS != rc) {
+        OBJ_RELEASE(op);
+    }
+
+    return pmix1_convert_rc(rc);
+
+}
+
+int pmix1_put(opal_pmix_scope_t opal_scope,
+              opal_value_t *val)
+{
+    pmix_value_t kv;
+    pmix_scope_t pmix_scope = pmix1_convert_opalscope(opal_scope);
+    pmix_status_t rc;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client put");
+
+    PMIX_VALUE_CONSTRUCT(&kv);
+    pmix1_value_load(&kv, val);
+
+    rc = PMIx_Put(pmix_scope, val->key, &kv);
+    PMIX_VALUE_DESTRUCT(&kv);
+    return pmix1_convert_rc(rc);
+}
+
+int pmix1_get(const opal_process_name_t *proc, const char *key,
+              opal_list_t *info, opal_value_t **val)
+{
+    int ret;
+    pmix_value_t *kv;
+    pmix_status_t rc;
+    pmix_proc_t p, *pptr;
+    size_t ninfo, n;
+    pmix_info_t *pinfo;
+    opal_value_t *ival;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "%s PMIx_client get on proc %s key %s",
+                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+
+    /* prep default response */
+    *val = NULL;
+    if (NULL != proc) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        job = NULL;
+        OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (jptr->jobid == proc->jobid) {
+                job = jptr;
+                break;
+            }
+        }
+        if (NULL == job) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+        p.rank = proc->vpid;
+        pptr = &p;
+    } else {
+        /* if they are asking for our jobid, then return it */
+        if (0 == strcmp(key, OPAL_PMIX_JOBID)) {
+            (*val) = OBJ_NEW(opal_value_t);
+            (*val)->type = OPAL_UINT32;
+            (*val)->data.uint32 = OPAL_PROC_MY_NAME.jobid;
+            return OPAL_SUCCESS;
+        } else if (0 == strcmp(key, OPAL_PMIX_RANK)) {
+            (*val) = OBJ_NEW(opal_value_t);
+            (*val)->type = OPAL_INT;
+            (*val)->data.integer = my_proc.rank;
+            return OPAL_SUCCESS;
+        }
+        pptr = NULL;
+    }
+
+    if (NULL != info) {
+        ninfo = opal_list_get_size(info);
+        if (0 < ninfo) {
+            PMIX_INFO_CREATE(pinfo, ninfo);
+            n=0;
+            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+                (void)strncpy(pinfo[n].key, ival->key, PMIX_MAX_KEYLEN);
+                pmix1_value_load(&pinfo[n].value, ival);
+            }
+        } else {
+            pinfo = NULL;
+        }
+    } else {
+        pinfo = NULL;
+        ninfo = 0;
+    }
+
+    /* pass the request down */
+    rc = PMIx_Get(pptr, key, pinfo, ninfo, &kv);
+    if (PMIX_SUCCESS == rc) {
+        if (NULL == kv) {
+            ret = OPAL_SUCCESS;
+        } else {
+            *val = OBJ_NEW(opal_value_t);
+            ret = pmix1_value_unload(*val, kv);
+            PMIX_VALUE_FREE(kv, 1);
+        }
+    } else {
+        ret = pmix1_convert_rc(rc);
+    }
+    PMIX_INFO_FREE(pinfo, ninfo);
+    return ret;
+}
+
+static void val_cbfunc(pmix_status_t status,
+                       pmix_value_t *kv, void *cbdata)
+{
+    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+    int rc;
+    opal_value_t val, *v=NULL;
+
+    rc = pmix1_convert_opalrc(status);
+    if (PMIX_SUCCESS == status && NULL != kv) {
+        rc = pmix1_value_unload(&val, kv);
+        v = &val;
+    }
+
+    if (NULL != op->valcbfunc) {
+        op->valcbfunc(rc, v, op->cbdata);
+    }
+    OBJ_RELEASE(op);
+}
+
+int pmix1_getnb(const opal_process_name_t *proc, const char *key,
+                opal_list_t *info,
+                opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix1_opcaddy_t *op;
+    pmix_status_t rc;
+    size_t n;
+    opal_value_t *ival;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "%s PMIx_client get_nb on proc %s key %s",
+                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->valcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    if (NULL != proc) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        job = NULL;
+        OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (jptr->jobid == proc->jobid) {
+                job = jptr;
+                break;
+            }
+        }
+        if (NULL == job) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        (void)strncpy(op->p.nspace, job->nspace, PMIX_MAX_NSLEN);
+        op->p.rank = proc->vpid;
+    } else {
+        (void)strncpy(op->p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+        op->p.rank = PMIX_RANK_WILDCARD;
+    }
+
+    if (NULL != info) {
+        op->sz = opal_list_get_size(info);
+        if (0 < op->sz) {
+            PMIX_INFO_CREATE(op->info, op->sz);
+            n=0;
+            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+                (void)strncpy(op->info[n].key, ival->key, PMIX_MAX_KEYLEN);
+                pmix1_value_load(&op->info[n].value, ival);
+            }
+        }
+    }
+
+    /* call the library function */
+    rc = PMIx_Get_nb(&op->p, key, op->info, op->sz, val_cbfunc, op);
+    if (PMIX_SUCCESS != rc) {
+        OBJ_RELEASE(op);
+    }
+
+    return pmix1_convert_rc(rc);
+}
+
+int pmix1_publish(opal_list_t *info)
+{
+    pmix_info_t *pinfo;
+    pmix_status_t ret;
+    opal_value_t *iptr;
+    size_t sz, n;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client publish");
+
+    if (NULL == info) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    sz = opal_list_get_size(info);
+    if (0 < sz) {
+        PMIX_INFO_CREATE(pinfo, sz);
+        n=0;
+        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+            (void)strncpy(pinfo[n].key, iptr->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&pinfo[n].value, iptr);
+            ++n;
+        }
+    } else {
+        pinfo = NULL;
+    }
+
+    ret = PMIx_Publish(pinfo, sz);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_publishnb(opal_list_t *info,
+                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_status_t ret;
+    opal_value_t *iptr;
+    size_t n;
+    pmix1_opcaddy_t *op;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client publish_nb");
+
+    if (NULL == info) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    op->sz = opal_list_get_size(info);
+    if (0 < op->sz) {
+        PMIX_INFO_CREATE(op->info, op->sz);
+        n=0;
+        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+            (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&op->info[n].value, iptr);
+            ++n;
+        }
+    }
+
+    ret = PMIx_Publish_nb(op->info, op->sz, opcbfunc, op);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_lookup(opal_list_t *data, opal_list_t *info)
+{
+    pmix_pdata_t *pdata;
+    pmix_info_t *pinfo;
+    size_t sz, ninfo, n;
+    int rc;
+    pmix_status_t ret;
+    opal_pmix_pdata_t *d;
+    opal_value_t *iptr;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client lookup");
+
+    if (NULL == data) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    sz = opal_list_get_size(data);
+    PMIX_PDATA_CREATE(pdata, sz);
+    n=0;
+    OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
+        (void)strncpy(pdata[n++].key, d->value.key, PMIX_MAX_KEYLEN);
+    }
+
+    if (NULL != info) {
+        ninfo = opal_list_get_size(info);
+        PMIX_INFO_CREATE(pinfo, ninfo);
+        n=0;
+        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&pinfo[n].value, iptr);
+            ++n;
+        }
+    } else {
+        pinfo = NULL;
+        ninfo = 0;
+    }
+
+    ret = PMIx_Lookup(pdata, sz, pinfo, ninfo);
+    PMIX_INFO_FREE(pinfo, ninfo);
+
+    if (PMIX_SUCCESS == ret) {
+        /* transfer the data back */
+        n=0;
+        OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
+            if (mca_pmix_external114_component.native_launch) {
+                /* if we were launched by the OMPI RTE, then
+                 * the jobid is in a special format - so get it */
+                opal_convert_string_to_jobid(&d->proc.jobid, pdata[n].proc.nspace);
+            } else {
+                /* we were launched by someone else, so make the
+                 * jobid just be the hash of the nspace */
+                OPAL_HASH_STR(pdata[n].proc.nspace, d->proc.jobid);
+            }
+            /* if we don't already have it, add this to our jobid tracker */
+            job = NULL;
+            OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+                if (jptr->jobid == d->proc.jobid) {
+                    job = jptr;
+                    break;
+                }
+            }
+            if (NULL == job) {
+               job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+                (void)strncpy(job->nspace, pdata[n].proc.nspace, PMIX_MAX_NSLEN);
+                job->jobid = d->proc.jobid;
+                opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
+            }
+            if (PMIX_RANK_WILDCARD == pdata[n].proc.rank) {
+                d->proc.vpid = OPAL_VPID_WILDCARD;
+            } else {
+                d->proc.vpid = pdata[n].proc.rank;
+            }
+            rc = pmix1_value_unload(&d->value, &pdata[n].value);
+            if (OPAL_SUCCESS != rc) {
+                OPAL_ERROR_LOG(rc);
+                PMIX_PDATA_FREE(pdata, sz);
+                return OPAL_ERR_BAD_PARAM;
+            }
+            ++n;
+        }
+    }
+
+    return pmix1_convert_rc(ret);
+}
+
+static void lk_cbfunc(pmix_status_t status,
+                      pmix_pdata_t data[], size_t ndata,
+                      void *cbdata)
+{
+    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+    opal_pmix_pdata_t *d;
+    opal_list_t results, *r = NULL;
+    int rc;
+    size_t n;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    if (NULL == op->lkcbfunc) {
+        OBJ_RELEASE(op);
+        return;
+    }
+
+    rc = pmix1_convert_rc(status);
+    if (OPAL_SUCCESS == rc) {
+        OBJ_CONSTRUCT(&results, opal_list_t);
+        for (n=0; n < ndata; n++) {
+            d = OBJ_NEW(opal_pmix_pdata_t);
+            opal_list_append(&results, &d->super);
+            if (mca_pmix_external114_component.native_launch) {
+                /* if we were launched by the OMPI RTE, then
+                 * the jobid is in a special format - so get it */
+                opal_convert_string_to_jobid(&d->proc.jobid, data[n].proc.nspace);
+            } else {
+                /* we were launched by someone else, so make the
+                 * jobid just be the hash of the nspace */
+                OPAL_HASH_STR(data[n].proc.nspace, d->proc.jobid);
+            }
+            /* if we don't already have it, add this to our jobid tracker */
+            job = NULL;
+            OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+                if (jptr->jobid == d->proc.jobid) {
+                    job = jptr;
+                    break;
+                }
+            }
+            if (NULL == job) {
+                job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+                (void)strncpy(job->nspace, data[n].proc.nspace, PMIX_MAX_NSLEN);
+                job->jobid = d->proc.jobid;
+                opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
+            }
+            if (PMIX_RANK_WILDCARD == data[n].proc.rank) {
+                d->proc.vpid = OPAL_VPID_WILDCARD;
+            } else {
+                d->proc.vpid = data[n].proc.rank;
+            }
+            d->value.key = strdup(data[n].key);
+            rc = pmix1_value_unload(&d->value, &data[n].value);
+            if (OPAL_SUCCESS != rc) {
+                rc = OPAL_ERR_BAD_PARAM;
+                OPAL_ERROR_LOG(rc);
+                goto release;
+            }
+        }
+        r = &results;
+    }
+  release:
+    /* execute the callback */
+    op->lkcbfunc(rc, r, op->cbdata);
+
+    if (NULL != r) {
+        OPAL_LIST_DESTRUCT(&results);
+    }
+    OBJ_RELEASE(op);
+}
+
+int pmix1_lookupnb(char **keys, opal_list_t *info,
+                   opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_status_t ret;
+    pmix1_opcaddy_t *op;
+    opal_value_t *iptr;
+    size_t n;
+
+
+    opal_output_verbose(1, opal_pmix_base_framework.framework_output,
+                        "PMIx_client lookup_nb");
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->lkcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    if (NULL != info) {
+        op->sz = opal_list_get_size(info);
+        if (0 < op->sz) {
+            PMIX_INFO_CREATE(op->info, op->sz);
+            n=0;
+            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+                pmix1_value_load(&op->info[n].value, iptr);
+                ++n;
+            }
+        }
+    }
+
+    ret = PMIx_Lookup_nb(keys, op->info, op->sz, lk_cbfunc, op);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_unpublish(char **keys, opal_list_t *info)
+{
+    pmix_status_t ret;
+    size_t ninfo, n;
+    pmix_info_t *pinfo;
+    opal_value_t *iptr;
+
+    if (NULL != info) {
+        ninfo = opal_list_get_size(info);
+        PMIX_INFO_CREATE(pinfo, ninfo);
+        n=0;
+        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&pinfo[n].value, iptr);
+            ++n;
+        }
+    } else {
+        pinfo = NULL;
+        ninfo = 0;
+    }
+
+    ret = PMIx_Unpublish(keys, pinfo, ninfo);
+    PMIX_INFO_FREE(pinfo, ninfo);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_unpublishnb(char **keys, opal_list_t *info,
+                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_status_t ret;
+    pmix1_opcaddy_t *op;
+    opal_value_t *iptr;
+    size_t n;
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    if (NULL != info) {
+        op->sz = opal_list_get_size(info);
+        if (0 < op->sz) {
+            PMIX_INFO_CREATE(op->info, op->sz);
+            n=0;
+            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+                pmix1_value_load(&op->info[n].value, iptr);
+                ++n;
+            }
+        }
+    }
+
+    ret = PMIx_Unpublish_nb(keys, op->info, op->sz, opcbfunc, op);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
+{
+    pmix_status_t ret;
+    pmix_info_t *pinfo = NULL;
+    pmix_app_t *papps;
+    size_t napps, n, m, ninfo = 0;
+    char nspace[PMIX_MAX_NSLEN+1];
+    opal_value_t *info;
+    opal_pmix_app_t *app;
+    opal_pmix1_jobid_trkr_t *job;
+
+    if (NULL != job_info && 0 < (ninfo = opal_list_get_size(job_info))) {
+        PMIX_INFO_CREATE(pinfo, ninfo);
+        n=0;
+        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+            (void)strncpy(pinfo[n].key, info->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&pinfo[n].value, info);
+            ++n;
+        }
+    }
+
+    napps = opal_list_get_size(apps);
+    PMIX_APP_CREATE(papps, napps);
+    n=0;
+    OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
+        papps[n].cmd = strdup(app->cmd);
+        papps[n].argc = app->argc;
+        papps[n].argv = opal_argv_copy(app->argv);
+        papps[n].env = opal_argv_copy(app->env);
+        papps[n].maxprocs = app->maxprocs;
+        if (0 < (papps[n].ninfo = opal_list_get_size(&app->info))) {
+            PMIX_INFO_CREATE(papps[n].info, papps[n].ninfo);
+            m=0;
+            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+                (void)strncpy(papps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+                pmix1_value_load(&papps[n].info[m].value, info);
+                ++m;
+            }
+        }
+        ++n;
+    }
+
+    ret = PMIx_Spawn(pinfo, ninfo, papps, napps, nspace);
+    if (PMIX_SUCCESS == ret) {
+        if (mca_pmix_external114_component.native_launch) {
+            /* if we were launched by the OMPI RTE, then
+             * the jobid is in a special format - so get it */
+            opal_convert_string_to_jobid(jobid, nspace);
+        } else {
+            /* we were launched by someone else, so make the
+             * jobid just be the hash of the nspace */
+            OPAL_HASH_STR(nspace, *jobid);
+        }
+        /* add this to our jobid tracker */
+        job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+        job->jobid = *jobid;
+        opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
+    }
+    PMIX_APP_FREE(papps, napps);
+
+    return pmix1_convert_rc(ret);
+}
+
+static void spcbfunc(pmix_status_t status,
+                     char *nspace, void *cbdata)
+{
+    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+    int rc;
+    opal_jobid_t jobid=OPAL_JOBID_INVALID;
+    opal_pmix1_jobid_trkr_t *job;
+
+    rc = pmix1_convert_rc(status);
+    if (PMIX_SUCCESS == status) {
+        if (mca_pmix_external114_component.native_launch) {
+            /* if we were launched by the OMPI RTE, then
+             * the jobid is in a special format - so get it */
+            opal_convert_string_to_jobid(&jobid, nspace);
+        } else {
+            /* we were launched by someone else, so make the
+             * jobid just be the hash of the nspace */
+            OPAL_HASH_STR(nspace, jobid);
+        }
+        /* add this to our jobid tracker */
+        job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+        job->jobid = jobid;
+        opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
+    }
+
+    op->spcbfunc(rc, jobid, op->cbdata);
+    OBJ_RELEASE(op);
+}
+
+int pmix1_spawnnb(opal_list_t *job_info, opal_list_t *apps,
+                    opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_status_t ret;
+    pmix1_opcaddy_t *op;
+    size_t n, m;
+    opal_value_t *info;
+    opal_pmix_app_t *app;
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->spcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    if (NULL != job_info && 0 < (op->ninfo = opal_list_get_size(job_info))) {
+        PMIX_INFO_CREATE(op->info, op->ninfo);
+        n=0;
+        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+            (void)strncpy(op->info[n].key, info->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&op->info[n].value, info);
+            ++n;
+        }
+    }
+
+    op->sz = opal_list_get_size(apps);
+    PMIX_APP_CREATE(op->apps, op->sz);
+    n=0;
+    OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
+        op->apps[n].cmd = strdup(app->cmd);
+        op->apps[n].argc = app->argc;
+        op->apps[n].argv = opal_argv_copy(app->argv);
+        op->apps[n].env = opal_argv_copy(app->env);
+        op->apps[n].maxprocs = app->maxprocs;
+        if (0 < (op->apps[n].ninfo = opal_list_get_size(&app->info))) {
+            PMIX_INFO_CREATE(op->apps[n].info, op->apps[n].ninfo);
+            m=0;
+            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+                (void)strncpy(op->apps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+                pmix1_value_load(&op->apps[n].info[m].value, info);
+                ++m;
+            }
+        }
+        ++n;
+    }
+
+    ret = PMIx_Spawn_nb(op->info, op->ninfo, op->apps, op->sz, spcbfunc, op);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_connect(opal_list_t *procs)
+{
+    pmix_status_t ret;
+    pmix_proc_t *parray=NULL;
+    size_t n, cnt=0;
+    opal_namelist_t *ptr;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    /* protect against bozo error */
+    if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* convert the list of procs to an array
+     * of pmix_proc_t */
+    PMIX_PROC_CREATE(parray, cnt);
+    n=0;
+    OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        job = NULL;
+        OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (jptr->jobid == ptr->name.jobid) {
+                job = jptr;
+                break;
+            }
+        }
+        if (NULL == job) {
+            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+            return OPAL_ERR_NOT_FOUND;
+        }
+        (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+            parray[n].rank = PMIX_RANK_WILDCARD;
+        } else {
+            parray[n].rank = ptr->name.vpid;
+        }
+        ++n;
+    }
+
+    ret = PMIx_Connect(parray, cnt, NULL, 0);
+    PMIX_PROC_FREE(parray, cnt);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_connectnb(opal_list_t *procs,
+                    opal_pmix_op_cbfunc_t cbfunc,
+                    void *cbdata)
+{
+    pmix_status_t ret;
+    size_t n, cnt=0;
+    opal_namelist_t *ptr;
+    pmix1_opcaddy_t *op;
+    opal_pmix1_jobid_trkr_t *job;
+
+    /* protect against bozo error */
+    if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+    op->nprocs = cnt;
+
+    /* convert the list of procs to an array
+     * of pmix_proc_t */
+    PMIX_PROC_CREATE(op->procs, op->nprocs);
+    n=0;
+    OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        OPAL_LIST_FOREACH(job, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (job->jobid == ptr->name.jobid) {
+                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+                break;
+            }
+        }
+        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+            op->procs[n].rank = PMIX_RANK_WILDCARD;
+        } else {
+            op->procs[n].rank = ptr->name.vpid;
+        }
+        ++n;
+    }
+
+    ret = PMIx_Connect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_disconnect(opal_list_t *procs)
+{
+    pmix_status_t ret;
+    pmix_proc_t *parray=NULL;
+    size_t n, cnt=0;
+    opal_namelist_t *ptr;
+    opal_pmix1_jobid_trkr_t *job;
+
+    /* protect against bozo error */
+    if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* convert the list of procs to an array
+     * of pmix_proc_t */
+    PMIX_PROC_CREATE(parray, cnt);
+    n=0;
+    OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        OPAL_LIST_FOREACH(job, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (job->jobid == ptr->name.jobid) {
+                (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+                break;
+            }
+        }
+        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+            parray[n].rank = PMIX_RANK_WILDCARD;
+        } else {
+            parray[n].rank = ptr->name.vpid;
+        }
+        ++n;
+    }
+
+    ret = PMIx_Disconnect(parray, cnt, NULL, 0);
+    PMIX_PROC_FREE(parray, cnt);
+
+    return pmix1_convert_rc(ret);
+}
+
+int pmix1_disconnectnb(opal_list_t *procs,
+                         opal_pmix_op_cbfunc_t cbfunc,
+                         void *cbdata)
+{
+    pmix_status_t ret;
+    size_t n, cnt=0;
+    opal_namelist_t *ptr;
+    pmix1_opcaddy_t *op;
+    opal_pmix1_jobid_trkr_t *job;
+
+    /* protect against bozo error */
+    if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    /* create the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+    op->nprocs = cnt;
+
+    /* convert the list of procs to an array
+     * of pmix_proc_t */
+    PMIX_PROC_CREATE(op->procs, op->nprocs);
+    n=0;
+    OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        OPAL_LIST_FOREACH(job, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (job->jobid == ptr->name.jobid) {
+                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+                break;
+            }
+        }
+        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+            op->procs[n].rank = PMIX_RANK_WILDCARD;
+        } else {
+            op->procs[n].rank = ptr->name.vpid;
+        }
+        ++n;
+    }
+
+    ret = PMIx_Disconnect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
+
+    return pmix1_convert_rc(ret);
+}
+
+
+int pmix1_resolve_peers(const char *nodename, opal_jobid_t jobid,
+                          opal_list_t *procs)
+{
+    char *nspace;
+    pmix_proc_t *array=NULL;
+    size_t nprocs, n;
+    opal_namelist_t *nm;
+    int rc;
+    pmix_status_t ret;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    if (OPAL_JOBID_WILDCARD == jobid) {
+        nspace = NULL;
+    } else {
+        job = NULL;
+        OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (jptr->jobid == jobid) {
+                job = jptr;
+                break;
+            }
+        }
+        if (NULL == job) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        nspace = job->nspace;
+    }
+
+    ret = PMIx_Resolve_peers(nodename, nspace, &array, &nprocs);
+    rc = pmix1_convert_rc(ret);
+
+    if (NULL != array && 0 < nprocs) {
+        for (n=0; n < nprocs; n++) {
+            nm = OBJ_NEW(opal_namelist_t);
+            opal_list_append(procs, &nm->super);
+            if (mca_pmix_external114_component.native_launch) {
+                /* if we were launched by the OMPI RTE, then
+                 * the jobid is in a special format - so get it */
+                opal_convert_string_to_jobid(&nm->name.jobid, array[n].nspace);
+            } else {
+                /* we were launched by someone else, so make the
+                 * jobid just be the hash of the nspace */
+                OPAL_HASH_STR(array[n].nspace, nm->name.jobid);
+            }
+            /* if we don't already have it, add this to our jobid tracker */
+            job = NULL;
+            OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+                if (jptr->jobid == nm->name.jobid) {
+                    job = jptr;
+                    break;
+                }
+            }
+            if (NULL == job) {
+                job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+                (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+                job->jobid = jobid;
+                opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
+            }
+            nm->name.vpid = array[n].rank;
+        }
+    }
+    PMIX_PROC_FREE(array, nprocs);
+
+    return rc;
+}
+
+int pmix1_resolve_nodes(opal_jobid_t jobid, char **nodelist)
+{
+    pmix_status_t ret;
+    char *nspace=NULL;
+    opal_pmix1_jobid_trkr_t *job, *jptr;
+
+    if (OPAL_JOBID_WILDCARD != jobid) {
+        /* look thru our list of jobids and find the
+         * corresponding nspace */
+        job = NULL;
+        OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+            if (jptr->jobid == jobid) {
+                job = jptr;
+                break;
+            }
+        }
+        if (NULL == job) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        nspace = job->nspace;
+    }
+
+    ret = PMIx_Resolve_nodes(nspace, nodelist);
+
+    return pmix1_convert_rc(ret);;
+}

--- a/opal/mca/pmix/external114/pmix_ext_component.c
+++ b/opal/mca/pmix/external114/pmix_ext_component.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "opal_config.h"
+
+#include "opal/constants.h"
+#include "opal/class/opal_list.h"
+#include "opal/util/proc.h"
+#include "opal/mca/pmix/pmix.h"
+#include "pmix_ext.h"
+
+/*
+ * Public string showing the pmix external component version number
+ */
+const char *opal_pmix_external_component_version_string =
+    "OPAL external pmix MCA component version " OPAL_VERSION;
+
+/*
+ * Local function
+ */
+static int external_open(void);
+static int external_close(void);
+static int external_component_query(mca_base_module_t **module, int *priority);
+
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+
+mca_pmix_pmix1_component_t mca_pmix_external114_component = {
+    {
+    /* First, the mca_component_t struct containing meta information
+       about the component itself */
+
+        .base_version = {
+        /* Indicate that we are a pmix v1.1.0 component (which also
+           implies a specific MCA version) */
+
+            OPAL_PMIX_BASE_VERSION_2_0_0,
+
+        /* Component name and version */
+
+            .mca_component_name = "external114",
+            MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+                                  OPAL_RELEASE_VERSION),
+
+        /* Component open and close functions */
+
+            .mca_open_component = external_open,
+            .mca_close_component = external_close,
+            .mca_query_component = external_component_query,
+        },
+        /* Next the MCA v1.0.0 component meta data */
+        .base_data = {
+        /* The component is checkpoint ready */
+            MCA_BASE_METADATA_PARAM_CHECKPOINT
+        }
+    },
+    .native_launch = false
+};
+
+static int external_open(void)
+{
+    OBJ_CONSTRUCT(&mca_pmix_external114_component.jobids, opal_list_t);
+    return OPAL_SUCCESS;
+}
+
+static int external_close(void)
+{
+    OPAL_LIST_DESTRUCT(&mca_pmix_external114_component.jobids);
+    return OPAL_SUCCESS;
+}
+
+
+static int external_component_query(mca_base_module_t **module, int *priority)
+{
+    char *t, *id;
+
+    /* see if a PMIx server is present */
+    if (NULL != (t = getenv("PMIX_SERVER_URI")) ||
+        NULL != (id = getenv("PMIX_ID"))) {
+        /* if PMIx is present, then we are a client and need to use it */
+        *priority = 80;
+    } else {
+        /* we could be a server, so we still need to be considered */
+        *priority = 5;
+    }
+    *module = (mca_base_module_t *)&opal_pmix_external_module;
+    return OPAL_SUCCESS;
+}

--- a/opal/mca/pmix/external114/pmix_ext_component.c
+++ b/opal/mca/pmix/external114/pmix_ext_component.c
@@ -27,15 +27,15 @@
 /*
  * Public string showing the pmix external component version number
  */
-const char *opal_pmix_external_component_version_string =
-    "OPAL external pmix MCA component version " OPAL_VERSION;
+const char *opal_pmix_external114_component_version_string =
+    "OPAL external pmix 1.1.4 MCA component version " OPAL_VERSION;
 
 /*
  * Local function
  */
-static int external_open(void);
-static int external_close(void);
-static int external_component_query(mca_base_module_t **module, int *priority);
+static int pmix_ext114_open(void);
+static int pmix_ext114_close(void);
+static int pmix_ext114_component_query(mca_base_module_t **module, int *priority);
 
 
 /*
@@ -62,9 +62,9 @@ mca_pmix_pmix1_component_t mca_pmix_external114_component = {
 
         /* Component open and close functions */
 
-            .mca_open_component = external_open,
-            .mca_close_component = external_close,
-            .mca_query_component = external_component_query,
+            .mca_open_component = pmix_ext114_open,
+            .mca_close_component = pmix_ext114_close,
+            .mca_query_component = pmix_ext114_component_query,
         },
         /* Next the MCA v1.0.0 component meta data */
         .base_data = {
@@ -75,20 +75,20 @@ mca_pmix_pmix1_component_t mca_pmix_external114_component = {
     .native_launch = false
 };
 
-static int external_open(void)
+static int pmix_ext114_open(void)
 {
     OBJ_CONSTRUCT(&mca_pmix_external114_component.jobids, opal_list_t);
     return OPAL_SUCCESS;
 }
 
-static int external_close(void)
+static int pmix_ext114_close(void)
 {
     OPAL_LIST_DESTRUCT(&mca_pmix_external114_component.jobids);
     return OPAL_SUCCESS;
 }
 
 
-static int external_component_query(mca_base_module_t **module, int *priority)
+static int pmix_ext114_component_query(mca_base_module_t **module, int *priority)
 {
     char *t, *id;
 
@@ -101,6 +101,6 @@ static int external_component_query(mca_base_module_t **module, int *priority)
         /* we could be a server, so we still need to be considered */
         *priority = 5;
     }
-    *module = (mca_base_module_t *)&opal_pmix_external_module;
+    *module = (mca_base_module_t *)&opal_pmix_external114_module;
     return OPAL_SUCCESS;
 }

--- a/opal/mca/pmix/external114/pmix_ext_server_north.c
+++ b/opal/mca/pmix/external114/pmix_ext_server_north.c
@@ -1,0 +1,781 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+#include "opal/constants.h"
+#include "opal/types.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "opal/dss/dss.h"
+#include "opal/mca/event/event.h"
+#include "opal/mca/hwloc/base/base.h"
+#include "opal/runtime/opal.h"
+#include "opal/runtime/opal_progress_threads.h"
+#include "opal/util/argv.h"
+#include "opal/util/error.h"
+#include "opal/util/output.h"
+#include "opal/util/proc.h"
+#include "opal/util/show_help.h"
+#include "opal/mca/pmix/base/base.h"
+#include "pmix_ext.h"
+
+#include <pmix.h>
+#include <pmix_server.h>
+
+/****    N.O.R.T.H.B.O.U.N.D   I.N.T.E.R.F.A.C.E.S     ****/
+
+/* These are the interfaces used by the embedded PMIx server
+ * to call up into ORTE for service requests */
+
+static pmix_status_t server_client_connected_fn(const pmix_proc_t *proc, void* server_object);
+static pmix_status_t server_client_finalized_fn(const pmix_proc_t *proc, void* server_object,
+                                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_abort_fn(const pmix_proc_t *proc, void *server_object,
+                                     int status, const char msg[],
+                                     pmix_proc_t procs[], size_t nprocs,
+                                     pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       char *data, size_t ndata,
+                                       pmix_modex_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *proc,
+                                          const pmix_info_t info[], size_t ninfo,
+                                          pmix_modex_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_publish_fn(const pmix_proc_t *proc,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_lookup_fn(const pmix_proc_t *proc,  char **keys,
+                                      const pmix_info_t info[], size_t ninfo,
+                                      pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_unpublish_fn(const pmix_proc_t *proc, char **keys,
+                                         const pmix_info_t info[], size_t ninfo,
+                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_spawn_fn(const pmix_proc_t *proc,
+                                     const pmix_info_t job_info[], size_t ninfo,
+                                     const pmix_app_t apps[], size_t napps,
+                                     pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                          const pmix_info_t info[], size_t ninfo,
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_register_events(const pmix_info_t info[], size_t ninfo,
+                                            pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_deregister_events(const pmix_info_t info[], size_t ninfo,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t server_listener_fn(int listening_sd,
+                                        pmix_connection_cbfunc_t cbfunc);
+
+pmix_server_module_t external_module = {
+    server_client_connected_fn,
+    server_client_finalized_fn,
+    server_abort_fn,
+    server_fencenb_fn,
+    server_dmodex_req_fn,
+    server_publish_fn,
+    server_lookup_fn,
+    server_unpublish_fn,
+    server_spawn_fn,
+    server_connect_fn,
+    server_disconnect_fn,
+    server_register_events,
+    server_deregister_events,
+    server_listener_fn
+};
+
+opal_pmix_server_module_t *external_host_module = NULL;
+
+
+static void opal_opcbfunc(int status, void *cbdata)
+{
+    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+
+    if (NULL != opalcaddy->opcbfunc) {
+        opalcaddy->opcbfunc(pmix1_convert_opalrc(status), opalcaddy->cbdata);
+    }
+    OBJ_RELEASE(opalcaddy);
+}
+
+static pmix_status_t server_client_connected_fn(const pmix_proc_t *p, void *server_object)
+{
+    int rc;
+    opal_process_name_t proc;
+
+    if (NULL == external_host_module || NULL == external_host_module->client_connected) {
+        return PMIX_SUCCESS;
+    }
+
+    /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    proc.vpid = p->rank;
+
+    /* pass it up */
+    rc = external_host_module->client_connected(&proc, server_object);
+    return pmix1_convert_opalrc(rc);
+}
+
+static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* server_object,
+                                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_process_name_t proc;
+
+    if (NULL == external_host_module || NULL == external_host_module->client_finalized) {
+        return PMIX_SUCCESS;
+    }
+
+    /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    proc.vpid = p->rank;
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->opcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* pass it up */
+    rc = external_host_module->client_finalized(&proc, server_object, opal_opcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+    return pmix1_convert_opalrc(rc);
+}
+
+static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
+                                     int status, const char msg[],
+                                     pmix_proc_t procs[], size_t nprocs,
+                                     pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    size_t n;
+    opal_namelist_t *nm;
+    opal_process_name_t proc;
+    int rc;
+    pmix1_opalcaddy_t *opalcaddy;
+
+    if (NULL == external_host_module || NULL == external_host_module->abort) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    proc.vpid = p->rank;
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->opcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the array of pmix_proc_t to the list of procs */
+    for (n=0; n < nprocs; n++) {
+        nm = OBJ_NEW(opal_namelist_t);
+        opal_list_append(&opalcaddy->procs, &nm->super);
+        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+        if (PMIX_RANK_WILDCARD == procs[n].rank) {
+            nm->name.vpid = OPAL_VPID_WILDCARD;
+        } else {
+            nm->name.vpid = procs[n].rank;
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->abort(&proc, server_object, status, msg,
+                            &opalcaddy->procs, opal_opcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+    return pmix1_convert_opalrc(rc);
+}
+
+static void _data_release(void *cbdata)
+{
+    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+
+    if (NULL != opalcaddy->odmdxfunc) {
+        opalcaddy->odmdxfunc(opalcaddy->ocbdata);
+    }
+    OBJ_RELEASE(opalcaddy);
+}
+
+static void opmdx_response(int status, const char *data, size_t sz, void *cbdata,
+                           opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
+{
+    pmix_status_t rc;
+    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+
+    rc = pmix1_convert_rc(status);
+    if (NULL != opalcaddy->mdxcbfunc) {
+        opalcaddy->odmdxfunc = relcbfunc;
+        opalcaddy->ocbdata = relcbdata;
+        opalcaddy->mdxcbfunc(rc, data, sz, opalcaddy->cbdata,
+                             _data_release, opalcaddy);
+    } else {
+        OBJ_RELEASE(opalcaddy);
+    }
+}
+
+static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       char *data, size_t ndata,
+                                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix1_opalcaddy_t *opalcaddy;
+    size_t n;
+    opal_namelist_t *nm;
+    opal_value_t *iptr;
+    int rc;
+
+    if (NULL == external_host_module || NULL == external_host_module->fence_nb) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->mdxcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the array of pmix_proc_t to the list of procs */
+    for (n=0; n < nprocs; n++) {
+        nm = OBJ_NEW(opal_namelist_t);
+        opal_list_append(&opalcaddy->procs, &nm->super);
+        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+        if (PMIX_RANK_WILDCARD == procs[n].rank) {
+            nm->name.vpid = OPAL_VPID_WILDCARD;
+        } else {
+            nm->name.vpid = procs[n].rank;
+        }
+    }
+
+    /* convert the array of pmix_info_t to the list of info */
+    for (n=0; n < ninfo; n++) {
+        iptr = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &iptr->super);
+        iptr->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->fence_nb(&opalcaddy->procs, &opalcaddy->info,
+                               data, ndata, opmdx_response, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+    return pmix1_convert_opalrc(rc);
+}
+
+static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
+                                          const pmix_info_t info[], size_t ninfo,
+                                          pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_process_name_t proc;
+    opal_value_t *iptr;
+    size_t n;
+
+    if (NULL == external_host_module || NULL == external_host_module->direct_modex) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    if (PMIX_RANK_WILDCARD == p->rank) {
+        proc.vpid = OPAL_VPID_WILDCARD;
+    } else {
+        proc.vpid = p->rank;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->mdxcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the array of pmix_info_t to the list of info */
+    for (n=0; n < ninfo; n++) {
+        iptr = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &iptr->super);
+        iptr->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->direct_modex(&proc, &opalcaddy->info, opmdx_response, opalcaddy);
+    if (OPAL_SUCCESS != rc && OPAL_ERR_IN_PROCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+    if (OPAL_ERR_IN_PROCESS == rc) {
+        rc = OPAL_SUCCESS;
+    }
+    return pmix1_convert_opalrc(rc);
+}
+
+static pmix_status_t server_publish_fn(const pmix_proc_t *p,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+    size_t n;
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_process_name_t proc;
+    opal_value_t *oinfo;
+
+    if (NULL == external_host_module || NULL == external_host_module->publish) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+   /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    if (PMIX_RANK_WILDCARD == p->rank) {
+        proc.vpid = OPAL_VPID_WILDCARD;
+    } else {
+        proc.vpid = p->rank;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->opcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the info array */
+    for (n=0; n < ninfo; n++) {
+        oinfo = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &oinfo->super);
+        oinfo->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->publish(&proc, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+
+    return pmix1_convert_opalrc(rc);
+}
+
+static void opal_lkupcbfunc(int status,
+                            opal_list_t *data,
+                            void *cbdata)
+{
+    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+    pmix_status_t rc;
+    pmix_pdata_t *d=NULL;
+    size_t nd=0, n;
+    opal_pmix_pdata_t *p;
+
+    if (NULL != opalcaddy->lkupcbfunc) {
+        rc = pmix1_convert_opalrc(status);
+        /* convert any returned data */
+        if (NULL != data) {
+            nd = opal_list_get_size(data);
+            PMIX_PDATA_CREATE(d, nd);
+            n=0;
+            OPAL_LIST_FOREACH(p, data, opal_pmix_pdata_t) {
+                /* convert the jobid */
+                (void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
+                d[n].proc.rank = p->proc.vpid;
+                (void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
+                pmix1_value_load(&d[n].value, &p->value);
+            }
+        }
+        opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
+    }
+    OBJ_RELEASE(opalcaddy);
+}
+
+static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
+                                      const pmix_info_t info[], size_t ninfo,
+                                      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_process_name_t proc;
+    opal_value_t *iptr;
+    size_t n;
+
+    if (NULL == external_host_module || NULL == external_host_module->lookup) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    if (PMIX_RANK_WILDCARD == p->rank) {
+        proc.vpid = OPAL_VPID_WILDCARD;
+    } else {
+        proc.vpid = p->rank;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->lkupcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the array of pmix_info_t to the list of info */
+    for (n=0; n < ninfo; n++) {
+        iptr = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &iptr->super);
+        iptr->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->lookup(&proc, keys, &opalcaddy->info, opal_lkupcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+
+    return pmix1_convert_opalrc(rc);
+}
+
+
+static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
+                                         const pmix_info_t info[], size_t ninfo,
+                                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_process_name_t proc;
+    opal_value_t *iptr;
+    size_t n;
+
+    if (NULL == external_host_module || NULL == external_host_module->unpublish) {
+        return PMIX_SUCCESS;
+    }
+
+    /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    if (PMIX_RANK_WILDCARD == p->rank) {
+        proc.vpid = OPAL_VPID_WILDCARD;
+    } else {
+        proc.vpid = p->rank;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->opcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the array of pmix_info_t to the list of info */
+    for (n=0; n < ninfo; n++) {
+        iptr = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &iptr->super);
+        iptr->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->unpublish(&proc, keys, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+
+    return pmix1_convert_opalrc(rc);
+}
+
+static void opal_spncbfunc(int status, opal_jobid_t jobid, void *cbdata)
+{
+    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+    pmix_status_t rc;
+    char nspace[PMIX_MAX_NSLEN];
+
+    if (NULL != opalcaddy->spwncbfunc) {
+        rc = pmix1_convert_opalrc(status);
+        /* convert the jobid */
+        (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
+        opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
+    }
+    OBJ_RELEASE(opalcaddy);
+}
+
+static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
+                                     const pmix_info_t job_info[], size_t ninfo,
+                                     const pmix_app_t apps[], size_t napps,
+                                     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_process_name_t proc;
+    opal_pmix_app_t *app;
+    opal_value_t *oinfo;
+    size_t k, n;
+    int rc;
+
+    if (NULL == external_host_module || NULL == external_host_module->spawn) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* convert the nspace/rank to an opal_process_name_t */
+    if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
+        return pmix1_convert_opalrc(rc);
+    }
+    if (PMIX_RANK_WILDCARD == p->rank) {
+        proc.vpid = OPAL_VPID_WILDCARD;
+    } else {
+        proc.vpid = p->rank;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->spwncbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the job info */
+    for (k=0; k < ninfo; k++) {
+        oinfo = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &oinfo->super);
+        oinfo->key = strdup(job_info[k].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &job_info[k].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* convert the apps */
+    for (n=0; n < napps; n++) {
+        app = OBJ_NEW(opal_pmix_app_t);
+        opal_list_append(&opalcaddy->apps, &app->super);
+        if (NULL != apps[n].cmd) {
+            app->cmd = strdup(apps[n].cmd);
+        }
+        app->argc = apps[n].argc;
+        if (NULL != apps[n].argv) {
+            app->argv = opal_argv_copy(apps[n].argv);
+        }
+        if (NULL != apps[n].env) {
+            app->env = opal_argv_copy(apps[n].env);
+        }
+        app->maxprocs = apps[n].maxprocs;
+        for (k=0; k < apps[n].ninfo; k++) {
+            oinfo = OBJ_NEW(opal_value_t);
+            opal_list_append(&app->info, &oinfo->super);
+            oinfo->key = strdup(apps[n].info[k].key);
+            if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &apps[n].info[k].value))) {
+                OBJ_RELEASE(opalcaddy);
+                return pmix1_convert_opalrc(rc);
+            }
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->spawn(&proc, &opalcaddy->info, &opalcaddy->apps, opal_spncbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OPAL_ERROR_LOG(rc);
+        OBJ_RELEASE(opalcaddy);
+    }
+
+    return pmix1_convert_opalrc(rc);
+}
+
+
+static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_namelist_t *nm;
+    size_t n;
+    opal_value_t *oinfo;
+
+    if (NULL == external_host_module || NULL == external_host_module->connect) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->opcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the array of pmix_proc_t to the list of procs */
+    for (n=0; n < nprocs; n++) {
+        nm = OBJ_NEW(opal_namelist_t);
+        opal_list_append(&opalcaddy->procs, &nm->super);
+        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+        if (PMIX_RANK_WILDCARD == procs[n].rank) {
+            nm->name.vpid = OPAL_VPID_WILDCARD;
+        } else {
+            nm->name.vpid = procs[n].rank;
+        }
+    }
+
+    /* convert the info */
+    for (n=0; n < ninfo; n++) {
+        oinfo = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &oinfo->super);
+        oinfo->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->connect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+
+    return pmix1_convert_opalrc(rc);
+}
+
+
+static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                          const pmix_info_t info[], size_t ninfo,
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    int rc;
+    pmix1_opalcaddy_t *opalcaddy;
+    opal_namelist_t *nm;
+    size_t n;
+    opal_value_t *oinfo;
+
+    if (NULL == external_host_module || NULL == external_host_module->disconnect) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->opcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the array of pmix_proc_t to the list of procs */
+    for (n=0; n < nprocs; n++) {
+        nm = OBJ_NEW(opal_namelist_t);
+        opal_list_append(&opalcaddy->procs, &nm->super);
+        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+        if (PMIX_RANK_WILDCARD == procs[n].rank) {
+            nm->name.vpid = OPAL_VPID_WILDCARD;
+        } else {
+            nm->name.vpid = procs[n].rank;
+        }
+    }
+
+    /* convert the info */
+    for (n=0; n < ninfo; n++) {
+        oinfo = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &oinfo->super);
+        oinfo->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->disconnect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+
+    return pmix1_convert_opalrc(rc);
+}
+
+static pmix_status_t server_register_events(const pmix_info_t info[], size_t ninfo,
+                                            pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix1_opalcaddy_t *opalcaddy;
+    size_t n;
+    opal_value_t *oinfo;
+    int rc;
+
+    /* setup the caddy */
+    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy->opcbfunc = cbfunc;
+    opalcaddy->cbdata = cbdata;
+
+    /* convert the info */
+    for (n=0; n < ninfo; n++) {
+        oinfo = OBJ_NEW(opal_value_t);
+        opal_list_append(&opalcaddy->info, &oinfo->super);
+        oinfo->key = strdup(info[n].key);
+        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+            OBJ_RELEASE(opalcaddy);
+            return pmix1_convert_opalrc(rc);
+        }
+    }
+
+    /* pass it up */
+    rc = external_host_module->register_events(&opalcaddy->info, opal_opcbfunc, opalcaddy);
+    if (OPAL_SUCCESS != rc) {
+        OBJ_RELEASE(opalcaddy);
+    }
+
+    return pmix1_convert_opalrc(rc);
+}
+
+static pmix_status_t server_deregister_events(const pmix_info_t info[], size_t ninfo,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_ERR_NOT_IMPLEMENTED;
+}
+static pmix_status_t server_listener_fn(int listening_sd,
+                                        pmix_connection_cbfunc_t cbfunc)
+{
+    int rc;
+
+    if (NULL == external_host_module || NULL == external_host_module->listener) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    rc = external_host_module->listener(listening_sd, cbfunc);
+    return pmix1_convert_opalrc(rc);
+}

--- a/opal/mca/pmix/external114/pmix_ext_server_north.c
+++ b/opal/mca/pmix/external114/pmix_ext_server_north.c
@@ -37,8 +37,6 @@
 #include "opal/mca/pmix/base/base.h"
 #include "pmix_ext.h"
 
-#include <pmix.h>
-#include <pmix_server.h>
 
 /****    N.O.R.T.H.B.O.U.N.D   I.N.T.E.R.F.A.C.E.S     ****/
 
@@ -85,7 +83,7 @@ static pmix_status_t server_deregister_events(const pmix_info_t info[], size_t n
 static pmix_status_t server_listener_fn(int listening_sd,
                                         pmix_connection_cbfunc_t cbfunc);
 
-pmix_server_module_t external_module = {
+pmix_server_module_t external114_module = {
     server_client_connected_fn,
     server_client_finalized_fn,
     server_abort_fn,
@@ -102,15 +100,15 @@ pmix_server_module_t external_module = {
     server_listener_fn
 };
 
-opal_pmix_server_module_t *external_host_module = NULL;
+opal_pmix_server_module_t *external114_host_module = NULL;
 
 
 static void opal_opcbfunc(int status, void *cbdata)
 {
-    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+    pmix_ext114_opalcaddy_t *opalcaddy = (pmix_ext114_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->opcbfunc) {
-        opalcaddy->opcbfunc(pmix1_convert_opalrc(status), opalcaddy->cbdata);
+        opalcaddy->opcbfunc(pmix_ext114_convert_opalrc(status), opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
@@ -120,49 +118,49 @@ static pmix_status_t server_client_connected_fn(const pmix_proc_t *p, void *serv
     int rc;
     opal_process_name_t proc;
 
-    if (NULL == external_host_module || NULL == external_host_module->client_connected) {
+    if (NULL == external114_host_module || NULL == external114_host_module->client_connected) {
         return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
     /* pass it up */
-    rc = external_host_module->client_connected(&proc, server_object);
-    return pmix1_convert_opalrc(rc);
+    rc = external114_host_module->client_connected(&proc, server_object);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* server_object,
                                                 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
 
-    if (NULL == external_host_module || NULL == external_host_module->client_finalized) {
+    if (NULL == external114_host_module || NULL == external114_host_module->client_finalized) {
         return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->opcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
     /* pass it up */
-    rc = external_host_module->client_finalized(&proc, server_object, opal_opcbfunc, opalcaddy);
+    rc = external114_host_module->client_finalized(&proc, server_object, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
@@ -174,20 +172,20 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
     opal_namelist_t *nm;
     opal_process_name_t proc;
     int rc;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
 
-    if (NULL == external_host_module || NULL == external_host_module->abort) {
+    if (NULL == external114_host_module || NULL == external114_host_module->abort) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->opcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -197,7 +195,7 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
         opal_list_append(&opalcaddy->procs, &nm->super);
         if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
         if (PMIX_RANK_WILDCARD == procs[n].rank) {
             nm->name.vpid = OPAL_VPID_WILDCARD;
@@ -207,17 +205,17 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
     }
 
     /* pass it up */
-    rc = external_host_module->abort(&proc, server_object, status, msg,
+    rc = external114_host_module->abort(&proc, server_object, status, msg,
                             &opalcaddy->procs, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static void _data_release(void *cbdata)
 {
-    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+    pmix_ext114_opalcaddy_t *opalcaddy = (pmix_ext114_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->odmdxfunc) {
         opalcaddy->odmdxfunc(opalcaddy->ocbdata);
@@ -229,9 +227,9 @@ static void opmdx_response(int status, const char *data, size_t sz, void *cbdata
                            opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
 {
     pmix_status_t rc;
-    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+    pmix_ext114_opalcaddy_t *opalcaddy = (pmix_ext114_opalcaddy_t*)cbdata;
 
-    rc = pmix1_convert_rc(status);
+    rc = pmix_ext114_convert_rc(status);
     if (NULL != opalcaddy->mdxcbfunc) {
         opalcaddy->odmdxfunc = relcbfunc;
         opalcaddy->ocbdata = relcbdata;
@@ -247,18 +245,18 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
                                        char *data, size_t ndata,
                                        pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     size_t n;
     opal_namelist_t *nm;
     opal_value_t *iptr;
     int rc;
 
-    if (NULL == external_host_module || NULL == external_host_module->fence_nb) {
+    if (NULL == external114_host_module || NULL == external114_host_module->fence_nb) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->mdxcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -268,7 +266,7 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
         opal_list_append(&opalcaddy->procs, &nm->super);
         if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
         if (PMIX_RANK_WILDCARD == procs[n].rank) {
             nm->name.vpid = OPAL_VPID_WILDCARD;
@@ -282,19 +280,19 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
         iptr = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &iptr->super);
         iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(iptr, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->fence_nb(&opalcaddy->procs, &opalcaddy->info,
+    rc = external114_host_module->fence_nb(&opalcaddy->procs, &opalcaddy->info,
                                data, ndata, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
@@ -302,18 +300,18 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
                                           pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
     opal_value_t *iptr;
     size_t n;
 
-    if (NULL == external_host_module || NULL == external_host_module->direct_modex) {
+    if (NULL == external114_host_module || NULL == external114_host_module->direct_modex) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
         proc.vpid = OPAL_VPID_WILDCARD;
@@ -322,7 +320,7 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->mdxcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -331,21 +329,21 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
         iptr = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &iptr->super);
         iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(iptr, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->direct_modex(&proc, &opalcaddy->info, opmdx_response, opalcaddy);
+    rc = external114_host_module->direct_modex(&proc, &opalcaddy->info, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc && OPAL_ERR_IN_PROCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
     if (OPAL_ERR_IN_PROCESS == rc) {
         rc = OPAL_SUCCESS;
     }
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static pmix_status_t server_publish_fn(const pmix_proc_t *p,
@@ -354,17 +352,17 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
 {
     int rc;
     size_t n;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
     opal_value_t *oinfo;
 
-    if (NULL == external_host_module || NULL == external_host_module->publish) {
+    if (NULL == external114_host_module || NULL == external114_host_module->publish) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
    /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
         proc.vpid = OPAL_VPID_WILDCARD;
@@ -373,7 +371,7 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->opcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -382,33 +380,33 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
         oinfo = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &oinfo->super);
         oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(oinfo, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->publish(&proc, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    rc = external114_host_module->publish(&proc, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
 
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static void opal_lkupcbfunc(int status,
                             opal_list_t *data,
                             void *cbdata)
 {
-    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+    pmix_ext114_opalcaddy_t *opalcaddy = (pmix_ext114_opalcaddy_t*)cbdata;
     pmix_status_t rc;
     pmix_pdata_t *d=NULL;
     size_t nd=0, n;
     opal_pmix_pdata_t *p;
 
     if (NULL != opalcaddy->lkupcbfunc) {
-        rc = pmix1_convert_opalrc(status);
+        rc = pmix_ext114_convert_opalrc(status);
         /* convert any returned data */
         if (NULL != data) {
             nd = opal_list_get_size(data);
@@ -419,7 +417,7 @@ static void opal_lkupcbfunc(int status,
                 (void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
                 d[n].proc.rank = p->proc.vpid;
                 (void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&d[n].value, &p->value);
+                pmix_ext114_value_load(&d[n].value, &p->value);
             }
         }
         opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
@@ -432,18 +430,18 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
                                       pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
     opal_value_t *iptr;
     size_t n;
 
-    if (NULL == external_host_module || NULL == external_host_module->lookup) {
+    if (NULL == external114_host_module || NULL == external114_host_module->lookup) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
         proc.vpid = OPAL_VPID_WILDCARD;
@@ -452,7 +450,7 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->lkupcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -461,19 +459,19 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
         iptr = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &iptr->super);
         iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(iptr, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->lookup(&proc, keys, &opalcaddy->info, opal_lkupcbfunc, opalcaddy);
+    rc = external114_host_module->lookup(&proc, keys, &opalcaddy->info, opal_lkupcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
 
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 
@@ -482,18 +480,18 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
     opal_value_t *iptr;
     size_t n;
 
-    if (NULL == external_host_module || NULL == external_host_module->unpublish) {
+    if (NULL == external114_host_module || NULL == external114_host_module->unpublish) {
         return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
         proc.vpid = OPAL_VPID_WILDCARD;
@@ -502,7 +500,7 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->opcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -511,29 +509,29 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
         iptr = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &iptr->super);
         iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(iptr, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->unpublish(&proc, keys, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    rc = external114_host_module->unpublish(&proc, keys, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
 
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static void opal_spncbfunc(int status, opal_jobid_t jobid, void *cbdata)
 {
-    pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
+    pmix_ext114_opalcaddy_t *opalcaddy = (pmix_ext114_opalcaddy_t*)cbdata;
     pmix_status_t rc;
     char nspace[PMIX_MAX_NSLEN];
 
     if (NULL != opalcaddy->spwncbfunc) {
-        rc = pmix1_convert_opalrc(status);
+        rc = pmix_ext114_convert_opalrc(status);
         /* convert the jobid */
         (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
         opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
@@ -546,20 +544,20 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
                                      const pmix_app_t apps[], size_t napps,
                                      pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
     opal_pmix_app_t *app;
     opal_value_t *oinfo;
     size_t k, n;
     int rc;
 
-    if (NULL == external_host_module || NULL == external_host_module->spawn) {
+    if (NULL == external114_host_module || NULL == external114_host_module->spawn) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+        return pmix_ext114_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
         proc.vpid = OPAL_VPID_WILDCARD;
@@ -568,7 +566,7 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->spwncbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -577,9 +575,9 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
         oinfo = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &oinfo->super);
         oinfo->key = strdup(job_info[k].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &job_info[k].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(oinfo, &job_info[k].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
@@ -602,21 +600,21 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
             oinfo = OBJ_NEW(opal_value_t);
             opal_list_append(&app->info, &oinfo->super);
             oinfo->key = strdup(apps[n].info[k].key);
-            if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &apps[n].info[k].value))) {
+            if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(oinfo, &apps[n].info[k].value))) {
                 OBJ_RELEASE(opalcaddy);
-                return pmix1_convert_opalrc(rc);
+                return pmix_ext114_convert_opalrc(rc);
             }
         }
     }
 
     /* pass it up */
-    rc = external_host_module->spawn(&proc, &opalcaddy->info, &opalcaddy->apps, opal_spncbfunc, opalcaddy);
+    rc = external114_host_module->spawn(&proc, &opalcaddy->info, &opalcaddy->apps, opal_spncbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OPAL_ERROR_LOG(rc);
         OBJ_RELEASE(opalcaddy);
     }
 
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 
@@ -625,17 +623,17 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                        pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_namelist_t *nm;
     size_t n;
     opal_value_t *oinfo;
 
-    if (NULL == external_host_module || NULL == external_host_module->connect) {
+    if (NULL == external114_host_module || NULL == external114_host_module->connect) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->opcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -645,7 +643,7 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
         opal_list_append(&opalcaddy->procs, &nm->super);
         if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
         if (PMIX_RANK_WILDCARD == procs[n].rank) {
             nm->name.vpid = OPAL_VPID_WILDCARD;
@@ -659,19 +657,19 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
         oinfo = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &oinfo->super);
         oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(oinfo, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->connect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    rc = external114_host_module->connect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
 
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 
@@ -680,17 +678,17 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
                                           pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     opal_namelist_t *nm;
     size_t n;
     opal_value_t *oinfo;
 
-    if (NULL == external_host_module || NULL == external_host_module->disconnect) {
+    if (NULL == external114_host_module || NULL == external114_host_module->disconnect) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->opcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -700,7 +698,7 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
         opal_list_append(&opalcaddy->procs, &nm->super);
         if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
         if (PMIX_RANK_WILDCARD == procs[n].rank) {
             nm->name.vpid = OPAL_VPID_WILDCARD;
@@ -714,31 +712,31 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
         oinfo = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &oinfo->super);
         oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(oinfo, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->disconnect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
+    rc = external114_host_module->disconnect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
 
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static pmix_status_t server_register_events(const pmix_info_t info[], size_t ninfo,
                                             pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix1_opalcaddy_t *opalcaddy;
+    pmix_ext114_opalcaddy_t *opalcaddy;
     size_t n;
     opal_value_t *oinfo;
     int rc;
 
     /* setup the caddy */
-    opalcaddy = OBJ_NEW(pmix1_opalcaddy_t);
+    opalcaddy = OBJ_NEW(pmix_ext114_opalcaddy_t);
     opalcaddy->opcbfunc = cbfunc;
     opalcaddy->cbdata = cbdata;
 
@@ -747,19 +745,19 @@ static pmix_status_t server_register_events(const pmix_info_t info[], size_t nin
         oinfo = OBJ_NEW(opal_value_t);
         opal_list_append(&opalcaddy->info, &oinfo->super);
         oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+        if (OPAL_SUCCESS != (rc = pmix_ext114_value_unload(oinfo, &info[n].value))) {
             OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
+            return pmix_ext114_convert_opalrc(rc);
         }
     }
 
     /* pass it up */
-    rc = external_host_module->register_events(&opalcaddy->info, opal_opcbfunc, opalcaddy);
+    rc = external114_host_module->register_events(&opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
         OBJ_RELEASE(opalcaddy);
     }
 
-    return pmix1_convert_opalrc(rc);
+    return pmix_ext114_convert_opalrc(rc);
 }
 
 static pmix_status_t server_deregister_events(const pmix_info_t info[], size_t ninfo,
@@ -772,10 +770,10 @@ static pmix_status_t server_listener_fn(int listening_sd,
 {
     int rc;
 
-    if (NULL == external_host_module || NULL == external_host_module->listener) {
+    if (NULL == external114_host_module || NULL == external114_host_module->listener) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
-    rc = external_host_module->listener(listening_sd, cbfunc);
-    return pmix1_convert_opalrc(rc);
+    rc = external114_host_module->listener(listening_sd, cbfunc);
+    return pmix_ext114_convert_opalrc(rc);
 }

--- a/opal/mca/pmix/external114/pmix_ext_server_south.c
+++ b/opal/mca/pmix/external114/pmix_ext_server_south.c
@@ -1,0 +1,441 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+#include "opal/constants.h"
+#include "opal/types.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "opal/dss/dss.h"
+#include "opal/mca/event/event.h"
+#include "opal/mca/hwloc/base/base.h"
+#include "opal/runtime/opal.h"
+#include "opal/runtime/opal_progress_threads.h"
+#include "opal/util/argv.h"
+#include "opal/util/error.h"
+#include "opal/util/output.h"
+#include "opal/util/proc.h"
+#include "opal/util/show_help.h"
+#include "opal/mca/pmix/base/base.h"
+#include "pmix_ext.h"
+
+#include <pmix.h>
+#include <pmix_server.h>
+
+/****    S.O.U.T.H.B.O.U.N.D   I.N.T.E.R.F.A.C.E.S     ****/
+
+/* These are the interfaces used by the OMPI/ORTE/OPAL layer to call
+ * down into the embedded PMIx server. */
+
+extern pmix_server_module_t external_module;
+extern opal_pmix_server_module_t *external_host_module;
+static char *dbgvalue=NULL;
+static int errhdler_ref = 0;
+
+static void release_cbfunc(void *cbdata)
+{
+    pmix1_opalcaddy_t *cd = (pmix1_opalcaddy_t*)cbdata;
+    OBJ_RELEASE(cd);
+}
+static void myerr(pmix_status_t status,
+                  pmix_proc_t procs[], size_t nprocs,
+                  pmix_info_t info[], size_t ninfo)
+{
+    int rc;
+    opal_namelist_t *nm;
+    opal_value_t *iptr;
+    size_t n;
+    pmix1_opalcaddy_t *cd;
+
+    /* convert the incoming status */
+    rc = pmix1_convert_rc(status);
+
+    /* setup the caddy */
+    cd = OBJ_NEW(pmix1_opalcaddy_t);
+
+    /* convert the array of procs */
+    for (n=0; n < nprocs; n++) {
+        nm = OBJ_NEW(opal_namelist_t);
+        nm->name.jobid = strtoul(procs[n].nspace, NULL, 10);
+        nm->name.vpid = procs[n].rank;
+        opal_list_append(&cd->procs, &nm->super);
+    }
+
+    /* convert the array of info */
+    for (n=0; n < ninfo; n++) {
+        iptr = OBJ_NEW(opal_value_t);
+        iptr->key = strdup(info[n].key);
+        pmix1_value_unload(iptr, &info[n].value);
+        opal_list_append(&cd->info, &iptr->super);
+    }
+
+    /* call the base errhandler */
+    opal_pmix_base_errhandler(rc, &cd->procs, &cd->info, release_cbfunc, cd);
+}
+
+static void errreg_cbfunc(pmix_status_t status,
+                          int errhandler_ref,
+                          void *cbdata)
+{
+    errhdler_ref = errhandler_ref;
+    opal_output_verbose(5, opal_pmix_base_framework.framework_output,
+                        "PMIX server errreg_cbfunc - error handler registered status=%d, reference=%d",
+                        status, errhandler_ref);
+}
+
+int pmix1_server_init(opal_pmix_server_module_t *module,
+                      opal_list_t *info)
+{
+    pmix_status_t rc;
+    int dbg;
+    opal_value_t *kv;
+    pmix_info_t *pinfo;
+    size_t sz, n;
+
+    if (0 < (dbg = opal_output_get_verbosity(opal_pmix_base_framework.framework_output))) {
+        asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
+        putenv(dbgvalue);
+    }
+
+    /* convert the list to an array of pmix_info_t */
+    if (NULL != info) {
+        sz = opal_list_get_size(info);
+        PMIX_INFO_CREATE(pinfo, sz);
+        n = 0;
+        OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&pinfo[n].value, kv);
+            ++n;
+        }
+    } else {
+        sz = 0;
+        pinfo = NULL;
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&external_module, pinfo, sz))) {
+        PMIX_INFO_FREE(pinfo, sz);
+        return pmix1_convert_rc(rc);
+    }
+    PMIX_INFO_FREE(pinfo, sz);
+
+    /* record the host module */
+    external_host_module = module;
+
+    /* register the errhandler */
+    PMIx_Register_errhandler(NULL, 0, myerr, errreg_cbfunc, NULL);
+    return OPAL_SUCCESS;
+}
+
+int pmix1_server_finalize(void)
+{
+    pmix_status_t rc;
+
+    /* deregister the errhandler */
+    PMIx_Deregister_errhandler(errhdler_ref, NULL, NULL);
+
+    rc = PMIx_server_finalize();
+    return pmix1_convert_rc(rc);
+}
+
+int pmix1_server_gen_regex(const char *input, char **regex)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_generate_regex(input, regex);
+    return pmix1_convert_rc(rc);
+}
+
+
+int pmix1_server_gen_ppn(const char *input, char **ppn)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_generate_ppn(input, ppn);
+    return pmix1_convert_rc(rc);
+}
+
+static void opcbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+
+    if (NULL != op->opcbfunc) {
+        op->opcbfunc(pmix1_convert_rc(status), op->cbdata);
+    }
+    OBJ_RELEASE(op);
+}
+
+int pmix1_server_register_nspace(opal_jobid_t jobid,
+                                 int nlocalprocs,
+                                 opal_list_t *info,
+                                 opal_pmix_op_cbfunc_t cbfunc,
+                                 void *cbdata)
+{
+    opal_value_t *kv, *k2;
+    pmix_info_t *pinfo, *pmap;
+    size_t sz, szmap, m, n;
+    char nspace[PMIX_MAX_NSLEN];
+    pmix_status_t rc;
+    pmix1_opcaddy_t *op;
+    opal_list_t *pmapinfo;
+    opal_pmix1_jobid_trkr_t *job;
+
+    /* convert the jobid */
+    (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
+
+    /* store this job in our list of known nspaces */
+    job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+    (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+    job->jobid = jobid;
+    opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
+
+    /* convert the list to an array of pmix_info_t */
+    if (NULL != info) {
+        sz = opal_list_get_size(info);
+        PMIX_INFO_CREATE(pinfo, sz);
+        n = 0;
+        OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+            if (0 == strcmp(kv->key, OPAL_PMIX_PROC_DATA)) {
+                pinfo[n].value.type = PMIX_INFO_ARRAY;
+                /* the value contains a list of values - convert
+                 * that list to another array */
+                pmapinfo = (opal_list_t*)kv->data.ptr;
+                szmap = opal_list_get_size(pmapinfo);
+                PMIX_INFO_CREATE(pmap, szmap);
+                pinfo[n].value.data.array.array = (struct pmix_info *)pmap;
+                pinfo[n].value.data.array.size = szmap;
+                m = 0;
+                OPAL_LIST_FOREACH(k2, pmapinfo, opal_value_t) {
+                    (void)strncpy(pmap[m].key, k2->key, PMIX_MAX_KEYLEN);
+                    pmix1_value_load(&pmap[m].value, k2);
+                    ++m;
+                }
+            } else {
+                pmix1_value_load(&pinfo[n].value, kv);
+            }
+            ++n;
+        }
+    } else {
+        sz = 0;
+        pinfo = NULL;
+    }
+
+    /* setup the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->info = pinfo;
+    op->sz = sz;
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+    rc = PMIx_server_register_nspace(nspace, nlocalprocs, pinfo, sz,
+                                     opcbfunc, op);
+    if (PMIX_SUCCESS != rc) {
+        OBJ_RELEASE(op);
+    }
+    return pmix1_convert_rc(rc);
+}
+
+void pmix1_server_deregister_nspace(opal_jobid_t jobid)
+{
+    opal_pmix1_jobid_trkr_t *jptr;
+
+    /* if we don't already have it, we can ignore this */
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+        if (jptr->jobid == jobid) {
+            /* found it - tell the server to deregister */
+            PMIx_server_deregister_nspace(jptr->nspace);
+            /* now get rid of it from our list */
+            opal_list_remove_item(&mca_pmix_external114_component.jobids, &jptr->super);
+            OBJ_RELEASE(jptr);
+            return;
+        }
+    }
+}
+
+int pmix1_server_register_client(const opal_process_name_t *proc,
+                                 uid_t uid, gid_t gid,
+                                 void *server_object,
+                                 opal_pmix_op_cbfunc_t cbfunc,
+                                 void *cbdata)
+{
+    pmix_status_t rc;
+    pmix1_opcaddy_t *op;
+
+    /* setup the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    /* convert the jobid */
+    (void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, proc->jobid);
+    op->p.rank = proc->vpid;
+
+    rc = PMIx_server_register_client(&op->p, uid, gid, server_object,
+                                     opcbfunc, op);
+    if (PMIX_SUCCESS != rc) {
+        OBJ_RELEASE(op);
+    }
+    return pmix1_convert_rc(rc);
+}
+
+void pmix1_server_deregister_client(const opal_process_name_t *proc)
+{
+    opal_pmix1_jobid_trkr_t *jptr;
+    pmix_proc_t p;
+
+    /* if we don't already have it, we can ignore this */
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+        if (jptr->jobid == proc->jobid) {
+            /* found it - tell the server to deregister */
+            (void)strncpy(p.nspace, jptr->nspace, PMIX_MAX_NSLEN);
+            p.rank = proc->vpid;
+            PMIx_server_deregister_client(&p);
+            return;
+        }
+    }
+}
+
+
+int pmix1_server_setup_fork(const opal_process_name_t *proc, char ***env)
+{
+    pmix_status_t rc;
+    pmix_proc_t p;
+
+    /* convert the jobid */
+    (void)opal_snprintf_jobid(p.nspace, PMIX_MAX_NSLEN, proc->jobid);
+    p.rank = proc->vpid;
+
+    rc = PMIx_server_setup_fork(&p, env);
+    return pmix1_convert_rc(rc);
+}
+
+/* this is the call back up from the embedded PMIx server that
+ * will contain the returned data. Note that the embedded server
+ * "owns" the data and will free it upon return from this function */
+static void dmdx_response(pmix_status_t status, char *data, size_t sz, void *cbdata)
+{
+    int rc;
+    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+
+    rc = pmix1_convert_rc(status);
+    if (NULL != op->mdxcbfunc) {
+        op->mdxcbfunc(rc, data, sz, op->cbdata, NULL, NULL);
+    }
+    OBJ_RELEASE(op);
+}
+
+int pmix1_server_dmodex(const opal_process_name_t *proc,
+                        opal_pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix1_opcaddy_t *op;
+    pmix_status_t rc;
+
+    /* setup the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->mdxcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    /* convert the jobid */
+    (void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, proc->jobid);
+    op->p.rank = proc->vpid;
+
+    /* find the internally-cached data for this proc */
+    rc = PMIx_server_dmodex_request(&op->p, dmdx_response, op);
+    if (PMIX_SUCCESS != rc) {
+        OBJ_RELEASE(op);
+    }
+    return pmix1_convert_rc(rc);
+}
+
+int pmix1_server_notify_error(int status,
+                                opal_list_t *procs,
+                                opal_list_t *error_procs,
+                                opal_list_t *info,
+                                opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    opal_value_t *kv;
+    pmix_info_t *pinfo;
+    size_t sz, psz, esz, n;
+    pmix_proc_t *ps, *eps;
+    pmix_status_t rc;
+    pmix1_opcaddy_t *op;
+    opal_namelist_t *nm;
+
+    /* convert the list of procs */
+    if (NULL != procs) {
+        psz = opal_list_get_size(procs);
+        PMIX_PROC_CREATE(ps, psz);
+        n = 0;
+        OPAL_LIST_FOREACH(nm, procs, opal_namelist_t) {
+            (void)opal_snprintf_jobid(ps[n].nspace, PMIX_MAX_NSLEN, nm->name.jobid);
+            ps[n].rank = (int)nm->name.vpid;
+            ++n;
+        }
+    } else {
+        psz = 0;
+        ps = NULL;
+    }
+    if (NULL != error_procs) {
+        esz = opal_list_get_size(error_procs);
+        PMIX_PROC_CREATE(eps, esz);
+        n = 0;
+        OPAL_LIST_FOREACH(nm, error_procs, opal_namelist_t) {
+            (void)opal_snprintf_jobid(eps[n].nspace, PMIX_MAX_NSLEN, nm->name.jobid);
+            eps[n].rank = (int)nm->name.vpid;
+            ++n;
+        }
+    } else {
+        esz = 0;
+        eps = NULL;
+    }
+
+    /* convert the list to an array of pmix_info_t */
+    if (NULL != info) {
+        sz = opal_list_get_size(info);
+        PMIX_INFO_CREATE(pinfo, sz);
+        n = 0;
+        OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+            pmix1_value_load(&pinfo[n].value, kv);
+        }
+    } else {
+        sz = 0;
+        pinfo = NULL;
+    }
+
+    /* setup the caddy */
+    op = OBJ_NEW(pmix1_opcaddy_t);
+    op->procs = ps;
+    op->nprocs = psz;
+    op->error_procs = eps;
+    op->nerror_procs = esz;
+    op->info = pinfo;
+    op->sz = sz;
+    op->opcbfunc = cbfunc;
+    op->cbdata = cbdata;
+
+    rc = pmix1_convert_opalrc(status);
+    rc = PMIx_Notify_error(rc, ps, psz, eps, esz,
+                           pinfo, sz, opcbfunc, op);
+    if (PMIX_SUCCESS != rc) {
+        OBJ_RELEASE(op);
+    }
+    return pmix1_convert_rc(rc);
+}

--- a/opal/mca/pmix/external114/pmix_ext_server_south.c
+++ b/opal/mca/pmix/external114/pmix_ext_server_south.c
@@ -37,22 +37,20 @@
 #include "opal/mca/pmix/base/base.h"
 #include "pmix_ext.h"
 
-#include <pmix.h>
-#include <pmix_server.h>
 
 /****    S.O.U.T.H.B.O.U.N.D   I.N.T.E.R.F.A.C.E.S     ****/
 
 /* These are the interfaces used by the OMPI/ORTE/OPAL layer to call
  * down into the embedded PMIx server. */
 
-extern pmix_server_module_t external_module;
-extern opal_pmix_server_module_t *external_host_module;
+extern pmix_server_module_t external114_module;
+extern opal_pmix_server_module_t *external114_host_module;
 static char *dbgvalue=NULL;
 static int errhdler_ref = 0;
 
 static void release_cbfunc(void *cbdata)
 {
-    pmix1_opalcaddy_t *cd = (pmix1_opalcaddy_t*)cbdata;
+    pmix_ext114_opalcaddy_t *cd = (pmix_ext114_opalcaddy_t*)cbdata;
     OBJ_RELEASE(cd);
 }
 static void myerr(pmix_status_t status,
@@ -63,13 +61,13 @@ static void myerr(pmix_status_t status,
     opal_namelist_t *nm;
     opal_value_t *iptr;
     size_t n;
-    pmix1_opalcaddy_t *cd;
+    pmix_ext114_opalcaddy_t *cd;
 
     /* convert the incoming status */
-    rc = pmix1_convert_rc(status);
+    rc = pmix_ext114_convert_rc(status);
 
     /* setup the caddy */
-    cd = OBJ_NEW(pmix1_opalcaddy_t);
+    cd = OBJ_NEW(pmix_ext114_opalcaddy_t);
 
     /* convert the array of procs */
     for (n=0; n < nprocs; n++) {
@@ -83,7 +81,7 @@ static void myerr(pmix_status_t status,
     for (n=0; n < ninfo; n++) {
         iptr = OBJ_NEW(opal_value_t);
         iptr->key = strdup(info[n].key);
-        pmix1_value_unload(iptr, &info[n].value);
+        pmix_ext114_value_unload(iptr, &info[n].value);
         opal_list_append(&cd->info, &iptr->super);
     }
 
@@ -101,7 +99,7 @@ static void errreg_cbfunc(pmix_status_t status,
                         status, errhandler_ref);
 }
 
-int pmix1_server_init(opal_pmix_server_module_t *module,
+int pmix_ext114_server_init(opal_pmix_server_module_t *module,
                       opal_list_t *info)
 {
     pmix_status_t rc;
@@ -122,7 +120,7 @@ int pmix1_server_init(opal_pmix_server_module_t *module,
         n = 0;
         OPAL_LIST_FOREACH(kv, info, opal_value_t) {
             (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&pinfo[n].value, kv);
+            pmix_ext114_value_load(&pinfo[n].value, kv);
             ++n;
         }
     } else {
@@ -130,21 +128,21 @@ int pmix1_server_init(opal_pmix_server_module_t *module,
         pinfo = NULL;
     }
 
-    if (PMIX_SUCCESS != (rc = PMIx_server_init(&external_module, pinfo, sz))) {
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&external114_module, pinfo, sz))) {
         PMIX_INFO_FREE(pinfo, sz);
-        return pmix1_convert_rc(rc);
+        return pmix_ext114_convert_rc(rc);
     }
     PMIX_INFO_FREE(pinfo, sz);
 
     /* record the host module */
-    external_host_module = module;
+    external114_host_module = module;
 
     /* register the errhandler */
     PMIx_Register_errhandler(NULL, 0, myerr, errreg_cbfunc, NULL);
     return OPAL_SUCCESS;
 }
 
-int pmix1_server_finalize(void)
+int pmix_ext114_server_finalize(void)
 {
     pmix_status_t rc;
 
@@ -152,37 +150,37 @@ int pmix1_server_finalize(void)
     PMIx_Deregister_errhandler(errhdler_ref, NULL, NULL);
 
     rc = PMIx_server_finalize();
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }
 
-int pmix1_server_gen_regex(const char *input, char **regex)
+int pmix_ext114_server_gen_regex(const char *input, char **regex)
 {
     pmix_status_t rc;
 
     rc = PMIx_generate_regex(input, regex);
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }
 
 
-int pmix1_server_gen_ppn(const char *input, char **ppn)
+int pmix_ext114_server_gen_ppn(const char *input, char **ppn)
 {
     pmix_status_t rc;
 
     rc = PMIx_generate_ppn(input, ppn);
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }
 
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {
-    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+    pmix_ext114_opcaddy_t *op = (pmix_ext114_opcaddy_t*)cbdata;
 
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(pmix1_convert_rc(status), op->cbdata);
+        op->opcbfunc(pmix_ext114_convert_rc(status), op->cbdata);
     }
     OBJ_RELEASE(op);
 }
 
-int pmix1_server_register_nspace(opal_jobid_t jobid,
+int pmix_ext114_server_register_nspace(opal_jobid_t jobid,
                                  int nlocalprocs,
                                  opal_list_t *info,
                                  opal_pmix_op_cbfunc_t cbfunc,
@@ -193,15 +191,15 @@ int pmix1_server_register_nspace(opal_jobid_t jobid,
     size_t sz, szmap, m, n;
     char nspace[PMIX_MAX_NSLEN];
     pmix_status_t rc;
-    pmix1_opcaddy_t *op;
+    pmix_ext114_opcaddy_t *op;
     opal_list_t *pmapinfo;
-    opal_pmix1_jobid_trkr_t *job;
+    opal_pmix_ext114_jobid_trkr_t *job;
 
     /* convert the jobid */
     (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
 
     /* store this job in our list of known nspaces */
-    job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+    job = OBJ_NEW(opal_pmix_ext114_jobid_trkr_t);
     (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
     job->jobid = jobid;
     opal_list_append(&mca_pmix_external114_component.jobids, &job->super);
@@ -225,11 +223,11 @@ int pmix1_server_register_nspace(opal_jobid_t jobid,
                 m = 0;
                 OPAL_LIST_FOREACH(k2, pmapinfo, opal_value_t) {
                     (void)strncpy(pmap[m].key, k2->key, PMIX_MAX_KEYLEN);
-                    pmix1_value_load(&pmap[m].value, k2);
+                    pmix_ext114_value_load(&pmap[m].value, k2);
                     ++m;
                 }
             } else {
-                pmix1_value_load(&pinfo[n].value, kv);
+                pmix_ext114_value_load(&pinfo[n].value, kv);
             }
             ++n;
         }
@@ -239,7 +237,7 @@ int pmix1_server_register_nspace(opal_jobid_t jobid,
     }
 
     /* setup the caddy */
-    op = OBJ_NEW(pmix1_opcaddy_t);
+    op = OBJ_NEW(pmix_ext114_opcaddy_t);
     op->info = pinfo;
     op->sz = sz;
     op->opcbfunc = cbfunc;
@@ -249,15 +247,15 @@ int pmix1_server_register_nspace(opal_jobid_t jobid,
     if (PMIX_SUCCESS != rc) {
         OBJ_RELEASE(op);
     }
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }
 
-void pmix1_server_deregister_nspace(opal_jobid_t jobid)
+void pmix_ext114_server_deregister_nspace(opal_jobid_t jobid)
 {
-    opal_pmix1_jobid_trkr_t *jptr;
+    opal_pmix_ext114_jobid_trkr_t *jptr;
 
     /* if we don't already have it, we can ignore this */
-    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix_ext114_jobid_trkr_t) {
         if (jptr->jobid == jobid) {
             /* found it - tell the server to deregister */
             PMIx_server_deregister_nspace(jptr->nspace);
@@ -269,17 +267,17 @@ void pmix1_server_deregister_nspace(opal_jobid_t jobid)
     }
 }
 
-int pmix1_server_register_client(const opal_process_name_t *proc,
+int pmix_ext114_server_register_client(const opal_process_name_t *proc,
                                  uid_t uid, gid_t gid,
                                  void *server_object,
                                  opal_pmix_op_cbfunc_t cbfunc,
                                  void *cbdata)
 {
     pmix_status_t rc;
-    pmix1_opcaddy_t *op;
+    pmix_ext114_opcaddy_t *op;
 
     /* setup the caddy */
-    op = OBJ_NEW(pmix1_opcaddy_t);
+    op = OBJ_NEW(pmix_ext114_opcaddy_t);
     op->opcbfunc = cbfunc;
     op->cbdata = cbdata;
 
@@ -292,16 +290,16 @@ int pmix1_server_register_client(const opal_process_name_t *proc,
     if (PMIX_SUCCESS != rc) {
         OBJ_RELEASE(op);
     }
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }
 
-void pmix1_server_deregister_client(const opal_process_name_t *proc)
+void pmix_ext114_server_deregister_client(const opal_process_name_t *proc)
 {
-    opal_pmix1_jobid_trkr_t *jptr;
+    opal_pmix_ext114_jobid_trkr_t *jptr;
     pmix_proc_t p;
 
     /* if we don't already have it, we can ignore this */
-    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix1_jobid_trkr_t) {
+    OPAL_LIST_FOREACH(jptr, &mca_pmix_external114_component.jobids, opal_pmix_ext114_jobid_trkr_t) {
         if (jptr->jobid == proc->jobid) {
             /* found it - tell the server to deregister */
             (void)strncpy(p.nspace, jptr->nspace, PMIX_MAX_NSLEN);
@@ -313,7 +311,7 @@ void pmix1_server_deregister_client(const opal_process_name_t *proc)
 }
 
 
-int pmix1_server_setup_fork(const opal_process_name_t *proc, char ***env)
+int pmix_ext114_server_setup_fork(const opal_process_name_t *proc, char ***env)
 {
     pmix_status_t rc;
     pmix_proc_t p;
@@ -323,7 +321,7 @@ int pmix1_server_setup_fork(const opal_process_name_t *proc, char ***env)
     p.rank = proc->vpid;
 
     rc = PMIx_server_setup_fork(&p, env);
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }
 
 /* this is the call back up from the embedded PMIx server that
@@ -332,23 +330,23 @@ int pmix1_server_setup_fork(const opal_process_name_t *proc, char ***env)
 static void dmdx_response(pmix_status_t status, char *data, size_t sz, void *cbdata)
 {
     int rc;
-    pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
+    pmix_ext114_opcaddy_t *op = (pmix_ext114_opcaddy_t*)cbdata;
 
-    rc = pmix1_convert_rc(status);
+    rc = pmix_ext114_convert_rc(status);
     if (NULL != op->mdxcbfunc) {
         op->mdxcbfunc(rc, data, sz, op->cbdata, NULL, NULL);
     }
     OBJ_RELEASE(op);
 }
 
-int pmix1_server_dmodex(const opal_process_name_t *proc,
+int pmix_ext114_server_dmodex(const opal_process_name_t *proc,
                         opal_pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix1_opcaddy_t *op;
+    pmix_ext114_opcaddy_t *op;
     pmix_status_t rc;
 
     /* setup the caddy */
-    op = OBJ_NEW(pmix1_opcaddy_t);
+    op = OBJ_NEW(pmix_ext114_opcaddy_t);
     op->mdxcbfunc = cbfunc;
     op->cbdata = cbdata;
 
@@ -361,10 +359,10 @@ int pmix1_server_dmodex(const opal_process_name_t *proc,
     if (PMIX_SUCCESS != rc) {
         OBJ_RELEASE(op);
     }
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }
 
-int pmix1_server_notify_error(int status,
+int pmix_ext114_server_notify_error(int status,
                                 opal_list_t *procs,
                                 opal_list_t *error_procs,
                                 opal_list_t *info,
@@ -375,7 +373,7 @@ int pmix1_server_notify_error(int status,
     size_t sz, psz, esz, n;
     pmix_proc_t *ps, *eps;
     pmix_status_t rc;
-    pmix1_opcaddy_t *op;
+    pmix_ext114_opcaddy_t *op;
     opal_namelist_t *nm;
 
     /* convert the list of procs */
@@ -413,7 +411,7 @@ int pmix1_server_notify_error(int status,
         n = 0;
         OPAL_LIST_FOREACH(kv, info, opal_value_t) {
             (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&pinfo[n].value, kv);
+            pmix_ext114_value_load(&pinfo[n].value, kv);
         }
     } else {
         sz = 0;
@@ -421,7 +419,7 @@ int pmix1_server_notify_error(int status,
     }
 
     /* setup the caddy */
-    op = OBJ_NEW(pmix1_opcaddy_t);
+    op = OBJ_NEW(pmix_ext114_opcaddy_t);
     op->procs = ps;
     op->nprocs = psz;
     op->error_procs = eps;
@@ -431,11 +429,11 @@ int pmix1_server_notify_error(int status,
     op->opcbfunc = cbfunc;
     op->cbdata = cbdata;
 
-    rc = pmix1_convert_opalrc(status);
+    rc = pmix_ext114_convert_opalrc(status);
     rc = PMIx_Notify_error(rc, ps, psz, eps, esz,
                            pinfo, sz, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {
         OBJ_RELEASE(op);
     }
-    return pmix1_convert_rc(rc);
+    return pmix_ext114_convert_rc(rc);
 }


### PR DESCRIPTION
**(This is not ready to merge. Posting for comment)**

 * Add an 'extern114' component that is targeted at the PMIx 1.1.4 release.
 * Add a opal_check_version macro that can help with checking version ranges.
 * Adjust the PMIx check to include getting the version information from the library.