### PR TITLE
v2.x: btl/self: fix fragment segment length in mca_btl_self_prepare_src()

### DIFF
--- a/opal/mca/btl/self/btl_self.c
+++ b/opal/mca/btl/self/btl_self.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -176,6 +178,7 @@ static struct mca_btl_base_descriptor_t *mca_btl_self_prepare_src (struct mca_bt
         }
 
         *size = max_data;
+        frag->segments[0].seg_len = reserve + max_data;
     } else {
         void *data_ptr;
 


### PR DESCRIPTION
opal_convertor_pack() might pack less bytes than requested,
so always set frag->segments[0].seg_len.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@1a279c4ee9daeb03d23f191d082f9fd4057a93b6)