### PR TITLE
Protect the tcp_endpoints list from concurrent accesses.

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -170,7 +170,10 @@ struct mca_btl_tcp_module_t {
 #endif
     struct sockaddr_storage tcp_ifaddr; /**< BTL interface address */
     uint32_t           tcp_ifmask;  /**< BTL interface netmask */
+
+    opal_mutex_t       tcp_endpoints_mutex;
     opal_list_t        tcp_endpoints;
+
     mca_btl_base_module_error_cb_fn_t tcp_error_cb;  /**< Upper layer error callback */
 #if MCA_BTL_TCP_STATISTICS
     size_t tcp_bytes_sent;

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -474,6 +474,7 @@ static int mca_btl_tcp_create(int if_kindex, const char* if_name)
             return OPAL_ERR_OUT_OF_RESOURCE;
         memcpy(btl, &mca_btl_tcp_module, sizeof(mca_btl_tcp_module));
         OBJ_CONSTRUCT(&btl->tcp_endpoints, opal_list_t);
+        OBJ_CONSTRUCT(&btl->tcp_endpoints_mutex, opal_mutex_t);
         mca_btl_tcp_component.tcp_btls[mca_btl_tcp_component.tcp_num_btls++] = btl;
 
         /* initialize the btl */


### PR DESCRIPTION
This patch will fix some [hopefully all] of the segfaults when TCP progress thread is on. Thanks Gilles for your help.