### PR TITLE
Swapped use of fprintf for opal_output_verbose

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -848,7 +848,7 @@ static int ompi_comm_allreduce_pmix_reduce_complete (ompi_comm_request_t *reques
 
     if (OPAL_SUCCESS != (rc = opal_dss.pack(&sbuf, context->tmpbuf, (int32_t)context->count, OPAL_INT))) {
         OBJ_DESTRUCT(&sbuf);
-        fprintf (stderr, "pack failed. rc  %d\n", rc);
+        opal_output_verbose (verbosity_level, output_id, "pack failed. rc  %d\n", rc);
         return rc;
     }
 


### PR DESCRIPTION
Thanks to @OMGtechy for the submission.

Signed-off-by: Joshua Gerrard <enquiries@joshuagerrard.com>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

(cherry picked from commit d5a45bc12ef637dcccd28dd4b26a631a524ae8ba)

Followup to #2485.

@hppritcha Please review.  Trivial.