### PR TITLE
op: Add a default value for MPI_OP o_name

### DIFF
--- a/ompi/op/op.c
+++ b/ompi/op/op.c
@@ -356,6 +356,9 @@ ompi_op_t *ompi_op_create_user(bool commute,
         new_op->o_flags |= OMPI_OP_FLAGS_COMMUTE;
     }
 
+    strncpy(new_op->o_name, "USER OP", sizeof(new_op->o_name) - 1);
+    new_op->o_name[sizeof(new_op->o_name) - 1] = '\0';
+
     /* Set the user-defined callback function.  The "fort_fn" member
        is part of a union, so it doesn't matter if this is a C or
        Fortan callback; we'll call the right flavor (per o_flags) at
@@ -446,6 +449,7 @@ static void ompi_op_construct(ompi_op_t *new_op)
     /* Provide a default of a high value. Useful for non-predefined ops. */
     new_op->op_type = OMPI_OP_NUM_OF_TYPES;
     new_op->o_flags = 0;
+    new_op->o_name[0] = '\0';
 
     /* assign entry in fortran <-> c translation array */
 


### PR DESCRIPTION
For user defined `MPI_Op` types the `o_name` field is never set. Some components use this field for verbose output, and leaving it undefined makes the output difficult to review. So this commit makes sure that it gets initialized in all paths.