### PR TITLE
sync_builtin: do not define *_64 if 64-bit not available

### DIFF
--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -86,6 +86,8 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
     return __sync_sub_and_fetch(addr, delta);
 }
 
+#if OPAL_ASM_SUPPORT_64BIT
+
 #define OPAL_HAVE_ATOMIC_CMPSET_64 1
 static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
                                              int64_t oldval, int64_t newval)
@@ -105,6 +107,8 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }
 
+#endif /* OPAL_ASM_SUPPORT_64BIT */
+
 #if OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
 static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
                                           opal_int128_t oldval, opal_int128_t newval)
@@ -115,6 +119,8 @@ static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
 #define OPAL_HAVE_ATOMIC_CMPSET_128 1
 
 #endif
+
+#if OPAL_ASM_SUPPORT_64BIT
 
 #define OPAL_HAVE_ATOMIC_MATH_64 1
 #define OPAL_HAVE_ATOMIC_ADD_64 1
@@ -128,5 +134,7 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 {
     return __sync_sub_and_fetch(addr, delta);
 }
+
+#endif /* OPAL_ASM_SUPPORT_64BIT */
 
 #endif /* ! OPAL_SYS_ARCH_ATOMIC_H */


### PR DESCRIPTION
This commit adds protection around the definitions of the 64-bit
atomics in sync_builtin. These should not be provided if
OPAL_ASM_SUPPORT_64BIT == 0.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>