### PR TITLE
In case, we do not build Fortran, Fortran 2008 or CXX, the regexp in …

### DIFF
--- a/Makefile.ompi-rules
+++ b/Makefile.ompi-rules
@@ -21,7 +21,7 @@ endif
 
 .1in.1:
 	@ echo "  BUILDING $@"
-	@ $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
+	$(AM_V_CC) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
 	  --package-name='@PACKAGE_NAME@' \
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \
@@ -32,7 +32,7 @@ endif
 
 .3in.3:
 	@ echo "  BUILDING $@"
-	@ $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
+	$(AM_V_CC) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
 	  --package-name='@PACKAGE_NAME@' \
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \
@@ -44,7 +44,7 @@ endif
 
 .7in.7:
 	@ echo "  BUILDING $@"
-	@ $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
+	$(AM_V_CC) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
 	  --package-name='@PACKAGE_NAME@' \
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \

--- a/Makefile.ompi-rules
+++ b/Makefile.ompi-rules
@@ -20,8 +20,7 @@ if ! MAN_PAGE_BUILD_USEMPIF08_BINDINGS
 endif
 
 .1in.1:
-	@ echo "  BUILDING $@"
-	$(AM_V_CC) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
+	$(OMPI_V_GEN) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
 	  --package-name='@PACKAGE_NAME@' \
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \
@@ -31,8 +30,7 @@ endif
 	  --output=$@
 
 .3in.3:
-	@ echo "  BUILDING $@"
-	$(AM_V_CC) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
+	$(OMPI_V_GEN) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
 	  --package-name='@PACKAGE_NAME@' \
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \
@@ -43,8 +41,7 @@ endif
 	  --output=$@
 
 .7in.7:
-	@ echo "  BUILDING $@"
-	$(AM_V_CC) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
+	$(OMPI_V_GEN) $(top_srcdir)/ompi/mpi/man/make_manpage.pl \
 	  --package-name='@PACKAGE_NAME@' \
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \

--- a/ompi/mpi/man/make_manpage.pl
+++ b/ompi/mpi/man/make_manpage.pl
@@ -62,15 +62,15 @@ $file =~ s/#OPAL_DATE#/$opal_date/g;
 $file =~ s/#ORTE_DATE#/$orte_date/g;
 
 if ($cxx == 0) {
-    $file =~ s/\n\.SH C\+\+ Syntax.+?fi\n/\n/s;
+    $file =~ s/\n\.SH C\+\+ Syntax.+?\n\.SH/\n\.SH/s;
 }
 
 if ($fortran == 0) {
-    $file =~ s/\n\.SH Fortran Syntax.+?fi\n/\n/s;
+    $file =~ s/\n\.SH Fortran Syntax.+?\n\.SH/\n\.SH/s;
 }
 
 if ($f08 == 0) {
-    $file =~ s/\n\.SH Fortran 2008 Syntax.+?fi\n/\n/s;
+    $file =~ s/\n\.SH Fortran 2008 Syntax.+?\n\.SH/\n\.SH/s;
 }
 
 open(FILE, ">$output") ||

--- a/ompi/mpiext/affinity/c/OMPI_Affinity_str.3in
+++ b/ompi/mpiext/affinity/c/OMPI_Affinity_str.3in
@@ -1,6 +1,8 @@
+.\" -*- nroff -*-
 .\" Copyright 2007-2010 Oracle and/or its affiliates.  All rights reserved.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" $COPYRIGHT$
 .TH OMPI_Affinity_str 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
 \fBOMPI_Affinity_str\fP \- Obtain prettyprint strings of processor affinity information for this process
@@ -19,6 +21,9 @@ int OMPI_Affinity_str(ompi_affinity_fmt_type_t \fIfmt_type\fP,
 .fi
 .SH Fortran Syntax
 There is no Fortran binding for this function.
+.
+.SH Fortran 2008 Syntax
+There is no Fortran 2008 binding for this function.
 .
 .SH C++ Syntax
 There is no C++ binding for this function.


### PR DESCRIPTION
…make_manpage.pl will delete all lines up to the next ".fi" -- which for functions that do not implement the corresponding interface "as code" will have all text eliminated. Change regexp to delete this language-specific content up to the next newline+section header ".SH"

Also in case of make V=1, we'd like to see the command line, too (see Makefile.ompi-rules)

Amend OMPI_Affinity_str according to the other man-pages definitions.