### PR TITLE
update the error codes reported by file_delete

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -113,9 +113,14 @@ int mca_io_ompio_file_delete (const char *filename,
     */
     ret = unlink(filename);
 
-    if (0 > ret && ENOENT != errno ) {
-	opal_output (1, "errno = %d %s\n", errno, strerror(errno));
-        return MPI_ERR_ACCESS;
+    if (0 > ret ) {
+        if ( ENOENT == errno ) {
+//            opal_output (1, "errno = %d %s\n", errno, strerror(errno));
+            return MPI_ERR_NO_SUCH_FILE;
+        } else {
+            opal_output (1, "errno = %d %s\n", errno, strerror(errno));
+            return MPI_ERR_ACCESS;
+        }
     }
 
     return OMPI_SUCCESS;


### PR DESCRIPTION
Follow up to the discussion on the mailing list, this commit restores/fixes the error code reported by file_delete in case the file is gone. 

https://github.com/open-mpi/ompi/issues/2232#issuecomment-254370372

I will analyze the behavior of IOR before committing this though, since the IOR benchmark was the reason I changed file_delete in the first place. 

signed-off: Edgar Gabriel