### PR TITLE
Support OpenVZ container networking

### DIFF
--- a/opal/mca/if/posix_ipv4/if_posix.c
+++ b/opal/mca/if/posix_ipv4/if_posix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
@@ -220,6 +220,15 @@ static int if_posix_open(void)
         memset(intf->if_name, 0, sizeof(intf->if_name));
         strncpy(intf->if_name, ifr->ifr_name, sizeof(intf->if_name) - 1);
         intf->if_flags = ifr->ifr_flags;
+
+        // JMS Hackaround for OpenVZ
+        if (strcmp(intf->if_name, "venet0") == 0) {
+            opal_output_verbose(1, opal_if_base_framework.framework_output,
+                                "OpenVZ hack:%s:%d: skipping interface venet0",
+                                __FILE__, __LINE__);
+            OBJ_RELEASE(intf);
+            continue;
+        }
 
         /* every new address gets its own internal if_index */
         intf->if_index = opal_list_get_size(&opal_if_list)+1;


### PR DESCRIPTION
[User Nikolay reported on the users mailing list](http://www.open-mpi.org/community/lists/users/2016/06/29540.php) that Open MPI 1.10.x has problems in OpenVZ containers.

I actually ran into a similar situation recently, and hacked a workaround (which is the initial patch on this PR).  Specifically, per Nikolay's description, here's the networking picture in an OpenVZ container:

```
[root@ct111 /]# ifconfig
lo        Link encap:Local Loopback
         inet addr:127.0.0.1  Mask:255.0.0.0
         inet6 addr: ::1/128 Scope:Host
         UP LOOPBACK RUNNING  MTU:65536  Metric:1
         RX packets:24 errors:0 dropped:0 overruns:0 frame:0
         TX packets:24 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:0
         RX bytes:1200 (1.1 KiB)  TX bytes:1200 (1.1 KiB)

venet0    Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
         inet addr:127.0.0.1  P-t-P:127.0.0.1  Bcast:0.0.0.0  Mask:255.255.255.255
         UP BROADCAST POINTOPOINT RUNNING NOARP  MTU:1500  Metric:1
         RX packets:855 errors:0 dropped:0 overruns:0 frame:0
         TX packets:774 errors:0 dropped:0 overruns:0 carrier:0
         collisions:0 txqueuelen:0
         RX bytes:122212 (119.3 KiB)  TX bytes:112304 (109.6 KiB)

venet0:0  Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
         inet addr:10.0.50.41  P-t-P:10.0.50.41  Bcast:10.0.50.41  Mask:255.255.255.255
         UP BROADCAST POINTOPOINT RUNNING NOARP  MTU:1500  Metric:1
```

Note the 10.0.40.41/32 (!) address.  That's just how OpenVZ sets up its networking environment -- it works fine.

Using `--mca btl_tcp_if_include venet0:0 --mca oob_tcp_if_include venet0:0` _does not work_ -- the jobs fail with the TCP BTL complaining about a broken pipe (!).

IIRC (from back when I created this patch), I think that somehow the TCP OOB is still using `venet0`, which ends up not working properly (i.e., it tries to open a socket to a peer, and it fails).  The issue is that OMPI isn't ignoring localhost based on its 127.0.0.0/8 address, but rather based on its _name_ of `lo*`.  I.e., it still tries to use `venet0`, even though it's _also_ 127.0.0.1 (same as `lo`).

I don't know offhand/remember why the `oob_tcp_if_include venet0:0` doesn't fix the problem.  ...something about string matching, perhaps?

Regardless, Nikolay replied that OMPI works for him when he applies this hackaround patch.  We should probably do something better / more formal -- here's some not-fully-thought-out suggestions:
- Ignore POINTOPOINT interfaces
- Ignore 127.0.0.0/8 interfaces (i.e., add 127.0.0.0/8 to `*_if_exclude` default values)
