### PR TITLE
Provide backward compatible keys so that the non-PMIx components in t…

### DIFF
--- a/contrib/cleanperms
+++ b/contrib/cleanperms
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+find . -type f -name "*.c" -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name Makefile.am -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name "*.h" -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name Makefile.include -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name Makefile -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name "*.m4" -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name "*.ac" -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name "*.txt" -perm /u+x -print -exec chmod -x {} \;
+find . -type f -name "*.l" -perm /u+x -print -exec chmod -x {} \;

--- a/opal/mca/pmix/pmix2x/pmix/src/server/Makefile.include
+++ b/opal/mca/pmix/pmix2x/pmix/src/server/Makefile.include
@@ -11,6 +11,8 @@
 # $HEADER$
 #
 
+dist_pmixdata_DATA += server/help-pmix-server.txt
+
 headers += \
         server/pmix_server_ops.h
 

--- a/opal/mca/pmix/pmix2x/pmix/src/server/help-pmix-server.txt
+++ b/opal/mca/pmix/pmix2x/pmix/src/server/help-pmix-server.txt
@@ -1,0 +1,35 @@
+# -*- text -*-
+#
+# Copyright (c) 2016      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+#
+[rnd-path-too-long]
+The PMIx server was unable to setup a rendezvous file due to your
+system's restriction for Unix's socket's path-length.
+
+   Temporary directory: %s
+   Rendezvous filename: %s
+
+Please try to set TMPDIR to something short (like /tmp) or change
+your computer's name to something shorter (see uname -n).
+[listener-failed-start]
+The PMIx server was unable to start its listening thread. This is
+usually due to a conflicting stale named pipe from a prior failed
+job, thus preventing the server from binding to its assigned socket.
+
+  Rendezvous filename: %s
+
+Please remove the stale file and try again.
+[data-store-failed]
+The PMIx server was unable to store the specified key-value:
+
+  Key: %s
+
+The precise reason for the failure was provided in the above
+"error-log" message. This is probably something that should
+be referred to the PMIx developers.

--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -314,12 +314,13 @@ static int rte_init(void)
         }
         /* retrieve the local peers */
         OPAL_MODEX_RECV_VALUE(ret, OPAL_PMIX_LOCAL_PEERS,
-                              ORTE_PROC_MY_NAME, &val, OPAL_STRING);
+                              &wildcard_rank, &val, OPAL_STRING);
         if (OPAL_SUCCESS == ret && NULL != val) {
             peers = opal_argv_split(val, ',');
             free(val);
             /* and their cpusets, if available */
-            OPAL_MODEX_RECV_VALUE_OPTIONAL(ret, OPAL_PMIX_LOCAL_CPUSETS, ORTE_PROC_MY_NAME, &val, OPAL_STRING);
+            OPAL_MODEX_RECV_VALUE_OPTIONAL(ret, OPAL_PMIX_LOCAL_CPUSETS,
+                                           &wildcard_rank, &val, OPAL_STRING);
             if (OPAL_SUCCESS == ret && NULL != val) {
                 cpusets = opal_argv_split(val, ':');
                 free(val);

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -272,10 +272,7 @@ int pmix_server_init(void)
 
     /* setup the local server */
     if (ORTE_SUCCESS != (rc = opal_pmix.server_init(&pmix_server, &info))) {
-        ORTE_ERROR_LOG(rc);
-        /* memory cleanup will occur when finalize is called */
-        orte_show_help("help-orterun.txt", "orterun:pmix-failed", true,
-                       orte_process_info.proc_session_dir);
+        /* pmix will provide a nice show_help output here */
         return rc;
     }
     OPAL_LIST_DESTRUCT(&info);


### PR DESCRIPTION
…he opal/pmix framework don't have to adjust as we continue to work on finalizing the PMIx reference scheme. Activate and utilize the new PMIx show_help capability to provide more meaningful error output when the server cannot start.

Add a contrib script to cleanup permissions incorrectly modified due to things like smb mounts

dd