### PR TITLE
master: usnic queue fixes

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_ack.h
+++ b/opal/mca/btl/usnic/btl_usnic_ack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +67,7 @@ void opal_btl_usnic_ack_complete(opal_btl_usnic_module_t *module,
 /*
  * Send an ACK
  */
-void opal_btl_usnic_ack_send(opal_btl_usnic_module_t *module,
+int opal_btl_usnic_ack_send(opal_btl_usnic_module_t *module,
                                opal_btl_usnic_endpoint_t *endpoint);
 
 /*

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2008-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
@@ -1202,13 +1202,15 @@ static int usnic_handle_completion(
                 (opal_btl_usnic_ack_segment_t *)seg);
         break;
 
-    /**** Send of frag segment completion ****/
+    /**** Send of frag segment completion (i.e., the MPI message's
+          one-and-only segment has completed sending) ****/
     case OPAL_BTL_USNIC_SEG_FRAG:
         opal_btl_usnic_frag_send_complete(module,
                 (opal_btl_usnic_frag_segment_t*)seg);
         break;
 
-    /**** Send of chunk segment completion ****/
+    /**** Send of chunk segment completion (i.e., part of a large MPI
+          message is done sending) ****/
     case OPAL_BTL_USNIC_SEG_CHUNK:
         opal_btl_usnic_chunk_send_complete(module,
                 (opal_btl_usnic_chunk_segment_t*)seg);

--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -1159,6 +1159,8 @@ static int usnic_component_progress(void)
                 if (OPAL_LIKELY(OPAL_BTL_USNIC_SEG_RECV ==
                             rseg->rs_base.us_type)) {
                     opal_btl_usnic_recv_fast(module, rseg, channel);
+                    ++module->stats.num_seg_total_completions;
+                    ++module->stats.num_seg_recv_completions;
                     fastpath_ok = false;    /* prevent starvation */
                     return 1;
                 } else {
@@ -1188,6 +1190,8 @@ static int usnic_handle_completion(
     seg = (opal_btl_usnic_segment_t*)completion->op_context;
     rseg = (opal_btl_usnic_recv_segment_t*)seg;
 
+    ++module->stats.num_seg_total_completions;
+
     /* Make the completion be Valgrind-defined */
     opal_memchecker_base_mem_defined(seg, sizeof(*seg));
 
@@ -1198,6 +1202,7 @@ static int usnic_handle_completion(
 
     /**** Send ACK completions ****/
     case OPAL_BTL_USNIC_SEG_ACK:
+        ++module->stats.num_seg_ack_completions;
         opal_btl_usnic_ack_complete(module,
                 (opal_btl_usnic_ack_segment_t *)seg);
         break;
@@ -1205,6 +1210,7 @@ static int usnic_handle_completion(
     /**** Send of frag segment completion (i.e., the MPI message's
           one-and-only segment has completed sending) ****/
     case OPAL_BTL_USNIC_SEG_FRAG:
+        ++module->stats.num_seg_frag_completions;
         opal_btl_usnic_frag_send_complete(module,
                 (opal_btl_usnic_frag_segment_t*)seg);
         break;
@@ -1212,12 +1218,14 @@ static int usnic_handle_completion(
     /**** Send of chunk segment completion (i.e., part of a large MPI
           message is done sending) ****/
     case OPAL_BTL_USNIC_SEG_CHUNK:
+        ++module->stats.num_seg_chunk_completions;
         opal_btl_usnic_chunk_send_complete(module,
                 (opal_btl_usnic_chunk_segment_t*)seg);
         break;
 
     /**** Receive completions ****/
     case OPAL_BTL_USNIC_SEG_RECV:
+        ++module->stats.num_seg_recv_completions;
         opal_btl_usnic_recv(module, rseg, channel);
         break;
 

--- a/opal/mca/btl/usnic/btl_usnic_endpoint.h
+++ b/opal/mca/btl/usnic/btl_usnic_endpoint.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -160,6 +160,8 @@ typedef struct mca_btl_base_endpoint_t {
     opal_btl_usnic_seq_t endpoint_next_seq_to_send; /* n_t */
     opal_btl_usnic_seq_t endpoint_ack_seq_rcvd; /* n_a */
 
+    /* Table where sent segments sit while waiting for their ACKs.
+       When a segment is ACKed, it is removed from this table. */
     struct opal_btl_usnic_send_segment_t *endpoint_sent_segs[WINDOW_SIZE];
 
     /* Values for the current proc to receive from this endpoint on

--- a/opal/mca/btl/usnic/btl_usnic_frag.c
+++ b/opal/mca/btl/usnic/btl_usnic_frag.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,15 +50,15 @@ common_send_seg_helper(opal_btl_usnic_send_segment_t *seg)
 
 static void
 chunk_seg_constructor(
-    opal_btl_usnic_send_segment_t *seg)
+    opal_btl_usnic_chunk_segment_t *cseg)
 {
     opal_btl_usnic_segment_t *bseg;
 
-    bseg = &seg->ss_base;
+    bseg = &cseg->ss_base;
     bseg->us_type = OPAL_BTL_USNIC_SEG_CHUNK;
 
     /* some more common initializaiton */
-    common_send_seg_helper(seg);
+    common_send_seg_helper(cseg);
 
     /* payload starts next byte beyond BTL chunk header */
     bseg->us_payload.raw = (uint8_t *)(bseg->us_btl_chunk_header + 1);
@@ -68,15 +68,15 @@ chunk_seg_constructor(
 
 static void
 frag_seg_constructor(
-    opal_btl_usnic_send_segment_t *seg)
+    opal_btl_usnic_frag_segment_t *fseg)
 {
     opal_btl_usnic_segment_t *bseg;
 
-    bseg = &seg->ss_base;
+    bseg = &fseg->ss_base;
     bseg->us_type = OPAL_BTL_USNIC_SEG_FRAG;
 
     /* some more common initializaiton */
-    common_send_seg_helper(seg);
+    common_send_seg_helper(fseg);
 
     /* payload starts next byte beyond BTL header */
     bseg->us_payload.raw = (uint8_t *)(bseg->us_btl_header + 1);
@@ -86,7 +86,7 @@ frag_seg_constructor(
 
 static void
 ack_seg_constructor(
-    opal_btl_usnic_send_segment_t *ack)
+    opal_btl_usnic_ack_segment_t *ack)
 {
     opal_btl_usnic_segment_t *bseg;
 

--- a/opal/mca/btl/usnic/btl_usnic_frag.h
+++ b/opal/mca/btl/usnic/btl_usnic_frag.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -370,6 +370,7 @@ opal_btl_usnic_small_send_frag_alloc(opal_btl_usnic_module_t *module)
 
     /* this belongs in constructor... */
     frag->ssf_base.sf_base.uf_freelist = &(module->small_send_frags);
+    frag->ssf_segment.ss_send_posted = 0;
 
     assert(frag);
     assert(OPAL_BTL_USNIC_FRAG_SMALL_SEND == frag->ssf_base.sf_base.uf_type);
@@ -478,6 +479,14 @@ opal_btl_usnic_frag_return(
             NULL == lfrag->lsf_des_src[1].seg_addr.pval) {
             opal_convertor_cleanup(&lfrag->lsf_base.sf_convertor);
         }
+    }
+
+    /* Reset the "send_posted" flag on the embedded segment for small
+       fragments */
+    else if (frag->uf_type == OPAL_BTL_USNIC_FRAG_SMALL_SEND) {
+        opal_btl_usnic_small_send_frag_t *sfrag;
+        sfrag = (opal_btl_usnic_small_send_frag_t *) frag;
+        sfrag->ssf_segment.ss_send_posted = 0;
     }
 
     USNIC_COMPAT_FREE_LIST_RETURN(frag->uf_freelist, &(frag->uf_base.super));

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1804,7 +1804,8 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
                        true,
                        opal_process_info.nodename,
                        module->linux_device_name,
-                       "failed to create CQ", __FILE__, __LINE__);
+                       "failed to create CQ", __FILE__, __LINE__,
+                       rc, fi_strerror(-rc));
         goto error;
     }
 

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1318,8 +1318,8 @@ usnic_send(
     if (frag->sf_base.uf_type == OPAL_BTL_USNIC_FRAG_SMALL_SEND &&
             frag->sf_ack_bytes_left < module->max_tiny_payload &&
             WINDOW_OPEN(endpoint) &&
-            (get_send_credits(&module->mod_channels[USNIC_PRIORITY_CHANNEL]) >=
-             module->mod_channels[USNIC_PRIORITY_CHANNEL].fastsend_wqe_thresh)) {
+            (get_send_credits(&module->mod_channels[USNIC_DATA_CHANNEL]) >=
+             module->mod_channels[USNIC_DATA_CHANNEL].fastsend_wqe_thresh)) {
         size_t payload_len;
 
         sfrag = (opal_btl_usnic_small_send_frag_t *)frag;

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1831,6 +1831,15 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
     assert(channel->info->ep_attr->msg_prefix_size ==
            (uint32_t) mca_btl_usnic_component.transport_header_len);
 
+    opal_output_verbose(15, USNIC_OUT,
+                        "btl:usnic:init_one_channel:%s: channel %s, rx queue size=%" PRIsize_t ", tx queue size=%" PRIsize_t ", cq size=%" PRIsize_t ", send credits=%d",
+                        module->linux_device_name,
+                        (index == USNIC_PRIORITY_CHANNEL) ? "priority" : "data",
+                        channel->info->rx_attr->size,
+                        channel->info->tx_attr->size,
+                        cq_attr.size,
+                        channel->credits);
+
     /*
      * Initialize pool of receive segments.  Round MTU up to cache
      * line size so that each segment is guaranteed to start on a

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1237,8 +1237,13 @@ opal_btl_usnic_module_progress_sends(
         /* Is it time to send ACK? */
         if (endpoint->endpoint_acktime == 0 ||
             endpoint->endpoint_acktime <= get_nsec()) {
-            opal_btl_usnic_ack_send(module, endpoint);
-            opal_btl_usnic_remove_from_endpoints_needing_ack(endpoint);
+            if (OPAL_LIKELY(opal_btl_usnic_ack_send(module, endpoint) == OPAL_SUCCESS)) {
+                opal_btl_usnic_remove_from_endpoints_needing_ack(endpoint);
+            } else {
+                // If we fail, it means we're out of send credits on
+                // the ACK channel
+                break;
+            }
         }
 
         endpoint = next_endpoint;

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -987,7 +987,7 @@ usnic_do_resends(
             /* resends are always standard segments */
             sseg->ss_channel = USNIC_DATA_CHANNEL;
 
-            /* re-send the segment */
+            /* re-send the segment (we have a send credit available) */
             opal_btl_usnic_post_segment(module, endpoint, sseg);
 
             /* consume a send credit for this endpoint.  May send us
@@ -1017,6 +1017,9 @@ usnic_do_resends(
  * endpoint_send_segment() it.  Takes care of subsequent frag
  * cleanup/bookkeeping (dequeue, descriptor callback, etc.) if this frag was
  * completed by this segment.
+ *
+ * ASSUMES THAT THE CALLER HAS ALREADY CHECKED TO SEE IF WE HAVE
+ * A SEND CREDIT!
  */
 static void
 usnic_handle_large_send(
@@ -1070,7 +1073,8 @@ usnic_handle_large_send(
     /* payload length into the header*/
     sseg->ss_base.us_btl_header->payload_len = payload_len;
 
-    /* do the send */
+    // We assume that the caller has checked to see that we have a
+    // send credit, so do the send.
     opal_btl_usnic_endpoint_send_segment(module, sseg);
 
     /* do fragment bookkeeping */
@@ -1182,7 +1186,7 @@ opal_btl_usnic_module_progress_sends(
                     sseg->ss_base.us_btl_header->tag);
 #endif
 
-            /* post the send */
+            /* post the send (we have a send credit available) */
             opal_btl_usnic_endpoint_send_segment(module, sseg);
 
             /* don't do callback yet if this is a put */
@@ -1342,7 +1346,7 @@ usnic_send(
         opal_output(0, "INLINE send, sseg=%p", (void *)sseg);
 #endif
 
-        /* post the segment now */
+        /* post the segment now (we have a send credit available) */
         opal_btl_usnic_endpoint_send_segment(module, sseg);
 
         /* If we own the frag and callback was requested, callback now,

--- a/opal/mca/btl/usnic/btl_usnic_module.h
+++ b/opal/mca/btl/usnic/btl_usnic_module.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -137,6 +137,7 @@ typedef struct opal_btl_usnic_module_t {
     int av_eq_num;
     int prio_sd_num;
     int prio_rd_num;
+    int prio_cq_num;
 
     /*
      * Fragments larger than max_frag_payload will be broken up into

--- a/opal/mca/btl/usnic/btl_usnic_module.h
+++ b/opal/mca/btl/usnic/btl_usnic_module.h
@@ -71,7 +71,7 @@ typedef struct opal_btl_usnic_channel_t {
     int chan_rd_num;
     int chan_sd_num;
 
-    int credits;  /* RFXXX until libfab credits fixed */
+    int credits;
     uint32_t rx_post_cnt;
 
     /* fastsend enabled if num_credits_available >= fastsend_wqe_thresh */

--- a/opal/mca/btl/usnic/btl_usnic_send.c
+++ b/opal/mca/btl/usnic/btl_usnic_send.c
@@ -60,13 +60,18 @@ opal_btl_usnic_frag_send_complete(opal_btl_usnic_module_t *module,
     --frag->sf_seg_post_cnt;
 
     /* checks for returnability made inside */
+    opal_btl_usnic_endpoint_t *ep = frag->sf_endpoint;
     opal_btl_usnic_send_frag_return_cond(module, frag);
 
+    // In a short frag segment, the sseg is embedded in the frag.  So
+    // there's no need to return the sseg (because we already returned
+    // the frag).
+
     /* do bookkeeping */
-    ++frag->sf_endpoint->endpoint_send_credits;
+    ++ep->endpoint_send_credits;
 
     /* see if this endpoint needs to be made ready-to-send */
-    opal_btl_usnic_check_rts(frag->sf_endpoint);
+    opal_btl_usnic_check_rts(ep);
 
     ++module->mod_channels[sseg->ss_channel].credits;
 }

--- a/opal/mca/btl/usnic/btl_usnic_send.c
+++ b/opal/mca/btl/usnic/btl_usnic_send.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -43,8 +43,9 @@
 
 
 /*
- * This function is called when a send of a full-fragment segment completes
- * Return the WQE and also return the segment if no ACK pending
+ * This function is called when a send of a segment completes that is
+ * the one-and-only segment of an MPI message.  Return the WQE and
+ * also return the segment if no ACK pending.
  */
 void
 opal_btl_usnic_frag_send_complete(opal_btl_usnic_module_t *module,
@@ -71,8 +72,10 @@ opal_btl_usnic_frag_send_complete(opal_btl_usnic_module_t *module,
 }
 
 /*
- * This function is called when a send segment completes
- * Return the WQE and also return the segment if no ACK pending
+ * This function is called when a send segment completes that is part
+ * of a larger MPI message (ie., there may still be other chunk
+ * segments that have not yet completed sending).  Return the WQE and
+ * also return the segment if no ACK pending.
  */
 void
 opal_btl_usnic_chunk_send_complete(opal_btl_usnic_module_t *module,

--- a/opal/mca/btl/usnic/btl_usnic_send.h
+++ b/opal/mca/btl/usnic/btl_usnic_send.h
@@ -80,6 +80,7 @@ opal_btl_usnic_post_segment(
 #endif
 
     assert(channel_id == USNIC_DATA_CHANNEL);
+    assert(channel->credits > 1);
 
     /* Send the segment */
     ret = fi_send(channel->ep,
@@ -135,6 +136,7 @@ opal_btl_usnic_post_ack(
 #endif
 
     assert(channel_id == USNIC_PRIORITY_CHANNEL);
+    assert(channel->credits > 1);
 
     ret = fi_send(channel->ep,
             sseg->ss_ptr,
@@ -241,6 +243,7 @@ opal_btl_usnic_endpoint_send_segment(
        receives its ACK.  To find a unique slot in this array, use
        (seq % WINDOW_SIZE). */
     sfi = WINDOW_SIZE_MOD(sseg->ss_base.us_btl_header->pkt_seq);
+    assert(NULL == endpoint->endpoint_sent_segs[sfi]);
     endpoint->endpoint_sent_segs[sfi] = sseg;
     sseg->ss_ack_pending = true;
 

--- a/opal/mca/btl/usnic/btl_usnic_send.h
+++ b/opal/mca/btl/usnic/btl_usnic_send.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,7 +52,10 @@ opal_btl_usnic_check_rts(
 }
 
 /*
- * Common point for posting a segment
+ * Common point for posting a segment.
+ *
+ * ASSUMES THAT THE CALLER HAS ALREADY CHECKED TO SEE IF WE HAVE
+ * A SEND CREDIT!
  */
 static inline void
 opal_btl_usnic_post_segment(
@@ -105,6 +108,9 @@ opal_btl_usnic_post_segment(
 
 /*
  * Common point for posting an ACK
+ *
+ * ASSUMES THAT THE CALLER HAS ALREADY CHECKED TO SEE IF WE HAVE
+ * A SEND CREDIT!
  */
 static inline void
 opal_btl_usnic_post_ack(
@@ -230,10 +236,10 @@ opal_btl_usnic_endpoint_send_segment(
     /* do the actual send */
     opal_btl_usnic_post_segment(module, endpoint, sseg);
 
-    /* Track this header by stashing in an array on the endpoint that
-       is the same length as the sender's window (i.e., WINDOW_SIZE).
-       To find a unique slot in this array, use (seq % WINDOW_SIZE).
-     */
+    /* Stash this segment in an array on the endpoint that is the same
+       length as the sender's window (i.e., WINDOW_SIZE) until it
+       receives its ACK.  To find a unique slot in this array, use
+       (seq % WINDOW_SIZE). */
     sfi = WINDOW_SIZE_MOD(sseg->ss_base.us_btl_header->pkt_seq);
     endpoint->endpoint_sent_segs[sfi] = sseg;
     sseg->ss_ack_pending = true;

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -123,6 +123,11 @@ void opal_btl_usnic_print_stats(
 
              module->stats.num_crc_errors);
 
+    // Shouldn't happen, but just in case the string ever grows long
+    // enough to someday potentially get truncated by snprintf, ensure
+    // that the string is terminated.
+    str[sizeof(str) - 1] = '\0';
+
     /* If our PML calls were 0, then show send and receive window
        extents instead */
     if (module->stats.pml_module_sends +

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,6 +60,12 @@ static inline void usnic_stats_reset(opal_btl_usnic_module_t *module)
         module->stats.pml_module_sends =
         module->stats.pml_send_callbacks =
 
+        module->stats.num_seg_total_completions =
+        module->stats.num_seg_ack_completions =
+        module->stats.num_seg_frag_completions =
+        module->stats.num_seg_chunk_completions =
+        module->stats.num_seg_recv_completions =
+
         0;
 
     for (i=0; i<USNIC_NUM_CHANNELS; ++i) {
@@ -82,7 +88,7 @@ void opal_btl_usnic_print_stats(
     char tmp[128], str[2048];
 
     /* The usuals */
-    snprintf(str, sizeof(str), "%s:MCW:%3u, %s, ST(P+D)/F/C/R(T+F)/A:%8lu(%8u+%8u)/%8lu/%8lu/%4lu(%4lu+%4lu)/%8lu, RcvTot/Chk/F/C/L/H/D/BF/A:%8lu/%c%c/%8lu/%8lu/%4lu+%2lu/%4lu/%4lu/%6lu OA/DA %4lu/%4lu CRC:%4lu ",
+    snprintf(str, sizeof(str), "%s:MCW:%3u, %s, ST(P+D)/F/C/R(T+F)/A:%8lu(%8u+%8u)/%8lu/%8lu/%4lu(%4lu+%4lu)/%8lu, RcvTot/Chk/F/C/L/H/D/BF/A:%8lu/%c%c/%8lu/%8lu/%4lu+%2lu/%4lu/%4lu/%6lu Comp:T(A/F/C/R) %8lu(%8lu/%8lu/%8lu/%8lu), OA/DA %4lu/%4lu CRC:%4lu ",
              prefix,
              opal_proc_local_get()->proc_name.vpid,
 
@@ -117,6 +123,12 @@ void opal_btl_usnic_print_stats(
              module->stats.num_dup_recvs,
              module->stats.num_badfrag_recvs,
              module->stats.num_ack_recvs,
+
+	     module->stats.num_seg_total_completions,
+	     module->stats.num_seg_ack_completions,
+	     module->stats.num_seg_frag_completions,
+	     module->stats.num_seg_chunk_completions,
+	     module->stats.num_seg_recv_completions,
 
              module->stats.num_old_dup_acks,
              module->stats.num_dup_acks,

--- a/opal/mca/btl/usnic/btl_usnic_stats.h
+++ b/opal/mca/btl/usnic/btl_usnic_stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,6 +55,12 @@ typedef struct opal_btl_usnic_module_stats_t {
 
     uint64_t pml_module_sends;
     uint64_t pml_send_callbacks;
+
+    uint64_t num_seg_total_completions;
+    uint64_t num_seg_ack_completions;
+    uint64_t num_seg_frag_completions;
+    uint64_t num_seg_chunk_completions;
+    uint64_t num_seg_recv_completions;
 
     opal_event_t timer_event;
     struct timeval timeout;


### PR DESCRIPTION
A series of minor improvements to the usnic BTL, with three important fixes that happen at large scale:

1. Fix a CQ overrun (d70aa3e)
1. Fix a TX queue overrun (6df502c)
1. Fix a memory leak for ACKs (7ccbac9)