### PR TITLE
oshmem: get rid of oshmem_proc_t

### DIFF
--- a/ompi/proc/proc.h
+++ b/ompi/proc/proc.h
@@ -65,13 +65,16 @@ BEGIN_C_DECLS
  * a tag increases the memory consumed by Open MPI, so should only be done
  * if unavoidable.
  */
+
+#define OMPI_PROC_PADDING_SIZE 16
+
 struct ompi_proc_t {
     opal_proc_t                     super;
 
     /* endpoint data */
     void *proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MAX];
 
-    char padding[16];         /* for future extensions (OSHMEM uses this area also)*/
+    char padding[OMPI_PROC_PADDING_SIZE]; /* for future extensions (OSHMEM uses this area also)*/
 };
 typedef struct ompi_proc_t ompi_proc_t;
 OBJ_CLASS_DECLARATION(ompi_proc_t);

--- a/oshmem/include/oshmem/types.h
+++ b/oshmem/include/oshmem/types.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,7 +18,7 @@
  * dependencies.
  */
 
-   struct oshmem_proc_t;
+   struct ompi_proc_t;
    struct oshmem_group_t;
    struct oshmem_op_t;
 

--- a/oshmem/mca/atomic/mxm/atomic_mxm_cswap.c
+++ b/oshmem/mca/atomic/mxm/atomic_mxm_cswap.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,7 +62,7 @@ int mca_atomic_mxm_cswap(void *target,
         return OSHMEM_ERR_BAD_PARAM;
     }
 
-    ptl_id = oshmem_proc_group_all(pe)->transport_ids[0];
+    ptl_id = OSHMEM_PROC_DATA(oshmem_proc_group_all(pe))->transport_ids[0];
     if (MXM_PTL_SHM == ptl_id) {
         ptl_id = MXM_PTL_RDMA;
     }

--- a/oshmem/mca/atomic/mxm/atomic_mxm_fadd.c
+++ b/oshmem/mca/atomic/mxm/atomic_mxm_fadd.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,7 +64,7 @@ int mca_atomic_mxm_fadd(void *target,
         return OSHMEM_ERR_BAD_PARAM;
     }
 
-    ptl_id = oshmem_proc_group_all(pe)->transport_ids[0];
+    ptl_id = OSHMEM_PROC_DATA(oshmem_proc_group_all(pe))->transport_ids[0];
     if (MXM_PTL_SHM == ptl_id) {
         ptl_id = MXM_PTL_RDMA;
     }

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2013-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
@@ -93,7 +93,7 @@ int mca_memheap_seg_cmp(const void *k, const void *v)
  */
 static int pack_local_mkeys(opal_buffer_t *msg, int pe, int seg, int all_trs)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
     int i, n, tr_id;
     sshmem_mkey_t *mkey;
 
@@ -111,7 +111,7 @@ static int pack_local_mkeys(opal_buffer_t *msg, int pe, int seg, int all_trs)
     MEMHEAP_VERBOSE(5, "found %d transports to %d", n, pe);
     for (i = 0; i < n; i++) {
         if (!all_trs) {
-            tr_id = proc->transport_ids[i];
+            tr_id = OSHMEM_PROC_DATA(proc)->transport_ids[i];
         }
         else {
             tr_id = i;
@@ -171,7 +171,7 @@ static void unpack_remote_mkeys(opal_buffer_t *msg, int remote_pe)
     int32_t n;
     int32_t tr_id;
     int i;
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
 
     proc = oshmem_proc_group_find(oshmem_group_all, remote_pe);
     cnt = 1;

--- a/oshmem/mca/scoll/fca/scoll_fca_module.c
+++ b/oshmem/mca/scoll/fca/scoll_fca_module.c
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -106,7 +106,7 @@ static int have_remote_peers(struct oshmem_group_t *group,
                              size_t size,
                              int *local_peers)
 {
-    struct oshmem_proc_t *proc;
+    struct ompi_proc_t *proc;
     size_t i;
     int ret;
 
@@ -130,7 +130,7 @@ static int have_remote_peers(struct oshmem_group_t *group,
 static int _get_local_ranks(mca_scoll_fca_module_t *fca_module)
 {
     struct oshmem_group_t *comm = fca_module->comm;
-    oshmem_proc_t* proc;
+    ompi_proc_t* proc;
     int i, rank;
 
     /* Count the local ranks */

--- a/oshmem/mca/spml/base/base.h
+++ b/oshmem/mca/spml/base/base.h
@@ -2,6 +2,8 @@
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +59,7 @@ OSHMEM_DECLSPEC int mca_spml_base_spml_selected(const char *name);
  * Verify that all new procs are using the currently selected component
  */
 OSHMEM_DECLSPEC int mca_spml_base_spml_check_selected(const char *my_spml,
-                                                      oshmem_proc_t **procs,
+                                                      ompi_proc_t **procs,
                                                       size_t nprocs);
 
 OSHMEM_DECLSPEC int mca_spml_base_wait(void* addr,

--- a/oshmem/mca/spml/base/spml_base_request.h
+++ b/oshmem/mca/spml/base/spml_base_request.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -72,7 +72,7 @@ struct mca_spml_base_request_t {
     void *req_addr; /**< pointer to application buffer */
     size_t req_count; /**< count of user datatype elements *//* TODO: Need to remove since we are going to remove datatype*/
     int32_t req_peer; /**< peer process - rank of process executing the parallel program */
-    oshmem_proc_t* req_proc; /**< peer process */
+    ompi_proc_t* req_proc; /**< peer process */
     uint64_t req_sequence; /**< sequence number for shmem one sided ordering */
 };
 typedef struct mca_spml_base_request_t mca_spml_base_request_t;

--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2013-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -332,31 +332,31 @@ int mca_spml_ikrit_enable(bool enable)
 
 static int create_ptl_idx(int dst_pe)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
 
     proc = oshmem_proc_group_find(oshmem_group_all, dst_pe);
 
-    proc->transport_ids = (char *) malloc(MXM_PTL_LAST * sizeof(char));
-    if (!proc->transport_ids)
+    OSHMEM_PROC_DATA(proc)->transport_ids = (char *) malloc(MXM_PTL_LAST * sizeof(char));
+    if (NULL == OSHMEM_PROC_DATA(proc)->transport_ids)
         return OSHMEM_ERROR;
 
-    proc->num_transports = 1;
+    OSHMEM_PROC_DATA(proc)->num_transports = 1;
 #if MXM_API < MXM_VERSION(2,0)
     if (oshmem_my_proc_id() == dst_pe)
-        proc->transport_ids[0] = MXM_PTL_SELF;
+        OSHMEM_PROC_DATA(proc)->transport_ids[0] = MXM_PTL_SELF;
     else
 #endif
-        proc->transport_ids[0] = MXM_PTL_RDMA;
+        OSHMEM_PROC_DATA(proc)->transport_ids[0] = MXM_PTL_RDMA;
     return OSHMEM_SUCCESS;
 }
 
 static void destroy_ptl_idx(int dst_pe)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
 
     proc = oshmem_proc_group_find(oshmem_group_all, dst_pe);
-    if (proc->transport_ids)
-        free(proc->transport_ids);
+    if (NULL != OSHMEM_PROC_DATA(proc)->transport_ids)
+        free(OSHMEM_PROC_DATA(proc)->transport_ids);
 }
 
 static void mxm_peer_construct(mxm_peer_t *p)
@@ -376,7 +376,7 @@ OBJ_CLASS_INSTANCE( mxm_peer_t,
                    mxm_peer_construct,
                    mxm_peer_destruct);
 
-int mca_spml_ikrit_del_procs(oshmem_proc_t** procs, size_t nprocs)
+int mca_spml_ikrit_del_procs(ompi_proc_t** procs, size_t nprocs)
 {
     size_t i, n;
     int my_rank = oshmem_my_proc_id();
@@ -407,7 +407,7 @@ int mca_spml_ikrit_del_procs(oshmem_proc_t** procs, size_t nprocs)
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_ikrit_add_procs(oshmem_proc_t** procs, size_t nprocs)
+int mca_spml_ikrit_add_procs(ompi_proc_t** procs, size_t nprocs)
 {
     spml_ikrit_mxm_ep_conn_info_t *ep_info = NULL;
     spml_ikrit_mxm_ep_conn_info_t *ep_hw_rdma_info = NULL;
@@ -421,7 +421,7 @@ int mca_spml_ikrit_add_procs(oshmem_proc_t** procs, size_t nprocs)
     mxm_error_t err;
     size_t i, n;
     int rc = OSHMEM_ERROR;
-    oshmem_proc_t *proc_self;
+    ompi_proc_t *proc_self;
     int my_rank = oshmem_my_proc_id();
 
     OBJ_CONSTRUCT(&mca_spml_ikrit.active_peers, opal_list_t);
@@ -589,9 +589,9 @@ int mca_spml_ikrit_add_procs(oshmem_proc_t** procs, size_t nprocs)
             continue;
 
         /* use zcopy for put/get via sysv shared memory */
-        procs[i]->transport_ids[0] = MXM_PTL_SHM;
-        procs[i]->transport_ids[1] = MXM_PTL_RDMA;
-        procs[i]->num_transports = 2;
+        OSHMEM_PROC_DATA(procs[i])->transport_ids[0] = MXM_PTL_SHM;
+        OSHMEM_PROC_DATA(procs[i])->transport_ids[1] = MXM_PTL_RDMA;
+        OSHMEM_PROC_DATA(procs[i])->num_transports = 2;
     }
 
     SPML_VERBOSE(50, "*** ADDED PROCS ***");
@@ -743,7 +743,7 @@ int mca_spml_ikrit_deregister(sshmem_mkey_t *mkeys)
 
 static inline int get_ptl_id(int dst)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
 
     /* get endpoint and btl */
     proc = oshmem_proc_group_all(dst);
@@ -752,7 +752,7 @@ static inline int get_ptl_id(int dst)
         oshmem_shmem_abort(-1);
         return -1;
     }
-    return proc->transport_ids[0];
+    return OSHMEM_PROC_DATA(proc)->transport_ids[0];
 }
 
 int mca_spml_ikrit_oob_get_mkeys(int pe, uint32_t seg, sshmem_mkey_t *mkeys)

--- a/oshmem/mca/spml/ikrit/spml_ikrit.h
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.h
@@ -4,6 +4,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -166,8 +168,8 @@ extern int mca_spml_ikrit_oob_get_mkeys(int pe,
                                         uint32_t seg,
                                         sshmem_mkey_t *mkeys);
 
-extern int mca_spml_ikrit_add_procs(oshmem_proc_t** procs, size_t nprocs);
-extern int mca_spml_ikrit_del_procs(oshmem_proc_t** procs, size_t nprocs);
+extern int mca_spml_ikrit_add_procs(ompi_proc_t** procs, size_t nprocs);
+extern int mca_spml_ikrit_del_procs(ompi_proc_t** procs, size_t nprocs);
 extern int mca_spml_ikrit_fence(void);
 extern int spml_ikrit_progress(void);
 

--- a/oshmem/mca/spml/spml.h
+++ b/oshmem/mca/spml/spml.h
@@ -5,6 +5,8 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -166,9 +168,9 @@ typedef int (*mca_spml_base_module_oob_get_mkeys_fn_t)(int pe,
  * @return OSHMEM_SUCCESS or failure status.
  *
  */
-typedef int (*mca_spml_base_module_add_procs_fn_t)(oshmem_proc_t** procs,
+typedef int (*mca_spml_base_module_add_procs_fn_t)(ompi_proc_t** procs,
                                                    size_t nprocs);
-typedef int (*mca_spml_base_module_del_procs_fn_t)(oshmem_proc_t** procs,
+typedef int (*mca_spml_base_module_del_procs_fn_t)(ompi_proc_t** procs,
                                                    size_t nprocs);
 
 /**

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -80,7 +80,7 @@ int mca_spml_ucx_enable(bool enable)
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_ucx_del_procs(oshmem_proc_t** procs, size_t nprocs)
+int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs)
 {
     size_t i, n;
     int my_rank = oshmem_my_proc_id();
@@ -177,7 +177,7 @@ static void dump_address(int pe, char *addr, size_t len)
 
 static char spml_ucx_transport_ids[1] = { 0 };
 
-int mca_spml_ucx_add_procs(oshmem_proc_t** procs, size_t nprocs)
+int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs)
 {
     size_t i, n;
     int rc = OSHMEM_ERROR;
@@ -219,8 +219,8 @@ int mca_spml_ucx_add_procs(oshmem_proc_t** procs, size_t nprocs)
             SPML_ERROR("ucp_ep_create failed!!!\n");
             goto error2;
         }
-        procs[i]->num_transports = 1;
-        procs[i]->transport_ids = spml_ucx_transport_ids;
+        OSHMEM_PROC_DATA(procs[i])->num_transports = 1;
+        OSHMEM_PROC_DATA(procs[i])->transport_ids = spml_ucx_transport_ids;
     }
 
     ucp_worker_release_address(mca_spml_ucx.ucp_worker, wk_local_addr);

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -102,8 +104,8 @@ extern int mca_spml_ucx_deregister(sshmem_mkey_t *mkeys);
 extern void mca_spml_ucx_rmkey_unpack(sshmem_mkey_t *mkey, int pe);
 extern void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey);
 
-extern int mca_spml_ucx_add_procs(oshmem_proc_t** procs, size_t nprocs);
-extern int mca_spml_ucx_del_procs(oshmem_proc_t** procs, size_t nprocs);
+extern int mca_spml_ucx_add_procs(ompi_proc_t** procs, size_t nprocs);
+extern int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs);
 extern int mca_spml_ucx_fence(void);
 extern int mca_spml_ucx_quiet(void);
 extern int spml_ucx_progress(void);

--- a/oshmem/mca/spml/yoda/spml_yoda.c
+++ b/oshmem/mca/spml/yoda/spml_yoda.c
@@ -539,7 +539,7 @@ static int _find_btl_id(mca_bml_base_btl_t *bml_btl)
  */
 static int create_btl_idx(int dst_pe)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
     int btl_id;
     mca_bml_base_endpoint_t* endpoint;
     mca_bml_base_btl_t* bml_btl = 0;
@@ -573,11 +573,11 @@ static int create_btl_idx(int dst_pe)
         }
     }
 
-    proc->transport_ids = (char *) malloc(size * sizeof(char));
-    if (!proc->transport_ids)
+    OSHMEM_PROC_DATA(proc)->transport_ids = (char *) malloc(size * sizeof(char));
+    if (NULL == OSHMEM_PROC_DATA(proc)->transport_ids)
         return OSHMEM_ERROR;
 
-    proc->num_transports = size;
+    OSHMEM_PROC_DATA(proc)->num_transports = size;
 
     for (i = 0; i < size; i++) {
         bml_btl = mca_bml_base_btl_array_get_index(btl_array,
@@ -592,7 +592,7 @@ static int create_btl_idx(int dst_pe)
                        dst_pe, bml_btl->btl->btl_component->btl_version.mca_component_name, btl_id);
             return OSHMEM_ERROR;
         }
-        proc->transport_ids[i] = btl_id;
+        OSHMEM_PROC_DATA(proc)->transport_ids[i] = btl_id;
         mca_spml_yoda.btl_type_map[btl_id].bml_btl = bml_btl;
         mca_spml_yoda.btl_type_map[btl_id].use_cnt++;
     }
@@ -610,17 +610,17 @@ static int destroy_btl_list(void)
 
 static int destroy_btl_idx(int dst_pe)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
 
     proc = oshmem_proc_group_find(oshmem_group_all, dst_pe);
-    if (proc->transport_ids) {
-        free(proc->transport_ids);
+    if (NULL != OSHMEM_PROC_DATA(proc)->transport_ids) {
+        free(OSHMEM_PROC_DATA(proc)->transport_ids);
     }
 
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_yoda_add_procs(oshmem_proc_t** procs, size_t nprocs)
+int mca_spml_yoda_add_procs(ompi_proc_t** procs, size_t nprocs)
 {
     opal_bitmap_t reachable;
     int rc;
@@ -666,7 +666,7 @@ cleanup_and_return:
     return rc;
 }
 
-int mca_spml_yoda_del_procs(oshmem_proc_t** procs, size_t nprocs)
+int mca_spml_yoda_del_procs(ompi_proc_t** procs, size_t nprocs)
 {
     size_t i;
 
@@ -682,7 +682,7 @@ static inline mca_bml_base_btl_t *get_next_btl(int dst, int *btl_id)
 {
     mca_bml_base_endpoint_t* endpoint;
     mca_bml_base_btl_t* bml_btl = NULL;
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
     mca_bml_base_btl_array_t *btl_array = 0;
     int shmem_index = -1;
     int size = 0;
@@ -718,7 +718,7 @@ static inline mca_bml_base_btl_t *get_next_btl(int dst, int *btl_id)
         bml_btl = mca_bml_base_btl_array_get_index(btl_array, shmem_index);
     }
 
-    *btl_id = proc->transport_ids[0];
+    *btl_id = OSHMEM_PROC_DATA(proc)->transport_ids[0];
 
 #if SPML_YODA_DEBUG == 1
     assert(*btl_id >= 0 && *btl_id < YODA_BTL_MAX);

--- a/oshmem/mca/spml/yoda/spml_yoda.h
+++ b/oshmem/mca/spml/yoda/spml_yoda.h
@@ -4,6 +4,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,9 +128,9 @@ extern sshmem_mkey_t *mca_spml_yoda_register(void* addr,
                                                uint64_t shmid,
                                                int *count);
 extern int mca_spml_yoda_deregister(sshmem_mkey_t *mkeys);
-extern int mca_spml_yoda_add_procs(oshmem_proc_t** procs,
+extern int mca_spml_yoda_add_procs(ompi_proc_t** procs,
                                    size_t nprocs);
-extern int mca_spml_yoda_del_procs(oshmem_proc_t** procs,
+extern int mca_spml_yoda_del_procs(ompi_proc_t** procs,
                                    size_t nprocs);
 extern int mca_spml_yoda_fence(void);
 extern void* mca_spml_yoda_get_remote_context(void*);

--- a/oshmem/proc/proc.h
+++ b/oshmem/proc/proc.h
@@ -41,8 +41,8 @@ struct oshmem_group_t;
  * so the size of oshmem_proc_data_t must be less or equal than
  * OMPI_PROC_PADDING_SIZE */
 struct oshmem_proc_data_t {
-    int num_transports;
     char * transport_ids;
+    int num_transports;
 };
 
 typedef struct oshmem_proc_data_t oshmem_proc_data_t;

--- a/oshmem/proc/proc.h
+++ b/oshmem/proc/proc.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,30 +37,18 @@ struct oshmem_group_t;
 
 #define OSHMEM_PE_INVALID   (-1)
 
-/**
- * Remote Open SHMEM process structure
- *
- * Remote Open SHMEM process structure.  Each process contains exactly
- * one oshmem_proc_t structure for each remote process it knows about.
- */
-struct oshmem_proc_t {
-    opal_proc_t                    super;
-    /* endpoint data */
-    void *proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MAX];
-    /*
-     * All transport channels are globally ordered.
-     * pe(s) can talk to each other via subset of transports
-     * these holds indexes of each transport into global array
-     *  proc -> id, where id can be btl id in yoda or mxm ptl id
-     *  in ikrit
-     *  spml is supposed to fill this during add_procs()
-     **/
-    int                             num_transports;
-    char                           *transport_ids;
+/* This struct will be copied into the padding field of an ompi_proc_t
+ * so the size of oshmem_proc_data_t must be less or equal than
+ * OMPI_PROC_PADDING_SIZE */
+struct oshmem_proc_data_t {
+    int num_transports;
+    char * transport_ids;
 };
 
-typedef struct oshmem_proc_t oshmem_proc_t;
-OBJ_CLASS_DECLARATION(oshmem_proc_t);
+typedef struct oshmem_proc_data_t oshmem_proc_data_t;
+
+#define OSHMEM_PROC_DATA(proc) \
+    ((oshmem_proc_data_t *)(proc)->padding)
 
 /**
  * Group of Open SHMEM processes structure
@@ -71,8 +61,8 @@ struct oshmem_group_t {
     int                         my_pe;
     int                         proc_count;     /**< number of processes in group */
     int                         is_member;   /* true if my_pe is part of the group, participate in collectives */
-    struct oshmem_proc_t      **proc_array;     /**< list of pointers to ompi_proc_t structures
-                                 for each process in the group */
+    struct ompi_proc_t          **proc_array; /**< list of pointers to ompi_proc_t structures
+                                                   for each process in the group */
     opal_list_t                 peer_list;
 
     /* Collectives module interface and data */
@@ -98,7 +88,7 @@ OSHMEM_DECLSPEC extern oshmem_group_t* oshmem_group_null;
  * easily determined by the run-time ahead of time (architecture and
  * hostname) will be published during this call.
  *
- * @note While an oshmem_proc_t will exist with mostly valid information
+ * @note While an ompi_proc_t will exist with mostly valid information
  * for each process in the pe set at the conclusion of this
  * call, some information will not be immediately available.  This
  * includes the architecture and hostname, which will be available by
@@ -114,7 +104,7 @@ OSHMEM_DECLSPEC int oshmem_proc_init(void);
  *
  * Finalize the Open SHMEM process subsystem.  This function will
  * release all memory created during the life of the application,
- * including all oshmem_proc_t structures.
+ * including all ompi_proc_t structures.
  *
  * @retval OSHMEM_SUCCESS  System successfully finalized
  */
@@ -129,9 +119,9 @@ OSHMEM_DECLSPEC int oshmem_proc_finalize(void);
  *
  * @return Pointer to the local process structure
  */
-static inline oshmem_proc_t *oshmem_proc_local(void)
+static inline ompi_proc_t *oshmem_proc_local(void)
 {
-    return (oshmem_proc_t *)ompi_proc_local_proc;
+    return (ompi_proc_t *)ompi_proc_local_proc;
 }
 
 /**
@@ -145,12 +135,12 @@ static inline oshmem_proc_t *oshmem_proc_local(void)
  *
  * @return Pointer to the process instance for \c name
  */
-static inline oshmem_proc_t *oshmem_proc_for_find(const orte_process_name_t name)
+static inline ompi_proc_t *oshmem_proc_for_find(const orte_process_name_t name)
 {
-    return (oshmem_proc_t *)ompi_proc_for_name(name);
+    return (ompi_proc_t *)ompi_proc_for_name(name);
 }
 
-static inline oshmem_proc_t *oshmem_proc_find(int pe)
+static inline ompi_proc_t *oshmem_proc_find(int pe)
 {
     orte_process_name_t name;
 
@@ -159,7 +149,7 @@ static inline oshmem_proc_t *oshmem_proc_find(int pe)
     return oshmem_proc_for_find(name);
 }
 
-static inline int oshmem_proc_pe(oshmem_proc_t *proc)
+static inline int oshmem_proc_pe(ompi_proc_t *proc)
 {
     return (proc ? (int) ((orte_process_name_t*)&proc->super.proc_name)->vpid : -1);
 }
@@ -222,16 +212,16 @@ OSHMEM_DECLSPEC oshmem_group_t *oshmem_proc_group_create(int pe_start,
  */
 OSHMEM_DECLSPEC void oshmem_proc_group_destroy(oshmem_group_t* group);
 
-static inline oshmem_proc_t *oshmem_proc_group_all(int pe)
+static inline ompi_proc_t *oshmem_proc_group_all(int pe)
 {
     return oshmem_group_all->proc_array[pe];
 }
 
-static inline oshmem_proc_t *oshmem_proc_group_find(oshmem_group_t* group,
+static inline ompi_proc_t *oshmem_proc_group_find(oshmem_group_t* group,
                                                     int pe)
 {
     int i = 0;
-    oshmem_proc_t* proc = NULL;
+    ompi_proc_t* proc = NULL;
 
     if (OPAL_LIKELY(group)) {
         if (OPAL_LIKELY(group == oshmem_group_all)) {
@@ -291,18 +281,18 @@ static inline int oshmem_my_proc_id(void)
 
 static inline int oshmem_get_transport_id(int pe)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
 
     proc = oshmem_proc_group_find(oshmem_group_all, pe);
 
-    return (int) proc->transport_ids[0];
+    return (int) OSHMEM_PROC_DATA(proc)->transport_ids[0];
 }
 
 static inline int oshmem_get_transport_count(int pe)
 {
-    oshmem_proc_t *proc;
+    ompi_proc_t *proc;
     proc = oshmem_proc_group_find(oshmem_group_all, pe);
-    return proc->num_transports;
+    return OSHMEM_PROC_DATA(proc)->num_transports;
 }
 
 END_C_DECLS


### PR DESCRIPTION
and use these macros to access oshmem related per proc data :
 - OSHMEM_PROC_NUM_TRANSPORTS(proc)
 - OSHMEM_PROC_TRANSPORT_IDS(proc)

Fixes open-mpi/ompi#2023