### PR TITLE
mpi/c: Add each check for count==0 in nonblocking reduce interface

### DIFF
--- a/ompi/mpi/c/iallreduce.c
+++ b/ompi/mpi/c/iallreduce.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,6 +93,16 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
             OMPI_CHECK_DATATYPE_FOR_SEND(err, datatype, count);
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+    }
+
+
+    /* MPI standard says that reductions have to have a count of at least 1,
+     * but some benchmarks (e.g., IMB) calls this function with a count of 0.
+     * So handle that case.
+     */
+    if (0 == count) {
+        *request = &ompi_request_empty;
+        return MPI_SUCCESS;
     }
 
     OPAL_CR_ENTER_LIBRARY();

--- a/ompi/mpi/c/ireduce.c
+++ b/ompi/mpi/c/ireduce.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,6 +119,15 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
                 return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ROOT, FUNC_NAME);
             }
         }
+    }
+
+    /* MPI standard says that reductions have to have a count of at least 1,
+     * but some benchmarks (e.g., IMB) calls this function with a count of 0.
+     * So handle that case.
+     */
+    if (0 == count) {
+        *request = &ompi_request_empty;
+        return MPI_SUCCESS;
     }
 
     OPAL_CR_ENTER_LIBRARY();


### PR DESCRIPTION
The IMB-NBC benchmark uses a count == 0 for the first test of the three reduce operations:
 - ireduce
 - iallreduce
 - ireduce_scatter

We have an early check for this in the blocking versions of those collectives, this patch copies that functionality to the nonblocking interface as well. This allows the collective components that provide these nonblocking interface to not have to worry about this non-standard compliant use case.