### PR TITLE
timer/linux: Add missing header

### DIFF
--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,7 @@
 #include "opal/mca/timer/base/base.h"
 #include "opal/mca/timer/linux/timer_linux.h"
 #include "opal/constants.h"
+#include "opal/util/show_help.h"
 
 static opal_timer_t opal_timer_base_get_cycles_sys_timer(void);
 static opal_timer_t opal_timer_base_get_usec_sys_timer(void);


### PR DESCRIPTION
Missing header found by MTT using either GNU or XL compilers and the following compiler option:
 ``` -Werror,-Wimplicit-function-declaration```

```shell
timer_linux_component.c:167:9: error: implicit declaration of function 'opal_show_help' is invalid
in C99 [-Werror,-Wimplicit-function-declaration]
        opal_show_help("help-opal-timer-linux.txt", "monotonic not supported", true);
        ^1 warning and 1 error generated.
Error while processing timer_linux_component.c.
```

This was fixed as part of a larger commit on `master`, so there is no commit to cherry-pick.