### PR TITLE
Compiler fixes for `win.c`

### DIFF
--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -46,7 +46,7 @@ opal_pointer_array_t ompi_mpi_windows = {{0}};
 ompi_predefined_win_t ompi_mpi_win_null = {{{0}}};
 ompi_predefined_win_t *ompi_mpi_win_null_addr = &ompi_mpi_win_null;
 mca_base_var_enum_t *ompi_win_accumulate_ops = NULL;
-mca_base_var_enum_t *ompi_win_accumulate_order = NULL;
+mca_base_var_enum_flag_t *ompi_win_accumulate_order = NULL;
 
 static mca_base_var_enum_value_t accumulate_ops_values[] = {
     {.value = OMPI_WIN_ACCUMULATE_OPS_SAME_OP_NO_OP, .string = "same_op_no_op",},

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -61,7 +61,7 @@ static mca_base_var_enum_value_flag_t accumulate_order_flags[] = {
     {.flag = OMPI_WIN_ACC_ORDER_WAR, .string = "war", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
     {.flag = OMPI_WIN_ACC_ORDER_RAW, .string = "raw", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
     {.flag = OMPI_WIN_ACC_ORDER_WAW, .string = "waw", .conflicting_flag = OMPI_WIN_ACC_ORDER_NONE},
-    {},
+    {0},
 };
 
 static void ompi_win_construct(ompi_win_t *win);

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -161,7 +161,7 @@ static int alloc_window(struct ompi_communicator_t *comm, ompi_info_t *info, int
     ret = ompi_info_get_value_enum (info, "accumulate_order", &acc_order,
                                     OMPI_WIN_ACC_ORDER_RAR | OMPI_WIN_ACC_ORDER_WAR |
                                     OMPI_WIN_ACC_ORDER_RAW | OMPI_WIN_ACC_ORDER_WAW,
-                                    ompi_win_accumulate_order, &flag);
+                                    &(ompi_win_accumulate_order->super), &flag);
     if (OMPI_SUCCESS != ret) {
         OBJ_RELEASE(win);
         return ret;

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -68,7 +68,7 @@ enum ompi_win_accumulate_order_flags_t {
 };
 
 OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_ops;
-OMPI_DECLSPEC extern mca_base_var_enum_t *ompi_win_accumulate_order;
+OMPI_DECLSPEC extern mca_base_var_enum_flag_t *ompi_win_accumulate_order;
 
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_windows;
 


### PR DESCRIPTION
PGI compiler stumbled on a couple of compiler fixes that did not get PR'ed over to the 2.x branch. One cases the PGI compiler to error out (initializer in `accumulate_ops_values`), the other two are warnings.