### PR TITLE
oob/usock: fix handling of orte_process_name_t *

### DIFF
--- a/orte/mca/oob/usock/oob_usock.c
+++ b/orte/mca/oob/usock/oob_usock.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -367,7 +369,7 @@ static void recv_handler(int sd, short flags, void *cbdata)
     mca_oob_usock_conn_op_t *op = (mca_oob_usock_conn_op_t*)cbdata;
     mca_oob_usock_hdr_t hdr;
     mca_oob_usock_peer_t *peer;
-    uint64_t *ui64;
+    uint64_t ui64;
 
     opal_output_verbose(OOB_USOCK_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
                         "%s:usock:recv:handler called",
@@ -407,8 +409,8 @@ static void recv_handler(int sd, short flags, void *cbdata)
                             peer->state);
             }
             CLOSE_THE_SOCKET(sd);
-            ui64 = (uint64_t*)(&peer->name);
-            opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, (*ui64), NULL);
+            memcpy(&ui64, &peer->name, sizeof(uint64_t));
+            opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, ui64, NULL);
             OBJ_RELEASE(peer);
         }
     }

--- a/orte/mca/oob/usock/oob_usock_component.c
+++ b/orte/mca/oob/usock/oob_usock_component.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -315,8 +317,9 @@ static int component_set_addr(orte_process_name_t *peer,
 {
     orte_proc_t *proc;
     mca_oob_usock_peer_t *pr;
-    uint64_t *ui64;
+    uint64_t ui64;
 
+    memcpy(&ui64, peer, sizeof(uint64_t));
     /* if I am an application, then everything is addressable
      * by me via my daemon
      */
@@ -324,12 +327,11 @@ static int component_set_addr(orte_process_name_t *peer,
         /* if this is my daemon, then take it - otherwise, ignore */
         if (ORTE_PROC_MY_DAEMON->jobid == peer->jobid &&
             ORTE_PROC_MY_DAEMON->vpid == peer->vpid) {
-            ui64 = (uint64_t*)peer;
             if (OPAL_SUCCESS != opal_hash_table_get_value_uint64(&mca_oob_usock_module.peers,
-                                                                 (*ui64), (void**)&pr) || NULL == pr) {
+                                                                 ui64, (void**)&pr) || NULL == pr) {
                 pr = OBJ_NEW(mca_oob_usock_peer_t);
                 pr->name = *peer;
-                opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, (*ui64), pr);
+                opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, ui64, pr);
             }
             /* we have to initiate the connection because otherwise the
              * daemon has no way to communicate to us via this component
@@ -354,12 +356,11 @@ static int component_set_addr(orte_process_name_t *peer,
         return ORTE_ERR_TAKE_NEXT_OPTION;
     }
     /* indicate that this peer is addressable by this component */
-    ui64 = (uint64_t*)peer;
     if (OPAL_SUCCESS != opal_hash_table_get_value_uint64(&mca_oob_usock_module.peers,
-                                                         (*ui64), (void**)&pr) || NULL == pr) {
+                                                         ui64, (void**)&pr) || NULL == pr) {
         pr = OBJ_NEW(mca_oob_usock_peer_t);
         pr->name = *peer;
-        opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, (*ui64), pr);
+        opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, ui64, pr);
     }
     return ORTE_SUCCESS;
 }

--- a/orte/mca/oob/usock/oob_usock_connection.c
+++ b/orte/mca/oob/usock/oob_usock_connection.c
@@ -515,7 +515,7 @@ int mca_oob_usock_peer_recv_connect_ack(mca_oob_usock_peer_t* pr, int sd,
     size_t credsize;
     mca_oob_usock_peer_t *peer;
     mca_oob_usock_hdr_t hdr;
-    uint64_t *ui64;
+    uint64_t ui64;
 
     opal_output_verbose(OOB_USOCK_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
                         "%s RECV CONNECT ACK FROM %s ON SOCKET %d",
@@ -590,8 +590,8 @@ int mca_oob_usock_peer_recv_connect_ack(mca_oob_usock_peer_t* pr, int sd,
             peer->name = hdr.origin;
             peer->state = MCA_OOB_USOCK_ACCEPTING;
             peer->sd = sd;
-            ui64 = (uint64_t*)(&peer->name);
-            if (OPAL_SUCCESS != opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, (*ui64), peer)) {
+            memcpy(&ui64, &peer->name, sizeof(uint64_t));
+            if (OPAL_SUCCESS != opal_hash_table_set_value_uint64(&mca_oob_usock_module.peers, ui64, peer)) {
                 OBJ_RELEASE(peer);
                 CLOSE_THE_SOCKET(sd);
                 return ORTE_ERR_UNREACH;


### PR DESCRIPTION
orte_process_name_t is aligned on 32 bits, so it cannot simply be casted
into an int64_t. use memcpy() instead

Thanks Paul Hargrove for the report