### PR TITLE
Fix btl/usnic deadlock when the connectivity check is turned off.

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_cclient.c
+++ b/opal/mca/btl/usnic/btl_usnic_cclient.c
@@ -228,12 +228,14 @@ int opal_btl_usnic_connectivity_ping(uint32_t src_ipv4_addr, int src_port,
                                      uint32_t dest_netmask, int dest_port,
                                      char *dest_nodename,
                                      size_t max_msg_size)
-{  
-    OPAL_THREAD_LOCK(&btl_usnic_lock);
+{
     /* If connectivity checking is not enabled, do nothing */
     if (!mca_btl_usnic_component.connectivity_enabled) {
         return OPAL_SUCCESS;
     }
+
+    /* Protect opal_fd_write for multithreaded case */
+    OPAL_THREAD_LOCK(&btl_usnic_lock);
 
     /* Send the PING command */
     int id = CONNECTIVITY_AGENT_CMD_PING;
@@ -260,6 +262,8 @@ int opal_btl_usnic_connectivity_ping(uint32_t src_ipv4_addr, int src_port,
         ABORT("usnic connectivity client IPC write failed");
         /* Will not return */
     }
+
+    /* Unlock and return */
     OPAL_THREAD_UNLOCK(&btl_usnic_lock);
 
     return OPAL_SUCCESS;


### PR DESCRIPTION
This patch fix the deadlock found in coverity test after #1778 . We will take the lock after we check that the connectivity check is needed. 

@jsquyres 