### PR TITLE
 Update signal handling to introduce a pause between SIGCONT and SIGT…

### DIFF
--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -329,9 +329,11 @@ static int do_child(orte_app_context_t* context,
     long fd, fdmax = sysconf(_SC_OPEN_MAX);
     char *param, *msg;
 
+#if HAVE_SETPGID
     /* Set a new process group for this child, so that any
      * signals we send to it will reach any children it spawns */
     setpgid(0, 0);
+#endif
 
     /* Setup the pipe to be close-on-exec */
     opal_fd_set_cloexec(write_fd);

--- a/orte/test/system/sigusr_trap.c
+++ b/orte/test/system/sigusr_trap.c
@@ -28,6 +28,10 @@ void sigusr_handler(int signum)
             fprintf(stderr, "%s Trapped SIGUSR2\n", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
             return;
 
+        case SIGCONT:
+            fprintf(stderr, "%s Trapped SIGCONT\n", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+            return;
+
         default:
             fprintf(stderr, "%s Undefined signal %d trapped\n", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), signum);
             return;
@@ -55,6 +59,7 @@ void exit_handler(int signum)
             fprintf(stderr, "%s Undefined signal %d trapped\n", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), signum);
             break;
     }
+    return;
 
     exit(1);
 }
@@ -75,6 +80,11 @@ int main(int argc, char* argv[])
     }
 
     if (signal(SIGUSR2, sigusr_handler) == SIG_IGN) {
+        fprintf(stderr, "Could not setup signal trap for SIGUSR2\n");
+        exit(1);
+    }
+
+    if (signal(SIGCONT, sigusr_handler) == SIG_IGN) {
         fprintf(stderr, "Could not setup signal trap for SIGUSR2\n");
         exit(1);
     }


### PR DESCRIPTION
…ERM, followed by another pause before SIGKILL. Do this within the odls/kill_local_procs function while we know we are blocked in an event, and before the daemon shuts down the event progress loop

Signed-off-by: Ralph Castain <rhc@open-mpi.org>