### PR TITLE
Fix dynamic operations by ensuring that we only fire the debugger rel…

### DIFF
--- a/opal/mca/pmix/ext20/pmix_ext20.c
+++ b/opal/mca/pmix/ext20/pmix_ext20.c
@@ -1183,6 +1183,7 @@ static void tscon(pmix20_threadshift_t *p)
     p->event_codes = NULL;
     p->info = NULL;
     p->evhandler = NULL;
+    p-<nondefault = false;
     p->cbfunc = NULL;
     p->opcbfunc = NULL;
     p->cbdata = NULL;

--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -1239,6 +1239,7 @@ static void tscon(pmix2x_threadshift_t *p)
     p->event_codes = NULL;
     p->info = NULL;
     p->evhandler = NULL;
+    p->nondefault = false;
     p->cbfunc = NULL;
     p->opcbfunc = NULL;
     p->cbdata = NULL;

--- a/opal/mca/pmix/pmix_types.h
+++ b/opal/mca/pmix/pmix_types.h
@@ -41,9 +41,9 @@ BEGIN_C_DECLS
  * these keys are RESERVED */
 #define OPAL_PMIX_ATTR_UNDEF      NULL
 
-#define OPAL_PMIX_SERVER_TOOL_SUPPORT            "pmix.srvr.tool"       // (bool) The host RM wants to declare itself as willing to
+#define OPAL_PMIX_SERVER_TOOL_SUPPORT           "pmix.srvr.tool"        // (bool) The host RM wants to declare itself as willing to
                                                                         //        accept tool connection requests
-#define OPAL_PMIX_SERVER_PIDINFO                 "pmix.srvr.pidinfo"    // (uint32_t) pid of the target server
+#define OPAL_PMIX_SERVER_PIDINFO                "pmix.srvr.pidinfo"     // (uint32_t) pid of the target server
 
 
 /* identification attributes */
@@ -145,7 +145,7 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_EVENT_CUSTOM_RANGE            "pmix.evrange"          // (pmix_proc_t*) array of pmix_proc_t defining range of event notification
 #define OPAL_PMIX_EVENT_AFFECTED_PROC           "pmix.evproc"           // (pmix_proc_t) single proc that was affected
 #define OPAL_PMIX_EVENT_AFFECTED_PROCS          "pmix.evaffected"       // (pmix_proc_t*) array of pmix_proc_t defining affected procs
-#define OPAL_PMIX_EVENT_NON_DEFAULT             "opal.evnondef"         // (bool) event is not to be delivered to default event handlers
+#define OPAL_PMIX_EVENT_NON_DEFAULT             "pmix.evnondef"         // (bool) event is not to be delivered to default event handlers
 /* fault tolerance-related events */
 #define OPAL_PMIX_EVENT_TERMINATE_SESSION       "pmix.evterm.sess"      // (bool) RM intends to terminate session
 #define OPAL_PMIX_EVENT_TERMINATE_JOB           "pmix.evterm.job"       // (bool) RM intends to terminate this job

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -2367,23 +2367,28 @@ void orte_debugger_init_after_spawn(int fd, short event, void *cbdata)
      * message by checking here
      */
     if (MPIR_proctable || 0 == jdata->num_procs) {
+
         /* already initialized */
         opal_output_verbose(5, orte_debug_output,
                             "%s: debugger already initialized or zero procs",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
-        OBJ_RELEASE(caddy);
-        if (!mpir_breakpoint_fired) {
-            /* record that we have triggered the debugger */
-            mpir_breakpoint_fired = true;
 
-            /* trigger the debugger */
-            MPIR_Breakpoint();
+        if (MPIR_being_debugged || NULL != orte_debugger_test_daemon ||
+            NULL != getenv("ORTE_TEST_DEBUGGER_ATTACH")) {
+            OBJ_RELEASE(caddy);
+            if (!mpir_breakpoint_fired) {
+                /* record that we have triggered the debugger */
+                mpir_breakpoint_fired = true;
 
-            opal_output_verbose(5, orte_debug_output,
-                                "%s NOTIFYING DEBUGGER RELEASE",
-                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
-            /* notify all procs that the debugger is ready */
-            _send_notification();
+                /* trigger the debugger */
+                MPIR_Breakpoint();
+
+                opal_output_verbose(5, orte_debug_output,
+                                    "%s NOTIFYING DEBUGGER RELEASE",
+                                    ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+                /* notify all procs that the debugger is ready */
+                _send_notification();
+            }
         }
         return;
     }


### PR DESCRIPTION
…ease if the debugger is attached, and that the OPAL pmix key for directing events to non-default handlers matches the PMIx spelling