### PR TITLE
v1.10: mpi: support MPI_Dims_create(..., ndims=0, ...)

### DIFF
--- a/ompi/mpi/c/dims_create.c
+++ b/ompi/mpi/c/dims_create.c
@@ -5,12 +5,14 @@
  * Copyright (c) 2004-2005 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
- *                         reserved. 
+ *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,14 +64,14 @@ int MPI_Dims_create(int nnodes, int ndims, int dims[])
     if (MPI_PARAM_CHECK) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
 
-        if (NULL == dims) {
+        if (0 > ndims) {
             return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD,
-                                           MPI_ERR_ARG, FUNC_NAME);
+                                           MPI_ERR_DIMS, FUNC_NAME);
         }
 
-        if (1 > ndims) {
-            return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD, 
-                                           MPI_ERR_DIMS, FUNC_NAME);
+        if ((0 != ndims) && (NULL == dims)) {
+            return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD,
+                                           MPI_ERR_ARG, FUNC_NAME);
         }
 
         if (1 > nnodes) {


### PR DESCRIPTION
this is a bozo case, but it should not fail with MPI_ERR_DIMS

Signed-off-by: Gilles Gouaillardet gilles@rist.or.jp

(back-ported from commit open-mpi/ompi@ad7f3f93b0b45588b172ed7f70f79cac2716512a)
