### PR TITLE
ompi/request: fix loop conditional

### DIFF
--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -125,7 +125,7 @@ int ompi_request_default_wait_any(size_t count,
   after_sync_wait:
     /* recheck the complete status and clean up the sync primitives. Do it backward to
      * return the earliest complete request to the user. */
-    for(i = completed-1; i >= 0; i--) {
+    for(i = completed-1; (i+1) > 0; i--) {
         request = requests[i];
 
         if( request->req_state == OMPI_REQUEST_INACTIVE ) {


### PR DESCRIPTION
This commit fixes a bug in waitany that causes the code to go past the
beginning of the request array. The loop conditional i >= 0 is invalid
since i is unsigned. Changed to loop to check (i+1) > 0.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>