### PR TITLE
oshmem: memheap: removes find_offset

### DIFF
--- a/oshmem/mca/memheap/base/base.h
+++ b/oshmem/mca/memheap/base/base.h
@@ -69,10 +69,6 @@ int mca_memheap_base_dereg(mca_memheap_map_t *);
 int memheap_oob_init(mca_memheap_map_t *);
 void memheap_oob_destruct(void);
 
-OSHMEM_DECLSPEC uint64_t mca_memheap_base_find_offset(int pe,
-                                                      int tr_id,
-                                                      void* va,
-                                                      void* rva);
 OSHMEM_DECLSPEC int mca_memheap_base_is_symmetric_addr(const void* va);
 OSHMEM_DECLSPEC sshmem_mkey_t *mca_memheap_base_get_mkey(void* va,
                                                            int tr_id);

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -715,23 +715,6 @@ sshmem_mkey_t *mca_memheap_base_get_mkey(void* va, int tr_id)
     return ((s && MAP_SEGMENT_IS_VALID(s)) ? &s->mkeys[tr_id] : NULL );
 }
 
-uint64_t mca_memheap_base_find_offset(int pe,
-                                      int tr_id,
-                                      void* va,
-                                      void* rva)
-{
-    map_segment_t *s;
-    int my_pe = oshmem_my_proc_id();
-
-    s = memheap_find_va(va);
-
-    if (my_pe == pe) {
-        return (uintptr_t)va - (uintptr_t)s->super.va_base;
-    }
-    else {
-        return ((s && MAP_SEGMENT_IS_VALID(s)) ? ((uintptr_t)rva - (uintptr_t)(s->mkeys_cache[pe][tr_id].va_base)) : 0);
-    }
-}
 
 int mca_memheap_base_is_symmetric_addr(const void* va)
 {

--- a/oshmem/mca/memheap/buddy/memheap_buddy.c
+++ b/oshmem/mca/memheap/buddy/memheap_buddy.c
@@ -34,7 +34,6 @@ mca_memheap_buddy_module_t memheap_buddy = {
         mca_memheap_buddy_private_free,
 
         mca_memheap_base_get_mkey,
-        mca_memheap_base_find_offset,
         mca_memheap_base_is_symmetric_addr,
         mca_memheap_modex_recv_all,
 

--- a/oshmem/mca/memheap/memheap.h
+++ b/oshmem/mca/memheap/memheap.h
@@ -59,10 +59,6 @@ typedef int (*mca_memheap_base_module_free_fn_t)(void*);
 /**
  * Service functions
  */
-typedef uint64_t (*mca_memheap_base_module_find_offset_fn_t)(int pe,
-                                                             int tr_id,
-                                                             void* va,
-                                                             void* rva);
 
 typedef sshmem_mkey_t * (*mca_memheap_base_module_get_local_mkey_fn_t)(void* va,
                                                                          int transport_id);
@@ -109,7 +105,6 @@ struct mca_memheap_base_module_t {
     mca_memheap_base_module_free_fn_t               memheap_private_free;
 
     mca_memheap_base_module_get_local_mkey_fn_t     memheap_get_local_mkey;
-    mca_memheap_base_module_find_offset_fn_t        memheap_find_offset;
     mca_memheap_base_is_memheap_addr_fn_t           memheap_is_symmetric_addr;
     mca_memheap_base_mkey_exchange_fn_t             memheap_get_all_mkeys;
 

--- a/oshmem/mca/memheap/ptmalloc/memheap_ptmalloc.c
+++ b/oshmem/mca/memheap/ptmalloc/memheap_ptmalloc.c
@@ -32,7 +32,6 @@ mca_memheap_ptmalloc_module_t memheap_ptmalloc = {
         mca_memheap_ptmalloc_free,
 
         mca_memheap_base_get_mkey,
-        mca_memheap_base_find_offset,
         mca_memheap_base_is_symmetric_addr,
         mca_memheap_modex_recv_all,
 


### PR DESCRIPTION
@miked-mellanox @yosefe @jladd-mlnx 
Reasons for removal are:
- the function is only used by the shmem_lock code
- only a subset of the function is used by the shmem_lock
- for the general case the function is not correct

Signed-off-by: Alex Mikheev <alexm@mellanox.com>
(cherry picked from commit d1723355d31e7a625daabf6a64cd2084a5d76c6a)