### PR TITLE
oshmem: scoll: fixes basic barrier broadcast and alltoall

### DIFF
--- a/oshmem/mca/scoll/basic/scoll_basic_alltoall.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_alltoall.c
@@ -105,6 +105,10 @@ static int _algorithm_simple(struct oshmem_group_t *group,
             break;
         }
     }
+    /* fence (which currently acts as quiet) is needed
+     * because scoll level barrier does not guarantee put completion
+     */
+    MCA_SPML_CALL(fence());
 
     /* Wait for operation completion */
     if (rc == OSHMEM_SUCCESS) {
@@ -116,3 +120,4 @@ static int _algorithm_simple(struct oshmem_group_t *group,
 
     return rc;
 }
+

--- a/oshmem/mca/scoll/basic/scoll_basic_barrier.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_barrier.c
@@ -528,7 +528,7 @@ static int _algorithm_basic(struct oshmem_group_t *group, long *pSync)
         for (i = 0; (i < group->proc_count) && (rc == OSHMEM_SUCCESS); i++) {
             pe_cur = oshmem_proc_pe(group->proc_array[i]);
             if (pe_cur != PE_root) {
-                rc = MCA_SPML_CALL(recv(NULL, 0, SHMEM_ANY_SOURCE));
+                rc = MCA_SPML_CALL(recv(NULL, 0, pe_cur)); 
             }
             if (OSHMEM_SUCCESS != rc) {
                 return rc;

--- a/oshmem/mca/scoll/basic/scoll_basic_broadcast.c
+++ b/oshmem/mca/scoll/basic/scoll_basic_broadcast.c
@@ -146,11 +146,15 @@ static int _algorithm_central_counter(struct oshmem_group_t *group,
                 rc = MCA_SPML_CALL(put(target, nlong, (void *)source, pe_cur));
             }
         }
+        /* fence (which currently acts as quiet) is needed
+         * because scoll level barrier does not guarantee put completion 
+         */
+        MCA_SPML_CALL(fence());
     }
 
-    /* Wait for operation completion to set needed size */
     if (rc == OSHMEM_SUCCESS) {
         SCOLL_VERBOSE(14, "[#%d] Wait for operation completion", group->my_pe);
+        /* wait until root finishes sending data  */
         rc = BARRIER_FUNC(group,
                 (pSync + 1),
                 SCOLL_DEFAULT_ALG);


### PR DESCRIPTION
@miked-mellanox @yosefe @jladd-mlnx 
Add missing fence() call to alltoall and central counter broadcast.

Signed-off-by: Alex Mikheev <alexm@mellanox.com>
(cherry picked from commit 0f83a1fd57d717207e8b89a70306d161fe367f9e)