### PR TITLE
rmaps/mindist: fix pmix errors

### DIFF
--- a/orte/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/orte/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -279,9 +279,21 @@ static int mindist_map(orte_job_t *jdata)
                         break;
                     }
                 }
-                opal_output_verbose(2, orte_rmaps_base_framework.framework_output,
-                        "mca:rmaps:mindist: assigned %d procs to node %s",
-                        j, node->name);
+                if (0 != j) {
+                    /* add the node to the map, if needed */
+                    if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
+                        if (ORTE_SUCCESS > (rc = opal_pointer_array_add(jdata->map->nodes, (void*)node))) {
+                            ORTE_ERROR_LOG(rc);
+                            goto error;
+                        }
+                        ORTE_FLAG_SET(node, ORTE_NODE_FLAG_MAPPED);
+                        OBJ_RETAIN(node);  /* maintain accounting on object */
+                        jdata->map->num_nodes++;
+                    }
+                    opal_output_verbose(2, orte_rmaps_base_framework.framework_output,
+                            "mca:rmaps:mindist: assigned %d procs to node %s",
+                            j, node->name);
+                }
             } else {
                 if (hwloc_get_nbobjs_by_type(node->topology, HWLOC_OBJ_SOCKET) > 1) {
                     /* don't have info about pci locality */
@@ -303,18 +315,6 @@ static int mindist_map(orte_job_t *jdata)
                     num_procs_to_assign--;
                 }
             }
-
-            /* add the node to the map, if needed */
-            if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
-                if (ORTE_SUCCESS > (rc = opal_pointer_array_add(jdata->map->nodes, (void*)node))) {
-                    ORTE_ERROR_LOG(rc);
-                    goto error;
-                }
-                ORTE_FLAG_SET(node, ORTE_NODE_FLAG_MAPPED);
-                OBJ_RETAIN(node);  /* maintain accounting on object */
-                jdata->map->num_nodes++;
-            }
-
         }
 
         /* If we get to the end of all the nodes and still have procs remaining, then


### PR DESCRIPTION
Corresponds to PR #2620 

Fixed the case were only part of the nodes in the allocation
are used by the applicaton proccesses.

Force PMIx nodemap key to only contain nodes that are actually
used by the application proccesses.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit 5fb3e0a9b696622511e8c557aa77061991e188a8)