### PR TITLE
v2.x asm updates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,8 @@ individual who committed them.
 
 -----
 
+Abhishek Joshi, Broadcom
+  abhishek.joshi@broadcom.com
 Abhishek Kulkarni, Indiana University
   adkulkar@cs.indiana.edu
 Adrian Knoth, Friedrich-Schiller-Universitat Jena
@@ -24,7 +26,7 @@ Alex Mikheev, Mellanox
   alexm@mellanox.com
 Alina Sklarevich, Mellanox
   alinas@mellanox.com
-Andreas Knüpfer, Technische Universitaet Dresden
+Andreas KnÃ¼pfer, Technische Universitaet Dresden
   andreas.knuepfer@tu-dresden.de
 Andrew Friedley, Indiana University, Sandia National Laboratory, Intel
   afriedle@osl.iu.edu
@@ -37,7 +39,7 @@ Anya Tatashina, Sun
   anya.tatashina@sun.com
 Artem Polyakov, Individual, Mellanox
   artpol84@gmail.com
-Aur�lien Bouteiller, University of Tennessee-Knoxville
+Aurélien Bouteiller, University of Tennessee-Knoxville
   bouteill@icl.utk.edu
 Avneesh Pant, QLogic
   avneesh.pant@qlogic.com

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -88,7 +88,9 @@ AC_DEFUN([OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128], [
 AC_DEFUN([OPAL_CHECK_SYNC_BUILTINS], [
   AC_MSG_CHECKING([for __sync builtin atomics])
 
-  AC_TRY_LINK([], [__sync_synchronize()],
+  AC_TRY_LINK([long tmp;], [__sync_synchronize();
+__sync_bool_compare_and_swap(&tmp, 0, 1);
+__sync_add_and_fetch(&tmp, 1);],
     [AC_MSG_RESULT([yes])
      $1],
     [AC_MSG_RESULT([no])

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -95,6 +95,21 @@ __sync_add_and_fetch(&tmp, 1);],
      $1],
     [AC_MSG_RESULT([no])
      $2])
+
+  AC_MSG_CHECKING([for 64-bit __sync builtin atomics])
+
+  AC_TRY_LINK([
+#include <stdint.h>
+uint64_t tmp;], [
+__sync_bool_compare_and_swap(&tmp, 0, 1);
+__sync_add_and_fetch(&tmp, 1);],
+    [AC_MSG_RESULT([yes])
+     opal_asm_sync_have_64bit=1],
+    [AC_MSG_RESULT([no])
+     opal_asm_sync_have_64bit=0])
+
+  AC_DEFINE_UNQUOTED([OPAL_ASM_SYNC_HAVE_64BIT],[$opal_asm_sync_have_64bit],
+		     [Whether 64-bit is supported by the __sync builtin atomics])
 ])
 
 

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -110,6 +110,97 @@ __sync_add_and_fetch(&tmp, 1);],
 
   AC_DEFINE_UNQUOTED([OPAL_ASM_SYNC_HAVE_64BIT],[$opal_asm_sync_have_64bit],
 		     [Whether 64-bit is supported by the __sync builtin atomics])
+
+  # Check for 128-bit support
+  OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
+])
+
+
+AC_DEFUN([OPAL_CHECK_GCC_BUILTIN_CSWAP_INT128], [
+
+  OPAL_VAR_SCOPE_PUSH([atomic_compare_exchange_n_128_result CFLAGS_save])
+
+  AC_ARG_ENABLE([cross-cmpset128],[AC_HELP_STRING([--enable-cross-cmpset128],
+                [enable the use of the __sync builtin atomic compare-and-swap 128 when cross compiling])])
+
+  atomic_compare_exchange_n_128_result=0
+
+  if test ! "$enable_cross_cmpset128" = "yes" ; then
+      AC_MSG_CHECKING([for processor support of __atomic builtin atomic compare-and-swap on 128-bit values])
+
+      AC_RUN_IFELSE([AC_LANG_PROGRAM([], [__int128 x = 0, y = 0; __atomic_compare_exchange_n (&x, &y, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);])],
+	  [AC_MSG_RESULT([yes])
+	      atomic_compare_exchange_n_128_result=1],
+	  [AC_MSG_RESULT([no])],
+	  [AC_MSG_RESULT([no (cross compiling)])])
+
+      if test $atomic_compare_exchange_n_128_result = 0 ; then
+	  CFLAGS_save=$CFLAGS
+	  CFLAGS="$CFLAGS -mcx16"
+
+	  AC_MSG_CHECKING([for __atomic builtin atomic compare-and-swap on 128-bit values with -mcx16 flag])
+          AC_RUN_IFELSE([AC_LANG_PROGRAM([], [__int128 x = 0, y = 0; __atomic_compare_exchange_n (&x, &y, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);])],
+              [AC_MSG_RESULT([yes])
+		  atomic_compare_exchange_n_128_result=1
+		  CFLAGS_save="$CFLAGS"],
+              [AC_MSG_RESULT([no])],
+	      [AC_MSG_RESULT([no (cross compiling)])])
+
+	  CFLAGS=$CFLAGS_save
+      fi
+
+      if test $atomic_compare_exchange_n_128_result = 1 ; then
+         AC_MSG_CHECKING([if __int128 atomic compare-and-swap is always lock-free])
+          AC_RUN_IFELSE([AC_LANG_PROGRAM([], [if (!__atomic_always_lock_free(16, 0)) { return 1; }])],
+              [AC_MSG_RESULT([yes])],
+              [AC_MSG_RESULT([no])
+                 OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128
+                 atomic_compare_exchange_n_128_result=0],
+             [AC_MSG_RESULT([no (cross compiling)])])
+      fi
+  else
+      AC_MSG_CHECKING([for compiler support of __atomic builtin atomic compare-and-swap on 128-bit values])
+
+      # Check if the compiler supports the __atomic builtin
+      AC_TRY_LINK([], [__int128 x = 0, y = 0; __atomic_compare_exchange_n (&x, &y, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);],
+	  [AC_MSG_RESULT([yes])
+	      atomic_compare_exchange_n_128_result=1],
+	  [AC_MSG_RESULT([no])])
+
+      if test $atomic_compare_exchange_n_128_result = 0 ; then
+	  CFLAGS_save=$CFLAGS
+	  CFLAGS="$CFLAGS -mcx16"
+
+	  AC_MSG_CHECKING([for __atomic builtin atomic compare-and-swap on 128-bit values with -mcx16 flag])
+          AC_TRY_LINK([], [__int128 x = 0, y = 0; __atomic_compare_exchange_n (&x, &y, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);],
+              [AC_MSG_RESULT([yes])
+		  atomic_compare_exchange_n_128_result=1
+		  CFLAGS_save="$CFLAGS"],
+              [AC_MSG_RESULT([no])])
+
+	  CFLAGS=$CFLAGS_save
+      fi
+  fi
+
+  AC_DEFINE_UNQUOTED([OPAL_HAVE_GCC_BUILTIN_CSWAP_INT128], [$atomic_compare_exchange_n_128_result],
+	[Whether the __atomic builtin atomic compare and swap is lock-free on 128-bit values])
+
+  OPAL_VAR_SCOPE_POP
+])
+
+AC_DEFUN([OPAL_CHECK_GCC_ATOMIC_BUILTINS], [
+  AC_MSG_CHECKING([for __atomic builtin atomics])
+
+  AC_TRY_LINK([long tmp, old = 0;], [__atomic_thread_fence(__ATOMIC_SEQ_CST);
+__atomic_compare_exchange_n(&tmp, &old, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+__atomic_add_fetch(&tmp, 1, __ATOMIC_RELAXED);],
+    [AC_MSG_RESULT([yes])
+     $1],
+    [AC_MSG_RESULT([no])
+     $2])
+
+  # Check for 128-bit support
+  OPAL_CHECK_GCC_BUILTIN_CSWAP_INT128
 ])
 
 

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -1024,6 +1024,14 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
             OPAL_ASM_SUPPORT_64BIT=1
             OPAL_GCC_INLINE_ASSIGN='"mov %0=r0\n;;\n" : "=&r"(ret)'
             ;;
+	aarch64*)
+            opal_cv_asm_arch="ARM64"
+            OPAL_ASM_SUPPORT_64BIT=1
+            OPAL_ASM_ARM_VERSION=8
+            AC_DEFINE_UNQUOTED([OPAL_ASM_ARM_VERSION], [$OPAL_ASM_ARM_VERSION],
+                               [What ARM assembly version to use])
+            OPAL_GCC_INLINE_ASSIGN='"mov %0, #0" : "=&r"(ret)'
+            ;;
 
         armv7*)
             opal_cv_asm_arch="ARM"

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -13,6 +13,8 @@ dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -86,7 +88,7 @@ AC_DEFUN([OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128], [
 AC_DEFUN([OPAL_CHECK_SYNC_BUILTINS], [
   AC_MSG_CHECKING([for __sync builtin atomics])
 
-  AC_TRY_COMPILE([], [__sync_synchronize()],
+  AC_TRY_LINK([], [__sync_synchronize()],
     [AC_MSG_RESULT([yes])
      $1],
     [AC_MSG_RESULT([no])

--- a/opal/include/opal/sys/Makefile.am
+++ b/opal/include/opal/sys/Makefile.am
@@ -11,6 +11,8 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +31,7 @@ headers += \
 
 include opal/sys/amd64/Makefile.am
 include opal/sys/arm/Makefile.am
+include opal/sys/arm64/Makefile.am
 include opal/sys/ia32/Makefile.am
 include opal/sys/ia64/Makefile.am
 include opal/sys/mips/Makefile.am

--- a/opal/include/opal/sys/architecture.h
+++ b/opal/include/opal/sys/architecture.h
@@ -39,7 +39,8 @@
 #define OPAL_ARM            0100
 #define OPAL_BUILTIN_SYNC   0200
 #define OPAL_BUILTIN_OSX    0201
-#define OPAL_BUILTIN_NO     0202
+#define OPAL_BUILTIN_GCC    0202
+#define OPAL_BUILTIN_NO     0203
 
 /* Formats */
 #define OPAL_DEFAULT        1000  /* standard for given architecture */

--- a/opal/include/opal/sys/architecture.h
+++ b/opal/include/opal/sys/architecture.h
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +39,7 @@
 #define OPAL_SPARCV9_64     0062
 #define OPAL_MIPS           0070
 #define OPAL_ARM            0100
+#define OPAL_ARM64          0101
 #define OPAL_BUILTIN_SYNC   0200
 #define OPAL_BUILTIN_OSX    0201
 #define OPAL_BUILTIN_GCC    0202

--- a/opal/include/opal/sys/arm64/Makefile.am
+++ b/opal/include/opal/sys/arm64/Makefile.am
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2008 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This makefile.am does not stand on its own - it is included from opal/include/Makefile.am
+
+headers += \
+       opal/sys/arm64/atomic.h \
+       opal/sys/arm64/timer.h
+

--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -30,8 +30,10 @@
 #define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
 #define OPAL_HAVE_ATOMIC_LLSC_32 1
 #define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_SWAP_32 1
 #define OPAL_HAVE_ATOMIC_MATH_32 1
 #define OPAL_HAVE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_ATOMIC_SWAP_64 1
 #define OPAL_HAVE_ATOMIC_LLSC_64 1
 #define OPAL_HAVE_ATOMIC_ADD_32 1
 #define OPAL_HAVE_ATOMIC_SUB_32 1
@@ -90,6 +92,20 @@ static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
                           : "cc", "memory");
 
     return (ret == oldval);
+}
+
+static inline int32_t opal_atomic_swap_32(volatile int32_t *addr, int32_t newval)
+{
+    int32_t ret, tmp;
+
+    __asm__ __volatile__ ("1:  ldaxr   %w0, [%2]       \n"
+                          "    stlxr   %w1, %w3, [%2]  \n"
+                          "    cbnz    %w1, 1b         \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (newval)
+                          : "cc", "memory");
+
+    return ret;
 }
 
 /* these two functions aren't inlined in the non-gcc case because then
@@ -174,6 +190,21 @@ static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
                           : "cc", "memory");
 
     return (ret == oldval);
+}
+
+static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newval)
+{
+    int64_t ret;
+    int tmp;
+
+    __asm__ __volatile__ ("1:  ldaxr   %0, [%2]        \n"
+                          "    stlxr   %w1, %3, [%2]   \n"
+                          "    cbnz    %w1, 1b         \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (newval)
+                          : "cc", "memory");
+
+    return ret;
 }
 
 /* these two functions aren't inlined in the non-gcc case because then

--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -1,0 +1,270 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2010      ARM ltd.  All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#if !defined(OPAL_SYS_ARCH_ATOMIC_H)
+
+#define OPAL_SYS_ARCH_ATOMIC_H 1
+
+#if OPAL_GCC_INLINE_ASSEMBLY
+
+#define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
+#define OPAL_HAVE_ATOMIC_LLSC_32 1
+#define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_MATH_32 1
+#define OPAL_HAVE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_ATOMIC_LLSC_64 1
+#define OPAL_HAVE_ATOMIC_ADD_32 1
+#define OPAL_HAVE_ATOMIC_SUB_32 1
+#define OPAL_HAVE_ATOMIC_ADD_64 1
+#define OPAL_HAVE_ATOMIC_SUB_64 1
+
+#define MB()  __asm__ __volatile__ ("dmb sy" : : : "memory")
+#define RMB() __asm__ __volatile__ ("dmb ld" : : : "memory")
+#define WMB() __asm__ __volatile__ ("dmb st" : : : "memory")
+
+/**********************************************************************
+ *
+ * Memory Barriers
+ *
+ *********************************************************************/
+
+static inline void opal_atomic_mb (void)
+{
+    MB();
+}
+
+static inline void opal_atomic_rmb (void)
+{
+    RMB();
+}
+
+static inline void opal_atomic_wmb (void)
+{
+    WMB();
+}
+
+static inline void opal_atomic_isync (void)
+{
+    __asm__ __volatile__ ("isb");
+}
+
+/**********************************************************************
+ *
+ * Atomic math operations
+ *
+ *********************************************************************/
+
+static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
+                                        int32_t oldval, int32_t newval)
+{
+    int32_t ret, tmp;
+
+    __asm__ __volatile__ ("1:  ldaxr    %w0, [%2]      \n"
+                          "    cmp     %w0, %w3        \n"
+                          "    bne     2f              \n"
+                          "    stxr    %w1, %w4, [%2]  \n"
+                          "    cbnz    %w1, 1b         \n"
+                          "2:                          \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "cc", "memory");
+
+    return (ret == oldval);
+}
+
+/* these two functions aren't inlined in the non-gcc case because then
+   there would be two function calls (since neither cmpset_32 nor
+   atomic_?mb can be inlined).  Instead, we "inline" them by hand in
+   the assembly, meaning there is one function call overhead instead
+   of two */
+static inline int opal_atomic_cmpset_acq_32(volatile int32_t *addr,
+                                            int32_t oldval, int32_t newval)
+{
+    int32_t ret, tmp;
+
+    __asm__ __volatile__ ("1:  ldaxr   %w0, [%2]       \n"
+                          "    cmp     %w0, %w3        \n"
+                          "    bne     2f              \n"
+                          "    stxr    %w1, %w4, [%2]  \n"
+                          "    cbnz    %w1, 1b         \n"
+                          "2:                          \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "cc", "memory");
+
+    return (ret == oldval);
+}
+
+
+static inline int opal_atomic_cmpset_rel_32(volatile int32_t *addr,
+                                            int32_t oldval, int32_t newval)
+{
+    int32_t ret, tmp;
+
+    __asm__ __volatile__ ("1:  ldxr    %w0, [%2]       \n"
+                          "    cmp     %w0, %w3        \n"
+                          "    bne     2f              \n"
+                          "    stlxr   %w1, %w4, [%2]  \n"
+                          "    cbnz    %w1, 1b         \n"
+                          "2:                          \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "cc", "memory");
+
+    return (ret == oldval);
+}
+
+static inline int32_t opal_atomic_ll_32 (volatile int32_t *addr)
+{
+    int32_t ret;
+
+    __asm__ __volatile__ ("ldaxr    %w0, [%1]          \n"
+                          : "=&r" (ret)
+                          : "r" (addr));
+
+    return ret;
+}
+
+static inline int opal_atomic_sc_32 (volatile int32_t *addr, int32_t newval)
+{
+    int ret;
+
+    __asm__ __volatile__ ("stlxr    %w0, %w2, [%1]     \n"
+                          : "=&r" (ret)
+                          : "r" (addr), "r" (newval)
+                          : "cc", "memory");
+
+    return ret == 0;
+}
+
+static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
+                                        int64_t oldval, int64_t newval)
+{
+    int64_t ret;
+    int tmp;
+
+    __asm__ __volatile__ ("1:  ldaxr    %0, [%2]       \n"
+                          "    cmp     %0, %3          \n"
+                          "    bne     2f              \n"
+                          "    stxr    %w1, %4, [%2]   \n"
+                          "    cbnz    %w1, 1b         \n"
+                          "2:                          \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "cc", "memory");
+
+    return (ret == oldval);
+}
+
+/* these two functions aren't inlined in the non-gcc case because then
+   there would be two function calls (since neither cmpset_64 nor
+   atomic_?mb can be inlined).  Instead, we "inline" them by hand in
+   the assembly, meaning there is one function call overhead instead
+   of two */
+static inline int opal_atomic_cmpset_acq_64(volatile int64_t *addr,
+                                            int64_t oldval, int64_t newval)
+{
+    int64_t ret;
+    int tmp;
+
+    __asm__ __volatile__ ("1:  ldaxr   %0, [%2]        \n"
+                          "    cmp     %0, %3          \n"
+                          "    bne     2f              \n"
+                          "    stxr    %w1, %4, [%2]   \n"
+                          "    cbnz    %w1, 1b         \n"
+                          "2:                          \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "cc", "memory");
+
+    return (ret == oldval);
+}
+
+
+static inline int opal_atomic_cmpset_rel_64(volatile int64_t *addr,
+                                            int64_t oldval, int64_t newval)
+{
+    int64_t ret;
+    int tmp;
+
+    __asm__ __volatile__ ("1:  ldxr    %0, [%2]        \n"
+                          "    cmp     %0, %3          \n"
+                          "    bne     2f              \n"
+                          "    stlxr   %w1, %4, [%2]   \n"
+                          "    cbnz    %w1, 1b         \n"
+                          "2:                          \n"
+                          : "=&r" (ret), "=&r" (tmp)
+                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "cc", "memory");
+
+    return (ret == oldval);
+}
+
+static inline int64_t opal_atomic_ll_64 (volatile int64_t *addr)
+{
+    int64_t ret;
+
+    __asm__ __volatile__ ("ldaxr    %0, [%1]        \n"
+                          : "=&r" (ret)
+                          : "r" (addr));
+
+    return ret;
+}
+
+static inline int opal_atomic_sc_64 (volatile int64_t *addr, int64_t newval)
+{
+    int ret;
+
+    __asm__ __volatile__ ("stlxr    %w0, %2, [%1]    \n"
+                          : "=&r" (ret)
+                          : "r" (addr), "r" (newval)
+                          : "cc", "memory");
+
+    return ret == 0;
+}
+
+#define OPAL_ASM_MAKE_ATOMIC(type, bits, name, inst, reg)                   \
+    static inline type opal_atomic_ ## name ## _ ## bits (volatile type *addr, type value) \
+    {                                                                   \
+        type newval;                                                    \
+        int32_t tmp;                                                    \
+                                                                        \
+        __asm__ __volatile__("1:  ldxr   %" reg "0, [%2]        \n"     \
+                             "    " inst "   %" reg "0, %" reg "0, %" reg "3 \n" \
+                             "    stxr   %w1, %" reg "0, [%2]   \n"     \
+                             "    cbnz   %w1, 1b         \n"            \
+                             : "=&r" (newval), "=&r" (tmp)              \
+                             : "r" (addr), "r" (value)                  \
+                             : "cc", "memory");                         \
+                                                                        \
+        return newval;                                                  \
+    }
+
+OPAL_ASM_MAKE_ATOMIC(int32_t, 32, add, "add", "w")
+OPAL_ASM_MAKE_ATOMIC(int32_t, 32, sub, "sub", "w")
+OPAL_ASM_MAKE_ATOMIC(int64_t, 64, add, "add", "")
+OPAL_ASM_MAKE_ATOMIC(int64_t, 64, sub, "sub", "")
+
+#endif /* OPAL_GCC_INLINE_ASSEMBLY */
+
+#endif /* ! OPAL_SYS_ARCH_ATOMIC_H */

--- a/opal/include/opal/sys/arm64/timer.h
+++ b/opal/include/opal/sys/arm64/timer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_SYS_ARCH_TIMER_H
+#define OPAL_SYS_ARCH_TIMER_H 1
+
+#include <sys/times.h>
+
+typedef uint64_t opal_timer_t;
+
+static inline opal_timer_t
+opal_sys_timer_get_cycles(void)
+{
+    opal_timer_t ret;
+    struct tms accurate_clock;
+
+    times(&accurate_clock);
+    ret = accurate_clock.tms_utime + accurate_clock.tms_stime;
+
+    return ret;
+}
+
+#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1
+
+#endif /* ! OPAL_SYS_ARCH_TIMER_H */

--- a/opal/include/opal/sys/arm64/timer.h
+++ b/opal/include/opal/sys/arm64/timer.h
@@ -1,8 +1,11 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2008      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2016      Broadcom Limited. All rights reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,7 +25,8 @@ opal_sys_timer_get_cycles(void)
 {
     opal_timer_t ret;
 
-     __asm__ __volatile__ ("mrs %0,  CNTVCT_EL0" : "=r" (ret));
+    __asm__ __volatile__ ("isb" ::: "memory");
+    __asm__ __volatile__ ("mrs %0,  CNTVCT_EL0" : "=r" (ret));
 
     return ret;
 }
@@ -31,9 +35,9 @@ opal_sys_timer_get_cycles(void)
 static inline opal_timer_t
 opal_sys_timer_freq(void)
 {
-        opal_timer_t freq;
-        __asm__ __volatile__ ("mrs %0,  CNTFRQ_EL0" : "=r" (freq));
-        return (opal_timer_t)(freq);
+    opal_timer_t freq;
+    __asm__ __volatile__ ("mrs %0,  CNTFRQ_EL0" : "=r" (freq));
+    return (opal_timer_t)(freq);
 }
 
 #define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1

--- a/opal/include/opal/sys/arm64/timer.h
+++ b/opal/include/opal/sys/arm64/timer.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2008      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2016      Broadcom Limited. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,12 +21,19 @@ static inline opal_timer_t
 opal_sys_timer_get_cycles(void)
 {
     opal_timer_t ret;
-    struct tms accurate_clock;
 
-    times(&accurate_clock);
-    ret = accurate_clock.tms_utime + accurate_clock.tms_stime;
+     __asm__ __volatile__ ("mrs %0,  CNTVCT_EL0" : "=r" (ret));
 
     return ret;
+}
+
+
+static inline opal_timer_t
+opal_sys_timer_freq(void)
+{
+        opal_timer_t freq;
+        __asm__ __volatile__ ("mrs %0,  CNTFRQ_EL0" : "=r" (freq));
+        return (opal_timer_t)(freq);
 }
 
 #define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1

--- a/opal/include/opal/sys/arm64/update.sh
+++ b/opal/include/opal/sys/arm64/update.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+CFILE=/tmp/opal_atomic_$$.c
+
+trap "/bin/rm -f $CFILE; exit 0" 0 1 2 15
+
+echo Updating atomic.s from atomic.h using gcc
+
+cat > $CFILE<<EOF
+#include <stdlib.h>
+#include <inttypes.h>
+#define static
+#define inline
+#define OPAL_GCC_INLINE_ASSEMBLY 1
+#include "../architecture.h"
+#include "atomic.h"
+EOF
+
+gcc -O1 -I. -S $CFILE -o atomic.s

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -157,6 +157,8 @@ enum {
 #include "opal/sys/amd64/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_ARM
 #include "opal/sys/arm/atomic.h"
+#elif OPAL_ASSEMBLY_ARCH == OPAL_ARM64
+#include "opal/sys/arm64/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_IA32
 #include "opal/sys/ia32/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_IA64

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -131,6 +131,14 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
 #define OPAL_HAVE_INLINE_ATOMIC_SWAP_64 1
 #endif
 
+/**
+ * Enumeration of lock states
+ */
+enum {
+    OPAL_ATOMIC_UNLOCKED = 0,
+    OPAL_ATOMIC_LOCKED = 1
+};
+
 /**********************************************************************
  *
  * Load the appropriate architecture files and set some reasonable
@@ -141,6 +149,8 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
 /* don't include system-level gorp when generating doxygen files */
 #elif OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_SYNC
 #include "opal/sys/sync_builtin/atomic.h"
+#elif OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_GCC
+#include "opal/sys/gcc_builtin/atomic.h"
 #elif OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_OSX
 #include "opal/sys/osx/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_AMD64
@@ -263,15 +273,6 @@ void opal_atomic_wmb(void);
 #endif
 
 #if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_SPINLOCKS || (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
-
-/**
- * Enumeration of lock states
- */
-enum {
-    OPAL_ATOMIC_UNLOCKED = 0,
-    OPAL_ATOMIC_LOCKED = 1
-};
-
 
 /**
  * Initialize a lock to value

--- a/opal/include/opal/sys/cma.h
+++ b/opal/include/opal/sys/cma.h
@@ -52,6 +52,13 @@
 #define __NR_process_vm_readv 376
 #define __NR_process_vm_writev 377
 
+#elif OPAL_ASSEMBLY_ARCH == OPAL_ARM64
+
+/* ARM64 uses the asm-generic syscall numbers */
+
+#define __NR_process_vm_readv 270
+#define __NR_process_vm_writev 271
+
 #elif OPAL_ASSEMBLY_ARCH == OPAL_MIPS
 
 #if _MIPS_SIM == _MIPS_SIM_ABI32

--- a/opal/include/opal/sys/cma.h
+++ b/opal/include/opal/sys/cma.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2011-2012      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016           Los Alamos National Security, LLC. All rights
+ *                              reserved.
  *
  */
 
@@ -45,6 +47,34 @@
 #elif OPAL_ASSEMBLY_ARCH == OPAL_POWERPC64
 #define __NR_process_vm_readv 351
 #define __NR_process_vm_writev 352
+#elif OPAL_ASSEMBLY_ARCH == OPAL_ARM
+
+#define __NR_process_vm_readv 376
+#define __NR_process_vm_writev 377
+
+#elif OPAL_ASSEMBLY_ARCH == OPAL_MIPS
+
+#if _MIPS_SIM == _MIPS_SIM_ABI32
+
+#define __NR_process_vm_readv 4345
+#define __NR_process_vm_writev 4346
+
+#elif _MIPS_SIM == _MIPS_SIM_ABI64
+
+#define __NR_process_vm_readv 5304
+#define __NR_process_vm_writev 5305
+
+#elif _MIPS_SIM == _MIPS_SIM_NABI32
+
+#define __NR_process_vm_readv 6309
+#define __NR_process_vm_writev 6310
+
+#else
+
+#error "Unsupported MIPS architecture for process_vm_readv and process_vm_writev syscalls"
+
+#endif
+
 #else
 #error "Unsupported architecture for process_vm_readv and process_vm_writev syscalls"
 #endif

--- a/opal/include/opal/sys/gcc_builtin/Makefile.am
+++ b/opal/include/opal/sys/gcc_builtin/Makefile.am
@@ -5,12 +5,13 @@
 # Copyright (c) 2004-2005 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,22 +19,7 @@
 # $HEADER$
 #
 
-# This makefile.am does not stand on its own - it is included from opal/Makefile.am
+# This makefile.am does not stand on its own - it is included from opal/include/Makefile.am
 
 headers += \
-	opal/sys/architecture.h \
-	opal/sys/atomic.h \
-	opal/sys/atomic_impl.h \
-	opal/sys/timer.h \
-        opal/sys/cma.h
-
-include opal/sys/amd64/Makefile.am
-include opal/sys/arm/Makefile.am
-include opal/sys/ia32/Makefile.am
-include opal/sys/ia64/Makefile.am
-include opal/sys/mips/Makefile.am
-include opal/sys/osx/Makefile.am
-include opal/sys/powerpc/Makefile.am
-include opal/sys/sparcv9/Makefile.am
-include opal/sys/sync_builtin/Makefile.am
-include opal/sys/gcc_builtin/Makefile.am
+	opal/sys/gcc_builtin/atomic.h

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -1,0 +1,202 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OPAL_SYS_ARCH_ATOMIC_H
+#define OPAL_SYS_ARCH_ATOMIC_H 1
+
+#include <stdbool.h>
+
+/**********************************************************************
+ *
+ * Memory Barriers
+ *
+ *********************************************************************/
+#define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
+
+#define OPAL_HAVE_ATOMIC_MATH_32 1
+#define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_ADD_32 1
+#define OPAL_HAVE_ATOMIC_SUB_32 1
+#define OPAL_HAVE_ATOMIC_SWAP_32 1
+#define OPAL_HAVE_ATOMIC_MATH_64 1
+#define OPAL_HAVE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_ATOMIC_ADD_64 1
+#define OPAL_HAVE_ATOMIC_SUB_64 1
+#define OPAL_HAVE_ATOMIC_SWAP_64 1
+
+
+static inline void opal_atomic_mb(void)
+{
+    __atomic_thread_fence (__ATOMIC_SEQ_CST);
+}
+
+static inline void opal_atomic_rmb(void)
+{
+    __atomic_thread_fence (__ATOMIC_ACQUIRE);
+}
+
+static inline void opal_atomic_wmb(void)
+{
+    __atomic_thread_fence (__ATOMIC_RELEASE);
+}
+
+#define MB() opal_atomic_mb()
+
+/**********************************************************************
+ *
+ * Atomic math operations
+ *
+ *********************************************************************/
+
+static inline int opal_atomic_cmpset_acq_32( volatile int32_t *addr,
+                                             int32_t oldval, int32_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+
+static inline int opal_atomic_cmpset_rel_32( volatile int32_t *addr,
+                                             int32_t oldval, int32_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+}
+
+static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
+                                         int32_t oldval, int32_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+static inline int32_t opal_atomic_swap_32 (volatile int32_t *addr, int32_t newval)
+{
+    int32_t oldval;
+    __atomic_exchange (addr, &newval, &oldval, __ATOMIC_RELAXED);
+    return oldval;
+}
+
+static inline int32_t opal_atomic_add_32(volatile int32_t *addr, int32_t delta)
+{
+    return __atomic_add_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
+{
+    return __atomic_sub_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
+                                             int64_t oldval, int64_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+static inline int opal_atomic_cmpset_rel_64( volatile int64_t *addr,
+                                             int64_t oldval, int64_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+}
+
+
+static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
+                                         int64_t oldval, int64_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newval)
+{
+    int64_t oldval;
+    __atomic_exchange (addr, &newval, &oldval, __ATOMIC_RELAXED);
+    return oldval;
+}
+
+static inline int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
+{
+    return __atomic_add_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
+{
+    return __atomic_sub_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+#if OPAL_HAVE_GCC_BUILTIN_CSWAP_INT128
+
+#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+
+static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
+                                          opal_int128_t oldval, opal_int128_t newval)
+{
+    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+#endif
+
+#if defined(__HLE__)
+
+#include <immintrin.h>
+
+#define OPAL_HAVE_ATOMIC_SPINLOCKS 1
+
+static inline void opal_atomic_init (opal_atomic_lock_t* lock, int32_t value)
+{
+   lock->u.lock = value;
+}
+
+static inline int opal_atomic_trylock(opal_atomic_lock_t *lock)
+{
+    int ret = __atomic_exchange_n (&lock->u.lock, OPAL_ATOMIC_LOCKED,
+                                   __ATOMIC_ACQUIRE | __ATOMIC_HLE_ACQUIRE);
+    if (OPAL_ATOMIC_LOCKED == ret) {
+        /* abort the transaction */
+        _mm_pause ();
+        return 1;
+    }
+
+    return 0;
+}
+
+static inline void opal_atomic_lock (opal_atomic_lock_t *lock)
+{
+    while (OPAL_ATOMIC_LOCKED == __atomic_exchange_n (&lock->u.lock, OPAL_ATOMIC_LOCKED,
+                                                      __ATOMIC_ACQUIRE | __ATOMIC_HLE_ACQUIRE)) {
+        /* abort the transaction */
+        _mm_pause ();
+    }
+}
+
+static inline void opal_atomic_unlock (opal_atomic_lock_t *lock)
+{
+    __atomic_store_n (&lock->u.lock, OPAL_ATOMIC_UNLOCKED,
+                       __ATOMIC_RELEASE | __ATOMIC_HLE_RELEASE);
+}
+
+#endif
+
+#endif /* ! OPAL_SYS_ARCH_ATOMIC_H */

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -156,6 +156,18 @@ static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
+#elif defined(OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128) && OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
+
+#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+
+/* __atomic version is not lock-free so use legacy __sync version */
+
+static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
+                                          opal_int128_t oldval, opal_int128_t newval)
+{
+    return __sync_bool_compare_and_swap (addr, oldval, newval);
+}
+
 #endif
 
 #if defined(__HLE__)

--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -86,6 +86,8 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
     return __sync_sub_and_fetch(addr, delta);
 }
 
+#if OPAL_ASM_SYNC_HAVE_64BIT
+
 #define OPAL_HAVE_ATOMIC_CMPSET_64 1
 static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
                                              int64_t oldval, int64_t newval)
@@ -105,17 +107,6 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }
 
-#if OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
-static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
-                                          opal_int128_t oldval, opal_int128_t newval)
-{
-    return __sync_bool_compare_and_swap(addr, oldval, newval);
-}
-
-#define OPAL_HAVE_ATOMIC_CMPSET_128 1
-
-#endif
-
 #define OPAL_HAVE_ATOMIC_MATH_64 1
 #define OPAL_HAVE_ATOMIC_ADD_64 1
 static inline int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
@@ -128,5 +119,18 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 {
     return __sync_sub_and_fetch(addr, delta);
 }
+
+#endif
+
+#if OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
+static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
+                                          opal_int128_t oldval, opal_int128_t newval)
+{
+    return __sync_bool_compare_and_swap(addr, oldval, newval);
+}
+
+#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+
+#endif
 
 #endif /* ! OPAL_SYS_ARCH_ATOMIC_H */

--- a/opal/include/opal/sys/timer.h
+++ b/opal/include/opal/sys/timer.h
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2016      Broadcom Limited. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -84,6 +85,8 @@ BEGIN_C_DECLS
 #include "opal/sys/amd64/timer.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_ARM
 #include "opal/sys/arm/timer.h"
+#elif OPAL_ASSEMBLY_ARCH == OPAL_ARM64
+#include "opal/sys/arm64/timer.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_IA32
 #include "opal/sys/ia32/timer.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_IA64

--- a/opal/mca/timer/linux/configure.m4
+++ b/opal/mca/timer/linux/configure.m4
@@ -13,6 +13,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Broadcom Limited. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,7 +47,7 @@ AC_DEFUN([MCA_opal_timer_linux_CONFIG],[
                  [timer_linux_happy="no"])])
 
    case "${host}" in
-   i?86-*linux*|x86_64*linux*|ia64-*linux*|powerpc-*linux*|powerpc64-*linux*|sparc*-*linux*)
+   i?86-*linux*|x86_64*linux*|ia64-*linux*|powerpc-*linux*|powerpc64-*linux*|sparc*-*linux*|aarch64-*linux*)
         AS_IF([test "$timer_linux_happy" = "yes"],
               [AS_IF([test -r "/proc/cpuinfo"],
                      [timer_linux_happy="yes"],

--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 Broadcom Limited. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,6 +107,10 @@ static int opal_timer_linux_find_freq(void)
     }
 
     opal_timer_linux_freq = 0;
+
+#if OPAL_ASSEMBLY_ARCH == OPAL_ARM64
+	opal_timer_linux_freq = opal_sys_timer_freq();
+#endif
 
     if (0 == opal_timer_linux_freq) {
         /* first, look for a timebase field.  probably only on PPC,


### PR DESCRIPTION
This PR brings over most of the assembly changes from master. This includes:

 - ARMv8 support
 - __sync builtin support (this is really desirable since the __builtin atomics are deprecated in gcc 5.x)
 - Allow PGI to use the inline assembly. We work around the bugs for ppc in 16.x so no need to have it disabled.
 - Add checks that builtin atomics support 64-bit values. This fixes a bug on some systems when using --enable-builtin-atomics.

This PR *does not* enable builtin atomics by default.

@artpol84 I ran performance tests before and after these commits and see no performance regression. You should probably do the same just to be sure.