### PR TITLE
Topic/osc controls

### DIFF
--- a/ompi/include/ompi/constants.h
+++ b/ompi/include/ompi/constants.h
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,6 +76,7 @@ enum {
     OMPI_ERR_WIN                    = OMPI_ERR_BASE - 7,
     OMPI_ERR_RMA_FLAVOR             = OMPI_ERR_BASE - 8,
 };
+/* it'd be nice to have a new OMPI_ERR_DISABLED error code. */
 
 #define OMPI_ERR_MAX                    (OMPI_ERR_BASE - 100)
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,6 +89,21 @@ struct ompi_osc_pt2pt_component_t {
 
     /** Is the progress function enabled? */
     bool progress_enable;
+
+    /** opal_output_verbose stream id */
+    int output;
+
+    /** MCA parameter: priority of this component */
+    int priority;
+
+    /** MCA parameter: Verbose level of this component */
+    int verbose;
+
+    /** MCA parameters: Enable osc_pt2pt component */
+    bool enable;
+
+    /** Allow osc_pt2pt to run when user passes in MPI_THREAD_MULTIPLE */
+    bool allow_thread_multiple;
 };
 typedef struct ompi_osc_pt2pt_component_t ompi_osc_pt2pt_component_t;
 

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,10 +95,19 @@ struct ompi_osc_rdma_component_t {
     bool acc_use_amo;
 
     /** Priority of the osc/rdma component */
-    unsigned int priority;
+    int priority;
 
     /** aggregation free list */
     opal_free_list_t aggregate;
+
+    /** MCA parameter: Verbose level of this component */
+    int verbose;
+
+    /** MCA parameters: Enable osc_pt2pt component */
+    bool enable;
+
+    /** Allow osc_rdma to run when user passes in MPI_THREAD_MULTIPLE */
+    bool allow_thread_multiple;
 };
 typedef struct ompi_osc_rdma_component_t ompi_osc_rdma_component_t;
 


### PR DESCRIPTION
Adding mca parameter "enable" to enable / disable osc_rdma and osc_pt2pt. 
Adding mca parameter "allow_thread_multiple" to enable (default) / disable osc_rdma and osc_pt2pt when user passed in MPI_THREAD_MULTIPLE to MPI_Init_threads().

Due to the Issue #2614, we recommend that v2.0.2 gets released with the following additions to the etc/openmpi-mca-params.conf file:
```
osc_rdma_enable = 1
osc_rdma_allow_thread_multiple = 0
osc_pt2pt_enable = 1
osc_pt2pt_allow_thread_multiple = 0
```

This PR does NOT make any changes to the mca params.conf file, the release engineer should make that decision / change.