### PR TITLE
mpool/hugepage mntent intro fallout

### DIFF
--- a/opal/mca/mpool/hugepage/mpool_hugepage_component.c
+++ b/opal/mca/mpool/hugepage/mpool_hugepage_component.c
@@ -230,7 +230,6 @@ static void mca_mpool_hugepage_find_hugepages (void) {
 
         do {
             if (0 == strncmp (tok, "pagesize", 8)) {
-                free(opts);
                 break;
             }
             tok = strtok_r (NULL, ",", &ctx);


### PR DESCRIPTION
On Cray, PR #1846 introduced a double free
situation which leads to all kinds of random memory
corruption problems.

This commit fixes this problem.
@ggouaillardet - this will need to be included when PR #1846 is pushed back to v2.x

Signed-off-by: Howard Pritchard <howardp@lanl.gov>