### PR TITLE
btl/ugni: reduce overhead of progress function

### DIFF
--- a/opal/mca/btl/ugni/btl_ugni.h
+++ b/opal/mca/btl/ugni/btl_ugni.h
@@ -129,6 +129,8 @@ typedef struct mca_btl_ugni_module_t {
     int nlocal_procs;
 
     volatile int active_send_count;
+    volatile int64_t connected_peer_count;
+    volatile int64_t active_rdma_count;
 
     mca_rcache_base_module_t *rcache;
 } mca_btl_ugni_module_t;

--- a/opal/mca/btl/ugni/btl_ugni_endpoint.c
+++ b/opal/mca/btl/ugni/btl_ugni_endpoint.c
@@ -81,6 +81,7 @@ int mca_btl_ugni_ep_disconnect (mca_btl_base_endpoint_t *ep, bool send_disconnec
     }
 
     ep->state = MCA_BTL_UGNI_EP_STATE_INIT;
+    (void) opal_atomic_add_64 (&ep->btl->connected_peer_count, -11);
 
     return OPAL_SUCCESS;
 }
@@ -152,6 +153,7 @@ static inline int mca_btl_ugni_ep_connect_finish (mca_btl_base_endpoint_t *ep) {
 
     ep->rmt_irq_mem_hndl = ep->remote_attr.rmt_irq_mem_hndl;
     ep->state = MCA_BTL_UGNI_EP_STATE_CONNECTED;
+    (void) opal_atomic_add_64 (&ep->btl->connected_peer_count, 1);
 
     /* send all pending messages */
     BTL_VERBOSE(("endpoint connected. posting %u sends", (unsigned int) opal_list_get_size (&ep->frag_wait_list)));

--- a/opal/mca/btl/ugni/btl_ugni_frag.h
+++ b/opal/mca/btl/ugni/btl_ugni_frag.h
@@ -112,12 +112,14 @@ static inline void mca_btl_ugni_alloc_post_descriptor (mca_btl_base_endpoint_t *
         (*desc)->cbdata        = cbdata;
         (*desc)->local_handle  = local_handle;
         (*desc)->endpoint      = endpoint;
+        (void) OPAL_THREAD_ADD64(&endpoint->btl->active_rdma_count, 1);
     }
 }
 
 static inline void mca_btl_ugni_return_post_descriptor (mca_btl_ugni_module_t *module,
                                                         mca_btl_ugni_post_descriptor_t *desc)
 {
+    (void) OPAL_THREAD_ADD64(&module->active_rdma_count, -1);
     opal_free_list_return (&module->post_descriptors, &desc->super);
 }
 

--- a/opal/mca/btl/ugni/btl_ugni_module.c
+++ b/opal/mca/btl/ugni/btl_ugni_module.c
@@ -76,6 +76,8 @@ mca_btl_ugni_module_init (mca_btl_ugni_module_t *ugni_module,
     ugni_module->initialized = false;
     ugni_module->nlocal_procs = 0;
     ugni_module->active_send_count = 0;
+    ugni_module->connected_peer_count = 0;
+    ugni_module->active_rdma_count = 0;
 
     OBJ_CONSTRUCT(&ugni_module->failed_frags, opal_list_t);
     OBJ_CONSTRUCT(&ugni_module->failed_frags_lock, opal_mutex_t);


### PR DESCRIPTION
This commit reduces the overhead of calling the ugni progress
function. It does the following:

 - Check for new connections once every eight calls.

 - Do not call remote smsg progress unless we are connected to at
   least one remote peer.

 - Do not call rdma progress unless at least one rdma fragment is
   outstanding.

 - Check endpoint wait list size before obtaining a lock.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>