### PR TITLE
pmix/cray: fix disable-dlopen problem

### DIFF
--- a/config/opal_check_alps.m4
+++ b/config/opal_check_alps.m4
@@ -22,15 +22,15 @@ dnl
 dnl $HEADER$
 dnl
 
-# ORTE_CHECK_ALPS_CLE4([action-if-found], [action-if-not-found])
+# OPAL_CHECK_ALPS_CLE4([action-if-found], [action-if-not-found])
 # --------------------------------------------------------
-AC_DEFUN([ORTE_CHECK_ALPS_CLE4],[
+AC_DEFUN([OPAL_CHECK_ALPS_CLE4],[
 
 #
 #   if we've gotten here, its because we are building on a CLE 4 system
 #
-    orte_check_alps_cle4_libdir_happy="no"
-    orte_check_alps_cle4_dir_happy="no"
+    opal_check_alps_cle4_libdir_happy="no"
+    opal_check_alps_cle4_dir_happy="no"
 
     AC_MSG_CHECKING([Checking for ALPS components on a CLE 4 system with alps  $with_alps])
 
@@ -48,31 +48,31 @@ AC_DEFUN([ORTE_CHECK_ALPS_CLE4],[
      AS_IF([test -z "$with_alps_libdir"],
            [AS_IF([test "$with_alps" != "yes" && test "$with_alps" != "auto"],
                   [AS_IF([test -d "$with_alps_libdir/lib64"],
-                         [orte_check_alps_libdir="$with_alps_libdir/lib64"],
-                         [orte_check_alps_libdir="$with_alps_libdir/lib"])],
-                  [ orte_check_alps_libdir="$default_alps_dir/lib/alps"])
+                         [opal_check_alps_libdir="$with_alps_libdir/lib64"],
+                         [opal_check_alps_libdir="$with_alps_libdir/lib"])],
+                  [ opal_check_alps_libdir="$default_alps_dir/lib/alps"])
            ],[])
 
      AS_IF([test "$with_alps" = "yes" || test "$with_alps" = "auto"],
-           [orte_check_alps_dir=$default_alps_dir],
-           [orte_check_alps_dir=$with_alps])
+           [opal_check_alps_dir=$default_alps_dir],
+           [opal_check_alps_dir=$with_alps])
 
-    AC_MSG_CHECKING([if $orte_check_alps_libdir/libalps.a is present])
-    AS_IF([test -f "$orte_check_alps_libdir/libalps.a"],
-          [orte_check_alps_libdir_cle4_happy="yes"],
-          [orte_check_alps_libdir_cle4_happy="no",
+    AC_MSG_CHECKING([if $opal_check_alps_libdir/libalps.a is present])
+    AS_IF([test -f "$opal_check_alps_libdir/libalps.a"],
+          [opal_check_alps_libdir_cle4_happy="yes"],
+          [opal_check_alps_libdir_cle4_happy="no",
            AC_MSG_RESULT([no])])
 
-    AC_MSG_CHECKING([if $orte_check_alps_dir/include/alps/apInfo.h is present])
-    AS_IF([test -f "$orte_check_alps_dir/include/alps/apInfo.h"],
-          [orte_check_alps_dir_cle4_happy="yes"],
-          [orte_check_alps_dir_cle4_happy="no"
+    AC_MSG_CHECKING([if $opal_check_alps_dir/include/alps/apInfo.h is present])
+    AS_IF([test -f "$opal_check_alps_dir/include/alps/apInfo.h"],
+          [opal_check_alps_dir_cle4_happy="yes"],
+          [opal_check_alps_dir_cle4_happy="no"
            AC_MSG_RESULT([no])])
 
-    AS_IF([test "$orte_check_alps_libdir_cle4_happy" = "yes" && test "$orte_check_alps_dir_cle4_happy" = "yes"],
-          [CRAY_ALPSLLI_CFLAGS="-I$orte_check_alps_dir/include"
-           CRAY_ALPSLLI_LIBS="-L$orte_check_alps_libdir -lalpslli -lalpsutil"
-           CRAY_ALPSLLI_STATIC_LIBS="-L$orte_check_alps_libdir -lalpslli -lalpsutil"
+    AS_IF([test "$opal_check_alps_libdir_cle4_happy" = "yes" && test "$opal_check_alps_dir_cle4_happy" = "yes"],
+          [CRAY_ALPSLLI_CFLAGS="-I$opal_check_alps_dir/include"
+           CRAY_ALPSLLI_LIBS="-L$opal_check_alps_libdir -lalpslli -lalpsutil"
+           CRAY_ALPSLLI_STATIC_LIBS="-L$opal_check_alps_libdir -lalpslli -lalpsutil"
            $1],
           [$2])
 ])
@@ -80,10 +80,10 @@ AC_DEFUN([ORTE_CHECK_ALPS_CLE4],[
 
 
 
-# ORTE_CHECK_ALPS(prefix, [action-if-found], [action-if-not-found])
+# OPAL_CHECK_ALPS(prefix, [action-if-found], [action-if-not-found])
 # --------------------------------------------------------
-AC_DEFUN([ORTE_CHECK_ALPS],[
-    if test -z "$orte_check_cray_alps_happy"; then
+AC_DEFUN([OPAL_CHECK_ALPS],[
+    if test -z "$opal_check_cray_alps_happy"; then
 
         AC_ARG_WITH([alps],
                     [AC_HELP_STRING([--with-alps(=DIR|yes|no)],
@@ -97,15 +97,15 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
 
         AC_MSG_CHECKING([for ALPS support cle level $cle_level])
         AS_IF([test "$cle_level" = "4" && test "$with_alps" != "no"],
-              [ORTE_CHECK_ALPS_CLE4([orte_check_cray_alps_happy="yes"],
-                                    [orte_check_cray_alps_happy="no"])],
+              [OPAL_CHECK_ALPS_CLE4([opal_check_cray_alps_happy="yes"],
+                                    [opal_check_cray_alps_happy="no"])],
               [AS_IF([test "$with_alps" = "no"],
                      [AC_MSG_RESULT([no])
                       $3],
                      [AS_IF([test "$with_alps" = "auto" || test "$with_alps" = "yes"],
                             [PKG_CHECK_MODULES_STATIC([CRAY_ALPSLLI], [cray-alpslli],
-                                                      [orte_check_cray_alps_happy="yes"],
-                                                      [orte_check_cray_alps_happy="no"]
+                                                      [opal_check_cray_alps_happy="yes"],
+                                                      [opal_check_cray_alps_happy="no"]
                                                       [AS_IF([test "$with_alps" = "yes"],
                                                              [AC_MSG_WARN([ALPS support requested but pkg-config failed.])
                                                               AC_MSG_WARN([Need to explicitly indicate ALPS directory])
@@ -113,8 +113,8 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
                                                               AC_MSG_ERROR([Aborting])],[])]
                                                       )
                               PKG_CHECK_MODULES_STATIC([CRAY_ALPSUTIL], [cray-alpsutil],
-                                                [orte_check_cray_alps_happy="yes"],
-                                                [orte_check_cray_alps_happy="no"]
+                                                [opal_check_cray_alps_happy="yes"],
+                                                [opal_check_cray_alps_happy="no"]
                                                 [AS_IF([test "$with_alps" = "yes"],
                                                        [AC_MSG_WARN([ALPS support requested but pkg-config failed.])
                                                         AC_MSG_WARN([Need to explicitly indicate ALPS directory])
@@ -123,8 +123,8 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
                                                        )
 
                                PKG_CHECK_MODULES_STATIC([CRAY_ALPS], [cray-alps],
-                                               [orte_check_cray_alps_happy="yes"],
-                                               [orte_check_cray_alps_happy="no"]
+                                               [opal_check_cray_alps_happy="yes"],
+                                               [opal_check_cray_alps_happy="no"]
                                                [AS_IF([test "$with_alps" = "yes"],
                                                       [AC_MSG_WARN([ALPS support requested but pkg-config failed.])
                                                        AC_MSG_WARN([Need to explicitly indicate ALPS directory])
@@ -132,11 +132,11 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
                                                        AC_MSG_ERROR([Aborting])],[])]
                                                        )
                                PKG_CHECK_MODULES_STATIC([CRAY_WLM_DETECT], [cray-wlm_detect],
-                                               [orte_check_cray_alps_happy="yes"
+                                               [opal_check_cray_alps_happy="yes"
                                                 AC_DEFINE_UNQUOTED([CRAY_WLM_DETECT],[1],
                                                                    [defined to 1 if cray wlm available, 0 otherwise])
                                                ],
-                                               [orte_check_cray_alps_happy="no"]
+                                               [opal_check_cray_alps_happy="no"]
                                                [AS_IF([test "$with_alps" = "yes"],
                                                       [AC_MSG_WARN([ALPS support requested but pkg-config failed.])
                                                        AC_MSG_WARN([Need to explicitly indicate ALPS directory])
@@ -150,17 +150,17 @@ AC_DEFUN([ORTE_CHECK_ALPS],[
                     ])
                ])
 
-        AC_MSG_RESULT([orte_check_cray_alps_happy = $orte_check_cray_alps_happy])
+        AC_MSG_RESULT([opal_check_cray_alps_happy = $opal_check_cray_alps_happy])
 
-        AS_IF([test "$orte_check_cray_alps_happy" = "yes" && test "$enable_static" = "yes"],
+        AS_IF([test "$opal_check_cray_alps_happy" = "yes" && test "$enable_static" = "yes"],
               [CRAY_ALPSLLI_LIBS = $CRAY_ALPSLLI_STATIC_LIBS
                CRAY_ALPSUTIL_LIBS = $CRAY_ALPSUTIL_STATIC_LIBS],
               [])
 
-	OPAL_SUMMARY_ADD([[Resource Managers]],[[Cray Alps]],[$1],[$orte_check_cray_alps_happy])
+	OPAL_SUMMARY_ADD([[Resource Managers]],[[Cray Alps]],[$1],[$opal_check_cray_alps_happy])
     fi
 
-    AS_IF([test "$orte_check_cray_alps_happy" = "yes"],
+    AS_IF([test "$opal_check_cray_alps_happy" = "yes"],
           [$1_LDFLAGS="[$]$1_LDFLAGS $CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS"
            $1_CPPFLAGS="[$]$1_CPPFLAGS $CRAY_ALPSLLI_CFLAGS $CRAY_ALPSUTIL_CFLAGS $CRAY_ALPS_CFLAGS $CRAY_WLM_DETECT_CFLAGS"
            $1_LIBS="[$]$1_LIBS $CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS"

--- a/opal/mca/pmix/cray/Makefile.am
+++ b/opal/mca/pmix/cray/Makefile.am
@@ -1,5 +1,7 @@
 #
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,12 +31,12 @@ endif
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_cray_la_SOURCES = $(sources)
-mca_pmix_cray_la_CPPFLAGS = $(pmix_cray_CPPFLAGS)
-mca_pmix_cray_la_LDFLAGS = -module -avoid-version $(pmix_cray_LDFLAGS)
-mca_pmix_cray_la_LIBADD = $(pmix_cray_LIBS)
+mca_pmix_cray_la_CPPFLAGS = $(pmix_cray_CPPFLAGS) $(pmix_alps_CPPFLAGS)
+mca_pmix_cray_la_LDFLAGS = -module -avoid-version $(pmix_cray_LDFLAGS) $(pmix_alps_LDFLAGS)
+mca_pmix_cray_la_LIBADD = $(pmix_cray_LIBS) $(pmix_alps_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_cray_la_SOURCES =$(sources)
-libmca_pmix_cray_la_CPPFLAGS = $(pmix_cray_CPPFLAGS)
-libmca_pmix_cray_la_LDFLAGS = -module -avoid-version $(pmix_cray_LDFLAGS)
-libmca_pmix_cray_la_LIBADD = $(pmix_cray_LIBS)
+libmca_pmix_cray_la_CPPFLAGS = $(pmix_cray_CPPFLAGS) $(pmix_alps_CPPFLAGS)
+libmca_pmix_cray_la_LDFLAGS = -module -avoid-version $(pmix_cray_LDFLAGS) $(pmix_alps_LDFLAGS)
+libmca_pmix_cray_la_LIBADD = $(pmix_cray_LIBS) $(pmix_alps_LIBS)

--- a/opal/mca/pmix/cray/configure.m4
+++ b/opal/mca/pmix/cray/configure.m4
@@ -1,6 +1,8 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -17,18 +19,22 @@ AC_DEFUN([MCA_opal_pmix_cray_CONFIG], [
 #   check specifically for Cray PMI here
 #
     OPAL_CHECK_CRAY_PMI([pmix_cray], [pmix_cray_good=1], [pmix_cray_good=0])
+    OPAL_CHECK_ALPS([pmix_alps], [pmix_alps_happy=1], [pmix_alps_happy=0])
 
     # Evaluate succeed / fail
-    AS_IF([test "$pmix_cray_good" = 1],
+    AS_IF([test "$pmix_cray_good" = 1 && test "$pmix_alps_happy" = 1],
           [$1
            # need to set the wrapper flags for static builds
-           pmix_cray_WRAPPER_EXTRA_LDFLAGS="$pmix_cray_LDFLAGS"
-           pmix_cray_WRAPPER_EXTRA_LIBS="$pmix_cray_LIBS"],
+           pmix_cray_WRAPPER_EXTRA_LDFLAGS="$pmix_cray_LDFLAGS $pmix_alps_LDFLAGS"
+           pmix_cray_WRAPPER_EXTRA_LIBS="$pmix_cray_LIBS $pmix_alps_LIBS"],
           [$2])
 
     # set build flags to use in makefile
     AC_SUBST([pmix_cray_CPPFLAGS])
     AC_SUBST([pmix_cray_LDFLAGS])
     AC_SUBST([pmix_cray_LIBS])
+    AC_SUBST([pmix_alps_CPPFLAGS])
+    AC_SUBST([pmix_alps_LDFLAGS])
+    AC_SUBST([pmix_alps_LIBS])
 
 ])

--- a/opal/mca/pmix/cray/pmix_cray.c
+++ b/opal/mca/pmix/cray/pmix_cray.c
@@ -207,6 +207,7 @@ static void cray_get_more_info(void)
     /*
      * get some items from alps placement file
      */
+
     place_ret = alps_get_placement_info(apid,
                                         &layout,
                                         NULL,

--- a/orte/mca/common/alps/configure.m4
+++ b/orte/mca/common/alps/configure.m4
@@ -13,7 +13,7 @@
 # Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2009-2012 Mellanox Technologies.  All rights reserved.
 # Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
-# Copyright (c) 2014      Los Alamos National Security, LLC.
+# Copyright (c) 2014-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # $COPYRIGHT$
 #
@@ -28,7 +28,7 @@
 AC_DEFUN([MCA_orte_common_alps_CONFIG],[
     AC_CONFIG_FILES([orte/mca/common/alps/Makefile])
 
-    ORTE_CHECK_ALPS([common_alps], [common_alps_happy="yes"], [common_alps_happy="no"])
+    OPAL_CHECK_ALPS([common_alps], [common_alps_happy="yes"], [common_alps_happy="no"])
 
     AS_IF([test "$common_alps_happy" = "yes"],
           [$1

--- a/orte/mca/ess/alps/configure.m4
+++ b/orte/mca/ess/alps/configure.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011      Los Alamos National Security, LLC.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # $COPYRIGHT$
 #
@@ -25,7 +25,7 @@
 AC_DEFUN([MCA_orte_ess_alps_CONFIG],[
     AC_CONFIG_FILES([orte/mca/ess/alps/Makefile])
 
-    ORTE_CHECK_ALPS([ess_alps], [ess_alps_happy="yes"], [ess_alps_happy="no"])
+    OPAL_CHECK_ALPS([ess_alps], [ess_alps_happy="yes"], [ess_alps_happy="no"])
 
     AS_IF([test "$ess_alps_happy" = "yes"],
           [$1

--- a/orte/mca/odls/alps/configure.m4
+++ b/orte/mca/odls/alps/configure.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2011-2014 Los Alamos National Security, LLC.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
@@ -25,7 +25,7 @@
 AC_DEFUN([MCA_orte_odls_alps_CONFIG],[
     AC_CONFIG_FILES([orte/mca/odls/alps/Makefile])
 
-    ORTE_CHECK_ALPS([odls_alps], [odls_alps_happy="yes"], [odls_alps_happy="no"])
+    OPAL_CHECK_ALPS([odls_alps], [odls_alps_happy="yes"], [odls_alps_happy="no"])
 
     AS_IF([test "$odls_alps_happy" = "yes"],
           [$1

--- a/orte/mca/oob/alps/configure.m4
+++ b/orte/mca/oob/alps/configure.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2011-2015 Los Alamos National Security, LLC.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
@@ -25,7 +25,7 @@
 AC_DEFUN([MCA_orte_oob_alps_CONFIG],[
     AC_CONFIG_FILES([orte/mca/oob/alps/Makefile])
 
-    ORTE_CHECK_ALPS([oob_alps], [oob_alps_happy="yes"], [oob_alps_happy="no"])
+    OPAL_CHECK_ALPS([oob_alps], [oob_alps_happy="yes"], [oob_alps_happy="no"])
 
     AS_IF([test "$oob_alps_happy" = "yes"],
           [$1

--- a/orte/mca/plm/alps/configure.m4
+++ b/orte/mca/plm/alps/configure.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # $COPYRIGHT$
 #
@@ -25,7 +25,7 @@
 AC_DEFUN([MCA_orte_plm_alps_CONFIG],[
     AC_CONFIG_FILES([orte/mca/plm/alps/Makefile])
 
-	ORTE_CHECK_ALPS([plm_alps], [plm_alps_happy="yes"], [plm_alps_happy="no"])
+    OPAL_CHECK_ALPS([plm_alps], [plm_alps_happy="yes"], [plm_alps_happy="no"])
 
     AS_IF([test "$plm_alps_happy" = "yes"],
           [$1

--- a/orte/mca/plm/slurm/configure.m4
+++ b/orte/mca/plm/slurm/configure.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011-2015 Los Alamos National Security, LLC.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # $COPYRIGHT$
 #
@@ -41,7 +41,7 @@ AC_DEFUN([MCA_orte_plm_slurm_CONFIG],[
     # check to see if this is a Cray nativized slurm env.
 
     slurm_cray_env=0
-    ORTE_CHECK_ALPS([plm_slurm_cray],
+    OPAL_CHECK_ALPS([plm_slurm_cray],
                     [slurm_cray_env=1])
 
     AC_DEFINE_UNQUOTED([SLURM_CRAY_ENV],[$slurm_cray_env],

--- a/orte/mca/ras/alps/configure.m4
+++ b/orte/mca/ras/alps/configure.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008      UT-Battelle, LLC
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # $COPYRIGHT$
 #
@@ -26,13 +26,13 @@
 AC_DEFUN([MCA_orte_ras_alps_CONFIG],[
     AC_CONFIG_FILES([orte/mca/ras/alps/Makefile])
 
-    ORTE_CHECK_ALPS([ras_alps], [ras_alps_happy="yes"], [ras_alps_happy="no"])
+    OPAL_CHECK_ALPS([ras_alps], [ras_alps_happy="yes"], [ras_alps_happy="no"])
 
     # check for alps/apInfo.h
     # save current CPPFLAGS
     MCA_orte_ras_save_CPPFLAGS="$CPPFLAGS"
 
-    # add flags obtained from ORTE_CHECK_ALPS
+    # add flags obtained from OPAL_CHECK_ALPS
     CPPFLAGS="$CPPFLAGS $ras_alps_CPPFLAGS"
 
     AC_CHECK_HEADERS([alps/apInfo.h], [], [ras_alps_happy="no"])

--- a/orte/mca/schizo/alps/configure.m4
+++ b/orte/mca/schizo/alps/configure.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008      UT-Battelle, LLC
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2016      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
@@ -27,13 +27,13 @@
 AC_DEFUN([MCA_orte_schizo_alps_CONFIG],[
     AC_CONFIG_FILES([orte/mca/schizo/alps/Makefile])
 
-    ORTE_CHECK_ALPS([schizo_alps], [schizo_alps_happy="yes"], [schizo_alps_happy="no"])
+    OPAL_CHECK_ALPS([schizo_alps], [schizo_alps_happy="yes"], [schizo_alps_happy="no"])
 
     # check for alps/apInfo.h
     # save current CPPFLAGS
     MCA_orte_schizo_save_CPPFLAGS="$CPPFLAGS"
 
-    # add flags obtained from ORTE_CHECK_ALPS
+    # add flags obtained from OPAL_CHECK_ALPS
     CPPFLAGS="$CPPFLAGS $schizo_alps_CPPFLAGS"
 
     AC_CHECK_HEADERS([alps/apInfo.h], [], [schizo_alps_happy="no"])


### PR DESCRIPTION
PR open-mpi/ompi#2432 introduced a regression where configure
and build with --disable-dlopn caused build failure owing
to unresolved alps lli symbols in the libopal-pal shared library.

@hjelmn heads up about --disable-dlopen failure when building for cray - this fixes the problem.

This commit fixes this problem.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>