### PR TITLE
pml/ob1: Reduce per-rank memory footprint slightly

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_comm.c
+++ b/ompi/mca/pml/ob1/pml_ob1_comm.c
@@ -26,8 +26,8 @@
 
 static void mca_pml_ob1_comm_proc_construct(mca_pml_ob1_comm_proc_t* proc)
 {
-    proc->expected_sequence = 1;
     proc->ompi_proc = NULL;
+    proc->expected_sequence = 1;
     proc->send_sequence = 0;
     OBJ_CONSTRUCT(&proc->frags_cant_match, opal_list_t);
     OBJ_CONSTRUCT(&proc->specific_receives, opal_list_t);

--- a/ompi/mca/pml/ob1/pml_ob1_comm.h
+++ b/ompi/mca/pml/ob1/pml_ob1_comm.h
@@ -33,8 +33,8 @@ BEGIN_C_DECLS
 
 struct mca_pml_ob1_comm_proc_t {
     opal_object_t super;
-    uint16_t expected_sequence;    /**< send message sequence number - receiver side */
     struct ompi_proc_t* ompi_proc;
+    uint16_t expected_sequence;    /**< send message sequence number - receiver side */
 #if OPAL_ENABLE_MULTI_THREADS
     volatile int32_t send_sequence; /**< send side sequence number */
 #else


### PR DESCRIPTION
`sturct mca_pml_ob1_comm_proc_t`, which is allocated per
connected rank in a communicator, had two paddings after
`expected_sequence` and `send_sequence` by alignments.
By changing the order of the members, the size of
`mca_pml_ob1_comm_proc_t` is reduced by 8 bytes on 64-bit
architectures.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>