### PR TITLE
pml/ob1: reset req_bytes_packed on start

### DIFF
--- a/ompi/mca/pml/base/pml_base_recvreq.h
+++ b/ompi/mca/pml/base/pml_base_recvreq.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -87,20 +90,21 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_pml_base_recv_request_t);
  */
 #define MCA_PML_BASE_RECV_START( request )                                      \
     do {                                                                        \
-        (request)->req_pml_complete = false;                                    \
+        (request)->req_bytes_packed = 0;                                        \
+        (request)->req_base.req_pml_complete = false;                           \
                                                                                 \
         /* always set the req_status.MPI_TAG to ANY_TAG before starting the     \
          * request. This field is used if cancelled to find out if the request  \
          * has been matched or not.                                             \
          */                                                                     \
-        (request)->req_ompi.req_status.MPI_SOURCE = OMPI_ANY_SOURCE;            \
-        (request)->req_ompi.req_status.MPI_TAG = OMPI_ANY_TAG;                  \
-        (request)->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;                \
-        (request)->req_ompi.req_status._ucount = 0;                             \
-        (request)->req_ompi.req_status._cancelled = 0;                          \
+        (request)->req_base.req_ompi.req_status.MPI_SOURCE = OMPI_ANY_SOURCE;   \
+        (request)->req_base.req_ompi.req_status.MPI_TAG = OMPI_ANY_TAG;         \
+        (request)->req_base.req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;       \
+        (request)->req_base.req_ompi.req_status._ucount = 0;                    \
+        (request)->req_base.req_ompi.req_status._cancelled = 0;                 \
                                                                                 \
-        (request)->req_ompi.req_complete = REQUEST_PENDING;                     \
-        (request)->req_ompi.req_state = OMPI_REQUEST_ACTIVE;                    \
+        (request)->req_base.req_ompi.req_complete = REQUEST_PENDING;            \
+        (request)->req_base.req_ompi.req_state = OMPI_REQUEST_ACTIVE;           \
     } while (0)
 
 /**

--- a/ompi/mca/pml/base/pml_base_sendreq.h
+++ b/ompi/mca/pml/base/pml_base_sendreq.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,6 +113,12 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION( mca_pml_base_send_request_t );
       }                                                                   \
    }
 
+#define MCA_PML_BASE_SEND_REQUEST_RESET(request)                        \
+    if ((request)->req_bytes_packed > 0) {                              \
+        opal_convertor_set_position(&(sendreq)->req_send.req_base.req_convertor, \
+                                    &(size_t){0});                      \
+    }
+
 /**
  * Mark the request as started from the PML base point of view.
  *
@@ -118,10 +127,11 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION( mca_pml_base_send_request_t );
 
 #define MCA_PML_BASE_SEND_START( request )                    \
     do {                                                      \
-        (request)->req_pml_complete = false;                  \
-        (request)->req_ompi.req_complete = REQUEST_PENDING;   \
-        (request)->req_ompi.req_state = OMPI_REQUEST_ACTIVE;  \
-        (request)->req_ompi.req_status._cancelled = 0;        \
+        (request)->req_base.req_pml_complete = false;         \
+        (request)->req_base.req_ompi.req_complete = REQUEST_PENDING;    \
+        (request)->req_base.req_ompi.req_state = OMPI_REQUEST_ACTIVE;   \
+        (request)->req_base.req_ompi.req_status._cancelled = 0;         \
+        MCA_PML_BASE_SEND_REQUEST_RESET(request);             \
     } while (0)
 
 /**

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -193,7 +193,7 @@ mca_pml_ob1_imrecv( void *buf,
     recvreq->req_pending = false;
     recvreq->req_ack_sent = false;
 
-    MCA_PML_BASE_RECV_START(&recvreq->req_recv.req_base);
+    MCA_PML_BASE_RECV_START(&recvreq->req_recv);
 
     /* Note - sequence number already assigned */
     recvreq->req_recv.req_base.req_sequence = seq;
@@ -285,7 +285,7 @@ mca_pml_ob1_mrecv( void *buf,
     recvreq->req_rdma_idx = 0;
     recvreq->req_pending = false;
 
-    MCA_PML_BASE_RECV_START(&recvreq->req_recv.req_base);
+    MCA_PML_BASE_RECV_START(&recvreq->req_recv);
 
     /* Note - sequence number already assigned */
     recvreq->req_recv.req_base.req_sequence = seq;

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -156,12 +156,7 @@ get_request_from_send_pending(mca_pml_ob1_send_pending_t *type)
     }
 
 #define MCA_PML_OB1_SEND_REQUEST_RESET(sendreq)                         \
-    if ((sendreq)->req_send.req_bytes_packed > 0) {                     \
-        size_t _position = 0;                                           \
-        opal_convertor_set_position(&(sendreq)->req_send.req_base.req_convertor, \
-                                    &_position);                        \
-        assert( 0 == _position );                                       \
-    }
+    MCA_PML_BASE_SEND_REQUEST_RESET(&(sendreq)->req_send)
 
 static inline void mca_pml_ob1_free_rdma_resources (mca_pml_ob1_send_request_t* sendreq)
 {
@@ -460,7 +455,7 @@ mca_pml_ob1_send_request_start_seq (mca_pml_ob1_send_request_t* sendreq, mca_bml
     sendreq->req_pending = MCA_PML_OB1_SEND_PENDING_NONE;
     sendreq->req_send.req_base.req_sequence = seqn;
 
-    MCA_PML_BASE_SEND_START( &sendreq->req_send.req_base );
+    MCA_PML_BASE_SEND_START( &sendreq->req_send );
 
     for(size_t i = 0; i < mca_bml_base_btl_array_get_size(&endpoint->btl_eager); i++) {
         mca_bml_base_btl_t* bml_btl;


### PR DESCRIPTION
On start we were not correctly resetting all request fields. This was
leading to a double-completion on persistent receives. This commit
updates the base start code to reset both the send and receive request
req_bytes_packed fields in the START macros. The only pml that appears
to be affected is ob1.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>