### PR TITLE
configure: check the actual may_alias syntax that we use

### DIFF
--- a/opal/mca/hwloc/hwloc1112/hwloc/README-ompi.txt
+++ b/opal/mca/hwloc/hwloc1112/hwloc/README-ompi.txt
@@ -2,3 +2,4 @@ Cherry-picked commits after 1.11.2:
 
 open-mpi/hwloc@d2d07b9a2268699e13e1644b4f2ef7a53ef7396c
 open-mpi/hwloc@9549fd59af04dca2e2340e17f0e685f8c552d818
+open-mpi/hwloc@0ab7af5e90fc2b58be30b2126cc2a73f9f7ecfe9

--- a/opal/mca/hwloc/hwloc1112/hwloc/config/hwloc_check_attributes.m4
+++ b/opal/mca/hwloc/hwloc1112/hwloc/config/hwloc_check_attributes.m4
@@ -322,9 +322,10 @@ AC_DEFUN([_HWLOC_CHECK_ATTRIBUTES], [
     # Attribute may_alias: No suitable cross-check available, that works for non-supporting compilers
     # Ignored by intel-9.1.045 -- turn off with -wd1292
     # Ignored by PGI-6.2.5; ignore not detected due to missing cross-check
+    # The test case is chosen to match our only use in topology-xml-*.c, and reproduces an xlc-13.1.0 bug.
     #
     _HWLOC_CHECK_SPECIFIC_ATTRIBUTE([may_alias],
-        [int * p_value __attribute__ ((__may_alias__));],
+        [struct { int i; } __attribute__ ((__may_alias__)) * p_value;],
         [],
         [])
 


### PR DESCRIPTION
xlc 13.1.0 crashes because of our may_alias attributes in nolibxml.c
on Power7. libxml.c and nolibxml.c are the only may_alias users for now,
so change our configure check to match the actual code using it.

Thanks to Paul Hargrove for reporting and debugging the issue,
and providing the patch.

https://www.open-mpi.org/community/lists/devel/2016/05/18918.php

(cherry picked from open-mpi/hwloc@0ab7af5e90fc2b58be30b2126cc2a73f9f7ecfe9)