### PR TITLE
ras/alps: use cpuCnt if using hwthreads as cores

### DIFF
--- a/orte/mca/ras/alps/ras_alps_module.c
+++ b/orte/mca/ras/alps/ras_alps_module.c
@@ -585,7 +585,7 @@ orte_ras_alps_read_appinfo_file(opal_list_t *nodes, char *filename,
             orte_set_attribute(&node->attributes, ORTE_NODE_LAUNCH_ID, ORTE_ATTR_LOCAL, &apNodes[ix].nid, OPAL_INT32);
             node->slots_inuse = 0;
             node->slots_max = 0;
-            node->slots = apNodes[ix].numPEs;
+            node->slots = opal_hwloc_use_hwthreads_as_cpus ? apNodes[ix].cpuCnt : apNodes[ix].numPEs;
             node->state = ORTE_NODE_STATE_UP;
             /* need to order these node ids so the regex generator
              * can properly function


### PR DESCRIPTION
This commit updates the alps ras component to allow the use of
hyperthreads on compute nodes. In this case we need to use the cpuCnt
value from the node structure instead of numPEs.

Signed-off-by: Nathan Hjelm hjelmn@lanl.gov
