### PR TITLE
Be able to auto-generate AUTHORS and preserve org affiliations

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,19 @@
-# This file exists to help map usernames to proper names and email addresses
-# in the Open MPI github mirror of the canonical SVN repository.  The github
-# mirror can be found here:
+# This file exists to help consolidate names and email addresses
+# (e.g., when people accidentally commit with an incorrect or local
+# email address).  Two common use cases:
 #
-#   https://github.com/open-mpi/ompi-svn-mirror
+# 1. Consolidate multiple email addresses from a single person.
+#    Example: one commit from John Smith is from
+#    <john.smith@his.work.com> and another is from
+#    <jsmith@workstation.his.work.com>, and a third is from
+#    <rocketman9982@users.noreply.github.com>.  But they're all from
+#    the same John Smith person.
+#
+# 2. Consolidate misspellings / altername names from a single person.
+#    Example: one commit is from "John Smith" and another is from
+#    "John Smith, CONTRACTOR", and third is from "RocketMan 9982".  But
+#    these are all really the same person, who can be listed once in
+#    AUTHORS as "John Smith".
 #
 # The format of this file is documented in git-shortlog(1).  Specifically,
 # a line like this:
@@ -12,12 +23,11 @@
 # means that when git sees "commit@email.xx" it will display
 # "Proper Name <proper@email.xx>" instead in certain circumstances.  Those
 # circumstances include:
+#
 #   - git shortlog
 #   - git blame
 #   - git log --format=tformat:"%aN <%aE>"   (and similar)
 #
-# A copy of this file should be present on each branch in SVN which is being
-# tracked in the Git mirror.
 
 # Jeff accidentally stomped on his $HOME/.gitconfig for a short while:
 Jeff Squyres <jsquyres@cisco.com> --quiet <--quiet>

--- a/.mailmap
+++ b/.mailmap
@@ -29,39 +29,73 @@
 #   - git log --format=tformat:"%aN <%aE>"   (and similar)
 #
 
-# Jeff accidentally stomped on his $HOME/.gitconfig for a short while:
-Jeff Squyres <jsquyres@cisco.com> --quiet <--quiet>
-
-# Commits from people with protected Github account address
 Jeff Squyres <jsquyres@cisco.com> <jsquyres@users.noreply.github.com>
+Jeff Squyres <jsquyres@cisco.com> --quiet <--quiet>
+Jeff Squyres <no-author@open-mpi.org>
+
 George Bosilca <bosilca@icl.utk.edu> <bosilca@users.noreply.github.com>
+
 Howard Pritchard <howardp@lanl.gov> <hppritcha@users.noreply.github.com>
+Howard Pritchard <howardp@lanl.gov> <howardp@lanl.gov>
+
 Andrew Friedley <andrew.friedley@intel.com> <afriedle-intel@users.noreply.github.com>
+
 Devendar Bureddy <devendar@mellanox.com> <bureddy@users.noreply.github.com>
+
 Edgar Gabriel <egabriel@central.uh.edu> <edgargabriel@users.noreply.github.com>
+Edgar Gabriel <gabriel@cs.uh.edu> <gabriel@Peggys-MacBook-Air.local>
+
 Gilles Gouaillardet <gilles@rist.or.jp> <ggouaillardet@users.noreply.github.com>
+
 Matias A Cabral <matias.a.cabral@intel.com> <matcabral@users.noreply.github.com>
+Matias A Cabral <matias.a.cabral@intel.com> <matias.a.cabral@intel.com>
+
 Pavel Shamis <shamisp@ornl.gov> <shamisp@ornl.gov>
 Pavel Shamis <shamisp@ornl.gov> <shamisp@users.noreply.github.com>
-Todd Kordenbrock <thkgcode@gmail.com> <tkordenbrock@users.noreply.github.com>
-Yohann Burette <yohann.burette@intel.com> <yburette@users.noreply.github.com>
+Pavel Shamis <pasharesearch@gmail.com> <pasharesearch@gmail.com>
 
-# Fix what look like accidental name mispellings / common-name-isms
+Todd Kordenbrock <thkgcode@gmail.com> <tkordenbrock@users.noreply.github.com>
+
+Yohann Burette <yohann.burette@intel.com> <yburette@users.noreply.github.com>
+Yohann Burette <yohann.burette@intel.com> <yohann.burette@intel.com>
+
+MPI Team (bot) <mpiteam@open-mpi.org> <mpiteam@open-mpi.org>
+
 Yossi Itigin <yosefe@mellanox.com> <yosefe@mellanox.com>
+
 Josh Hursey <jjhursey@open-mpi.org> <jjhursey@open-mpi.org>
+Josh Hursey <jhursey@us.ibm.com> <jhursey@us.ibm.com>
+
 Adrian Reber <adrian@lisas.de> <adrian@lisas.de>
-Elena <elena.elkina@itseez.com> <elena.elkina89@gmail.com>
-Howard Pritchard <howardp@lanl.gov> <howardp@lanl.gov>
+
+Elena Elkina <elena.elkina@itseez.com> <elena.elkina@itseez.com>
+Elena Elkina <elena.elkina@itseez.com> <elena.elkina89@gmail.com>
+
 Igor Ivanov <igor.ivanov.va@gmail.com> <igor.ivanov.va@gmail.com>
 Igor Ivanov <Igor.Ivanov@itseez.com> <Igor.Ivanov@itseez.com>
-Matias A Cabral <matias.a.cabral@intel.com> <matias.a.cabral@intel.com>
+
 Mangala Jyothi Bhaskar <mjbhaskar@uh.edu> <mjbhaskar@uh.edu>
 Mangala Jyothi Bhaskar <mjbhaskar@uh.edu> <mjbhaskar@crill.cs.uh.edu>
+
 Ralph Castain <rhc@open-mpi.org> <rhc@open-mpi.org>
+Ralph Castain <rhc@open-mpi.org> <rhc@odin.cs.indiana.edu>
+
 Rolf vandeVaart <rvandevaart@nvidia.com> <rvandevaart@nvidia.com>
-Yohann Burette <yohann.burette@intel.com> <yohann.burette@intel.com>
+
 Karol Mroz <mroz.karol@gmail.com> <mroz.karol@gmail.com>
+
 Nadezhda Kogteva <nadezhda.kogteva@itseez.com> <nadezhda@mngx-orion-01.dmz.e2e.mlnx>
-Nysal Jan <jnysal@in.ibm.com> <jnysal@in.ibm.com>
-Nysal Jan <jnysal@in.ibm.com> <jnysal@gmail.com>
+
 Thananon Patinyasakdikul <apatinya@cisco.com> <apatinya@savbu-usnic-a.cisco.com>
+
+Nysal Jan K A <jnysal@in.ibm.com> <jnysal@in.ibm.com>
+Nysal Jan K A <jnysal@in.ibm.com> <jnysal@gmail.com>
+
+Zhi Ming Wang <wangzm@cn.ibm.com> <wangzm@cn.ibm.com>
+
+Annapurna Dasari <annapurna.dasari@intel.com> <annapurna.dasari@intel.com>
+
+L. R. Rajeshnarayanan <l.r.rajeshnarayanan@intel.com> <l.r.rajeshnarayanan@intel.com>
+
+Aurélien Bouteiller <bouteill@icl.utk.edu> <bouteill@icl.utk.edu>
+Aurélien Bouteiller <bouteill@icl.utk.edu> <darter4.nics.utk.edu>

--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,8 @@ Bert Wesarg, Technische Universitaet Dresden
   bert.wesarg@tu-dresden.de
 Bill D'Amico, Cisco
   bdamico@cisco.com
+Boris Karasev, Mellanox
+  karasev.b@gmail.com
 Brad Benton, IBM, AMD
   brad.benton@us.ibm.com
 Brad Penoff, University of British Columbia
@@ -59,7 +61,7 @@ Brad Penoff, University of British Columbia
 Brian Barrett, Indiana University, Los Alamos National Laboratory, Sandia National Laboratory
   brbarret@open-mpi.org
 Brice Goglin, INRIA
-  Brice.Goglin@inria.fr
+  brice.goglin@inria.fr
 Camille Coti, University of Tennessee-Knoxville, INRIA
   ccoti@icl.utk.edu
 Christian Bell, QLogic
@@ -88,11 +90,10 @@ Donald Kerr, Sun, Oracle
 Doron Shoham, Mellanox
   dorons@mellanox.com
 Edgar Gabriel, High Performance Computing Center, Stuttgart, University of Tennessee-Knoxville, University of Houston
-  gabriel@Peggys-MacBook-Air.local
   gabriel@cs.uh.edu
 Elena Elkina, Mellanox
-  elena.elkina@itseez.com
   elena.elkina89@gmail.com
+  elena.elkina@itseez.com
 Ethan Mallove, Sun, Oracle
   ethan.mallove@oracle.com
 Eugene Loh, Sun, Oracle
@@ -112,7 +113,6 @@ George Bosilca, University of Tennessee-Knoxville
   bosilca@eecs.utk.edu
   bosilca@icl.utk.edu
 Gilles Gouaillardet, Research Organization for Information Science and Technology
-
   gilles.gouaillardet@iferc.org
   gilles@rist.or.jp
 Ginger Young, Los Alamos National Laboratory
@@ -170,6 +170,8 @@ Kenneth Matney, Oak Ridge National Laboratory
   matneykdsr@ornl.gov
 L. R. Rajeshnarayanan, Intel
   l.r.rajeshnarayanan@intel.com
+LANL OMPI Bot, Los Alamos National Laboratory
+  openmpihpp@gmail.com
 Laura Casswell, Los Alamos National Laboratory
   lcasswell@lanl.gov
 Lenny Verkhovsky, Volataine
@@ -204,10 +206,10 @@ Mitch Sukalski, Sandia National Laboratory
 Mohamad Chaarawi, University of Houston
   mschaara@cs.uh.edu
 Nadezhda Kogteva, Mellanox
-  nadezhda@mngx-orion-01.dmz.e2e.mlnx
   nadezhda.kogteva@itseez.com
+  nadezhda@mngx-orion-01.dmz.e2e.mlnx
 Nadia Derbey, Bull
-  Nadia.Derbey@bull.net
+  nadia.derbey@bull.net
 Nathan Hjelm, Los Alamos National Laboratory
   hjelmn@cs.unm.edu
   hjelmn@lanl.gov
@@ -217,6 +219,8 @@ Nathaniel Graham, Los Alamos National Laboratory
   nrgraham23@gmail.com
 Nick Papior Andersen, Individual
   nickpapior@gmail.com
+Nicolas Chevalier, Bull
+  nicolas.chevalier@bull.net
 Nysal Jan K A, IBM
   jnysal@gmail.com
   jnysal@in.ibm.com
@@ -226,6 +230,8 @@ Oscar Vega-Gisbert, Universitat Politecnica de Valencia
   ovega@dsic.upv.es
 Pak Lui, Sun
   pak.lui@sun.com
+Pascal Deveze, Bull
+  pascal.deveze@atos.net
 Patrick Geoffray, Myricom
   patrick@myri.com
 Pavel Shamis, Mellanox, Oak Ridge National Laboratory
@@ -242,7 +248,6 @@ Rainer Keller, High Performance Computing Center, Stuttgart, Oak Ridge National 
   rainer.keller@hft-stuttgart.de
   rainer.keller@hlrs.de
 Ralph Castain, Los Alamos National Laboratory, Cisco, Greenplum, Intel
-  rhc@odin.cs.indiana.edu
   rhc@open-mpi.org
 Reese Faucette, Cisco
   rfaucett@cisco.com

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,8 @@ Github.com pull request).  Note that these email addresses are not
 guaranteed to be current; they are simply a unique indicator of the
 individual who committed them.
 
+-----
+
 Abhishek Joshi, Broadcom
   abhishek.joshi@broadcom.com
 Abhishek Kulkarni, Indiana University
@@ -31,7 +33,6 @@ Anandhi S Jayakumar, Intel
 Andreas Knüpfer, Technische Universitaet Dresden
   andreas.knuepfer@tu-dresden.de
 Andrew Friedley, Indiana University, Sandia National Laboratory, Intel
-  afriedle-intel@users.noreply.github.com
   afriedle@osl.iu.edu
   andrew.friedley@intel.com
 Andrew Lumsdaine, Indiana University
@@ -42,7 +43,7 @@ Anya Tatashina, Sun
   anya.tatashina@sun.com
 Artem Polyakov, Individual, Mellanox
   artpol84@gmail.com
-Aurélien Bouteiller, University of Tennessee-Knoxville
+Aur�lien Bouteiller, University of Tennessee-Knoxville
   bouteill@icl.utk.edu
   darter4.nics.utk.edu
 Avneesh Pant, QLogic
@@ -79,7 +80,6 @@ David Daniel, Los Alamos National Laboratory
 Denis Dimick, Los Alamos National Laboratory
   dgdimick@lnal.gov
 Devendar Bureddy, Mellanox
-  bureddy@users.noreply.github.com
   devendar@mellanox.com
 Dimitar Pashov, Individual
   d.pashov@gmail.com
@@ -87,9 +87,8 @@ Donald Kerr, Sun, Oracle
   donald.kerr@oracle.com
 Doron Shoham, Mellanox
   dorons@mellanox.com
-Edagr Gabriel, High Performance Computing Center, Stuttgart, University of Tennessee-Knoxville, University of Houston
+Edgar Gabriel, High Performance Computing Center, Stuttgart, University of Tennessee-Knoxville, University of Houston
   gabriel@Peggys-MacBook-Air.local
-  edgargabriel@users.noreply.github.com
   gabriel@cs.uh.edu
 Elena Elkina, Mellanox
   elena.elkina@itseez.com
@@ -112,9 +111,8 @@ Geoffrey Paulsen, IBM
 George Bosilca, University of Tennessee-Knoxville
   bosilca@eecs.utk.edu
   bosilca@icl.utk.edu
-  bosilca@users.noreply.github.com
 Gilles Gouaillardet, Research Organization for Information Science and Technology
-  ggouaillardet@users.noreply.github.com
+
   gilles.gouaillardet@iferc.org
   gilles@rist.or.jp
 Ginger Young, Los Alamos National Laboratory
@@ -136,7 +134,6 @@ Hadi Montakhabi, University of Houston
 Howard Pritchard, Los Alamos National Laboratory
   howardp@lanl.gov
   hppritcha@gmail.com
-  hppritcha@users.noreply.github.com
 Iain Bason, Sun, Oracle
   iain.bason@oracle.com
 Igor Ivanov, Mellanox
@@ -147,7 +144,6 @@ Igor Usarov, Mellanox
 Jeff Squyres, University of Indiana, Cisco
   jeff@squyres.com
   jsquyres@cisco.com
-  jsquyres@users.noreply.github.com
 Jelena Pjesivac-Grbovic, University of Tennessee-Knoxville
   pjesa@icl.iu.edu
 Jithin Jose, Intel
@@ -197,7 +193,6 @@ Mark Taylor, Los Alamos National Laboratory
   mt@lanl.gov
 Matias A Cabral, Intel
   matias.a.cabral@intel.com
-  matcabral@users.noreply.github.com
 Matthias Jurenz, Technische Universitaet Dresden
   matthias.jurenz@tu-dresden.de
 Maximilien Levesque, Individual
@@ -235,7 +230,6 @@ Patrick Geoffray, Myricom
   patrick@myri.com
 Pavel Shamis, Mellanox, Oak Ridge National Laboratory
   shamisp@ornl.gov
-  shamisp@users.noreply.github.com
 Pierre Lemarinier, University of Tennessee-Knoxville
   lemarini@icl.utk.edu
 Piotr Lesnicki, Bull
@@ -307,7 +301,6 @@ Tim Woodall, Los Alamos National Laboratory
 Todd Kordenbrock, Sandia National Laboratory
   thkgcode@gmail.com
   thkorde@sandia.gov
-  tkordenbrock@users.noreply.github.com
 Tom Naughton, Oak Ridge National Laboratory
   naughtont@ornl.gov
 Tomislav Janjusic, Mellanox
@@ -333,7 +326,6 @@ Yael Dayan, Mellanox
 Yevgeny Kliteynik, Mellanox
   kliteyn@mellanox.co.il
 Yohann Burette, Intel
-  yburette@users.noreply.github.com
   yohann.burette@intel.com
 Yossi Itigin, Mellanox
   yosefe@mellanox.com


### PR DESCRIPTION
**TL;DR: PLEASE CHECK THE NEW `AUTHORS` AND `.mailmap` FILES TO ENSURE YOUR NAME / EMAIL ADDRESS(ES) ARE SHOWN AS YOU WANT THEM TO BE SHOWN!**

* Update the `AUTHORS` file to be slightly more parsable.
* Update `.mailmap` to fully de-duplicate names / people
* Remove all `@users.noreply.github.com` addresses
* Commit a newly generated `AUTHORS` file
* Remove a bunch of stale SVN references in .mailmap in the process.