### PR TITLE
ompi/request: fix loop conditional

### DIFF
--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -125,7 +125,7 @@ int ompi_request_default_wait_any(size_t count,
   after_sync_wait:
     /* recheck the complete status and clean up the sync primitives. Do it backward to
      * return the earliest complete request to the user. */
-    for(i = completed-1; i >= 0; i--) {
+    for(i = completed-1; (i+1) > 0; i--) {
         request = requests[i];
 
         if( request->req_state == OMPI_REQUEST_INACTIVE ) {
@@ -137,7 +137,7 @@ int ompi_request_default_wait_any(size_t count,
          * marked as REQUEST_COMPLETE.
          */
         if( !OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING) ) {
-            *index = i;
+            *index = (int) i;
         }
     }
 


### PR DESCRIPTION
This commit fixes a bug intoduced when attempting to fix a warning
about comparing signed and unsigned. By making i unsigned this loop
was not correctly terminating.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>