### PR TITLE
Resolve a duplicate symbol issue when the rml/ofi component is enabled

### DIFF
--- a/orte/mca/rml/base/base.h
+++ b/orte/mca/rml/base/base.h
@@ -184,6 +184,22 @@ typedef struct {
 } orte_rml_recv_request_t;
 OBJ_CLASS_DECLARATION(orte_rml_recv_request_t);
 
+/* define a structure for sending a message to myself */
+typedef struct {
+    opal_object_t object;
+    opal_event_t ev;
+    orte_rml_tag_t tag;
+    struct iovec* iov;
+    int count;
+    opal_buffer_t *buffer;
+    union {
+        orte_rml_callback_fn_t        iov;
+        orte_rml_buffer_callback_fn_t buffer;
+    } cbfunc;
+    void *cbdata;
+} orte_self_send_xfer_t;
+OBJ_CLASS_DECLARATION(orte_self_send_xfer_t);
+
 #define ORTE_RML_POST_MESSAGE(p, t, s, b, l)                            \
     do {                                                                \
         orte_rml_recv_t *msg;                                           \

--- a/orte/mca/rml/base/rml_base_frame.c
+++ b/orte/mca/rml/base/rml_base_frame.c
@@ -252,6 +252,18 @@ void orte_rml_recv_callback(int status, orte_process_name_t* sender,
 
 
 /***   RML CLASS INSTANCES   ***/
+static void xfer_cons(orte_self_send_xfer_t *xfer)
+{
+    xfer->iov = NULL;
+    xfer->cbfunc.iov = NULL;
+    xfer->buffer = NULL;
+    xfer->cbfunc.buffer = NULL;
+    xfer->cbdata = NULL;
+}
+OBJ_CLASS_INSTANCE(orte_self_send_xfer_t,
+                   opal_object_t,
+                   xfer_cons, NULL);
+
 static void send_cons(orte_rml_send_t *ptr)
 {
     ptr->retries = 0;

--- a/orte/mca/rml/ofi/rml_ofi_send.c
+++ b/orte/mca/rml/ofi/rml_ofi_send.c
@@ -73,32 +73,6 @@ OBJ_CLASS_INSTANCE(ofi_recv_msg_queue_t,
                    ofi_recv_msg_queue_cons, ofi_recv_msg_queue_des);
 
 
-typedef struct {
-    opal_object_t object;
-    opal_event_t ev;
-    orte_rml_tag_t tag;
-    struct iovec* iov;
-    int count;
-    opal_buffer_t *buffer;
-    union {
-        orte_rml_callback_fn_t        iov;
-        orte_rml_buffer_callback_fn_t buffer;
-    } cbfunc;
-    void *cbdata;
-} orte_self_send_xfer_t;
-static void xfer_cons(orte_self_send_xfer_t *xfer)
-{
-    xfer->iov = NULL;
-    xfer->cbfunc.iov = NULL;
-    xfer->buffer = NULL;
-    xfer->cbfunc.buffer = NULL;
-    xfer->cbdata = NULL;
-}
-OBJ_CLASS_INSTANCE(orte_self_send_xfer_t,
-                   opal_object_t,
-                   xfer_cons, NULL);
-
-
 static void send_self_exe(int fd, short args, void* data)
 {
     orte_self_send_xfer_t *xfer = (orte_self_send_xfer_t*)data;

--- a/orte/mca/rml/oob/rml_oob_send.c
+++ b/orte/mca/rml/oob/rml_oob_send.c
@@ -35,31 +35,6 @@
 #include "orte/mca/rml/rml_types.h"
 #include "rml_oob.h"
 
-typedef struct {
-    opal_object_t object;
-    opal_event_t ev;
-    orte_rml_tag_t tag;
-    struct iovec* iov;
-    int count;
-    opal_buffer_t *buffer;
-    union {
-        orte_rml_callback_fn_t        iov;
-        orte_rml_buffer_callback_fn_t buffer;
-    } cbfunc;
-    void *cbdata;
-} orte_self_send_xfer_t;
-static void xfer_cons(orte_self_send_xfer_t *xfer)
-{
-    xfer->iov = NULL;
-    xfer->cbfunc.iov = NULL;
-    xfer->buffer = NULL;
-    xfer->cbfunc.buffer = NULL;
-    xfer->cbdata = NULL;
-}
-OBJ_CLASS_INSTANCE(orte_self_send_xfer_t,
-                   opal_object_t,
-                   xfer_cons, NULL);
-
 static void send_self_exe(int fd, short args, void* data)
 {
     orte_self_send_xfer_t *xfer = (orte_self_send_xfer_t*)data;


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>