### PR TITLE
configury: check the existence of perl

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -11,7 +11,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
-dnl Copyright (c) 2015      Research Organization for Information Science
+dnl Copyright (c) 2015-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
@@ -1235,8 +1235,6 @@ AC_DEFUN([OPAL_ASM_FIND_FILE], [
     AC_REQUIRE([AC_PROG_FGREP])
 
 if test "$opal_cv_asm_arch" != "WINDOWS" && test "$opal_cv_asm_builtin" != "BUILTIN_SYNC" && test "$opal_cv_asm_builtin" != "BUILTIN_OSX" ; then
-    AC_CHECK_PROG([PERL], [perl], [perl])
-
     # see if we have a pre-built one already
     AC_MSG_CHECKING([for pre-built assembly file])
     opal_cv_asm_file=""

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,10 @@ OPAL_LOAD_PLATFORM
 # Start it up
 #
 
+AC_CHECK_PROG([PERL],[perl],[perl],[no])
+AS_IF([test "X$PERL" = "Xno"],
+      [AC_MSG_ERROR(["Open MPI requires perl. Aborting"])])
+
 OPAL_CONFIGURE_SETUP
 opal_show_title "Configuring project_name_long"
 


### PR DESCRIPTION
perl is required by ompi/mpi/man/make_manpage.pl, that is even used in opal.
so simply aborts at configure time if perl is not available

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>