### PR TITLE
mpi/cxx: limit exposure of internal header to C++

### DIFF
--- a/ompi/mpi/cxx/mpicxx.cc
+++ b/ompi/mpi/cxx/mpicxx.cc
@@ -34,14 +34,13 @@ namespace MPI {
     const char ompi_libcxx_version_string[] = OMPI_IDENT_STRING;
 }
 
-#include "ompi/errhandler/errhandler.h"
-
 namespace MPI {
 
 #if ! OMPI_HAVE_CXX_EXCEPTION_SUPPORT
 int mpi_errno = MPI_SUCCESS;
 #endif
 
+extern ompi_predefined_errhandler_t ompi_mpi_errors_throw_exceptions;
 
 void* const BOTTOM = (void*) MPI_BOTTOM;
 void* const IN_PLACE = (void*) MPI_IN_PLACE;


### PR DESCRIPTION
This commit removes the #include of errhandler/errhandler.h (which
includes opal_object.h). The inlude was only needed to get the extern
declaration of ompi_mpi_errors_throw_exceptions. Since we have the
ompi_predefined_errhandler_t in mpi.h we can declare the extern in
mpicxx.c without needing the C errhandler header.

This should fix open-mpi/ompi#2055

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>