### PR TITLE
amd64/atomic: silence warnings

### DIFF
--- a/opal/include/opal/sys/amd64/atomic.h
+++ b/opal/include/opal/sys/amd64/atomic.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserverd.
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -158,8 +160,8 @@ static inline int32_t opal_atomic_swap_32( volatile int32_t *addr,
     int32_t oldval;
 
     __asm__ __volatile__("xchg %1, %0" :
-			 "=r" (oldval), "=m" (*addr) :
-			 "0" (newval), "m" (*addr) :
+			 "=r" (oldval), "+m" (*addr) :
+			 "0" (newval) :
 			 "memory");
     return oldval;
 }
@@ -174,8 +176,8 @@ static inline int64_t opal_atomic_swap_64( volatile int64_t *addr,
     int64_t oldval;
 
     __asm__ __volatile__("xchgq %1, %0" :
-			 "=r" (oldval) :
-			 "m" (*addr), "0" (newval) :
+			 "=r" (oldval), "+m" (*addr) :
+			 "0" (newval) :
 			 "memory");
     return oldval;
 }
@@ -203,8 +205,8 @@ static inline int32_t opal_atomic_add_32(volatile int32_t* v, int i)
     int ret = i;
    __asm__ __volatile__(
                         SMPLOCK "xaddl %1,%0"
-                        :"=m" (*v), "+r" (ret)
-                        :"m" (*v)
+                        :"+m" (*v), "+r" (ret)
+                        :
                         :"memory", "cc"
                         );
    return (ret+i);
@@ -224,8 +226,8 @@ static inline int64_t opal_atomic_add_64(volatile int64_t* v, int64_t i)
     int64_t ret = i;
    __asm__ __volatile__(
                         SMPLOCK "xaddq %1,%0"
-                        :"=m" (*v), "+r" (ret)
-                        :"m" (*v)
+                        :"+m" (*v), "+r" (ret)
+                        :
                         :"memory", "cc"
                         );
    return (ret+i);
@@ -245,8 +247,8 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t* v, int i)
     int ret = -i;
    __asm__ __volatile__(
                         SMPLOCK "xaddl %1,%0"
-                        :"=m" (*v), "+r" (ret)
-                        :"m" (*v)
+                        :"+m" (*v), "+r" (ret)
+                        :
                         :"memory", "cc"
                         );
    return (ret-i);
@@ -266,8 +268,8 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t* v, int64_t i)
     int64_t ret = -i;
    __asm__ __volatile__(
                         SMPLOCK "xaddq %1,%0"
-                        :"=m" (*v), "+r" (ret)
-                        :"m" (*v)
+                        :"+m" (*v), "+r" (ret)
+                        :
                         :"memory", "cc"
                         );
    return (ret-i);


### PR DESCRIPTION
Solaris Studio compilers issue (tons of) warnings because one arguments of several __asm__ __volatile__ section is not needed