### PR TITLE
osc/pt2pt: do not use frag send to send lock request

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -1546,12 +1546,6 @@ static inline int process_frag (ompi_osc_pt2pt_module_t *module,
                 ret = process_acc_long (module, frag->source, &header->acc);
                 break;
 
-            case OMPI_OSC_PT2PT_HDR_TYPE_LOCK_REQ:
-                ret = ompi_osc_pt2pt_process_lock(module, frag->source, &header->lock);
-                if (OPAL_LIKELY(OMPI_SUCCESS == ret)) {
-                    ret = sizeof (header->lock);
-                }
-                break;
             case OMPI_OSC_PT2PT_HDR_TYPE_UNLOCK_REQ:
                 ret = process_unlock(module, frag->source, &header->unlock);
                 break;
@@ -1655,6 +1649,9 @@ int ompi_osc_pt2pt_process_receive (ompi_osc_pt2pt_receive_t *recv)
         break;
     case OMPI_OSC_PT2PT_HDR_TYPE_POST:
         osc_pt2pt_incoming_post (module, source);
+        break;
+    case OMPI_OSC_PT2PT_HDR_TYPE_LOCK_REQ:
+        ompi_osc_pt2pt_process_lock(module, source, (ompi_osc_pt2pt_header_lock_t *) base_header);
         break;
     case OMPI_OSC_PT2PT_HDR_TYPE_LOCK_ACK:
         ompi_osc_pt2pt_process_lock_ack(module, (ompi_osc_pt2pt_header_lock_ack_t *) base_header);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
@@ -151,38 +151,6 @@ int ompi_osc_pt2pt_frag_flush_target (ompi_osc_pt2pt_module_t *module, int targe
     return ret;
 }
 
-int ompi_osc_pt2pt_frag_flush_target_locked (ompi_osc_pt2pt_module_t *module, int target)
-{
-    ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, target);
-    ompi_osc_pt2pt_frag_t *frag;
-    int ret = OMPI_SUCCESS;
-
-    OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: frag flush to target target %d. queue fragments: %lu",
-                         target, (unsigned long) opal_list_get_size (&peer->queued_frags)));
-
-    /* walk through the pending list and send */
-    while (NULL != (frag = ((ompi_osc_pt2pt_frag_t *) opal_list_remove_first (&peer->queued_frags)))) {
-        ret = frag_send(module, frag);
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
-            break;
-        }
-    }
-
-    /* XXX -- TODO -- better error handling */
-    if (OMPI_SUCCESS != ret) {
-        return ret;
-    }
-
-    /* flush the active frag */
-    ret = ompi_osc_pt2pt_flush_active_frag (module, peer);
-
-    OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
-                         "osc pt2pt: frag flush target %d finished", target));
-
-    return ret;
-}
-
 int ompi_osc_pt2pt_frag_flush_all (ompi_osc_pt2pt_module_t *module)
 {
     int ret = OMPI_SUCCESS;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
@@ -43,7 +43,6 @@ OBJ_CLASS_DECLARATION(ompi_osc_pt2pt_frag_t);
 
 int ompi_osc_pt2pt_frag_start(ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_frag_t *buffer);
 int ompi_osc_pt2pt_frag_flush_target(ompi_osc_pt2pt_module_t *module, int target);
-int ompi_osc_pt2pt_frag_flush_target_locked(ompi_osc_pt2pt_module_t *module, int target);
 int ompi_osc_pt2pt_frag_flush_all(ompi_osc_pt2pt_module_t *module);
 
 static inline int ompi_osc_pt2pt_frag_finish (ompi_osc_pt2pt_module_t *module,


### PR DESCRIPTION
This commit cleans up some code in the passive target path. The code
used the buffered frag control send path but it is more appropriate to
use the unbuffered one. This avoids checking structures that are
should not be in use in this path.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>