### PR TITLE
hwloc1113: add missing file to Makefile.am

### DIFF
--- a/opal/mca/hwloc/hwloc1113/Makefile.am
+++ b/opal/mca/hwloc/hwloc1113/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2015 Intel, Inc. All right reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
@@ -21,6 +21,7 @@ DISTCLEANFILES = \
 # the tarball (in case someone invokes autogen.sh on a dist tarball).
 EXTRA_DIST = \
         hwloc/doc/README.txt \
+        hwloc/contrib/systemd/README.txt \
         hwloc/tests/README.txt \
         hwloc/utils/README.txt
 


### PR DESCRIPTION
Lack of this file causes a failure when you run autogen.pl on a distribution tarball.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>