### PR TITLE
mpit: Fix MPI_T_pvar_get_index

### DIFF
--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -60,6 +60,7 @@ int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype
 
         break;
     case MCA_BASE_VAR_TYPE_STRING:
+    case MCA_BASE_VAR_TYPE_VERSION_STRING:
         *datatype = MPI_CHAR;
         break;
     case MCA_BASE_VAR_TYPE_BOOL:

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -183,7 +183,7 @@ int mca_base_pvar_register (const char *project, const char *framework, const ch
                             int bind, mca_base_pvar_flag_t flags, mca_base_get_value_fn_t get_value,
                             mca_base_set_value_fn_t set_value, mca_base_notify_fn_t notify, void *ctx)
 {
-    int ret, group_index;
+    int ret, group_index, pvar_index;
     mca_base_pvar_t *pvar;
 
     /* assert on usage errors */
@@ -288,15 +288,18 @@ int mca_base_pvar_register (const char *project, const char *framework, const ch
                 }
             }
 
-            /* add this performance variable to the MCA variable group */
-            ret = mca_base_var_group_add_pvar (group_index, pvar_count);
-            if (0 > ret) {
+            pvar_index = opal_pointer_array_add (&registered_pvars, pvar);
+            if (0 > pvar_index) {
                 break;
             }
+            pvar->pvar_index = pvar_index;
 
-            ret = opal_pointer_array_add (&registered_pvars, pvar);
-            if (0 > ret) {
-                break;
+            /* add this performance variable to the MCA variable group */
+            if (0 <= group_index) {
+                ret = mca_base_var_group_add_pvar (group_index, pvar_index);
+                if (0 > ret) {
+                    break;
+                }
             }
 
             pvar->pvar_index = pvar_count;


### PR DESCRIPTION
@hjelmn Please take a look.

MPI_T_pvar_get_index was returning an incorrect index. The index
was never set correctly while registering the performance variables.
Additionally fix a missing case in the mca_base_var_type_t to MPI
datatype conversion. This type is currently used for control variables
registered by mxm, fca and hcoll components.

This fixes the mpich test - http://git.mpich.org/mpich.git/blob/HEAD:/test/mpi/mpi_t/getindex.c
You might need a few changes to run the test:
```diff
--- getindex.c	2016-11-15 17:20:56.089095214 +0530
+++ getindex_new.c	2016-11-15 17:23:15.891400761 +0530
@@ -31,7 +31,8 @@
         fprintf(stdout, "%d MPI Control Variables\n", num_cvar);
     for (i = 0; i < num_cvar; i++) {
         namelen = sizeof(name);
-        MPI_T_cvar_get_info(i, name, &namelen, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        errno = MPI_T_cvar_get_info(i, name, &namelen, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        if(errno != MPI_SUCCESS) continue;
         if (namelen <= 128) {
             errno = MPI_T_cvar_get_index(name, &cvar_index);
             if (errno != MPI_SUCCESS || cvar_index != i)
@@ -52,8 +53,9 @@
 
     for (i = 0; i < num_pvar; i++) {
         namelen = sizeof(name);
-        MPI_T_pvar_get_info(i, name, &namelen, NULL, &pvar_class, NULL, NULL, NULL,
+        errno = MPI_T_pvar_get_info(i, name, &namelen, NULL, &pvar_class, NULL, NULL, NULL,
                             NULL, NULL, NULL, NULL, NULL);
+        if(errno != MPI_SUCCESS) continue;
         if (namelen <= 128) {
             errno = MPI_T_pvar_get_index(name, pvar_class, &pvar_index);
             if (errno != MPI_SUCCESS || pvar_index != i)
@@ -74,7 +76,8 @@
         fprintf(stdout, "%d MPI_T categories\n", num_cat);
     for (i = 0; i < num_cat; i++) {
         namelen = sizeof(name);
-        MPI_T_category_get_info(i, name, &namelen, NULL, NULL, NULL, NULL, NULL);
+        errno = MPI_T_category_get_info(i, name, &namelen, NULL, NULL, NULL, NULL, NULL);
+        if(errno != MPI_SUCCESS) continue;
         if (namelen <= 128) {
             errno = MPI_T_category_get_index(name, &cat_index);
             if (errno != MPI_SUCCESS || cat_index != i)
```