### PR TITLE
v2.x: ompi/request: Fix a persistent request creation bug

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_iprobe.c
+++ b/ompi/mca/pml/ob1/pml_ob1_iprobe.c
@@ -36,7 +36,7 @@ int mca_pml_ob1_iprobe(int src,
     recvreq.req_recv.req_base.req_ompi.req_type = OMPI_REQUEST_PML;
     recvreq.req_recv.req_base.req_type = MCA_PML_REQUEST_IPROBE;
 
-    MCA_PML_OB1_RECV_REQUEST_INIT(&recvreq, NULL, 0, &ompi_mpi_char.dt, src, tag, comm, true);
+    MCA_PML_OB1_RECV_REQUEST_INIT(&recvreq, NULL, 0, &ompi_mpi_char.dt, src, tag, comm, false);
     MCA_PML_OB1_RECV_REQUEST_START(&recvreq);
 
     if( REQUEST_COMPLETE( &(recvreq.req_recv.req_base.req_ompi)) ) {
@@ -66,7 +66,7 @@ int mca_pml_ob1_probe(int src,
     recvreq.req_recv.req_base.req_ompi.req_type = OMPI_REQUEST_PML;
     recvreq.req_recv.req_base.req_type = MCA_PML_REQUEST_PROBE;
 
-    MCA_PML_OB1_RECV_REQUEST_INIT(&recvreq, NULL, 0, &ompi_mpi_char.dt, src, tag, comm, true);
+    MCA_PML_OB1_RECV_REQUEST_INIT(&recvreq, NULL, 0, &ompi_mpi_char.dt, src, tag, comm, false);
     MCA_PML_OB1_RECV_REQUEST_START(&recvreq);
 
     ompi_request_wait_completion(&recvreq.req_recv.req_base.req_ompi);

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -142,13 +142,14 @@ typedef struct ompi_predefined_request_t ompi_predefined_request_t;
  * performance path (since requests may be re-used, it is possible
  * that we will have to initialize a request multiple times).
  */
-#define OMPI_REQUEST_INIT(request, persistent)        \
-    do {                                              \
-        (request)->req_complete = REQUEST_PENDING;    \
-        (request)->req_state = OMPI_REQUEST_INACTIVE; \
-        (request)->req_persistent = (persistent);     \
-        (request)->req_complete_cb  = NULL;           \
-        (request)->req_complete_cb_data = NULL;       \
+#define OMPI_REQUEST_INIT(request, persistent)                  \
+    do {                                                        \
+        (request)->req_complete =                               \
+            (persistent) ? REQUEST_COMPLETED : REQUEST_PENDING; \
+        (request)->req_state = OMPI_REQUEST_INACTIVE;           \
+        (request)->req_persistent = (persistent);               \
+        (request)->req_complete_cb  = NULL;                     \
+        (request)->req_complete_cb_data = NULL;                 \
     } while (0);
 
 


### PR DESCRIPTION
@bosilca Please review.

`ompi/mca/pml/bfo` is not included in this commit because it is dropped in v2.x.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>
(back-ported from commit 6510800c1642a9b459dadb2720ae57df9fbea934)