### PR TITLE
ras/*: Fix !orte_keep_fqdn_hostnames for RAS components

### DIFF
--- a/orte/mca/ras/gridengine/ras_gridengine_module.c
+++ b/orte/mca/ras/gridengine/ras_gridengine_module.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2010 Oracle and/or its affiliates.  All rights reserved
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,6 +29,7 @@
 #include <string.h>
 
 #include "opal/util/output.h"
+#include "opal/util/net.h"
 #include "orte/util/show_help.h"
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/runtime/orte_globals.h"
@@ -62,7 +64,7 @@ static int orte_ras_gridengine_allocate(orte_job_t *jdata, opal_list_t *nodelist
 {
     char *pe_hostfile = getenv("PE_HOSTFILE");
     char *job_id = getenv("JOB_ID");
-    char buf[1024], *tok, *num, *queue, *arch, *ptr;
+    char buf[1024], *tok, *num, *queue, *arch, *ptr, *tmp;
     int rc;
     FILE *fp;
     orte_node_t *node;
@@ -95,6 +97,12 @@ static int orte_ras_gridengine_allocate(orte_job_t *jdata, opal_list_t *nodelist
         num = strtok_r(NULL, " \n", &tok);
         queue = strtok_r(NULL, " \n", &tok);
         arch = strtok_r(NULL, " \n", &tok);
+
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(ptr) ) {
+            if (NULL != (tmp = strchr(ptr, '.'))) {
+                *tmp = '\0';
+            }
+        }
 
         /* see if we already have this node */
         found = false;

--- a/orte/mca/ras/loadleveler/ras_loadleveler_module.c
+++ b/orte/mca/ras/loadleveler/ras_loadleveler_module.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2011 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2010-2016 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +26,7 @@
 
 #include "opal/util/argv.h"
 #include "opal/util/output.h"
+#include "opal/util/net.h"
 
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/runtime/orte_globals.h"
@@ -106,6 +107,7 @@ static int orte_ras_loadleveler_discover(opal_list_t* nodelist)
     char *hostname;
     char *filename;
     char input[LL_FILE_MAX_LINE_LENGTH];
+    char *ptr;
 
     /* Ignore anything that the user already specified -- we're
        getting nodes only from LoadLeveler. */
@@ -125,6 +127,12 @@ static int orte_ras_loadleveler_discover(opal_list_t* nodelist)
     /* Iterate through all the nodes and make an entry for each */
     while (0 != ll_getline(fp, input)) {
         hostname = strdup(input);
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(hostname) ) {
+            if (NULL != (ptr = strchr(hostname, '.'))) {
+                *ptr = '\0';
+            }
+        }
+
         OPAL_OUTPUT_VERBOSE((1, orte_ras_base_framework.framework_output,
                              "%s ras:loadleveler:allocate:discover: got hostname %s",
                              ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), hostname));

--- a/orte/mca/ras/lsf/ras_lsf_module.c
+++ b/orte/mca/ras/lsf/ras_lsf_module.c
@@ -31,6 +31,7 @@
 #include <lsf/lsbatch.h>
 
 #include "opal/util/argv.h"
+#include "opal/util/net.h"
 #include "opal/mca/hwloc/hwloc.h"
 
 #include "orte/mca/rmaps/rmaps_types.h"
@@ -60,31 +61,15 @@ orte_ras_base_module_t orte_ras_lsf_module = {
     finalize
 };
 
-static char *orte_getline(FILE *fp)
-{
-    char *ret, *buff;
-    char input[1024];
-
-    ret = fgets(input, 1024, fp);
-    if (NULL != ret) {
-	   input[strlen(input)-1] = '\0';  /* remove newline */
-	   buff = strdup(input);
-	   return buff;
-    }
-
-    return NULL;
-}
-
 
 static int allocate(orte_job_t *jdata, opal_list_t *nodes)
 {
     char **nodelist;
     orte_node_t *node;
     int i, num_nodes;
-    char *affinity_file, *hstname;
-    bool found;
+    char *affinity_file;
     struct stat buf;
-    orte_app_context_t *app;
+    char *ptr;
 
     /* get the list of allocated nodes */
     if ((num_nodes = lsb_getalloc(&nodelist)) < 0) {
@@ -96,6 +81,12 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
 
     /* step through the list */
     for (i = 0; i < num_nodes; i++) {
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(nodelist[i]) ) {
+            if (NULL != (ptr = strchr(nodelist[i], '.'))) {
+                *ptr = '\0';
+            }
+        }
+
         /* is this a repeat of the current node? */
         if (NULL != node && 0 == strcmp(nodelist[i], node->name)) {
             /* it is a repeat - just bump the slot count */

--- a/orte/mca/ras/slurm/ras_slurm_module.c
+++ b/orte/mca/ras/slurm/ras_slurm_module.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -405,6 +406,7 @@ static int orte_ras_slurm_discover(char *regexp, char *tasks_per_node,
     int *slots;
     bool found_range = false;
     bool more_to_come = false;
+    char *ptr;
 
     orig = base = strdup(regexp);
     if (NULL == base) {
@@ -567,6 +569,12 @@ static int orte_ras_slurm_discover(char *regexp, char *tasks_per_node,
 
     for (i = 0; NULL != names && NULL != names[i]; ++i) {
         orte_node_t *node;
+
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(names[i]) ) {
+            if (NULL != (ptr = strchr(names[i], '.'))) {
+                *ptr = '\0';
+            }
+        }
 
         OPAL_OUTPUT_VERBOSE((1, orte_ras_base_framework.framework_output,
                              "%s ras:slurm:allocate:discover: adding node %s (%d slot%s)",

--- a/orte/mca/ras/tm/ras_tm_module.c
+++ b/orte/mca/ras/tm/ras_tm_module.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +28,7 @@
 
 #include "orte/util/show_help.h"
 #include "opal/util/os_path.h"
+#include "opal/util/net.h"
 
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/runtime/orte_globals.h"
@@ -127,6 +129,7 @@ static int discover(opal_list_t* nodelist, char *pbs_jobid)
     FILE *fp;
     char *hostname, *cppn;
     int ppn;
+    char *ptr;
 
     /* Ignore anything that the user already specified -- we're
        getting nodes only from TM. */
@@ -168,6 +171,11 @@ static int discover(opal_list_t* nodelist, char *pbs_jobid)
 
     nodeid=0;
     while (NULL != (hostname = tm_getline(fp))) {
+        if( !orte_keep_fqdn_hostnames && !opal_net_isaddr(hostname) ) {
+            if (NULL != (ptr = strchr(hostname, '.'))) {
+                *ptr = '\0';
+            }
+        }
 
         OPAL_OUTPUT_VERBOSE((1, orte_ras_base_framework.framework_output,
                              "%s ras:tm:allocate:discover: got hostname %s",


### PR DESCRIPTION
 * By default, make sure that we are using the short hostnames and not the fully qualified hostnames when running under LSF and other resource managers with RAS components.
 * The previous commit missed updating the RAS components to strip of the hostnames that they discover from the environment.
 * Related to commit open-mpi/ompi@d26dd2c20e19be864bd5a2e20770d1773fd75406
