### PR TITLE
Topic/osc pt2pt fixes

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -46,6 +46,19 @@
 
 BEGIN_C_DECLS
 
+/*
+ * JJH: This is a hack, but it'll help us make forward progress for now.
+ * It is possible, in a multthreaded scenario, that the 'outgoing_frag_{signal_} count'
+ * is incremented in such a way that those waiting in opal_condition_wait for it
+ * to change never receive a signal. This is because the functions incrementing this
+ * value do not grab the 'module' lock, and doing so can lead to deadlock...
+ *
+ * Ideally we would grab the module lock in the mark_outgoing_completion() to
+ * prevent that race, but this can result in a deadlock by double locking that
+ * mutex. So that code need to be audited a bit more.
+ */
+#define OSC_PT2PT_HARD_SPIN_NO_CV_WAIT 1
+
 struct ompi_osc_pt2pt_frag_t;
 struct ompi_osc_pt2pt_receive_t;
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -913,11 +913,14 @@ static inline ompi_osc_pt2pt_sync_t *ompi_osc_pt2pt_module_sync_lookup (ompi_osc
 
         return &module->all_sync;
     case OMPI_OSC_PT2PT_SYNC_TYPE_PSCW:
+        OPAL_THREAD_LOCK(&module->all_sync.lock);
         if (ompi_osc_pt2pt_sync_pscw_peer (module, target, peer)) {
+            OPAL_THREAD_UNLOCK(&module->all_sync.lock);
             OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                                  "osc/pt2pt: found PSCW access epoch target for %d", target));
             return &module->all_sync;
         }
+        OPAL_THREAD_UNLOCK(&module->all_sync.lock);
     }
 
     return NULL;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
@@ -227,6 +227,12 @@ int ompi_osc_pt2pt_start (ompi_group_t *group, int assert, ompi_win_t *win)
     /* haven't processed any post messages yet */
     sync->sync_expected = sync->num_peers;
 
+    /* If the previous epoch was from Fence, then eager_send_active is still
+     * set to true at this time, but it shoulnd't be true until we get our
+     * incoming Posts. So reset to 'false' for this new epoch.
+     */
+    sync->eager_send_active = false;
+
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "ompi_osc_pt2pt_start entering with group size %d...",
                          sync->num_peers));

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
@@ -337,10 +337,12 @@ static inline int ompi_osc_pt2pt_put_w_req (const void *origin_addr, int origin_
     if (is_long_msg) {
         /* wait for eager sends to be active before starting a long put */
         if (pt2pt_sync->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK) {
+            OPAL_THREAD_LOCK(&pt2pt_sync->lock);
             ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, target);
-            while (!(peer->flags | OMPI_OSC_PT2PT_PEER_FLAG_EAGER)) {
+            while (!(peer->flags & OMPI_OSC_PT2PT_PEER_FLAG_EAGER)) {
                 opal_condition_wait(&pt2pt_sync->cond, &pt2pt_sync->lock);
             }
+            OPAL_THREAD_UNLOCK(&pt2pt_sync->lock);
         } else {
             ompi_osc_pt2pt_sync_wait_expected (pt2pt_sync);
         }
@@ -503,10 +505,12 @@ ompi_osc_pt2pt_accumulate_w_req (const void *origin_addr, int origin_count,
     if (is_long_msg) {
         /* wait for synchronization before posting a long message */
         if (pt2pt_sync->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK) {
+            OPAL_THREAD_LOCK(&pt2pt_sync->lock);
             ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, target);
-            while (!(peer->flags | OMPI_OSC_PT2PT_PEER_FLAG_EAGER)) {
+            while (!(peer->flags & OMPI_OSC_PT2PT_PEER_FLAG_EAGER)) {
                 opal_condition_wait(&pt2pt_sync->cond, &pt2pt_sync->lock);
             }
+            OPAL_THREAD_UNLOCK(&pt2pt_sync->lock);
         } else {
             ompi_osc_pt2pt_sync_wait_expected (pt2pt_sync);
         }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -153,8 +153,12 @@ static int component_register (void)
 
 static int component_progress (void)
 {
+    OPAL_THREAD_LOCK(&mca_osc_pt2pt_component.pending_operations_lock);
     int pending_count = opal_list_get_size (&mca_osc_pt2pt_component.pending_operations);
+    OPAL_THREAD_UNLOCK(&mca_osc_pt2pt_component.pending_operations_lock);
+    OPAL_THREAD_LOCK(&mca_osc_pt2pt_component.pending_receives_lock);
     int recv_count = opal_list_get_size (&mca_osc_pt2pt_component.pending_receives);
+    OPAL_THREAD_UNLOCK(&mca_osc_pt2pt_component.pending_receives_lock);
     ompi_osc_pt2pt_pending_t *pending, *next;
 
     if (recv_count) {
@@ -335,6 +339,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     if (OPAL_SUCCESS != ret) {
         goto cleanup;
     }
+
+    module->num_complete_msgs = 0;
 
     /* options */
     /* FIX ME: should actually check this value... */

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -747,7 +747,9 @@ static int ompi_osc_pt2pt_acc_op_queue (ompi_osc_pt2pt_module_t *module, ompi_os
     }
 
     /* add to the pending acc queue */
-    OPAL_THREAD_SCOPED_LOCK(&module->lock, opal_list_append (&module->pending_acc, &pending_acc->super));
+    ompi_osc_pt2pt_accumulate_lock(module);
+    opal_list_append (&module->pending_acc, &pending_acc->super);
+    ompi_osc_pt2pt_accumulate_unlock(module);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
@@ -419,6 +419,16 @@ static int ompi_osc_pt2pt_unlock_internal (int target, ompi_win_t *win)
             /* wait for unlock acks. this signals remote completion of fragments */
             ompi_osc_pt2pt_sync_wait_expected (lock);
 
+            /* Mark - It is possible for the unlock to finish too early before
+             * the data is actually present in teh recv buf (for non-contiguous datatypes)
+             * So make sure to wait for all of the fragments to arrive.
+             */
+            OPAL_THREAD_LOCK(&module->lock);
+            while (module->outgoing_frag_count < module->outgoing_frag_signal_count) {
+                opal_condition_wait(&module->cond, &module->lock);
+            }
+            OPAL_THREAD_UNLOCK(&module->lock);
+
             OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,
                                  "ompi_osc_pt2pt_unlock: unlock of %d complete", target));
         } else {

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_request.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_request.h
@@ -40,7 +40,8 @@ OBJ_CLASS_DECLARATION(ompi_osc_pt2pt_request_t);
     do {                                                                \
         opal_free_list_item_t *item;                                    \
         do {                                                            \
-            item = opal_free_list_get (&mca_osc_pt2pt_component.requests); \
+            OPAL_THREAD_SCOPED_LOCK(&mca_osc_pt2pt_component.lock, \
+                                    item = opal_free_list_get (&mca_osc_pt2pt_component.requests)); \
             if (NULL == item) {                                         \
                 opal_progress();                                        \
             }                                                           \
@@ -58,8 +59,9 @@ OBJ_CLASS_DECLARATION(ompi_osc_pt2pt_request_t);
     do {                                                                \
         OMPI_REQUEST_FINI(&(req)->super);                               \
         (req)->outstanding_requests = 0;                                \
-        opal_free_list_return (&mca_osc_pt2pt_component.requests,       \
-                                 (opal_free_list_item_t *) (req));      \
+        OPAL_THREAD_SCOPED_LOCK(&mca_osc_pt2pt_component.lock, \
+                                opal_free_list_return (&mca_osc_pt2pt_component.requests, \
+                                                       (opal_free_list_item_t *) (req))); \
     } while (0)
 
 static inline void ompi_osc_pt2pt_request_complete (ompi_osc_pt2pt_request_t *request, int mpi_error)

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
@@ -164,18 +164,9 @@ static inline void ompi_osc_pt2pt_sync_expected (ompi_osc_pt2pt_sync_t *sync)
     int32_t new_value = OPAL_THREAD_ADD32 (&sync->sync_expected, -1);
     if (0 == new_value) {
         OPAL_THREAD_LOCK(&sync->lock);
-#if 0
         if (!(sync->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK && sync->num_peers > 1)) {
             sync->eager_send_active = true;
         }
-#else
-        if ((sync->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK && sync->num_peers > 1)) {
-            opal_output_verbose(1, ompi_osc_base_framework.framework_output,
-                                "WARNING: Setting 'eager_send_active' even though sync->type = %d and sync->num_peers = %d",
-                                sync->type, sync->num_peers);
-        }
-        sync->eager_send_active = true;
-#endif
         opal_condition_broadcast (&sync->cond);
         OPAL_THREAD_UNLOCK(&sync->lock);
     }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
@@ -164,9 +164,18 @@ static inline void ompi_osc_pt2pt_sync_expected (ompi_osc_pt2pt_sync_t *sync)
     int32_t new_value = OPAL_THREAD_ADD32 (&sync->sync_expected, -1);
     if (0 == new_value) {
         OPAL_THREAD_LOCK(&sync->lock);
+#if 0
         if (!(sync->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK && sync->num_peers > 1)) {
             sync->eager_send_active = true;
         }
+#else
+        if ((sync->type == OMPI_OSC_PT2PT_SYNC_TYPE_LOCK && sync->num_peers > 1)) {
+            opal_output_verbose(1, ompi_osc_base_framework.framework_output,
+                                "WARNING: Setting 'eager_send_active' even though sync->type = %d and sync->num_peers = %d",
+                                sync->type, sync->num_peers);
+        }
+        sync->eager_send_active = true;
+#endif
         opal_condition_broadcast (&sync->cond);
         OPAL_THREAD_UNLOCK(&sync->lock);
     }

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -428,7 +428,7 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
                 ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWAP_PTR(&request->req_complete,
                                                                                        REQUEST_COMPLETED);
                 /* In the case where another thread concurrently changed the request to REQUEST_PENDING */
-                if( REQUEST_PENDING != tmp_sync )
+                if( REQUEST_PENDING != tmp_sync && REQUEST_COMPLETED != tmp_sync )
                     wait_sync_update(tmp_sync, 1, request->req_status.MPI_ERROR);
             }
         } else


### PR DESCRIPTION
Fixes related to Issue #2505 

 * Note that this PR is against `v2.0.x`. That's just to make it easier on our testing. We will file a real PR against `master` once we have more of this working.
 * With these patches the single threaded (`1sided.c`) case seems to be working.
 * The multithreaded case is not working. These patches are progress towards that, but there are still outstanding hangs and wrong answers being generated by the multithreaded version of the test (`mt_1sided.c`).
 * We will keep this PR updated with any progress that is made. We wanted to get this posted to have more eyes on the problem from the community.

I'm going to turn off the CI for a little while:
 * bot:notest  (IBM's version)
 * [skip ci]  (Default for GHPRB)