### PR TITLE
fs/lustre and fs/pvfs2: fix netbsd compilation problems

### DIFF
--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -78,9 +78,6 @@ int mca_fs_lustre_component_init_query(bool enable_progress_threads,
 struct mca_fs_base_module_1_0_0_t *
 mca_fs_lustre_component_file_query (mca_io_ompio_file_t *fh, int *priority)
 {
-    int err;
-    char *dir;
-    struct statfs fsbuf;
     char *tmp;
 
     /* The code in this function is based on the ADIO FS selection in ROMIO

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.c
@@ -81,9 +81,6 @@ mca_fs_pvfs2_component_file_query (mca_io_ompio_file_t *fh, int *priority)
      *   See COPYRIGHT notice in top-level directory.
      */
 
-    int err;
-    char *dir;
-    struct statfs fsbuf;
     char *tmp;
 
     /* The code in this function is based on the ADIO FS selection in ROMIO


### PR DESCRIPTION
a slightly modified version of this patch was already applied to 2.x (since it also contains a similar section in io/ompio that is not present on master due to the fact, that ompio disqualifies itself in 2.x for lustre file systems, but not on master). Bring the fixes to the other sections also to master. 