### PR TITLE
orte: !FQDN implementation to use opal_net_isaddr

### DIFF
--- a/orte/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/orte/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -34,13 +34,11 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif  /* HAVE_UNISTD_H */
-#if HAVE_ARPA_INET_H
-#include <arpa/inet.h>
-#endif
 #include <string.h>
 
 #include "opal/util/argv.h"
 #include "opal/util/if.h"
+#include "opal/util/net.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/mca/hwloc/base/base.h"
 
@@ -493,16 +491,11 @@ static int orte_rmaps_rank_file_parse(const char *rankfile)
                         }
                         opal_argv_free (argv);
 
-                        // Strip off the FQDN if present
-                        if( !orte_keep_fqdn_hostnames ) {
+                        // Strip off the FQDN if present, ignore IP addresses
+                        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(node_name) ) {
                             char *ptr;
-                            struct in_addr buf;
-                            /* if the nodename is an IP address, do not mess with it! */
-                            if (0 == inet_pton(AF_INET, node_name, &buf) &&
-                                0 == inet_pton(AF_INET6, node_name, &buf)) {
-                                if (NULL != (ptr = strchr(node_name, '.'))) {
-                                    *ptr = '\0';
-                                }
+                            if (NULL != (ptr = strchr(node_name, '.'))) {
+                                *ptr = '\0';
                             }
                         }
 

--- a/orte/mca/rmaps/seq/rmaps_seq.c
+++ b/orte/mca/rmaps/seq/rmaps_seq.c
@@ -35,6 +35,7 @@
 #include <ctype.h>
 
 #include "opal/util/if.h"
+#include "opal/util/net.h"
 #include "opal/mca/hwloc/hwloc.h"
 
 #include "orte/util/show_help.h"
@@ -191,17 +192,11 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
                 sq->cpuset = strdup(sep);
             }
 
-            // Strip off the FQDN if present
-            if( !orte_keep_fqdn_hostnames ) {
+            // Strip off the FQDN if present, ignore IP addresses
+            if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(hstname) ) {
                 char *ptr;
-                struct in_addr buf;
-
-                /* if the nodename is an IP address, do not mess with it! */
-                if (0 == inet_pton(AF_INET, hstname, &buf) &&
-                    0 == inet_pton(AF_INET6, hstname, &buf)) {
-                    if (NULL != (ptr = strchr(hstname, '.'))) {
-                        *ptr = '\0';
-                    }
+                if (NULL != (ptr = strchr(hstname, '.'))) {
+                    *ptr = '\0';
                 }
             }
 
@@ -301,16 +296,11 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
                     sq->cpuset = strdup(sep);
                 }
 
-                // Strip off the FQDN if present
-                if( !orte_keep_fqdn_hostnames ) {
+                // Strip off the FQDN if present, ignore IP addresses
+                if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(hstname) ) {
                     char *ptr;
-                    struct in_addr buf;
-                    /* if the nodename is an IP address, do not mess with it! */
-                    if (0 == inet_pton(AF_INET, hstname, &buf) &&
-                        0 == inet_pton(AF_INET6, hstname, &buf)) {
-                        if (NULL != (ptr = strchr(hstname, '.'))) {
-                            (*ptr) = '\0';
-                        }
+                    if (NULL != (ptr = strchr(hstname, '.'))) {
+                        (*ptr) = '\0';
                     }
                 }
 

--- a/orte/util/dash_host/dash_host.c
+++ b/orte/util/dash_host/dash_host.c
@@ -24,9 +24,6 @@
 #include "orte_config.h"
 
 #include <string.h>
-#if HAVE_ARPA_INET_H
-#include <arpa/inet.h>
-#endif
 
 #include "orte/constants.h"
 #include "orte/types.h"
@@ -34,6 +31,7 @@
 #include "orte/util/show_help.h"
 #include "opal/util/argv.h"
 #include "opal/util/if.h"
+#include "opal/util/net.h"
 
 #include "orte/mca/ras/base/base.h"
 #include "orte/mca/plm/plm_types.h"
@@ -211,16 +209,11 @@ int orte_util_add_dash_host_nodes(opal_list_t *nodes,
             ndname = mini_map[i];
         }
 
-        // Strip off the FQDN if present
-        if( !orte_keep_fqdn_hostnames ) {
+        // Strip off the FQDN if present, ignore IP addresses
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(ndname) ) {
             char *ptr;
-            struct in_addr buf;
-            /* if the nodename is an IP address, do not mess with it! */
-            if (0 == inet_pton(AF_INET, ndname, &buf) &&
-                0 == inet_pton(AF_INET6, ndname, &buf)) {
-                if (NULL != (ptr = strchr(ndname, '.'))) {
-                    *ptr = '\0';
-                }
+            if (NULL != (ptr = strchr(ndname, '.'))) {
+                *ptr = '\0';
             }
         }
 

--- a/orte/util/hostfile/hostfile.c
+++ b/orte/util/hostfile/hostfile.c
@@ -28,9 +28,6 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#if HAVE_ARPA_INET_H
-#include <arpa/inet.h>
-#endif
 #include <errno.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -41,6 +38,7 @@
 #include "opal/mca/mca.h"
 #include "opal/mca/base/base.h"
 #include "opal/util/if.h"
+#include "opal/util/net.h"
 #include "opal/mca/installdirs/installdirs.h"
 
 #include "orte/util/show_help.h"
@@ -168,16 +166,11 @@ static int hostfile_parse_line(int token, opal_list_t* updates,
         }
         opal_argv_free (argv);
 
-        // Strip off the FQDN if present
-        if( !orte_keep_fqdn_hostnames ) {
+        // Strip off the FQDN if present, ignore IP addresses
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(node_name) ) {
             char *ptr;
-            struct in_addr buf;
-            /* if the nodename is an IP address, do not mess with it! */
-            if (0 == inet_pton(AF_INET, node_name, &buf) &&
-                0 == inet_pton(AF_INET6, node_name, &buf)) {
-                if (NULL != (ptr = strchr(node_name, '.'))) {
-                    *ptr = '\0';
-                }
+            if (NULL != (ptr = strchr(node_name, '.'))) {
+                *ptr = '\0';
             }
         }
 
@@ -288,16 +281,11 @@ static int hostfile_parse_line(int token, opal_list_t* updates,
         }
         opal_argv_free (argv);
 
-        // Strip off the FQDN if present
-        if( !orte_keep_fqdn_hostnames ) {
+        // Strip off the FQDN if present, ignore IP addresses
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(node_name) ) {
             char *ptr;
-            struct in_addr buf;
-            /* if the nodename is an IP address, do not mess with it! */
-            if (0 == inet_pton(AF_INET, node_name, &buf) &&
-                0 == inet_pton(AF_INET6, node_name, &buf)) {
-                if (NULL != (ptr = strchr(node_name, '.'))) {
-                    *ptr = '\0';
-                }
+            if (NULL != (ptr = strchr(node_name, '.'))) {
+                *ptr = '\0';
             }
         }
 

--- a/orte/util/proc_info.c
+++ b/orte/util/proc_info.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,9 +32,6 @@
 #endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
-#if HAVE_ARPA_INET_H
-#include <arpa/inet.h>
 #endif
 #include <ctype.h>
 
@@ -173,16 +171,12 @@ int orte_proc_info(void)
     /* add this to our list of aliases */
     opal_argv_append_nosize(&orte_process_info.aliases, hostname);
 
-    if (!orte_keep_fqdn_hostnames) {
-        /* if the nodename is an IP address, do not mess with it! */
-        if (0 == inet_pton(AF_INET, hostname, &buf) &&
-            0 == inet_pton(AF_INET6, hostname, &buf)) {
-            /* not an IP address, so remove any domain info */
-            if (NULL != (ptr = strchr(hostname, '.'))) {
-                *ptr = '\0';
-                /* add this to our list of aliases */
-                opal_argv_append_nosize(&orte_process_info.aliases, hostname);
-            }
+    // Strip off the FQDN if present, ignore IP addresses
+    if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(hostname) ) {
+        if (NULL != (ptr = strchr(hostname, '.'))) {
+            *ptr = '\0';
+            /* add this to our list of aliases */
+            opal_argv_append_nosize(&orte_process_info.aliases, hostname);
         }
     }
 


### PR DESCRIPTION
 * Switch to use opal_net_isaddr() for checking if a name is an IP
   address - as it is a bit cleaner, and uses common functionality.
 * Related to PR #2015 