### PR TITLE
update the error codes reported by file_delete

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -415,9 +415,14 @@ int mca_io_ompio_file_delete (const char *filename,
 
     ret = unlink(filename);
 
-    if (0 > ret && ENOENT != errno ) {
-	opal_output (1, "errno = %d %s\n", errno, strerror(errno));
-        return MPI_ERR_ACCESS;
+    if (0 > ret ) {
+        if ( ENOENT == errno ) {
+            return MPI_ERR_NO_SUCH_FILE;
+        } else {
+            opal_output (0, "mca_io_ompio_file_delete: Could not remove file %s errno = %d %s\n", filename, 
+                         errno, strerror(errno));
+            return MPI_ERR_ACCESS;
+        }
     }
 
     return OMPI_SUCCESS;


### PR DESCRIPTION
This pr brings the fix to the error codes of MPI_File_delete operations over to the 2.x branch. It has already been reviewed by @vvenkates27 (although the review button was pressed by @jsquyres ) for the 2.0.x branch. @jsquyres could you please provide formally the review again ?

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>