### PR TITLE
Abstract the strnlen function for environments that do not have it (e.g., Solaris 10)

### DIFF
--- a/opal/mca/pmix/pmix114/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix114/pmix/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+dnl Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -495,7 +495,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
     PMIX_SEARCH_LIBS_CORE([ceil], [m])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep getpeereid])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep getpeereid strnlen])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/opal/mca/pmix/pmix114/pmix/src/server/pmix_server_listener.c
+++ b/opal/mca/pmix/pmix114/pmix/src/server/pmix_server_listener.c
@@ -56,6 +56,7 @@
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/progress_threads.h"
+#include "src/util/strnlen.h"
 #include "src/usock/usock.h"
 #include "src/sec/pmix_sec.h"
 
@@ -315,31 +316,41 @@ static pmix_status_t parse_connect_ack (char *msg, int len,
                                         char **nspace, int *rank,
                                         char **version, char **cred)
 {
-    if ((int)strnlen (msg, len) < len) {
+    int msglen;
+
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen < len) {
         *nspace = msg;
         msg += strlen(*nspace) + 1;
         len -= strlen(*nspace) + 1;
-    } else
+    } else {
         return PMIX_ERR_BAD_PARAM;
+    }
 
-    if ((int)sizeof(int) <= len) {
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen <= len) {
         *rank = *(int *)msg;
         msg += sizeof(int);
         len -= sizeof(int);
-    } else
+    } else {
         return PMIX_ERR_BAD_PARAM;
+    }
 
-    if ((int)strnlen (msg, len) < len) {
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen < len) {
         *version = msg;
         msg += strlen(*version) + 1;
         len -= strlen(*version) + 1;
-    } else
+    } else {
         return PMIX_ERR_BAD_PARAM;
+    }
 
-    if ((int)strnlen (msg, len) < len)
+    PMIX_STRNLEN(msglen, msg, len);
+    if (msglen < len)
         *cred = msg;
-    else
+    else {
         *cred = NULL;
+    }
 
     return PMIX_SUCCESS;
 }

--- a/opal/mca/pmix/pmix114/pmix/src/util/Makefile.am
+++ b/opal/mca/pmix/pmix114/pmix/src/util/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2013      Intel, Inc. All rights reserved
-# Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +34,8 @@ headers += \
         src/util/timings.h \
         src/util/os_path.h \
         src/util/basename.h \
-        src/util/hash.h
+        src/util/hash.h \
+        src/util/strnlen.h
 
 sources += \
         src/util/argv.c \

--- a/opal/mca/pmix/pmix114/pmix/src/util/strnlen.h
+++ b/opal/mca/pmix/pmix114/pmix/src/util/strnlen.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file
+ *
+ * Buffer strnlen function for portability to archaic platforms.
+ */
+
+#ifndef PMIX_STRNLEN_H
+#define PMIX_STRNLEN_H
+
+#include <src/include/pmix_config.h>
+
+#if defined(HAVE_STRNLEN)
+#define PMIX_STRNLEN(c, a, b)       \
+    (c) = (int)strnlen(a, b)
+#else
+#define PMIX_STRNLEN(c, a, b)           \
+    do {                                \
+        int _x;                         \
+        (c) = 0;                        \
+        for (_x=0; _x < (b); _x++) {    \
+            if ('\0' == (a)[_x]) {       \
+                break;                  \
+            }                           \
+            ++(c);                      \
+        }                               \
+    } while(0)
+#endif
+
+#endif /* PMIX_STRNLEN_H */
+


### PR DESCRIPTION
Fixes https://github.com/open-mpi/ompi/issues/1771
