### PR TITLE
v1.10: usnic queue fixes

### DIFF
--- a/ompi/mca/btl/usnic/btl_usnic_ack.h
+++ b/ompi/mca/btl/usnic/btl_usnic_ack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +67,7 @@ void opal_btl_usnic_ack_complete(opal_btl_usnic_module_t *module,
 /*
  * Send an ACK
  */
-void opal_btl_usnic_ack_send(opal_btl_usnic_module_t *module,
+int opal_btl_usnic_ack_send(opal_btl_usnic_module_t *module,
                                opal_btl_usnic_endpoint_t *endpoint);
 
 /*

--- a/ompi/mca/btl/usnic/btl_usnic_component.c
+++ b/ompi/mca/btl/usnic/btl_usnic_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
@@ -1160,13 +1160,15 @@ static int usnic_handle_completion(
                 (opal_btl_usnic_ack_segment_t *)seg);
         break;
 
-    /**** Send of frag segment completion ****/
+    /**** Send of frag segment completion (i.e., the MPI message's
+          one-and-only segment has completed sending) ****/
     case OPAL_BTL_USNIC_SEG_FRAG:
         opal_btl_usnic_frag_send_complete(module,
                 (opal_btl_usnic_frag_segment_t*)seg);
         break;
 
-    /**** Send of chunk segment completion ****/
+    /**** Send of chunk segment completion (i.e., part of a large MPI
+          message is done sending) ****/
     case OPAL_BTL_USNIC_SEG_CHUNK:
         opal_btl_usnic_chunk_send_complete(module,
                 (opal_btl_usnic_chunk_segment_t*)seg);

--- a/ompi/mca/btl/usnic/btl_usnic_endpoint.h
+++ b/ompi/mca/btl/usnic/btl_usnic_endpoint.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -160,6 +160,8 @@ typedef struct mca_btl_base_endpoint_t {
     opal_btl_usnic_seq_t endpoint_next_seq_to_send; /* n_t */
     opal_btl_usnic_seq_t endpoint_ack_seq_rcvd; /* n_a */
 
+    /* Table where sent segments sit while waiting for their ACKs.
+       When a segment is ACKed, it is removed from this table. */
     struct opal_btl_usnic_send_segment_t *endpoint_sent_segs[WINDOW_SIZE];
 
     /* Values for the current proc to receive from this endpoint on

--- a/ompi/mca/btl/usnic/btl_usnic_frag.c
+++ b/ompi/mca/btl/usnic/btl_usnic_frag.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,15 +50,15 @@ common_send_seg_helper(opal_btl_usnic_send_segment_t *seg)
 
 static void
 chunk_seg_constructor(
-    opal_btl_usnic_send_segment_t *seg)
+    opal_btl_usnic_chunk_segment_t *cseg)
 {
     opal_btl_usnic_segment_t *bseg;
 
-    bseg = &seg->ss_base;
+    bseg = &cseg->ss_base;
     bseg->us_type = OPAL_BTL_USNIC_SEG_CHUNK;
 
     /* some more common initializaiton */
-    common_send_seg_helper(seg);
+    common_send_seg_helper(cseg);
 
     /* payload starts next byte beyond BTL chunk header */
     bseg->us_payload.raw = (uint8_t *)(bseg->us_btl_chunk_header + 1);
@@ -68,15 +68,15 @@ chunk_seg_constructor(
 
 static void
 frag_seg_constructor(
-    opal_btl_usnic_send_segment_t *seg)
+    opal_btl_usnic_frag_segment_t *fseg)
 {
     opal_btl_usnic_segment_t *bseg;
 
-    bseg = &seg->ss_base;
+    bseg = &fseg->ss_base;
     bseg->us_type = OPAL_BTL_USNIC_SEG_FRAG;
 
     /* some more common initializaiton */
-    common_send_seg_helper(seg);
+    common_send_seg_helper(fseg);
 
     /* payload starts next byte beyond BTL header */
     bseg->us_payload.raw = (uint8_t *)(bseg->us_btl_header + 1);
@@ -86,7 +86,7 @@ frag_seg_constructor(
 
 static void
 ack_seg_constructor(
-    opal_btl_usnic_send_segment_t *ack)
+    opal_btl_usnic_ack_segment_t *ack)
 {
     opal_btl_usnic_segment_t *bseg;
 

--- a/ompi/mca/btl/usnic/btl_usnic_frag.h
+++ b/ompi/mca/btl/usnic/btl_usnic_frag.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -370,6 +370,7 @@ opal_btl_usnic_small_send_frag_alloc(opal_btl_usnic_module_t *module)
 
     /* this belongs in constructor... */
     frag->ssf_base.sf_base.uf_freelist = &(module->small_send_frags);
+    frag->ssf_segment.ss_send_posted = 0;
 
     assert(frag);
     assert(OPAL_BTL_USNIC_FRAG_SMALL_SEND == frag->ssf_base.sf_base.uf_type);
@@ -478,6 +479,14 @@ opal_btl_usnic_frag_return(
             NULL == lfrag->lsf_des_src[1].seg_addr.pval) {
             opal_convertor_cleanup(&lfrag->lsf_base.sf_convertor);
         }
+    }
+
+    /* Reset the "send_posted" flag on the embedded segment for small
+       fragments */
+    else if (frag->uf_type == OPAL_BTL_USNIC_FRAG_SMALL_SEND) {
+        opal_btl_usnic_small_send_frag_t *sfrag;
+        sfrag = (opal_btl_usnic_small_send_frag_t *) frag;
+        sfrag->ssf_segment.ss_send_posted = 0;
     }
 
     USNIC_COMPAT_FREE_LIST_RETURN(frag->uf_freelist, &(frag->uf_base.super));

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -1736,7 +1736,8 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
                        true,
                        opal_process_info.nodename,
                        module->fabric_info->fabric_attr->name,
-                       "failed to create CQ", __FILE__, __LINE__);
+                       "failed to create CQ", __FILE__, __LINE__,
+                       rc, fi_strerror(-rc));
         goto error;
     }
 

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -938,7 +938,7 @@ usnic_do_resends(
             /* resends are always standard segments */
             sseg->ss_channel = USNIC_DATA_CHANNEL;
 
-            /* re-send the segment */
+            /* re-send the segment (we have a send credit available) */
             opal_btl_usnic_post_segment(module, endpoint, sseg);
 
             /* consume a send credit for this endpoint.  May send us
@@ -968,6 +968,9 @@ usnic_do_resends(
  * endpoint_send_segment() it.  Takes care of subsequent frag
  * cleanup/bookkeeping (dequeue, descriptor callback, etc.) if this frag was
  * completed by this segment.
+ *
+ * ASSUMES THAT THE CALLER HAS ALREADY CHECKED TO SEE IF WE HAVE
+ * A SEND CREDIT!
  */
 static void
 usnic_handle_large_send(
@@ -1021,7 +1024,8 @@ usnic_handle_large_send(
     /* payload length into the header*/
     sseg->ss_base.us_btl_header->payload_len = payload_len;
 
-    /* do the send */
+    // We assume that the caller has checked to see that we have a
+    // send credit, so do the send.
     opal_btl_usnic_endpoint_send_segment(module, sseg);
 
     /* do fragment bookkeeping */
@@ -1132,7 +1136,7 @@ opal_btl_usnic_module_progress_sends(
                     sseg->ss_base.us_btl_header->tag);
 #endif
 
-            /* post the send */
+            /* post the send (we have a send credit available) */
             opal_btl_usnic_endpoint_send_segment(module, sseg);
 
             /* don't do callback yet if this is a put */
@@ -1290,7 +1294,7 @@ usnic_send(
         opal_output(0, "INLINE send, sseg=%p", (void *)sseg);
 #endif
 
-        /* post the segment now */
+        /* post the segment now (we have a send credit available) */
         opal_btl_usnic_endpoint_send_segment(module, sseg);
 
         /* If we own the frag and callback was requested, callback now,

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -1187,8 +1187,13 @@ opal_btl_usnic_module_progress_sends(
         /* Is it time to send ACK? */
         if (endpoint->endpoint_acktime == 0 ||
             endpoint->endpoint_acktime <= get_nsec()) {
-            opal_btl_usnic_ack_send(module, endpoint);
-            opal_btl_usnic_remove_from_endpoints_needing_ack(endpoint);
+            if (OPAL_LIKELY(opal_btl_usnic_ack_send(module, endpoint) == OPAL_SUCCESS)) {
+                opal_btl_usnic_remove_from_endpoints_needing_ack(endpoint);
+            } else {
+                // If we fail, it means we're out of send credits on
+                // the ACK channel
+                break;
+            }
         }
 
         endpoint = next_endpoint;

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -1625,10 +1625,6 @@ static int create_ep(opal_btl_usnic_module_t* module,
         assert(0 != sin->sin_port);
     }
 
-    /* actual sizes */
-    channel->chan_rd_num = channel->info->rx_attr->size;
-    channel->chan_sd_num = channel->info->tx_attr->size;
-
     return OPAL_SUCCESS;
 }
 
@@ -1671,7 +1667,8 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
                             int index,
                             int max_msg_size,
                             int rd_num,
-                            int sd_num)
+                            int sd_num,
+                            int cq_num)
 {
     int i;
     int rc;
@@ -1701,7 +1698,7 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
     memset(&cq_attr, 0, sizeof(cq_attr));
     cq_attr.format = FI_CQ_FORMAT_CONTEXT;
     cq_attr.wait_obj = FI_WAIT_NONE;
-    cq_attr.size = module->cq_num;
+    cq_attr.size = cq_num;
     rc = fi_cq_open(module->domain, &cq_attr, &channel->cq, NULL);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
@@ -1899,6 +1896,11 @@ static void init_find_transport_header_len(opal_btl_usnic_module_t *module)
  */
 static void init_queue_lengths(opal_btl_usnic_module_t *module)
 {
+    bool cq_is_sum = false;
+    if (-1 == mca_btl_usnic_component.cq_num) {
+        cq_is_sum = true;
+    }
+
     if (-1 == mca_btl_usnic_component.sd_num) {
         module->sd_num = module->fabric_info->tx_attr->size;
     } else {
@@ -1909,7 +1911,7 @@ static void init_queue_lengths(opal_btl_usnic_module_t *module)
     } else {
         module->rd_num = mca_btl_usnic_component.rd_num;
     }
-    if (-1 == mca_btl_usnic_component.cq_num) {
+    if (cq_is_sum) {
         module->cq_num = module->rd_num + module->sd_num;
     } else {
         module->cq_num = mca_btl_usnic_component.cq_num;
@@ -1943,6 +1945,11 @@ static void init_queue_lengths(opal_btl_usnic_module_t *module)
         (unsigned) module->prio_rd_num >
          module->fabric_info->rx_attr->size) {
         module->prio_rd_num = module->fabric_info->rx_attr->size;
+    }
+    if (cq_is_sum) {
+        module->prio_cq_num = module->prio_rd_num + module->prio_sd_num;
+    } else {
+        module->prio_cq_num = module->cq_num;
     }
 }
 
@@ -2131,14 +2138,14 @@ static int init_channels(opal_btl_usnic_module_t *module)
     rc = init_one_channel(module,
             USNIC_PRIORITY_CHANNEL,
             module->max_tiny_msg_size,
-            module->prio_rd_num, module->prio_sd_num);
+            module->prio_rd_num, module->prio_sd_num, module->prio_cq_num);
     if (rc != OPAL_SUCCESS) {
         goto destroy;
     }
     rc = init_one_channel(module,
             USNIC_DATA_CHANNEL,
             module->fabric_info->ep_attr->max_msg_size,
-            module->rd_num, module->sd_num);
+            module->rd_num, module->sd_num, module->cq_num);
     if (rc != OPAL_SUCCESS) {
         goto destroy;
     }

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -1763,6 +1763,15 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
     assert(channel->info->ep_attr->msg_prefix_size ==
            (uint32_t) mca_btl_usnic_component.transport_header_len);
 
+    opal_output_verbose(15, USNIC_OUT,
+                        "btl:usnic:init_one_channel:%s: channel %s, rx queue size=%" PRIsize_t ", tx queue size=%" PRIsize_t ", cq size=%" PRIsize_t ", send credits=%d",
+                        module->fabric_info->fabric_attr->name,
+                        (index == USNIC_PRIORITY_CHANNEL) ? "priority" : "data",
+                        channel->info->rx_attr->size,
+                        channel->info->tx_attr->size,
+                        cq_attr.size,
+                        channel->credits);
+
     /*
      * Initialize pool of receive segments.  Round MTU up to cache
      * line size so that each segment is guaranteed to start on a

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved
@@ -1558,6 +1558,31 @@ static int create_ep(opal_btl_usnic_module_t* module,
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
 
+    /* Check to ensure that the RX/TX queue lengths are at least as
+       long as we asked for */
+    if ((int) channel->info->rx_attr->size < channel->chan_rd_num) {
+        rc = FI_ETOOSMALL;
+        opal_show_help("help-mpi-btl-usnic.txt",
+                       "internal error during init",
+                       true,
+                       opal_process_info.nodename,
+                       module->fabric_info->fabric_attr->name,
+                       "endpoint RX queue length is too short", __FILE__, __LINE__,
+                       rc, fi_strerror(rc));
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+    if ((int) channel->info->tx_attr->size < channel->chan_sd_num) {
+        rc = FI_ETOOSMALL;
+        opal_show_help("help-mpi-btl-usnic.txt",
+                       "internal error during init",
+                       true,
+                       opal_process_info.nodename,
+                       module->fabric_info->fabric_attr->name,
+                       "endpoint TX queue length is too short", __FILE__, __LINE__,
+                       rc, fi_strerror(rc));
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
     /* attach CQ to EP */
     rc = fi_ep_bind(channel->ep, &channel->cq->fid, FI_SEND);
     if (0 != rc) {
@@ -1712,6 +1737,20 @@ static int init_one_channel(opal_btl_usnic_module_t *module,
                        opal_process_info.nodename,
                        module->fabric_info->fabric_attr->name,
                        "failed to create CQ", __FILE__, __LINE__);
+        goto error;
+    }
+
+    /* Ensure that we got a CQ that is at least as long as we asked
+       for */
+    if ((int) cq_attr.size < cq_num) {
+        rc = FI_ETOOSMALL;
+        opal_show_help("help-mpi-btl-usnic.txt",
+                       "internal error during init",
+                       true,
+                       opal_process_info.nodename,
+                       module->fabric_info->fabric_attr->name,
+                       "created CQ is too small", __FILE__, __LINE__,
+                       rc, fi_strerror(rc));
         goto error;
     }
 

--- a/ompi/mca/btl/usnic/btl_usnic_module.c
+++ b/ompi/mca/btl/usnic/btl_usnic_module.c
@@ -1266,8 +1266,8 @@ usnic_send(
     if (frag->sf_base.uf_type == OPAL_BTL_USNIC_FRAG_SMALL_SEND &&
             frag->sf_ack_bytes_left < module->max_tiny_payload &&
             WINDOW_OPEN(endpoint) &&
-            (get_send_credits(&module->mod_channels[USNIC_PRIORITY_CHANNEL]) >=
-             module->mod_channels[USNIC_PRIORITY_CHANNEL].fastsend_wqe_thresh)) {
+            (get_send_credits(&module->mod_channels[USNIC_DATA_CHANNEL]) >=
+             module->mod_channels[USNIC_DATA_CHANNEL].fastsend_wqe_thresh)) {
         size_t payload_len;
 
         sfrag = (opal_btl_usnic_small_send_frag_t *)frag;

--- a/ompi/mca/btl/usnic/btl_usnic_module.h
+++ b/ompi/mca/btl/usnic/btl_usnic_module.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -132,6 +132,7 @@ typedef struct opal_btl_usnic_module_t {
     int av_eq_num;
     int prio_sd_num;
     int prio_rd_num;
+    int prio_cq_num;
 
     /*
      * Fragments larger than max_frag_payload will be broken up into

--- a/ompi/mca/btl/usnic/btl_usnic_module.h
+++ b/ompi/mca/btl/usnic/btl_usnic_module.h
@@ -68,7 +68,7 @@ typedef struct opal_btl_usnic_channel_t {
     int chan_rd_num;
     int chan_sd_num;
 
-    int credits;  /* RFXXX until libfab credits fixed */
+    int credits;
     uint32_t rx_post_cnt;
 
     /* fastsend enabled if num_credits_available >= fastsend_wqe_thresh */

--- a/ompi/mca/btl/usnic/btl_usnic_send.c
+++ b/ompi/mca/btl/usnic/btl_usnic_send.c
@@ -60,13 +60,18 @@ opal_btl_usnic_frag_send_complete(opal_btl_usnic_module_t *module,
     --frag->sf_seg_post_cnt;
 
     /* checks for returnability made inside */
+    opal_btl_usnic_endpoint_t *ep = frag->sf_endpoint;
     opal_btl_usnic_send_frag_return_cond(module, frag);
 
+    // In a short frag segment, the sseg is embedded in the frag.  So
+    // there's no need to return the sseg (because we already returned
+    // the frag).
+
     /* do bookkeeping */
-    ++frag->sf_endpoint->endpoint_send_credits;
+    ++ep->endpoint_send_credits;
 
     /* see if this endpoint needs to be made ready-to-send */
-    opal_btl_usnic_check_rts(frag->sf_endpoint);
+    opal_btl_usnic_check_rts(ep);
 
     ++module->mod_channels[sseg->ss_channel].credits;
 }

--- a/ompi/mca/btl/usnic/btl_usnic_send.c
+++ b/ompi/mca/btl/usnic/btl_usnic_send.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -43,8 +43,9 @@
 
 
 /*
- * This function is called when a send of a full-fragment segment completes
- * Return the WQE and also return the segment if no ACK pending
+ * This function is called when a send of a segment completes that is
+ * the one-and-only segment of an MPI message.  Return the WQE and
+ * also return the segment if no ACK pending.
  */
 void
 opal_btl_usnic_frag_send_complete(opal_btl_usnic_module_t *module,
@@ -71,8 +72,10 @@ opal_btl_usnic_frag_send_complete(opal_btl_usnic_module_t *module,
 }
 
 /*
- * This function is called when a send segment completes
- * Return the WQE and also return the segment if no ACK pending
+ * This function is called when a send segment completes that is part
+ * of a larger MPI message (ie., there may still be other chunk
+ * segments that have not yet completed sending).  Return the WQE and
+ * also return the segment if no ACK pending.
  */
 void
 opal_btl_usnic_chunk_send_complete(opal_btl_usnic_module_t *module,

--- a/ompi/mca/btl/usnic/btl_usnic_send.h
+++ b/ompi/mca/btl/usnic/btl_usnic_send.h
@@ -80,6 +80,7 @@ opal_btl_usnic_post_segment(
 #endif
 
     assert(channel_id == USNIC_DATA_CHANNEL);
+    assert(channel->credits > 1);
 
     /* Send the segment */
     ret = fi_send(channel->ep,
@@ -135,6 +136,7 @@ opal_btl_usnic_post_ack(
 #endif
 
     assert(channel_id == USNIC_PRIORITY_CHANNEL);
+    assert(channel->credits > 1);
 
     ret = fi_send(channel->ep,
             sseg->ss_ptr,
@@ -241,6 +243,7 @@ opal_btl_usnic_endpoint_send_segment(
        receives its ACK.  To find a unique slot in this array, use
        (seq % WINDOW_SIZE). */
     sfi = WINDOW_SIZE_MOD(sseg->ss_base.us_btl_header->pkt_seq);
+    assert(NULL == endpoint->endpoint_sent_segs[sfi]);
     endpoint->endpoint_sent_segs[sfi] = sseg;
     sseg->ss_ack_pending = true;
 

--- a/ompi/mca/btl/usnic/btl_usnic_send.h
+++ b/ompi/mca/btl/usnic/btl_usnic_send.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,7 +52,10 @@ opal_btl_usnic_check_rts(
 }
 
 /*
- * Common point for posting a segment
+ * Common point for posting a segment.
+ *
+ * ASSUMES THAT THE CALLER HAS ALREADY CHECKED TO SEE IF WE HAVE
+ * A SEND CREDIT!
  */
 static inline void
 opal_btl_usnic_post_segment(
@@ -105,6 +108,9 @@ opal_btl_usnic_post_segment(
 
 /*
  * Common point for posting an ACK
+ *
+ * ASSUMES THAT THE CALLER HAS ALREADY CHECKED TO SEE IF WE HAVE
+ * A SEND CREDIT!
  */
 static inline void
 opal_btl_usnic_post_ack(
@@ -230,10 +236,10 @@ opal_btl_usnic_endpoint_send_segment(
     /* do the actual send */
     opal_btl_usnic_post_segment(module, endpoint, sseg);
 
-    /* Track this header by stashing in an array on the endpoint that
-       is the same length as the sender's window (i.e., WINDOW_SIZE).
-       To find a unique slot in this array, use (seq % WINDOW_SIZE).
-     */
+    /* Stash this segment in an array on the endpoint that is the same
+       length as the sender's window (i.e., WINDOW_SIZE) until it
+       receives its ACK.  To find a unique slot in this array, use
+       (seq % WINDOW_SIZE). */
     sfi = WINDOW_SIZE_MOD(sseg->ss_base.us_btl_header->pkt_seq);
     endpoint->endpoint_sent_segs[sfi] = sseg;
     sseg->ss_ack_pending = true;

--- a/ompi/mca/btl/usnic/btl_usnic_stats.c
+++ b/ompi/mca/btl/usnic/btl_usnic_stats.c
@@ -121,6 +121,11 @@ void opal_btl_usnic_print_stats(
 
              module->stats.num_crc_errors);
 
+    // Shouldn't happen, but just in case the string ever grows long
+    // enough to someday potentially get truncated by snprintf, ensure
+    // that the string is terminated.
+    str[sizeof(str) - 1] = '\0';
+
     /* If our PML calls were 0, then show send and receive window
        extents instead */
     if (module->stats.pml_module_sends +


### PR DESCRIPTION
This is the v1.10 version of master PR #2692.

It includes all but the last commit from #2692 (i.e., the one that change the output format of statistics).

This is a blocker because it fixes some usnic bugs when running at scale.