### PR TITLE
pmix: fix a typo in a help file

### DIFF
--- a/opal/mca/pmix/base/help-pmix-base.txt
+++ b/opal/mca/pmix/base/help-pmix-base.txt
@@ -16,4 +16,4 @@ except due to an internal OPAL error.
 
 Job state: %s
 
-This information should probably be repopald to the OMPI developers.
+This information should probably be reported to the OMPI developers.


### PR DESCRIPTION
Fixes #2391

cherry-pick from 703b464c

Thanks to @njoly for reporting

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 703b464c03d1fc7cfce502462a7b52a22fe939fe)