### PR TITLE
v1.10: linux timer: fix missing include

### DIFF
--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -14,7 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +30,7 @@
 #include "opal/mca/timer/base/base.h"
 #include "opal/mca/timer/linux/timer_linux.h"
 #include "opal/constants.h"
+#include "opal/util/show_help.h"
 
 static opal_timer_t opal_timer_base_get_cycles_sys_timer(void);
 static opal_timer_t opal_timer_base_get_usec_sys_timer(void);


### PR DESCRIPTION
Need to include opal/util/show_help.h for the case where we don't have a timer.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

This is already fixed on trunk, but was part of a larger commit that worked on other issues.  So I separated out this specific include and made a new commit (which is why this is not a cherry pick).

This is likely not hugely important / shouldn't force a new v1.10 release, but it does cause an MTT compile failure at Absoft (for assumedly quite old versions of gcc -- 4.1.0).