### PR TITLE
io/ompio: change the default value of mca parameter

### DIFF
--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -72,6 +72,7 @@ OMPI_DECLSPEC extern int mca_io_ompio_coll_timing_info;
  * General values
  */
 #define OMPIO_PREALLOC_MAX_BUF_SIZE   33554432
+#define OMPIO_DEFAULT_CYCLE_BUF_SIZE  536870912
 #define OMPIO_PERM_NULL               -1
 #define OMPIO_IOVEC_INITIAL_SIZE      100
 #define OMPIO_ROOT                    0

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -31,7 +31,7 @@
 #include "ompi/mca/io/io.h"
 #include "io_ompio.h"
 
-int mca_io_ompio_cycle_buffer_size = -1;
+int mca_io_ompio_cycle_buffer_size = OMPIO_DEFAULT_CYCLE_BUF_SIZE;
 int mca_io_ompio_bytes_per_agg = OMPIO_PREALLOC_MAX_BUF_SIZE;
 int mca_io_ompio_num_aggregators = -1;
 int mca_io_ompio_record_offset_info = 0;
@@ -165,7 +165,7 @@ static int register_component(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_io_ompio_coll_timing_info);
 
-    mca_io_ompio_cycle_buffer_size = -1;
+    mca_io_ompio_cycle_buffer_size = OMPIO_DEFAULT_CYCLE_BUF_SIZE;
     (void) mca_base_component_var_register(&mca_io_ompio_component.io_version,
                                            "cycle_buffer_size",
                                            "Data size issued by individual reads/writes per call",


### PR DESCRIPTION
change the default value of the mca_io_ompio_cycle_buffer_size parameter in order to avoid accidental truncation of a file for very large individual operations.
Thanks to @cniethammer for reporting it.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>