### PR TITLE
Mtl portals4 short msg split msg

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -73,6 +73,8 @@ struct mca_mtl_portals4_module_t {
 
     /** Network interface handle for matched interface */
     ptl_handle_ni_t ni_h;
+    /** Limit given by portals after NIInit */
+    uint64_t max_msg_size_mtl;
     /** Uid for current user */
     ptl_uid_t uid;
 

--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -53,6 +53,8 @@ struct mca_mtl_portals4_module_t {
     /* Use flow control: 1 (true) : 0 (false) */
     int32_t use_flowctl;
 
+    /** Short limit; Size limit for short messages */
+    uint64_t short_limit;
     /** Eager limit; messages greater than this use a rendezvous protocol */
     uint64_t eager_limit;
     /** Size of short message blocks */

--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -46,6 +46,10 @@ struct mca_mtl_portals4_module_t {
 
     /* Use the logical to physical table to accelerate portals4 adressing: 1 (true) : 0 (false) */
     int32_t use_logical;
+
+    /* Process_id */
+    ptl_process_t ptl_process_id;
+
     /* Use flow control: 1 (true) : 0 (false) */
     int32_t use_flowctl;
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -350,6 +350,10 @@ ompi_mtl_portals4_component_init(bool enable_progress_threads,
         goto error;
     }
 
+    ompi_mtl_portals4.ptl_process_id = id;
+    OPAL_OUTPUT_VERBOSE((90, ompi_mtl_base_framework.framework_output,
+        "PtlGetPhysId rank=%x nid=%x pid=%x\n", id.rank, id.phys.nid, id.phys.pid));
+
     OPAL_MODEX_SEND(ret, OPAL_PMIX_GLOBAL,
                     &mca_mtl_portals4_component.mtl_version,
                     &id, sizeof(id));

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -100,6 +100,18 @@ ompi_mtl_portals4_component_register(void)
                                             OPAL_INFO_LVL_9,
                                             MCA_BASE_VAR_SCOPE_READONLY,
                                             &param_priority);
+    ompi_mtl_portals4.short_limit = 2 * 1024;
+    (void) mca_base_component_var_register(&mca_mtl_portals4_component.mtl_version,
+                                           "short_limit",
+                                           "Size limit for short messages",
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_LONG_LONG,
+                                           NULL,
+                                           0,
+                                           0,
+                                           OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_mtl_portals4.short_limit);
+
 
     ompi_mtl_portals4.eager_limit = 2 * 1024;
     (void) mca_base_component_var_register(&mca_mtl_portals4_component.mtl_version,
@@ -196,6 +208,9 @@ ompi_mtl_portals4_component_open(void)
                         "no"
 #endif
                         );
+    opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+                        "Short limit: %d", (int)
+                        ompi_mtl_portals4.short_limit);
     opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                         "Eager limit: %d", (int)
                         ompi_mtl_portals4.eager_limit);

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -185,6 +185,19 @@ ompi_mtl_portals4_component_register(void)
                                            OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &ompi_mtl_portals4.protocol);
+
+    ompi_mtl_portals4.max_msg_size_mtl = PTL_SIZE_MAX;
+    (void) mca_base_component_var_register(&mca_mtl_portals4_component.mtl_version,
+                                           "max_msg_size",
+                                           "Max size supported by portals4 (above that, a message is cut into messages less than that size)",
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_LONG,
+                                           NULL,
+                                           0,
+                                           0,
+                                           OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_mtl_portals4.max_msg_size_mtl);
+
     OBJ_RELEASE(new_enum);
     if (0 > ret) {
         return OMPI_ERR_NOT_SUPPORTED;
@@ -208,6 +221,9 @@ ompi_mtl_portals4_component_open(void)
                         "no"
 #endif
                         );
+    opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+                        "Max message size: %lu", (unsigned long)
+                        ompi_mtl_portals4.max_msg_size_mtl);
     opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                         "Short limit: %d", (int)
                         ompi_mtl_portals4.short_limit);
@@ -328,6 +344,11 @@ ompi_mtl_portals4_component_init(bool enable_progress_threads,
                             __FILE__, __LINE__, ret);
         goto error;
     }
+
+    if (actual_limits.max_msg_size < ompi_mtl_portals4.max_msg_size_mtl)
+        ompi_mtl_portals4.max_msg_size_mtl = actual_limits.max_msg_size;
+    OPAL_OUTPUT_VERBOSE((10, ompi_mtl_base_framework.framework_output,
+        "Due to portals4 and user configuration messages will not go over the size of %lu", ompi_mtl_portals4.max_msg_size_mtl));
 
     if (ompi_comm_rank(MPI_COMM_WORLD) == 0) {
         opal_output_verbose(10, ompi_mtl_base_framework.framework_output, "max_entries=%d", actual_limits.max_entries);

--- a/ompi/mca/mtl/portals4/mtl_portals4_flowctl.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_flowctl.c
@@ -70,6 +70,13 @@ ompi_mtl_portals4_flowctl_init(void)
         goto error;
     }
 
+    if (ompi_mtl_portals4.flowctl_idx != REQ_FLOWCTL_TABLE_ID) {
+        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+                            "%s:%d: PtlPTAlloc did not allocate the requested PT: %d\n",
+                            __FILE__, __LINE__, ompi_mtl_portals4.flowctl_idx);
+        goto error;
+    }
+
     ret = PtlCTAlloc(ompi_mtl_portals4.ni_h,
                      &ompi_mtl_portals4.flowctl.trigger_ct_h);
     if (OPAL_UNLIKELY(PTL_OK != ret)) {
@@ -291,9 +298,7 @@ ompi_mtl_portals4_flowctl_trigger(void)
 {
     int ret;
 
-    if (false == ompi_mtl_portals4.flowctl.flowctl_active) {
-        ompi_mtl_portals4.flowctl.flowctl_active = true;
-
+    if (true == OPAL_ATOMIC_CMPSET_32(&ompi_mtl_portals4.flowctl.flowctl_active, false, true)) {
         /* send trigger to root */
         ret = PtlPut(ompi_mtl_portals4.zero_md_h,
                      0,

--- a/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_flowctl.h
@@ -34,7 +34,7 @@ OBJ_CLASS_DECLARATION(ompi_mtl_portals4_pending_request_t);
 
 
 struct ompi_mtl_portals4_flowctl_t {
-    bool flowctl_active;
+    int32_t flowctl_active;
 
     int32_t send_slots;
     int32_t max_send_slots;

--- a/ompi/mca/mtl/portals4/mtl_portals4_probe.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_probe.c
@@ -32,7 +32,7 @@ completion_fn(ptl_event_t *ev, ompi_mtl_portals4_base_request_t *ptl_base_reques
     ompi_mtl_portals4_probe_request_t *ptl_request =
         (ompi_mtl_portals4_probe_request_t*) ptl_base_request;
 
-    opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+    opal_output_verbose(10, ompi_mtl_base_framework.framework_output,
                         "%s:%d: completion_fn: %d %d",
                         __FILE__, __LINE__, ev->type, ev->ni_fail_type);
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv_short.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv_short.c
@@ -191,7 +191,7 @@ ompi_mtl_portals4_activate_block(ompi_mtl_portals4_recv_short_block_t *block)
     me.start = block->start;
     me.length = ompi_mtl_portals4.recv_short_size;
     me.ct_handle = PTL_CT_NONE;
-    me.min_free = ompi_mtl_portals4.eager_limit;
+    me.min_free = ompi_mtl_portals4.short_limit;
     me.uid = ompi_mtl_portals4.uid;
     me.options =
         PTL_ME_OP_PUT |

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -52,6 +52,7 @@ struct ompi_mtl_portals4_isend_request_t {
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
     struct ompi_mtl_portals4_pending_request_t *pending;
 #endif
+    ptl_size_t length;
     uint32_t event_count;
 };
 typedef struct ompi_mtl_portals4_isend_request_t ompi_mtl_portals4_isend_request_t;

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -53,6 +53,7 @@ struct ompi_mtl_portals4_isend_request_t {
     struct ompi_mtl_portals4_pending_request_t *pending;
 #endif
     ptl_size_t length;
+    int32_t pending_get;
     uint32_t event_count;
 };
 typedef struct ompi_mtl_portals4_isend_request_t ompi_mtl_portals4_isend_request_t;
@@ -74,6 +75,7 @@ struct ompi_mtl_portals4_recv_request_t {
     void *delivery_ptr;
     size_t delivery_len;
     volatile bool req_started;
+    int32_t pending_reply;
 #if OPAL_ENABLE_DEBUG
     uint64_t opcount;
     ptl_hdr_data_t hdr_data;

--- a/ompi/mca/mtl/portals4/mtl_portals4_send.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_send.c
@@ -44,6 +44,29 @@ ompi_mtl_portals4_callback(ptl_event_t *ev,
     ompi_mtl_portals4_isend_request_t* ptl_request =
         (ompi_mtl_portals4_isend_request_t*) ptl_base_request;
 
+    if (PTL_EVENT_GET == ev->type) {
+        ret = OPAL_THREAD_ADD32(&(ptl_request->pending_get), -1);
+        if (ret > 0) {
+            /* wait for other gets */
+            OPAL_OUTPUT_VERBOSE((90, ompi_mtl_base_framework.framework_output, "PTL_EVENT_GET received now pending_get=%d",ret));
+            return retval;
+        }
+        assert(ptl_request->pending_get == 0);
+
+        /* last get received */
+        OPAL_OUTPUT_VERBOSE((90, ompi_mtl_base_framework.framework_output, "PTL_EVENT_GET: PtlMEUnlink is called ptl_request->me_h=%d (pending get=%d)", ptl_request->me_h, ret));
+
+        if (!PtlHandleIsEqual(ptl_request->me_h, PTL_INVALID_HANDLE)) {
+            ret = PtlMEUnlink(ptl_request->me_h);
+            if (PTL_OK != ret) {
+                opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+                                "%s:%d: send callback PtlMEUnlink returned %d",
+                                __FILE__, __LINE__, ret);
+            }
+            ptl_request->me_h = PTL_INVALID_HANDLE;
+        }
+    }
+
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
     if (OPAL_UNLIKELY(ev->ni_fail_type == PTL_NI_PT_DISABLED)) {
         ompi_mtl_portals4_pending_request_t *pending =
@@ -66,6 +89,7 @@ ompi_mtl_portals4_callback(ptl_event_t *ev,
                                     "%s:%d: send callback PtlMEUnlink returned %d",
                                     __FILE__, __LINE__, ret);
             }
+            ptl_request->me_h = PTL_INVALID_HANDLE;
         }
 
         opal_list_append(&ompi_mtl_portals4.flowctl.pending_sends,
@@ -89,6 +113,33 @@ ompi_mtl_portals4_callback(ptl_event_t *ev,
                          "send %lu got event of type %d",
                          ptl_request->opcount, ev->type));
 
+    /* First put achieved successfully (In the Priority List), so it may be necessary to decrement the number of pending get
+     * If the protocol is eager, just decrement pending_get 
+     * Else (the protocol is rndv), decrement pending_get only if length % max_msg_size <= eager_limit
+     * (This is the case where the eager part allows to save one get)
+     */
+    if ((PTL_EVENT_ACK == ev->type) &&
+        (PTL_PRIORITY_LIST == ev->ptl_list) &&
+        (0 <  ptl_request->pending_get)) {
+
+        if ((eager == ompi_mtl_portals4.protocol) ||
+             (ptl_request->length % ompi_mtl_portals4.max_msg_size_mtl <= ompi_mtl_portals4.eager_limit)) {
+           val = OPAL_THREAD_ADD32(&(ptl_request->pending_get), -1);
+        }
+        if (0 == val) {
+            add = 2; /* We haven't to wait for any get, so we have to add an extra count to cause the message to complete */
+            if (!PtlHandleIsEqual(ptl_request->me_h, PTL_INVALID_HANDLE)) {
+                ret = PtlMEUnlink(ptl_request->me_h);
+                if (PTL_OK != ret) {
+                    opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+                                "%s:%d: send callback PtlMEUnlink returned %d",
+                                __FILE__, __LINE__, ret);
+                }
+                ptl_request->me_h = PTL_INVALID_HANDLE;
+            }
+        }
+    }
+
     if ((PTL_EVENT_ACK == ev->type) &&
         (PTL_PRIORITY_LIST == ev->ptl_list) &&
         (ev->mlength == ptl_request->length) &&
@@ -107,10 +158,10 @@ ompi_mtl_portals4_callback(ptl_event_t *ev,
                                 "%s:%d: send callback PtlMEUnlink returned %d",
                                 __FILE__, __LINE__, ret);
         }
+        ptl_request->me_h = PTL_INVALID_HANDLE;
         add++;
     }
     val = OPAL_THREAD_ADD32((int32_t*)&ptl_request->event_count, add);
-
     assert(val <= 3);
 
     if (val == 3) {
@@ -193,6 +244,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
 
     MTL_PORTALS4_SET_HDR_DATA(hdr_data, ptl_request->opcount, length,
                               (MCA_PML_BASE_SEND_SYNCHRONOUS == mode) ? 1 : 0);
+    ptl_request->me_h = PTL_INVALID_HANDLE;
 
     if (MCA_PML_BASE_SEND_SYNCHRONOUS == mode) {
         me.start = NULL;
@@ -219,6 +271,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
             opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                                 "%s:%d: PtlMEAppend failed: %d",
                                 __FILE__, __LINE__, ret);
+            ptl_request->me_h = PTL_INVALID_HANDLE;
             return ompi_mtl_portals4_get_error(ret);
         }
 
@@ -227,7 +280,6 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
                              ptl_request->opcount, hdr_data, match_bits));
     } else {
         ptl_request->event_count = 1;
-        ptl_request->me_h = PTL_INVALID_HANDLE;
 
         OPAL_OUTPUT_VERBOSE((50, ompi_mtl_base_framework.framework_output,
                              "Send %lu short send with hdr_data 0x%lx (0x%lx)",
@@ -238,6 +290,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
                          "Send %lu, start: %p",
                          ptl_request->opcount, start));
 
+    ptl_request->pending_get = 0;
     ret = PtlPut(ompi_mtl_portals4.send_md_h,
                  (ptl_size_t) start,
                  length,
@@ -254,6 +307,7 @@ ompi_mtl_portals4_short_isend(mca_pml_base_send_mode_t mode,
                             __FILE__, __LINE__, ret);
         if (MCA_PML_BASE_SEND_SYNCHRONOUS == mode) {
             PtlMEUnlink(ptl_request->me_h);
+            ptl_request->me_h = PTL_INVALID_HANDLE;
         }
         return ompi_mtl_portals4_get_error(ret);
     }
@@ -285,7 +339,6 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
     me.uid = ompi_mtl_portals4.uid;
     me.options =
         PTL_ME_OP_GET |
-        PTL_ME_USE_ONCE |
         PTL_ME_EVENT_LINK_DISABLE |
         PTL_ME_EVENT_UNLINK_DISABLE;
     me.match_id = ptl_proc;
@@ -309,10 +362,32 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
                          "Send %lu long send with hdr_data 0x%lx (0x%lx)",
                          ptl_request->opcount, hdr_data, match_bits));
 
-    if ((rndv == ompi_mtl_portals4.protocol) && ((ptl_size_t) length > (ptl_size_t) ompi_mtl_portals4.eager_limit))
-        put_length = (ptl_size_t) ompi_mtl_portals4.eager_limit;
-    else put_length = (ptl_size_t) length;
+    if (rndv == ompi_mtl_portals4.protocol) {
+        ptl_size_t min = (OPAL_LIKELY (ompi_mtl_portals4.eager_limit < ompi_mtl_portals4.max_msg_size_mtl)) ?
+            ompi_mtl_portals4.eager_limit :
+            ompi_mtl_portals4.max_msg_size_mtl;
+        if ((ptl_size_t) length > (ptl_size_t) min) {
+            OPAL_OUTPUT_VERBOSE((90, ompi_mtl_base_framework.framework_output,
+                                 "msg truncated by %ld", length - min));
+            put_length = (ptl_size_t) min;
+        }
+        else
+            put_length = (ptl_size_t) length;
+    } else { // eager protocol
+        if (length >  ompi_mtl_portals4.max_msg_size_mtl)
+            put_length = (ptl_size_t) ompi_mtl_portals4.max_msg_size_mtl;
+        else
+            put_length = (ptl_size_t) length;
+    }
 
+    /* We have to wait for some GET events.
+       If the first put falls in overflow list, the number of GET event is egal to:
+           (length - 1) / ompi_mtl_portals4.max_msg_size_mtl + 1
+       else we will re-calculate this number when we received the first ACK event (with remote overflow list)
+     */
+
+    ptl_request->pending_get = (length - 1) / ompi_mtl_portals4.max_msg_size_mtl + 1;
+    OPAL_OUTPUT_VERBOSE((90, ompi_mtl_base_framework.framework_output, "pending_get=%d", ptl_request->pending_get));
 
     ret = PtlPut(ompi_mtl_portals4.send_md_h,
                  (ptl_size_t) start,
@@ -328,7 +403,8 @@ ompi_mtl_portals4_long_isend(void *start, size_t length, int contextid, int tag,
         opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                             "%s:%d: PtlPut failed: %d",
                             __FILE__, __LINE__, ret);
-	PtlMEUnlink(ptl_request->me_h);
+        PtlMEUnlink(ptl_request->me_h);
+        ptl_request->me_h = PTL_INVALID_HANDLE;
         return ompi_mtl_portals4_get_error(ret);
     }
 


### PR DESCRIPTION
This set of patchs controls that flowctl_idx is egal to REQ_FLOWCTL_TABLE_ID and uses OPAL_ATOMIC_CMPSET_32 to test and set flowctl_active flag to true. It stores and displays the ptl_process_id. It corrects the calculation of request_status._ucount. It introduces a "short_limit" to specify the maximum size of SHORT messages ("eager_limit" will therefore only be used to limit the eager part of the messages sent with the rndv protocol). At least, it splits messages greater than the portals4 limitation.
