### PR TITLE
Since static ports are only used by ORTE if the runtime option is given,

### DIFF
--- a/config/orte_configure_options.m4
+++ b/config/orte_configure_options.m4
@@ -17,6 +17,7 @@ dnl Copyright (c) 2009-2013 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl
+dnl Copyright (c) 2016      Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -52,20 +53,5 @@ AC_DEFINE_UNQUOTED([ORTE_WANT_ORTERUN_PREFIX_BY_DEFAULT],
                    [$orte_want_orterun_prefix_by_default],
                    [Whether we want orterun to effect "--prefix $prefix" by default])
 
-
-AC_MSG_CHECKING([if want orte static ports])
-AC_ARG_ENABLE([orte-static-ports],
-              [AC_HELP_STRING([--enable-orte-static-ports],
-	        [Enable orte static ports for tcp oob. (default: enabled)])])
-if test "$enable_orte_static_ports" = "no"; then
-    AC_MSG_RESULT([no])
-    orte_enable_static_ports=0
-else
-    AC_MSG_RESULT([yes])
-    orte_enable_static_ports=1
-fi
-AC_DEFINE_UNQUOTED([ORTE_ENABLE_STATIC_PORTS],
-                   [$orte_enable_static_ports],
-		   [Whether we want static ports enabled])
 
 ])dnl

--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -493,7 +493,6 @@ int orte_ess_base_orted_setup(char **hosts)
         goto error;
     }
 
-#if ORTE_ENABLE_STATIC_PORTS
     /* if we are using static ports, then we need to setup
      * the daemon info so the RML can function properly
      * without requiring a wireup stage. This must be done
@@ -501,25 +500,22 @@ int orte_ess_base_orted_setup(char **hosts)
      * own port, which we need in order to construct the nidmap
      */
     if (orte_static_ports) {
-        /* define the routing tree so we know the pattern
-         * if we are trying to setup common or static ports
-         */
-        orte_routed.update_routing_plan(NULL);
         /* extract the node info from the environment and
-         * build a nidmap from it
+         * build a nidmap from it - this will update the
+         * routing plan as well
          */
         if (ORTE_SUCCESS != (ret = orte_util_build_daemon_nidmap(hosts))) {
             ORTE_ERROR_LOG(ret);
             error = "construct daemon map from static ports";
             goto error;
         }
+    } else {
+        /* be sure to update the routing tree so the initial "phone home"
+         * to mpirun goes through the tree if static ports were enabled - still
+         * need to do it anyway just to initialize things
+         */
+        orte_routed.update_routing_plan(NULL);
     }
-#endif
-    /* be sure to update the routing tree so the initial "phone home"
-     * to mpirun goes through the tree if static ports were enabled - still
-     * need to do it anyway just to initialize things
-     */
-    orte_routed.update_routing_plan(NULL);
 
     /* Now provide a chance for the PLM
      * to perform any module-specific init functions. This

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -195,12 +195,10 @@ static int tcp_component_close(void)
 
     return ORTE_SUCCESS;
 }
-#if ORTE_ENABLE_STATIC_PORTS
 static char *static_port_string;
 #if OPAL_ENABLE_IPV6
 static char *static_port_string6;
 #endif // OPAL_ENABLE_IPV6
-#endif // OPAL_ENABLE_STATIC_PORTS
 
 static char *dyn_port_string;
 #if OPAL_ENABLE_IPV6
@@ -276,7 +274,6 @@ static int tcp_component_register(void)
         return ORTE_ERR_NOT_AVAILABLE;
     }
 
-#if ORTE_ENABLE_STATIC_PORTS
     static_port_string = NULL;
     (void)mca_base_component_var_register(component, "static_ipv4_ports",
                                           "Static ports for daemons and procs (IPv4)",
@@ -322,7 +319,7 @@ static int tcp_component_register(void)
         orte_static_ports = true;
     }
 #endif // OPAL_ENABLE_IPV6
-#endif // OPAL_ENABLE_STATIC_PORTS
+
     dyn_port_string = NULL;
     (void)mca_base_component_var_register(component, "dynamic_ipv4_ports",
                                           "Range of ports to be dynamically used by daemons and procs (IPv4)",

--- a/orte/util/nidmap.c
+++ b/orte/util/nidmap.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -72,7 +72,6 @@
 
 #include "orte/util/nidmap.h"
 
-#if ORTE_ENABLE_STATIC_PORTS
 int orte_util_build_daemon_nidmap(char **nodes)
 {
     int i, num_nodes;
@@ -184,7 +183,6 @@ int orte_util_build_daemon_nidmap(char **nodes)
 
     return rc;
 }
-#endif
 
 int orte_util_encode_nodemap(opal_byte_object_t *boptr, bool update)
 {
@@ -290,6 +288,7 @@ int orte_util_decode_daemon_nodemap(opal_byte_object_t *bo)
             dptr = OBJ_NEW(orte_proc_t);
             dptr->name.jobid = ORTE_PROC_MY_NAME->jobid;
             dptr->name.vpid = vpid;
+            ORTE_FLAG_SET(dptr, ORTE_PROC_FLAG_ALIVE);  // assume the daemon is alive until discovered otherwise
             opal_pointer_array_set_item(daemons->procs, vpid, dptr);
         }
         if (NULL != node->daemon) {

--- a/orte/util/nidmap.h
+++ b/orte/util/nidmap.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,9 +44,7 @@ BEGIN_C_DECLS
 ORTE_DECLSPEC int orte_util_encode_nodemap(opal_byte_object_t *boptr, bool update);
 ORTE_DECLSPEC int orte_util_decode_daemon_nodemap(opal_byte_object_t *bo);
 
-#if ORTE_ENABLE_STATIC_PORTS
 ORTE_DECLSPEC int orte_util_build_daemon_nidmap(char **nodes);
-#endif
 
 END_C_DECLS
 


### PR DESCRIPTION
there is no need for a configure option as well - so remove the
--enable-orte-static-ports configure option. When decoding the daemon
nidmap, mark new daemons as ALIVE by default - we will discover dead
ones as we go.

Refs #2362 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>