### PR TITLE
btl/openib: Disqualify rdmacm CPC if MPI_THREAD_MULTIPLE

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_rdmacm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_rdmacm.c
@@ -63,6 +63,8 @@
 #include "btl_openib_ip.h"
 #include "btl_openib_ini.h"
 
+#include "ompi/runtime/mpiruntime.h"
+
 #if BTL_OPENIB_RDMACM_IB_ADDR
 #include <stdio.h>
 #include <netinet/in.h>
@@ -1999,6 +2001,15 @@ static int rdmacm_component_query(mca_btl_openib_module_t *openib_btl, opal_btl_
 #else
     struct sockaddr_in sin;
 #endif
+
+    /* RDMACM is not supported for MPI_THREAD_MULTIPLE */
+    if (opal_using_threads()) {
+	BTL_VERBOSE(("rdmacm CPC is not supported with MPI_THREAD_MULTIPLE; skipped on %s:%d",
+		     ibv_get_device_name(openib_btl->device->ib_dev),
+		     openib_btl->port_num));
+	rc = OPAL_ERR_NOT_SUPPORTED;
+	goto out;
+    }
 
     /* RDMACM is not supported if we have any XRC QPs */
     if (mca_btl_openib_component.num_xrc_qps > 0) {


### PR DESCRIPTION
The rdmacm CPC in the openib BTL is not thread safe. The rdmacm CPC
should disqualify itself (instead of failing in random ways) if
MPI_THREAD_MULTIPLE is the thread level.

Fixes open-mpi/ompi#1848

Signed-off-by: Potnuri Bharat Teja <bharat@chelsio.com>
