### PR TITLE
build: Custom libmpi_FOO name fix for wrapper compilers

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -17,6 +17,7 @@ dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2014-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -340,9 +341,9 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
           [OMPI_BUILD_FORTRAN_BINDINGS=$OMPI_FORTRAN_USEMPI_BINDINGS
            AS_IF([test $OMPI_FORTRAN_HAVE_IGNORE_TKR -eq 1],
                  [OMPI_FORTRAN_USEMPI_DIR=mpi/fortran/use-mpi-ignore-tkr
-                  OMPI_FORTRAN_USEMPI_LIB=-lmpi_usempi_ignore_tkr],
+                  OMPI_FORTRAN_USEMPI_LIB=-l${with_libmpi_name}_usempi_ignore_tkr],
                  [OMPI_FORTRAN_USEMPI_DIR=mpi/fortran/use-mpi-tkr
-                  OMPI_FORTRAN_USEMPI_LIB=-lmpi_usempi])
+                  OMPI_FORTRAN_USEMPI_LIB=-l${with_libmpi_name}_usempi])
           ])
 
     OMPI_FORTRAN_HAVE_ISO_C_BINDING=0
@@ -574,7 +575,7 @@ end type test_mpi_handle],
 
     AC_MSG_CHECKING([if building Fortran 'use mpi_f08' bindings])
     AS_IF([test $OMPI_BUILD_FORTRAN_BINDINGS -ge $OMPI_FORTRAN_USEMPIF08_BINDINGS],
-          [OMPI_FORTRAN_USEMPIF08_LIB=-lmpi_usempif08
+          [OMPI_FORTRAN_USEMPIF08_LIB=-l${with_libmpi_name}_usempif08
            AC_MSG_RESULT([yes])],
           [OMPI_TRY_FORTRAN_BINDIGS=$OMPI_FORTRAN_USEMPI_BINDINGS
            AC_MSG_RESULT([no])])

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -14,6 +14,7 @@ dnl Copyright (c) 2006-2010 Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -500,7 +501,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
       # support.  However, we do want it to fail if there is no C++
       # compiler.
        if test "$WANT_MPI_CXX_SUPPORT" = "1" ; then
-          OMPI_WRAPPER_CXX_LIB="-lmpi_cxx"
+          OMPI_WRAPPER_CXX_LIB="-l${with_libmpi_name}_cxx"
           OMPI_WRAPPER_CXX_REQUIRED_FILE=""
        elif test "$CXX" = "none"; then
           OMPI_WRAPPER_CXX_LIB=""

--- a/contrib/build-mca-comps-outside-of-tree/configure.ac
+++ b/contrib/build-mca-comps-outside-of-tree/configure.ac
@@ -11,6 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -154,7 +155,7 @@ EOF
              # Open MPI v1.7 libraries
              LDFLAGS="$LDFLAGS -L$withval/ompi/.libs"
              # For OMPI v1.7 and later
-             LIBS="$LIBS -lmpi"
+             LIBS="$LIBS -l@OMPI_LIBMPI_NAME@"
 
              CPPFLAGS="$CPPFLAGS $source_CPPFLAGS"
              CFLAGS="$CFLAGS $source_CFLAGS"

--- a/ompi/mpi/cxx/Makefile.am
+++ b/ompi/mpi/cxx/Makefile.am
@@ -28,10 +28,10 @@ AM_CPPFLAGS = -DOMPI_BUILDING_CXX_BINDINGS_LIBRARY=1 -DOMPI_SKIP_MPICXX=1
 
 if OMPI_BUILD_MPI_CXX_BINDINGS
 
-mpi_lib = libmpi_cxx.la
+mpi_lib = lib@OMPI_LIBMPI_NAME@_cxx.la
 
-lib_LTLIBRARIES = libmpi_cxx.la
-libmpi_cxx_la_SOURCES = \
+lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@_cxx.la
+lib@OMPI_LIBMPI_NAME@_cxx_la_SOURCES = \
 	mpicxx.cc \
 	intercepts.cc \
 	comm.cc \
@@ -39,12 +39,12 @@ libmpi_cxx_la_SOURCES = \
 	win.cc
 
 if OMPI_PROVIDE_MPI_FILE_INTERFACE
-libmpi_cxx_la_SOURCES += \
+lib@OMPI_LIBMPI_NAME@_cxx_la_SOURCES += \
 	file.cc
 endif
 
-libmpi_cxx_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
-libmpi_cxx_la_LDFLAGS = -version-info $(libmpi_cxx_so_version)
+lib@OMPI_LIBMPI_NAME@_cxx_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+lib@OMPI_LIBMPI_NAME@_cxx_la_LDFLAGS = -version-info $(libmpi_cxx_so_version)
 
 headers = \
 	mpicxx.h \

--- a/ompi/mpi/java/c/Makefile.am
+++ b/ompi/mpi/java/c/Makefile.am
@@ -25,8 +25,8 @@ ompidir = $(ompiincludedir)/ompi/mpi/java
 ompi_HEADERS = \
         $(headers)
 
-lib_LTLIBRARIES = libmpi_java.la
-libmpi_java_la_SOURCES = \
+lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@_java.la
+lib@OMPI_LIBMPI_NAME@_java_la_SOURCES = \
 	mpi_CartComm.c \
 	mpi_Comm.c \
 	mpi_Constant.c \
@@ -47,7 +47,7 @@ libmpi_java_la_SOURCES = \
 	mpi_Status.c \
 	mpi_Win.c
 
-libmpi_java_la_LIBADD = -ldl $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
-libmpi_java_la_LDFLAGS = -version-info $(libmpi_java_so_version)
+lib@OMPI_LIBMPI_NAME@_java_la_LIBADD = -ldl $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+lib@OMPI_LIBMPI_NAME@_java_la_LDFLAGS = -version-info $(libmpi_java_so_version)
 
 endif

--- a/ompi/tools/wrappers/mpifort-wrapper-data.txt.in
+++ b/ompi/tools/wrappers/mpifort-wrapper-data.txt.in
@@ -19,8 +19,8 @@ linker_flags=@OMPI_WRAPPER_EXTRA_FC_LDFLAGS@
 # intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
-libs=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -l@OMPI_LIBMPI_NAME@
-libs_static=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal  @OMPI_WRAPPER_EXTRA_LIBS@
+libs=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@
+libs_static=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal  @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=lib@OMPI_LIBMPI_NAME@.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=lib@OMPI_LIBMPI_NAME@.a
 required_file=@OMPI_WRAPPER_FORTRAN_REQUIRED_FILE@

--- a/ompi/tools/wrappers/ompi-fort.pc.in
+++ b/ompi/tools/wrappers/ompi-fort.pc.in
@@ -16,6 +16,6 @@ pkgincludedir=@opalincludedir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -lmpi_mpifh -l@OMPI_LIBMPI_NAME@
+Libs: -L${libdir} @OMPI_PKG_CONFIG_LDFLAGS@ @OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@
 Libs.private: -lopen-rte -lopen-pal @OMPI_WRAPPER_EXTRA_LIBS@
 Cflags: -I${includedir} @OMPI_WRAPPER_EXTRA_CPPFLAGS@ @OMPI_WRAPPER_EXTRA_FCFLAGS@

--- a/ompi/tools/wrappers/ompi_wrapper_script.in
+++ b/ompi/tools/wrappers/ompi_wrapper_script.in
@@ -125,7 +125,7 @@ elsif (basename($0) eq "mpifort" ||
     # no extra includes for Fortran.
     $comp_flags = $extra_fcflags;
     $comp_flags_prefix = $extra_fcflags_prefix;
-    $libs = $fortran_libs . " -lmpi_mpifh " . $libs;
+    $libs = $fortran_libs . " -l".$ompi_libmpi_name."_mpifh " . $libs;
 }
 
 if ($lang eq "none") {

--- a/oshmem/tools/wrappers/shmemfort-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemfort-wrapper-data.txt.in
@@ -29,8 +29,8 @@ linker_flags=@OMPI_WRAPPER_EXTRA_FC_LDFLAGS@
 # intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
 # etc. are pulled in implicitly) because we intend SHMEM/MPI
 # applications to only use the SHMEM and MPI APIs.
-libs=-loshmem -lmpi_mpifh -l@OMPI_LIBMPI_NAME@
-libs_static=-loshmem -lmpi_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs=-loshmem -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@
+libs_static=-loshmem -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=liboshmem.a
 required_file=@OMPI_WRAPPER_FORTRAN_REQUIRED_FILE@


### PR DESCRIPTION
 * In open-mpi/ompi@f6f24a4f671ec4750dfbe0609aa6ae15984ccee9 I missed
   updating the library references for the wrapper compilers.
 * Fixes the CXX wrapper compiler and CXX library is renamed as needed.
 * Fixes the Java wrapper compiler and the Java library is renamed as needed.