### PR TITLE
oshmem/fortran: fix shmem_put_f (waits for #2127)

### DIFF
--- a/config/oshmem_configure_options.m4
+++ b/config/oshmem_configure_options.m4
@@ -73,7 +73,7 @@ AC_DEFINE_UNQUOTED([OSHMEM_SPEC_COMPAT], [$OSHMEM_SPEC_COMPAT],
 #
 AC_MSG_CHECKING([if want OSHMEM API parameter checking])
 AC_ARG_WITH(oshmem-param-check,
-    AC_HELP_STRING([--oshmem-param-check(=VALUE)],
+    AC_HELP_STRING([--with-oshmem-param-check(=VALUE)],
                    [behavior of OSHMEM API function parameter checking.  Valid values are: always, never.  If --with-oshmem-param-check is specified with no VALUE argument, it is equivalent to a VALUE of "always"; --without-oshmem-param-check is equivalent to "never" (default: always).]))
 if test "$enable_oshmem" != "no"; then
     if test "$with_oshmem_param_check" = "no" || \
@@ -86,10 +86,11 @@ if test "$enable_oshmem" != "no"; then
         shmem_param_check=1
         AC_MSG_RESULT([always])
     else
+        shmem_param_check=1
         AC_MSG_RESULT([unknown])
         AC_MSG_WARN([*** Unrecognized --with-oshmem-param-check value])
         AC_MSG_WARN([*** See "configure --help" output])
-        AC_MSG_WARN([*** Defaulting to "runtime"])
+        AC_MSG_WARN([*** Defaulting to "always"])
     fi
 else
     shmem_param_check=0

--- a/oshmem/shmem/fortran/shmem_put_f.c
+++ b/oshmem/shmem/fortran/shmem_put_f.c
@@ -14,6 +14,7 @@
 #include "oshmem/include/shmem.h"
 #include "oshmem/shmem/shmem_api_logger.h"
 #include "oshmem/runtime/runtime.h"
+#include "oshmem/mca/spml/spml.h"
 #include "stdio.h"
 
 #if OSHMEM_PROFILING
@@ -32,9 +33,9 @@ SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
 
 void shmem_put_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
 {
-    shmem_put(FPTR_2_VOID_PTR(target),
+    MCA_SPML_CALL(put(FPTR_2_VOID_PTR(target),
         FPTR_2_VOID_PTR(source),
         OMPI_FINT_2_INT(*length),
-        OMPI_FINT_2_INT(*pe));
+        OMPI_FINT_2_INT(*pe)));
 }
 

--- a/oshmem/shmem/fortran/shmem_put_f.c
+++ b/oshmem/shmem/fortran/shmem_put_f.c
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2013      Mellanox Technologies, Inc.
- *                         All rights reserved.
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2016 Mellanox Technologies, Inc. All rights reserved.
+ * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,8 +33,8 @@ SHMEM_GENERATE_FORTRAN_BINDINGS_SUB (void,
 void shmem_put_f(FORTRAN_POINTER_T target, FORTRAN_POINTER_T source, MPI_Fint *length, MPI_Fint *pe)
 {
     MCA_SPML_CALL(put(FPTR_2_VOID_PTR(target),
+        OMPI_FINT_2_INT(*length) * 8,
         FPTR_2_VOID_PTR(source),
-        OMPI_FINT_2_INT(*length),
         OMPI_FINT_2_INT(*pe)));
 }
 

--- a/oshmem/shmem/fortran/shmem_put_nb_f.c
+++ b/oshmem/shmem/fortran/shmem_put_nb_f.c
@@ -13,6 +13,7 @@
 #include "oshmem/include/shmem.h"
 #include "oshmem/shmem/shmem_api_logger.h"
 #include "oshmem/runtime/runtime.h"
+#include "oshmem/mca/spml/spml.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "stdio.h"
 


### PR DESCRIPTION
Corresponds to #1867 (backing up open-mpi/ompi-release#1330)
Don't merge until #2127 is merged. Once merged - need to rebase it and then good to go.