### PR TITLE
Cleanup the forced termination a bit by restoring the delay before is…

### DIFF
--- a/orte/mca/odls/base/odls_private.h
+++ b/orte/mca/odls/base/odls_private.h
@@ -121,8 +121,7 @@ typedef bool (*orte_odls_base_child_died_fn_t)(orte_proc_t *child);
 
 ORTE_DECLSPEC int
 orte_odls_base_default_kill_local_procs(opal_pointer_array_t *procs,
-                                        orte_odls_base_kill_local_fn_t kill_local,
-                                        orte_odls_base_child_died_fn_t child_died);
+                                        orte_odls_base_kill_local_fn_t kill_local);
 
 ORTE_DECLSPEC int orte_odls_base_default_restart_proc(orte_proc_t *child,
                                                       orte_odls_base_fork_local_proc_fn_t fork_local);

--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -164,71 +164,6 @@ orte_odls_base_module_t orte_odls_default_module = {
 };
 
 
-static bool odls_default_child_died(orte_proc_t *child)
-{
-    time_t end;
-    pid_t ret;
-
-    /* Because of rounding in time (which returns whole seconds) we
-     * have to add 1 to our wait number: this means that we wait
-     * somewhere between (target) and (target)+1 seconds.  Otherwise,
-     * the default 1s actually means 'somwhere between 0 and 1s'. */
-    end = time(NULL) + orte_odls_globals.timeout_before_sigkill + 1;
-    do {
-        OPAL_OUTPUT_VERBOSE((20, orte_odls_base_framework.framework_output,
-                             "%s odls:default:WAITPID CHECKING PID %d WITH TIMEOUT %d SECONDS",
-                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), (int)(child->pid),
-                             orte_odls_globals.timeout_before_sigkill + 1));
-        ret = waitpid(child->pid, &child->exit_code, WNOHANG);
-        if (child->pid == ret) {
-            OPAL_OUTPUT_VERBOSE((20, orte_odls_base_framework.framework_output,
-                                 "%s odls:default:WAITPID INDICATES PROC %d IS DEAD",
-                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), (int)(child->pid)));
-            /* It died -- return success */
-            return true;
-        } else if (0 == ret) {
-            /* with NOHANG specified, if a process has already exited
-             * while waitpid was registered, then waitpid returns 0
-             * as there is no error - this is a race condition problem
-             * that occasionally causes us to incorrectly report a proc
-             * as refusing to die. Unfortunately, errno may not be reset
-             * by waitpid in this case, so we cannot check it.
-             *
-             * (note the previous fix to this, to return 'process dead'
-             * here, fixes the race condition at the cost of reporting
-             * all live processes have immediately died!  Better to
-             * occasionally report a dead process as still living -
-             * which will occasionally trip the timeout for cases that
-             * are right on the edge.)
-             */
-            OPAL_OUTPUT_VERBOSE((20, orte_odls_base_framework.framework_output,
-                                 "%s odls:default:WAITPID INDICATES PID %d MAY HAVE ALREADY EXITED",
-                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), (int)(child->pid)));
-            /* Do nothing, process still alive */
-        } else if (-1 == ret && ECHILD == errno) {
-            /* The pid no longer exists, so we'll call this "good
-               enough for government work" */
-            OPAL_OUTPUT_VERBOSE((20, orte_odls_base_framework.framework_output,
-                                 "%s odls:default:WAITPID INDICATES PID %d NO LONGER EXISTS",
-                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), (int)(child->pid)));
-            return true;
-        }
-
-        /* Bogus delay for 1 msec - let's actually give the CPU some time
-         * to quit the other process (sched_yield() -- even if we have it
-         * -- changed behavior in 2.6.3x Linux flavors to be undesirable)
-         * Don't use select on a bogus file descriptor here as it has proven
-         * unreliable and sometimes immediately returns - we really, really
-         * -do- want to wait a bit!
-         */
-        usleep(1000);
-    } while (time(NULL) < end);
-
-    /* The child didn't die, so return false */
-    return false;
-}
-
-
 /* deliver a signal to a specified pid. */
 static int odls_default_kill_local(pid_t pid, int signum)
 {
@@ -251,7 +186,7 @@ int orte_odls_default_kill_local_procs(opal_pointer_array_t *procs)
     int rc;
 
     if (ORTE_SUCCESS != (rc = orte_odls_base_default_kill_local_procs(procs,
-                                    odls_default_kill_local, odls_default_child_died))) {
+                                            odls_default_kill_local))) {
         ORTE_ERROR_LOG(rc);
         return rc;
     }


### PR DESCRIPTION
…suing the sigkill, and eliminating the large time loss spent checking if the proc died. The latter is responsible for a large number of test timeouts in MTT