### PR TITLE
configury: capture configury command line

### DIFF
--- a/config/opal_setup_cli.m4
+++ b/config/opal_setup_cli.m4
@@ -1,0 +1,37 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2016      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl OPAL_CAPTURE_CONFIGURE_CLI
+dnl
+dnl Capture configure command line and do the AC substitution
+dnl
+dnl Arguments: the variable in which command line will be captured
+dnl
+dnl Dependencies: None
+dnl
+AC_DEFUN([OPAL_CAPTURE_CONFIGURE_CLI],[
+    # Capture configure command line do the AC substitution
+    OPAL_VAR_SCOPE_PUSH([sed_quote_subst arg quoted_arg])
+    $1=
+    for arg in "$[]@"; do
+        sed_quote_subst='s/\(@<:@`"$\\@:>@\)/\\\1/g'
+        case "$arg" in
+          *@<:@\\\`\"\$[]@:>@*)
+	    quoted_arg=\'`echo "$arg" | sed $sed_quote_subst`\' ;;
+          *)
+            quoted_arg="\'$arg\'" ;;
+        esac
+
+        eval "$1=\$$1\\ \$quoted_arg"
+    done
+    OPAL_VAR_SCOPE_POP
+    AC_SUBST($1)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,8 @@ AC_PREREQ(2.60)
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 
+OPAL_CAPTURE_CONFIGURE_CLI([OPAL_CONFIGURE_CLI])
+
 # Get our platform support file.  This has to be done very, very early
 # because it twiddles random bits of autoconf
 OPAL_LOAD_PLATFORM

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved
  * $COPYRIGHT$
@@ -37,6 +37,7 @@
 #endif
 
 #include MCA_timer_IMPLEMENTATION_HEADER
+#include "opal/include/opal/version.h"
 #include "opal/class/opal_value_array.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/util/printf.h"
@@ -315,6 +316,7 @@ void ompi_info_do_config(bool want_all)
     opal_info_out("Configured by", "config:user", OPAL_CONFIGURE_USER);
     opal_info_out("Configured on", "config:timestamp", OPAL_CONFIGURE_DATE);
     opal_info_out("Configure host", "config:host", OPAL_CONFIGURE_HOST);
+    opal_info_out("Configure command line", "config:cli", OPAL_CONFIGURE_CLI);
 
     opal_info_out("Built by", "build:user", OMPI_BUILD_USER);
     opal_info_out("Built on", "build:timestamp", OMPI_BUILD_DATE);

--- a/opal/include/opal/version.h.in
+++ b/opal/include/opal/version.h.in
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,5 +37,6 @@
 #undef OPAL_VERSION
 #endif
 #define OPAL_VERSION "@OPAL_VERSION@"
+#define OPAL_CONFIGURE_CLI "@OPAL_CONFIGURE_CLI@"
 
 #endif

--- a/orte/tools/orte-info/param.c
+++ b/orte/tools/orte-info/param.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -35,6 +35,7 @@
 #endif
 
 #include MCA_timer_IMPLEMENTATION_HEADER
+#include "opal/include/opal/version.h"
 #include "opal/mca/installdirs/installdirs.h"
 #include "opal/class/opal_value_array.h"
 #include "opal/class/opal_pointer_array.h"
@@ -367,6 +368,7 @@ void orte_info_do_config(bool want_all)
     orte_info_out("Configured by", "config:user", OPAL_CONFIGURE_USER);
     orte_info_out("Configured on", "config:timestamp", OPAL_CONFIGURE_DATE);
     orte_info_out("Configure host", "config:host", OPAL_CONFIGURE_HOST);
+    orte_info_out("Configure command line", "config:cli", OPAL_CONFIGURE_CLI);
 
     orte_info_out("Built by", "build:user", OMPI_BUILD_USER);
     orte_info_out("Built on", "build:timestamp", OMPI_BUILD_DATE);

--- a/oshmem/tools/oshmem_info/param.c
+++ b/oshmem/tools/oshmem_info/param.c
@@ -3,7 +3,7 @@
  *                         All rights reserved.
  *
  * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -29,6 +29,7 @@
 #endif
 
 #include MCA_timer_IMPLEMENTATION_HEADER
+#include "opal/include/opal/version.h"
 #include "opal/class/opal_value_array.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/util/printf.h"
@@ -283,6 +284,7 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("Configured by", "config:user", OPAL_CONFIGURE_USER);
     opal_info_out("Configured on", "config:timestamp", OPAL_CONFIGURE_DATE);
     opal_info_out("Configure host", "config:host", OPAL_CONFIGURE_HOST);
+    opal_info_out("Configure command line", "config:cli", OPAL_CONFIGURE_CLI);
 
     opal_info_out("Built by", "build:user", OMPI_BUILD_USER);
     opal_info_out("Built on", "build:timestamp", OMPI_BUILD_DATE);


### PR DESCRIPTION
configury command line is quoted and made available via the OPAL_CONFIGURE_CLI macro.
it can be retrieved via {orte-info,ompi_info,oshmem_info} -c, or
{orte-info,ompi_info,oshmem_info} --all --parseable | grep ^config:cli: