### PR TITLE
ompi/comm: make communicator.h safe for C++ bindings

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -48,8 +48,8 @@
 
 #include "ompi/attribute/attribute.h"
 #include "ompi/communicator/communicator.h"
+#include "ompi/communicator/comm_request.h"
 #include "ompi/mca/pml/pml.h"
-#include "ompi/request/request.h"
 
 /*
 ** sort-function for MPI_Comm_split

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -34,6 +34,7 @@
 
 #include "ompi/proc/proc.h"
 #include "ompi/communicator/communicator.h"
+#include "ompi/communicator/comm_request.h"
 #include "ompi/op/op.h"
 #include "ompi/constants.h"
 #include "opal/class/opal_pointer_array.h"
@@ -41,7 +42,6 @@
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/rte/rte.h"
 #include "ompi/mca/coll/base/base.h"
-#include "ompi/request/request.h"
 #include "ompi/runtime/mpiruntime.h"
 
 struct ompi_comm_cid_context_t;

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -39,6 +39,7 @@
 #include "ompi/mca/topo/base/base.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
+#include "ompi/communicator/comm_request.h"
 #include "ompi/attribute/attribute.h"
 #include "ompi/dpm/dpm.h"
 #include "ompi/memchecker.h"

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -34,7 +34,6 @@
 #include "opal/class/opal_object.h"
 #include "ompi/errhandler/errhandler.h"
 #include "opal/threads/mutex.h"
-#include "ompi/communicator/comm_request.h"
 
 #include "mpi.h"
 #include "ompi/group/group.h"


### PR DESCRIPTION
Fixes #2055

Signed-off-by: Nathan Hjelm hjelmn@me.com
