### PR TITLE
btl/openib: fix more exp verbs compilation issues

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_udcm.c
@@ -1350,7 +1350,7 @@ static int udcm_rc_qp_create_one(udcm_module_t *m, mca_btl_base_endpoint_t* lcl_
     init_attr.comp_mask = IBV_EXP_QP_INIT_ATTR_PD;
     init_attr.pd = m->btl->device->ib_pd;
 
-#if HAVE_DECL_IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG
+#if defined(HAVE_DECL_IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG) && HAVE_DECL_IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG
     init_attr.comp_mask |= IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG;
     init_attr.max_atomic_arg = sizeof (int64_t);
 #endif


### PR DESCRIPTION
The macro HAVE_DECL_IBV_EXP_QP_INIT_ATTR_ATOMICS_ARG may not be
defined so protect its usage.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>