### PR TITLE
v2.0.x: fix --disable-mpi-io

### DIFF
--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2013      Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2015      Research Organization for Information Science
+dnl Copyright (c) 2015-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
 dnl $COPYRIGHT$
@@ -254,6 +254,14 @@ AS_IF([test $OMPI_TRY_FORTRAN_BINDINGS -lt $OMPI_FORTRAN_USEMPIF08_BINDINGS],
 AC_DEFINE_UNQUOTED([OMPI_BUILD_FORTRAN_F08_SUBARRAYS],
                    [$OMPI_BUILD_FORTRAN_F08_SUBARRAYS],
                    [Whether we built the 'use mpi_f08' prototype subarray-based implementation or not (i.e., whether to build the use-mpi-f08-desc prototype or the regular use-mpi-f08 implementation)])
+
+AC_ARG_ENABLE([mpi-io],
+    [AC_HELP_STRING([--disable-mpi-io],
+        [Disable built-in support for MPI-2 I/O, likely because
+         an externally-provided MPI I/O package will be used.
+         Default is to use the internal framework system that uses
+         the ompio component and a specially modified version of ROMIO
+         that fits inside the romio314 component])])
 
 ])dnl
 

--- a/ompi/mca/common/ompio/configure.m4
+++ b/ompi/mca/common/ompio/configure.m4
@@ -1,0 +1,21 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_ompi_common_ompio_CONFIG([action-if-can-compile],
+#                         [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_common_ompio_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/common/ompio/Makefile])
+
+    AS_IF([test "$enable_mpi_io" != "no"],
+          [$1],
+          [$2])
+])dnl

--- a/ompi/mca/io/configure.m4
+++ b/ompi/mca/io/configure.m4
@@ -1,8 +1,10 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2006-2007 Los Alamos National Security, LLC.
-# All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+#                         All rights reserved.
+# Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -14,20 +16,15 @@
 # -------------------------------------------
 AC_DEFUN([MCA_ompi_io_CONFIG],
 [
-    AC_ARG_ENABLE([mpi-io],
-        [AC_HELP_STRING([--disable-mpi-io],
-            [Disable built-in support for MPI-2 I/O, likely because
-             an externally-provided MPI I/O package will be used.
-             Default is to use the internal component system and
-             its specially modified version of ROMIO])])
+    OPAL_VAR_SCOPE_PUSH([define_mpi_io])
 
-    OMPI_MPIF_IO_CONSTANTS_INCLUDE=
-    OMPI_MPIF_IO_HANDLES_INCLUDE=
     AS_IF([test "$enable_mpi_io" != "no"],
-          [define_mpi_io=1
-           OMPI_MPIF_IO_CONSTANTS_INCLUDE="include \"mpif-io-constants.h\""
-           OMPI_MPIF_IO_HANDLES_INCLUDE="include \"mpif-io-handles.h\""],
-          [define_mpi_io=0])
+          [OMPI_MPIF_IO_CONSTANTS_INCLUDE="include \"mpif-io-constants.h\""
+           OMPI_MPIF_IO_HANDLES_INCLUDE="include \"mpif-io-handles.h\""
+           define_mpi_io=1],
+          [OMPI_MPIF_IO_CONSTANTS_INCLUDE=
+           OMPI_MPIF_IO_HANDLES_INCLUDE=
+           define_mpi_io=0])
     AC_SUBST(OMPI_MPIF_IO_CONSTANTS_INCLUDE)
     AC_SUBST(OMPI_MPIF_IO_HANDLES_INCLUDE)
 
@@ -37,6 +34,7 @@ AC_DEFUN([MCA_ompi_io_CONFIG],
     AC_SUBST(OMPI_PROVIDE_MPI_FILE_INTERFACE)
     AC_DEFINE_UNQUOTED([OMPI_PROVIDE_MPI_FILE_INTERFACE], [$define_mpi_io],
                        [Whether OMPI should provide MPI File interface])
-    AM_CONDITIONAL([OMPI_PROVIDE_MPI_FILE_INTERFACE], [test "$define_mpi_io" = "1"])
+    AM_CONDITIONAL([OMPI_PROVIDE_MPI_FILE_INTERFACE], [test "$enable_mpi_io" != "no"])
 
+    OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
 - move the mpi-io configury option into config/ompi_configure_options.m4
 - add ompi/mca/common/ompio/configure.m4 so this component is not built when
   Open MPI is configure'd with --disable-mpi-io

Fixes open-mpi/ompi#2009

(cherry picked from commit c3f4b7bd46d1ff5851193e68765bc4b9f426aae9)