### PR TITLE
pmix/{cray,s1,s2}: make pmi_opcaddy_t class static

### DIFF
--- a/opal/mca/pmix/cray/pmix_cray.c
+++ b/opal/mca/pmix/cray/pmix_cray.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All
  *                         rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -127,9 +127,9 @@ typedef struct {
     opal_pmix_op_cbfunc_t opcbfunc;
     void *cbdata;
 } pmi_opcaddy_t;
-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
-		   opal_object_t,
-		   NULL, NULL);
+static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+		          opal_object_t,
+		          NULL, NULL);
 
 // PMI constant values:
 static int pmix_kvslen_max = 0;

--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -89,9 +89,9 @@ typedef struct {
     opal_pmix_op_cbfunc_t opcbfunc;
     void *cbdata;
 } pmi_opcaddy_t;
-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
-                   opal_object_t,
-                   NULL, NULL);
+static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                          opal_object_t,
+                          NULL, NULL);
 
 // PMI constant values:
 static int pmix_kvslen_max = 0;

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC. All
  *                         rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -95,9 +95,9 @@ typedef struct {
     opal_pmix_op_cbfunc_t opcbfunc;
     void *cbdata;
 } pmi_opcaddy_t;
-OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
-                   opal_object_t,
-                   NULL, NULL);
+static OBJ_CLASS_INSTANCE(pmi_opcaddy_t,
+                          opal_object_t,
+                          NULL, NULL);
 
 // PMI constant values:
 static int pmix_kvslen_max = 0;


### PR DESCRIPTION
theses three pmix components use the same class name,
declare it as static so Open MPI can be built with --disable-dlopen

Thanks Limin Gu for the report