### PR TITLE
v2.x: enable mca no build help update

### DIFF
--- a/README
+++ b/README
@@ -827,6 +827,11 @@ INSTALLATION OPTIONS
   libraries for their own purposes. This option is *not* intended for
   typical users of Open MPI.
 
+--enable-mca-no-build=LIST
+  Comma-separated list of <type>-<component> pairs that will not be
+  built. For example, "--enable-mca-no-build=btl-portals,oob-ud" will
+  disable building the portals BTL and the ud OOB component.
+
 NETWORKING SUPPORT / OPTIONS
 
 --with-fca=<directory>

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -56,7 +56,10 @@ AC_DEFUN([OPAL_MCA],[
     AC_ARG_ENABLE([mca-no-build],
         [AC_HELP_STRING([--enable-mca-no-build=LIST],
                         [Comma-separated list of <type>-<component> pairs
-                         that will not be built.  Example: "--enable-mca-no-build=maffinity,btl-portals" will disable building all maffinity components and the "portals" btl components.])])
+                         that will not be built.  Example:
+                         "--enable-mca-no-build=btl-portals,oob-ud" will
+                         disable building the "portals" btl and the "ud"
+                         oob components.])])
     AC_ARG_ENABLE(mca-dso,
         AC_HELP_STRING([--enable-mca-dso=LIST],
                        [Comma-separated list of types and/or


### PR DESCRIPTION
Also update the configure.ac help message for --enable-mca-no-build to
avoid using a framework name that does not exist any more.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

(cherry picked from commit c54dc87f719da65b2446dee16e0578f259541f43)

@hppritcha Please review.