### PR TITLE
btl/openib: remove unwanted ompi header inclusion in opal code.

### DIFF
--- a/opal/mca/btl/openib/connect/btl_openib_connect_rdmacm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_rdmacm.c
@@ -63,8 +63,6 @@
 #include "btl_openib_ip.h"
 #include "btl_openib_ini.h"
 
-#include "ompi/runtime/mpiruntime.h"
-
 #if BTL_OPENIB_RDMACM_IB_ADDR
 #include <stdio.h>
 #include <netinet/in.h>


### PR DESCRIPTION
OMPI header cannot be included in OPAL source code, hence removed it.
Fixes: (740b636db) btl/openib: Disqualify rdmacm CPC if
MPI_THREAD_MULTIPLE.

Signed-off-by: Potnuri Bharat Teja <bharat@chelsio.com>