### PR TITLE
VADER: Replacing VADER_MAX_ADDRESS with XPMEM_MAXADDR_SIZE

### DIFF
--- a/opal/mca/btl/vader/btl_vader_xpmem.c
+++ b/opal/mca/btl/vader/btl_vader_xpmem.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2014      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2016      ARM, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +22,7 @@
 
 int mca_btl_vader_xpmem_init (void)
 {
-    mca_btl_vader_component.my_seg_id = xpmem_make (0, VADER_MAX_ADDRESS, XPMEM_PERMIT_MODE, (void *)0666);
+    mca_btl_vader_component.my_seg_id = xpmem_make (0, XPMEM_MAXADDR_SIZE, XPMEM_PERMIT_MODE, (void *)0666);
     if (-1 == mca_btl_vader_component.my_seg_id) {
         return OPAL_ERR_NOT_AVAILABLE;
     }
@@ -52,8 +53,8 @@ mca_rcache_base_registration_t *vader_get_registation (struct mca_btl_base_endpo
 
     base = OPAL_DOWN_ALIGN((uintptr_t) rem_ptr, attach_align, uintptr_t);
     bound = OPAL_ALIGN((uintptr_t) rem_ptr + size - 1, attach_align, uintptr_t) + 1;
-    if (OPAL_UNLIKELY(bound > VADER_MAX_ADDRESS)) {
-        bound = VADER_MAX_ADDRESS;
+    if (OPAL_UNLIKELY(bound > XPMEM_MAXADDR_SIZE)) {
+        bound = XPMEM_MAXADDR_SIZE;
     }
 
     /* several segments may match the base pointer */

--- a/opal/mca/btl/vader/btl_vader_xpmem.h
+++ b/opal/mca/btl/vader/btl_vader_xpmem.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      ARM, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,9 +31,6 @@
 
 /* look up the remote pointer in the peer rcache and attach if
  * necessary */
-
-/* largest address we can attach to using xpmem */
-#define VADER_MAX_ADDRESS ((uintptr_t)0x7ffffffff000ul)
 
 int mca_btl_vader_xpmem_init (void);
 


### PR DESCRIPTION
XPMEM already defines the max address value XPMEM_MAXADDR_SIZE,
which has special handling on the kernel level. Therefore we should
avoid usage of VADER_MAX_ADDRESS, which actually causes failures
on some systems.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>