### PR TITLE
btl/ugni: fix erroneous warning message

### DIFF
--- a/opal/mca/btl/ugni/btl_ugni_endpoint.c
+++ b/opal/mca/btl/ugni/btl_ugni_endpoint.c
@@ -208,8 +208,11 @@ int mca_btl_ugni_ep_connect_progress (mca_btl_base_endpoint_t *ep) {
                 ep->dg_posted = true;
                 rc = OPAL_ERR_RESOURCE_BUSY;
             }
+
             return rc;
         }
+
+        return OPAL_SUCCESS;
     }
 
     return mca_btl_ugni_ep_connect_finish (ep);


### PR DESCRIPTION
This commit prevents the connection code from trying to connect an
endpoint if the directed datagram has been posted but not received.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>