### PR TITLE
orte: Expand use of !orte_keep_fqdn_hostnames MCA parameter

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1528,7 +1529,7 @@ int orte_plm_base_setup_virtual_machine(orte_job_t *jdata)
     bool one_filter = false;
     int num_nodes;
     bool default_hostfile_used;
-    char *hosts;
+    char *hosts = NULL;
     bool singleton=false;
     bool multi_sim = false;
 

--- a/orte/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/orte/mca/rmaps/base/rmaps_base_support_fns.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -147,7 +148,7 @@ int orte_rmaps_base_get_target_nodes(opal_list_t *allocated_nodes, orte_std_cntr
     orte_job_t *daemons;
     bool novm;
     opal_list_t nodes;
-    char *hosts;
+    char *hosts = NULL;
 
     /** set default answer */
     *total_num_slots = 0;

--- a/orte/util/dash_host/dash_host.c
+++ b/orte/util/dash_host/dash_host.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,6 +24,9 @@
 #include "orte_config.h"
 
 #include <string.h>
+#if HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"
@@ -205,6 +209,19 @@ int orte_util_add_dash_host_nodes(opal_list_t *nodes,
             ndname = orte_process_info.nodename;
         } else {
             ndname = mini_map[i];
+        }
+
+        // Strip off the FQDN if present
+        if( !orte_keep_fqdn_hostnames ) {
+            char *ptr;
+            struct in_addr buf;
+            /* if the nodename is an IP address, do not mess with it! */
+            if (0 == inet_pton(AF_INET, ndname, &buf) &&
+                0 == inet_pton(AF_INET6, ndname, &buf)) {
+                if (NULL != (ptr = strchr(ndname, '.'))) {
+                    *ptr = '\0';
+                }
+            }
         }
 
         /* see if the node is already on the list */


### PR DESCRIPTION
 * Expand the use of the `orte_keep_fqdn_hostnames` MCA parameter when it is set to false.
 * If that parameter is set to false (default) then short hostnames (e.g., `node01`) will match with the long hostnames (e.g., `node01.mycluster.org`). This allows a user (or resource manager) to mix the use of short and long hostnames.
  - Note that this mechanism does _not_ perform a DNS lookup, but instead strips off the FQDN by truncating the hostname string at the first `.` character (when not an IP address).
     - By default (`false`) the following is true: `node01 == node01.mycluster.org == node01.bogus.com` we use `node01` as the hostname.