### PR TITLE
Fix IOF when outputing to files - the remote orteds were failing to o…

### DIFF
--- a/orte/mca/iof/orted/iof_orted.c
+++ b/orte/mca/iof/orted/iof_orted.c
@@ -152,6 +152,8 @@ static int orted_push(const orte_process_name_t* dst_name, orte_iof_tag_t src_ta
     proct->name.jobid = dst_name->jobid;
     proct->name.vpid = dst_name->vpid;
     opal_list_append(&mca_iof_orted_component.procs, &proct->super);
+
+SETUP:
     /* get the local jobdata for this proc */
     if (NULL == (jobdat = orte_get_job_data_object(proct->name.jobid))) {
         ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
@@ -162,8 +164,6 @@ static int orted_push(const orte_process_name_t* dst_name, orte_iof_tag_t src_ta
         ORTE_ERROR_LOG(rc);
         return rc;
     }
-
-SETUP:
     /* define a read event and activate it */
     if (src_tag & ORTE_IOF_STDOUT) {
         ORTE_IOF_READ_EVENT(&proct->revstdout, proct, fd, ORTE_IOF_STDOUT,

--- a/orte/mca/oob/tcp/oob_tcp_connection.c
+++ b/orte/mca/oob/tcp/oob_tcp_connection.c
@@ -191,6 +191,7 @@ void mca_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
                         ORTE_NAME_PRINT(&(peer->name)), peer->sd);
 
     addrlen = sizeof(struct sockaddr_in);
+    peer->active_addr = NULL;
     OPAL_LIST_FOREACH(addr, &peer->addrs, mca_oob_tcp_addr_t) {
         opal_output_verbose(OOB_TCP_DEBUG_CONNECT, orte_oob_base_framework.framework_output,
                             "%s orte_tcp_peer_try_connect: "
@@ -288,7 +289,7 @@ void mca_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         /* no address succeeded, so we cannot reach this peer */
         peer->state = MCA_OOB_TCP_FAILED;
         host = orte_get_proc_hostname(&(peer->name));
-        if (NULL == host) {
+        if (NULL == host && NULL != peer->active_addr) {
             host = opal_net_get_hostname((struct sockaddr*)&(peer->active_addr->addr));
         }
         /* use an opal_output here instead of show_help as we may well

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -900,7 +900,7 @@ int orte_submit_job(char *argv[], int *index,
     if (NULL != getenv("ORTE_TEST_DEBUGGER_ATTACH")) {
         char *evar;
         evar = getenv("ORTE_TEST_DEBUGGER_SLEEP");
-        for (i=0; i < (int)jdata->num_apps; i++) {
+        for (i=0; i < (orte_app_idx_t)jdata->num_apps; i++) {
             if (NULL != (app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, i))) {
                 opal_setenv("ORTE_TEST_DEBUGGER_ATTACH", "1", true, &app->env);
                 if (NULL != evar) {


### PR DESCRIPTION
…utput stdout/err from their procs.

Silence a warning in orted_submit

Protect against a free'd value in an error path when forming oob tcp connections

Signed-off-by: Ralph Castain <rhc@open-mpi.org>