### PR TITLE
atomic: add support for __atomic builtins

### DIFF
--- a/opal/include/opal/sys/architecture.h
+++ b/opal/include/opal/sys/architecture.h
@@ -39,7 +39,8 @@
 #define OPAL_ARM            0100
 #define OPAL_BUILTIN_SYNC   0200
 #define OPAL_BUILTIN_OSX    0201
-#define OPAL_BUILTIN_NO     0202
+#define OPAL_BUILTIN_GCC    0202
+#define OPAL_BUILTIN_NO     0203
 
 /* Formats */
 #define OPAL_DEFAULT        1000  /* standard for given architecture */

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -141,6 +141,8 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
 /* don't include system-level gorp when generating doxygen files */
 #elif OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_SYNC
 #include "opal/sys/sync_builtin/atomic.h"
+#elif OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_GCC
+#include "opal/sys/gcc_builtin/atomic.h"
 #elif OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_OSX
 #include "opal/sys/osx/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_AMD64

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -131,6 +131,14 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
 #define OPAL_HAVE_INLINE_ATOMIC_SWAP_64 1
 #endif
 
+/**
+ * Enumeration of lock states
+ */
+enum {
+    OPAL_ATOMIC_UNLOCKED = 0,
+    OPAL_ATOMIC_LOCKED = 1
+};
+
 /**********************************************************************
  *
  * Load the appropriate architecture files and set some reasonable
@@ -265,15 +273,6 @@ void opal_atomic_wmb(void);
 #endif
 
 #if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_SPINLOCKS || (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
-
-/**
- * Enumeration of lock states
- */
-enum {
-    OPAL_ATOMIC_UNLOCKED = 0,
-    OPAL_ATOMIC_LOCKED = 1
-};
-
 
 /**
  * Initialize a lock to value

--- a/opal/include/opal/sys/gcc_builtin/Makefile.am
+++ b/opal/include/opal/sys/gcc_builtin/Makefile.am
@@ -5,12 +5,13 @@
 # Copyright (c) 2004-2005 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,22 +19,7 @@
 # $HEADER$
 #
 
-# This makefile.am does not stand on its own - it is included from opal/Makefile.am
+# This makefile.am does not stand on its own - it is included from opal/include/Makefile.am
 
 headers += \
-	opal/sys/architecture.h \
-	opal/sys/atomic.h \
-	opal/sys/atomic_impl.h \
-	opal/sys/timer.h \
-        opal/sys/cma.h
-
-include opal/sys/amd64/Makefile.am
-include opal/sys/arm/Makefile.am
-include opal/sys/ia32/Makefile.am
-include opal/sys/ia64/Makefile.am
-include opal/sys/mips/Makefile.am
-include opal/sys/osx/Makefile.am
-include opal/sys/powerpc/Makefile.am
-include opal/sys/sparcv9/Makefile.am
-include opal/sys/sync_builtin/Makefile.am
-include opal/sys/gcc_builtin/Makefile.am
+	opal/sys/gcc_builtin/atomic.h

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -1,0 +1,161 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_SYS_ARCH_ATOMIC_H
+#define OPAL_SYS_ARCH_ATOMIC_H 1
+
+#include <stdbool.h>
+
+/**********************************************************************
+ *
+ * Memory Barriers
+ *
+ *********************************************************************/
+#define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
+
+#define OPAL_HAVE_ATOMIC_MATH_32 1
+#define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_ADD_32 1
+#define OPAL_HAVE_ATOMIC_SUB_32 1
+#define OPAL_HAVE_ATOMIC_SWAP_32 1
+#define OPAL_HAVE_ATOMIC_MATH_64 1
+#define OPAL_HAVE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_ATOMIC_ADD_64 1
+#define OPAL_HAVE_ATOMIC_SUB_64 1
+#define OPAL_HAVE_ATOMIC_SWAP_64 1
+
+
+static inline void opal_atomic_mb(void)
+{
+    __atomic_thread_fence (__ATOMIC_SEQ_CST);
+}
+
+static inline void opal_atomic_rmb(void)
+{
+    __atomic_thread_fence (__ATOMIC_ACQUIRE);
+}
+
+static inline void opal_atomic_wmb(void)
+{
+    __atomic_thread_fence (__ATOMIC_RELEASE);
+}
+
+#define MB() opal_atomic_mb()
+
+/**********************************************************************
+ *
+ * Atomic math operations
+ *
+ *********************************************************************/
+
+static inline int opal_atomic_cmpset_acq_32( volatile int32_t *addr,
+                                             int32_t oldval, int32_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+
+static inline int opal_atomic_cmpset_rel_32( volatile int32_t *addr,
+                                             int32_t oldval, int32_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+}
+
+static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
+                                         int32_t oldval, int32_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+}
+
+static inline int32_t opal_atomic_swap_32 (volatile int32_t *addr, int32_t newval)
+{
+    int32_t oldval;
+    __atomic_exchange (addr, &newval, &oldval, __ATOMIC_RELAXED);
+    return oldval;
+}
+
+static inline int32_t opal_atomic_add_32(volatile int32_t *addr, int32_t delta)
+{
+    return __atomic_add_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
+{
+    return __atomic_sub_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
+                                             int64_t oldval, int64_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+static inline int opal_atomic_cmpset_rel_64( volatile int64_t *addr,
+                                             int64_t oldval, int64_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+}
+
+
+static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
+                                         int64_t oldval, int64_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+}
+
+static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newval)
+{
+    int64_t oldval;
+    __atomic_exchange (addr, &newval, &oldval, __ATOMIC_RELAXED);
+    return oldval;
+}
+
+static inline int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
+{
+    return __atomic_add_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
+{
+    return __atomic_sub_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+#if OPAL_HAVE_GCC_BUILTIN_CSWAP_INT128
+
+#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+
+static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
+                                          opal_int128_t oldval, opal_int128_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+}
+
+#endif
+
+#endif /* ! OPAL_SYS_ARCH_ATOMIC_H */


### PR DESCRIPTION
This commit adds support for the gcc __atomic builtins. The __sync
builtins are deprecated and have been replaced by these atomics. In
addition, the new atomics support atomic exchange which was not
supported by __sync.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>