### PR TITLE
v2.x:  fortran/use-mp-ignore-tkr typo

### DIFF
--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -1,7 +1,7 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
@@ -53,7 +53,7 @@ endif
 # libmpi_usempi_ignore_tkr.la, so we need to link in the OPAL library
 # directly (pulling it in indirectly via libmpi.la does not work on
 # all platforms).
-libOMPI_LIBMPI_NAME_usempi_ignore_tkr_la_LIBADD = \
+lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_LIBADD = \
         $(OMPI_MPIEXT_USEMPI_LIBS) \
         $(OMPI_TOP_BUILDDIR)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_LDFLAGS = \


### PR DESCRIPTION
looks like a typo when back-porting open-mpi/ompi@acf08897a9db0a081870e8d81539b9a2c8ba26ee
this is a one-off commit for the v2.x branch

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>