### PR TITLE
romio: update REFRESH_NOTES to accommodate the random() patch.

### DIFF
--- a/ompi/mca/io/romio314/REFRESH_NOTES.txt
+++ b/ompi/mca/io/romio314/REFRESH_NOTES.txt
@@ -34,6 +34,7 @@ git add <new romio>
 # git show 74a46863ca3d0806050e7a55377a4fbde612f3fe | patch -p5
 # git show 2b5c52fb05ab54e4fa72e948acabc42e3f979ebd | patch -p5
 # git show 24a6f1425734eb3e6ffb9e37f510507a4a65ebd1 | patch -p5
+# git show 23b27c510c2c626a09457abad7699cfc4740d1eb | patch -p5
 # cd ../../../..
 # git add ompi/mca/io/romio314
 # git commit


### PR DESCRIPTION
From patch: open-mpi/ompi@23b27c510c2c626a09457abad7699cfc4740d1eb
