### PR TITLE
rcache: fix leave_pinned failure path

### DIFF
--- a/opal/mca/rcache/base/help-rcache-base.txt
+++ b/opal/mca/rcache/base/help-rcache-base.txt
@@ -22,9 +22,9 @@ Open MPI will disable any transports that are attempting to use the
 leave pinned functionality; your job may still run, but may fall back
 to a slower network transport (such as TCP).
 
-  Mpool name: %s
-  Process:    %s
-  Local host: %s
+  rcache name: %s
+  Process:     %s
+  Local host:  %s
 #
 [cannot deregister in-use memory]
 Open MPI intercepted a call to free memory that is still being used by
@@ -32,7 +32,7 @@ an ongoing MPI communication.  This usually reflects an error in the
 MPI application; it may signify memory corruption.  Open MPI will now
 abort your job.
 
-  Mpool name:     %s
+  rcache name:    %s
   Local host:     %s
   Buffer address: %p
   Buffer size:    %lu

--- a/opal/mca/rcache/base/rcache_base_create.c
+++ b/opal/mca/rcache/base/rcache_base_create.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -59,9 +59,7 @@ mca_rcache_base_module_t* mca_rcache_base_module_create (const char* name, void 
                actually).  This is a hook available for memory manager hooks
                without good initialization routine support */
             (void) mca_base_framework_open (&opal_memory_base_framework, 0);
-        }
 
-        if (opal_leave_pinned != 0 || opal_leave_pinned_pipeline) {
             if ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) ==
                 ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) &
                  opal_mem_hooks_support_level())) {
@@ -69,7 +67,7 @@ mca_rcache_base_module_t* mca_rcache_base_module_create (const char* name, void 
                     opal_leave_pinned = !opal_leave_pinned_pipeline;
                 }
                 opal_mem_hooks_register_release(mca_rcache_base_mem_cb, NULL);
-            } else {
+            } else if (1 == opal_leave_pinned || opal_leave_pinned_pipeline) {
                 opal_show_help("help-rcache-base.txt", "leave pinned failed",
                                true, name, OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
                                opal_proc_local_get()->proc_hostname);


### PR DESCRIPTION
This commit fixes an error in the failure path of leave_pinned. When
the rcache tries to enable leave_pinned but leave_pinned was not
specifically requested (opal_leave_pinned == -1) the code was
erroneously printing an error and returning NULL.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>