### PR TITLE
v2.x: mpi/ialltoall*: allow MPI_IN_PLACE as the send buffer for intra-commu…

### DIFF
--- a/ompi/mpi/c/ialltoall.c
+++ b/ompi/mpi/c/ialltoall.c
@@ -70,12 +70,15 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         if (ompi_comm_invalid(comm)) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
                                           FUNC_NAME);
-        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
+        } else if ((MPI_IN_PLACE == sendbuf && OMPI_COMM_IS_INTER(comm)) ||
+                   MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                           FUNC_NAME);
         } else {
-            OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
-            OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+            if (MPI_IN_PLACE != sendbuf) {
+                OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
+                OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+            }
             OMPI_CHECK_DATATYPE_FOR_RECV(err, recvtype, recvcount);
             OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
         }

--- a/ompi/mpi/c/ialltoallv.c
+++ b/ompi/mpi/c/ialltoallv.c
@@ -48,7 +48,6 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
                    MPI_Request *request)
 {
     int i, size, err;
-    size_t sendtype_size, recvtype_size;
 
     MEMCHECKER(
         ptrdiff_t recv_ext;
@@ -98,7 +97,8 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 
         if ((NULL == sendcounts) || (NULL == sdispls) ||
             (NULL == recvcounts) || (NULL == rdispls) ||
-            MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
+            (MPI_IN_PLACE == sendbuf && OMPI_COMM_IS_INTER(comm)) ||
+            MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
         }
 
@@ -112,6 +112,7 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 
         if (MPI_IN_PLACE != sendbuf && !OMPI_COMM_IS_INTER(comm)) {
             int me = ompi_comm_rank(comm);
+            size_t sendtype_size, recvtype_size;
             ompi_datatype_type_size(sendtype, &sendtype_size);
             ompi_datatype_type_size(recvtype, &recvtype_size);
             if ((sendtype_size*sendcounts[me]) != (recvtype_size*recvcounts[me])) {


### PR DESCRIPTION
…nicators

open-mpi/ompi@1ee1e1996fb38ddc07d3962f42c9c20df356de56 incorrectly cherry-picked
open-mpi/ompi@7cae36f5ab6735239a91632d3c4e7f5a84d9d930
fix that by backporting all MPI param checks from master

Refs: open-mpi/ompi#2235

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>