### PR TITLE
RFC: ignore more local TCP interfaces by default

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -246,7 +246,7 @@ static int mca_btl_tcp_component_register(void)
     mca_btl_tcp_param_register_uint("links", NULL, 1, OPAL_INFO_LVL_4, &mca_btl_tcp_component.tcp_num_links);
     mca_btl_tcp_param_register_string("if_include", "Comma-delimited list of devices and/or CIDR notation of networks to use for MPI communication (e.g., \"eth0,192.168.0.0/16\").  Mutually exclusive with btl_tcp_if_exclude.", "", OPAL_INFO_LVL_1, &mca_btl_tcp_component.tcp_if_include);
     mca_btl_tcp_param_register_string("if_exclude", "Comma-delimited list of devices and/or CIDR notation of networks to NOT use for MPI communication -- all devices not matching these specifications will be used (e.g., \"eth0,192.168.0.0/16\").  If set to a non-default value, it is mutually exclusive with btl_tcp_if_include.",
-                                      "127.0.0.1/8,sppp",
+                                      "127.0.0.1/8,sppp,virbr,docker,mic",
                                       OPAL_INFO_LVL_1, &mca_btl_tcp_component.tcp_if_exclude);
 
     mca_btl_tcp_param_register_int ("free_list_num", NULL, 8, OPAL_INFO_LVL_5,  &mca_btl_tcp_component.tcp_free_list_num);


### PR DESCRIPTION
By default, the ignored list of TCP interface includes only lo(127.0.0.1) and sppp. 

There are many interfaces that are not routable. However, the TCP btl will try to use them between nodes of a pair that both feature a similar (address range) interface. This case happen often with virtual machines, docker containers, Xeon Phi, etc. 

A similar discussion happened in the past, the solution was to add an item in the FAQ. 
https://www.open-mpi.org/community/lists/devel/2012/02/10390.php

The current proposal is to go one step further and increase the list of interfaces that are ignored by default with common cases (complete list TBD). 

One may note that some users may actually want to use the virtual machine interface. In this case, the proposed change will yield an error "some processes could not be reached etc". While this may be unsettling, this is hinting the user in the right direction as to how to fix it (i.e. alter the default if_exclude). In comparison, the current behavior is to silently select non-routable interfaces, then the program runs for a while as-if things were fine, then deadlocks (the deadlock may be delayed until multirail kicks in, thus triggering the first use of the offending non-routable interface). This gives no hint about the possible remediation and looks like to an end-user as if Open MPI has a bug rather than a system configuration issue. 
