### PR TITLE
v2.x: configure: add the --disable-io-ompio configure option

### DIFF
--- a/README
+++ b/README
@@ -1207,12 +1207,24 @@ MPI FUNCTIONALITY
 
   See "Open MPI API Extensions", below, for more details.
 
+--disable-mpi-io
+  Disable built-in support for MPI-2 I/O, likely because an externally-provided
+  MPI I/O package will be used. Default is to use the internal framework
+  system that uses the ompio component and a specially modified version of ROMIO
+  that fits inside the romio component
+
+--disable-io-romio
+  Disable the ROMIO MPI-IO component
+
 --with-io-romio-flags=flags
   Pass flags to the ROMIO distribution configuration script.  This
   option is usually only necessary to pass
   parallel-filesystem-specific preprocessor/compiler/linker flags back
   to the ROMIO system.
 
+--disable-io-ompio
+  Disable the ompio MPI-IO component
+ 
 --enable-sparse-groups
   Enable the usage of sparse groups. This would save memory
   significantly especially if you are creating large

--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -257,7 +257,7 @@ AC_DEFINE_UNQUOTED([OMPI_BUILD_FORTRAN_F08_SUBARRAYS],
 
 AC_ARG_ENABLE([io-ompio],
     [AC_HELP_STRING([--disable-io-ompio],
-        [Disable the ompio ROM-IO component])])
+        [Disable the ompio MPI-IO component])])
 
 ])dnl
 

--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -255,5 +255,9 @@ AC_DEFINE_UNQUOTED([OMPI_BUILD_FORTRAN_F08_SUBARRAYS],
                    [$OMPI_BUILD_FORTRAN_F08_SUBARRAYS],
                    [Whether we built the 'use mpi_f08' prototype subarray-based implementation or not (i.e., whether to build the use-mpi-f08-desc prototype or the regular use-mpi-f08 implementation)])
 
+AC_ARG_ENABLE([io-ompio],
+    [AC_HELP_STRING([--disable-io-ompio],
+        [Disable the ompio ROM-IO component])])
+
 ])dnl
 

--- a/ompi/mca/fbtl/configure.m4
+++ b/ompi/mca/fbtl/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -13,10 +15,14 @@
 # -------------------------------------------
 AC_DEFUN([MCA_ompi_fbtl_CONFIG],
 [
-    # An AC-ARG-ENABLE for mpi-io was set in ompi/mca/io/configure.m4.
-    # If it's no, we shouldn't bother building anything in fcoll.
-    AS_IF([test "$enable_mpi_io" != "no"],
-          [want_mpi_io=1],
-          [want_mpi_io=0])
-    MCA_CONFIGURE_FRAMEWORK([$1], [$2], [$want_mpi_io])
+    OPAL_VAR_SCOPE_PUSH([want_io_ompio])
+
+    AS_IF([test "$enable_mpi_io" != "no" &&
+           test "$enable_io_ompio" != "no"],
+          [want_io_ompio=1],
+          [want_io_ompio=0])
+
+    MCA_CONFIGURE_FRAMEWORK([$1], [$2], [$want_io_ompio])
+
+    OPAL_VAR_SCOPE_POP
 ])

--- a/ompi/mca/fcoll/configure.m4
+++ b/ompi/mca/fcoll/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -13,10 +15,14 @@
 # -------------------------------------------
 AC_DEFUN([MCA_ompi_fcoll_CONFIG],
 [
-    # An AC-ARG-ENABLE for mpi-io was set in ompi/mca/io/configure.m4.
-    # If it's no, we shouldn't bother building anything in fcoll.
-    AS_IF([test "$enable_mpi_io" != "no"],
-          [want_mpi_io=1],
-          [want_mpi_io=0])
-    MCA_CONFIGURE_FRAMEWORK([$1], [$2], [$want_mpi_io])
+    OPAL_VAR_SCOPE_PUSH([want_io_ompio])
+
+    AS_IF([test "$enable_mpi_io" != "no" &&
+           test "$enable_io_ompio" != "no"],
+          [want_io_ompio=1],
+          [want_io_ompio=0])
+
+    MCA_CONFIGURE_FRAMEWORK([$1], [$2], [$want_io_ompio])
+
+    OPAL_VAR_SCOPE_POP
 ])

--- a/ompi/mca/io/ompio/configure.m4
+++ b/ompi/mca/io/ompio/configure.m4
@@ -1,0 +1,21 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_ompi_io_ompio_CONFIG([action-if-can-compile],
+#                          [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_io_ompio_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/io/ompio/Makefile])
+
+    AS_IF([test "$enable_io_ompio" != "no"],
+          [$1],
+          [$2])
+])dnl

--- a/ompi/mca/sharedfp/configure.m4
+++ b/ompi/mca/sharedfp/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -13,10 +15,14 @@
 # -------------------------------------------
 AC_DEFUN([MCA_ompi_sharedfp_CONFIG],
 [
-    # An AC-ARG-ENABLE for mpi-io was set in ompi/mca/io/configure.m4.
-    # If it's no, we shouldn't bother building anything in fcoll.
-    AS_IF([test "$enable_mpi_io" != "no"],
-          [want_mpi_io=1],
-          [want_mpi_io=0])
-    MCA_CONFIGURE_FRAMEWORK([$1], [$2], [$want_mpi_io])
+    OPAL_VAR_SCOPE_PUSH([want_io_ompio])
+
+    AS_IF([test "$enable_mpi_io" != "no" &&
+           test "$enable_io_ompio" != "no"],
+          [want_io_ompio=1],
+          [want_io_ompio=0])
+
+    MCA_CONFIGURE_FRAMEWORK([$1], [$2], [$want_io_ompio])
+
+    OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
--disable-io-ompio is a shortcut that disable the following
frameworks and components
- fbtl
- fcoll
- sharedfp
- common/ompio
- io/ompio

Fixes open-mpi/ompi#1934

(back-ported from commit 6b57b77ecb7f4ceee8e5d5da72e96d7692975bb5)