### PR TITLE
Fix a bug in the handling of nper<foo> when -host or -hostfile was gi…

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -107,6 +107,8 @@ void orte_plm_base_set_slots(orte_node_t *node)
         /* must be a number */
         node->slots = strtol(orte_set_slots, NULL, 10);
     }
+    /* mark the node as having its slots "given" */
+    ORTE_FLAG_SET(node, ORTE_NODE_FLAG_SLOTS_GIVEN);
 }
 
 void orte_plm_base_daemons_reported(int fd, short args, void *cbdata)

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -105,7 +105,9 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     }
                 }
                 OPAL_LIST_DESTRUCT(&nodes);
-                nprocs += slots;
+                if (ORTE_MAPPING_PPR != ORTE_GET_MAPPING_POLICY(jdata->map->mapping)) {
+                    nprocs += slots;
+                }
             } else {
                 nprocs += app->num_procs;
             }


### PR DESCRIPTION
…ven. Correctly mark slots as "given" when we auto-assign them. Ensure we don't set the number of procs when using nper<foo> so the PPR mapper can correctly assing them.