### PR TITLE
spml/yoda: fix support for BTLs that do not register memory in mca_sp…

### DIFF
--- a/oshmem/mca/spml/yoda/spml_yoda.c
+++ b/oshmem/mca/spml/yoda/spml_yoda.c
@@ -1166,6 +1166,9 @@ int mca_spml_yoda_get(void* src_addr, size_t size, void* dst_addr, int src)
                 }
 
                 frag->local_handle = local_handle;
+            } else if (NULL == l_mkey) {
+                local_handle = NULL;
+                frag->local_handle = NULL;
             } else {
                 local_handle = ((mca_spml_yoda_context_t*)l_mkey->spml_context)->registration;
                 frag->local_handle = NULL;


### PR DESCRIPTION
…ml_yoda_get()

Refs open-mpi/ompi#2499

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>