### PR TITLE
pmix: replace all tabs with spaces

### DIFF
--- a/opal/mca/pmix/base/pmix_base_fns.c
+++ b/opal/mca/pmix/base/pmix_base_fns.c
@@ -7,6 +7,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,42 +52,42 @@ void opal_pmix_base_set_evbase(opal_event_base_t *evbase)
 static opal_pmix_notification_fn_t evhandler = NULL;
 
 void opal_pmix_base_register_handler(opal_list_t *event_codes,
-                                     opal_list_t *info,
-                                     opal_pmix_notification_fn_t err,
-                                     opal_pmix_evhandler_reg_cbfunc_t cbfunc,
-                                     void *cbdata)
+				     opal_list_t *info,
+				     opal_pmix_notification_fn_t err,
+				     opal_pmix_evhandler_reg_cbfunc_t cbfunc,
+				     void *cbdata)
 {
     evhandler = err;
     if (NULL != cbfunc) {
-        cbfunc(OPAL_SUCCESS, 0, cbdata);
+	cbfunc(OPAL_SUCCESS, 0, cbdata);
     }
 }
 
 void opal_pmix_base_evhandler(int status,
-                              const opal_process_name_t *source,
-                              opal_list_t *info, opal_list_t *results,
-                              opal_pmix_notification_complete_fn_t cbfunc, void *cbdata)
+			      const opal_process_name_t *source,
+			      opal_list_t *info, opal_list_t *results,
+			      opal_pmix_notification_complete_fn_t cbfunc, void *cbdata)
 {
     if (NULL != evhandler) {
-        evhandler(status, source, info, results, cbfunc, cbdata);
+	evhandler(status, source, info, results, cbfunc, cbdata);
     }
 }
 
 void opal_pmix_base_deregister_handler(size_t errid,
-                                       opal_pmix_op_cbfunc_t cbfunc,
-                                       void *cbdata)
+				       opal_pmix_op_cbfunc_t cbfunc,
+				       void *cbdata)
 {
     evhandler = NULL;
     if (NULL != cbfunc) {
-        cbfunc(OPAL_SUCCESS, cbdata);
+	cbfunc(OPAL_SUCCESS, cbdata);
     }
 }
 
 int opal_pmix_base_notify_event(int status,
-                                const opal_process_name_t *source,
-                                opal_pmix_data_range_t range,
-                                opal_list_t *info,
-                                opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+				const opal_process_name_t *source,
+				opal_pmix_data_range_t range,
+				opal_list_t *info,
+				opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_SUCCESS;
 }
@@ -103,20 +104,20 @@ static void lookup_cbfunc(int status, opal_list_t *data, void *cbdata)
     struct lookup_caddy_t *cd = (struct lookup_caddy_t*)cbdata;
     cd->status = status;
     if (OPAL_SUCCESS == status && NULL != data) {
-        opal_pmix_pdata_t *p = (opal_pmix_pdata_t*)opal_list_get_first(data);
-        if (NULL != p) {
-            cd->pdat->proc = p->proc;
-            if (p->value.type == cd->pdat->value.type) {
-                (void)opal_value_xfer(&cd->pdat->value, &p->value);
-            }
-        }
+	opal_pmix_pdata_t *p = (opal_pmix_pdata_t*)opal_list_get_first(data);
+	if (NULL != p) {
+	    cd->pdat->proc = p->proc;
+	    if (p->value.type == cd->pdat->value.type) {
+		(void)opal_value_xfer(&cd->pdat->value, &p->value);
+	    }
+	}
     }
     cd->active = false;
 }
 
 int opal_pmix_base_exchange(opal_value_t *indat,
-                            opal_pmix_pdata_t *outdat,
-                            int timeout)
+			    opal_pmix_pdata_t *outdat,
+			    int timeout)
 {
     int rc;
     opal_list_t ilist, mlist;
@@ -140,8 +141,8 @@ int opal_pmix_base_exchange(opal_value_t *indat,
     rc = opal_pmix.publish(&ilist);
     OPAL_LIST_DESTRUCT(&ilist);
     if (OPAL_SUCCESS != rc) {
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
 
    /* lookup the other side's info - if a non-blocking form
@@ -162,49 +163,49 @@ int opal_pmix_base_exchange(opal_value_t *indat,
     info->data.flag = true;
     opal_list_append(&mlist, &info->super);
     if (0 < timeout) {
-        /* give it a decent timeout as we don't know when
-         * the other side will publish - it doesn't
-         * have to be simultaneous */
-        info = OBJ_NEW(opal_value_t);
-        info->key = strdup(OPAL_PMIX_TIMEOUT);
-        info->type = OPAL_INT;
-        info->data.integer = timeout;
-        opal_list_append(&mlist, &info->super);
+	/* give it a decent timeout as we don't know when
+	 * the other side will publish - it doesn't
+	 * have to be simultaneous */
+	info = OBJ_NEW(opal_value_t);
+	info->key = strdup(OPAL_PMIX_TIMEOUT);
+	info->type = OPAL_INT;
+	info->data.integer = timeout;
+	opal_list_append(&mlist, &info->super);
     }
 
     /* if a non-blocking version of lookup isn't
      * available, then use the blocking version */
     if (NULL == opal_pmix.lookup_nb) {
-        rc = opal_pmix.lookup(&ilist, &mlist);
-        OPAL_LIST_DESTRUCT(&mlist);
-        if (OPAL_SUCCESS != rc) {
-            OPAL_ERROR_LOG(rc);
-            OPAL_LIST_DESTRUCT(&ilist);
-            return rc;
-        }
+	rc = opal_pmix.lookup(&ilist, &mlist);
+	OPAL_LIST_DESTRUCT(&mlist);
+	if (OPAL_SUCCESS != rc) {
+	    OPAL_ERROR_LOG(rc);
+	    OPAL_LIST_DESTRUCT(&ilist);
+	    return rc;
+	}
     } else {
-        caddy.active = true;
-        caddy.pdat = pdat;
-        keys = NULL;
-        opal_argv_append_nosize(&keys, pdat->value.key);
-        rc = opal_pmix.lookup_nb(keys, &mlist, lookup_cbfunc, &caddy);
-        if (OPAL_SUCCESS != rc) {
-            OPAL_ERROR_LOG(rc);
-            OPAL_LIST_DESTRUCT(&ilist);
-            OPAL_LIST_DESTRUCT(&mlist);
-            opal_argv_free(keys);
-            return rc;
-        }
-        while (caddy.active) {
-            usleep(10);
-        }
-        opal_argv_free(keys);
-        OPAL_LIST_DESTRUCT(&mlist);
-        if (OPAL_SUCCESS != caddy.status) {
-            OPAL_ERROR_LOG(caddy.status);
-            OPAL_LIST_DESTRUCT(&ilist);
-            return caddy.status;
-        }
+	caddy.active = true;
+	caddy.pdat = pdat;
+	keys = NULL;
+	opal_argv_append_nosize(&keys, pdat->value.key);
+	rc = opal_pmix.lookup_nb(keys, &mlist, lookup_cbfunc, &caddy);
+	if (OPAL_SUCCESS != rc) {
+	    OPAL_ERROR_LOG(rc);
+	    OPAL_LIST_DESTRUCT(&ilist);
+	    OPAL_LIST_DESTRUCT(&mlist);
+	    opal_argv_free(keys);
+	    return rc;
+	}
+	while (caddy.active) {
+	    usleep(10);
+	}
+	opal_argv_free(keys);
+	OPAL_LIST_DESTRUCT(&mlist);
+	if (OPAL_SUCCESS != caddy.status) {
+	    OPAL_ERROR_LOG(caddy.status);
+	    OPAL_LIST_DESTRUCT(&ilist);
+	    return caddy.status;
+	}
     }
 
     /* pass back the result */
@@ -222,7 +223,7 @@ static char *pmi_encode(const void *val, size_t vallen);
 static uint8_t *pmi_decode (const char *data, size_t *retlen);
 
 int opal_pmix_base_store_encoded(const char *key, const void *data,
-                                 opal_data_type_t type, char** buffer, int* length)
+				 opal_data_type_t type, char** buffer, int* length)
 {
     opal_byte_object_t *bo;
     size_t data_len = 0;
@@ -232,56 +233,56 @@ int opal_pmix_base_store_encoded(const char *key, const void *data,
     char* pmi_packed_data = *buffer;
 
     switch (type) {
-        case OPAL_STRING:
-        {
-            char *ptr = *(char **)data;
-            data_len = ptr ? strlen(ptr) + 1 : 0;
-            data = ptr;
-            break;
-        }
-        case OPAL_INT:
-        case OPAL_UINT:
-            data_len = sizeof (int);
-            break;
-        case OPAL_INT16:
-        case OPAL_UINT16:
-            data_len = sizeof (int16_t);
-            break;
-        case OPAL_INT32:
-        case OPAL_UINT32:
-            data_len = sizeof (int32_t);
-            break;
-        case OPAL_INT64:
-        case OPAL_UINT64:
-            data_len = sizeof (int64_t);
-            break;
-        case OPAL_BYTE_OBJECT:
-            bo = (opal_byte_object_t *) data;
-            data = bo->bytes;
-            data_len = bo->size;
+	case OPAL_STRING:
+	{
+	    char *ptr = *(char **)data;
+	    data_len = ptr ? strlen(ptr) + 1 : 0;
+	    data = ptr;
+	    break;
+	}
+	case OPAL_INT:
+	case OPAL_UINT:
+	    data_len = sizeof (int);
+	    break;
+	case OPAL_INT16:
+	case OPAL_UINT16:
+	    data_len = sizeof (int16_t);
+	    break;
+	case OPAL_INT32:
+	case OPAL_UINT32:
+	    data_len = sizeof (int32_t);
+	    break;
+	case OPAL_INT64:
+	case OPAL_UINT64:
+	    data_len = sizeof (int64_t);
+	    break;
+	case OPAL_BYTE_OBJECT:
+	    bo = (opal_byte_object_t *) data;
+	    data = bo->bytes;
+	    data_len = bo->size;
     }
 
     needed = 10 + data_len + strlen (key);
 
     if (NULL == pmi_packed_data) {
-        pmi_packed_data = calloc (needed, 1);
+	pmi_packed_data = calloc (needed, 1);
     } else {
-        /* grow the region */
-        pmi_packed_data = realloc (pmi_packed_data, pmi_packed_data_off + needed);
+	/* grow the region */
+	pmi_packed_data = realloc (pmi_packed_data, pmi_packed_data_off + needed);
     }
 
     /* special length meaning NULL */
     if (NULL == data) {
-        data_len = 0xffff;
+	data_len = 0xffff;
     }
 
     /* serialize the opal datatype */
     pmi_packed_data_off += sprintf (pmi_packed_data + pmi_packed_data_off,
-            "%s%c%02x%c%04x%c", key, '\0', type, '\0',
-            (int) data_len, '\0');
+	    "%s%c%02x%c%04x%c", key, '\0', type, '\0',
+	    (int) data_len, '\0');
     if (NULL != data) {
-        memmove (pmi_packed_data + pmi_packed_data_off, data, data_len);
-        pmi_packed_data_off += data_len;
+	memmove (pmi_packed_data + pmi_packed_data_off, data, data_len);
+	pmi_packed_data_off += data_len;
     }
 
     *length = pmi_packed_data_off;
@@ -290,8 +291,8 @@ int opal_pmix_base_store_encoded(const char *key, const void *data,
 }
 
 int opal_pmix_base_commit_packed( char** data, int* data_offset,
-                                  char** enc_data, int* enc_data_offset,
-                                  int max_key, int* pack_key, kvs_put_fn fn)
+				  char** enc_data, int* enc_data_offset,
+				  int max_key, int* pack_key, kvs_put_fn fn)
 {
     int rc;
     char *pmikey = NULL, *tmp;
@@ -304,45 +305,45 @@ int opal_pmix_base_commit_packed( char** data, int* data_offset,
     pkey = *pack_key;
 
     if (NULL == (tmp = malloc(max_key))) {
-        OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
+	return OPAL_ERR_OUT_OF_RESOURCE;
     }
     data_len = *data_offset;
     if (NULL == (encoded_data = pmi_encode(*data, data_len))) {
-        OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
-        free(tmp);
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
+	free(tmp);
+	return OPAL_ERR_OUT_OF_RESOURCE;
     }
     *data = NULL;
     *data_offset = 0;
 
     encoded_data_len = (int)strlen(encoded_data);
     while (encoded_data_len+*enc_data_offset > max_key - 2) {
-        memcpy(tmp, *enc_data, *enc_data_offset);
-        memcpy(tmp+*enc_data_offset, encoded_data, max_key-*enc_data_offset-1);
-        tmp[max_key-1] = 0;
+	memcpy(tmp, *enc_data, *enc_data_offset);
+	memcpy(tmp+*enc_data_offset, encoded_data, max_key-*enc_data_offset-1);
+	tmp[max_key-1] = 0;
 
-        sprintf (tmp_key, "key%d", pkey);
+	sprintf (tmp_key, "key%d", pkey);
 
-        if (NULL == (pmikey = setup_key(&OPAL_PROC_MY_NAME, tmp_key, max_key))) {
-            OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
-            rc = OPAL_ERR_BAD_PARAM;
-            break;
-        }
+	if (NULL == (pmikey = setup_key(&OPAL_PROC_MY_NAME, tmp_key, max_key))) {
+	    OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
+	    rc = OPAL_ERR_BAD_PARAM;
+	    break;
+	}
 
-        rc = fn(pmikey, tmp);
-        free(pmikey);
-        if (OPAL_SUCCESS != rc) {
-            *pack_key = pkey;
-            free(tmp);
-            free(encoded_data);
-            return rc;
-        }
+	rc = fn(pmikey, tmp);
+	free(pmikey);
+	if (OPAL_SUCCESS != rc) {
+	    *pack_key = pkey;
+	    free(tmp);
+	    free(encoded_data);
+	    return rc;
+	}
 
-        pkey++;
-        memmove(encoded_data, encoded_data+max_key-1-*enc_data_offset, encoded_data_len - max_key + *enc_data_offset + 2);
-        *enc_data_offset = 0;
-        encoded_data_len = (int)strlen(encoded_data);
+	pkey++;
+	memmove(encoded_data, encoded_data+max_key-1-*enc_data_offset, encoded_data_len - max_key + *enc_data_offset + 2);
+	*enc_data_offset = 0;
+	encoded_data_len = (int)strlen(encoded_data);
     }
     memcpy(tmp, *enc_data, *enc_data_offset);
     memcpy(tmp+*enc_data_offset, encoded_data, encoded_data_len+1);
@@ -353,18 +354,18 @@ int opal_pmix_base_commit_packed( char** data, int* data_offset,
     sprintf (tmp_key, "key%d", pkey);
 
     if (NULL == (pmikey = setup_key(&OPAL_PROC_MY_NAME, tmp_key, max_key))) {
-        OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
-        rc = OPAL_ERR_BAD_PARAM;
-        free(tmp);
-        return rc;
+	OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
+	rc = OPAL_ERR_BAD_PARAM;
+	free(tmp);
+	return rc;
     }
 
     rc = fn(pmikey, tmp);
     free(pmikey);
     if (OPAL_SUCCESS != rc) {
-        *pack_key = pkey;
-        free(tmp);
-        return rc;
+	*pack_key = pkey;
+	free(tmp);
+	return rc;
     }
 
     pkey++;
@@ -373,17 +374,17 @@ int opal_pmix_base_commit_packed( char** data, int* data_offset,
     *data_offset = 0;
     free(tmp);
     if (NULL != *enc_data) {
-        free(*enc_data);
-        *enc_data = NULL;
-        *enc_data_offset = 0;
+	free(*enc_data);
+	*enc_data = NULL;
+	*enc_data_offset = 0;
     }
     *pack_key = pkey;
     return OPAL_SUCCESS;
 }
 
 int opal_pmix_base_partial_commit_packed( char** data, int* data_offset,
-                                          char** enc_data, int* enc_data_offset,
-                                          int max_key, int* pack_key, kvs_put_fn fn)
+					  char** enc_data, int* enc_data_offset,
+					  int max_key, int* pack_key, kvs_put_fn fn)
 {
     int rc;
     char *pmikey = NULL, *tmp;
@@ -396,55 +397,55 @@ int opal_pmix_base_partial_commit_packed( char** data, int* data_offset,
     pkey = *pack_key;
 
     if (NULL == (tmp = malloc(max_key))) {
-        OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
+	return OPAL_ERR_OUT_OF_RESOURCE;
     }
     data_len = *data_offset - (*data_offset%3);
     if (NULL == (encoded_data = pmi_encode(*data, data_len))) {
-        OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
-        free(tmp);
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
+	free(tmp);
+	return OPAL_ERR_OUT_OF_RESOURCE;
     }
     if (*data_offset == data_len) {
-        *data = NULL;
-        *data_offset = 0;
+	*data = NULL;
+	*data_offset = 0;
     } else {
-        memmove(*data, *data+data_len, *data_offset - data_len);
-        *data = realloc(*data, *data_offset - data_len);
-        *data_offset -= data_len;
+	memmove(*data, *data+data_len, *data_offset - data_len);
+	*data = realloc(*data, *data_offset - data_len);
+	*data_offset -= data_len;
     }
 
     encoded_data_len = (int)strlen(encoded_data);
     while (encoded_data_len+*enc_data_offset > max_key - 2) {
-        memcpy(tmp, *enc_data, *enc_data_offset);
-        memcpy(tmp+*enc_data_offset, encoded_data, max_key-*enc_data_offset-1);
-        tmp[max_key-1] = 0;
+	memcpy(tmp, *enc_data, *enc_data_offset);
+	memcpy(tmp+*enc_data_offset, encoded_data, max_key-*enc_data_offset-1);
+	tmp[max_key-1] = 0;
 
-        sprintf (tmp_key, "key%d", pkey);
+	sprintf (tmp_key, "key%d", pkey);
 
-        if (NULL == (pmikey = setup_key(&OPAL_PROC_MY_NAME, tmp_key, max_key))) {
-            OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
-            rc = OPAL_ERR_BAD_PARAM;
-            break;
-        }
+	if (NULL == (pmikey = setup_key(&OPAL_PROC_MY_NAME, tmp_key, max_key))) {
+	    OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
+	    rc = OPAL_ERR_BAD_PARAM;
+	    break;
+	}
 
-        rc = fn(pmikey, tmp);
-        free(pmikey);
-        if (OPAL_SUCCESS != rc) {
-            *pack_key = pkey;
-            free(tmp);
-            free(encoded_data);
-            return rc;
-        }
+	rc = fn(pmikey, tmp);
+	free(pmikey);
+	if (OPAL_SUCCESS != rc) {
+	    *pack_key = pkey;
+	    free(tmp);
+	    free(encoded_data);
+	    return rc;
+	}
 
-        pkey++;
-        memmove(encoded_data, encoded_data+max_key-1-*enc_data_offset, encoded_data_len - max_key + *enc_data_offset + 2);
-        *enc_data_offset = 0;
-        encoded_data_len = (int)strlen(encoded_data);
+	pkey++;
+	memmove(encoded_data, encoded_data+max_key-1-*enc_data_offset, encoded_data_len - max_key + *enc_data_offset + 2);
+	*enc_data_offset = 0;
+	encoded_data_len = (int)strlen(encoded_data);
     }
     free(tmp);
     if (NULL != *enc_data) {
-        free(*enc_data);
+	free(*enc_data);
     }
     *enc_data = realloc(encoded_data, strlen(encoded_data)+1);
     *enc_data_offset = strlen(encoded_data);
@@ -453,7 +454,7 @@ int opal_pmix_base_partial_commit_packed( char** data, int* data_offset,
 }
 
 int opal_pmix_base_get_packed(const opal_process_name_t* proc, char **packed_data,
-                              size_t *len, int vallen, kvs_get_fn fn)
+			      size_t *len, int vallen, kvs_get_fn fn)
 {
     char *tmp_encoded = NULL, *pmikey, *pmi_tmp;
     int remote_key, size;
@@ -466,71 +467,71 @@ int opal_pmix_base_get_packed(const opal_process_name_t* proc, char **packed_dat
 
     pmi_tmp = calloc (vallen, 1);
     if (NULL == pmi_tmp) {
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
     /* read all of the packed data from this proc */
     for (remote_key = 0, bytes_read = 0 ; ; ++remote_key) {
-        char tmp_key[32];
+	char tmp_key[32];
 
-        sprintf (tmp_key, "key%d", remote_key);
+	sprintf (tmp_key, "key%d", remote_key);
 
-        if (NULL == (pmikey = setup_key(proc, tmp_key, vallen))) {
-            rc = OPAL_ERR_OUT_OF_RESOURCE;
-            OPAL_ERROR_LOG(rc);
-            free(pmi_tmp);
-            if (NULL != tmp_encoded) {
-                free(tmp_encoded);
-            }
-            return rc;
-        }
+	if (NULL == (pmikey = setup_key(proc, tmp_key, vallen))) {
+	    rc = OPAL_ERR_OUT_OF_RESOURCE;
+	    OPAL_ERROR_LOG(rc);
+	    free(pmi_tmp);
+	    if (NULL != tmp_encoded) {
+		free(tmp_encoded);
+	    }
+	    return rc;
+	}
 
-        OPAL_OUTPUT_VERBOSE((10, opal_pmix_base_framework.framework_output,
-                             "GETTING KEY %s", pmikey));
+	OPAL_OUTPUT_VERBOSE((10, opal_pmix_base_framework.framework_output,
+			     "GETTING KEY %s", pmikey));
 
-        rc = fn(pmikey, pmi_tmp, vallen);
-        free (pmikey);
-        if (OPAL_SUCCESS != rc) {
-            break;
-        }
+	rc = fn(pmikey, pmi_tmp, vallen);
+	free (pmikey);
+	if (OPAL_SUCCESS != rc) {
+	    break;
+	}
 
-        size = strlen (pmi_tmp);
+	size = strlen (pmi_tmp);
 
-        if (NULL == tmp_encoded) {
-            tmp_encoded = malloc (size + 1);
-        } else {
-            tmp_encoded = realloc (tmp_encoded, bytes_read + size + 1);
-        }
+	if (NULL == tmp_encoded) {
+	    tmp_encoded = malloc (size + 1);
+	} else {
+	    tmp_encoded = realloc (tmp_encoded, bytes_read + size + 1);
+	}
 
-        strcpy (tmp_encoded + bytes_read, pmi_tmp);
-        bytes_read += size;
+	strcpy (tmp_encoded + bytes_read, pmi_tmp);
+	bytes_read += size;
 
-        /* is the string terminator present? */
-        if ('-' == tmp_encoded[bytes_read-1]) {
-            break;
-        }
+	/* is the string terminator present? */
+	if ('-' == tmp_encoded[bytes_read-1]) {
+	    break;
+	}
     }
 
     free (pmi_tmp);
 
     OPAL_OUTPUT_VERBOSE((10, opal_pmix_base_framework.framework_output,
-                         "Read data %s\n",
-                         (NULL == tmp_encoded) ? "NULL" : tmp_encoded));
+			 "Read data %s\n",
+			 (NULL == tmp_encoded) ? "NULL" : tmp_encoded));
 
     if (NULL != tmp_encoded) {
-        *packed_data = (char *) pmi_decode (tmp_encoded, len);
-        free (tmp_encoded);
-        if (NULL == *packed_data) {
-            return OPAL_ERR_OUT_OF_RESOURCE;
-        }
+	*packed_data = (char *) pmi_decode (tmp_encoded, len);
+	free (tmp_encoded);
+	if (NULL == *packed_data) {
+	    return OPAL_ERR_OUT_OF_RESOURCE;
+	}
     }
 
     return rc;
 }
 
 int opal_pmix_base_cache_keys_locally(const opal_process_name_t* id, const char* key,
-                                      opal_value_t **out_kv, char* kvs_name,
-                                      int vallen, kvs_get_fn fn)
+				      opal_value_t **out_kv, char* kvs_name,
+				      int vallen, kvs_get_fn fn)
 {
     char *tmp, *tmp2, *tmp3, *tmp_val;
     opal_data_type_t stored_type;
@@ -546,119 +547,119 @@ int opal_pmix_base_cache_keys_locally(const opal_process_name_t* id, const char*
     OBJ_CONSTRUCT(&values, opal_list_t);
     rc = opal_pmix_base_fetch(id, key, &values);
     if (OPAL_SUCCESS == rc) {
-        kv = (opal_value_t*)opal_list_get_first(&values);
-        /* create the copy */
-        if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&knew, kv, OPAL_VALUE))) {
-            OPAL_ERROR_LOG(rc);
-        } else {
-            *out_kv = knew;
-        }
-        OPAL_LIST_DESTRUCT(&values);
-        return rc;
+	kv = (opal_value_t*)opal_list_get_first(&values);
+	/* create the copy */
+	if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&knew, kv, OPAL_VALUE))) {
+	    OPAL_ERROR_LOG(rc);
+	} else {
+	    *out_kv = knew;
+	}
+	OPAL_LIST_DESTRUCT(&values);
+	return rc;
     }
     OPAL_LIST_DESTRUCT(&values);
 
     OPAL_OUTPUT_VERBOSE((1, opal_pmix_base_framework.framework_output,
-                         "pmix: get all keys for proc %s in KVS %s",
-                         OPAL_NAME_PRINT(*id), kvs_name));
+			 "pmix: get all keys for proc %s in KVS %s",
+			 OPAL_NAME_PRINT(*id), kvs_name));
 
     rc = opal_pmix_base_get_packed(id, &tmp_val, &len, vallen, fn);
     if (OPAL_SUCCESS != rc) {
-        return rc;
+	return rc;
     }
 
     /* search for each key in the decoded data */
     for (offset = 0 ; offset < len ; ) {
-        /* type */
-        tmp = tmp_val + offset + strlen (tmp_val + offset) + 1;
-        /* size */
-        tmp2 = tmp + strlen (tmp) + 1;
-        /* data */
-        tmp3 = tmp2 + strlen (tmp2) + 1;
+	/* type */
+	tmp = tmp_val + offset + strlen (tmp_val + offset) + 1;
+	/* size */
+	tmp2 = tmp + strlen (tmp) + 1;
+	/* data */
+	tmp3 = tmp2 + strlen (tmp2) + 1;
 
-        stored_type = (opal_data_type_t) strtol (tmp, NULL, 16);
-        size = strtol (tmp2, NULL, 16);
-        /* cache value locally so we don't have to look it up via pmi again */
-        kv = OBJ_NEW(opal_value_t);
-        kv->key = strdup(tmp_val + offset);
-        kv->type = stored_type;
+	stored_type = (opal_data_type_t) strtol (tmp, NULL, 16);
+	size = strtol (tmp2, NULL, 16);
+	/* cache value locally so we don't have to look it up via pmi again */
+	kv = OBJ_NEW(opal_value_t);
+	kv->key = strdup(tmp_val + offset);
+	kv->type = stored_type;
 
-        switch (stored_type) {
-            case OPAL_BYTE:
-                kv->data.byte = *tmp3;
-                break;
-            case OPAL_STRING:
-                kv->data.string = strdup(tmp3);
-                break;
-            case OPAL_PID:
-                kv->data.pid = strtoul(tmp3, NULL, 10);
-                break;
-            case OPAL_INT:
-                kv->data.integer = strtol(tmp3, NULL, 10);
-                break;
-            case OPAL_INT8:
-                kv->data.int8 = strtol(tmp3, NULL, 10);
-                break;
-            case OPAL_INT16:
-                kv->data.int16 = strtol(tmp3, NULL, 10);
-                break;
-            case OPAL_INT32:
-                kv->data.int32 = strtol(tmp3, NULL, 10);
-                break;
-            case OPAL_INT64:
-                kv->data.int64 = strtol(tmp3, NULL, 10);
-                break;
-            case OPAL_UINT:
-                kv->data.uint = strtoul(tmp3, NULL, 10);
-                break;
-            case OPAL_UINT8:
-                kv->data.uint8 = strtoul(tmp3, NULL, 10);
-                break;
-            case OPAL_UINT16:
-                kv->data.uint16 = strtoul(tmp3, NULL, 10);
-                break;
-            case OPAL_UINT32:
-                kv->data.uint32 = strtoul(tmp3, NULL, 10);
-                break;
-            case OPAL_UINT64:
-                kv->data.uint64 = strtoull(tmp3, NULL, 10);
-                break;
-            case OPAL_BYTE_OBJECT:
-                if (size == 0xffff) {
-                    kv->data.bo.bytes = NULL;
-                    kv->data.bo.size = 0;
-                    size = 0;
-                } else {
-                    kv->data.bo.bytes = malloc(size);
-                    memcpy(kv->data.bo.bytes, tmp3, size);
-                    kv->data.bo.size = size;
-                }
-                break;
-            default:
-                opal_output(0, "UNSUPPORTED TYPE %d", stored_type);
-                return OPAL_ERROR;
-        }
-        /* store data in local hash table */
-        if (OPAL_SUCCESS != (rc = opal_pmix_base_store(id, kv))) {
-            OPAL_ERROR_LOG(rc);
-        }
-        /* keep going and cache everything locally */
-        offset = (size_t) (tmp3 - tmp_val) + size;
-        if (0 == strcmp(kv->key, key)) {
-            /* create the copy */
-            if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&knew, kv, OPAL_VALUE))) {
-                OPAL_ERROR_LOG(rc);
-            } else {
-                *out_kv = knew;
-            }
-        }
+	switch (stored_type) {
+	    case OPAL_BYTE:
+		kv->data.byte = *tmp3;
+		break;
+	    case OPAL_STRING:
+		kv->data.string = strdup(tmp3);
+		break;
+	    case OPAL_PID:
+		kv->data.pid = strtoul(tmp3, NULL, 10);
+		break;
+	    case OPAL_INT:
+		kv->data.integer = strtol(tmp3, NULL, 10);
+		break;
+	    case OPAL_INT8:
+		kv->data.int8 = strtol(tmp3, NULL, 10);
+		break;
+	    case OPAL_INT16:
+		kv->data.int16 = strtol(tmp3, NULL, 10);
+		break;
+	    case OPAL_INT32:
+		kv->data.int32 = strtol(tmp3, NULL, 10);
+		break;
+	    case OPAL_INT64:
+		kv->data.int64 = strtol(tmp3, NULL, 10);
+		break;
+	    case OPAL_UINT:
+		kv->data.uint = strtoul(tmp3, NULL, 10);
+		break;
+	    case OPAL_UINT8:
+		kv->data.uint8 = strtoul(tmp3, NULL, 10);
+		break;
+	    case OPAL_UINT16:
+		kv->data.uint16 = strtoul(tmp3, NULL, 10);
+		break;
+	    case OPAL_UINT32:
+		kv->data.uint32 = strtoul(tmp3, NULL, 10);
+		break;
+	    case OPAL_UINT64:
+		kv->data.uint64 = strtoull(tmp3, NULL, 10);
+		break;
+	    case OPAL_BYTE_OBJECT:
+		if (size == 0xffff) {
+		    kv->data.bo.bytes = NULL;
+		    kv->data.bo.size = 0;
+		    size = 0;
+		} else {
+		    kv->data.bo.bytes = malloc(size);
+		    memcpy(kv->data.bo.bytes, tmp3, size);
+		    kv->data.bo.size = size;
+		}
+		break;
+	    default:
+		opal_output(0, "UNSUPPORTED TYPE %d", stored_type);
+		return OPAL_ERROR;
+	}
+	/* store data in local hash table */
+	if (OPAL_SUCCESS != (rc = opal_pmix_base_store(id, kv))) {
+	    OPAL_ERROR_LOG(rc);
+	}
+	/* keep going and cache everything locally */
+	offset = (size_t) (tmp3 - tmp_val) + size;
+	if (0 == strcmp(kv->key, key)) {
+	    /* create the copy */
+	    if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&knew, kv, OPAL_VALUE))) {
+		OPAL_ERROR_LOG(rc);
+	    } else {
+		*out_kv = knew;
+	    }
+	}
     }
     free (tmp_val);
     /* if there was no issue with unpacking the message, but
      * we didn't find the requested info, then indicate that
      * the info wasn't found */
     if (OPAL_SUCCESS == rc && NULL == *out_kv) {
-        return OPAL_ERR_NOT_FOUND;
+	return OPAL_ERR_NOT_FOUND;
     }
     return rc;
 }
@@ -668,9 +669,9 @@ static char* setup_key(const opal_process_name_t* name, const char *key, int pmi
     char *pmi_kvs_key;
 
     if (pmix_keylen_max <= asprintf(&pmi_kvs_key, "%" PRIu32 "-%" PRIu32 "-%s",
-                                        name->jobid, name->vpid, key)) {
-        free(pmi_kvs_key);
-        return NULL;
+					name->jobid, name->vpid, key)) {
+	free(pmi_kvs_key);
+	return NULL;
     }
 
     return pmi_kvs_key;
@@ -681,11 +682,11 @@ static inline unsigned char pmi_base64_encsym (unsigned char value) {
     assert (value < 64);
 
     if (value < 26) {
-        return 'A' + value;
+	return 'A' + value;
     } else if (value < 52) {
-        return 'a' + (value - 26);
+	return 'a' + (value - 26);
     } else if (value < 62) {
-        return '0' + (value - 52);
+	return '0' + (value - 52);
     }
 
     return (62 == value) ? '+' : '/';
@@ -693,17 +694,17 @@ static inline unsigned char pmi_base64_encsym (unsigned char value) {
 
 static inline unsigned char pmi_base64_decsym (unsigned char value) {
     if ('+' == value) {
-        return 62;
+	return 62;
     } else if ('/' == value) {
-        return 63;
+	return 63;
     } else if (' ' == value) {
-        return 64;
+	return 64;
     } else if (value <= '9') {
-        return (value - '0') + 52;
+	return (value - '0') + 52;
     } else if (value <= 'Z') {
-        return (value - 'A');
+	return (value - 'A');
     } else if (value <= 'z') {
-        return (value - 'a') + 26;
+	return (value - 'a') + 26;
     }
     return 64;
 }
@@ -726,12 +727,12 @@ static inline int pmi_base64_decode_block (const char in[4], unsigned char out[3
 
     out[0] = in_dec[0] << 2 | in_dec[1] >> 4;
     if (64 == in_dec[2]) {
-        return 1;
+	return 1;
     }
 
     out[1] = in_dec[1] << 4 | in_dec[2] >> 2;
     if (64 == in_dec[3]) {
-        return 2;
+	return 2;
     }
 
     out[2] = ((in_dec[2] << 6) & 0xc0) | in_dec[3];
@@ -747,11 +748,11 @@ static char *pmi_encode(const void *val, size_t vallen)
 
     outdata = calloc (((2 + vallen) * 4) / 3 + 2, 1);
     if (NULL == outdata) {
-        return NULL;
+	return NULL;
     }
 
     for (i = 0, tmp = outdata ; i < vallen ; i += 3, tmp += 4) {
-        pmi_base64_encode_block((unsigned char *) val + i, tmp, vallen - i);
+	pmi_base64_encode_block((unsigned char *) val + i, tmp, vallen - i);
     }
 
     tmp[0] = (unsigned char)'\0';
@@ -771,10 +772,10 @@ static uint8_t *pmi_decode (const char *data, size_t *retlen)
 
     ret = calloc (1, 3 * input_len);
     if (NULL == ret) {
-        return ret;
+	return ret;
     }
     for (i = 0, out_len = 0 ; i < input_len ; i++, data += 4) {
-        out_len += pmi_base64_decode_block(data, ret + 3 * i);
+	out_len += pmi_base64_decode_block(data, ret + 3 * i);
     }
     *retlen = out_len;
     return ret;

--- a/opal/mca/pmix/base/pmix_base_frame.c
+++ b/opal/mca/pmix/base/pmix_base_frame.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,12 +41,12 @@ static int opal_pmix_base_frame_register(mca_base_register_flag_t flags)
 {
     opal_pmix_base_async_modex = false;
     (void) mca_base_var_register("opal", "pmix", "base", "async_modex", "Use asynchronous modex mode",
-                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_9,
-                                 MCA_BASE_VAR_SCOPE_READONLY, &opal_pmix_base_async_modex);
+				 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_9,
+				 MCA_BASE_VAR_SCOPE_READONLY, &opal_pmix_base_async_modex);
     opal_pmix_collect_all_data = true;
     (void) mca_base_var_register("opal", "pmix", "base", "collect_data", "Collect all data during modex",
-                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_9,
-                                 MCA_BASE_VAR_SCOPE_READONLY, &opal_pmix_collect_all_data);
+				 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_9,
+				 MCA_BASE_VAR_SCOPE_READONLY, &opal_pmix_collect_all_data);
     return OPAL_SUCCESS;
 }
 
@@ -74,10 +74,10 @@ static int opal_pmix_base_frame_open(mca_base_open_flag_t flags)
 }
 
 MCA_BASE_FRAMEWORK_DECLARE(opal, pmix, "OPAL PMI Client Framework",
-                           opal_pmix_base_frame_register,
-                           opal_pmix_base_frame_open,
-                           opal_pmix_base_frame_close,
-                           mca_pmix_base_static_components, 0);
+			   opal_pmix_base_frame_register,
+			   opal_pmix_base_frame_open,
+			   opal_pmix_base_frame_close,
+			   mca_pmix_base_static_components, 0);
 
 /****  PMIX FRAMEWORK OBJECTS  ****/
 static void lkcon(opal_pmix_pdata_t *p)
@@ -91,8 +91,8 @@ static void lkdes(opal_pmix_pdata_t *p)
     OBJ_DESTRUCT(&p->value);
 }
 OBJ_CLASS_INSTANCE(opal_pmix_pdata_t,
-                   opal_list_item_t,
-                   lkcon, lkdes);
+		   opal_list_item_t,
+		   lkcon, lkdes);
 
 static void mdcon(opal_pmix_modex_data_t *p)
 {
@@ -104,12 +104,12 @@ static void mdcon(opal_pmix_modex_data_t *p)
 static void mddes(opal_pmix_modex_data_t *p)
 {
     if (NULL != p->blob) {
-        free(p->blob);
+	free(p->blob);
     }
 }
 OBJ_CLASS_INSTANCE(opal_pmix_modex_data_t,
-                   opal_list_item_t,
-                   mdcon, mddes);
+		   opal_list_item_t,
+		   mdcon, mddes);
 
 static void apcon(opal_pmix_app_t *p)
 {
@@ -123,16 +123,16 @@ static void apcon(opal_pmix_app_t *p)
 static void apdes(opal_pmix_app_t *p)
 {
     if (NULL != p->cmd) {
-        free(p->cmd);
+	free(p->cmd);
     }
     if (NULL != p->argv) {
-        opal_argv_free(p->argv);
+	opal_argv_free(p->argv);
     }
     if (NULL != p->env) {
-        opal_argv_free(p->env);
+	opal_argv_free(p->env);
     }
     OPAL_LIST_DESTRUCT(&p->info);
 }
 OBJ_CLASS_INSTANCE(opal_pmix_app_t,
-                   opal_list_item_t,
-                   apcon, apdes);
+		   opal_list_item_t,
+		   apcon, apdes);

--- a/opal/mca/pmix/base/pmix_base_hash.c
+++ b/opal/mca/pmix/base/pmix_base_hash.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2004-2011 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -59,23 +59,23 @@ static void proc_data_destruct(opal_pmix_proc_data_t *ptr)
     OPAL_LIST_DESTRUCT(&ptr->data);
 }
 OBJ_CLASS_INSTANCE(opal_pmix_proc_data_t,
-                   opal_list_item_t,
-                   proc_data_construct,
-                   proc_data_destruct);
+		   opal_list_item_t,
+		   proc_data_construct,
+		   proc_data_destruct);
 
 /**
  * Find data for a given key in a given proc_data_t
  * container.
  */
 static opal_value_t* lookup_keyval(opal_pmix_proc_data_t *proc_data,
-                                   const char *key)
+				   const char *key)
 {
     opal_value_t *kv;
 
     OPAL_LIST_FOREACH(kv, &proc_data->data, opal_value_t) {
-        if (0 == strcmp(key, kv->key)) {
-            return kv;
-        }
+	if (0 == strcmp(key, kv->key)) {
+	    return kv;
+	}
     }
     return NULL;
 }
@@ -85,18 +85,18 @@ static opal_value_t* lookup_keyval(opal_pmix_proc_data_t *proc_data,
  * opal_process_name_t.
  */
 static opal_pmix_proc_data_t* lookup_proc(opal_proc_table_t *ptable,
-                                          opal_process_name_t id, bool create)
+					  opal_process_name_t id, bool create)
 {
     opal_pmix_proc_data_t *proc_data = NULL;
 
     opal_proc_table_get_value(ptable, id, (void**)&proc_data);
     if (NULL == proc_data && create) {
-        proc_data = OBJ_NEW(opal_pmix_proc_data_t);
-        if (NULL == proc_data) {
-            opal_output(0, "pmix:hash:lookup_proc: unable to allocate proc_data_t\n");
-            return NULL;
-        }
-        opal_proc_table_set_value(ptable, id, proc_data);
+	proc_data = OBJ_NEW(opal_pmix_proc_data_t);
+	if (NULL == proc_data) {
+	    opal_output(0, "pmix:hash:lookup_proc: unable to allocate proc_data_t\n");
+	    return NULL;
+	}
+	opal_proc_table_set_value(ptable, id, proc_data);
     }
 
     return proc_data;
@@ -122,19 +122,19 @@ void opal_pmix_base_hash_finalize(void)
      * and release all data stored in it
      */
     if (OPAL_SUCCESS == opal_proc_table_get_first_key(&ptable, &key,
-                                                      (void**)&proc_data,
-                                                      &node1, &node2)) {
-        if (NULL != proc_data) {
-            OBJ_RELEASE(proc_data);
-        }
-        while (OPAL_SUCCESS == opal_proc_table_get_next_key(&ptable, &key,
-                                                            (void**)&proc_data,
-                                                            node1, &node1,
-                                                            node2, &node2)) {
-            if (NULL != proc_data) {
-                OBJ_RELEASE(proc_data);
-            }
-        }
+						      (void**)&proc_data,
+						      &node1, &node2)) {
+	if (NULL != proc_data) {
+	    OBJ_RELEASE(proc_data);
+	}
+	while (OPAL_SUCCESS == opal_proc_table_get_next_key(&ptable, &key,
+							    (void**)&proc_data,
+							    node1, &node1,
+							    node2, &node2)) {
+	    if (NULL != proc_data) {
+		OBJ_RELEASE(proc_data);
+	    }
+	}
     }
     OBJ_DESTRUCT(&ptable);
 }
@@ -142,23 +142,23 @@ void opal_pmix_base_hash_finalize(void)
 
 
 int opal_pmix_base_store(const opal_process_name_t *id,
-                         opal_value_t *val)
+			 opal_value_t *val)
 {
     opal_pmix_proc_data_t *proc_data;
     opal_value_t *kv;
     int rc;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "%s pmix:hash:store storing data for proc %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(*id));
+			"%s pmix:hash:store storing data for proc %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(*id));
 
     /* lookup the proc data object for this proc */
     if (NULL == (proc_data = lookup_proc(&ptable, *id, true))) {
-        /* unrecoverable error */
-        OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
-                             "%s pmix:hash:store: storing data for proc %s unrecoverably failed",
-                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(*id)));
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	/* unrecoverable error */
+	OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
+			     "%s pmix:hash:store: storing data for proc %s unrecoverably failed",
+			     OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), OPAL_NAME_PRINT(*id)));
+	return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
     /* see if we already have this key in the data - means we are updating
@@ -168,21 +168,21 @@ int opal_pmix_base_store(const opal_process_name_t *id,
 #if OPAL_ENABLE_DEBUG
     char *_data_type = opal_dss.lookup_data_type(val->type);
     OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
-                         "%s pmix:hash:store: %s key %s[%s] for proc %s",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                         (NULL == kv ? "storing" : "updating"),
-                         val->key, _data_type, OPAL_NAME_PRINT(*id)));
+			 "%s pmix:hash:store: %s key %s[%s] for proc %s",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			 (NULL == kv ? "storing" : "updating"),
+			 val->key, _data_type, OPAL_NAME_PRINT(*id)));
     free (_data_type);
 #endif
 
     if (NULL != kv) {
-        opal_list_remove_item(&proc_data->data, &kv->super);
-        OBJ_RELEASE(kv);
+	opal_list_remove_item(&proc_data->data, &kv->super);
+	OBJ_RELEASE(kv);
     }
     /* create the copy */
     if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&kv, val, OPAL_VALUE))) {
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
     opal_list_append(&proc_data->data, &kv->super);
 
@@ -190,71 +190,71 @@ int opal_pmix_base_store(const opal_process_name_t *id,
 }
 
 int opal_pmix_base_fetch(const opal_process_name_t *id,
-                         const char *key, opal_list_t *kvs)
+			 const char *key, opal_list_t *kvs)
 {
     opal_pmix_proc_data_t *proc_data;
     opal_value_t *kv, *knew;
     int rc;
 
     OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
-                         "%s pmix:hash:fetch: searching for key %s on proc %s",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                         (NULL == key) ? "NULL" : key, OPAL_NAME_PRINT(*id)));
+			 "%s pmix:hash:fetch: searching for key %s on proc %s",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			 (NULL == key) ? "NULL" : key, OPAL_NAME_PRINT(*id)));
 
     /* lookup the proc data object for this proc */
     if (NULL == (proc_data = lookup_proc(&ptable, *id, true))) {
-        OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
-                             "%s pmix_hash:fetch data for proc %s not found",
-                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                             OPAL_NAME_PRINT(*id)));
-        return OPAL_ERR_NOT_FOUND;
+	OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
+			     "%s pmix_hash:fetch data for proc %s not found",
+			     OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			     OPAL_NAME_PRINT(*id)));
+	return OPAL_ERR_NOT_FOUND;
     }
 
     /* if the key is NULL, that we want everything */
     if (NULL == key) {
-        /* must provide an output list or this makes no sense */
-        if (NULL == kvs) {
-            OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
-            return OPAL_ERR_BAD_PARAM;
-        }
-        OPAL_LIST_FOREACH(kv, &proc_data->data, opal_value_t) {
-            /* copy the value */
-            if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&knew, kv, OPAL_VALUE))) {
-                OPAL_ERROR_LOG(rc);
-                return rc;
-            }
-            OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
-                                 "%s pmix:hash:fetch: adding data for key %s on proc %s",
-                                 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                                 (NULL == kv->key) ? "NULL" : kv->key,
-                                 OPAL_NAME_PRINT(*id)));
+	/* must provide an output list or this makes no sense */
+	if (NULL == kvs) {
+	    OPAL_ERROR_LOG(OPAL_ERR_BAD_PARAM);
+	    return OPAL_ERR_BAD_PARAM;
+	}
+	OPAL_LIST_FOREACH(kv, &proc_data->data, opal_value_t) {
+	    /* copy the value */
+	    if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&knew, kv, OPAL_VALUE))) {
+		OPAL_ERROR_LOG(rc);
+		return rc;
+	    }
+	    OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
+				 "%s pmix:hash:fetch: adding data for key %s on proc %s",
+				 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+				 (NULL == kv->key) ? "NULL" : kv->key,
+				 OPAL_NAME_PRINT(*id)));
 
-            /* add it to the output list */
-            opal_list_append(kvs, &knew->super);
-        }
-        return OPAL_SUCCESS;
+	    /* add it to the output list */
+	    opal_list_append(kvs, &knew->super);
+	}
+	return OPAL_SUCCESS;
     }
 
     /* find the value */
     if (NULL == (kv = lookup_keyval(proc_data, key))) {
-        OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
-                             "%s pmix_hash:fetch key %s for proc %s not found",
-                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                             (NULL == key) ? "NULL" : key,
-                             OPAL_NAME_PRINT(*id)));
-        return OPAL_ERR_NOT_FOUND;
+	OPAL_OUTPUT_VERBOSE((5, opal_pmix_base_framework.framework_output,
+			     "%s pmix_hash:fetch key %s for proc %s not found",
+			     OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			     (NULL == key) ? "NULL" : key,
+			     OPAL_NAME_PRINT(*id)));
+	return OPAL_ERR_NOT_FOUND;
     }
 
     /* if the user provided a NULL list object, then they
      * just wanted to know if the key was present */
     if (NULL == kvs) {
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     }
 
     /* create the copy */
     if (OPAL_SUCCESS != (rc = opal_dss.copy((void**)&knew, kv, OPAL_VALUE))) {
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
     /* add it to the output list */
     opal_list_append(kvs, &knew->super);
@@ -269,31 +269,30 @@ int opal_pmix_base_remove(const opal_process_name_t *id, const char *key)
 
     /* lookup the specified proc */
     if (NULL == (proc_data = lookup_proc(&ptable, *id, false))) {
-        /* no data for this proc */
-        return OPAL_SUCCESS;
+	/* no data for this proc */
+	return OPAL_SUCCESS;
     }
 
     /* if key is NULL, remove all data for this proc */
     if (NULL == key) {
-        while (NULL != (kv = (opal_value_t *) opal_list_remove_first(&proc_data->data))) {
-            OBJ_RELEASE(kv);
-        }
-        /* remove the proc_data object itself from the jtable */
-        opal_proc_table_remove_value(&ptable, *id);
-        /* cleanup */
-        OBJ_RELEASE(proc_data);
-        return OPAL_SUCCESS;
+	while (NULL != (kv = (opal_value_t *) opal_list_remove_first(&proc_data->data))) {
+	    OBJ_RELEASE(kv);
+	}
+	/* remove the proc_data object itself from the jtable */
+	opal_proc_table_remove_value(&ptable, *id);
+	/* cleanup */
+	OBJ_RELEASE(proc_data);
+	return OPAL_SUCCESS;
     }
 
     /* remove this item */
     OPAL_LIST_FOREACH(kv, &proc_data->data, opal_value_t) {
-        if (0 == strcmp(key, kv->key)) {
-            opal_list_remove_item(&proc_data->data, &kv->super);
-            OBJ_RELEASE(kv);
-            break;
-        }
+	if (0 == strcmp(key, kv->key)) {
+	    opal_list_remove_item(&proc_data->data, &kv->super);
+	    OBJ_RELEASE(kv);
+	    break;
+	}
     }
 
     return OPAL_SUCCESS;
 }
-

--- a/opal/mca/pmix/base/pmix_base_select.c
+++ b/opal/mca/pmix/base/pmix_base_select.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,11 +33,11 @@ int opal_pmix_base_select(void)
      * Select the best component
      */
     if( OPAL_SUCCESS != mca_base_select("pmix", opal_pmix_base_framework.framework_output,
-                                        &opal_pmix_base_framework.framework_components,
-                                        (mca_base_module_t **) &best_module,
-                                        (mca_base_component_t **) &best_component, NULL) ) {
-        /* notify caller that no available component found */
-        return OPAL_ERR_NOT_FOUND;
+					&opal_pmix_base_framework.framework_components,
+					(mca_base_module_t **) &best_module,
+					(mca_base_component_t **) &best_component, NULL) ) {
+	/* notify caller that no available component found */
+	return OPAL_ERR_NOT_FOUND;
     }
 
     /* Save the winner */

--- a/opal/mca/pmix/cray/pmix_cray.c
+++ b/opal/mca/pmix/cray/pmix_cray.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2007      The Trustees of Indiana University.
  *                         All rights reserved.
- * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All
  *                         rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
@@ -42,42 +42,42 @@ static int cray_init(void);
 static int cray_fini(void);
 static int cray_initialized(void);
 static int cray_abort(int flat, const char *msg,
-                      opal_list_t *procs);
+		      opal_list_t *procs);
 static int cray_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t *jobid);
 static int cray_spawn_nb(opal_list_t *jobinfo, opal_list_t *apps,
-                         opal_pmix_spawn_cbfunc_t cbfunc,
-                         void *cbdata);
+			 opal_pmix_spawn_cbfunc_t cbfunc,
+			 void *cbdata);
 static int cray_job_connect(opal_list_t *procs);
 static int cray_job_disconnect(opal_list_t *procs);
 static int cray_job_disconnect_nb(opal_list_t *procs,
-                                  opal_pmix_op_cbfunc_t cbfunc,
-                                  void *cbdata);
+				  opal_pmix_op_cbfunc_t cbfunc,
+				  void *cbdata);
 static int cray_resolve_peers(const char *nodename,
-                              opal_jobid_t jobid,
-                              opal_list_t *procs);
+			      opal_jobid_t jobid,
+			      opal_list_t *procs);
 static int cray_resolve_nodes(opal_jobid_t jobid, char **nodelist);
 static int cray_put(opal_pmix_scope_t scope, opal_value_t *kv);
 static int cray_fencenb(opal_list_t *procs, int collect_data,
-                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static int cray_commit(void);
 static int cray_get(const opal_process_name_t *id,
-                    const char *key, opal_list_t *info,
-                    opal_value_t **kv);
+		    const char *key, opal_list_t *info,
+		    opal_value_t **kv);
 static int cray_get_nb(const opal_process_name_t *id, const char *key,
-                       opal_list_t *info,
-                       opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
+		       opal_list_t *info,
+		       opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
 static int cray_publish(opal_list_t *info);
 static int cray_publish_nb(opal_list_t *info,
-                           opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			   opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static int cray_lookup(opal_list_t *data, opal_list_t *info);
 static int cray_lookup_nb(char **keys, opal_list_t *info,
-                          opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+			  opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 static int cray_unpublish(char **keys, opal_list_t *info);
 static int cray_unpublish_nb(char **keys, opal_list_t *info,
-                            opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			    opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static const char *cray_get_version(void);
 static int cray_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val);
+			  opal_value_t *val);
 static const char *cray_get_nspace(opal_jobid_t jobid);
 static void cray_register_jobid(opal_jobid_t jobid, const char *nspace);
 
@@ -128,8 +128,8 @@ typedef struct {
     void *cbdata;
 } pmi_opcaddy_t;
 OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
-                   opal_object_t,
-                   NULL, NULL);
+		   opal_object_t,
+		   NULL, NULL);
 
 // PMI constant values:
 static int pmix_kvslen_max = 0;
@@ -153,9 +153,9 @@ static uint32_t pmix_jobid = -1;
 static char* pmix_error(int pmix_err);
 #define OPAL_PMI_ERROR(pmi_err, pmi_func)                       \
     do {                                                        \
-        opal_output(0, "%s [%s:%d:%s]: %s\n",                   \
-                    pmi_func, __FILE__, __LINE__, __func__,     \
-                    pmix_error(pmi_err));                       \
+	opal_output(0, "%s [%s:%d:%s]: %s\n",                   \
+		    pmi_func, __FILE__, __LINE__, __func__,     \
+		    pmix_error(pmi_err));                       \
     } while(0);
 
 static int cray_init(void)
@@ -176,21 +176,21 @@ static int cray_init(void)
 
     /* if we can't startup PMI, we can't be used */
     if ( PMI2_Initialized () ) {
-        opal_output_verbose(10, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray: pmi already initialized",
-                        OPAL_NAME_PRINT(pmix_pname));
-        return OPAL_SUCCESS;
+	opal_output_verbose(10, opal_pmix_base_framework.framework_output,
+			"%s pmix:cray: pmi already initialized",
+			OPAL_NAME_PRINT(pmix_pname));
+	return OPAL_SUCCESS;
     }
     size = -1;
     rank = -1;
     appnum = -1;
     if (PMI_SUCCESS != (rc = PMI2_Init(&spawned, &size, &rank, &appnum))) {
-        opal_show_help("help-pmix-base.txt", "pmix2-init-failed", true, rc);
-        return OPAL_ERROR;
+	opal_show_help("help-pmix-base.txt", "pmix2-init-failed", true, rc);
+	return OPAL_ERROR;
     }
     if( size < 0 || rank < 0 ){
-        opal_show_help("help-pmix-base.txt", "pmix2-init-returned-bad-values", true);
-        goto err_exit;
+	opal_show_help("help-pmix-base.txt", "pmix2-init-returned-bad-values", true);
+	goto err_exit;
     }
 
     pmix_size = size;
@@ -208,32 +208,32 @@ static int cray_init(void)
      */
 
     if (PMI_SUCCESS != PMI_Get_version_info(&major,&minor,&revision)) {
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     }
 
     snprintf(cray_pmi_version, sizeof(cray_pmi_version),
-             "%d.%d.%d", major, minor, revision);
+	     "%d.%d.%d", major, minor, revision);
 
     pmix_kvs_name = (char*)malloc(pmix_kvslen_max);
     if( pmix_kvs_name == NULL ){
-         PMI2_Finalize();
-         ret = OPAL_ERR_OUT_OF_RESOURCE;
-         goto err_exit;
+	 PMI2_Finalize();
+	 ret = OPAL_ERR_OUT_OF_RESOURCE;
+	 goto err_exit;
     }
 
     rc = PMI2_Job_GetId(pmix_kvs_name, pmix_kvslen_max);
     if( PMI_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc, "PMI2_Job_GetId");
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI2_Job_GetId");
+	goto err_exit;
     }
 
     rc = sscanf(pmix_kvs_name,"kvs_%u",&jobfam);
     if (rc != 1) {
-        opal_output_verbose(10, opal_pmix_base_framework.framework_output,
-                           "%s pmix:cray: pmix_kvs_name %s",
-                            OPAL_NAME_PRINT(pmix_pname), pmix_kvs_name);
-        rc = OPAL_ERROR;
-        goto err_exit;
+	opal_output_verbose(10, opal_pmix_base_framework.framework_output,
+			   "%s pmix:cray: pmix_kvs_name %s",
+			    OPAL_NAME_PRINT(pmix_pname), pmix_kvs_name);
+	rc = OPAL_ERROR;
+	goto err_exit;
     }
 
     pmix_jobid = jobfam << 16;
@@ -246,27 +246,27 @@ static int cray_init(void)
     pmix_pname.vpid = pmix_rank;
     opal_proc_set_name(&pmix_pname);
     opal_output_verbose(10, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray: assigned tmp name %d %d pmix_kvs_name %s",
-                        OPAL_NAME_PRINT(pmix_pname),pmix_pname.jobid,pmix_pname.vpid,pmix_kvs_name);
+			"%s pmix:cray: assigned tmp name %d %d pmix_kvs_name %s",
+			OPAL_NAME_PRINT(pmix_pname),pmix_pname.jobid,pmix_pname.vpid,pmix_kvs_name);
 
     pmapping = (char*)malloc(PMI2_MAX_VALLEN);
     if( pmapping == NULL ){
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
 
     rc = PMI2_Info_GetJobAttr("PMI_process_mapping", pmapping, PMI2_MAX_VALLEN, &found);
     if( !found || PMI_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc,"PMI2_Info_GetJobAttr");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc,"PMI2_Info_GetJobAttr");
+	return OPAL_ERROR;
     }
 
     pmix_lranks = pmix_cray_parse_pmap(pmapping, pmix_rank, &my_node, &pmix_nlranks);
     if (NULL == pmix_lranks) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
 
     free(pmapping);
@@ -280,9 +280,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = pmix_size;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -292,16 +292,16 @@ static int cray_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = pmix_appnum;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
     rc = PMI2_Info_GetJobAttr("universeSize", buf, 16, &found);
     if( PMI_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc, "PMI_Get_universe_size");
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI_Get_universe_size");
+	goto err_exit;
     }
 
     pmix_usize = atoi(buf);
@@ -311,9 +311,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = pmix_usize;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -323,9 +323,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = atoi(buf);
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -334,9 +334,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = pmix_jobid;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -346,9 +346,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = pmix_nlranks;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -358,12 +358,12 @@ static int cray_init(void)
     /* find ourselves and build up a string for local peer info */
     memset(nmtmp, 0, 64);
     for (i=0; i < pmix_nlranks; i++) {
-        ret = snprintf(nmtmp, 64, "%d", pmix_lranks[i]);
-        opal_argv_append_nosize(&localranks, nmtmp);
-        if (pmix_rank == pmix_lranks[i]) {
-            pmix_lrank = i;
-            pmix_nrank = i;
-        }
+	ret = snprintf(nmtmp, 64, "%d", pmix_lranks[i]);
+	opal_argv_append_nosize(&localranks, nmtmp);
+	if (pmix_rank == pmix_lranks[i]) {
+	    pmix_lrank = i;
+	    pmix_nrank = i;
+	}
     }
 
     str = opal_argv_join(localranks, ',');
@@ -374,9 +374,9 @@ static int cray_init(void)
     kv.type = OPAL_STRING;
     kv.data.string = str;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -386,9 +386,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT64;
     kv.data.uint64 = *(uint64_t*)&ldr;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
 
     /* save our local rank */
@@ -397,9 +397,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = pmix_lrank;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
 
     /* and our node rank */
@@ -408,9 +408,9 @@ static int cray_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = pmix_nrank;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -423,21 +423,21 @@ err_exit:
 static int cray_fini(void) {
 
     if (0 == pmix_init_count) {
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     }
 
     if (0 == --pmix_init_count) {
-        PMI2_Finalize();
+	PMI2_Finalize();
     }
 
     if (NULL != pmix_kvs_name) {
-        free(pmix_kvs_name);
-        pmix_kvs_name = NULL;
+	free(pmix_kvs_name);
+	pmix_kvs_name = NULL;
     }
 
     if (NULL != pmix_lranks) {
-        free(pmix_lranks);
-        pmix_lranks = NULL;
+	free(pmix_lranks);
+	pmix_lranks = NULL;
     }
 
     return OPAL_SUCCESS;
@@ -446,13 +446,13 @@ static int cray_fini(void) {
 static int cray_initialized(void)
 {
     if (0 < pmix_init_count) {
-        return 1;
+	return 1;
     }
     return 0;
 }
 
 static int cray_abort(int flag, const char *msg,
-                      opal_list_t *procs)
+		      opal_list_t *procs)
 {
     PMI2_Abort(flag, msg);
     return OPAL_SUCCESS;
@@ -464,8 +464,8 @@ static int cray_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t *job
 }
 
 static int cray_spawn_nb(opal_list_t *jobinfo, opal_list_t *apps,
-                         opal_pmix_spawn_cbfunc_t cbfunc,
-                         void *cbdata)
+			 opal_pmix_spawn_cbfunc_t cbfunc,
+			 void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -481,15 +481,15 @@ static int cray_job_disconnect(opal_list_t *procs)
 }
 
 static int cray_job_disconnect_nb(opal_list_t *procs,
-                                  opal_pmix_op_cbfunc_t cbfunc,
-                                  void *cbdata)
+				  opal_pmix_op_cbfunc_t cbfunc,
+				  void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
 
 static int cray_resolve_peers(const char *nodename,
-                              opal_jobid_t jobid,
-                              opal_list_t *procs)
+			      opal_jobid_t jobid,
+			      opal_list_t *procs)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
@@ -500,16 +500,16 @@ static int cray_resolve_nodes(opal_jobid_t jobid, char **nodelist)
 }
 
 static int cray_put(opal_pmix_scope_t scope,
-                  opal_value_t *kv)
+		  opal_value_t *kv)
 {
     int rc;
 
     opal_output_verbose(10, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray cray_put key %s scope %d\n",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key, scope);
+			"%s pmix:cray cray_put key %s scope %d\n",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key, scope);
 
     if (!pmix_init_count) {
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     }
 
     /*
@@ -517,15 +517,15 @@ static int cray_put(opal_pmix_scope_t scope,
      */
 
     if (NULL == mca_pmix_cray_component.cache_global) {
-        mca_pmix_cray_component.cache_global = OBJ_NEW(opal_buffer_t);
+	mca_pmix_cray_component.cache_global = OBJ_NEW(opal_buffer_t);
     }
 
     opal_output_verbose(20, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray put global data for key %s type %d",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key, kv->type);
+			"%s pmix:cray put global data for key %s type %d",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key, kv->type);
     if (OPAL_SUCCESS != (rc = opal_dss.pack(mca_pmix_cray_component.cache_global, &kv, 1, OPAL_VALUE))) {
-        OPAL_PMI_ERROR(rc,"pmix:cray opal_dss.pack returned error");
-        OPAL_ERROR_LOG(rc);
+	OPAL_PMI_ERROR(rc,"pmix:cray opal_dss.pack returned error");
+	OPAL_ERROR_LOG(rc);
     }
 
     return rc;
@@ -549,9 +549,9 @@ static void fencenb(int sd, short args, void *cbdata)
     char *cptr, *rcv_buff = NULL;
     opal_process_name_t id;
     typedef struct {
-        uint32_t pmix_rank;
-        opal_process_name_t name;
-        int32_t nbytes;
+	uint32_t pmix_rank;
+	opal_process_name_t name;
+	int32_t nbytes;
     } bytes_and_rank_t;
     int32_t rcv_nbytes_tot;
     bytes_and_rank_t s_bytes_and_rank;
@@ -561,10 +561,10 @@ static void fencenb(int sd, short args, void *cbdata)
     char *cpuset = NULL;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray executing fence cache_global %p cache_local %p",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (void *)mca_pmix_cray_component.cache_global,
-                        (void *)mca_pmix_cray_component.cache_local);
+			"%s pmix:cray executing fence cache_global %p cache_local %p",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(void *)mca_pmix_cray_component.cache_global,
+			(void *)mca_pmix_cray_component.cache_local);
 
 
     /*
@@ -575,8 +575,8 @@ static void fencenb(int sd, short args, void *cbdata)
 
     send_buffer = OBJ_NEW(opal_buffer_t);
     if (NULL == send_buffer) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        goto fn_exit;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	goto fn_exit;
     }
 
     opal_dss.copy_payload(send_buffer, mca_pmix_cray_component.cache_global);
@@ -586,8 +586,8 @@ static void fencenb(int sd, short args, void *cbdata)
 
     r_bytes_and_ranks = (bytes_and_rank_t *)malloc(pmix_size * sizeof(bytes_and_rank_t));
     if (NULL == r_bytes_and_ranks) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        goto fn_exit;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	goto fn_exit;
     }
 
     /*
@@ -598,39 +598,39 @@ static void fencenb(int sd, short args, void *cbdata)
      */
 
     if (PMI_SUCCESS != (rc = PMI_Allgather(&s_bytes_and_rank,r_bytes_and_ranks,sizeof(bytes_and_rank_t)))) {
-        OPAL_PMI_ERROR(rc,"PMI_Allgather");
-        rc = OPAL_ERR_COMM_FAILURE;
-        goto fn_exit;
+	OPAL_PMI_ERROR(rc,"PMI_Allgather");
+	rc = OPAL_ERR_COMM_FAILURE;
+	goto fn_exit;
     }
 
 
     for (rcv_nbytes_tot=0,i=0; i < pmix_size; i++) {
-        rcv_nbytes_tot += r_bytes_and_ranks[i].nbytes;
+	rcv_nbytes_tot += r_bytes_and_ranks[i].nbytes;
     }
 
     opal_output_verbose(20, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray total number of bytes to receive %d",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), rcv_nbytes_tot);
+			"%s pmix:cray total number of bytes to receive %d",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), rcv_nbytes_tot);
 
     rcv_buff = (char *) malloc(rcv_nbytes_tot * sizeof(char));
     if (NULL == rcv_buff) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        goto fn_exit;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	goto fn_exit;
     }
 
     all_lens = (int *)malloc(sizeof(int) * pmix_size);
     if (NULL == all_lens) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        goto fn_exit;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	goto fn_exit;
     }
     for (i=0; i< pmix_size; i++) {
-        all_lens[r_bytes_and_ranks[i].pmix_rank] = r_bytes_and_ranks[i].nbytes;
+	all_lens[r_bytes_and_ranks[i].pmix_rank] = r_bytes_and_ranks[i].nbytes;
     }
 
     if (PMI_SUCCESS != (rc = PMI_Allgatherv(sbuf_ptr,s_bytes_and_rank.nbytes,rcv_buff,all_lens))) {
-        OPAL_PMI_ERROR(rc,"PMI_Allgatherv");
-        rc = OPAL_ERR_COMM_FAILURE;
-        goto fn_exit;
+	OPAL_PMI_ERROR(rc,"PMI_Allgatherv");
+	rc = OPAL_ERR_COMM_FAILURE;
+	goto fn_exit;
     }
 
     OBJ_RELEASE(send_buffer);
@@ -638,36 +638,36 @@ static void fencenb(int sd, short args, void *cbdata)
 
     buf = OBJ_NEW(opal_buffer_t);
     if (buf == NULL) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        goto fn_exit;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	goto fn_exit;
     }
 
     for (cptr = rcv_buff, i=0; i < pmix_size; i++) {
 
-        id = r_bytes_and_ranks[i].name;
+	id = r_bytes_and_ranks[i].name;
 
-        buf->base_ptr = NULL;  /* TODO: ugh */
-        if (OPAL_SUCCESS != (rc = opal_dss.load(buf, (void *)cptr, r_bytes_and_ranks[i].nbytes))) {
-            OPAL_PMI_ERROR(rc,"pmix:cray opal_dss.load failed");
-            goto fn_exit;
-        }
+	buf->base_ptr = NULL;  /* TODO: ugh */
+	if (OPAL_SUCCESS != (rc = opal_dss.load(buf, (void *)cptr, r_bytes_and_ranks[i].nbytes))) {
+	    OPAL_PMI_ERROR(rc,"pmix:cray opal_dss.load failed");
+	    goto fn_exit;
+	}
 
-        /* unpack and stuff in to the dstore */
+	/* unpack and stuff in to the dstore */
 
-        cnt = 1;
-        while (OPAL_SUCCESS == (rc = opal_dss.unpack(buf, &kp, &cnt, OPAL_VALUE))) {
-            opal_output_verbose(20, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray unpacked kp with key %s type(%d) for id  %s",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kp->key, kp->type, OPAL_NAME_PRINT(id));
-            if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&id, kp))) {
-                OPAL_ERROR_LOG(rc);
-                goto fn_exit;
-            }
-             OBJ_RELEASE(kp);
-             cnt = 1;
-        }
+	cnt = 1;
+	while (OPAL_SUCCESS == (rc = opal_dss.unpack(buf, &kp, &cnt, OPAL_VALUE))) {
+	    opal_output_verbose(20, opal_pmix_base_framework.framework_output,
+			"%s pmix:cray unpacked kp with key %s type(%d) for id  %s",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kp->key, kp->type, OPAL_NAME_PRINT(id));
+	    if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&id, kp))) {
+		OPAL_ERROR_LOG(rc);
+		goto fn_exit;
+	    }
+	     OBJ_RELEASE(kp);
+	     cnt = 1;
+	}
 
-        cptr += r_bytes_and_ranks[i].nbytes;
+	cptr += r_bytes_and_ranks[i].nbytes;
 
     }
 
@@ -675,17 +675,17 @@ static void fencenb(int sd, short args, void *cbdata)
     OBJ_RELEASE(buf);
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray kvs_fence complete",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+			"%s pmix:cray kvs_fence complete",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
 
     /* fetch my cpuset */
     OBJ_CONSTRUCT(&vals, opal_list_t);
     if (OPAL_SUCCESS == (rc = opal_pmix_base_fetch(&pmix_pname,
-                                                   OPAL_PMIX_CPUSET, &vals))) {
-        kp = (opal_value_t*)opal_list_get_first(&vals);
-        cpuset = strdup(kp->data.string);
+						   OPAL_PMIX_CPUSET, &vals))) {
+	kp = (opal_value_t*)opal_list_get_first(&vals);
+	cpuset = strdup(kp->data.string);
     } else {
-        cpuset = NULL;
+	cpuset = NULL;
     }
     OPAL_LIST_DESTRUCT(&vals);
 
@@ -698,75 +698,75 @@ static void fencenb(int sd, short args, void *cbdata)
      */
 
     for (i=0; i < pmix_nlranks; i++) {
-        id.vpid = pmix_lranks[i];
-        id.jobid = pmix_jobid;
-        opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s checking out if %s is local to me",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                                OPAL_NAME_PRINT(id));
-        /* fetch cpuset for this vpid */
-        OBJ_CONSTRUCT(&vals, opal_list_t);
-        if (OPAL_SUCCESS != (rc = opal_pmix_base_fetch(&id,
-                                                    OPAL_PMIX_CPUSET, &vals))) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s cpuset for local proc %s not found",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                                OPAL_NAME_PRINT(id));
-            OPAL_LIST_DESTRUCT(&vals);
-            /* even though the cpuset wasn't found, we at least know it is
-             * on the same node with us */
-            locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
-        } else {
-            kp = (opal_value_t*)opal_list_get_first(&vals);
-            if (NULL == kp->data.string) {
-                /* if we share a node, but we don't know anything more, then
-                 * mark us as on the node as this is all we know
-                 */
-                locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
-            } else {
-                /* determine relative location on our node */
-                locality = opal_hwloc_base_get_relative_locality(opal_hwloc_topology,
-                                                                 cpuset,
-                                                                 kp->data.string);
-            }
-            OPAL_LIST_DESTRUCT(&vals);
-        }
-        OPAL_OUTPUT_VERBOSE((1, opal_pmix_base_framework.framework_output,
-                             "%s pmix:cray proc %s locality %s",
-                             OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                             OPAL_NAME_PRINT(id),
-                             opal_hwloc_base_print_locality(locality)));
+	id.vpid = pmix_lranks[i];
+	id.jobid = pmix_jobid;
+	opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s checking out if %s is local to me",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+				OPAL_NAME_PRINT(id));
+	/* fetch cpuset for this vpid */
+	OBJ_CONSTRUCT(&vals, opal_list_t);
+	if (OPAL_SUCCESS != (rc = opal_pmix_base_fetch(&id,
+						    OPAL_PMIX_CPUSET, &vals))) {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s cpuset for local proc %s not found",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+				OPAL_NAME_PRINT(id));
+	    OPAL_LIST_DESTRUCT(&vals);
+	    /* even though the cpuset wasn't found, we at least know it is
+	     * on the same node with us */
+	    locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
+	} else {
+	    kp = (opal_value_t*)opal_list_get_first(&vals);
+	    if (NULL == kp->data.string) {
+		/* if we share a node, but we don't know anything more, then
+		 * mark us as on the node as this is all we know
+		 */
+		locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
+	    } else {
+		/* determine relative location on our node */
+		locality = opal_hwloc_base_get_relative_locality(opal_hwloc_topology,
+								 cpuset,
+								 kp->data.string);
+	    }
+	    OPAL_LIST_DESTRUCT(&vals);
+	}
+	OPAL_OUTPUT_VERBOSE((1, opal_pmix_base_framework.framework_output,
+			     "%s pmix:cray proc %s locality %s",
+			     OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			     OPAL_NAME_PRINT(id),
+			     opal_hwloc_base_print_locality(locality)));
 
-        OBJ_CONSTRUCT(&kvn, opal_value_t);
-        kvn.key = strdup(OPAL_PMIX_LOCALITY);
-        kvn.type = OPAL_UINT16;
-        kvn.data.uint16 = locality;
-        opal_pmix_base_store(&id, &kvn);
-        OBJ_DESTRUCT(&kvn);
+	OBJ_CONSTRUCT(&kvn, opal_value_t);
+	kvn.key = strdup(OPAL_PMIX_LOCALITY);
+	kvn.type = OPAL_UINT16;
+	kvn.data.uint16 = locality;
+	opal_pmix_base_store(&id, &kvn);
+	OBJ_DESTRUCT(&kvn);
     }
 
 fn_exit:
     if (NULL != cpuset) {
-        free(cpuset);
+	free(cpuset);
     }
     if (all_lens != NULL) {
-        free(all_lens);
+	free(all_lens);
     }
     if (rcv_buff != NULL) {
-        free(rcv_buff);
+	free(rcv_buff);
     }
     if (r_bytes_and_ranks != NULL) {
-        free(r_bytes_and_ranks);
+	free(r_bytes_and_ranks);
     }
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(rc, op->cbdata);
+	op->opcbfunc(rc, op->cbdata);
     }
     OBJ_RELEASE(op);
     return;
 }
 
 static int cray_fencenb(opal_list_t *procs, int collect_data,
-                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmi_opcaddy_t *op;
 
@@ -775,7 +775,7 @@ static int cray_fencenb(opal_list_t *procs, int collect_data,
     op->opcbfunc = cbfunc;
     op->cbdata = cbdata;
     event_assign(&op->ev, opal_pmix_base.evbase, -1,
-                 EV_WRITE, fencenb, op);
+		 EV_WRITE, fencenb, op);
     event_active(&op->ev, EV_WRITE, 1);
 
     return OPAL_SUCCESS;
@@ -787,19 +787,19 @@ static int cray_get(const opal_process_name_t *id, const char *key, opal_list_t 
     opal_list_t vals;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:cray getting value for proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        OPAL_NAME_PRINT(*id), key);
+			"%s pmix:cray getting value for proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			OPAL_NAME_PRINT(*id), key);
 
     OBJ_CONSTRUCT(&vals, opal_list_t);
     rc = opal_pmix_base_fetch(id, key, &vals);
     if (OPAL_SUCCESS == rc) {
-        *kv = (opal_value_t*)opal_list_remove_first(&vals);
-        return OPAL_SUCCESS;
+	*kv = (opal_value_t*)opal_list_remove_first(&vals);
+	return OPAL_SUCCESS;
     } else {
-        opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                "%s pmix:cray fetch from dstore failed: %d",
-                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), rc);
+	opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+		"%s pmix:cray fetch from dstore failed: %d",
+		OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), rc);
     }
     OPAL_LIST_DESTRUCT(&vals);
 
@@ -808,7 +808,7 @@ static int cray_get(const opal_process_name_t *id, const char *key, opal_list_t 
 }
 
 static int cray_get_nb(const opal_process_name_t *id, const char *key,
-                       opal_list_t *info, opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
+		       opal_list_t *info, opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
@@ -819,7 +819,7 @@ static int cray_publish(opal_list_t *info)
 }
 
 static int cray_publish_nb(opal_list_t *info,
-                           opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			   opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -830,7 +830,7 @@ static int cray_lookup(opal_list_t *data, opal_list_t *info)
 }
 
 static int cray_lookup_nb(char **keys, opal_list_t *info,
-                          opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+			  opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -841,7 +841,7 @@ static int cray_unpublish(char **keys, opal_list_t *info)
 }
 
 static int cray_unpublish_nb(char **keys, opal_list_t *info,
-                            opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -852,7 +852,7 @@ static const char *cray_get_version(void)
 }
 
 static int cray_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val)
+			  opal_value_t *val)
 {
     opal_pmix_base_store(proc, val);
 
@@ -874,26 +874,26 @@ static char* pmix_error(int pmix_err)
     char * err_msg;
 
     switch(pmix_err) {
-        case PMI_FAIL: err_msg = "Operation failed"; break;
-        case PMI_ERR_INIT: err_msg = "PMI is not initialized"; break;
-        case PMI_ERR_NOMEM: err_msg = "Input buffer not large enough"; break;
-        case PMI_ERR_INVALID_ARG: err_msg = "Invalid argument"; break;
-        case PMI_ERR_INVALID_KEY: err_msg = "Invalid key argument"; break;
-        case PMI_ERR_INVALID_KEY_LENGTH: err_msg = "Invalid key length argument"; break;
-        case PMI_ERR_INVALID_VAL: err_msg = "Invalid value argument"; break;
-        case PMI_ERR_INVALID_VAL_LENGTH: err_msg = "Invalid value length argument"; break;
-        case PMI_ERR_INVALID_LENGTH: err_msg = "Invalid length argument"; break;
-        case PMI_ERR_INVALID_NUM_ARGS: err_msg = "Invalid number of arguments"; break;
-        case PMI_ERR_INVALID_ARGS: err_msg = "Invalid args argument"; break;
-        case PMI_ERR_INVALID_NUM_PARSED: err_msg = "Invalid num_parsed length argument"; break;
-        case PMI_ERR_INVALID_KEYVALP: err_msg = "Invalid keyvalp argument"; break;
-        case PMI_ERR_INVALID_SIZE: err_msg = "Invalid size argument"; break;
+	case PMI_FAIL: err_msg = "Operation failed"; break;
+	case PMI_ERR_INIT: err_msg = "PMI is not initialized"; break;
+	case PMI_ERR_NOMEM: err_msg = "Input buffer not large enough"; break;
+	case PMI_ERR_INVALID_ARG: err_msg = "Invalid argument"; break;
+	case PMI_ERR_INVALID_KEY: err_msg = "Invalid key argument"; break;
+	case PMI_ERR_INVALID_KEY_LENGTH: err_msg = "Invalid key length argument"; break;
+	case PMI_ERR_INVALID_VAL: err_msg = "Invalid value argument"; break;
+	case PMI_ERR_INVALID_VAL_LENGTH: err_msg = "Invalid value length argument"; break;
+	case PMI_ERR_INVALID_LENGTH: err_msg = "Invalid length argument"; break;
+	case PMI_ERR_INVALID_NUM_ARGS: err_msg = "Invalid number of arguments"; break;
+	case PMI_ERR_INVALID_ARGS: err_msg = "Invalid args argument"; break;
+	case PMI_ERR_INVALID_NUM_PARSED: err_msg = "Invalid num_parsed length argument"; break;
+	case PMI_ERR_INVALID_KEYVALP: err_msg = "Invalid keyvalp argument"; break;
+	case PMI_ERR_INVALID_SIZE: err_msg = "Invalid size argument"; break;
 #if defined(PMI_ERR_INVALID_KVS)
 	/* pmi.h calls this a valid return code but mpich doesn't define it (slurm does). */
-        case PMI_ERR_INVALID_KVS: err_msg = "Invalid kvs argument"; break;
+	case PMI_ERR_INVALID_KVS: err_msg = "Invalid kvs argument"; break;
 #endif
-        case PMI_SUCCESS: err_msg = "Success"; break;
-        default: err_msg = "Unkown error";
+	case PMI_SUCCESS: err_msg = "Success"; break;
+	default: err_msg = "Unkown error";
     }
     return err_msg;
 }

--- a/opal/mca/pmix/cray/pmix_cray_component.c
+++ b/opal/mca/pmix/cray/pmix_cray_component.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,29 +49,29 @@ opal_pmix_cray_component_t mca_pmix_cray_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
-        .base_version = {
-            /* Indicate that we are a pmix v1.1.0 component (which also
-               implies a specific MCA version) */
+	.base_version = {
+	    /* Indicate that we are a pmix v1.1.0 component (which also
+	       implies a specific MCA version) */
 
-            OPAL_PMIX_BASE_VERSION_2_0_0,
+	    OPAL_PMIX_BASE_VERSION_2_0_0,
 
-            /* Component name and version */
+	    /* Component name and version */
 
-            .mca_component_name = "cray",
-            MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                                  OPAL_RELEASE_VERSION),
+	    .mca_component_name = "cray",
+	    MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+				  OPAL_RELEASE_VERSION),
 
-            /* Component open and close functions */
+	    /* Component open and close functions */
 
-            .mca_open_component = pmix_cray_component_open,
-            .mca_close_component = pmix_cray_component_close,
-            .mca_query_component = pmix_cray_component_query,
-        },
-        /* Next the MCA v1.0.0 component meta data */
-        .base_data = {
-            /* The component is checkpoint ready */
-            MCA_BASE_METADATA_PARAM_CHECKPOINT
-        }
+	    .mca_open_component = pmix_cray_component_open,
+	    .mca_close_component = pmix_cray_component_close,
+	    .mca_query_component = pmix_cray_component_query,
+	},
+	/* Next the MCA v1.0.0 component meta data */
+	.base_data = {
+	    /* The component is checkpoint ready */
+	    MCA_BASE_METADATA_PARAM_CHECKPOINT
+	}
     },
     .cache_local = NULL,
     .cache_global = NULL,
@@ -92,23 +93,23 @@ static int pmix_cray_component_query(mca_base_module_t **module, int *priority)
        were launched by the orte/mpirun launcher */
     fd = fopen(proc_job_file, "r");
     if ((fd == NULL) || (getenv("OMPI_NO_USE_CRAY_PMI") != NULL)) {
-        *priority = 0;
-        *module = NULL;
-        rc = OPAL_ERROR;
+	*priority = 0;
+	*module = NULL;
+	rc = OPAL_ERROR;
     } else {
-        snprintf(task_is_app_fname,sizeof(task_is_app_fname),
-                 "/proc/self/task/%ld/task_is_app",syscall(SYS_gettid));
-        fd_task_is_app = fopen(task_is_app_fname, "r");
-        if (fd_task_is_app != NULL) {   /* okay we're in a PAGG container,
-                                           and we are an app task (not just a process
-                                           running on a mom node, for example),
-                                           so we should give cray pmi a shot. */
-            *priority = 90;
-            *module = (mca_base_module_t *)&opal_pmix_cray_module;
-            fclose(fd_task_is_app);
-            rc = OPAL_SUCCESS;
-        }
-        fclose(fd);
+	snprintf(task_is_app_fname,sizeof(task_is_app_fname),
+		 "/proc/self/task/%ld/task_is_app",syscall(SYS_gettid));
+	fd_task_is_app = fopen(task_is_app_fname, "r");
+	if (fd_task_is_app != NULL) {   /* okay we're in a PAGG container,
+					   and we are an app task (not just a process
+					   running on a mom node, for example),
+					   so we should give cray pmi a shot. */
+	    *priority = 90;
+	    *module = (mca_base_module_t *)&opal_pmix_cray_module;
+	    fclose(fd_task_is_app);
+	    rc = OPAL_SUCCESS;
+	}
+	fclose(fd);
     }
 
     return rc;
@@ -118,4 +119,3 @@ static int pmix_cray_component_close(void)
 {
     return OPAL_SUCCESS;
 }
-

--- a/opal/mca/pmix/cray/pmix_cray_pmap_parser.c
+++ b/opal/mca/pmix/cray/pmix_cray_pmap_parser.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * Additional copyrights may follow
  *
@@ -31,14 +32,14 @@ slurm block distro of 4 ranks over 2 nodes:
  Tuple can be visualized as a rectangle on two
  dimensional (Hosts, Local Ranks) plane:
 
-           ------------------------------------ Hosts ->
-           |              H
-           |           +--------+
-           |<- base -->|        |
-           |           |        | L
-           |           +--------+
-        Local Ranks
-           V
+	   ------------------------------------ Hosts ->
+	   |              H
+	   |           +--------+
+	   |<- base -->|        |
+	   |           |        | L
+	   |           +--------+
+	Local Ranks
+	   V
 
 Note that ranks increase by column. Tuple (0,2,3) looks like:
 0 3
@@ -58,14 +59,14 @@ static int find_my_node(char *map, int me)
     p = map;
     abs_rank = 0;
     while (NULL != (p = strstr(p+1, ",("))) {
-        if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
-            return -1;
-        }
-        if (me >= abs_rank && me < abs_rank + H*L) {
-            /* found my rectangle, compute node */
-            return base + (me - abs_rank)/L;
-        }
-        abs_rank += H*L;
+	if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
+	    return -1;
+	}
+	if (me >= abs_rank && me < abs_rank + H*L) {
+	    /* found my rectangle, compute node */
+	    return base + (me - abs_rank)/L;
+	}
+	abs_rank += H*L;
     }
     return -1;
 }
@@ -85,34 +86,34 @@ static int *find_lrs(char *map, int my_node, int *nlrs)
     max_lr = 16;
     lrs = malloc(max_lr * sizeof(int));
     while (NULL != (p = strstr(p+1, ",("))) {
-        if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
-            free(lrs);
-            return NULL;
-        }
-        if (base <= my_node && my_node < base + H) {
-            if (*nlrs + L >= max_lr) {
-                lrs = realloc(lrs, (max_lr + L) * sizeof(int));
-                if (NULL == lrs) {
-                    *nlrs = 0;
-                    free(lrs);
-                    return NULL;
-                }
-                max_lr += L;
-            }
-            /* skip (my_node - base) columns of L elems,
-             * numbers in my column are local to me
-             */
-            for (i = 0; i < L; i++) {
-                lrs[*nlrs] = (my_node - base) * L + i + abs_rank;
-                (*nlrs) ++;
-            }
-        }
-        abs_rank += H*L;
+	if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
+	    free(lrs);
+	    return NULL;
+	}
+	if (base <= my_node && my_node < base + H) {
+	    if (*nlrs + L >= max_lr) {
+		lrs = realloc(lrs, (max_lr + L) * sizeof(int));
+		if (NULL == lrs) {
+		    *nlrs = 0;
+		    free(lrs);
+		    return NULL;
+		}
+		max_lr += L;
+	    }
+	    /* skip (my_node - base) columns of L elems,
+	     * numbers in my column are local to me
+	     */
+	    for (i = 0; i < L; i++) {
+		lrs[*nlrs] = (my_node - base) * L + i + abs_rank;
+		(*nlrs) ++;
+	    }
+	}
+	abs_rank += H*L;
     }
 
     if (0 == *nlrs) {
-        free(lrs);
-        lrs = 0;
+	free(lrs);
+	lrs = 0;
     }
     return lrs;
 }
@@ -128,13 +129,13 @@ static int *find_lrs(char *map, int my_node, int *nlrs)
  * on failure. Array must be freed by the caller.
  */
 int *pmix_cray_parse_pmap(char *pmap, int my_rank,
-                          int *node, int *nlrs)
+			  int *node, int *nlrs)
 {
     char *p;
 
     p = strstr(pmap, "(vector");
     if (NULL == p) {
-        return NULL;
+	return NULL;
     }
 
     *node = find_my_node(p, my_rank);
@@ -154,7 +155,7 @@ static void dump_lrs(int *lrs, int me, int node, int n)
 
     printf("Total %d ranks/node, node %d me %d\n", n, node, me);
     for (i = 0; i < n; i++) {
-        printf("%d ", lrs[i]);
+	printf("%d ", lrs[i]);
     }
     printf("\n");
     free(lrs);
@@ -174,14 +175,14 @@ int main(int argc, char **argv)
 
 
     if (argc == 3) {
-        me = atoi(argv[1]);
-        lrs = orte_grpcomm_pmi2_parse_pmap(argv[2], me, &node, &n);
-        if (NULL == lrs) {
-            printf("can not parse pmap\n");
-            exit(1);
-        }
-        dump_lrs(lrs, me, node, n);
-        exit(0);
+	me = atoi(argv[1]);
+	lrs = orte_grpcomm_pmi2_parse_pmap(argv[2], me, &node, &n);
+	if (NULL == lrs) {
+	    printf("can not parse pmap\n");
+	    exit(1);
+	}
+	dump_lrs(lrs, me, node, n);
+	exit(0);
     }
     /* built in cases */
 

--- a/opal/mca/pmix/ext114/pmix_ext.c
+++ b/opal/mca/pmix/ext114/pmix_ext.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,9 +101,9 @@ static const char *pmix1_get_nspace(opal_jobid_t jobid)
     opal_pmix1_jobid_trkr_t *jptr;
 
     OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-        if (jptr->jobid == jobid) {
-            return jptr->nspace;
-        }
+	if (jptr->jobid == jobid) {
+	    return jptr->nspace;
+	}
     }
     return NULL;
 }
@@ -113,9 +114,9 @@ static void pmix1_register_jobid(opal_jobid_t jobid, const char *nspace)
 
     /* if we don't already have it, add this to our jobid tracker */
     OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-        if (jptr->jobid == jobid) {
-            return;
-        }
+	if (jptr->jobid == jobid) {
+	    return;
+	}
     }
     jptr = OBJ_NEW(opal_pmix1_jobid_trkr_t);
     (void)strncpy(jptr->nspace, nspace, PMIX_MAX_NSLEN);
@@ -127,61 +128,61 @@ pmix_status_t pmix1_convert_opalrc(int rc)
 {
     switch (rc) {
     case OPAL_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+	return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
     case OPAL_ERR_COMM_FAILURE:
-        return PMIX_ERR_COMM_FAILURE;
+	return PMIX_ERR_COMM_FAILURE;
     case OPAL_ERR_NOT_IMPLEMENTED:
-        return PMIX_ERR_NOT_IMPLEMENTED;
+	return PMIX_ERR_NOT_IMPLEMENTED;
     case OPAL_ERR_NOT_SUPPORTED:
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     case OPAL_ERR_NOT_FOUND:
-        return PMIX_ERR_NOT_FOUND;
+	return PMIX_ERR_NOT_FOUND;
     case OPAL_ERR_SERVER_NOT_AVAIL:
-        return PMIX_ERR_SERVER_NOT_AVAIL;
+	return PMIX_ERR_SERVER_NOT_AVAIL;
 
     case OPAL_ERR_BAD_PARAM:
-        return PMIX_ERR_BAD_PARAM;
+	return PMIX_ERR_BAD_PARAM;
     case OPAL_ERR_OUT_OF_RESOURCE:
-        return PMIX_ERR_NOMEM;
+	return PMIX_ERR_NOMEM;
 
     case OPAL_ERR_DATA_VALUE_NOT_FOUND:
-        return PMIX_ERR_DATA_VALUE_NOT_FOUND;
+	return PMIX_ERR_DATA_VALUE_NOT_FOUND;
     case OPAL_ERR_IN_ERRNO:
-        return PMIX_ERR_IN_ERRNO;
+	return PMIX_ERR_IN_ERRNO;
     case OPAL_ERR_UNREACH:
-        return PMIX_ERR_UNREACH;
+	return PMIX_ERR_UNREACH;
     case OPAL_ERR_TIMEOUT:
-        return PMIX_ERR_TIMEOUT;
+	return PMIX_ERR_TIMEOUT;
     case OPAL_ERR_PERM:
-        return PMIX_ERR_NO_PERMISSIONS;
+	return PMIX_ERR_NO_PERMISSIONS;
     case OPAL_ERR_PACK_MISMATCH:
-        return PMIX_ERR_PACK_MISMATCH;
+	return PMIX_ERR_PACK_MISMATCH;
     case OPAL_ERR_PACK_FAILURE:
-        return PMIX_ERR_PACK_FAILURE;
+	return PMIX_ERR_PACK_FAILURE;
 
     case OPAL_ERR_UNPACK_FAILURE:
-        return PMIX_ERR_UNPACK_FAILURE;
+	return PMIX_ERR_UNPACK_FAILURE;
     case OPAL_ERR_UNPACK_INADEQUATE_SPACE:
-        return PMIX_ERR_UNPACK_INADEQUATE_SPACE;
+	return PMIX_ERR_UNPACK_INADEQUATE_SPACE;
     case OPAL_ERR_TYPE_MISMATCH:
-        return PMIX_ERR_TYPE_MISMATCH;
+	return PMIX_ERR_TYPE_MISMATCH;
     case OPAL_ERR_PROC_ENTRY_NOT_FOUND:
-        return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+	return PMIX_ERR_PROC_ENTRY_NOT_FOUND;
     case OPAL_ERR_UNKNOWN_DATA_TYPE:
-        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+	return PMIX_ERR_UNKNOWN_DATA_TYPE;
     case OPAL_ERR_WOULD_BLOCK:
-        return PMIX_ERR_WOULD_BLOCK;
+	return PMIX_ERR_WOULD_BLOCK;
     case OPAL_EXISTS:
-        return PMIX_EXISTS;
+	return PMIX_EXISTS;
 
     case OPAL_ERR_SILENT:
-        return PMIX_ERR_SILENT;
+	return PMIX_ERR_SILENT;
     case OPAL_ERROR:
-        return PMIX_ERROR;
+	return PMIX_ERROR;
     case OPAL_SUCCESS:
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     default:
-        return PMIX_ERROR;
+	return PMIX_ERROR;
     }
 }
 
@@ -189,17 +190,17 @@ int pmix1_convert_rc(pmix_status_t rc)
 {
     switch (rc) {
     case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
-        return OPAL_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+	return OPAL_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
     case PMIX_ERR_COMM_FAILURE:
-        return OPAL_ERR_COMM_FAILURE;
+	return OPAL_ERR_COMM_FAILURE;
     case PMIX_ERR_NOT_IMPLEMENTED:
-        return OPAL_ERR_NOT_IMPLEMENTED;
+	return OPAL_ERR_NOT_IMPLEMENTED;
     case PMIX_ERR_NOT_SUPPORTED:
-        return OPAL_ERR_NOT_SUPPORTED;
+	return OPAL_ERR_NOT_SUPPORTED;
     case PMIX_ERR_NOT_FOUND:
-        return OPAL_ERR_NOT_FOUND;
+	return OPAL_ERR_NOT_FOUND;
     case PMIX_ERR_SERVER_NOT_AVAIL:
-        return OPAL_ERR_SERVER_NOT_AVAIL;
+	return OPAL_ERR_SERVER_NOT_AVAIL;
 
     case PMIX_ERR_INVALID_NAMESPACE:
     case PMIX_ERR_INVALID_SIZE:
@@ -213,276 +214,276 @@ int pmix1_convert_rc(pmix_status_t rc)
     case PMIX_ERR_INVALID_KEY_LENGTH:
     case PMIX_ERR_INVALID_KEY:
     case PMIX_ERR_INVALID_ARG:
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     case PMIX_ERR_NOMEM:
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	return OPAL_ERR_OUT_OF_RESOURCE;
     case PMIX_ERR_INIT:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
 
     case PMIX_ERR_DATA_VALUE_NOT_FOUND:
-        return OPAL_ERR_DATA_VALUE_NOT_FOUND;
+	return OPAL_ERR_DATA_VALUE_NOT_FOUND;
     case PMIX_ERR_OUT_OF_RESOURCE:
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	return OPAL_ERR_OUT_OF_RESOURCE;
     case PMIX_ERR_RESOURCE_BUSY:
-        return OPAL_ERR_TEMP_OUT_OF_RESOURCE;
+	return OPAL_ERR_TEMP_OUT_OF_RESOURCE;
     case PMIX_ERR_BAD_PARAM:
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     case PMIX_ERR_IN_ERRNO:
-        return OPAL_ERR_IN_ERRNO;
+	return OPAL_ERR_IN_ERRNO;
     case PMIX_ERR_UNREACH:
-        return OPAL_ERR_UNREACH;
+	return OPAL_ERR_UNREACH;
     case PMIX_ERR_TIMEOUT:
-        return OPAL_ERR_TIMEOUT;
+	return OPAL_ERR_TIMEOUT;
     case PMIX_ERR_NO_PERMISSIONS:
-        return OPAL_ERR_PERM;
+	return OPAL_ERR_PERM;
     case PMIX_ERR_PACK_MISMATCH:
-        return OPAL_ERR_PACK_MISMATCH;
+	return OPAL_ERR_PACK_MISMATCH;
     case PMIX_ERR_PACK_FAILURE:
-        return OPAL_ERR_PACK_FAILURE;
+	return OPAL_ERR_PACK_FAILURE;
 
     case PMIX_ERR_UNPACK_FAILURE:
-        return OPAL_ERR_UNPACK_FAILURE;
+	return OPAL_ERR_UNPACK_FAILURE;
     case PMIX_ERR_UNPACK_INADEQUATE_SPACE:
-        return OPAL_ERR_UNPACK_INADEQUATE_SPACE;
+	return OPAL_ERR_UNPACK_INADEQUATE_SPACE;
     case PMIX_ERR_TYPE_MISMATCH:
-        return OPAL_ERR_TYPE_MISMATCH;
+	return OPAL_ERR_TYPE_MISMATCH;
     case PMIX_ERR_PROC_ENTRY_NOT_FOUND:
-        return OPAL_ERR_PROC_ENTRY_NOT_FOUND;
+	return OPAL_ERR_PROC_ENTRY_NOT_FOUND;
     case PMIX_ERR_UNKNOWN_DATA_TYPE:
-        return OPAL_ERR_UNKNOWN_DATA_TYPE;
+	return OPAL_ERR_UNKNOWN_DATA_TYPE;
     case PMIX_ERR_WOULD_BLOCK:
-        return OPAL_ERR_WOULD_BLOCK;
+	return OPAL_ERR_WOULD_BLOCK;
     case PMIX_ERR_READY_FOR_HANDSHAKE:
     case PMIX_ERR_HANDSHAKE_FAILED:
     case PMIX_ERR_INVALID_CRED:
-        return OPAL_ERR_COMM_FAILURE;
+	return OPAL_ERR_COMM_FAILURE;
     case PMIX_EXISTS:
-        return OPAL_EXISTS;
+	return OPAL_EXISTS;
 
     case PMIX_ERR_SILENT:
-        return OPAL_ERR_SILENT;
+	return OPAL_ERR_SILENT;
     case PMIX_ERROR:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     case PMIX_SUCCESS:
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     default:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     }
 }
 
 pmix_scope_t pmix1_convert_opalscope(opal_pmix_scope_t scope) {
     switch(scope) {
     case OPAL_PMIX_LOCAL:
-        return PMIX_LOCAL;
+	return PMIX_LOCAL;
     case OPAL_PMIX_REMOTE:
-        return PMIX_REMOTE;
+	return PMIX_REMOTE;
     case OPAL_PMIX_GLOBAL:
-        return PMIX_GLOBAL;
+	return PMIX_GLOBAL;
     default:
-        return PMIX_SCOPE_UNDEF;
+	return PMIX_SCOPE_UNDEF;
     }
 }
 
 void pmix1_value_load(pmix_value_t *v,
-                      opal_value_t *kv)
+		      opal_value_t *kv)
 {
     switch(kv->type) {
-        case OPAL_UNDEF:
-            v->type = PMIX_UNDEF;
-            opal_output(0, "TYPE WAS UNDEF");
-            break;
-        case OPAL_BOOL:
-            v->type = PMIX_BOOL;
-            memcpy(&(v->data.flag), &kv->data.flag, 1);
-            break;
-        case OPAL_BYTE:
-            v->type = PMIX_BYTE;
-            memcpy(&(v->data.byte), &kv->data.byte, 1);
-            break;
-        case OPAL_STRING:
-            v->type = PMIX_STRING;
-            if (NULL != kv->data.string) {
-                v->data.string = strdup(kv->data.string);
-            } else {
-                v->data.string = NULL;
-            }
-            break;
-        case OPAL_SIZE:
-            v->type = PMIX_SIZE;
-            v->data.size = (size_t)kv->data.size;
-            break;
-        case OPAL_PID:
-            v->type = PMIX_PID;
-            memcpy(&(v->data.pid), &kv->data.pid, sizeof(pid_t));
-            break;
-        case OPAL_INT:
-            v->type = PMIX_INT;
-            memcpy(&(v->data.integer), &kv->data.integer, sizeof(int));
-            break;
-        case OPAL_INT8:
-            v->type = PMIX_INT8;
-            memcpy(&(v->data.int8), &kv->data.int8, 1);
-            break;
-        case OPAL_INT16:
-            v->type = PMIX_INT16;
-            memcpy(&(v->data.int16), &kv->data.int16, 2);
-            break;
-        case OPAL_INT32:
-            v->type = PMIX_INT32;
-            memcpy(&(v->data.int32), &kv->data.int32, 4);
-            break;
-        case OPAL_INT64:
-            v->type = PMIX_INT64;
-            memcpy(&(v->data.int64), &kv->data.int64, 8);
-            break;
-        case OPAL_UINT:
-            v->type = PMIX_UINT;
-            memcpy(&(v->data.uint), &kv->data.uint, sizeof(int));
-            break;
-        case OPAL_UINT8:
-            v->type = PMIX_UINT8;
-            memcpy(&(v->data.uint8), &kv->data.uint8, 1);
-            break;
-        case OPAL_UINT16:
-            v->type = PMIX_UINT16;
-            memcpy(&(v->data.uint16), &kv->data.uint16, 2);
-            break;
-        case OPAL_UINT32:
-            v->type = PMIX_UINT32;
-            memcpy(&(v->data.uint32), &kv->data.uint32, 4);
-            break;
-        case OPAL_UINT64:
-            v->type = PMIX_UINT64;
-            memcpy(&(v->data.uint64), &kv->data.uint64, 8);
-            break;
-        case OPAL_FLOAT:
-            v->type = PMIX_FLOAT;
-            memcpy(&(v->data.fval), &kv->data.fval, sizeof(float));
-            break;
-        case OPAL_DOUBLE:
-            v->type = PMIX_DOUBLE;
-            memcpy(&(v->data.dval), &kv->data.dval, sizeof(double));
-            break;
-        case OPAL_TIMEVAL:
-            v->type = PMIX_TIMEVAL;
-            memcpy(&(v->data.tv), &kv->data.tv, sizeof(struct timeval));
-            break;
-        case OPAL_BYTE_OBJECT:
-            v->type = PMIX_BYTE_OBJECT;
-            if (NULL != kv->data.bo.bytes) {
-                v->data.bo.bytes = (char*)malloc(kv->data.bo.size);
-                memcpy(v->data.bo.bytes, kv->data.bo.bytes, kv->data.bo.size);
-                v->data.bo.size = (size_t)kv->data.bo.size;
-            } else {
-                v->data.bo.bytes = NULL;
-                v->data.bo.size = 0;
-            }
-            break;
-        default:
-            /* silence warnings */
-            break;
+	case OPAL_UNDEF:
+	    v->type = PMIX_UNDEF;
+	    opal_output(0, "TYPE WAS UNDEF");
+	    break;
+	case OPAL_BOOL:
+	    v->type = PMIX_BOOL;
+	    memcpy(&(v->data.flag), &kv->data.flag, 1);
+	    break;
+	case OPAL_BYTE:
+	    v->type = PMIX_BYTE;
+	    memcpy(&(v->data.byte), &kv->data.byte, 1);
+	    break;
+	case OPAL_STRING:
+	    v->type = PMIX_STRING;
+	    if (NULL != kv->data.string) {
+		v->data.string = strdup(kv->data.string);
+	    } else {
+		v->data.string = NULL;
+	    }
+	    break;
+	case OPAL_SIZE:
+	    v->type = PMIX_SIZE;
+	    v->data.size = (size_t)kv->data.size;
+	    break;
+	case OPAL_PID:
+	    v->type = PMIX_PID;
+	    memcpy(&(v->data.pid), &kv->data.pid, sizeof(pid_t));
+	    break;
+	case OPAL_INT:
+	    v->type = PMIX_INT;
+	    memcpy(&(v->data.integer), &kv->data.integer, sizeof(int));
+	    break;
+	case OPAL_INT8:
+	    v->type = PMIX_INT8;
+	    memcpy(&(v->data.int8), &kv->data.int8, 1);
+	    break;
+	case OPAL_INT16:
+	    v->type = PMIX_INT16;
+	    memcpy(&(v->data.int16), &kv->data.int16, 2);
+	    break;
+	case OPAL_INT32:
+	    v->type = PMIX_INT32;
+	    memcpy(&(v->data.int32), &kv->data.int32, 4);
+	    break;
+	case OPAL_INT64:
+	    v->type = PMIX_INT64;
+	    memcpy(&(v->data.int64), &kv->data.int64, 8);
+	    break;
+	case OPAL_UINT:
+	    v->type = PMIX_UINT;
+	    memcpy(&(v->data.uint), &kv->data.uint, sizeof(int));
+	    break;
+	case OPAL_UINT8:
+	    v->type = PMIX_UINT8;
+	    memcpy(&(v->data.uint8), &kv->data.uint8, 1);
+	    break;
+	case OPAL_UINT16:
+	    v->type = PMIX_UINT16;
+	    memcpy(&(v->data.uint16), &kv->data.uint16, 2);
+	    break;
+	case OPAL_UINT32:
+	    v->type = PMIX_UINT32;
+	    memcpy(&(v->data.uint32), &kv->data.uint32, 4);
+	    break;
+	case OPAL_UINT64:
+	    v->type = PMIX_UINT64;
+	    memcpy(&(v->data.uint64), &kv->data.uint64, 8);
+	    break;
+	case OPAL_FLOAT:
+	    v->type = PMIX_FLOAT;
+	    memcpy(&(v->data.fval), &kv->data.fval, sizeof(float));
+	    break;
+	case OPAL_DOUBLE:
+	    v->type = PMIX_DOUBLE;
+	    memcpy(&(v->data.dval), &kv->data.dval, sizeof(double));
+	    break;
+	case OPAL_TIMEVAL:
+	    v->type = PMIX_TIMEVAL;
+	    memcpy(&(v->data.tv), &kv->data.tv, sizeof(struct timeval));
+	    break;
+	case OPAL_BYTE_OBJECT:
+	    v->type = PMIX_BYTE_OBJECT;
+	    if (NULL != kv->data.bo.bytes) {
+		v->data.bo.bytes = (char*)malloc(kv->data.bo.size);
+		memcpy(v->data.bo.bytes, kv->data.bo.bytes, kv->data.bo.size);
+		v->data.bo.size = (size_t)kv->data.bo.size;
+	    } else {
+		v->data.bo.bytes = NULL;
+		v->data.bo.size = 0;
+	    }
+	    break;
+	default:
+	    /* silence warnings */
+	    break;
     }
 }
 
 int pmix1_value_unload(opal_value_t *kv,
-                       const pmix_value_t *v)
+		       const pmix_value_t *v)
 {
     int rc=OPAL_SUCCESS;
 
 
     switch(v->type) {
     case PMIX_UNDEF:
-        rc = OPAL_ERR_UNKNOWN_DATA_TYPE;
-        break;
+	rc = OPAL_ERR_UNKNOWN_DATA_TYPE;
+	break;
     case PMIX_BOOL:
-        kv->type = OPAL_BOOL;
-        memcpy(&kv->data.flag, &(v->data.flag), 1);
-        break;
+	kv->type = OPAL_BOOL;
+	memcpy(&kv->data.flag, &(v->data.flag), 1);
+	break;
     case PMIX_BYTE:
-        kv->type = OPAL_BYTE;
-        memcpy(&kv->data.byte, &(v->data.byte), 1);
-        break;
+	kv->type = OPAL_BYTE;
+	memcpy(&kv->data.byte, &(v->data.byte), 1);
+	break;
     case PMIX_STRING:
-        kv->type = OPAL_STRING;
-        if (NULL != v->data.string) {
-            kv->data.string = strdup(v->data.string);
-        }
-        break;
+	kv->type = OPAL_STRING;
+	if (NULL != v->data.string) {
+	    kv->data.string = strdup(v->data.string);
+	}
+	break;
     case PMIX_SIZE:
-        kv->type = OPAL_SIZE;
-        kv->data.size = (int)v->data.size;
-        break;
+	kv->type = OPAL_SIZE;
+	kv->data.size = (int)v->data.size;
+	break;
     case PMIX_PID:
-        kv->type = OPAL_PID;
-        memcpy(&kv->data.pid, &(v->data.pid), sizeof(pid_t));
-        break;
+	kv->type = OPAL_PID;
+	memcpy(&kv->data.pid, &(v->data.pid), sizeof(pid_t));
+	break;
     case PMIX_INT:
-        kv->type = OPAL_INT;
-        memcpy(&kv->data.integer, &(v->data.integer), sizeof(int));
-        break;
+	kv->type = OPAL_INT;
+	memcpy(&kv->data.integer, &(v->data.integer), sizeof(int));
+	break;
     case PMIX_INT8:
-        kv->type = OPAL_INT8;
-        memcpy(&kv->data.int8, &(v->data.int8), 1);
-        break;
+	kv->type = OPAL_INT8;
+	memcpy(&kv->data.int8, &(v->data.int8), 1);
+	break;
     case PMIX_INT16:
-        kv->type = OPAL_INT16;
-        memcpy(&kv->data.int16, &(v->data.int16), 2);
-        break;
+	kv->type = OPAL_INT16;
+	memcpy(&kv->data.int16, &(v->data.int16), 2);
+	break;
     case PMIX_INT32:
-        kv->type = OPAL_INT32;
-        memcpy(&kv->data.int32, &(v->data.int32), 4);
-        break;
+	kv->type = OPAL_INT32;
+	memcpy(&kv->data.int32, &(v->data.int32), 4);
+	break;
     case PMIX_INT64:
-        kv->type = OPAL_INT64;
-        memcpy(&kv->data, &(v->data.int64), 8);
-        break;
+	kv->type = OPAL_INT64;
+	memcpy(&kv->data, &(v->data.int64), 8);
+	break;
     case PMIX_UINT:
-        kv->type = OPAL_UINT;
-        memcpy(&kv->data, &(v->data.uint), sizeof(int));
-        break;
+	kv->type = OPAL_UINT;
+	memcpy(&kv->data, &(v->data.uint), sizeof(int));
+	break;
     case PMIX_UINT8:
-        kv->type = OPAL_UINT8;
-        memcpy(&kv->data, &(v->data.uint8), 1);
-        break;
+	kv->type = OPAL_UINT8;
+	memcpy(&kv->data, &(v->data.uint8), 1);
+	break;
     case PMIX_UINT16:
-        kv->type = OPAL_UINT16;
-        memcpy(&kv->data, &(v->data.uint16), 2);
-        break;
+	kv->type = OPAL_UINT16;
+	memcpy(&kv->data, &(v->data.uint16), 2);
+	break;
     case PMIX_UINT32:
-        kv->type = OPAL_UINT32;
-        memcpy(&kv->data, &(v->data.uint32), 4);
-        break;
+	kv->type = OPAL_UINT32;
+	memcpy(&kv->data, &(v->data.uint32), 4);
+	break;
     case PMIX_UINT64:
-        kv->type = OPAL_UINT64;
-        memcpy(&kv->data, &(v->data.uint64), 8);
-        break;
+	kv->type = OPAL_UINT64;
+	memcpy(&kv->data, &(v->data.uint64), 8);
+	break;
     case PMIX_FLOAT:
-        kv->type = OPAL_FLOAT;
-        memcpy(&kv->data, &(v->data.fval), sizeof(float));
-        break;
+	kv->type = OPAL_FLOAT;
+	memcpy(&kv->data, &(v->data.fval), sizeof(float));
+	break;
     case PMIX_DOUBLE:
-        kv->type = OPAL_DOUBLE;
-        memcpy(&kv->data, &(v->data.dval), sizeof(double));
-        break;
+	kv->type = OPAL_DOUBLE;
+	memcpy(&kv->data, &(v->data.dval), sizeof(double));
+	break;
     case PMIX_TIMEVAL:
-        kv->type = OPAL_TIMEVAL;
-        memcpy(&kv->data, &(v->data.tv), sizeof(struct timeval));
-        break;
+	kv->type = OPAL_TIMEVAL;
+	memcpy(&kv->data, &(v->data.tv), sizeof(struct timeval));
+	break;
     case PMIX_BYTE_OBJECT:
-        kv->type = OPAL_BYTE_OBJECT;
-        if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
-            kv->data.bo.bytes = (uint8_t*)malloc(v->data.bo.size);
-            memcpy(kv->data.bo.bytes, v->data.bo.bytes, v->data.bo.size);
-            kv->data.bo.size = (int)v->data.bo.size;
-        } else {
-            kv->data.bo.bytes = NULL;
-            kv->data.bo.size = 0;
-        }
-        break;
+	kv->type = OPAL_BYTE_OBJECT;
+	if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
+	    kv->data.bo.bytes = (uint8_t*)malloc(v->data.bo.size);
+	    memcpy(kv->data.bo.bytes, v->data.bo.bytes, v->data.bo.size);
+	    kv->data.bo.size = (int)v->data.bo.size;
+	} else {
+	    kv->data.bo.bytes = NULL;
+	    kv->data.bo.size = 0;
+	}
+	break;
     default:
-        /* silence warnings */
-        rc = OPAL_ERROR;
-        break;
+	/* silence warnings */
+	rc = OPAL_ERROR;
+	break;
     }
     return rc;
 }
@@ -490,8 +491,8 @@ int pmix1_value_unload(opal_value_t *kv,
 
 /****  INSTANTIATE INTERNAL CLASSES  ****/
 OBJ_CLASS_INSTANCE(opal_pmix1_jobid_trkr_t,
-                   opal_list_item_t,
-                   NULL, NULL);
+		   opal_list_item_t,
+		   NULL, NULL);
 
 static void opcon(pmix1_opcaddy_t *p)
 {
@@ -514,21 +515,21 @@ static void opcon(pmix1_opcaddy_t *p)
 static void opdes(pmix1_opcaddy_t *p)
 {
     if (NULL != p->procs) {
-        PMIX_PROC_FREE(p->procs, p->nprocs);
+	PMIX_PROC_FREE(p->procs, p->nprocs);
     }
     if (NULL != p->error_procs) {
-        PMIX_PROC_FREE(p->error_procs, p->nerror_procs);
+	PMIX_PROC_FREE(p->error_procs, p->nerror_procs);
     }
     if (NULL != p->info) {
-        PMIX_INFO_FREE(p->info, p->sz);
+	PMIX_INFO_FREE(p->info, p->sz);
     }
     if (NULL != p->apps) {
-        PMIX_APP_FREE(p->apps, p->sz);
+	PMIX_APP_FREE(p->apps, p->sz);
     }
 }
 OBJ_CLASS_INSTANCE(pmix1_opcaddy_t,
-                   opal_object_t,
-                   opcon, opdes);
+		   opal_object_t,
+		   opcon, opdes);
 
 static void ocadcon(pmix1_opalcaddy_t *p)
 {
@@ -551,5 +552,5 @@ static void ocaddes(pmix1_opalcaddy_t *p)
     OPAL_LIST_DESTRUCT(&p->apps);
 }
 OBJ_CLASS_INSTANCE(pmix1_opalcaddy_t,
-                   opal_object_t,
-                   ocadcon, ocaddes);
+		   opal_object_t,
+		   ocadcon, ocaddes);

--- a/opal/mca/pmix/ext114/pmix_ext_client.c
+++ b/opal/mca/pmix/ext114/pmix_ext_client.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,22 +38,22 @@ static int errhdler_ref = 0;
 
 #define PMIX_WAIT_FOR_COMPLETION(a)             \
     do {                                        \
-        while ((a)) {                           \
-            usleep(10);                         \
-        }                                       \
+	while ((a)) {                           \
+	    usleep(10);                         \
+	}                                       \
     } while (0)
 
 
 static void completion_handler(int status, opal_list_t *results,
-                               opal_pmix_op_cbfunc_t cbfunc, void *thiscbdata,
-                               void *notification_cbdata) {
+			       opal_pmix_op_cbfunc_t cbfunc, void *thiscbdata,
+			       void *notification_cbdata) {
     int * cond = (int *)notification_cbdata;
     *cond = 0;
 }
 
 static void myerr(pmix_status_t status,
-                  pmix_proc_t procs[], size_t nprocs,
-                  pmix_info_t info[], size_t ninfo)
+		  pmix_proc_t procs[], size_t nprocs,
+		  pmix_info_t info[], size_t ninfo)
 {
     int rc;
     opal_list_t plist, ilist;
@@ -67,19 +68,19 @@ static void myerr(pmix_status_t status,
     /* convert the array of procs */
     OBJ_CONSTRUCT(&plist, opal_list_t);
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        nm->name.jobid = strtoul(procs[n].nspace, NULL, 10);
-        nm->name.vpid = procs[n].rank;
-        opal_list_append(&plist, &nm->super);
+	nm = OBJ_NEW(opal_namelist_t);
+	nm->name.jobid = strtoul(procs[n].nspace, NULL, 10);
+	nm->name.vpid = procs[n].rank;
+	opal_list_append(&plist, &nm->super);
     }
 
     /* convert the array of info */
     OBJ_CONSTRUCT(&ilist, opal_list_t);
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        iptr->key = strdup(info[n].key);
-        pmix1_value_unload(iptr, &info[n].value);
-        opal_list_append(&plist, &iptr->super);
+	iptr = OBJ_NEW(opal_value_t);
+	iptr->key = strdup(info[n].key);
+	pmix1_value_unload(iptr, &info[n].value);
+	opal_list_append(&plist, &iptr->super);
     }
 
     /* call the base errhandler */
@@ -91,13 +92,13 @@ static void myerr(pmix_status_t status,
 }
 
 static void errreg_cbfunc (pmix_status_t status,
-                          int errhandler_ref,
-                          void *cbdata)
+			  int errhandler_ref,
+			  void *cbdata)
 {
     errhdler_ref = errhandler_ref;
     opal_output_verbose(5, opal_pmix_base_framework.framework_output,
-                        "PMIX client errreg_cbfunc - error handler registered status=%d, reference=%d",
-                         status, errhandler_ref);
+			"PMIX client errreg_cbfunc - error handler registered status=%d, reference=%d",
+			 status, errhandler_ref);
 }
 
 int pmix1_client_init(void)
@@ -108,28 +109,28 @@ int pmix1_client_init(void)
     opal_pmix1_jobid_trkr_t *job;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client init");
+			"PMIx_client init");
 
     if (0 < (dbg = opal_output_get_verbosity(opal_pmix_base_framework.framework_output))) {
-        asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
-        putenv(dbgvalue);
+	asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
+	putenv(dbgvalue);
     }
 
     rc = PMIx_Init(&my_proc);
     if (PMIX_SUCCESS != rc) {
-        return pmix1_convert_rc(rc);
+	return pmix1_convert_rc(rc);
     }
 
     /* store our jobid and rank */
    if (NULL != getenv(OPAL_MCA_PREFIX"orte_launch")) {
-        /* if we were launched by the OMPI RTE, then
-         * the jobid is in a special format - so get it */
-        mca_pmix_ext114_component.native_launch = true;
-        opal_convert_string_to_jobid(&pname.jobid, my_proc.nspace);
+	/* if we were launched by the OMPI RTE, then
+	 * the jobid is in a special format - so get it */
+	mca_pmix_ext114_component.native_launch = true;
+	opal_convert_string_to_jobid(&pname.jobid, my_proc.nspace);
     } else {
-        /* we were launched by someone else, so make the
-         * jobid just be the hash of the nspace */
-        OPAL_HASH_STR(my_proc.nspace, pname.jobid);
+	/* we were launched by someone else, so make the
+	 * jobid just be the hash of the nspace */
+	OPAL_HASH_STR(my_proc.nspace, pname.jobid);
     }
     /* insert this into our list of jobids - it will be the
      * first, and so we'll check it first */
@@ -152,7 +153,7 @@ int pmix1_client_finalize(void)
     pmix_status_t rc;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client finalize");
+			"PMIx_client finalize");
 
     /* deregister the errhandler */
     PMIx_Deregister_errhandler(errhdler_ref, NULL, NULL);
@@ -164,13 +165,13 @@ int pmix1_client_finalize(void)
 int pmix1_initialized(void)
 {
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client initialized");
+			"PMIx_client initialized");
 
     return PMIx_Initialized();
 }
 
 int pmix1_abort(int flag, const char *msg,
-                  opal_list_t *procs)
+		  opal_list_t *procs)
 {
     pmix_status_t rc;
     pmix_proc_t *parray=NULL;
@@ -179,30 +180,30 @@ int pmix1_abort(int flag, const char *msg,
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client abort");
+			"PMIx_client abort");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
 
     /* call the library abort */
@@ -222,25 +223,25 @@ int pmix1_store_local(const opal_process_name_t *proc, opal_value_t *val)
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        p.rank = proc->vpid;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	p.rank = proc->vpid;
     } else {
-        /* use our name */
-        (void)strncpy(p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
-        p.rank = OPAL_PROC_MY_NAME.vpid;
+	/* use our name */
+	(void)strncpy(p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+	p.rank = OPAL_PROC_MY_NAME.vpid;
     }
 
     PMIX_VALUE_CONSTRUCT(&kv);
@@ -265,7 +266,7 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
 
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(pmix1_convert_rc(status), op->cbdata);
+	op->opcbfunc(pmix1_convert_rc(status), op->cbdata);
     }
     OBJ_RELEASE(op);
 }
@@ -280,41 +281,41 @@ int pmix1_fence(opal_list_t *procs, int collect_data)
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client fence");
+			"PMIx_client fence");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
     if (collect_data) {
-        PMIX_INFO_CONSTRUCT(&info);
-        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-        info.value.type = PMIX_BOOL;
-        info.value.data.flag = true;
-        iptr = &info;
-        n = 1;
+	PMIX_INFO_CONSTRUCT(&info);
+	(void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+	info.value.type = PMIX_BOOL;
+	info.value.data.flag = true;
+	iptr = &info;
+	n = 1;
     } else {
-        iptr = NULL;
-        n = 0;
+	iptr = NULL;
+	n = 0;
     }
 
     /* call the library function */
@@ -323,7 +324,7 @@ int pmix1_fence(opal_list_t *procs, int collect_data)
     /* release the array */
     PMIX_PROC_FREE(parray, cnt);
     if (NULL != iptr) {
-        PMIX_INFO_DESTRUCT(&info);
+	PMIX_INFO_DESTRUCT(&info);
     }
 
     return pmix1_convert_rc(rc);
@@ -331,7 +332,7 @@ int pmix1_fence(opal_list_t *procs, int collect_data)
 }
 
 int pmix1_fencenb(opal_list_t *procs, int collect_data,
-                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t rc;
     pmix_proc_t *parray=NULL;
@@ -342,42 +343,42 @@ int pmix1_fencenb(opal_list_t *procs, int collect_data,
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client fence_nb");
+			"PMIx_client fence_nb");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
 
     if (collect_data) {
-        PMIX_INFO_CONSTRUCT(&info);
-        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-        info.value.type = PMIX_BOOL;
-        info.value.data.flag = true;
-        iptr = &info;
-        n = 1;
+	PMIX_INFO_CONSTRUCT(&info);
+	(void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+	info.value.type = PMIX_BOOL;
+	info.value.data.flag = true;
+	iptr = &info;
+	n = 1;
     } else {
-        iptr = NULL;
-        n = 0;
+	iptr = NULL;
+	n = 0;
     }
 
     /* create the caddy */
@@ -390,7 +391,7 @@ int pmix1_fencenb(opal_list_t *procs, int collect_data,
     /* call the library function */
     rc = PMIx_Fence_nb(parray, cnt, iptr, n, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 
     return pmix1_convert_rc(rc);
@@ -398,14 +399,14 @@ int pmix1_fencenb(opal_list_t *procs, int collect_data,
 }
 
 int pmix1_put(opal_pmix_scope_t opal_scope,
-              opal_value_t *val)
+	      opal_value_t *val)
 {
     pmix_value_t kv;
     pmix_scope_t pmix_scope = pmix1_convert_opalscope(opal_scope);
     pmix_status_t rc;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client put");
+			"PMIx_client put");
 
     PMIX_VALUE_CONSTRUCT(&kv);
     pmix1_value_load(&kv, val);
@@ -416,7 +417,7 @@ int pmix1_put(opal_pmix_scope_t opal_scope,
 }
 
 int pmix1_get(const opal_process_name_t *proc, const char *key,
-              opal_list_t *info, opal_value_t **val)
+	      opal_list_t *info, opal_value_t **val)
 {
     int ret;
     pmix_value_t *kv;
@@ -428,80 +429,80 @@ int pmix1_get(const opal_process_name_t *proc, const char *key,
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "%s PMIx_client get on proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+			"%s PMIx_client get on proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
 
     /* prep default response */
     *val = NULL;
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        p.rank = proc->vpid;
-        pptr = &p;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	p.rank = proc->vpid;
+	pptr = &p;
     } else {
-        /* if they are asking for our jobid, then return it */
-        if (0 == strcmp(key, OPAL_PMIX_JOBID)) {
-            (*val) = OBJ_NEW(opal_value_t);
-            (*val)->type = OPAL_UINT32;
-            (*val)->data.uint32 = OPAL_PROC_MY_NAME.jobid;
-            return OPAL_SUCCESS;
-        } else if (0 == strcmp(key, OPAL_PMIX_RANK)) {
-            (*val) = OBJ_NEW(opal_value_t);
-            (*val)->type = OPAL_INT;
-            (*val)->data.integer = my_proc.rank;
-            return OPAL_SUCCESS;
-        }
-        pptr = NULL;
+	/* if they are asking for our jobid, then return it */
+	if (0 == strcmp(key, OPAL_PMIX_JOBID)) {
+	    (*val) = OBJ_NEW(opal_value_t);
+	    (*val)->type = OPAL_UINT32;
+	    (*val)->data.uint32 = OPAL_PROC_MY_NAME.jobid;
+	    return OPAL_SUCCESS;
+	} else if (0 == strcmp(key, OPAL_PMIX_RANK)) {
+	    (*val) = OBJ_NEW(opal_value_t);
+	    (*val)->type = OPAL_INT;
+	    (*val)->data.integer = my_proc.rank;
+	    return OPAL_SUCCESS;
+	}
+	pptr = NULL;
     }
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        if (0 < ninfo) {
-            PMIX_INFO_CREATE(pinfo, ninfo);
-            n=0;
-            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
-                (void)strncpy(pinfo[n].key, ival->key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&pinfo[n].value, ival);
-            }
-        } else {
-            pinfo = NULL;
-        }
+	ninfo = opal_list_get_size(info);
+	if (0 < ninfo) {
+	    PMIX_INFO_CREATE(pinfo, ninfo);
+	    n=0;
+	    OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+		(void)strncpy(pinfo[n].key, ival->key, PMIX_MAX_KEYLEN);
+		pmix1_value_load(&pinfo[n].value, ival);
+	    }
+	} else {
+	    pinfo = NULL;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     /* pass the request down */
     rc = PMIx_Get(pptr, key, pinfo, ninfo, &kv);
     if (PMIX_SUCCESS == rc) {
-        if (NULL == kv) {
-            ret = OPAL_SUCCESS;
-        } else {
-            *val = OBJ_NEW(opal_value_t);
-            ret = pmix1_value_unload(*val, kv);
-            PMIX_VALUE_FREE(kv, 1);
-        }
+	if (NULL == kv) {
+	    ret = OPAL_SUCCESS;
+	} else {
+	    *val = OBJ_NEW(opal_value_t);
+	    ret = pmix1_value_unload(*val, kv);
+	    PMIX_VALUE_FREE(kv, 1);
+	}
     } else {
-        ret = pmix1_convert_rc(rc);
+	ret = pmix1_convert_rc(rc);
     }
     PMIX_INFO_FREE(pinfo, ninfo);
     return ret;
 }
 
 static void val_cbfunc(pmix_status_t status,
-                       pmix_value_t *kv, void *cbdata)
+		       pmix_value_t *kv, void *cbdata)
 {
     pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
     int rc;
@@ -509,19 +510,19 @@ static void val_cbfunc(pmix_status_t status,
 
     rc = pmix1_convert_opalrc(status);
     if (PMIX_SUCCESS == status && NULL != kv) {
-        rc = pmix1_value_unload(&val, kv);
-        v = &val;
+	rc = pmix1_value_unload(&val, kv);
+	v = &val;
     }
 
     if (NULL != op->valcbfunc) {
-        op->valcbfunc(rc, v, op->cbdata);
+	op->valcbfunc(rc, v, op->cbdata);
     }
     OBJ_RELEASE(op);
 }
 
 int pmix1_getnb(const opal_process_name_t *proc, const char *key,
-                opal_list_t *info,
-                opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
+		opal_list_t *info,
+		opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     pmix1_opcaddy_t *op;
     pmix_status_t rc;
@@ -530,9 +531,9 @@ int pmix1_getnb(const opal_process_name_t *proc, const char *key,
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "%s PMIx_client get_nb on proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+			"%s PMIx_client get_nb on proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
 
     /* create the caddy */
     op = OBJ_NEW(pmix1_opcaddy_t);
@@ -540,41 +541,41 @@ int pmix1_getnb(const opal_process_name_t *proc, const char *key,
     op->cbdata = cbdata;
 
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(op->p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        op->p.rank = proc->vpid;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(op->p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	op->p.rank = proc->vpid;
     } else {
-        (void)strncpy(op->p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
-        op->p.rank = PMIX_RANK_WILDCARD;
+	(void)strncpy(op->p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+	op->p.rank = PMIX_RANK_WILDCARD;
     }
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, ival->key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&op->info[n].value, ival);
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, ival->key, PMIX_MAX_KEYLEN);
+		pmix1_value_load(&op->info[n].value, ival);
+	    }
+	}
     }
 
     /* call the library function */
     rc = PMIx_Get_nb(&op->p, key, op->info, op->sz, val_cbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 
     return pmix1_convert_rc(rc);
@@ -588,23 +589,23 @@ int pmix1_publish(opal_list_t *info)
     size_t sz, n;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client publish");
+			"PMIx_client publish");
 
     if (NULL == info) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     sz = opal_list_get_size(info);
     if (0 < sz) {
-        PMIX_INFO_CREATE(pinfo, sz);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	PMIX_INFO_CREATE(pinfo, sz);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix1_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
+	pinfo = NULL;
     }
 
     ret = PMIx_Publish(pinfo, sz);
@@ -613,7 +614,7 @@ int pmix1_publish(opal_list_t *info)
 }
 
 int pmix1_publishnb(opal_list_t *info,
-                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     opal_value_t *iptr;
@@ -621,10 +622,10 @@ int pmix1_publishnb(opal_list_t *info,
     pmix1_opcaddy_t *op;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client publish_nb");
+			"PMIx_client publish_nb");
 
     if (NULL == info) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -634,13 +635,13 @@ int pmix1_publishnb(opal_list_t *info,
 
     op->sz = opal_list_get_size(info);
     if (0 < op->sz) {
-        PMIX_INFO_CREATE(op->info, op->sz);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&op->info[n].value, iptr);
-            ++n;
-        }
+	PMIX_INFO_CREATE(op->info, op->sz);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix1_value_load(&op->info[n].value, iptr);
+	    ++n;
+	}
     }
 
     ret = PMIx_Publish_nb(op->info, op->sz, opcbfunc, op);
@@ -660,84 +661,84 @@ int pmix1_lookup(opal_list_t *data, opal_list_t *info)
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client lookup");
+			"PMIx_client lookup");
 
     if (NULL == data) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     sz = opal_list_get_size(data);
     PMIX_PDATA_CREATE(pdata, sz);
     n=0;
     OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
-        (void)strncpy(pdata[n++].key, d->value.key, PMIX_MAX_KEYLEN);
+	(void)strncpy(pdata[n++].key, d->value.key, PMIX_MAX_KEYLEN);
     }
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	ninfo = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix1_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     ret = PMIx_Lookup(pdata, sz, pinfo, ninfo);
     PMIX_INFO_FREE(pinfo, ninfo);
 
     if (PMIX_SUCCESS == ret) {
-        /* transfer the data back */
-        n=0;
-        OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
-            if (mca_pmix_ext114_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&d->proc.jobid, pdata[n].proc.nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(pdata[n].proc.nspace, d->proc.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-                if (jptr->jobid == d->proc.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-               job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
-                (void)strncpy(job->nspace, pdata[n].proc.nspace, PMIX_MAX_NSLEN);
-                job->jobid = d->proc.jobid;
-                opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
-            }
-            if (PMIX_RANK_WILDCARD == pdata[n].proc.rank) {
-                d->proc.vpid = OPAL_VPID_WILDCARD;
-            } else {
-                d->proc.vpid = pdata[n].proc.rank;
-            }
-            rc = pmix1_value_unload(&d->value, &pdata[n].value);
-            if (OPAL_SUCCESS != rc) {
-                OPAL_ERROR_LOG(rc);
-                PMIX_PDATA_FREE(pdata, sz);
-                return OPAL_ERR_BAD_PARAM;
-            }
-            ++n;
-        }
+	/* transfer the data back */
+	n=0;
+	OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
+	    if (mca_pmix_ext114_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&d->proc.jobid, pdata[n].proc.nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(pdata[n].proc.nspace, d->proc.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+		if (jptr->jobid == d->proc.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+	       job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+		(void)strncpy(job->nspace, pdata[n].proc.nspace, PMIX_MAX_NSLEN);
+		job->jobid = d->proc.jobid;
+		opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
+	    }
+	    if (PMIX_RANK_WILDCARD == pdata[n].proc.rank) {
+		d->proc.vpid = OPAL_VPID_WILDCARD;
+	    } else {
+		d->proc.vpid = pdata[n].proc.rank;
+	    }
+	    rc = pmix1_value_unload(&d->value, &pdata[n].value);
+	    if (OPAL_SUCCESS != rc) {
+		OPAL_ERROR_LOG(rc);
+		PMIX_PDATA_FREE(pdata, sz);
+		return OPAL_ERR_BAD_PARAM;
+	    }
+	    ++n;
+	}
     }
 
     return pmix1_convert_rc(ret);
 }
 
 static void lk_cbfunc(pmix_status_t status,
-                      pmix_pdata_t data[], size_t ndata,
-                      void *cbdata)
+		      pmix_pdata_t data[], size_t ndata,
+		      void *cbdata)
 {
     pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
     opal_pmix_pdata_t *d;
@@ -747,66 +748,66 @@ static void lk_cbfunc(pmix_status_t status,
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     if (NULL == op->lkcbfunc) {
-        OBJ_RELEASE(op);
-        return;
+	OBJ_RELEASE(op);
+	return;
     }
 
     rc = pmix1_convert_rc(status);
     if (OPAL_SUCCESS == rc) {
-        OBJ_CONSTRUCT(&results, opal_list_t);
-        for (n=0; n < ndata; n++) {
-            d = OBJ_NEW(opal_pmix_pdata_t);
-            opal_list_append(&results, &d->super);
-            if (mca_pmix_ext114_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&d->proc.jobid, data[n].proc.nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(data[n].proc.nspace, d->proc.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-                if (jptr->jobid == d->proc.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
-                (void)strncpy(job->nspace, data[n].proc.nspace, PMIX_MAX_NSLEN);
-                job->jobid = d->proc.jobid;
-                opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
-            }
-            if (PMIX_RANK_WILDCARD == data[n].proc.rank) {
-                d->proc.vpid = OPAL_VPID_WILDCARD;
-            } else {
-                d->proc.vpid = data[n].proc.rank;
-            }
-            d->value.key = strdup(data[n].key);
-            rc = pmix1_value_unload(&d->value, &data[n].value);
-            if (OPAL_SUCCESS != rc) {
-                rc = OPAL_ERR_BAD_PARAM;
-                OPAL_ERROR_LOG(rc);
-                goto release;
-            }
-        }
-        r = &results;
+	OBJ_CONSTRUCT(&results, opal_list_t);
+	for (n=0; n < ndata; n++) {
+	    d = OBJ_NEW(opal_pmix_pdata_t);
+	    opal_list_append(&results, &d->super);
+	    if (mca_pmix_ext114_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&d->proc.jobid, data[n].proc.nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(data[n].proc.nspace, d->proc.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+		if (jptr->jobid == d->proc.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+		(void)strncpy(job->nspace, data[n].proc.nspace, PMIX_MAX_NSLEN);
+		job->jobid = d->proc.jobid;
+		opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
+	    }
+	    if (PMIX_RANK_WILDCARD == data[n].proc.rank) {
+		d->proc.vpid = OPAL_VPID_WILDCARD;
+	    } else {
+		d->proc.vpid = data[n].proc.rank;
+	    }
+	    d->value.key = strdup(data[n].key);
+	    rc = pmix1_value_unload(&d->value, &data[n].value);
+	    if (OPAL_SUCCESS != rc) {
+		rc = OPAL_ERR_BAD_PARAM;
+		OPAL_ERROR_LOG(rc);
+		goto release;
+	    }
+	}
+	r = &results;
     }
   release:
     /* execute the callback */
     op->lkcbfunc(rc, r, op->cbdata);
 
     if (NULL != r) {
-        OPAL_LIST_DESTRUCT(&results);
+	OPAL_LIST_DESTRUCT(&results);
     }
     OBJ_RELEASE(op);
 }
 
 int pmix1_lookupnb(char **keys, opal_list_t *info,
-                   opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+		   opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix1_opcaddy_t *op;
@@ -815,7 +816,7 @@ int pmix1_lookupnb(char **keys, opal_list_t *info,
 
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client lookup_nb");
+			"PMIx_client lookup_nb");
 
     /* create the caddy */
     op = OBJ_NEW(pmix1_opcaddy_t);
@@ -823,16 +824,16 @@ int pmix1_lookupnb(char **keys, opal_list_t *info,
     op->cbdata = cbdata;
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&op->info[n].value, iptr);
-                ++n;
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+		pmix1_value_load(&op->info[n].value, iptr);
+		++n;
+	    }
+	}
     }
 
     ret = PMIx_Lookup_nb(keys, op->info, op->sz, lk_cbfunc, op);
@@ -848,17 +849,17 @@ int pmix1_unpublish(char **keys, opal_list_t *info)
     opal_value_t *iptr;
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	ninfo = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix1_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     ret = PMIx_Unpublish(keys, pinfo, ninfo);
@@ -868,7 +869,7 @@ int pmix1_unpublish(char **keys, opal_list_t *info)
 }
 
 int pmix1_unpublishnb(char **keys, opal_list_t *info,
-                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix1_opcaddy_t *op;
@@ -881,16 +882,16 @@ int pmix1_unpublishnb(char **keys, opal_list_t *info,
     op->cbdata = cbdata;
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&op->info[n].value, iptr);
-                ++n;
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+		pmix1_value_load(&op->info[n].value, iptr);
+		++n;
+	    }
+	}
     }
 
     ret = PMIx_Unpublish_nb(keys, op->info, op->sz, opcbfunc, op);
@@ -910,52 +911,52 @@ int pmix1_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
     opal_pmix1_jobid_trkr_t *job;
 
     if (NULL != job_info && 0 < (ninfo = opal_list_get_size(job_info))) {
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, info->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&pinfo[n].value, info);
-            ++n;
-        }
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, info->key, PMIX_MAX_KEYLEN);
+	    pmix1_value_load(&pinfo[n].value, info);
+	    ++n;
+	}
     }
 
     napps = opal_list_get_size(apps);
     PMIX_APP_CREATE(papps, napps);
     n=0;
     OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
-        papps[n].cmd = strdup(app->cmd);
-        papps[n].argc = app->argc;
-        papps[n].argv = opal_argv_copy(app->argv);
-        papps[n].env = opal_argv_copy(app->env);
-        papps[n].maxprocs = app->maxprocs;
-        if (0 < (papps[n].ninfo = opal_list_get_size(&app->info))) {
-            PMIX_INFO_CREATE(papps[n].info, papps[n].ninfo);
-            m=0;
-            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
-                (void)strncpy(papps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&papps[n].info[m].value, info);
-                ++m;
-            }
-        }
-        ++n;
+	papps[n].cmd = strdup(app->cmd);
+	papps[n].argc = app->argc;
+	papps[n].argv = opal_argv_copy(app->argv);
+	papps[n].env = opal_argv_copy(app->env);
+	papps[n].maxprocs = app->maxprocs;
+	if (0 < (papps[n].ninfo = opal_list_get_size(&app->info))) {
+	    PMIX_INFO_CREATE(papps[n].info, papps[n].ninfo);
+	    m=0;
+	    OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+		(void)strncpy(papps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+		pmix1_value_load(&papps[n].info[m].value, info);
+		++m;
+	    }
+	}
+	++n;
     }
 
     ret = PMIx_Spawn(pinfo, ninfo, papps, napps, nspace);
     if (PMIX_SUCCESS == ret) {
-        if (mca_pmix_ext114_component.native_launch) {
-            /* if we were launched by the OMPI RTE, then
-             * the jobid is in a special format - so get it */
-            opal_convert_string_to_jobid(jobid, nspace);
-        } else {
-            /* we were launched by someone else, so make the
-             * jobid just be the hash of the nspace */
-            OPAL_HASH_STR(nspace, *jobid);
-        }
-        /* add this to our jobid tracker */
-        job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
-        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-        job->jobid = *jobid;
-        opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
+	if (mca_pmix_ext114_component.native_launch) {
+	    /* if we were launched by the OMPI RTE, then
+	     * the jobid is in a special format - so get it */
+	    opal_convert_string_to_jobid(jobid, nspace);
+	} else {
+	    /* we were launched by someone else, so make the
+	     * jobid just be the hash of the nspace */
+	    OPAL_HASH_STR(nspace, *jobid);
+	}
+	/* add this to our jobid tracker */
+	job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+	(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+	job->jobid = *jobid;
+	opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
     }
     PMIX_APP_FREE(papps, napps);
 
@@ -963,7 +964,7 @@ int pmix1_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
 }
 
 static void spcbfunc(pmix_status_t status,
-                     char *nspace, void *cbdata)
+		     char *nspace, void *cbdata)
 {
     pmix1_opcaddy_t *op = (pmix1_opcaddy_t*)cbdata;
     int rc;
@@ -972,20 +973,20 @@ static void spcbfunc(pmix_status_t status,
 
     rc = pmix1_convert_rc(status);
     if (PMIX_SUCCESS == status) {
-        if (mca_pmix_ext114_component.native_launch) {
-            /* if we were launched by the OMPI RTE, then
-             * the jobid is in a special format - so get it */
-            opal_convert_string_to_jobid(&jobid, nspace);
-        } else {
-            /* we were launched by someone else, so make the
-             * jobid just be the hash of the nspace */
-            OPAL_HASH_STR(nspace, jobid);
-        }
-        /* add this to our jobid tracker */
-        job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
-        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-        job->jobid = jobid;
-        opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
+	if (mca_pmix_ext114_component.native_launch) {
+	    /* if we were launched by the OMPI RTE, then
+	     * the jobid is in a special format - so get it */
+	    opal_convert_string_to_jobid(&jobid, nspace);
+	} else {
+	    /* we were launched by someone else, so make the
+	     * jobid just be the hash of the nspace */
+	    OPAL_HASH_STR(nspace, jobid);
+	}
+	/* add this to our jobid tracker */
+	job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+	(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+	job->jobid = jobid;
+	opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
     }
 
     op->spcbfunc(rc, jobid, op->cbdata);
@@ -993,7 +994,7 @@ static void spcbfunc(pmix_status_t status,
 }
 
 int pmix1_spawnnb(opal_list_t *job_info, opal_list_t *apps,
-                    opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix1_opcaddy_t *op;
@@ -1007,34 +1008,34 @@ int pmix1_spawnnb(opal_list_t *job_info, opal_list_t *apps,
     op->cbdata = cbdata;
 
     if (NULL != job_info && 0 < (op->ninfo = opal_list_get_size(job_info))) {
-        PMIX_INFO_CREATE(op->info, op->ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
-            (void)strncpy(op->info[n].key, info->key, PMIX_MAX_KEYLEN);
-            pmix1_value_load(&op->info[n].value, info);
-            ++n;
-        }
+	PMIX_INFO_CREATE(op->info, op->ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+	    (void)strncpy(op->info[n].key, info->key, PMIX_MAX_KEYLEN);
+	    pmix1_value_load(&op->info[n].value, info);
+	    ++n;
+	}
     }
 
     op->sz = opal_list_get_size(apps);
     PMIX_APP_CREATE(op->apps, op->sz);
     n=0;
     OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
-        op->apps[n].cmd = strdup(app->cmd);
-        op->apps[n].argc = app->argc;
-        op->apps[n].argv = opal_argv_copy(app->argv);
-        op->apps[n].env = opal_argv_copy(app->env);
-        op->apps[n].maxprocs = app->maxprocs;
-        if (0 < (op->apps[n].ninfo = opal_list_get_size(&app->info))) {
-            PMIX_INFO_CREATE(op->apps[n].info, op->apps[n].ninfo);
-            m=0;
-            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
-                (void)strncpy(op->apps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&op->apps[n].info[m].value, info);
-                ++m;
-            }
-        }
-        ++n;
+	op->apps[n].cmd = strdup(app->cmd);
+	op->apps[n].argc = app->argc;
+	op->apps[n].argv = opal_argv_copy(app->argv);
+	op->apps[n].env = opal_argv_copy(app->env);
+	op->apps[n].maxprocs = app->maxprocs;
+	if (0 < (op->apps[n].ninfo = opal_list_get_size(&app->info))) {
+	    PMIX_INFO_CREATE(op->apps[n].info, op->apps[n].ninfo);
+	    m=0;
+	    OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+		(void)strncpy(op->apps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+		pmix1_value_load(&op->apps[n].info[m].value, info);
+		++m;
+	    }
+	}
+	++n;
     }
 
     ret = PMIx_Spawn_nb(op->info, op->ninfo, op->apps, op->sz, spcbfunc, op);
@@ -1052,7 +1053,7 @@ int pmix1_connect(opal_list_t *procs)
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* convert the list of procs to an array
@@ -1060,26 +1061,26 @@ int pmix1_connect(opal_list_t *procs)
     PMIX_PROC_CREATE(parray, cnt);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (jptr->jobid == ptr->name.jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            parray[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            parray[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (jptr->jobid == ptr->name.jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    parray[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    parray[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Connect(parray, cnt, NULL, 0);
@@ -1089,8 +1090,8 @@ int pmix1_connect(opal_list_t *procs)
 }
 
 int pmix1_connectnb(opal_list_t *procs,
-                    opal_pmix_op_cbfunc_t cbfunc,
-                    void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc,
+		    void *cbdata)
 {
     pmix_status_t ret;
     size_t n, cnt=0;
@@ -1100,7 +1101,7 @@ int pmix1_connectnb(opal_list_t *procs,
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -1114,20 +1115,20 @@ int pmix1_connectnb(opal_list_t *procs,
     PMIX_PROC_CREATE(op->procs, op->nprocs);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            op->procs[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            op->procs[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    op->procs[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    op->procs[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Connect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
@@ -1145,7 +1146,7 @@ int pmix1_disconnect(opal_list_t *procs)
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* convert the list of procs to an array
@@ -1153,20 +1154,20 @@ int pmix1_disconnect(opal_list_t *procs)
     PMIX_PROC_CREATE(parray, cnt);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            parray[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            parray[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    parray[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    parray[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Disconnect(parray, cnt, NULL, 0);
@@ -1176,8 +1177,8 @@ int pmix1_disconnect(opal_list_t *procs)
 }
 
 int pmix1_disconnectnb(opal_list_t *procs,
-                         opal_pmix_op_cbfunc_t cbfunc,
-                         void *cbdata)
+			 opal_pmix_op_cbfunc_t cbfunc,
+			 void *cbdata)
 {
     pmix_status_t ret;
     size_t n, cnt=0;
@@ -1187,7 +1188,7 @@ int pmix1_disconnectnb(opal_list_t *procs,
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -1201,20 +1202,20 @@ int pmix1_disconnectnb(opal_list_t *procs,
     PMIX_PROC_CREATE(op->procs, op->nprocs);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            op->procs[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            op->procs[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    op->procs[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    op->procs[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Disconnect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
@@ -1224,7 +1225,7 @@ int pmix1_disconnectnb(opal_list_t *procs,
 
 
 int pmix1_resolve_peers(const char *nodename, opal_jobid_t jobid,
-                          opal_list_t *procs)
+			  opal_list_t *procs)
 {
     char *nspace;
     pmix_proc_t *array=NULL;
@@ -1235,53 +1236,53 @@ int pmix1_resolve_peers(const char *nodename, opal_jobid_t jobid,
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     if (OPAL_JOBID_WILDCARD == jobid) {
-        nspace = NULL;
+	nspace = NULL;
     } else {
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (jptr->jobid == jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        nspace = job->nspace;
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (jptr->jobid == jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	nspace = job->nspace;
     }
 
     ret = PMIx_Resolve_peers(nodename, nspace, &array, &nprocs);
     rc = pmix1_convert_rc(ret);
 
     if (NULL != array && 0 < nprocs) {
-        for (n=0; n < nprocs; n++) {
-            nm = OBJ_NEW(opal_namelist_t);
-            opal_list_append(procs, &nm->super);
-            if (mca_pmix_ext114_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&nm->name.jobid, array[n].nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(array[n].nspace, nm->name.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-                if (jptr->jobid == nm->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
-                (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-                job->jobid = jobid;
-                opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
-            }
-            nm->name.vpid = array[n].rank;
-        }
+	for (n=0; n < nprocs; n++) {
+	    nm = OBJ_NEW(opal_namelist_t);
+	    opal_list_append(procs, &nm->super);
+	    if (mca_pmix_ext114_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&nm->name.jobid, array[n].nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(array[n].nspace, nm->name.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+		if (jptr->jobid == nm->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		job = OBJ_NEW(opal_pmix1_jobid_trkr_t);
+		(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+		job->jobid = jobid;
+		opal_list_append(&mca_pmix_ext114_component.jobids, &job->super);
+	    }
+	    nm->name.vpid = array[n].rank;
+	}
     }
     PMIX_PROC_FREE(array, nprocs);
 
@@ -1295,19 +1296,19 @@ int pmix1_resolve_nodes(opal_jobid_t jobid, char **nodelist)
     opal_pmix1_jobid_trkr_t *job, *jptr;
 
     if (OPAL_JOBID_WILDCARD != jobid) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
-            if (jptr->jobid == jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        nspace = job->nspace;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext114_component.jobids, opal_pmix1_jobid_trkr_t) {
+	    if (jptr->jobid == jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	nspace = job->nspace;
     }
 
     ret = PMIx_Resolve_nodes(nspace, nodelist);

--- a/opal/mca/pmix/ext114/pmix_ext_component.c
+++ b/opal/mca/pmix/ext114/pmix_ext_component.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,29 +48,29 @@ mca_pmix_ext114_component_t mca_pmix_ext114_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
-        .base_version = {
-        /* Indicate that we are a pmix v1.1.0 component (which also
-           implies a specific MCA version) */
+	.base_version = {
+	/* Indicate that we are a pmix v1.1.0 component (which also
+	   implies a specific MCA version) */
 
-            OPAL_PMIX_BASE_VERSION_2_0_0,
+	    OPAL_PMIX_BASE_VERSION_2_0_0,
 
-        /* Component name and version */
+	/* Component name and version */
 
-            .mca_component_name = "ext114",
-            MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                                  OPAL_RELEASE_VERSION),
+	    .mca_component_name = "ext114",
+	    MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+				  OPAL_RELEASE_VERSION),
 
-        /* Component open and close functions */
+	/* Component open and close functions */
 
-            .mca_open_component = external_open,
-            .mca_close_component = external_close,
-            .mca_query_component = external_component_query,
-        },
-        /* Next the MCA v1.0.0 component meta data */
-        .base_data = {
-        /* The component is checkpoint ready */
-            MCA_BASE_METADATA_PARAM_CHECKPOINT
-        }
+	    .mca_open_component = external_open,
+	    .mca_close_component = external_close,
+	    .mca_query_component = external_component_query,
+	},
+	/* Next the MCA v1.0.0 component meta data */
+	.base_data = {
+	/* The component is checkpoint ready */
+	    MCA_BASE_METADATA_PARAM_CHECKPOINT
+	}
     },
     .native_launch = false
 };
@@ -93,12 +94,12 @@ static int external_component_query(mca_base_module_t **module, int *priority)
 
     /* see if a PMIx server is present */
     if (NULL != (t = getenv("PMIX_SERVER_URI")) ||
-        NULL != (id = getenv("PMIX_ID"))) {
-        /* if PMIx is present, then we are a client and need to use it */
-        *priority = 100;
+	NULL != (id = getenv("PMIX_ID"))) {
+	/* if PMIx is present, then we are a client and need to use it */
+	*priority = 100;
     } else {
-        /* we could be a server, so we still need to be considered */
-        *priority = 5;
+	/* we could be a server, so we still need to be considered */
+	*priority = 5;
     }
     *module = (mca_base_module_t *)&opal_pmix_ext114_module;
     return OPAL_SUCCESS;

--- a/opal/mca/pmix/ext114/pmix_ext_server_north.c
+++ b/opal/mca/pmix/ext114/pmix_ext_server_north.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,43 +47,43 @@
 
  static pmix_status_t server_client_connected_fn(const pmix_proc_t *proc, void* server_object);
 static pmix_status_t server_client_finalized_fn(const pmix_proc_t *proc, void* server_object,
-                                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+						pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_abort_fn(const pmix_proc_t *proc, void *server_object,
-                                     int status, const char msg[],
-                                     pmix_proc_t procs[], size_t nprocs,
-                                     pmix_op_cbfunc_t cbfunc, void *cbdata);
+				     int status, const char msg[],
+				     pmix_proc_t procs[], size_t nprocs,
+				     pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       char *data, size_t ndata,
-                                       pmix_modex_cbfunc_t cbfunc, void *cbdata);
+				       const pmix_info_t info[], size_t ninfo,
+				       char *data, size_t ndata,
+				       pmix_modex_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *proc,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_modex_cbfunc_t cbfunc, void *cbdata);
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_modex_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_publish_fn(const pmix_proc_t *proc,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_lookup_fn(const pmix_proc_t *proc,  char **keys,
-                                      const pmix_info_t info[], size_t ninfo,
-                                      pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+				      const pmix_info_t info[], size_t ninfo,
+				      pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_unpublish_fn(const pmix_proc_t *proc, char **keys,
-                                         const pmix_info_t info[], size_t ninfo,
-                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
+					 const pmix_info_t info[], size_t ninfo,
+					 pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_spawn_fn(const pmix_proc_t *proc,
-                                     const pmix_info_t job_info[], size_t ninfo,
-                                     const pmix_app_t apps[], size_t napps,
-                                     pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+				     const pmix_info_t job_info[], size_t ninfo,
+				     const pmix_app_t apps[], size_t napps,
+				     pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_register_events(const pmix_info_t info[], size_t ninfo,
-                                            pmix_op_cbfunc_t cbfunc, void *cbdata);
+					    pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_deregister_events(const pmix_info_t info[], size_t ninfo,
-                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
+					   pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t server_listener_fn(int listening_sd,
-                                        pmix_connection_cbfunc_t cbfunc);
+					pmix_connection_cbfunc_t cbfunc);
 
 pmix_server_module_t mymodule = {
     .client_connected = server_client_connected_fn,
@@ -109,7 +110,7 @@ static void opal_opcbfunc(int status, void *cbdata)
     pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->opcbfunc) {
-        opalcaddy->opcbfunc(pmix1_convert_opalrc(status), opalcaddy->cbdata);
+	opalcaddy->opcbfunc(pmix1_convert_opalrc(status), opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
@@ -120,35 +121,35 @@ static pmix_status_t server_client_connected_fn(const pmix_proc_t *p, void *serv
     opal_process_name_t proc;
 
     if (NULL == host_module || NULL == host_module->client_connected) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
     /* pass it up */
     rc = host_module->client_connected(&proc, server_object,
-                                       NULL, NULL);
+				       NULL, NULL);
     return pmix1_convert_opalrc(rc);
 }
 
 static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* server_object,
-                                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+						pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix1_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
 
     if (NULL == host_module || NULL == host_module->client_finalized) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
@@ -160,15 +161,15 @@ static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* serv
     /* pass it up */
     rc = host_module->client_finalized(&proc, server_object, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix1_convert_opalrc(rc);
 }
 
 static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
-                                     int status, const char msg[],
-                                     pmix_proc_t procs[], size_t nprocs,
-                                     pmix_op_cbfunc_t cbfunc, void *cbdata)
+				     int status, const char msg[],
+				     pmix_proc_t procs[], size_t nprocs,
+				     pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     size_t n;
     opal_namelist_t *nm;
@@ -177,12 +178,12 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
     pmix1_opalcaddy_t *opalcaddy;
 
     if (NULL == host_module || NULL == host_module->abort) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
@@ -193,24 +194,24 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* pass it up */
     rc = host_module->abort(&proc, server_object, status, msg,
-                            &opalcaddy->procs, opal_opcbfunc, opalcaddy);
+			    &opalcaddy->procs, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix1_convert_opalrc(rc);
 }
@@ -220,32 +221,32 @@ static void _data_release(void *cbdata)
     pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->odmdxfunc) {
-        opalcaddy->odmdxfunc(opalcaddy->ocbdata);
+	opalcaddy->odmdxfunc(opalcaddy->ocbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static void opmdx_response(int status, const char *data, size_t sz, void *cbdata,
-                           opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
+			   opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
 {
     pmix_status_t rc;
     pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
 
     rc = pmix1_convert_rc(status);
     if (NULL != opalcaddy->mdxcbfunc) {
-        opalcaddy->odmdxfunc = relcbfunc;
-        opalcaddy->ocbdata = relcbdata;
-        opalcaddy->mdxcbfunc(rc, data, sz, opalcaddy->cbdata,
-                             _data_release, opalcaddy);
+	opalcaddy->odmdxfunc = relcbfunc;
+	opalcaddy->ocbdata = relcbdata;
+	opalcaddy->mdxcbfunc(rc, data, sz, opalcaddy->cbdata,
+			     _data_release, opalcaddy);
     } else {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 }
 
 static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       char *data, size_t ndata,
-                                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       char *data, size_t ndata,
+				       pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix1_opalcaddy_t *opalcaddy;
     size_t n;
@@ -254,7 +255,7 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
     int rc;
 
     if (NULL == host_module || NULL == host_module->fence_nb) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -264,42 +265,42 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->fence_nb(&opalcaddy->procs, &opalcaddy->info,
-                               data, ndata, opmdx_response, opalcaddy);
+			       data, ndata, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix1_convert_opalrc(rc);
 }
 
 static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_modex_cbfunc_t cbfunc, void *cbdata)
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix1_opalcaddy_t *opalcaddy;
@@ -308,17 +309,17 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->direct_modex) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -328,29 +329,29 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->direct_modex(&proc, &opalcaddy->info, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc && OPAL_ERR_IN_PROCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     if (OPAL_ERR_IN_PROCESS == rc) {
-        rc = OPAL_SUCCESS;
+	rc = OPAL_SUCCESS;
     }
     return pmix1_convert_opalrc(rc);
 }
 
 static pmix_status_t server_publish_fn(const pmix_proc_t *p,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     size_t n;
@@ -359,17 +360,17 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->publish) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
    /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -379,27 +380,27 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
 
     /* convert the info array */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->publish(&proc, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix1_convert_opalrc(rc);
 }
 
 static void opal_lkupcbfunc(int status,
-                            opal_list_t *data,
-                            void *cbdata)
+			    opal_list_t *data,
+			    void *cbdata)
 {
     pmix1_opalcaddy_t *opalcaddy = (pmix1_opalcaddy_t*)cbdata;
     pmix_status_t rc;
@@ -408,28 +409,28 @@ static void opal_lkupcbfunc(int status,
     opal_pmix_pdata_t *p;
 
     if (NULL != opalcaddy->lkupcbfunc) {
-        rc = pmix1_convert_opalrc(status);
-        /* convert any returned data */
-        if (NULL != data) {
-            nd = opal_list_get_size(data);
-            PMIX_PDATA_CREATE(d, nd);
-            n=0;
-            OPAL_LIST_FOREACH(p, data, opal_pmix_pdata_t) {
-                /* convert the jobid */
-                (void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
-                d[n].proc.rank = p->proc.vpid;
-                (void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
-                pmix1_value_load(&d[n].value, &p->value);
-            }
-        }
-        opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
+	rc = pmix1_convert_opalrc(status);
+	/* convert any returned data */
+	if (NULL != data) {
+	    nd = opal_list_get_size(data);
+	    PMIX_PDATA_CREATE(d, nd);
+	    n=0;
+	    OPAL_LIST_FOREACH(p, data, opal_pmix_pdata_t) {
+		/* convert the jobid */
+		(void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
+		d[n].proc.rank = p->proc.vpid;
+		(void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
+		pmix1_value_load(&d[n].value, &p->value);
+	    }
+	}
+	opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
-                                      const pmix_info_t info[], size_t ninfo,
-                                      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+				      const pmix_info_t info[], size_t ninfo,
+				      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix1_opalcaddy_t *opalcaddy;
@@ -438,17 +439,17 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->lookup) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -458,19 +459,19 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->lookup(&proc, keys, &opalcaddy->info, opal_lkupcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix1_convert_opalrc(rc);
@@ -478,8 +479,8 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
 
 
 static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
-                                         const pmix_info_t info[], size_t ninfo,
-                                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+					 const pmix_info_t info[], size_t ninfo,
+					 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix1_opalcaddy_t *opalcaddy;
@@ -488,17 +489,17 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->unpublish) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -508,19 +509,19 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->unpublish(&proc, keys, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix1_convert_opalrc(rc);
@@ -533,18 +534,18 @@ static void opal_spncbfunc(int status, opal_jobid_t jobid, void *cbdata)
     char nspace[PMIX_MAX_NSLEN];
 
     if (NULL != opalcaddy->spwncbfunc) {
-        rc = pmix1_convert_opalrc(status);
-        /* convert the jobid */
-        (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
-        opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
+	rc = pmix1_convert_opalrc(status);
+	/* convert the jobid */
+	(void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
+	opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
-                                     const pmix_info_t job_info[], size_t ninfo,
-                                     const pmix_app_t apps[], size_t napps,
-                                     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+				     const pmix_info_t job_info[], size_t ninfo,
+				     const pmix_app_t apps[], size_t napps,
+				     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     pmix1_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
@@ -554,17 +555,17 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
     int rc;
 
     if (NULL == host_module || NULL == host_module->spawn) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix1_convert_opalrc(rc);
+	return pmix1_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -574,46 +575,46 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
 
     /* convert the job info */
     for (k=0; k < ninfo; k++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(job_info[k].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &job_info[k].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(job_info[k].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &job_info[k].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* convert the apps */
     for (n=0; n < napps; n++) {
-        app = OBJ_NEW(opal_pmix_app_t);
-        opal_list_append(&opalcaddy->apps, &app->super);
-        if (NULL != apps[n].cmd) {
-            app->cmd = strdup(apps[n].cmd);
-        }
-        app->argc = apps[n].argc;
-        if (NULL != apps[n].argv) {
-            app->argv = opal_argv_copy(apps[n].argv);
-        }
-        if (NULL != apps[n].env) {
-            app->env = opal_argv_copy(apps[n].env);
-        }
-        app->maxprocs = apps[n].maxprocs;
-        for (k=0; k < apps[n].ninfo; k++) {
-            oinfo = OBJ_NEW(opal_value_t);
-            opal_list_append(&app->info, &oinfo->super);
-            oinfo->key = strdup(apps[n].info[k].key);
-            if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &apps[n].info[k].value))) {
-                OBJ_RELEASE(opalcaddy);
-                return pmix1_convert_opalrc(rc);
-            }
-        }
+	app = OBJ_NEW(opal_pmix_app_t);
+	opal_list_append(&opalcaddy->apps, &app->super);
+	if (NULL != apps[n].cmd) {
+	    app->cmd = strdup(apps[n].cmd);
+	}
+	app->argc = apps[n].argc;
+	if (NULL != apps[n].argv) {
+	    app->argv = opal_argv_copy(apps[n].argv);
+	}
+	if (NULL != apps[n].env) {
+	    app->env = opal_argv_copy(apps[n].env);
+	}
+	app->maxprocs = apps[n].maxprocs;
+	for (k=0; k < apps[n].ninfo; k++) {
+	    oinfo = OBJ_NEW(opal_value_t);
+	    opal_list_append(&app->info, &oinfo->super);
+	    oinfo->key = strdup(apps[n].info[k].key);
+	    if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &apps[n].info[k].value))) {
+		OBJ_RELEASE(opalcaddy);
+		return pmix1_convert_opalrc(rc);
+	    }
+	}
     }
 
     /* pass it up */
     rc = host_module->spawn(&proc, &opalcaddy->info, &opalcaddy->apps, opal_spncbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_RELEASE(opalcaddy);
+	OPAL_ERROR_LOG(rc);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix1_convert_opalrc(rc);
@@ -621,8 +622,8 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
 
 
 static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix1_opalcaddy_t *opalcaddy;
@@ -631,7 +632,7 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->connect) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -641,34 +642,34 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->connect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix1_convert_opalrc(rc);
@@ -676,8 +677,8 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
 
 
 static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix1_opalcaddy_t *opalcaddy;
@@ -686,7 +687,7 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->disconnect) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -696,41 +697,41 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->disconnect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix1_convert_opalrc(rc);
 }
 
 static pmix_status_t server_register_events(const pmix_info_t info[], size_t ninfo,
-                                            pmix_op_cbfunc_t cbfunc, void *cbdata)
+					    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix1_opalcaddy_t *opalcaddy;
     size_t n;
@@ -744,36 +745,36 @@ static pmix_status_t server_register_events(const pmix_info_t info[], size_t nin
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix1_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix1_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix1_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->register_events(&opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix1_convert_opalrc(rc);
 }
 
 static pmix_status_t server_deregister_events(const pmix_info_t info[], size_t ninfo,
-                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+					      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return PMIX_ERR_NOT_IMPLEMENTED;
 }
 static pmix_status_t server_listener_fn(int listening_sd,
-                                        pmix_connection_cbfunc_t cbfunc)
+					pmix_connection_cbfunc_t cbfunc)
 {
     int rc;
 
     if (NULL == host_module || NULL == host_module->listener) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     rc = host_module->listener(listening_sd, cbfunc);

--- a/opal/mca/pmix/ext20/pmix_ext20.c
+++ b/opal/mca/pmix/ext20/pmix_ext20.c
@@ -49,18 +49,18 @@
 static const char *pmix20_get_nspace(opal_jobid_t jobid);
 static void pmix20_register_jobid(opal_jobid_t jobid, const char *nspace);
 static void register_handler(opal_list_t *event_codes,
-                             opal_list_t *info,
-                             opal_pmix_notification_fn_t evhandler,
-                             opal_pmix_evhandler_reg_cbfunc_t cbfunc,
-                             void *cbdata);
+			     opal_list_t *info,
+			     opal_pmix_notification_fn_t evhandler,
+			     opal_pmix_evhandler_reg_cbfunc_t cbfunc,
+			     void *cbdata);
 static void deregister_handler(size_t evhandler,
-                               opal_pmix_op_cbfunc_t cbfunc,
-                               void *cbdata);
+			       opal_pmix_op_cbfunc_t cbfunc,
+			       void *cbdata);
 static int notify_event(int status,
-                        const opal_process_name_t *source,
-                        opal_pmix_data_range_t range,
-                        opal_list_t *info,
-                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			const opal_process_name_t *source,
+			opal_pmix_data_range_t range,
+			opal_list_t *info,
+			opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 const opal_pmix_base_module_t opal_pmix_ext20_module = {
     /* client APIs */
@@ -115,9 +115,9 @@ static const char *pmix20_get_nspace(opal_jobid_t jobid)
     opal_pmix20_jobid_trkr_t *jptr;
 
     OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-        if (jptr->jobid == jobid) {
-            return jptr->nspace;
-        }
+	if (jptr->jobid == jobid) {
+	    return jptr->nspace;
+	}
     }
     return NULL;
 }
@@ -128,9 +128,9 @@ static void pmix20_register_jobid(opal_jobid_t jobid, const char *nspace)
 
     /* if we don't already have it, add this to our jobid tracker */
     OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-        if (jptr->jobid == jobid) {
-            return;
-        }
+	if (jptr->jobid == jobid) {
+	    return;
+	}
     }
     jptr = OBJ_NEW(opal_pmix20_jobid_trkr_t);
     (void)strncpy(jptr->nspace, nspace, PMIX_MAX_NSLEN);
@@ -142,14 +142,14 @@ static void completion_handler(int status, void *cbdata)
 {
     opal_pmix20_event_chain_t *chain = (opal_pmix20_event_chain_t*)cbdata;
     if (NULL != chain->info) {
-        OPAL_LIST_RELEASE(chain->info);
+	OPAL_LIST_RELEASE(chain->info);
     }
 }
 
 static void progress_local_event_hdlr(int status,
-                                      opal_list_t *results,
-                                      opal_pmix_op_cbfunc_t cbfunc, void *thiscbdata,
-                                      void *notification_cbdata)
+				      opal_list_t *results,
+				      opal_pmix_op_cbfunc_t cbfunc, void *thiscbdata,
+				      void *notification_cbdata)
 {
     opal_pmix20_event_chain_t *chain = (opal_pmix20_event_chain_t*)notification_cbdata;
     size_t n;
@@ -160,92 +160,92 @@ static void progress_local_event_hdlr(int status,
 
     /* if any results were provided, then add them here */
     if (NULL != results) {
-        while (NULL != (nxt = opal_list_remove_first(results))) {
-            opal_list_append(results, nxt);
-        }
+	while (NULL != (nxt = opal_list_remove_first(results))) {
+	    opal_list_append(results, nxt);
+	}
     }
 
     /* if the caller indicates that the chain is completed, then stop here */
     if (OPAL_ERR_HANDLERS_COMPLETE == status) {
-        goto complete;
+	goto complete;
     }
 
     /* see if we need to continue, starting with the single code events */
     if (NULL != chain->sing) {
-        /* the last handler was for a single code - see if there are
-         * any others that match this event */
-        while (opal_list_get_end(&mca_pmix_ext20_component.single_events) != (nxt = opal_list_get_next(&chain->sing->super))) {
-            sing = (opal_pmix20_single_event_t*)nxt;
-            if (sing->code == chain->status) {
-                OBJ_RETAIN(chain);
-                chain->sing = sing;
-                sing->handler(chain->status, &chain->source,
-                              chain->info, &chain->results,
-                              progress_local_event_hdlr, (void*)chain);
-                goto complete;
-            }
-        }
-        /* if we get here, then there are no more single code
-         * events that match */
-        chain->sing = NULL;
-        /* pickup the beginning of the multi-code event list */
-        if (0 < opal_list_get_size(&mca_pmix_ext20_component.multi_events)) {
-            chain->multi = (opal_pmix20_multi_event_t*)opal_list_get_begin(&mca_pmix_ext20_component.multi_events);
-        }
+	/* the last handler was for a single code - see if there are
+	 * any others that match this event */
+	while (opal_list_get_end(&mca_pmix_ext20_component.single_events) != (nxt = opal_list_get_next(&chain->sing->super))) {
+	    sing = (opal_pmix20_single_event_t*)nxt;
+	    if (sing->code == chain->status) {
+		OBJ_RETAIN(chain);
+		chain->sing = sing;
+		sing->handler(chain->status, &chain->source,
+			      chain->info, &chain->results,
+			      progress_local_event_hdlr, (void*)chain);
+		goto complete;
+	    }
+	}
+	/* if we get here, then there are no more single code
+	 * events that match */
+	chain->sing = NULL;
+	/* pickup the beginning of the multi-code event list */
+	if (0 < opal_list_get_size(&mca_pmix_ext20_component.multi_events)) {
+	    chain->multi = (opal_pmix20_multi_event_t*)opal_list_get_begin(&mca_pmix_ext20_component.multi_events);
+	}
     }
 
     /* see if we need to continue with the multi code events */
     if (NULL != chain->multi) {
-        while (opal_list_get_end(&mca_pmix_ext20_component.multi_events) != (nxt = opal_list_get_next(&chain->multi->super))) {
-            multi = (opal_pmix20_multi_event_t*)nxt;
-            for (n=0; n < multi->ncodes; n++) {
-                if (multi->codes[n] == chain->status) {
-                    /* found it - invoke the handler, pointing its
-                     * callback function to our progression function */
-                    OBJ_RETAIN(chain);
-                    chain->multi = multi;
-                    multi->handler(chain->status, &chain->source,
-                                   chain->info, &chain->results,
-                                   progress_local_event_hdlr, (void*)chain);
-                    goto complete;
-                }
-            }
-        }
-        /* if we get here, then there are no more multi-mode
-         * events that match */
-        chain->multi = NULL;
-        /* pickup the beginning of the default event list */
-        if (0 < opal_list_get_size(&mca_pmix_ext20_component.default_events)) {
-            chain->def = (opal_pmix20_default_event_t*)opal_list_get_begin(&mca_pmix_ext20_component.default_events);
-        }
+	while (opal_list_get_end(&mca_pmix_ext20_component.multi_events) != (nxt = opal_list_get_next(&chain->multi->super))) {
+	    multi = (opal_pmix20_multi_event_t*)nxt;
+	    for (n=0; n < multi->ncodes; n++) {
+		if (multi->codes[n] == chain->status) {
+		    /* found it - invoke the handler, pointing its
+		     * callback function to our progression function */
+		    OBJ_RETAIN(chain);
+		    chain->multi = multi;
+		    multi->handler(chain->status, &chain->source,
+				   chain->info, &chain->results,
+				   progress_local_event_hdlr, (void*)chain);
+		    goto complete;
+		}
+	    }
+	}
+	/* if we get here, then there are no more multi-mode
+	 * events that match */
+	chain->multi = NULL;
+	/* pickup the beginning of the default event list */
+	if (0 < opal_list_get_size(&mca_pmix_ext20_component.default_events)) {
+	    chain->def = (opal_pmix20_default_event_t*)opal_list_get_begin(&mca_pmix_ext20_component.default_events);
+	}
     }
 
     /* if they didn't want it to go to a default handler, then we are done */
     if (chain->nondefault) {
-        goto complete;
+	goto complete;
     }
 
     if (NULL != chain->def) {
-        if (opal_list_get_end(&mca_pmix_ext20_component.default_events) != (nxt = opal_list_get_next(&chain->def->super))) {
-            def = (opal_pmix20_default_event_t*)nxt;
-            OBJ_RETAIN(chain);
-            chain->def = def;
-            def->handler(chain->status, &chain->source,
-                         chain->info, &chain->results,
-                         progress_local_event_hdlr, (void*)chain);
-        }
+	if (opal_list_get_end(&mca_pmix_ext20_component.default_events) != (nxt = opal_list_get_next(&chain->def->super))) {
+	    def = (opal_pmix20_default_event_t*)nxt;
+	    OBJ_RETAIN(chain);
+	    chain->def = def;
+	    def->handler(chain->status, &chain->source,
+			 chain->info, &chain->results,
+			 progress_local_event_hdlr, (void*)chain);
+	}
     }
 
   complete:
     /* we still have to call their final callback */
     if (NULL != chain->final_cbfunc) {
-        chain->final_cbfunc(OPAL_SUCCESS, chain->final_cbdata);
+	chain->final_cbfunc(OPAL_SUCCESS, chain->final_cbdata);
     }
     /* maintain acctng */
     OBJ_RELEASE(chain);
     /* let the caller know that we are done with their callback */
     if (NULL != cbfunc) {
-        cbfunc(OPAL_SUCCESS, thiscbdata);
+	cbfunc(OPAL_SUCCESS, thiscbdata);
     }
 }
 
@@ -259,8 +259,8 @@ static void _event_hdlr(int sd, short args, void *cbdata)
     opal_pmix20_default_event_t *def;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s RECEIVED NOTIFICATION OF STATUS %d",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), cd->status);
+			"%s RECEIVED NOTIFICATION OF STATUS %d",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), cd->status);
 
     chain = OBJ_NEW(opal_pmix20_event_chain_t);
     /* point it at our final callback */
@@ -275,47 +275,47 @@ static void _event_hdlr(int sd, short args, void *cbdata)
 
     /* cycle thru the single-event registrations first */
     OPAL_LIST_FOREACH(sing, &mca_pmix_ext20_component.single_events, opal_pmix20_single_event_t) {
-        if (sing->code == chain->status) {
-            /* found it - invoke the handler, pointing its
-             * callback function to our progression function */
-            OBJ_RETAIN(chain);
-            chain->sing = sing;
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s CALLING SINGLE EVHDLR",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            sing->handler(chain->status, &chain->source,
-                          chain->info, &chain->results,
-                          progress_local_event_hdlr, (void*)chain);
-            return;
-        }
+	if (sing->code == chain->status) {
+	    /* found it - invoke the handler, pointing its
+	     * callback function to our progression function */
+	    OBJ_RETAIN(chain);
+	    chain->sing = sing;
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s CALLING SINGLE EVHDLR",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    sing->handler(chain->status, &chain->source,
+			  chain->info, &chain->results,
+			  progress_local_event_hdlr, (void*)chain);
+	    return;
+	}
     }
 
     /* if we didn't find any match in the single-event registrations,
      * then cycle thru the multi-event registrations next */
     OPAL_LIST_FOREACH(multi, &mca_pmix_ext20_component.multi_events, opal_pmix20_multi_event_t) {
-        for (n=0; n < multi->ncodes; n++) {
-            if (multi->codes[n] == chain->status) {
-                /* found it - invoke the handler, pointing its
-                 * callback function to our progression function */
-                OBJ_RETAIN(chain);
-                chain->multi = multi;
-                opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                    "%s CALLING MULTI EVHDLR",
-                                    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-                multi->handler(chain->status, &chain->source,
-                               chain->info, &chain->results,
-                               progress_local_event_hdlr, (void*)chain);
-                return;
-            }
-        }
+	for (n=0; n < multi->ncodes; n++) {
+	    if (multi->codes[n] == chain->status) {
+		/* found it - invoke the handler, pointing its
+		 * callback function to our progression function */
+		OBJ_RETAIN(chain);
+		chain->multi = multi;
+		opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				    "%s CALLING MULTI EVHDLR",
+				    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+		multi->handler(chain->status, &chain->source,
+			       chain->info, &chain->results,
+			       progress_local_event_hdlr, (void*)chain);
+		return;
+	    }
+	}
     }
 
       /* if they didn't want it to go to a default handler, then we are done */
     if (chain->nondefault) {
-        /* if we get here, then we need to cache this event in case they
-         * register for it later - we cannot lose individual events */
-        opal_list_append(&mca_pmix_ext20_component.cache, &chain->super);
-        return;
+	/* if we get here, then we need to cache this event in case they
+	 * register for it later - we cannot lose individual events */
+	opal_list_append(&mca_pmix_ext20_component.cache, &chain->super);
+	return;
     }
 
     /* we are done with the threadshift caddy */
@@ -323,21 +323,21 @@ static void _event_hdlr(int sd, short args, void *cbdata)
 
     /* finally, pass it to any default handlers */
     if (0 < opal_list_get_size(&mca_pmix_ext20_component.default_events)) {
-        def = (opal_pmix20_default_event_t*)opal_list_get_first(&mca_pmix_ext20_component.default_events);
-        OBJ_RETAIN(chain);
-        chain->def = def;
-        opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                            "%s CALLING DEFAULT EVHDLR",
-                            OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-        def->handler(chain->status, &chain->source,
-                     chain->info, &chain->results,
-                     progress_local_event_hdlr, (void*)chain);
-        return;
+	def = (opal_pmix20_default_event_t*)opal_list_get_first(&mca_pmix_ext20_component.default_events);
+	OBJ_RETAIN(chain);
+	chain->def = def;
+	opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+			    "%s CALLING DEFAULT EVHDLR",
+			    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	def->handler(chain->status, &chain->source,
+		     chain->info, &chain->results,
+		     progress_local_event_hdlr, (void*)chain);
+	return;
     }
 
     /* we still have to call their final callback */
     if (NULL != chain->final_cbfunc) {
-        chain->final_cbfunc(PMIX_SUCCESS, chain->final_cbdata);
+	chain->final_cbfunc(PMIX_SUCCESS, chain->final_cbdata);
     }
     return;
 }
@@ -349,11 +349,11 @@ static void _event_hdlr(int sd, short args, void *cbdata)
  * from another process (via the local daemon).
  * The call will occur in the PMIx event base */
 void pmix20_event_hdlr(size_t evhdlr_registration_id,
-                       pmix_status_t status, const pmix_proc_t *source,
-                       pmix_info_t info[], size_t ninfo,
-                       pmix_info_t results[], size_t nresults,
-                       pmix_event_notification_cbfunc_fn_t cbfunc,
-                       void *cbdata)
+		       pmix_status_t status, const pmix_proc_t *source,
+		       pmix_info_t info[], size_t ninfo,
+		       pmix_info_t results[], size_t nresults,
+		       pmix_event_notification_cbfunc_fn_t cbfunc,
+		       void *cbdata)
 {
     pmix20_threadshift_t *cd;
     int rc;
@@ -365,51 +365,51 @@ void pmix20_event_hdlr(size_t evhdlr_registration_id,
      * lists and objects */
 
      opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                         "%s RECEIVED NOTIFICATION OF STATUS %d",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status);
+			 "%s RECEIVED NOTIFICATION OF STATUS %d",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status);
 
     cd = OBJ_NEW(pmix20_threadshift_t);
 
     /* convert the incoming status */
     cd->status = pmix20_convert_rc(status);
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s CONVERTED STATUS %d TO STATUS %d",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status, cd->status);
+			"%s CONVERTED STATUS %d TO STATUS %d",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status, cd->status);
     /* convert the nspace/rank to an opal_process_name_t */
     if (NULL == source) {
-        cd->pname.jobid = OPAL_NAME_INVALID->jobid;
-        cd->pname.vpid = OPAL_NAME_INVALID->vpid;
+	cd->pname.jobid = OPAL_NAME_INVALID->jobid;
+	cd->pname.vpid = OPAL_NAME_INVALID->vpid;
     } else {
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&cd->pname.jobid, source->nspace))) {
-            OPAL_ERROR_LOG(rc);
-            OBJ_RELEASE(cd);
-            return;
-        }
-        cd->pname.vpid = source->rank;
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&cd->pname.jobid, source->nspace))) {
+	    OPAL_ERROR_LOG(rc);
+	    OBJ_RELEASE(cd);
+	    return;
+	}
+	cd->pname.vpid = source->rank;
     }
 
     /* convert the array of info */
     if (NULL != info) {
-        cd->info = OBJ_NEW(opal_list_t);
-        for (n=0; n < ninfo; n++) {
-            if (0 == strncmp(info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
-                cd->nondefault = true;
-            }
-            iptr = OBJ_NEW(opal_value_t);
-            iptr->key = strdup(info[n].key);
-            pmix20_value_unload(iptr, &info[n].value);
-            opal_list_append(cd->info, &iptr->super);
-        }
+	cd->info = OBJ_NEW(opal_list_t);
+	for (n=0; n < ninfo; n++) {
+	    if (0 == strncmp(info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
+		cd->nondefault = true;
+	    }
+	    iptr = OBJ_NEW(opal_value_t);
+	    iptr->key = strdup(info[n].key);
+	    pmix20_value_unload(iptr, &info[n].value);
+	    opal_list_append(cd->info, &iptr->super);
+	}
     }
     /* now push it into the local thread */
     event_assign(&cd->ev, opal_pmix_base.evbase,
-                 -1, EV_WRITE, _event_hdlr, cd);
+		 -1, EV_WRITE, _event_hdlr, cd);
     event_active(&cd->ev, EV_WRITE, 1);
 
     /* we don't need any of the data they provided,
      * so let them go */
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+	cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
@@ -417,44 +417,44 @@ pmix_status_t pmix20_convert_opalrc(int rc)
 {
     switch (rc) {
     case OPAL_ERR_DEBUGGER_RELEASE:
-        return PMIX_ERR_DEBUGGER_RELEASE;
+	return PMIX_ERR_DEBUGGER_RELEASE;
 
     case OPAL_ERR_NOT_IMPLEMENTED:
     case OPAL_ERR_NOT_SUPPORTED:
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
 
     case OPAL_ERR_NOT_FOUND:
-        return PMIX_ERR_NOT_FOUND;
+	return PMIX_ERR_NOT_FOUND;
 
     case OPAL_ERR_PERM:
     case OPAL_ERR_UNREACH:
     case OPAL_ERR_SERVER_NOT_AVAIL:
-        return PMIX_ERR_UNREACH;
+	return PMIX_ERR_UNREACH;
 
     case OPAL_ERR_BAD_PARAM:
-        return PMIX_ERR_BAD_PARAM;
+	return PMIX_ERR_BAD_PARAM;
 
     case OPAL_ERR_OUT_OF_RESOURCE:
-        return PMIX_ERR_OUT_OF_RESOURCE;
+	return PMIX_ERR_OUT_OF_RESOURCE;
 
     case OPAL_ERR_DATA_VALUE_NOT_FOUND:
-        return PMIX_ERR_DATA_VALUE_NOT_FOUND;
+	return PMIX_ERR_DATA_VALUE_NOT_FOUND;
 
     case OPAL_ERR_TIMEOUT:
-        return PMIX_ERR_TIMEOUT;
+	return PMIX_ERR_TIMEOUT;
 
     case OPAL_ERR_WOULD_BLOCK:
-        return PMIX_ERR_WOULD_BLOCK;
+	return PMIX_ERR_WOULD_BLOCK;
 
     case OPAL_EXISTS:
-        return PMIX_EXISTS;
+	return PMIX_EXISTS;
 
     case OPAL_ERROR:
-        return PMIX_ERROR;
+	return PMIX_ERROR;
     case OPAL_SUCCESS:
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     default:
-        return PMIX_ERROR;
+	return PMIX_ERROR;
     }
 }
 
@@ -462,317 +462,317 @@ int pmix20_convert_rc(pmix_status_t rc)
 {
     switch (rc) {
     case PMIX_ERR_DEBUGGER_RELEASE:
-        return OPAL_ERR_DEBUGGER_RELEASE;
+	return OPAL_ERR_DEBUGGER_RELEASE;
 
     case PMIX_ERR_NOT_SUPPORTED:
-        return OPAL_ERR_NOT_SUPPORTED;
+	return OPAL_ERR_NOT_SUPPORTED;
 
     case PMIX_ERR_NOT_FOUND:
-        return OPAL_ERR_NOT_FOUND;
+	return OPAL_ERR_NOT_FOUND;
 
     case PMIX_ERR_OUT_OF_RESOURCE:
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	return OPAL_ERR_OUT_OF_RESOURCE;
 
     case PMIX_ERR_INIT:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
 
     case PMIX_ERR_BAD_PARAM:
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
 
     case PMIX_ERR_UNREACH:
     case PMIX_ERR_NO_PERMISSIONS:
-        return OPAL_ERR_UNREACH;
+	return OPAL_ERR_UNREACH;
 
     case PMIX_ERR_TIMEOUT:
-        return OPAL_ERR_TIMEOUT;
+	return OPAL_ERR_TIMEOUT;
 
     case PMIX_ERR_WOULD_BLOCK:
-        return OPAL_ERR_WOULD_BLOCK;
+	return OPAL_ERR_WOULD_BLOCK;
 
     case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
     case PMIX_ERR_LOST_PEER_CONNECTION:
     case PMIX_ERR_LOST_CONNECTION_TO_CLIENT:
-        return OPAL_ERR_COMM_FAILURE;
+	return OPAL_ERR_COMM_FAILURE;
 
     case PMIX_EXISTS:
-        return OPAL_EXISTS;
+	return OPAL_EXISTS;
 
     case PMIX_ERROR:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     case PMIX_SUCCESS:
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     default:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     }
 }
 
 pmix_scope_t pmix20_convert_opalscope(opal_pmix_scope_t scope) {
     switch(scope) {
     case OPAL_PMIX_LOCAL:
-        return PMIX_LOCAL;
+	return PMIX_LOCAL;
     case OPAL_PMIX_REMOTE:
-        return PMIX_REMOTE;
+	return PMIX_REMOTE;
     case OPAL_PMIX_GLOBAL:
-        return PMIX_GLOBAL;
+	return PMIX_GLOBAL;
     default:
-        return PMIX_SCOPE_UNDEF;
+	return PMIX_SCOPE_UNDEF;
     }
 }
 
 pmix_data_range_t pmix20_convert_opalrange(opal_pmix_data_range_t range) {
     switch(range) {
     case OPAL_PMIX_RANGE_UNDEF:
-        return PMIX_RANGE_UNDEF;
+	return PMIX_RANGE_UNDEF;
     case OPAL_PMIX_RANGE_LOCAL:
-        return PMIX_RANGE_LOCAL;
+	return PMIX_RANGE_LOCAL;
     case OPAL_PMIX_RANGE_NAMESPACE:
-        return PMIX_RANGE_NAMESPACE;
+	return PMIX_RANGE_NAMESPACE;
     case OPAL_PMIX_RANGE_SESSION:
-        return PMIX_RANGE_SESSION;
+	return PMIX_RANGE_SESSION;
     case OPAL_PMIX_RANGE_GLOBAL:
-        return PMIX_RANGE_GLOBAL;
+	return PMIX_RANGE_GLOBAL;
     case OPAL_PMIX_RANGE_CUSTOM:
-        return PMIX_RANGE_CUSTOM;
+	return PMIX_RANGE_CUSTOM;
     default:
-        return PMIX_SCOPE_UNDEF;
+	return PMIX_SCOPE_UNDEF;
     }
 }
 
 opal_pmix_data_range_t pmix20_convert_range(pmix_data_range_t range) {
     switch(range) {
     case PMIX_RANGE_UNDEF:
-        return OPAL_PMIX_RANGE_UNDEF;
+	return OPAL_PMIX_RANGE_UNDEF;
     case PMIX_RANGE_LOCAL:
-        return OPAL_PMIX_RANGE_LOCAL;
+	return OPAL_PMIX_RANGE_LOCAL;
     case PMIX_RANGE_NAMESPACE:
-        return OPAL_PMIX_RANGE_NAMESPACE;
+	return OPAL_PMIX_RANGE_NAMESPACE;
     case PMIX_RANGE_SESSION:
-        return OPAL_PMIX_RANGE_SESSION;
+	return OPAL_PMIX_RANGE_SESSION;
     case PMIX_RANGE_GLOBAL:
-        return OPAL_PMIX_RANGE_GLOBAL;
+	return OPAL_PMIX_RANGE_GLOBAL;
     case PMIX_RANGE_CUSTOM:
-        return OPAL_PMIX_RANGE_CUSTOM;
+	return OPAL_PMIX_RANGE_CUSTOM;
     default:
-        return OPAL_PMIX_SCOPE_UNDEF;
+	return OPAL_PMIX_SCOPE_UNDEF;
     }
 }
 
 
 void pmix20_value_load(pmix_value_t *v,
-                       opal_value_t *kv)
+		       opal_value_t *kv)
 {
     size_t n;
     char nspace[PMIX_MAX_NSLEN + 1];
 
     switch(kv->type) {
-        case OPAL_UNDEF:
-            v->type = PMIX_UNDEF;
-            break;
-        case OPAL_BOOL:
-            v->type = PMIX_BOOL;
-            memcpy(&(v->data.flag), &kv->data.flag, 1);
-            break;
-        case OPAL_BYTE:
-            v->type = PMIX_BYTE;
-            memcpy(&(v->data.byte), &kv->data.byte, 1);
-            break;
-        case OPAL_STRING:
-            v->type = PMIX_STRING;
-            if (NULL != kv->data.string) {
-                v->data.string = strdup(kv->data.string);
-            } else {
-                v->data.string = NULL;
-            }
-            break;
-        case OPAL_SIZE:
-            v->type = PMIX_SIZE;
-            v->data.size = (size_t)kv->data.size;
-            break;
-        case OPAL_PID:
-            v->type = PMIX_PID;
-            memcpy(&(v->data.pid), &kv->data.pid, sizeof(pid_t));
-            break;
-        case OPAL_INT:
-            v->type = PMIX_INT;
-            memcpy(&(v->data.integer), &kv->data.integer, sizeof(int));
-            break;
-        case OPAL_INT8:
-            v->type = PMIX_INT8;
-            memcpy(&(v->data.int8), &kv->data.int8, 1);
-            break;
-        case OPAL_INT16:
-            v->type = PMIX_INT16;
-            memcpy(&(v->data.int16), &kv->data.int16, 2);
-            break;
-        case OPAL_INT32:
-            v->type = PMIX_INT32;
-            memcpy(&(v->data.int32), &kv->data.int32, 4);
-            break;
-        case OPAL_INT64:
-            v->type = PMIX_INT64;
-            memcpy(&(v->data.int64), &kv->data.int64, 8);
-            break;
-        case OPAL_UINT:
-            v->type = PMIX_UINT;
-            memcpy(&(v->data.uint), &kv->data.uint, sizeof(int));
-            break;
-        case OPAL_UINT8:
-            v->type = PMIX_UINT8;
-            memcpy(&(v->data.uint8), &kv->data.uint8, 1);
-            break;
-        case OPAL_UINT16:
-            v->type = PMIX_UINT16;
-            memcpy(&(v->data.uint16), &kv->data.uint16, 2);
-            break;
-        case OPAL_UINT32:
-            v->type = PMIX_UINT32;
-            memcpy(&(v->data.uint32), &kv->data.uint32, 4);
-            break;
-        case OPAL_UINT64:
-            v->type = PMIX_UINT64;
-            memcpy(&(v->data.uint64), &kv->data.uint64, 8);
-            break;
-        case OPAL_FLOAT:
-            v->type = PMIX_FLOAT;
-            memcpy(&(v->data.fval), &kv->data.fval, sizeof(float));
-            break;
-        case OPAL_DOUBLE:
-            v->type = PMIX_DOUBLE;
-            memcpy(&(v->data.dval), &kv->data.dval, sizeof(double));
-            break;
-        case OPAL_TIMEVAL:
-            v->type = PMIX_TIMEVAL;
-            memcpy(&(v->data.tv), &kv->data.tv, sizeof(struct timeval));
-            break;
-        case OPAL_BYTE_OBJECT:
-            v->type = PMIX_BYTE_OBJECT;
-            if (NULL != kv->data.bo.bytes) {
-                v->data.bo.bytes = (char*)malloc(kv->data.bo.size);
-                memcpy(v->data.bo.bytes, kv->data.bo.bytes, kv->data.bo.size);
-                v->data.bo.size = (size_t)kv->data.bo.size;
-            } else {
-                v->data.bo.bytes = NULL;
-                v->data.bo.size = 0;
-            }
-            break;
-        case OPAL_UINT32_ARRAY:
-            /* an array of 32-bit jobids */
-            v->type = PMIX_INFO_ARRAY;
-            v->data.array.size = kv->data.uint32_array.size;
-            if (0 < v->data.array.size) {
-                PMIX_INFO_CREATE(v->data.array.array, v->data.array.size);
-                for (n=0; n < v->data.array.size; n++) {
-                    v->data.array.array[n].value.type = PMIX_STRING;
-                    (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, kv->data.uint32_array.data[n]);
-                    v->data.array.array[n].value.data.string = strdup(nspace);
-                }
-            }
-            break;
-        default:
-            /* silence warnings */
-            break;
+	case OPAL_UNDEF:
+	    v->type = PMIX_UNDEF;
+	    break;
+	case OPAL_BOOL:
+	    v->type = PMIX_BOOL;
+	    memcpy(&(v->data.flag), &kv->data.flag, 1);
+	    break;
+	case OPAL_BYTE:
+	    v->type = PMIX_BYTE;
+	    memcpy(&(v->data.byte), &kv->data.byte, 1);
+	    break;
+	case OPAL_STRING:
+	    v->type = PMIX_STRING;
+	    if (NULL != kv->data.string) {
+		v->data.string = strdup(kv->data.string);
+	    } else {
+		v->data.string = NULL;
+	    }
+	    break;
+	case OPAL_SIZE:
+	    v->type = PMIX_SIZE;
+	    v->data.size = (size_t)kv->data.size;
+	    break;
+	case OPAL_PID:
+	    v->type = PMIX_PID;
+	    memcpy(&(v->data.pid), &kv->data.pid, sizeof(pid_t));
+	    break;
+	case OPAL_INT:
+	    v->type = PMIX_INT;
+	    memcpy(&(v->data.integer), &kv->data.integer, sizeof(int));
+	    break;
+	case OPAL_INT8:
+	    v->type = PMIX_INT8;
+	    memcpy(&(v->data.int8), &kv->data.int8, 1);
+	    break;
+	case OPAL_INT16:
+	    v->type = PMIX_INT16;
+	    memcpy(&(v->data.int16), &kv->data.int16, 2);
+	    break;
+	case OPAL_INT32:
+	    v->type = PMIX_INT32;
+	    memcpy(&(v->data.int32), &kv->data.int32, 4);
+	    break;
+	case OPAL_INT64:
+	    v->type = PMIX_INT64;
+	    memcpy(&(v->data.int64), &kv->data.int64, 8);
+	    break;
+	case OPAL_UINT:
+	    v->type = PMIX_UINT;
+	    memcpy(&(v->data.uint), &kv->data.uint, sizeof(int));
+	    break;
+	case OPAL_UINT8:
+	    v->type = PMIX_UINT8;
+	    memcpy(&(v->data.uint8), &kv->data.uint8, 1);
+	    break;
+	case OPAL_UINT16:
+	    v->type = PMIX_UINT16;
+	    memcpy(&(v->data.uint16), &kv->data.uint16, 2);
+	    break;
+	case OPAL_UINT32:
+	    v->type = PMIX_UINT32;
+	    memcpy(&(v->data.uint32), &kv->data.uint32, 4);
+	    break;
+	case OPAL_UINT64:
+	    v->type = PMIX_UINT64;
+	    memcpy(&(v->data.uint64), &kv->data.uint64, 8);
+	    break;
+	case OPAL_FLOAT:
+	    v->type = PMIX_FLOAT;
+	    memcpy(&(v->data.fval), &kv->data.fval, sizeof(float));
+	    break;
+	case OPAL_DOUBLE:
+	    v->type = PMIX_DOUBLE;
+	    memcpy(&(v->data.dval), &kv->data.dval, sizeof(double));
+	    break;
+	case OPAL_TIMEVAL:
+	    v->type = PMIX_TIMEVAL;
+	    memcpy(&(v->data.tv), &kv->data.tv, sizeof(struct timeval));
+	    break;
+	case OPAL_BYTE_OBJECT:
+	    v->type = PMIX_BYTE_OBJECT;
+	    if (NULL != kv->data.bo.bytes) {
+		v->data.bo.bytes = (char*)malloc(kv->data.bo.size);
+		memcpy(v->data.bo.bytes, kv->data.bo.bytes, kv->data.bo.size);
+		v->data.bo.size = (size_t)kv->data.bo.size;
+	    } else {
+		v->data.bo.bytes = NULL;
+		v->data.bo.size = 0;
+	    }
+	    break;
+	case OPAL_UINT32_ARRAY:
+	    /* an array of 32-bit jobids */
+	    v->type = PMIX_INFO_ARRAY;
+	    v->data.array.size = kv->data.uint32_array.size;
+	    if (0 < v->data.array.size) {
+		PMIX_INFO_CREATE(v->data.array.array, v->data.array.size);
+		for (n=0; n < v->data.array.size; n++) {
+		    v->data.array.array[n].value.type = PMIX_STRING;
+		    (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, kv->data.uint32_array.data[n]);
+		    v->data.array.array[n].value.data.string = strdup(nspace);
+		}
+	    }
+	    break;
+	default:
+	    /* silence warnings */
+	    break;
     }
 }
 
 int pmix20_value_unload(opal_value_t *kv,
-                       const pmix_value_t *v)
+		       const pmix_value_t *v)
 {
     int rc=OPAL_SUCCESS;
 
 
     switch(v->type) {
     case PMIX_UNDEF:
-        kv->type = OPAL_UNDEF;
-        break;
+	kv->type = OPAL_UNDEF;
+	break;
     case PMIX_BOOL:
-        kv->type = OPAL_BOOL;
-        memcpy(&kv->data.flag, &(v->data.flag), 1);
-        break;
+	kv->type = OPAL_BOOL;
+	memcpy(&kv->data.flag, &(v->data.flag), 1);
+	break;
     case PMIX_BYTE:
-        kv->type = OPAL_BYTE;
-        memcpy(&kv->data.byte, &(v->data.byte), 1);
-        break;
+	kv->type = OPAL_BYTE;
+	memcpy(&kv->data.byte, &(v->data.byte), 1);
+	break;
     case PMIX_STRING:
-        kv->type = OPAL_STRING;
-        if (NULL != v->data.string) {
-            kv->data.string = strdup(v->data.string);
-        }
-        break;
+	kv->type = OPAL_STRING;
+	if (NULL != v->data.string) {
+	    kv->data.string = strdup(v->data.string);
+	}
+	break;
     case PMIX_SIZE:
-        kv->type = OPAL_SIZE;
-        kv->data.size = (int)v->data.size;
-        break;
+	kv->type = OPAL_SIZE;
+	kv->data.size = (int)v->data.size;
+	break;
     case PMIX_PID:
-        kv->type = OPAL_PID;
-        memcpy(&kv->data.pid, &(v->data.pid), sizeof(pid_t));
-        break;
+	kv->type = OPAL_PID;
+	memcpy(&kv->data.pid, &(v->data.pid), sizeof(pid_t));
+	break;
     case PMIX_INT:
-        kv->type = OPAL_INT;
-        memcpy(&kv->data.integer, &(v->data.integer), sizeof(int));
-        break;
+	kv->type = OPAL_INT;
+	memcpy(&kv->data.integer, &(v->data.integer), sizeof(int));
+	break;
     case PMIX_INT8:
-        kv->type = OPAL_INT8;
-        memcpy(&kv->data.int8, &(v->data.int8), 1);
-        break;
+	kv->type = OPAL_INT8;
+	memcpy(&kv->data.int8, &(v->data.int8), 1);
+	break;
     case PMIX_INT16:
-        kv->type = OPAL_INT16;
-        memcpy(&kv->data.int16, &(v->data.int16), 2);
-        break;
+	kv->type = OPAL_INT16;
+	memcpy(&kv->data.int16, &(v->data.int16), 2);
+	break;
     case PMIX_INT32:
-        kv->type = OPAL_INT32;
-        memcpy(&kv->data.int32, &(v->data.int32), 4);
-        break;
+	kv->type = OPAL_INT32;
+	memcpy(&kv->data.int32, &(v->data.int32), 4);
+	break;
     case PMIX_INT64:
-        kv->type = OPAL_INT64;
-        memcpy(&kv->data, &(v->data.int64), 8);
-        break;
+	kv->type = OPAL_INT64;
+	memcpy(&kv->data, &(v->data.int64), 8);
+	break;
     case PMIX_UINT:
-        kv->type = OPAL_UINT;
-        memcpy(&kv->data, &(v->data.uint), sizeof(int));
-        break;
+	kv->type = OPAL_UINT;
+	memcpy(&kv->data, &(v->data.uint), sizeof(int));
+	break;
     case PMIX_UINT8:
-        kv->type = OPAL_UINT8;
-        memcpy(&kv->data, &(v->data.uint8), 1);
-        break;
+	kv->type = OPAL_UINT8;
+	memcpy(&kv->data, &(v->data.uint8), 1);
+	break;
     case PMIX_UINT16:
-        kv->type = OPAL_UINT16;
-        memcpy(&kv->data, &(v->data.uint16), 2);
-        break;
+	kv->type = OPAL_UINT16;
+	memcpy(&kv->data, &(v->data.uint16), 2);
+	break;
     case PMIX_UINT32:
-        kv->type = OPAL_UINT32;
-        memcpy(&kv->data, &(v->data.uint32), 4);
-        break;
+	kv->type = OPAL_UINT32;
+	memcpy(&kv->data, &(v->data.uint32), 4);
+	break;
     case PMIX_UINT64:
-        kv->type = OPAL_UINT64;
-        memcpy(&kv->data, &(v->data.uint64), 8);
-        break;
+	kv->type = OPAL_UINT64;
+	memcpy(&kv->data, &(v->data.uint64), 8);
+	break;
     case PMIX_FLOAT:
-        kv->type = OPAL_FLOAT;
-        memcpy(&kv->data, &(v->data.fval), sizeof(float));
-        break;
+	kv->type = OPAL_FLOAT;
+	memcpy(&kv->data, &(v->data.fval), sizeof(float));
+	break;
     case PMIX_DOUBLE:
-        kv->type = OPAL_DOUBLE;
-        memcpy(&kv->data, &(v->data.dval), sizeof(double));
-        break;
+	kv->type = OPAL_DOUBLE;
+	memcpy(&kv->data, &(v->data.dval), sizeof(double));
+	break;
     case PMIX_TIMEVAL:
-        kv->type = OPAL_TIMEVAL;
-        memcpy(&kv->data, &(v->data.tv), sizeof(struct timeval));
-        break;
+	kv->type = OPAL_TIMEVAL;
+	memcpy(&kv->data, &(v->data.tv), sizeof(struct timeval));
+	break;
     case PMIX_BYTE_OBJECT:
-        kv->type = OPAL_BYTE_OBJECT;
-        if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
-            kv->data.bo.bytes = (uint8_t*)malloc(v->data.bo.size);
-            memcpy(kv->data.bo.bytes, v->data.bo.bytes, v->data.bo.size);
-            kv->data.bo.size = (int)v->data.bo.size;
-        } else {
-            kv->data.bo.bytes = NULL;
-            kv->data.bo.size = 0;
-        }
-        break;
+	kv->type = OPAL_BYTE_OBJECT;
+	if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
+	    kv->data.bo.bytes = (uint8_t*)malloc(v->data.bo.size);
+	    memcpy(kv->data.bo.bytes, v->data.bo.bytes, v->data.bo.size);
+	    kv->data.bo.size = (int)v->data.bo.size;
+	} else {
+	    kv->data.bo.bytes = NULL;
+	    kv->data.bo.size = 0;
+	}
+	break;
     default:
-        /* silence warnings */
-        rc = OPAL_ERROR;
-        break;
+	/* silence warnings */
+	rc = OPAL_ERROR;
+	break;
     }
     return rc;
 }
@@ -790,125 +790,125 @@ static void _reg_hdlr(int sd, short args, void *cbdata)
     size_t n;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s REGISTER HANDLER CODES %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == cd->event_codes) ? "NULL" : "NON-NULL");
+			"%s REGISTER HANDLER CODES %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == cd->event_codes) ? "NULL" : "NON-NULL");
 
     if (NULL != cd->info) {
-        OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
-            if (0 == strcmp(kv->key, OPAL_PMIX_EVENT_ORDER_PREPEND)) {
-                prepend = true;
-                break;
-            }
-        }
+	OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
+	    if (0 == strcmp(kv->key, OPAL_PMIX_EVENT_ORDER_PREPEND)) {
+		prepend = true;
+		break;
+	    }
+	}
     }
 
     if (NULL == cd->event_codes) {
-        /* this is a default handler */
-        def = OBJ_NEW(opal_pmix20_default_event_t);
-        def->handler = cd->evhandler;
-        def->index = mca_pmix_ext20_component.evindex;
-        if (prepend) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s PREPENDING TO DEFAULT EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_prepend(&mca_pmix_ext20_component.default_events, &def->super);
-        } else {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s APPENDING TO DEFAULT EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_append(&mca_pmix_ext20_component.default_events, &def->super);
-        }
+	/* this is a default handler */
+	def = OBJ_NEW(opal_pmix20_default_event_t);
+	def->handler = cd->evhandler;
+	def->index = mca_pmix_ext20_component.evindex;
+	if (prepend) {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s PREPENDING TO DEFAULT EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_prepend(&mca_pmix_ext20_component.default_events, &def->super);
+	} else {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s APPENDING TO DEFAULT EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_append(&mca_pmix_ext20_component.default_events, &def->super);
+	}
     } else if (1 == opal_list_get_size(cd->event_codes)) {
-        /* single handler */
-        sing = OBJ_NEW(opal_pmix20_single_event_t);
-        kv = (opal_value_t*)opal_list_get_first(cd->event_codes);
-        sing->code = kv->data.integer;
-        sing->index = mca_pmix_ext20_component.evindex;
-        sing->handler = cd->evhandler;
-        if (prepend) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s PREPENDING TO SINGLE EVENTS WITH CODE %d",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
-            opal_list_prepend(&mca_pmix_ext20_component.single_events, &sing->super);
-        } else {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s APPENDING TO SINGLE EVENTS WITH CODE %d",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
-            opal_list_append(&mca_pmix_ext20_component.single_events, &sing->super);
-        }
+	/* single handler */
+	sing = OBJ_NEW(opal_pmix20_single_event_t);
+	kv = (opal_value_t*)opal_list_get_first(cd->event_codes);
+	sing->code = kv->data.integer;
+	sing->index = mca_pmix_ext20_component.evindex;
+	sing->handler = cd->evhandler;
+	if (prepend) {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s PREPENDING TO SINGLE EVENTS WITH CODE %d",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
+	    opal_list_prepend(&mca_pmix_ext20_component.single_events, &sing->super);
+	} else {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s APPENDING TO SINGLE EVENTS WITH CODE %d",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
+	    opal_list_append(&mca_pmix_ext20_component.single_events, &sing->super);
+	}
     } else {
-        multi = OBJ_NEW(opal_pmix20_multi_event_t);
-        multi->ncodes = opal_list_get_size(cd->event_codes);
-        multi->codes = (int*)malloc(multi->ncodes * sizeof(int));
-        i=0;
-        OPAL_LIST_FOREACH(kv, cd->event_codes, opal_value_t) {
-            multi->codes[i] = kv->data.integer;
-            ++i;
-        }
-        multi->index = mca_pmix_ext20_component.evindex;
-        multi->handler = cd->evhandler;
-        if (prepend) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s PREPENDING TO MULTI EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_prepend(&mca_pmix_ext20_component.multi_events, &multi->super);
-        } else {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s APPENDING TO MULTI EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_append(&mca_pmix_ext20_component.multi_events, &multi->super);
-        }
+	multi = OBJ_NEW(opal_pmix20_multi_event_t);
+	multi->ncodes = opal_list_get_size(cd->event_codes);
+	multi->codes = (int*)malloc(multi->ncodes * sizeof(int));
+	i=0;
+	OPAL_LIST_FOREACH(kv, cd->event_codes, opal_value_t) {
+	    multi->codes[i] = kv->data.integer;
+	    ++i;
+	}
+	multi->index = mca_pmix_ext20_component.evindex;
+	multi->handler = cd->evhandler;
+	if (prepend) {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s PREPENDING TO MULTI EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_prepend(&mca_pmix_ext20_component.multi_events, &multi->super);
+	} else {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s APPENDING TO MULTI EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_append(&mca_pmix_ext20_component.multi_events, &multi->super);
+	}
     }
 
     /* release the caller */
     if (NULL != cd->cbfunc) {
-        cd->cbfunc(OPAL_SUCCESS, mca_pmix_ext20_component.evindex, cd->cbdata);
+	cd->cbfunc(OPAL_SUCCESS, mca_pmix_ext20_component.evindex, cd->cbdata);
     }
     mca_pmix_ext20_component.evindex++;
 
     /* check if any matching notifications have been cached - only nondefault
      * events will have been cached*/
     if (NULL == def) {
-        /* check single code registrations */
-        if (NULL != sing) {
-            OPAL_LIST_FOREACH(chain, &mca_pmix_ext20_component.cache, opal_pmix20_event_chain_t) {
-                if (sing->code == chain->status) {
-                    opal_list_remove_item(&mca_pmix_ext20_component.cache, &chain->super);
-                    chain->sing = sing;
-                    sing->handler(chain->status, &chain->source,
-                                  chain->info, &chain->results,
-                                  progress_local_event_hdlr, (void*)chain);
-                    OBJ_RELEASE(cd);
-                    return;
-                }
-            }
-        } else if (NULL != multi) {
-            /* check for multi code registrations */
-            OPAL_LIST_FOREACH(chain, &mca_pmix_ext20_component.cache, opal_pmix20_event_chain_t) {
-                for (n=0; n < multi->ncodes; n++) {
-                    if (multi->codes[n] == chain->status) {
-                        opal_list_remove_item(&mca_pmix_ext20_component.cache, &chain->super);
-                        chain->multi = multi;
-                        multi->handler(chain->status, &chain->source,
-                                      chain->info, &chain->results,
-                                      progress_local_event_hdlr, (void*)chain);
-                        OBJ_RELEASE(cd);
-                        return;
-                    }
-                }
-            }
-        }
+	/* check single code registrations */
+	if (NULL != sing) {
+	    OPAL_LIST_FOREACH(chain, &mca_pmix_ext20_component.cache, opal_pmix20_event_chain_t) {
+		if (sing->code == chain->status) {
+		    opal_list_remove_item(&mca_pmix_ext20_component.cache, &chain->super);
+		    chain->sing = sing;
+		    sing->handler(chain->status, &chain->source,
+				  chain->info, &chain->results,
+				  progress_local_event_hdlr, (void*)chain);
+		    OBJ_RELEASE(cd);
+		    return;
+		}
+	    }
+	} else if (NULL != multi) {
+	    /* check for multi code registrations */
+	    OPAL_LIST_FOREACH(chain, &mca_pmix_ext20_component.cache, opal_pmix20_event_chain_t) {
+		for (n=0; n < multi->ncodes; n++) {
+		    if (multi->codes[n] == chain->status) {
+			opal_list_remove_item(&mca_pmix_ext20_component.cache, &chain->super);
+			chain->multi = multi;
+			multi->handler(chain->status, &chain->source,
+				      chain->info, &chain->results,
+				      progress_local_event_hdlr, (void*)chain);
+			OBJ_RELEASE(cd);
+			return;
+		    }
+		}
+	    }
+	}
     }
 
     OBJ_RELEASE(cd);
     return;
 }
 static void register_handler(opal_list_t *event_codes,
-                             opal_list_t *info,
-                             opal_pmix_notification_fn_t evhandler,
-                             opal_pmix_evhandler_reg_cbfunc_t cbfunc,
-                             void *cbdata)
+			     opal_list_t *info,
+			     opal_pmix_notification_fn_t evhandler,
+			     opal_pmix_evhandler_reg_cbfunc_t cbfunc,
+			     void *cbdata)
 {
     /* we must threadshift this request as we might not be in an event
      * and we are going to access framework-global lists/objects */
@@ -926,39 +926,39 @@ static void _dereg_hdlr(int sd, short args, void *cbdata)
 
     /* check the single events first */
     OPAL_LIST_FOREACH(sing, &mca_pmix_ext20_component.single_events, opal_pmix20_single_event_t) {
-        if (cd->handler == sing->index) {
-            opal_list_remove_item(&mca_pmix_ext20_component.single_events, &sing->super);
-            OBJ_RELEASE(sing);
-            goto release;
-        }
+	if (cd->handler == sing->index) {
+	    opal_list_remove_item(&mca_pmix_ext20_component.single_events, &sing->super);
+	    OBJ_RELEASE(sing);
+	    goto release;
+	}
     }
     /* check multi events */
     OPAL_LIST_FOREACH(multi, &mca_pmix_ext20_component.multi_events, opal_pmix20_multi_event_t) {
-        if (cd->handler == multi->index) {
-            opal_list_remove_item(&mca_pmix_ext20_component.multi_events, &multi->super);
-            OBJ_RELEASE(multi);
-            goto release;
-        }
+	if (cd->handler == multi->index) {
+	    opal_list_remove_item(&mca_pmix_ext20_component.multi_events, &multi->super);
+	    OBJ_RELEASE(multi);
+	    goto release;
+	}
     }
     /* check default events */
     OPAL_LIST_FOREACH(def, &mca_pmix_ext20_component.default_events, opal_pmix20_default_event_t) {
-        if (cd->handler == def->index) {
-            opal_list_remove_item(&mca_pmix_ext20_component.default_events, &def->super);
-            OBJ_RELEASE(def);
-            break;
-        }
+	if (cd->handler == def->index) {
+	    opal_list_remove_item(&mca_pmix_ext20_component.default_events, &def->super);
+	    OBJ_RELEASE(def);
+	    break;
+	}
     }
 
   release:
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(OPAL_SUCCESS, cd->cbdata);
+	cd->opcbfunc(OPAL_SUCCESS, cd->cbdata);
     }
     OBJ_RELEASE(cd);
 }
 
 static void deregister_handler(size_t evhandler,
-                               opal_pmix_op_cbfunc_t cbfunc,
-                               void *cbdata)
+			       opal_pmix_op_cbfunc_t cbfunc,
+			       void *cbdata)
 {
     /* we must threadshift this request as we might not be in an event
      * and we are going to access framework-global lists/objects */
@@ -977,86 +977,86 @@ static void _notify_event(int sd, short args, void *cbdata)
 
     /* check the single events first */
     OPAL_LIST_FOREACH(sing, &mca_pmix_ext20_component.single_events, opal_pmix20_single_event_t) {
-        if (cd->status == sing->code) {
-            /* found it - invoke the handler, pointing its
-             * callback function to our progression function */
-            chain = OBJ_NEW(opal_pmix20_event_chain_t);
-            chain->status = cd->status;
-            chain->range = pmix20_convert_opalrange(cd->range);
-            chain->source = *(cd->source);
-            chain->info = cd->info;
-            chain->final_cbfunc = cd->opcbfunc;
-            chain->final_cbdata = cd->cbdata;
-            chain->sing = sing;
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "[%s] CALLING SINGLE EVHDLR FOR STATUS %d",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
-            sing->handler(chain->status, &chain->source,
-                          chain->info, &chain->results,
-                          progress_local_event_hdlr, (void*)chain);
-            OBJ_RELEASE(cd);
-            return;
-        }
+	if (cd->status == sing->code) {
+	    /* found it - invoke the handler, pointing its
+	     * callback function to our progression function */
+	    chain = OBJ_NEW(opal_pmix20_event_chain_t);
+	    chain->status = cd->status;
+	    chain->range = pmix20_convert_opalrange(cd->range);
+	    chain->source = *(cd->source);
+	    chain->info = cd->info;
+	    chain->final_cbfunc = cd->opcbfunc;
+	    chain->final_cbdata = cd->cbdata;
+	    chain->sing = sing;
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"[%s] CALLING SINGLE EVHDLR FOR STATUS %d",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
+	    sing->handler(chain->status, &chain->source,
+			  chain->info, &chain->results,
+			  progress_local_event_hdlr, (void*)chain);
+	    OBJ_RELEASE(cd);
+	    return;
+	}
     }
     /* check multi events */
     OPAL_LIST_FOREACH(multi, &mca_pmix_ext20_component.multi_events, opal_pmix20_multi_event_t) {
-        for (i=0; i < multi->ncodes; i++) {
-            if (cd->status == multi->codes[i]) {
-                /* found it - invoke the handler, pointing its
-                 * callback function to our progression function */
-                chain = OBJ_NEW(opal_pmix20_event_chain_t);
-                chain->status = cd->status;
-                chain->range = pmix20_convert_opalrange(cd->range);
-                chain->source = *(cd->source);
-                chain->info = cd->info;
-                chain->final_cbfunc = cd->opcbfunc;
-                chain->final_cbdata = cd->cbdata;
-                chain->multi = multi;
-                opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                    "[%s] CALLING MULTI EVHDLR FOR STATUS %d",
-                                    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
-                multi->handler(chain->status, &chain->source,
-                               chain->info, &chain->results,
-                               progress_local_event_hdlr, (void*)chain);
-                OBJ_RELEASE(cd);
-                return;
-            }
-        }
+	for (i=0; i < multi->ncodes; i++) {
+	    if (cd->status == multi->codes[i]) {
+		/* found it - invoke the handler, pointing its
+		 * callback function to our progression function */
+		chain = OBJ_NEW(opal_pmix20_event_chain_t);
+		chain->status = cd->status;
+		chain->range = pmix20_convert_opalrange(cd->range);
+		chain->source = *(cd->source);
+		chain->info = cd->info;
+		chain->final_cbfunc = cd->opcbfunc;
+		chain->final_cbdata = cd->cbdata;
+		chain->multi = multi;
+		opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				    "[%s] CALLING MULTI EVHDLR FOR STATUS %d",
+				    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
+		multi->handler(chain->status, &chain->source,
+			       chain->info, &chain->results,
+			       progress_local_event_hdlr, (void*)chain);
+		OBJ_RELEASE(cd);
+		return;
+	    }
+	}
     }
     /* check default events */
     if (0 < opal_list_get_size(&mca_pmix_ext20_component.default_events)) {
-        def = (opal_pmix20_default_event_t*)opal_list_get_first(&mca_pmix_ext20_component.default_events);
-        chain = OBJ_NEW(opal_pmix20_event_chain_t);
-        chain->status = cd->status;
-        chain->range = pmix20_convert_opalrange(cd->range);
-        chain->source = *(cd->source);
-        chain->info = cd->info;
-        chain->final_cbfunc = cd->opcbfunc;
-        chain->final_cbdata = cd->cbdata;
-        chain->def = def;
-        opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                            "[%s] CALLING DEFAULT EVHDLR FOR STATUS %d",
-                            OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
-        def->handler(chain->status, &chain->source,
-                     chain->info, &chain->results,
-                     progress_local_event_hdlr, (void*)chain);
-        OBJ_RELEASE(cd);
-        return;
+	def = (opal_pmix20_default_event_t*)opal_list_get_first(&mca_pmix_ext20_component.default_events);
+	chain = OBJ_NEW(opal_pmix20_event_chain_t);
+	chain->status = cd->status;
+	chain->range = pmix20_convert_opalrange(cd->range);
+	chain->source = *(cd->source);
+	chain->info = cd->info;
+	chain->final_cbfunc = cd->opcbfunc;
+	chain->final_cbdata = cd->cbdata;
+	chain->def = def;
+	opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+			    "[%s] CALLING DEFAULT EVHDLR FOR STATUS %d",
+			    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
+	def->handler(chain->status, &chain->source,
+		     chain->info, &chain->results,
+		     progress_local_event_hdlr, (void*)chain);
+	OBJ_RELEASE(cd);
+	return;
     }
 
     /* if we get here, then there are no registered event handlers */
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(OPAL_ERR_NOT_FOUND, cd->cbdata);
+	cd->opcbfunc(OPAL_ERR_NOT_FOUND, cd->cbdata);
     }
     OBJ_RELEASE(cd);
     return;
 }
 
 static int notify_event(int status,
-                        const opal_process_name_t *source,
-                        opal_pmix_data_range_t range,
-                        opal_list_t *info,
-                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			const opal_process_name_t *source,
+			opal_pmix_data_range_t range,
+			opal_list_t *info,
+			opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     /* we must threadshift this request as we might not be in an event
      * and we are going to access framework-global lists/objects */
@@ -1066,12 +1066,12 @@ static int notify_event(int status,
 
 /****  INSTANTIATE INTERNAL CLASSES  ****/
 OBJ_CLASS_INSTANCE(opal_pmix20_jobid_trkr_t,
-                   opal_list_item_t,
-                   NULL, NULL);
+		   opal_list_item_t,
+		   NULL, NULL);
 
 OBJ_CLASS_INSTANCE(opal_pmix20_single_event_t,
-                   opal_list_item_t,
-                   NULL, NULL);
+		   opal_list_item_t,
+		   NULL, NULL);
 
 static void mtevcon(opal_pmix20_multi_event_t *p)
 {
@@ -1081,16 +1081,16 @@ static void mtevcon(opal_pmix20_multi_event_t *p)
 static void mtevdes(opal_pmix20_multi_event_t *p)
 {
     if (NULL != p->codes) {
-        free(p->codes);
+	free(p->codes);
     }
 }
 OBJ_CLASS_INSTANCE(opal_pmix20_multi_event_t,
-                   opal_list_item_t,
-                   mtevcon, mtevdes);
+		   opal_list_item_t,
+		   mtevcon, mtevdes);
 
 OBJ_CLASS_INSTANCE(opal_pmix20_default_event_t,
-                   opal_list_item_t,
-                   NULL, NULL);
+		   opal_list_item_t,
+		   NULL, NULL);
 
 static void chcon(opal_pmix20_event_chain_t *p)
 {
@@ -1108,8 +1108,8 @@ static void chdes(opal_pmix20_event_chain_t *p)
     OPAL_LIST_DESTRUCT(&p->results);
 }
 OBJ_CLASS_INSTANCE(opal_pmix20_event_chain_t,
-                   opal_list_item_t,
-                   chcon, chdes);
+		   opal_list_item_t,
+		   chcon, chdes);
 
 static void opcon(pmix20_opcaddy_t *p)
 {
@@ -1133,21 +1133,21 @@ static void opcon(pmix20_opcaddy_t *p)
 static void opdes(pmix20_opcaddy_t *p)
 {
     if (NULL != p->procs) {
-        PMIX_PROC_FREE(p->procs, p->nprocs);
+	PMIX_PROC_FREE(p->procs, p->nprocs);
     }
     if (NULL != p->error_procs) {
-        PMIX_PROC_FREE(p->error_procs, p->nerror_procs);
+	PMIX_PROC_FREE(p->error_procs, p->nerror_procs);
     }
     if (NULL != p->info) {
-        PMIX_INFO_FREE(p->info, p->sz);
+	PMIX_INFO_FREE(p->info, p->sz);
     }
     if (NULL != p->apps) {
-        PMIX_APP_FREE(p->apps, p->sz);
+	PMIX_APP_FREE(p->apps, p->sz);
     }
 }
 OBJ_CLASS_INSTANCE(pmix20_opcaddy_t,
-                   opal_object_t,
-                   opcon, opdes);
+		   opal_object_t,
+		   opcon, opdes);
 
 static void ocadcon(pmix20_opalcaddy_t *p)
 {
@@ -1174,8 +1174,8 @@ static void ocaddes(pmix20_opalcaddy_t *p)
     OPAL_LIST_DESTRUCT(&p->apps);
 }
 OBJ_CLASS_INSTANCE(pmix20_opalcaddy_t,
-                   opal_object_t,
-                   ocadcon, ocaddes);
+		   opal_object_t,
+		   ocadcon, ocaddes);
 
 static void tscon(pmix20_threadshift_t *p)
 {
@@ -1190,5 +1190,5 @@ static void tscon(pmix20_threadshift_t *p)
     p->cbdata = NULL;
 }
 OBJ_CLASS_INSTANCE(pmix20_threadshift_t,
-                   opal_object_t,
-                   tscon, NULL);
+		   opal_object_t,
+		   tscon, NULL);

--- a/opal/mca/pmix/ext20/pmix_ext20.h
+++ b/opal/mca/pmix/ext20/pmix_ext20.h
@@ -4,6 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -163,58 +164,58 @@ OBJ_CLASS_DECLARATION(pmix20_threadshift_t);
 
 #define OPAL_PMIX_OPCD_THREADSHIFT(i, s, sr, if, nif, fn, cb, cd)   \
     do {                                                    \
-        pmix20_opalcaddy_t *_cd;                            \
-        _cd = OBJ_NEW(pmix20_opalcaddy_t);                  \
-        _cd->id = (i);                                      \
-        _cd->status = (s);                                  \
-        _cd->source = (sr);                                 \
-        _cd->info = (i);                                    \
-        _cd->evcbfunc = (cb);                               \
-        _cd->cbdata = (cd);                                 \
-        event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
-                     -1, EV_WRITE, (fn), (_cd));            \
-        event_active(&((_cd)->ev), EV_WRITE, 1);            \
+	pmix20_opalcaddy_t *_cd;                            \
+	_cd = OBJ_NEW(pmix20_opalcaddy_t);                  \
+	_cd->id = (i);                                      \
+	_cd->status = (s);                                  \
+	_cd->source = (sr);                                 \
+	_cd->info = (i);                                    \
+	_cd->evcbfunc = (cb);                               \
+	_cd->cbdata = (cd);                                 \
+	event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
+		     -1, EV_WRITE, (fn), (_cd));            \
+	event_active(&((_cd)->ev), EV_WRITE, 1);            \
     } while(0)
 
 #define OPAL_PMIX_OP_THREADSHIFT(e, fn, cb, cd)             \
     do {                                                    \
-        pmix20_threadshift_t *_cd;                          \
-        _cd = OBJ_NEW(pmix20_threadshift_t);                \
-        _cd->handler = (e);                                 \
-        _cd->opcbfunc = (cb);                               \
-        _cd->cbdata = (cd);                                 \
-        event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
-                     -1, EV_WRITE, (fn), (_cd));            \
-        event_active(&((_cd)->ev), EV_WRITE, 1);            \
+	pmix20_threadshift_t *_cd;                          \
+	_cd = OBJ_NEW(pmix20_threadshift_t);                \
+	_cd->handler = (e);                                 \
+	_cd->opcbfunc = (cb);                               \
+	_cd->cbdata = (cd);                                 \
+	event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
+		     -1, EV_WRITE, (fn), (_cd));            \
+	event_active(&((_cd)->ev), EV_WRITE, 1);            \
     } while(0)
 
 #define OPAL_PMIX_THREADSHIFT(e, i, eh, fn, cb, cd)         \
     do {                                                    \
-        pmix20_threadshift_t *_cd;                          \
-        _cd = OBJ_NEW(pmix20_threadshift_t);                \
-        _cd->event_codes = (e);                             \
-        _cd->info = (i);                                    \
-        _cd->evhandler = (eh);                              \
-        _cd->cbfunc = (cb);                                 \
-        _cd->cbdata = (cd);                                 \
-        event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
-                     -1, EV_WRITE, (fn), (_cd));            \
-        event_active(&((_cd)->ev), EV_WRITE, 1);            \
+	pmix20_threadshift_t *_cd;                          \
+	_cd = OBJ_NEW(pmix20_threadshift_t);                \
+	_cd->event_codes = (e);                             \
+	_cd->info = (i);                                    \
+	_cd->evhandler = (eh);                              \
+	_cd->cbfunc = (cb);                                 \
+	_cd->cbdata = (cd);                                 \
+	event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
+		     -1, EV_WRITE, (fn), (_cd));            \
+	event_active(&((_cd)->ev), EV_WRITE, 1);            \
     } while(0)
 
 #define OPAL_PMIX_NOTIFY_THREADSHIFT(s, sr, r, i, fn, cb, cd)   \
     do {                                                        \
-        pmix20_threadshift_t *_cd;                              \
-        _cd = OBJ_NEW(pmix20_threadshift_t);                    \
-        _cd->status = (s);                                      \
-        _cd->source = (sr);                                     \
-        _cd->range = (r);                                       \
-        _cd->info = (i);                                        \
-        _cd->opcbfunc = (cb);                                   \
-        _cd->cbdata = (cd);                                     \
-        event_assign(&((_cd)->ev), opal_pmix_base.evbase,       \
-                     -1, EV_WRITE, (fn), (_cd));                \
-        event_active(&((_cd)->ev), EV_WRITE, 1);                \
+	pmix20_threadshift_t *_cd;                              \
+	_cd = OBJ_NEW(pmix20_threadshift_t);                    \
+	_cd->status = (s);                                      \
+	_cd->source = (sr);                                     \
+	_cd->range = (r);                                       \
+	_cd->info = (i);                                        \
+	_cd->opcbfunc = (cb);                                   \
+	_cd->cbdata = (cd);                                     \
+	event_assign(&((_cd)->ev), opal_pmix_base.evbase,       \
+		     -1, EV_WRITE, (fn), (_cd));                \
+	event_active(&((_cd)->ev), EV_WRITE, 1);                \
     } while(0)
 
 /****  CLIENT FUNCTIONS  ****/
@@ -222,93 +223,93 @@ OPAL_MODULE_DECLSPEC int pmix20_client_init(void);
 OPAL_MODULE_DECLSPEC int pmix20_client_finalize(void);
 OPAL_MODULE_DECLSPEC int pmix20_initialized(void);
 OPAL_MODULE_DECLSPEC int pmix20_abort(int flag, const char *msg,
-                                     opal_list_t *procs);
+				     opal_list_t *procs);
 OPAL_MODULE_DECLSPEC int pmix20_commit(void);
 OPAL_MODULE_DECLSPEC int pmix20_fence(opal_list_t *procs, int collect_data);
 OPAL_MODULE_DECLSPEC int pmix20_fencenb(opal_list_t *procs, int collect_data,
-                                       opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+				       opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_put(opal_pmix_scope_t scope,
-                                     opal_value_t *val);
+				     opal_value_t *val);
 OPAL_MODULE_DECLSPEC int pmix20_get(const opal_process_name_t *proc, const char *key,
-                                   opal_list_t *info, opal_value_t **val);
+				   opal_list_t *info, opal_value_t **val);
 OPAL_MODULE_DECLSPEC int pmix20_getnb(const opal_process_name_t *proc, const char *key,
-                                     opal_list_t *info,
-                                     opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
+				     opal_list_t *info,
+				     opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_publish(opal_list_t *info);
 OPAL_MODULE_DECLSPEC int pmix20_publishnb(opal_list_t *info,
-                                         opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+					 opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_lookup(opal_list_t *data, opal_list_t *info);
 OPAL_MODULE_DECLSPEC int pmix20_lookupnb(char **keys, opal_list_t *info,
-                                        opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+					opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_unpublish(char **keys, opal_list_t *info);
 OPAL_MODULE_DECLSPEC int pmix20_unpublishnb(char **keys, opal_list_t *info,
-                                           opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+					   opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid);
 OPAL_MODULE_DECLSPEC int pmix20_spawnnb(opal_list_t *job_info, opal_list_t *apps,
-                                       opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+				       opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_connect(opal_list_t *procs);
 OPAL_MODULE_DECLSPEC int pmix20_connectnb(opal_list_t *procs,
-                                         opal_pmix_op_cbfunc_t cbfunc,
-                                         void *cbdata);
+					 opal_pmix_op_cbfunc_t cbfunc,
+					 void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_disconnect(opal_list_t *procs);
 OPAL_MODULE_DECLSPEC int pmix20_disconnectnb(opal_list_t *procs,
-                                            opal_pmix_op_cbfunc_t cbfunc,
-                                            void *cbdata);
+					    opal_pmix_op_cbfunc_t cbfunc,
+					    void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_resolve_peers(const char *nodename, opal_jobid_t jobid,
-                                             opal_list_t *procs);
+					     opal_list_t *procs);
 OPAL_MODULE_DECLSPEC int pmix20_resolve_nodes(opal_jobid_t jobid, char **nodelist);
 
 /****  COMMON FUNCTIONS  ****/
 OPAL_MODULE_DECLSPEC int pmix20_store_local(const opal_process_name_t *proc,
-                                             opal_value_t *val);
+					     opal_value_t *val);
 
 /****  SERVER SOUTHBOUND FUNCTIONS  ****/
 OPAL_MODULE_DECLSPEC int pmix20_server_init(opal_pmix_server_module_t *module,
-                                           opal_list_t *info);
+					   opal_list_t *info);
 OPAL_MODULE_DECLSPEC int pmix20_server_finalize(void);
 OPAL_MODULE_DECLSPEC int pmix20_server_gen_regex(const char *input, char **regex);
 OPAL_MODULE_DECLSPEC int pmix20_server_gen_ppn(const char *input, char **ppn);
 OPAL_MODULE_DECLSPEC int pmix20_server_register_nspace(opal_jobid_t jobid,
-                                                      int nlocalprocs,
-                                                      opal_list_t *info,
-                                                      opal_pmix_op_cbfunc_t cbfunc,
-                                                      void *cbdata);
+						      int nlocalprocs,
+						      opal_list_t *info,
+						      opal_pmix_op_cbfunc_t cbfunc,
+						      void *cbdata);
 OPAL_MODULE_DECLSPEC void pmix20_server_deregister_nspace(opal_jobid_t jobid,
-                                                          opal_pmix_op_cbfunc_t cbfunc,
-                                                          void *cbdata);
+							  opal_pmix_op_cbfunc_t cbfunc,
+							  void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_server_register_client(const opal_process_name_t *proc,
-                                                      uid_t uid, gid_t gid,
-                                                      void *server_object,
-                                                      opal_pmix_op_cbfunc_t cbfunc,
-                                                      void *cbdata);
+						      uid_t uid, gid_t gid,
+						      void *server_object,
+						      opal_pmix_op_cbfunc_t cbfunc,
+						      void *cbdata);
 OPAL_MODULE_DECLSPEC void pmix20_server_deregister_client(const opal_process_name_t *proc,
-                                                          opal_pmix_op_cbfunc_t cbfunc,
-                                                          void *cbdata);
+							  opal_pmix_op_cbfunc_t cbfunc,
+							  void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_server_setup_fork(const opal_process_name_t *proc, char ***env);
 OPAL_MODULE_DECLSPEC int pmix20_server_dmodex(const opal_process_name_t *proc,
-                                             opal_pmix_modex_cbfunc_t cbfunc, void *cbdata);
+					     opal_pmix_modex_cbfunc_t cbfunc, void *cbdata);
 OPAL_MODULE_DECLSPEC int pmix20_server_notify_event(int status,
-                                                    const opal_process_name_t *source,
-                                                    opal_list_t *info,
-                                                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+						    const opal_process_name_t *source,
+						    opal_list_t *info,
+						    opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
 /****  COMPONENT UTILITY FUNCTIONS  ****/
 OPAL_MODULE_DECLSPEC void pmix20_event_hdlr(size_t evhdlr_registration_id,
-                                            pmix_status_t status, const pmix_proc_t *source,
-                                            pmix_info_t info[], size_t ninfo,
-                                            pmix_info_t results[], size_t nresults,
-                                            pmix_event_notification_cbfunc_fn_t cbfunc,
-                                            void *cbdata);
+					    pmix_status_t status, const pmix_proc_t *source,
+					    pmix_info_t info[], size_t ninfo,
+					    pmix_info_t results[], size_t nresults,
+					    pmix_event_notification_cbfunc_fn_t cbfunc,
+					    void *cbdata);
 OPAL_MODULE_DECLSPEC pmix_status_t pmix20_convert_opalrc(int rc);
 OPAL_MODULE_DECLSPEC int pmix20_convert_rc(pmix_status_t rc);
 OPAL_MODULE_DECLSPEC pmix_scope_t pmix20_convert_opalscope(opal_pmix_scope_t scope);
 OPAL_MODULE_DECLSPEC pmix_data_range_t pmix20_convert_opalrange(opal_pmix_data_range_t range);
 OPAL_MODULE_DECLSPEC opal_pmix_data_range_t pmix20_convert_range(pmix_data_range_t range);
 OPAL_MODULE_DECLSPEC void pmix20_value_load(pmix_value_t *v,
-                                           opal_value_t *kv);
+					   opal_value_t *kv);
 OPAL_MODULE_DECLSPEC int pmix20_value_unload(opal_value_t *kv,
-                                            const pmix_value_t *v);
+					    const pmix_value_t *v);
 
 END_C_DECLS
 

--- a/opal/mca/pmix/ext20/pmix_ext20_client.c
+++ b/opal/mca/pmix/ext20/pmix_ext20_client.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,20 +38,20 @@ static size_t errhdler_ref = 0;
 
 #define PMIX_WAIT_FOR_COMPLETION(a)             \
     do {                                        \
-        while ((a)) {                           \
-            usleep(10);                         \
-        }                                       \
+	while ((a)) {                           \
+	    usleep(10);                         \
+	}                                       \
     } while (0)
 
 
 static void errreg_cbfunc (pmix_status_t status,
-                          size_t errhandler_ref,
-                          void *cbdata)
+			  size_t errhandler_ref,
+			  void *cbdata)
 {
     errhdler_ref = errhandler_ref;
     opal_output_verbose(5, opal_pmix_base_framework.framework_output,
-                        "PMIX client errreg_cbfunc - error handler registered status=%d, reference=%lu",
-                         status, (unsigned long)errhandler_ref);
+			"PMIX client errreg_cbfunc - error handler registered status=%d, reference=%lu",
+			 status, (unsigned long)errhandler_ref);
 }
 
 int pmix20_client_init(void)
@@ -61,28 +62,28 @@ int pmix20_client_init(void)
     opal_pmix20_jobid_trkr_t *job;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client init");
+			"PMIx_client init");
 
     if (0 < (dbg = opal_output_get_verbosity(opal_pmix_base_framework.framework_output))) {
-        asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
-        putenv(dbgvalue);
+	asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
+	putenv(dbgvalue);
     }
 
     rc = PMIx_Init(&my_proc, NULL, 0);
     if (PMIX_SUCCESS != rc) {
-        return pmix20_convert_rc(rc);
+	return pmix20_convert_rc(rc);
     }
 
     /* store our jobid and rank */
    if (NULL != getenv(OPAL_MCA_PREFIX"orte_launch")) {
-        /* if we were launched by the OMPI RTE, then
-         * the jobid is in a special format - so get it */
-        mca_pmix_ext20_component.native_launch = true;
-        opal_convert_string_to_jobid(&pname.jobid, my_proc.nspace);
+	/* if we were launched by the OMPI RTE, then
+	 * the jobid is in a special format - so get it */
+	mca_pmix_ext20_component.native_launch = true;
+	opal_convert_string_to_jobid(&pname.jobid, my_proc.nspace);
     } else {
-        /* we were launched by someone else, so make the
-         * jobid just be the hash of the nspace */
-        OPAL_HASH_STR(my_proc.nspace, pname.jobid);
+	/* we were launched by someone else, so make the
+	 * jobid just be the hash of the nspace */
+	OPAL_HASH_STR(my_proc.nspace, pname.jobid);
     }
     /* insert this into our list of jobids - it will be the
      * first, and so we'll check it first */
@@ -105,7 +106,7 @@ int pmix20_client_finalize(void)
     pmix_status_t rc;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client finalize");
+			"PMIx_client finalize");
 
     /* deregister the default event handler */
     PMIx_Deregister_event_handler(errhdler_ref, NULL, NULL);
@@ -117,13 +118,13 @@ int pmix20_client_finalize(void)
 int pmix20_initialized(void)
 {
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client initialized");
+			"PMIx_client initialized");
 
     return PMIx_Initialized();
 }
 
 int pmix20_abort(int flag, const char *msg,
-                  opal_list_t *procs)
+		  opal_list_t *procs)
 {
     pmix_status_t rc;
     pmix_proc_t *parray=NULL;
@@ -132,30 +133,30 @@ int pmix20_abort(int flag, const char *msg,
     opal_pmix20_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client abort");
+			"PMIx_client abort");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
 
     /* call the library abort */
@@ -178,25 +179,25 @@ int pmix20_store_local(const opal_process_name_t *proc, opal_value_t *val)
      * and we are going to access framework-global lists/objects */
 
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        p.rank = proc->vpid;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	p.rank = proc->vpid;
     } else {
-        /* use our name */
-        (void)strncpy(p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
-        p.rank = OPAL_PROC_MY_NAME.vpid;
+	/* use our name */
+	(void)strncpy(p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+	p.rank = OPAL_PROC_MY_NAME.vpid;
     }
 
     PMIX_VALUE_CONSTRUCT(&kv);
@@ -221,7 +222,7 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     pmix20_opcaddy_t *op = (pmix20_opcaddy_t*)cbdata;
 
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(pmix20_convert_rc(status), op->cbdata);
+	op->opcbfunc(pmix20_convert_rc(status), op->cbdata);
     }
     OBJ_RELEASE(op);
 }
@@ -236,41 +237,41 @@ int pmix20_fence(opal_list_t *procs, int collect_data)
     opal_pmix20_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client fence");
+			"PMIx_client fence");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
     if (collect_data) {
-        PMIX_INFO_CONSTRUCT(&info);
-        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-        info.value.type = PMIX_BOOL;
-        info.value.data.flag = true;
-        iptr = &info;
-        n = 1;
+	PMIX_INFO_CONSTRUCT(&info);
+	(void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+	info.value.type = PMIX_BOOL;
+	info.value.data.flag = true;
+	iptr = &info;
+	n = 1;
     } else {
-        iptr = NULL;
-        n = 0;
+	iptr = NULL;
+	n = 0;
     }
 
     /* call the library function */
@@ -279,7 +280,7 @@ int pmix20_fence(opal_list_t *procs, int collect_data)
     /* release the array */
     PMIX_PROC_FREE(parray, cnt);
     if (NULL != iptr) {
-        PMIX_INFO_DESTRUCT(&info);
+	PMIX_INFO_DESTRUCT(&info);
     }
 
     return pmix20_convert_rc(rc);
@@ -287,7 +288,7 @@ int pmix20_fence(opal_list_t *procs, int collect_data)
 }
 
 int pmix20_fencenb(opal_list_t *procs, int collect_data,
-                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t rc;
     pmix_proc_t *parray=NULL;
@@ -301,42 +302,42 @@ int pmix20_fencenb(opal_list_t *procs, int collect_data,
      * and we are going to access framework-global lists/objects */
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client fence_nb");
+			"PMIx_client fence_nb");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
 
     if (collect_data) {
-        PMIX_INFO_CONSTRUCT(&info);
-        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-        info.value.type = PMIX_BOOL;
-        info.value.data.flag = true;
-        iptr = &info;
-        n = 1;
+	PMIX_INFO_CONSTRUCT(&info);
+	(void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+	info.value.type = PMIX_BOOL;
+	info.value.data.flag = true;
+	iptr = &info;
+	n = 1;
     } else {
-        iptr = NULL;
-        n = 0;
+	iptr = NULL;
+	n = 0;
     }
 
     /* create the caddy */
@@ -349,7 +350,7 @@ int pmix20_fencenb(opal_list_t *procs, int collect_data,
     /* call the library function */
     rc = PMIx_Fence_nb(parray, cnt, iptr, n, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 
     return pmix20_convert_rc(rc);
@@ -357,14 +358,14 @@ int pmix20_fencenb(opal_list_t *procs, int collect_data,
 }
 
 int pmix20_put(opal_pmix_scope_t opal_scope,
-              opal_value_t *val)
+	      opal_value_t *val)
 {
     pmix_value_t kv;
     pmix_scope_t pmix_scope = pmix20_convert_opalscope(opal_scope);
     pmix_status_t rc;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client put");
+			"PMIx_client put");
 
     PMIX_VALUE_CONSTRUCT(&kv);
     pmix20_value_load(&kv, val);
@@ -375,7 +376,7 @@ int pmix20_put(opal_pmix_scope_t opal_scope,
 }
 
 int pmix20_get(const opal_process_name_t *proc, const char *key,
-              opal_list_t *info, opal_value_t **val)
+	      opal_list_t *info, opal_value_t **val)
 {
     int ret;
     pmix_value_t *kv;
@@ -387,80 +388,80 @@ int pmix20_get(const opal_process_name_t *proc, const char *key,
     opal_pmix20_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "%s PMIx_client get on proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+			"%s PMIx_client get on proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
 
     /* prep default response */
     *val = NULL;
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        p.rank = proc->vpid;
-        pptr = &p;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	p.rank = proc->vpid;
+	pptr = &p;
     } else {
-        /* if they are asking for our jobid, then return it */
-        if (0 == strcmp(key, OPAL_PMIX_JOBID)) {
-            (*val) = OBJ_NEW(opal_value_t);
-            (*val)->type = OPAL_UINT32;
-            (*val)->data.uint32 = OPAL_PROC_MY_NAME.jobid;
-            return OPAL_SUCCESS;
-        } else if (0 == strcmp(key, OPAL_PMIX_RANK)) {
-            (*val) = OBJ_NEW(opal_value_t);
-            (*val)->type = OPAL_INT;
-            (*val)->data.integer = my_proc.rank;
-            return OPAL_SUCCESS;
-        }
-        pptr = NULL;
+	/* if they are asking for our jobid, then return it */
+	if (0 == strcmp(key, OPAL_PMIX_JOBID)) {
+	    (*val) = OBJ_NEW(opal_value_t);
+	    (*val)->type = OPAL_UINT32;
+	    (*val)->data.uint32 = OPAL_PROC_MY_NAME.jobid;
+	    return OPAL_SUCCESS;
+	} else if (0 == strcmp(key, OPAL_PMIX_RANK)) {
+	    (*val) = OBJ_NEW(opal_value_t);
+	    (*val)->type = OPAL_INT;
+	    (*val)->data.integer = my_proc.rank;
+	    return OPAL_SUCCESS;
+	}
+	pptr = NULL;
     }
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        if (0 < ninfo) {
-            PMIX_INFO_CREATE(pinfo, ninfo);
-            n=0;
-            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
-                (void)strncpy(pinfo[n].key, ival->key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&pinfo[n].value, ival);
-            }
-        } else {
-            pinfo = NULL;
-        }
+	ninfo = opal_list_get_size(info);
+	if (0 < ninfo) {
+	    PMIX_INFO_CREATE(pinfo, ninfo);
+	    n=0;
+	    OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+		(void)strncpy(pinfo[n].key, ival->key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&pinfo[n].value, ival);
+	    }
+	} else {
+	    pinfo = NULL;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     /* pass the request down */
     rc = PMIx_Get(pptr, key, pinfo, ninfo, &kv);
     if (PMIX_SUCCESS == rc) {
-        if (NULL == kv) {
-            ret = OPAL_SUCCESS;
-        } else {
-            *val = OBJ_NEW(opal_value_t);
-            ret = pmix20_value_unload(*val, kv);
-            PMIX_VALUE_FREE(kv, 1);
-        }
+	if (NULL == kv) {
+	    ret = OPAL_SUCCESS;
+	} else {
+	    *val = OBJ_NEW(opal_value_t);
+	    ret = pmix20_value_unload(*val, kv);
+	    PMIX_VALUE_FREE(kv, 1);
+	}
     } else {
-        ret = pmix20_convert_rc(rc);
+	ret = pmix20_convert_rc(rc);
     }
     PMIX_INFO_FREE(pinfo, ninfo);
     return ret;
 }
 
 static void val_cbfunc(pmix_status_t status,
-                       pmix_value_t *kv, void *cbdata)
+		       pmix_value_t *kv, void *cbdata)
 {
     pmix20_opcaddy_t *op = (pmix20_opcaddy_t*)cbdata;
     int rc;
@@ -468,19 +469,19 @@ static void val_cbfunc(pmix_status_t status,
 
     rc = pmix20_convert_opalrc(status);
     if (PMIX_SUCCESS == status && NULL != kv) {
-        rc = pmix20_value_unload(&val, kv);
-        v = &val;
+	rc = pmix20_value_unload(&val, kv);
+	v = &val;
     }
 
     if (NULL != op->valcbfunc) {
-        op->valcbfunc(rc, v, op->cbdata);
+	op->valcbfunc(rc, v, op->cbdata);
     }
     OBJ_RELEASE(op);
 }
 
 int pmix20_getnb(const opal_process_name_t *proc, const char *key,
-                opal_list_t *info,
-                opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
+		opal_list_t *info,
+		opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     pmix20_opcaddy_t *op;
     pmix_status_t rc;
@@ -492,9 +493,9 @@ int pmix20_getnb(const opal_process_name_t *proc, const char *key,
      * and we are going to access shared lists/objects */
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "%s PMIx_client get_nb on proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+			"%s PMIx_client get_nb on proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
 
     /* create the caddy */
     op = OBJ_NEW(pmix20_opcaddy_t);
@@ -502,41 +503,41 @@ int pmix20_getnb(const opal_process_name_t *proc, const char *key,
     op->cbdata = cbdata;
 
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(op->p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        op->p.rank = proc->vpid;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(op->p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	op->p.rank = proc->vpid;
     } else {
-        (void)strncpy(op->p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
-        op->p.rank = PMIX_RANK_WILDCARD;
+	(void)strncpy(op->p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+	op->p.rank = PMIX_RANK_WILDCARD;
     }
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, ival->key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&op->info[n].value, ival);
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, ival->key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&op->info[n].value, ival);
+	    }
+	}
     }
 
     /* call the library function */
     rc = PMIx_Get_nb(&op->p, key, op->info, op->sz, val_cbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 
     return pmix20_convert_rc(rc);
@@ -550,23 +551,23 @@ int pmix20_publish(opal_list_t *info)
     size_t sz, n;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client publish");
+			"PMIx_client publish");
 
     if (NULL == info) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     sz = opal_list_get_size(info);
     if (0 < sz) {
-        PMIX_INFO_CREATE(pinfo, sz);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	PMIX_INFO_CREATE(pinfo, sz);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
+	pinfo = NULL;
     }
 
     ret = PMIx_Publish(pinfo, sz);
@@ -575,7 +576,7 @@ int pmix20_publish(opal_list_t *info)
 }
 
 int pmix20_publishnb(opal_list_t *info,
-                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     opal_value_t *iptr;
@@ -583,10 +584,10 @@ int pmix20_publishnb(opal_list_t *info,
     pmix20_opcaddy_t *op;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client publish_nb");
+			"PMIx_client publish_nb");
 
     if (NULL == info) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -596,13 +597,13 @@ int pmix20_publishnb(opal_list_t *info,
 
     op->sz = opal_list_get_size(info);
     if (0 < op->sz) {
-        PMIX_INFO_CREATE(op->info, op->sz);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&op->info[n].value, iptr);
-            ++n;
-        }
+	PMIX_INFO_CREATE(op->info, op->sz);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&op->info[n].value, iptr);
+	    ++n;
+	}
     }
 
     ret = PMIx_Publish_nb(op->info, op->sz, opcbfunc, op);
@@ -624,84 +625,84 @@ int pmix20_lookup(opal_list_t *data, opal_list_t *info)
     /* we must threadshift this request as we might not be in an event
      * and we are going to access shared lists/objects */
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client lookup");
+			"PMIx_client lookup");
 
     if (NULL == data) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     sz = opal_list_get_size(data);
     PMIX_PDATA_CREATE(pdata, sz);
     n=0;
     OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
-        (void)strncpy(pdata[n++].key, d->value.key, PMIX_MAX_KEYLEN);
+	(void)strncpy(pdata[n++].key, d->value.key, PMIX_MAX_KEYLEN);
     }
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	ninfo = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     ret = PMIx_Lookup(pdata, sz, pinfo, ninfo);
     PMIX_INFO_FREE(pinfo, ninfo);
 
     if (PMIX_SUCCESS == ret) {
-        /* transfer the data back */
-        n=0;
-        OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
-            if (mca_pmix_ext20_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&d->proc.jobid, pdata[n].proc.nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(pdata[n].proc.nspace, d->proc.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-                if (jptr->jobid == d->proc.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-               job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
-                (void)strncpy(job->nspace, pdata[n].proc.nspace, PMIX_MAX_NSLEN);
-                job->jobid = d->proc.jobid;
-                opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
-            }
-            if (PMIX_RANK_WILDCARD == pdata[n].proc.rank) {
-                d->proc.vpid = OPAL_VPID_WILDCARD;
-            } else {
-                d->proc.vpid = pdata[n].proc.rank;
-            }
-            rc = pmix20_value_unload(&d->value, &pdata[n].value);
-            if (OPAL_SUCCESS != rc) {
-                OPAL_ERROR_LOG(rc);
-                PMIX_PDATA_FREE(pdata, sz);
-                return OPAL_ERR_BAD_PARAM;
-            }
-            ++n;
-        }
+	/* transfer the data back */
+	n=0;
+	OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
+	    if (mca_pmix_ext20_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&d->proc.jobid, pdata[n].proc.nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(pdata[n].proc.nspace, d->proc.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+		if (jptr->jobid == d->proc.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+	       job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
+		(void)strncpy(job->nspace, pdata[n].proc.nspace, PMIX_MAX_NSLEN);
+		job->jobid = d->proc.jobid;
+		opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
+	    }
+	    if (PMIX_RANK_WILDCARD == pdata[n].proc.rank) {
+		d->proc.vpid = OPAL_VPID_WILDCARD;
+	    } else {
+		d->proc.vpid = pdata[n].proc.rank;
+	    }
+	    rc = pmix20_value_unload(&d->value, &pdata[n].value);
+	    if (OPAL_SUCCESS != rc) {
+		OPAL_ERROR_LOG(rc);
+		PMIX_PDATA_FREE(pdata, sz);
+		return OPAL_ERR_BAD_PARAM;
+	    }
+	    ++n;
+	}
     }
 
     return pmix20_convert_rc(ret);
 }
 
 static void lk_cbfunc(pmix_status_t status,
-                      pmix_pdata_t data[], size_t ndata,
-                      void *cbdata)
+		      pmix_pdata_t data[], size_t ndata,
+		      void *cbdata)
 {
     pmix20_opcaddy_t *op = (pmix20_opcaddy_t*)cbdata;
     opal_pmix_pdata_t *d;
@@ -715,66 +716,66 @@ static void lk_cbfunc(pmix_status_t status,
   * lists and objects */
 
    if (NULL == op->lkcbfunc) {
-        OBJ_RELEASE(op);
-        return;
+	OBJ_RELEASE(op);
+	return;
     }
 
     rc = pmix20_convert_rc(status);
     if (OPAL_SUCCESS == rc) {
-        OBJ_CONSTRUCT(&results, opal_list_t);
-        for (n=0; n < ndata; n++) {
-            d = OBJ_NEW(opal_pmix_pdata_t);
-            opal_list_append(&results, &d->super);
-            if (mca_pmix_ext20_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&d->proc.jobid, data[n].proc.nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(data[n].proc.nspace, d->proc.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-                if (jptr->jobid == d->proc.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
-                (void)strncpy(job->nspace, data[n].proc.nspace, PMIX_MAX_NSLEN);
-                job->jobid = d->proc.jobid;
-                opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
-            }
-            if (PMIX_RANK_WILDCARD == data[n].proc.rank) {
-                d->proc.vpid = OPAL_VPID_WILDCARD;
-            } else {
-                d->proc.vpid = data[n].proc.rank;
-            }
-            d->value.key = strdup(data[n].key);
-            rc = pmix20_value_unload(&d->value, &data[n].value);
-            if (OPAL_SUCCESS != rc) {
-                rc = OPAL_ERR_BAD_PARAM;
-                OPAL_ERROR_LOG(rc);
-                goto release;
-            }
-        }
-        r = &results;
+	OBJ_CONSTRUCT(&results, opal_list_t);
+	for (n=0; n < ndata; n++) {
+	    d = OBJ_NEW(opal_pmix_pdata_t);
+	    opal_list_append(&results, &d->super);
+	    if (mca_pmix_ext20_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&d->proc.jobid, data[n].proc.nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(data[n].proc.nspace, d->proc.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+		if (jptr->jobid == d->proc.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
+		(void)strncpy(job->nspace, data[n].proc.nspace, PMIX_MAX_NSLEN);
+		job->jobid = d->proc.jobid;
+		opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
+	    }
+	    if (PMIX_RANK_WILDCARD == data[n].proc.rank) {
+		d->proc.vpid = OPAL_VPID_WILDCARD;
+	    } else {
+		d->proc.vpid = data[n].proc.rank;
+	    }
+	    d->value.key = strdup(data[n].key);
+	    rc = pmix20_value_unload(&d->value, &data[n].value);
+	    if (OPAL_SUCCESS != rc) {
+		rc = OPAL_ERR_BAD_PARAM;
+		OPAL_ERROR_LOG(rc);
+		goto release;
+	    }
+	}
+	r = &results;
     }
   release:
     /* execute the callback */
     op->lkcbfunc(rc, r, op->cbdata);
 
     if (NULL != r) {
-        OPAL_LIST_DESTRUCT(&results);
+	OPAL_LIST_DESTRUCT(&results);
     }
     OBJ_RELEASE(op);
 }
 
 int pmix20_lookupnb(char **keys, opal_list_t *info,
-                   opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+		   opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix20_opcaddy_t *op;
@@ -783,7 +784,7 @@ int pmix20_lookupnb(char **keys, opal_list_t *info,
 
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client lookup_nb");
+			"PMIx_client lookup_nb");
 
     /* create the caddy */
     op = OBJ_NEW(pmix20_opcaddy_t);
@@ -791,16 +792,16 @@ int pmix20_lookupnb(char **keys, opal_list_t *info,
     op->cbdata = cbdata;
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&op->info[n].value, iptr);
-                ++n;
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&op->info[n].value, iptr);
+		++n;
+	    }
+	}
     }
 
     ret = PMIx_Lookup_nb(keys, op->info, op->sz, lk_cbfunc, op);
@@ -816,17 +817,17 @@ int pmix20_unpublish(char **keys, opal_list_t *info)
     opal_value_t *iptr;
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	ninfo = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     ret = PMIx_Unpublish(keys, pinfo, ninfo);
@@ -836,7 +837,7 @@ int pmix20_unpublish(char **keys, opal_list_t *info)
 }
 
 int pmix20_unpublishnb(char **keys, opal_list_t *info,
-                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix20_opcaddy_t *op;
@@ -849,16 +850,16 @@ int pmix20_unpublishnb(char **keys, opal_list_t *info,
     op->cbdata = cbdata;
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&op->info[n].value, iptr);
-                ++n;
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&op->info[n].value, iptr);
+		++n;
+	    }
+	}
     }
 
     ret = PMIx_Unpublish_nb(keys, op->info, op->sz, opcbfunc, op);
@@ -878,52 +879,52 @@ int pmix20_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
     opal_pmix20_jobid_trkr_t *job;
 
     if (NULL != job_info && 0 < (ninfo = opal_list_get_size(job_info))) {
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, info->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&pinfo[n].value, info);
-            ++n;
-        }
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, info->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&pinfo[n].value, info);
+	    ++n;
+	}
     }
 
     napps = opal_list_get_size(apps);
     PMIX_APP_CREATE(papps, napps);
     n=0;
     OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
-        papps[n].cmd = strdup(app->cmd);
-        papps[n].argc = app->argc;
-        papps[n].argv = opal_argv_copy(app->argv);
-        papps[n].env = opal_argv_copy(app->env);
-        papps[n].maxprocs = app->maxprocs;
-        if (0 < (papps[n].ninfo = opal_list_get_size(&app->info))) {
-            PMIX_INFO_CREATE(papps[n].info, papps[n].ninfo);
-            m=0;
-            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
-                (void)strncpy(papps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&papps[n].info[m].value, info);
-                ++m;
-            }
-        }
-        ++n;
+	papps[n].cmd = strdup(app->cmd);
+	papps[n].argc = app->argc;
+	papps[n].argv = opal_argv_copy(app->argv);
+	papps[n].env = opal_argv_copy(app->env);
+	papps[n].maxprocs = app->maxprocs;
+	if (0 < (papps[n].ninfo = opal_list_get_size(&app->info))) {
+	    PMIX_INFO_CREATE(papps[n].info, papps[n].ninfo);
+	    m=0;
+	    OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+		(void)strncpy(papps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&papps[n].info[m].value, info);
+		++m;
+	    }
+	}
+	++n;
     }
 
     ret = PMIx_Spawn(pinfo, ninfo, papps, napps, nspace);
     if (PMIX_SUCCESS == ret) {
-        if (mca_pmix_ext20_component.native_launch) {
-            /* if we were launched by the OMPI RTE, then
-             * the jobid is in a special format - so get it */
-            opal_convert_string_to_jobid(jobid, nspace);
-        } else {
-            /* we were launched by someone else, so make the
-             * jobid just be the hash of the nspace */
-            OPAL_HASH_STR(nspace, *jobid);
-        }
-        /* add this to our jobid tracker */
-        job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
-        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-        job->jobid = *jobid;
-        opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
+	if (mca_pmix_ext20_component.native_launch) {
+	    /* if we were launched by the OMPI RTE, then
+	     * the jobid is in a special format - so get it */
+	    opal_convert_string_to_jobid(jobid, nspace);
+	} else {
+	    /* we were launched by someone else, so make the
+	     * jobid just be the hash of the nspace */
+	    OPAL_HASH_STR(nspace, *jobid);
+	}
+	/* add this to our jobid tracker */
+	job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
+	(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+	job->jobid = *jobid;
+	opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
     }
     PMIX_APP_FREE(papps, napps);
 
@@ -931,7 +932,7 @@ int pmix20_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
 }
 
 static void spcbfunc(pmix_status_t status,
-                     char *nspace, void *cbdata)
+		     char *nspace, void *cbdata)
 {
     pmix20_opcaddy_t *op = (pmix20_opcaddy_t*)cbdata;
     int rc;
@@ -944,20 +945,20 @@ static void spcbfunc(pmix_status_t status,
 
     rc = pmix20_convert_rc(status);
     if (PMIX_SUCCESS == status) {
-        if (mca_pmix_ext20_component.native_launch) {
-            /* if we were launched by the OMPI RTE, then
-             * the jobid is in a special format - so get it */
-            opal_convert_string_to_jobid(&jobid, nspace);
-        } else {
-            /* we were launched by someone else, so make the
-             * jobid just be the hash of the nspace */
-            OPAL_HASH_STR(nspace, jobid);
-        }
-        /* add this to our jobid tracker */
-        job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
-        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-        job->jobid = jobid;
-        opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
+	if (mca_pmix_ext20_component.native_launch) {
+	    /* if we were launched by the OMPI RTE, then
+	     * the jobid is in a special format - so get it */
+	    opal_convert_string_to_jobid(&jobid, nspace);
+	} else {
+	    /* we were launched by someone else, so make the
+	     * jobid just be the hash of the nspace */
+	    OPAL_HASH_STR(nspace, jobid);
+	}
+	/* add this to our jobid tracker */
+	job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
+	(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+	job->jobid = jobid;
+	opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
     }
 
     op->spcbfunc(rc, jobid, op->cbdata);
@@ -965,7 +966,7 @@ static void spcbfunc(pmix_status_t status,
 }
 
 int pmix20_spawnnb(opal_list_t *job_info, opal_list_t *apps,
-                    opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix20_opcaddy_t *op;
@@ -979,34 +980,34 @@ int pmix20_spawnnb(opal_list_t *job_info, opal_list_t *apps,
     op->cbdata = cbdata;
 
     if (NULL != job_info && 0 < (op->ninfo = opal_list_get_size(job_info))) {
-        PMIX_INFO_CREATE(op->info, op->ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
-            (void)strncpy(op->info[n].key, info->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&op->info[n].value, info);
-            ++n;
-        }
+	PMIX_INFO_CREATE(op->info, op->ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+	    (void)strncpy(op->info[n].key, info->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&op->info[n].value, info);
+	    ++n;
+	}
     }
 
     op->sz = opal_list_get_size(apps);
     PMIX_APP_CREATE(op->apps, op->sz);
     n=0;
     OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
-        op->apps[n].cmd = strdup(app->cmd);
-        op->apps[n].argc = app->argc;
-        op->apps[n].argv = opal_argv_copy(app->argv);
-        op->apps[n].env = opal_argv_copy(app->env);
-        op->apps[n].maxprocs = app->maxprocs;
-        if (0 < (op->apps[n].ninfo = opal_list_get_size(&app->info))) {
-            PMIX_INFO_CREATE(op->apps[n].info, op->apps[n].ninfo);
-            m=0;
-            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
-                (void)strncpy(op->apps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&op->apps[n].info[m].value, info);
-                ++m;
-            }
-        }
-        ++n;
+	op->apps[n].cmd = strdup(app->cmd);
+	op->apps[n].argc = app->argc;
+	op->apps[n].argv = opal_argv_copy(app->argv);
+	op->apps[n].env = opal_argv_copy(app->env);
+	op->apps[n].maxprocs = app->maxprocs;
+	if (0 < (op->apps[n].ninfo = opal_list_get_size(&app->info))) {
+	    PMIX_INFO_CREATE(op->apps[n].info, op->apps[n].ninfo);
+	    m=0;
+	    OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+		(void)strncpy(op->apps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&op->apps[n].info[m].value, info);
+		++m;
+	    }
+	}
+	++n;
     }
 
     ret = PMIx_Spawn_nb(op->info, op->ninfo, op->apps, op->sz, spcbfunc, op);
@@ -1024,7 +1025,7 @@ int pmix20_connect(opal_list_t *procs)
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* convert the list of procs to an array
@@ -1032,26 +1033,26 @@ int pmix20_connect(opal_list_t *procs)
     PMIX_PROC_CREATE(parray, cnt);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (jptr->jobid == ptr->name.jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            parray[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            parray[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (jptr->jobid == ptr->name.jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    parray[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    parray[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Connect(parray, cnt, NULL, 0);
@@ -1061,8 +1062,8 @@ int pmix20_connect(opal_list_t *procs)
 }
 
 int pmix20_connectnb(opal_list_t *procs,
-                    opal_pmix_op_cbfunc_t cbfunc,
-                    void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc,
+		    void *cbdata)
 {
     pmix_status_t ret;
     size_t n, cnt=0;
@@ -1075,7 +1076,7 @@ int pmix20_connectnb(opal_list_t *procs,
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -1089,20 +1090,20 @@ int pmix20_connectnb(opal_list_t *procs,
     PMIX_PROC_CREATE(op->procs, op->nprocs);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            op->procs[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            op->procs[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    op->procs[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    op->procs[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Connect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
@@ -1120,7 +1121,7 @@ int pmix20_disconnect(opal_list_t *procs)
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* convert the list of procs to an array
@@ -1128,20 +1129,20 @@ int pmix20_disconnect(opal_list_t *procs)
     PMIX_PROC_CREATE(parray, cnt);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            parray[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            parray[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    parray[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    parray[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Disconnect(parray, cnt, NULL, 0);
@@ -1151,8 +1152,8 @@ int pmix20_disconnect(opal_list_t *procs)
 }
 
 int pmix20_disconnectnb(opal_list_t *procs,
-                         opal_pmix_op_cbfunc_t cbfunc,
-                         void *cbdata)
+			 opal_pmix_op_cbfunc_t cbfunc,
+			 void *cbdata)
 {
     pmix_status_t ret;
     size_t n, cnt=0;
@@ -1165,7 +1166,7 @@ int pmix20_disconnectnb(opal_list_t *procs,
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -1179,20 +1180,20 @@ int pmix20_disconnectnb(opal_list_t *procs,
     PMIX_PROC_CREATE(op->procs, op->nprocs);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            op->procs[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            op->procs[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    op->procs[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    op->procs[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Disconnect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
@@ -1202,7 +1203,7 @@ int pmix20_disconnectnb(opal_list_t *procs,
 
 
 int pmix20_resolve_peers(const char *nodename, opal_jobid_t jobid,
-                          opal_list_t *procs)
+			  opal_list_t *procs)
 {
     char *nspace;
     pmix_proc_t *array=NULL;
@@ -1216,53 +1217,53 @@ int pmix20_resolve_peers(const char *nodename, opal_jobid_t jobid,
      * and we are going to access framework-global lists/objects */
 
     if (OPAL_JOBID_WILDCARD == jobid) {
-        nspace = NULL;
+	nspace = NULL;
     } else {
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (jptr->jobid == jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        nspace = job->nspace;
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (jptr->jobid == jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	nspace = job->nspace;
     }
 
     ret = PMIx_Resolve_peers(nodename, nspace, &array, &nprocs);
     rc = pmix20_convert_rc(ret);
 
     if (NULL != array && 0 < nprocs) {
-        for (n=0; n < nprocs; n++) {
-            nm = OBJ_NEW(opal_namelist_t);
-            opal_list_append(procs, &nm->super);
-            if (mca_pmix_ext20_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&nm->name.jobid, array[n].nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(array[n].nspace, nm->name.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-                if (jptr->jobid == nm->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
-                (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-                job->jobid = jobid;
-                opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
-            }
-            nm->name.vpid = array[n].rank;
-        }
+	for (n=0; n < nprocs; n++) {
+	    nm = OBJ_NEW(opal_namelist_t);
+	    opal_list_append(procs, &nm->super);
+	    if (mca_pmix_ext20_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&nm->name.jobid, array[n].nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(array[n].nspace, nm->name.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+		if (jptr->jobid == nm->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		job = OBJ_NEW(opal_pmix20_jobid_trkr_t);
+		(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+		job->jobid = jobid;
+		opal_list_append(&mca_pmix_ext20_component.jobids, &job->super);
+	    }
+	    nm->name.vpid = array[n].rank;
+	}
     }
     PMIX_PROC_FREE(array, nprocs);
 
@@ -1279,19 +1280,19 @@ int pmix20_resolve_nodes(opal_jobid_t jobid, char **nodelist)
      * and we are going to access framework-global lists/objects */
 
     if (OPAL_JOBID_WILDCARD != jobid) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-            if (jptr->jobid == jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        nspace = job->nspace;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
+	    if (jptr->jobid == jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	nspace = job->nspace;
     }
 
     ret = PMIx_Resolve_nodes(nspace, nodelist);

--- a/opal/mca/pmix/ext20/pmix_ext20_component.c
+++ b/opal/mca/pmix/ext20/pmix_ext20_component.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,30 +49,30 @@ mca_pmix_ext20_component_t mca_pmix_ext20_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
-        .base_version = {
-        /* Indicate that we are a pmix v1.1.0 component (which also
-           implies a specific MCA version) */
+	.base_version = {
+	/* Indicate that we are a pmix v1.1.0 component (which also
+	   implies a specific MCA version) */
 
-            OPAL_PMIX_BASE_VERSION_2_0_0,
+	    OPAL_PMIX_BASE_VERSION_2_0_0,
 
-        /* Component name and version */
+	/* Component name and version */
 
-            .mca_component_name = "ext20",
-            MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                                  OPAL_RELEASE_VERSION),
+	    .mca_component_name = "ext20",
+	    MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+				  OPAL_RELEASE_VERSION),
 
-        /* Component open and close functions */
+	/* Component open and close functions */
 
-            .mca_open_component = external_open,
-            .mca_close_component = external_close,
-            .mca_query_component = external_component_query,
-            .mca_register_component_params = external_register,
-        },
-        /* Next the MCA v1.0.0 component meta data */
-        .base_data = {
-        /* The component is checkpoint ready */
-            MCA_BASE_METADATA_PARAM_CHECKPOINT
-        }
+	    .mca_open_component = external_open,
+	    .mca_close_component = external_close,
+	    .mca_query_component = external_component_query,
+	    .mca_register_component_params = external_register,
+	},
+	/* Next the MCA v1.0.0 component meta data */
+	.base_data = {
+	/* The component is checkpoint ready */
+	    MCA_BASE_METADATA_PARAM_CHECKPOINT
+	}
     },
     .native_launch = false
 };
@@ -80,10 +81,10 @@ static int external_register(void)
 {
     mca_pmix_ext20_component.cache_size = 256;
     mca_base_component_var_register(&mca_pmix_ext20_component.super.base_version,
-                                    "cache_size", "Size of the ring buffer cache for events",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_CONSTANT,
-                                    &mca_pmix_ext20_component.cache_size);
+				    "cache_size", "Size of the ring buffer cache for events",
+				    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_5,
+				    MCA_BASE_VAR_SCOPE_CONSTANT,
+				    &mca_pmix_ext20_component.cache_size);
 
     return OPAL_SUCCESS;
 }
@@ -118,12 +119,12 @@ static int external_component_query(mca_base_module_t **module, int *priority)
 
     /* see if a PMIx server is present */
     if (NULL != (t = getenv("PMIX_SERVER_URI")) ||
-        NULL != (id = getenv("PMIX_ID"))) {
-        /* if PMIx is present, then we are a client and need to use it */
-        *priority = 100;
+	NULL != (id = getenv("PMIX_ID"))) {
+	/* if PMIx is present, then we are a client and need to use it */
+	*priority = 100;
     } else {
-        /* we could be a server, so we still need to be considered */
-        *priority = 5;
+	/* we could be a server, so we still need to be considered */
+	*priority = 5;
     }
     *module = (mca_base_module_t *)&opal_pmix_ext20_module;
     return OPAL_SUCCESS;

--- a/opal/mca/pmix/ext20/pmix_ext20_server_north.c
+++ b/opal/mca/pmix/ext20/pmix_ext20_server_north.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,58 +46,58 @@
  * to call up into ORTE for service requests */
 
  static pmix_status_t server_client_connected_fn(const pmix_proc_t *proc, void* server_object,
-                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+						 pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_client_finalized_fn(const pmix_proc_t *proc, void* server_object,
-                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+						 pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_abort_fn(const pmix_proc_t *proc, void *server_object,
-                                      int status, const char msg[],
-                                      pmix_proc_t procs[], size_t nprocs,
-                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
+				      int status, const char msg[],
+				      pmix_proc_t procs[], size_t nprocs,
+				      pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
-                                        const pmix_info_t info[], size_t ninfo,
-                                        char *data, size_t ndata,
-                                        pmix_modex_cbfunc_t cbfunc, void *cbdata);
+					const pmix_info_t info[], size_t ninfo,
+					char *data, size_t ndata,
+					pmix_modex_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *proc,
-                                           const pmix_info_t info[], size_t ninfo,
-                                           pmix_modex_cbfunc_t cbfunc, void *cbdata);
+					   const pmix_info_t info[], size_t ninfo,
+					   pmix_modex_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_publish_fn(const pmix_proc_t *proc,
-                                        const pmix_info_t info[], size_t ninfo,
-                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+					const pmix_info_t info[], size_t ninfo,
+					pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_lookup_fn(const pmix_proc_t *proc,  char **keys,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_lookup_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_unpublish_fn(const pmix_proc_t *proc, char **keys,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_spawn_fn(const pmix_proc_t *proc,
-                                      const pmix_info_t job_info[], size_t ninfo,
-                                      const pmix_app_t apps[], size_t napps,
-                                      pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+				      const pmix_info_t job_info[], size_t ninfo,
+				      const pmix_app_t apps[], size_t napps,
+				      pmix_spawn_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                        const pmix_info_t info[], size_t ninfo,
-                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+					const pmix_info_t info[], size_t ninfo,
+					pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                           const pmix_info_t info[], size_t ninfo,
-                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
+					   const pmix_info_t info[], size_t ninfo,
+					   pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_register_events(pmix_status_t *codes, size_t ncodes,
-                                             const pmix_info_t info[], size_t ninfo,
-                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+					     const pmix_info_t info[], size_t ninfo,
+					     pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_deregister_events(pmix_status_t *codes, size_t ncodes,
-                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+					       pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_notify_event(pmix_status_t code,
-                                          const pmix_proc_t *source,
-                                          pmix_data_range_t range,
-                                          pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+					  const pmix_proc_t *source,
+					  pmix_data_range_t range,
+					  pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata);
  #if HAVE_PMIX_QUERY_FUNCTION
 static pmix_status_t server_query(pmix_proc_t *proct,
-                                  pmix_info_t *info, size_t ninfo,
-                                  pmix_info_t *directives, size_t ndirs,
-                                  pmix_info_cbfunc_t cbfunc,
-                                  void *cbdata);
+				  pmix_info_t *info, size_t ninfo,
+				  pmix_info_t *directives, size_t ndirs,
+				  pmix_info_cbfunc_t cbfunc,
+				  void *cbdata);
 static void server_tool_connection(pmix_info_t *info, size_t ninfo,
-                                   pmix_tool_connection_cbfunc_t cbfunc,
-                                   void *cbdata);
+				   pmix_tool_connection_cbfunc_t cbfunc,
+				   void *cbdata);
 #endif
 
   pmix_server_module_t mymodule = {
@@ -128,20 +129,20 @@ static void opal_opcbfunc(int status, void *cbdata)
     pmix20_opalcaddy_t *opalcaddy = (pmix20_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->opcbfunc) {
-        opalcaddy->opcbfunc(pmix20_convert_opalrc(status), opalcaddy->cbdata);
+	opalcaddy->opcbfunc(pmix20_convert_opalrc(status), opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_client_connected_fn(const pmix_proc_t *p, void *server_object,
-                                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+						pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     opal_process_name_t proc;
     pmix20_opalcaddy_t *opalcaddy;
 
     if (NULL == host_module || NULL == host_module->client_connected) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     opalcaddy = OBJ_NEW(pmix20_opalcaddy_t);
@@ -150,30 +151,30 @@ static pmix_status_t server_client_connected_fn(const pmix_proc_t *p, void *serv
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
     /* pass it up */
     rc = host_module->client_connected(&proc, server_object,
-                                       opal_opcbfunc, opalcaddy);
+				       opal_opcbfunc, opalcaddy);
     return pmix20_convert_opalrc(rc);
 }
 
 static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* server_object,
-                                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+						pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix20_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
 
     if (NULL == host_module || NULL == host_module->client_finalized) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
@@ -185,15 +186,15 @@ static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* serv
     /* pass it up */
     rc = host_module->client_finalized(&proc, server_object, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix20_convert_opalrc(rc);
 }
 
 static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
-                                     int status, const char msg[],
-                                     pmix_proc_t procs[], size_t nprocs,
-                                     pmix_op_cbfunc_t cbfunc, void *cbdata)
+				     int status, const char msg[],
+				     pmix_proc_t procs[], size_t nprocs,
+				     pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     size_t n;
     opal_namelist_t *nm;
@@ -202,12 +203,12 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
     pmix20_opalcaddy_t *opalcaddy;
 
     if (NULL == host_module || NULL == host_module->abort) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
@@ -218,24 +219,24 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* pass it up */
     rc = host_module->abort(&proc, server_object, status, msg,
-                            &opalcaddy->procs, opal_opcbfunc, opalcaddy);
+			    &opalcaddy->procs, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix20_convert_opalrc(rc);
 }
@@ -245,32 +246,32 @@ static void _data_release(void *cbdata)
     pmix20_opalcaddy_t *opalcaddy = (pmix20_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->odmdxfunc) {
-        opalcaddy->odmdxfunc(opalcaddy->ocbdata);
+	opalcaddy->odmdxfunc(opalcaddy->ocbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static void opmdx_response(int status, const char *data, size_t sz, void *cbdata,
-                           opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
+			   opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
 {
     pmix_status_t rc;
     pmix20_opalcaddy_t *opalcaddy = (pmix20_opalcaddy_t*)cbdata;
 
     rc = pmix20_convert_rc(status);
     if (NULL != opalcaddy->mdxcbfunc) {
-        opalcaddy->odmdxfunc = relcbfunc;
-        opalcaddy->ocbdata = relcbdata;
-        opalcaddy->mdxcbfunc(rc, data, sz, opalcaddy->cbdata,
-                             _data_release, opalcaddy);
+	opalcaddy->odmdxfunc = relcbfunc;
+	opalcaddy->ocbdata = relcbdata;
+	opalcaddy->mdxcbfunc(rc, data, sz, opalcaddy->cbdata,
+			     _data_release, opalcaddy);
     } else {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 }
 
 static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       char *data, size_t ndata,
-                                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       char *data, size_t ndata,
+				       pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy;
     size_t n;
@@ -279,7 +280,7 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
     int rc;
 
     if (NULL == host_module || NULL == host_module->fence_nb) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -289,42 +290,42 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->fence_nb(&opalcaddy->procs, &opalcaddy->info,
-                               data, ndata, opmdx_response, opalcaddy);
+			       data, ndata, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix20_convert_opalrc(rc);
 }
 
 static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_modex_cbfunc_t cbfunc, void *cbdata)
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix20_opalcaddy_t *opalcaddy;
@@ -333,17 +334,17 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->direct_modex) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -353,29 +354,29 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->direct_modex(&proc, &opalcaddy->info, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc && OPAL_ERR_IN_PROCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     if (OPAL_ERR_IN_PROCESS == rc) {
-        rc = OPAL_SUCCESS;
+	rc = OPAL_SUCCESS;
     }
     return pmix20_convert_opalrc(rc);
 }
 
 static pmix_status_t server_publish_fn(const pmix_proc_t *p,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     size_t n;
@@ -384,17 +385,17 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->publish) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
    /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -404,27 +405,27 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
 
     /* convert the info array */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->publish(&proc, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
 }
 
 static void opal_lkupcbfunc(int status,
-                            opal_list_t *data,
-                            void *cbdata)
+			    opal_list_t *data,
+			    void *cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy = (pmix20_opalcaddy_t*)cbdata;
     pmix_status_t rc;
@@ -433,28 +434,28 @@ static void opal_lkupcbfunc(int status,
     opal_pmix_pdata_t *p;
 
     if (NULL != opalcaddy->lkupcbfunc) {
-        rc = pmix20_convert_opalrc(status);
-        /* convert any returned data */
-        if (NULL != data) {
-            nd = opal_list_get_size(data);
-            PMIX_PDATA_CREATE(d, nd);
-            n=0;
-            OPAL_LIST_FOREACH(p, data, opal_pmix_pdata_t) {
-                /* convert the jobid */
-                (void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
-                d[n].proc.rank = p->proc.vpid;
-                (void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&d[n].value, &p->value);
-            }
-        }
-        opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
+	rc = pmix20_convert_opalrc(status);
+	/* convert any returned data */
+	if (NULL != data) {
+	    nd = opal_list_get_size(data);
+	    PMIX_PDATA_CREATE(d, nd);
+	    n=0;
+	    OPAL_LIST_FOREACH(p, data, opal_pmix_pdata_t) {
+		/* convert the jobid */
+		(void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
+		d[n].proc.rank = p->proc.vpid;
+		(void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&d[n].value, &p->value);
+	    }
+	}
+	opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
-                                      const pmix_info_t info[], size_t ninfo,
-                                      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+				      const pmix_info_t info[], size_t ninfo,
+				      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix20_opalcaddy_t *opalcaddy;
@@ -463,17 +464,17 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->lookup) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -483,19 +484,19 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->lookup(&proc, keys, &opalcaddy->info, opal_lkupcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
@@ -503,8 +504,8 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
 
 
 static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
-                                         const pmix_info_t info[], size_t ninfo,
-                                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+					 const pmix_info_t info[], size_t ninfo,
+					 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix20_opalcaddy_t *opalcaddy;
@@ -513,17 +514,17 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->unpublish) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -533,19 +534,19 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->unpublish(&proc, keys, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
@@ -558,18 +559,18 @@ static void opal_spncbfunc(int status, opal_jobid_t jobid, void *cbdata)
     char nspace[PMIX_MAX_NSLEN];
 
     if (NULL != opalcaddy->spwncbfunc) {
-        rc = pmix20_convert_opalrc(status);
-        /* convert the jobid */
-        (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
-        opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
+	rc = pmix20_convert_opalrc(status);
+	/* convert the jobid */
+	(void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
+	opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
-                                     const pmix_info_t job_info[], size_t ninfo,
-                                     const pmix_app_t apps[], size_t napps,
-                                     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+				     const pmix_info_t job_info[], size_t ninfo,
+				     const pmix_app_t apps[], size_t napps,
+				     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
@@ -579,17 +580,17 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
     int rc;
 
     if (NULL == host_module || NULL == host_module->spawn) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix20_convert_opalrc(rc);
+	return pmix20_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -599,46 +600,46 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
 
     /* convert the job info */
     for (k=0; k < ninfo; k++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(job_info[k].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &job_info[k].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(job_info[k].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &job_info[k].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* convert the apps */
     for (n=0; n < napps; n++) {
-        app = OBJ_NEW(opal_pmix_app_t);
-        opal_list_append(&opalcaddy->apps, &app->super);
-        if (NULL != apps[n].cmd) {
-            app->cmd = strdup(apps[n].cmd);
-        }
-        app->argc = apps[n].argc;
-        if (NULL != apps[n].argv) {
-            app->argv = opal_argv_copy(apps[n].argv);
-        }
-        if (NULL != apps[n].env) {
-            app->env = opal_argv_copy(apps[n].env);
-        }
-        app->maxprocs = apps[n].maxprocs;
-        for (k=0; k < apps[n].ninfo; k++) {
-            oinfo = OBJ_NEW(opal_value_t);
-            opal_list_append(&app->info, &oinfo->super);
-            oinfo->key = strdup(apps[n].info[k].key);
-            if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &apps[n].info[k].value))) {
-                OBJ_RELEASE(opalcaddy);
-                return pmix20_convert_opalrc(rc);
-            }
-        }
+	app = OBJ_NEW(opal_pmix_app_t);
+	opal_list_append(&opalcaddy->apps, &app->super);
+	if (NULL != apps[n].cmd) {
+	    app->cmd = strdup(apps[n].cmd);
+	}
+	app->argc = apps[n].argc;
+	if (NULL != apps[n].argv) {
+	    app->argv = opal_argv_copy(apps[n].argv);
+	}
+	if (NULL != apps[n].env) {
+	    app->env = opal_argv_copy(apps[n].env);
+	}
+	app->maxprocs = apps[n].maxprocs;
+	for (k=0; k < apps[n].ninfo; k++) {
+	    oinfo = OBJ_NEW(opal_value_t);
+	    opal_list_append(&app->info, &oinfo->super);
+	    oinfo->key = strdup(apps[n].info[k].key);
+	    if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &apps[n].info[k].value))) {
+		OBJ_RELEASE(opalcaddy);
+		return pmix20_convert_opalrc(rc);
+	    }
+	}
     }
 
     /* pass it up */
     rc = host_module->spawn(&proc, &opalcaddy->info, &opalcaddy->apps, opal_spncbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_RELEASE(opalcaddy);
+	OPAL_ERROR_LOG(rc);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
@@ -646,8 +647,8 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
 
 
 static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix20_opalcaddy_t *opalcaddy;
@@ -656,7 +657,7 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->connect) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -666,34 +667,34 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->connect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
@@ -701,8 +702,8 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
 
 
 static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix20_opalcaddy_t *opalcaddy;
@@ -711,7 +712,7 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->disconnect) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -721,42 +722,42 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->disconnect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
 }
 
 static pmix_status_t server_register_events(pmix_status_t *codes, size_t ncodes,
-                                            const pmix_info_t info[], size_t ninfo,
-                                            pmix_op_cbfunc_t cbfunc, void *cbdata)
+					    const pmix_info_t info[], size_t ninfo,
+					    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy;
     size_t n;
@@ -770,35 +771,35 @@ static pmix_status_t server_register_events(pmix_status_t *codes, size_t ncodes,
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->register_events(&opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
 }
 
 static pmix_status_t server_deregister_events(pmix_status_t *codes, size_t ncodes,
-                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+					      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 static pmix_status_t server_notify_event(pmix_status_t code,
-                                         const pmix_proc_t *source,
-                                         pmix_data_range_t range,
-                                         pmix_info_t info[], size_t ninfo,
-                                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+					 const pmix_proc_t *source,
+					 pmix_data_range_t range,
+					 pmix_info_t info[], size_t ninfo,
+					 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
@@ -811,10 +812,10 @@ static void _info_rel(void *cbdata)
     OBJ_RELEASE(pcaddy);
 }
 static void info_cbfunc(int status,
-                        opal_list_t *info,
-                        void *cbdata,
-                        opal_pmix_release_cbfunc_t release_fn,
-                        void *release_cbdata)
+			opal_list_t *info,
+			void *cbdata,
+			opal_pmix_release_cbfunc_t release_fn,
+			void *release_cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy = (pmix20_opalcaddy_t*)cbdata;
     pmix20_opcaddy_t *pcaddy;
@@ -828,34 +829,34 @@ static void info_cbfunc(int status,
 
     /* convert the list to a pmix_info_t array */
     if (NULL != info) {
-        pcaddy->ninfo = opal_list_get_size(info);
-        if (0 < pcaddy->ninfo) {
-            PMIX_INFO_CREATE(pcaddy->info, pcaddy->ninfo);
-            n = 0;
-            OPAL_LIST_FOREACH(kv, info, opal_value_t) {
-                (void)strncpy(pcaddy->info[n].key, kv->key, PMIX_MAX_KEYLEN);
-                pmix20_value_load(&pcaddy->info[n].value, kv);
-            }
-        }
+	pcaddy->ninfo = opal_list_get_size(info);
+	if (0 < pcaddy->ninfo) {
+	    PMIX_INFO_CREATE(pcaddy->info, pcaddy->ninfo);
+	    n = 0;
+	    OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+		(void)strncpy(pcaddy->info[n].key, kv->key, PMIX_MAX_KEYLEN);
+		pmix20_value_load(&pcaddy->info[n].value, kv);
+	    }
+	}
     }
     /* we are done with the incoming data */
     if (NULL != release_fn) {
-        release_fn(release_cbdata);
+	release_fn(release_cbdata);
     }
 
     /* provide the answer downward */
     if (NULL != opalcaddy->infocbfunc) {
-        opalcaddy->infocbfunc(pcaddy->status, pcaddy->info, pcaddy->ninfo,
-                              opalcaddy->cbdata, _info_rel, pcaddy);
+	opalcaddy->infocbfunc(pcaddy->status, pcaddy->info, pcaddy->ninfo,
+			      opalcaddy->cbdata, _info_rel, pcaddy);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_query(pmix_proc_t *proct,
-                                  pmix_info_t *info, size_t ninfo,
-                                  pmix_info_t *directives, size_t ndirs,
-                                  pmix_info_cbfunc_t cbfunc,
-                                  void *cbdata)
+				  pmix_info_t *info, size_t ninfo,
+				  pmix_info_t *directives, size_t ndirs,
+				  pmix_info_cbfunc_t cbfunc,
+				  void *cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy;
     opal_process_name_t requestor;
@@ -864,7 +865,7 @@ static pmix_status_t server_query(pmix_proc_t *proct,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->query) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -874,37 +875,37 @@ static pmix_status_t server_query(pmix_proc_t *proct,
 
     /* convert the requestor */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&requestor.jobid, proct->nspace))) {
-        OBJ_RELEASE(opalcaddy);
-        return pmix20_convert_opalrc(rc);
+	OBJ_RELEASE(opalcaddy);
+	return pmix20_convert_opalrc(rc);
     }
     requestor.vpid = proct->rank;
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix20_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix20_convert_opalrc(rc);
+	}
     }
 
     /* we ignore directives for now */
 
     /* pass the call upwards */
     if (OPAL_SUCCESS != (rc = host_module->query(&requestor,
-                                                 &opalcaddy->info, NULL,
-                                                 info_cbfunc, opalcaddy))) {
-        OBJ_RELEASE(opalcaddy);
+						 &opalcaddy->info, NULL,
+						 info_cbfunc, opalcaddy))) {
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix20_convert_opalrc(rc);
 }
 
 static void toolcbfunc(int status,
-                       opal_process_name_t proc,
-                       void *cbdata)
+		       opal_process_name_t proc,
+		       void *cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy = (pmix20_opalcaddy_t*)cbdata;
     pmix_status_t rc;
@@ -920,14 +921,14 @@ static void toolcbfunc(int status,
 
     /* pass it down */
     if (NULL != opalcaddy->toolcbfunc) {
-        opalcaddy->toolcbfunc(rc, &p, opalcaddy->cbdata);
+	opalcaddy->toolcbfunc(rc, &p, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static void server_tool_connection(pmix_info_t *info, size_t ninfo,
-                                   pmix_tool_connection_cbfunc_t cbfunc,
-                                   void *cbdata)
+				   pmix_tool_connection_cbfunc_t cbfunc,
+				   void *cbdata)
 {
     pmix20_opalcaddy_t *opalcaddy;
     size_t n;
@@ -942,16 +943,16 @@ static void server_tool_connection(pmix_info_t *info, size_t ninfo,
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            err = pmix20_convert_opalrc(rc);
-            if (NULL != cbfunc) {
-                cbfunc(err, NULL, cbdata);
-            }
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix20_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    err = pmix20_convert_opalrc(rc);
+	    if (NULL != cbfunc) {
+		cbfunc(err, NULL, cbdata);
+	    }
+	}
     }
 
     /* pass it up */

--- a/opal/mca/pmix/ext20/pmix_ext20_server_south.c
+++ b/opal/mca/pmix/ext20/pmix_ext20_server_south.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,26 +53,26 @@ static size_t errhdler_ref = 0;
 
 #define PMIX_WAIT_FOR_COMPLETION(a)             \
     do {                                        \
-        while ((a)) {                           \
-            usleep(10);                         \
-        }                                       \
+	while ((a)) {                           \
+	    usleep(10);                         \
+	}                                       \
     } while (0)
 
 static void errreg_cbfunc (pmix_status_t status,
-                          size_t errhandler_ref,
-                          void *cbdata)
+			  size_t errhandler_ref,
+			  void *cbdata)
 {
     volatile bool *active = (volatile bool*)cbdata;
 
     errhdler_ref = errhandler_ref;
     opal_output_verbose(5, opal_pmix_base_framework.framework_output,
-                        "PMIX server errreg_cbfunc - error handler registered status=%d, reference=%lu",
-                         status, (unsigned long)errhandler_ref);
+			"PMIX server errreg_cbfunc - error handler registered status=%d, reference=%lu",
+			 status, (unsigned long)errhandler_ref);
     *active = false;
 }
 
 int pmix20_server_init(opal_pmix_server_module_t *module,
-                      opal_list_t *info)
+		      opal_list_t *info)
 {
     pmix_status_t rc;
     int dbg;
@@ -81,28 +82,28 @@ int pmix20_server_init(opal_pmix_server_module_t *module,
     volatile bool active;
 
     if (0 < (dbg = opal_output_get_verbosity(opal_pmix_base_framework.framework_output))) {
-        asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
-        putenv(dbgvalue);
+	asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
+	putenv(dbgvalue);
     }
 
     /* convert the list to an array of pmix_info_t */
     if (NULL != info) {
-        sz = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, sz);
-        n = 0;
-        OPAL_LIST_FOREACH(kv, info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&pinfo[n].value, kv);
-            ++n;
-        }
+	sz = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, sz);
+	n = 0;
+	OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&pinfo[n].value, kv);
+	    ++n;
+	}
     } else {
-        sz = 0;
-        pinfo = NULL;
+	sz = 0;
+	pinfo = NULL;
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, pinfo, sz))) {
-        PMIX_INFO_FREE(pinfo, sz);
-        return pmix20_convert_rc(rc);
+	PMIX_INFO_FREE(pinfo, sz);
+	return pmix20_convert_rc(rc);
     }
     PMIX_INFO_FREE(pinfo, sz);
 
@@ -159,13 +160,13 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     pmix20_opcaddy_t *op = (pmix20_opcaddy_t*)cbdata;
 
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(pmix20_convert_rc(status), op->cbdata);
+	op->opcbfunc(pmix20_convert_rc(status), op->cbdata);
     }
     if (op->active) {
-        op->status = status;
-        op->active = false;
+	op->status = status;
+	op->active = false;
     } else {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 }
 
@@ -195,61 +196,61 @@ static void _reg_nspace(int sd, short args, void *cbdata)
 
     /* convert the list to an array of pmix_info_t */
     if (NULL != cd->info) {
-        sz = opal_list_get_size(cd->info);
-        PMIX_INFO_CREATE(pinfo, sz);
-        n = 0;
-        OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            if (0 == strcmp(kv->key, OPAL_PMIX_PROC_DATA)) {
-                pinfo[n].value.type = PMIX_INFO_ARRAY;
-                /* the value contains a list of values - convert
-                 * that list to another array */
-                pmapinfo = (opal_list_t*)kv->data.ptr;
-                szmap = opal_list_get_size(pmapinfo);
-                PMIX_INFO_CREATE(pmap, szmap);
-                pinfo[n].value.data.array.array = (struct pmix_info_t*)pmap;
-                pinfo[n].value.data.array.size = szmap;
-                m = 0;
-                OPAL_LIST_FOREACH(k2, pmapinfo, opal_value_t) {
-                    (void)strncpy(pmap[m].key, k2->key, PMIX_MAX_KEYLEN);
-                    pmix20_value_load(&pmap[m].value, k2);
-                    ++m;
-                }
-            } else {
-                pmix20_value_load(&pinfo[n].value, kv);
-            }
-            ++n;
-        }
+	sz = opal_list_get_size(cd->info);
+	PMIX_INFO_CREATE(pinfo, sz);
+	n = 0;
+	OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+	    if (0 == strcmp(kv->key, OPAL_PMIX_PROC_DATA)) {
+		pinfo[n].value.type = PMIX_INFO_ARRAY;
+		/* the value contains a list of values - convert
+		 * that list to another array */
+		pmapinfo = (opal_list_t*)kv->data.ptr;
+		szmap = opal_list_get_size(pmapinfo);
+		PMIX_INFO_CREATE(pmap, szmap);
+		pinfo[n].value.data.array.array = (struct pmix_info_t*)pmap;
+		pinfo[n].value.data.array.size = szmap;
+		m = 0;
+		OPAL_LIST_FOREACH(k2, pmapinfo, opal_value_t) {
+		    (void)strncpy(pmap[m].key, k2->key, PMIX_MAX_KEYLEN);
+		    pmix20_value_load(&pmap[m].value, k2);
+		    ++m;
+		}
+	    } else {
+		pmix20_value_load(&pinfo[n].value, kv);
+	    }
+	    ++n;
+	}
     } else {
-        sz = 0;
-        pinfo = NULL;
+	sz = 0;
+	pinfo = NULL;
     }
 
     OBJ_CONSTRUCT(&op, pmix20_opcaddy_t);
     op.active = true;
     rc = PMIx_server_register_nspace(nspace, cd->status, pinfo, sz,
-                                     opcbfunc, (void*)&op);
+				     opcbfunc, (void*)&op);
     if (PMIX_SUCCESS == rc) {
-        PMIX_WAIT_FOR_COMPLETION(op.active);
+	PMIX_WAIT_FOR_COMPLETION(op.active);
     } else {
-        op.status = rc;
+	op.status = rc;
     }
     /* ensure we execute the cbfunc so the caller doesn't hang */
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(pmix20_convert_rc(op.status), cd->cbdata);
+	cd->opcbfunc(pmix20_convert_rc(op.status), cd->cbdata);
     }
     if (NULL != pinfo) {
-        PMIX_INFO_FREE(pinfo, sz);
+	PMIX_INFO_FREE(pinfo, sz);
     }
     OBJ_DESTRUCT(&op);
     OBJ_RELEASE(cd);
 }
 
 int pmix20_server_register_nspace(opal_jobid_t jobid,
-                                 int nlocalprocs,
-                                 opal_list_t *info,
-                                 opal_pmix_op_cbfunc_t cbfunc,
-                                 void *cbdata)
+				 int nlocalprocs,
+				 opal_list_t *info,
+				 opal_pmix_op_cbfunc_t cbfunc,
+				 void *cbdata)
 {
     pmix20_threadshift_t *cd;
 
@@ -264,11 +265,11 @@ int pmix20_server_register_nspace(opal_jobid_t jobid,
     /* if the cbfunc is NULL, then the caller is in an event
      * and we can directly call the processing function */
     if (NULL == cbfunc) {
-        _reg_nspace(0, 0, cd);
+	_reg_nspace(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
-                     -1, EV_WRITE, _reg_nspace, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+	event_assign(&cd->ev, opal_pmix_base.evbase,
+		     -1, EV_WRITE, _reg_nspace, cd);
+	event_active(&cd->ev, EV_WRITE, 1);
     }
 
     return OPAL_SUCCESS;
@@ -279,12 +280,12 @@ static void tdcbfunc(pmix_status_t status, void *cbdata)
     pmix20_threadshift_t *cd = (pmix20_threadshift_t*)cbdata;
 
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(pmix20_convert_rc(status), cd->cbdata);
+	cd->opcbfunc(pmix20_convert_rc(status), cd->cbdata);
     }
     if (cd->active) {
-        cd->active = false;
+	cd->active = false;
     } else {
-        OBJ_RELEASE(cd);
+	OBJ_RELEASE(cd);
     }
 }
 
@@ -295,25 +296,25 @@ static void _dereg_nspace(int sd, short args, void *cbdata)
 
     /* if we don't already have it, we can ignore this */
     OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-        if (jptr->jobid == cd->jobid) {
-            /* found it - tell the server to deregister */
-            cd->active = true;
-            PMIx_server_deregister_nspace(jptr->nspace, tdcbfunc, cd);
-            PMIX_WAIT_FOR_COMPLETION(cd->active);
-            OBJ_RELEASE(cd);
-            /* now get rid of it from our list */
-            opal_list_remove_item(&mca_pmix_ext20_component.jobids, &jptr->super);
-            OBJ_RELEASE(jptr);
-            return;
-        }
+	if (jptr->jobid == cd->jobid) {
+	    /* found it - tell the server to deregister */
+	    cd->active = true;
+	    PMIx_server_deregister_nspace(jptr->nspace, tdcbfunc, cd);
+	    PMIX_WAIT_FOR_COMPLETION(cd->active);
+	    OBJ_RELEASE(cd);
+	    /* now get rid of it from our list */
+	    opal_list_remove_item(&mca_pmix_ext20_component.jobids, &jptr->super);
+	    OBJ_RELEASE(jptr);
+	    return;
+	}
     }
     /* must release the caller */
     tdcbfunc(PMIX_ERR_NOT_FOUND, cd);
 }
 
 void pmix20_server_deregister_nspace(opal_jobid_t jobid,
-                                     opal_pmix_op_cbfunc_t cbfunc,
-                                     void *cbdata)
+				     opal_pmix_op_cbfunc_t cbfunc,
+				     void *cbdata)
 {
     pmix20_threadshift_t *cd;
 
@@ -324,19 +325,19 @@ void pmix20_server_deregister_nspace(opal_jobid_t jobid,
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
     if (NULL == cbfunc) {
-        _dereg_nspace(0, 0, cd);
+	_dereg_nspace(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
-                     -1, EV_WRITE, _dereg_nspace, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+	event_assign(&cd->ev, opal_pmix_base.evbase,
+		     -1, EV_WRITE, _dereg_nspace, cd);
+	event_active(&cd->ev, EV_WRITE, 1);
     }
 }
 
 int pmix20_server_register_client(const opal_process_name_t *proc,
-                                 uid_t uid, gid_t gid,
-                                 void *server_object,
-                                 opal_pmix_op_cbfunc_t cbfunc,
-                                 void *cbdata)
+				 uid_t uid, gid_t gid,
+				 void *server_object,
+				 opal_pmix_op_cbfunc_t cbfunc,
+				 void *cbdata)
 {
     pmix_status_t rc;
     pmix_proc_t p;
@@ -349,10 +350,10 @@ int pmix20_server_register_client(const opal_process_name_t *proc,
     OBJ_CONSTRUCT(&op, pmix20_opcaddy_t);
     op.active = true;
     rc = PMIx_server_register_client(&p, uid, gid, server_object,
-                                     opcbfunc, (void*)&op);
+				     opcbfunc, (void*)&op);
     if (PMIX_SUCCESS == rc) {
-        PMIX_WAIT_FOR_COMPLETION(op.active);
-        rc = op.status;
+	PMIX_WAIT_FOR_COMPLETION(op.active);
+	rc = op.status;
     }
     OBJ_DESTRUCT(&op);
     return pmix20_convert_rc(rc);
@@ -366,15 +367,15 @@ static void _dereg_client(int sd, short args, void *cbdata)
 
     /* if we don't already have it, we can ignore this */
     OPAL_LIST_FOREACH(jptr, &mca_pmix_ext20_component.jobids, opal_pmix20_jobid_trkr_t) {
-        if (jptr->jobid == cd->source->jobid) {
-            /* found it - tell the server to deregister */
-            (void)strncpy(p.nspace, jptr->nspace, PMIX_MAX_NSLEN);
-            p.rank = cd->source->vpid;
-            cd->active = true;
-            PMIx_server_deregister_client(&p, tdcbfunc, (void*)cd);
-            PMIX_WAIT_FOR_COMPLETION(cd->active);
-            break;
-        }
+	if (jptr->jobid == cd->source->jobid) {
+	    /* found it - tell the server to deregister */
+	    (void)strncpy(p.nspace, jptr->nspace, PMIX_MAX_NSLEN);
+	    p.rank = cd->source->vpid;
+	    cd->active = true;
+	    PMIx_server_deregister_client(&p, tdcbfunc, (void*)cd);
+	    PMIX_WAIT_FOR_COMPLETION(cd->active);
+	    break;
+	}
     }
     OBJ_RELEASE(cd);
 }
@@ -382,8 +383,8 @@ static void _dereg_client(int sd, short args, void *cbdata)
 /* tell the local PMIx server to cleanup this client as it is
  * done executing */
 void pmix20_server_deregister_client(const opal_process_name_t *proc,
-                                     opal_pmix_op_cbfunc_t cbfunc,
-                                     void *cbdata)
+				     opal_pmix_op_cbfunc_t cbfunc,
+				     void *cbdata)
 {
     pmix20_threadshift_t *cd;
 
@@ -394,11 +395,11 @@ void pmix20_server_deregister_client(const opal_process_name_t *proc,
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
     if (NULL == cbfunc) {
-        _dereg_client(0, 0, cd);
+	_dereg_client(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
-                     -1, EV_WRITE, _dereg_client, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+	event_assign(&cd->ev, opal_pmix_base.evbase,
+		     -1, EV_WRITE, _dereg_client, cd);
+	event_active(&cd->ev, EV_WRITE, 1);
     }
 }
 
@@ -426,14 +427,14 @@ static void dmdx_response(pmix_status_t status, char *data, size_t sz, void *cbd
 
     rc = pmix20_convert_rc(status);
     if (NULL != op->mdxcbfunc) {
-        op->mdxcbfunc(rc, data, sz, op->cbdata, NULL, NULL);
+	op->mdxcbfunc(rc, data, sz, op->cbdata, NULL, NULL);
     }
     OBJ_RELEASE(op);
 }
 
 /* request modex data for a local proc from the PMIx server */
 int pmix20_server_dmodex(const opal_process_name_t *proc,
-                        opal_pmix_modex_cbfunc_t cbfunc, void *cbdata)
+			opal_pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix20_opcaddy_t *op;
     pmix_status_t rc;
@@ -450,16 +451,16 @@ int pmix20_server_dmodex(const opal_process_name_t *proc,
     /* find the internally-cached data for this proc */
     rc = PMIx_server_dmodex_request(&op->p, dmdx_response, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
     return pmix20_convert_rc(rc);
 }
 
 /* tell the PMIx server to notify its local clients of an event */
 int pmix20_server_notify_event(int status,
-                               const opal_process_name_t *source,
-                               opal_list_t *info,
-                               opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			       const opal_process_name_t *source,
+			       opal_list_t *info,
+			       opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     opal_value_t *kv;
     pmix_info_t *pinfo;
@@ -469,16 +470,16 @@ int pmix20_server_notify_event(int status,
 
     /* convert the list to an array of pmix_info_t */
     if (NULL != info) {
-        sz = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, sz);
-        n = 0;
-        OPAL_LIST_FOREACH(kv, info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            pmix20_value_load(&pinfo[n].value, kv);
-        }
+	sz = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, sz);
+	n = 0;
+	OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+	    pmix20_value_load(&pinfo[n].value, kv);
+	}
     } else {
-        sz = 0;
-        pinfo = NULL;
+	sz = 0;
+	pinfo = NULL;
     }
     /* setup the caddy */
     op = OBJ_NEW(pmix20_opcaddy_t);
@@ -488,11 +489,11 @@ int pmix20_server_notify_event(int status,
     op->cbdata = cbdata;
     /* convert the jobid */
     if (NULL == source) {
-        (void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, OPAL_JOBID_INVALID);
-        op->p.rank = OPAL_VPID_INVALID;
+	(void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, OPAL_JOBID_INVALID);
+	op->p.rank = OPAL_VPID_INVALID;
     } else {
-        (void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, source->jobid);
-        op->p.rank = source->vpid;
+	(void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, source->jobid);
+	op->p.rank = source->vpid;
     }
 
 
@@ -500,9 +501,9 @@ int pmix20_server_notify_event(int status,
     /* the range is irrelevant here as the server is passing
      * the event down to its local clients */
     rc = PMIx_Notify_event(rc, &op->p, PMIX_RANGE_LOCAL,
-                           pinfo, sz, opcbfunc, op);
+			   pinfo, sz, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
     return pmix20_convert_rc(rc);
 }

--- a/opal/mca/pmix/isolated/pmix_isolated.c
+++ b/opal/mca/pmix/isolated/pmix_isolated.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All
  *                         rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,43 +42,43 @@ static int isolated_init(void);
 static int isolated_fini(void);
 static int isolated_initialized(void);
 static int isolated_abort(int flat, const char *msg,
-                      opal_list_t *procs);
+		      opal_list_t *procs);
 static int isolated_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t *jobid);
 static int isolated_spawn_nb(opal_list_t *jobinfo, opal_list_t *apps,
-                         opal_pmix_spawn_cbfunc_t cbfunc,
-                         void *cbdata);
+			 opal_pmix_spawn_cbfunc_t cbfunc,
+			 void *cbdata);
 static int isolated_job_connect(opal_list_t *procs);
 static int isolated_job_disconnect(opal_list_t *procs);
 static int isolated_job_disconnect_nb(opal_list_t *procs,
-                                  opal_pmix_op_cbfunc_t cbfunc,
-                                  void *cbdata);
+				  opal_pmix_op_cbfunc_t cbfunc,
+				  void *cbdata);
 static int isolated_resolve_peers(const char *nodename,
-                              opal_jobid_t jobid,
-                              opal_list_t *procs);
+			      opal_jobid_t jobid,
+			      opal_list_t *procs);
 static int isolated_resolve_nodes(opal_jobid_t jobid, char **nodelist);
 static int isolated_put(opal_pmix_scope_t scope, opal_value_t *kv);
 static int isolated_fence(opal_list_t *procs, int collect_data);
 static int isolated_fence_nb(opal_list_t *procs, int collect_data,
-                         opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			 opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static int isolated_commit(void);
 static int isolated_get(const opal_process_name_t *id,
-                    const char *key, opal_list_t *info,
-                    opal_value_t **kv);
+		    const char *key, opal_list_t *info,
+		    opal_value_t **kv);
 static int isolated_get_nb(const opal_process_name_t *id, const char *key,
-                       opal_list_t *info,
-                       opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
+		       opal_list_t *info,
+		       opal_pmix_value_cbfunc_t cbfunc, void *cbdata);
 static int isolated_publish(opal_list_t *info);
 static int isolated_publish_nb(opal_list_t *info,
-                           opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			   opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static int isolated_lookup(opal_list_t *data, opal_list_t *info);
 static int isolated_lookup_nb(char **keys, opal_list_t *info,
-                          opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+			  opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 static int isolated_unpublish(char **keys, opal_list_t *info);
 static int isolated_unpublish_nb(char **keys, opal_list_t *info,
-                            opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			    opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static const char *isolated_get_version(void);
 static int isolated_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val);
+			  opal_value_t *val);
 static const char *isolated_get_nspace(opal_jobid_t jobid);
 static void isolated_register_jobid(opal_jobid_t jobid, const char *nspace);
 
@@ -132,8 +133,8 @@ static int isolated_init(void)
     isolated_pname.vpid = 0;
     opal_proc_set_name(&isolated_pname);
     opal_output_verbose(10, opal_pmix_base_framework.framework_output,
-                        "%s pmix:isolated: assigned tmp name %d %d",
-                        OPAL_NAME_PRINT(isolated_pname),isolated_pname.jobid,isolated_pname.vpid);
+			"%s pmix:isolated: assigned tmp name %d %d",
+			OPAL_NAME_PRINT(isolated_pname),isolated_pname.jobid,isolated_pname.vpid);
 
     // setup hash table
     opal_pmix_base_hash_init();
@@ -144,9 +145,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = 1;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -156,9 +157,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = 0;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -167,9 +168,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = 1;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -178,9 +179,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = 1;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -190,9 +191,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = 1;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -201,9 +202,9 @@ static int isolated_init(void)
     kv.type = OPAL_STRING;
     kv.data.string = strdup("0");
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -213,9 +214,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT64;
     kv.data.uint64 = 0;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
 
     /* save our local rank */
@@ -224,9 +225,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = 0;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
 
     /* and our node rank */
@@ -235,9 +236,9 @@ static int isolated_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = 0;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -250,11 +251,11 @@ err_exit:
 static int isolated_fini(void)
 {
     if (0 == isolated_init_count) {
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     }
 
     if (0 != --isolated_init_count) {
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     }
     opal_pmix_base_hash_finalize();
     return OPAL_SUCCESS;
@@ -263,13 +264,13 @@ static int isolated_fini(void)
 static int isolated_initialized(void)
 {
     if (0 < isolated_init_count) {
-        return 1;
+	return 1;
     }
     return 0;
 }
 
 static int isolated_abort(int flag, const char *msg,
-                      opal_list_t *procs)
+		      opal_list_t *procs)
 {
     return OPAL_SUCCESS;
 }
@@ -280,8 +281,8 @@ static int isolated_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t 
 }
 
 static int isolated_spawn_nb(opal_list_t *jobinfo, opal_list_t *apps,
-                         opal_pmix_spawn_cbfunc_t cbfunc,
-                         void *cbdata)
+			 opal_pmix_spawn_cbfunc_t cbfunc,
+			 void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -297,15 +298,15 @@ static int isolated_job_disconnect(opal_list_t *procs)
 }
 
 static int isolated_job_disconnect_nb(opal_list_t *procs,
-                                  opal_pmix_op_cbfunc_t cbfunc,
-                                  void *cbdata)
+				  opal_pmix_op_cbfunc_t cbfunc,
+				  void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
 
 static int isolated_resolve_peers(const char *nodename,
-                              opal_jobid_t jobid,
-                              opal_list_t *procs)
+			      opal_jobid_t jobid,
+			      opal_list_t *procs)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
@@ -316,16 +317,16 @@ static int isolated_resolve_nodes(opal_jobid_t jobid, char **nodelist)
 }
 
 static int isolated_put(opal_pmix_scope_t scope,
-                  opal_value_t *kv)
+		  opal_value_t *kv)
 {
     int rc;
 
     opal_output_verbose(10, opal_pmix_base_framework.framework_output,
-                        "%s pmix:isolated isolated_put key %s scope %d\n",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key, scope);
+			"%s pmix:isolated isolated_put key %s scope %d\n",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key, scope);
 
     if (!isolated_init_count) {
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     }
 
     rc = opal_pmix_base_store(&isolated_pname, kv);
@@ -344,39 +345,39 @@ static int isolated_fence(opal_list_t *procs, int collect_data)
 }
 
 static int isolated_fence_nb(opal_list_t *procs, int collect_data,
-                         opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			 opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
 
 static int isolated_get(const opal_process_name_t *id,
-                    const char *key, opal_list_t *info,
-                    opal_value_t **kv)
+		    const char *key, opal_list_t *info,
+		    opal_value_t **kv)
 {
     int rc;
     opal_list_t vals;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:isolated getting value for proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        OPAL_NAME_PRINT(*id), key);
+			"%s pmix:isolated getting value for proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			OPAL_NAME_PRINT(*id), key);
 
     OBJ_CONSTRUCT(&vals, opal_list_t);
     rc = opal_pmix_base_fetch(id, key, &vals);
     if (OPAL_SUCCESS == rc) {
-        *kv = (opal_value_t*)opal_list_remove_first(&vals);
-        return OPAL_SUCCESS;
+	*kv = (opal_value_t*)opal_list_remove_first(&vals);
+	return OPAL_SUCCESS;
     } else {
-        opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                "%s pmix:isolated fetch from dstore failed: %d",
-                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), rc);
+	opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+		"%s pmix:isolated fetch from dstore failed: %d",
+		OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), rc);
     }
     OPAL_LIST_DESTRUCT(&vals);
 
     return rc;
 }
 static int isolated_get_nb(const opal_process_name_t *id, const char *key,
-                       opal_list_t *info, opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
+		       opal_list_t *info, opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
@@ -387,7 +388,7 @@ static int isolated_publish(opal_list_t *info)
 }
 
 static int isolated_publish_nb(opal_list_t *info,
-                           opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			   opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -398,7 +399,7 @@ static int isolated_lookup(opal_list_t *data, opal_list_t *info)
 }
 
 static int isolated_lookup_nb(char **keys, opal_list_t *info,
-                          opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+			  opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -409,7 +410,7 @@ static int isolated_unpublish(char **keys, opal_list_t *info)
 }
 
 static int isolated_unpublish_nb(char **keys, opal_list_t *info,
-                            opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return OPAL_ERR_NOT_SUPPORTED;
 }
@@ -420,7 +421,7 @@ static const char *isolated_get_version(void)
 }
 
 static int isolated_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val)
+			  opal_value_t *val)
 {
     opal_pmix_base_store(proc, val);
 
@@ -436,4 +437,3 @@ static void isolated_register_jobid(opal_jobid_t jobid, const char *nspace)
 {
     return;
 }
-

--- a/opal/mca/pmix/isolated/pmix_isolated_component.c
+++ b/opal/mca/pmix/isolated/pmix_isolated_component.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,27 +43,27 @@ static int isolated_component_query(mca_base_module_t **module, int *priority);
 
 opal_pmix_base_component_t mca_pmix_isolated_component = {
     .base_version = {
-        /* Indicate that we are a pmix v1.1.0 component (which also
-           implies a specific MCA version) */
+	/* Indicate that we are a pmix v1.1.0 component (which also
+	   implies a specific MCA version) */
 
-        OPAL_PMIX_BASE_VERSION_2_0_0,
+	OPAL_PMIX_BASE_VERSION_2_0_0,
 
-        /* Component name and version */
+	/* Component name and version */
 
-        .mca_component_name = "isolated",
-        MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                              OPAL_RELEASE_VERSION),
+	.mca_component_name = "isolated",
+	MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+			      OPAL_RELEASE_VERSION),
 
-        /* Component open and close functions */
+	/* Component open and close functions */
 
-        .mca_open_component = isolated_open,
-        .mca_close_component = isolated_close,
-        .mca_query_component = isolated_component_query,
+	.mca_open_component = isolated_open,
+	.mca_close_component = isolated_close,
+	.mca_query_component = isolated_component_query,
     },
     /* Next the MCA v1.0.0 component meta data */
     .base_data = {
-        /* The component is checkpoint ready */
-        MCA_BASE_METADATA_PARAM_CHECKPOINT
+	/* The component is checkpoint ready */
+	MCA_BASE_METADATA_PARAM_CHECKPOINT
     }
 };
 

--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,18 +49,18 @@
 static const char *pmix2x_get_nspace(opal_jobid_t jobid);
 static void pmix2x_register_jobid(opal_jobid_t jobid, const char *nspace);
 static void register_handler(opal_list_t *event_codes,
-                             opal_list_t *info,
-                             opal_pmix_notification_fn_t evhandler,
-                             opal_pmix_evhandler_reg_cbfunc_t cbfunc,
-                             void *cbdata);
+			     opal_list_t *info,
+			     opal_pmix_notification_fn_t evhandler,
+			     opal_pmix_evhandler_reg_cbfunc_t cbfunc,
+			     void *cbdata);
 static void deregister_handler(size_t evhandler,
-                               opal_pmix_op_cbfunc_t cbfunc,
-                               void *cbdata);
+			       opal_pmix_op_cbfunc_t cbfunc,
+			       void *cbdata);
 static int notify_event(int status,
-                        const opal_process_name_t *source,
-                        opal_pmix_data_range_t range,
-                        opal_list_t *info,
-                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+			const opal_process_name_t *source,
+			opal_pmix_data_range_t range,
+			opal_list_t *info,
+			opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 const opal_pmix_base_module_t opal_pmix_pmix2x_module = {
     /* client APIs */
@@ -114,9 +115,9 @@ static const char *pmix2x_get_nspace(opal_jobid_t jobid)
     opal_pmix2x_jobid_trkr_t *jptr;
 
     OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-        if (jptr->jobid == jobid) {
-            return jptr->nspace;
-        }
+	if (jptr->jobid == jobid) {
+	    return jptr->nspace;
+	}
     }
     return NULL;
 }
@@ -127,9 +128,9 @@ static void pmix2x_register_jobid(opal_jobid_t jobid, const char *nspace)
 
     /* if we don't already have it, add this to our jobid tracker */
     OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-        if (jptr->jobid == jobid) {
-            return;
-        }
+	if (jptr->jobid == jobid) {
+	    return;
+	}
     }
     jptr = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
     (void)strncpy(jptr->nspace, nspace, PMIX_MAX_NSLEN);
@@ -141,14 +142,14 @@ static void completion_handler(int status, void *cbdata)
 {
     opal_pmix2x_event_chain_t *chain = (opal_pmix2x_event_chain_t*)cbdata;
     if (NULL != chain->info) {
-        OPAL_LIST_RELEASE(chain->info);
+	OPAL_LIST_RELEASE(chain->info);
     }
 }
 
 static void progress_local_event_hdlr(int status,
-                                      opal_list_t *results,
-                                      opal_pmix_op_cbfunc_t cbfunc, void *thiscbdata,
-                                      void *notification_cbdata)
+				      opal_list_t *results,
+				      opal_pmix_op_cbfunc_t cbfunc, void *thiscbdata,
+				      void *notification_cbdata)
 {
     opal_pmix2x_event_chain_t *chain = (opal_pmix2x_event_chain_t*)notification_cbdata;
     size_t n;
@@ -159,92 +160,92 @@ static void progress_local_event_hdlr(int status,
 
     /* if the caller indicates that the chain is completed, then stop here */
     if (OPAL_ERR_HANDLERS_COMPLETE == status) {
-        goto complete;
+	goto complete;
     }
 
     /* if any results were provided, then add them here */
     if (NULL != results) {
-        while (NULL != (nxt = opal_list_remove_first(results))) {
-            opal_list_append(results, nxt);
-        }
+	while (NULL != (nxt = opal_list_remove_first(results))) {
+	    opal_list_append(results, nxt);
+	}
     }
 
     /* see if we need to continue, starting with the single code events */
     if (NULL != chain->sing) {
-        /* the last handler was for a single code - see if there are
-         * any others that match this event */
-        while (opal_list_get_end(&mca_pmix_pmix2x_component.single_events) != (nxt = opal_list_get_next(&chain->sing->super))) {
-            sing = (opal_pmix2x_single_event_t*)nxt;
-            if (sing->code == chain->status) {
-                OBJ_RETAIN(chain);
-                chain->sing = sing;
-                sing->handler(chain->status, &chain->source,
-                              chain->info, &chain->results,
-                              progress_local_event_hdlr, (void*)chain);
-                goto complete;
-            }
-        }
-        /* if we get here, then there are no more single code
-         * events that match */
-        chain->sing = NULL;
-        /* pickup the beginning of the multi-code event list */
-        if (0 < opal_list_get_size(&mca_pmix_pmix2x_component.multi_events)) {
-            chain->multi = (opal_pmix2x_multi_event_t*)opal_list_get_begin(&mca_pmix_pmix2x_component.multi_events);
-        }
+	/* the last handler was for a single code - see if there are
+	 * any others that match this event */
+	while (opal_list_get_end(&mca_pmix_pmix2x_component.single_events) != (nxt = opal_list_get_next(&chain->sing->super))) {
+	    sing = (opal_pmix2x_single_event_t*)nxt;
+	    if (sing->code == chain->status) {
+		OBJ_RETAIN(chain);
+		chain->sing = sing;
+		sing->handler(chain->status, &chain->source,
+			      chain->info, &chain->results,
+			      progress_local_event_hdlr, (void*)chain);
+		goto complete;
+	    }
+	}
+	/* if we get here, then there are no more single code
+	 * events that match */
+	chain->sing = NULL;
+	/* pickup the beginning of the multi-code event list */
+	if (0 < opal_list_get_size(&mca_pmix_pmix2x_component.multi_events)) {
+	    chain->multi = (opal_pmix2x_multi_event_t*)opal_list_get_begin(&mca_pmix_pmix2x_component.multi_events);
+	}
     }
 
     /* see if we need to continue with the multi code events */
     if (NULL != chain->multi) {
-        while (opal_list_get_end(&mca_pmix_pmix2x_component.multi_events) != (nxt = opal_list_get_next(&chain->multi->super))) {
-            multi = (opal_pmix2x_multi_event_t*)nxt;
-            for (n=0; n < multi->ncodes; n++) {
-                if (multi->codes[n] == chain->status) {
-                    /* found it - invoke the handler, pointing its
-                     * callback function to our progression function */
-                    OBJ_RETAIN(chain);
-                    chain->multi = multi;
-                    multi->handler(chain->status, &chain->source,
-                                   chain->info, &chain->results,
-                                   progress_local_event_hdlr, (void*)chain);
-                    goto complete;
-                }
-            }
-        }
-        /* if we get here, then there are no more multi-mode
-         * events that match */
-        chain->multi = NULL;
-        /* pickup the beginning of the default event list */
-        if (0 < opal_list_get_size(&mca_pmix_pmix2x_component.default_events)) {
-            chain->def = (opal_pmix2x_default_event_t*)opal_list_get_begin(&mca_pmix_pmix2x_component.default_events);
-        }
+	while (opal_list_get_end(&mca_pmix_pmix2x_component.multi_events) != (nxt = opal_list_get_next(&chain->multi->super))) {
+	    multi = (opal_pmix2x_multi_event_t*)nxt;
+	    for (n=0; n < multi->ncodes; n++) {
+		if (multi->codes[n] == chain->status) {
+		    /* found it - invoke the handler, pointing its
+		     * callback function to our progression function */
+		    OBJ_RETAIN(chain);
+		    chain->multi = multi;
+		    multi->handler(chain->status, &chain->source,
+				   chain->info, &chain->results,
+				   progress_local_event_hdlr, (void*)chain);
+		    goto complete;
+		}
+	    }
+	}
+	/* if we get here, then there are no more multi-mode
+	 * events that match */
+	chain->multi = NULL;
+	/* pickup the beginning of the default event list */
+	if (0 < opal_list_get_size(&mca_pmix_pmix2x_component.default_events)) {
+	    chain->def = (opal_pmix2x_default_event_t*)opal_list_get_begin(&mca_pmix_pmix2x_component.default_events);
+	}
     }
 
     /* if they didn't want it to go to a default handler, then we are done */
     if (chain->nondefault) {
-        goto complete;
+	goto complete;
     }
 
     if (NULL != chain->def) {
-        if (opal_list_get_end(&mca_pmix_pmix2x_component.default_events) != (nxt = opal_list_get_next(&chain->def->super))) {
-            def = (opal_pmix2x_default_event_t*)nxt;
-            OBJ_RETAIN(chain);
-            chain->def = def;
-            def->handler(chain->status, &chain->source,
-                         chain->info, &chain->results,
-                         progress_local_event_hdlr, (void*)chain);
-        }
+	if (opal_list_get_end(&mca_pmix_pmix2x_component.default_events) != (nxt = opal_list_get_next(&chain->def->super))) {
+	    def = (opal_pmix2x_default_event_t*)nxt;
+	    OBJ_RETAIN(chain);
+	    chain->def = def;
+	    def->handler(chain->status, &chain->source,
+			 chain->info, &chain->results,
+			 progress_local_event_hdlr, (void*)chain);
+	}
     }
 
   complete:
     /* we still have to call their final callback */
     if (NULL != chain->final_cbfunc) {
-        chain->final_cbfunc(OPAL_SUCCESS, chain->final_cbdata);
+	chain->final_cbfunc(OPAL_SUCCESS, chain->final_cbdata);
     }
     /* maintain acctng */
     OBJ_RELEASE(chain);
     /* let the caller know that we are done with their callback */
     if (NULL != cbfunc) {
-        cbfunc(OPAL_SUCCESS, thiscbdata);
+	cbfunc(OPAL_SUCCESS, thiscbdata);
     }
 }
 
@@ -258,8 +259,8 @@ static void _event_hdlr(int sd, short args, void *cbdata)
     opal_pmix2x_default_event_t *def;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s RECEIVED NOTIFICATION OF STATUS %d",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), cd->status);
+			"%s RECEIVED NOTIFICATION OF STATUS %d",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), cd->status);
 
     chain = OBJ_NEW(opal_pmix2x_event_chain_t);
     /* point it at our final callback */
@@ -274,47 +275,47 @@ static void _event_hdlr(int sd, short args, void *cbdata)
 
     /* cycle thru the single-event registrations first */
     OPAL_LIST_FOREACH(sing, &mca_pmix_pmix2x_component.single_events, opal_pmix2x_single_event_t) {
-        if (sing->code == chain->status) {
-            /* found it - invoke the handler, pointing its
-             * callback function to our progression function */
-            OBJ_RETAIN(chain);
-            chain->sing = sing;
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s CALLING SINGLE EVHDLR",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            sing->handler(chain->status, &chain->source,
-                          chain->info, &chain->results,
-                          progress_local_event_hdlr, (void*)chain);
-            return;
-        }
+	if (sing->code == chain->status) {
+	    /* found it - invoke the handler, pointing its
+	     * callback function to our progression function */
+	    OBJ_RETAIN(chain);
+	    chain->sing = sing;
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s CALLING SINGLE EVHDLR",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    sing->handler(chain->status, &chain->source,
+			  chain->info, &chain->results,
+			  progress_local_event_hdlr, (void*)chain);
+	    return;
+	}
     }
 
     /* if we didn't find any match in the single-event registrations,
      * then cycle thru the multi-event registrations next */
     OPAL_LIST_FOREACH(multi, &mca_pmix_pmix2x_component.multi_events, opal_pmix2x_multi_event_t) {
-        for (n=0; n < multi->ncodes; n++) {
-            if (multi->codes[n] == chain->status) {
-                /* found it - invoke the handler, pointing its
-                 * callback function to our progression function */
-                OBJ_RETAIN(chain);
-                chain->multi = multi;
-                opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                    "%s CALLING MULTI EVHDLR",
-                                    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-                multi->handler(chain->status, &chain->source,
-                               chain->info, &chain->results,
-                               progress_local_event_hdlr, (void*)chain);
-                return;
-            }
-        }
+	for (n=0; n < multi->ncodes; n++) {
+	    if (multi->codes[n] == chain->status) {
+		/* found it - invoke the handler, pointing its
+		 * callback function to our progression function */
+		OBJ_RETAIN(chain);
+		chain->multi = multi;
+		opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				    "%s CALLING MULTI EVHDLR",
+				    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+		multi->handler(chain->status, &chain->source,
+			       chain->info, &chain->results,
+			       progress_local_event_hdlr, (void*)chain);
+		return;
+	    }
+	}
     }
 
       /* if they didn't want it to go to a default handler, then we are done */
     if (chain->nondefault) {
-        /* if we get here, then we need to cache this event in case they
-         * register for it later - we cannot lose individual events */
-        opal_list_append(&mca_pmix_pmix2x_component.cache, &chain->super);
-        return;
+	/* if we get here, then we need to cache this event in case they
+	 * register for it later - we cannot lose individual events */
+	opal_list_append(&mca_pmix_pmix2x_component.cache, &chain->super);
+	return;
     }
 
     /* we are done with the threadshift caddy */
@@ -322,21 +323,21 @@ static void _event_hdlr(int sd, short args, void *cbdata)
 
     /* finally, pass it to any default handlers */
     if (0 < opal_list_get_size(&mca_pmix_pmix2x_component.default_events)) {
-        def = (opal_pmix2x_default_event_t*)opal_list_get_first(&mca_pmix_pmix2x_component.default_events);
-        OBJ_RETAIN(chain);
-        chain->def = def;
-        opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                            "%s CALLING DEFAULT EVHDLR",
-                            OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-        def->handler(chain->status, &chain->source,
-                     chain->info, &chain->results,
-                     progress_local_event_hdlr, (void*)chain);
-        return;
+	def = (opal_pmix2x_default_event_t*)opal_list_get_first(&mca_pmix_pmix2x_component.default_events);
+	OBJ_RETAIN(chain);
+	chain->def = def;
+	opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+			    "%s CALLING DEFAULT EVHDLR",
+			    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	def->handler(chain->status, &chain->source,
+		     chain->info, &chain->results,
+		     progress_local_event_hdlr, (void*)chain);
+	return;
     }
 
     /* we still have to call their final callback */
     if (NULL != chain->final_cbfunc) {
-        chain->final_cbfunc(PMIX_SUCCESS, chain->final_cbdata);
+	chain->final_cbfunc(PMIX_SUCCESS, chain->final_cbdata);
     }
     return;
 }
@@ -348,11 +349,11 @@ static void _event_hdlr(int sd, short args, void *cbdata)
  * from another process (via the local daemon).
  * The call will occur in the PMIx event base */
 void pmix2x_event_hdlr(size_t evhdlr_registration_id,
-                       pmix_status_t status, const pmix_proc_t *source,
-                       pmix_info_t info[], size_t ninfo,
-                       pmix_info_t results[], size_t nresults,
-                       pmix_event_notification_cbfunc_fn_t cbfunc,
-                       void *cbdata)
+		       pmix_status_t status, const pmix_proc_t *source,
+		       pmix_info_t info[], size_t ninfo,
+		       pmix_info_t results[], size_t nresults,
+		       pmix_event_notification_cbfunc_fn_t cbfunc,
+		       void *cbdata)
 {
     pmix2x_threadshift_t *cd;
     int rc;
@@ -364,55 +365,55 @@ void pmix2x_event_hdlr(size_t evhdlr_registration_id,
      * lists and objects */
 
      opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                         "%s RECEIVED NOTIFICATION OF STATUS %d",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status);
+			 "%s RECEIVED NOTIFICATION OF STATUS %d",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status);
 
     cd = OBJ_NEW(pmix2x_threadshift_t);
 
     /* convert the incoming status */
     cd->status = pmix2x_convert_rc(status);
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s CONVERTED STATUS %d TO STATUS %d",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status, cd->status);
+			"%s CONVERTED STATUS %d TO STATUS %d",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status, cd->status);
     /* convert the nspace/rank to an opal_process_name_t */
     if (NULL == source) {
-        cd->pname.jobid = OPAL_NAME_INVALID->jobid;
-        cd->pname.vpid = OPAL_NAME_INVALID->vpid;
+	cd->pname.jobid = OPAL_NAME_INVALID->jobid;
+	cd->pname.vpid = OPAL_NAME_INVALID->vpid;
     } else {
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&cd->pname.jobid, source->nspace))) {
-            OPAL_ERROR_LOG(rc);
-            OBJ_RELEASE(cd);
-            return;
-        }
-        cd->pname.vpid = source->rank;
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&cd->pname.jobid, source->nspace))) {
+	    OPAL_ERROR_LOG(rc);
+	    OBJ_RELEASE(cd);
+	    return;
+	}
+	cd->pname.vpid = source->rank;
     }
 
     /* convert the array of info */
     if (NULL != info) {
-        cd->info = OBJ_NEW(opal_list_t);
-        for (n=0; n < ninfo; n++) {
-            if (0 == strncmp(info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
-                cd->nondefault = true;
-            }
-            iptr = OBJ_NEW(opal_value_t);
-            iptr->key = strdup(info[n].key);
-            if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
-                OPAL_ERROR_LOG(rc);
-                OBJ_RELEASE(iptr);
-                continue;
-            }
-            opal_list_append(cd->info, &iptr->super);
-        }
+	cd->info = OBJ_NEW(opal_list_t);
+	for (n=0; n < ninfo; n++) {
+	    if (0 == strncmp(info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
+		cd->nondefault = true;
+	    }
+	    iptr = OBJ_NEW(opal_value_t);
+	    iptr->key = strdup(info[n].key);
+	    if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
+		OPAL_ERROR_LOG(rc);
+		OBJ_RELEASE(iptr);
+		continue;
+	    }
+	    opal_list_append(cd->info, &iptr->super);
+	}
     }
     /* now push it into the local thread */
     event_assign(&cd->ev, opal_pmix_base.evbase,
-                 -1, EV_WRITE, _event_hdlr, cd);
+		 -1, EV_WRITE, _event_hdlr, cd);
     event_active(&cd->ev, EV_WRITE, 1);
 
     /* we don't need any of the data they provided,
      * so let them go */
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+	cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
@@ -420,65 +421,65 @@ pmix_status_t pmix2x_convert_opalrc(int rc)
 {
     switch (rc) {
     case OPAL_ERR_DEBUGGER_RELEASE:
-        return PMIX_ERR_DEBUGGER_RELEASE;
+	return PMIX_ERR_DEBUGGER_RELEASE;
 
     case OPAL_ERR_HANDLERS_COMPLETE:
-        return PMIX_EVENT_ACTION_COMPLETE;
+	return PMIX_EVENT_ACTION_COMPLETE;
 
     case OPAL_ERR_PROC_ABORTED:
-        return PMIX_ERR_PROC_ABORTED;
+	return PMIX_ERR_PROC_ABORTED;
 
     case OPAL_ERR_PROC_REQUESTED_ABORT:
-        return PMIX_ERR_PROC_REQUESTED_ABORT;
+	return PMIX_ERR_PROC_REQUESTED_ABORT;
 
     case OPAL_ERR_PROC_ABORTING:
-        return PMIX_ERR_PROC_ABORTING;
+	return PMIX_ERR_PROC_ABORTING;
 
     case OPAL_ERR_NODE_DOWN:
-        return PMIX_ERR_NODE_DOWN;
+	return PMIX_ERR_NODE_DOWN;
 
     case OPAL_ERR_NODE_OFFLINE:
-        return PMIX_ERR_NODE_OFFLINE;
+	return PMIX_ERR_NODE_OFFLINE;
 
     case OPAL_ERR_NOT_IMPLEMENTED:
     case OPAL_ERR_NOT_SUPPORTED:
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
 
     case OPAL_ERR_NOT_FOUND:
-        return PMIX_ERR_NOT_FOUND;
+	return PMIX_ERR_NOT_FOUND;
 
     case OPAL_ERR_PERM:
     case OPAL_ERR_UNREACH:
     case OPAL_ERR_SERVER_NOT_AVAIL:
-        return PMIX_ERR_UNREACH;
+	return PMIX_ERR_UNREACH;
 
     case OPAL_ERR_BAD_PARAM:
-        return PMIX_ERR_BAD_PARAM;
+	return PMIX_ERR_BAD_PARAM;
 
     case OPAL_ERR_OUT_OF_RESOURCE:
-        return PMIX_ERR_OUT_OF_RESOURCE;
+	return PMIX_ERR_OUT_OF_RESOURCE;
 
     case OPAL_ERR_DATA_VALUE_NOT_FOUND:
-        return PMIX_ERR_DATA_VALUE_NOT_FOUND;
+	return PMIX_ERR_DATA_VALUE_NOT_FOUND;
 
     case OPAL_ERR_TIMEOUT:
-        return PMIX_ERR_TIMEOUT;
+	return PMIX_ERR_TIMEOUT;
 
     case OPAL_ERR_WOULD_BLOCK:
-        return PMIX_ERR_WOULD_BLOCK;
+	return PMIX_ERR_WOULD_BLOCK;
 
     case OPAL_EXISTS:
-        return PMIX_EXISTS;
+	return PMIX_EXISTS;
 
     case OPAL_ERR_PARTIAL_SUCCESS:
-        return PMIX_QUERY_PARTIAL_SUCCESS;
+	return PMIX_QUERY_PARTIAL_SUCCESS;
 
     case OPAL_ERROR:
-        return PMIX_ERROR;
+	return PMIX_ERROR;
     case OPAL_SUCCESS:
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     default:
-        return PMIX_ERROR;
+	return PMIX_ERROR;
     }
 }
 
@@ -486,350 +487,350 @@ int pmix2x_convert_rc(pmix_status_t rc)
 {
     switch (rc) {
     case PMIX_ERR_DEBUGGER_RELEASE:
-        return OPAL_ERR_DEBUGGER_RELEASE;
+	return OPAL_ERR_DEBUGGER_RELEASE;
 
     case PMIX_EVENT_ACTION_COMPLETE:
-        return OPAL_ERR_HANDLERS_COMPLETE;
+	return OPAL_ERR_HANDLERS_COMPLETE;
 
     case PMIX_ERR_PROC_ABORTED:
-        return OPAL_ERR_PROC_ABORTED;
+	return OPAL_ERR_PROC_ABORTED;
 
     case PMIX_ERR_PROC_REQUESTED_ABORT:
-        return OPAL_ERR_PROC_REQUESTED_ABORT;
+	return OPAL_ERR_PROC_REQUESTED_ABORT;
 
     case PMIX_ERR_PROC_ABORTING:
-        return OPAL_ERR_PROC_ABORTING;
+	return OPAL_ERR_PROC_ABORTING;
 
     case PMIX_ERR_NODE_DOWN:
-        return OPAL_ERR_NODE_DOWN;
+	return OPAL_ERR_NODE_DOWN;
 
     case PMIX_ERR_NODE_OFFLINE:
-        return OPAL_ERR_NODE_OFFLINE;
+	return OPAL_ERR_NODE_OFFLINE;
 
     case PMIX_ERR_NOT_SUPPORTED:
-        return OPAL_ERR_NOT_SUPPORTED;
+	return OPAL_ERR_NOT_SUPPORTED;
 
     case PMIX_ERR_NOT_FOUND:
-        return OPAL_ERR_NOT_FOUND;
+	return OPAL_ERR_NOT_FOUND;
 
     case PMIX_ERR_OUT_OF_RESOURCE:
-        return OPAL_ERR_OUT_OF_RESOURCE;
+	return OPAL_ERR_OUT_OF_RESOURCE;
 
     case PMIX_ERR_INIT:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
 
     case PMIX_ERR_BAD_PARAM:
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
 
     case PMIX_ERR_UNREACH:
     case PMIX_ERR_NO_PERMISSIONS:
-        return OPAL_ERR_UNREACH;
+	return OPAL_ERR_UNREACH;
 
     case PMIX_ERR_TIMEOUT:
-        return OPAL_ERR_TIMEOUT;
+	return OPAL_ERR_TIMEOUT;
 
     case PMIX_ERR_WOULD_BLOCK:
-        return OPAL_ERR_WOULD_BLOCK;
+	return OPAL_ERR_WOULD_BLOCK;
 
     case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
     case PMIX_ERR_LOST_PEER_CONNECTION:
     case PMIX_ERR_LOST_CONNECTION_TO_CLIENT:
-        return OPAL_ERR_COMM_FAILURE;
+	return OPAL_ERR_COMM_FAILURE;
 
     case PMIX_EXISTS:
-        return OPAL_EXISTS;
+	return OPAL_EXISTS;
 
     case PMIX_QUERY_PARTIAL_SUCCESS:
-        return OPAL_ERR_PARTIAL_SUCCESS;
+	return OPAL_ERR_PARTIAL_SUCCESS;
 
     case PMIX_ERROR:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     case PMIX_SUCCESS:
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     default:
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     }
 }
 
 pmix_scope_t pmix2x_convert_opalscope(opal_pmix_scope_t scope) {
     switch(scope) {
     case OPAL_PMIX_LOCAL:
-        return PMIX_LOCAL;
+	return PMIX_LOCAL;
     case OPAL_PMIX_REMOTE:
-        return PMIX_REMOTE;
+	return PMIX_REMOTE;
     case OPAL_PMIX_GLOBAL:
-        return PMIX_GLOBAL;
+	return PMIX_GLOBAL;
     default:
-        return PMIX_SCOPE_UNDEF;
+	return PMIX_SCOPE_UNDEF;
     }
 }
 
 pmix_data_range_t pmix2x_convert_opalrange(opal_pmix_data_range_t range) {
     switch(range) {
     case OPAL_PMIX_RANGE_UNDEF:
-        return PMIX_RANGE_UNDEF;
+	return PMIX_RANGE_UNDEF;
     case OPAL_PMIX_RANGE_LOCAL:
-        return PMIX_RANGE_LOCAL;
+	return PMIX_RANGE_LOCAL;
     case OPAL_PMIX_RANGE_NAMESPACE:
-        return PMIX_RANGE_NAMESPACE;
+	return PMIX_RANGE_NAMESPACE;
     case OPAL_PMIX_RANGE_SESSION:
-        return PMIX_RANGE_SESSION;
+	return PMIX_RANGE_SESSION;
     case OPAL_PMIX_RANGE_GLOBAL:
-        return PMIX_RANGE_GLOBAL;
+	return PMIX_RANGE_GLOBAL;
     case OPAL_PMIX_RANGE_CUSTOM:
-        return PMIX_RANGE_CUSTOM;
+	return PMIX_RANGE_CUSTOM;
     default:
-        return PMIX_SCOPE_UNDEF;
+	return PMIX_SCOPE_UNDEF;
     }
 }
 
 opal_pmix_data_range_t pmix2x_convert_range(pmix_data_range_t range) {
     switch(range) {
     case PMIX_RANGE_UNDEF:
-        return OPAL_PMIX_RANGE_UNDEF;
+	return OPAL_PMIX_RANGE_UNDEF;
     case PMIX_RANGE_LOCAL:
-        return OPAL_PMIX_RANGE_LOCAL;
+	return OPAL_PMIX_RANGE_LOCAL;
     case PMIX_RANGE_NAMESPACE:
-        return OPAL_PMIX_RANGE_NAMESPACE;
+	return OPAL_PMIX_RANGE_NAMESPACE;
     case PMIX_RANGE_SESSION:
-        return OPAL_PMIX_RANGE_SESSION;
+	return OPAL_PMIX_RANGE_SESSION;
     case PMIX_RANGE_GLOBAL:
-        return OPAL_PMIX_RANGE_GLOBAL;
+	return OPAL_PMIX_RANGE_GLOBAL;
     case PMIX_RANGE_CUSTOM:
-        return OPAL_PMIX_RANGE_CUSTOM;
+	return OPAL_PMIX_RANGE_CUSTOM;
     default:
-        return OPAL_PMIX_SCOPE_UNDEF;
+	return OPAL_PMIX_SCOPE_UNDEF;
     }
 }
 
 
 void pmix2x_value_load(pmix_value_t *v,
-                       opal_value_t *kv)
+		       opal_value_t *kv)
 {
     char nspace[PMIX_MAX_NSLEN + 1];
     size_t n;
 
     switch(kv->type) {
-        case OPAL_UNDEF:
-            v->type = PMIX_UNDEF;
-            break;
-        case OPAL_BOOL:
-            v->type = PMIX_BOOL;
-            memcpy(&(v->data.flag), &kv->data.flag, 1);
-            break;
-        case OPAL_BYTE:
-            v->type = PMIX_BYTE;
-            memcpy(&(v->data.byte), &kv->data.byte, 1);
-            break;
-        case OPAL_STRING:
-            v->type = PMIX_STRING;
-            if (NULL != kv->data.string) {
-                v->data.string = strdup(kv->data.string);
-            } else {
-                v->data.string = NULL;
-            }
-            break;
-        case OPAL_SIZE:
-            v->type = PMIX_SIZE;
-            v->data.size = (size_t)kv->data.size;
-            break;
-        case OPAL_PID:
-            v->type = PMIX_PID;
-            memcpy(&(v->data.pid), &kv->data.pid, sizeof(pid_t));
-            break;
-        case OPAL_INT:
-            v->type = PMIX_INT;
-            memcpy(&(v->data.integer), &kv->data.integer, sizeof(int));
-            break;
-        case OPAL_INT8:
-            v->type = PMIX_INT8;
-            memcpy(&(v->data.int8), &kv->data.int8, 1);
-            break;
-        case OPAL_INT16:
-            v->type = PMIX_INT16;
-            memcpy(&(v->data.int16), &kv->data.int16, 2);
-            break;
-        case OPAL_INT32:
-            v->type = PMIX_INT32;
-            memcpy(&(v->data.int32), &kv->data.int32, 4);
-            break;
-        case OPAL_INT64:
-            v->type = PMIX_INT64;
-            memcpy(&(v->data.int64), &kv->data.int64, 8);
-            break;
-        case OPAL_UINT:
-            v->type = PMIX_UINT;
-            memcpy(&(v->data.uint), &kv->data.uint, sizeof(int));
-            break;
-        case OPAL_UINT8:
-            v->type = PMIX_UINT8;
-            memcpy(&(v->data.uint8), &kv->data.uint8, 1);
-            break;
-        case OPAL_UINT16:
-            v->type = PMIX_UINT16;
-            memcpy(&(v->data.uint16), &kv->data.uint16, 2);
-            break;
-        case OPAL_UINT32:
-            v->type = PMIX_UINT32;
-            memcpy(&(v->data.uint32), &kv->data.uint32, 4);
-            break;
-        case OPAL_UINT64:
-            v->type = PMIX_UINT64;
-            memcpy(&(v->data.uint64), &kv->data.uint64, 8);
-            break;
-        case OPAL_FLOAT:
-            v->type = PMIX_FLOAT;
-            memcpy(&(v->data.fval), &kv->data.fval, sizeof(float));
-            break;
-        case OPAL_DOUBLE:
-            v->type = PMIX_DOUBLE;
-            memcpy(&(v->data.dval), &kv->data.dval, sizeof(double));
-            break;
-        case OPAL_TIMEVAL:
-            v->type = PMIX_TIMEVAL;
-            memcpy(&(v->data.tv), &kv->data.tv, sizeof(struct timeval));
-            break;
-        case OPAL_BYTE_OBJECT:
-            v->type = PMIX_BYTE_OBJECT;
-            if (NULL != kv->data.bo.bytes) {
-                v->data.bo.bytes = (char*)malloc(kv->data.bo.size);
-                memcpy(v->data.bo.bytes, kv->data.bo.bytes, kv->data.bo.size);
-                v->data.bo.size = (size_t)kv->data.bo.size;
-            } else {
-                v->data.bo.bytes = NULL;
-                v->data.bo.size = 0;
-            }
-            break;
-        case OPAL_UINT32_ARRAY:
-            /* an array of 32-bit jobids */
-            v->type = PMIX_INFO_ARRAY;
-            v->data.array.size = kv->data.uint32_array.size;
-            if (0 < v->data.array.size) {
-                PMIX_INFO_CREATE(v->data.array.array, v->data.array.size);
-                for (n=0; n < v->data.array.size; n++) {
-                    v->data.array.array[n].value.type = PMIX_STRING;
-                    (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, kv->data.uint32_array.data[n]);
-                    v->data.array.array[n].value.data.string = strdup(nspace);
-                }
-            }
-            break;
-        case OPAL_NAME:
-            v->type = PMIX_PROC;
-            (void)opal_snprintf_jobid(v->data.proc.nspace, PMIX_MAX_NSLEN, kv->data.name.jobid);
-            v->data.proc.rank = kv->data.name.vpid;
-            break;
-        default:
-            /* silence warnings */
-            break;
+	case OPAL_UNDEF:
+	    v->type = PMIX_UNDEF;
+	    break;
+	case OPAL_BOOL:
+	    v->type = PMIX_BOOL;
+	    memcpy(&(v->data.flag), &kv->data.flag, 1);
+	    break;
+	case OPAL_BYTE:
+	    v->type = PMIX_BYTE;
+	    memcpy(&(v->data.byte), &kv->data.byte, 1);
+	    break;
+	case OPAL_STRING:
+	    v->type = PMIX_STRING;
+	    if (NULL != kv->data.string) {
+		v->data.string = strdup(kv->data.string);
+	    } else {
+		v->data.string = NULL;
+	    }
+	    break;
+	case OPAL_SIZE:
+	    v->type = PMIX_SIZE;
+	    v->data.size = (size_t)kv->data.size;
+	    break;
+	case OPAL_PID:
+	    v->type = PMIX_PID;
+	    memcpy(&(v->data.pid), &kv->data.pid, sizeof(pid_t));
+	    break;
+	case OPAL_INT:
+	    v->type = PMIX_INT;
+	    memcpy(&(v->data.integer), &kv->data.integer, sizeof(int));
+	    break;
+	case OPAL_INT8:
+	    v->type = PMIX_INT8;
+	    memcpy(&(v->data.int8), &kv->data.int8, 1);
+	    break;
+	case OPAL_INT16:
+	    v->type = PMIX_INT16;
+	    memcpy(&(v->data.int16), &kv->data.int16, 2);
+	    break;
+	case OPAL_INT32:
+	    v->type = PMIX_INT32;
+	    memcpy(&(v->data.int32), &kv->data.int32, 4);
+	    break;
+	case OPAL_INT64:
+	    v->type = PMIX_INT64;
+	    memcpy(&(v->data.int64), &kv->data.int64, 8);
+	    break;
+	case OPAL_UINT:
+	    v->type = PMIX_UINT;
+	    memcpy(&(v->data.uint), &kv->data.uint, sizeof(int));
+	    break;
+	case OPAL_UINT8:
+	    v->type = PMIX_UINT8;
+	    memcpy(&(v->data.uint8), &kv->data.uint8, 1);
+	    break;
+	case OPAL_UINT16:
+	    v->type = PMIX_UINT16;
+	    memcpy(&(v->data.uint16), &kv->data.uint16, 2);
+	    break;
+	case OPAL_UINT32:
+	    v->type = PMIX_UINT32;
+	    memcpy(&(v->data.uint32), &kv->data.uint32, 4);
+	    break;
+	case OPAL_UINT64:
+	    v->type = PMIX_UINT64;
+	    memcpy(&(v->data.uint64), &kv->data.uint64, 8);
+	    break;
+	case OPAL_FLOAT:
+	    v->type = PMIX_FLOAT;
+	    memcpy(&(v->data.fval), &kv->data.fval, sizeof(float));
+	    break;
+	case OPAL_DOUBLE:
+	    v->type = PMIX_DOUBLE;
+	    memcpy(&(v->data.dval), &kv->data.dval, sizeof(double));
+	    break;
+	case OPAL_TIMEVAL:
+	    v->type = PMIX_TIMEVAL;
+	    memcpy(&(v->data.tv), &kv->data.tv, sizeof(struct timeval));
+	    break;
+	case OPAL_BYTE_OBJECT:
+	    v->type = PMIX_BYTE_OBJECT;
+	    if (NULL != kv->data.bo.bytes) {
+		v->data.bo.bytes = (char*)malloc(kv->data.bo.size);
+		memcpy(v->data.bo.bytes, kv->data.bo.bytes, kv->data.bo.size);
+		v->data.bo.size = (size_t)kv->data.bo.size;
+	    } else {
+		v->data.bo.bytes = NULL;
+		v->data.bo.size = 0;
+	    }
+	    break;
+	case OPAL_UINT32_ARRAY:
+	    /* an array of 32-bit jobids */
+	    v->type = PMIX_INFO_ARRAY;
+	    v->data.array.size = kv->data.uint32_array.size;
+	    if (0 < v->data.array.size) {
+		PMIX_INFO_CREATE(v->data.array.array, v->data.array.size);
+		for (n=0; n < v->data.array.size; n++) {
+		    v->data.array.array[n].value.type = PMIX_STRING;
+		    (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, kv->data.uint32_array.data[n]);
+		    v->data.array.array[n].value.data.string = strdup(nspace);
+		}
+	    }
+	    break;
+	case OPAL_NAME:
+	    v->type = PMIX_PROC;
+	    (void)opal_snprintf_jobid(v->data.proc.nspace, PMIX_MAX_NSLEN, kv->data.name.jobid);
+	    v->data.proc.rank = kv->data.name.vpid;
+	    break;
+	default:
+	    /* silence warnings */
+	    break;
     }
 }
 
 int pmix2x_value_unload(opal_value_t *kv,
-                       const pmix_value_t *v)
+		       const pmix_value_t *v)
 {
     int rc=OPAL_SUCCESS;
 
 
     switch(v->type) {
     case PMIX_UNDEF:
-        kv->type = OPAL_UNDEF;
-        break;
+	kv->type = OPAL_UNDEF;
+	break;
     case PMIX_BOOL:
-        kv->type = OPAL_BOOL;
-        memcpy(&kv->data.flag, &(v->data.flag), 1);
-        break;
+	kv->type = OPAL_BOOL;
+	memcpy(&kv->data.flag, &(v->data.flag), 1);
+	break;
     case PMIX_BYTE:
-        kv->type = OPAL_BYTE;
-        memcpy(&kv->data.byte, &(v->data.byte), 1);
-        break;
+	kv->type = OPAL_BYTE;
+	memcpy(&kv->data.byte, &(v->data.byte), 1);
+	break;
     case PMIX_STRING:
-        kv->type = OPAL_STRING;
-        if (NULL != v->data.string) {
-            kv->data.string = strdup(v->data.string);
-        }
-        break;
+	kv->type = OPAL_STRING;
+	if (NULL != v->data.string) {
+	    kv->data.string = strdup(v->data.string);
+	}
+	break;
     case PMIX_SIZE:
-        kv->type = OPAL_SIZE;
-        kv->data.size = (int)v->data.size;
-        break;
+	kv->type = OPAL_SIZE;
+	kv->data.size = (int)v->data.size;
+	break;
     case PMIX_PID:
-        kv->type = OPAL_PID;
-        memcpy(&kv->data.pid, &(v->data.pid), sizeof(pid_t));
-        break;
+	kv->type = OPAL_PID;
+	memcpy(&kv->data.pid, &(v->data.pid), sizeof(pid_t));
+	break;
     case PMIX_INT:
-        kv->type = OPAL_INT;
-        memcpy(&kv->data.integer, &(v->data.integer), sizeof(int));
-        break;
+	kv->type = OPAL_INT;
+	memcpy(&kv->data.integer, &(v->data.integer), sizeof(int));
+	break;
     case PMIX_INT8:
-        kv->type = OPAL_INT8;
-        memcpy(&kv->data.int8, &(v->data.int8), 1);
-        break;
+	kv->type = OPAL_INT8;
+	memcpy(&kv->data.int8, &(v->data.int8), 1);
+	break;
     case PMIX_INT16:
-        kv->type = OPAL_INT16;
-        memcpy(&kv->data.int16, &(v->data.int16), 2);
-        break;
+	kv->type = OPAL_INT16;
+	memcpy(&kv->data.int16, &(v->data.int16), 2);
+	break;
     case PMIX_INT32:
-        kv->type = OPAL_INT32;
-        memcpy(&kv->data.int32, &(v->data.int32), 4);
-        break;
+	kv->type = OPAL_INT32;
+	memcpy(&kv->data.int32, &(v->data.int32), 4);
+	break;
     case PMIX_INT64:
-        kv->type = OPAL_INT64;
-        memcpy(&kv->data, &(v->data.int64), 8);
-        break;
+	kv->type = OPAL_INT64;
+	memcpy(&kv->data, &(v->data.int64), 8);
+	break;
     case PMIX_UINT:
-        kv->type = OPAL_UINT;
-        memcpy(&kv->data, &(v->data.uint), sizeof(int));
-        break;
+	kv->type = OPAL_UINT;
+	memcpy(&kv->data, &(v->data.uint), sizeof(int));
+	break;
     case PMIX_UINT8:
-        kv->type = OPAL_UINT8;
-        memcpy(&kv->data, &(v->data.uint8), 1);
-        break;
+	kv->type = OPAL_UINT8;
+	memcpy(&kv->data, &(v->data.uint8), 1);
+	break;
     case PMIX_UINT16:
-        kv->type = OPAL_UINT16;
-        memcpy(&kv->data, &(v->data.uint16), 2);
-        break;
+	kv->type = OPAL_UINT16;
+	memcpy(&kv->data, &(v->data.uint16), 2);
+	break;
     case PMIX_UINT32:
-        kv->type = OPAL_UINT32;
-        memcpy(&kv->data, &(v->data.uint32), 4);
-        break;
+	kv->type = OPAL_UINT32;
+	memcpy(&kv->data, &(v->data.uint32), 4);
+	break;
     case PMIX_UINT64:
-        kv->type = OPAL_UINT64;
-        memcpy(&kv->data, &(v->data.uint64), 8);
-        break;
+	kv->type = OPAL_UINT64;
+	memcpy(&kv->data, &(v->data.uint64), 8);
+	break;
     case PMIX_FLOAT:
-        kv->type = OPAL_FLOAT;
-        memcpy(&kv->data, &(v->data.fval), sizeof(float));
-        break;
+	kv->type = OPAL_FLOAT;
+	memcpy(&kv->data, &(v->data.fval), sizeof(float));
+	break;
     case PMIX_DOUBLE:
-        kv->type = OPAL_DOUBLE;
-        memcpy(&kv->data, &(v->data.dval), sizeof(double));
-        break;
+	kv->type = OPAL_DOUBLE;
+	memcpy(&kv->data, &(v->data.dval), sizeof(double));
+	break;
     case PMIX_TIMEVAL:
-        kv->type = OPAL_TIMEVAL;
-        memcpy(&kv->data, &(v->data.tv), sizeof(struct timeval));
-        break;
+	kv->type = OPAL_TIMEVAL;
+	memcpy(&kv->data, &(v->data.tv), sizeof(struct timeval));
+	break;
     case PMIX_BYTE_OBJECT:
-        kv->type = OPAL_BYTE_OBJECT;
-        if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
-            kv->data.bo.bytes = (uint8_t*)malloc(v->data.bo.size);
-            memcpy(kv->data.bo.bytes, v->data.bo.bytes, v->data.bo.size);
-            kv->data.bo.size = (int)v->data.bo.size;
-        } else {
-            kv->data.bo.bytes = NULL;
-            kv->data.bo.size = 0;
-        }
-        break;
+	kv->type = OPAL_BYTE_OBJECT;
+	if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
+	    kv->data.bo.bytes = (uint8_t*)malloc(v->data.bo.size);
+	    memcpy(kv->data.bo.bytes, v->data.bo.bytes, v->data.bo.size);
+	    kv->data.bo.size = (int)v->data.bo.size;
+	} else {
+	    kv->data.bo.bytes = NULL;
+	    kv->data.bo.size = 0;
+	}
+	break;
     case PMIX_PROC:
-        kv->type = OPAL_NAME;
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&kv->data.name.jobid, v->data.proc.nspace))) {
-            return pmix2x_convert_opalrc(rc);
-        }
-        kv->data.name.vpid = v->data.proc.rank;
-        break;
+	kv->type = OPAL_NAME;
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&kv->data.name.jobid, v->data.proc.nspace))) {
+	    return pmix2x_convert_opalrc(rc);
+	}
+	kv->data.name.vpid = v->data.proc.rank;
+	break;
     default:
-        /* silence warnings */
-        rc = OPAL_ERROR;
-        break;
+	/* silence warnings */
+	rc = OPAL_ERROR;
+	break;
     }
     return rc;
 }
@@ -847,125 +848,125 @@ static void _reg_hdlr(int sd, short args, void *cbdata)
     size_t n;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s REGISTER HANDLER CODES %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == cd->event_codes) ? "NULL" : "NON-NULL");
+			"%s REGISTER HANDLER CODES %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == cd->event_codes) ? "NULL" : "NON-NULL");
 
     if (NULL != cd->info) {
-        OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
-            if (0 == strcmp(kv->key, OPAL_PMIX_EVENT_ORDER_PREPEND)) {
-                prepend = true;
-                break;
-            }
-        }
+	OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
+	    if (0 == strcmp(kv->key, OPAL_PMIX_EVENT_ORDER_PREPEND)) {
+		prepend = true;
+		break;
+	    }
+	}
     }
 
     if (NULL == cd->event_codes) {
-        /* this is a default handler */
-        def = OBJ_NEW(opal_pmix2x_default_event_t);
-        def->handler = cd->evhandler;
-        def->index = mca_pmix_pmix2x_component.evindex;
-        if (prepend) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s PREPENDING TO DEFAULT EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_prepend(&mca_pmix_pmix2x_component.default_events, &def->super);
-        } else {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s APPENDING TO DEFAULT EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_append(&mca_pmix_pmix2x_component.default_events, &def->super);
-        }
+	/* this is a default handler */
+	def = OBJ_NEW(opal_pmix2x_default_event_t);
+	def->handler = cd->evhandler;
+	def->index = mca_pmix_pmix2x_component.evindex;
+	if (prepend) {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s PREPENDING TO DEFAULT EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_prepend(&mca_pmix_pmix2x_component.default_events, &def->super);
+	} else {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s APPENDING TO DEFAULT EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_append(&mca_pmix_pmix2x_component.default_events, &def->super);
+	}
     } else if (1 == opal_list_get_size(cd->event_codes)) {
-        /* single handler */
-        sing = OBJ_NEW(opal_pmix2x_single_event_t);
-        kv = (opal_value_t*)opal_list_get_first(cd->event_codes);
-        sing->code = kv->data.integer;
-        sing->index = mca_pmix_pmix2x_component.evindex;
-        sing->handler = cd->evhandler;
-        if (prepend) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s PREPENDING TO SINGLE EVENTS WITH CODE %d",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
-            opal_list_prepend(&mca_pmix_pmix2x_component.single_events, &sing->super);
-        } else {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s APPENDING TO SINGLE EVENTS WITH CODE %d",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
-            opal_list_append(&mca_pmix_pmix2x_component.single_events, &sing->super);
-        }
+	/* single handler */
+	sing = OBJ_NEW(opal_pmix2x_single_event_t);
+	kv = (opal_value_t*)opal_list_get_first(cd->event_codes);
+	sing->code = kv->data.integer;
+	sing->index = mca_pmix_pmix2x_component.evindex;
+	sing->handler = cd->evhandler;
+	if (prepend) {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s PREPENDING TO SINGLE EVENTS WITH CODE %d",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
+	    opal_list_prepend(&mca_pmix_pmix2x_component.single_events, &sing->super);
+	} else {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s APPENDING TO SINGLE EVENTS WITH CODE %d",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), sing->code);
+	    opal_list_append(&mca_pmix_pmix2x_component.single_events, &sing->super);
+	}
     } else {
-        multi = OBJ_NEW(opal_pmix2x_multi_event_t);
-        multi->ncodes = opal_list_get_size(cd->event_codes);
-        multi->codes = (int*)malloc(multi->ncodes * sizeof(int));
-        i=0;
-        OPAL_LIST_FOREACH(kv, cd->event_codes, opal_value_t) {
-            multi->codes[i] = kv->data.integer;
-            ++i;
-        }
-        multi->index = mca_pmix_pmix2x_component.evindex;
-        multi->handler = cd->evhandler;
-        if (prepend) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s PREPENDING TO MULTI EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_prepend(&mca_pmix_pmix2x_component.multi_events, &multi->super);
-        } else {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "%s APPENDING TO MULTI EVENTS",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
-            opal_list_append(&mca_pmix_pmix2x_component.multi_events, &multi->super);
-        }
+	multi = OBJ_NEW(opal_pmix2x_multi_event_t);
+	multi->ncodes = opal_list_get_size(cd->event_codes);
+	multi->codes = (int*)malloc(multi->ncodes * sizeof(int));
+	i=0;
+	OPAL_LIST_FOREACH(kv, cd->event_codes, opal_value_t) {
+	    multi->codes[i] = kv->data.integer;
+	    ++i;
+	}
+	multi->index = mca_pmix_pmix2x_component.evindex;
+	multi->handler = cd->evhandler;
+	if (prepend) {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s PREPENDING TO MULTI EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_prepend(&mca_pmix_pmix2x_component.multi_events, &multi->super);
+	} else {
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"%s APPENDING TO MULTI EVENTS",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+	    opal_list_append(&mca_pmix_pmix2x_component.multi_events, &multi->super);
+	}
     }
 
     /* release the caller */
     if (NULL != cd->cbfunc) {
-        cd->cbfunc(OPAL_SUCCESS, mca_pmix_pmix2x_component.evindex, cd->cbdata);
+	cd->cbfunc(OPAL_SUCCESS, mca_pmix_pmix2x_component.evindex, cd->cbdata);
     }
     mca_pmix_pmix2x_component.evindex++;
 
     /* check if any matching notifications have been cached - only nondefault
      * events will have been cached*/
     if (NULL == def) {
-        /* check single code registrations */
-        if (NULL != sing) {
-            OPAL_LIST_FOREACH(chain, &mca_pmix_pmix2x_component.cache, opal_pmix2x_event_chain_t) {
-                if (sing->code == chain->status) {
-                    opal_list_remove_item(&mca_pmix_pmix2x_component.cache, &chain->super);
-                    chain->sing = sing;
-                    sing->handler(chain->status, &chain->source,
-                                  chain->info, &chain->results,
-                                  progress_local_event_hdlr, (void*)chain);
-                    OBJ_RELEASE(cd);
-                    return;
-                }
-            }
-        } else if (NULL != multi) {
-            /* check for multi code registrations */
-            OPAL_LIST_FOREACH(chain, &mca_pmix_pmix2x_component.cache, opal_pmix2x_event_chain_t) {
-                for (n=0; n < multi->ncodes; n++) {
-                    if (multi->codes[n] == chain->status) {
-                        opal_list_remove_item(&mca_pmix_pmix2x_component.cache, &chain->super);
-                        chain->multi = multi;
-                        multi->handler(chain->status, &chain->source,
-                                      chain->info, &chain->results,
-                                      progress_local_event_hdlr, (void*)chain);
-                        OBJ_RELEASE(cd);
-                        return;
-                    }
-                }
-            }
-        }
+	/* check single code registrations */
+	if (NULL != sing) {
+	    OPAL_LIST_FOREACH(chain, &mca_pmix_pmix2x_component.cache, opal_pmix2x_event_chain_t) {
+		if (sing->code == chain->status) {
+		    opal_list_remove_item(&mca_pmix_pmix2x_component.cache, &chain->super);
+		    chain->sing = sing;
+		    sing->handler(chain->status, &chain->source,
+				  chain->info, &chain->results,
+				  progress_local_event_hdlr, (void*)chain);
+		    OBJ_RELEASE(cd);
+		    return;
+		}
+	    }
+	} else if (NULL != multi) {
+	    /* check for multi code registrations */
+	    OPAL_LIST_FOREACH(chain, &mca_pmix_pmix2x_component.cache, opal_pmix2x_event_chain_t) {
+		for (n=0; n < multi->ncodes; n++) {
+		    if (multi->codes[n] == chain->status) {
+			opal_list_remove_item(&mca_pmix_pmix2x_component.cache, &chain->super);
+			chain->multi = multi;
+			multi->handler(chain->status, &chain->source,
+				      chain->info, &chain->results,
+				      progress_local_event_hdlr, (void*)chain);
+			OBJ_RELEASE(cd);
+			return;
+		    }
+		}
+	    }
+	}
     }
 
     OBJ_RELEASE(cd);
     return;
 }
 static void register_handler(opal_list_t *event_codes,
-                             opal_list_t *info,
-                             opal_pmix_notification_fn_t evhandler,
-                             opal_pmix_evhandler_reg_cbfunc_t cbfunc,
-                             void *cbdata)
+			     opal_list_t *info,
+			     opal_pmix_notification_fn_t evhandler,
+			     opal_pmix_evhandler_reg_cbfunc_t cbfunc,
+			     void *cbdata)
 {
     /* we must threadshift this request as we might not be in an event
      * and we are going to access framework-global lists/objects */
@@ -983,39 +984,39 @@ static void _dereg_hdlr(int sd, short args, void *cbdata)
 
     /* check the single events first */
     OPAL_LIST_FOREACH(sing, &mca_pmix_pmix2x_component.single_events, opal_pmix2x_single_event_t) {
-        if (cd->handler == sing->index) {
-            opal_list_remove_item(&mca_pmix_pmix2x_component.single_events, &sing->super);
-            OBJ_RELEASE(sing);
-            goto release;
-        }
+	if (cd->handler == sing->index) {
+	    opal_list_remove_item(&mca_pmix_pmix2x_component.single_events, &sing->super);
+	    OBJ_RELEASE(sing);
+	    goto release;
+	}
     }
     /* check multi events */
     OPAL_LIST_FOREACH(multi, &mca_pmix_pmix2x_component.multi_events, opal_pmix2x_multi_event_t) {
-        if (cd->handler == multi->index) {
-            opal_list_remove_item(&mca_pmix_pmix2x_component.multi_events, &multi->super);
-            OBJ_RELEASE(multi);
-            goto release;
-        }
+	if (cd->handler == multi->index) {
+	    opal_list_remove_item(&mca_pmix_pmix2x_component.multi_events, &multi->super);
+	    OBJ_RELEASE(multi);
+	    goto release;
+	}
     }
     /* check default events */
     OPAL_LIST_FOREACH(def, &mca_pmix_pmix2x_component.default_events, opal_pmix2x_default_event_t) {
-        if (cd->handler == def->index) {
-            opal_list_remove_item(&mca_pmix_pmix2x_component.default_events, &def->super);
-            OBJ_RELEASE(def);
-            break;
-        }
+	if (cd->handler == def->index) {
+	    opal_list_remove_item(&mca_pmix_pmix2x_component.default_events, &def->super);
+	    OBJ_RELEASE(def);
+	    break;
+	}
     }
 
   release:
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(OPAL_SUCCESS, cd->cbdata);
+	cd->opcbfunc(OPAL_SUCCESS, cd->cbdata);
     }
     OBJ_RELEASE(cd);
 }
 
 static void deregister_handler(size_t evhandler,
-                               opal_pmix_op_cbfunc_t cbfunc,
-                               void *cbdata)
+			       opal_pmix_op_cbfunc_t cbfunc,
+			       void *cbdata)
 {
     /* we must threadshift this request as we might not be in an event
      * and we are going to access framework-global lists/objects */
@@ -1034,86 +1035,86 @@ static void _notify_event(int sd, short args, void *cbdata)
 
     /* check the single events first */
     OPAL_LIST_FOREACH(sing, &mca_pmix_pmix2x_component.single_events, opal_pmix2x_single_event_t) {
-        if (cd->status == sing->code) {
-            /* found it - invoke the handler, pointing its
-             * callback function to our progression function */
-            chain = OBJ_NEW(opal_pmix2x_event_chain_t);
-            chain->status = cd->status;
-            chain->range = pmix2x_convert_opalrange(cd->range);
-            chain->source = *(cd->source);
-            chain->info = cd->info;
-            chain->final_cbfunc = cd->opcbfunc;
-            chain->final_cbdata = cd->cbdata;
-            chain->sing = sing;
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                "[%s] CALLING SINGLE EVHDLR FOR STATUS %d",
-                                OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
-            sing->handler(chain->status, &chain->source,
-                          chain->info, &chain->results,
-                          progress_local_event_hdlr, (void*)chain);
-            OBJ_RELEASE(cd);
-            return;
-        }
+	if (cd->status == sing->code) {
+	    /* found it - invoke the handler, pointing its
+	     * callback function to our progression function */
+	    chain = OBJ_NEW(opal_pmix2x_event_chain_t);
+	    chain->status = cd->status;
+	    chain->range = pmix2x_convert_opalrange(cd->range);
+	    chain->source = *(cd->source);
+	    chain->info = cd->info;
+	    chain->final_cbfunc = cd->opcbfunc;
+	    chain->final_cbdata = cd->cbdata;
+	    chain->sing = sing;
+	    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				"[%s] CALLING SINGLE EVHDLR FOR STATUS %d",
+				OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
+	    sing->handler(chain->status, &chain->source,
+			  chain->info, &chain->results,
+			  progress_local_event_hdlr, (void*)chain);
+	    OBJ_RELEASE(cd);
+	    return;
+	}
     }
     /* check multi events */
     OPAL_LIST_FOREACH(multi, &mca_pmix_pmix2x_component.multi_events, opal_pmix2x_multi_event_t) {
-        for (i=0; i < multi->ncodes; i++) {
-            if (cd->status == multi->codes[i]) {
-                /* found it - invoke the handler, pointing its
-                 * callback function to our progression function */
-                chain = OBJ_NEW(opal_pmix2x_event_chain_t);
-                chain->status = cd->status;
-                chain->range = pmix2x_convert_opalrange(cd->range);
-                chain->source = *(cd->source);
-                chain->info = cd->info;
-                chain->final_cbfunc = cd->opcbfunc;
-                chain->final_cbdata = cd->cbdata;
-                chain->multi = multi;
-                opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                                    "[%s] CALLING MULTI EVHDLR FOR STATUS %d",
-                                    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
-                multi->handler(chain->status, &chain->source,
-                               chain->info, &chain->results,
-                               progress_local_event_hdlr, (void*)chain);
-                OBJ_RELEASE(cd);
-                return;
-            }
-        }
+	for (i=0; i < multi->ncodes; i++) {
+	    if (cd->status == multi->codes[i]) {
+		/* found it - invoke the handler, pointing its
+		 * callback function to our progression function */
+		chain = OBJ_NEW(opal_pmix2x_event_chain_t);
+		chain->status = cd->status;
+		chain->range = pmix2x_convert_opalrange(cd->range);
+		chain->source = *(cd->source);
+		chain->info = cd->info;
+		chain->final_cbfunc = cd->opcbfunc;
+		chain->final_cbdata = cd->cbdata;
+		chain->multi = multi;
+		opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+				    "[%s] CALLING MULTI EVHDLR FOR STATUS %d",
+				    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
+		multi->handler(chain->status, &chain->source,
+			       chain->info, &chain->results,
+			       progress_local_event_hdlr, (void*)chain);
+		OBJ_RELEASE(cd);
+		return;
+	    }
+	}
     }
     /* check default events */
     if (0 < opal_list_get_size(&mca_pmix_pmix2x_component.default_events)) {
-        def = (opal_pmix2x_default_event_t*)opal_list_get_first(&mca_pmix_pmix2x_component.default_events);
-        chain = OBJ_NEW(opal_pmix2x_event_chain_t);
-        chain->status = cd->status;
-        chain->range = pmix2x_convert_opalrange(cd->range);
-        chain->source = *(cd->source);
-        chain->info = cd->info;
-        chain->final_cbfunc = cd->opcbfunc;
-        chain->final_cbdata = cd->cbdata;
-        chain->def = def;
-        opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                            "[%s] CALLING DEFAULT EVHDLR FOR STATUS %d",
-                            OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
-        def->handler(chain->status, &chain->source,
-                     chain->info, &chain->results,
-                     progress_local_event_hdlr, (void*)chain);
-        OBJ_RELEASE(cd);
-        return;
+	def = (opal_pmix2x_default_event_t*)opal_list_get_first(&mca_pmix_pmix2x_component.default_events);
+	chain = OBJ_NEW(opal_pmix2x_event_chain_t);
+	chain->status = cd->status;
+	chain->range = pmix2x_convert_opalrange(cd->range);
+	chain->source = *(cd->source);
+	chain->info = cd->info;
+	chain->final_cbfunc = cd->opcbfunc;
+	chain->final_cbdata = cd->cbdata;
+	chain->def = def;
+	opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+			    "[%s] CALLING DEFAULT EVHDLR FOR STATUS %d",
+			    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), chain->status);
+	def->handler(chain->status, &chain->source,
+		     chain->info, &chain->results,
+		     progress_local_event_hdlr, (void*)chain);
+	OBJ_RELEASE(cd);
+	return;
     }
 
     /* if we get here, then there are no registered event handlers */
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(OPAL_ERR_NOT_FOUND, cd->cbdata);
+	cd->opcbfunc(OPAL_ERR_NOT_FOUND, cd->cbdata);
     }
     OBJ_RELEASE(cd);
     return;
 }
 
 static int notify_event(int status,
-                        const opal_process_name_t *source,
-                        opal_pmix_data_range_t range,
-                        opal_list_t *info,
-                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			const opal_process_name_t *source,
+			opal_pmix_data_range_t range,
+			opal_list_t *info,
+			opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     /* we must threadshift this request as we might not be in an event
      * and we are going to access framework-global lists/objects */
@@ -1123,12 +1124,12 @@ static int notify_event(int status,
 
 /****  INSTANTIATE INTERNAL CLASSES  ****/
 OBJ_CLASS_INSTANCE(opal_pmix2x_jobid_trkr_t,
-                   opal_list_item_t,
-                   NULL, NULL);
+		   opal_list_item_t,
+		   NULL, NULL);
 
 OBJ_CLASS_INSTANCE(opal_pmix2x_single_event_t,
-                   opal_list_item_t,
-                   NULL, NULL);
+		   opal_list_item_t,
+		   NULL, NULL);
 
 static void mtevcon(opal_pmix2x_multi_event_t *p)
 {
@@ -1138,16 +1139,16 @@ static void mtevcon(opal_pmix2x_multi_event_t *p)
 static void mtevdes(opal_pmix2x_multi_event_t *p)
 {
     if (NULL != p->codes) {
-        free(p->codes);
+	free(p->codes);
     }
 }
 OBJ_CLASS_INSTANCE(opal_pmix2x_multi_event_t,
-                   opal_list_item_t,
-                   mtevcon, mtevdes);
+		   opal_list_item_t,
+		   mtevcon, mtevdes);
 
 OBJ_CLASS_INSTANCE(opal_pmix2x_default_event_t,
-                   opal_list_item_t,
-                   NULL, NULL);
+		   opal_list_item_t,
+		   NULL, NULL);
 
 static void chcon(opal_pmix2x_event_chain_t *p)
 {
@@ -1165,8 +1166,8 @@ static void chdes(opal_pmix2x_event_chain_t *p)
     OPAL_LIST_DESTRUCT(&p->results);
 }
 OBJ_CLASS_INSTANCE(opal_pmix2x_event_chain_t,
-                   opal_list_item_t,
-                   chcon, chdes);
+		   opal_list_item_t,
+		   chcon, chdes);
 
 static void opcon(pmix2x_opcaddy_t *p)
 {
@@ -1190,21 +1191,21 @@ static void opcon(pmix2x_opcaddy_t *p)
 static void opdes(pmix2x_opcaddy_t *p)
 {
     if (NULL != p->procs) {
-        PMIX_PROC_FREE(p->procs, p->nprocs);
+	PMIX_PROC_FREE(p->procs, p->nprocs);
     }
     if (NULL != p->error_procs) {
-        PMIX_PROC_FREE(p->error_procs, p->nerror_procs);
+	PMIX_PROC_FREE(p->error_procs, p->nerror_procs);
     }
     if (NULL != p->info) {
-        PMIX_INFO_FREE(p->info, p->sz);
+	PMIX_INFO_FREE(p->info, p->sz);
     }
     if (NULL != p->apps) {
-        PMIX_APP_FREE(p->apps, p->sz);
+	PMIX_APP_FREE(p->apps, p->sz);
     }
 }
 OBJ_CLASS_INSTANCE(pmix2x_opcaddy_t,
-                   opal_object_t,
-                   opcon, opdes);
+		   opal_object_t,
+		   opcon, opdes);
 
 static void ocadcon(pmix2x_opalcaddy_t *p)
 {
@@ -1229,8 +1230,8 @@ static void ocaddes(pmix2x_opalcaddy_t *p)
     OPAL_LIST_DESTRUCT(&p->apps);
 }
 OBJ_CLASS_INSTANCE(pmix2x_opalcaddy_t,
-                   opal_object_t,
-                   ocadcon, ocaddes);
+		   opal_object_t,
+		   ocadcon, ocaddes);
 
 static void tscon(pmix2x_threadshift_t *p)
 {
@@ -1245,5 +1246,5 @@ static void tscon(pmix2x_threadshift_t *p)
     p->cbdata = NULL;
 }
 OBJ_CLASS_INSTANCE(pmix2x_threadshift_t,
-                   opal_object_t,
-                   tscon, NULL);
+		   opal_object_t,
+		   tscon, NULL);

--- a/opal/mca/pmix/pmix2x/pmix2x_client.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_client.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,20 +38,20 @@ static size_t errhdler_ref = 0;
 
 #define PMIX_WAIT_FOR_COMPLETION(a)             \
     do {                                        \
-        while ((a)) {                           \
-            usleep(10);                         \
-        }                                       \
+	while ((a)) {                           \
+	    usleep(10);                         \
+	}                                       \
     } while (0)
 
 
 static void errreg_cbfunc (pmix_status_t status,
-                          size_t errhandler_ref,
-                          void *cbdata)
+			  size_t errhandler_ref,
+			  void *cbdata)
 {
     errhdler_ref = errhandler_ref;
     opal_output_verbose(5, opal_pmix_base_framework.framework_output,
-                        "PMIX client errreg_cbfunc - error handler registered status=%d, reference=%lu",
-                         status, (unsigned long)errhandler_ref);
+			"PMIX client errreg_cbfunc - error handler registered status=%d, reference=%lu",
+			 status, (unsigned long)errhandler_ref);
 }
 
 int pmix2x_client_init(void)
@@ -61,28 +62,28 @@ int pmix2x_client_init(void)
     opal_pmix2x_jobid_trkr_t *job;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client init");
+			"PMIx_client init");
 
     if (0 < (dbg = opal_output_get_verbosity(opal_pmix_base_framework.framework_output))) {
-        asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
-        putenv(dbgvalue);
+	asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
+	putenv(dbgvalue);
     }
 
     rc = PMIx_Init(&my_proc, NULL, 0);
     if (PMIX_SUCCESS != rc) {
-        return pmix2x_convert_rc(rc);
+	return pmix2x_convert_rc(rc);
     }
 
     /* store our jobid and rank */
    if (NULL != getenv(OPAL_MCA_PREFIX"orte_launch")) {
-        /* if we were launched by the OMPI RTE, then
-         * the jobid is in a special format - so get it */
-        mca_pmix_pmix2x_component.native_launch = true;
-        opal_convert_string_to_jobid(&pname.jobid, my_proc.nspace);
+	/* if we were launched by the OMPI RTE, then
+	 * the jobid is in a special format - so get it */
+	mca_pmix_pmix2x_component.native_launch = true;
+	opal_convert_string_to_jobid(&pname.jobid, my_proc.nspace);
     } else {
-        /* we were launched by someone else, so make the
-         * jobid just be the hash of the nspace */
-        OPAL_HASH_STR(my_proc.nspace, pname.jobid);
+	/* we were launched by someone else, so make the
+	 * jobid just be the hash of the nspace */
+	OPAL_HASH_STR(my_proc.nspace, pname.jobid);
     }
     /* insert this into our list of jobids - it will be the
      * first, and so we'll check it first */
@@ -105,7 +106,7 @@ int pmix2x_client_finalize(void)
     pmix_status_t rc;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client finalize");
+			"PMIx_client finalize");
 
     /* deregister the default event handler */
     PMIx_Deregister_event_handler(errhdler_ref, NULL, NULL);
@@ -117,13 +118,13 @@ int pmix2x_client_finalize(void)
 int pmix2x_initialized(void)
 {
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client initialized");
+			"PMIx_client initialized");
 
     return PMIx_Initialized();
 }
 
 int pmix2x_abort(int flag, const char *msg,
-                  opal_list_t *procs)
+		  opal_list_t *procs)
 {
     pmix_status_t rc;
     pmix_proc_t *parray=NULL;
@@ -132,31 +133,31 @@ int pmix2x_abort(int flag, const char *msg,
     opal_pmix2x_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client abort");
+			"PMIx_client abort");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                PMIX_PROC_FREE(parray, cnt);
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		PMIX_PROC_FREE(parray, cnt);
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
 
     /* call the library abort */
@@ -179,25 +180,25 @@ int pmix2x_store_local(const opal_process_name_t *proc, opal_value_t *val)
      * and we are going to access framework-global lists/objects */
 
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        p.rank = proc->vpid;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	p.rank = proc->vpid;
     } else {
-        /* use our name */
-        (void)strncpy(p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
-        p.rank = OPAL_PROC_MY_NAME.vpid;
+	/* use our name */
+	(void)strncpy(p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+	p.rank = OPAL_PROC_MY_NAME.vpid;
     }
 
     PMIX_VALUE_CONSTRUCT(&kv);
@@ -222,7 +223,7 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     pmix2x_opcaddy_t *op = (pmix2x_opcaddy_t*)cbdata;
 
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(pmix2x_convert_rc(status), op->cbdata);
+	op->opcbfunc(pmix2x_convert_rc(status), op->cbdata);
     }
     OBJ_RELEASE(op);
 }
@@ -237,41 +238,41 @@ int pmix2x_fence(opal_list_t *procs, int collect_data)
     opal_pmix2x_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client fence");
+			"PMIx_client fence");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
     if (collect_data) {
-        PMIX_INFO_CONSTRUCT(&info);
-        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-        info.value.type = PMIX_BOOL;
-        info.value.data.flag = true;
-        iptr = &info;
-        n = 1;
+	PMIX_INFO_CONSTRUCT(&info);
+	(void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+	info.value.type = PMIX_BOOL;
+	info.value.data.flag = true;
+	iptr = &info;
+	n = 1;
     } else {
-        iptr = NULL;
-        n = 0;
+	iptr = NULL;
+	n = 0;
     }
 
     /* call the library function */
@@ -280,7 +281,7 @@ int pmix2x_fence(opal_list_t *procs, int collect_data)
     /* release the array */
     PMIX_PROC_FREE(parray, cnt);
     if (NULL != iptr) {
-        PMIX_INFO_DESTRUCT(&info);
+	PMIX_INFO_DESTRUCT(&info);
     }
 
     return pmix2x_convert_rc(rc);
@@ -288,7 +289,7 @@ int pmix2x_fence(opal_list_t *procs, int collect_data)
 }
 
 int pmix2x_fencenb(opal_list_t *procs, int collect_data,
-                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t rc;
     pmix_proc_t *parray=NULL;
@@ -302,43 +303,43 @@ int pmix2x_fencenb(opal_list_t *procs, int collect_data,
      * and we are going to access framework-global lists/objects */
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client fence_nb");
+			"PMIx_client fence_nb");
 
     /* convert the list of procs to an array
      * of pmix_proc_t */
     if (NULL != procs && 0 < (cnt = opal_list_get_size(procs))) {
-        PMIX_PROC_CREATE(parray, cnt);
-        n=0;
-        OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-            /* look thru our list of jobids and find the
-             * corresponding nspace */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-                if (jptr->jobid == ptr->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                PMIX_PROC_FREE(parray, cnt);
-                return OPAL_ERR_NOT_FOUND;
-            }
-            (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-            parray[n].rank = ptr->name.vpid;
-            ++n;
-        }
+	PMIX_PROC_CREATE(parray, cnt);
+	n=0;
+	OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
+	    /* look thru our list of jobids and find the
+	     * corresponding nspace */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+		if (jptr->jobid == ptr->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		PMIX_PROC_FREE(parray, cnt);
+		return OPAL_ERR_NOT_FOUND;
+	    }
+	    (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	    parray[n].rank = ptr->name.vpid;
+	    ++n;
+	}
     }
 
     if (collect_data) {
-        PMIX_INFO_CONSTRUCT(&info);
-        (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-        info.value.type = PMIX_BOOL;
-        info.value.data.flag = true;
-        iptr = &info;
-        n = 1;
+	PMIX_INFO_CONSTRUCT(&info);
+	(void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+	info.value.type = PMIX_BOOL;
+	info.value.data.flag = true;
+	iptr = &info;
+	n = 1;
     } else {
-        iptr = NULL;
-        n = 0;
+	iptr = NULL;
+	n = 0;
     }
 
     /* create the caddy */
@@ -351,7 +352,7 @@ int pmix2x_fencenb(opal_list_t *procs, int collect_data,
     /* call the library function */
     rc = PMIx_Fence_nb(parray, cnt, iptr, n, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 
     return pmix2x_convert_rc(rc);
@@ -359,14 +360,14 @@ int pmix2x_fencenb(opal_list_t *procs, int collect_data,
 }
 
 int pmix2x_put(opal_pmix_scope_t opal_scope,
-              opal_value_t *val)
+	      opal_value_t *val)
 {
     pmix_value_t kv;
     pmix_scope_t pmix_scope = pmix2x_convert_opalscope(opal_scope);
     pmix_status_t rc;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client put");
+			"PMIx_client put");
 
     PMIX_VALUE_CONSTRUCT(&kv);
     pmix2x_value_load(&kv, val);
@@ -377,7 +378,7 @@ int pmix2x_put(opal_pmix_scope_t opal_scope,
 }
 
 int pmix2x_get(const opal_process_name_t *proc, const char *key,
-              opal_list_t *info, opal_value_t **val)
+	      opal_list_t *info, opal_value_t **val)
 {
     int ret;
     pmix_value_t *kv;
@@ -389,80 +390,80 @@ int pmix2x_get(const opal_process_name_t *proc, const char *key,
     opal_pmix2x_jobid_trkr_t *job, *jptr;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "%s PMIx_client get on proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+			"%s PMIx_client get on proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
 
     /* prep default response */
     *val = NULL;
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        p.rank = proc->vpid;
-        pptr = &p;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	p.rank = proc->vpid;
+	pptr = &p;
     } else {
-        /* if they are asking for our jobid, then return it */
-        if (0 == strcmp(key, OPAL_PMIX_JOBID)) {
-            (*val) = OBJ_NEW(opal_value_t);
-            (*val)->type = OPAL_UINT32;
-            (*val)->data.uint32 = OPAL_PROC_MY_NAME.jobid;
-            return OPAL_SUCCESS;
-        } else if (0 == strcmp(key, OPAL_PMIX_RANK)) {
-            (*val) = OBJ_NEW(opal_value_t);
-            (*val)->type = OPAL_INT;
-            (*val)->data.integer = my_proc.rank;
-            return OPAL_SUCCESS;
-        }
-        pptr = NULL;
+	/* if they are asking for our jobid, then return it */
+	if (0 == strcmp(key, OPAL_PMIX_JOBID)) {
+	    (*val) = OBJ_NEW(opal_value_t);
+	    (*val)->type = OPAL_UINT32;
+	    (*val)->data.uint32 = OPAL_PROC_MY_NAME.jobid;
+	    return OPAL_SUCCESS;
+	} else if (0 == strcmp(key, OPAL_PMIX_RANK)) {
+	    (*val) = OBJ_NEW(opal_value_t);
+	    (*val)->type = OPAL_INT;
+	    (*val)->data.integer = my_proc.rank;
+	    return OPAL_SUCCESS;
+	}
+	pptr = NULL;
     }
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        if (0 < ninfo) {
-            PMIX_INFO_CREATE(pinfo, ninfo);
-            n=0;
-            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
-                (void)strncpy(pinfo[n].key, ival->key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&pinfo[n].value, ival);
-            }
-        } else {
-            pinfo = NULL;
-        }
+	ninfo = opal_list_get_size(info);
+	if (0 < ninfo) {
+	    PMIX_INFO_CREATE(pinfo, ninfo);
+	    n=0;
+	    OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+		(void)strncpy(pinfo[n].key, ival->key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&pinfo[n].value, ival);
+	    }
+	} else {
+	    pinfo = NULL;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     /* pass the request down */
     rc = PMIx_Get(pptr, key, pinfo, ninfo, &kv);
     if (PMIX_SUCCESS == rc) {
-        if (NULL == kv) {
-            ret = OPAL_SUCCESS;
-        } else {
-            *val = OBJ_NEW(opal_value_t);
-            ret = pmix2x_value_unload(*val, kv);
-            PMIX_VALUE_FREE(kv, 1);
-        }
+	if (NULL == kv) {
+	    ret = OPAL_SUCCESS;
+	} else {
+	    *val = OBJ_NEW(opal_value_t);
+	    ret = pmix2x_value_unload(*val, kv);
+	    PMIX_VALUE_FREE(kv, 1);
+	}
     } else {
-        ret = pmix2x_convert_rc(rc);
+	ret = pmix2x_convert_rc(rc);
     }
     PMIX_INFO_FREE(pinfo, ninfo);
     return ret;
 }
 
 static void val_cbfunc(pmix_status_t status,
-                       pmix_value_t *kv, void *cbdata)
+		       pmix_value_t *kv, void *cbdata)
 {
     pmix2x_opcaddy_t *op = (pmix2x_opcaddy_t*)cbdata;
     int rc;
@@ -470,19 +471,19 @@ static void val_cbfunc(pmix_status_t status,
 
     rc = pmix2x_convert_opalrc(status);
     if (PMIX_SUCCESS == status && NULL != kv) {
-        rc = pmix2x_value_unload(&val, kv);
-        v = &val;
+	rc = pmix2x_value_unload(&val, kv);
+	v = &val;
     }
 
     if (NULL != op->valcbfunc) {
-        op->valcbfunc(rc, v, op->cbdata);
+	op->valcbfunc(rc, v, op->cbdata);
     }
     OBJ_RELEASE(op);
 }
 
 int pmix2x_getnb(const opal_process_name_t *proc, const char *key,
-                opal_list_t *info,
-                opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
+		opal_list_t *info,
+		opal_pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     pmix2x_opcaddy_t *op;
     pmix_status_t rc;
@@ -494,9 +495,9 @@ int pmix2x_getnb(const opal_process_name_t *proc, const char *key,
      * and we are going to access shared lists/objects */
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "%s PMIx_client get_nb on proc %s key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                        (NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
+			"%s PMIx_client get_nb on proc %s key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+			(NULL == proc) ? "NULL" : OPAL_NAME_PRINT(*proc), key);
 
     /* create the caddy */
     op = OBJ_NEW(pmix2x_opcaddy_t);
@@ -504,41 +505,41 @@ int pmix2x_getnb(const opal_process_name_t *proc, const char *key,
     op->cbdata = cbdata;
 
     if (NULL != proc) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (jptr->jobid == proc->jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(op->p.nspace, job->nspace, PMIX_MAX_NSLEN);
-        op->p.rank = proc->vpid;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (jptr->jobid == proc->jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(op->p.nspace, job->nspace, PMIX_MAX_NSLEN);
+	op->p.rank = proc->vpid;
     } else {
-        (void)strncpy(op->p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
-        op->p.rank = PMIX_RANK_WILDCARD;
+	(void)strncpy(op->p.nspace, my_proc.nspace, PMIX_MAX_NSLEN);
+	op->p.rank = PMIX_RANK_WILDCARD;
     }
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(ival, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, ival->key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&op->info[n].value, ival);
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(ival, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, ival->key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&op->info[n].value, ival);
+	    }
+	}
     }
 
     /* call the library function */
     rc = PMIx_Get_nb(&op->p, key, op->info, op->sz, val_cbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 
     return pmix2x_convert_rc(rc);
@@ -552,23 +553,23 @@ int pmix2x_publish(opal_list_t *info)
     size_t sz, n;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client publish");
+			"PMIx_client publish");
 
     if (NULL == info) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     sz = opal_list_get_size(info);
     if (0 < sz) {
-        PMIX_INFO_CREATE(pinfo, sz);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	PMIX_INFO_CREATE(pinfo, sz);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
+	pinfo = NULL;
     }
 
     ret = PMIx_Publish(pinfo, sz);
@@ -577,7 +578,7 @@ int pmix2x_publish(opal_list_t *info)
 }
 
 int pmix2x_publishnb(opal_list_t *info,
-                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     opal_value_t *iptr;
@@ -585,10 +586,10 @@ int pmix2x_publishnb(opal_list_t *info,
     pmix2x_opcaddy_t *op;
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client publish_nb");
+			"PMIx_client publish_nb");
 
     if (NULL == info) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -598,13 +599,13 @@ int pmix2x_publishnb(opal_list_t *info,
 
     op->sz = opal_list_get_size(info);
     if (0 < op->sz) {
-        PMIX_INFO_CREATE(op->info, op->sz);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&op->info[n].value, iptr);
-            ++n;
-        }
+	PMIX_INFO_CREATE(op->info, op->sz);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&op->info[n].value, iptr);
+	    ++n;
+	}
     }
 
     ret = PMIx_Publish_nb(op->info, op->sz, opcbfunc, op);
@@ -626,84 +627,84 @@ int pmix2x_lookup(opal_list_t *data, opal_list_t *info)
     /* we must threadshift this request as we might not be in an event
      * and we are going to access shared lists/objects */
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client lookup");
+			"PMIx_client lookup");
 
     if (NULL == data) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     sz = opal_list_get_size(data);
     PMIX_PDATA_CREATE(pdata, sz);
     n=0;
     OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
-        (void)strncpy(pdata[n++].key, d->value.key, PMIX_MAX_KEYLEN);
+	(void)strncpy(pdata[n++].key, d->value.key, PMIX_MAX_KEYLEN);
     }
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	ninfo = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     ret = PMIx_Lookup(pdata, sz, pinfo, ninfo);
     PMIX_INFO_FREE(pinfo, ninfo);
 
     if (PMIX_SUCCESS == ret) {
-        /* transfer the data back */
-        n=0;
-        OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
-            if (mca_pmix_pmix2x_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&d->proc.jobid, pdata[n].proc.nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(pdata[n].proc.nspace, d->proc.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-                if (jptr->jobid == d->proc.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-               job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
-                (void)strncpy(job->nspace, pdata[n].proc.nspace, PMIX_MAX_NSLEN);
-                job->jobid = d->proc.jobid;
-                opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
-            }
-            if (PMIX_RANK_WILDCARD == pdata[n].proc.rank) {
-                d->proc.vpid = OPAL_VPID_WILDCARD;
-            } else {
-                d->proc.vpid = pdata[n].proc.rank;
-            }
-            rc = pmix2x_value_unload(&d->value, &pdata[n].value);
-            if (OPAL_SUCCESS != rc) {
-                OPAL_ERROR_LOG(rc);
-                PMIX_PDATA_FREE(pdata, sz);
-                return OPAL_ERR_BAD_PARAM;
-            }
-            ++n;
-        }
+	/* transfer the data back */
+	n=0;
+	OPAL_LIST_FOREACH(d, data, opal_pmix_pdata_t) {
+	    if (mca_pmix_pmix2x_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&d->proc.jobid, pdata[n].proc.nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(pdata[n].proc.nspace, d->proc.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+		if (jptr->jobid == d->proc.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+	       job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
+		(void)strncpy(job->nspace, pdata[n].proc.nspace, PMIX_MAX_NSLEN);
+		job->jobid = d->proc.jobid;
+		opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
+	    }
+	    if (PMIX_RANK_WILDCARD == pdata[n].proc.rank) {
+		d->proc.vpid = OPAL_VPID_WILDCARD;
+	    } else {
+		d->proc.vpid = pdata[n].proc.rank;
+	    }
+	    rc = pmix2x_value_unload(&d->value, &pdata[n].value);
+	    if (OPAL_SUCCESS != rc) {
+		OPAL_ERROR_LOG(rc);
+		PMIX_PDATA_FREE(pdata, sz);
+		return OPAL_ERR_BAD_PARAM;
+	    }
+	    ++n;
+	}
     }
 
     return pmix2x_convert_rc(ret);
 }
 
 static void lk_cbfunc(pmix_status_t status,
-                      pmix_pdata_t data[], size_t ndata,
-                      void *cbdata)
+		      pmix_pdata_t data[], size_t ndata,
+		      void *cbdata)
 {
     pmix2x_opcaddy_t *op = (pmix2x_opcaddy_t*)cbdata;
     opal_pmix_pdata_t *d;
@@ -717,66 +718,66 @@ static void lk_cbfunc(pmix_status_t status,
   * lists and objects */
 
    if (NULL == op->lkcbfunc) {
-        OBJ_RELEASE(op);
-        return;
+	OBJ_RELEASE(op);
+	return;
     }
 
     rc = pmix2x_convert_rc(status);
     if (OPAL_SUCCESS == rc) {
-        OBJ_CONSTRUCT(&results, opal_list_t);
-        for (n=0; n < ndata; n++) {
-            d = OBJ_NEW(opal_pmix_pdata_t);
-            opal_list_append(&results, &d->super);
-            if (mca_pmix_pmix2x_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&d->proc.jobid, data[n].proc.nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(data[n].proc.nspace, d->proc.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-                if (jptr->jobid == d->proc.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
-                (void)strncpy(job->nspace, data[n].proc.nspace, PMIX_MAX_NSLEN);
-                job->jobid = d->proc.jobid;
-                opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
-            }
-            if (PMIX_RANK_WILDCARD == data[n].proc.rank) {
-                d->proc.vpid = OPAL_VPID_WILDCARD;
-            } else {
-                d->proc.vpid = data[n].proc.rank;
-            }
-            d->value.key = strdup(data[n].key);
-            rc = pmix2x_value_unload(&d->value, &data[n].value);
-            if (OPAL_SUCCESS != rc) {
-                rc = OPAL_ERR_BAD_PARAM;
-                OPAL_ERROR_LOG(rc);
-                goto release;
-            }
-        }
-        r = &results;
+	OBJ_CONSTRUCT(&results, opal_list_t);
+	for (n=0; n < ndata; n++) {
+	    d = OBJ_NEW(opal_pmix_pdata_t);
+	    opal_list_append(&results, &d->super);
+	    if (mca_pmix_pmix2x_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&d->proc.jobid, data[n].proc.nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(data[n].proc.nspace, d->proc.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+		if (jptr->jobid == d->proc.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
+		(void)strncpy(job->nspace, data[n].proc.nspace, PMIX_MAX_NSLEN);
+		job->jobid = d->proc.jobid;
+		opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
+	    }
+	    if (PMIX_RANK_WILDCARD == data[n].proc.rank) {
+		d->proc.vpid = OPAL_VPID_WILDCARD;
+	    } else {
+		d->proc.vpid = data[n].proc.rank;
+	    }
+	    d->value.key = strdup(data[n].key);
+	    rc = pmix2x_value_unload(&d->value, &data[n].value);
+	    if (OPAL_SUCCESS != rc) {
+		rc = OPAL_ERR_BAD_PARAM;
+		OPAL_ERROR_LOG(rc);
+		goto release;
+	    }
+	}
+	r = &results;
     }
   release:
     /* execute the callback */
     op->lkcbfunc(rc, r, op->cbdata);
 
     if (NULL != r) {
-        OPAL_LIST_DESTRUCT(&results);
+	OPAL_LIST_DESTRUCT(&results);
     }
     OBJ_RELEASE(op);
 }
 
 int pmix2x_lookupnb(char **keys, opal_list_t *info,
-                   opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+		   opal_pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix2x_opcaddy_t *op;
@@ -785,7 +786,7 @@ int pmix2x_lookupnb(char **keys, opal_list_t *info,
 
 
     opal_output_verbose(1, opal_pmix_base_framework.framework_output,
-                        "PMIx_client lookup_nb");
+			"PMIx_client lookup_nb");
 
     /* create the caddy */
     op = OBJ_NEW(pmix2x_opcaddy_t);
@@ -793,16 +794,16 @@ int pmix2x_lookupnb(char **keys, opal_list_t *info,
     op->cbdata = cbdata;
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&op->info[n].value, iptr);
-                ++n;
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&op->info[n].value, iptr);
+		++n;
+	    }
+	}
     }
 
     ret = PMIx_Lookup_nb(keys, op->info, op->sz, lk_cbfunc, op);
@@ -818,17 +819,17 @@ int pmix2x_unpublish(char **keys, opal_list_t *info)
     opal_value_t *iptr;
 
     if (NULL != info) {
-        ninfo = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-            (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&pinfo[n].value, iptr);
-            ++n;
-        }
+	ninfo = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+	    (void)strncpy(pinfo[n++].key, iptr->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&pinfo[n].value, iptr);
+	    ++n;
+	}
     } else {
-        pinfo = NULL;
-        ninfo = 0;
+	pinfo = NULL;
+	ninfo = 0;
     }
 
     ret = PMIx_Unpublish(keys, pinfo, ninfo);
@@ -838,7 +839,7 @@ int pmix2x_unpublish(char **keys, opal_list_t *info)
 }
 
 int pmix2x_unpublishnb(char **keys, opal_list_t *info,
-                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix2x_opcaddy_t *op;
@@ -851,16 +852,16 @@ int pmix2x_unpublishnb(char **keys, opal_list_t *info,
     op->cbdata = cbdata;
 
     if (NULL != info) {
-        op->sz = opal_list_get_size(info);
-        if (0 < op->sz) {
-            PMIX_INFO_CREATE(op->info, op->sz);
-            n=0;
-            OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
-                (void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&op->info[n].value, iptr);
-                ++n;
-            }
-        }
+	op->sz = opal_list_get_size(info);
+	if (0 < op->sz) {
+	    PMIX_INFO_CREATE(op->info, op->sz);
+	    n=0;
+	    OPAL_LIST_FOREACH(iptr, info, opal_value_t) {
+		(void)strncpy(op->info[n].key, iptr->key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&op->info[n].value, iptr);
+		++n;
+	    }
+	}
     }
 
     ret = PMIx_Unpublish_nb(keys, op->info, op->sz, opcbfunc, op);
@@ -880,52 +881,52 @@ int pmix2x_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
     opal_pmix2x_jobid_trkr_t *job;
 
     if (NULL != job_info && 0 < (ninfo = opal_list_get_size(job_info))) {
-        PMIX_INFO_CREATE(pinfo, ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, info->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&pinfo[n].value, info);
-            ++n;
-        }
+	PMIX_INFO_CREATE(pinfo, ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, info->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&pinfo[n].value, info);
+	    ++n;
+	}
     }
 
     napps = opal_list_get_size(apps);
     PMIX_APP_CREATE(papps, napps);
     n=0;
     OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
-        papps[n].cmd = strdup(app->cmd);
-        papps[n].argc = app->argc;
-        papps[n].argv = opal_argv_copy(app->argv);
-        papps[n].env = opal_argv_copy(app->env);
-        papps[n].maxprocs = app->maxprocs;
-        if (0 < (papps[n].ninfo = opal_list_get_size(&app->info))) {
-            PMIX_INFO_CREATE(papps[n].info, papps[n].ninfo);
-            m=0;
-            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
-                (void)strncpy(papps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&papps[n].info[m].value, info);
-                ++m;
-            }
-        }
-        ++n;
+	papps[n].cmd = strdup(app->cmd);
+	papps[n].argc = app->argc;
+	papps[n].argv = opal_argv_copy(app->argv);
+	papps[n].env = opal_argv_copy(app->env);
+	papps[n].maxprocs = app->maxprocs;
+	if (0 < (papps[n].ninfo = opal_list_get_size(&app->info))) {
+	    PMIX_INFO_CREATE(papps[n].info, papps[n].ninfo);
+	    m=0;
+	    OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+		(void)strncpy(papps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&papps[n].info[m].value, info);
+		++m;
+	    }
+	}
+	++n;
     }
 
     ret = PMIx_Spawn(pinfo, ninfo, papps, napps, nspace);
     if (PMIX_SUCCESS == ret) {
-        if (mca_pmix_pmix2x_component.native_launch) {
-            /* if we were launched by the OMPI RTE, then
-             * the jobid is in a special format - so get it */
-            opal_convert_string_to_jobid(jobid, nspace);
-        } else {
-            /* we were launched by someone else, so make the
-             * jobid just be the hash of the nspace */
-            OPAL_HASH_STR(nspace, *jobid);
-        }
-        /* add this to our jobid tracker */
-        job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
-        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-        job->jobid = *jobid;
-        opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
+	if (mca_pmix_pmix2x_component.native_launch) {
+	    /* if we were launched by the OMPI RTE, then
+	     * the jobid is in a special format - so get it */
+	    opal_convert_string_to_jobid(jobid, nspace);
+	} else {
+	    /* we were launched by someone else, so make the
+	     * jobid just be the hash of the nspace */
+	    OPAL_HASH_STR(nspace, *jobid);
+	}
+	/* add this to our jobid tracker */
+	job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
+	(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+	job->jobid = *jobid;
+	opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
     }
     PMIX_APP_FREE(papps, napps);
 
@@ -933,7 +934,7 @@ int pmix2x_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
 }
 
 static void spcbfunc(pmix_status_t status,
-                     char *nspace, void *cbdata)
+		     char *nspace, void *cbdata)
 {
     pmix2x_opcaddy_t *op = (pmix2x_opcaddy_t*)cbdata;
     int rc;
@@ -946,20 +947,20 @@ static void spcbfunc(pmix_status_t status,
 
     rc = pmix2x_convert_rc(status);
     if (PMIX_SUCCESS == status) {
-        if (mca_pmix_pmix2x_component.native_launch) {
-            /* if we were launched by the OMPI RTE, then
-             * the jobid is in a special format - so get it */
-            opal_convert_string_to_jobid(&jobid, nspace);
-        } else {
-            /* we were launched by someone else, so make the
-             * jobid just be the hash of the nspace */
-            OPAL_HASH_STR(nspace, jobid);
-        }
-        /* add this to our jobid tracker */
-        job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
-        (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-        job->jobid = jobid;
-        opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
+	if (mca_pmix_pmix2x_component.native_launch) {
+	    /* if we were launched by the OMPI RTE, then
+	     * the jobid is in a special format - so get it */
+	    opal_convert_string_to_jobid(&jobid, nspace);
+	} else {
+	    /* we were launched by someone else, so make the
+	     * jobid just be the hash of the nspace */
+	    OPAL_HASH_STR(nspace, jobid);
+	}
+	/* add this to our jobid tracker */
+	job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
+	(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+	job->jobid = jobid;
+	opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
     }
 
     op->spcbfunc(rc, jobid, op->cbdata);
@@ -967,7 +968,7 @@ static void spcbfunc(pmix_status_t status,
 }
 
 int pmix2x_spawnnb(opal_list_t *job_info, opal_list_t *apps,
-                    opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
     pmix2x_opcaddy_t *op;
@@ -981,34 +982,34 @@ int pmix2x_spawnnb(opal_list_t *job_info, opal_list_t *apps,
     op->cbdata = cbdata;
 
     if (NULL != job_info && 0 < (op->ninfo = opal_list_get_size(job_info))) {
-        PMIX_INFO_CREATE(op->info, op->ninfo);
-        n=0;
-        OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
-            (void)strncpy(op->info[n].key, info->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&op->info[n].value, info);
-            ++n;
-        }
+	PMIX_INFO_CREATE(op->info, op->ninfo);
+	n=0;
+	OPAL_LIST_FOREACH(info, job_info, opal_value_t) {
+	    (void)strncpy(op->info[n].key, info->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&op->info[n].value, info);
+	    ++n;
+	}
     }
 
     op->sz = opal_list_get_size(apps);
     PMIX_APP_CREATE(op->apps, op->sz);
     n=0;
     OPAL_LIST_FOREACH(app, apps, opal_pmix_app_t) {
-        op->apps[n].cmd = strdup(app->cmd);
-        op->apps[n].argc = app->argc;
-        op->apps[n].argv = opal_argv_copy(app->argv);
-        op->apps[n].env = opal_argv_copy(app->env);
-        op->apps[n].maxprocs = app->maxprocs;
-        if (0 < (op->apps[n].ninfo = opal_list_get_size(&app->info))) {
-            PMIX_INFO_CREATE(op->apps[n].info, op->apps[n].ninfo);
-            m=0;
-            OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
-                (void)strncpy(op->apps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&op->apps[n].info[m].value, info);
-                ++m;
-            }
-        }
-        ++n;
+	op->apps[n].cmd = strdup(app->cmd);
+	op->apps[n].argc = app->argc;
+	op->apps[n].argv = opal_argv_copy(app->argv);
+	op->apps[n].env = opal_argv_copy(app->env);
+	op->apps[n].maxprocs = app->maxprocs;
+	if (0 < (op->apps[n].ninfo = opal_list_get_size(&app->info))) {
+	    PMIX_INFO_CREATE(op->apps[n].info, op->apps[n].ninfo);
+	    m=0;
+	    OPAL_LIST_FOREACH(info, &app->info, opal_value_t) {
+		(void)strncpy(op->apps[n].info[m].key, info->key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&op->apps[n].info[m].value, info);
+		++m;
+	    }
+	}
+	++n;
     }
 
     ret = PMIx_Spawn_nb(op->info, op->ninfo, op->apps, op->sz, spcbfunc, op);
@@ -1026,7 +1027,7 @@ int pmix2x_connect(opal_list_t *procs)
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* convert the list of procs to an array
@@ -1034,27 +1035,27 @@ int pmix2x_connect(opal_list_t *procs)
     PMIX_PROC_CREATE(parray, cnt);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (jptr->jobid == ptr->name.jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
-            PMIX_PROC_FREE(parray, cnt);
-            return OPAL_ERR_NOT_FOUND;
-        }
-        (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            parray[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            parray[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (jptr->jobid == ptr->name.jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
+	    PMIX_PROC_FREE(parray, cnt);
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	(void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    parray[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    parray[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Connect(parray, cnt, NULL, 0);
@@ -1064,8 +1065,8 @@ int pmix2x_connect(opal_list_t *procs)
 }
 
 int pmix2x_connectnb(opal_list_t *procs,
-                    opal_pmix_op_cbfunc_t cbfunc,
-                    void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc,
+		    void *cbdata)
 {
     pmix_status_t ret;
     size_t n, cnt=0;
@@ -1078,7 +1079,7 @@ int pmix2x_connectnb(opal_list_t *procs,
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -1092,20 +1093,20 @@ int pmix2x_connectnb(opal_list_t *procs,
     PMIX_PROC_CREATE(op->procs, op->nprocs);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            op->procs[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            op->procs[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    op->procs[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    op->procs[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Connect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
@@ -1123,7 +1124,7 @@ int pmix2x_disconnect(opal_list_t *procs)
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* convert the list of procs to an array
@@ -1131,20 +1132,20 @@ int pmix2x_disconnect(opal_list_t *procs)
     PMIX_PROC_CREATE(parray, cnt);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            parray[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            parray[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(parray[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    parray[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    parray[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Disconnect(parray, cnt, NULL, 0);
@@ -1154,8 +1155,8 @@ int pmix2x_disconnect(opal_list_t *procs)
 }
 
 int pmix2x_disconnectnb(opal_list_t *procs,
-                         opal_pmix_op_cbfunc_t cbfunc,
-                         void *cbdata)
+			 opal_pmix_op_cbfunc_t cbfunc,
+			 void *cbdata)
 {
     pmix_status_t ret;
     size_t n, cnt=0;
@@ -1168,7 +1169,7 @@ int pmix2x_disconnectnb(opal_list_t *procs,
 
     /* protect against bozo error */
     if (NULL == procs || 0 == (cnt = opal_list_get_size(procs))) {
-        return OPAL_ERR_BAD_PARAM;
+	return OPAL_ERR_BAD_PARAM;
     }
 
     /* create the caddy */
@@ -1182,20 +1183,20 @@ int pmix2x_disconnectnb(opal_list_t *procs,
     PMIX_PROC_CREATE(op->procs, op->nprocs);
     n=0;
     OPAL_LIST_FOREACH(ptr, procs, opal_namelist_t) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        OPAL_LIST_FOREACH(job, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (job->jobid == ptr->name.jobid) {
-                (void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
-                break;
-            }
-        }
-        if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
-            op->procs[n].rank = PMIX_RANK_WILDCARD;
-        } else {
-            op->procs[n].rank = ptr->name.vpid;
-        }
-        ++n;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	OPAL_LIST_FOREACH(job, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (job->jobid == ptr->name.jobid) {
+		(void)strncpy(op->procs[n].nspace, job->nspace, PMIX_MAX_NSLEN);
+		break;
+	    }
+	}
+	if (OPAL_VPID_WILDCARD == ptr->name.vpid) {
+	    op->procs[n].rank = PMIX_RANK_WILDCARD;
+	} else {
+	    op->procs[n].rank = ptr->name.vpid;
+	}
+	++n;
     }
 
     ret = PMIx_Disconnect_nb(op->procs, op->nprocs, NULL, 0, opcbfunc, op);
@@ -1205,7 +1206,7 @@ int pmix2x_disconnectnb(opal_list_t *procs,
 
 
 int pmix2x_resolve_peers(const char *nodename, opal_jobid_t jobid,
-                          opal_list_t *procs)
+			  opal_list_t *procs)
 {
     char *nspace;
     pmix_proc_t *array=NULL;
@@ -1219,53 +1220,53 @@ int pmix2x_resolve_peers(const char *nodename, opal_jobid_t jobid,
      * and we are going to access framework-global lists/objects */
 
     if (OPAL_JOBID_WILDCARD == jobid) {
-        nspace = NULL;
+	nspace = NULL;
     } else {
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (jptr->jobid == jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        nspace = job->nspace;
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (jptr->jobid == jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	nspace = job->nspace;
     }
 
     ret = PMIx_Resolve_peers(nodename, nspace, &array, &nprocs);
     rc = pmix2x_convert_rc(ret);
 
     if (NULL != array && 0 < nprocs) {
-        for (n=0; n < nprocs; n++) {
-            nm = OBJ_NEW(opal_namelist_t);
-            opal_list_append(procs, &nm->super);
-            if (mca_pmix_pmix2x_component.native_launch) {
-                /* if we were launched by the OMPI RTE, then
-                 * the jobid is in a special format - so get it */
-                opal_convert_string_to_jobid(&nm->name.jobid, array[n].nspace);
-            } else {
-                /* we were launched by someone else, so make the
-                 * jobid just be the hash of the nspace */
-                OPAL_HASH_STR(array[n].nspace, nm->name.jobid);
-            }
-            /* if we don't already have it, add this to our jobid tracker */
-            job = NULL;
-            OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-                if (jptr->jobid == nm->name.jobid) {
-                    job = jptr;
-                    break;
-                }
-            }
-            if (NULL == job) {
-                job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
-                (void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
-                job->jobid = jobid;
-                opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
-            }
-            nm->name.vpid = array[n].rank;
-        }
+	for (n=0; n < nprocs; n++) {
+	    nm = OBJ_NEW(opal_namelist_t);
+	    opal_list_append(procs, &nm->super);
+	    if (mca_pmix_pmix2x_component.native_launch) {
+		/* if we were launched by the OMPI RTE, then
+		 * the jobid is in a special format - so get it */
+		opal_convert_string_to_jobid(&nm->name.jobid, array[n].nspace);
+	    } else {
+		/* we were launched by someone else, so make the
+		 * jobid just be the hash of the nspace */
+		OPAL_HASH_STR(array[n].nspace, nm->name.jobid);
+	    }
+	    /* if we don't already have it, add this to our jobid tracker */
+	    job = NULL;
+	    OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+		if (jptr->jobid == nm->name.jobid) {
+		    job = jptr;
+		    break;
+		}
+	    }
+	    if (NULL == job) {
+		job = OBJ_NEW(opal_pmix2x_jobid_trkr_t);
+		(void)strncpy(job->nspace, nspace, PMIX_MAX_NSLEN);
+		job->jobid = jobid;
+		opal_list_append(&mca_pmix_pmix2x_component.jobids, &job->super);
+	    }
+	    nm->name.vpid = array[n].rank;
+	}
     }
     PMIX_PROC_FREE(array, nprocs);
 
@@ -1282,19 +1283,19 @@ int pmix2x_resolve_nodes(opal_jobid_t jobid, char **nodelist)
      * and we are going to access framework-global lists/objects */
 
     if (OPAL_JOBID_WILDCARD != jobid) {
-        /* look thru our list of jobids and find the
-         * corresponding nspace */
-        job = NULL;
-        OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-            if (jptr->jobid == jobid) {
-                job = jptr;
-                break;
-            }
-        }
-        if (NULL == job) {
-            return OPAL_ERR_NOT_FOUND;
-        }
-        nspace = job->nspace;
+	/* look thru our list of jobids and find the
+	 * corresponding nspace */
+	job = NULL;
+	OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+	    if (jptr->jobid == jobid) {
+		job = jptr;
+		break;
+	    }
+	}
+	if (NULL == job) {
+	    return OPAL_ERR_NOT_FOUND;
+	}
+	nspace = job->nspace;
     }
 
     ret = PMIx_Resolve_nodes(nspace, nodelist);

--- a/opal/mca/pmix/pmix2x/pmix2x_component.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_component.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,30 +49,30 @@ mca_pmix_pmix2x_component_t mca_pmix_pmix2x_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
 
-        .base_version = {
-        /* Indicate that we are a pmix v1.1.0 component (which also
-           implies a specific MCA version) */
+	.base_version = {
+	/* Indicate that we are a pmix v1.1.0 component (which also
+	   implies a specific MCA version) */
 
-            OPAL_PMIX_BASE_VERSION_2_0_0,
+	    OPAL_PMIX_BASE_VERSION_2_0_0,
 
-        /* Component name and version */
+	/* Component name and version */
 
-            .mca_component_name = "pmix2x",
-            MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                                  OPAL_RELEASE_VERSION),
+	    .mca_component_name = "pmix2x",
+	    MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+				  OPAL_RELEASE_VERSION),
 
-        /* Component open and close functions */
+	/* Component open and close functions */
 
-            .mca_open_component = external_open,
-            .mca_close_component = external_close,
-            .mca_query_component = external_component_query,
-            .mca_register_component_params = external_register,
-        },
-        /* Next the MCA v1.0.0 component meta data */
-        .base_data = {
-        /* The component is checkpoint ready */
-            MCA_BASE_METADATA_PARAM_CHECKPOINT
-        }
+	    .mca_open_component = external_open,
+	    .mca_close_component = external_close,
+	    .mca_query_component = external_component_query,
+	    .mca_register_component_params = external_register,
+	},
+	/* Next the MCA v1.0.0 component meta data */
+	.base_data = {
+	/* The component is checkpoint ready */
+	    MCA_BASE_METADATA_PARAM_CHECKPOINT
+	}
     },
     .native_launch = false
 };
@@ -80,10 +81,10 @@ static int external_register(void)
 {
     mca_pmix_pmix2x_component.cache_size = 256;
     mca_base_component_var_register(&mca_pmix_pmix2x_component.super.base_version,
-                                    "cache_size", "Size of the ring buffer cache for events",
-                                    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_5,
-                                    MCA_BASE_VAR_SCOPE_CONSTANT,
-                                    &mca_pmix_pmix2x_component.cache_size);
+				    "cache_size", "Size of the ring buffer cache for events",
+				    MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_5,
+				    MCA_BASE_VAR_SCOPE_CONSTANT,
+				    &mca_pmix_pmix2x_component.cache_size);
 
     return OPAL_SUCCESS;
 }
@@ -118,12 +119,12 @@ static int external_component_query(mca_base_module_t **module, int *priority)
 
     /* see if a PMIx server is present */
     if (NULL != (t = getenv("PMIX_SERVER_URI")) ||
-        NULL != (id = getenv("PMIX_ID"))) {
-        /* if PMIx is present, then we are a client and need to use it */
-        *priority = 100;
+	NULL != (id = getenv("PMIX_ID"))) {
+	/* if PMIx is present, then we are a client and need to use it */
+	*priority = 100;
     } else {
-        /* we could be a server, so we still need to be considered */
-        *priority = 5;
+	/* we could be a server, so we still need to be considered */
+	*priority = 5;
     }
     *module = (mca_base_module_t *)&opal_pmix_pmix2x_module;
     return OPAL_SUCCESS;

--- a/opal/mca/pmix/pmix2x/pmix2x_server_north.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_north.c
@@ -5,6 +5,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,57 +46,57 @@
  * to call up into ORTE for service requests */
 
  static pmix_status_t server_client_connected_fn(const pmix_proc_t *proc, void* server_object,
-                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+						 pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_client_finalized_fn(const pmix_proc_t *proc, void* server_object,
-                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+						 pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_abort_fn(const pmix_proc_t *proc, void *server_object,
-                                      int status, const char msg[],
-                                      pmix_proc_t procs[], size_t nprocs,
-                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
+				      int status, const char msg[],
+				      pmix_proc_t procs[], size_t nprocs,
+				      pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
-                                        const pmix_info_t info[], size_t ninfo,
-                                        char *data, size_t ndata,
-                                        pmix_modex_cbfunc_t cbfunc, void *cbdata);
+					const pmix_info_t info[], size_t ninfo,
+					char *data, size_t ndata,
+					pmix_modex_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *proc,
-                                           const pmix_info_t info[], size_t ninfo,
-                                           pmix_modex_cbfunc_t cbfunc, void *cbdata);
+					   const pmix_info_t info[], size_t ninfo,
+					   pmix_modex_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_publish_fn(const pmix_proc_t *proc,
-                                        const pmix_info_t info[], size_t ninfo,
-                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+					const pmix_info_t info[], size_t ninfo,
+					pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_lookup_fn(const pmix_proc_t *proc,  char **keys,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_lookup_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_unpublish_fn(const pmix_proc_t *proc, char **keys,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_spawn_fn(const pmix_proc_t *proc,
-                                      const pmix_info_t job_info[], size_t ninfo,
-                                      const pmix_app_t apps[], size_t napps,
-                                      pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+				      const pmix_info_t job_info[], size_t ninfo,
+				      const pmix_app_t apps[], size_t napps,
+				      pmix_spawn_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                        const pmix_info_t info[], size_t ninfo,
-                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+					const pmix_info_t info[], size_t ninfo,
+					pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                           const pmix_info_t info[], size_t ninfo,
-                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
+					   const pmix_info_t info[], size_t ninfo,
+					   pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_register_events(pmix_status_t *codes, size_t ncodes,
-                                             const pmix_info_t info[], size_t ninfo,
-                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+					     const pmix_info_t info[], size_t ninfo,
+					     pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_deregister_events(pmix_status_t *codes, size_t ncodes,
-                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+					       pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_notify_event(pmix_status_t code,
-                                          const pmix_proc_t *source,
-                                          pmix_data_range_t range,
-                                          pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+					  const pmix_proc_t *source,
+					  pmix_data_range_t range,
+					  pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata);
  static pmix_status_t server_query(pmix_proc_t *proct,
-                                   pmix_info_t *info, size_t ninfo,
-                                   pmix_info_t *directives, size_t ndirs,
-                                   pmix_info_cbfunc_t cbfunc,
-                                   void *cbdata);
+				   pmix_info_t *info, size_t ninfo,
+				   pmix_info_t *directives, size_t ndirs,
+				   pmix_info_cbfunc_t cbfunc,
+				   void *cbdata);
  static void server_tool_connection(pmix_info_t *info, size_t ninfo,
-                                    pmix_tool_connection_cbfunc_t cbfunc,
-                                    void *cbdata);
+				    pmix_tool_connection_cbfunc_t cbfunc,
+				    void *cbdata);
 
   pmix_server_module_t mymodule = {
     .client_connected = server_client_connected_fn,
@@ -124,20 +125,20 @@ static void opal_opcbfunc(int status, void *cbdata)
     pmix2x_opalcaddy_t *opalcaddy = (pmix2x_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->opcbfunc) {
-        opalcaddy->opcbfunc(pmix2x_convert_opalrc(status), opalcaddy->cbdata);
+	opalcaddy->opcbfunc(pmix2x_convert_opalrc(status), opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_client_connected_fn(const pmix_proc_t *p, void *server_object,
-                                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+						pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     opal_process_name_t proc;
     pmix2x_opalcaddy_t *opalcaddy;
 
     if (NULL == host_module || NULL == host_module->client_connected) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     opalcaddy = OBJ_NEW(pmix2x_opalcaddy_t);
@@ -146,30 +147,30 @@ static pmix_status_t server_client_connected_fn(const pmix_proc_t *p, void *serv
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
     /* pass it up */
     rc = host_module->client_connected(&proc, server_object,
-                                       opal_opcbfunc, opalcaddy);
+				       opal_opcbfunc, opalcaddy);
     return pmix2x_convert_opalrc(rc);
 }
 
 static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* server_object,
-                                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+						pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix2x_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
 
     if (NULL == host_module || NULL == host_module->client_finalized) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
@@ -181,15 +182,15 @@ static pmix_status_t server_client_finalized_fn(const pmix_proc_t *p, void* serv
     /* pass it up */
     rc = host_module->client_finalized(&proc, server_object, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix2x_convert_opalrc(rc);
 }
 
 static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
-                                     int status, const char msg[],
-                                     pmix_proc_t procs[], size_t nprocs,
-                                     pmix_op_cbfunc_t cbfunc, void *cbdata)
+				     int status, const char msg[],
+				     pmix_proc_t procs[], size_t nprocs,
+				     pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     size_t n;
     opal_namelist_t *nm;
@@ -198,12 +199,12 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
     pmix2x_opalcaddy_t *opalcaddy;
 
     if (NULL == host_module || NULL == host_module->abort) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     proc.vpid = p->rank;
 
@@ -214,24 +215,24 @@ static pmix_status_t server_abort_fn(const pmix_proc_t *p, void *server_object,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* pass it up */
     rc = host_module->abort(&proc, server_object, status, msg,
-                            &opalcaddy->procs, opal_opcbfunc, opalcaddy);
+			    &opalcaddy->procs, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix2x_convert_opalrc(rc);
 }
@@ -241,32 +242,32 @@ static void _data_release(void *cbdata)
     pmix2x_opalcaddy_t *opalcaddy = (pmix2x_opalcaddy_t*)cbdata;
 
     if (NULL != opalcaddy->odmdxfunc) {
-        opalcaddy->odmdxfunc(opalcaddy->ocbdata);
+	opalcaddy->odmdxfunc(opalcaddy->ocbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static void opmdx_response(int status, const char *data, size_t sz, void *cbdata,
-                           opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
+			   opal_pmix_release_cbfunc_t relcbfunc, void *relcbdata)
 {
     pmix_status_t rc;
     pmix2x_opalcaddy_t *opalcaddy = (pmix2x_opalcaddy_t*)cbdata;
 
     rc = pmix2x_convert_rc(status);
     if (NULL != opalcaddy->mdxcbfunc) {
-        opalcaddy->odmdxfunc = relcbfunc;
-        opalcaddy->ocbdata = relcbdata;
-        opalcaddy->mdxcbfunc(rc, data, sz, opalcaddy->cbdata,
-                             _data_release, opalcaddy);
+	opalcaddy->odmdxfunc = relcbfunc;
+	opalcaddy->ocbdata = relcbdata;
+	opalcaddy->mdxcbfunc(rc, data, sz, opalcaddy->cbdata,
+			     _data_release, opalcaddy);
     } else {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 }
 
 static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       char *data, size_t ndata,
-                                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       char *data, size_t ndata,
+				       pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy;
     size_t n;
@@ -275,7 +276,7 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
     int rc;
 
     if (NULL == host_module || NULL == host_module->fence_nb) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -285,42 +286,42 @@ static pmix_status_t server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->fence_nb(&opalcaddy->procs, &opalcaddy->info,
-                               data, ndata, opmdx_response, opalcaddy);
+			       data, ndata, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     return pmix2x_convert_opalrc(rc);
 }
 
 static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_modex_cbfunc_t cbfunc, void *cbdata)
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix2x_opalcaddy_t *opalcaddy;
@@ -329,17 +330,17 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->direct_modex) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -349,29 +350,29 @@ static pmix_status_t server_dmodex_req_fn(const pmix_proc_t *p,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->direct_modex(&proc, &opalcaddy->info, opmdx_response, opalcaddy);
     if (OPAL_SUCCESS != rc && OPAL_ERR_IN_PROCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
     if (OPAL_ERR_IN_PROCESS == rc) {
-        rc = OPAL_SUCCESS;
+	rc = OPAL_SUCCESS;
     }
     return pmix2x_convert_opalrc(rc);
 }
 
 static pmix_status_t server_publish_fn(const pmix_proc_t *p,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     size_t n;
@@ -380,17 +381,17 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->publish) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
    /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -400,27 +401,27 @@ static pmix_status_t server_publish_fn(const pmix_proc_t *p,
 
     /* convert the info array */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->publish(&proc, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
 }
 
 static void opal_lkupcbfunc(int status,
-                            opal_list_t *data,
-                            void *cbdata)
+			    opal_list_t *data,
+			    void *cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy = (pmix2x_opalcaddy_t*)cbdata;
     pmix_status_t rc;
@@ -429,28 +430,28 @@ static void opal_lkupcbfunc(int status,
     opal_pmix_pdata_t *p;
 
     if (NULL != opalcaddy->lkupcbfunc) {
-        rc = pmix2x_convert_opalrc(status);
-        /* convert any returned data */
-        if (NULL != data) {
-            nd = opal_list_get_size(data);
-            PMIX_PDATA_CREATE(d, nd);
-            n=0;
-            OPAL_LIST_FOREACH(p, data, opal_pmix_pdata_t) {
-                /* convert the jobid */
-                (void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
-                d[n].proc.rank = p->proc.vpid;
-                (void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&d[n].value, &p->value);
-            }
-        }
-        opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
+	rc = pmix2x_convert_opalrc(status);
+	/* convert any returned data */
+	if (NULL != data) {
+	    nd = opal_list_get_size(data);
+	    PMIX_PDATA_CREATE(d, nd);
+	    n=0;
+	    OPAL_LIST_FOREACH(p, data, opal_pmix_pdata_t) {
+		/* convert the jobid */
+		(void)opal_snprintf_jobid(d[n].proc.nspace, PMIX_MAX_NSLEN, p->proc.jobid);
+		d[n].proc.rank = p->proc.vpid;
+		(void)strncpy(d[n].key, p->value.key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&d[n].value, &p->value);
+	    }
+	}
+	opalcaddy->lkupcbfunc(rc, d, nd, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
-                                      const pmix_info_t info[], size_t ninfo,
-                                      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+				      const pmix_info_t info[], size_t ninfo,
+				      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix2x_opalcaddy_t *opalcaddy;
@@ -459,17 +460,17 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->lookup) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -479,19 +480,19 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->lookup(&proc, keys, &opalcaddy->info, opal_lkupcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
@@ -499,8 +500,8 @@ static pmix_status_t server_lookup_fn(const pmix_proc_t *p, char **keys,
 
 
 static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
-                                         const pmix_info_t info[], size_t ninfo,
-                                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+					 const pmix_info_t info[], size_t ninfo,
+					 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix2x_opalcaddy_t *opalcaddy;
@@ -509,17 +510,17 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
     size_t n;
 
     if (NULL == host_module || NULL == host_module->unpublish) {
-        return PMIX_SUCCESS;
+	return PMIX_SUCCESS;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -529,19 +530,19 @@ static pmix_status_t server_unpublish_fn(const pmix_proc_t *p, char **keys,
 
     /* convert the array of pmix_info_t to the list of info */
     for (n=0; n < ninfo; n++) {
-        iptr = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &iptr->super);
-        iptr->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	iptr = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &iptr->super);
+	iptr->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(iptr, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->unpublish(&proc, keys, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
@@ -554,18 +555,18 @@ static void opal_spncbfunc(int status, opal_jobid_t jobid, void *cbdata)
     char nspace[PMIX_MAX_NSLEN];
 
     if (NULL != opalcaddy->spwncbfunc) {
-        rc = pmix2x_convert_opalrc(status);
-        /* convert the jobid */
-        (void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
-        opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
+	rc = pmix2x_convert_opalrc(status);
+	/* convert the jobid */
+	(void)opal_snprintf_jobid(nspace, PMIX_MAX_NSLEN, jobid);
+	opalcaddy->spwncbfunc(rc, nspace, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
-                                     const pmix_info_t job_info[], size_t ninfo,
-                                     const pmix_app_t apps[], size_t napps,
-                                     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+				     const pmix_info_t job_info[], size_t ninfo,
+				     const pmix_app_t apps[], size_t napps,
+				     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy;
     opal_process_name_t proc;
@@ -575,17 +576,17 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
     int rc;
 
     if (NULL == host_module || NULL == host_module->spawn) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* convert the nspace/rank to an opal_process_name_t */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&proc.jobid, p->nspace))) {
-        return pmix2x_convert_opalrc(rc);
+	return pmix2x_convert_opalrc(rc);
     }
     if (PMIX_RANK_WILDCARD == p->rank) {
-        proc.vpid = OPAL_VPID_WILDCARD;
+	proc.vpid = OPAL_VPID_WILDCARD;
     } else {
-        proc.vpid = p->rank;
+	proc.vpid = p->rank;
     }
 
     /* setup the caddy */
@@ -595,46 +596,46 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
 
     /* convert the job info */
     for (k=0; k < ninfo; k++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(job_info[k].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &job_info[k].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(job_info[k].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &job_info[k].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* convert the apps */
     for (n=0; n < napps; n++) {
-        app = OBJ_NEW(opal_pmix_app_t);
-        opal_list_append(&opalcaddy->apps, &app->super);
-        if (NULL != apps[n].cmd) {
-            app->cmd = strdup(apps[n].cmd);
-        }
-        app->argc = apps[n].argc;
-        if (NULL != apps[n].argv) {
-            app->argv = opal_argv_copy(apps[n].argv);
-        }
-        if (NULL != apps[n].env) {
-            app->env = opal_argv_copy(apps[n].env);
-        }
-        app->maxprocs = apps[n].maxprocs;
-        for (k=0; k < apps[n].ninfo; k++) {
-            oinfo = OBJ_NEW(opal_value_t);
-            opal_list_append(&app->info, &oinfo->super);
-            oinfo->key = strdup(apps[n].info[k].key);
-            if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &apps[n].info[k].value))) {
-                OBJ_RELEASE(opalcaddy);
-                return pmix2x_convert_opalrc(rc);
-            }
-        }
+	app = OBJ_NEW(opal_pmix_app_t);
+	opal_list_append(&opalcaddy->apps, &app->super);
+	if (NULL != apps[n].cmd) {
+	    app->cmd = strdup(apps[n].cmd);
+	}
+	app->argc = apps[n].argc;
+	if (NULL != apps[n].argv) {
+	    app->argv = opal_argv_copy(apps[n].argv);
+	}
+	if (NULL != apps[n].env) {
+	    app->env = opal_argv_copy(apps[n].env);
+	}
+	app->maxprocs = apps[n].maxprocs;
+	for (k=0; k < apps[n].ninfo; k++) {
+	    oinfo = OBJ_NEW(opal_value_t);
+	    opal_list_append(&app->info, &oinfo->super);
+	    oinfo->key = strdup(apps[n].info[k].key);
+	    if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &apps[n].info[k].value))) {
+		OBJ_RELEASE(opalcaddy);
+		return pmix2x_convert_opalrc(rc);
+	    }
+	}
     }
 
     /* pass it up */
     rc = host_module->spawn(&proc, &opalcaddy->info, &opalcaddy->apps, opal_spncbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_RELEASE(opalcaddy);
+	OPAL_ERROR_LOG(rc);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
@@ -642,8 +643,8 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
 
 
 static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+				       const pmix_info_t info[], size_t ninfo,
+				       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix2x_opalcaddy_t *opalcaddy;
@@ -652,7 +653,7 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->connect) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -662,34 +663,34 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->connect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
@@ -697,8 +698,8 @@ static pmix_status_t server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
 
 
 static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
-                                          const pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
+					  const pmix_info_t info[], size_t ninfo,
+					  pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     pmix2x_opalcaddy_t *opalcaddy;
@@ -707,7 +708,7 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->disconnect) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -717,42 +718,42 @@ static pmix_status_t server_disconnect_fn(const pmix_proc_t procs[], size_t npro
 
     /* convert the array of pmix_proc_t to the list of procs */
     for (n=0; n < nprocs; n++) {
-        nm = OBJ_NEW(opal_namelist_t);
-        opal_list_append(&opalcaddy->procs, &nm->super);
-        if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
-        if (PMIX_RANK_WILDCARD == procs[n].rank) {
-            nm->name.vpid = OPAL_VPID_WILDCARD;
-        } else {
-            nm->name.vpid = procs[n].rank;
-        }
+	nm = OBJ_NEW(opal_namelist_t);
+	opal_list_append(&opalcaddy->procs, &nm->super);
+	if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&nm->name.jobid, procs[n].nspace))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
+	if (PMIX_RANK_WILDCARD == procs[n].rank) {
+	    nm->name.vpid = OPAL_VPID_WILDCARD;
+	} else {
+	    nm->name.vpid = procs[n].rank;
+	}
     }
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->disconnect(&opalcaddy->procs, &opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
 }
 
 static pmix_status_t server_register_events(pmix_status_t *codes, size_t ncodes,
-                                            const pmix_info_t info[], size_t ninfo,
-                                            pmix_op_cbfunc_t cbfunc, void *cbdata)
+					    const pmix_info_t info[], size_t ninfo,
+					    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy;
     size_t n;
@@ -766,35 +767,35 @@ static pmix_status_t server_register_events(pmix_status_t *codes, size_t ncodes,
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* pass it up */
     rc = host_module->register_events(&opalcaddy->info, opal_opcbfunc, opalcaddy);
     if (OPAL_SUCCESS != rc) {
-        OBJ_RELEASE(opalcaddy);
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
 }
 
 static pmix_status_t server_deregister_events(pmix_status_t *codes, size_t ncodes,
-                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+					      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 static pmix_status_t server_notify_event(pmix_status_t code,
-                                         const pmix_proc_t *source,
-                                         pmix_data_range_t range,
-                                         pmix_info_t info[], size_t ninfo,
-                                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+					 const pmix_proc_t *source,
+					 pmix_data_range_t range,
+					 pmix_info_t info[], size_t ninfo,
+					 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
@@ -806,10 +807,10 @@ static void _info_rel(void *cbdata)
     OBJ_RELEASE(pcaddy);
 }
 static void info_cbfunc(int status,
-                        opal_list_t *info,
-                        void *cbdata,
-                        opal_pmix_release_cbfunc_t release_fn,
-                        void *release_cbdata)
+			opal_list_t *info,
+			void *cbdata,
+			opal_pmix_release_cbfunc_t release_fn,
+			void *release_cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy = (pmix2x_opalcaddy_t*)cbdata;
     pmix2x_opcaddy_t *pcaddy;
@@ -823,34 +824,34 @@ static void info_cbfunc(int status,
 
     /* convert the list to a pmix_info_t array */
     if (NULL != info) {
-        pcaddy->ninfo = opal_list_get_size(info);
-        if (0 < pcaddy->ninfo) {
-            PMIX_INFO_CREATE(pcaddy->info, pcaddy->ninfo);
-            n = 0;
-            OPAL_LIST_FOREACH(kv, info, opal_value_t) {
-                (void)strncpy(pcaddy->info[n].key, kv->key, PMIX_MAX_KEYLEN);
-                pmix2x_value_load(&pcaddy->info[n].value, kv);
-            }
-        }
+	pcaddy->ninfo = opal_list_get_size(info);
+	if (0 < pcaddy->ninfo) {
+	    PMIX_INFO_CREATE(pcaddy->info, pcaddy->ninfo);
+	    n = 0;
+	    OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+		(void)strncpy(pcaddy->info[n].key, kv->key, PMIX_MAX_KEYLEN);
+		pmix2x_value_load(&pcaddy->info[n].value, kv);
+	    }
+	}
     }
     /* we are done with the incoming data */
     if (NULL != release_fn) {
-        release_fn(release_cbdata);
+	release_fn(release_cbdata);
     }
 
     /* provide the answer downward */
     if (NULL != opalcaddy->infocbfunc) {
-        opalcaddy->infocbfunc(pcaddy->status, pcaddy->info, pcaddy->ninfo,
-                              opalcaddy->cbdata, _info_rel, pcaddy);
+	opalcaddy->infocbfunc(pcaddy->status, pcaddy->info, pcaddy->ninfo,
+			      opalcaddy->cbdata, _info_rel, pcaddy);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static pmix_status_t server_query(pmix_proc_t *proct,
-                                  pmix_info_t *info, size_t ninfo,
-                                  pmix_info_t *directives, size_t ndirs,
-                                  pmix_info_cbfunc_t cbfunc,
-                                  void *cbdata)
+				  pmix_info_t *info, size_t ninfo,
+				  pmix_info_t *directives, size_t ndirs,
+				  pmix_info_cbfunc_t cbfunc,
+				  void *cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy;
     opal_process_name_t requestor;
@@ -859,7 +860,7 @@ static pmix_status_t server_query(pmix_proc_t *proct,
     opal_value_t *oinfo;
 
     if (NULL == host_module || NULL == host_module->query) {
-        return PMIX_ERR_NOT_SUPPORTED;
+	return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* setup the caddy */
@@ -869,38 +870,38 @@ static pmix_status_t server_query(pmix_proc_t *proct,
 
     /* convert the requestor */
     if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&requestor.jobid, proct->nspace))) {
-        opal_output(0, "FILE: %s LINE %d", __FILE__, __LINE__);
-        OBJ_RELEASE(opalcaddy);
-        return pmix2x_convert_opalrc(rc);
+	opal_output(0, "FILE: %s LINE %d", __FILE__, __LINE__);
+	OBJ_RELEASE(opalcaddy);
+	return pmix2x_convert_opalrc(rc);
     }
     requestor.vpid = proct->rank;
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
-           OBJ_RELEASE(opalcaddy);
-            return pmix2x_convert_opalrc(rc);
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
+	   OBJ_RELEASE(opalcaddy);
+	    return pmix2x_convert_opalrc(rc);
+	}
     }
 
     /* we ignore directives for now */
 
     /* pass the call upwards */
     if (OPAL_SUCCESS != (rc = host_module->query(&requestor,
-                                                 &opalcaddy->info, NULL,
-                                                 info_cbfunc, opalcaddy))) {
-        OBJ_RELEASE(opalcaddy);
+						 &opalcaddy->info, NULL,
+						 info_cbfunc, opalcaddy))) {
+	OBJ_RELEASE(opalcaddy);
     }
 
     return pmix2x_convert_opalrc(rc);
 }
 
 static void toolcbfunc(int status,
-                       opal_process_name_t proc,
-                       void *cbdata)
+		       opal_process_name_t proc,
+		       void *cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy = (pmix2x_opalcaddy_t*)cbdata;
     pmix_status_t rc;
@@ -915,14 +916,14 @@ static void toolcbfunc(int status,
 
     /* pass it down */
     if (NULL != opalcaddy->toolcbfunc) {
-        opalcaddy->toolcbfunc(rc, &p, opalcaddy->cbdata);
+	opalcaddy->toolcbfunc(rc, &p, opalcaddy->cbdata);
     }
     OBJ_RELEASE(opalcaddy);
 }
 
 static void server_tool_connection(pmix_info_t *info, size_t ninfo,
-                                   pmix_tool_connection_cbfunc_t cbfunc,
-                                   void *cbdata)
+				   pmix_tool_connection_cbfunc_t cbfunc,
+				   void *cbdata)
 {
     pmix2x_opalcaddy_t *opalcaddy;
     size_t n;
@@ -937,16 +938,16 @@ static void server_tool_connection(pmix_info_t *info, size_t ninfo,
 
     /* convert the info */
     for (n=0; n < ninfo; n++) {
-        oinfo = OBJ_NEW(opal_value_t);
-        opal_list_append(&opalcaddy->info, &oinfo->super);
-        oinfo->key = strdup(info[n].key);
-        if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
-            OBJ_RELEASE(opalcaddy);
-            err = pmix2x_convert_opalrc(rc);
-            if (NULL != cbfunc) {
-                cbfunc(err, NULL, cbdata);
-            }
-        }
+	oinfo = OBJ_NEW(opal_value_t);
+	opal_list_append(&opalcaddy->info, &oinfo->super);
+	oinfo->key = strdup(info[n].key);
+	if (OPAL_SUCCESS != (rc = pmix2x_value_unload(oinfo, &info[n].value))) {
+	    OBJ_RELEASE(opalcaddy);
+	    err = pmix2x_convert_opalrc(rc);
+	    if (NULL != cbfunc) {
+		cbfunc(err, NULL, cbdata);
+	    }
+	}
     }
 
     /* pass it up */

--- a/opal/mca/pmix/pmix2x/pmix2x_server_south.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_south.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,26 +53,26 @@ static size_t errhdler_ref = 0;
 
 #define PMIX_WAIT_FOR_COMPLETION(a)             \
     do {                                        \
-        while ((a)) {                           \
-            usleep(10);                         \
-        }                                       \
+	while ((a)) {                           \
+	    usleep(10);                         \
+	}                                       \
     } while (0)
 
 static void errreg_cbfunc (pmix_status_t status,
-                          size_t errhandler_ref,
-                          void *cbdata)
+			  size_t errhandler_ref,
+			  void *cbdata)
 {
     volatile bool *active = (volatile bool*)cbdata;
 
     errhdler_ref = errhandler_ref;
     opal_output_verbose(5, opal_pmix_base_framework.framework_output,
-                        "PMIX server errreg_cbfunc - error handler registered status=%d, reference=%lu",
-                         status, (unsigned long)errhandler_ref);
+			"PMIX server errreg_cbfunc - error handler registered status=%d, reference=%lu",
+			 status, (unsigned long)errhandler_ref);
     *active = false;
 }
 
 int pmix2x_server_init(opal_pmix_server_module_t *module,
-                      opal_list_t *info)
+		      opal_list_t *info)
 {
     pmix_status_t rc;
     int dbg;
@@ -81,28 +82,28 @@ int pmix2x_server_init(opal_pmix_server_module_t *module,
     volatile bool active;
 
     if (0 < (dbg = opal_output_get_verbosity(opal_pmix_base_framework.framework_output))) {
-        asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
-        putenv(dbgvalue);
+	asprintf(&dbgvalue, "PMIX_DEBUG=%d", dbg);
+	putenv(dbgvalue);
     }
 
     /* convert the list to an array of pmix_info_t */
     if (NULL != info) {
-        sz = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, sz);
-        n = 0;
-        OPAL_LIST_FOREACH(kv, info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&pinfo[n].value, kv);
-            ++n;
-        }
+	sz = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, sz);
+	n = 0;
+	OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&pinfo[n].value, kv);
+	    ++n;
+	}
     } else {
-        sz = 0;
-        pinfo = NULL;
+	sz = 0;
+	pinfo = NULL;
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, pinfo, sz))) {
-        PMIX_INFO_FREE(pinfo, sz);
-        return pmix2x_convert_rc(rc);
+	PMIX_INFO_FREE(pinfo, sz);
+	return pmix2x_convert_rc(rc);
     }
     PMIX_INFO_FREE(pinfo, sz);
 
@@ -159,13 +160,13 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     pmix2x_opcaddy_t *op = (pmix2x_opcaddy_t*)cbdata;
 
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(pmix2x_convert_rc(status), op->cbdata);
+	op->opcbfunc(pmix2x_convert_rc(status), op->cbdata);
     }
     if (op->active) {
-        op->status = status;
-        op->active = false;
+	op->status = status;
+	op->active = false;
     } else {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
 }
 
@@ -195,61 +196,61 @@ static void _reg_nspace(int sd, short args, void *cbdata)
 
     /* convert the list to an array of pmix_info_t */
     if (NULL != cd->info) {
-        sz = opal_list_get_size(cd->info);
-        PMIX_INFO_CREATE(pinfo, sz);
-        n = 0;
-        OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            if (0 == strcmp(kv->key, OPAL_PMIX_PROC_DATA)) {
-                pinfo[n].value.type = PMIX_INFO_ARRAY;
-                /* the value contains a list of values - convert
-                 * that list to another array */
-                pmapinfo = (opal_list_t*)kv->data.ptr;
-                szmap = opal_list_get_size(pmapinfo);
-                PMIX_INFO_CREATE(pmap, szmap);
-                pinfo[n].value.data.array.array = (struct pmix_info_t*)pmap;
-                pinfo[n].value.data.array.size = szmap;
-                m = 0;
-                OPAL_LIST_FOREACH(k2, pmapinfo, opal_value_t) {
-                    (void)strncpy(pmap[m].key, k2->key, PMIX_MAX_KEYLEN);
-                    pmix2x_value_load(&pmap[m].value, k2);
-                    ++m;
-                }
-            } else {
-                pmix2x_value_load(&pinfo[n].value, kv);
-            }
-            ++n;
-        }
+	sz = opal_list_get_size(cd->info);
+	PMIX_INFO_CREATE(pinfo, sz);
+	n = 0;
+	OPAL_LIST_FOREACH(kv, cd->info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+	    if (0 == strcmp(kv->key, OPAL_PMIX_PROC_DATA)) {
+		pinfo[n].value.type = PMIX_INFO_ARRAY;
+		/* the value contains a list of values - convert
+		 * that list to another array */
+		pmapinfo = (opal_list_t*)kv->data.ptr;
+		szmap = opal_list_get_size(pmapinfo);
+		PMIX_INFO_CREATE(pmap, szmap);
+		pinfo[n].value.data.array.array = (struct pmix_info_t*)pmap;
+		pinfo[n].value.data.array.size = szmap;
+		m = 0;
+		OPAL_LIST_FOREACH(k2, pmapinfo, opal_value_t) {
+		    (void)strncpy(pmap[m].key, k2->key, PMIX_MAX_KEYLEN);
+		    pmix2x_value_load(&pmap[m].value, k2);
+		    ++m;
+		}
+	    } else {
+		pmix2x_value_load(&pinfo[n].value, kv);
+	    }
+	    ++n;
+	}
     } else {
-        sz = 0;
-        pinfo = NULL;
+	sz = 0;
+	pinfo = NULL;
     }
 
     OBJ_CONSTRUCT(&op, pmix2x_opcaddy_t);
     op.active = true;
     rc = PMIx_server_register_nspace(nspace, cd->status, pinfo, sz,
-                                     opcbfunc, (void*)&op);
+				     opcbfunc, (void*)&op);
     if (PMIX_SUCCESS == rc) {
-        PMIX_WAIT_FOR_COMPLETION(op.active);
+	PMIX_WAIT_FOR_COMPLETION(op.active);
     } else {
-        op.status = rc;
+	op.status = rc;
     }
     /* ensure we execute the cbfunc so the caller doesn't hang */
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(pmix2x_convert_rc(op.status), cd->cbdata);
+	cd->opcbfunc(pmix2x_convert_rc(op.status), cd->cbdata);
     }
     if (NULL != pinfo) {
-        PMIX_INFO_FREE(pinfo, sz);
+	PMIX_INFO_FREE(pinfo, sz);
     }
     OBJ_DESTRUCT(&op);
     OBJ_RELEASE(cd);
 }
 
 int pmix2x_server_register_nspace(opal_jobid_t jobid,
-                                 int nlocalprocs,
-                                 opal_list_t *info,
-                                 opal_pmix_op_cbfunc_t cbfunc,
-                                 void *cbdata)
+				 int nlocalprocs,
+				 opal_list_t *info,
+				 opal_pmix_op_cbfunc_t cbfunc,
+				 void *cbdata)
 {
     pmix2x_threadshift_t *cd;
 
@@ -264,11 +265,11 @@ int pmix2x_server_register_nspace(opal_jobid_t jobid,
     /* if the cbfunc is NULL, then the caller is in an event
      * and we can directly call the processing function */
     if (NULL == cbfunc) {
-        _reg_nspace(0, 0, cd);
+	_reg_nspace(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
-                     -1, EV_WRITE, _reg_nspace, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+	event_assign(&cd->ev, opal_pmix_base.evbase,
+		     -1, EV_WRITE, _reg_nspace, cd);
+	event_active(&cd->ev, EV_WRITE, 1);
     }
 
     return OPAL_SUCCESS;
@@ -279,12 +280,12 @@ static void tdcbfunc(pmix_status_t status, void *cbdata)
     pmix2x_threadshift_t *cd = (pmix2x_threadshift_t*)cbdata;
 
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(pmix2x_convert_rc(status), cd->cbdata);
+	cd->opcbfunc(pmix2x_convert_rc(status), cd->cbdata);
     }
     if (cd->active) {
-        cd->active = false;
+	cd->active = false;
     } else {
-        OBJ_RELEASE(cd);
+	OBJ_RELEASE(cd);
     }
 }
 
@@ -295,25 +296,25 @@ static void _dereg_nspace(int sd, short args, void *cbdata)
 
     /* if we don't already have it, we can ignore this */
     OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-        if (jptr->jobid == cd->jobid) {
-            /* found it - tell the server to deregister */
-            cd->active = true;
-            PMIx_server_deregister_nspace(jptr->nspace, tdcbfunc, cd);
-            PMIX_WAIT_FOR_COMPLETION(cd->active);
-            OBJ_RELEASE(cd);
-            /* now get rid of it from our list */
-            opal_list_remove_item(&mca_pmix_pmix2x_component.jobids, &jptr->super);
-            OBJ_RELEASE(jptr);
-            return;
-        }
+	if (jptr->jobid == cd->jobid) {
+	    /* found it - tell the server to deregister */
+	    cd->active = true;
+	    PMIx_server_deregister_nspace(jptr->nspace, tdcbfunc, cd);
+	    PMIX_WAIT_FOR_COMPLETION(cd->active);
+	    OBJ_RELEASE(cd);
+	    /* now get rid of it from our list */
+	    opal_list_remove_item(&mca_pmix_pmix2x_component.jobids, &jptr->super);
+	    OBJ_RELEASE(jptr);
+	    return;
+	}
     }
     /* must release the caller */
     tdcbfunc(PMIX_ERR_NOT_FOUND, cd);
 }
 
 void pmix2x_server_deregister_nspace(opal_jobid_t jobid,
-                                     opal_pmix_op_cbfunc_t cbfunc,
-                                     void *cbdata)
+				     opal_pmix_op_cbfunc_t cbfunc,
+				     void *cbdata)
 {
     pmix2x_threadshift_t *cd;
 
@@ -324,19 +325,19 @@ void pmix2x_server_deregister_nspace(opal_jobid_t jobid,
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
     if (NULL == cbfunc) {
-        _dereg_nspace(0, 0, cd);
+	_dereg_nspace(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
-                     -1, EV_WRITE, _dereg_nspace, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+	event_assign(&cd->ev, opal_pmix_base.evbase,
+		     -1, EV_WRITE, _dereg_nspace, cd);
+	event_active(&cd->ev, EV_WRITE, 1);
     }
 }
 
 int pmix2x_server_register_client(const opal_process_name_t *proc,
-                                 uid_t uid, gid_t gid,
-                                 void *server_object,
-                                 opal_pmix_op_cbfunc_t cbfunc,
-                                 void *cbdata)
+				 uid_t uid, gid_t gid,
+				 void *server_object,
+				 opal_pmix_op_cbfunc_t cbfunc,
+				 void *cbdata)
 {
     pmix_status_t rc;
     pmix_proc_t p;
@@ -349,10 +350,10 @@ int pmix2x_server_register_client(const opal_process_name_t *proc,
     OBJ_CONSTRUCT(&op, pmix2x_opcaddy_t);
     op.active = true;
     rc = PMIx_server_register_client(&p, uid, gid, server_object,
-                                     opcbfunc, (void*)&op);
+				     opcbfunc, (void*)&op);
     if (PMIX_SUCCESS == rc) {
-        PMIX_WAIT_FOR_COMPLETION(op.active);
-        rc = op.status;
+	PMIX_WAIT_FOR_COMPLETION(op.active);
+	rc = op.status;
     }
     OBJ_DESTRUCT(&op);
     return pmix2x_convert_rc(rc);
@@ -366,15 +367,15 @@ static void _dereg_client(int sd, short args, void *cbdata)
 
     /* if we don't already have it, we can ignore this */
     OPAL_LIST_FOREACH(jptr, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
-        if (jptr->jobid == cd->source->jobid) {
-            /* found it - tell the server to deregister */
-            (void)strncpy(p.nspace, jptr->nspace, PMIX_MAX_NSLEN);
-            p.rank = cd->source->vpid;
-            cd->active = true;
-            PMIx_server_deregister_client(&p, tdcbfunc, (void*)cd);
-            PMIX_WAIT_FOR_COMPLETION(cd->active);
-            break;
-        }
+	if (jptr->jobid == cd->source->jobid) {
+	    /* found it - tell the server to deregister */
+	    (void)strncpy(p.nspace, jptr->nspace, PMIX_MAX_NSLEN);
+	    p.rank = cd->source->vpid;
+	    cd->active = true;
+	    PMIx_server_deregister_client(&p, tdcbfunc, (void*)cd);
+	    PMIX_WAIT_FOR_COMPLETION(cd->active);
+	    break;
+	}
     }
     OBJ_RELEASE(cd);
 }
@@ -382,8 +383,8 @@ static void _dereg_client(int sd, short args, void *cbdata)
 /* tell the local PMIx server to cleanup this client as it is
  * done executing */
 void pmix2x_server_deregister_client(const opal_process_name_t *proc,
-                                     opal_pmix_op_cbfunc_t cbfunc,
-                                     void *cbdata)
+				     opal_pmix_op_cbfunc_t cbfunc,
+				     void *cbdata)
 {
     pmix2x_threadshift_t *cd;
 
@@ -394,11 +395,11 @@ void pmix2x_server_deregister_client(const opal_process_name_t *proc,
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
     if (NULL == cbfunc) {
-        _dereg_client(0, 0, cd);
+	_dereg_client(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
-                     -1, EV_WRITE, _dereg_client, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+	event_assign(&cd->ev, opal_pmix_base.evbase,
+		     -1, EV_WRITE, _dereg_client, cd);
+	event_active(&cd->ev, EV_WRITE, 1);
     }
 }
 
@@ -426,14 +427,14 @@ static void dmdx_response(pmix_status_t status, char *data, size_t sz, void *cbd
 
     rc = pmix2x_convert_rc(status);
     if (NULL != op->mdxcbfunc) {
-        op->mdxcbfunc(rc, data, sz, op->cbdata, NULL, NULL);
+	op->mdxcbfunc(rc, data, sz, op->cbdata, NULL, NULL);
     }
     OBJ_RELEASE(op);
 }
 
 /* request modex data for a local proc from the PMIx server */
 int pmix2x_server_dmodex(const opal_process_name_t *proc,
-                        opal_pmix_modex_cbfunc_t cbfunc, void *cbdata)
+			opal_pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix2x_opcaddy_t *op;
     pmix_status_t rc;
@@ -450,16 +451,16 @@ int pmix2x_server_dmodex(const opal_process_name_t *proc,
     /* find the internally-cached data for this proc */
     rc = PMIx_server_dmodex_request(&op->p, dmdx_response, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
     return pmix2x_convert_rc(rc);
 }
 
 /* tell the PMIx server to notify its local clients of an event */
 int pmix2x_server_notify_event(int status,
-                               const opal_process_name_t *source,
-                               opal_list_t *info,
-                               opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+			       const opal_process_name_t *source,
+			       opal_list_t *info,
+			       opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     opal_value_t *kv;
     pmix_info_t *pinfo;
@@ -469,16 +470,16 @@ int pmix2x_server_notify_event(int status,
 
     /* convert the list to an array of pmix_info_t */
     if (NULL != info) {
-        sz = opal_list_get_size(info);
-        PMIX_INFO_CREATE(pinfo, sz);
-        n = 0;
-        OPAL_LIST_FOREACH(kv, info, opal_value_t) {
-            (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
-            pmix2x_value_load(&pinfo[n].value, kv);
-        }
+	sz = opal_list_get_size(info);
+	PMIX_INFO_CREATE(pinfo, sz);
+	n = 0;
+	OPAL_LIST_FOREACH(kv, info, opal_value_t) {
+	    (void)strncpy(pinfo[n].key, kv->key, PMIX_MAX_KEYLEN);
+	    pmix2x_value_load(&pinfo[n].value, kv);
+	}
     } else {
-        sz = 0;
-        pinfo = NULL;
+	sz = 0;
+	pinfo = NULL;
     }
     /* setup the caddy */
     op = OBJ_NEW(pmix2x_opcaddy_t);
@@ -488,11 +489,11 @@ int pmix2x_server_notify_event(int status,
     op->cbdata = cbdata;
     /* convert the jobid */
     if (NULL == source) {
-        (void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, OPAL_JOBID_INVALID);
-        op->p.rank = OPAL_VPID_INVALID;
+	(void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, OPAL_JOBID_INVALID);
+	op->p.rank = OPAL_VPID_INVALID;
     } else {
-        (void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, source->jobid);
-        op->p.rank = source->vpid;
+	(void)opal_snprintf_jobid(op->p.nspace, PMIX_MAX_NSLEN, source->jobid);
+	op->p.rank = source->vpid;
     }
 
 
@@ -500,9 +501,9 @@ int pmix2x_server_notify_event(int status,
     /* the range is irrelevant here as the server is passing
      * the event down to its local clients */
     rc = PMIx_Notify_event(rc, &op->p, PMIX_RANGE_LOCAL,
-                           pinfo, sz, opcbfunc, op);
+			   pinfo, sz, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {
-        OBJ_RELEASE(op);
+	OBJ_RELEASE(op);
     }
     return pmix2x_convert_rc(rc);
 }

--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,16 +35,16 @@ static int s1_init(void);
 static int s1_fini(void);
 static int s1_initialized(void);
 static int s1_abort(int flag, const char msg[],
-                    opal_list_t *procs);
+		    opal_list_t *procs);
 static int s1_commit(void);
 static int s1_fencenb(opal_list_t *procs, int collect_data,
-                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+		      opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static int s1_fence(opal_list_t *procs, int collect_data);
 static int s1_put(opal_pmix_scope_t scope,
-                  opal_value_t *kv);
+		  opal_value_t *kv);
 static int s1_get(const opal_process_name_t *id,
-                  const char *key, opal_list_t *info,
-                  opal_value_t **kv);
+		  const char *key, opal_list_t *info,
+		  opal_value_t **kv);
 static int s1_publish(opal_list_t *info);
 static int s1_lookup(opal_list_t *data, opal_list_t *info);
 static int s1_unpublish(char **keys, opal_list_t *info);
@@ -51,7 +52,7 @@ static int s1_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t *jobid
 static int s1_job_connect(opal_list_t *procs);
 static int s1_job_disconnect(opal_list_t *procs);
 static int s1_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val);
+			  opal_value_t *val);
 static const char *s1_get_nspace(opal_jobid_t jobid);
 static void s1_register_jobid(opal_jobid_t jobid, const char *nspace);
 
@@ -89,8 +90,8 @@ typedef struct {
     void *cbdata;
 } pmi_opcaddy_t;
 OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
-                   opal_object_t,
-                   NULL, NULL);
+		   opal_object_t,
+		   NULL, NULL);
 
 // PMI constant values:
 static int pmix_kvslen_max = 0;
@@ -113,9 +114,9 @@ static bool got_modex_data = false;
 static char* pmix_error(int pmix_err);
 #define OPAL_PMI_ERROR(pmi_err, pmi_func)                       \
     do {                                                        \
-        opal_output(0, "%s [%s:%d:%s]: %s\n",                   \
-                    pmi_func, __FILE__, __LINE__, __func__,     \
-                    pmix_error(pmi_err));                        \
+	opal_output(0, "%s [%s:%d:%s]: %s\n",                   \
+		    pmi_func, __FILE__, __LINE__, __func__,     \
+		    pmix_error(pmi_err));                        \
     } while(0);
 
 static int kvs_get(const char key[], char value [], int maxvalue)
@@ -123,8 +124,8 @@ static int kvs_get(const char key[], char value [], int maxvalue)
     int rc;
     rc = PMI_KVS_Get(pmix_kvs_name, key, value, maxvalue);
     if( PMI_SUCCESS != rc ){
-        /* silently return an error - might be okay */
-        return OPAL_ERROR;
+	/* silently return an error - might be okay */
+	return OPAL_ERROR;
     }
     return OPAL_SUCCESS;
 }
@@ -134,8 +135,8 @@ static int kvs_put(const char key[], const char value[])
     int rc;
     rc = PMI_KVS_Put(pmix_kvs_name, key, value);
     if( PMI_SUCCESS != rc ){
-        OPAL_PMI_ERROR(rc, "PMI_KVS_Put");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI_KVS_Put");
+	return OPAL_ERROR;
     }
     return rc;
 }
@@ -154,13 +155,13 @@ static int s1_init(void)
     char **localranks=NULL;
 
     if (PMI_SUCCESS != (rc = PMI_Initialized(&initialized))) {
-        OPAL_PMI_ERROR(rc, "PMI_Initialized");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI_Initialized");
+	return OPAL_ERROR;
     }
 
     if (PMI_TRUE != initialized && PMI_SUCCESS != (rc = PMI_Init(&spawned))) {
-        OPAL_PMI_ERROR(rc, "PMI_Init");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI_Init");
+	return OPAL_ERROR;
     }
 
     // setup hash table
@@ -169,42 +170,42 @@ static int s1_init(void)
     // Initialize space demands
     rc = PMI_KVS_Get_value_length_max(&pmix_vallen_max);
     if (PMI_SUCCESS != rc) {
-        OPAL_PMI_ERROR(rc, "PMI_KVS_Get_value_length_max");
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI_KVS_Get_value_length_max");
+	goto err_exit;
     }
     pmix_vallen_threshold = pmix_vallen_max * 3;
     pmix_vallen_threshold >>= 2;
 
     rc = PMI_KVS_Get_name_length_max(&pmix_kvslen_max);
     if (PMI_SUCCESS != rc) {
-        OPAL_PMI_ERROR(rc, "PMI_KVS_Get_name_length_max");
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI_KVS_Get_name_length_max");
+	goto err_exit;
     }
 
     rc = PMI_KVS_Get_key_length_max(&pmix_keylen_max);
     if (PMI_SUCCESS != rc) {
-        OPAL_PMI_ERROR(rc, "PMI_KVS_Get_key_length_max");
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI_KVS_Get_key_length_max");
+	goto err_exit;
     }
 
     // Initialize job environment information
     pmix_id = (char*)malloc(pmix_vallen_max);
     if (pmix_id == NULL) {
-        ret = OPAL_ERR_OUT_OF_RESOURCE;
-        goto err_exit;
+	ret = OPAL_ERR_OUT_OF_RESOURCE;
+	goto err_exit;
     }
     /* Get domain id */
     if (PMI_SUCCESS != (rc = PMI_Get_kvs_domain_id(pmix_id, pmix_vallen_max))) {
-        free(pmix_id);
-        goto err_exit;
+	free(pmix_id);
+	goto err_exit;
     }
 
     /* get our rank */
     ret = PMI_Get_rank(&rank);
     if( PMI_SUCCESS != ret ) {
-        OPAL_PMI_ERROR(ret, "PMI_Get_rank");
-        free(pmix_id);
-        goto err_exit;
+	OPAL_PMI_ERROR(ret, "PMI_Get_rank");
+	free(pmix_id);
+	goto err_exit;
     }
 
     /* Slurm PMI provides the job id as an integer followed
@@ -214,8 +215,8 @@ static int s1_init(void)
     s1_pname.jobid = strtoul(pmix_id, &str, 10);
     s1_pname.jobid = (s1_pname.jobid << 16) & 0xffff0000;
     if (NULL != str) {
-        ui32 = strtoul(str, NULL, 10);
-        s1_pname.jobid |= (ui32 & 0x0000ffff);
+	ui32 = strtoul(str, NULL, 10);
+	s1_pname.jobid |= (ui32 & 0x0000ffff);
     }
     ldr.jobid = s1_pname.jobid;
     s1_pname.vpid = rank;
@@ -225,17 +226,17 @@ static int s1_init(void)
      * won't do any harm */
     opal_proc_set_name(&s1_pname);
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s1: assigned tmp name",
-                        OPAL_NAME_PRINT(s1_pname));
+			"%s pmix:s1: assigned tmp name",
+			OPAL_NAME_PRINT(s1_pname));
 
     OBJ_CONSTRUCT(&kv, opal_value_t);
     kv.key = strdup(OPAL_PMIX_JOBID);
     kv.type = OPAL_UINT32;
     kv.data.uint32 = s1_pname.jobid;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -245,28 +246,28 @@ static int s1_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = rank;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
     pmix_kvs_name = (char*)malloc(pmix_kvslen_max);
     if (pmix_kvs_name == NULL) {
-        ret = OPAL_ERR_OUT_OF_RESOURCE;
-        goto err_exit;
+	ret = OPAL_ERR_OUT_OF_RESOURCE;
+	goto err_exit;
     }
 
     rc = PMI_KVS_Get_my_name(pmix_kvs_name, pmix_kvslen_max);
     if (PMI_SUCCESS != rc) {
-        OPAL_PMI_ERROR(rc, "PMI_KVS_Get_my_name");
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI_KVS_Get_my_name");
+	goto err_exit;
     }
 
     /* get our local proc info to find our local rank */
     if (PMI_SUCCESS != (rc = PMI_Get_clique_size(&nlranks))) {
-        OPAL_PMI_ERROR(rc, "PMI_Get_clique_size");
-        return rc;
+	OPAL_PMI_ERROR(rc, "PMI_Get_clique_size");
+	return rc;
     }
     /* save the local size */
     OBJ_CONSTRUCT(&kv, opal_value_t);
@@ -274,51 +275,51 @@ static int s1_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = nlranks;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
     lrank = 0;
     nrank = 0;
     ldr.vpid = rank;
     if (0 < nlranks) {
-        /* now get the specific ranks */
-        lranks = (int*)calloc(nlranks, sizeof(int));
-        if (NULL == lranks) {
-            rc = OPAL_ERR_OUT_OF_RESOURCE;
-            OPAL_ERROR_LOG(rc);
-            return rc;
-        }
-        if (PMI_SUCCESS != (rc = PMI_Get_clique_ranks(lranks, nlranks))) {
-            OPAL_PMI_ERROR(rc, "PMI_Get_clique_ranks");
-            free(lranks);
-            return rc;
-        }
-        /* note the local ldr */
-        ldr.vpid = lranks[0];
-        /* save this */
-        memset(tmp, 0, 64);
-        for (i=0; i < nlranks; i++) {
-            (void)snprintf(tmp, 64, "%d", lranks[i]);
-            opal_argv_append_nosize(&localranks, tmp);
-            if (rank == lranks[i]) {
-                lrank = i;
-                nrank = i;
-            }
-        }
-        str = opal_argv_join(localranks, ',');
-        opal_argv_free(localranks);
-        OBJ_CONSTRUCT(&kv, opal_value_t);
-        kv.key = strdup(OPAL_PMIX_LOCAL_PEERS);
-        kv.type = OPAL_STRING;
-        kv.data.string = str;
-        if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-            OPAL_ERROR_LOG(ret);
-            OBJ_DESTRUCT(&kv);
-            goto err_exit;
-        }
-        OBJ_DESTRUCT(&kv);
+	/* now get the specific ranks */
+	lranks = (int*)calloc(nlranks, sizeof(int));
+	if (NULL == lranks) {
+	    rc = OPAL_ERR_OUT_OF_RESOURCE;
+	    OPAL_ERROR_LOG(rc);
+	    return rc;
+	}
+	if (PMI_SUCCESS != (rc = PMI_Get_clique_ranks(lranks, nlranks))) {
+	    OPAL_PMI_ERROR(rc, "PMI_Get_clique_ranks");
+	    free(lranks);
+	    return rc;
+	}
+	/* note the local ldr */
+	ldr.vpid = lranks[0];
+	/* save this */
+	memset(tmp, 0, 64);
+	for (i=0; i < nlranks; i++) {
+	    (void)snprintf(tmp, 64, "%d", lranks[i]);
+	    opal_argv_append_nosize(&localranks, tmp);
+	    if (rank == lranks[i]) {
+		lrank = i;
+		nrank = i;
+	    }
+	}
+	str = opal_argv_join(localranks, ',');
+	opal_argv_free(localranks);
+	OBJ_CONSTRUCT(&kv, opal_value_t);
+	kv.key = strdup(OPAL_PMIX_LOCAL_PEERS);
+	kv.type = OPAL_STRING;
+	kv.data.string = str;
+	if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
+	    OPAL_ERROR_LOG(ret);
+	    OBJ_DESTRUCT(&kv);
+	    goto err_exit;
+	}
+	OBJ_DESTRUCT(&kv);
     }
 
     /* save the local leader */
@@ -327,9 +328,9 @@ static int s1_init(void)
     kv.type = OPAL_UINT64;
     kv.data.uint64 = *(uint64_t*)&ldr;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
     /* save our local rank */
@@ -338,9 +339,9 @@ static int s1_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = lrank;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
     /* and our node rank */
@@ -349,17 +350,17 @@ static int s1_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = nrank;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
     /* get universe size */
     ret = PMI_Get_universe_size(&i);
     if (PMI_SUCCESS != ret) {
-        OPAL_PMI_ERROR(ret, "PMI_Get_universe_size");
-        goto err_exit;
+	OPAL_PMI_ERROR(ret, "PMI_Get_universe_size");
+	goto err_exit;
     }
     /* push this into the dstore for subsequent fetches */
     OBJ_CONSTRUCT(&kv, opal_value_t);
@@ -367,9 +368,9 @@ static int s1_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = i;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
     /* push this into the dstore for subsequent fetches */
@@ -378,9 +379,9 @@ static int s1_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = i;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -388,34 +389,34 @@ static int s1_init(void)
     /* get job size */
     ret = PMI_Get_size(&i);
     if (PMI_SUCCESS != ret) {
-        OPAL_PMI_ERROR(ret, "PMI_Get_size");
-        goto err_exit;
+	OPAL_PMI_ERROR(ret, "PMI_Get_size");
+	goto err_exit;
     }
     OBJ_CONSTRUCT(&kv, opal_value_t);
     kv.key = strdup(OPAL_PMIX_JOB_SIZE);
     kv.type = OPAL_UINT32;
     kv.data.uint32 = i;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
     /* get appnum */
     ret = PMI_Get_appnum(&i);
     if (PMI_SUCCESS != ret) {
-        OPAL_PMI_ERROR(ret, "PMI_Get_appnum");
-        goto err_exit;
+	OPAL_PMI_ERROR(ret, "PMI_Get_appnum");
+	goto err_exit;
     }
     OBJ_CONSTRUCT(&kv, opal_value_t);
     kv.key = strdup(OPAL_PMIX_APPNUM);
     kv.type = OPAL_UINT32;
     kv.data.uint32 = i;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -431,11 +432,11 @@ static int s1_init(void)
 
 static int s1_fini(void) {
     if (0 == pmix_init_count) {
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     }
 
     if (0 == --pmix_init_count) {
-        PMI_Finalize ();
+	PMI_Finalize ();
     }
 
     // teardown hash table
@@ -447,13 +448,13 @@ static int s1_fini(void) {
 static int s1_initialized(void)
 {
     if (0 < pmix_init_count) {
-        return 1;
+	return 1;
     }
     return 0;
 }
 
 static int s1_abort(int flag, const char msg[],
-                    opal_list_t *procs)
+		    opal_list_t *procs)
 {
     PMI_Abort(flag, msg);
     return OPAL_SUCCESS;
@@ -470,41 +471,41 @@ static int s1_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t *jobid
     preput_vector_size = opal_list_get_size(preput_keyval_vector);
     rc = PMI_Spawn_multiple(count, cmds, argcs, argvs, maxprocs, info_keyval_sizes, info_keyval_vector, (int)preput_vector_size, preput_keyval_vector);
     if( PMI_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc, "PMI_Spawn_multiple");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI_Spawn_multiple");
+	return OPAL_ERROR;
     }*/
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
 
 static int s1_put(opal_pmix_scope_t scope,
-                  opal_value_t *kv)
+		  opal_value_t *kv)
 {
     int rc;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s1 put for key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key);
+			"%s pmix:s1 put for key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key);
 
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store_encoded (kv->key, (void*)&kv->data, kv->type, &pmix_packed_data, &pmix_packed_data_offset))) {
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
 
     if (pmix_packed_data_offset == 0) {
-        /* nothing to write */
-        return OPAL_SUCCESS;
+	/* nothing to write */
+	return OPAL_SUCCESS;
     }
 
     if (((pmix_packed_data_offset/3)*4) + pmix_packed_encoded_data_offset < pmix_vallen_max) {
-        /* this meta-key is still being filled,
-         * nothing to put yet
-         */
-        return OPAL_SUCCESS;
+	/* this meta-key is still being filled,
+	 * nothing to put yet
+	 */
+	return OPAL_SUCCESS;
     }
 
     rc = opal_pmix_base_partial_commit_packed (&pmix_packed_data, &pmix_packed_data_offset,
-                                               &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
-                                               pmix_vallen_max, &pmix_pack_key, kvs_put);
+					       &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
+					       pmix_vallen_max, &pmix_pack_key, kvs_put);
 
     s1_committed = false;
     return rc;
@@ -516,12 +517,12 @@ static int s1_commit(void)
 
     /* check if there is partially filled meta key and put them */
     opal_pmix_base_commit_packed (&pmix_packed_data, &pmix_packed_data_offset,
-                                  &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
-                                  pmix_vallen_max, &pmix_pack_key, kvs_put);
+				  &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
+				  pmix_vallen_max, &pmix_pack_key, kvs_put);
 
     if (PMI_SUCCESS != (rc = PMI_KVS_Commit(pmix_kvs_name))) {
-        OPAL_PMI_ERROR(rc, "PMI_KVS_Commit");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI_KVS_Commit");
+	return OPAL_ERROR;
     }
     return OPAL_SUCCESS;
 }
@@ -536,75 +537,75 @@ static void fencenb(int sd, short args, void *cbdata)
     opal_process_name_t s1_pname;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s1 called fence",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+			"%s pmix:s1 called fence",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
 
     /* use the PMI barrier function */
     if (PMI_SUCCESS != (rc = PMI_Barrier())) {
-        OPAL_PMI_ERROR(rc, "PMI_Barrier");
-        rc = OPAL_ERROR;
-        goto cleanup;
+	OPAL_PMI_ERROR(rc, "PMI_Barrier");
+	rc = OPAL_ERROR;
+	goto cleanup;
     }
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s1 barrier complete",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+			"%s pmix:s1 barrier complete",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
 
     /* get the modex data from each local process and set the
      * localities to avoid having the MPI layer fetch data
      * for every process in the job */
     s1_pname.jobid = OPAL_PROC_MY_NAME.jobid;
     if (!got_modex_data) {
-        got_modex_data = true;
-        /* we only need to set locality for each local rank as "not found"
-         * equates to "non-local" */
-        for (i=0; i < nlranks; i++) {
-            s1_pname.vpid = lranks[i];
-            rc = opal_pmix_base_cache_keys_locally(&s1_pname, OPAL_PMIX_CPUSET,
-                                                   &kp, pmix_kvs_name, pmix_vallen_max, kvs_get);
-            if (OPAL_SUCCESS != rc) {
-                OPAL_ERROR_LOG(rc);
-                goto cleanup;
-            }
-            if (NULL == kp || NULL == kp->data.string) {
-                /* if we share a node, but we don't know anything more, then
-                 * mark us as on the node as this is all we know
-                 */
-                locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
-            } else {
-                /* determine relative location on our node */
-                locality = opal_hwloc_base_get_relative_locality(opal_hwloc_topology,
-                                                                 opal_process_info.cpuset,
-                                                                 kp->data.string);
-            }
-            if (NULL != kp) {
-                OBJ_RELEASE(kp);
-            }
-            OPAL_OUTPUT_VERBOSE((1, opal_pmix_base_framework.framework_output,
-                                 "%s pmix:s1 proc %s locality %s",
-                                 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                                 OPAL_NAME_PRINT(s1_pname),
-                                 opal_hwloc_base_print_locality(locality)));
+	got_modex_data = true;
+	/* we only need to set locality for each local rank as "not found"
+	 * equates to "non-local" */
+	for (i=0; i < nlranks; i++) {
+	    s1_pname.vpid = lranks[i];
+	    rc = opal_pmix_base_cache_keys_locally(&s1_pname, OPAL_PMIX_CPUSET,
+						   &kp, pmix_kvs_name, pmix_vallen_max, kvs_get);
+	    if (OPAL_SUCCESS != rc) {
+		OPAL_ERROR_LOG(rc);
+		goto cleanup;
+	    }
+	    if (NULL == kp || NULL == kp->data.string) {
+		/* if we share a node, but we don't know anything more, then
+		 * mark us as on the node as this is all we know
+		 */
+		locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
+	    } else {
+		/* determine relative location on our node */
+		locality = opal_hwloc_base_get_relative_locality(opal_hwloc_topology,
+								 opal_process_info.cpuset,
+								 kp->data.string);
+	    }
+	    if (NULL != kp) {
+		OBJ_RELEASE(kp);
+	    }
+	    OPAL_OUTPUT_VERBOSE((1, opal_pmix_base_framework.framework_output,
+				 "%s pmix:s1 proc %s locality %s",
+				 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+				 OPAL_NAME_PRINT(s1_pname),
+				 opal_hwloc_base_print_locality(locality)));
 
-            OBJ_CONSTRUCT(&kvn, opal_value_t);
-            kvn.key = strdup(OPAL_PMIX_LOCALITY);
-            kvn.type = OPAL_UINT16;
-            kvn.data.uint16 = locality;
-            opal_pmix_base_store(&s1_pname, &kvn);
-            OBJ_DESTRUCT(&kvn);
-        }
+	    OBJ_CONSTRUCT(&kvn, opal_value_t);
+	    kvn.key = strdup(OPAL_PMIX_LOCALITY);
+	    kvn.type = OPAL_UINT16;
+	    kvn.data.uint16 = locality;
+	    opal_pmix_base_store(&s1_pname, &kvn);
+	    OBJ_DESTRUCT(&kvn);
+	}
     }
 
   cleanup:
     if (NULL != op->opcbfunc) {
-        op->opcbfunc(rc, op->cbdata);
+	op->opcbfunc(rc, op->cbdata);
     }
     OBJ_RELEASE(op);
     return;
 }
 
 static int s1_fencenb(opal_list_t *procs, int collect_data,
-                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		      opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmi_opcaddy_t *op;
 
@@ -613,7 +614,7 @@ static int s1_fencenb(opal_list_t *procs, int collect_data,
     op->opcbfunc = cbfunc;
     op->cbdata = cbdata;
     event_assign(&op->ev, opal_pmix_base.evbase, -1,
-                 EV_WRITE, fencenb, op);
+		 EV_WRITE, fencenb, op);
     event_active(&op->ev, EV_WRITE, 1);
 
     return OPAL_SUCCESS;
@@ -621,9 +622,9 @@ static int s1_fencenb(opal_list_t *procs, int collect_data,
 
 #define S1_WAIT_FOR_COMPLETION(a)               \
     do {                                        \
-        while ((a)) {                           \
-            usleep(10);                         \
-        }                                       \
+	while ((a)) {                           \
+	    usleep(10);                         \
+	}                                       \
     } while (0)
 
 struct fence_result {
@@ -649,18 +650,18 @@ static int s1_fence(opal_list_t *procs, int collect_data)
 
 
 static int s1_get(const opal_process_name_t *id,
-                  const char *key, opal_list_t *info,
-                  opal_value_t **kv)
+		  const char *key, opal_list_t *info,
+		  opal_value_t **kv)
 {
     int rc;
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s1 called get for key %s",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), key);
+			"%s pmix:s1 called get for key %s",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), key);
 
     rc = opal_pmix_base_cache_keys_locally(id, key, kv, pmix_kvs_name, pmix_vallen_max, kvs_get);
      opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s1 got key %s",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), key);
+			"%s pmix:s1 got key %s",
+			 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), key);
 
    return rc;
 }
@@ -698,7 +699,7 @@ static int s1_job_disconnect(opal_list_t *procs)
 }
 
 static int s1_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val)
+			  opal_value_t *val)
 {
     opal_pmix_base_store(proc, val);
 
@@ -719,26 +720,26 @@ static char* pmix_error(int pmix_err)
     char * err_msg;
 
     switch(pmix_err) {
-        case PMI_FAIL: err_msg = "Operation failed"; break;
-        case PMI_ERR_INIT: err_msg = "PMI is not initialized"; break;
-        case PMI_ERR_NOMEM: err_msg = "Input buffer not large enough"; break;
-        case PMI_ERR_INVALID_ARG: err_msg = "Invalid argument"; break;
-        case PMI_ERR_INVALID_KEY: err_msg = "Invalid key argument"; break;
-        case PMI_ERR_INVALID_KEY_LENGTH: err_msg = "Invalid key length argument"; break;
-        case PMI_ERR_INVALID_VAL: err_msg = "Invalid value argument"; break;
-        case PMI_ERR_INVALID_VAL_LENGTH: err_msg = "Invalid value length argument"; break;
-        case PMI_ERR_INVALID_LENGTH: err_msg = "Invalid length argument"; break;
-        case PMI_ERR_INVALID_NUM_ARGS: err_msg = "Invalid number of arguments"; break;
-        case PMI_ERR_INVALID_ARGS: err_msg = "Invalid args argument"; break;
-        case PMI_ERR_INVALID_NUM_PARSED: err_msg = "Invalid num_parsed length argument"; break;
-        case PMI_ERR_INVALID_KEYVALP: err_msg = "Invalid keyvalp argument"; break;
-        case PMI_ERR_INVALID_SIZE: err_msg = "Invalid size argument"; break;
+	case PMI_FAIL: err_msg = "Operation failed"; break;
+	case PMI_ERR_INIT: err_msg = "PMI is not initialized"; break;
+	case PMI_ERR_NOMEM: err_msg = "Input buffer not large enough"; break;
+	case PMI_ERR_INVALID_ARG: err_msg = "Invalid argument"; break;
+	case PMI_ERR_INVALID_KEY: err_msg = "Invalid key argument"; break;
+	case PMI_ERR_INVALID_KEY_LENGTH: err_msg = "Invalid key length argument"; break;
+	case PMI_ERR_INVALID_VAL: err_msg = "Invalid value argument"; break;
+	case PMI_ERR_INVALID_VAL_LENGTH: err_msg = "Invalid value length argument"; break;
+	case PMI_ERR_INVALID_LENGTH: err_msg = "Invalid length argument"; break;
+	case PMI_ERR_INVALID_NUM_ARGS: err_msg = "Invalid number of arguments"; break;
+	case PMI_ERR_INVALID_ARGS: err_msg = "Invalid args argument"; break;
+	case PMI_ERR_INVALID_NUM_PARSED: err_msg = "Invalid num_parsed length argument"; break;
+	case PMI_ERR_INVALID_KEYVALP: err_msg = "Invalid keyvalp argument"; break;
+	case PMI_ERR_INVALID_SIZE: err_msg = "Invalid size argument"; break;
 #if defined(PMI_ERR_INVALID_KVS)
 	/* pmix.h calls this a valid return code but mpich doesn't define it (slurm does). */
-        case PMI_ERR_INVALID_KVS: err_msg = "Invalid kvs argument"; break;
+	case PMI_ERR_INVALID_KVS: err_msg = "Invalid kvs argument"; break;
 #endif
-        case PMI_SUCCESS: err_msg = "Success"; break;
-        default: err_msg = "Unkown error";
+	case PMI_SUCCESS: err_msg = "Success"; break;
+	default: err_msg = "Unkown error";
     }
     return err_msg;
 }

--- a/opal/mca/pmix/s1/pmix_s1_component.c
+++ b/opal/mca/pmix/s1/pmix_s1_component.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,25 +47,25 @@ opal_pmix_base_component_t mca_pmix_s1_component = {
        about the component itself */
 
     .base_version = {
-        /* Indicate that we are a pmix v1.1.0 component (which also
-           implies a specific MCA version) */
+	/* Indicate that we are a pmix v1.1.0 component (which also
+	   implies a specific MCA version) */
 
-        OPAL_PMIX_BASE_VERSION_2_0_0,
+	OPAL_PMIX_BASE_VERSION_2_0_0,
 
-        /* Component name and version */
+	/* Component name and version */
 
-        .mca_component_name = "s1",
-        MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                              OPAL_RELEASE_VERSION),
+	.mca_component_name = "s1",
+	MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+			      OPAL_RELEASE_VERSION),
 
-        /* Component open and close functions */
-        .mca_query_component = pmix_s1_component_query,
-        .mca_register_component_params = pmix_s1_component_register,
+	/* Component open and close functions */
+	.mca_query_component = pmix_s1_component_query,
+	.mca_register_component_params = pmix_s1_component_register,
     },
     /* Next the MCA v1.0.0 component meta data */
     .base_data = {
-        /* The component is checkpoint ready */
-        MCA_BASE_METADATA_PARAM_CHECKPOINT
+	/* The component is checkpoint ready */
+	MCA_BASE_METADATA_PARAM_CHECKPOINT
     },
     .priority = 10,
 };
@@ -76,12 +77,12 @@ static int pmix_s1_component_register(void)
 
     mca_pmix_s1_component.priority = 10;
     ret = mca_base_component_var_register(component, "priority",
-                                          "Priority of the pmix s1 component (default: 10)",
-                                          MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-                                          &mca_pmix_s1_component.priority);
+					  "Priority of the pmix s1 component (default: 10)",
+					  MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+					  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+					  &mca_pmix_s1_component.priority);
     if (0 > ret) {
-        return ret;
+	return ret;
     }
 
     return OPAL_SUCCESS;
@@ -91,9 +92,9 @@ static int pmix_s1_component_query(mca_base_module_t **module, int *priority)
 {
     /* disqualify ourselves if we are not under slurm */
     if (NULL == getenv("SLURM_STEP_NUM_TASKS")) {
-        *priority = 0;
-        *module = NULL;
-        return OPAL_ERROR;
+	*priority = 0;
+	*module = NULL;
+	return OPAL_ERROR;
     }
 
     /* we can be considered, but set our priority by default

--- a/opal/mca/pmix/s2/pmi2_pmap_parser.c
+++ b/opal/mca/pmix/s2/pmi2_pmap_parser.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  * Additional copyrights may follow
  *
@@ -31,14 +32,14 @@ slurm block distro of 4 ranks over 2 nodes:
  Tuple can be visualized as a rectangle on two
  dimensional (Hosts, Local Ranks) plane:
 
-           ------------------------------------ Hosts ->
-           |              H
-           |           +--------+
-           |<- base -->|        |
-           |           |        | L
-           |           +--------+
-        Local Ranks
-           V
+	   ------------------------------------ Hosts ->
+	   |              H
+	   |           +--------+
+	   |<- base -->|        |
+	   |           |        | L
+	   |           +--------+
+	Local Ranks
+	   V
 
 Note that ranks increase by column. Tuple (0,2,3) looks like:
 0 3
@@ -58,14 +59,14 @@ static int find_my_node(char *map, int me)
     p = map;
     abs_rank = 0;
     while (NULL != (p = strstr(p+1, ",("))) {
-        if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
-            return -1;
-        }
-        if (me >= abs_rank && me < abs_rank + H*L) {
-            /* found my rectangle, compute node */
-            return base + (me - abs_rank)/L;
-        }
-        abs_rank += H*L;
+	if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
+	    return -1;
+	}
+	if (me >= abs_rank && me < abs_rank + H*L) {
+	    /* found my rectangle, compute node */
+	    return base + (me - abs_rank)/L;
+	}
+	abs_rank += H*L;
     }
     return -1;
 }
@@ -85,34 +86,34 @@ static int *find_lrs(char *map, int my_node, int *nlrs)
     max_lr = 16;
     lrs = malloc(max_lr * sizeof(int));
     while (NULL != (p = strstr(p+1, ",("))) {
-        if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
-            free(lrs);
-            return NULL;
-        }
-        if (base <= my_node && my_node < base + H) {
-            if (*nlrs + L >= max_lr) {
-                lrs = realloc(lrs, (max_lr + L) * sizeof(int));
-                if (NULL == lrs) {
-                    *nlrs = 0;
-                    free(lrs);
-                    return NULL;
-                }
-                max_lr += L;
-            }
-            /* skip (my_node - base) columns of L elems,
-             * numbers in my column are local to me
-             */
-            for (i = 0; i < L; i++) {
-                lrs[*nlrs] = (my_node - base) * L + i + abs_rank;
-                (*nlrs) ++;
-            }
-        }
-        abs_rank += H*L;
+	if (3 != sscanf(p, ",(%d,%d,%d)", &base, &H, &L)) {
+	    free(lrs);
+	    return NULL;
+	}
+	if (base <= my_node && my_node < base + H) {
+	    if (*nlrs + L >= max_lr) {
+		lrs = realloc(lrs, (max_lr + L) * sizeof(int));
+		if (NULL == lrs) {
+		    *nlrs = 0;
+		    free(lrs);
+		    return NULL;
+		}
+		max_lr += L;
+	    }
+	    /* skip (my_node - base) columns of L elems,
+	     * numbers in my column are local to me
+	     */
+	    for (i = 0; i < L; i++) {
+		lrs[*nlrs] = (my_node - base) * L + i + abs_rank;
+		(*nlrs) ++;
+	    }
+	}
+	abs_rank += H*L;
     }
 
     if (0 == *nlrs) {
-        free(lrs);
-        lrs = 0;
+	free(lrs);
+	lrs = 0;
     }
     return lrs;
 }
@@ -128,13 +129,13 @@ static int *find_lrs(char *map, int my_node, int *nlrs)
  * on failure. Array must be freed by the caller.
  */
 int *mca_common_pmi2_parse_pmap(char *pmap, int my_rank,
-                                  int *node, int *nlrs)
+				  int *node, int *nlrs)
 {
     char *p;
 
     p = strstr(pmap, "(vector");
     if (NULL == p) {
-        return NULL;
+	return NULL;
     }
 
     *node = find_my_node(p, my_rank);
@@ -154,7 +155,7 @@ static void dump_lrs(int *lrs, int me, int node, int n)
 
     printf("Total %d ranks/node, node %d me %d\n", n, node, me);
     for (i = 0; i < n; i++) {
-        printf("%d ", lrs[i]);
+	printf("%d ", lrs[i]);
     }
     printf("\n");
     free(lrs);
@@ -174,14 +175,14 @@ int main(int argc, char **argv)
 
 
     if (argc == 3) {
-        me = atoi(argv[1]);
-        lrs = orte_grpcomm_pmi2_parse_pmap(argv[2], me, &node, &n);
-        if (NULL == lrs) {
-            printf("can not parse pmap\n");
-            exit(1);
-        }
-        dump_lrs(lrs, me, node, n);
-        exit(0);
+	me = atoi(argv[1]);
+	lrs = orte_grpcomm_pmi2_parse_pmap(argv[2], me, &node, &n);
+	if (NULL == lrs) {
+	    printf("can not parse pmap\n");
+	    exit(1);
+	}
+	dump_lrs(lrs, me, node, n);
+	exit(0);
     }
     /* built in cases */
 

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2007      The Trustees of Indiana University.
  *                         All rights reserved.
- * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC. All
  *                         rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
@@ -41,16 +41,16 @@ static int s2_init(void);
 static int s2_fini(void);
 static int s2_initialized(void);
 static int s2_abort(int flag, const char msg[],
-                    opal_list_t *procs);
+		    opal_list_t *procs);
 static int s2_commit(void);
 static int s2_fencenb(opal_list_t *procs, int collect_data,
-                      opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
+		      opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 static int s2_fence(opal_list_t *procs, int collect_data);
 static int s2_put(opal_pmix_scope_t scope,
-                  opal_value_t *kv);
+		  opal_value_t *kv);
 static int s2_get(const opal_process_name_t *id,
-                  const char *key, opal_list_t *info,
-                  opal_value_t **kv);
+		  const char *key, opal_list_t *info,
+		  opal_value_t **kv);
 static int s2_publish(opal_list_t *info);
 static int s2_lookup(opal_list_t *data, opal_list_t *info);
 static int s2_unpublish(char **keys, opal_list_t *info);
@@ -58,7 +58,7 @@ static int s2_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t *jobid
 static int s2_job_connect(opal_list_t *procs);
 static int s2_job_disconnect(opal_list_t *procs);
 static int s2_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val);
+			  opal_value_t *val);
 static const char *s2_get_nspace(opal_jobid_t jobid);
 static void s2_register_jobid(opal_jobid_t jobid, const char *nspace);
 
@@ -96,8 +96,8 @@ typedef struct {
     void *cbdata;
 } pmi_opcaddy_t;
 OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
-                   opal_object_t,
-                   NULL, NULL);
+		   opal_object_t,
+		   NULL, NULL);
 
 // PMI constant values:
 static int pmix_kvslen_max = 0;
@@ -127,9 +127,9 @@ static bool got_modex_data = false;
 static char* pmix_error(int pmix_err);
 #define OPAL_PMI_ERROR(pmi_err, pmi_func)                       \
     do {                                                        \
-        opal_output(0, "%s [%s:%d:%s]: %s\n",                   \
-                    pmi_func, __FILE__, __LINE__, __func__,     \
-                    pmix_error(pmi_err));                        \
+	opal_output(0, "%s [%s:%d:%s]: %s\n",                   \
+		    pmi_func, __FILE__, __LINE__, __func__,     \
+		    pmix_error(pmi_err));                        \
     } while(0);
 
 static int kvs_put(const char key[], const char value[])
@@ -137,8 +137,8 @@ static int kvs_put(const char key[], const char value[])
     int rc;
     rc = PMI2_KVS_Put(key, value);
     if( PMI2_SUCCESS != rc ){
-        OPAL_PMI_ERROR(rc, "PMI2_KVS_Put");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI2_KVS_Put");
+	return OPAL_ERROR;
     }
     return OPAL_SUCCESS;
 }
@@ -154,7 +154,7 @@ static int kvs_get(const char key[], char value [], int maxvalue)
      * case
      */
     if (PMI2_SUCCESS != rc) {
-        return OPAL_ERROR;
+	return OPAL_ERROR;
     }
     return OPAL_SUCCESS;
 }
@@ -176,7 +176,7 @@ static int s2_init(void)
 
     /* if we can't startup PMI, we can't be used */
     if ( PMI2_Initialized () ) {
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     }
     size = -1;
     rank = -1;
@@ -185,12 +185,12 @@ static int s2_init(void)
     opal_pmix_base_hash_init();
 
     if (PMI2_SUCCESS != (rc = PMI2_Init(&spawned, &size, &rank, &appnum))) {
-        opal_show_help("help-pmix-base.txt", "pmix2-init-failed", true, rc);
-        return OPAL_ERROR;
+	opal_show_help("help-pmix-base.txt", "pmix2-init-failed", true, rc);
+	return OPAL_ERROR;
     }
     if( size < 0 || rank < 0 ){
-        opal_show_help("help-pmix-base.txt", "pmix2-init-returned-bad-values", true);
-        goto err_exit;
+	opal_show_help("help-pmix-base.txt", "pmix2-init-returned-bad-values", true);
+	goto err_exit;
     }
 
     s2_jsize = size;
@@ -205,15 +205,15 @@ static int s2_init(void)
 
     pmix_kvs_name = (char*)malloc(pmix_kvslen_max);
     if( pmix_kvs_name == NULL ){
-        PMI2_Finalize();
-        ret = OPAL_ERR_OUT_OF_RESOURCE;
-        goto err_exit;
+	PMI2_Finalize();
+	ret = OPAL_ERR_OUT_OF_RESOURCE;
+	goto err_exit;
     }
     rc = PMI2_Job_GetId(pmix_kvs_name, pmix_kvslen_max);
     if( PMI2_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc, "PMI2_Job_GetId");
-        free(pmix_kvs_name);
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI2_Job_GetId");
+	free(pmix_kvs_name);
+	goto err_exit;
     }
 
     /* store our name in the opal_proc_t so that
@@ -223,14 +223,14 @@ static int s2_init(void)
     s2_pname.jobid = strtoul(pmix_kvs_name, &str, 10);
     s2_pname.jobid = (s2_pname.jobid << 16) & 0xffff0000;
     if (NULL != str) {
-        stepid = strtoul(str, NULL, 10);
-        s2_pname.jobid |= (stepid & 0x0000ffff);
+	stepid = strtoul(str, NULL, 10);
+	s2_pname.jobid |= (stepid & 0x0000ffff);
     }
     s2_pname.vpid = s2_rank;
     opal_proc_set_name(&s2_pname);
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s2: assigned tmp name",
-                        OPAL_NAME_PRINT(s2_pname));
+			"%s pmix:s2: assigned tmp name",
+			OPAL_NAME_PRINT(s2_pname));
 
     /* Slurm PMI provides the job id as an integer followed
      * by a '.', followed by essentially a stepid. The first integer
@@ -242,9 +242,9 @@ static int s2_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = s2_pname.jobid;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);  // frees pmix_kvs_name
 
@@ -254,9 +254,9 @@ static int s2_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = size;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -266,16 +266,16 @@ static int s2_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = appnum;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
     rc = PMI2_Info_GetJobAttr("universeSize", buf, 16, &found);
     if( PMI2_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc, "PMI_Get_universe_size");
-        goto err_exit;
+	OPAL_PMI_ERROR(rc, "PMI_Get_universe_size");
+	goto err_exit;
     }
     /* save it */
     OBJ_CONSTRUCT(&kv, opal_value_t);
@@ -283,9 +283,9 @@ static int s2_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = atoi(buf);
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
     /* push this into the dstore for subsequent fetches */
@@ -294,30 +294,30 @@ static int s2_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = atoi(buf);
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
     char *pmapping = (char*)malloc(PMI2_MAX_VALLEN);
     if( pmapping == NULL ){
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
 
     rc = PMI2_Info_GetJobAttr("PMI_process_mapping", pmapping, PMI2_MAX_VALLEN, &found);
     if( !found || PMI2_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc,"PMI2_Info_GetJobAttr");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc,"PMI2_Info_GetJobAttr");
+	return OPAL_ERROR;
     }
 
     s2_lranks = mca_common_pmi2_parse_pmap(pmapping, s2_pname.vpid, &my_node, &s2_nlranks);
     if (NULL == s2_lranks) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	rc = OPAL_ERR_OUT_OF_RESOURCE;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
 
     free(pmapping);
@@ -328,9 +328,9 @@ static int s2_init(void)
     kv.type = OPAL_UINT32;
     kv.data.uint32 = s2_nlranks;
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(rc);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -339,32 +339,32 @@ static int s2_init(void)
     ldr.vpid = rank;
     localranks = NULL;
     if (0 < s2_nlranks && NULL != s2_lranks) {
-        /* note the local ldr */
-        ldr.vpid = s2_lranks[0];
-        /* find ourselves */
-        ldr.jobid = s2_pname.jobid;
-        ldr.vpid = s2_pname.vpid;
-        memset(nmtmp, 0, 64);
-        for (i=0; i < s2_nlranks; i++) {
-            (void)snprintf(nmtmp, 64, "%d", s2_lranks[i]);
-            opal_argv_append_nosize(&localranks, nmtmp);
-            if (s2_rank == s2_lranks[i]) {
-                s2_lrank = i;
-                s2_nrank = i;
-            }
-        }
-        str = opal_argv_join(localranks, ',');
-        opal_argv_free(localranks);
-        OBJ_CONSTRUCT(&kv, opal_value_t);
-        kv.key = strdup(OPAL_PMIX_LOCAL_PEERS);
-        kv.type = OPAL_STRING;
-        kv.data.string = str;
-        if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-            OPAL_ERROR_LOG(ret);
-            OBJ_DESTRUCT(&kv);
-            goto err_exit;
-        }
-        OBJ_DESTRUCT(&kv);
+	/* note the local ldr */
+	ldr.vpid = s2_lranks[0];
+	/* find ourselves */
+	ldr.jobid = s2_pname.jobid;
+	ldr.vpid = s2_pname.vpid;
+	memset(nmtmp, 0, 64);
+	for (i=0; i < s2_nlranks; i++) {
+	    (void)snprintf(nmtmp, 64, "%d", s2_lranks[i]);
+	    opal_argv_append_nosize(&localranks, nmtmp);
+	    if (s2_rank == s2_lranks[i]) {
+		s2_lrank = i;
+		s2_nrank = i;
+	    }
+	}
+	str = opal_argv_join(localranks, ',');
+	opal_argv_free(localranks);
+	OBJ_CONSTRUCT(&kv, opal_value_t);
+	kv.key = strdup(OPAL_PMIX_LOCAL_PEERS);
+	kv.type = OPAL_STRING;
+	kv.data.string = str;
+	if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
+	    OPAL_ERROR_LOG(ret);
+	    OBJ_DESTRUCT(&kv);
+	    goto err_exit;
+	}
+	OBJ_DESTRUCT(&kv);
     }
 
     /* save the local leader */
@@ -373,9 +373,9 @@ static int s2_init(void)
     kv.type = OPAL_UINT64;
     kv.data.uint64 = *(uint64_t*)&ldr;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
     /* save our local rank */
@@ -384,9 +384,9 @@ static int s2_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = s2_lrank;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
     /* and our node rank */
@@ -395,9 +395,9 @@ static int s2_init(void)
     kv.type = OPAL_UINT16;
     kv.data.uint16 = s2_nrank;
     if (OPAL_SUCCESS != (ret = opal_pmix_base_store(&OPAL_PROC_MY_NAME, &kv))) {
-        OPAL_ERROR_LOG(ret);
-        OBJ_DESTRUCT(&kv);
-        goto err_exit;
+	OPAL_ERROR_LOG(ret);
+	OBJ_DESTRUCT(&kv);
+	goto err_exit;
     }
     OBJ_DESTRUCT(&kv);
 
@@ -412,18 +412,18 @@ static int s2_init(void)
 
 static int s2_fini(void) {
     if (0 == pmix_init_count) {
-        return OPAL_SUCCESS;
+	return OPAL_SUCCESS;
     }
 
     if (0 == --pmix_init_count) {
-        PMI2_Finalize();
+	PMI2_Finalize();
     }
     if (NULL != pmix_kvs_name) {
-        free(pmix_kvs_name);
-        pmix_kvs_name = NULL;
+	free(pmix_kvs_name);
+	pmix_kvs_name = NULL;
     }
     if (NULL != s2_lranks) {
-        free(s2_lranks);
+	free(s2_lranks);
     }
     return OPAL_SUCCESS;
 }
@@ -431,13 +431,13 @@ static int s2_fini(void) {
 static int s2_initialized(void)
 {
     if (0 < pmix_init_count) {
-        return 1;
+	return 1;
     }
     return 0;
 }
 
 static int s2_abort(int flag, const char msg[],
-                    opal_list_t *procs)
+		    opal_list_t *procs)
 {
     PMI2_Abort(flag, msg);
     return OPAL_SUCCESS;
@@ -454,8 +454,8 @@ static int s2_spawn(opal_list_t *jobinfo, opal_list_t *apps, opal_jobid_t *jobid
     preput_vector_size = opal_list_get_size(preput_keyval_vector);
     rc = PMI2_Job_Spawn(count, cmds, argcs, argvs, maxprocs, info_keyval_sizes, info_keyval_vector, (int)preput_vector_size, preput_keyval_vector, jobId, jobIdSize, errors);
     if( PMI2_SUCCESS != rc ) {
-        OPAL_PMI_ERROR(rc, "PMI2_Job_Spawn");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI2_Job_Spawn");
+	return OPAL_ERROR;
     }*/
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
@@ -468,7 +468,7 @@ static int s2_job_connect(opal_list_t *procs)
     char *jobid;
 
     if (NULL == procs || 1 < opal_list_get_size(procs)) {
-        return OPAL_ERR_NOT_SUPPORTED;
+	return OPAL_ERR_NOT_SUPPORTED;
     }
     nm = (opal_namelist_t*)opal_list_get_first(procs);
     (void)asprintf(&jobid, "%s", OPAL_JOBID_PRINT(nm->name.jobid));
@@ -476,9 +476,9 @@ static int s2_job_connect(opal_list_t *procs)
     /*FIXME should change function prototype to add void* conn */
     rc = PMI2_Job_Connect(jobid, &conn);
     if( PMI2_SUCCESS != rc ){
-        OPAL_PMI_ERROR(rc, "PMI2_Job_Connect");
-        free(jobid);
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI2_Job_Connect");
+	free(jobid);
+	return OPAL_ERROR;
     }
     free(jobid);
     return OPAL_SUCCESS;
@@ -491,50 +491,50 @@ static int s2_job_disconnect(opal_list_t *procs)
     char *jobid;
 
     if (NULL == procs || 1 < opal_list_get_size(procs)) {
-        return OPAL_ERR_NOT_SUPPORTED;
+	return OPAL_ERR_NOT_SUPPORTED;
     }
     nm = (opal_namelist_t*)opal_list_get_first(procs);
     (void)asprintf(&jobid, "%s", OPAL_JOBID_PRINT(nm->name.jobid));
 
     rc = PMI2_Job_Disconnect(jobid);
     if( PMI2_SUCCESS != rc ){
-        OPAL_PMI_ERROR(rc, "PMI2_Job_Disconnect");
-        free(jobid);
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI2_Job_Disconnect");
+	free(jobid);
+	return OPAL_ERROR;
     }
     free(jobid);
     return OPAL_SUCCESS;
 }
 
 static int s2_put(opal_pmix_scope_t scope,
-                  opal_value_t *kv)
+		  opal_value_t *kv)
 {
     int rc;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-            "%s pmix:s2 put for key %s",
-            OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key);
+	    "%s pmix:s2 put for key %s",
+	    OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), kv->key);
 
     if (OPAL_SUCCESS != (rc = opal_pmix_base_store_encoded (kv->key, (void*)&kv->data, kv->type, &pmix_packed_data, &pmix_packed_data_offset))) {
-        OPAL_ERROR_LOG(rc);
-        return rc;
+	OPAL_ERROR_LOG(rc);
+	return rc;
     }
 
     if (pmix_packed_data_offset == 0) {
-        /* nothing to write */
-        return OPAL_SUCCESS;
+	/* nothing to write */
+	return OPAL_SUCCESS;
     }
 
     if (((pmix_packed_data_offset/3)*4) + pmix_packed_encoded_data_offset < pmix_vallen_max) {
-        /* this meta-key is still being filled,
-         * nothing to put yet
-         */
-        return OPAL_SUCCESS;
+	/* this meta-key is still being filled,
+	 * nothing to put yet
+	 */
+	return OPAL_SUCCESS;
     }
 
     rc = opal_pmix_base_partial_commit_packed (&pmix_packed_data, &pmix_packed_data_offset,
-                                               &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
-                                               pmix_vallen_max, &pmix_pack_key, kvs_put);
+					       &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
+					       pmix_vallen_max, &pmix_pack_key, kvs_put);
 
     return rc;
 }
@@ -554,18 +554,18 @@ static void fencenb(int sd, short args, void *cbdata)
     opal_process_name_t pname;
 
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                        "%s pmix:s2 called fence",
-                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
+			"%s pmix:s2 called fence",
+			OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
 
     /* check if there is partially filled meta key and put them */
     opal_pmix_base_commit_packed (&pmix_packed_data, &pmix_packed_data_offset,
-                                  &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
-                                  pmix_vallen_max, &pmix_pack_key, kvs_put);
+				  &pmix_packed_encoded_data, &pmix_packed_encoded_data_offset,
+				  pmix_vallen_max, &pmix_pack_key, kvs_put);
 
     /* now call fence */
     if (PMI2_SUCCESS != PMI2_KVS_Fence()) {
-        rc = OPAL_ERROR;
-        goto cleanup;
+	rc = OPAL_ERROR;
+	goto cleanup;
     }
 
     /* get the modex data from each local process and set the
@@ -573,44 +573,44 @@ static void fencenb(int sd, short args, void *cbdata)
      * for every process in the job */
     pname.jobid = OPAL_PROC_MY_NAME.jobid;
     if (!got_modex_data) {
-        got_modex_data = true;
-        /* we only need to set locality for each local rank as "not found"
-         * equates to "non-local" */
-        for (i=0; i < s2_nlranks; i++) {
-            pname.vpid = s2_lranks[i];
-            rc = opal_pmix_base_cache_keys_locally(&s2_pname, OPAL_PMIX_CPUSET,
-                                                   &kp, pmix_kvs_name, pmix_vallen_max, kvs_get);
-            if (OPAL_SUCCESS != rc) {
-                OPAL_ERROR_LOG(rc);
-                goto cleanup;
-            }
-            if (NULL == kp || NULL == kp->data.string) {
-                /* if we share a node, but we don't know anything more, then
-                 * mark us as on the node as this is all we know
-                 */
-                locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
-            } else {
-                /* determine relative location on our node */
-                locality = opal_hwloc_base_get_relative_locality(opal_hwloc_topology,
-                                                                 opal_process_info.cpuset,
-                                                                 kp->data.string);
-            }
-            if (NULL != kp) {
-                OBJ_RELEASE(kp);
-            }
-            OPAL_OUTPUT_VERBOSE((1, opal_pmix_base_framework.framework_output,
-                                 "%s pmix:s2 proc %s locality %s",
-                                 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
-                                 OPAL_NAME_PRINT(s2_pname),
-                                 opal_hwloc_base_print_locality(locality)));
+	got_modex_data = true;
+	/* we only need to set locality for each local rank as "not found"
+	 * equates to "non-local" */
+	for (i=0; i < s2_nlranks; i++) {
+	    pname.vpid = s2_lranks[i];
+	    rc = opal_pmix_base_cache_keys_locally(&s2_pname, OPAL_PMIX_CPUSET,
+						   &kp, pmix_kvs_name, pmix_vallen_max, kvs_get);
+	    if (OPAL_SUCCESS != rc) {
+		OPAL_ERROR_LOG(rc);
+		goto cleanup;
+	    }
+	    if (NULL == kp || NULL == kp->data.string) {
+		/* if we share a node, but we don't know anything more, then
+		 * mark us as on the node as this is all we know
+		 */
+		locality = OPAL_PROC_ON_CLUSTER | OPAL_PROC_ON_CU | OPAL_PROC_ON_NODE;
+	    } else {
+		/* determine relative location on our node */
+		locality = opal_hwloc_base_get_relative_locality(opal_hwloc_topology,
+								 opal_process_info.cpuset,
+								 kp->data.string);
+	    }
+	    if (NULL != kp) {
+		OBJ_RELEASE(kp);
+	    }
+	    OPAL_OUTPUT_VERBOSE((1, opal_pmix_base_framework.framework_output,
+				 "%s pmix:s2 proc %s locality %s",
+				 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),
+				 OPAL_NAME_PRINT(s2_pname),
+				 opal_hwloc_base_print_locality(locality)));
 
-            OBJ_CONSTRUCT(&kvn, opal_value_t);
-            kvn.key = strdup(OPAL_PMIX_LOCALITY);
-            kvn.type = OPAL_UINT16;
-            kvn.data.uint16 = locality;
-            opal_pmix_base_store(&pname, &kvn);
-            OBJ_DESTRUCT(&kvn);
-        }
+	    OBJ_CONSTRUCT(&kvn, opal_value_t);
+	    kvn.key = strdup(OPAL_PMIX_LOCALITY);
+	    kvn.type = OPAL_UINT16;
+	    kvn.data.uint16 = locality;
+	    opal_pmix_base_store(&pname, &kvn);
+	    OBJ_DESTRUCT(&kvn);
+	}
     }
 
   cleanup:
@@ -622,7 +622,7 @@ static void fencenb(int sd, short args, void *cbdata)
 }
 
 static int s2_fencenb(opal_list_t *procs, int collect_data,
-                    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
+		    opal_pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmi_opcaddy_t *op;
 
@@ -631,7 +631,7 @@ static int s2_fencenb(opal_list_t *procs, int collect_data,
     op->opcbfunc = cbfunc;
     op->cbdata = cbdata;
     event_assign(&op->ev, opal_pmix_base.evbase, -1,
-                 EV_WRITE, fencenb, op);
+		 EV_WRITE, fencenb, op);
     event_active(&op->ev, EV_WRITE, 1);
 
     return OPAL_SUCCESS;
@@ -639,9 +639,9 @@ static int s2_fencenb(opal_list_t *procs, int collect_data,
 
 #define S2_WAIT_FOR_COMPLETION(a)               \
     do {                                        \
-        while ((a)) {                           \
-            usleep(10);                         \
-        }                                       \
+	while ((a)) {                           \
+	    usleep(10);                         \
+	}                                       \
     } while (0)
 
 struct fence_result {
@@ -667,8 +667,8 @@ static int s2_fence(opal_list_t *procs, int collect_data)
 
 
 static int s2_get(const opal_process_name_t *id,
-                  const char *key, opal_list_t *info,
-                  opal_value_t **kv)
+		  const char *key, opal_list_t *info,
+		  opal_value_t **kv)
 {
     int rc;
     rc = opal_pmix_base_cache_keys_locally(id, key, kv, pmix_kvs_name, pmix_vallen_max, kvs_get);
@@ -681,8 +681,8 @@ static int s2_publish(opal_list_t *info)
     int rc;
 
     if (PMI2_SUCCESS != (rc = PMI2_Nameserv_publish(service_name, NULL, port))) {
-        OPAL_PMI_ERROR(rc, "PMI2_Nameserv_publish");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI2_Nameserv_publish");
+	return OPAL_ERROR;
     }
 #endif
     return OPAL_ERR_NOT_IMPLEMENTED;
@@ -694,8 +694,8 @@ static int s2_lookup(opal_list_t *data, opal_list_t *info)
     int rc;
 
     if (PMI2_SUCCESS != (rc = PMI2_Nameserv_lookup(service_name, NULL, port, portLen))) {
-        OPAL_PMI_ERROR(rc, "PMI2_Nameserv_lookup");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI2_Nameserv_lookup");
+	return OPAL_ERROR;
     }
 
 #endif
@@ -708,15 +708,15 @@ static int s2_unpublish(char **keys, opal_list_t *info)
     int rc;
 
     if (PMI2_SUCCESS != (rc = PMI2_Nameserv_unpublish(service_name, NULL))) {
-        OPAL_PMI_ERROR(rc, "PMI2_Nameserv_unpublish");
-        return OPAL_ERROR;
+	OPAL_PMI_ERROR(rc, "PMI2_Nameserv_unpublish");
+	return OPAL_ERROR;
     }
 #endif
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
 
 static int s2_store_local(const opal_process_name_t *proc,
-                          opal_value_t *val)
+			  opal_value_t *val)
 {
     opal_pmix_base_store(proc, val);
 
@@ -737,22 +737,22 @@ static char* pmix_error(int pmix_err)
     char * err_msg;
 
     switch(pmix_err) {
-        case PMI2_FAIL: err_msg = "Operation failed"; break;
-        case PMI2_ERR_INIT: err_msg = "PMI is not initialized"; break;
-        case PMI2_ERR_NOMEM: err_msg = "Input buffer not large enough"; break;
-        case PMI2_ERR_INVALID_ARG: err_msg = "Invalid argument"; break;
-        case PMI2_ERR_INVALID_KEY: err_msg = "Invalid key argument"; break;
-        case PMI2_ERR_INVALID_KEY_LENGTH: err_msg = "Invalid key length argument"; break;
-        case PMI2_ERR_INVALID_VAL: err_msg = "Invalid value argument"; break;
-        case PMI2_ERR_INVALID_VAL_LENGTH: err_msg = "Invalid value length argument"; break;
-        case PMI2_ERR_INVALID_LENGTH: err_msg = "Invalid length argument"; break;
-        case PMI2_ERR_INVALID_NUM_ARGS: err_msg = "Invalid number of arguments"; break;
-        case PMI2_ERR_INVALID_ARGS: err_msg = "Invalid args argument"; break;
-        case PMI2_ERR_INVALID_NUM_PARSED: err_msg = "Invalid num_parsed length argument"; break;
-        case PMI2_ERR_INVALID_KEYVALP: err_msg = "Invalid keyvalp argument"; break;
-        case PMI2_ERR_INVALID_SIZE: err_msg = "Invalid size argument"; break;
-        case PMI2_SUCCESS: err_msg = "Success"; break;
-        default: err_msg = "Unkown error";
+	case PMI2_FAIL: err_msg = "Operation failed"; break;
+	case PMI2_ERR_INIT: err_msg = "PMI is not initialized"; break;
+	case PMI2_ERR_NOMEM: err_msg = "Input buffer not large enough"; break;
+	case PMI2_ERR_INVALID_ARG: err_msg = "Invalid argument"; break;
+	case PMI2_ERR_INVALID_KEY: err_msg = "Invalid key argument"; break;
+	case PMI2_ERR_INVALID_KEY_LENGTH: err_msg = "Invalid key length argument"; break;
+	case PMI2_ERR_INVALID_VAL: err_msg = "Invalid value argument"; break;
+	case PMI2_ERR_INVALID_VAL_LENGTH: err_msg = "Invalid value length argument"; break;
+	case PMI2_ERR_INVALID_LENGTH: err_msg = "Invalid length argument"; break;
+	case PMI2_ERR_INVALID_NUM_ARGS: err_msg = "Invalid number of arguments"; break;
+	case PMI2_ERR_INVALID_ARGS: err_msg = "Invalid args argument"; break;
+	case PMI2_ERR_INVALID_NUM_PARSED: err_msg = "Invalid num_parsed length argument"; break;
+	case PMI2_ERR_INVALID_KEYVALP: err_msg = "Invalid keyvalp argument"; break;
+	case PMI2_ERR_INVALID_SIZE: err_msg = "Invalid size argument"; break;
+	case PMI2_SUCCESS: err_msg = "Success"; break;
+	default: err_msg = "Unkown error";
     }
     return err_msg;
 }

--- a/opal/mca/pmix/s2/pmix_s2_component.c
+++ b/opal/mca/pmix/s2/pmix_s2_component.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,24 +47,24 @@ opal_pmix_base_component_t mca_pmix_s2_component = {
        about the component itself */
 
     .base_version = {
-        /* Indicate that we are a pmix v1.1.0 component (which also
-           implies a specific MCA version) */
+	/* Indicate that we are a pmix v1.1.0 component (which also
+	   implies a specific MCA version) */
 
-        OPAL_PMIX_BASE_VERSION_2_0_0,
+	OPAL_PMIX_BASE_VERSION_2_0_0,
 
-        /* Component name and version */
+	/* Component name and version */
 
-        .mca_component_name = "s2",
-        MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
-                              OPAL_RELEASE_VERSION),
+	.mca_component_name = "s2",
+	MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+			      OPAL_RELEASE_VERSION),
 
-        .mca_query_component = pmix_s2_component_query,
-        .mca_register_component_params = pmix_s2_component_register,
+	.mca_query_component = pmix_s2_component_query,
+	.mca_register_component_params = pmix_s2_component_register,
     },
     /* Next the MCA v1.0.0 component meta data */
     .base_data = {
-        /* The component is checkpoint ready */
-        MCA_BASE_METADATA_PARAM_CHECKPOINT
+	/* The component is checkpoint ready */
+	MCA_BASE_METADATA_PARAM_CHECKPOINT
     },
     .priority = 20,
 };
@@ -75,12 +76,12 @@ static int pmix_s2_component_register(void)
     mca_base_component_t *component = &(mca_pmix_s2_component.base_version);
 
     ret = mca_base_component_var_register(component, "priority",
-                                          "Priority of the pmix s2 component (default: 20)",
-                                          MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                          OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-                                          &mca_pmix_s2_component.priority);
+					  "Priority of the pmix s2 component (default: 20)",
+					  MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+					  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+					  &mca_pmix_s2_component.priority);
     if (0 > ret) {
-        return ret;
+	return ret;
     }
 
     return OPAL_SUCCESS;
@@ -91,10 +92,10 @@ static int pmix_s2_component_query(mca_base_module_t **module, int *priority)
     /* disqualify ourselves if we are not under slurm, and
      * if they didn't set mpi=pmix2 */
     if (NULL == getenv("SLURM_STEP_NUM_TASKS") ||
-        NULL == getenv("PMI_FD")) {
-        *priority = 0;
-        *module = NULL;
-        return OPAL_ERROR;
+	NULL == getenv("PMI_FD")) {
+	*priority = 0;
+	*module = NULL;
+	return OPAL_ERROR;
     }
 
     /* we can be considered */


### PR DESCRIPTION
No code or logic changes

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@rhc54 It looks like all the pmix components and base used the mixed tabs+spaces formatting to achieve 4-space indenting.  This PR simply replaces all tabs with 8 spaces (since that's our main code style point: no tabs).  Ok?