### PR TITLE
v2.x: ompi/debugger: fix mqs_version_string()

### DIFF
--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -193,8 +193,6 @@ static char mqs_version_str[OMPI_MAX_VER_SIZE];
 /* This one can say what you like */
 char *mqs_version_string (void)
 {
-    return "Open MPI message queue support for parallel"
-           " debuggers compiled on " __DATE__;
     int offset;
     offset = snprintf(mqs_version_str, OMPI_MAX_VER_SIZE-1,  
                       "Open MPI message queue support for parallel debuggers ");


### PR DESCRIPTION
Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@773cad6b3ed039042db25da1a32d49a6b0f1b249)