### PR TITLE
v2.0.x: osc-portals4: fix offset bug in raccumulate()

### DIFF
--- a/ompi/mca/osc/portals4/osc_portals4_comm.c
+++ b/ompi/mca/osc/portals4/osc_portals4_comm.c
@@ -514,7 +514,7 @@ ompi_osc_portals4_raccumulate(const void *origin_addr,
                 OPAL_OUTPUT_VERBOSE((90,ompi_osc_base_framework.framework_output,
                                       "%s,%d Atomic", __FUNCTION__, __LINE__));
                 ret = PtlAtomic(module->req_md_h,
-                                offset + sent + origin_lb,
+                                md_offset + sent + origin_lb,
                                 msg_length,
                                 PTL_ACK_REQ,
                                 peer,


### PR DESCRIPTION
This commit fixes a bug where the remote offset was used as both
the local and remote offset.

Thanks to @PDeveze for the patch.

(cherry-pick of c536e11)
