### PR TITLE
pmix/cray: set some envars for MPI_INFO_ENV object

### DIFF
--- a/opal/mca/pmix/cray/pmix_cray.h
+++ b/opal/mca/pmix/cray/pmix_cray.h
@@ -10,12 +10,21 @@
 #ifndef MCA_PMIX_CRAY_H
 #define MCA_PMIX_CRAY_H
 
+#include <pmi.h>
+#include <pmi2.h>
+
 #include "opal_config.h"
 
 #include "opal/mca/mca.h"
 #include "opal/mca/pmix/pmix.h"
 #include "opal/mca/pmix/base/pmix_base_fns.h"
 #include "opal/util/proc.h"
+
+#include "alps/alps.h"
+#include "alps/alps_toolAssist.h"
+#include "alps/libalpsutil.h"
+#include "alps/libalpslli.h"
+
 #include "pmix_cray_pmap_parser.h"
 
 BEGIN_C_DECLS


### PR DESCRIPTION
Enhance the cray pmix component to set some OMPI internal
env. variables used to set some key/value pairs
on the MPI_INFO_ENV object.  This allows more of the
ompi-tests ibm unit tests to pass when using aprun/srun
direct launch and Cray PMI.

@hjelmn please take a look when you have time.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>