### PR TITLE
Fix the --tune problem by searching the argv for MCA params in advance of opal_init_util

### DIFF
--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -334,6 +334,13 @@ opal_init_util(int* pargc, char*** pargv)
         goto return_error;
     }
 
+    /* read any param files that were provided */
+    if (OPAL_SUCCESS != (ret = mca_base_var_cache_files(false))) {
+        error = "failed to cache files";
+        goto return_error;
+    }
+
+
     /* register params for opal */
     if (OPAL_SUCCESS != (ret = opal_register_params())) {
         error = "opal_register_params";
@@ -414,13 +421,6 @@ opal_init(int* pargc, char*** pargv)
     if (OPAL_SUCCESS != (ret = opal_init_util(pargc, pargv))) {
         return ret;
     }
-
-    /* read any param files that were provided */
-    if (OPAL_SUCCESS != (ret = mca_base_var_cache_files(false))) {
-        error = "failed to cache files";
-        goto return_error;
-    }
-
 
     /* open hwloc - since this is a static framework, no
      * select is required

--- a/orte/bindings/python/src/orte-cffi/build.py
+++ b/orte/bindings/python/src/orte-cffi/build.py
@@ -118,11 +118,11 @@ ffi.set_source("orte_cffi", """
 ffi.cdef("""
 /* Types */
 typedef ... orte_job_t;
-typedef ... opal_cmd_line_t;
+typedef ... opal_cmd_line_init_t;
 typedef void (*orte_submit_cbfunc_t)(int index, orte_job_t *jdata, int ret, void *cbdata);
 
 /* Functions */
-int orte_submit_init(int argc, char *argv[], opal_cmd_line_t *opts);
+int orte_submit_init(int argc, char *argv[], opal_cmd_line_init_t *opts);
 int orte_submit_job(char *cmd[], int *index,
                     orte_submit_cbfunc_t launch_cb, void *launch_cbdata,
                     orte_submit_cbfunc_t complete_cb, void *complete_cbdata);

--- a/orte/orted/orted_submit.h
+++ b/orte/orted/orted_submit.h
@@ -23,7 +23,7 @@ BEGIN_C_DECLS
 typedef void (*orte_submit_cbfunc_t)(int index, orte_job_t *jdata, int ret, void *cbdata);
 
 ORTE_DECLSPEC int orte_submit_init(int argc, char *argv[],
-                                   opal_cmd_line_t *opts);
+                                   opal_cmd_line_init_t *opts);
 ORTE_DECLSPEC int orte_submit_cancel(int index);
 ORTE_DECLSPEC void orte_submit_finalize(void);
 ORTE_DECLSPEC int orte_submit_job(char *cmd[], int *index,


### PR DESCRIPTION
Only search the first app_context as we historically have done - we can debate whether or not to search all app_contexts