### PR TITLE
VADER: Adjusting VADER_MAX_ADDRESS for non x86 platforms.

### DIFF
--- a/opal/mca/btl/vader/btl_vader_xpmem.h
+++ b/opal/mca/btl/vader/btl_vader_xpmem.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      ARM, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,12 @@
  * necessary */
 
 /* largest address we can attach to using xpmem */
+#if defined(__x86_64__)
 #define VADER_MAX_ADDRESS ((uintptr_t)0x7ffffffff000ul)
+#else
+#define VADER_MAX_ADDRESS XPMEM_MAXADDR_SIZE
+#endif
+
 
 int mca_btl_vader_xpmem_init (void);
 


### PR DESCRIPTION
The original VADER_MAX_ADDRESS was tunned for x86_64 platforms only.
For non x86_64 platforms we can use XPMEM_MAXADDR_SIZE.

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>