### PR TITLE
mpi/ialltoall*: allow MPI_IN_PLACE as the send buffer for intra-communicators

### DIFF
--- a/ompi/mpi/c/ialltoall.c
+++ b/ompi/mpi/c/ialltoall.c
@@ -70,12 +70,15 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         if (ompi_comm_invalid(comm)) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
                                           FUNC_NAME);
-        } else if (MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
+        } else if ((MPI_IN_PLACE == sendbuf && OMPI_COMM_IS_INTER(comm)) ||
+                   MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
                                           FUNC_NAME);
         } else {
-            OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
-            OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+            if (MPI_IN_PLACE != sendbuf) {
+                OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
+                OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+            }
             OMPI_CHECK_DATATYPE_FOR_RECV(err, recvtype, recvcount);
             OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
         }

--- a/ompi/mpi/c/ialltoallv.c
+++ b/ompi/mpi/c/ialltoallv.c
@@ -48,7 +48,6 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
                    MPI_Request *request)
 {
     int i, size, err;
-    size_t sendtype_size, recvtype_size;
 
     MEMCHECKER(
         ptrdiff_t recv_ext;
@@ -98,7 +97,8 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 
         if ((NULL == sendcounts) || (NULL == sdispls) ||
             (NULL == recvcounts) || (NULL == rdispls) ||
-            MPI_IN_PLACE == sendbuf || MPI_IN_PLACE == recvbuf) {
+            (MPI_IN_PLACE == sendbuf && OMPI_COMM_IS_INTER(comm)) ||
+            MPI_IN_PLACE == recvbuf) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
         }
 
@@ -112,6 +112,7 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 
         if (MPI_IN_PLACE != sendbuf && !OMPI_COMM_IS_INTER(comm)) {
             int me = ompi_comm_rank(comm);
+            size_t sendtype_size, recvtype_size;
             ompi_datatype_type_size(sendtype, &sendtype_size);
             ompi_datatype_type_size(recvtype, &recvtype_size);
             if ((sendtype_size*sendcounts[me]) != (recvtype_size*recvcounts[me])) {


### PR DESCRIPTION

open-mpi/ompi@d0c959c96e315e3078bea079bc9a2bfac6031ab1 incorrectly cherry-picked
open-mpi/ompi@7cae36f5ab6735239a91632d3c4e7f5a84d9d930
fix that by backporting all MPI param checks from master

Refs: open-mpi/ompi#2236

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit fa8b85acef9af02b8d2aa7fd47e05e02cbb0dd35)
Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>