### PR TITLE
openib btl: guard against null descriptor pointer

### DIFF
--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1864,7 +1864,9 @@ int mca_btl_openib_sendi( struct mca_btl_base_module_t* btl,
 #if BTL_OPENIB_FAILOVER_ENABLED
         else {
             /* Return up in case needed for failover */
-            *descriptor = (struct mca_btl_base_descriptor_t *) frag;
+            if (NULL != descriptor) {
+		*descriptor = (struct mca_btl_base_descriptor_t *) frag;
+	    }
         }
 #endif
         OPAL_THREAD_UNLOCK(&ep->endpoint_lock);


### PR DESCRIPTION
In mca_btl_openib_sendi(), the BTL_OPENIB_FAILOVER_ENABLED code was not
guarding against a possible NULL descriptor pointer, which can cause a
seg fault.

Signed-off-by: Steve Wise <swise@opengridcomputing.com>