### PR TITLE
atomic/gcc: add check for 128-bit CAS being lock-free

### DIFF
--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -156,6 +156,18 @@ static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
+#elif defined(OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128) && OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
+
+#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+
+/* __atomic version is not lock-free so use legacy __sync version */
+
+static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
+                                          opal_int128_t oldval, opal_int128_t newval)
+{
+    return __sync_bool_compare_and_swap (addr, oldval, newval);
+}
+
 #endif
 
 #if defined(__HLE__)


### PR DESCRIPTION
Compiler implementations are free to include support for atomics that
use locks. Unfortunately lock-free and lock atomics do not mix. Older
versions of llvm on OS X use locks to provide
__atomic_compare_exchange on 128-bit values but are lock-free on
64-bit values. This screws up our lifo implementation which mixes
64-bit and 128-bit atomics on the same values to improve
performance. This commit adds a configure-time check if 128-bit
atomics are lock free. If they are not then the 128-bit __atomic CAS
is disabled and we check for the __sync version as a fallback.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>