### PR TITLE
v2.0.x: oshmem: move finalisation to oshmem_onexit

### DIFF
--- a/oshmem/include/oshmem_config.h
+++ b/oshmem/include/oshmem_config.h
@@ -2,7 +2,9 @@
  *
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,18 +54,12 @@
 #    ifndef OSHMEM_MODULE_DECLSPEC
 #      define OSHMEM_MODULE_DECLSPEC     __opal_attribute_visibility__("default")
 #    endif
-#    ifndef OSHMEM_DESTRUCTOR
-#      define OSHMEM_DESTRUCTOR     	__opal_attribute_destructor__
-#    endif
 #  else
 #    ifndef OSHMEM_DECLSPEC
 #      define OSHMEM_DECLSPEC
 #    endif
 #    ifndef OSHMEM_MODULE_DECLSPEC
 #      define OSHMEM_MODULE_DECLSPEC
-#    endif
-#    ifndef OSHMEM_DESTRUCTOR
-#      define OSHMEM_DESTRUCTOR
 #    endif
 #  endif
 #endif  /* defined(__WINDOWS__) */

--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -32,14 +32,6 @@
 #  endif
 #endif
 
-#ifndef OSHMEM_DESTRUCTOR
-#    if defined(OPAL_C_HAVE_VISIBILITY) && (OPAL_C_HAVE_VISIBILITY == 1)
-#       define OSHMEM_DESTRUCTOR  __attribute__((__destructor__))
-#    else
-#       define OSHMEM_DESTRUCTOR
-#    endif
-#endif
-
 #include <pshmemx.h>
 
 #if defined(c_plusplus) || defined(__cplusplus)
@@ -59,7 +51,7 @@ OSHMEM_DECLSPEC  void pshmem_global_exit(int status);
 /*
  * Finalization routines
  */
-OSHMEM_DECLSPEC  void pshmem_finalize(void) OSHMEM_DESTRUCTOR;
+OSHMEM_DECLSPEC  void pshmem_finalize(void);
 
 /*
  * Query routines

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -2,6 +2,8 @@
  * Copyright (c) 2014-2016 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,14 +40,6 @@
 #  else
 #     define OSHMEM_DECLSPEC
 #  endif
-#endif
-
-#ifndef OSHMEM_DESTRUCTOR
-#    if defined(OPAL_C_HAVE_VISIBILITY) && (OPAL_C_HAVE_VISIBILITY == 1)
-#       define OSHMEM_DESTRUCTOR  __attribute__((__destructor__))
-#    else
-#       define OSHMEM_DESTRUCTOR
-#    endif
 #endif
 
 #include <shmem-compat.h>
@@ -116,7 +110,7 @@ enum shmem_wait_ops {
  * Initialization routines
  */
 OSHMEM_DECLSPEC  void shmem_init(void);
-OSHMEM_DECLSPEC  void shmem_finalize(void) OSHMEM_DESTRUCTOR;
+OSHMEM_DECLSPEC  void shmem_finalize(void);
 OSHMEM_DECLSPEC  void shmem_global_exit(int status);
 
 /*

--- a/oshmem/shmem/c/shmem_init.c
+++ b/oshmem/shmem/c/shmem_init.c
@@ -3,6 +3,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,6 +52,7 @@ void start_pes(int npes)
 static void shmem_onexit(int exitcode, void *arg)
 {
     oshmem_shmem_globalexit_status = exitcode;
+    shmem_finalize();
 }
 
 static inline void _shmem_init(void)


### PR DESCRIPTION
…nexit()

so we can use the legacy start_pes even when Open MPI is compiled with
--enable-static or --disable-visibility

(back-ported from commit 92dd719df1c5478c4524be311e8bb40444f7462c)