### PR TITLE
opal/thread: clean up and add additional OPAL_THREAD macros

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_active_target.c
+++ b/ompi/mca/osc/sm/osc_sm_active_target.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
@@ -133,7 +133,7 @@ ompi_osc_sm_start(struct ompi_group_t *group,
 
     OBJ_RETAIN(group);
 
-    if (!OPAL_ATOMIC_CMPSET(&module->start_group, NULL, group)) {
+    if (!OPAL_ATOMIC_CMPSET_PTR(&module->start_group, NULL, group)) {
         OBJ_RELEASE(group);
         return OMPI_ERR_RMA_SYNC;
     }
@@ -185,7 +185,7 @@ ompi_osc_sm_complete(struct ompi_win_t *win)
     opal_atomic_mb();
 
     group = module->start_group;
-    if (NULL == group || !OPAL_ATOMIC_CMPSET(&module->start_group, group, NULL)) {
+    if (NULL == group || !OPAL_ATOMIC_CMPSET_PTR(&module->start_group, group, NULL)) {
         return OMPI_ERR_RMA_SYNC;
     }
 

--- a/ompi/mpi/c/comm_get_errhandler.c
+++ b/ompi/mpi/c/comm_get_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,7 +69,7 @@ int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler)
      error_handler became atomic. */
   do {
       tmp = comm->error_handler;
-  } while (!OPAL_ATOMIC_CMPSET(&(comm->error_handler), tmp, tmp));
+  } while (!OPAL_ATOMIC_CMPSET_PTR(&(comm->error_handler), tmp, tmp));
 
   /* Retain the errhandler, corresponding to object refcount decrease
      in errhandler_free.c. */

--- a/ompi/mpi/c/comm_set_errhandler.c
+++ b/ompi/mpi/c/comm_set_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,9 +72,7 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
     /* Ditch the old errhandler, and decrement its refcount.  On 64
        bits environments we have to make sure the reading of the
        error_handler became atomic. */
-    do {
-        tmp = comm->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(comm->error_handler), tmp, errhandler));
+    tmp = OPAL_ATOMIC_SWAP_PTR(&comm->error_handler, errhandler);
     OBJ_RELEASE(tmp);
 
     /* All done */

--- a/ompi/mpi/c/file_get_errhandler.c
+++ b/ompi/mpi/c/file_get_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,7 +68,7 @@ int MPI_File_get_errhandler( MPI_File file, MPI_Errhandler *errhandler)
      error_handler became atomic. */
   do {
       tmp = file->error_handler;
-  } while (!OPAL_ATOMIC_CMPSET(&(file->error_handler), tmp, tmp));
+  } while (!OPAL_ATOMIC_CMPSET_PTR(&(file->error_handler), tmp, tmp));
 
   /* Retain the errhandler, corresponding to object refcount
      decrease in errhandler_free.c. */

--- a/ompi/mpi/c/file_set_errhandler.c
+++ b/ompi/mpi/c/file_set_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,9 +71,7 @@ int MPI_File_set_errhandler( MPI_File file, MPI_Errhandler errhandler)
     /* Ditch the old errhandler, and decrement its refcount.  On 64
        bits environments we have to make sure the reading of the
        error_handler became atomic. */
-    do {
-        tmp = file->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(file->error_handler), tmp, errhandler));
+    tmp = OPAL_ATOMIC_SWAP_PTR (&file->error_handler, errhandler);
     OBJ_RELEASE(tmp);
 
     /* All done */

--- a/ompi/mpi/c/win_get_errhandler.c
+++ b/ompi/mpi/c/win_get_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,7 +61,7 @@ int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler)
        error_handler became atomic. */
     do {
         tmp = win->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(win->error_handler), tmp, tmp));
+    } while (!OPAL_ATOMIC_CMPSET_PTR(&(win->error_handler), tmp, tmp));
 
     /* Retain the errhandler, corresponding to object refcount
        decrease in errhandler_free.c. */

--- a/ompi/mpi/c/win_set_errhandler.c
+++ b/ompi/mpi/c/win_set_errhandler.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,9 +66,7 @@ int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler)
     /* Ditch the old errhandler, and decrement its refcount.  On 64
        bits environments we have to make sure the reading of the
        error_handler became atomic. */
-    do {
-        tmp = win->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET(&(win->error_handler), tmp, errhandler));
+    tmp = OPAL_ATOMIC_SWAP_PTR(&win->error_handler, errhandler);
     OBJ_RELEASE(tmp);
 
     /* All done */


### PR DESCRIPTION
This commit expands the OPAL_THREAD macros to include 32- and 64-bit
atomic swap. Additionally, macro declararations have been updated to
include both OPAL_THREAD_* and OPAL_ATOMIC_*. Before this commit the
former was used with add and the later with cmpset.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>