### PR TITLE
Fix shmem.fh: fails to compile with F77 fixed-form compiled programs...

### DIFF
--- a/oshmem/include/shmem.fh
+++ b/oshmem/include/shmem.fh
@@ -19,10 +19,11 @@
       integer SHMEM_MINOR_VERSION
       parameter ( SHMEM_MINOR_VERSION = 2 )
 
-      CHARACTER(LEN = 256), PARAMETER :: SHMEM_VENDOR_STRING = "http://www.open-mpi.org/"
-
       integer SHMEM_MAX_NAME_LEN
       parameter ( SHMEM_MAX_NAME_LEN = 256-1 )
+
+      character(LEN = SHMEM_MAX_NAME_LEN) SHMEM_VENDOR_STRING
+      parameter ( SHMEM_VENDOR_STRING = "http://www.open-mpi.org/" )
 
       integer SHMEM_BARRIER_SYNC_SIZE
       parameter ( SHMEM_BARRIER_SYNC_SIZE = 4 )


### PR DESCRIPTION
Dear @miked-mellanox and @igor-ivanov,
please consider the following patch to allow compilation of F77 fixed-form programs.

Please note, this should _not_ conflict with your branch https://github.com/igor-ivanov/ompi/tree/pr/oshmem-v1.3
