### PR TITLE
v2.x: fix CFLAGS uniqueness

### DIFF
--- a/config/ompi_fortran_check_real16_c_equiv.m4
+++ b/config/ompi_fortran_check_real16_c_equiv.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2008-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
@@ -49,7 +49,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_REAL16_C_EQUIV],[
                              [AC_MSG_CHECKING([if intel compiler _Quad == REAL*16])
                               CFLAGS_save="$CFLAGS"
                               CFLAGS="$CFLAGS -Qoption,cpp,--extended_float_types"
-                              OPAL_UNIQ([CFLAGS])
+                              OPAL_FLAGS_UNIQ([CFLAGS])
                               OMPI_FORTRAN_CHECK_REAL16_EQUIV_TYPE([_Quad], [q])
                               AS_IF([test "$happy" = "yes"],
                                     [OMPI_FORTRAN_REAL16_C_TYPE="_Quad"
@@ -59,7 +59,7 @@ AC_DEFUN([OMPI_FORTRAN_CHECK_REAL16_C_EQUIV],[
                              ])
                        AS_IF([test "$opal_cv_c_compiler_vendor" = "gnu" && test "$ac_cv_type___float128" = "yes"],
                              [AC_MSG_CHECKING([if gnu compiler __float128 == REAL*16])
-                              OPAL_UNIQ([CFLAGS])
+                              OPAL_FLAGS_UNIQ([CFLAGS])
                               OMPI_FORTRAN_CHECK_REAL16_EQUIV_TYPE([__float128], [q])
                               AS_IF([test "$happy" = "yes"],
                                     [OMPI_FORTRAN_REAL16_C_TYPE="__float128"

--- a/opal/mca/pmix/pmix112/pmix/config/pmix_functions.m4
+++ b/opal/mca/pmix/pmix112/pmix/config/pmix_functions.m4
@@ -317,6 +317,103 @@ dnl #######################################################################
 dnl #######################################################################
 dnl #######################################################################
 
+# Remove all duplicate -I, -L, and -l flags from the variable named $1
+AC_DEFUN([PMIX_FLAGS_UNIQ],[
+    # 1 is the variable name to be uniq-ized
+    pmix_name=$1
+
+    # Go through each item in the variable and only keep the unique ones
+
+    pmix_count=0
+    for val in ${$1}; do
+        pmix_done=0
+        pmix_i=1
+        pmix_found=0
+
+        # Loop over every token we've seen so far
+
+        pmix_done="`expr $pmix_i \> $pmix_count`"
+        while test "$pmix_found" = "0" && test "$pmix_done" = "0"; do
+
+            # Have we seen this token already?  Prefix the comparison
+            # with "x" so that "-Lfoo" values won't be cause an error.
+
+	    pmix_eval="expr x$val = x\$pmix_array_$pmix_i"
+	    pmix_found=`eval $pmix_eval`
+
+            # Check the ending condition
+
+	    pmix_done="`expr $pmix_i \>= $pmix_count`"
+
+            # Increment the counter
+
+	    pmix_i="`expr $pmix_i + 1`"
+        done
+
+        # Check for special cases where we do want to allow repeated
+        # arguments (per
+        # http://www.open-mpi.org/community/lists/devel/2012/08/11362.php
+        # and
+        # https://github.com/open-mpi/ompi/issues/324).
+
+        case $val in
+        -Xclang)
+                pmix_found=0
+                pmix_i=`expr $pmix_count + 1`
+                ;;
+        -framework)
+                pmix_found=0
+                pmix_i=`expr $pmix_count + 1`
+                ;;
+        --param)
+                pmix_found=0
+                pmix_i=`expr $pmix_count + 1`
+                ;;
+        esac
+
+        # If we didn't find the token, add it to the "array"
+
+        if test "$pmix_found" = "0"; then
+	    pmix_eval="pmix_array_$pmix_i=$val"
+	    eval $pmix_eval
+	    pmix_count="`expr $pmix_count + 1`"
+        else
+	    pmix_i="`expr $pmix_i - 1`"
+        fi
+    done
+
+    # Take all the items in the "array" and assemble them back into a
+    # single variable
+
+    pmix_i=1
+    pmix_done="`expr $pmix_i \> $pmix_count`"
+    pmix_newval=
+    while test "$pmix_done" = "0"; do
+        pmix_eval="pmix_newval=\"$pmix_newval \$pmix_array_$pmix_i\""
+        eval $pmix_eval
+
+        pmix_eval="unset pmix_array_$pmix_i"
+        eval $pmix_eval
+
+        pmix_done="`expr $pmix_i \>= $pmix_count`"
+        pmix_i="`expr $pmix_i + 1`"
+    done
+
+    # Done; do the assignment
+
+    pmix_newval="`echo $pmix_newval`"
+    pmix_eval="$pmix_name=\"$pmix_newval\""
+    eval $pmix_eval
+
+    # Clean up
+
+    unset pmix_name pmix_i pmix_done pmix_newval pmix_eval pmix_count
+])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
 # PMIX_APPEND_UNIQ(variable, new_argument)
 # ----------------------------------------
 # Append new_argument to variable if not already in variable.  This assumes a

--- a/opal/mca/pmix/pmix112/pmix/config/pmix_setup_cc.m4
+++ b/opal/mca/pmix/pmix112/pmix/config/pmix_setup_cc.m4
@@ -72,7 +72,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
     if test "$WANT_DEBUG" = "1" && test "$enable_debug_symbols" != "no" ; then
         CFLAGS="$CFLAGS -g"
 
-        PMIX_UNIQ(CFLAGS)
+        PMIX_FLAGS_UNIQ(CFLAGS)
         AC_MSG_WARN([-g has been added to CFLAGS (--enable-debug)])
     fi
 
@@ -138,7 +138,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
         fi
 
         CFLAGS="$CFLAGS_orig $add"
-        PMIX_UNIQ(CFLAGS)
+        PMIX_FLAGS_UNIQ(CFLAGS)
         AC_MSG_WARN([$add has been added to CFLAGS (--enable-picky)])
         unset add
     fi
@@ -188,7 +188,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
         fi
         CFLAGS="$CFLAGS_orig$add"
 
-        PMIX_UNIQ(CFLAGS)
+        PMIX_FLAGS_UNIQ(CFLAGS)
         AC_MSG_WARN([$add has been added to CFLAGS])
         unset add
     fi
@@ -217,7 +217,7 @@ AC_DEFUN([PMIX_SETUP_CC],[
         fi
 
         CFLAGS="${CFLAGS_orig}${add}"
-        PMIX_UNIQ([CFLAGS])
+        PMIX_FLAGS_UNIQ([CFLAGS])
         if test "$add" != "" ; then
             AC_MSG_WARN([$add has been added to CFLAGS])
         fi


### PR DESCRIPTION
This is the v2.x PR for the fixes from #2636 and #2638.

@Telemin This is the same fixes we rolled in to master, but for the v2.x branch (i.e., what will eventually become v2.1.0)

@rhc54 Please review.
