### PR TITLE
Silence numerous warnings from Studio compilers

### DIFF
--- a/opal/include/opal/sys/amd64/atomic.h
+++ b/opal/include/opal/sys/amd64/atomic.h
@@ -24,6 +24,12 @@
 #ifndef OPAL_SYS_ARCH_ATOMIC_H
 #define OPAL_SYS_ARCH_ATOMIC_H 1
 
+/* Suppress numerous warnings from Studio compilers */
+#if OPAL_GCC_INLINE_ASSEMBLY && (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
+#  pragma error_messages(off, E_ASM_UNUSED_PARAM)
+#endif
+
+
 /*
  * On amd64, we use cmpxchg.
  */
@@ -276,5 +282,9 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t* v, int64_t i)
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
+
+#if OPAL_GCC_INLINE_ASSEMBLY && (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
+#  pragma error_messages(default, E_ASM_UNUSED_PARAM)
+#endif
 
 #endif /* ! OPAL_SYS_ARCH_ATOMIC_H */

--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -25,6 +25,12 @@
 #ifndef OPAL_SYS_ARCH_ATOMIC_H
 #define OPAL_SYS_ARCH_ATOMIC_H 1
 
+/* Suppress numerous warnings from Studio compilers */
+#if OPAL_GCC_INLINE_ASSEMBLY && (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
+#  pragma error_messages(off, E_ASM_UNUSED_PARAM)
+#endif
+
+
 /*
  * On ia32, we use cmpxchg.
  */
@@ -218,5 +224,9 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t* v, int i)
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
+
+#if OPAL_GCC_INLINE_ASSEMBLY && (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
+#  pragma error_messages(default, E_ASM_UNUSED_PARAM)
+#endif
 
 #endif /* ! OPAL_SYS_ARCH_ATOMIC_H */


### PR DESCRIPTION
This commit adds selective use of a compiler-specific pragma to
silence the numerous warnings the Sun/Oracle/Studio compilers emit for
the GNU-style inline asm used in atomic.h.

Now that there are a non-trivial number of *real* warnings, the improvement
this change make to the signal-to-noise ratio is valuable.

I would like follow-up with a PR for v2.x as well (with 2.0.2 milestone) if this is PR is accepted.