### PR TITLE
coll/libnbc: Fix error path on internal error

### DIFF
--- a/ompi/mca/coll/libnbc/nbc.c
+++ b/ompi/mca/coll/libnbc/nbc.c
@@ -16,6 +16,7 @@
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  */
 #include "nbc_internal.h"
@@ -312,6 +313,8 @@ int NBC_Progress(NBC_Handle *handle) {
   int flag, res, ret=NBC_CONTINUE;
   unsigned long size;
   char *delim;
+  int i;
+  ompi_status_public_t status;
 
   /* the handle is done if there is no schedule attached */
   if (NULL == handle->schedule) {
@@ -325,8 +328,30 @@ int NBC_Progress(NBC_Handle *handle) {
 #endif
     res = ompi_request_test_all(handle->req_count, handle->req_array, &flag, MPI_STATUSES_IGNORE);
     if(res != OMPI_SUCCESS) {
-      NBC_Error ("MPI Error in MPI_Testall() (%i)", res);
-      return res;
+      // Attempt to cancel outstanding requests
+      for(i = 0; i < handle->req_count; ++i ) {
+        // If the request is complete, then try to report the error code
+        if( handle->req_array[i]->req_complete ) {
+          if( OMPI_SUCCESS != handle->req_array[i]->req_status.MPI_ERROR ) {
+            NBC_Error ("MPI Error in MPI_Testall() (req %d = %d)", i, handle->req_array[i]->req_status.MPI_ERROR);
+          }
+        }
+        else {
+          ompi_request_cancel(handle->req_array[i]);
+          // If the PML actually canceled the request, then wait on it
+          if( handle->req_array[i]->req_status._cancelled) {
+            ompi_request_wait(&handle->req_array[i], &status);
+          }
+          // Warn the user that we had to leave a PML message outstanding so
+          // bad things could happen if they continue using nonblocking collectives
+          else {
+            NBC_Error ("MPI Error: Not able to cancel the internal request %d. "
+                       "Be aware that continuing to use nonblocking collectives on this communicator may result in undefined behavior.", i);
+          }
+        }
+      }
+
+      return OMPI_ERROR;
     }
 #ifdef NBC_TIMING
     Test_time += MPI_Wtime();


### PR DESCRIPTION
- If an error is detected internal to libnbc (e.g., PML truncation error)
  this patch makes sure that the request is completed and the `MPI_ERROR`
  field is set approprately.
- Make an attempt to cleanup outstanding requests before returning.
  - This is a "best attempt" since not all PMLs support canceling requests.
- Fixes #2245 

(cherry picked from commit 8748e54c11486615fc12eb6afbe7150dc74324e3)
