### PR TITLE
Remove the tcp_local field from the TCP component.

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -156,10 +156,8 @@ int mca_btl_tcp_del_procs(struct mca_btl_base_module_t* btl,
     OPAL_THREAD_LOCK(&tcp_btl->tcp_endpoints_mutex);
     for( i = 0; i < nprocs; i++ ) {
         mca_btl_tcp_endpoint_t* tcp_endpoint = endpoints[i];
-        if(tcp_endpoint->endpoint_proc != mca_btl_tcp_proc_local()) {
-            opal_list_remove_item(&tcp_btl->tcp_endpoints, (opal_list_item_t*)tcp_endpoint);
-            OBJ_RELEASE(tcp_endpoint);
-        }
+        opal_list_remove_item(&tcp_btl->tcp_endpoints, (opal_list_item_t*)tcp_endpoint);
+        OBJ_RELEASE(tcp_endpoint);
         opal_progress_event_users_decrement();
     }
     OPAL_THREAD_UNLOCK(&tcp_btl->tcp_endpoints_mutex);

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -107,7 +107,6 @@ struct mca_btl_tcp_component_t {
     uint32_t tcp_num_btls;                  /**< number of interfaces available to the TCP component */
     unsigned int tcp_num_links;             /**< number of logical links per physical device */
     struct mca_btl_tcp_module_t **tcp_btls; /**< array of available BTL modules */
-    struct mca_btl_tcp_proc_t* tcp_local;   /**< local proc struct */
     int tcp_free_list_num;                  /**< initial size of free lists */
     int tcp_free_list_max;                  /**< maximum size of free lists */
     int tcp_free_list_inc;                  /**< number of elements to alloc when growing free lists */

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -150,7 +150,6 @@ mca_btl_tcp_endpoint_dump(int level,
     opal_socklen_t obtlen;
     opal_socklen_t addrlen = sizeof(inaddr);
     mca_btl_tcp_frag_t* item;
-    mca_btl_tcp_proc_t* this_proc = mca_btl_tcp_proc_local();
 
     used += snprintf(&outmsg[used], DEBUG_LENGTH - used, "%s: ", msg);
     if (used >= DEBUG_LENGTH) goto out;
@@ -280,7 +279,7 @@ out:
     opal_output_verbose(level, opal_btl_base_framework.framework_output,
                         "[%s:%d:%s][%s -> %s] %s",
                         fname, lineno, funcname,
-                        (NULL != this_proc ? OPAL_NAME_PRINT(mca_btl_tcp_proc_local()->proc_opal->proc_name) : "unknown"),
+                        OPAL_NAME_PRINT(opal_proc_local_get()->proc_name),
                         (NULL != btl_endpoint->endpoint_proc ? OPAL_NAME_PRINT(btl_endpoint->endpoint_proc->proc_opal->proc_name) : "unknown remote"),
                         outmsg);
 }
@@ -408,8 +407,7 @@ mca_btl_tcp_endpoint_send_blocking(mca_btl_base_endpoint_t* btl_endpoint,
 static int mca_btl_tcp_endpoint_send_connect_ack(mca_btl_base_endpoint_t* btl_endpoint)
 {
     /* send process identifier to remote endpoint */
-    mca_btl_tcp_proc_t* btl_proc = mca_btl_tcp_proc_local();
-    opal_process_name_t guid = btl_proc->proc_opal->proc_name;
+    opal_process_name_t guid = opal_proc_local_get()->proc_name;
 
     OPAL_PROCESS_NAME_HTON(guid);
     if(mca_btl_tcp_endpoint_send_blocking(btl_endpoint, &guid, sizeof(guid)) !=
@@ -422,7 +420,6 @@ static int mca_btl_tcp_endpoint_send_connect_ack(mca_btl_base_endpoint_t* btl_en
 static void *mca_btl_tcp_endpoint_complete_accept(int fd, int flags, void *context)
 {
     mca_btl_base_endpoint_t* btl_endpoint = (mca_btl_base_endpoint_t*)context;
-    mca_btl_tcp_proc_t* this_proc = mca_btl_tcp_proc_local();
     struct timeval now = {0, 0};
     int cmpval;
 
@@ -451,7 +448,7 @@ static void *mca_btl_tcp_endpoint_complete_accept(int fd, int flags, void *conte
     }
 
     cmpval = opal_compare_proc(btl_endpoint->endpoint_proc->proc_opal->proc_name,
-                               this_proc->proc_opal->proc_name);
+                               opal_proc_local_get()->proc_name);
     if((btl_endpoint->endpoint_sd < 0) ||
        (btl_endpoint->endpoint_state != MCA_BTL_TCP_CONNECTED &&
         cmpval < 0)) {

--- a/opal/mca/btl/tcp/btl_tcp_proc.h
+++ b/opal/mca/btl/tcp/btl_tcp_proc.h
@@ -111,16 +111,5 @@ int  mca_btl_tcp_proc_remove(mca_btl_tcp_proc_t*, mca_btl_base_endpoint_t*);
 void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t*, struct sockaddr*, int);
 bool mca_btl_tcp_proc_tosocks(mca_btl_tcp_addr_t*, struct sockaddr_storage*);
 
-/**
- * Inlined function to return local TCP proc instance.
- */
-
-static inline mca_btl_tcp_proc_t* mca_btl_tcp_proc_local(void)
-{
-    if(NULL == mca_btl_tcp_component.tcp_local)
-        mca_btl_tcp_component.tcp_local = mca_btl_tcp_proc_create(opal_proc_local_get());
-    return mca_btl_tcp_component.tcp_local;
-}
-
 END_C_DECLS
 #endif


### PR DESCRIPTION
Instead use the OPAL process name to get the name
of the local process.