### PR TITLE
oshmem: add C++ wrapper compilers

### DIFF
--- a/config/oshmem_config_files.m4
+++ b/config/oshmem_config_files.m4
@@ -2,7 +2,9 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,6 +25,7 @@ AC_DEFUN([OSHMEM_CONFIG_FILES],[
     oshmem/tools/oshmem_info/Makefile
     oshmem/tools/wrappers/Makefile
     oshmem/tools/wrappers/shmemcc-wrapper-data.txt
+    oshmem/tools/wrappers/shmemc++-wrapper-data.txt
     oshmem/tools/wrappers/shmemfort-wrapper-data.txt
     ])
 ])

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -13,6 +13,8 @@
 # Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +32,7 @@ CCC = mpic++
 FC = mpifort
 JAVAC = mpijavac
 SHMEMCC = shmemcc
+SHMEMCXX = shmemc++
 SHMEMFC = shmemfort
 
 # Using -g is not necessary, but it is helpful for example programs,
@@ -51,6 +54,7 @@ EXAMPLES = \
 	 hello_usempi \
 	 hello_usempif08 \
 	 hello_oshmem \
+	 hello_oshmemcxx \
 	 hello_oshmemfh \
 	 Hello.class \
 	 ring_c \
@@ -105,6 +109,7 @@ mpi:
 oshmem:
 	@ if oshmem_info --parsable | grep oshmem:bindings:c:yes >/dev/null; then \
 	    $(MAKE) hello_oshmem; \
+	    $(MAKE) hello_oshmemcxx; \
 	    $(MAKE) ring_oshmem; \
 	    $(MAKE) oshmem_shmalloc; \
 	    $(MAKE) oshmem_circular_shift; \
@@ -146,6 +151,8 @@ Ring.class: Ring.java
 
 hello_oshmem: hello_oshmem_c.c
 	$(SHMEMCC) $(CFLAGS) $? -o $@
+hello_oshmemcxx: hello_oshmem_cxx.cc
+	$(SHMEMCXX) $(CXXFLAGS) $? -o $@
 hello_oshmemfh: hello_oshmemfh.f90
 	$(SHMEMFC) $(FCFLAGS) $? -o $@
 

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -14,6 +14,8 @@
 # Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +41,7 @@ EXTRA_DIST += \
         examples/hello_usempi.f90 \
         examples/hello_usempif08.f90 \
         examples/hello_oshmem_c.c \
+        examples/hello_oshmem_cxx.cc \
         examples/hello_oshmemfh.f90 \
         examples/ring_c.c \
         examples/ring_cxx.cc \

--- a/examples/hello_oshmem_cxx.cc
+++ b/examples/hello_oshmem_cxx.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <iostream>
+#include "shmem.h"
+
+#if !defined(OSHMEM_SPEC_VERSION) || OSHMEM_SPEC_VERSION < 10200
+#error This application uses API 1.2 and up
+#endif
+
+int main(int argc, char* argv[])
+{
+    int proc, nproc;
+    char name[SHMEM_MAX_NAME_LEN];
+    int major, minor;
+
+    shmem_init();
+    nproc = shmem_n_pes();
+    proc = shmem_my_pe();
+    shmem_info_get_name(name);
+    shmem_info_get_version(&major, &minor);
+
+    std::cout << "Hello, world, I am " << proc << " of " << nproc << ": " << name
+              << " (version: " << major << "." << minor << ")" << std::endl;
+
+    shmem_finalize();
+
+    return 0;
+}

--- a/oshmem/tools/oshmem_info/param.c
+++ b/oshmem/tools/oshmem_info/param.c
@@ -3,7 +3,7 @@
  *                         All rights reserved.
  *
  * Copyright (c) 2014-2017 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2014-2016 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
@@ -49,24 +49,6 @@
 
 const char *opal_info_deprecated_value = "deprecated-ompi-info-value";
 
-static void append(char *dest, size_t max, int *first, char *src)
-{
-    size_t len;
-
-    if (NULL == src) {
-        return;
-    }
-
-    len = max - strlen(dest);
-    if (!(*first)) {
-        strncat(dest, ", ", len);
-        len = max - strlen(dest);
-    }
-    strncat(dest, src, len);
-    *first = 0;
-}
-
-
 /*
  * do_config
  * Accepts:
@@ -81,23 +63,7 @@ static void append(char *dest, size_t max, int *first, char *src)
  */
 void oshmem_info_do_config(bool want_all)
 {
-    char *cxx;
-    char *fortran_mpifh;
-    char *fortran_usempi;
-    char *fortran_usempif08;
-    char *fortran_usempif08_compliance;
-    char *fortran_have_ignore_tkr;
-    char *fortran_have_f08_assumed_rank;
-    char *fortran_build_f08_subarrays;
-    char *fortran_have_optional_args;
-    char *fortran_have_bind_c;
-    char *fortran_have_private;
-    char *fortran_have_abstract;
-    char *fortran_have_asynchronous;
-    char *fortran_have_procedure;
-    char *fortran_have_c_funloc;
-    char *fortran_08_using_wrappers_for_choice_buffer_functions;
-    char *java;
+    char *fortran;
     char *heterogeneous;
     char *memprofile;
     char *memdebug;
@@ -105,9 +71,7 @@ void oshmem_info_do_config(bool want_all)
     char *mpi_interface_warning;
     char *cprofiling;
     char *cxxprofiling;
-    char *fortran_mpifh_profiling;
-    char *fortran_usempi_profiling;
-    char *fortran_usempif08_profiling;
+    char *fortran_profiling;
     char *cxxexceptions;
     char *threads;
     char *have_dl;
@@ -146,94 +110,6 @@ void oshmem_info_do_config(bool want_all)
     paramcheck = "runtime";
 #endif
 
-    /* The current mpi_f08 implementation does not support Fortran
-       subarrays.  However, someday it may/will.  Hence, I'm leaving
-       in all the logic that checks to see whether subarrays are
-       supported, but I'm just hard-coding
-       OMPI_BUILD_FORTRAN_F08_SUBARRAYS to 0 (we used to have a
-       prototype mpi_f08 module that implemented a handful of
-       descriptor-based interfaces and supported subarrays, but that
-       has been removed). */
-    const int OMPI_BUILD_FORTRAN_F08_SUBARRAYS = 0;
-
-    /* setup the strings that don't require allocations*/
-    cxx = OMPI_BUILD_CXX_BINDINGS ? "yes" : "no";
-    if (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_USEMPI_BINDINGS) {
-        if (OMPI_FORTRAN_HAVE_IGNORE_TKR) {
-            fortran_usempi = "yes (full: ignore TKR)";
-        } else {
-            fortran_usempi = "yes (limited: overloading)";
-        }
-    } else {
-        fortran_usempi = "no";
-    }
-    fortran_usempif08 = OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_USEMPIF08_BINDINGS ? "yes" : "no";
-    fortran_have_f08_assumed_rank = OMPI_FORTRAN_HAVE_F08_ASSUMED_RANK ?
-        "yes" : "no";
-    fortran_build_f08_subarrays = OMPI_BUILD_FORTRAN_F08_SUBARRAYS ?
-        "yes" : "no";
-    fortran_have_optional_args = OMPI_FORTRAN_HAVE_OPTIONAL_ARGS ?
-        "yes" : "no";
-    fortran_have_bind_c = OMPI_FORTRAN_HAVE_BIND_C ? "yes" : "no";
-    fortran_have_private = OMPI_FORTRAN_HAVE_PRIVATE ? "yes" : "no";
-    fortran_have_abstract = OMPI_FORTRAN_HAVE_ABSTRACT ? "yes" : "no";
-    fortran_have_asynchronous = OMPI_FORTRAN_HAVE_ASYNCHRONOUS ? "yes" : "no";
-    fortran_have_procedure = OMPI_FORTRAN_HAVE_PROCEDURE ? "yes" : "no";
-    fortran_have_c_funloc = OMPI_FORTRAN_HAVE_C_FUNLOC ? "yes" : "no";
-    fortran_08_using_wrappers_for_choice_buffer_functions =
-        OMPI_FORTRAN_NEED_WRAPPER_ROUTINES ? "yes" : "no";
-
-    /* Build a string describing what level of compliance the mpi_f08
-       module has */
-    char f08_msg[1024];
-    if (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_USEMPIF08_BINDINGS) {
-
-        /* Do we have everything? */
-        if (OMPI_BUILD_FORTRAN_F08_SUBARRAYS &&
-            OMPI_FORTRAN_HAVE_PRIVATE &&
-            OMPI_FORTRAN_HAVE_ABSTRACT &&
-            OMPI_FORTRAN_HAVE_ASYNCHRONOUS &&
-            OMPI_FORTRAN_HAVE_PROCEDURE &&
-            OMPI_FORTRAN_HAVE_C_FUNLOC &&
-            OMPI_FORTRAN_NEED_WRAPPER_ROUTINES) {
-            fortran_usempif08_compliance = "The mpi_f08 module is available, and is fully compliant.  w00t!";
-        } else {
-            int first = 1;
-            snprintf(f08_msg, sizeof(f08_msg),
-                     "The mpi_f08 module is available, but due to limitations in the %s compiler and/or Open MPI, does not support the following: ",
-                     OMPI_FC);
-            if (!OMPI_BUILD_FORTRAN_F08_SUBARRAYS) {
-                append(f08_msg, sizeof(f08_msg), &first, "array subsections");
-            }
-            if (!OMPI_FORTRAN_HAVE_PRIVATE) {
-                append(f08_msg, sizeof(f08_msg), &first,
-                       "private MPI_Status members");
-            }
-            if (!OMPI_FORTRAN_HAVE_ABSTRACT) {
-                append(f08_msg, sizeof(f08_msg), &first,
-                       "ABSTRACT INTERFACE function pointers");
-            }
-            if (!OMPI_FORTRAN_HAVE_ASYNCHRONOUS) {
-                append(f08_msg, sizeof(f08_msg), &first,
-                       "Fortran '08-specified ASYNCHRONOUS behavior");
-            }
-            if (!OMPI_FORTRAN_HAVE_PROCEDURE) {
-                append(f08_msg, sizeof(f08_msg), &first, "PROCEDUREs");
-            }
-            if (!OMPI_FORTRAN_HAVE_C_FUNLOC) {
-                append(f08_msg, sizeof(f08_msg), &first, "C_FUNLOCs");
-            }
-            if (OMPI_FORTRAN_NEED_WRAPPER_ROUTINES) {
-                append(f08_msg, sizeof(f08_msg), &first,
-                       "direct passthru (where possible) to underlying Open MPI's C functionality");
-            }
-            fortran_usempif08_compliance = f08_msg;
-        }
-    } else {
-        fortran_usempif08_compliance = "The mpi_f08 module was not built";
-    }
-
-    java = OMPI_WANT_JAVA_BINDINGS ? "yes" : "no";
     heterogeneous = OPAL_ENABLE_HETEROGENEOUS_SUPPORT ? "yes" : "no";
     memprofile = OPAL_ENABLE_MEM_PROFILE ? "yes" : "no";
     memdebug = OPAL_ENABLE_MEM_DEBUG ? "yes" : "no";
@@ -242,9 +118,7 @@ void oshmem_info_do_config(bool want_all)
     cprofiling = "yes";
     cxxprofiling = OMPI_BUILD_CXX_BINDINGS ? "yes" : "no";
     cxxexceptions = (OMPI_BUILD_CXX_BINDINGS && OMPI_HAVE_CXX_EXCEPTION_SUPPORT) ? "yes" : "no";
-    fortran_mpifh_profiling = (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_MPIFH_BINDINGS) ? "yes" : "no";
-    fortran_usempi_profiling = (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_USEMPI_BINDINGS) ? "yes" : "no";
-    fortran_usempif08_profiling = (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_USEMPIF08_BINDINGS) ? "yes" : "no";
+    fortran_profiling = (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_MPIFH_BINDINGS) ? "yes" : "no";
     have_dl = OPAL_HAVE_DL_SUPPORT ? "yes" : "no";
 #if OMPI_RTE_ORTE
     mpirun_prefix_by_default = ORTE_WANT_ORTERUN_PREFIX_BY_DEFAULT ? "yes" : "no";
@@ -257,24 +131,13 @@ void oshmem_info_do_config(bool want_all)
 
     /* setup strings that require allocation */
     if (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_MPIFH_BINDINGS) {
-        (void)asprintf(&fortran_mpifh, "yes (%s)",
+        (void)asprintf(&fortran, "yes (%s)",
                        (OPAL_HAVE_WEAK_SYMBOLS ? "all" :
                         (OMPI_FORTRAN_CAPS ? "caps" :
                          (OMPI_FORTRAN_PLAIN ? "lower case" :
                           (OMPI_FORTRAN_SINGLE_UNDERSCORE ? "single underscore" : "double underscore")))));
     } else {
-        fortran_mpifh = strdup("no");
-    }
-
-    if (OMPI_FORTRAN_HAVE_IGNORE_TKR) {
-        /* OMPI_FORTRAN_IGNORE_TKR_PREDECL is already in quotes; it
-           didn't work consistently to put it in _STRINGIFY because
-           sometimes the compiler would actually interpret the pragma
-           in there before stringify-ing it. */
-        (void)asprintf(&fortran_have_ignore_tkr, "yes (%s)",
-                       OMPI_FORTRAN_IGNORE_TKR_PREDECL);
-    } else {
-        fortran_have_ignore_tkr = strdup("no");
+        fortran = strdup("no");
     }
 
 #if OMPI_RTE_ORTE
@@ -302,20 +165,8 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("Built host", "build:host", OMPI_BUILD_HOST);
 
     opal_info_out("C bindings", "bindings:c", "yes");
-    opal_info_out("C++ bindings", "bindings:cxx", cxx);
-    opal_info_out("Fort mpif.h", "bindings:mpif.h", fortran_mpifh);
-    free(fortran_mpifh);
-    opal_info_out("Fort use mpi", "bindings:use_mpi",
-                  fortran_usempi);
-    opal_info_out("Fort use mpi size", "bindings:use_mpi:size",
-                  opal_info_deprecated_value);
-    opal_info_out("Fort use mpi_f08", "bindings:use_mpi_f08",
-                  fortran_usempif08);
-    opal_info_out("Fort mpi_f08 compliance", "bindings:use_mpi_f08:compliance",
-                  fortran_usempif08_compliance);
-    opal_info_out("Fort mpi_f08 subarrays", "bindings:use_mpi_f08:subarrays-supported",
-                  fortran_build_f08_subarrays);
-    opal_info_out("Java bindings", "bindings:java", java);
+    opal_info_out("Fort shmem.fh", "bindings:fortran", fortran);
+    free(fortran);
 
     opal_info_out("Wrapper compiler rpath", "compiler:all:rpath",
                   WRAPPER_RPATH_SUPPORT);
@@ -362,36 +213,6 @@ void oshmem_info_do_config(bool want_all)
     opal_info_out("Fort compiler", "compiler:fortran:command", OMPI_FC);
     opal_info_out("Fort compiler abs", "compiler:fortran:absolute",
                   OMPI_FC_ABSOLUTE);
-    opal_info_out("Fort ignore TKR", "compiler:fortran:ignore_tkr",
-                  fortran_have_ignore_tkr);
-    free(fortran_have_ignore_tkr);
-    opal_info_out("Fort 08 assumed shape",
-                  "compiler:fortran:f08_assumed_rank",
-                  fortran_have_f08_assumed_rank);
-    opal_info_out("Fort optional args",
-                  "compiler:fortran:optional_arguments",
-                  fortran_have_optional_args);
-    opal_info_out("Fort BIND(C)",
-                  "compiler:fortran:bind_c",
-                  fortran_have_bind_c);
-    opal_info_out("Fort PRIVATE",
-                  "compiler:fortran:private",
-                  fortran_have_private);
-    opal_info_out("Fort ABSTRACT",
-                  "compiler:fortran:abstract",
-                  fortran_have_abstract);
-    opal_info_out("Fort ASYNCHRONOUS",
-                  "compiler:fortran:asynchronous",
-                  fortran_have_asynchronous);
-    opal_info_out("Fort PROCEDURE",
-                  "compiler:fortran:procedure",
-                  fortran_have_procedure);
-    opal_info_out("Fort C_FUNLOC",
-                  "compiler:fortran:c_funloc",
-                  fortran_have_c_funloc);
-    opal_info_out("Fort f08 using wrappers",
-                  "compiler:fortran:08_wrappers",
-                  fortran_08_using_wrappers_for_choice_buffer_functions);
 
     if (want_all) {
 
@@ -528,13 +349,8 @@ void oshmem_info_do_config(bool want_all)
 
     opal_info_out("C profiling", "option:profiling:c", cprofiling);
     opal_info_out("C++ profiling", "option:profiling:cxx", cxxprofiling);
-    opal_info_out("Fort mpif.h profiling", "option:profiling:mpif.h",
-                  fortran_mpifh_profiling);
-    opal_info_out("Fort use mpi profiling", "option:profiling:use_mpi",
-                  fortran_usempi_profiling);
-    opal_info_out("Fort use mpi_f08 prof",
-                  "option:profiling:use_mpi_f08",
-                  fortran_usempif08_profiling);
+    opal_info_out("Fort shmem.fh profiling", "option:profiling:shmem.fh",
+                  fortran_profiling);
 
     opal_info_out("C++ exceptions", "option:cxx_exceptions", cxxexceptions);
     opal_info_out("Thread support", "option:threads", threads);

--- a/oshmem/tools/wrappers/Makefile.am
+++ b/oshmem/tools/wrappers/Makefile.am
@@ -2,7 +2,7 @@
 #                         All rights reserved.
 # Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
-# Copyright (c) 2014      Research Organization for Information Science
+# Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
@@ -12,41 +12,87 @@
 
 include $(top_srcdir)/Makefile.ompi-rules
 
-man_pages = oshcc.1 shmemcc.1 oshfort.1 shmemfort.1 oshrun.1 shmemrun.1
+man_pages = oshcc.1 shmemcc.1 oshc++.1 shmemc++.1 oshcxx.1 shmemcxx.1 oshfort.1 shmemfort.1 oshrun.1 shmemrun.1
 
 if PROJECT_OSHMEM
 man_MANS = $(man_pages)
 
 nodist_oshmemdata_DATA =  \
 	shmemcc-wrapper-data.txt \
+	shmemc++-wrapper-data.txt \
 	shmemfort-wrapper-data.txt
 
 # Only install / uninstall if we're building oshmem
-install-exec-hook:
+install-exec-hook-always:
 	test -z "$(bindir)" || $(mkdir_p) "$(DESTDIR)$(bindir)"
 	(cd $(DESTDIR)$(bindir); rm -f shmemrun$(EXEEXT); $(LN_S) mpirun$(EXEEXT) shmemrun$(EXEEXT))
 	(cd $(DESTDIR)$(bindir); rm -f oshrun$(EXEEXT); $(LN_S) mpirun$(EXEEXT) oshrun$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f shmemcc$(EXEEXT); $(LN_S) mpicc$(EXEEXT) shmemcc$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f oshcc$(EXEEXT); $(LN_S) mpicc$(EXEEXT) oshcc$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f shmemfort$(EXEEXT); $(LN_S) mpifort$(EXEEXT) shmemfort$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f oshfort$(EXEEXT); $(LN_S) mpifort$(EXEEXT) oshfort$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemcc$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemcc$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshcc$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshcc$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemc++$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemc++$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemcxx$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemcxx$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshc++$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshc++$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshcxx$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshcxx$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemfort$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemfort$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshfort$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshfort$(EXEEXT))
 
-install-data-hook:
+install-data-hook-always:
 	(cd $(DESTDIR)$(pkgdatadir); rm -f oshcc-wrapper-data.txt; $(LN_S) shmemcc-wrapper-data.txt oshcc-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f shmemcxx-wrapper-data.txt; $(LN_S) shmemc++-wrapper-data.txt shmemcxx-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f oshc++-wrapper-data.txt; $(LN_S) shmemc++-wrapper-data.txt oshc++-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f oshcxx-wrapper-data.txt; $(LN_S) shmemc++-wrapper-data.txt oshcxx-wrapper-data.txt)
 	(cd $(DESTDIR)$(pkgdatadir); rm -f oshfort-wrapper-data.txt; $(LN_S) shmemfort-wrapper-data.txt oshfort-wrapper-data.txt)
 
-uninstall-local:
+uninstall-local-always:
 	rm -f $(DESTDIR)$(bindir)/shmemrun$(EXEEXT) \
 	$(DESTDIR)$(bindir)/oshrun$(EXEEXT) \
 	$(DESTDIR)$(bindir)/shmemcc$(EXEEXT) \
 	$(DESTDIR)$(bindir)/oshcc$(EXEEXT) \
+	$(DESTDIR)$(bindir)/shmemcxx$(EXEEXT) \
+	$(DESTDIR)$(bindir)/oshcxx$(EXEEXT) \
 	$(DESTDIR)$(bindir)/shmemfort$(EXEEXT) \
 	$(DESTDIR)$(bindir)/oshfort$(EXEEXT) \
 	$(DESTDIR)$(pkgdatadir)/shmemcc-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/oshcc-wrapper-data.txt \
+	$(DESTDIR)$(pkgdatadir)/shmemcxx-wrapper-data.txt \
+	$(DESTDIR)$(pkgdatadir)/oshcxx-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/shmemfort-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/oshfort-wrapper-data.txt
 
+
+if CASE_SENSITIVE_FS
+man_MANS += oshCC.1 shmemCC.1
+
+install-exec-hook: install-exec-hook-always
+	(cd $(DESTDIR)$(bindir); rm -f shmemCC$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemCC$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshCC$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshCC$(EXEEXT))
+
+install-data-hook: install-data-hook-always
+	(cd $(DESTDIR)$(pkgdatadir); rm -f shmemCC-wrapper-data.txt; $(LN_S) shmemcxx-wrapper-data.txt shmemCC-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f oshCC-wrapper-data.txt; $(LN_S) oshcxx-wrapper-data.txt oshCC-wrapper-data.txt)
+
+uninstall-local: uninstall-local-always
+	rm -f $(DESTDIR)$(bindir)/shmemCC$(EXEEXT) \
+	$(DESTDIR)$(mandir)/man1/shmemCC.1 \
+	$(DESTDIR)$(pkgdatadir)/shmemCC-wrapper-data.txt
+	rm -f $(DESTDIR)$(bindir)/oshCC$(EXEEXT) \
+	$(DESTDIR)$(mandir)/man1/oshCC.1 \
+	$(DESTDIR)$(pkgdatadir)/oshCC-wrapper-data.txt
+
+oshCC.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshCC.1
+	sed -e 's/#COMMAND#/oshCC/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshCC.1
+
+shmemCC.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemCC.1
+	sed -e 's/#COMMAND#/shmemCC/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemCC.1
+
+else # CASE_SENSITIVE_FS
+install-exec-hook: install-exec-hook-always
+install-data-hook: install-data-hook-always
+uninstall-local: uninstall-local-always
+
+endif # CASE_SENSITIVE_FS
 
 ########################################################
 #
@@ -54,7 +100,7 @@ uninstall-local:
 #
 ########################################################
 distclean-local:
-	rm -f $(man_pages)
+	rm -f $(man_MANS)
 
 $(top_builddir)/opal/tools/wrappers/generic_wrapper.1:
 	(cd $(top_builddir)/opal/tools/wrappers && $(MAKE) $(AM_MAKEFLAGS) generic_wrapper.1)
@@ -66,6 +112,22 @@ oshcc.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
 shmemcc.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
 	rm -f shmemcc.1
 	sed -e 's/#COMMAND#/shmemcc/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemcc.1
+
+oshc++.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshc++.1
+	sed -e 's/#COMMAND#/oshc++/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshc++.1
+
+shmemc++.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemc++.1
+	sed -e 's/#COMMAND#/shmemc++/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemc++.1
+
+oshcxx.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshcxx.1
+	sed -e 's/#COMMAND#/oshcxx/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshcxx.1
+
+shmemcxx.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemcxx.1
+	sed -e 's/#COMMAND#/shmemcxx/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemcxx.1
 
 oshfort.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
 	rm -f oshfort.1

--- a/oshmem/tools/wrappers/shmemc++-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemc++-wrapper-data.txt.in
@@ -1,0 +1,37 @@
+# Copyright (c) 2013      Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# There can be multiple blocks of configuration data, chosen by
+# compiler flags (using the compiler_args key to chose which block
+# should be activated.  This can be useful for multilib builds.  See the
+# multilib page at:
+#    https://github.com/open-mpi/ompi/wiki/compilerwrapper3264
+# for more information.
+
+project=Open SHMEM
+project_short=OSHMEM
+version=@OSHMEM_VERSION@
+language=C++
+compiler_env=CXX
+compiler_flags_env=CXXFLAGS
+compiler=@CXX@
+preprocessor_flags=@OMPI_WRAPPER_EXTRA_CPPFLAGS@
+compiler_flags=@OMPI_WRAPPER_EXTRA_CXXFLAGS@
+linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
+# Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
+# intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
+# etc. are pulled in implicitly) because we intend SHMEM/MPI
+# applications to only use the SHMEM and MPI APIs.
+libs=-loshmem -lmpi
+libs_static=-loshmem -lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
+static_lib_file=liboshmem.a
+required_file=
+includedir=${includedir}
+libdir=${libdir}


### PR DESCRIPTION
though there are no C++ bindings for oshmem, we need C++ wrappers
since a C compiler might not be able to compile a C++ source.
the C++ wrappers are :
- shmemc++ / oshc++
- shmemcxx / oshcxx
- shmemCC / oshCC (on case sensitive filesystems)

Thanks Bert Wesarg for bringing this to our attention
