### PR TITLE
mpisync: Fix a compilation error.

### DIFF
--- a/ompi/tools/mpisync/sync.c
+++ b/ompi/tools/mpisync/sync.c
@@ -8,6 +8,8 @@
  * $HEADER$
  */
 
+#include "opal_config.h"
+
 #include <stdio.h>
 #include <mpi.h>
 #include <unistd.h>


### PR DESCRIPTION
This commit fixes the undefined `OPAL_MAXHOSTNAMELEN` error
which arises only when `--enable-timing` is specified for
`configure`.

This bug exists only in master branch because the commit 3322347
is not merged into other branches.