### PR TITLE
v2.0.x: opal_configure_options: remove stale option help

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -503,11 +503,6 @@ OPAL_WITH_OPTION_MIN_MAX_VALUE(port_name,      1024, 255, 2048)
 # Min length accroding to MPI-2.1, p. 418
 OPAL_WITH_OPTION_MIN_MAX_VALUE(datarep_string,  128,  64,  256)
 
-# How to build libltdl
-AC_ARG_WITH([libltdl],
-    [AC_HELP_STRING([--with-libltdl(=DIR)],
-         [Where to find libltdl (this option is ignored if --disable-dlopen is used).  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" (or no DIR value) forces Open MPI to use its internal copy of libltdl.  "external" forces Open MPI to use an external installation of libltdl.  Supplying a valid directory name also forces Open MPI to use an external installation of libltdl, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries.])])
-
 AC_DEFINE_UNQUOTED([OPAL_ENABLE_CRDEBUG], [0],
     [Whether we want checkpoint/restart enabled debugging functionality or not])
 


### PR DESCRIPTION
--with-libltdl is now added (via AC_ARG_WITH) in
opal/mca/dl/libltdl/configure.m4 -- it no longer belongs up here in
this top-level m4 file.  Plus, the help string in this stale entry is
also stale/incorrect.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 678e314c0ef0325946b88878db487e73553f9982)

@hppritcha This can be 2.0.2 (it's trivial), but it can also easily slip to v2.0.3 (i.e., not critical at all).

Refs #1092.