### PR TITLE
Continue tracking the debugger enablement:

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/include/pmix_common.h
+++ b/opal/mca/pmix/pmix2x/pmix/include/pmix_common.h
@@ -263,6 +263,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_FWD_STDOUT                     "pmix.fwd.stdout"        // (bool) forward stdout from spawned procs to me
 #define PMIX_FWD_STDERR                     "pmix.fwd.stderr"        // (bool) forward stderr from spawned procs to me
 #define PMIX_DEBUGGER_DAEMONS               "pmix.debugger"          // (bool) spawned app consists of debugger daemons
+#define PMIX_COSPAWN_APP                    "pmix.cospawn"           // (bool) designated app is to be spawned as a disconnected
+                                                                     //     job - i.e., not part of the "comm_world" of the job
 
 /* query attributes */
 #define PMIX_QUERY_NAMESPACES               "pmix.qry.ns"            // (char*) request a comma-delimited list of active nspaces
@@ -274,7 +276,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_QUERY_LOCAL_PROC_TABLE         "pmix.qry.lptable"       // (char*) input nspace of job whose info is being requested
                                                                      //     returns (pmix_data_array_t) an array of pmix_proc_info_t for
                                                                      //     procs in job on same node
-#define PMIX_QUERY_AUTHORIZATIONS           "pmix.qry.auths"         // return operations tool is authorized to perform"
+#define PMIX_QUERY_AUTHORIZATIONS           "pmix.qry.auths"         // return operations tool is authorized to perform
+#define PMIX_QUERY_SPAWN_SUPPORT            "pmix.qry.spawn"         // return a comma-delimited list of supported spawn attributes
+#define PMIX_QUERY_DEBUG_SUPPORT            "pmix.qry.debug"         // return a comma-delimited list of supported debug attributes
 
 /* log attributes */
 #define PMIX_LOG_STDERR                     "pmix.log.stderr"        // (bool) log data to stderr
@@ -282,9 +286,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_LOG_SYSLOG                     "pmix.log.syslog"        // (bool) log data to syslog - defaults to ERROR priority unless
                                                                      //        modified by directive
 /* debugger attributes */
-#define PMIX_SPAWN_UNDER_DEBUGGER           "pmix.dbg.pause"         // (bool) job is being spawned under debugger - instruct it to pause on start
-#define PMIX_JOB_BEING_DEBUGGED             "pmix.dbg.job"           // (char*) nspace of the job to be debugged - the RM/PMIx server are
-                                                                     //     to provide the job-level info of that job to each debugger daemon
+#define PMIX_DEBUG_STOP_ON_EXEC             "pmix.dbg.exec"          // (bool) job is being spawned under debugger - instruct it to pause on start
+#define PMIX_DEBUG_STOP_IN_INIT             "pmix.dbg.init"          // (bool) instruct job to stop during init (e.g., MPI_Init) - must
+                                                                     //     occur after PMIx init completes
+#define PMIX_DEBUG_JOB                      "pmix.dbg.job"           // (char*) nspace of the job to be debugged - the RM/PMIx server are
 
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;

--- a/opal/mca/pmix/pmix2x/pmix2x.h
+++ b/opal/mca/pmix/pmix2x/pmix2x.h
@@ -116,6 +116,7 @@ typedef struct {
     opal_pmix_value_cbfunc_t valcbfunc;
     opal_pmix_lookup_cbfunc_t lkcbfunc;
     opal_pmix_spawn_cbfunc_t spcbfunc;
+    opal_pmix_info_cbfunc_t infocbfunc;
     void *cbdata;
 } pmix2x_opcaddy_t;
 OBJ_CLASS_DECLARATION(pmix2x_opcaddy_t);

--- a/opal/mca/pmix/pmix2x/pmix2x_server_north.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_north.c
@@ -843,6 +843,7 @@ static void info_cbfunc(int status,
             OPAL_LIST_FOREACH(kv, info, opal_value_t) {
                 (void)strncpy(pcaddy->info[n].key, kv->key, PMIX_MAX_KEYLEN);
                 pmix2x_value_load(&pcaddy->info[n].value, kv);
+                ++n;
             }
         }
     }

--- a/opal/mca/pmix/pmix_types.h
+++ b/opal/mca/pmix/pmix_types.h
@@ -212,11 +212,20 @@ BEGIN_C_DECLS
                                                                         //     returns (pmix_data_array_t) an array of pmix_proc_info_t for
                                                                         //     procs in job on same node
 #define OPAL_PMIX_QUERY_AUTHORIZATIONS          "pmix.qry.auths"        // return operations tool is authorized to perform"
+#define OPAL_PMIX_QUERY_SPAWN_SUPPORT           "pmix.qry.spawn"        // return a comma-delimited list of supported spawn attributes
+#define OPAL_PMIX_QUERY_DEBUG_SUPPORT           "pmix.qry.debug"        // return a comma-delimited list of supported debug attributes
 
 /* log attributes */
 #define OPAL_PMIX_LOG_STDERR                    "pmix.log.stderr"        // (bool) log data to stderr
 #define OPAL_PMIX_LOG_STDOUT                    "pmix.log.stdout"        // (bool) log data to stdout
 #define OPAL_PMIX_LOG_SYSLOG                    "pmix.log.syslog"        // (bool) log data to syslog - defaults to ERROR priority unless
+
+/* debugger attributes */
+#define OPAL_PMIX_DEBUG_STOP_ON_EXEC            "pmix.dbg.exec"          // (bool) job is being spawned under debugger - instruct it to pause on start
+#define OPAL_PMIX_DEBUG_STOP_IN_INIT            "pmix.dbg.init"          // (bool) instruct job to stop during init (e.g., MPI_Init) - must
+                                                                         //     occur after PMIx init completes
+#define OPAL_PMIX_DEBUG_JOB                     "pmix.dbg.job"           // (char*) nspace of the job to be debugged - the RM/PMIx server are
+
 
 /* define a scope for data "put" by PMI per the following:
  *

--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -447,6 +447,7 @@ static void _query(int sd, short args, void *cbdata)
     uint32_t key;
     void *nptr;
     char **nspaces=NULL, nspace[512];
+    char **ans = NULL;
 
     opal_output_verbose(2, orte_pmix_server_globals.output,
                         "%s processing query",
@@ -457,6 +458,9 @@ static void _query(int sd, short args, void *cbdata)
     /* see what they wanted */
     OPAL_LIST_FOREACH(q, cd->info, opal_pmix_query_t) {
         for (n=0; NULL != q->keys[n]; n++) {
+            opal_output_verbose(2, orte_pmix_server_globals.output,
+                                "%s processing key %s",
+                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), q->keys[n]);
             if (0 == strcmp(q->keys[n], OPAL_PMIX_QUERY_NAMESPACES)) {
                 /* get the current jobids */
                 rc = opal_hash_table_get_first_key_uint32(orte_job_data, &key, (void **)&jdata, &nptr);
@@ -470,6 +474,7 @@ static void _query(int sd, short args, void *cbdata)
                 }
                 /* join the results into a single comma-delimited string */
                 kv = OBJ_NEW(opal_value_t);
+                kv->key = strdup(OPAL_PMIX_QUERY_NAMESPACES);
                 kv->type = OPAL_STRING;
                 if (NULL != nspaces) {
                     kv->data.string = opal_argv_join(nspaces, ',');
@@ -477,6 +482,37 @@ static void _query(int sd, short args, void *cbdata)
                     kv->data.string = NULL;
                 }
                 opal_list_append(results, &kv->super);
+            } else if (0 == strcmp(q->keys[n], OPAL_PMIX_QUERY_SPAWN_SUPPORT)) {
+                opal_argv_append_nosize(&ans, OPAL_PMIX_HOST);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_HOSTFILE);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_ADD_HOST);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_ADD_HOSTFILE);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_PREFIX);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_WDIR);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_MAPPER);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_PPR);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_MAPBY);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_RANKBY);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_BINDTO);
+                /* create the return kv */
+                kv = OBJ_NEW(opal_value_t);
+                kv->key = strdup(OPAL_PMIX_QUERY_SPAWN_SUPPORT);
+                kv->type = OPAL_STRING;
+                kv->data.string = opal_argv_join(ans, ',');
+                opal_list_append(results, &kv->super);
+                opal_argv_free(ans);
+                ans = NULL;
+            } else if (0 == strcmp(q->keys[n], OPAL_PMIX_QUERY_DEBUG_SUPPORT)) {
+                opal_argv_append_nosize(&ans, OPAL_PMIX_DEBUG_STOP_IN_INIT);
+                opal_argv_append_nosize(&ans, OPAL_PMIX_DEBUG_JOB);
+                /* create the return kv */
+                kv = OBJ_NEW(opal_value_t);
+                kv->key = strdup(OPAL_PMIX_QUERY_DEBUG_SUPPORT);
+                kv->type = OPAL_STRING;
+                kv->data.string = opal_argv_join(ans, ',');
+                opal_list_append(results, &kv->super);
+                opal_argv_free(ans);
+                ans = NULL;
             }
         }
     }


### PR DESCRIPTION
* fix the query response passdown thru OPAL so all keys get returned

* add ability to query ORTE for spawn and debugger support options

Signed-off-by: Ralph Castain <rhc@open-mpi.org>