### PR TITLE
osc/pt2pt: workaround for issue 2614 for v2.0.2

### DIFF
--- a/ompi/mca/osc/pt2pt/Makefile.am
+++ b/ompi/mca/osc/pt2pt/Makefile.am
@@ -18,6 +18,8 @@
 # $HEADER$
 #
 
+dist_ompidata_DATA = help-osc-pt2pt.txt
+
 pt2pt_sources = \
 	osc_pt2pt.h \
 	osc_pt2pt_module.c \

--- a/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
+++ b/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
@@ -1,0 +1,15 @@
+# -*- text -*-
+#
+# Copyright (c) 2016 Los Alamos National Security, LLC. All rights
+#                    reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+[mpi-thread-multiple-not-supported]
+The OSC pt2pt component does not support MPI_THREAD_MULTIPLE in this release.
+Workarounds are to run on a single node, or to use a system with an RDMA
+capable network such as Infiniband.


### PR DESCRIPTION
As a workaround for issue #2614 for the v2.0.2 release,
do not allow for selection of the OSC PT2PT when
creating an MPI RMA window.  Print a hopefully helpful
message and return an not-supported error.

This PR should be reverted once a fix for #2614
is in place.

This PR/commit is a one off for the v2.0.x branch.

Tested against modified osu one-sided benchmarks.

@bosilca 
@gpaulsen 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>