### PR TITLE
Configure fixes

### DIFF
--- a/opal/mca/event/configure.m4
+++ b/opal/mca/event/configure.m4
@@ -61,5 +61,6 @@ AC_DEFUN([MCA_opal_event_CONFIG],[
     AC_DEFINE_UNQUOTED([MCA_event_IMPLEMENTATION_HEADER],
                        ["opal/mca/event/$opal_event_base_include"],
                        [Header to include for event implementation])
+    AM_CONDITIONAL(OPAL_EVENT_USE_EXTERNAL,[test "x$opal_event_external_support" = "xyes"])
     AC_MSG_RESULT([$opal_event_base_include])
 ])dnl

--- a/opal/mca/event/libevent2022/Makefile.am
+++ b/opal/mca/event/libevent2022/Makefile.am
@@ -18,20 +18,19 @@ if !OPAL_EVENT_USE_EXTERNAL
 
     SUBDIRS = libevent
     EXTRA_DIST = autogen.subdirs
+    headers = libevent2022.h
+    sources = \
+        libevent2022_component.c \
+        libevent2022_module.c
 
 else
-
+    headers =
+    sources =
     SUBDIRS =
 
 endif
 
 DIST_SUBDIRS = $(SUBDIRS)
-
-headers = libevent2022.h
-
-sources = \
-        libevent2022_component.c \
-        libevent2022_module.c
 
 # Conditionally install the header files
 if WANT_INSTALL_HEADERS

--- a/opal/mca/event/libevent2022/Makefile.am
+++ b/opal/mca/event/libevent2022/Makefile.am
@@ -11,11 +11,21 @@
 # $HEADER$
 #
 
-EXTRA_DIST = autogen.subdirs
 
 AM_CPPFLAGS = -I$(srcdir)/libevent -I$(srcdir)/libevent/include -I$(builddir)/libevent/include -I$(srcdir)/libevent/compat
 
-SUBDIRS = libevent
+if !OPAL_EVENT_USE_EXTERNAL
+
+    SUBDIRS = libevent
+    EXTRA_DIST = autogen.subdirs
+
+else
+
+    SUBDIRS =
+
+endif
+
+DIST_SUBDIRS = $(SUBDIRS)
 
 headers = libevent2022.h
 

--- a/opal/mca/hwloc/configure.m4
+++ b/opal/mca/hwloc/configure.m4
@@ -143,6 +143,8 @@ AC_DEFUN([MCA_opal_hwloc_CONFIG_REQUIRE],[
         OPAL_VAR_SCOPE_POP
     ])
 
+   AM_CONDITIONAL(OPAL_HWLOC_USE_EXTERNAL,[test "x$opal_hwloc_external_support" = "xyes"])
+
    # Similar to above, if this m4 is being invoked "early" via AC
    # REQUIRE, print out a nice banner that we have now finished
    # pre-emption and are returning to the Normal Order Of Things.

--- a/opal/mca/hwloc/hwloc1113/Makefile.am
+++ b/opal/mca/hwloc/hwloc1113/Makefile.am
@@ -29,19 +29,22 @@ EXTRA_DIST = \
 
 SUBDIRS = hwloc
 
+# Headers and sources
+headers = hwloc1113.h
+sources = hwloc1113_component.c
 
 else
 
 SUBDIRS =
+
+headers =
+sources =
 
 endif
 
 DIST_SUBDIRS= $(SUBDIRS)
 
 
-# Headers and sources
-headers = hwloc1113.h
-sources = hwloc1113_component.c
 
 # We only ever build this component statically
 noinst_LTLIBRARIES = libmca_hwloc_hwloc1113.la

--- a/opal/mca/hwloc/hwloc1113/Makefile.am
+++ b/opal/mca/hwloc/hwloc1113/Makefile.am
@@ -10,6 +10,8 @@
 # $HEADER$
 #
 
+if !OPAL_HWLOC_USE_EXTERNAL
+
 # Due to what might be a bug in Automake, we need to remove stamp-h?
 # files manually.  See
 # http://debbugs.gnu.org/cgi/bugreport.cgi?bug=19418.
@@ -26,6 +28,16 @@ EXTRA_DIST = \
         hwloc/utils/README.txt
 
 SUBDIRS = hwloc
+
+
+else
+
+SUBDIRS =
+
+endif
+
+DIST_SUBDIRS= $(SUBDIRS)
+
 
 # Headers and sources
 headers = hwloc1113.h

--- a/opal/mca/pmix/ext114/configure.m4
+++ b/opal/mca/pmix/ext114/configure.m4
@@ -51,7 +51,7 @@ AC_DEFUN([MCA_opal_pmix_ext114_CONFIG],[
                               [pmix.h],
                               [pmix],
                               [PMIx_Register_errhandler],
-                              [-lpmix],
+                              [],
                               [$pmix_ext_install_dir],
                               [$pmix_ext_install_dir/lib],
                               [AC_MSG_RESULT([yes])

--- a/opal/mca/pmix/ext20/configure.m4
+++ b/opal/mca/pmix/ext20/configure.m4
@@ -51,7 +51,7 @@ AC_DEFUN([MCA_opal_pmix_ext20_CONFIG],[
                               [pmix.h],
                               [pmix],
                               [PMIx_Register_event_handler],
-                              [-lpmix],
+                              [],
                               [$pmix_ext_install_dir],
                               [$pmix_ext_install_dir/lib],
                               [AC_MSG_RESULT([yes])

--- a/opal/mca/pmix/pmix2x/Makefile.am
+++ b/opal/mca/pmix/pmix2x/Makefile.am
@@ -10,6 +10,8 @@
 # $HEADER$
 #
 
+if !OPAL_PMIX_USE_EXTERNAL
+
 EXTRA_DIST = autogen.subdirs
 
 SUBDIRS = pmix
@@ -21,6 +23,12 @@ sources = \
         pmix2x_client.c \
         pmix2x_server_south.c \
         pmix2x_server_north.c
+else
+SUBDISR =
+
+endif
+
+DIST_SUBDIRS = $(SUBDIRS)
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -73,5 +73,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
           [$1],
           [$2])
 
+    AM_CONDITIONAL(OPAL_PMIX_USE_EXTERNAL,[test "x$opal_external_pmix_happy" = "xyes"])
+
     OPAL_VAR_SCOPE_POP
 ])dnl


### PR DESCRIPTION
Fixed problem in `make distclean` after configure with external `pmix, hwloc, libevent`:
```
./configure \
  --with-hwloc=/sandbox/hwloc \
  --with-libevent=/home/user/pmix/libevent-2.0.22-stable/install \
  --with-pmix=/sandbox/pmix \
  --prefix=`pwd`/install
```
Error log:
```
rm -f TAGS ID GTAGS GRTAGS GSYMS GPATH tags
rm -rf ./.deps
rm -f Makefile
make[2]: Leaving directory `/home/user/ompi_master/opal/mca/event/external'
Making distclean in mca/event/libevent2022
make[2]: Entering directory `/home/user/ompi_master/opal/mca/event/libevent2022'
Making distclean in libevent
make[3]: Entering directory `/home/user/ompi_master/opal/mca/event/libevent2022/libevent'
make[3]: *** No rule to make target `distclean'.  Stop.
make[3]: Leaving directory `/home/user/ompi_master/opal/mca/event/libevent2022/libevent'
make[2]: *** [distclean-recursive] Error 1
make[2]: Leaving directory `/home/user/ompi_master/opal/mca/event/libevent2022'
make[1]: *** [distclean-recursive] Error 1
make[1]: Leaving directory `/home/user/ompi_master/opal'
make: *** [distclean-recursive] Error 1
```