### PR TITLE
asm/ppc: work around apparent PGI 16.9 bug

### DIFF
--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -238,7 +238,7 @@ static inline int64_t opal_atomic_add_64 (volatile int64_t* v, int64_t inc)
                         "     add     %0, %2, %0   \n\t"
                         "     stdcx.  %0, 0, %3    \n\t"
                         "     bne-    1b           \n\t"
-                        : "=&r" (t), "+m" (*v)
+                        : "=&r" (t), "=m" (*v)
                         : "r" (OPAL_ASM_VALUE64(inc)), "r" OPAL_ASM_ADDR(v)
                         : "cc");
 
@@ -255,7 +255,7 @@ static inline int64_t opal_atomic_sub_64 (volatile int64_t* v, int64_t dec)
                         "     subf    %0,%2,%0     \n\t"
                         "     stdcx.  %0,0,%3      \n\t"
                         "     bne-    1b           \n\t"
-                        : "=&r" (t), "+m" (*v)
+                        : "=&r" (t), "=m" (*v)
                         : "r" (OPAL_ASM_VALUE64(dec)), "r" OPAL_ASM_ADDR(v)
                         : "cc");
 
@@ -274,7 +274,7 @@ static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
                          "   stdcx.  %4, 0, %2  \n\t"
                          "   bne-    1b         \n\t"
                          "2:"
-                         : "=&r" (ret), "+m" (*addr)
+                         : "=&r" (ret), "=m" (*addr)
                          : "r" (addr), "r" (OPAL_ASM_VALUE64(oldval)), "r" (OPAL_ASM_VALUE64(newval))
                          : "cc", "memory");
 


### PR DESCRIPTION
The add_64, sub_64, and cmpset_64 atomics used "+m" (*addr) to
indicate the asm also writes the memory location. This is better than
using a memory clobber. PGI 16.9 introduced a bug that causes a
compiler failure on the "+m" constraint (input/output). It seems to
work with "=m" (output) which matches the 32-bit atomics.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>