### PR TITLE
orted/pmix: fix spawn in singleton mode

### DIFF
--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -85,9 +85,7 @@ static int rte_init(void)
 {
     int rc, ret;
     char *error = NULL;
-    char *envar, *ev1, *ev2;
-    uint64_t unique_key[2];
-    char *string_key;
+    char *ev1, *ev2;
     opal_value_t *kv;
     char *val;
     int u32, *u32ptr;
@@ -265,19 +263,7 @@ static int rte_init(void)
      * we can use the jobfam and stepid as unique keys
      * because they are unique values assigned by the RM
      */
-    if (NULL == getenv(OPAL_MCA_PREFIX"orte_precondition_transports")) {
-        unique_key[0] = ORTE_JOB_FAMILY(ORTE_PROC_MY_NAME->jobid);
-        unique_key[1] = ORTE_LOCAL_JOBID(ORTE_PROC_MY_NAME->jobid);
-        if (NULL == (string_key = orte_pre_condition_transports_print(unique_key))) {
-            ORTE_ERROR_LOG(ORTE_ERR_OUT_OF_RESOURCE);
-            return ORTE_ERR_OUT_OF_RESOURCE;
-        }
-        asprintf(&envar, OPAL_MCA_PREFIX"orte_precondition_transports=%s", string_key);
-        putenv(envar);
-        added_transport_keys = true;
-        /* cannot free the envar as that messes up our environ */
-        free(string_key);
-    }
+    assert (NULL != getenv(OPAL_MCA_PREFIX"orte_precondition_transports"));
 
     /* retrieve our topology */
     OPAL_MODEX_RECV_VALUE(ret, OPAL_PMIX_LOCAL_TOPO,

--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -572,6 +572,12 @@ static int fork_hnp(void)
         memset(orted_uri, 0, buffer_length);
 
         while (chunk == (rc = read(p[0], &orted_uri[num_chars_read], chunk))) {
+            if (rc < 0 && (EAGAIN == errno || EINTR == errno)) {
+                continue;
+            } else {
+                num_chars_read = 0;
+                break;
+            }
             /* we read an entire buffer - better get more */
             num_chars_read += chunk;
             orted_uri = realloc((void*)orted_uri, buffer_length+ORTE_URI_MSG_LGTH);

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -60,6 +60,7 @@
 #include "opal/util/os_path.h"
 #include "opal/util/printf.h"
 #include "opal/util/argv.h"
+#include "opal/util/fd.h"
 #include "opal/runtime/opal.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/util/daemon_init.h"
@@ -598,8 +599,8 @@ int orte_daemon(int argc, char *argv[])
         }
         /* use setup fork to create the envars needed by the singleton */
         if (OPAL_SUCCESS != (ret = opal_pmix.server_setup_fork(&proc->name, &singenv))) {
-          ORTE_ERROR_LOG(ret);
-          goto DONE;
+            ORTE_ERROR_LOG(ret);
+            goto DONE;
         }
 
         /* append the transport key to the envars needed by the singleton */
@@ -620,7 +621,10 @@ int orte_daemon(int argc, char *argv[])
         free(nptr);
 
         /* pass that info to the singleton */
-        write(orted_globals.uri_pipe, tmp, strlen(tmp)+1); /* need to add 1 to get the NULL */
+        if (OPAL_SUCCESS != (ret = opal_fd_write(orted_globals.uri_pipe, strlen(tmp)+1, tmp))) { ; /* need to add 1 to get the NULL */
+            ORTE_ERROR_LOG(ret);
+            goto DONE;
+        }
 
         /* cleanup */
         free(tmp);


### PR DESCRIPTION
invoke orte_pre_condition_transports() in order to set the
ORTE_JOB_TRANSPORT_KEY attribute.