### PR TITLE
Remove the stale protection around the debugger option for orterun - …

### DIFF
--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -1181,16 +1181,7 @@ static int parse_globals(int argc, char* argv[], opal_cmd_line_t *cmd_line)
     /* Do we want a user-level debugger? */
 
     if (orterun_globals.debugger) {
-#if 0
-        /* see https://github.com/open-mpi/ompi/issues/1225
-         * Once things are fixed, the orte_show_help/exit can be removed
-         * and this code re-enabled.
-         */
         run_debugger(orte_basename, cmd_line, argc, argv, orterun_globals.num_procs);
-#else
-        orte_show_help("help-orterun.txt", "no_debugger_launch_support", false);
-        exit(-1);
-#endif
     }
 
      /* if recovery was disabled on the cmd line, do so */


### PR DESCRIPTION
…debugger attach is fully functional

Signed-off-by: Ralph Castain <rhc@open-mpi.org>