### PR TITLE
opal/util/ethtool: use system ethtool_cmd_speed when available

### DIFF
--- a/opal/util/ethtool.c
+++ b/opal/util/ethtool.c
@@ -64,7 +64,9 @@ opal_ethtool_get_speed (const char *if_name)
         goto out;
     }
 
-#ifdef HAVE_STRUCT_ETHTOOL_CMD_SPEED_HI
+#if HAVE_DECL_ETHTOOL_CMD_SPEED
+    speed = ethtool_cmd_speed(&edata);
+#elif defined(HAVE_STRUCT_ETHTOOL_CMD_SPEED_HI)
     speed = (edata.speed_hi << 16) | edata.speed;
 #else
     speed = edata.speed;


### PR DESCRIPTION
Refs: open-mpi/ompi#1679