### PR TITLE
oshmem/spml/yoda: fixed the btl operations

### DIFF
--- a/oshmem/mca/spml/yoda/spml_yoda.c
+++ b/oshmem/mca/spml/yoda/spml_yoda.c
@@ -118,7 +118,7 @@ static inline void calc_nfrags_put (mca_bml_base_btl_t* bml_btl,
         *frag_size = bml_btl->btl->btl_max_send_size - SPML_YODA_SEND_CONTEXT_SIZE;
     }
     else {
-        *frag_size = bml_btl->btl->btl_put_limit;
+        *frag_size = bml_btl->btl->btl_max_send_size;
     }
     *nfrags = 1 + (size - 1) / (*frag_size);
 }
@@ -133,7 +133,7 @@ static inline void calc_nfrags_get (mca_bml_base_btl_t* bml_btl,
         *frag_size = bml_btl->btl->btl_max_send_size - SPML_YODA_SEND_CONTEXT_SIZE;
     }
     else {
-        *frag_size = bml_btl->btl->btl_get_limit;
+        *frag_size = bml_btl->btl->btl_max_send_size;
     }
     *nfrags = 1 + (size - 1) / (*frag_size);
 }


### PR DESCRIPTION
Fixed the shmem OOM error which is referenced on #2028

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit 68b5acd9f427480b53e1bc249286cd7aea097404)