### PR TITLE
topo/treematch: fix hang in mca_topo_treematch_dist_graph_create()

### DIFF
--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2015 INRIA.  All rights reserved.
  * Copyright (c) 2012-2015 Bordeaux Poytechnic Institute
  * Copyright (c) 2015      Intel, Inc. All rights reserved
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -415,12 +415,12 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
                     local_pattern[topo->in[i]] += topo->inw[i];
                 for(i = 0; i < topo->outdegree ; i++)
                     local_pattern[topo->out[i]] += topo->outw[i];
-                if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_gather(MPI_IN_PLACE, size, MPI_DOUBLE,
-                                                                        local_pattern, size, MPI_DOUBLE,
-                                                                        0, comm_old,
-                                                                        comm_old->c_coll.coll_gather_module)))
-                    return err;
             }
+            if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_gather(MPI_IN_PLACE, size, MPI_DOUBLE,
+                                                                    local_pattern, size, MPI_DOUBLE,
+                                                                    0, comm_old,
+                                                                    comm_old->c_coll.coll_gather_module)))
+                return err;
         } else {
             local_pattern = (double *)calloc(size,sizeof(double));
             if( true == topo->weighted ) {
@@ -428,12 +428,12 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
                     local_pattern[topo->in[i]] += topo->inw[i];
                 for(i = 0; i < topo->outdegree ; i++)
                     local_pattern[topo->out[i]] += topo->outw[i];
-                if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_gather(local_pattern, size, MPI_DOUBLE,
-                                                                        NULL,0,0,
-                                                                        0, comm_old,
-                                                                        comm_old->c_coll.coll_gather_module)))
-                    return err;
             }
+            if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_gather(local_pattern, size, MPI_DOUBLE,
+                                                                    NULL,0,0,
+                                                                    0, comm_old,
+                                                                    comm_old->c_coll.coll_gather_module)))
+                return err;
         }
 
         if( rank == local_procs[0]) {


### PR DESCRIPTION
since topo->weighted (boolean) might be differ between tasks,
always perform the gather.