### PR TITLE
build: Custom libmpi name option in configure

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006-2011 Mellanox Technologies. All rights reserved.
 Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2007      Myricom, Inc.  All rights reserved.
-Copyright (c) 2008      IBM Corporation.  All rights reserved.
+Copyright (c) 2008-2016 IBM Corporation.  All rights reserved.
 Copyright (c) 2010      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2011      University of Houston. All rights reserved.
 Copyright (c) 2013-2015 Intel, Inc. All rights reserved
@@ -829,6 +829,14 @@ INSTALLATION OPTIONS
   Load configure options for the build from FILE.  Options on the
   command line that are not in FILE are also used.  Options on the
   command line and in FILE are replaced by what is in FILE.
+
+--with-libmpi-name=STRING
+  Replace libmpi.* and libmpi_FOO.* (where FOO is one of the fortran
+  supporting libraries installed in lib) with libSTRING.* and
+  libSTRING_FOO.*. This is provided as a convenience mechanism for
+  third-party packagers of Open MPI that might want to rename these
+  libraries for their own purposes. This option is *not* intended for
+  typical users of Open MPI.
 
 NETWORKING SUPPORT / OPTIONS
 

--- a/config/opal_set_lib_prefix.m4
+++ b/config/opal_set_lib_prefix.m4
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,4 +38,25 @@ AC_DEFUN([ORTE_SET_LIB_PREFIX],[
     ORTE_LIB_PREFIX=$1
     orte_lib_prefix_set=yes
     AC_SUBST(ORTE_LIB_PREFIX)
+])dnl
+
+#
+# Rename 'libmpi' and 'libmpi_FOO' with a configure time option.
+#
+AC_DEFUN([OMPI_SET_LIB_NAME],[
+    AC_MSG_CHECKING([if want custom libmpi(_FOO) name])
+    AC_ARG_WITH([libmpi-name],
+        [AC_HELP_STRING([--with-libmpi-name=STRING],
+                ["Replace \"libmpi(_FOO)\" with \"libSTRING(_FOO)\" (default=mpi)"])])
+
+    AS_IF([test "$with_libmpi_name" = "no"],
+        [AC_MSG_RESULT([Error])
+         AC_MSG_WARN([Invalid to specify --without-libmpi-name])
+         AC_MSG_ERROR([Cannot continue])])
+
+    AS_IF([test "$with_libmpi_name" = "" || test "$with_libmpi_name" = "yes"],
+        [with_libmpi_name="mpi"])
+
+    AC_MSG_RESULT([$with_libmpi_name])
+    AC_SUBST(OMPI_LIBMPI_NAME, $with_libmpi_name)
 ])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,8 @@ fi
 OPAL_SET_LIB_PREFIX([])
 m4_ifdef([project_orte],
           [ORTE_SET_LIB_PREFIX([])])
+m4_ifdef([project_ompi],
+          [OMPI_SET_LIB_NAME([])])
 
 ############################################################################
 # Libtool: part one

--- a/ompi/Makefile.am
+++ b/ompi/Makefile.am
@@ -17,6 +17,7 @@
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -128,9 +129,9 @@ DIST_SUBDIRS = \
 
 # Build the main MPI library
 
-lib_LTLIBRARIES = libmpi.la
-libmpi_la_SOURCES =
-libmpi_la_LIBADD = \
+lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@.la
+lib@OMPI_LIBMPI_NAME@_la_SOURCES =
+lib@OMPI_LIBMPI_NAME@_la_LIBADD = \
         datatype/libdatatype.la \
         debuggers/libdebuggers.la \
         mpi/c/libmpi_c.la \
@@ -144,13 +145,13 @@ libmpi_la_LIBADD = \
 
 
 if OMPI_RTE_ORTE
-libmpi_la_LIBADD += \
+lib@OMPI_LIBMPI_NAME@_la_LIBADD += \
         $(OMPI_TOP_BUILDDIR)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 endif
-libmpi_la_LIBADD += \
+lib@OMPI_LIBMPI_NAME@_la_LIBADD += \
         $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
-libmpi_la_DEPENDENCIES = $(libmpi_la_LIBADD)
-libmpi_la_LDFLAGS = \
+lib@OMPI_LIBMPI_NAME@_la_DEPENDENCIES = $(lib@OMPI_LIBMPI_NAME@_la_LIBADD)
+lib@OMPI_LIBMPI_NAME@_la_LDFLAGS = \
        -version-info $(libmpi_so_version) \
         $(OMPI_LIBMPI_EXTRA_LDFLAGS)
 
@@ -159,7 +160,7 @@ headers =
 noinst_LTLIBRARIES =
 include_HEADERS =
 dist_ompidata_DATA =
-libmpi_la_SOURCES += $(headers)
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += $(headers)
 nodist_man_MANS =
 
 # Conditionally install the header files

--- a/ompi/attribute/Makefile.am
+++ b/ompi/attribute/Makefile.am
@@ -9,6 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,6 +22,6 @@
 headers += \
         attribute/attribute.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         attribute/attribute.c \
         attribute/attribute_predefined.c

--- a/ompi/class/Makefile.am
+++ b/ompi/class/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,6 +23,6 @@
 headers += \
         class/ompi_seq_tracker.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         class/ompi_seq_tracker.c
 

--- a/ompi/communicator/Makefile.am
+++ b/ompi/communicator/Makefile.am
@@ -14,6 +14,7 @@
 #                         reserved.
 # Copyright (c) 2014      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,7 +29,7 @@ headers += \
 	communicator/comm_request.h \
 	communicator/comm_helpers.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         communicator/comm_init.c \
 	communicator/comm.c \
 	communicator/comm_cid.c \

--- a/ompi/debuggers/Makefile.am
+++ b/ompi/debuggers/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,13 +45,13 @@ headers = \
 
 dlopen_test_SOURCES = dlopen_test.c
 dlopen_test_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 dlopen_test_DEPENDENCIES = $(ompi_predefined_LDADD)
 
 predefined_gap_test_SOURCES = predefined_gap_test.c
 predefined_gap_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-predefined_gap_test_LDADD = $(top_builddir)/ompi/libmpi.la
+predefined_gap_test_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 predefined_gap_test_DEPENDENCIES = $(ompi_predefined_LDADD)
 
 libdebuggers_la_SOURCES = \
@@ -78,7 +79,7 @@ libompi_dbg_msgq_la_LDFLAGS = -module -avoid-version
 # and "make check" will *build* a test in runtime/, but it won't *run*
 # it.  :-(
 predefined_pad_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-predefined_pad_test_LDADD = $(top_builddir)/ompi/libmpi.la
+predefined_pad_test_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 predefined_pad_test_DEPENDENCIES = $(ompi_predefined_LDADD)
 
 # Conditionally install the header files

--- a/ompi/dpm/Makefile.am
+++ b/ompi/dpm/Makefile.am
@@ -1,6 +1,7 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -13,6 +14,6 @@
 headers += \
         dpm/dpm.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         dpm/dpm.c
 

--- a/ompi/errhandler/Makefile.am
+++ b/ompi/errhandler/Makefile.am
@@ -11,6 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,7 +29,7 @@ headers += \
         errhandler/errhandler.h \
         errhandler/errhandler_predefined.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         errhandler/errhandler.c \
         errhandler/errhandler_invoke.c \
         errhandler/errhandler_predefined.c \

--- a/ompi/file/Makefile.am
+++ b/ompi/file/Makefile.am
@@ -9,6 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,5 +22,5 @@
 headers += \
         file/file.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         file/file.c

--- a/ompi/group/Makefile.am
+++ b/ompi/group/Makefile.am
@@ -11,6 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2007 University of Houston. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,11 +25,11 @@ headers += \
         group/group.h \
 	group/group_dbg.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         group/group.c \
         group/group_init.c \
         group/group_set_rank.c \
         group/group_plist.c \
 	group/group_sporadic.c \
 	group/group_strided.c \
- 	group/group_bitmap.c
+	group/group_bitmap.c

--- a/ompi/info/Makefile.am
+++ b/ompi/info/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,5 +23,5 @@
 headers += \
         info/info.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         info/info.c

--- a/ompi/mca/common/ompio/Makefile.am
+++ b/ompi/mca/common/ompio/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2016 University of Houston. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -43,8 +44,8 @@ sources = \
 
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES =
-comp_inst = lib@OPAL_LIB_PREFIX@mca_common_ompio.la
-comp_noinst = lib@OPAL_LIB_PREFIX@mca_common_ompio_noinst.la
+comp_inst = libmca_common_ompio.la
+comp_noinst = libmca_common_ompio_noinst.la
 
 if MCA_BUILD_ompi_common_ompio_DSO
 lib_LTLIBRARIES += $(comp_inst)
@@ -52,13 +53,13 @@ else
 noinst_LTLIBRARIES += $(comp_noinst)
 endif
 
-lib@OPAL_LIB_PREFIX@mca_common_ompio_la_SOURCES = $(headers) $(sources)
-lib@OPAL_LIB_PREFIX@mca_common_ompio_la_CPPFLAGS = $(common_ompio_CPPFLAGS)
-lib@OPAL_LIB_PREFIX@mca_common_ompio_la_LDFLAGS =  \
+libmca_common_ompio_la_SOURCES = $(headers) $(sources)
+libmca_common_ompio_la_CPPFLAGS = $(common_ompio_CPPFLAGS)
+libmca_common_ompio_la_LDFLAGS =  \
         -version-info $(libmca_ompi_common_ompio_so_version) \
         $(common_ompio_LDFLAGS)
-lib@OPAL_LIB_PREFIX@mca_common_ompio_la_LIBADD = $(common_ompio_LIBS)
-lib@OPAL_LIB_PREFIX@mca_common_ompio_noinst_la_SOURCES = $(headers) $(sources)
+libmca_common_ompio_la_LIBADD = $(common_ompio_LIBS)
+libmca_common_ompio_noinst_la_SOURCES = $(headers) $(sources)
 
 # Conditionally install the header files
 

--- a/ompi/mca/io/ompio/Makefile.am
+++ b/ompi/mca/io/ompio/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2012 University of Houston. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +35,7 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_io_ompio_la_SOURCES = $(headers) $(sources)
 mca_io_ompio_la_LDFLAGS = -module -avoid-version
 mca_io_ompio_la_LIBADD = $(io_ompio_LIBS) \
-    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/lib@OPAL_LIB_PREFIX@mca_common_ompio.la
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_io_ompio_la_SOURCES = $(headers) $(sources)

--- a/ompi/mca/sharedfp/addproc/Makefile.am
+++ b/ompi/mca/sharedfp/addproc/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2013      University of Houston. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -60,4 +61,4 @@ mca_sharedfp_addproc_control_SOURCES = \
     sharedfp_addproc_control.h \
     sharedfp_addproc_control.c
 
-mca_sharedfp_addproc_control_LDADD = $(top_builddir)/ompi/libmpi.la
+mca_sharedfp_addproc_control_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la

--- a/ompi/message/Makefile.am
+++ b/ompi/message/Makefile.am
@@ -11,6 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,5 +24,5 @@
 headers += \
 	message/message.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
 	message/message.c

--- a/ompi/mpi/cxx/Makefile.am
+++ b/ompi/mpi/cxx/Makefile.am
@@ -11,6 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,7 +43,7 @@ libmpi_cxx_la_SOURCES += \
 	file.cc
 endif
 
-libmpi_cxx_la_LIBADD = $(top_builddir)/ompi/libmpi.la
+libmpi_cxx_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 libmpi_cxx_la_LDFLAGS = -version-info $(libmpi_cxx_so_version)
 
 headers = \

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -16,6 +16,7 @@
 #                         reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -50,22 +51,22 @@ CLEANFILES =
 # Note that we invoke some OPAL functions directly in libmpi_mpifh.la,
 # so we need to link in the OPAL library directly (pulling it in
 # indirectly via libmpi.la does not work on all platforms).
-libmpi_mpifh_la_LIBADD = \
-        $(top_builddir)/ompi/libmpi.la \
+lib@OMPI_LIBMPI_NAME@_mpifh_la_LIBADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(OMPI_MPIEXT_MPIFH_LIBS) \
         $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
-libmpi_mpifh_la_LDFLAGS = -version-info $(libmpi_mpifh_so_version)
+lib@OMPI_LIBMPI_NAME@_mpifh_la_LDFLAGS = -version-info $(libmpi_mpifh_so_version)
 
 # Are we building the mpif.h bindings at all?
 if OMPI_BUILD_FORTRAN_MPIFH_BINDINGS
 # If yes, then we need to build the installable library and the glue
 # convenience library that will be sucked up into the main libmpi.
-lib_LTLIBRARIES += libmpi_mpifh.la
+lib_LTLIBRARIES += lib@OMPI_LIBMPI_NAME@_mpifh.la
 # Do we need to suck in the convenience library from the lower
 # directory?
 if BUILD_PMPI_FORTRAN_MPIFH_BINDINGS_LAYER
-libmpi_mpifh_la_LIBADD += profile/libmpi_mpifh_pmpi.la
+lib@OMPI_LIBMPI_NAME@_mpifh_la_LIBADD += profile/libmpi_mpifh_pmpi.la
 endif
 endif
 
@@ -77,7 +78,7 @@ headers = \
 #
 # These files are only built and added to libmpi_mpifh.la in certain cases.
 #
-libmpi_mpifh_la_SOURCES =
+lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES =
 
 # sizeof_f.f90 is generated based on some results from configure tests.
 CLEANFILES += sizeof_f.f90
@@ -107,7 +108,7 @@ if BUILD_FORTRAN_SIZEOF
 noinst_LTLIBRARIES += libmpi_mpifh_sizeof.la
 # Do not dist this file; it is generated
 nodist_libmpi_mpifh_sizeof_la_SOURCES = sizeof_f.f90
-libmpi_mpifh_la_LIBADD += libmpi_mpifh_sizeof.la
+lib@OMPI_LIBMPI_NAME@_mpifh_la_LIBADD += libmpi_mpifh_sizeof.la
 endif
 
 sizeof_pl = $(top_srcdir)/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -123,7 +124,7 @@ sizeof_f.f90:
 	    --complex32=$(OMPI_HAVE_FORTRAN_COMPLEX32)
 
 if BUILD_MPI_FORTRAN_MPIFH_BINDINGS_LAYER
-libmpi_mpifh_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         abort_f.c \
         add_error_class_f.c \
         add_error_code_f.c \
@@ -431,7 +432,7 @@ libmpi_mpifh_la_SOURCES += \
         win_flush_local_all_f.c
 
 if OMPI_PROVIDE_MPI_FILE_INTERFACE
-libmpi_mpifh_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         file_call_errhandler_f.c \
         file_close_f.c \
         file_create_errhandler_f.c \

--- a/ompi/mpi/fortran/use-mpi-f08-desc/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08-desc/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -18,7 +19,7 @@ if OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS
 AM_FCFLAGS = -I$(top_builddir)/ompi/include -I$(top_srcdir)/ompi/include \
              -I$(top_srcdir) $(FCFLAGS)
 
-lib_LTLIBRARIES = libmpi_usempif08.la
+lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@_usempif08.la
 
 #
 # This list is a subset of the full MPI API used for testing Fortran
@@ -35,7 +36,7 @@ mpi_api_files = \
         type_contiguous_f08.f90 \
         type_vector_f08.f90
 
-libmpi_usempif08_la_SOURCES = \
+lib@OMPI_LIBMPI_NAME@_usempif08_la_SOURCES = \
         $(mpi_api_files) \
         mpi-f08-types.f90 \
         mpi-f08-interfaces.F90 \

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -9,6 +9,7 @@
 #                         reserved.
 # Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -33,7 +34,7 @@ MOSTLYCLEANFILES = *.mod
 
 CLEANFILES += *.i90
 
-lib_LTLIBRARIES = libmpi_usempif08.la
+lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@_usempif08.la
 
 module_sentinel_file = \
         libforce_usempif08_internal_modules_to_be_built.la
@@ -793,7 +794,7 @@ pmpi_api_files += \
         profile/pregister_datarep_f08.F90
 endif
 
-libmpi_usempif08_la_SOURCES = \
+lib@OMPI_LIBMPI_NAME@_usempif08_la_SOURCES = \
         $(mpi_api_files) \
         $(pmpi_api_files) \
         mpi-f-interfaces-bind.h \
@@ -804,11 +805,11 @@ libmpi_usempif08_la_SOURCES = \
         constants.c
 
 # These are generated; do not ship them
-nodist_libmpi_usempif08_la_SOURCES =
+nodist_lib@OMPI_LIBMPI_NAME@_usempif08_la_SOURCES =
 
 if BUILD_FORTRAN_SIZEOF
 SIZEOF_H = sizeof_f08.h
-nodist_libmpi_usempif08_la_SOURCES += \
+nodist_lib@OMPI_LIBMPI_NAME@_usempif08_la_SOURCES += \
         sizeof_f08.h \
         sizeof_f08.f90 \
         profile/psizeof_f08.f90
@@ -818,13 +819,13 @@ endif
 # Include the mpi_f08-based MPI extensions in libmpi_usempif08, too.
 #
 
-libmpi_usempif08_la_LIBADD = \
+lib@OMPI_LIBMPI_NAME@_usempif08_la_LIBADD = \
         $(module_sentinel_file) \
         $(OMPI_MPIEXT_USEMPIF08_LIBS) \
-        $(top_builddir)/ompi/mpi/fortran/mpif-h/libmpi_mpifh.la \
-        $(top_builddir)/ompi/libmpi.la
-libmpi_usempif08_la_DEPENDENCIES = $(module_sentinel_file)
-libmpi_usempif08_la_LDFLAGS = -version-info $(libmpi_usempif08_so_version)
+        $(top_builddir)/ompi/mpi/fortran/mpif-h/lib@OMPI_LIBMPI_NAME@_mpifh.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+lib@OMPI_LIBMPI_NAME@_usempif08_la_DEPENDENCIES = $(module_sentinel_file)
+lib@OMPI_LIBMPI_NAME@_usempif08_la_LDFLAGS = -version-info $(libmpi_usempif08_so_version)
 
 #
 # Automake doesn't do Fortran dependency analysis, so must list them

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -22,7 +23,7 @@ AM_CPPFLAGS = -DOMPI_PROFILE_LAYER=0 -DOMPI_COMPILING_FORTRAN_WRAPPERS=1
 AM_FCFLAGS = -I$(top_builddir)/ompi/include -I$(top_srcdir)/ompi/include \
              -I$(top_builddir) -I$(top_srcdir) $(FCFLAGS_f90)
 
-lib_LTLIBRARIES = libmpi_usempi_ignore_tkr.la
+lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr.la
 
 mpi-ignore-tkr-interfaces.h: mpi-ignore-tkr-interfaces.h.in
 mpi-ignore-tkr-file-interfaces.h: mpi-ignore-tkr-file-interfaces.h.in
@@ -35,15 +36,15 @@ mpi-ignore-tkr.lo: mpi-ignore-tkr-sizeof.h
 mpi-ignore-tkr.lo: mpi-ignore-tkr-sizeof.f90
 mpi-ignore-tkr.lo: mpi-ignore-tkr.F90
 
-libmpi_usempi_ignore_tkr_la_SOURCES = \
+lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_SOURCES = \
         mpi-ignore-tkr.F90
-nodist_libmpi_usempi_ignore_tkr_la_SOURCES = \
+nodist_lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_SOURCES = \
         mpi-ignore-tkr-interfaces.h \
         mpi-ignore-tkr-file-interfaces.h
 
 if BUILD_FORTRAN_SIZEOF
 # These files are generated; do not distribute them
-nodist_libmpi_usempi_ignore_tkr_la_SOURCES += \
+nodist_lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_SOURCES += \
         mpi-ignore-tkr-sizeof.h \
         mpi-ignore-tkr-sizeof.f90
 endif
@@ -52,9 +53,9 @@ endif
 # libmpi_usempi_ignore_tkr.la, so we need to link in the OPAL library
 # directly (pulling it in indirectly via libmpi.la does not work on
 # all platforms).
-libmpi_usempi_ignore_tkr_la_LIBADD = \
+lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_LIBADD = \
         $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
-libmpi_usempi_ignore_tkr_la_LDFLAGS = \
+lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_LDFLAGS = \
         -version-info $(libmpi_usempi_ignore_tkr_so_version) \
         $(OMPI_FORTRAN_EXTRA_SHARED_LIBRARY_FLAGS)
 

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -15,6 +15,7 @@
 #                         reserved.
 # Copyright (c) 2014-2015 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -49,7 +50,7 @@ lib_LTLIBRARIES =
 
 # Add the f90 library to the list of libraries to build
 
-lib_LTLIBRARIES += libmpi_usempi.la
+lib_LTLIBRARIES += lib@OMPI_LIBMPI_NAME@_usempi.la
 
 # Automake doesn't know how to do F90 dependency analysis, so manually
 # list this here (i.e., "mpi-f90-interfaces.h" is included in
@@ -65,7 +66,7 @@ mpi.lo: mpi-f90-cptr-interfaces.F90
 # buffer dummy argument.  We therefore really only need to build a
 # handful of subroutines.
 
-libmpi_usempi_la_SOURCES = \
+lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES = \
      mpi.F90 \
      mpi_aint_add_f90.f90 \
      mpi_aint_diff_f90.f90 \
@@ -79,9 +80,9 @@ libmpi_usempi_la_SOURCES = \
 
 # Don't distribute mpi-tkr-sizeof-*; they're generated.
 
-nodist_libmpi_usempi_la_SOURCES =
+nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES =
 if BUILD_FORTRAN_SIZEOF
-nodist_libmpi_usempi_la_SOURCES += \
+nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES += \
      mpi-tkr-sizeof.h \
      mpi-tkr-sizeof.f90
 endif
@@ -90,11 +91,11 @@ endif
 # libmpi_usempi.la, so we need to link in the OPAL library directly
 # (pulling it in indirectly via libmpi.la does not work on all
 # platforms).
-libmpi_usempi_la_LIBADD = \
-        $(top_builddir)/ompi/mpi/fortran/mpif-h/libmpi_mpifh.la \
+lib@OMPI_LIBMPI_NAME@_usempi_la_LIBADD = \
+        $(top_builddir)/ompi/mpi/fortran/mpif-h/lib@OMPI_LIBMPI_NAME@_mpifh.la \
         $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 # Set the library version
-libmpi_usempi_la_LDFLAGS = \
+lib@OMPI_LIBMPI_NAME@_usempi_la_LDFLAGS = \
         -version-info $(libmpi_usempi_tkr_so_version) \
         $(OMPI_FORTRAN_EXTRA_SHARED_LIBRARY_FLAGS)
 
@@ -131,7 +132,7 @@ mpi-tkr-sizeof.f90:
 
 CLEANFILES += mpi-tkr-sizeof.h mpi-tkr-sizeof.f90
 MOSTLYCLEANFILES = *.mod
-DISTCLEANFILES = $(nodist_libmpi_usempi_la_SOURCES)
+DISTCLEANFILES = $(nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES)
 
 #
 # Install the generated .mod files.  Unfortunately, each F90 compiler

--- a/ompi/mpi/java/c/Makefile.am
+++ b/ompi/mpi/java/c/Makefile.am
@@ -6,6 +6,7 @@
 #                         reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -16,7 +17,7 @@
 if OMPI_WANT_JAVA_BINDINGS
 
 # Get the include files that were generated from the .java source files
-AM_CPPFLAGS = -I$(top_builddir)/ompi/mpi/java/java $(OPAL_JDK_CPPFLAGS) -DOPAL_DYN_LIB_SUFFIX=\"$(OPAL_DYN_LIB_SUFFIX)\"
+AM_CPPFLAGS = -I$(top_builddir)/ompi/mpi/java/java $(OPAL_JDK_CPPFLAGS) -DOMPI_LIBMPI_NAME=\"$(OMPI_LIBMPI_NAME)\" -DOPAL_DYN_LIB_SUFFIX=\"$(OPAL_DYN_LIB_SUFFIX)\"
 
 headers = \
         mpiJava.h
@@ -46,7 +47,7 @@ libmpi_java_la_SOURCES = \
 	mpi_Status.c \
 	mpi_Win.c
 
-libmpi_java_la_LIBADD = -ldl $(top_builddir)/ompi/libmpi.la
+libmpi_java_la_LIBADD = -ldl $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 libmpi_java_la_LDFLAGS = -version-info $(libmpi_java_so_version)
 
 endif

--- a/ompi/mpi/java/c/mpi_MPI.c
+++ b/ompi/mpi/java/c/mpi_MPI.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,7 +136,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
     // the library (see comment in the function for more detail).
     opal_init_psm();
 
-    libmpi = dlopen("libmpi." OPAL_DYN_LIB_SUFFIX, RTLD_NOW | RTLD_GLOBAL);
+    libmpi = dlopen("lib" OMPI_LIBMPI_NAME "." OPAL_DYN_LIB_SUFFIX, RTLD_NOW | RTLD_GLOBAL);
 
 #if defined(HAVE_DL_INFO) && defined(HAVE_LIBGEN_H)
     /*
@@ -149,7 +150,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
             char libmpipath[OPAL_PATH_MAX];
             char *libmpijavapath = strdup(info.dli_fname);
             if (NULL != libmpijavapath) {
-                snprintf(libmpipath, OPAL_PATH_MAX-1, "%s/libmpi." OPAL_DYN_LIB_SUFFIX, dirname(libmpijavapath));
+                snprintf(libmpipath, OPAL_PATH_MAX-1, "%s/lib" OMPI_LIBMPI_NAME "." OPAL_DYN_LIB_SUFFIX, dirname(libmpijavapath));
                 free(libmpijavapath);
                 libmpi = dlopen(libmpipath, RTLD_NOW | RTLD_GLOBAL);
             }
@@ -159,7 +160,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
     if(NULL == libmpi)
     {
-        fprintf(stderr, "Java bindings failed to load libmpi: %s\n",dlerror());
+        fprintf(stderr, "Java bindings failed to load lib" OMPI_LIBMPI_NAME ": %s\n",dlerror());
         exit(1);
     }
 

--- a/ompi/mpiext/Makefile.am
+++ b/ompi/mpiext/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
 #                         Corporation.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -15,5 +16,5 @@
 headers += \
 	mpiext/mpiext.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
 	mpiext/mpiext.c

--- a/ompi/op/Makefile.am
+++ b/ompi/op/Makefile.am
@@ -11,6 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,4 +24,4 @@
 
 headers += op/op.h
 
-libmpi_la_SOURCES += op/op.c
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += op/op.c

--- a/ompi/patterns/comm/Makefile.am
+++ b/ompi/patterns/comm/Makefile.am
@@ -1,4 +1,5 @@
 # Copyright (c) 2013 Oak Ridge National Laboratory.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -10,7 +11,7 @@ headers += \
         patterns/comm/coll_ops.h \
         patterns/comm/commpatterns.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         patterns/comm/allreduce.c \
         patterns/comm/allgather.c \
         patterns/comm/bcast.c

--- a/ompi/patterns/net/Makefile.am
+++ b/ompi/patterns/net/Makefile.am
@@ -1,4 +1,5 @@
 # Copyright (c) 2013 Oak Ridge National Laboratory.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -11,7 +12,7 @@ headers += \
         patterns/net/netpatterns_knomial_tree.h \
         patterns/net/coll_ops.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
 		patterns/net/netpatterns_base.c \
 		patterns/net/netpatterns_multinomial_tree.c \
 		patterns/net/netpatterns_nary_tree.c \

--- a/ompi/peruse/Makefile.am
+++ b/ompi/peruse/Makefile.am
@@ -5,6 +5,7 @@
 #                         reserved.
 # Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,7 +21,7 @@ if WANT_PERUSE
 # do NOT want this nobase - we want the peruse stripped off...
 include_HEADERS += peruse/peruse.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         peruse/peruse.c \
 	peruse/peruse_module.c
 endif

--- a/ompi/proc/Makefile.am
+++ b/ompi/proc/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,5 +23,5 @@
 headers += \
         proc/proc.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         proc/proc.c

--- a/ompi/request/Makefile.am
+++ b/ompi/request/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,7 +26,7 @@ headers += \
         request/request.h \
 	request/request_dbg.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         request/grequest.c \
         request/request.c \
         request/req_test.c \

--- a/ompi/runtime/Makefile.am
+++ b/ompi/runtime/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,7 +29,7 @@ headers += \
         runtime/params.h \
 	runtime/ompi_info_support.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         runtime/ompi_mpi_abort.c \
         runtime/ompi_mpi_dynamics.c \
         runtime/ompi_mpi_init.c \

--- a/ompi/tools/mpisync/Makefile.am
+++ b/ompi/tools/mpisync/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2012      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2014      Artem Polyakov <artpol84@gmail.com>
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -71,7 +72,7 @@ mpisync_SOURCES = \
         mpigclock.c \
         sync.c
 
-mpisync_LDADD = $(top_builddir)/ompi/libmpi.la
+mpisync_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 if OMPI_RTE_ORTE
 mpisync_LDADD +=  $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 endif

--- a/ompi/tools/ompi_info/Makefile.am
+++ b/ompi/tools/ompi_info/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -61,7 +62,7 @@ ompi_info_SOURCES = \
         ompi_info.c \
         param.c
 
-ompi_info_LDADD = $(top_builddir)/ompi/libmpi.la
+ompi_info_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 if OMPI_RTE_ORTE
 ompi_info_LDADD +=  $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 endif

--- a/ompi/tools/wrappers/mpic++-wrapper-data.txt.in
+++ b/ompi/tools/wrappers/mpic++-wrapper-data.txt.in
@@ -20,10 +20,10 @@ linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
 # intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
-libs=@OMPI_WRAPPER_CXX_LIB@ -lmpi
-libs_static=@OMPI_WRAPPER_CXX_LIB@ -lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
-dyn_lib_file=libmpi.@OPAL_DYN_LIB_SUFFIX@
-static_lib_file=libmpi.a
+libs=@OMPI_WRAPPER_CXX_LIB@ -l@OMPI_LIBMPI_NAME@
+libs_static=@OMPI_WRAPPER_CXX_LIB@ -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+dyn_lib_file=lib@OMPI_LIBMPI_NAME@.@OPAL_DYN_LIB_SUFFIX@
+static_lib_file=lib@OMPI_LIBMPI_NAME@.a
 required_file=@OMPI_WRAPPER_CXX_REQUIRED_FILE@
 includedir=${includedir}
 libdir=${libdir}

--- a/ompi/tools/wrappers/mpicc-wrapper-data.txt.in
+++ b/ompi/tools/wrappers/mpicc-wrapper-data.txt.in
@@ -20,10 +20,10 @@ linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
 # intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
-libs=-lmpi
-libs_static=-lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
-dyn_lib_file=libmpi.@OPAL_DYN_LIB_SUFFIX@
-static_lib_file=libmpi.a
+libs=-l@OMPI_LIBMPI_NAME@
+libs_static=-l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+dyn_lib_file=lib@OMPI_LIBMPI_NAME@.@OPAL_DYN_LIB_SUFFIX@
+static_lib_file=lib@OMPI_LIBMPI_NAME@.a
 required_file=
 includedir=${includedir}
 libdir=${libdir}

--- a/ompi/tools/wrappers/mpifort-wrapper-data.txt.in
+++ b/ompi/tools/wrappers/mpifort-wrapper-data.txt.in
@@ -19,10 +19,10 @@ linker_flags=@OMPI_WRAPPER_EXTRA_FC_LDFLAGS@
 # intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
-libs=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -lmpi
-libs_static=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal  @OMPI_WRAPPER_EXTRA_LIBS@
-dyn_lib_file=libmpi.@OPAL_DYN_LIB_SUFFIX@
-static_lib_file=libmpi.a
+libs=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -l@OMPI_LIBMPI_NAME@
+libs_static=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal  @OMPI_WRAPPER_EXTRA_LIBS@
+dyn_lib_file=lib@OMPI_LIBMPI_NAME@.@OPAL_DYN_LIB_SUFFIX@
+static_lib_file=lib@OMPI_LIBMPI_NAME@.a
 required_file=@OMPI_WRAPPER_FORTRAN_REQUIRED_FILE@
 includedir=${includedir}
 libdir=${libdir}

--- a/ompi/tools/wrappers/ompi-c.pc.in
+++ b/ompi/tools/wrappers/ompi-c.pc.in
@@ -1,4 +1,5 @@
 # Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 Name: Open MPI
 Description: Portable high-performance MPI implementation
@@ -15,7 +16,7 @@ pkgincludedir=@opalincludedir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ -l@OMPI_LIBMPI_NAME@
 Libs.private: -lopen-rte -lopen-pal @OMPI_WRAPPER_EXTRA_LIBS@
 #
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_CFLAGS@

--- a/ompi/tools/wrappers/ompi-cxx.pc.in
+++ b/ompi/tools/wrappers/ompi-cxx.pc.in
@@ -1,4 +1,5 @@
 # Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 Name: Open MPI
 Description: Portable high-performance MPI implementation
@@ -15,7 +16,7 @@ pkgincludedir=@opalincludedir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_WRAPPER_CXX_LIB@ -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_WRAPPER_CXX_LIB@ -l@OMPI_LIBMPI_NAME@
 Libs.private: -lopen-rte -lopen-pal @OMPI_WRAPPER_EXTRA_LIBS@
 #
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_CXXFLAGS@

--- a/ompi/tools/wrappers/ompi-fort.pc.in
+++ b/ompi/tools/wrappers/ompi-fort.pc.in
@@ -1,4 +1,5 @@
 # Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 Name: Open MPI
 Description: Portable high-performance MPI implementation
@@ -15,6 +16,6 @@ pkgincludedir=@opalincludedir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -l@OMPI_LIBMPI_NAME@
 Libs.private: -lopen-rte -lopen-pal @OMPI_WRAPPER_EXTRA_LIBS@
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_FCFLAGS@

--- a/ompi/tools/wrappers/ompi.pc.in
+++ b/ompi/tools/wrappers/ompi.pc.in
@@ -1,4 +1,5 @@
 # Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 Name: Open MPI
 Description: Portable high-performance MPI implementation
@@ -15,7 +16,7 @@ pkgincludedir=@opalincludedir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ -lmpi
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ -l@OMPI_LIBMPI_NAME@
 Libs.private: @OMPI_WRAPPER_EXTRA_LIBS@
 #
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_CFLAGS@

--- a/ompi/tools/wrappers/ompi_wrapper_script.in
+++ b/ompi/tools/wrappers/ompi_wrapper_script.in
@@ -7,6 +7,7 @@
 # Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,6 +47,7 @@ my $cxx_lib = "@OMPI_WRAPPER_CXX_LIB@";
 my $fc_module_flag = "@OMPI_FC_MODULE_FLAG@";
 my $dynamic_lib_suffix = "@OPAL_DYN_LIB_SUFFIX@";
 my $fortran_libs = "@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@";
+my $ompi_libmpi_name = "@OMPI_LIBMPI_NAME@";
 
 # Someone might want to fix for windows
 my $include_flag = "-I";
@@ -61,15 +63,15 @@ my $linker_flags = $libdir_flag . $libdir . " " . $extra_ldflags;
 # intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
-my $libs = "-lmpi " . $extra_libs;
-my $libs_static = "-lmpi -lopen-rte -lopen-pal " . $extra_libs;
+my $libs = "-l".$ompi_libmpi_name." " . $extra_libs;
+my $libs_static = "-l".$ompi_libmpi_name." -lopen-rte -lopen-pal " . $extra_libs;
 
 my $have_dynamic = 0;
-if (-e $libdir . "/libmpi." . $dynamic_lib_suffix) {
+if (-e $libdir . "/lib".$ompi_libmpi_name."." . $dynamic_lib_suffix) {
     $have_dynamic = 1;
 }
 my $have_static = 0;
-if (-e $libdir . "/libmpi.a") {
+if (-e $libdir . "/lib".$ompi_libmpi_name.".a") {
     $have_static = 1;
 }
 

--- a/ompi/win/Makefile.am
+++ b/ompi/win/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,5 +23,5 @@
 headers += \
         win/win.h
 
-libmpi_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         win/win.c

--- a/opal/mca/btl/usnic/Makefile.am
+++ b/opal/mca/btl/usnic/Makefile.am
@@ -13,6 +13,7 @@
 #                         reserved.
 # Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,7 +21,7 @@
 # $HEADER$
 #
 
-AM_CPPFLAGS = -DBTL_IN_OPAL=1 $(opal_common_libfabric_CPPFLAGS)
+AM_CPPFLAGS = -DBTL_IN_OPAL=1 $(opal_common_libfabric_CPPFLAGS) -DOMPI_LIBMPI_NAME=\"$(OMPI_LIBMPI_NAME)\"
 
 EXTRA_DIST = README.txt README.test
 

--- a/opal/mca/btl/usnic/test/usnic_btl_run_tests.c
+++ b/opal/mca/btl/usnic/test/usnic_btl_run_tests.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +39,7 @@ int main(int argc, char **argv)
     char *to;
     int path_len;
 
-    mpi_handle = dlopen("libmpi.so", RTLD_NOW|RTLD_GLOBAL);
+    mpi_handle = dlopen("lib" OMPI_LIBMPI_NAME ".so", RTLD_NOW|RTLD_GLOBAL);
     if (mpi_handle == NULL) {
         fprintf(stderr, "mpi_handle=NULL dlerror()=%s\n", dlerror());
         abort();

--- a/oshmem/Makefile.am
+++ b/oshmem/Makefile.am
@@ -5,6 +5,7 @@
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -66,7 +67,7 @@ liboshmem_la_LIBADD = \
 	$(fortran_oshmem_lib) \
 	$(fortran_pshmem_lib) \
 	$(MCA_oshmem_FRAMEWORK_LIBS) \
-	$(OSHMEM_TOP_BUILDDIR)/ompi/libmpi.la
+	$(OSHMEM_TOP_BUILDDIR)/ompi/lib@OMPI_LIBMPI_NAME@.la
 liboshmem_la_DEPENDENCIES = $(liboshmem_la_LIBADD)
 liboshmem_la_LDFLAGS = \
         -version-info $(liboshmem_so_version) \

--- a/oshmem/mca/memheap/base/Makefile.am
+++ b/oshmem/mca/memheap/base/Makefile.am
@@ -1,5 +1,6 @@
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -8,6 +9,8 @@
 #
 
 dist_oshmemdata_DATA += base/help-oshmem-memheap.txt
+
+AM_CPPFLAGS = -DOMPI_LIBMPI_NAME=\"$(OMPI_LIBMPI_NAME)\"
 
 headers += \
         base/base.h

--- a/oshmem/mca/memheap/base/memheap_base_static.c
+++ b/oshmem/mca/memheap/base/memheap_base_static.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -157,7 +158,7 @@ static int _check_pathname(struct map_segment_desc *seg)
         if (0 == strncmp(p+1, "libshmem.so", 11))
         return OSHMEM_ERROR;
 
-        if (0 == strncmp(p+1, "libmpi.so", 9))
+        if (0 == strncmp(p+1, "lib" OMPI_LIBMPI_NAME ".so", 9))
         return OSHMEM_ERROR;
 
         if (0 == strncmp(p+1, "libmca_common_sm.so", 19))

--- a/oshmem/tools/oshmem_info/Makefile.am
+++ b/oshmem/tools/oshmem_info/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -66,7 +67,7 @@ oshmem_info_SOURCES = \
         oshmem_info.c \
         param.c
 
-oshmem_info_LDADD = $(top_builddir)/ompi/libmpi.la
+oshmem_info_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 oshmem_info_LDADD += $(top_builddir)/oshmem/liboshmem.la
 if OMPI_RTE_ORTE
 oshmem_info_LDADD +=  $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la

--- a/oshmem/tools/wrappers/shmemcc-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemcc-wrapper-data.txt.in
@@ -1,6 +1,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,8 +29,8 @@ linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
 # intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
 # etc. are pulled in implicitly) because we intend SHMEM/MPI
 # applications to only use the SHMEM and MPI APIs.
-libs=-loshmem -lmpi
-libs_static=-loshmem -lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs=-loshmem -l@OMPI_LIBMPI_NAME@
+libs_static=-loshmem -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=liboshmem.a
 required_file=

--- a/oshmem/tools/wrappers/shmemfort-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemfort-wrapper-data.txt.in
@@ -1,6 +1,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,8 +29,8 @@ linker_flags=@OMPI_WRAPPER_EXTRA_FC_LDFLAGS@
 # intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
 # etc. are pulled in implicitly) because we intend SHMEM/MPI
 # applications to only use the SHMEM and MPI APIs.
-libs=-loshmem -lmpi_mpifh -lmpi
-libs_static=-loshmem -lmpi_mpifh -lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs=-loshmem -lmpi_mpifh -l@OMPI_LIBMPI_NAME@
+libs_static=-loshmem -lmpi_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=liboshmem.a
 required_file=@OMPI_WRAPPER_FORTRAN_REQUIRED_FILE@

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -83,7 +84,7 @@ opal_value_array_DEPENDENCIES = $(opal_value_array_LDADD)
 
 ompi_rb_tree_SOURCES = ompi_rb_tree.c
 ompi_rb_tree_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(top_builddir)/test/support/libsupport.a
 ompi_rb_tree_DEPENDENCIES = $(ompi_rb_tree_LDADD)

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -6,6 +6,7 @@
 # Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2014-2015 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,48 +25,48 @@ check_PROGRAMS = $(TESTS) $(MPI_CHECKS)
 unpack_ooo_SOURCES = unpack_ooo.c ddt_lib.c ddt_lib.h
 unpack_ooo_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 unpack_ooo_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 ddt_test_SOURCES = ddt_test.c ddt_lib.c ddt_lib.h
 ddt_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 ddt_test_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 ddt_raw_SOURCES = ddt_raw.c ddt_lib.c ddt_lib.h
 ddt_raw_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 ddt_raw_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 ddt_pack_SOURCES = ddt_pack.c
 ddt_pack_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 ddt_pack_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 checksum_SOURCES = checksum.c
 checksum_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 checksum_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 position_SOURCES = position.c
 position_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 position_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 position_noncontig_SOURCES = position_noncontig.c
 position_noncontig_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 position_noncontig_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 to_self_SOURCES = to_self.c
 to_self_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
-to_self_LDADD = $(top_builddir)/ompi/libmpi.la
+to_self_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 opal_datatype_test_SOURCES = opal_datatype_test.c opal_ddt_lib.c opal_ddt_lib.h
 opal_datatype_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
@@ -75,7 +76,7 @@ opal_datatype_test_LDADD = \
 external32_SOURCES = external32.c
 external32_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 external32_LDADD = \
-        $(top_builddir)/ompi/libmpi.la \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 distclean:

--- a/test/monitoring/Makefile.am
+++ b/test/monitoring/Makefile.am
@@ -5,6 +5,7 @@
 # Copyright (c) 2013-2015 Inria.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,13 +19,13 @@ if PROJECT_OMPI
     noinst_PROGRAMS = monitoring_test
     monitoring_test_SOURCES = monitoring_test.c
     monitoring_test_LDFLAGS = $(WRAPPER_EXTRA_LDFLAGS)
-    monitoring_test_LDADD = $(top_builddir)/ompi/libmpi.la $(top_builddir)/opal/libopen-pal.la
+    monitoring_test_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la $(top_builddir)/opal/libopen-pal.la
 
 if MCA_BUILD_ompi_pml_monitoring_DSO
     lib_LTLIBRARIES = monitoring_prof.la
     monitoring_prof_la_SOURCES = monitoring_prof.c
     monitoring_prof_la_LDFLAGS=-module -avoid-version -shared $(WRAPPER_EXTRA_LDFLAGS)
-    monitoring_prof_la_LIBADD = $(top_builddir)/ompi/libmpi.la $(top_builddir)/opal/libopen-pal.la
+    monitoring_prof_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la $(top_builddir)/opal/libopen-pal.la
 endif
 
 endif

--- a/test/mpi/environment/Makefile.am
+++ b/test/mpi/environment/Makefile.am
@@ -10,6 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,7 +24,7 @@ noinst_PROGRAMS = chello
 
 chello_SOURCES = chello.c
 chello_LDADD = \
-	$(top_builddir)/src/libmpi.la \
+	$(top_builddir)/src/lib@OMPI_LIBMPI_NAME@.la \
 	$(top_builddir)/src/libompi.la
 chello_DEPENDENCIES = $(chello_LDADD)
 


### PR DESCRIPTION
 * Add a configure time option to rename `libmpi(_FOO).*`
   - `--with-libmpi-name=STRING` defaults `STRING` to `mpi` (so `libmpi(_FOO).*` is not changed)
