### PR TITLE
configury: correctly perform make distclean when {libevent,hwloc,pmix…

### DIFF
--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
@@ -92,7 +92,7 @@ AC_DEFUN([MCA_opal_event_libevent2022_CONFIG],[
     libevent_basedir="opal/mca/event/libevent2022"
 
     # If we're not building externally, configure this component
-    AS_IF([test "$with_libevent" = "internal" || test -z "$with_libevent" || test "$with_libevent" = "yes"],
+    AS_IF([true],
           [MCA_opal_event_libevent2022_DO_THE_CONFIG],
           [AC_MSG_WARN([using an external libevent; disqualifiying this component])
            $2])
@@ -189,6 +189,18 @@ AC_DEFUN([MCA_opal_event_libevent2022_DO_THE_CONFIG], [
     # libevent/include/event2/event-config.h!).  Otherwise, set it to
     # 0.
     libevent_file=$libevent_basedir/libevent/config.h
+
+    # If we are not building the internal libevent, then indicate that
+    # this component should not be built.  NOTE: we still did all the
+    # above configury so that all the proper GNU Autotools
+    # infrastructure is setup properly (e.g., w.r.t. SUBDIRS=libevent in
+    # this directory's Makefile.am, we still need the Autotools "make
+    # distclean" infrastructure to work properly).
+
+    AS_IF([test "$with_libevent" != "internal" && test -n "$with_libevent" && test "$with_libevent" != "yes"],
+          [AC_MSG_WARN([using an external libevent; disqualifying this component])
+           libevent_happy=no])
+
     AS_IF([test "$libevent_happy" = "yes" && test -r $libevent_file],
           [OPAL_HAVE_WORKING_EVENTOPS=`grep HAVE_WORKING_EVENTOPS $libevent_file | awk '{print [$]3 }'`
            $1],

--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -91,15 +91,6 @@ AC_DEFUN([MCA_opal_event_libevent2022_CONFIG],[
     AC_CONFIG_FILES([opal/mca/event/libevent2022/Makefile])
     libevent_basedir="opal/mca/event/libevent2022"
 
-    # If we're not building externally, configure this component
-    AS_IF([true],
-          [MCA_opal_event_libevent2022_DO_THE_CONFIG],
-          [AC_MSG_WARN([using an external libevent; disqualifiying this component])
-           $2])
-    OPAL_VAR_SCOPE_POP
-])
-
-AC_DEFUN([MCA_opal_event_libevent2022_DO_THE_CONFIG], [
     CFLAGS_save="$CFLAGS"
     CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"
     CPPFLAGS_save="$CPPFLAGS"
@@ -206,4 +197,6 @@ AC_DEFUN([MCA_opal_event_libevent2022_DO_THE_CONFIG], [
            $1],
           [$2
            OPAL_HAVE_WORKING_EVENTOPS=0])
+
+    OPAL_VAR_SCOPE_POP
 ])

--- a/opal/mca/hwloc/hwloc1113/configure.m4
+++ b/opal/mca/hwloc/hwloc1113/configure.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
@@ -72,20 +72,25 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1113_CONFIG],[
 
     AC_CONFIG_FILES([opal/mca/hwloc/hwloc1113/Makefile])
 
-    OPAL_VAR_SCOPE_PUSH([HWLOC_VERSION opal_hwloc_hwloc1113_save_CPPFLAGS opal_hwloc_hwloc1113_save_LDFLAGS opal_hwloc_hwloc1113_save_LIBS opal_hwloc_hwloc1113_save_cairo opal_hwloc_hwloc1113_save_xml opal_hwloc_hwloc1113_basedir opal_hwloc_hwloc1113_file opal_hwloc_hwloc1113_save_cflags CPPFLAGS_save LIBS_save])
+    OPAL_VAR_SCOPE_PUSH([HWLOC_VERSION opal_hwloc_hwloc1113_save_CPPFLAGS opal_hwloc_hwloc1113_save_LDFLAGS opal_hwloc_hwloc1113_save_LIBS opal_hwloc_hwloc1113_save_cairo opal_hwloc_hwloc1113_save_xml opal_hwloc_hwloc1113_basedir opal_hwloc_hwloc1113_file opal_hwloc_hwloc1113_save_cflags CPPFLAGS_save LIBS_save opal_hwloc_external])
 
     # default to this component not providing support
     opal_hwloc_hwloc1113_basedir=opal/mca/hwloc/hwloc1113
     opal_hwloc_hwloc1113_support=no
 
-    if test "$with_hwloc" = "internal" || test -z "$with_hwloc" || test "$with_hwloc" = "yes"; then
+    AS_IF([test "$with_hwloc" = "internal" || test -z "$with_hwloc" || test "$with_hwloc" = "yes"],
+          [opal_hwloc_external="no"],
+          [opal_hwloc_external="yes"])
+
+    if true; then
         opal_hwloc_hwloc1113_save_CPPFLAGS=$CPPFLAGS
         opal_hwloc_hwloc1113_save_LDFLAGS=$LDFLAGS
         opal_hwloc_hwloc1113_save_LIBS=$LIBS
 
-        # Run the hwloc configuration - set the prefix to minimize
-        # the chance that someone will use the internal symbols
-        HWLOC_SET_SYMBOL_PREFIX([opal_hwloc1113_])
+        # Run the hwloc configuration - if no external hwloc, then set the prefix
+        # to minimize the chance that someone will use the internal symbols
+        AS_IF([test "$opal_hwloc_external" = "no"],
+              [HWLOC_SET_SYMBOL_PREFIX([opal_hwloc1113_])])
 
         # save XML or graphical options
         opal_hwloc_hwloc1113_save_cairo=$enable_cairo
@@ -164,6 +169,16 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1113_CONFIG],[
         hwloc_hwloc1113_WRAPPER_EXTRA_LIBS="$HWLOC_EMBEDDED_LIBS"
         hwloc_hwloc1113_WRAPPER_EXTRA_CPPFLAGS='-I${pkgincludedir}/'"$opal_hwloc_hwloc1113_basedir/hwloc/include"
     fi
+
+    # If we are not building the internal hwloc, then indicate that
+    # this component should not be built.  NOTE: we still did all the
+    # above configury so that all the proper GNU Autotools
+    # infrastructure is setup properly (e.g., w.r.t. SUBDIRS=hwloc in
+    # this directory's Makefile.am, we still need the Autotools "make
+    # distclean" infrastructure to work properly).
+    AS_IF([test "$opal_hwloc_external" = "yes"],
+          [AC_MSG_WARN([using an external hwloc; disqualifying this component])
+           opal_hwloc_hwloc1113_support=no])
 
     # Done!
     AS_IF([test "$opal_hwloc_hwloc1113_support" = "yes"],

--- a/opal/mca/hwloc/hwloc1113/configure.m4
+++ b/opal/mca/hwloc/hwloc1113/configure.m4
@@ -82,93 +82,91 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1113_CONFIG],[
           [opal_hwloc_external="no"],
           [opal_hwloc_external="yes"])
 
-    if true; then
-        opal_hwloc_hwloc1113_save_CPPFLAGS=$CPPFLAGS
-        opal_hwloc_hwloc1113_save_LDFLAGS=$LDFLAGS
-        opal_hwloc_hwloc1113_save_LIBS=$LIBS
+    opal_hwloc_hwloc1113_save_CPPFLAGS=$CPPFLAGS
+    opal_hwloc_hwloc1113_save_LDFLAGS=$LDFLAGS
+    opal_hwloc_hwloc1113_save_LIBS=$LIBS
 
-        # Run the hwloc configuration - if no external hwloc, then set the prefix
-        # to minimize the chance that someone will use the internal symbols
-        AS_IF([test "$opal_hwloc_external" = "no"],
-              [HWLOC_SET_SYMBOL_PREFIX([opal_hwloc1113_])])
+    # Run the hwloc configuration - if no external hwloc, then set the prefixi
+    # to minimize the chance that someone will use the internal symbols
+    AS_IF([test "$opal_hwloc_external" = "no"],
+          [HWLOC_SET_SYMBOL_PREFIX([opal_hwloc1113_])])
 
-        # save XML or graphical options
-        opal_hwloc_hwloc1113_save_cairo=$enable_cairo
-        opal_hwloc_hwloc1113_save_xml=$enable_xml
-        opal_hwloc_hwloc1113_save_static=$enable_static
-        opal_hwloc_hwloc1113_save_shared=$enable_shared
-        opal_hwloc_hwloc1113_save_plugins=$enable_plugins
+    # save XML or graphical options
+    opal_hwloc_hwloc1113_save_cairo=$enable_cairo
+    opal_hwloc_hwloc1113_save_xml=$enable_xml
+    opal_hwloc_hwloc1113_save_static=$enable_static
+    opal_hwloc_hwloc1113_save_shared=$enable_shared
+    opal_hwloc_hwloc1113_save_plugins=$enable_plugins
 
-        # never enable hwloc's graphical option
-        enable_cairo=no
+    # never enable hwloc's graphical option
+    enable_cairo=no
 
-        # never enable hwloc's plugin system
-        enable_plugins=no
-        enable_static=yes
-        enable_shared=no
+    # never enable hwloc's plugin system
+    enable_plugins=no
+    enable_static=yes
+    enable_shared=no
 
-        # Override -- disable hwloc's libxml2 support, but enable the
-        # native hwloc XML support
-        enable_libxml2=no
-        enable_xml=yes
+    # Override -- disable hwloc's libxml2 support, but enable the
+    # native hwloc XML support
+    enable_libxml2=no
+    enable_xml=yes
 
-        # hwloc checks for compiler visibility, and its needs to do
-        # this without "picky" flags.
-        opal_hwloc_hwloc1113_save_cflags=$CFLAGS
-        CFLAGS=$OPAL_CFLAGS_BEFORE_PICKY
-        HWLOC_SETUP_CORE([opal/mca/hwloc/hwloc1113/hwloc],
-                  [AC_MSG_CHECKING([whether hwloc configure succeeded])
-                   AC_MSG_RESULT([yes])
-                   HWLOC_VERSION="internal v`$srcdir/$opal_hwloc_hwloc1113_basedir/hwloc/config/hwloc_get_version.sh $srcdir/$opal_hwloc_hwloc1113_basedir/hwloc/VERSION`"
+    # hwloc checks for compiler visibility, and its needs to do
+    # this without "picky" flags.
+    opal_hwloc_hwloc1113_save_cflags=$CFLAGS
+    CFLAGS=$OPAL_CFLAGS_BEFORE_PICKY
+    HWLOC_SETUP_CORE([opal/mca/hwloc/hwloc1113/hwloc],
+              [AC_MSG_CHECKING([whether hwloc configure succeeded])
+               AC_MSG_RESULT([yes])
+               HWLOC_VERSION="internal v`$srcdir/$opal_hwloc_hwloc1113_basedir/hwloc/config/hwloc_get_version.sh $srcdir/$opal_hwloc_hwloc1113_basedir/hwloc/VERSION`"
 
-                   # Build flags for our Makefile.am
-                   opal_hwloc_hwloc1113_LDFLAGS='$(HWLOC_EMBEDDED_LDFLAGS)'
-                   opal_hwloc_hwloc1113_LIBS='$(OPAL_TOP_BUILDDIR)/'"$opal_hwloc_hwloc1113_basedir"'/hwloc/src/libhwloc_embedded.la $(HWLOC_EMBEDDED_LIBS)'
-                   opal_hwloc_hwloc1113_support=yes
+               # Build flags for our Makefile.am
+               opal_hwloc_hwloc1113_LDFLAGS='$(HWLOC_EMBEDDED_LDFLAGS)'
+               opal_hwloc_hwloc1113_LIBS='$(OPAL_TOP_BUILDDIR)/'"$opal_hwloc_hwloc1113_basedir"'/hwloc/src/libhwloc_embedded.la $(HWLOC_EMBEDDED_LIBS)'
+               opal_hwloc_hwloc1113_support=yes
 
-                   AC_DEFINE_UNQUOTED([HWLOC_HWLOC1113_HWLOC_VERSION],
-                       ["$HWLOC_VERSION"],
-                       [Version of hwloc])
+               AC_DEFINE_UNQUOTED([HWLOC_HWLOC1113_HWLOC_VERSION],
+                   ["$HWLOC_VERSION"],
+                   [Version of hwloc])
 
-                   # Do we have verbs support?
-                   CPPFLAGS_save=$CPPFLAGS
-                   AS_IF([test "$opal_want_verbs" = "yes"],
-                         [CPPFLAGS="-I$opal_verbs_dir/include $CPPFLAGS"])
-                   AC_CHECK_HEADERS([infiniband/verbs.h])
-                   CPPFLAGS=$CPPFLAGS_save
-                  ],
-                  [AC_MSG_CHECKING([whether hwloc configure succeeded])
-                   AC_MSG_RESULT([no])
-                   opal_hwloc_hwloc1113_support=no])
-        CFLAGS=$opal_hwloc_hwloc1113_save_cflags
+               # Do we have verbs support?
+               CPPFLAGS_save=$CPPFLAGS
+               AS_IF([test "$opal_want_verbs" = "yes"],
+                     [CPPFLAGS="-I$opal_verbs_dir/include $CPPFLAGS"])
+               AC_CHECK_HEADERS([infiniband/verbs.h])
+               CPPFLAGS=$CPPFLAGS_save
+              ],
+              [AC_MSG_CHECKING([whether hwloc configure succeeded])
+               AC_MSG_RESULT([no])
+               opal_hwloc_hwloc1113_support=no])
+    CFLAGS=$opal_hwloc_hwloc1113_save_cflags
 
-        # Restore some env variables, if necessary
-        AS_IF([test -n "$opal_hwloc_hwloc1113_save_cairo"],
-              [enable_cairo=$opal_hwloc_hwloc1113_save_cairo])
-        AS_IF([test -n "$opal_hwloc_hwloc1113_save_xml"],
-              [enable_xml=$opal_hwloc_hwloc1113_save_xml])
-        AS_IF([test -n "$opal_hwloc_hwloc1113_save_static"],
-              [enable_static=$opal_hwloc_hwloc1113_save_static])
-        AS_IF([test -n "$opal_hwloc_hwloc1113_save_shared"],
-              [enable_shared=$opal_hwloc_hwloc1113_save_shared])
-        AS_IF([test -n "$opal_hwloc_hwloc1113_save_plugins"],
-              [enable_plugins=$opal_hwloc_hwloc1113_save_shared])
+    # Restore some env variables, if necessary
+    AS_IF([test -n "$opal_hwloc_hwloc1113_save_cairo"],
+          [enable_cairo=$opal_hwloc_hwloc1113_save_cairo])
+    AS_IF([test -n "$opal_hwloc_hwloc1113_save_xml"],
+          [enable_xml=$opal_hwloc_hwloc1113_save_xml])
+    AS_IF([test -n "$opal_hwloc_hwloc1113_save_static"],
+          [enable_static=$opal_hwloc_hwloc1113_save_static])
+    AS_IF([test -n "$opal_hwloc_hwloc1113_save_shared"],
+          [enable_shared=$opal_hwloc_hwloc1113_save_shared])
+    AS_IF([test -n "$opal_hwloc_hwloc1113_save_plugins"],
+          [enable_plugins=$opal_hwloc_hwloc1113_save_shared])
 
-        CPPFLAGS=$opal_hwloc_hwloc1113_save_CPPFLAGS
-        LDFLAGS=$opal_hwloc_hwloc1113_save_LDFLAGS
-        LIBS=$opal_hwloc_hwloc1113_save_LIBS
+    CPPFLAGS=$opal_hwloc_hwloc1113_save_CPPFLAGS
+    LDFLAGS=$opal_hwloc_hwloc1113_save_LDFLAGS
+    LIBS=$opal_hwloc_hwloc1113_save_LIBS
 
-        AC_SUBST([opal_hwloc_hwloc1113_CFLAGS])
-        AC_SUBST([opal_hwloc_hwloc1113_CPPFLAGS])
-        AC_SUBST([opal_hwloc_hwloc1113_LDFLAGS])
-        AC_SUBST([opal_hwloc_hwloc1113_LIBS])
+    AC_SUBST([opal_hwloc_hwloc1113_CFLAGS])
+    AC_SUBST([opal_hwloc_hwloc1113_CPPFLAGS])
+    AC_SUBST([opal_hwloc_hwloc1113_LDFLAGS])
+    AC_SUBST([opal_hwloc_hwloc1113_LIBS])
 
-        # Finally, add some flags to the wrapper compiler so that our
-        # headers can be found.
-        hwloc_hwloc1113_WRAPPER_EXTRA_LDFLAGS="$HWLOC_EMBEDDED_LDFLAGS"
-        hwloc_hwloc1113_WRAPPER_EXTRA_LIBS="$HWLOC_EMBEDDED_LIBS"
-        hwloc_hwloc1113_WRAPPER_EXTRA_CPPFLAGS='-I${pkgincludedir}/'"$opal_hwloc_hwloc1113_basedir/hwloc/include"
-    fi
+    # Finally, add some flags to the wrapper compiler so that our
+    # headers can be found.
+    hwloc_hwloc1113_WRAPPER_EXTRA_LDFLAGS="$HWLOC_EMBEDDED_LDFLAGS"
+    hwloc_hwloc1113_WRAPPER_EXTRA_LIBS="$HWLOC_EMBEDDED_LIBS"
+    hwloc_hwloc1113_WRAPPER_EXTRA_CPPFLAGS='-I${pkgincludedir}/'"$opal_hwloc_hwloc1113_basedir/hwloc/include"
 
     # If we are not building the internal hwloc, then indicate that
     # this component should not be built.  NOTE: we still did all the

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -14,7 +14,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
@@ -30,7 +30,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
 
     OPAL_VAR_SCOPE_PUSH([PMIX_VERSION opal_pmix_pmix2x_save_CPPFLAGS opal_pmix_pmix2x_save_LDFLAGS opal_pmix_pmix2x_save_LIBS opal_pmix_pmix2x_basedir opal_pmix_pmix2x_save_cflags])
 
-    AS_IF([test "$opal_external_pmix_happy" = "yes"],
+    AS_IF([false],
           [AC_MSG_WARN([using an external pmix; disqualifiying this component])
            opal_pmix_pmix2x_happy=0],
           [PMIX_VERSION=
@@ -68,6 +68,16 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
            LDFLAGS=$opal_pmix_pmix2x_save_LDFLAGS
            LIBS=$opal_pmix_pmix2x_save_LIBS
           ])
+
+    # If we are not building the internal pmix, then indicate that
+    # this component should not be built.  NOTE: we still did all the
+    # above configury so that all the proper GNU Autotools
+    # infrastructure is setup properly (e.g., w.r.t. SUBDIRS=pmix in
+    # this directory's Makefile.am, we still need the Autotools "make
+    # distclean" infrastructure to work properly).
+    AS_IF([test "$opal_external_pmix_happy" = "yes"],
+          [AC_MSG_WARN([using an external pmix; disqualifying this component])
+           opal_pmix_pmix2x_happy=0])
 
     AS_IF([test $opal_pmix_pmix2x_happy -eq 1],
           [$1],

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -30,44 +30,40 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
 
     OPAL_VAR_SCOPE_PUSH([PMIX_VERSION opal_pmix_pmix2x_save_CPPFLAGS opal_pmix_pmix2x_save_LDFLAGS opal_pmix_pmix2x_save_LIBS opal_pmix_pmix2x_basedir opal_pmix_pmix2x_save_cflags])
 
-    AS_IF([false],
-          [AC_MSG_WARN([using an external pmix; disqualifiying this component])
-           opal_pmix_pmix2x_happy=0],
-          [PMIX_VERSION=
-           opal_pmix_pmix2x_basedir=opal/mca/pmix/pmix2x
+    PMIX_VERSION=
+    opal_pmix_pmix2x_basedir=opal/mca/pmix/pmix2x
 
-           opal_pmix_pmix2x_save_CFLAGS=$CFLAGS
-           opal_pmix_pmix2x_save_CPPFLAGS=$CPPFLAGS
-           opal_pmix_pmix2x_save_LDFLAGS=$LDFLAGS
-           opal_pmix_pmix2x_save_LIBS=$LIBS
+    opal_pmix_pmix2x_save_CFLAGS=$CFLAGS
+    opal_pmix_pmix2x_save_CPPFLAGS=$CPPFLAGS
+    opal_pmix_pmix2x_save_LDFLAGS=$LDFLAGS
+    opal_pmix_pmix2x_save_LIBS=$LIBS
 
-           opal_pmix_pmix2x_args="--without-tests-examples --with-pmix-symbol-prefix=opal_pmix_pmix2x_ --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-hwloc --with-hwloc-header=\\\"$opal_hwloc_base_include\\\""
-           AS_IF([test "$enable_debug" = "yes"],
-                 [opal_pmix_pmix2x_args="--enable-debug $opal_pmix_pmix2x_args"
-                  CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
-                 [opal_pmix_pmix2x_args="--disable-debug $opal_pmix_pmix2x_args"
-                  CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
-           AS_IF([test "$with_devel_headers" = "yes"], [],
-                 [opal_pmix_pmix2x_args="--enable-embedded-mode $opal_pmix_pmix2x_args"])
-           CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"
+    opal_pmix_pmix2x_args="--without-tests-examples --with-pmix-symbol-prefix=opal_pmix_pmix2x_ --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-hwloc --with-hwloc-header=\\\"$opal_hwloc_base_include\\\""
+    AS_IF([test "$enable_debug" = "yes"],
+          [opal_pmix_pmix2x_args="--enable-debug $opal_pmix_pmix2x_args"
+           CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
+          [opal_pmix_pmix2x_args="--disable-debug $opal_pmix_pmix2x_args"
+           CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
+    AS_IF([test "$with_devel_headers" = "yes"], [],
+          [opal_pmix_pmix2x_args="--enable-embedded-mode $opal_pmix_pmix2x_args"])
+    CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"
 
-           OPAL_CONFIG_SUBDIR([$opal_pmix_pmix2x_basedir/pmix],
-               [$opal_pmix_pmix2x_args $opal_subdir_args 'CFLAGS=$CFLAGS' 'CPPFLAGS=$CPPFLAGS'],
-               [opal_pmix_pmix2x_happy=1], [opal_pmix_pmix2x_happy=0])
+    OPAL_CONFIG_SUBDIR([$opal_pmix_pmix2x_basedir/pmix],
+        [$opal_pmix_pmix2x_args $opal_subdir_args 'CFLAGS=$CFLAGS' 'CPPFLAGS=$CPPFLAGS'],
+        [opal_pmix_pmix2x_happy=1], [opal_pmix_pmix2x_happy=0])
 
-           AS_IF([test $opal_pmix_pmix2x_happy -eq 1],
-                 [PMIX_VERSION="internal v`$srcdir/$opal_pmix_pmix2x_basedir/pmix/config/pmix_get_version.sh $srcdir/$opal_pmix_pmix2x_basedir/pmix/VERSION`"
-                  # Build flags for our Makefile.am
-                  opal_pmix_pmix2x_LIBS='$(OPAL_TOP_BUILDDIR)/'"$opal_pmix_pmix2x_basedir"'/pmix/libpmix.la'
-                  opal_pmix_pmix2x_CPPFLAGS='-I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix/include/pmix -I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix/include -I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix -I$(OPAL_TOP_SRCDIR)/opal/mca/pmix/pmix2x/pmix'
-                  AC_SUBST([opal_pmix_pmix2x_LIBS])
-                  AC_SUBST([opal_pmix_pmix2x_CPPFLAGS])])
+    AS_IF([test $opal_pmix_pmix2x_happy -eq 1],
+          [PMIX_VERSION="internal v`$srcdir/$opal_pmix_pmix2x_basedir/pmix/config/pmix_get_version.sh $srcdir/$opal_pmix_pmix2x_basedir/pmix/VERSION`"
+           # Build flags for our Makefile.am
+           opal_pmix_pmix2x_LIBS='$(OPAL_TOP_BUILDDIR)/'"$opal_pmix_pmix2x_basedir"'/pmix/libpmix.la'
+           opal_pmix_pmix2x_CPPFLAGS='-I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix/include/pmix -I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix/include -I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix -I$(OPAL_TOP_SRCDIR)/opal/mca/pmix/pmix2x/pmix'
+           AC_SUBST([opal_pmix_pmix2x_LIBS])
+           AC_SUBST([opal_pmix_pmix2x_CPPFLAGS])])
 
-           CFLAGS=$opal_pmix_pmix2x_save_CFLAGS
-           CPPFLAGS=$opal_pmix_pmix2x_save_CPPFLAGS
-           LDFLAGS=$opal_pmix_pmix2x_save_LDFLAGS
-           LIBS=$opal_pmix_pmix2x_save_LIBS
-          ])
+    CFLAGS=$opal_pmix_pmix2x_save_CFLAGS
+    CPPFLAGS=$opal_pmix_pmix2x_save_CPPFLAGS
+    LDFLAGS=$opal_pmix_pmix2x_save_LDFLAGS
+    LIBS=$opal_pmix_pmix2x_save_LIBS
 
     # If we are not building the internal pmix, then indicate that
     # this component should not be built.  NOTE: we still did all the


### PR DESCRIPTION
…} are external components

Fixes open-mpi/ompi#1683