### PR TITLE
Fix configure for FreePGI on OSX

### DIFF
--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -391,9 +391,13 @@ AC_DEFUN([OPAL_FLAGS_UNIQ],[
                 opal_found=0
                 opal_i=`expr $opal_count + 1`
                 ;;
+        -framework)
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
+                ;;
         --param)
-                ompi_found=0
-                ompi_i=`expr $ompi_count + 1`
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
                 ;;
         esac
 

--- a/opal/mca/event/libevent2022/libevent/configure.ac
+++ b/opal/mca/event/libevent2022/libevent/configure.ac
@@ -64,12 +64,14 @@ fi
 
 # OS X Lion started deprecating the system openssl. Let's just disable
 # all deprecation warnings on OS X.
+if test "$GCC" = "yes" ; then
 case "$host_os" in
 
  darwin*)
     CFLAGS="$CFLAGS -Wno-deprecated-declarations"
     ;;
 esac
+fi
 
 AC_ARG_ENABLE(gcc-warnings,
      AS_HELP_STRING(--enable-gcc-warnings, enable verbose warnings with GCC))


### PR DESCRIPTION
Our checks and the ones of libevent are somewhat flawed.
If adding multiple "-framework" to CXXFLAGS or CFLAGS, we strip
the keyword from the command-line, not good.
libevent however assumes plain gcc without testing properly
that the compiler supports -Wno-deprecated-declarations.