### PR TITLE
mtl/ofi: fix a botched assignment of av_type

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -457,7 +457,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
      * The remote fi_addr will be stored in the ofi_endpoint struct.
      */
 
-    av_attr.type = (MTL_OFI_AV_TABLE == av_type) ? FI_AV_MAP: FI_AV_TABLE;
+    av_attr.type = (MTL_OFI_AV_TABLE == av_type) ? FI_AV_TABLE: FI_AV_MAP;
 
     ret = fi_av_open(ompi_mtl_ofi.domain, &av_attr, &ompi_mtl_ofi.av, NULL);
     if (ret) {


### PR DESCRIPTION
Well now the av_type is being assigned correctly
@yburette 

hopefully finally fixed this simple thing.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>