### PR TITLE
v2.x: basemuma: remove stale owner.txt file

### DIFF
--- a/ompi/mca/bcol/basesmuma/owner.txt
+++ b/ompi/mca/bcol/basesmuma/owner.txt
@@ -1,7 +1,0 @@
-#
-# owner/status file
-# owner: institution that is responsible for this package
-# status: e.g. active, maintenance, unmaintained
-#
-owner: ORNL
-status: unmaintained


### PR DESCRIPTION
Somehow this owner.txt file got left in this tree (the tree is
otherwise empty).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@hppritcha This is a v2.x version of #2659