### PR TITLE
Ensure that we always send a SIGTERM prior to SIGKILL to give child processes a chance to cleanup

### DIFF
--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -194,18 +194,18 @@ static bool odls_default_child_died(orte_proc_t *child)
              * that occasionally causes us to incorrectly report a proc
              * as refusing to die. Unfortunately, errno may not be reset
              * by waitpid in this case, so we cannot check it.
-	     *
-	     * (note the previous fix to this, to return 'process dead'
-	     * here, fixes the race condition at the cost of reporting
-	     * all live processes have immediately died!  Better to
-	     * occasionally report a dead process as still living -
-	     * which will occasionally trip the timeout for cases that
-	     * are right on the edge.)
+             *
+             * (note the previous fix to this, to return 'process dead'
+             * here, fixes the race condition at the cost of reporting
+             * all live processes have immediately died!  Better to
+             * occasionally report a dead process as still living -
+             * which will occasionally trip the timeout for cases that
+             * are right on the edge.)
              */
             OPAL_OUTPUT_VERBOSE((20, orte_odls_base_framework.framework_output,
                                  "%s odls:default:WAITPID INDICATES PID %d MAY HAVE ALREADY EXITED",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), (int)(child->pid)));
-	    /* Do nothing, process still alive */
+            /* Do nothing, process still alive */
         } else if (-1 == ret && ECHILD == errno) {
             /* The pid no longer exists, so we'll call this "good
                enough for government work" */
@@ -392,12 +392,12 @@ static int do_child(orte_app_context_t* context,
     long fd, fdmax = sysconf(_SC_OPEN_MAX);
     char *param, *msg;
 
-    if (orte_forward_job_control) {
-        /* Set a new process group for this child, so that a
-           SIGSTOP can be sent to it without being sent to the
-           orted. */
-        setpgid(0, 0);
-    }
+#if HAVE_SETPGID
+    /* Set a new process group for this child, so that a
+       SIGSTOP can be sent to it without being sent to the
+       orted. */
+    setpgid(0, 0);
+#endif
 
     /* Setup the pipe to be close-on-exec */
     opal_fd_set_cloexec(write_fd);
@@ -710,7 +710,7 @@ static int odls_default_fork_local_proc(orte_app_context_t* context,
     }
 
     if (pid == 0) {
-	close(p[0]);
+        close(p[0]);
 #if HAVE_SETPGID
         setpgid(0, 0);
 #endif
@@ -760,11 +760,12 @@ static int send_signal(pid_t pid, int signal)
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                          signal, (long)pid));
 
-    if (orte_forward_job_control) {
-	/* Send the signal to the process group rather than the
-	   process.  The child is the leader of its process group. */
-	pid = -pid;
-    }
+#if HAVE_SETPGID
+    /* Send the signal to the process group rather than the
+       process.  The child is the leader of its process group. */
+    pid = -pid;
+#endif
+
     if (kill(pid, signal) != 0) {
         switch(errno) {
             case EINVAL:
@@ -811,4 +812,3 @@ static int orte_odls_default_restart_proc(orte_proc_t *child)
     }
     return rc;
 }
-


### PR DESCRIPTION


Thanks to Noel Rycroft for the report

Signed-off-by: Ralph Castain <rhc@open-mpi.org>