### PR TITLE
v2.0.x: coll/libnbc: fix iallgather[v]

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_iallgather.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgather.c
@@ -5,7 +5,7 @@
  *                         Corporation.  All rights reserved.
  * Copyright (c) 2006      The Technical University of Chemnitz. All
  *                         rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -104,7 +104,7 @@ int ompi_coll_libnbc_iallgather(const void* sendbuf, int sendcount, MPI_Datatype
         }
 
         /* send to rank r - not from the sendbuf to optimize MPI_IN_PLACE */
-        res = NBC_Sched_send (sbuf, false, sendcount, sendtype, r, schedule, false);
+        res = NBC_Sched_send (sbuf, false, recvcount, recvtype, r, schedule, false);
         if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
           OBJ_RELEASE(schedule);
           return res;

--- a/ompi/mca/coll/libnbc/nbc_iallgatherv.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgatherv.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
  */
@@ -82,7 +82,8 @@ int ompi_coll_libnbc_iallgatherv(const void* sendbuf, int sendcount, MPI_Datatyp
       return res;
     }
 
-    res = NBC_Sched_send (sbuf, false, sendcount, sendtype, speer, schedule, false);
+    /* send to rank r - not from the sendbuf to optimize MPI_IN_PLACE */
+    res = NBC_Sched_send (sbuf, false, recvcounts[rank], recvtype, speer, schedule, false);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
       OBJ_RELEASE(schedule);
       return res;


### PR DESCRIPTION
In order to optimize for MPI_IN_PLACE, data is sent from the receive buffer.
consequently, it should be sent with the receive type and count.

Thanks Josh Hursey for the report and test case

Refs open-mpi/ompi#2256

(cherry picked from commit open-mpi/ompi@45336d0bead7dfaba8d0c41196925f6086eb3309)