### PR TITLE
Performance Degradation in Derived Datatype creation - Open MPI

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -120,6 +120,7 @@ OMPI_DECLSPEC int32_t ompi_datatype_default_convertors_fini( void );
 
 OMPI_DECLSPEC void ompi_datatype_dump (const ompi_datatype_t* pData);
 OMPI_DECLSPEC ompi_datatype_t* ompi_datatype_create( int32_t expectedSize );
+OMPI_DECLSPEC ompi_datatype_t* ompi_datatype_create_temporary( int32_t expectedSize );
 
 static inline int32_t
 ompi_datatype_is_committed( const ompi_datatype_t* type )

--- a/ompi/datatype/ompi_datatype_create_vector.c
+++ b/ompi/datatype/ompi_datatype_create_vector.c
@@ -45,15 +45,16 @@ int32_t ompi_datatype_create_vector( int count, int bLength, int stride,
         return OMPI_SUCCESS;
     }
 
-    pData = ompi_datatype_create( oldType->super.desc.used + 2 );
     if( (bLength == stride) || (1 >= count) ) {  /* the elements are contiguous */
+        pData = ompi_datatype_create( oldType->super.desc.used + 2 );
         ompi_datatype_add( pData, oldType, count * bLength, 0, extent );
     } else {
         if( 1 == bLength ) {
+            pData = ompi_datatype_create( oldType->super.desc.used + 2 );
             ompi_datatype_add( pData, oldType, count, 0, extent * stride );
         } else {
-            ompi_datatype_add( pData, oldType, bLength, 0, extent );
-            pTempData = pData;
+            pTempData = ompi_datatype_create_temporary( oldType->super.desc.used + 2 ); 
+            ompi_datatype_add( pTempData , oldType, bLength, 0, extent );
             pData = ompi_datatype_create( oldType->super.desc.used + 2 + 2 );
             ompi_datatype_add( pData, pTempData, count, 0, extent * stride );
             OBJ_RELEASE( pTempData );
@@ -76,15 +77,15 @@ int32_t ompi_datatype_create_hvector( int count, int bLength, OPAL_PTRDIFF_TYPE 
         return OMPI_SUCCESS;
     }
 
-    pTempData = ompi_datatype_create( oldType->super.desc.used + 2 );
     if( ((extent * bLength) == stride) || (1 >= count) ) {  /* contiguous */
-        pData = pTempData;
+        pData = ompi_datatype_create( oldType->super.desc.used + 2 );
         ompi_datatype_add( pData, oldType, count * bLength, 0, extent );
     } else {
         if( 1 == bLength ) {
-            pData = pTempData;
+            pData = ompi_datatype_create( oldType->super.desc.used + 2 );
             ompi_datatype_add( pData, oldType, count, 0, stride );
         } else {
+            pTempData =  ompi_datatype_create_temporary( oldType->super.desc.used + 2 );
             ompi_datatype_add( pTempData, oldType, bLength, 0, extent );
             pData = ompi_datatype_create( oldType->super.desc.used + 2 + 2 );
             ompi_datatype_add( pData, pTempData, count, 0, stride );


### PR DESCRIPTION
There is a performance degradation in ompi - derived datatype creation under a specific corner case, when compared to MPICH.

It occurs in OpenMPI MPI_Type_vector - create,  whenever the allocated DDTs are not freed simultaneously.

This suspected case of performance degradation can be reproduced by,
```c
#include "mpi.h"
#include <stdio.h>

#define free_loop 200000
#define main_tv_loop 600000

int main(int argc, char *argv[])
{
    int rank, size, i=0, j=0;
    double t_start = 0, t_end = 0, t_tv_start=0,t_tv_end=0,t_tv_total=0,t_commit_start=0,t_commit_end=0,t_commit_total=0,t_free_start=0,t_free_end=0,t_free_total=0;

    MPI_Datatype type[main_tv_loop], type2;
    MPI_Status status;

    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &size);
    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   
    while(i<main_tv_loop) {
        for (j=0;j<free_loop;j++){
           
            t_tv_start = MPI_Wtime();
            MPI_Type_vector( 24, 24,  3000 , MPI_LONG, &type[j] );
            t_tv_total += (MPI_Wtime() - t_tv_start);
           
            MPI_Type_commit(&type[j]);
            i++;
            if(i == main_tv_loop)
                break;
        }
        for (j=0;j<free_loop;j++){
            MPI_Type_free(&type[j]);

            if(i == main_tv_loop)
                break;
         }
    } 
    printf("time taken type_vector : %0.3f s \n",  (t_tv_total));

    MPI_Finalize();
    return 0;
}
```
**Results:**

**MPICH:**
```
[c712f5n12][/u/abdevara/ompi-tv]> mpicc tv.c -o tv
[c712f5n12][/u/abdevara/ompi-tv]> mpirun -np 2 tv
time taken type_vector : 0.457 s
time taken type_vector : 0.460 s
```

**OMPI:**
```
[c712f5n12][/u/abdevara/ompi-tv]> mpicc tv.c -o tv
[c712f5n12][/u/abdevara/ompi-tv]> mpirun -np 2 tv
time taken type_vector : 116.760 s
time taken type_vector : 116.774 s
```
This is specifically due to the insertion of temporary datatype in the list `ompi_datatype_f_to_c_table`, which could be skipped [ompi/datatype/ompi_datatype_create_vector.c L:57 ](   https://github.com/open-mpi/ompi/blob/master/ompi/datatype/ompi_datatype_create_vector.c#L57)

Here is a possible fix for the issue,
https://github.com/AboorvaDevarajan/ompi/commit/f1ae4a814668c3a484fcbd0037bac09ed19646c1

By skipping the addition of temporarily created datatype to `ompi_datatype_f_to_c_table`, we get this result with the same test,

**OMPI:**

```
[c712f5n12][/u/abdevara/ompi-tv]> mpicc tv.c -o tv
[c712f5n12][/u/abdevara/ompi-tv]> mpirun -np 2 tv
time taken type_vector : 1.439 s 
time taken type_vector : 1.445 s 
```

Extended `opal_object` to accept a custom construtor during object creation, using the macro 
```
OBJ_NEW_CONSTRUCTOR(type, constructor) 
```
where, 
```
type - Type of the object.
constructor - Function pointer to the custom constructor.
```

This could also be done using the same macro OBJ_NEW and extend its functionality to accept variable arguments (variadic macro)