### PR TITLE
mpi.h: fix types of MPI_UNWEIGHTED and MPI_WEIGHTS_EMPTY

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Rigde National Laboratory.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
@@ -434,8 +434,8 @@ typedef int (MPI_Grequest_cancel_function)(void *, int);
 /*
  * More constants
  */
-#define MPI_UNWEIGHTED           ((void *) 2)          /* unweighted graph */
-#define MPI_WEIGHTS_EMPTY        ((void *) 3)          /* empty weights */
+#define MPI_UNWEIGHTED           ((int *) 2)           /* unweighted graph */
+#define MPI_WEIGHTS_EMPTY        ((int *) 3)           /* empty weights */
 #define MPI_BOTTOM               ((void *) 0)          /* base reference address */
 #define MPI_IN_PLACE             ((void *) 1)          /* in place buffer */
 #define MPI_BSEND_OVERHEAD       128                   /* size of bsend header + ptr */


### PR DESCRIPTION
Thanks to @dalcinl for reporting.

Fixes open-mpi/ompi#1865.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>