### PR TITLE
Repair event notification support and resync to PMIx master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,6 +371,7 @@ orte/test/mpi/parallel_r8
 orte/test/mpi/parallel_r64
 orte/test/mpi/parallel_w8
 orte/test/mpi/parallel_w64
+orte/test/mpi/pmix
 orte/test/mpi/pubsub
 orte/test/mpi/read_write
 orte/test/mpi/reduce-hang

--- a/opal/mca/pmix/pmix3x/configure.m4
+++ b/opal/mca/pmix/pmix3x/configure.m4
@@ -49,7 +49,7 @@ AC_DEFUN([MCA_opal_pmix_pmix3x_CONFIG],[
         opal_pmix_pmix3x_sm_flag=--disable-dstore
     fi
 
-    opal_pmix_pmix3x_args="$opal_pmix_pmix3x_sm_flag --without-tests-examples --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-hwloc --with-hwloc-header=\\\"$opal_hwloc_base_include\\\""
+    opal_pmix_pmix3x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX3X_ $opal_pmix_pmix3x_sm_flag --without-tests-examples --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-hwloc --with-hwloc-header=\\\"$opal_hwloc_base_include\\\""
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix3x_args="--enable-debug $opal_pmix_pmix3x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],

--- a/opal/mca/pmix/pmix3x/pmix/VERSION
+++ b/opal/mca/pmix/pmix3x/pmix/VERSION
@@ -30,7 +30,7 @@ greek=
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=git6ea0747
+repo_rev=gitd2aa31f
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Oct 11, 2016"
+date="Oct 13, 2016"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/opal/mca/pmix/pmix3x/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix3x/pmix/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+dnl Copyright (c) 2013-2016 Intel, Inc. All rights reserved.
 dnl Copyright (c) 2015-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.

--- a/opal/mca/pmix/pmix3x/pmix/include/pmix.h
+++ b/opal/mca/pmix/pmix3x/pmix/include/pmix.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -48,7 +50,6 @@
 
 /* Structure and constant definitions */
 #include <pmix_common.h>
-#include <pmix_rename.h>
 
 #if defined(c_plusplus) || defined(__cplusplus)
 extern "C" {

--- a/opal/mca/pmix/pmix3x/pmix/include/pmix_common.h
+++ b/opal/mca/pmix/pmix3x/pmix/include/pmix_common.h
@@ -59,6 +59,7 @@
 #include <sys/time.h> /* for struct timeval */
 #include <unistd.h> /* for uid_t and gid_t */
 #include <sys/types.h> /* for uid_t and gid_t */
+#include <pmix_rename.h>
 #include <pmix_version.h>
 
 #if defined(c_plusplus) || defined(__cplusplus)

--- a/opal/mca/pmix/pmix3x/pmix/include/pmix_rename.h.in
+++ b/opal/mca/pmix/pmix3x/pmix/include/pmix_rename.h.in
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,62 +12,63 @@
 #ifndef PMIX_RENAME_H
 #define PMIX_RENAME_H
 
-#define @PMIX_RENAME@PMIx_Init                      PMIx_Init
-#define @PMIX_RENAME@PMIx_Finalize                  PMIx_Finalize
-#define @PMIX_RENAME@PMIx_Abort                     PMIx_Abort
-#define @PMIX_RENAME@PMIx_Put                       PMIx_Put
-#define @PMIX_RENAME@PMIx_Commit                    PMIx_Commit
-#define @PMIX_RENAME@PMIx_Fence                     PMIx_Fence
-#define @PMIX_RENAME@PMIx_Fence_nb                  PMIx_Fence_nb
-#define @PMIX_RENAME@PMIx_Get                       PMIx_Get
-#define @PMIX_RENAME@PMIx_Get_nb                    PMIx_Get_nb
-#define @PMIX_RENAME@PMIx_Publish                   PMIx_Publish
-#define @PMIX_RENAME@PMIx_Publish_nb                PMIx_Publish_nb
-#define @PMIX_RENAME@PMIx_Lookup                    PMIx_Lookup
-#define @PMIX_RENAME@PMIx_Lookup_nb                 PMIx_Lookup_nb
-#define @PMIX_RENAME@PMIx_Unpublish                 PMIx_Unpublish
-#define @PMIX_RENAME@PMIx_Unpublish_nb              PMIx_Unpublish_nb
-#define @PMIX_RENAME@PMIx_Spawn                     PMIx_Spawn
-#define @PMIX_RENAME@PMIx_Spawn_nb                  PMIx_Spawn_nb
-#define @PMIX_RENAME@PMIx_Connect                   PMIx_Connect
-#define @PMIX_RENAME@PMIx_Connect_nb                PMIx_Connect_nb
-#define @PMIX_RENAME@PMIx_Disconnect                PMIx_Disconnect
-#define @PMIX_RENAME@PMIx_Disconnect_nb             PMIx_Disconnect_nb
-#define @PMIX_RENAME@PMIx_Resolve_peers             PMIx_Resolve_peers
-#define @PMIX_RENAME@PMIx_Resolve_nodes             PMIx_Resolve_nodes
-#define @PMIX_RENAME@PMIx_Query_info_nb             PMIx_Query_info_nb
-#define @PMIX_RENAME@PMIx_Log_nb                    PMIx_Log_nb
+#define PMIx_Init                      @PMIX_RENAME@PMIx_Init
+#define PMIx_Initialized               @PMIX_RENAME@PMIx_Initialized
+#define PMIx_Finalize                  @PMIX_RENAME@PMIx_Finalize
+#define PMIx_Abort                     @PMIX_RENAME@PMIx_Abort
+#define PMIx_Put                       @PMIX_RENAME@PMIx_Put
+#define PMIx_Commit                    @PMIX_RENAME@PMIx_Commit
+#define PMIx_Fence                     @PMIX_RENAME@PMIx_Fence
+#define PMIx_Fence_nb                  @PMIX_RENAME@PMIx_Fence_nb
+#define PMIx_Get                       @PMIX_RENAME@PMIx_Get
+#define PMIx_Get_nb                    @PMIX_RENAME@PMIx_Get_nb
+#define PMIx_Publish                   @PMIX_RENAME@PMIx_Publish
+#define PMIx_Publish_nb                @PMIX_RENAME@PMIx_Publish_nb
+#define PMIx_Lookup                    @PMIX_RENAME@PMIx_Lookup
+#define PMIx_Lookup_nb                 @PMIX_RENAME@PMIx_Lookup_nb
+#define PMIx_Unpublish                 @PMIX_RENAME@PMIx_Unpublish
+#define PMIx_Unpublish_nb              @PMIX_RENAME@PMIx_Unpublish_nb
+#define PMIx_Spawn                     @PMIX_RENAME@PMIx_Spawn
+#define PMIx_Spawn_nb                  @PMIX_RENAME@PMIx_Spawn_nb
+#define PMIx_Connect                   @PMIX_RENAME@PMIx_Connect
+#define PMIx_Connect_nb                @PMIX_RENAME@PMIx_Connect_nb
+#define PMIx_Disconnect                @PMIX_RENAME@PMIx_Disconnect
+#define PMIx_Disconnect_nb             @PMIX_RENAME@PMIx_Disconnect_nb
+#define PMIx_Resolve_peers             @PMIX_RENAME@PMIx_Resolve_peers
+#define PMIx_Resolve_nodes             @PMIX_RENAME@PMIx_Resolve_nodes
+#define PMIx_Query_info_nb             @PMIX_RENAME@PMIx_Query_info_nb
+#define PMIx_Log_nb                    @PMIX_RENAME@PMIx_Log_nb
 
-#define @PMIX_RENAME@PMIx_server_init               PMIx_server_init
-#define @PMIX_RENAME@PMIx_server_finalize           PMIx_server_finalize
-#define @PMIX_RENAME@PMIx_generate_regex            PMIx_generate_regex
-#define @PMIX_RENAME@PMIx_generate_ppn              PMIx_generate_ppn
-#define @PMIX_RENAME@PMIx_server_register_nspace    PMIx_server_register_nspace
-#define @PMIX_RENAME@PMIx_server_deregister_nspace  PMIx_server_deregister_nspace
-#define @PMIX_RENAME@PMIx_server_register_client    PMIx_server_register_client
-#define @PMIX_RENAME@PMIx_server_deregister_client  PMIx_server_deregister_client
-#define @PMIX_RENAME@PMIx_server_setup_fork         PMIx_server_setup_fork
-#define @PMIX_RENAME@PMIx_server_dmodex_request     PMIx_server_dmodex_request
+#define PMIx_server_init               @PMIX_RENAME@PMIx_server_init
+#define PMIx_server_finalize           @PMIX_RENAME@PMIx_server_finalize
+#define PMIx_generate_regex            @PMIX_RENAME@PMIx_generate_regex
+#define PMIx_generate_ppn              @PMIX_RENAME@PMIx_generate_ppn
+#define PMIx_server_register_nspace    @PMIX_RENAME@PMIx_server_register_nspace
+#define PMIx_server_deregister_nspace  @PMIX_RENAME@PMIx_server_deregister_nspace
+#define PMIx_server_register_client    @PMIX_RENAME@PMIx_server_register_client
+#define PMIx_server_deregister_client  @PMIX_RENAME@PMIx_server_deregister_client
+#define PMIx_server_setup_fork         @PMIX_RENAME@PMIx_server_setup_fork
+#define PMIx_server_dmodex_request     @PMIX_RENAME@PMIx_server_dmodex_request
 
-#define @PMIX_RENAME@PMIx_tool_init                 PMIx_tool_init
-#define @PMIX_RENAME@PMIx_tool_finalize             PMIx_tool_finalize
+#define PMIx_tool_init                 @PMIX_RENAME@PMIx_tool_init
+#define PMIx_tool_finalize             @PMIX_RENAME@PMIx_tool_finalize
 
-#define @PMIX_RENAME@PMIx_Register_event_handler    PMIx_Register_event_handler
-#define @PMIX_RENAME@PMIx_Deregister_event_handler  PMIx_Deregister_event_handler
-#define @PMIX_RENAME@PMIx_Notify_event              PMIx_Notify_event
-#define @PMIX_RENAME@PMIx_Error_string              PMIx_Error_string
-#define @PMIX_RENAME@PMIx_Proc_state_string         PMIx_Proc_state_string
-#define @PMIX_RENAME@PMIx_Persistence_string        PMIx_Persistence_string
-#define @PMIX_RENAME@PMIx_Data_range_string         PMIx_Data_range_string
-#define @PMIX_RENAME@PMIx_Info_directives_string    PMIx_Info_directives_string
-#define @PMIX_RENAME@PMIx_Data_type_string          PMIx_Data_type_string
-#define @PMIX_RENAME@PMIx_Get_version               PMIx_Get_version
-#define @PMIX_RENAME@PMIx_Store_internal            PMIx_Store_internal
+#define PMIx_Register_event_handler    @PMIX_RENAME@PMIx_Register_event_handler
+#define PMIx_Deregister_event_handler  @PMIX_RENAME@PMIx_Deregister_event_handler
+#define PMIx_Notify_event              @PMIX_RENAME@PMIx_Notify_event
+#define PMIx_Error_string              @PMIX_RENAME@PMIx_Error_string
+#define PMIx_Proc_state_string         @PMIX_RENAME@PMIx_Proc_state_string
+#define PMIx_Persistence_string        @PMIX_RENAME@PMIx_Persistence_string
+#define PMIx_Data_range_string         @PMIX_RENAME@PMIx_Data_range_string
+#define PMIx_Info_directives_string    @PMIX_RENAME@PMIx_Info_directives_string
+#define PMIx_Data_type_string          @PMIX_RENAME@PMIx_Data_type_string
+#define PMIx_Get_version               @PMIX_RENAME@PMIx_Get_version
+#define PMIx_Store_internal            @PMIX_RENAME@PMIx_Store_internal
 
-#define @PMIX_RENAME@pmix_value_load                pmix_value_load
-#define @PMIX_RENAME@pmix_value_xfer                pmix_value_xfer
-#define @PMIX_RENAME@pmix_globals                   pmix_globals
-#define @PMIX_RENAME@pmix_output                    pmix_output
-#define @PMIX_RENAME@pmix_output_verbose            pmix_output_verbose
+#define pmix_value_load                @PMIX_RENAME@pmix_value_load
+#define pmix_value_xfer                @PMIX_RENAME@pmix_value_xfer
+#define pmix_globals                   @PMIX_RENAME@pmix_globals
+#define pmix_output                    @PMIX_RENAME@pmix_output
+#define pmix_output_verbose            @PMIX_RENAME@pmix_output_verbose
 
 #endif

--- a/opal/mca/pmix/pmix3x/pmix/src/client/pmix_client.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/client/pmix_client.c
@@ -351,17 +351,6 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     }
 #endif /* PMIX_ENABLE_DSTORE */
 
-    if (!pmix_globals.external_evbase) {
-        /* tell the event library we need thread support */
-        pmix_event_use_threads();
-
-        /* create an event base and progress thread for us */
-        if (NULL == (pmix_globals.evbase = pmix_progress_thread_init(NULL))) {
-            return -1;
-
-        }
-    }
-
     /* setup an object to track server connection */
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     cb.active = true;
@@ -882,7 +871,6 @@ static pmix_status_t send_connect_ack(int sd)
     pmix_usock_hdr_t hdr;
     size_t sdsize=0, csize=0;
     char *cred = NULL;
-    char *bfrop;
     char *sec;
 
     pmix_output_verbose(2, pmix_globals.debug_output,

--- a/opal/mca/pmix/pmix3x/pmix/src/dstore/pmix_dstore.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/dstore/pmix_dstore.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/opal/mca/pmix/pmix3x/pmix/src/dstore/pmix_esh.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/dstore/pmix_esh.c
@@ -617,7 +617,10 @@ int _esh_init(pmix_info_t info[], size_t ninfo)
                      *
                      * PMIX_DSTPATH has higher priority than PMIX_SERVER_TMPDIR
                      */
-                    dstor_tmpdir = (char*)info[n].value.data.ptr;
+                    if (NULL != dstor_tmpdir) {
+                        free(dstor_tmpdir);
+                    }
+                    dstor_tmpdir = strdup((char*)info[n].value.data.string);
                     continue;
                 }
                 if (0 == strcmp(PMIX_SERVER_TMPDIR, info[n].key)) {
@@ -1002,7 +1005,7 @@ int _esh_fetch(const char *nspace, pmix_rank_t rank, const char *key, pmix_value
                 goto done;
             } else {
                 char ckey[PMIX_MAX_KEYLEN+1] = {0};
-                strncpy(ckey, (const char *)addr, PMIX_MAX_KEYLEN+1);
+                strncpy(ckey, (const char *)addr, PMIX_MAX_KEYLEN);
                 size_t size;
                 memcpy(&size, addr + PMIX_MAX_KEYLEN + 1, sizeof(size_t));
                 PMIX_OUTPUT_VERBOSE((10, pmix_globals.debug_output,

--- a/opal/mca/pmix/pmix3x/pmix/src/dstore/pmix_esh.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/dstore/pmix_esh.h
@@ -2,7 +2,6 @@
  * Copyright (c) 2015-2016 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
- *
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event.h
@@ -117,13 +117,19 @@ PMIX_CLASS_DECLARATION(pmix_event_chain_t);
  * affected, plus any additional info provided by the server */
 void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain);
 
-#define PMIX_REPORT_EVENT(e)                        \
+#define PMIX_REPORT_EVENT(e, f)                     \
     do {                                            \
         pmix_event_chain_t *_ch;                    \
         _ch = PMIX_NEW(pmix_event_chain_t);         \
         _ch->status = (e);                          \
+        _ch->ninfo = 1;                             \
+        _ch->final_cbfunc = (f);                    \
+        _ch->final_cbdata = _ch;                    \
+        PMIX_INFO_CREATE(_ch->info, _ch->ninfo);    \
+        PMIX_INFO_LOAD(&_ch->info[0],               \
+                       PMIX_EVENT_RETURN_OBJECT,    \
+                       NULL, PMIX_POINTER);         \
         pmix_invoke_local_event_hdlr(_ch);          \
-        PMIX_RELEASE(_ch);                          \
     } while(0)
 
 

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/pdl/pdlopen/configure.m4
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/pdl/pdlopen/configure.m4
@@ -3,8 +3,8 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2016      Intel, Inc. All rights reserved.
 #
+# Copyright (c) 2016      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/psec/base/psec_base_fns.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/psec/base/psec_base_fns.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/psec/psec.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/psec/psec.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.

--- a/opal/mca/pmix/pmix3x/pmix/src/server/pmix_server_ops.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/server/pmix_server_ops.c
@@ -1188,8 +1188,8 @@ void pmix_server_deregister_events(pmix_peer_t *peer,
     /* unpack the number of codes */
     cnt=1;
     if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &ncodes, &cnt, PMIX_SIZE))) {
-        PMIX_ERROR_LOG(rc);
-        return;
+        /* it is okay if there aren't any - equivalent to a wildcard */
+        ncodes = 0;
     }
     /* unpack the array of codes */
     if (0 < ncodes) {

--- a/opal/mca/pmix/pmix3x/pmix/src/usock/usock.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/usock/usock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science

--- a/opal/mca/pmix/pmix3x/pmix/src/util/keyval/keyval_lex.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/keyval/keyval_lex.c
@@ -52,7 +52,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -69,7 +69,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -187,7 +187,7 @@ extern FILE *pmix_util_keyval_yyin, *pmix_util_keyval_yyout;
 
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE pmix_util_keyval_yylex. 
+     *       existing scanners that call yyless() from OUTSIDE pmix_util_keyval_yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-pmix_util_keyval_yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
@@ -199,7 +199,7 @@ extern FILE *pmix_util_keyval_yyin, *pmix_util_keyval_yyout;
                     if ( pmix_util_keyval_yytext[yyl] == '\n' )\
                         --pmix_util_keyval_yylineno;\
             }while(0)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -256,7 +256,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -566,7 +566,7 @@ static yyconst flex_int16_t yy_chk[269] =
 /* Table of booleans, true if rule could match eol. */
 static yyconst flex_int32_t yy_rule_can_match_eol[23] =
     {   0,
-1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 
+1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0,
     1, 0, 0,     };
 
 extern int pmix_util_keyval_yy_flex_debug;
@@ -611,6 +611,7 @@ char *pmix_util_keyval_yytext;
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -829,7 +830,7 @@ YY_DECL
 	register yy_state_type yy_current_state;
 	register char *yy_cp, *yy_bp;
 	register int yy_act;
-    
+
 #line 61 "keyval_lex.l"
 
 
@@ -946,7 +947,7 @@ find_rule: /* we branch to this label when backing up */
 			int yyl;
 			for ( yyl = 0; yyl < pmix_util_keyval_yyleng; ++yyl )
 				if ( pmix_util_keyval_yytext[yyl] == '\n' )
-					   
+
     pmix_util_keyval_yylineno++;
 ;
 			}
@@ -1330,7 +1331,7 @@ static int yy_get_next_buffer (void)
 {
 	register yy_state_type yy_current_state;
 	register char *yy_cp;
-    
+
 	yy_current_state = (yy_start);
 
 	(yy_state_ptr) = (yy_state_buf);
@@ -1360,7 +1361,7 @@ static int yy_get_next_buffer (void)
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
 	register int yy_is_jam;
-    
+
 	register YY_CHAR yy_c = 1;
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
@@ -1385,7 +1386,7 @@ static int yy_get_next_buffer (void)
 
 {
 	int c;
-    
+
 	*(yy_c_buf_p) = (yy_hold_char);
 
 	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
@@ -1447,7 +1448,7 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	if ( c == '\n' )
-		   
+
     pmix_util_keyval_yylineno++;
 ;
 
@@ -1457,12 +1458,12 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- * 
+ *
  * @note This function does not reset the start condition to @c INITIAL .
  */
     void pmix_util_keyval_yyrestart  (FILE * input_file )
 {
-    
+
 	if ( ! YY_CURRENT_BUFFER ){
         pmix_util_keyval_yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
@@ -1475,11 +1476,11 @@ static int yy_get_next_buffer (void)
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- * 
+ *
  */
     void pmix_util_keyval_yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
-    
+
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		pmix_util_keyval_yypop_buffer_state();
@@ -1519,13 +1520,13 @@ static void pmix_util_keyval_yy_load_buffer_state  (void)
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- * 
+ *
  * @return the allocated buffer state.
  */
     YY_BUFFER_STATE pmix_util_keyval_yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) pmix_util_keyval_yyalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in pmix_util_keyval_yy_create_buffer()" );
@@ -1548,11 +1549,11 @@ static void pmix_util_keyval_yy_load_buffer_state  (void)
 
 /** Destroy the buffer.
  * @param b a buffer created with pmix_util_keyval_yy_create_buffer()
- * 
+ *
  */
     void pmix_util_keyval_yy_delete_buffer (YY_BUFFER_STATE  b )
 {
-    
+
 	if ( ! b )
 		return;
 
@@ -1573,7 +1574,7 @@ static void pmix_util_keyval_yy_load_buffer_state  (void)
 
 {
 	int oerrno = errno;
-    
+
 	pmix_util_keyval_yy_flush_buffer(b );
 
 	b->yy_input_file = file;
@@ -1589,13 +1590,13 @@ static void pmix_util_keyval_yy_load_buffer_state  (void)
     }
 
         b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
-    
+
 	errno = oerrno;
 }
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- * 
+ *
  */
     void pmix_util_keyval_yy_flush_buffer (YY_BUFFER_STATE  b )
 {
@@ -1624,7 +1625,7 @@ static void pmix_util_keyval_yy_load_buffer_state  (void)
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *  
+ *
  */
 void pmix_util_keyval_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
@@ -1654,7 +1655,7 @@ void pmix_util_keyval_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *  
+ *
  */
 void pmix_util_keyval_yypop_buffer_state (void)
 {
@@ -1678,7 +1679,7 @@ void pmix_util_keyval_yypop_buffer_state (void)
 static void pmix_util_keyval_yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
-    
+
 	if (!(yy_buffer_stack)) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
@@ -1691,9 +1692,9 @@ static void pmix_util_keyval_yyensure_buffer_stack (void)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in pmix_util_keyval_yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1721,13 +1722,13 @@ static void pmix_util_keyval_yyensure_buffer_stack (void)
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- * 
- * @return the newly allocated buffer state object. 
+ *
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE pmix_util_keyval_yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -1756,14 +1757,14 @@ YY_BUFFER_STATE pmix_util_keyval_yy_scan_buffer  (char * base, yy_size_t  size )
 /** Setup the input buffer state to scan a string. The next call to pmix_util_keyval_yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- * 
+ *
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
  *       pmix_util_keyval_yy_scan_bytes() instead.
  */
 YY_BUFFER_STATE pmix_util_keyval_yy_scan_string (yyconst char * yystr )
 {
-    
+
 	return pmix_util_keyval_yy_scan_bytes(yystr,strlen(yystr) );
 }
 
@@ -1771,7 +1772,7 @@ YY_BUFFER_STATE pmix_util_keyval_yy_scan_string (yyconst char * yystr )
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
- * 
+ *
  * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE pmix_util_keyval_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
@@ -1780,7 +1781,7 @@ YY_BUFFER_STATE pmix_util_keyval_yy_scan_bytes  (yyconst char * yybytes, yy_size
 	char *buf;
 	yy_size_t n;
 	int i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) pmix_util_keyval_yyalloc(n  );
@@ -1834,16 +1835,16 @@ static void yy_fatal_error (yyconst char* msg )
 /* Accessor  methods (get/set functions) to struct members. */
 
 /** Get the current line number.
- * 
+ *
  */
 int pmix_util_keyval_yyget_lineno  (void)
 {
-        
+
     return pmix_util_keyval_yylineno;
 }
 
 /** Get the input stream.
- * 
+ *
  */
 FILE *pmix_util_keyval_yyget_in  (void)
 {
@@ -1851,7 +1852,7 @@ FILE *pmix_util_keyval_yyget_in  (void)
 }
 
 /** Get the output stream.
- * 
+ *
  */
 FILE *pmix_util_keyval_yyget_out  (void)
 {
@@ -1859,7 +1860,7 @@ FILE *pmix_util_keyval_yyget_out  (void)
 }
 
 /** Get the length of the current token.
- * 
+ *
  */
 yy_size_t pmix_util_keyval_yyget_leng  (void)
 {
@@ -1867,7 +1868,7 @@ yy_size_t pmix_util_keyval_yyget_leng  (void)
 }
 
 /** Get the current token.
- * 
+ *
  */
 
 char *pmix_util_keyval_yyget_text  (void)
@@ -1877,18 +1878,18 @@ char *pmix_util_keyval_yyget_text  (void)
 
 /** Set the current line number.
  * @param line_number
- * 
+ *
  */
 void pmix_util_keyval_yyset_lineno (int  line_number )
 {
-    
+
     pmix_util_keyval_yylineno = line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param in_str A readable stream.
- * 
+ *
  * @see pmix_util_keyval_yy_switch_to_buffer
  */
 void pmix_util_keyval_yyset_in (FILE *  in_str )
@@ -1919,7 +1920,7 @@ static int yy_init_globals (void)
 
     /* We do not touch pmix_util_keyval_yylineno unless the option is enabled. */
     pmix_util_keyval_yylineno =  1;
-    
+
     (yy_buffer_stack) = 0;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
@@ -1950,7 +1951,7 @@ static int yy_init_globals (void)
 /* pmix_util_keyval_yylex_destroy is for both reentrant and non-reentrant scanners. */
 int pmix_util_keyval_yylex_destroy  (void)
 {
-    
+
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
 		pmix_util_keyval_yy_delete_buffer(YY_CURRENT_BUFFER  );

--- a/opal/mca/pmix/pmix3x/pmix/src/util/output.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/output.h
@@ -11,7 +11,9 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,6 +73,7 @@
 #include <stdarg.h>
 #endif
 
+#include "pmix_rename.h"
 #include "src/class/pmix_object.h"
 
 BEGIN_C_DECLS

--- a/opal/mca/pmix/pmix3x/pmix/src/util/show_help_lex.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/show_help_lex.c
@@ -52,7 +52,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -69,7 +69,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -186,7 +186,7 @@ extern FILE *pmix_show_help_yyin, *pmix_show_help_yyout;
 #define EOB_ACT_LAST_MATCH 2
 
     #define YY_LESS_LINENO(n)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -243,7 +243,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -729,7 +729,7 @@ YY_DECL
 	register yy_state_type yy_current_state;
 	register char *yy_cp, *yy_bp;
 	register int yy_act;
-    
+
 #line 60 "util/show_help_lex.l"
 
 
@@ -1128,7 +1128,7 @@ static int yy_get_next_buffer (void)
 {
 	register yy_state_type yy_current_state;
 	register char *yy_cp;
-    
+
 	yy_current_state = (yy_start);
 	yy_current_state += YY_AT_BOL();
 
@@ -1159,7 +1159,7 @@ static int yy_get_next_buffer (void)
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
 	register int yy_is_jam;
-    
+
 	register YY_CHAR yy_c = 1;
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
@@ -1184,7 +1184,7 @@ static int yy_get_next_buffer (void)
 
 {
 	int c;
-    
+
 	*(yy_c_buf_p) = (yy_hold_char);
 
 	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
@@ -1253,12 +1253,12 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- * 
+ *
  * @note This function does not reset the start condition to @c INITIAL .
  */
     void pmix_show_help_yyrestart  (FILE * input_file )
 {
-    
+
 	if ( ! YY_CURRENT_BUFFER ){
         pmix_show_help_yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
@@ -1271,11 +1271,11 @@ static int yy_get_next_buffer (void)
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- * 
+ *
  */
     void pmix_show_help_yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
-    
+
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		pmix_show_help_yypop_buffer_state();
@@ -1315,13 +1315,13 @@ static void pmix_show_help_yy_load_buffer_state  (void)
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- * 
+ *
  * @return the allocated buffer state.
  */
     YY_BUFFER_STATE pmix_show_help_yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) pmix_show_help_yyalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in pmix_show_help_yy_create_buffer()" );
@@ -1344,11 +1344,11 @@ static void pmix_show_help_yy_load_buffer_state  (void)
 
 /** Destroy the buffer.
  * @param b a buffer created with pmix_show_help_yy_create_buffer()
- * 
+ *
  */
     void pmix_show_help_yy_delete_buffer (YY_BUFFER_STATE  b )
 {
-    
+
 	if ( ! b )
 		return;
 
@@ -1369,7 +1369,7 @@ static void pmix_show_help_yy_load_buffer_state  (void)
 
 {
 	int oerrno = errno;
-    
+
 	pmix_show_help_yy_flush_buffer(b );
 
 	b->yy_input_file = file;
@@ -1385,13 +1385,13 @@ static void pmix_show_help_yy_load_buffer_state  (void)
     }
 
         b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
-    
+
 	errno = oerrno;
 }
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- * 
+ *
  */
     void pmix_show_help_yy_flush_buffer (YY_BUFFER_STATE  b )
 {
@@ -1420,7 +1420,7 @@ static void pmix_show_help_yy_load_buffer_state  (void)
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *  
+ *
  */
 void pmix_show_help_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
@@ -1450,7 +1450,7 @@ void pmix_show_help_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *  
+ *
  */
 void pmix_show_help_yypop_buffer_state (void)
 {
@@ -1474,7 +1474,7 @@ void pmix_show_help_yypop_buffer_state (void)
 static void pmix_show_help_yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
-    
+
 	if (!(yy_buffer_stack)) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
@@ -1487,9 +1487,9 @@ static void pmix_show_help_yyensure_buffer_stack (void)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in pmix_show_help_yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1517,13 +1517,13 @@ static void pmix_show_help_yyensure_buffer_stack (void)
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- * 
- * @return the newly allocated buffer state object. 
+ *
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE pmix_show_help_yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -1552,14 +1552,14 @@ YY_BUFFER_STATE pmix_show_help_yy_scan_buffer  (char * base, yy_size_t  size )
 /** Setup the input buffer state to scan a string. The next call to pmix_show_help_yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- * 
+ *
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
  *       pmix_show_help_yy_scan_bytes() instead.
  */
 YY_BUFFER_STATE pmix_show_help_yy_scan_string (yyconst char * yystr )
 {
-    
+
 	return pmix_show_help_yy_scan_bytes(yystr,strlen(yystr) );
 }
 
@@ -1567,7 +1567,7 @@ YY_BUFFER_STATE pmix_show_help_yy_scan_string (yyconst char * yystr )
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
- * 
+ *
  * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE pmix_show_help_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
@@ -1576,7 +1576,7 @@ YY_BUFFER_STATE pmix_show_help_yy_scan_bytes  (yyconst char * yybytes, yy_size_t
 	char *buf;
 	yy_size_t n;
 	int i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) pmix_show_help_yyalloc(n  );
@@ -1630,16 +1630,16 @@ static void yy_fatal_error (yyconst char* msg )
 /* Accessor  methods (get/set functions) to struct members. */
 
 /** Get the current line number.
- * 
+ *
  */
 int pmix_show_help_yyget_lineno  (void)
 {
-        
+
     return pmix_show_help_yylineno;
 }
 
 /** Get the input stream.
- * 
+ *
  */
 FILE *pmix_show_help_yyget_in  (void)
 {
@@ -1647,7 +1647,7 @@ FILE *pmix_show_help_yyget_in  (void)
 }
 
 /** Get the output stream.
- * 
+ *
  */
 FILE *pmix_show_help_yyget_out  (void)
 {
@@ -1655,7 +1655,7 @@ FILE *pmix_show_help_yyget_out  (void)
 }
 
 /** Get the length of the current token.
- * 
+ *
  */
 yy_size_t pmix_show_help_yyget_leng  (void)
 {
@@ -1663,7 +1663,7 @@ yy_size_t pmix_show_help_yyget_leng  (void)
 }
 
 /** Get the current token.
- * 
+ *
  */
 
 char *pmix_show_help_yyget_text  (void)
@@ -1673,18 +1673,18 @@ char *pmix_show_help_yyget_text  (void)
 
 /** Set the current line number.
  * @param line_number
- * 
+ *
  */
 void pmix_show_help_yyset_lineno (int  line_number )
 {
-    
+
     pmix_show_help_yylineno = line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param in_str A readable stream.
- * 
+ *
  * @see pmix_show_help_yy_switch_to_buffer
  */
 void pmix_show_help_yyset_in (FILE *  in_str )
@@ -1743,7 +1743,7 @@ static int yy_init_globals (void)
 /* pmix_show_help_yylex_destroy is for both reentrant and non-reentrant scanners. */
 int pmix_show_help_yylex_destroy  (void)
 {
-    
+
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
 		pmix_show_help_yy_delete_buffer(YY_CURRENT_BUFFER  );

--- a/opal/mca/pmix/pmix3x/pmix/test/pmix_client_otheruser.sh
+++ b/opal/mca/pmix/pmix3x/pmix/test/pmix_client_otheruser.sh
@@ -12,7 +12,7 @@ OTHERUSER=dummy
 # - give yourself passwordless sudo capability to that user
 #
 # The test should fail with message similar to
-#   PMIX ERROR: INVALID-CREDENTIAL in file 
+#   PMIX ERROR: INVALID-CREDENTIAL in file
 #       ../src/server/pmix_server_listener.c at line 524
 #
 

--- a/opal/mca/pmix/pmix3x/pmix3x.c
+++ b/opal/mca/pmix/pmix3x/pmix3x.c
@@ -391,6 +391,7 @@ void pmix3x_event_hdlr(size_t evhdlr_registration_id,
     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
                         "%s CONVERTED STATUS %d TO STATUS %d",
                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status, cd->status);
+
     /* convert the nspace/rank to an opal_process_name_t */
     if (NULL == source) {
         cd->pname.jobid = OPAL_NAME_INVALID->jobid;
@@ -427,9 +428,10 @@ void pmix3x_event_hdlr(size_t evhdlr_registration_id,
     event_active(&cd->ev, EV_WRITE, 1);
 
     /* we don't need any of the data they provided,
-     * so let them go */
+     * so let them go - also tell them that we will handle
+     * everything from this point forward */
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
@@ -1045,7 +1047,7 @@ static void _reg_hdlr(int sd, short args, void *cbdata)
         def->handler = cd->evhandler;
         def->index = mca_pmix_pmix3x_component.evindex;
         if (prepend) {
-            opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+             opal_output_verbose(2, opal_pmix_base_framework.framework_output,
                                 "%s PREPENDING TO DEFAULT EVENTS",
                                 OPAL_NAME_PRINT(OPAL_PROC_MY_NAME));
             opal_list_prepend(&mca_pmix_pmix3x_component.default_events, &def->super);

--- a/orte/test/mpi/pmix.c
+++ b/orte/test/mpi/pmix.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,8 +18,10 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <mpi.h>
+#include <time.h>
 #include <sys/time.h>
 
+#include "opal/class/opal_list.h"
 #include "opal/mca/pmix/pmix.h"
 #include "ompi/proc/proc.h"
 
@@ -27,55 +30,72 @@
         if (flag) {                         \
             fprintf(stderr, format, args);  \
         }                                   \
-        if (opal_pmix.initialized) {        \
-            opal_pmix.finalize();           \
-        }                                   \
         MPI_Finalize();                     \
         return rc;                          \
     } while(0);
 
-inline double get_timestamp(void)
+static int my_rank;
+static volatile bool waiting = true;
+
+static double get_timestamp(void)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return ((tv.tv_sec) + (tv.tv_usec) * 1.0e-6);
 }
 
+static void evhandler(int status,
+                      const opal_process_name_t *source,
+                      opal_list_t *info, opal_list_t *results,
+                      opal_pmix_notification_complete_fn_t cbfunc,
+                      void *cbdata)
+{
+    fprintf(stderr, "%d: received notification status %d\n", my_rank, status);
+    if (NULL != cbfunc) {
+        cbfunc(OPAL_ERR_HANDLERS_COMPLETE, NULL, NULL, NULL, cbdata);
+    }
+    waiting = false;
+}
+
 int main(int argc, char* argv[])
 {
-    int rc, my_rank;
+    int rc;
     int recv_data;
     size_t i, numprocs;
     ompi_proc_t **procs, *thisproc;
     double t0, t1, t2, t3, t4, t5, t6;
     int *ptr;
+    struct timespec tp;
+    opal_list_t info;
+    opal_value_t *kv;
 
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-    if (NULL != opal_pmix.init) {
-        rc = opal_pmix.init();
-        if (OPAL_SUCCESS != rc) {
-            DO_FINALIZE(rc, 1, "[%d] pmix_init failed.\n", my_rank);
-        }
-    }
+
+    /* register an event */
+    OBJ_CONSTRUCT(&info, opal_list_t);
+    kv = OBJ_NEW(opal_value_t);
+    kv->key = strdup(OPAL_PMIX_EVENT_ORDER_PREPEND);
+    opal_list_append(&info, &kv->super);
+    opal_pmix.register_evhandler(NULL, &info, evhandler, NULL, NULL);
 
     int data = my_rank;
     t0 = get_timestamp();
-    OPAL_MODEX_SEND_VALUE(rc, PMIX_SYNC_REQD, PMIX_GLOBAL,
-                           "MY_RANK", &data, OPAL_INT);
+    OPAL_MODEX_SEND_VALUE(rc, OPAL_PMIX_GLOBAL, "MY_RANK", &data, OPAL_INT);
     t1 = get_timestamp();
     if (OPAL_SUCCESS != rc) {
         DO_FINALIZE(rc, 1, "[%d] OPAL_MODEX_SEND_STRING failed.\n", my_rank);
     }
     t2 = get_timestamp();
-    OPAL_FENCE(NULL, 0, NULL, NULL);
+    opal_pmix.commit();
+    opal_pmix.fence(NULL, 1);
     t3 = get_timestamp();
     procs = ompi_proc_world ( &numprocs );
     ptr = &recv_data;
     t4 = get_timestamp();
     for ( i = 0; i < numprocs; i++ ) {
         thisproc = procs[i];
-        OPAL_MODEX_RECV_VALUE(rc, "MY_RANK", &thisproc->super, (void**)&ptr, OPAL_INT);
+        OPAL_MODEX_RECV_VALUE(rc, "MY_RANK", &thisproc->super.proc_name, (void**)&ptr, OPAL_INT);
         /* check return status and received data */
         if (OPAL_SUCCESS != rc || i != recv_data) {
             rc = OPAL_ERROR;
@@ -88,14 +108,23 @@ int main(int argc, char* argv[])
     opal_pmix.fence(NULL, 0);
     t6 = get_timestamp();
 
-    free(procs);
-
     fprintf(stderr, "[%d] Test passed.\n", my_rank);
     fprintf(stderr, "[%d] \"MODEX_SEND\" %f\n", my_rank, t1-t0);
     fprintf(stderr, "[%d] \"FENCE\" %f\n", my_rank, t3-t2);
     fprintf(stderr, "[%d] \"MODEX_RECV\" %f\n", my_rank, t5-t4);
     fprintf(stderr, "[%d] \"BARRIER\" %f\n", my_rank, t6-t5);
     fprintf(stderr, "[%d] \"TOTAL\" %f\n", my_rank, t6-t0);
+
+    fprintf(stderr, "[%d] Pid %d waiting for notification\n", my_rank, (int)getpid());
+
+    /* now wait for notification of someone failing */
+    tp.tv_sec = 0;
+    tp.tv_nsec = 100000;
+    waiting = true;
+    while (waiting) {
+        nanosleep(&tp, NULL);
+    }
+    free(procs);
 
     DO_FINALIZE(0, 0, 0, 0);
 }


### PR DESCRIPTION
Cleanup the long-suffering "epoll: warning" coming out of libevent whenever a process abnormally terminated. Repair event notification support. Support symbol renaming. Updates on dstore support.