### PR TITLE
Avoid mangling user-provided CFLAGS by using the new PMIX_FLAGS_UNIQ autoconf script in place of PMIX_UNIQ

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/config/pmix_setup_cc.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix_setup_cc.m4
@@ -72,7 +72,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
     if test "$WANT_DEBUG" = "1" && test "$enable_debug_symbols" != "no" ; then
         CFLAGS="$CFLAGS -g"
 
-        PMIX_UNIQ(CFLAGS)
+        PMIX_FLAGS_UNIQ(CFLAGS)
         AC_MSG_WARN([-g has been added to CFLAGS (--enable-debug)])
     fi
 
@@ -138,7 +138,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
         fi
 
         CFLAGS="$CFLAGS_orig $add"
-        PMIX_UNIQ(CFLAGS)
+        PMIX_FLAGS_UNIQ(CFLAGS)
         AC_MSG_WARN([$add has been added to CFLAGS (--enable-picky)])
         unset add
     fi
@@ -188,7 +188,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
         fi
         CFLAGS="$CFLAGS_orig$add"
 
-        PMIX_UNIQ(CFLAGS)
+        PMIX_FLAGS_UNIQ(CFLAGS)
         AC_MSG_WARN([$add has been added to CFLAGS])
         unset add
     fi
@@ -217,7 +217,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
         fi
 
         CFLAGS="${CFLAGS_orig}${add}"
-        PMIX_UNIQ([CFLAGS])
+        PMIX_FLAGS_UNIQ([CFLAGS])
         if test "$add" != "" ; then
             AC_MSG_WARN([$add has been added to CFLAGS])
         fi


### PR DESCRIPTION
Per @jsquyres 

Refs #2636

Signed-off-by: Ralph Castain <rhc@open-mpi.org>