### PR TITLE
V2.0.x: hcoll lost commits

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll.h
@@ -289,6 +289,7 @@ int mca_coll_hcoll_ialltoall(const void *sbuf, int scount,
                             ompi_request_t **req,
                             mca_coll_base_module_t *module);
 
+#if HCOLL_API >= HCOLL_VERSION(3,7)
 int mca_coll_hcoll_ialltoallv(void *sbuf, int *scounts,
                             int *sdisps,
                             struct ompi_datatype_t *sdtype,
@@ -298,6 +299,7 @@ int mca_coll_hcoll_ialltoallv(void *sbuf, int *scounts,
                             struct ompi_communicator_t *comm,
                             ompi_request_t **req,
                             mca_coll_base_module_t *module);
+#endif
 
 int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
                             struct ompi_datatype_t *sdtype,

--- a/ompi/mca/coll/hcoll/coll_hcoll_dtypes.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll_dtypes.h
@@ -125,6 +125,32 @@ ompi_predefined_derived_2_hcoll(int ompi_id) {
         return DTE_LONG_DOUBLE_INT;
     case OMPI_DATATYPE_MPI_2INT:
         return DTE_2INT;
+#if HCOLL_API >= HCOLL_VERSION(3,7)
+    case OMPI_DATATYPE_MPI_2INTEGER:
+#if OMPI_SIZEOF_FORTRAN_INTEGER == 4
+        return DTE_2INT;
+#elif OMPI_SIZEOF_FORTRAN_INTEGER == 8
+        return DTE_2INT64;
+#else
+        return DTE_ZERO;
+#endif
+    case OMPI_DATATYPE_MPI_2REAL:
+#if OMPI_SIZEOF_FORTRAN_REAL == 4
+        return DTE_2FLOAT32;
+#elif OMPI_SIZEOF_FORTRAN_REAL == 8
+        return DTE_2FLOAT64;
+#else
+        return DTE_ZERO;
+#endif
+    case OMPI_DATATYPE_MPI_2DBLPREC:
+#if OMPI_SIZEOF_FORTRAN_DOUBLE_PRECISION == 4
+        return DTE_2FLOAT32;
+#elif OMPI_SIZEOF_FORTRAN_DOUBLE_PRECISION == 8
+        return DTE_2FLOAT64;
+#else
+        return DTE_ZERO;
+#endif
+#endif
     default:
         break;
     }

--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -404,8 +404,11 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
     hcoll_module->super.coll_gather = /*hcoll_collectives.coll_gather ? mca_coll_hcoll_gather :*/ NULL;
     hcoll_module->super.coll_igatherv = hcoll_collectives.coll_igatherv ? mca_coll_hcoll_igatherv : NULL;
     hcoll_module->super.coll_ialltoall = /*hcoll_collectives.coll_ialltoall ? mca_coll_hcoll_ialltoall : */ NULL;
-    hcoll_module->super.coll_ialltoallv = /*hcoll_collectives.coll_ialltoallv ? mca_coll_hcoll_ialltoallv : */ NULL;
-
+#if HCOLL_API >= HCOLL_VERSION(3,7)
+    hcoll_module->super.coll_ialltoallv = hcoll_collectives.coll_ialltoallv ? mca_coll_hcoll_ialltoallv : NULL;
+#else
+    hcoll_module->super.coll_ialltoallv = NULL;
+#endif
     *priority = cm->hcoll_priority;
     module = &hcoll_module->super;
 

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -685,3 +685,41 @@ int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
 
 }
 
+
+#if HCOLL_API >= HCOLL_VERSION(3,7)
+int mca_coll_hcoll_ialltoallv(void *sbuf, int *scounts, int *sdisps,
+                              struct ompi_datatype_t *sdtype,
+                              void *rbuf, int *rcounts, int *rdisps,
+                              struct ompi_datatype_t *rdtype,
+                              struct ompi_communicator_t *comm,
+                              ompi_request_t ** request,
+                              mca_coll_base_module_t *module)
+{
+    dte_data_representation_t stype;
+    dte_data_representation_t rtype;
+    int rc;
+    HCOL_VERBOSE(20,"RUNNING HCOL IALLTOALLV");
+    mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
+    stype = ompi_dtype_2_hcoll_dtype(sdtype, NO_DERIVED);
+    rtype = ompi_dtype_2_hcoll_dtype(rdtype, NO_DERIVED);
+    if (OPAL_UNLIKELY(HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype))) {
+        HCOL_VERBOSE(20,"Ompi_datatype is not supported: sdtype = %s, rdtype = %s; calling fallback ialltoallv;",
+                     sdtype->super.name,
+                     rdtype->super.name);
+        rc = hcoll_module->previous_ialltoallv(sbuf, scounts, sdisps, sdtype,
+                                               rbuf, rcounts, rdisps, rdtype,
+                                               comm, request, hcoll_module->previous_alltoallv_module);
+        return rc;
+    }
+    rc = hcoll_collectives.coll_ialltoallv((void *)sbuf, (int *)scounts, (int *)sdisps, stype,
+                                           rbuf, (int *)rcounts, (int *)rdisps, rtype,
+                                           hcoll_module->hcoll_context, (void**)request);
+    if (HCOLL_SUCCESS != rc){
+        HCOL_VERBOSE(20,"RUNNING FALLBACK IALLTOALLV");
+        rc = hcoll_module->previous_ialltoallv(sbuf, scounts, sdisps, sdtype,
+                                               rbuf, rcounts, rdisps, rdtype,
+                                               comm, request, hcoll_module->previous_alltoallv_module);
+    }
+    return rc;
+}
+#endif


### PR DESCRIPTION
2 PRs (1 commit each) have been never moved to v2.0.x.
The first [commit](https://github.com/open-mpi/ompi/commit/140d92595968e939a262bb56f868c85d69e5afc5): is a v2.0.x version of #2305 

The [second](https://github.com/open-mpi/ompi/commit/1648a70d280bfc5a3cd8a6bb09e9301df685cc57): is a v2.0.x version of #2199 