### PR TITLE
Release file updates

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -82,7 +82,7 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=12:4:0
+libmpi_so_version=12:5:0
 libmpi_cxx_so_version=2:3:1
 libmpi_mpifh_so_version=12:1:0
 libmpi_usempi_tkr_so_version=6:0:1

--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=5
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=a1
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
Only one library changed since v1.10.4 -- libmpi.

Please check this -- I used: `git log log --stat --no-merges v1.10.4..HEAD` to see what files changed.