### PR TITLE
ess/base: invoke orte_routed.update_routing_plan() earlier

### DIFF
--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -493,6 +493,12 @@ int orte_ess_base_orted_setup(char **hosts)
         goto error;
     }
 
+    /* be sure to update the routing tree so the initial "phone home"
+     * to mpirun goes through the tree if static ports were enabled - still
+     * need to do it anyway just to initialize things
+     */
+    orte_routed.update_routing_plan(NULL);
+
     /* if we are using static ports, then we need to setup
      * the daemon info so the RML can function properly
      * without requiring a wireup stage. This must be done
@@ -509,12 +515,6 @@ int orte_ess_base_orted_setup(char **hosts)
             error = "construct daemon map from static ports";
             goto error;
         }
-    } else {
-        /* be sure to update the routing tree so the initial "phone home"
-         * to mpirun goes through the tree if static ports were enabled - still
-         * need to do it anyway just to initialize things
-         */
-        orte_routed.update_routing_plan(NULL);
     }
 
     /* Now provide a chance for the PLM


### PR DESCRIPTION
fix an issue that can be evidenced with two nodes
n0$ mpirun --host n1:1 --mca oob_tcp_static_ipv4_ports 1234 -np 1 --mca routed radix --mca oob tcp true

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>