### PR TITLE
mpi/cxx: isolate internal headers from C++ bindings

### DIFF
--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +13,8 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,9 +94,8 @@ struct ompi_errhandler_t;
 /**
  * C++ invocation function signature
  */
-typedef void (ompi_errhandler_cxx_dispatch_fn_t)(struct ompi_errhandler_t *errhandler,
-                                                 void *handle, int *err_code,
-                                                 const char *message);
+typedef void (ompi_errhandler_cxx_dispatch_fn_t)(void *handle, int *err_code,
+                                                 const char *message, void *fn);
 
 /**
  * Back-end type for MPI_Errorhandler.

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,8 +57,8 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
             break;
 
         case OMPI_ERRHANDLER_LANG_CXX:
-            errhandler->eh_cxx_dispatch_fn(errhandler, &comm,
-                                           &err_code, message);
+            errhandler->eh_cxx_dispatch_fn(&comm, &err_code, message,
+                                           errhandler->eh_comm_fn);
             break;
 
         case OMPI_ERRHANDLER_LANG_FORTRAN:
@@ -74,8 +77,8 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
             break;
 
         case OMPI_ERRHANDLER_LANG_CXX:
-            errhandler->eh_cxx_dispatch_fn(errhandler, &win,
-                                           &err_code, message);
+            errhandler->eh_cxx_dispatch_fn(&win, &err_code, message,
+                                           errhandler->eh_win_fn);
             break;
 
         case OMPI_ERRHANDLER_LANG_FORTRAN:
@@ -94,8 +97,8 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
             break;
 
         case OMPI_ERRHANDLER_LANG_CXX:
-            errhandler->eh_cxx_dispatch_fn(errhandler, &file,
-                                           &err_code, message);
+            errhandler->eh_cxx_dispatch_fn(&file, &err_code, message,
+                                           errhandler->eh_file_fn);
             break;
 
         case OMPI_ERRHANDLER_LANG_FORTRAN:

--- a/ompi/mpi/cxx/Makefile.am
+++ b/ompi/mpi/cxx/Makefile.am
@@ -36,7 +36,8 @@ lib@OMPI_LIBMPI_NAME@_cxx_la_SOURCES = \
 	intercepts.cc \
 	comm.cc \
 	datatype.cc \
-	win.cc
+	win.cc \
+	cxx_glue.c
 
 if OMPI_PROVIDE_MPI_FILE_INTERFACE
 lib@OMPI_LIBMPI_NAME@_cxx_la_SOURCES += \
@@ -77,7 +78,8 @@ headers = \
         group_inln.h \
         op_inln.h \
         errhandler_inln.h \
-        status_inln.h
+        status_inln.h \
+        cxx_glue.h
 
 ompidir = $(ompiincludedir)/ompi/mpi/cxx
 ompi_HEADERS = \

--- a/ompi/mpi/cxx/comm.cc
+++ b/ompi/mpi/cxx/comm.cc
@@ -11,6 +11,8 @@
 // Copyright (c) 2004-2005 The Regents of the University of California.
 //                         All rights reserved.
 // Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
+// Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+//                         reserved.
 // $COPYRIGHT$
 //
 // Additional copyrights may follow
@@ -20,16 +22,9 @@
 
 // do not include ompi_config.h because it kills the free/malloc defines
 #include "mpi.h"
+#include "ompi/constants.h"
 #include "ompi/mpi/cxx/mpicxx.h"
-
-#ifdef HAVE_SCHED_H
-#include <sched.h>
-#endif
-
-
-#include "ompi/communicator/communicator.h"
-#include "ompi/attribute/attribute.h"
-#include "ompi/errhandler/errhandler.h"
+#include "cxx_glue.h"
 
 
 //
@@ -56,14 +51,7 @@ MPI::Comm::Comm(const Comm_Null& data) : Comm_Null(data)
 MPI::Errhandler
 MPI::Comm::Create_errhandler(MPI::Comm::_MPI2CPP_ERRHANDLERFN_* function)
 {
-    MPI_Errhandler c_errhandler =
-        ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_COMM,
-                               (ompi_errhandler_generic_handler_fn_t*) function,
-                               OMPI_ERRHANDLER_LANG_CXX);
-    c_errhandler->eh_cxx_dispatch_fn =
-        (ompi_errhandler_cxx_dispatch_fn_t*)
-        ompi_mpi_cxx_comm_errhandler_invoke;
-    return c_errhandler;
+    return ompi_cxx_errhandler_create_comm ((void *) function);
 }
 
 
@@ -77,20 +65,15 @@ MPI::Comm::do_create_keyval(MPI_Comm_copy_attr_function* c_copy_fn,
                             void* extra_state, int &keyval)
 {
     int ret, count = 0;
-    ompi_attribute_fn_ptr_union_t copy_fn;
-    ompi_attribute_fn_ptr_union_t delete_fn;
     keyval_intercept_data_t *cxx_extra_state;
 
     // If both the callbacks are C, then do the simple thing -- no
     // need for all the C++ machinery.
     if (NULL != c_copy_fn && NULL != c_delete_fn) {
-        copy_fn.attr_communicator_copy_fn =
-            (MPI_Comm_internal_copy_attr_function*) c_copy_fn;
-        delete_fn.attr_communicator_delete_fn = c_delete_fn;
-        ret = ompi_attr_create_keyval(COMM_ATTR, copy_fn, delete_fn,
-                                      &keyval, extra_state, 0, NULL);
+        ret = ompi_cxx_attr_create_keyval_comm (c_copy_fn, c_delete_fn, &keyval,
+                                                extra_state, 0, NULL);
         if (MPI_SUCCESS != ret) {
-            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, ret,
+            return ompi_cxx_errhandler_invoke_comm(MPI_COMM_WORLD, ret,
                                           "MPI::Comm::Create_keyval");
         }
     }
@@ -107,8 +90,8 @@ MPI::Comm::do_create_keyval(MPI_Comm_copy_attr_function* c_copy_fn,
     cxx_extra_state = (keyval_intercept_data_t*)
         malloc(sizeof(keyval_intercept_data_t));
     if (NULL == cxx_extra_state) {
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_NO_MEM,
-                                      "MPI::Comm::Create_keyval");
+        return ompi_cxx_errhandler_invoke_comm (MPI_COMM_WORLD, MPI_ERR_NO_MEM,
+                                                "MPI::Comm::Create_keyval");
     }
     cxx_extra_state->c_copy_fn = c_copy_fn;
     cxx_extra_state->cxx_copy_fn = cxx_copy_fn;
@@ -131,26 +114,20 @@ MPI::Comm::do_create_keyval(MPI_Comm_copy_attr_function* c_copy_fn,
     }
     if (2 != count) {
         free(cxx_extra_state);
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
-                                      "MPI::Comm::Create_keyval");
+        return ompi_cxx_errhandler_invoke_comm (MPI_COMM_WORLD, MPI_ERR_ARG,
+                                                "MPI::Comm::Create_keyval");
     }
 
     // We do not call MPI_Comm_create_keyval() here because we need to
     // pass in the cxx_extra_state to the backend keyval creation so
     // that when the keyval is destroyed (i.e., when its refcount goes
     // to 0), the cxx_extra_state is free()'ed.
-
-    copy_fn.attr_communicator_copy_fn =
-        (MPI_Comm_internal_copy_attr_function*)
-        ompi_mpi_cxx_comm_copy_attr_intercept;
-    delete_fn.attr_communicator_delete_fn =
-        ompi_mpi_cxx_comm_delete_attr_intercept;
-    ret = ompi_attr_create_keyval(COMM_ATTR, copy_fn, delete_fn,
-                                  &keyval, cxx_extra_state, 0,
-                                  cxx_extra_state);
+    ret = ompi_cxx_attr_create_keyval_comm ((MPI_Comm_copy_attr_function *) ompi_mpi_cxx_comm_copy_attr_intercept,
+                                            ompi_mpi_cxx_comm_delete_attr_intercept,
+                                            &keyval, cxx_extra_state, 0, cxx_extra_state);
     if (OMPI_SUCCESS != ret) {
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, ret,
-                                      "MPI::Comm::Create_keyval");
+        return ompi_cxx_errhandler_invoke_comm (MPI_COMM_WORLD, ret,
+                                                "MPI::Comm::Create_keyval");
     }
 
     return MPI_SUCCESS;

--- a/ompi/mpi/cxx/cxx_glue.c
+++ b/ompi/mpi/cxx/cxx_glue.c
@@ -1,0 +1,158 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/communicator/communicator.h"
+#include "ompi/attribute/attribute.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/file/file.h"
+#include "opal/class/opal_list.h"
+#include "cxx_glue.h"
+
+typedef struct ompi_cxx_intercept_file_extra_state_item_t {
+    opal_list_item_t super;
+    ompi_cxx_intercept_file_extra_state_t state;
+} ompi_cxx_intercept_file_extra_state_item_t;
+
+OBJ_CLASS_DECLARATION(ompi_cxx_intercept_file_extra_state_item_t);
+OBJ_CLASS_INSTANCE(ompi_cxx_intercept_file_extra_state_item_t, opal_list_item_t,
+                   NULL, NULL);
+
+ompi_cxx_communicator_type_t ompi_cxx_comm_get_type (MPI_Comm comm)
+{
+    if (OMPI_COMM_IS_GRAPH(comm)) {
+        return OMPI_CXX_COMM_TYPE_GRAPH;
+    } else if (OMPI_COMM_IS_CART(comm)) {
+        return OMPI_CXX_COMM_TYPE_CART;
+    } else if (OMPI_COMM_IS_INTRA(comm)) {
+        return OMPI_CXX_COMM_TYPE_INTRACOMM;
+    } else if (OMPI_COMM_IS_INTER(comm)) {
+        return OMPI_CXX_COMM_TYPE_INTERCOMM;
+    }
+
+    return OMPI_CXX_COMM_TYPE_UNKNOWN;
+}
+
+int ompi_cxx_errhandler_invoke_comm (MPI_Comm comm, int ret, const char *message)
+{
+    return OMPI_ERRHANDLER_INVOKE (comm, ret, message);
+}
+
+int ompi_cxx_errhandler_invoke_file (MPI_File file, int ret, const char *message)
+{
+    return OMPI_ERRHANDLER_INVOKE (file, ret, message);
+}
+
+int ompi_cxx_attr_create_keyval_comm (MPI_Comm_copy_attr_function *copy_fn,
+                                      MPI_Comm_delete_attr_function* delete_fn, int *keyval, void *extra_state,
+                                      int flags, void *bindings_extra_state)
+{
+    ompi_attribute_fn_ptr_union_t copy_fn_u = {.attr_communicator_copy_fn =
+                                               (MPI_Comm_internal_copy_attr_function *) copy_fn};
+    ompi_attribute_fn_ptr_union_t delete_fn_u = {.attr_communicator_delete_fn =
+                                                 (MPI_Comm_delete_attr_function *) delete_fn};
+
+    return ompi_attr_create_keyval (COMM_ATTR, copy_fn_u, delete_fn_u, keyval, extra_state, 0, bindings_extra_state);
+}
+
+int ompi_cxx_attr_create_keyval_win (MPI_Win_copy_attr_function *copy_fn,
+                                      MPI_Win_delete_attr_function* delete_fn, int *keyval, void *extra_state,
+                                      int flags, void *bindings_extra_state)
+{
+    ompi_attribute_fn_ptr_union_t copy_fn_u = {.attr_win_copy_fn =
+                                               (MPI_Win_internal_copy_attr_function *) copy_fn};
+    ompi_attribute_fn_ptr_union_t delete_fn_u = {.attr_win_delete_fn =
+                                                 (MPI_Win_delete_attr_function *) delete_fn};
+
+    return ompi_attr_create_keyval (WIN_ATTR, copy_fn_u, delete_fn_u, keyval, extra_state, 0, NULL);
+}
+
+int ompi_cxx_attr_create_keyval_type (MPI_Type_copy_attr_function *copy_fn,
+                                      MPI_Type_delete_attr_function* delete_fn, int *keyval, void *extra_state,
+                                      int flags, void *bindings_extra_state)
+{
+    ompi_attribute_fn_ptr_union_t copy_fn_u = {.attr_datatype_copy_fn =
+                                               (MPI_Type_internal_copy_attr_function *) copy_fn};
+    ompi_attribute_fn_ptr_union_t delete_fn_u = {.attr_datatype_delete_fn =
+                                                 (MPI_Type_delete_attr_function *) delete_fn};
+
+    return ompi_attr_create_keyval (TYPE_ATTR, copy_fn_u, delete_fn_u, keyval, extra_state, 0, NULL);
+}
+
+MPI_Errhandler ompi_cxx_errhandler_create_comm (void *fn)
+{
+    ompi_errhandler_t *errhandler;
+    errhandler = ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_COMM,
+                                        (ompi_errhandler_generic_handler_fn_t *) fn,
+                                        OMPI_ERRHANDLER_LANG_CXX);
+    errhandler->eh_cxx_dispatch_fn =
+        (ompi_errhandler_cxx_dispatch_fn_t *) ompi_mpi_cxx_comm_errhandler_invoke;
+    return errhandler;
+}
+
+MPI_Errhandler ompi_cxx_errhandler_create_win (void *fn)
+{
+    ompi_errhandler_t *errhandler;
+    errhandler = ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_WIN,
+                                        (ompi_errhandler_generic_handler_fn_t *) fn,
+                                        OMPI_ERRHANDLER_LANG_CXX);
+    errhandler->eh_cxx_dispatch_fn =
+        (ompi_errhandler_cxx_dispatch_fn_t *) ompi_mpi_cxx_win_errhandler_invoke;
+    return errhandler;
+}
+
+MPI_Errhandler ompi_cxx_errhandler_create_file (void *fn)
+{
+    ompi_errhandler_t *errhandler;
+    errhandler = ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_FILE,
+                                        (ompi_errhandler_generic_handler_fn_t *) fn,
+                                        OMPI_ERRHANDLER_LANG_CXX);
+    errhandler->eh_cxx_dispatch_fn =
+        (ompi_errhandler_cxx_dispatch_fn_t *) ompi_mpi_cxx_file_errhandler_invoke;
+    return errhandler;
+}
+
+ompi_cxx_intercept_file_extra_state_t
+*ompi_cxx_new_intercept_state (void *read_fn_cxx, void *write_fn_cxx, void *extent_fn_cxx,
+                               void *extra_state_cxx)
+{
+    ompi_cxx_intercept_file_extra_state_item_t *intercept;
+
+    intercept = OBJ_NEW(ompi_cxx_intercept_file_extra_state_item_t);
+    if (NULL == intercept) {
+        return NULL;
+    }
+
+    opal_list_append(&ompi_registered_datareps, &intercept->super);
+    intercept->state.read_fn_cxx = read_fn_cxx;
+    intercept->state.write_fn_cxx = write_fn_cxx;
+    intercept->state.extent_fn_cxx = extent_fn_cxx;
+    intercept->state.extra_state_cxx = extra_state_cxx;
+
+    return &intercept->state;
+}
+
+void ompi_cxx_errhandler_set_dispatch_fn (ompi_errhandler_t *errhandler,
+                                          ompi_errhandler_cxx_dispatch_fn_t *dispatch_fn)
+{
+    errhandler->eh_cxx_dispatch_fn = dispatch_fn;
+}
+
+void ompi_cxx_errhandler_set_callbacks (struct ompi_errhandler_t *errhandler, MPI_Comm_errhandler_function *eh_comm_fn,
+                                        ompi_file_errhandler_fn *eh_file_fn, MPI_Win_errhandler_function *eh_win_fn)
+{
+    errhandler->eh_comm_fn = eh_comm_fn;
+#if OMPI_PROVIDE_MPI_FILE_INTERFACE
+    errhandler->eh_file_fn = eh_file_fn;
+#endif
+    errhandler->eh_win_fn = eh_win_fn;
+}

--- a/ompi/mpi/cxx/cxx_glue.h
+++ b/ompi/mpi/cxx/cxx_glue.h
@@ -1,0 +1,92 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#if !defined(OMPI_CXX_COMM_GLUE_H)
+#define OMPI_CXX_COMM_GLUE_H
+
+#include "ompi_config.h"
+#include <stdlib.h>
+
+#include "mpi.h"
+
+#if defined(c_plusplus) || defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef struct ompi_cxx_intercept_file_extra_state_t {
+    void *read_fn_cxx;
+    void *write_fn_cxx;
+    void *extent_fn_cxx;
+    void *extra_state_cxx;
+} ompi_cxx_intercept_file_extra_state_t;
+
+enum ompi_cxx_communicator_type_t {
+  OMPI_CXX_COMM_TYPE_UNKNOWN,
+  OMPI_CXX_COMM_TYPE_INTRACOMM,
+  OMPI_CXX_COMM_TYPE_INTERCOMM,
+  OMPI_CXX_COMM_TYPE_CART,
+  OMPI_CXX_COMM_TYPE_GRAPH,
+};
+typedef enum ompi_cxx_communicator_type_t ompi_cxx_communicator_type_t;
+
+/* need to declare this error handler here */
+struct ompi_predefined_errhandler_t;
+extern struct ompi_predefined_errhandler_t ompi_mpi_errors_throw_exceptions;
+
+/**
+ * C++ invocation function signature
+ */
+typedef void (ompi_errhandler_cxx_dispatch_fn_t)(void *handle, int *err_code,
+                                                 const char *message, void *fn);
+
+ompi_cxx_communicator_type_t ompi_cxx_comm_get_type (MPI_Comm comm);
+
+int ompi_cxx_errhandler_invoke_comm (MPI_Comm comm, int ret, const char *message);
+int ompi_cxx_errhandler_invoke_file (MPI_File file, int ret, const char *message);
+
+int ompi_cxx_attr_create_keyval_comm (MPI_Comm_copy_attr_function *copy_fn,
+                                      MPI_Comm_delete_attr_function* delete_fn, int *keyval, void *extra_state,
+                                      int flags, void *bindings_extra_state);
+int ompi_cxx_attr_create_keyval_win (MPI_Win_copy_attr_function *copy_fn,
+                                      MPI_Win_delete_attr_function* delete_fn, int *keyval, void *extra_state,
+                                      int flags, void *bindings_extra_state);
+int ompi_cxx_attr_create_keyval_type (MPI_Type_copy_attr_function *copy_fn,
+                                      MPI_Type_delete_attr_function* delete_fn, int *keyval, void *extra_state,
+                                      int flags, void *bindings_extra_state);
+
+void ompi_mpi_cxx_comm_errhandler_invoke (MPI_Comm *mpi_comm, int *err,
+                                          const char *message, void *comm_fn);
+void ompi_mpi_cxx_win_errhandler_invoke (MPI_Win *mpi_comm, int *err,
+                                         const char *message, void *win_fn);
+#if OMPI_PROVIDE_MPI_FILE_INTERFACE
+void ompi_mpi_cxx_file_errhandler_invoke (MPI_File *mpi_comm, int *err,
+                                          const char *message, void *file_fn);
+#endif
+
+MPI_Errhandler ompi_cxx_errhandler_create_comm (void *fn);
+MPI_Errhandler ompi_cxx_errhandler_create_win (void *fn);
+MPI_Errhandler ompi_cxx_errhandler_create_file (void *fn);
+
+ompi_cxx_intercept_file_extra_state_t
+*ompi_cxx_new_intercept_state (void *read_fn_cxx, void *write_fn_cxx, void *extent_fn_cxx,
+                               void *extra_state_cxx);
+
+void ompi_cxx_errhandler_set_cxx_dispatch_fn (struct ompi_errhandler_t *errhandler,
+                                              ompi_errhandler_cxx_dispatch_fn_t *dispatch_fn);
+
+void ompi_cxx_errhandler_set_callbacks (struct ompi_errhandler_t *errhandler, MPI_Comm_errhandler_function *eh_comm_fn,
+                                        ompi_file_errhandler_fn *eh_file_fn, MPI_Win_errhandler_function *eh_win_fn);
+
+#if defined(c_plusplus) || defined(__cplusplus)
+}
+#endif
+
+#endif /* OMPI_CXX_COMM_GLUE_H */

--- a/ompi/mpi/cxx/file.cc
+++ b/ompi/mpi/cxx/file.cc
@@ -1,6 +1,6 @@
 // -*- c++ -*-
 //
-// Copyright (c) 2006      Los Alamos National Security, LLC.  All rights
+// Copyright (c) 2006-2016 Los Alamos National Security, LLC.  All rights
 //                         reserved.
 // Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
 // $COPYRIGHT$
@@ -16,10 +16,7 @@
 
 #include "ompi/constants.h"
 #include "ompi/mpi/cxx/mpicxx.h"
-#include "opal/class/opal_list.h"
-#include "ompi/file/file.h"
-#include "ompi/errhandler/errhandler.h"
-#include "ompi/runtime/mpiruntime.h"
+#include "cxx_glue.h"
 
 void
 MPI::File::Close()
@@ -31,14 +28,7 @@ MPI::File::Close()
 MPI::Errhandler
 MPI::File::Create_errhandler(MPI::File::Errhandler_function* function)
 {
-    MPI_Errhandler c_errhandler =
-        ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_FILE,
-                               (ompi_errhandler_generic_handler_fn_t*) function,
-                               OMPI_ERRHANDLER_LANG_CXX);
-    c_errhandler->eh_cxx_dispatch_fn =
-        (ompi_errhandler_cxx_dispatch_fn_t*)
-        ompi_mpi_cxx_file_errhandler_invoke;
-    return c_errhandler;
+    return ompi_cxx_errhandler_create_file ((void *) function);
 }
 
 
@@ -54,26 +44,6 @@ MPI::File::Create_errhandler(MPI::File::Errhandler_function* function)
 // Data structure passed to the intercepts (see below).  It is an OPAL
 // list_item_t so that we can clean this memory up during
 // MPI_FINALIZE.
-typedef struct intercept_extra_state {
-    opal_list_item_t base;
-    MPI::Datarep_conversion_function *read_fn_cxx;
-    MPI::Datarep_conversion_function *write_fn_cxx;
-    MPI::Datarep_extent_function *extent_fn_cxx;
-    void *extra_state_cxx;
-} intercept_extra_state_t;
-
-static void intercept_extra_state_constructor(intercept_extra_state_t *obj)
-{
-    obj->read_fn_cxx = NULL;
-    obj->write_fn_cxx = NULL;
-    obj->extent_fn_cxx = NULL;
-    obj->extra_state_cxx = NULL;
-}
-
-OBJ_CLASS_DECLARATION(intercept_extra_state_t);
-OBJ_CLASS_INSTANCE(intercept_extra_state_t,
-                   opal_list_item_t,
-                   intercept_extra_state_constructor, NULL);
 
 // Intercept function for read conversions
 static int read_intercept_fn(void *userbuf, MPI_Datatype type_c, int count_c,
@@ -82,11 +52,13 @@ static int read_intercept_fn(void *userbuf, MPI_Datatype type_c, int count_c,
 {
     MPI::Datatype type_cxx(type_c);
     MPI::Offset position_cxx(position_c);
-    intercept_extra_state_t *intercept_data =
-        (intercept_extra_state_t*) extra_state;
+    ompi_cxx_intercept_file_extra_state_t *intercept_data =
+        (ompi_cxx_intercept_file_extra_state_t*) extra_state;
+    MPI::Datarep_conversion_function *read_fn_cxx =
+        (MPI::Datarep_conversion_function *) intercept_data->read_fn_cxx;
 
-    intercept_data->read_fn_cxx(userbuf, type_cxx, count_c, filebuf,
-                                position_cxx, intercept_data->extra_state_cxx);
+    read_fn_cxx (userbuf, type_cxx, count_c, filebuf, position_cxx,
+                 intercept_data->extra_state_cxx);
     return MPI_SUCCESS;
 }
 
@@ -97,11 +69,13 @@ static int write_intercept_fn(void *userbuf, MPI_Datatype type_c, int count_c,
 {
     MPI::Datatype type_cxx(type_c);
     MPI::Offset position_cxx(position_c);
-    intercept_extra_state_t *intercept_data =
-        (intercept_extra_state_t*) extra_state;
+    ompi_cxx_intercept_file_extra_state_t *intercept_data =
+        (ompi_cxx_intercept_file_extra_state_t*) extra_state;
+    MPI::Datarep_conversion_function *write_fn_cxx =
+        (MPI::Datarep_conversion_function *) intercept_data->write_fn_cxx;
 
-    intercept_data->write_fn_cxx(userbuf, type_cxx, count_c, filebuf,
-                                 position_cxx, intercept_data->extra_state_cxx);
+    write_fn_cxx (userbuf, type_cxx, count_c, filebuf, position_cxx,
+                  intercept_data->extra_state_cxx);
     return MPI_SUCCESS;
 }
 
@@ -111,11 +85,12 @@ static int extent_intercept_fn(MPI_Datatype type_c, MPI_Aint *file_extent_c,
 {
     MPI::Datatype type_cxx(type_c);
     MPI::Aint file_extent_cxx(*file_extent_c);
-    intercept_extra_state_t *intercept_data =
-        (intercept_extra_state_t*) extra_state;
+    ompi_cxx_intercept_file_extra_state_t *intercept_data =
+        (ompi_cxx_intercept_file_extra_state_t*) extra_state;
+    MPI::Datarep_extent_function *extent_fn_cxx =
+        (MPI::Datarep_extent_function *) intercept_data->extent_fn_cxx;
 
-    intercept_data->extent_fn_cxx(type_cxx, file_extent_cxx,
-                                  intercept_data->extra_state_cxx);
+    extent_fn_cxx (type_cxx, file_extent_cxx, intercept_data->extra_state_cxx);
     *file_extent_c = file_extent_cxx;
     return MPI_SUCCESS;
 }
@@ -128,23 +103,18 @@ MPI::Register_datarep(const char* datarep,
                       Datarep_extent_function* extent_fn_cxx,
                       void* extra_state_cxx)
 {
-    intercept_extra_state_t *intercept;
+    ompi_cxx_intercept_file_extra_state_t *intercept;
 
-    intercept = OBJ_NEW(intercept_extra_state_t);
+    intercept = ompi_cxx_new_intercept_state ((void *) read_fn_cxx, (void *) write_fn_cxx,
+                                              (void *) extent_fn_cxx, extra_state_cxx);
     if (NULL == intercept) {
-        OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
-                               "MPI::Register_datarep");
+        ompi_cxx_errhandler_invoke_file (MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
+                                         "MPI::Register_datarep");
         return;
     }
-    opal_list_append(&ompi_registered_datareps, &(intercept->base));
-    intercept->read_fn_cxx = read_fn_cxx;
-    intercept->write_fn_cxx = write_fn_cxx;
-    intercept->extent_fn_cxx = extent_fn_cxx;
-    intercept->extra_state_cxx = extra_state_cxx;
 
-    (void)MPI_Register_datarep(const_cast<char*>(datarep), read_intercept_fn,
-                               write_intercept_fn,
-                               extent_intercept_fn, intercept);
+    (void)MPI_Register_datarep (const_cast<char*>(datarep), read_intercept_fn,
+                                write_intercept_fn, extent_intercept_fn, intercept);
 }
 
 
@@ -155,22 +125,18 @@ MPI::Register_datarep(const char* datarep,
                       Datarep_extent_function* extent_fn_cxx,
                       void* extra_state_cxx)
 {
-    intercept_extra_state_t *intercept;
+    ompi_cxx_intercept_file_extra_state_t *intercept;
 
-    intercept = OBJ_NEW(intercept_extra_state_t);
+    intercept = ompi_cxx_new_intercept_state (NULL, (void *) write_fn_cxx, (void *) extent_fn_cxx,
+                                              extra_state_cxx);
     if (NULL == intercept) {
-        OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
-                               "MPI::Register_datarep");
+        ompi_cxx_errhandler_invoke_file (MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
+                                         "MPI::Register_datarep");
         return;
     }
-    opal_list_append(&ompi_registered_datareps, &(intercept->base));
-    intercept->write_fn_cxx = write_fn_cxx;
-    intercept->extent_fn_cxx = extent_fn_cxx;
-    intercept->extra_state_cxx = extra_state_cxx;
 
-    (void)MPI_Register_datarep(const_cast<char*>(datarep), read_fn_c,
-                               write_intercept_fn,
-                               extent_intercept_fn, intercept);
+    (void)MPI_Register_datarep (const_cast<char*>(datarep), read_fn_c, write_intercept_fn,
+                                extent_intercept_fn, intercept);
 }
 
 
@@ -181,22 +147,18 @@ MPI::Register_datarep(const char* datarep,
                       Datarep_extent_function* extent_fn_cxx,
                       void* extra_state_cxx)
 {
-    intercept_extra_state_t *intercept;
+    ompi_cxx_intercept_file_extra_state_t *intercept;
 
-    intercept = OBJ_NEW(intercept_extra_state_t);
+    intercept = ompi_cxx_new_intercept_state ((void *) read_fn_cxx, NULL, (void *) extent_fn_cxx,
+                                              extra_state_cxx);
     if (NULL == intercept) {
-        OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
-                               "MPI::Register_datarep");
+        ompi_cxx_errhandler_invoke_file (MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
+                                         "MPI::Register_datarep");
         return;
     }
-    opal_list_append(&ompi_registered_datareps, &(intercept->base));
-    intercept->read_fn_cxx = read_fn_cxx;
-    intercept->extent_fn_cxx = extent_fn_cxx;
-    intercept->extra_state_cxx = extra_state_cxx;
 
-    (void)MPI_Register_datarep(const_cast<char*>(datarep), read_intercept_fn,
-                               write_fn_c,
-                               extent_intercept_fn, intercept);
+    (void)MPI_Register_datarep (const_cast<char*>(datarep), read_intercept_fn, write_fn_c,
+                                extent_intercept_fn, intercept);
 }
 
 
@@ -207,21 +169,17 @@ MPI::Register_datarep(const char* datarep,
                       Datarep_extent_function* extent_fn_cxx,
                       void* extra_state_cxx)
 {
-    intercept_extra_state_t *intercept;
+    ompi_cxx_intercept_file_extra_state_t *intercept;
 
-    intercept = OBJ_NEW(intercept_extra_state_t);
+    intercept = ompi_cxx_new_intercept_state (NULL, NULL, (void *) extent_fn_cxx, extra_state_cxx);
     if (NULL == intercept) {
-        OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
-                               "MPI::Register_datarep");
+        ompi_cxx_errhandler_invoke_file (MPI_FILE_NULL, OMPI_ERR_OUT_OF_RESOURCE,
+                                         "MPI::Register_datarep");
         return;
     }
-    opal_list_append(&ompi_registered_datareps, &(intercept->base));
-    intercept->extent_fn_cxx = extent_fn_cxx;
-    intercept->extra_state_cxx = extra_state_cxx;
 
-    (void)MPI_Register_datarep(const_cast<char*>(datarep), read_fn_c,
-                               write_fn_c,
-                               extent_intercept_fn, intercept);
+    (void)MPI_Register_datarep (const_cast<char*>(datarep), read_fn_c, write_fn_c,
+                                extent_intercept_fn, intercept);
 }
 
 

--- a/ompi/mpi/cxx/mpicxx.cc
+++ b/ompi/mpi/cxx/mpicxx.cc
@@ -25,6 +25,8 @@
    SEEK_SET and friends right */
 #include "ompi_config.h"
 
+#include "cxx_glue.h"
+
 #if OPAL_CXX_USE_PRAGMA_IDENT
 #pragma ident OMPI_IDENT_STRING
 #elif OPAL_CXX_USE_IDENT
@@ -33,8 +35,6 @@
 namespace MPI {
     const char ompi_libcxx_version_string[] = OMPI_IDENT_STRING;
 }
-
-#include "ompi/errhandler/errhandler.h"
 
 namespace MPI {
 

--- a/ompi/mpi/cxx/mpicxx.h
+++ b/ompi/mpi/cxx/mpicxx.h
@@ -13,6 +13,8 @@
 // Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
 // Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 // Copyright (c) 2011      FUJITSU LIMITED.  All rights reserved.
+// Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+//                         reserved.
 // $COPYRIGHT$
 //
 // Additional copyrights may follow
@@ -96,21 +98,6 @@ struct opal_mutex_t;
 extern "C" void
 ompi_mpi_cxx_op_intercept(void *invec, void *outvec, int *len,
                           MPI_Datatype *datatype, MPI_User_function *fn);
-
-extern "C" void
-ompi_mpi_cxx_comm_errhandler_invoke(ompi_errhandler_t *c_errhandler,
-                                    MPI_Comm *mpi_comm, int *err,
-                                    const char *message);
-extern "C" void
-ompi_mpi_cxx_win_errhandler_invoke(ompi_errhandler_t *c_errhandler,
-                                   MPI_Win *mpi_comm, int *err,
-                                   const char *message);
-#if OMPI_PROVIDE_MPI_FILE_INTERFACE
-extern "C" void
-ompi_mpi_cxx_file_errhandler_invoke(ompi_errhandler_t *c_errhandler,
-                                    MPI_File *mpi_comm, int *err,
-                                    const char *message);
-#endif
 
 //used for attr intercept functions
 enum CommType { eIntracomm, eIntercomm, eCartcomm, eGraphcomm};

--- a/ompi/mpi/cxx/win.cc
+++ b/ompi/mpi/cxx/win.cc
@@ -1,6 +1,6 @@
 // -*- c++ -*-
 //
-// Copyright (c) 2006      Los Alamos National Security, LLC.  All rights
+// Copyright (c) 2006-2016 Los Alamos National Security, LLC.  All rights
 //                         reserved.
 // Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
 // Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
@@ -13,12 +13,9 @@
 
 // do not include ompi_config.h because it kills the free/malloc defines
 #include "mpi.h"
+#include "ompi/constants.h"
 #include "ompi/mpi/cxx/mpicxx.h"
-
-
-#include "ompi/communicator/communicator.h"
-#include "ompi/attribute/attribute.h"
-#include "ompi/errhandler/errhandler.h"
+#include "cxx_glue.h"
 
 void
 MPI::Win::Free()
@@ -31,14 +28,7 @@ MPI::Win::Free()
 MPI::Errhandler
 MPI::Win::Create_errhandler(MPI::Win::Errhandler_function* function)
 {
-    MPI_Errhandler c_errhandler =
-        ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_WIN,
-                               (ompi_errhandler_generic_handler_fn_t*) function,
-                               OMPI_ERRHANDLER_LANG_CXX);
-    c_errhandler->eh_cxx_dispatch_fn =
-        (ompi_errhandler_cxx_dispatch_fn_t*)
-        ompi_mpi_cxx_win_errhandler_invoke;
-    return c_errhandler;
+    return ompi_cxx_errhandler_create_win ((void *) function);
 }
 
 
@@ -50,21 +40,16 @@ MPI::Win::do_create_keyval(MPI_Win_copy_attr_function* c_copy_fn,
                                 void* extra_state, int &keyval)
 {
     int ret, count = 0;
-    ompi_attribute_fn_ptr_union_t copy_fn;
-    ompi_attribute_fn_ptr_union_t delete_fn;
     keyval_intercept_data_t *cxx_extra_state;
 
     // If both the callbacks are C, then do the simple thing -- no
     // need for all the C++ machinery.
     if (NULL != c_copy_fn && NULL != c_delete_fn) {
-        copy_fn.attr_win_copy_fn =
-            (MPI_Win_internal_copy_attr_function*) c_copy_fn;
-        delete_fn.attr_win_delete_fn = c_delete_fn;
-        ret = ompi_attr_create_keyval(COMM_ATTR, copy_fn, delete_fn,
-                                      &keyval, extra_state, 0, NULL);
+        ret = ompi_cxx_attr_create_keyval_win (c_copy_fn, c_delete_fn, &keyval,
+                                               extra_state, 0, NULL);
         if (MPI_SUCCESS != ret) {
-            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, ret,
-                                          "MPI::Win::Create_keyval");
+            return ompi_cxx_errhandler_invoke_comm (MPI_COMM_WORLD, ret,
+                                                    "MPI::Win::Create_keyval");
         }
     }
 
@@ -78,8 +63,8 @@ MPI::Win::do_create_keyval(MPI_Win_copy_attr_function* c_copy_fn,
     cxx_extra_state = (keyval_intercept_data_t*)
         malloc(sizeof(keyval_intercept_data_t));
     if (NULL == cxx_extra_state) {
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_NO_MEM,
-                                      "MPI::Win::Create_keyval");
+        return ompi_cxx_errhandler_invoke_comm (MPI_COMM_WORLD, MPI_ERR_NO_MEM,
+                                                "MPI::Win::Create_keyval");
     }
     cxx_extra_state->c_copy_fn = c_copy_fn;
     cxx_extra_state->cxx_copy_fn = cxx_copy_fn;
@@ -102,8 +87,8 @@ MPI::Win::do_create_keyval(MPI_Win_copy_attr_function* c_copy_fn,
     }
     if (2 != count) {
         free(cxx_extra_state);
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
-                                      "MPI::Win::Create_keyval");
+        return ompi_cxx_errhandler_invoke_comm (MPI_COMM_WORLD, MPI_ERR_ARG,
+                                                "MPI::Win::Create_keyval");
     }
 
     // We do not call MPI_Win_create_keyval() here because we need to
@@ -116,17 +101,12 @@ MPI::Win::do_create_keyval(MPI_Win_copy_attr_function* c_copy_fn,
     // ensure to set the destructor atomicly when the keyval is
     // created).
 
-    copy_fn.attr_win_copy_fn =
-        (MPI_Win_internal_copy_attr_function*)
-        ompi_mpi_cxx_win_copy_attr_intercept;
-    delete_fn.attr_win_delete_fn =
-        ompi_mpi_cxx_win_delete_attr_intercept;
-    ret = ompi_attr_create_keyval(WIN_ATTR, copy_fn, delete_fn,
-                                  &keyval, cxx_extra_state, 0,
-                                  cxx_extra_state);
+    ret = ompi_cxx_attr_create_keyval_win ((MPI_Win_copy_attr_function *) ompi_mpi_cxx_win_copy_attr_intercept,
+                                           ompi_mpi_cxx_win_delete_attr_intercept, &keyval,
+                                           cxx_extra_state, 0, NULL);
     if (OMPI_SUCCESS != ret) {
-        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, ret,
-                                      "MPI::Win::Create_keyval");
+        return ompi_cxx_errhandler_invoke_comm (MPI_COMM_WORLD, ret,
+                                                "MPI::Win::Create_keyval");
     }
 
     return MPI_SUCCESS;


### PR DESCRIPTION
This commit adds some glue code to support the C++ bindings and
updates the bindings to use the new glue code. This protects our
internal headers (which are C99) from C++. This is done as a quick
workaround to compilation errors when the legacy C++ bindings are
requested.

Fixes open-mpi/ompi#2055

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>