### PR TITLE
opal/asm: fix syntax of timer code for ia32

### DIFF
--- a/opal/include/opal/sys/ia32/timer.h
+++ b/opal/include/opal/sys/ia32/timer.h
@@ -35,9 +35,9 @@ opal_sys_timer_get_cycles(void)
     int tmp;
 
     __asm__ __volatile__(
-                         "xchg{l} {%%}ebx, %1\n"
+                         "xchgl %%ebx, %1\n"
                          "cpuid\n"
-                         "xchg{l} {%%}ebx, %1\n"
+                         "xchgl %%ebx, %1\n"
                          "rdtsc\n"
                          : "=A"(ret), "=r"(tmp)
                          :: "ecx");


### PR DESCRIPTION
Thanks to Paul Hargrove for pointing this out.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>