### PR TITLE
rcache: fix deadlock in multi-threaded environments

### DIFF
--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -539,6 +539,17 @@ static void mca_btl_vader_endpoint_constructor (mca_btl_vader_endpoint_t *ep)
     ep->fifo = NULL;
 }
 
+#if OPAL_BTL_VADER_HAVE_XPMEM
+static int mca_btl_vader_endpoint_rcache_cleanup (mca_rcache_base_registration_t *reg, void *ctx)
+{
+    mca_rcache_base_vma_module_t *vma_module = (mca_rcache_base_vma_module_t *) ctx;
+    /* otherwise dereg will fail on assert */
+    reg->ref_count = 0;
+    (void) mca_rcache_base_vma_delete (vma_module, reg);
+    return OPAL_SUCCESS;
+}
+#endif
+
 static void mca_btl_vader_endpoint_destructor (mca_btl_vader_endpoint_t *ep)
 {
     OBJ_DESTRUCT(&ep->pending_frags);
@@ -548,21 +559,11 @@ static void mca_btl_vader_endpoint_destructor (mca_btl_vader_endpoint_t *ep)
     if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
         if (ep->segment_data.xpmem.vma_module) {
             /* clean out the registration cache */
-            const int nregs = 100;
-            mca_rcache_base_registration_t *regs[nregs];
-            int reg_cnt;
-
-            do {
-                reg_cnt = mca_rcache_base_vma_find_all (ep->segment_data.xpmem.vma_module,
-                                                        0, (size_t) -1, regs, nregs);
-                for (int i = 0 ; i < reg_cnt ; ++i) {
-                    /* otherwise dereg will fail on assert */
-                    regs[i]->ref_count = 0;
-                    OBJ_RELEASE(regs[i]);
-                }
-            } while (reg_cnt == nregs);
-
-            ep->segment_data.xpmem.vma_module = NULL;
+            (void) mca_rcache_base_vma_iterate (ep->segment_data.xpmem.vma_module,
+                                                NULL, (size_t) -1,
+                                                mca_btl_vader_endpoint_rcache_cleanup,
+                                                (void *) ep->segment_data.xpmem.vma_module);
+            OBJ_RELEASE(ep->segment_data.xpmem.vma_module);
         }
 
         if (ep->segment_base) {

--- a/opal/mca/rcache/base/rcache_base_vma.c
+++ b/opal/mca/rcache/base/rcache_base_vma.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -142,6 +142,14 @@ int mca_rcache_base_vma_delete (mca_rcache_base_vma_module_t *vma_module,
                                      (uint64_t) (reg->bound - reg->base),
                                      (uint64_t) (uintptr_t) reg);
     return mca_rcache_base_vma_tree_delete (vma_module, reg);
+}
+
+int mca_rcache_base_vma_iterate (mca_rcache_base_vma_module_t *vma_module,
+                                 unsigned char *base, size_t size,
+                                 int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
+                                 void *ctx)
+{
+    return mca_rcache_base_vma_tree_iterate (vma_module, base, size, callback_fn, ctx);
 }
 
 void mca_rcache_base_vma_dump_range (mca_rcache_base_vma_module_t *vma_module,

--- a/opal/mca/rcache/base/rcache_base_vma.h
+++ b/opal/mca/rcache/base/rcache_base_vma.h
@@ -13,7 +13,7 @@
  *
  * Copyright (c) 2006      Voltaire. All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -34,6 +34,7 @@
 #include "opal_config.h"
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_rb_tree.h"
+#include "opal/class/opal_lifo.h"
 
 BEGIN_C_DECLS
 
@@ -68,6 +69,26 @@ int mca_rcache_base_vma_delete (mca_rcache_base_vma_module_t *vma_module,
 
 void mca_rcache_base_vma_dump_range (mca_rcache_base_vma_module_t *vma_module,
                                      unsigned char *base, size_t size, char *msg);
+
+/**
+ * Iterate over registrations in the specified range.
+ *
+ * @param[in] vma_module  vma tree
+ * @param[in] base        base address of region
+ * @param[in] size        size of region
+ * @param[in] callback_fn function to call for each matching registration handle
+ * @param[in] ctx         callback context
+ *
+ * The callback will be made with the vma lock held. This is a recursive lock so
+ * it is still safe to call any vma functions on this vma_module. Keep in mind it
+ * is only safe to call mca_rcache_base_vma_delete() on the supplied registration
+ * from the callback. The iteration will terminate if the callback returns anything
+ * other than OPAL_SUCCESS.
+ */
+int mca_rcache_base_vma_iterate (mca_rcache_base_vma_module_t *vma_module,
+                                 unsigned char *base, size_t size,
+                                 int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
+                                 void *ctx);
 
 END_C_DECLS
 

--- a/opal/mca/rcache/base/rcache_base_vma_tree.h
+++ b/opal/mca/rcache/base/rcache_base_vma_tree.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -105,5 +105,13 @@ int mca_rcache_base_vma_tree_delete (mca_rcache_base_vma_module_t *vma_module,
 void mca_rcache_base_vma_tree_dump_range (mca_rcache_base_vma_module_t *vma_module,
                                           unsigned char *base, size_t size, char *msg);
 
+
+/*
+ * Iterate over matching registration handles in the tree.
+ */
+int mca_rcache_base_vma_tree_iterate (mca_rcache_base_vma_module_t *vma_module,
+                                      unsigned char *base, size_t size,
+                                      int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
+                                      void *ctx);
 
 #endif /* MCA_RCACHE_BASE_VMA_TREE_H */

--- a/opal/mca/rcache/grdma/rcache_grdma.h
+++ b/opal/mca/rcache/grdma/rcache_grdma.h
@@ -40,7 +40,7 @@ struct mca_rcache_grdma_cache_t {
     opal_list_item_t super;
     char *cache_name;
     opal_list_t lru_list;
-    opal_list_t gc_list;
+    opal_lifo_t gc_lifo;
     mca_rcache_base_vma_module_t *vma_module;
 };
 typedef struct mca_rcache_grdma_cache_t mca_rcache_grdma_cache_t;


### PR DESCRIPTION
This commit fixes several bugs in the registration cache code:

 - Fix a programming error in the grdma invalidation function that can
   cause an infinite loop if more than 100 registrations are
   associated with a munmapped region. This happens because the
   mca_rcache_base_vma_find_all function returns the same 100
   registrations on each call. This has been fixed by adding an
   iterate function to the vma tree interface.

 - Always obtain the vma lock when needed. This is required because
   there may be other threads in the system even if
   opal_using_threads() is false. Additionally, since it is safe to do
   so (the vma lock is recursive) the vma interface has been made
   thread safe.

 - Avoid calling free() while holding a lock. This avoids race
   conditions with locks held outside the Open MPI code.

Fixes open-mpi/ompi#1654.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>