### PR TITLE
opal: fix opal_class_finalize() usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -823,20 +823,6 @@ AC_TRY_LINK([void finalize (void) {}], [], [AC_MSG_RESULT([yes])
 LDFLAGS=$LDFLAGS_save
 OPAL_VAR_SCOPE_POP
 
-opal_destructor_use_fini=0
-opal_no_destructor=0
-if test x$opal_cv___attribute__destructor = x0 ; then
-    if test x$opal_ld_have_fini = x1 ; then
-        opal_destructor_use_fini=1
-    else
-        opal_no_destructor=1;
-    fi
-fi
-
-AC_DEFINE_UNQUOTED(OPAL_NO_LIB_DESTRUCTOR, [$opal_no_destructor],
-    [Whether libraries can be configured with destructor functions])
-AM_CONDITIONAL(OPAL_DESTRUCTOR_USE_FINI, [test x$opal_destructor_use_fini = x1])
-
 ##################################
 # Libraries
 ##################################

--- a/opal/Makefile.am
+++ b/opal/Makefile.am
@@ -11,6 +11,8 @@
 #                         All rights reserved.
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -55,12 +57,6 @@ lib@OPAL_LIB_PREFIX@open_pal_la_LIBADD = \
 	$(MCA_opal_FRAMEWORK_LIBS)
 lib@OPAL_LIB_PREFIX@open_pal_la_DEPENDENCIES = $(lib@OPAL_LIB_PREFIX@open_pal_la_LIBADD)
 lib@OPAL_LIB_PREFIX@open_pal_la_LDFLAGS = -version-info $(libopen_pal_so_version)
-
-if OPAL_DESTRUCTOR_USE_FINI
-
-lib@OPAL_LIB_PREFIX@open_pal_la_LDFLAGS += -Wl,-fini -Wl,opal_cleanup
-
-endif
 
 # included subdirectory Makefile.am's and appended-to variables
 headers =

--- a/opal/runtime/opal_finalize.c
+++ b/opal/runtime/opal_finalize.c
@@ -60,12 +60,6 @@ extern int opal_initialized;
 extern int opal_util_initialized;
 extern bool opal_init_called;
 
-static void __opal_attribute_destructor__ opal_cleanup (void)
-{
-    /* finalize the class/object system */
-    opal_class_finalize();
-}
-
 int
 opal_finalize_util(void)
 {
@@ -109,9 +103,8 @@ opal_finalize_util(void)
 
     opal_datatype_finalize();
 
-#if OPAL_NO_LIB_DESTRUCTOR
-    opal_cleanup ();
-#endif
+    /* finalize the class/object system */
+    opal_class_finalize();
 
     free (opal_process_info.nodename);
     opal_process_info.nodename = NULL;

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -342,16 +342,6 @@ opal_init_util(int* pargc, char*** pargv)
         }
         return OPAL_SUCCESS;
     }
-
-#if OPAL_NO_LIB_DESTRUCTOR
-    if (opal_init_called) {
-        /* can't use show_help here */
-        fprintf (stderr, "opal_init_util: attempted to initialize after finalize without compiler "
-                 "support for either __attribute__(destructor) or linker support for -fini -- process "
-                 "will likely abort\n");
-        return OPAL_ERR_NOT_SUPPORTED;
-    }
-#endif
 
     opal_init_called = true;
 


### PR DESCRIPTION
the class system can be initialized/finalized as many times as we like,
so there is no more need to have opal_class_finalize() invoked in a destructor