### PR TITLE
oshmem/fortran: fix warning mesages

### DIFF
--- a/oshmem/shmem/fortran/shmem_put_f.c
+++ b/oshmem/shmem/fortran/shmem_put_f.c
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2013      Mellanox Technologies, Inc.
- *                         All rights reserved.
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2016 Mellanox Technologies, Inc. All rights reserved.
+ * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,8 +33,8 @@ SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
 void shmem_put_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
 {
     MCA_SPML_CALL(put(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * 8,
         FPTR_2_VOID_PTR(source),
-        OMPI_FINT_2_INT(*length),
         OMPI_FINT_2_INT(*pe)));
 }
 


### PR DESCRIPTION
fix warning:
```
pshmem_put_f.c: In function 'shmem_put_f':
pshmem_put_f.c:36:5: warning: passing argument 2 of 'mca_spml.spml_put' makes integer from pointer without a cast [enabled by default]
     MCA_SPML_CALL(put(FPTR_2_VOID_PTR(target),
     ^
pshmem_put_f.c:36:5: note: expected 'size_t' but argument is of type 'void *'
pshmem_put_f.c:36:5: warning: passing argument 3 of 'mca_spml.spml_put' makes pointer from integer
without a cast [enabled by default]
pshmem_put_f.c:36:5: note: expected 'void *' but argument is of type 'int'
```
Please review this PR