### PR TITLE
Revert "mellanox/optimized: set enable_openib_rdmacm_ibaddr=yes in the mellanox/optimized file."

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -6,7 +6,6 @@ with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes
 disable_wrapper_rpath=yes
-enable_openib_rdmacm_ibaddr=yes
 
 mellanox_autodetect=${mellanox_autodetect:="no"}
 mellanox_debug=${mellanox_debug:="no"}


### PR DESCRIPTION
This reverts commit 6cd7282631bf999336c975a1a418aeda83a244c6.

@jladd-mlnx Please review.