### PR TITLE
mca/base: account for NULL string_value in verbose set

### DIFF
--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -171,7 +171,9 @@ static int mca_base_var_enum_verbose_sfv (mca_base_var_enum_t *self, const int v
 
     for (int i = 0 ; verbose_values[i].string ; ++i) {
         if (verbose_values[i].value == value) {
-            *string_value = strdup (verbose_values[i].string);
+            if (string_value) {
+                *string_value = strdup (verbose_values[i].string);
+            }
             return OPAL_SUCCESS;
         }
     }


### PR DESCRIPTION
The MCA variable code calls the string from value function with a NULL
string to verify values. The verbosity enumerator was not correctly
checking for a non-NULL value before trying to set the string.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>