### PR TITLE
Mucho thanks to Gilles - his patch to reorder the CPPFLAGS solves the…

### DIFF
--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -75,9 +75,9 @@ EOF
            # Add some stuff to CPPFLAGS so that the rest of the source
            # tree can be built
            libevent_file=$libevent_basedir/libevent
-           CPPFLAGS="$CPPFLAGS -I$OPAL_TOP_SRCDIR/$libevent_file -I$OPAL_TOP_SRCDIR/$libevent_file/include"
+           CPPFLAGS="-I$OPAL_TOP_SRCDIR/$libevent_file -I$OPAL_TOP_SRCDIR/$libevent_file/include $CPPFLAGS"
            AS_IF([test "$OPAL_TOP_BUILDDIR" != "$OPAL_TOP_SRCDIR"],
-                 [CPPFLAGS="$CPPFLAGS -I$OPAL_TOP_BUILDDIR/$libevent_file/include"])
+                 [CPPFLAGS="-I$OPAL_TOP_BUILDDIR/$libevent_file/include $CPPFLAGS"])
            unset libevent_file
           ])
 ])

--- a/opal/mca/hwloc/hwloc1113/configure.m4
+++ b/opal/mca/hwloc/hwloc1113/configure.m4
@@ -52,9 +52,9 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1113_POST_CONFIG],[
            # Add some stuff to CPPFLAGS so that the rest of the source
            # tree can be built
            file=$opal_hwloc_hwloc1113_basedir/hwloc
-           CPPFLAGS="$CPPFLAGS -I$OPAL_TOP_SRCDIR/$file/include"
+           CPPFLAGS="-I$OPAL_TOP_SRCDIR/$file/include $CPPFLAGS"
            AS_IF([test "$OPAL_TOP_BUILDDIR" != "$OPAL_TOP_SRCDIR"],
-                 [CPPFLAGS="$CPPFLAGS -I$OPAL_TOP_BUILDDIR/$file/include"])
+                 [CPPFLAGS="-I$OPAL_TOP_BUILDDIR/$file/include $CPPFLAGS"])
            unset file
           ])
     OPAL_VAR_SCOPE_POP

--- a/orte/util/session_dir.c
+++ b/orte/util/session_dir.c
@@ -443,7 +443,7 @@ CLEANUP:
 int
 orte_session_dir_finalize(orte_process_name_t *proc)
 {
-    int rc;
+    int rc=ORTE_SUCCESS;
 
     if (!orte_create_session_dirs || orte_process_info.rm_session_dirs ) {
         /* we haven't created them or RM will clean them up for us*/


### PR DESCRIPTION
… problem of inadvertently picking up hwloc and libevent headers from locations in CPPFLAGS while continuing to build the embedded versions. Also silence a minor warning about an uninitialized var.