### PR TITLE
osc/pt2pt updates

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -91,6 +91,15 @@ struct ompi_osc_pt2pt_component_t {
 };
 typedef struct ompi_osc_pt2pt_component_t ompi_osc_pt2pt_component_t;
 
+enum {
+    /** peer has sent an unexpected post message (no matching start) */
+    OMPI_OSC_PT2PT_PEER_FLAG_UNEX = 1,
+    /** eager sends are active on this peer */
+    OMPI_OSC_PT2PT_PEER_FLAG_EAGER = 2,
+    /** peer has been locked (on-demand locking for lock_all) */
+    OMPI_OSC_PT2PT_PEER_FLAG_LOCK = 4,
+};
+
 
 struct ompi_osc_pt2pt_peer_t {
     /** make this an opal object */
@@ -111,10 +120,51 @@ struct ompi_osc_pt2pt_peer_t {
     /** number of fragments incomming (negative - expected, positive - unsynchronized) */
     int32_t passive_incoming_frag_count;
 
-    /** unexpected post message arrived */
-    bool unexpected_post;
+    /** peer flags */
+    int32_t flags;
 };
 typedef struct ompi_osc_pt2pt_peer_t ompi_osc_pt2pt_peer_t;
+
+OBJ_CLASS_DECLARATION(ompi_osc_pt2pt_peer_t);
+
+static inline bool ompi_osc_pt2pt_peer_locked (ompi_osc_pt2pt_peer_t *peer)
+{
+    return !!(peer->flags & OMPI_OSC_PT2PT_PEER_FLAG_LOCK);
+}
+
+static inline bool ompi_osc_pt2pt_peer_unex (ompi_osc_pt2pt_peer_t *peer)
+{
+    return !!(peer->flags & OMPI_OSC_PT2PT_PEER_FLAG_UNEX);
+}
+
+static inline bool ompi_osc_pt2pt_peer_eager_active (ompi_osc_pt2pt_peer_t *peer)
+{
+    return !!(peer->flags & OMPI_OSC_PT2PT_PEER_FLAG_EAGER);
+}
+
+static inline void ompi_osc_pt2pt_peer_set_flag (ompi_osc_pt2pt_peer_t *peer, int32_t flag, bool value)
+{
+    if (value) {
+        peer->flags |= flag;
+    } else {
+        peer->flags &= ~flag;
+    }
+}
+
+static inline bool ompi_osc_pt2pt_peer_set_locked (ompi_osc_pt2pt_peer_t *peer, bool value)
+{
+    ompi_osc_pt2pt_peer_set_flag (peer, OMPI_OSC_PT2PT_PEER_FLAG_LOCK, value);
+}
+
+static inline bool ompi_osc_pt2pt_peer_set_unex (ompi_osc_pt2pt_peer_t *peer, bool value)
+{
+    ompi_osc_pt2pt_peer_set_flag (peer, OMPI_OSC_PT2PT_PEER_FLAG_UNEX, value);
+}
+
+static inline bool ompi_osc_pt2pt_peer_set_eager_active (ompi_osc_pt2pt_peer_t *peer, bool value)
+{
+    ompi_osc_pt2pt_peer_set_flag (peer, OMPI_OSC_PT2PT_PEER_FLAG_EAGER, value);
+}
 
 OBJ_CLASS_DECLARATION(ompi_osc_pt2pt_peer_t);
 
@@ -430,6 +480,8 @@ int ompi_osc_pt2pt_component_irecv(ompi_osc_pt2pt_module_t *module,
                                   int src,
                                   int tag,
                                   struct ompi_communicator_t *comm);
+
+int ompi_osc_pt2pt_lock_remote (ompi_osc_pt2pt_module_t *module, int target, ompi_osc_pt2pt_sync_t *lock);
 
 /**
  * ompi_osc_pt2pt_progress_pending_acc:
@@ -845,6 +897,12 @@ static inline void ompi_osc_pt2pt_module_lock_remove (struct ompi_osc_pt2pt_modu
 static inline ompi_osc_pt2pt_sync_t *ompi_osc_pt2pt_module_sync_lookup (ompi_osc_pt2pt_module_t *module, int target,
                                                                         struct ompi_osc_pt2pt_peer_t **peer)
 {
+    ompi_osc_pt2pt_peer_t *tmp;
+
+    if (NULL == peer) {
+        peer = &tmp;
+    }
+
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "osc/pt2pt: looking for synchronization object for target %d", target));
 
@@ -862,8 +920,9 @@ static inline ompi_osc_pt2pt_sync_t *ompi_osc_pt2pt_module_sync_lookup (ompi_osc
 
         /* fence epoch is now active */
         module->all_sync.epoch_active = true;
-        if (peer) {
-            *peer = ompi_osc_pt2pt_peer_lookup (module, target);
+        *peer = ompi_osc_pt2pt_peer_lookup (module, target);
+        if (OMPI_OSC_PT2PT_SYNC_TYPE_LOCK == module->all_sync.type && !ompi_osc_pt2pt_peer_locked (*peer)) {
+            (void) ompi_osc_pt2pt_lock_remote (module, target, &module->all_sync);
         }
 
         return &module->all_sync;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
@@ -261,13 +261,13 @@ int ompi_osc_pt2pt_start (ompi_group_t *group, int assert, ompi_win_t *win)
         for (int i = 0 ; i < sync->num_peers ; ++i) {
             ompi_osc_pt2pt_peer_t *peer = sync->peer_list.peers[i];
 
-            if (peer->unexpected_post) {
+            if (ompi_osc_pt2pt_peer_unex (peer)) {
                 /* the peer already sent a post message for this pscw access epoch */
                 OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                                      "found unexpected post from %d",
                                      peer->rank));
                 OPAL_THREAD_ADD32 (&sync->sync_expected, -1);
-                peer->unexpected_post = false;
+                ompi_osc_pt2pt_peer_set_unex (peer, false);
             }
         }
         OPAL_THREAD_UNLOCK(&sync->lock);
@@ -600,7 +600,7 @@ void osc_pt2pt_incoming_post (ompi_osc_pt2pt_module_t *module, int source)
                              "received unexpected post message from %d for future PSCW synchronization",
                              source));
 
-        peer->unexpected_post = true;
+        ompi_osc_pt2pt_peer_set_unex (peer, true);
         OPAL_THREAD_UNLOCK(&sync->lock);
     } else {
         OPAL_THREAD_UNLOCK(&sync->lock);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -492,7 +492,7 @@ static void ompi_osc_pt2pt_peer_construct (ompi_osc_pt2pt_peer_t *peer)
     OBJ_CONSTRUCT(&peer->lock, opal_mutex_t);
     peer->active_frag = NULL;
     peer->passive_incoming_frag_count = 0;
-    peer->unexpected_post = false;
+    peer->flags = 0;
 }
 
 static void ompi_osc_pt2pt_peer_destruct (ompi_osc_pt2pt_peer_t *peer)

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -142,44 +142,62 @@ static int component_register (void)
 					    NULL, 0, 0, OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
 					    &mca_osc_pt2pt_component.buffer_size);
 
+    mca_osc_pt2pt_component.receive_count = 4;
+    (void) mca_base_component_var_register (&mca_osc_pt2pt_component.super.osc_version, "receive_count",
+                                            "Number of receives to post for each window for incoming fragments "
+                                            "(default: 4)", MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_4,
+                                            MCA_BASE_VAR_SCOPE_READONLY, &mca_osc_pt2pt_component.receive_count);
+
     return OMPI_SUCCESS;
 }
 
 static int component_progress (void)
 {
-    int count = opal_list_get_size (&mca_osc_pt2pt_component.pending_operations);
+    int pending_count = opal_list_get_size (&mca_osc_pt2pt_component.pending_operations);
+    int recv_count = opal_list_get_size (&mca_osc_pt2pt_component.pending_receives);
     ompi_osc_pt2pt_pending_t *pending, *next;
 
-    if (0 == count) {
-	return 0;
+    if (recv_count) {
+        for (int i = 0 ; i < recv_count ; ++i) {
+            OPAL_THREAD_LOCK(&mca_osc_pt2pt_component.pending_receives_lock);
+            ompi_osc_pt2pt_receive_t *recv = (ompi_osc_pt2pt_receive_t *) opal_list_remove_first (&mca_osc_pt2pt_component.pending_receives);
+            OPAL_THREAD_UNLOCK(&mca_osc_pt2pt_component.pending_receives_lock);
+            if (NULL == recv) {
+                break;
+            }
+
+            (void) ompi_osc_pt2pt_process_receive (recv);
+        }
     }
 
     /* process one incoming request */
-    OPAL_THREAD_LOCK(&mca_osc_pt2pt_component.pending_operations_lock);
-    OPAL_LIST_FOREACH_SAFE(pending, next, &mca_osc_pt2pt_component.pending_operations, ompi_osc_pt2pt_pending_t) {
-	int ret;
+    if (pending_count) {
+        OPAL_THREAD_LOCK(&mca_osc_pt2pt_component.pending_operations_lock);
+        OPAL_LIST_FOREACH_SAFE(pending, next, &mca_osc_pt2pt_component.pending_operations, ompi_osc_pt2pt_pending_t) {
+            int ret;
 
-	switch (pending->header.base.type) {
-	case OMPI_OSC_PT2PT_HDR_TYPE_FLUSH_REQ:
-	    ret = ompi_osc_pt2pt_process_flush (pending->module, pending->source,
-					       &pending->header.flush);
-	    break;
-	case OMPI_OSC_PT2PT_HDR_TYPE_UNLOCK_REQ:
-	    ret = ompi_osc_pt2pt_process_unlock (pending->module, pending->source,
-						&pending->header.unlock);
-	    break;
-	default:
-	    /* shouldn't happen */
-	    assert (0);
-	    abort ();
-	}
+            switch (pending->header.base.type) {
+            case OMPI_OSC_PT2PT_HDR_TYPE_FLUSH_REQ:
+                ret = ompi_osc_pt2pt_process_flush (pending->module, pending->source,
+                                                    &pending->header.flush);
+                break;
+            case OMPI_OSC_PT2PT_HDR_TYPE_UNLOCK_REQ:
+                ret = ompi_osc_pt2pt_process_unlock (pending->module, pending->source,
+                                                     &pending->header.unlock);
+                break;
+            default:
+                /* shouldn't happen */
+                assert (0);
+                abort ();
+            }
 
-	if (OMPI_SUCCESS == ret) {
-	    opal_list_remove_item (&mca_osc_pt2pt_component.pending_operations, &pending->super);
-	    OBJ_RELEASE(pending);
-	}
+            if (OMPI_SUCCESS == ret) {
+                opal_list_remove_item (&mca_osc_pt2pt_component.pending_operations, &pending->super);
+                OBJ_RELEASE(pending);
+            }
+        }
+        OPAL_THREAD_UNLOCK(&mca_osc_pt2pt_component.pending_operations_lock);
     }
-    OPAL_THREAD_UNLOCK(&mca_osc_pt2pt_component.pending_operations_lock);
 
     return 1;
 }
@@ -193,6 +211,8 @@ component_init(bool enable_progress_threads,
     OBJ_CONSTRUCT(&mca_osc_pt2pt_component.lock, opal_mutex_t);
     OBJ_CONSTRUCT(&mca_osc_pt2pt_component.pending_operations, opal_list_t);
     OBJ_CONSTRUCT(&mca_osc_pt2pt_component.pending_operations_lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&mca_osc_pt2pt_component.pending_receives, opal_list_t);
+    OBJ_CONSTRUCT(&mca_osc_pt2pt_component.pending_receives_lock, opal_mutex_t);
 
     OBJ_CONSTRUCT(&mca_osc_pt2pt_component.modules,
                   opal_hash_table_t);
@@ -253,6 +273,8 @@ component_finalize(void)
     OBJ_DESTRUCT(&mca_osc_pt2pt_component.requests);
     OBJ_DESTRUCT(&mca_osc_pt2pt_component.pending_operations);
     OBJ_DESTRUCT(&mca_osc_pt2pt_component.pending_operations_lock);
+    OBJ_DESTRUCT(&mca_osc_pt2pt_component.pending_receives);
+    OBJ_DESTRUCT(&mca_osc_pt2pt_component.pending_receives_lock);
 
     return OMPI_SUCCESS;
 }
@@ -385,11 +407,6 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     /* sync memory - make sure all initialization completed */
     opal_atomic_mb();
 
-    module->incoming_buffer = malloc (mca_osc_pt2pt_component.buffer_size + sizeof (ompi_osc_pt2pt_frag_header_t));
-    if (OPAL_UNLIKELY(NULL == module->incoming_buffer)) {
-	goto cleanup;
-    }
-
     ret = ompi_osc_pt2pt_frag_start_receive (module);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
 	goto cleanup;
@@ -448,6 +465,26 @@ ompi_osc_pt2pt_get_info(struct ompi_win_t *win, struct ompi_info_t **info_used)
 }
 
 OBJ_CLASS_INSTANCE(ompi_osc_pt2pt_pending_t, opal_list_item_t, NULL, NULL);
+
+void ompi_osc_pt2pt_receive_construct (ompi_osc_pt2pt_receive_t *recv)
+{
+    recv->buffer = NULL;
+    recv->pml_request = NULL;
+}
+
+void ompi_osc_pt2pt_receive_destruct (ompi_osc_pt2pt_receive_t *recv)
+{
+    free (recv->buffer);
+    if (recv->pml_request && MPI_REQUEST_NULL != recv->pml_request) {
+        recv->pml_request->req_complete_cb = NULL;
+        ompi_request_cancel (recv->pml_request);
+        ompi_request_free (&recv->pml_request);
+    }
+}
+
+OBJ_CLASS_INSTANCE(ompi_osc_pt2pt_receive_t, opal_list_item_t,
+                   ompi_osc_pt2pt_receive_construct,
+                   ompi_osc_pt2pt_receive_destruct);
 
 static void ompi_osc_pt2pt_peer_construct (ompi_osc_pt2pt_peer_t *peer)
 {

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.h
@@ -144,4 +144,16 @@ void ompi_osc_pt2pt_process_flush_ack (ompi_osc_pt2pt_module_t *module, int sour
  */
 int ompi_osc_pt2pt_frag_start_receive (ompi_osc_pt2pt_module_t *module);
 
+/**
+ * ompi_osc_pt2pt_process_receive:
+ *
+ * @short Report a receive request
+ *
+ * @param[in] recv     - Receive structure
+ *
+ * @long This function reposts a receive request. This function should not be called from
+ *       a pml request callback as it can lead to deep recursion during heavy load.
+ */
+int ompi_osc_pt2pt_process_receive (ompi_osc_pt2pt_receive_t *recv);
+
 #endif

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
@@ -93,18 +93,20 @@ int ompi_osc_pt2pt_free(ompi_win_t *win)
     OBJ_DESTRUCT(&module->peer_hash);
     OBJ_DESTRUCT(&module->peer_lock);
 
-    if (NULL != module->epoch_outgoing_frag_count) free(module->epoch_outgoing_frag_count);
+    if (NULL != module->recv_frags) {
+        for (int i = 0 ; i < module->recv_frag_count ; ++i) {
+            OBJ_DESTRUCT(module->recv_frags + i);
+        }
 
-    if (NULL != module->frag_request && MPI_REQUEST_NULL != module->frag_request) {
-        module->frag_request->req_complete_cb = NULL;
-        ompi_request_cancel (module->frag_request);
-        ompi_request_free (&module->frag_request);
+        free (module->recv_frags);
     }
+
+    if (NULL != module->epoch_outgoing_frag_count) free(module->epoch_outgoing_frag_count);
 
     if (NULL != module->comm) {
         ompi_comm_free(&module->comm);
     }
-    if (NULL != module->incoming_buffer) free (module->incoming_buffer);
+
     if (NULL != module->free_after) free(module->free_after);
 
     free (module);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
@@ -58,10 +58,13 @@ static int ompi_osc_pt2pt_flush_lock (ompi_osc_pt2pt_module_t *module, ompi_osc_
 static inline int ompi_osc_pt2pt_lock_self (ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_sync_t *lock)
 {
     const int my_rank = ompi_comm_rank (module->comm);
+    ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, my_rank);
     int lock_type = lock->sync.lock.type;
     bool acquired = false;
 
     assert (lock->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK);
+
+    (void) OPAL_THREAD_ADD32(&lock->sync_expected, 1);
 
     acquired = ompi_osc_pt2pt_lock_try_acquire (module, my_rank, lock_type, (uint64_t) (uintptr_t) lock);
     if (!acquired) {
@@ -73,6 +76,9 @@ static inline int ompi_osc_pt2pt_lock_self (ompi_osc_pt2pt_module_t *module, omp
         ompi_osc_pt2pt_sync_wait_expected (lock);
     }
 
+    ompi_osc_pt2pt_peer_set_locked (peer, true);
+    ompi_osc_pt2pt_peer_set_eager_active (peer, true);
+
     OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,
                          "local lock aquired"));
 
@@ -81,7 +87,11 @@ static inline int ompi_osc_pt2pt_lock_self (ompi_osc_pt2pt_module_t *module, omp
 
 static inline void ompi_osc_pt2pt_unlock_self (ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_sync_t *lock)
 {
+    const int my_rank = ompi_comm_rank (module->comm);
+    ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, my_rank);
     int lock_type = lock->sync.lock.type;
+
+    (void) OPAL_THREAD_ADD32(&lock->sync_expected, 1);
 
     assert (lock->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK);
 
@@ -98,15 +108,21 @@ static inline void ompi_osc_pt2pt_unlock_self (ompi_osc_pt2pt_module_t *module, 
     /* need to ensure we make progress */
     opal_progress();
 
+    ompi_osc_pt2pt_peer_set_locked (peer, false);
+    ompi_osc_pt2pt_peer_set_eager_active (peer, false);
+
     ompi_osc_pt2pt_sync_expected (lock);
 }
 
-static inline int ompi_osc_pt2pt_lock_remote (ompi_osc_pt2pt_module_t *module, int target, ompi_osc_pt2pt_sync_t *lock)
+int ompi_osc_pt2pt_lock_remote (ompi_osc_pt2pt_module_t *module, int target, ompi_osc_pt2pt_sync_t *lock)
 {
+    ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, target);
     int lock_type = lock->sync.lock.type;
     ompi_osc_pt2pt_header_lock_t lock_req;
 
     int ret;
+
+    (void) OPAL_THREAD_ADD32(&lock->sync_expected, 1);
 
     assert (lock->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK);
 
@@ -128,6 +144,9 @@ static inline int ompi_osc_pt2pt_lock_remote (ompi_osc_pt2pt_module_t *module, i
 
     /* make sure the request gets sent, so we can start eager sending... */
     ret = ompi_osc_pt2pt_frag_flush_target (module, target);
+    if (OPAL_LIKELY(OMPI_SUCCESS == ret)) {
+        ompi_osc_pt2pt_peer_set_locked (peer, true);
+    }
 
     return ret;
 }
@@ -139,6 +158,8 @@ static inline int ompi_osc_pt2pt_unlock_remote (ompi_osc_pt2pt_module_t *module,
     int lock_type = lock->sync.lock.type;
     ompi_osc_pt2pt_header_unlock_t unlock_req;
     int ret;
+
+    (void) OPAL_THREAD_ADD32(&lock->sync_expected, 1);
 
     assert (lock->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK);
 
@@ -169,6 +190,9 @@ static inline int ompi_osc_pt2pt_unlock_remote (ompi_osc_pt2pt_module_t *module,
         return ret;
     }
 
+    ompi_osc_pt2pt_peer_set_locked (peer, false);
+    ompi_osc_pt2pt_peer_set_eager_active (peer, false);
+
     return ompi_osc_pt2pt_frag_flush_target(module, target);
 }
 
@@ -178,6 +202,8 @@ static inline int ompi_osc_pt2pt_flush_remote (ompi_osc_pt2pt_module_t *module, 
     ompi_osc_pt2pt_header_flush_t flush_req;
     int32_t frag_count = opal_atomic_swap_32 ((int32_t *) module->epoch_outgoing_frag_count + target, -1);
     int ret;
+
+    (void) OPAL_THREAD_ADD32(&lock->sync_expected, 1);
 
     assert (lock->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK);
 
@@ -218,8 +244,6 @@ static int ompi_osc_pt2pt_lock_internal_execute (ompi_osc_pt2pt_module_t *module
     assert (lock->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK);
 
     if (0 == (assert & MPI_MODE_NOCHECK)) {
-        lock->sync_expected = (-1 == target) ? ompi_comm_size (module->comm) : 1;
-
         if (my_rank != target && target != -1) {
             ret = ompi_osc_pt2pt_lock_remote (module, target, lock);
         } else {
@@ -231,19 +255,7 @@ static int ompi_osc_pt2pt_lock_internal_execute (ompi_osc_pt2pt_module_t *module
             return ret;
         }
 
-        if (-1 == target) {
-            for (int i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
-                if (my_rank == i) {
-                    continue;
-                }
-
-                ret = ompi_osc_pt2pt_lock_remote (module, i, lock);
-                if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-                    return ret;
-                }
-            }
-
-        }
+        /* for lock_all there is nothing more to do. we will lock peer's on demand */
     } else {
         lock->eager_send_active = true;
     }
@@ -312,7 +324,7 @@ static int ompi_osc_pt2pt_lock_internal (int lock_type, int target, int assert, 
     lock->sync.lock.target = target;
     lock->sync.lock.type = lock_type;
     lock->sync.lock.assert = assert;
-
+    lock->num_peers = (-1 == target) ? ompi_comm_size (&module->comm) : 1;
     lock->sync_expected = 0;
 
     /* delay all eager sends until we've heard back.. */
@@ -376,13 +388,13 @@ static int ompi_osc_pt2pt_unlock_internal (int target, ompi_win_t *win)
                          "ompi_osc_pt2pt_unlock_internal: all lock acks received"));
 
     if (!(lock->sync.lock.assert & MPI_MODE_NOCHECK)) {
-        lock->sync_expected = (-1 == target) ? ompi_comm_size (module->comm) : 1;
-
         if (my_rank != target) {
             if (-1 == target) {
                 /* send unlock messages to all of my peers */
                 for (int i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
-                    if (my_rank == i) {
+                    ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, i);
+
+                    if (my_rank == i || !ompi_osc_pt2pt_peer_locked (peer)) {
                         continue;
                     }
 
@@ -470,12 +482,6 @@ static int ompi_osc_pt2pt_flush_lock (ompi_osc_pt2pt_module_t *module, ompi_osc_
     ompi_osc_pt2pt_sync_wait_expected (lock);
 
     if (-1 == target) {
-        lock->sync_expected = ompi_comm_size(module->comm) - 1;
-    } else {
-        lock->sync_expected = 1;
-    }
-
-    if (-1 == target) {
         /* NTH: no local flush */
         for (int i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
             if (i == my_rank) {
@@ -488,7 +494,6 @@ static int ompi_osc_pt2pt_flush_lock (ompi_osc_pt2pt_module_t *module, ompi_osc_
             }
         }
     } else {
-
         /* send control message with flush request and count */
         ret = ompi_osc_pt2pt_flush_remote (module, target, lock);
         if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
@@ -787,6 +792,7 @@ int ompi_osc_pt2pt_process_lock (ompi_osc_pt2pt_module_t* module, int source,
 void ompi_osc_pt2pt_process_lock_ack (ompi_osc_pt2pt_module_t *module,
                                       ompi_osc_pt2pt_header_lock_ack_t *lock_ack_header)
 {
+    ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, lock_ack_header->source);
     ompi_osc_pt2pt_sync_t *lock;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
@@ -795,6 +801,8 @@ void ompi_osc_pt2pt_process_lock_ack (ompi_osc_pt2pt_module_t *module,
 
     lock = (ompi_osc_pt2pt_sync_t *) (uintptr_t) lock_ack_header->lock_ptr;
     assert (NULL != lock);
+
+    ompi_osc_pt2pt_peer_set_eager_active (peer, true);
 
     ompi_osc_pt2pt_sync_expected (lock);
 }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
@@ -164,7 +164,9 @@ static inline void ompi_osc_pt2pt_sync_expected (ompi_osc_pt2pt_sync_t *sync)
     int32_t new_value = OPAL_THREAD_ADD32 (&sync->sync_expected, -1);
     if (0 == new_value) {
         OPAL_THREAD_LOCK(&sync->lock);
-        sync->eager_send_active = true;
+        if (!(sync->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK && sync->num_peers > 1)) {
+            sync->eager_send_active = true;
+        }
         opal_condition_broadcast (&sync->cond);
         OPAL_THREAD_UNLOCK(&sync->lock);
     }

--- a/ompi/mca/pml/cm/pml_cm_start.c
+++ b/ompi/mca/pml/cm/pml_cm_start.c
@@ -42,10 +42,6 @@ mca_pml_cm_start(size_t count, ompi_request_t** requests)
             continue;
         }
 
-        if (OMPI_REQUEST_ACTIVE == pml_request->req_ompi.req_state) {
-            return OMPI_ERR_REQUEST;
-        }
-
         /* start the request */
         switch (pml_request->req_pml_type) {
         case MCA_PML_CM_REQUEST_SEND_HEAVY:

--- a/ompi/mca/pml/ob1/pml_ob1_start.c
+++ b/ompi/mca/pml/ob1/pml_ob1_start.c
@@ -49,10 +49,6 @@ int mca_pml_ob1_start(size_t count, ompi_request_t** requests)
         opal_atomic_rmb();
 #endif
 
-        if (OMPI_REQUEST_ACTIVE == pml_request->req_ompi.req_state) {
-            return OMPI_ERR_REQUEST;
-        }
-
         /* start the request */
         switch(pml_request->req_type) {
             case MCA_PML_REQUEST_SEND:


### PR DESCRIPTION
This PR brings multiple updates to the osc/pt2pt component:

 - Do no repost a fragment receive request from a request callback. This can lead to smashing the stack.

 - Do not send all lock requests during MPI_Win_lock_all. This does not scale. Lock requests are now sent on-demand when first communicating with a peer.