### PR TITLE
pml/ob1: correctly reset receive request type before init

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -14,7 +14,9 @@
  *                         reserved.
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,6 +53,7 @@ int mca_pml_ob1_irecv_init(void *addr,
     if (NULL == recvreq)
         return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
+    recvreq->req_recv.req_base.req_type = MCA_PML_REQUEST_RECV;
     MCA_PML_OB1_RECV_REQUEST_INIT(recvreq,
                                    addr,
                                    count, datatype, src, tag, comm, true);
@@ -82,6 +85,7 @@ int mca_pml_ob1_irecv(void *addr,
     if (NULL == recvreq)
         return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
+    recvreq->req_recv.req_base.req_type = MCA_PML_REQUEST_RECV;
     MCA_PML_OB1_RECV_REQUEST_INIT(recvreq,
                                    addr,
                                    count, datatype, src, tag, comm, false);
@@ -118,6 +122,7 @@ int mca_pml_ob1_recv(void *addr,
             return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
     }
 
+    recvreq->req_recv.req_base.req_type = MCA_PML_REQUEST_RECV;
     MCA_PML_OB1_RECV_REQUEST_INIT(recvreq, addr, count, datatype,
                                   src, tag, comm, false);
 

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -1048,10 +1048,6 @@ int mca_pml_ob1_recv_request_schedule_once( mca_pml_ob1_recv_request_t* recvreq,
 static inline void append_recv_req_to_queue(opal_list_t *queue,
         mca_pml_ob1_recv_request_t *req)
 {
-    if(OPAL_UNLIKELY(req->req_recv.req_base.req_type == MCA_PML_REQUEST_IPROBE ||
-                     req->req_recv.req_base.req_type == MCA_PML_REQUEST_IMPROBE))
-        return;
-
     opal_list_append(queue, (opal_list_item_t*)req);
 
 #if OMPI_WANT_PERUSE
@@ -1202,7 +1198,7 @@ void mca_pml_ob1_recv_req_start(mca_pml_ob1_recv_request_t *req)
         req->req_recv.req_base.req_proc = proc->ompi_proc;
         frag = recv_req_match_specific_proc(req, proc);
         queue = &proc->specific_receives;
-        /* wild cardrecv will be prepared on match */
+        /* wildcard recv will be prepared on match */
         prepare_recv_req_converter(req);
     }
 
@@ -1211,7 +1207,9 @@ void mca_pml_ob1_recv_req_start(mca_pml_ob1_recv_request_t *req)
                                 &(req->req_recv.req_base), PERUSE_RECV);
         /* We didn't find any matches.  Record this irecv so we can match
            it when the message comes in. */
-        append_recv_req_to_queue(queue, req);
+        if(OPAL_LIKELY(req->req_recv.req_base.req_type != MCA_PML_REQUEST_IPROBE &&
+                       req->req_recv.req_base.req_type != MCA_PML_REQUEST_IMPROBE))
+            append_recv_req_to_queue(queue, req);
         req->req_match_received = false;
         OB1_MATCHING_UNLOCK(&ob1_comm->matching_lock);
     } else {


### PR DESCRIPTION
recvreq->req_recv.req_base.req_type should always be set before invoking
MCA_PML_OB1_RECV_REQUEST_INIT(recvreq, ...) otherwise, the previous type
might be set, and you could end up with MPC_PML_REQUEST_IMPROBE when
MCA_PML_REQUEST_RECV is expected.

Thanks Chris Pattison for the report and test case.

Fixes open-mpi/ompi#2275