### PR TITLE
v1.10: coll/libnbc: fix race condition with multi threaded apps

### DIFF
--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -71,6 +73,7 @@ struct ompi_coll_libnbc_component_t {
     opal_list_t active_requests;
     int32_t active_comms;
     opal_atomic_lock_t progress_lock;
+    opal_mutex_t lock;
 };
 typedef struct ompi_coll_libnbc_component_t ompi_coll_libnbc_component_t;
 

--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -72,8 +72,8 @@ struct ompi_coll_libnbc_component_t {
     ompi_free_list_t requests;
     opal_list_t active_requests;
     int32_t active_comms;
-    opal_atomic_lock_t progress_lock;
-    opal_mutex_t lock;
+    opal_atomic_lock_t progress_lock; /* protect from recursive calls */
+    opal_mutex_t lock;                /* protect access to the active_requests list */
 };
 typedef struct ompi_coll_libnbc_component_t ompi_coll_libnbc_component_t;
 

--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -242,8 +242,11 @@ ompi_coll_libnbc_progress(void)
 {
     ompi_coll_libnbc_request_t* request, *next;
 
+    /* return if invoked recursively */
     if (opal_atomic_trylock(&mca_coll_libnbc_component.progress_lock)) return 0;
 
+    /* process active requests, and use mca_coll_libnbc_component.lock to access the
+     * mca_coll_libnbc_component.active_requests list */
     OPAL_THREAD_LOCK(&mca_coll_libnbc_component.lock);
     OPAL_LIST_FOREACH_SAFE(request, next, &mca_coll_libnbc_component.active_requests,
                            ompi_coll_libnbc_request_t) {

--- a/ompi/mca/coll/libnbc/nbc.c
+++ b/ompi/mca/coll/libnbc/nbc.c
@@ -659,7 +659,9 @@ int NBC_Start(NBC_Handle *handle, NBC_Schedule *schedule) {
   res = NBC_Start_round(handle);
   if((NBC_OK != res)) { printf("Error in NBC_Start_round() (%i)\n", res); return res; }
 
+  OPAL_THREAD_LOCK(&mca_coll_libnbc_component.lock);
   opal_list_append(&mca_coll_libnbc_component.active_requests, &(handle->super.super.super));
+  OPAL_THREAD_UNLOCK(&mca_coll_libnbc_component.lock);
 
   return NBC_OK;
 }


### PR DESCRIPTION
protect the mca_coll_libnbc_component.active_requests list with
the new mca_coll_libnbc_component.lock mutex.

Thanks Jie Hu for the report

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@2c94a3a6f398e187dff67386e9e1a7fe4bc26f15)