### PR TITLE
memory/patcher: check for <sys/syscall.h>

### DIFF
--- a/opal/mca/memory/patcher/configure.m4
+++ b/opal/mca/memory/patcher/configure.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -84,7 +84,7 @@ AC_DEFUN([MCA_opal_memory_patcher_CONFIG],[
     AC_DEFINE_UNQUOTED([OPAL_MEMORY_PATCHER_HAVE___SYSCALL], [$memory_patcher_have___syscall],
                        [Whether the internal __syscall call exists])
 
-    AC_CHECK_HEADERS([linux/mman.h])
+    AC_CHECK_HEADERS([linux/mman.h sys/syscall.h])
 
     [$1]
 

--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -42,8 +42,9 @@
 #include <dlfcn.h>
 #include <assert.h>
 #include <sys/time.h>
+#if defined(HAVE_SYS_SYSCALL_H)
 #include <sys/syscall.h>
-
+#endif
 #if defined(HAVE_LINUX_MMAN_H)
 #include <linux/mman.h>
 #endif


### PR DESCRIPTION
Thanks to @PHHargrove for reporting in http://www.open-mpi.org/community/lists/devel/2016/05/18935.php.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@hjelmn Please review: is this sufficient?  It looks like this component should build even if `<sys/syscall.h>` is not present, so I just added it to `AC_CHECK_HEADERS`.