### PR TITLE
ompi/datatype: Fix args of HINDEXED_BLOCK

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -788,7 +788,7 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( int32_t* i, MPI_Aint* 
         ompi_datatype_create_hindexed_block( i[0], i[1], a, d[0], &datatype );
         {
             const int* a_i[2] = {&i[0], &i[1]};
-            ompi_datatype_set_args( datatype, 2 + i[0], a_i, i[0], a, 1, d, MPI_COMBINER_HINDEXED_BLOCK );
+            ompi_datatype_set_args( datatype, 2, a_i, i[0], a, 1, d, MPI_COMBINER_HINDEXED_BLOCK );
         }
         break;
         /******************************************************************/


### PR DESCRIPTION
According to MPI-3.1 P.121, `ni` for `MPI_COMBINER_HINDEXED_BLOCK` should be `2`, not `2 + count`.

This bug was introduced in 113b45b4 (when `MPI_Type_create_hindexed_block` support was added in Open MPI) and fixed partially in 7f5314ee and 8de93982. This commit fixes the remaining part.

Probably this bug has no user impact. It only consumes a bit more memory on one-sided communication (pt2pt OSC).

@bosilca Please review.
