### PR TITLE
coll/hcoll: hcoll_context_free

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -138,11 +138,12 @@ static void mca_coll_hcoll_module_destruct(mca_coll_hcoll_module_t *hcoll_module
         OBJ_RELEASE(hcoll_module->previous_reduce_scatter_module);
         OBJ_RELEASE(hcoll_module->previous_reduce_module);
         */
-
+#if HCOLL_API < HCOLL_VERSION(3,7)
         context_destroyed = 0;
         hcoll_destroy_context(hcoll_module->hcoll_context,
                               (rte_grp_handle_t)hcoll_module->comm,
                               &context_destroyed);
+#endif
     }
     mca_coll_hcoll_module_clear(hcoll_module);
 }
@@ -205,7 +206,11 @@ static int hcoll_comm_attr_del_fn(MPI_Comm comm, int keyval, void *attr_val, voi
     mca_coll_hcoll_module_t *hcoll_module;
     hcoll_module = (mca_coll_hcoll_module_t*) attr_val;
 
+#if HCOLL_API >= HCOLL_VERSION(3,7)
+    hcoll_context_free(hcoll_module->hcoll_context, (rte_grp_handle_t)comm);
+#else
     hcoll_group_destroy_notify(hcoll_module->hcoll_context);
+#endif
     return OMPI_SUCCESS;
 
 }


### PR DESCRIPTION
    Adds the new API hcoll_conetxt_free that resolves the issues
    observed with the ctx cache and group_destroy_notify.

    @bureddy @jladd-mlnx Plz review.