### PR TITLE
oshmem: sshmem: make mmap allocator a default instead of verbs

### DIFF
--- a/oshmem/mca/sshmem/mmap/sshmem_mmap_component.c
+++ b/oshmem/mca/sshmem/mmap/sshmem_mmap_component.c
@@ -94,10 +94,10 @@ mmap_register(void)
 {
     /* ////////////////////////////////////////////////////////////////////// */
     /* (default) priority - set high to make mmap the default */
-    mca_sshmem_mmap_component.priority = 20;
+    mca_sshmem_mmap_component.priority = 40;
     mca_base_component_var_register (&mca_sshmem_mmap_component.super.base_version,
                                      "priority", "Priority for sshmem mmap "
-                                     "component (default: 20)", MCA_BASE_VAR_TYPE_INT,
+                                     "component (default: 40)", MCA_BASE_VAR_TYPE_INT,
                                      NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                      OPAL_INFO_LVL_3,
                                      MCA_BASE_VAR_SCOPE_ALL_EQ,

--- a/oshmem/mca/sshmem/verbs/sshmem_verbs_component.c
+++ b/oshmem/mca/sshmem/verbs/sshmem_verbs_component.c
@@ -269,10 +269,10 @@ verbs_register(void)
 
     /* ////////////////////////////////////////////////////////////////////// */
     /* (default) priority - set high to make verbs the default */
-    mca_sshmem_verbs_component.priority = 40;
+    mca_sshmem_verbs_component.priority = 20;
     index = mca_base_component_var_register (&mca_sshmem_verbs_component.super.base_version,
                                            "priority", "Priority for sshmem verbs "
-                                           "component (default: 40)", MCA_BASE_VAR_TYPE_INT,
+                                           "component (default: 20)", MCA_BASE_VAR_TYPE_INT,
                                            NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_3,
                                            MCA_BASE_VAR_SCOPE_ALL_EQ,


### PR DESCRIPTION
@miked-mellanox @yosefe @jladd-mlnx 

By default use mmap() to allocate memory for the symmetric heap.
It is safer and more portable choice than sysv and verbs.

Signed-off-by: Alex Mikheev <alexm@mellanox.com>
(cherry picked from commit 67d66c2326b9060673e6d884d536d2ae1312524b)