### PR TITLE
coll/hcoll: bugfix: initialize req_type field

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_rte.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_rte.c
@@ -408,6 +408,7 @@ static void* get_coll_handle(void)
     ompi_req->req_status.MPI_ERROR = MPI_SUCCESS;
     ompi_req->req_state = OMPI_REQUEST_ACTIVE;
     ompi_req->req_free = request_free;
+    ompi_req->req_type = OMPI_REQUEST_COLL;
     return (void *)ompi_req;
 }
 


### PR DESCRIPTION
    If left uninitialized then segfault is possible in MPI_Waitall in
    the case the field by chance equals OMPI_REQUEST_GEN.