### PR TITLE
ompi/errhandler: silence warnings

### DIFF
--- a/ompi/mpi/cxx/comm.cc
+++ b/ompi/mpi/cxx/comm.cc
@@ -13,6 +13,8 @@
 // Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
 // Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 //                         reserved.
+// Copyright (c) 2016      Research Organization for Information Science
+//                         and Technology (RIST). All rights reserved.
 // $COPYRIGHT$
 //
 // Additional copyrights may follow
@@ -51,7 +53,7 @@ MPI::Comm::Comm(const Comm_Null& data) : Comm_Null(data)
 MPI::Errhandler
 MPI::Comm::Create_errhandler(MPI::Comm::_MPI2CPP_ERRHANDLERFN_* function)
 {
-    return ompi_cxx_errhandler_create_comm ((void *) function);
+    return ompi_cxx_errhandler_create_comm ((ompi_errhandler_generic_handler_fn_t *)function);
 }
 
 

--- a/ompi/mpi/cxx/cxx_glue.c
+++ b/ompi/mpi/cxx/cxx_glue.c
@@ -15,7 +15,6 @@
 
 #include "ompi/communicator/communicator.h"
 #include "ompi/attribute/attribute.h"
-#include "ompi/errhandler/errhandler.h"
 #include "ompi/file/file.h"
 #include "opal/class/opal_list.h"
 #include "cxx_glue.h"
@@ -92,22 +91,22 @@ int ompi_cxx_attr_create_keyval_type (MPI_Type_copy_attr_function *copy_fn,
     return ompi_attr_create_keyval (TYPE_ATTR, copy_fn_u, delete_fn_u, keyval, extra_state, 0, NULL);
 }
 
-MPI_Errhandler ompi_cxx_errhandler_create_comm (void *fn)
+MPI_Errhandler ompi_cxx_errhandler_create_comm (ompi_errhandler_generic_handler_fn_t *fn)
 {
     ompi_errhandler_t *errhandler;
     errhandler = ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_COMM,
-                                        (ompi_errhandler_generic_handler_fn_t *) fn,
+                                        fn,
                                         OMPI_ERRHANDLER_LANG_CXX);
     errhandler->eh_cxx_dispatch_fn =
         (ompi_errhandler_cxx_dispatch_fn_t *) ompi_mpi_cxx_comm_errhandler_invoke;
     return errhandler;
 }
 
-MPI_Errhandler ompi_cxx_errhandler_create_win (void *fn)
+MPI_Errhandler ompi_cxx_errhandler_create_win (ompi_errhandler_generic_handler_fn_t *fn)
 {
     ompi_errhandler_t *errhandler;
     errhandler = ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_WIN,
-                                        (ompi_errhandler_generic_handler_fn_t *) fn,
+                                        fn,
                                         OMPI_ERRHANDLER_LANG_CXX);
     errhandler->eh_cxx_dispatch_fn =
         (ompi_errhandler_cxx_dispatch_fn_t *) ompi_mpi_cxx_win_errhandler_invoke;
@@ -115,11 +114,11 @@ MPI_Errhandler ompi_cxx_errhandler_create_win (void *fn)
 }
 
 #if OMPI_PROVIDE_MPI_FILE_INTERFACE
-MPI_Errhandler ompi_cxx_errhandler_create_file (void *fn)
+MPI_Errhandler ompi_cxx_errhandler_create_file (ompi_errhandler_generic_handler_fn_t *fn)
 {
     ompi_errhandler_t *errhandler;
     errhandler = ompi_errhandler_create(OMPI_ERRHANDLER_TYPE_FILE,
-                                        (ompi_errhandler_generic_handler_fn_t *) fn,
+                                        fn,
                                         OMPI_ERRHANDLER_LANG_CXX);
     errhandler->eh_cxx_dispatch_fn =
         (ompi_errhandler_cxx_dispatch_fn_t *) ompi_mpi_cxx_file_errhandler_invoke;
@@ -145,12 +144,6 @@ ompi_cxx_intercept_file_extra_state_t
     intercept->state.extra_state_cxx = extra_state_cxx;
 
     return &intercept->state;
-}
-
-void ompi_cxx_errhandler_set_dispatch_fn (ompi_errhandler_t *errhandler,
-                                          ompi_errhandler_cxx_dispatch_fn_t *dispatch_fn)
-{
-    errhandler->eh_cxx_dispatch_fn = dispatch_fn;
 }
 
 void ompi_cxx_errhandler_set_callbacks (struct ompi_errhandler_t *errhandler, MPI_Comm_errhandler_function *eh_comm_fn,

--- a/ompi/mpi/cxx/cxx_glue.h
+++ b/ompi/mpi/cxx/cxx_glue.h
@@ -44,12 +44,6 @@ typedef enum ompi_cxx_communicator_type_t ompi_cxx_communicator_type_t;
 struct ompi_predefined_errhandler_t;
 extern struct ompi_predefined_errhandler_t ompi_mpi_errors_throw_exceptions;
 
-/**
- * C++ invocation function signature
- */
-typedef void (ompi_errhandler_cxx_dispatch_fn_t)(void *handle, int *err_code,
-                                                 const char *message, ompi_errhandler_generic_handler_fn_t *fn);
-
 ompi_cxx_communicator_type_t ompi_cxx_comm_get_type (MPI_Comm comm);
 
 int ompi_cxx_errhandler_invoke_comm (MPI_Comm comm, int ret, const char *message);
@@ -74,9 +68,9 @@ void ompi_mpi_cxx_file_errhandler_invoke (MPI_File *mpi_comm, int *err,
                                           const char *message, void *file_fn);
 #endif
 
-MPI_Errhandler ompi_cxx_errhandler_create_comm (void *fn);
-MPI_Errhandler ompi_cxx_errhandler_create_win (void *fn);
-MPI_Errhandler ompi_cxx_errhandler_create_file (void *fn);
+MPI_Errhandler ompi_cxx_errhandler_create_comm (ompi_errhandler_generic_handler_fn_t *fn);
+MPI_Errhandler ompi_cxx_errhandler_create_win (ompi_errhandler_generic_handler_fn_t *fn);
+MPI_Errhandler ompi_cxx_errhandler_create_file (ompi_errhandler_generic_handler_fn_t *fn);
 
 ompi_cxx_intercept_file_extra_state_t
 *ompi_cxx_new_intercept_state (void *read_fn_cxx, void *write_fn_cxx, void *extent_fn_cxx,

--- a/ompi/mpi/cxx/file.cc
+++ b/ompi/mpi/cxx/file.cc
@@ -3,6 +3,8 @@
 // Copyright (c) 2006-2016 Los Alamos National Security, LLC.  All rights
 //                         reserved.
 // Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
+// Copyright (c) 2016      Research Organization for Information Science
+//                         and Technology (RIST). All rights reserved.
 // $COPYRIGHT$
 //
 // Additional copyrights may follow
@@ -28,7 +30,7 @@ MPI::File::Close()
 MPI::Errhandler
 MPI::File::Create_errhandler(MPI::File::Errhandler_function* function)
 {
-    return ompi_cxx_errhandler_create_file ((void *) function);
+    return ompi_cxx_errhandler_create_file ((ompi_errhandler_generic_handler_fn_t *) function);
 }
 
 

--- a/ompi/mpi/cxx/win.cc
+++ b/ompi/mpi/cxx/win.cc
@@ -4,6 +4,8 @@
 //                         reserved.
 // Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
 // Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
+// Copyright (c) 2016      Research Organization for Information Science
+//                         and Technology (RIST). All rights reserved.
 // $COPYRIGHT$
 //
 // Additional copyrights may follow
@@ -14,8 +16,8 @@
 // do not include ompi_config.h because it kills the free/malloc defines
 #include "mpi.h"
 #include "ompi/constants.h"
-#include "ompi/mpi/cxx/mpicxx.h"
 #include "cxx_glue.h"
+#include "ompi/mpi/cxx/mpicxx.h"
 
 void
 MPI::Win::Free()
@@ -28,7 +30,7 @@ MPI::Win::Free()
 MPI::Errhandler
 MPI::Win::Create_errhandler(MPI::Win::Errhandler_function* function)
 {
-    return ompi_cxx_errhandler_create_win ((void *) function);
+    return ompi_cxx_errhandler_create_win ((ompi_errhandler_generic_handler_fn_t *) function);
 }
 
 


### PR DESCRIPTION
ISO C forbids mixing object pointer and function pointer