### PR TITLE
ompi/mpi_init: lazy-wait during PMIx fence execution

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -20,6 +20,7 @@
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies Ltd. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -639,7 +640,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
         if (NULL != opal_pmix.fence_nb) {
             opal_pmix.fence_nb(NULL, opal_pmix_collect_all_data,
                                fence_release, (void*)&active);
-            OMPI_WAIT_FOR_COMPLETION(active);
+            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
         } else {
             opal_pmix.fence(NULL, opal_pmix_collect_all_data);
         }
@@ -809,7 +810,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
     if (NULL != opal_pmix.fence_nb) {
         opal_pmix.fence_nb(NULL, opal_pmix_collect_all_data,
                            fence_release, (void*)&active);
-        OMPI_WAIT_FOR_COMPLETION(active);
+        OMPI_LAZY_WAIT_FOR_COMPLETION(active);
     } else {
         opal_pmix.fence(NULL, opal_pmix_collect_all_data);
     }


### PR DESCRIPTION
Relax CPU usage pressure from the application processes when doing
modex and barrier in ompi_mpi_init.

We see significant latencies in SLURM/pmix plugin barrier progress
because app processes are aggressively call opal_progress pushing
away daemon process doing collective progress.

(ported from 08618845a4de7ce7010f3ad0cb65aa7b4bf39fe1 and 06a73da5ea62992527995303c3c159de12db332d)

Signed-off-by: Artem Polyakov <artpol84@gmail.com>