### PR TITLE
v1.10: ompi/debuggers: make the binary bit reproducible

### DIFF
--- a/ompi/debuggers/ompi_common_dll.c
+++ b/ompi/debuggers/ompi_common_dll.c
@@ -5,6 +5,8 @@
  *                         reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc. All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  * 
@@ -38,6 +40,8 @@
 #include "ompi_config.h"
 
 #include "ompi_common_dll_defs.h"
+
+#include <string.h>
 
 /* Basic callbacks into the debugger */
 const mqs_basic_callbacks *mqs_basic_entrypoints;
@@ -634,4 +638,21 @@ int ompi_fetch_opal_pointer_array_item(mqs_process *proc, mqs_taddr_t addr,
                                p_info);
 
     return mqs_ok;
+}
+
+int ompi_get_lib_version(char * buf, int size) {
+    int ret;
+    ret = snprintf(buf, size-1, "Open MPI v%d.%d.%d%s%s%s%s%s%s%s%s%s",
+                   OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION,
+                   (strlen(OMPI_GREEK_VERSION) > 0)?OMPI_GREEK_VERSION:"",
+                   (strlen(OPAL_PACKAGE_STRING) > 0)?", package: ":"",
+                   (strlen(OPAL_PACKAGE_STRING) > 0)?OPAL_PACKAGE_STRING:"",
+                   (strlen(OPAL_IDENT_STRING)> 0)?", ident: ":"",
+                   (strlen(OPAL_IDENT_STRING)> 0)?OMPI_IDENT_STRING:"",
+                   (strlen(OMPI_REPO_REV) > 0)?", repo rev: ":"",
+                   (strlen(OMPI_REPO_REV) > 0)?OMPI_REPO_REV:"",
+                   (strlen(OMPI_RELEASE_DATE) > 0)?", ":"",
+                   (strlen(OMPI_RELEASE_DATE) > 0)?OMPI_RELEASE_DATE:"");
+    buf[size-1] = '\0';
+    return ret;
 }

--- a/ompi/debuggers/ompi_common_dll_defs.h
+++ b/ompi/debuggers/ompi_common_dll_defs.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2004-2013 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -325,4 +327,6 @@ int ompi_fetch_opal_pointer_array_info(mqs_process *proc, mqs_taddr_t addr,
 int ompi_fetch_opal_pointer_array_item(mqs_process *proc, mqs_taddr_t addr, 
                                        mpi_process_info *p_info, int index,
                                        mqs_taddr_t *item);
+#define OMPI_MAX_VER_SIZE 256
+int ompi_get_lib_version(char *buf, int size);
 #endif

--- a/ompi/debuggers/ompi_mpihandles_dll.c
+++ b/ompi/debuggers/ompi_mpihandles_dll.c
@@ -4,6 +4,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -167,12 +169,17 @@ int mpidbg_interface_version_compatibility(void)
 }
 
 
+static char mpidbg_version_str[OMPI_MAX_VER_SIZE];
+
 /* Returns a string specific to OMPI */
 char *mpidbg_version_string(void)
 {
+    int offset;
     printf("mpidbg_version_string\n");
-    return "Open MPI handle interpretation support for parallel"
-           " debuggers compiled on " __DATE__;
+    offset = snprintf(mpidbg_version_str, OMPI_MAX_VER_SIZE-1,  
+                      "Open MPI handle interpretation support for parallel debuggers ");
+    ompi_get_lib_version(mpidbg_version_str+offset, OMPI_MAX_VER_SIZE-offset);
+    return mpidbg_version_str;
 }
 
 

--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -4,6 +4,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -186,11 +188,18 @@ int mqs_version_compatibility (void)
     return MQS_INTERFACE_COMPATIBILITY;
 } /* mqs_version_compatibility */
 
+static char mqs_version_str[OMPI_MAX_VER_SIZE];
+
 /* This one can say what you like */
 char *mqs_version_string (void)
 {
     return "Open MPI message queue support for parallel"
            " debuggers compiled on " __DATE__;
+    int offset;
+    offset = snprintf(mqs_version_str, OMPI_MAX_VER_SIZE-1,  
+                      "Open MPI message queue support for parallel debuggers ");
+    ompi_get_lib_version(mqs_version_str+offset, OMPI_MAX_VER_SIZE-offset);
+    return mqs_version_str;
 } /* mqs_version_string */
 
 /* So the debugger can tell what interface width the library was compiled with */


### PR DESCRIPTION
instead of compilation date __DATE__, use a MPI_Get_library_version() like string

Thanks Alastair McKinstry for the report

Fixes open-mpi/ompi#2518

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@4d8f6064206545410da6c54a3470e4cf52e7325a)