### PR TITLE
sync_builtin: check for 64-bit atomic support

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -110,6 +110,9 @@ __sync_add_and_fetch(&tmp, 1);],
 
   AC_DEFINE_UNQUOTED([OPAL_ASM_SYNC_HAVE_64BIT],[$opal_asm_sync_have_64bit],
 		     [Whether 64-bit is supported by the __sync builtin atomics])
+
+  # Check for 128-bit support
+  OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
 ])
 
 
@@ -893,7 +896,6 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
     opal_cv_asm_builtin="BUILTIN_NO"
     if test "$opal_cv_asm_builtin" = "BUILTIN_NO" && test "$enable_builtin_atomics" = "yes" ; then
        OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"], [])
-       OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
     fi
     if test "$opal_cv_asm_builtin" = "BUILTIN_NO" && test "$enable_osx_builtin_atomics" = "yes" ; then
        AC_CHECK_HEADER([libkern/OSAtomic.h],
@@ -1023,6 +1025,12 @@ AC_MSG_ERROR([Can not continue.])
               [AC_MSG_ERROR([No atomic primitives available for $host])])
             ;;
         esac
+
+	if test "x$OPAL_ASM_SUPPORT_64BIT" = "x1" && test "$opal_cv_asm_builtin" = "BUILTIN_SYNC" &&
+		test "$opal_asm_sync_have_64bit" = "0" ; then
+	    # __sync builtins exist but do not implement 64-bit support. Fall back on inline asm.
+	    opal_cv_asm_builtin="BUILTIN_NO"
+	fi
 
       if test "$opal_cv_asm_builtin" = "BUILTIN_SYNC" ; then
         AC_DEFINE([OPAL_C_GCC_INLINE_ASSEMBLY], [1],

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -95,6 +95,21 @@ __sync_add_and_fetch(&tmp, 1);],
      $1],
     [AC_MSG_RESULT([no])
      $2])
+
+  AC_MSG_CHECKING([for 64-bit __sync builtin atomics])
+
+  AC_TRY_LINK([
+#include <stdint.h>
+uint64_t tmp;], [
+__sync_bool_compare_and_swap(&tmp, 0, 1);
+__sync_add_and_fetch(&tmp, 1);],
+    [AC_MSG_RESULT([yes])
+     opal_asm_sync_have_64bit=1],
+    [AC_MSG_RESULT([no])
+     opal_asm_sync_have_64bit=0])
+
+  AC_DEFINE_UNQUOTED([OPAL_ASM_SYNC_HAVE_64BIT],[$opal_asm_sync_have_64bit],
+		     [Whether 64-bit is supported by the __sync builtin atomics])
 ])
 
 

--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -86,6 +86,8 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
     return __sync_sub_and_fetch(addr, delta);
 }
 
+#if OPAL_ASM_SYNC_HAVE_64BIT
+
 #define OPAL_HAVE_ATOMIC_CMPSET_64 1
 static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
                                              int64_t oldval, int64_t newval)
@@ -105,17 +107,6 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }
 
-#if OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
-static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
-                                          opal_int128_t oldval, opal_int128_t newval)
-{
-    return __sync_bool_compare_and_swap(addr, oldval, newval);
-}
-
-#define OPAL_HAVE_ATOMIC_CMPSET_128 1
-
-#endif
-
 #define OPAL_HAVE_ATOMIC_MATH_64 1
 #define OPAL_HAVE_ATOMIC_ADD_64 1
 static inline int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
@@ -128,5 +119,18 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 {
     return __sync_sub_and_fetch(addr, delta);
 }
+
+#endif
+
+#if OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
+static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
+                                          opal_int128_t oldval, opal_int128_t newval)
+{
+    return __sync_bool_compare_and_swap(addr, oldval, newval);
+}
+
+#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+
+#endif
 
 #endif /* ! OPAL_SYS_ARCH_ATOMIC_H */


### PR DESCRIPTION
This commit adds an additional check for 64-bit atomic support for __sync
builtins. If 64-bit support is not available the opal_atomic_*_64 atomics
are disabled.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>