### PR TITLE
Fixed common symbol error in btl/usnic.

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic.h
+++ b/opal/mca/btl/usnic/btl_usnic.h
@@ -63,6 +63,10 @@ BEGIN_C_DECLS
  * at other times as needed or as tuning dictates.
  */
 extern uint64_t opal_btl_usnic_ticks;
+
+/* Lock for MPU_THREAD_MULTIPLE support */
+extern opal_recursive_mutex_t btl_usnic_lock;
+
 static inline uint64_t
 get_nsec(void)
 {

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -87,7 +87,7 @@
 #define OPAL_BTL_USNIC_NUM_COMPLETIONS 500
 
 /* MPI_THREAD_MULTIPLE_SUPPORT */
-opal_recursive_mutex_t btl_usnic_lock;
+opal_recursive_mutex_t btl_usnic_lock =  OPAL_RECURSIVE_MUTEX_STATIC_INIT;
 
 /* RNG buffer definition */
 opal_rng_buff_t opal_btl_usnic_rand_buff = {0};

--- a/opal/mca/btl/usnic/btl_usnic_module.h
+++ b/opal/mca/btl/usnic/btl_usnic_module.h
@@ -54,12 +54,6 @@
 BEGIN_C_DECLS
 
 /*
- * MPI_THREAD_MULTIPLE support
- */
-extern opal_recursive_mutex_t btl_usnic_lock;
-
-
-/*
  * Forward declarations to avoid include loops
  */
 struct opal_btl_usnic_send_segment_t;


### PR DESCRIPTION
- This patch fixed the common symbol error when do make install. 
- Move btl_usnic_lock declaration to btl_usnic.h

@jsquyres 