### PR TITLE
win: add support for accumulate_ordering info key

### DIFF
--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -46,11 +46,22 @@ opal_pointer_array_t ompi_mpi_windows = {{0}};
 ompi_predefined_win_t ompi_mpi_win_null = {{{0}}};
 ompi_predefined_win_t *ompi_mpi_win_null_addr = &ompi_mpi_win_null;
 mca_base_var_enum_t *ompi_win_accumulate_ops = NULL;
+mca_base_var_enum_t *ompi_win_accumulate_order = NULL;
 
 static mca_base_var_enum_value_t accumulate_ops_values[] = {
     {.value = OMPI_WIN_ACCUMULATE_OPS_SAME_OP_NO_OP, .string = "same_op_no_op",},
     {.value = OMPI_WIN_ACCUMULATE_OPS_SAME_OP, .string = "same_op",},
     {.value = -1, .string = NULL},
+};
+
+static mca_base_var_enum_value_flag_t accumulate_order_flags[] = {
+    {.flag = OMPI_WIN_ACC_ORDER_NONE, .string = "none", .conflicting_flag = OMPI_WIN_ACC_ORDER_RAR |
+     OMPI_WIN_ACC_ORDER_WAR | OMPI_WIN_ACC_ORDER_RAW | OMPI_WIN_ACC_ORDER_WAW},
+    {.flag = OMPI_WIN_ACC_ORDER_RAR, .string = "rar", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {.flag = OMPI_WIN_ACC_ORDER_WAR, .string = "war", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {.flag = OMPI_WIN_ACC_ORDER_RAW, .string = "raw", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {.flag = OMPI_WIN_ACC_ORDER_WAW, .string = "waw", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
+    {},
 };
 
 static void ompi_win_construct(ompi_win_t *win);
@@ -86,6 +97,11 @@ ompi_win_init(void)
         return ret;
     }
 
+    ret = mca_base_var_enum_create_flag ("accumulate_order", accumulate_order_flags, &ompi_win_accumulate_order);
+    if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
     return OMPI_SUCCESS;
 }
 
@@ -115,6 +131,7 @@ int ompi_win_finalize(void)
     OBJ_DESTRUCT(&ompi_mpi_win_null.win);
     OBJ_DESTRUCT(&ompi_mpi_windows);
     OBJ_RELEASE(ompi_win_accumulate_ops);
+    OBJ_RELEASE(ompi_win_accumulate_order);
 
     return OMPI_SUCCESS;
 }
@@ -123,7 +140,7 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
 {
     ompi_win_t *win;
     ompi_group_t *group;
-    int acc_ops, flag, ret;
+    int acc_ops, acc_order, flag, ret;
 
     /* create the object */
     win = OBJ_NEW(ompi_win_t);
@@ -140,6 +157,18 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
     }
 
     win->w_acc_ops = (ompi_win_accumulate_ops_t)acc_ops;
+
+    ret = ompi_info_get_value_enum (info, "accumulate_order", &acc_order,
+                                    OMPI_WIN_ACC_ORDER_RAR | OMPI_WIN_ACC_ORDER_WAR |
+                                    OMPI_WIN_ACC_ORDER_RAW | OMPI_WIN_ACC_ORDER_WAW,
+                                    ompi_win_accumulate_order, &flag);
+    if (OMPI_SUCCESS != ret) {
+        OBJ_RELEASE(win);
+        return ret;
+    }
+
+    win->w_acc_order = acc_order;
+
     win->w_flavor = flavor;
 
     /* setup data that is independent of osc component */

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -50,7 +50,25 @@ enum ompi_win_accumulate_ops_t {
 };
 typedef enum ompi_win_accumulate_ops_t ompi_win_accumulate_ops_t;
 
+/**
+ * Accumulate ordering flags. The default accumulate ordering in
+ * MPI-3.1 is rar,war,raw,waw.
+ */
+enum ompi_win_accumulate_order_flags_t {
+    /** no accumulate ordering (may valid with any other flag) */
+    OMPI_WIN_ACC_ORDER_NONE = 0x01,
+    /** read-after-read ordering */
+    OMPI_WIN_ACC_ORDER_RAR  = 0x02,
+    /** write-after-read ordering */
+    OMPI_WIN_ACC_ORDER_WAR  = 0x04,
+    /** read-after-write ordering */
+    OMPI_WIN_ACC_ORDER_RAW  = 0x08,
+    /** write-after-write ordering */
+    OMPI_WIN_ACC_ORDER_WAW  = 0x10,
+};
+
 OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_ops;
+OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_order;
 
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_windows;
 
@@ -87,6 +105,9 @@ struct ompi_win_t {
 
     /* one sided interface */
     ompi_osc_base_module_t *w_osc_module;
+
+    /** Accumulate ordering (see ompi_win_accumulate_order_flags_t above) */
+    int32_t w_acc_order;
 };
 typedef struct ompi_win_t ompi_win_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_win_t);


### PR DESCRIPTION
This commit adds support for the MPI-3.1 accumulate_ordering info
key. The default value is rar,war,raw,waw and is supported using an
MCA variable flag enumerator.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>