### PR TITLE
ompi request callback update

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_rte.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_rte.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2013      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -358,7 +358,6 @@ static void* get_coll_handle(void)
     }
     ompi_req = (ompi_request_t *)item;
     OMPI_REQUEST_INIT(ompi_req,false);
-    ompi_req->req_complete_cb = NULL;
     ompi_req->req_status.MPI_ERROR = MPI_SUCCESS;
     ompi_req->req_state = OMPI_REQUEST_ACTIVE;
     ompi_req->req_free = request_free;

--- a/ompi/mca/pml/yalla/pml_yalla_request.c
+++ b/ompi/mca/pml/yalla/pml_yalla_request.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -150,8 +150,6 @@ static void init_base_req(mca_pml_yalla_base_request_t *req)
     OMPI_REQUEST_INIT(&req->ompi, false);
     req->ompi.req_type             = OMPI_REQUEST_PML;
     req->ompi.req_cancel           = NULL;
-    req->ompi.req_complete_cb      = NULL;
-    req->ompi.req_complete_cb_data = NULL;
     req->convertor                  = NULL;
 }
 


### PR DESCRIPTION
This PR changes when the callback happens on a completed request. This is completely internal to Open MPI and currently only affects osc/pt2pt. This fixes a race condition between returning a request and its completion.