### PR TITLE
debuggers: remove some useless code

### DIFF
--- a/ompi/debuggers/debuggers.h
+++ b/ompi/debuggers/debuggers.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,18 +35,6 @@ BEGIN_C_DECLS
  * necessary for understanding the queues and other structures.
  */
 extern void ompi_debugger_setup_dlls(void);
-
-/**
- * Notify a debugger that we're about to abort
- */
-extern void ompi_debugger_notify_abort(char *string);
-
-/**
- * Breakpoint function for parallel debuggers.
- * This function is also defined in orterun for the starter.
- * It should never conflict with this one
- */
-OMPI_DECLSPEC void* MPIR_Breakpoint(void);
 
 /**
  * Flag debugger will set when an application may proceed past

--- a/ompi/debuggers/ompi_debuggers.c
+++ b/ompi/debuggers/ompi_debuggers.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -124,9 +124,6 @@ OMPI_DECLSPEC opal_datatype_t* opal_datatype_t_type_force_inclusion = NULL;
 OMPI_DECLSPEC ompi_datatype_t* ompi_datatype_t_type_force_inclusion = NULL;
 
 OMPI_DECLSPEC volatile int MPIR_debug_gate = 0;
-OMPI_DECLSPEC volatile int MPIR_being_debugged = 0;
-OMPI_DECLSPEC volatile int MPIR_debug_state = 0;
-OMPI_DECLSPEC char *MPIR_debug_abort_string = "";
 
 static char *ompi_debugger_dll_path = NULL;
 
@@ -192,32 +189,4 @@ ompi_debugger_setup_dlls(void)
        non-NULL values only when the entire array is ready). */
     mpimsgq_dll_locations = tmp1;
     mpidbg_dll_locations = tmp2;
-}
-
-
-/*
- * Tell the debugger that we are about to abort
- */
-void ompi_debugger_notify_abort(char *reason)
-{
-    MPIR_debug_state = MPIR_DEBUG_ABORTING;
-
-    if (NULL != reason && strlen(reason) > 0) {
-        MPIR_debug_abort_string = reason;
-    } else {
-        MPIR_debug_abort_string = "Unknown";
-    }
-
-    /* Now tell the debugger */
-    MPIR_Breakpoint();
-}
-
-/*
- * Breakpoint function for parallel debuggers.  This function is also
- * defined in orterun for the starter.  It should never conflict with
- * this
- */
-void* MPIR_Breakpoint(void)
-{
-    return NULL;
 }

--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2004-2010 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -380,7 +380,7 @@ int mqs_image_has_queues (mqs_image *image, char **message)
      * that types have been read from there before we try to look them
      * up.
      */
-    mqs_find_function (image, "MPIR_Breakpoint", mqs_lang_c, NULL);
+    mqs_find_function (image, "ompi_debugger_setup_dlls", mqs_lang_c, NULL);
 
     /* Are we supposed to ignore this ? (e.g. it's really an HPF
      * runtime using the Open MPI process acquisition, but not wanting

--- a/ompi/runtime/ompi_mpi_abort.c
+++ b/ompi/runtime/ompi_mpi_abort.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -119,7 +119,7 @@ int
 ompi_mpi_abort(struct ompi_communicator_t* comm,
                int errcode)
 {
-    char *msg, *host, hostname[OPAL_MAXHOSTNAMELEN];
+    char *host, hostname[OPAL_MAXHOSTNAMELEN];
     pid_t pid = 0;
 
     /* Protection for recursive invocation */
@@ -157,20 +157,6 @@ ompi_mpi_abort(struct ompi_communicator_t* comm,
                if opal_backtrace_print() is not supported. */
             opal_backtrace_print(stderr, NULL, 1);
         }
-    }
-
-    /* Notify the debugger that we're about to abort */
-
-    if (errcode < 0 ||
-        asprintf(&msg, "[%s:%d] aborting with MPI error %s%s",
-                 host, (int) pid, ompi_mpi_errnum_get_string(errcode),
-                 opal_abort_print_stack ?
-                 " (stack trace available on stderr)" : "") < 0) {
-        msg = NULL;
-    }
-    ompi_debugger_notify_abort(msg);
-    if (NULL != msg) {
-        free(msg);
     }
 
     /* Should we wait for a while before aborting? */


### PR DESCRIPTION
MPIR-1.0 specifies that the following symbols are only relevant in the starter process:

- MPIR_Breakpoint
- MPIR_being_debugged
- MPIR_debug_state
- MPIR_debug_abort_string

I.e., the code filling in values in these various symbols was useless / never used.

MPIR-1.1 will define that MPIR_being_debugged *is* relevant in MPI processes.  That symbol is currently defined in libopen-rte (which is currently causing a duplicate symbol error for static builds -- this commit fixes that error), and is therefore still available for MPI processes.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bosilca @rhc54 Please review.