### PR TITLE
Update the session dir structure. Restore the creation of a top-level…

### DIFF
--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -944,6 +944,7 @@ static int setup_fork(orte_job_t *jdata,
     /* forcibly set the local tmpdir base and top session dir to match ours */
     opal_setenv("OMPI_MCA_orte_tmpdir_base", orte_process_info.tmpdir_base, true, &app->env);
     opal_setenv("OMPI_MCA_orte_top_session_dir", orte_process_info.top_session_dir, true, &app->env);
+    opal_setenv("OMPI_MCA_orte_jobfam_session_dir", orte_process_info.jobfam_session_dir, true, &app->env);
 
     /* MPI-3 requires we provide some further info to the procs,
      * so we pass them as envars to avoid introducing further

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -57,6 +57,7 @@
 #include "opal/util/show_help.h"
 #include "opal/util/error.h"
 #include "opal/util/output.h"
+#include "opal/util/os_path.h"
 #include "opal/util/argv.h"
 
 #include "orte/mca/errmgr/errmgr.h"
@@ -261,9 +262,12 @@ int pmix_server_init(void)
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_SERVER_TMPDIR);
     kv->type = OPAL_STRING;
-    kv->data.string = strdup(orte_process_info.tmpdir_base);
+    kv->data.string = opal_os_path(false, orte_process_info.tmpdir_base,
+                                   orte_process_info.top_session_dir,
+                                   orte_process_info.jobfam_session_dir, NULL);
     opal_list_append(&info, &kv->super);
-    /* use the same for the system temp directory */
+    /* use the same for the system temp directory - this is
+     * where the system-level tool connections will go */
     kv = OBJ_NEW(opal_value_t);
     kv->key = strdup(OPAL_PMIX_SYSTEM_TMPDIR);
     kv->type = OPAL_STRING;

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -51,6 +51,7 @@ static char *orte_tmpdir_base = NULL;
 static char *orte_local_tmpdir_base = NULL;
 static char *orte_remote_tmpdir_base = NULL;
 static char *orte_top_session_dir = NULL;
+static char *orte_jobfam_session_dir = NULL;
 
 int orte_register_params(void)
 {
@@ -163,6 +164,20 @@ int orte_register_params(void)
             free(orte_process_info.top_session_dir);
         }
         orte_process_info.top_session_dir = strdup(orte_top_session_dir);
+    }
+
+    orte_jobfam_session_dir = NULL;
+    (void) mca_base_var_register ("orte", "orte", NULL, "jobfam_session_dir",
+                                  "The jobfamily session directory for applications",
+                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL_EQ,
+                                  &orte_jobfam_session_dir);
+
+    if (NULL != orte_jobfam_session_dir) {
+        if (NULL != orte_process_info.jobfam_session_dir) {
+            free(orte_process_info.jobfam_session_dir);
+        }
+        orte_process_info.jobfam_session_dir = strdup(orte_jobfam_session_dir);
     }
 
     orte_prohibited_session_dirs = NULL;

--- a/orte/util/proc_info.c
+++ b/orte/util/proc_info.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,6 +80,7 @@ ORTE_DECLSPEC orte_proc_info_t orte_process_info = {
     .num_local_peers =                 0,
     .tmpdir_base =                     NULL,
     .top_session_dir =                 NULL,
+    .jobfam_session_dir =              NULL,
     .job_session_dir =                 NULL,
     .proc_session_dir =                NULL,
     .sock_stdin =                      NULL,
@@ -292,6 +293,11 @@ int orte_proc_info_finalize(void)
     if (NULL != orte_process_info.top_session_dir) {
         free(orte_process_info.top_session_dir);
         orte_process_info.top_session_dir = NULL;
+    }
+
+    if (NULL != orte_process_info.jobfam_session_dir) {
+        free(orte_process_info.jobfam_session_dir);
+        orte_process_info.jobfam_session_dir = NULL;
     }
 
     if (NULL != orte_process_info.job_session_dir) {

--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -119,6 +119,7 @@ struct orte_proc_info_t {
      */
     char *tmpdir_base;                  /**< Base directory of the session dir tree */
     char *top_session_dir;              /**< Top-most directory of the session tree */
+    char *jobfam_session_dir;           /**< Session directory for this family of jobs (i.e., share same mpirun) */
     char *job_session_dir;              /**< Session directory for job */
     char *proc_session_dir;             /**< Session directory for the process */
 


### PR DESCRIPTION
… dir based on userid so that everything is contained under the user's top-level dir. Make the next level down (the "job family" level) be either the pid (indicated by a name of "pid.N") or the job family if not launched by mpirun. This allows for proper rendezvous by direct-launched procs.