### PR TITLE
memory/patcher: add #if check for MREMAP_FIXED

### DIFF
--- a/opal/mca/memory/patcher/configure.m4
+++ b/opal/mca/memory/patcher/configure.m4
@@ -84,6 +84,8 @@ AC_DEFUN([MCA_opal_memory_patcher_CONFIG],[
     AC_DEFINE_UNQUOTED([OPAL_MEMORY_PATCHER_HAVE___SYSCALL], [$memory_patcher_have___syscall],
                        [Whether the internal __syscall call exists])
 
+    AC_CHECK_HEADERS([linux/mman.h])
+
     [$1]
 
     OPAL_VAR_SCOPE_POP

--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -175,9 +175,11 @@ static void *intercept_mremap (void *start, size_t oldlen, size_t newlen, int fl
         opal_mem_hooks_release_hook (start, oldlen, true);
     }
 
+#if defined(MREMAP_FIXED)
     if (!(flags & MREMAP_FIXED)) {
         new_address = NULL;
     }
+#endif
 
     if (!original_mremap) {
         result = (void *)(intptr_t) memory_patcher_syscall (SYS_mremap, start, oldlen, newlen, flags, new_address);

--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -43,6 +43,10 @@
 #include <sys/time.h>
 #include <sys/syscall.h>
 
+#if defined(HAVE_LINUX_MMAN_H)
+#include <linux/mman.h>
+#endif
+
 #include "memory_patcher.h"
 #undef opal_memory_changed
 

--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -166,11 +166,20 @@ static int intercept_munmap(void *start, size_t length)
 
 #if defined (SYS_mremap)
 
+#if defined(__linux__)
 /* on linux this function has an optional extra argument but ... can not be used here because it
  * causes issues when intercepting a 4-argument mremap call */
 static void *(*original_mremap) (void *, size_t, size_t, int, void *);
+#else
+/* mremap has a different signature on BSD systems */
+static void *(*original_mremap) (void *, size_t, void *, size_t, int);
+#endif
 
+#if defined(__linux__)
 static void *intercept_mremap (void *start, size_t oldlen, size_t newlen, int flags, void *new_address)
+#else
+static void *intercept_mremap (void *start, size_t oldlen, void *new_address, size_t newlen, int flags)
+#endif
 {
     OPAL_PATCHER_BEGIN;
     void *result = MAP_FAILED;
@@ -185,11 +194,19 @@ static void *intercept_mremap (void *start, size_t oldlen, size_t newlen, int fl
     }
 #endif
 
+#if defined(__linux__)
     if (!original_mremap) {
         result = (void *)(intptr_t) memory_patcher_syscall (SYS_mremap, start, oldlen, newlen, flags, new_address);
     } else {
         result = original_mremap (start, oldlen, newlen, flags, new_address);
     }
+#else
+    if (!original_mremap) {
+        result = (void *)(intptr_t) memory_patcher_syscall (SYS_mremap, start, oldlen, new_address, newlen, flags);
+    } else {
+        result = original_mremap (start, oldlen, new_address, newlen, flags);
+    }
+#endif
 
     OPAL_PATCHER_END;
     return result;

--- a/opal/mca/patcher/overwrite/patcher_overwrite_module.c
+++ b/opal/mca/patcher/overwrite/patcher_overwrite_module.c
@@ -105,7 +105,7 @@ static int mca_patcher_overwrite_apply_patch (mca_patcher_base_patch_t *patch)
  * imm64 = i << 63 | imm41 << 22 | ic << 21 | imm5c << 16 | imm9d << 7 | imm7b
  */
          unsigned char buf[16];
-         unsigned long long imm64 =  func_new_addr - func_old_addr - 16;
+         unsigned long long imm64 =  func_new_addr - patch->patch_orig - 16;
          register unsigned long long glb_ptr  __asm__("r1");
          unsigned long long nop =
             (0x0ULL<<37) | /* O     */
@@ -133,7 +133,7 @@ static int mca_patcher_overwrite_apply_patch (mca_patcher_base_patch_t *patch)
             (1ULL                      <<  6) |
             (0x0ULL                    <<  0);
 
-         patch->data_size = 32;
+         patch->patch_data_size = 32;
 
          make_ia64_bundle(buf, movl, (glb_ptr>>22)&0x1FFFFFFFFFFULL, nop, 5);
          for (int i = 0 ; i < 16 ; ++i) {


### PR DESCRIPTION
This commit fixes a compile error when the system has mremap but not
MREMAP_FIXED. In this case we do not care about the value of
new_address as the argument does not exist.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>