### PR TITLE
pmix: Fix pmix base help file.

### DIFF
--- a/opal/mca/pmix/base/help-pmix-base.txt
+++ b/opal/mca/pmix/base/help-pmix-base.txt
@@ -1,6 +1,8 @@
  -*- text -*-
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
 #
 # $COPYRIGHT$
 #
@@ -8,12 +10,11 @@
 #
 # $HEADER$
 #
-# This is the US/English general help file for OPAL Errmgr HNP module.
+# This is the US/English general help file for OPAL PMIx base.
 #
-[errmgr-hnp:unknown-job-error]
-An error has occurred in an unknown job. This generally should not happen
-except due to an internal OPAL error.
+[pmix2-init-failed]
+PMI2_Init failed to intialize.  Return code: %d
 
-Job state: %s
-
-This information should probably be reported to the OMPI developers.
+[pmix2-init-returned-bad-values]
+PMI2_Init was intialized but negative values for job size and/or
+rank was returned.


### PR DESCRIPTION
Content of the pmix base help file was totally wrong.
Looked like it had just been copied from a help file for
another MCA framework.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>