### PR TITLE
Fixes to shmem

### DIFF
--- a/config/oshmem_configure_options.m4
+++ b/config/oshmem_configure_options.m4
@@ -73,7 +73,7 @@ AC_DEFINE_UNQUOTED([OSHMEM_SPEC_COMPAT], [$OSHMEM_SPEC_COMPAT],
 #
 AC_MSG_CHECKING([if want OSHMEM API parameter checking])
 AC_ARG_WITH(oshmem-param-check,
-    AC_HELP_STRING([--oshmem-param-check(=VALUE)],
+    AC_HELP_STRING([--with-oshmem-param-check(=VALUE)],
                    [behavior of OSHMEM API function parameter checking.  Valid values are: always, never.  If --with-oshmem-param-check is specified with no VALUE argument, it is equivalent to a VALUE of "always"; --without-oshmem-param-check is equivalent to "never" (default: always).]))
 if test "$enable_oshmem" != "no"; then
     if test "$with_oshmem_param_check" = "no" || \
@@ -86,10 +86,11 @@ if test "$enable_oshmem" != "no"; then
         shmem_param_check=1
         AC_MSG_RESULT([always])
     else
+        shmem_param_check=1
         AC_MSG_RESULT([unknown])
         AC_MSG_WARN([*** Unrecognized --with-oshmem-param-check value])
         AC_MSG_WARN([*** See "configure --help" output])
-        AC_MSG_WARN([*** Defaulting to "runtime"])
+        AC_MSG_WARN([*** Defaulting to "always"])
     fi
 else
     shmem_param_check=0

--- a/oshmem/shmem/fortran/shmem_put_f.c
+++ b/oshmem/shmem/fortran/shmem_put_f.c
@@ -14,6 +14,7 @@
 #include "oshmem/include/shmem.h"
 #include "oshmem/shmem/shmem_api_logger.h"
 #include "oshmem/runtime/runtime.h"
+#include "oshmem/mca/spml/spml.h"
 #include "stdio.h"
 
 #if OSHMEM_PROFILING
@@ -32,9 +33,9 @@ SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
 
 void shmem_put_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
 {
-    shmem_put(FPTR_2_VOID_PTR(target),
+    MCA_SPML_CALL(put(FPTR_2_VOID_PTR(target),
         FPTR_2_VOID_PTR(source),
         OMPI_FINT_2_INT(*length),
-        OMPI_FINT_2_INT(*pe));
+        OMPI_FINT_2_INT(*pe)));
 }
 

--- a/oshmem/shmem/fortran/shmem_put_nb_f.c
+++ b/oshmem/shmem/fortran/shmem_put_nb_f.c
@@ -13,6 +13,7 @@
 #include "oshmem/include/shmem.h"
 #include "oshmem/shmem/shmem_api_logger.h"
 #include "oshmem/runtime/runtime.h"
+#include "oshmem/mca/spml/spml.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "stdio.h"
 


### PR DESCRIPTION
Dear @jladd-mlnx and @miked-mellanox ,
could You please review this PR?

The fix to `oshmem/shmem/fortran/shmem_put_f.c` has been in since the earliest logs of git's repo: I see df7654e8cfa6b147357b6e8d03bfa5b16994abba

AFAICT there are no other missing `MCA_SPML_CALL` and `MCA_ATOMIC_CALL`.
