### PR TITLE
topo/treematch: fix misleading indentation warnings

### DIFF
--- a/ompi/mca/topo/treematch/treematch/tm_malloc.c
+++ b/ompi/mca/topo/treematch/treematch/tm_malloc.c
@@ -57,7 +57,7 @@ void my_mem_check(void){
     for(s=size_hash; s != NULL; s=s->hh.next) {
       if(get_verbose_level()>=ERROR)
         printf("pointer %p of size %ld has not been freed!\n", s->key, s->size);
-	nb_errors ++;
+      nb_errors ++;
     }
 
     if(get_verbose_level() >= INFO)

--- a/ompi/mca/topo/treematch/treematch/tm_tree.c
+++ b/ompi/mca/topo/treematch/treematch/tm_tree.c
@@ -1164,17 +1164,18 @@ void group_nodes(affinity_mat_t *aff_mat,tree_t *tab_node, tree_t *new_tab_node,
       else if(last_best>best_val)
 	printf("Cost most last impoved solution\n");
     }
-      if( n < 10000 ){
+
+    if( n < 10000 ){
       /* perform a mapping in the weighted degree order */
 
 
-    if(verbose_level>=INFO)
-      printf("----WG----\n");
+      if(verbose_level>=INFO)
+        printf("----WG----\n");
 
       compute_weighted_degree(tab_group,n,arity);
 
       if(verbose_level>=INFO)
-	printf("Weigted degree computed\n");
+        printf("Weigted degree computed\n");
 
       qsort(tab_group,n,sizeof(group_list_t*),weighted_degree_dsc);
       /* display_tab_group(tab_group,n,arity);*/
@@ -1183,10 +1184,10 @@ void group_nodes(affinity_mat_t *aff_mat,tree_t *tab_node, tree_t *new_tab_node,
       /* timeout = select_independent_groups(tab_group,n,arity,M,&best_val,best_selection,n,0); */
 
       if(verbose_level>=DEBUG){
-	if(timeout)
-	  printf("WG timeout!\n");
-	else if(last_best>best_val)
-	  printf("WG impoved solution\n");
+        if(timeout)
+          printf("WG timeout!\n");
+        else if(last_best>best_val)
+          printf("WG impoved solution\n");
       }
     }
 

--- a/test/monitoring/monitoring_test.c
+++ b/test/monitoring/monitoring_test.c
@@ -78,7 +78,6 @@ I	3	2	860 bytes	24 msgs sent
 
 static MPI_T_pvar_handle flush_handle;
 static const char flush_pvar_name[] = "pml_monitoring_flush";
-static const char flush_cvar_name[] = "pml_monitoring_enable";
 static int flush_pvar_idx;
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This commit fixes a pair of warnings caused by misleading indentation.
This is a new warning in gcc 6.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
