### PR TITLE
osc-rdma: fix datatype lower bound errors in ompi_osc_rdma_master()

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -301,10 +301,10 @@ static inline int ompi_osc_rdma_master (ompi_osc_rdma_sync_t *sync, void *local_
         }
 
         /* ignore failure here */
-        (void) ompi_datatype_get_extent (local_datatype, &lb, &extent);
+        (void) ompi_datatype_get_true_extent (local_datatype, &lb, &extent);
         local_address = (void *)((intptr_t) local_address + lb);
 
-        (void) ompi_datatype_get_extent (remote_datatype, &lb, &extent);
+        (void) ompi_datatype_get_true_extent (remote_datatype, &lb, &extent);
         remote_address += lb;
 
         OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "performing rdma on contiguous region. local: %p, "


### PR DESCRIPTION
Instead of ompi_datatype_get_extent(), use ompi_datatype_get_true_extent()
to get the local and remote lower bound.  For derived types like
subarray, true_lb is the correct offset for RDMA operations.
