### PR TITLE
Cleanup some configure stuff for static builds

### DIFF
--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -12,8 +12,8 @@
 #                         All rights reserved.
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
-# Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
@@ -28,7 +28,7 @@
 AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
     AC_CONFIG_FILES([opal/mca/pmix/pmix2x/Makefile])
 
-    OPAL_VAR_SCOPE_PUSH([PMIX_VERSION opal_pmix_pmix2x_save_CPPFLAGS opal_pmix_pmix2x_save_LDFLAGS opal_pmix_pmix2x_save_LIBS opal_pmix_pmix2x_basedir opal_pmix_pmix2x_save_cflags opal_pmix_pmix2x_sm_flag])
+    OPAL_VAR_SCOPE_PUSH([PMIX_VERSION opal_pmix_pmix2x_save_CPPFLAGS opal_pmix_pmix2_save_CFLAGS opal_pmix_pmix2x_save_LDFLAGS opal_pmix_pmix2x_save_LIBS opal_pmix_pmix2x_basedir opal_pmix_pmix2x_args opal_pmix_pmix2x_happy opal_pmix_pmix2x_sm_flag pmix_pmix2x_status_filename])
 
     opal_pmix_pmix2x_basedir=opal/mca/pmix/pmix2x
 
@@ -49,7 +49,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
         opal_pmix_pmix2x_sm_flag=--disable-dstore
     fi
 
-    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX3X_ $opal_pmix_pmix2x_sm_flag --without-tests-examples --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
+    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_sm_flag --without-tests-examples --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix2x_args="--enable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
@@ -82,14 +82,28 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
           [AC_MSG_RESULT([yes - using the internal v2.x library])
            # Build flags for our Makefile.am
            opal_pmix_pmix2x_LDFLAGS=
-           opal_pmix_pmix2x_LIBS='$(OPAL_TOP_BUILDDIR)/'"$opal_pmix_pmix2x_basedir"'/pmix/src/libpmix.la'
-           opal_pmix_pmix2x_CPPFLAGS='-I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix/include -I$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix -I$(OPAL_TOP_SRCDIR)/opal/mca/pmix/pmix2x/pmix/include -I$(OPAL_TOP_SRCDIR)/opal/mca/pmix/pmix2x/pmix'
-           opal_pmix_pmix2x_DEPENDENCIES='$(OPAL_TOP_BUILDDIR)/opal/mca/pmix/pmix2x/pmix/src/libpmix.la'])
+           opal_pmix_pmix2x_LIBS="$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix/src/libpmix.la"
+           opal_pmix_pmix2x_CPPFLAGS="-I$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix/include -I$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix -I$OPAL_TOP_SRCDIR/$opal_pmix_pmix2x_basedir/pmix/include -I$OPAL_TOP_SRCDIR/$opal_pmix_pmix2x_basedir/pmix"
+           opal_pmix_pmix2x_DEPENDENCIES="$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix/src/libpmix.la"])
 
    AC_SUBST([opal_pmix_pmix2x_LIBS])
    AC_SUBST([opal_pmix_pmix2x_CPPFLAGS])
    AC_SUBST([opal_pmix_pmix2x_LDFLAGS])
    AC_SUBST([opal_pmix_pmix2x_DEPENDENCIES])
+
+   # Finally, add some flags to the wrapper compiler so that our
+   # headers can be found.
+   pmix_pmix2x_status_filename="$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix/config.status"
+   pmix_pmix2x_WRAPPER_EXTRA_CPPFLAGS=`egrep PMIX_EMBEDDED_CPPFLAGS $pmix_pmix2x_status_filename | cut -d\" -f4`
+   pmix_pmix2x_WRAPPER_EXTRA_LDFLAGS=`egrep PMIX_EMBEDDED_LDFLAGS $pmix_pmix2x_status_filename | cut -d\" -f4`
+   pmix_pmix2x_WRAPPER_EXTRA_LIBS=`egrep PMIX_EMBEDDED_LIBS $pmix_pmix2x_status_filename | cut -d\" -f4`
+
+   AC_MSG_CHECKING([PMIx extra wrapper CPPFLAGS])
+   AC_MSG_RESULT([$pmix_pmix2x_WRAPPER_EXTRA_CPPFLAGS])
+   AC_MSG_CHECKING([PMIx extra wrapper LDFLAGS])
+   AC_MSG_RESULT([$pmix_pmix2x_WRAPPER_EXTRA_LDFLAGS])
+   AC_MSG_CHECKING([PMIx extra wrapper LIBS])
+   AC_MSG_RESULT([$pmix_pmix2x_WRAPPER_EXTRA_LIBS])
 
     AS_IF([test $opal_pmix_pmix2x_happy -eq 1],
           [$1],

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -90,7 +90,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_MAJOR_VERSION])
     AC_SUBST(PMIX_MAJOR_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_MAJOR_VERSION], [$PMIX_MAJOR_VERSION],
                        [The library major version is always available, contrary to VERSION])
@@ -99,7 +98,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_MINOR_VERSION])
     AC_SUBST(PMIX_MINOR_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_MINOR_VERSION], [$PMIX_MINOR_VERSION],
                        [The library minor version is always available, contrary to VERSION])
@@ -114,7 +112,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_RELEASE_VERSION])
     AC_SUBST(PMIX_RELEASE_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_RELEASE_VERSION], [$PMIX_RELEASE_VERSION],
                        [The library release version is always available, contrary to VERSION])
@@ -679,9 +676,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         # rather than have successive assignments to these shell
         # variables, lest the $(foo) names try to get evaluated here.
         # Yuck!
-        CPPFLAGS='-I$(PMIX_top_builddir) -I$(PMIX_top_srcdir) -I$(PMIX_top_srcdir)/src -I$(PMIX_top_builddir)/include -I$(PMIX_top_srcdir)/include'" $CPPFLAGS"
+        CPPFLAGS="-I$PMIX_top_builddir -I$PMIX_top_srcdir -I$PMIX_top_srcdir/src -I$PMIX_top_builddir/include -I$PMIX_top_srcdir/include $CPPFLAGS"
     else
-        CPPFLAGS='-I$(PMIX_top_srcdir) -I$(PMIX_top_srcdir)/src -I$(PMIX_top_srcdir)/include'" $CPPFLAGS"
+        CPPFLAGS="-I$PMIX_top_srcdir -I$PMIX_top_srcdir/src -I$PMIX_top_srcdir/include $CPPFLAGS"
     fi
 
     # pmixdatadir, pmixlibdir, and pmixinclude are essentially the same as
@@ -707,6 +704,11 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         pmix_config_prefix[src/util/keyval/Makefile]
         pmix_config_prefix[src/mca/base/Makefile]
         )
+
+    # publish any embedded flags so external wrappers can use them
+    AC_SUBST(PMIX_EMBEDDED_LIBS)
+    AC_SUBST(PMIX_EMBEDDED_LDFLAGS)
+    AC_SUBST(PMIX_EMBEDDED_CPPFLAGS)
 
     # Success
     $2

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix_setup_zlib.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix_setup_zlib.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -58,10 +58,13 @@ AC_DEFUN([PMIX_ZLIB_CONFIG],[
                            [pmix_zlib_support=0])
         if test $pmix_zlib_support == "1"; then
             LIBS="$LIBS -lz"
+            PMIX_EMBEDDED_LIBS="$PMIX_EMBEDDED_LIBS -lz"
             if test "$pmix_zlib_standard_header_location" != "yes"; then
+                PMIX_EMBEDDED_CPPFLAGS="$PMIX_EMBEDDED_CPPFLAGS $pmix_zlib_CPPFLAGS"
                 CPPFLAGS="$CPPFLAGS $pmix_zlib_CPPFLAGS"
             fi
             if test "$pmix_zlib_standard_lib_location" != "yes"; then
+                PMIX_EMBEDDED_LDFLAGS="$PMIX_EMBEDDED_LDFLAGS $pmix_zlib_LDFLAGS"
                 LDFLAGS="$LDFLAGS $pmix_zlib_LDFLAGS"
             fi
         fi


### PR DESCRIPTION
Ensure any PMIx externally required libs get added to the wrapper compilers

Signed-off-by: Ralph Castain <rhc@open-mpi.org>