### PR TITLE
osc/pt2pt: make receive count an unsigned int

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -256,7 +256,7 @@ struct ompi_osc_pt2pt_module_t {
     struct ompi_osc_pt2pt_receive_t *recv_frags;
 
     /** number of receive fragments */
-    int recv_frag_count;
+    unsigned int recv_frag_count;
 
     /* enforce accumulate semantics */
     opal_atomic_lock_t accumulate_lock;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -145,7 +145,7 @@ static int component_register (void)
     mca_osc_pt2pt_component.receive_count = 4;
     (void) mca_base_component_var_register (&mca_osc_pt2pt_component.super.osc_version, "receive_count",
                                             "Number of receives to post for each window for incoming fragments "
-                                            "(default: 4)", MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_4,
+                                            "(default: 4)", MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0, OPAL_INFO_LVL_4,
                                             MCA_BASE_VAR_SCOPE_READONLY, &mca_osc_pt2pt_component.receive_count);
 
     return OMPI_SUCCESS;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -1701,7 +1701,7 @@ int ompi_osc_pt2pt_frag_start_receive (ompi_osc_pt2pt_module_t *module)
     int rc;
 
     module->recv_frag_count = mca_osc_pt2pt_component.receive_count;
-    if (module->recv_frag_count < 0) {
+    if (0 == module->recv_frag_count) {
         module->recv_frag_count = 1;
     }
 


### PR DESCRIPTION
This receive_count MCA variable should never be negative. Change it
to an unsigned int.

Signed-off-by: Nathan Hjelm <hjelmn@me.com>