### PR TITLE
OSHMEM: fixes crash during initialization

### DIFF
--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -149,35 +149,37 @@ int oshmem_shmem_init(int argc, char **argv, int requested, int *provided)
         if (!ompi_mpi_initialized && !ompi_mpi_finalized) {
             ret = ompi_mpi_init(argc, argv, requested, provided);
         }
+
+        if (OSHMEM_SUCCESS != ret) {
+            return ret;
+        }
+
         PMPI_Comm_dup(MPI_COMM_WORLD, &oshmem_comm_world);
+        ret = _shmem_init(argc, argv, requested, provided);
 
-        if (OSHMEM_SUCCESS == ret) {
-            ret = _shmem_init(argc, argv, requested, provided);
+        if (OSHMEM_SUCCESS != ret) {
+            return ret;
+        }
+        oshmem_shmem_initialized = true;
+
+        if (OSHMEM_SUCCESS != shmem_lock_init()) {
+            SHMEM_API_ERROR( "shmem_lock_init() failed");
+            return OSHMEM_ERROR;
         }
 
-        if (OSHMEM_SUCCESS == ret) {
-            oshmem_shmem_initialized = true;
+        /* this is a collective op, implies barrier */
+        MCA_MEMHEAP_CALL(get_all_mkeys());
 
-            if (OSHMEM_SUCCESS != shmem_lock_init()) {
-                SHMEM_API_ERROR( "shmem_lock_init() failed");
-                return OSHMEM_ERROR;
-            }
-
-            /* this is a collective op, implies barrier */
-            MCA_MEMHEAP_CALL(get_all_mkeys());
-
-            oshmem_shmem_preconnect_all();
+        oshmem_shmem_preconnect_all();
 #if OSHMEM_OPAL_THREAD_ENABLE
-            pthread_t thread_id;
-            int perr;
-            perr = pthread_create(&thread_id, NULL, &shmem_opal_thread, NULL);
-            if (perr != 0)
-            {
-                SHMEM_API_ERROR("cannot creat opal thread for SHMEM");
-                return OSHMEM_ERROR;
-            }
-#endif
+        pthread_t thread_id;
+        int perr;
+        perr = pthread_create(&thread_id, NULL, &shmem_opal_thread, NULL);
+        if (0 != perr) {
+            SHMEM_API_ERROR("cannot creat opal thread for SHMEM");
+            return OSHMEM_ERROR;
         }
+#endif
     }
 #ifdef SIGUSR1
     signal(SIGUSR1,sighandler__SIGUSR1);

--- a/oshmem/runtime/oshmem_shmem_init.c
+++ b/oshmem/runtime/oshmem_shmem_init.c
@@ -176,7 +176,7 @@ int oshmem_shmem_init(int argc, char **argv, int requested, int *provided)
         int perr;
         perr = pthread_create(&thread_id, NULL, &shmem_opal_thread, NULL);
         if (0 != perr) {
-            SHMEM_API_ERROR("cannot creat opal thread for SHMEM");
+            SHMEM_API_ERROR("cannot create opal thread for SHMEM");
             return OSHMEM_ERROR;
         }
 #endif


### PR DESCRIPTION
@jladd-mlnx @yosefe 
Do not call mpi comm_dup() if mpi failed to initialize. Also do not set
signal handlers.
Small code styling fixes.

Signed-off-by: Alex Mikheev <alexm@mellanox.com>