### PR TITLE
v2.x: pml/ob1: initialize one more field in mca_pml_ob1_recv_request_progre…

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -634,6 +634,7 @@ void mca_pml_ob1_recv_request_progress_rget( mca_pml_ob1_recv_request_t* recvreq
     bytes_remaining = hdr->hdr_rndv.hdr_msg_length;
     recvreq->req_recv.req_bytes_packed = hdr->hdr_rndv.hdr_msg_length;
     recvreq->req_send_offset = 0;
+    recvreq->req_rdma_offset = 0;
 
     MCA_PML_OB1_RECV_REQUEST_MATCHED(recvreq, &hdr->hdr_rndv.hdr_match);
 


### PR DESCRIPTION
…ss_rget()

always initialize recvreq->req_rdma_offset to zero.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@3f1486a5081908c2ce93c71668c73641113b7aa6)