### PR TITLE
code cleanup: clang is now a happier panda

### DIFF
--- a/ompi/mca/coll/base/coll_base_alltoall.c
+++ b/ompi/mca/coll/base/coll_base_alltoall.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2013      Los Alamos National Security, LLC. All Rights
+ * Copyright (c) 2013-2016 Los Alamos National Security, LLC. All Rights
  *                         reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -343,7 +343,8 @@ int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, int scount,
                                                mca_coll_base_module_t *module,
                                                int max_outstanding_reqs)
 {
-    int line, error, ri, si, rank, size, nreqs, nrreqs, nsreqs, total_reqs;
+    int line, error, ri, si, rank, size, nrreqs, nsreqs, total_reqs;
+    int nreqs = 0;
     char *psnd, *prcv;
     ptrdiff_t slb, sext, rlb, rext;
 
@@ -565,7 +566,8 @@ int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, int scount,
                                                struct ompi_communicator_t *comm,
                                                mca_coll_base_module_t *module)
 {
-    int i, rank, size, err, nreqs, line;
+    int i, rank, size, err, line;
+    int nreqs = 0;
     char *psnd, *prcv;
     MPI_Aint lb, sndinc, rcvinc;
     ompi_request_t **req, **sreq, **rreq;

--- a/orte/runtime/orte_data_server.c
+++ b/orte/runtime/orte_data_server.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012      Los Alamos National Security, LLC.
+ * Copyright (c) 2012-2016 Los Alamos National Security, LLC.
  *                         All rights reserved
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
@@ -178,7 +178,7 @@ void orte_data_server(int status, orte_process_name_t* sender,
     uint32_t uid = UINT32_MAX;
     opal_pmix_data_range_t range;
     orte_data_req_t *req, *rqnext;
-    orte_jobid_t jobid;
+    orte_jobid_t jobid = ORTE_JOBID_INVALID;
 
     OPAL_OUTPUT_VERBOSE((1, orte_debug_output,
                          "%s data server got message from %s",


### PR DESCRIPTION
Clang 5.1 on my mac was a sad panda compiling a couple
of files,  complaining about uninitialized stack variables.

This commit makes clang a happier panda (or at least not so sad).
@rhc54 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>