### PR TITLE
openmpi.spec: don't export FFLAGS

### DIFF
--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
@@ -436,9 +436,8 @@ fi
 
 CFLAGS="%{?cflags:%{cflags}}%{!?cflags:$RPM_OPT_FLAGS}"
 CXXFLAGS="%{?cxxflags:%{cxxflags}}%{!?cxxflags:$RPM_OPT_FLAGS}"
-FFLAGS="%{?f77flags:%{f77flags}}%{!?f7flags:$RPM_OPT_FLAGS}"
 FCFLAGS="%{?fcflags:%{fcflags}}%{!?fcflags:$RPM_OPT_FLAGS}"
-export CFLAGS CXXFLAGS F77FLAGS FCFLAGS
+export CFLAGS CXXFLAGS FCFLAGS
 
 %configure %{configure_options}
 %{__make} %{?mflags}


### PR DESCRIPTION
The Open MPI configure script has long-since only paid attention to
FCFLAGS.  Indeed, it will warn if you set FFLAGS or F77FLAGS.  So
remove them from the spec file.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>