### PR TITLE
Error handling improvements

### DIFF
--- a/ompi/mpi/java/c/mpi_Datatype.c
+++ b/ompi/mpi/java/c/mpi_Datatype.c
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,7 +94,8 @@ JNIEXPORT void JNICALL Java_mpi_Datatype_getLbExtent(
 {
     MPI_Aint lb, extent;
     int rc = MPI_Type_get_extent((MPI_Datatype)type, &lb, &extent);
-    ompi_java_exceptionCheck(env, rc);
+    if(ompi_java_exceptionCheck(env, rc))
+        return;
 
     jint *lbExt = (*env)->GetIntArrayElements(env, jLbExt, NULL);
     lbExt[0] = (jint)lb;
@@ -105,7 +108,8 @@ JNIEXPORT void JNICALL Java_mpi_Datatype_getTrueLbExtent(
 {
     MPI_Aint lb, extent;
     int rc = MPI_Type_get_true_extent((MPI_Datatype)type, &lb, &extent);
-    ompi_java_exceptionCheck(env, rc);
+    if(ompi_java_exceptionCheck(env, rc))
+        return;
 
     jint *lbExt = (*env)->GetIntArrayElements(env, jLbExt, NULL);
     lbExt[0] = (jint)lb;

--- a/ompi/mpi/java/c/mpi_File.c
+++ b/ompi/mpi/java/c/mpi_File.c
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -137,6 +139,7 @@ JNIEXPORT void JNICALL Java_mpi_File_readAt(
         jobject buf, jboolean db, jint off, jint count,
         jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
@@ -146,9 +149,11 @@ JNIEXPORT void JNICALL Java_mpi_File_readAt(
     int rc = MPI_File_read_at((MPI_File)fh, (MPI_Offset)fileOffset,
                               ptr, count, type, &status);
 
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseWritePtr(ptr, item, env, buf, db, off, count, type, bType);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_readAtAll(
@@ -156,6 +161,7 @@ JNIEXPORT void JNICALL Java_mpi_File_readAtAll(
         jobject buf, jboolean db, jint off, jint count,
         jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
@@ -165,9 +171,11 @@ JNIEXPORT void JNICALL Java_mpi_File_readAtAll(
     int rc = MPI_File_read_at_all((MPI_File)fh, (MPI_Offset)fileOffset,
                                   ptr, count, type, &status);
 
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseWritePtr(ptr, item, env, buf, db, off, count, type, bType);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeAt(
@@ -175,6 +183,7 @@ JNIEXPORT void JNICALL Java_mpi_File_writeAt(
         jobject buf, jboolean db, jint off, jint count,
         jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
@@ -184,9 +193,11 @@ JNIEXPORT void JNICALL Java_mpi_File_writeAt(
     int rc = MPI_File_write_at((MPI_File)fh, (MPI_Offset)fileOffset,
                                ptr, count, type, &status);
 
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseReadPtr(ptr, item, buf, db);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeAtAll(
@@ -194,6 +205,7 @@ JNIEXPORT void JNICALL Java_mpi_File_writeAtAll(
         jobject buf, jboolean db, jint off, jint count,
         jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
@@ -203,9 +215,11 @@ JNIEXPORT void JNICALL Java_mpi_File_writeAtAll(
     int rc = MPI_File_write_at_all((MPI_File)fh, (MPI_Offset)fileOffset,
                                    ptr, count, (MPI_Datatype)type, &status);
 
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseReadPtr(ptr, item, buf, db);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT jlong JNICALL Java_mpi_File_iReadAt(
@@ -240,60 +254,72 @@ JNIEXPORT void JNICALL Java_mpi_File_read(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getWritePtr(&ptr, &item, env, buf, db, count, type);
     MPI_Status status;
     int rc = MPI_File_read((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseWritePtr(ptr, item, env, buf, db, off, count, type, bType);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_readAll(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getWritePtr(&ptr, &item, env, buf, db, count, type);
     MPI_Status status;
     int rc = MPI_File_read_all((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseWritePtr(ptr, item, env, buf, db, off, count, type, bType);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_write(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getReadPtr(&ptr, &item, env, buf, db, off, count, type, bType);
     MPI_Status status;
     int rc = MPI_File_write((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseReadPtr(ptr, item, buf, db);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeAll(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getReadPtr(&ptr, &item, env, buf, db, off, count, type, bType);
     MPI_Status status;
     int rc = MPI_File_write_all((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseReadPtr(ptr, item, buf, db);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT jlong JNICALL Java_mpi_File_iRead(
@@ -353,30 +379,36 @@ JNIEXPORT void JNICALL Java_mpi_File_readShared(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getWritePtr(&ptr, &item, env, buf, db, count, type);
     MPI_Status status;
     int rc = MPI_File_read_shared((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseWritePtr(ptr, item, env, buf, db, off, count, type, bType);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeShared(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getReadPtr(&ptr, &item, env, buf, db, off, count, type, bType);
     MPI_Status status;
     int rc = MPI_File_write_shared((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseReadPtr(ptr, item, buf, db);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT jlong JNICALL Java_mpi_File_iReadShared(
@@ -411,30 +443,36 @@ JNIEXPORT void JNICALL Java_mpi_File_readOrdered(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getWritePtr(&ptr, &item, env, buf, db, count, type);
     MPI_Status status;
     int rc = MPI_File_read_ordered((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseWritePtr(ptr, item, env, buf, db, off, count, type, bType);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeOrdered(
         JNIEnv *env, jobject jthis, jlong fh, jobject buf, jboolean db,
         jint off, jint count, jlong jType, jint bType, jlongArray stat)
 {
+    jboolean exception;
     MPI_Datatype type = (MPI_Datatype)jType;
     void *ptr;
     ompi_java_buffer_t *item;
     ompi_java_getReadPtr(&ptr, &item, env, buf, db, off, count, type, bType);
     MPI_Status status;
     int rc = MPI_File_write_ordered((MPI_File)fh, ptr, count, type, &status);
-    ompi_java_exceptionCheck(env, rc);
+    exception = ompi_java_exceptionCheck(env, rc);
     ompi_java_releaseReadPtr(ptr, item, buf, db);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!exception)
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_seekShared(
@@ -470,8 +508,9 @@ JNIEXPORT void JNICALL Java_mpi_File_readAtAllEnd(
     MPI_Status status;
     void *ptr = (*env)->GetDirectBufferAddress(env, buf);
     int rc = MPI_File_read_at_all_end((MPI_File)fh, ptr, &status);
-    ompi_java_exceptionCheck(env, rc);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeAtAllBegin(
@@ -491,8 +530,9 @@ JNIEXPORT void JNICALL Java_mpi_File_writeAtAllEnd(
     MPI_Status status;
     void *ptr = (*env)->GetDirectBufferAddress(env, buf);
     int rc = MPI_File_write_at_all_end((MPI_File)fh, ptr, &status);
-    ompi_java_exceptionCheck(env, rc);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_readAllBegin(
@@ -513,8 +553,9 @@ JNIEXPORT void JNICALL Java_mpi_File_readAllEnd(
     MPI_Status status;
     void *ptr = (*env)->GetDirectBufferAddress(env, buf);
     int rc = MPI_File_read_all_end((MPI_File)fh, ptr, &status);
-    ompi_java_exceptionCheck(env, rc);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeAllBegin(
@@ -535,8 +576,9 @@ JNIEXPORT void JNICALL Java_mpi_File_writeAllEnd(
     MPI_Status status;
     void *ptr = (*env)->GetDirectBufferAddress(env, buf);
     int rc = MPI_File_write_all_end((MPI_File)fh, ptr, &status);
-    ompi_java_exceptionCheck(env, rc);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_readOrderedBegin(
@@ -557,8 +599,9 @@ JNIEXPORT void JNICALL Java_mpi_File_readOrderedEnd(
     MPI_Status status;
     void *ptr = (*env)->GetDirectBufferAddress(env, buf);
     int rc = MPI_File_read_ordered_end((MPI_File)fh, ptr, &status);
-    ompi_java_exceptionCheck(env, rc);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT void JNICALL Java_mpi_File_writeOrderedBegin(
@@ -579,8 +622,9 @@ JNIEXPORT void JNICALL Java_mpi_File_writeOrderedEnd(
     MPI_Status status;
     void *ptr = (*env)->GetDirectBufferAddress(env, buf);
     int rc = MPI_File_write_ordered_end((MPI_File)fh, ptr, &status);
-    ompi_java_exceptionCheck(env, rc);
-    ompi_java_status_set(env, stat, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, stat, &status);
 }
 
 JNIEXPORT jint JNICALL Java_mpi_File_getTypeExtent(

--- a/ompi/mpi/java/c/mpi_Message.c
+++ b/ompi/mpi/java/c/mpi_Message.c
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,8 +43,10 @@ JNIEXPORT jlong JNICALL Java_mpi_Message_mProbe(
     MPI_Message message;
     MPI_Status  status;
     int rc = MPI_Mprobe(source, tag, comm, &message, &status);
-    ompi_java_exceptionCheck(env, rc);
-    ompi_java_status_set(env, jStatus, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, jStatus, &status);
+    
     return (jlong)message;
 }
 
@@ -75,9 +79,10 @@ JNIEXPORT jlong JNICALL Java_mpi_Message_mRecv(
 
     MPI_Status status;
     int rc = MPI_Mrecv(ptr, count, type, &message, &status);
-    ompi_java_exceptionCheck(env, rc);
-
-    ompi_java_status_set(env, jStatus, &status);
+    
+    if(!ompi_java_exceptionCheck(env, rc))
+        ompi_java_status_set(env, jStatus, &status);
+    
     ompi_java_releaseWritePtr(ptr, item, env, buf, db, off, count, type, bType);
     return (jlong)message;
 }


### PR DESCRIPTION
This commit improves and corrects error handling.  In
cases where existing objects are altered after a call
to ompi_java_exceptionCheck, the results of the exception
check method are checked.  In the case of an exception,
memory is cleaned up and the code returns to Java without
altering existing objects.

Signed-off-by: Nathaniel Graham <ngraham@lanl.gov>

Fixes #1698

@hppritcha please review this when you get a chance.