### PR TITLE
coll/libnbc: Work around for non-uniform data types in ibcast

### DIFF
--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -66,6 +67,8 @@ BEGIN_C_DECLS
 
 /* number of implemented collective functions */
 #define NBC_NUM_COLL 17
+
+extern bool libnbc_ibcast_skip_dt_decision;
 
 struct ompi_coll_libnbc_component_t {
     mca_coll_base_component_2_0_0_t super;

--- a/ompi/mca/coll/libnbc/nbc_ibcast.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast.c
@@ -9,6 +9,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -65,16 +66,26 @@ int ompi_coll_libnbc_ibcast(void *buffer, int count, MPI_Datatype datatype, int 
 
   segsize = 16384;
   /* algorithm selection */
-  if (p <= 4) {
-    alg = NBC_BCAST_LINEAR;
-  } else if (size * count < 65536) {
-    alg = NBC_BCAST_BINOMIAL;
-  } else if (size * count < 524288) {
-    alg = NBC_BCAST_CHAIN;
-    segsize = 8192;
-  } else {
-    alg = NBC_BCAST_CHAIN;
-    segsize = 32768;
+  if( libnbc_ibcast_skip_dt_decision ) {
+    if (p <= 4) {
+      alg = NBC_BCAST_LINEAR;
+    }
+    else {
+      alg = NBC_BCAST_BINOMIAL;
+    }
+  }
+  else {
+    if (p <= 4) {
+      alg = NBC_BCAST_LINEAR;
+    } else if (size * count < 65536) {
+      alg = NBC_BCAST_BINOMIAL;
+    } else if (size * count < 524288) {
+      alg = NBC_BCAST_CHAIN;
+      segsize = 8192;
+    } else {
+      alg = NBC_BCAST_CHAIN;
+      segsize = 32768;
+    }
   }
 
 #ifdef NBC_CACHE_SCHEDULE


### PR DESCRIPTION
 * If (legal) non-uniform data type signatures are used in ibcast
   then the chosen algorithm may fail on the request, and worst case
   it could produce wrong answers.
 * Add an MCA parameter that, by default, protects the user from this
   scenario. If the user really wants to use it then they have to
   'opt-in' by setting the following parameter to false:
   - `-mca coll_libnbc_ibcast_skip_dt_decision f`
 * Once the following Issues are resolved then this parameter can
   be removed.
   - https://github.com/open-mpi/ompi/issues/2256
   - https://github.com/open-mpi/ompi/issues/1763