### PR TITLE
Enable PMIx external support for both 1.1.4 and 2.0 versions

### DIFF
--- a/config/opal_check_version.m4
+++ b/config/opal_check_version.m4
@@ -1,0 +1,79 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# Parameters: (use a version "1.1.4rc2" as the example)
+# * prefix
+#   Will export a variable $prefix_version_cmp
+#   - action_if_less         => "less"
+#   - action_if_equal        => "equal"
+#   - action_if_equal_series => "series"
+#   - action_if_greater      => "greater"
+# * version_actual
+#   Actual version string
+# * version_desired
+#   Desired version string to check against
+# * action_if_less
+#   Action to take if the version is strictly less than
+#   "1.1.3" < "1.1.4rc2"
+# * action_if_equal
+#   Action to take if the version matches exactly
+#   "1.1.4rc2" = "1.1.4rc2"
+# * action_if_equal_series
+#   Action to take if the version matches to this series
+#   "1.1.4rc1" ~=~ "1.1.4rc2"
+#   "1.1.4" ~=~ "1.1.4rc2"
+# * action_if_greater
+#   Action to take if the version is strictly greater than
+#   "1.1.5" > "1.1.4rc2"
+#   "2.0" > "1.1.4rc2"
+#
+# See documentation on m4_version_compare and AS_VERSION_COMPARE for more
+# precise definitions
+# OPAL_CHECK_VERSION(prefix, version_actual, version_desired,
+#                    action_if_less, action_if_equal, action_if_equal_series,
+#                    action_if_greater)
+# ----------------------------------------------------
+AC_DEFUN([OPAL_CHECK_VERSION],[
+    version_actual=$2
+    version_desired=$3
+
+    AC_MSG_CHECKING([Checking library version is $version_desired])
+    #
+    # Example: If version_desired=1.1.4 and
+    # version_actual=1.1.3    -> -1
+    # version_actual=1.1.4    ->  0
+    # version_actual=1.1.4rc1 ->  1
+    # version_actual=1.1.5    ->  1 (need further check)
+    #
+    AS_VERSION_COMPARE(["$version_actual"], [$version_desired],
+            [AC_MSG_RESULT([Earlier than expected ($version_actual < $$version_desired)])
+             $1_version_cmp="less"
+             $4],
+            [AC_MSG_RESULT([Equal])
+             $1_version_cmp="equal"
+             $5],
+            [
+             # Need further check to make sure we are < 1.1.5
+             # version_actual=1.1.4rc1 ->  -1
+             # version_actual=1.1.4    ->   0 (caught above)
+             # version_actual=1.1.5    ->   1
+             AS_VERSION_COMPARE(["$version_actual"], [$version_desired"zzzz"],
+                 [AC_MSG_RESULT([Within release series ($version_actual)])
+                  $1_version_cmp="series"
+                  $6],
+                 [AC_MSG_RESULT([Within release series ($version_actual)])
+                  $1_version_cmp="series"
+                  $6],
+                 [AC_MSG_RESULT([Later than expected ($version_actual > $$version_desired)])
+                  $1_version_cmp="greater"
+                  $7]
+             )]
+         )
+])dnl

--- a/opal/mca/pmix/external/Makefile.am
+++ b/opal/mca/pmix/external/Makefile.am
@@ -36,9 +36,7 @@ mca_pmix_external_la_SOURCES = $(sources)
 mca_pmix_external_la_CFLAGS =
 mca_pmix_external_la_CPPFLAGS = $(opal_pmix_ext_CPPFLAGS)
 mca_pmix_external_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext_LDFLAGS)
-mca_pmix_external_la_LIBADD = $(opal_pmix_ext_LIBS) \
-        $(OPAL_TOP_BUILDDIR)/opal/mca/event/lib@OPAL_LIB_PREFIX@mca_event.la \
-        $(OPAL_TOP_BUILDDIR)/opal/mca/hwloc/lib@OPAL_LIB_PREFIX@mca_hwloc.la
+mca_pmix_external_la_LIBADD = $(opal_pmix_ext_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_external_la_SOURCES =$(sources)

--- a/opal/mca/pmix/external/configure.m4
+++ b/opal/mca/pmix/external/configure.m4
@@ -44,6 +44,18 @@ AC_DEFUN([MCA_opal_pmix_external_CONFIG],[
                   AC_MSG_WARN([TO BUILD PMIX OR ELSE UNPREDICTABLE BEHAVIOR MAY RESULT])
                   AC_MSG_ERROR([PLEASE CORRECT THE CONFIGURE COMMAND LINE AND REBUILD])])
            external_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}/openmpi/$opal_pmix_external_basedir/pmix -I${includedir}/openmpi/$opal_pmix_external_basedir/pmix/include'
+           # check the version
+           AC_MSG_CHECKING([pmix version])
+           OPAL_CHECK_VERSION([opal_pmix_external],
+                              [$opal_external_pmix_version],
+                              ["2.0"],
+                              [opal_external_pmix_version_flag=1.1],
+                              [opal_external_pmix_version_flag=2.0],
+                              [opal_external_pmix_version_flag=2.0],
+                              [opal_external_pmix_version_flag=2.0])
+           AC_MSG_RESULT([$opal_external_pmix_version])
+           AS_IF([test "$opal_external_pmix_version_flag" = "1.1"],
+                 [AC_DEFINE([OPAL_PMIX_VERSION_11], [1], [PMIx external version])])
            $1],
           [$2])
 ])dnl

--- a/opal/mca/pmix/external/pmix_ext_client.c
+++ b/opal/mca/pmix/external/pmix_ext_client.c
@@ -112,7 +112,12 @@ int pmix1_client_init(void)
         asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
         putenv(dbgvalue);
     }
+
+#ifdef OPAL_PMIX_VERSION_11
+    rc = PMIx_Init(&my_proc);
+#else
     rc = PMIx_Init(&my_proc, NULL, 0);
+#endif
     if (PMIX_SUCCESS != rc) {
         return pmix1_convert_rc(rc);
     }
@@ -154,7 +159,11 @@ int pmix1_client_finalize(void)
     /* deregister the errhandler */
     PMIx_Deregister_errhandler(errhdler_ref, NULL, NULL);
 
+#ifdef OPAL_PMIX_VERSION_11
+    rc = PMIx_Finalize();
+#else
     rc = PMIx_Finalize(NULL, 0);
+#endif
 
     return pmix1_convert_rc(rc);
 }

--- a/opal/mca/pmix/external/pmix_ext_server_south.c
+++ b/opal/mca/pmix/external/pmix_ext_server_south.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
@@ -231,7 +231,7 @@ int pmix1_server_register_nspace(opal_jobid_t jobid,
                 pmapinfo = (opal_list_t*)kv->data.ptr;
                 szmap = opal_list_get_size(pmapinfo);
                 PMIX_INFO_CREATE(pmap, szmap);
-                pinfo[n].value.data.array.array = (struct pmix_info*)pmap;
+                pinfo[n].value.data.array.array = (struct pmix_info_t*)pmap;
                 pinfo[n].value.data.array.size = szmap;
                 m = 0;
                 OPAL_LIST_FOREACH(k2, pmapinfo, opal_value_t) {


### PR DESCRIPTION
Stealing some pieces of Josh Hursey's PR #1583 and modifying a bit, allow the opal/pmix external component to handle both PMIx 1.1.4 and PMIx 2.0 versions. Automatically detect the version of the target external library and adjust the only two APIs that changed (PMIx_Init and PMIx_Finalize)
