### PR TITLE
MPI_Waitsome performance improvement (version #2)

### DIFF
--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -391,8 +391,8 @@ int ompi_request_default_wait_some(size_t count,
             num_requests_null_inactive++;
             continue;
         }
-
-        if( !OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync) ) {
+        indices[i] = OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync);
+        if( !indices[i] ) {
             /* If the request is completed go ahead and mark it as such */
             assert( REQUEST_COMPLETE(request) );
             num_requests_done++;
@@ -423,15 +423,23 @@ int ompi_request_default_wait_some(size_t count,
         if( request->req_state == OMPI_REQUEST_INACTIVE ) {
             continue;
         }
-        /* Atomically mark the request as pending. If this succeed
-         * then the request was not completed, and it is now marked as
-         * pending. Otherwise, the request is complete )either it was
-         * before or it has been meanwhile). The major drawback here
-         * is that we will do all the atomics operations in all cases.
+        /* Here we have 3 possibilities:
+         * a) request was found completed in the first loop
+         *    => ( indices[i] == 0 )
+         * b) request was completed between first loop and this check
+         *    => ( indices[i] == 1 ) and we can NOT atomically mark the 
+         *    request as pending.
+         * c) request wasn't finished yet
+         *    => ( indices[i] == 1 ) and we CAN  atomically mark the 
+         *    request as pending.
+         * NOTE that in any case (i >= num_requests_done) as latter grows
+         * either slowly (in case of partial completion)
+         * OR in parallel with `i` (in case of full set completion)  
          */
-        if( !OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING) ) {
-            indices[num_requests_done] = i;
-            num_requests_done++;
+        if( !indices[i] ){
+            indices[num_requests_done++] = i;
+        } else if( !OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING) ) {
+            indices[num_requests_done++] = i;
         }
     }
     sync_unsets = count - num_requests_null_inactive - num_requests_done;


### PR DESCRIPTION
This is an alternative (to PR https://github.com/open-mpi/ompi/pull/1820) implementation of MPI_Waitsome optimization according to @bosilca [suggestion](https://github.com/open-mpi/ompi/pull/1820#issuecomment-228905750).

@bosilca, please check if I understood you correctly. Consider only the last commit (https://github.com/open-mpi/ompi/commit/35c3f0cd67887c0d50a4f9448bb4f64992c3a3ec). First three are from PR https://github.com/open-mpi/ompi/pull/1816 because this PR depends on it. I'll rebase this one if the base https://github.com/open-mpi/ompi/pull/1816 will be merged.

In terms of performance here (compared to https://github.com/open-mpi/ompi/pull/1820) we have to memset the array of indices at the beginning. 

I didn't considered the case where we put signalled indexes compactly (back to back) in the `indices` array like this:
```C
{ 0, 10, 14, 25, ... }
```
because in this case in the second loop you'll have to search. And even though indexes are in the increasing order and you can apply binary search I don't think it will be faster that setting indices to 0 once at the beginning of the waitsome.

