### PR TITLE
hwloc: fix Valgrind warning

### DIFF
--- a/opal/mca/hwloc/hwloc1113/README-ompi.txt
+++ b/opal/mca/hwloc/hwloc1113/README-ompi.txt
@@ -3,3 +3,4 @@ Cherry-picked commits after 1.11.3:
 open-mpi/hwloc@9549fd59af04dca2e2340e17f0e685f8c552d818
 open-mpi/hwloc@0ab7af5e90fc2b58be30b2126cc2a73f9f7ecfe9
 open-mpi/hwloc@8b44fb1c812d01582887548c2fc28ee78255619
+open-mpi/hwloc@d4565c351e5f01e27d3e106e3a4c2f971a37c9dd

--- a/opal/mca/hwloc/hwloc1113/hwloc/config/hwloc.m4
+++ b/opal/mca/hwloc/hwloc1113/hwloc/config/hwloc.m4
@@ -681,6 +681,8 @@ EOF])
     AS_IF([test "$hwloc_mode" != "embedded"],
         [AC_CHECK_HEADERS([valgrind/valgrind.h])
          AC_CHECK_DECLS([RUNNING_ON_VALGRIND],,[:],[[#include <valgrind/valgrind.h>]])
+	],[
+	 AC_DEFINE([HAVE_DECL_RUNNING_ON_VALGRIND], [0], [Embedded mode; just assume we do not have Valgrind support])
 	])
 
     AC_CHECK_HEADERS([pthread_np.h])


### PR DESCRIPTION
Cherry picked from open-mpi/hwloc@d4565c351e5f01e27d3e106e3a4c2f971a37c9dd

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>