### PR TITLE
pml/ob1: fix race on pml completion of send requests

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -262,17 +262,18 @@ send_request_pml_complete(mca_pml_ob1_send_request_t *sendreq)
             mca_pml_base_bsend_request_fini((ompi_request_t*)sendreq);
         }
 
-        sendreq->req_send.req_base.req_pml_complete = true;
+        if (!sendreq->req_send.req_base.req_free_called) {
+            sendreq->req_send.req_base.req_pml_complete = true;
 
-        if( !REQUEST_COMPLETE( &((sendreq->req_send).req_base.req_ompi)) ) {
-            /* Should only be called for long messages (maybe synchronous) */
-            MCA_PML_OB1_SEND_REQUEST_MPI_COMPLETE(sendreq, true);
-        } else {
-            if( MPI_SUCCESS != sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR ) {
-                ompi_mpi_abort(&ompi_mpi_comm_world.comm, MPI_ERR_REQUEST);
+            if( !REQUEST_COMPLETE( &((sendreq->req_send).req_base.req_ompi)) ) {
+                /* Should only be called for long messages (maybe synchronous) */
+                MCA_PML_OB1_SEND_REQUEST_MPI_COMPLETE(sendreq, true);
+            } else {
+                if( MPI_SUCCESS != sendreq->req_send.req_base.req_ompi.req_status.MPI_ERROR ) {
+                    ompi_mpi_abort(&ompi_mpi_comm_world.comm, MPI_ERR_REQUEST);
+                }
             }
-        }
-        if(true == sendreq->req_send.req_base.req_free_called) {
+        } else {
             MCA_PML_OB1_SEND_REQUEST_RETURN(sendreq);
         }
     }


### PR DESCRIPTION
The request code was setting the request as pml_complete before
calling MCA_PML_OB1_SEND_REQUEST_MPI_COMPLETE. This was causing
MCA_PML_OB1_SEND_REQUEST_RETURN to be called twice in some cases. The
code now mirrors the recvreq code and only sets the request as pml
complete if the request has not already been freed.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>