### PR TITLE
pmix3x: configury: correctly handle --disable-dlopen

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix3x/pmix/config/pmix.m4
@@ -670,6 +670,20 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 ])dnl
 
 AC_DEFUN([PMIX_DEFINE_ARGS],[
+    # do we want dlopen support ?
+    AC_MSG_CHECKING([if want dlopen support])
+    AC_ARG_ENABLE([dlopen],
+        [AC_HELP_STRING([--enable-dlopen],
+                        [Whether build should attempt to use dlopen (or
+                         similar) to dynamically load components.
+                         Disabling dlopen implies --disable-pdl-dlopen
+                         (default: enabled)])])
+    AS_IF([test "$enable_dlopen" = "no"],
+          [PMIX_ENABLE_DLOPEN_SUPPORT=0
+           AC_MSG_RESULT([no])],
+          [PMIX_ENABLE_DLOPEN_SUPPORT=1
+           AC_MSG_RESULT([yes])])
+
     # Embedded mode, or standalone?
     AC_MSG_CHECKING([if embedded mode is enabled])
     AC_ARG_ENABLE([embedded-mode],

--- a/opal/mca/pmix/pmix3x/pmix/configure.ac
+++ b/opal/mca/pmix/pmix3x/pmix/configure.ac
@@ -21,6 +21,8 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Intel, Inc. All rights reserved
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -146,10 +148,6 @@ AM_DISABLE_STATIC
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AM_PROG_LEX
 
-LT_INIT()
-LT_LANG([C])
-LT_LANG([C++])
-
 ############################################################################
 # Configuration options
 ############################################################################
@@ -162,6 +160,10 @@ PMIX_BASIC_SETUP
 # If debug mode, add -g
 AS_IF([test "$pmix_debug" = "1"],
       [CFLAGS="$CFLAGS -g"])
+
+LT_INIT()
+LT_LANG([C])
+LT_LANG([C++])
 
 ############################################################################
 # Setup the core

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/pdl/configure.m4
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/pdl/configure.m4
@@ -2,6 +2,8 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2016      Intel, Inc. All right reserved
+dnl Copyright (c) 2016      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -25,7 +27,7 @@ AC_DEFUN([MCA_pmix_pdl_CONFIG],[
     # (we still need to configure them all so that things like "make
     # dist" work", but we just want the MCA system to (artificially)
     # conclude that it can't build any of the components.
-    AS_IF([test "$enable_dlopen" = "no"],
+    AS_IF([test $PMIX_ENABLE_DLOPEN_SUPPORT -eq 0],
           [want_pdl=0], [want_pdl=1])
 
     MCA_CONFIGURE_FRAMEWORK([pdl], [$want_pdl])
@@ -33,7 +35,7 @@ AC_DEFUN([MCA_pmix_pdl_CONFIG],[
     # If we found no suitable static pdl component and dlopen support
     # was not specifically disabled, this is an error.
     AS_IF([test "$MCA_pmix_pdl_STATIC_COMPONENTS" = "" && \
-           test "$enable_dlopen" != "no"],
+           test $PMIX_ENABLE_DLOPEN_SUPPORT -ne 0],
           [AC_MSG_WARN([Did not find a suitable static pmix pdl component])
            AC_MSG_WARN([You might need to install libltld (and its headers) or])
            AC_MSG_WARN([specify --disable-dlopen to configure.])


### PR DESCRIPTION
the LT_* macros do overwrite the enable_dlopen variable,
so it must be tested and saved before invoking LT_INIT.
use the PMIX_ENABLE_DLOPEN_SUPPORT variable later