### PR TITLE
mca/base: fix typo in flag enumeration

### DIFF
--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -688,7 +688,7 @@ static int var_set_from_string (mca_base_var_t *var, char *src)
     case MCA_BASE_VAR_TYPE_BOOL:
     case MCA_BASE_VAR_TYPE_SIZE_T:
         ret = int_from_string(src, var->mbv_enumerator, &int_value);
-        if (OPAL_ERR_VALUE_OUT_OF_BOUNDS == ret ||
+        if (OPAL_SUCCESS != ret ||
             (MCA_BASE_VAR_TYPE_INT == var->mbv_type && ((int) int_value != (int64_t) int_value)) ||
             (MCA_BASE_VAR_TYPE_UNSIGNED_INT == var->mbv_type && ((unsigned int) int_value != int_value))) {
             if (var->mbv_enumerator) {

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -494,21 +494,28 @@ static int enum_value_from_string_flag (mca_base_var_enum_t *self, const char *s
 
         bool found = false, conflict = false;
         for (int j = 0 ; j < count ; ++j) {
-            if ((is_int && (value == flag_enum->enum_flags[i].flag)) ||
-                0 == strcasecmp (flags[i], flag_enum->enum_flags[i].string)) {
+            if ((is_int && (value & flag_enum->enum_flags[j].flag)) ||
+                0 == strcasecmp (flags[i], flag_enum->enum_flags[j].string)) {
                 found = true;
 
-                if (flag & flag_enum->enum_flags[i].conflicting_flag) {
+                if (flag & flag_enum->enum_flags[j].conflicting_flag) {
                     conflict = true;
                 } else {
-                    flag |= flag_enum->enum_flags[i].flag;
+                    flag |= flag_enum->enum_flags[j].flag;
                 }
 
-                break;
+                if (is_int) {
+                    value &= ~flag_enum->enum_flags[j].flag;
+                    if (0 == value) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
             }
         }
 
-        if (!found || conflict) {
+        if (!found || conflict || (is_int && value)) {
             opal_argv_free (flags);
             return !found ? OPAL_ERR_VALUE_OUT_OF_BOUNDS : OPAL_ERR_BAD_PARAM;
         }


### PR DESCRIPTION
This commit fixes a typo in flag enumeration that can cause the parser
to miss valid flags or crash.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>