### PR TITLE
btl/vader: fix fragment leak on fifo write back

### DIFF
--- a/opal/mca/btl/vader/btl_vader_fbox.h
+++ b/opal/mca/btl/vader/btl_vader_fbox.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -231,7 +231,7 @@ static inline bool mca_btl_vader_check_fboxes (void)
             } else if (OPAL_LIKELY(0xfe == hdr.data.tag)) {
                 /* process fragment header */
                 fifo_value_t *value = (fifo_value_t *)(ep->fbox_in.buffer + start + sizeof (hdr));
-                mca_btl_vader_hdr_t *hdr = relative2virtual(*value);
+                mca_btl_vader_hdr_t *hdr = relative2virtualpeer (ep, *value);
                 mca_btl_vader_poll_handle_frag (hdr, ep);
             }
 


### PR DESCRIPTION
This commit modifies the write-back of complete fragments to use the
fifo instead of fast boxes. This ensures fragments do not get lost
when a peer's fast box is full.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>