### PR TITLE
v2.1.0: amd64: save/restore all 64 bits of rbx around cpuid

### DIFF
--- a/opal/include/opal/sys/amd64/timer.h
+++ b/opal/include/opal/sys/amd64/timer.h
@@ -61,16 +61,18 @@ opal_sys_timer_get_cycles(void)
 
 static inline bool opal_sys_timer_is_monotonic (void)
 {
-    int32_t cpuid1, cpuid2, tmp;
+    int64_t tmp;
+    int32_t cpuid1, cpuid2;
     const int32_t level = 0x80000007;
+
     /* cpuid clobbers ebx but it must be restored for -fPIC so save
      * then restore ebx */
-    __asm__ volatile ("xchgl %%ebx, %2\n"
+    __asm__ volatile ("xchg %%rbx, %2\n"
                       "cpuid\n"
-                      "xchgl %%ebx, %2\n":
+                      "xchg %%rbx, %2\n":
                       "=a" (cpuid1), "=d" (cpuid2), "=r" (tmp) :
                       "a" (level) :
-                      "ecx");
+                      "ecx", "ebx");
     /* bit 8 of edx contains the invariant tsc flag */
     return !!(cpuid2 & (1 << 8));
 }


### PR DESCRIPTION
This commit fixes a bug in the timer check. When -fPIC is used we need
to save/restore ebx. The code copied from patcher was meant for 32-bit
systems and did not work correctly on 64-bit systems. This commit
updates the save/restore to use rbx instead of ebx.

Fixes #2678

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 5b70ae3ec0f36e422c6401c5f7d4ec363a1059e1)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>