### PR TITLE
OSHMEM Specification version: Bump to v1.3.

### DIFF
--- a/oshmem/include/shmem.fh
+++ b/oshmem/include/shmem.fh
@@ -17,7 +17,7 @@
       parameter ( SHMEM_MAJOR_VERSION = 1 )
 
       integer SHMEM_MINOR_VERSION
-      parameter ( SHMEM_MINOR_VERSION = 2 )
+      parameter ( SHMEM_MINOR_VERSION = 3 )
 
       CHARACTER(LEN = 256), PARAMETER :: SHMEM_VENDOR_STRING = "http://www.open-mpi.org/"
 

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -79,7 +79,7 @@ extern "C" {
  * Constants and definitions
  */
 #define SHMEM_MAJOR_VERSION             1
-#define SHMEM_MINOR_VERSION             2
+#define SHMEM_MINOR_VERSION             3 
 #define SHMEM_VENDOR_STRING             "http://www.open-mpi.org/"
 #define SHMEM_MAX_NAME_LEN              256
 


### PR DESCRIPTION
Cherry-picked from: https://github.com/open-mpi/ompi/commit/4f1b63d9a272d95f3de381e7008535312560a7c3