### PR TITLE
ess/hnp: add support for forwarding additional signals

### DIFF
--- a/orte/mca/ess/hnp/Makefile.am
+++ b/orte/mca/ess/hnp/Makefile.am
@@ -10,6 +10,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+#                         reseved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/orte/mca/ess/hnp/ess_hnp.h
+++ b/orte/mca/ess/hnp/ess_hnp.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,16 +28,19 @@ BEGIN_C_DECLS
 /*
  * Module open / close
  */
-int orte_ess_hnp_component_open(void);
-int orte_ess_hnp_component_close(void);
-int orte_ess_hnp_component_query(mca_base_module_t **module, int *priority);
+typedef struct {
+    opal_list_item_t super;
+    char *signame;
+    int signal;
+} ess_hnp_signal_t;
+OBJ_CLASS_DECLARATION(ess_hnp_signal_t);
 
-#define ORTE_ESS_HNP_MAX_FORWARD_SIGNALS 32
+typedef struct {
+    orte_ess_base_component_t base;
+    opal_list_t signals;
+} orte_ess_hnp_component_t;
 
-extern int orte_ess_hnp_forward_signals[ORTE_ESS_HNP_MAX_FORWARD_SIGNALS];
-extern unsigned int orte_ess_hnp_forward_signals_count;
-
-ORTE_MODULE_DECLSPEC extern orte_ess_base_component_t mca_ess_hnp_component;
+ORTE_MODULE_DECLSPEC extern orte_ess_hnp_component_t mca_ess_hnp_component;
 
 END_C_DECLS
 

--- a/orte/mca/ess/hnp/ess_hnp.h
+++ b/orte/mca/ess/hnp/ess_hnp.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,6 +31,10 @@ int orte_ess_hnp_component_open(void);
 int orte_ess_hnp_component_close(void);
 int orte_ess_hnp_component_query(mca_base_module_t **module, int *priority);
 
+#define ORTE_ESS_HNP_MAX_FORWARD_SIGNALS 32
+
+extern int orte_ess_hnp_forward_signals[ORTE_ESS_HNP_MAX_FORWARD_SIGNALS];
+extern unsigned int orte_ess_hnp_forward_signals_count;
 
 ORTE_MODULE_DECLSPEC extern orte_ess_base_component_t mca_ess_hnp_component;
 

--- a/orte/mca/ess/hnp/ess_hnp_component.c
+++ b/orte/mca/ess/hnp/ess_hnp_component.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -32,8 +32,14 @@
 
 #include "orte/mca/ess/ess.h"
 #include "orte/mca/ess/hnp/ess_hnp.h"
+#include "orte/runtime/orte_globals.h"
 
 extern orte_ess_base_module_t orte_ess_hnp_module;
+static int orte_ess_hnp_component_register (void);
+
+int orte_ess_hnp_forward_signals[ORTE_ESS_HNP_MAX_FORWARD_SIGNALS] = {SIGUSR1, SIGUSR2, SIGTSTP, SIGCONT};
+unsigned int orte_ess_hnp_forward_signals_count = 4;
+static char *orte_ess_hnp_forward_additional_signals;
 
 /*
  * Instantiate the public struct with all of our public information
@@ -52,6 +58,7 @@ orte_ess_base_component_t mca_ess_hnp_component = {
         .mca_open_component = orte_ess_hnp_component_open,
         .mca_close_component = orte_ess_hnp_component_close,
         .mca_query_component = orte_ess_hnp_component_query,
+        .mca_register_component_params = orte_ess_hnp_component_register,
     },
     .base_data = {
         /* The component is checkpoint ready */
@@ -59,10 +66,61 @@ orte_ess_base_component_t mca_ess_hnp_component = {
     },
 };
 
+static int orte_ess_hnp_component_register (void)
+{
+    orte_ess_hnp_forward_additional_signals = NULL;
+    (void) mca_base_component_var_register (&mca_ess_hnp_component.base_version,
+                                            "forward_signals", "Comma-delimited list "
+                                            "of additional signals (integers) to forward to "
+                                            "application processes", MCA_BASE_VAR_TYPE_STRING,
+                                            NULL, 0, 0, OPAL_INFO_LVL_4, MCA_BASE_VAR_SCOPE_READONLY,
+                                            &orte_ess_hnp_forward_additional_signals);
+
+    return ORTE_SUCCESS;
+}
 
 int
 orte_ess_hnp_component_open(void)
 {
+    /* reset the signal count to the original value */
+    orte_ess_hnp_forward_signals_count = 4;
+
+    if (NULL != orte_ess_hnp_forward_additional_signals && 0 != strlen (orte_ess_hnp_forward_additional_signals)) {
+        char **signals = opal_argv_split (orte_ess_hnp_forward_additional_signals, ',');
+        int forward_signal;
+        char *tmp = NULL;
+
+        for (int i = 0 ; signals[i] ; ++i) {
+            if (orte_ess_hnp_forward_signals_count == ORTE_ESS_HNP_MAX_FORWARD_SIGNALS) {
+                /* print out an error here */
+                break;
+            }
+
+            errno = 0;
+            forward_signal = (int) strtol (signals[i], &tmp, 0);
+            if (0 == errno && '\0' == *tmp) {
+                bool duplicate_signal = false;
+                for (int j = 0 ; j < orte_ess_hnp_forward_signals_count ; ++j) {
+                    if (orte_ess_hnp_forward_signals[j] == forward_signal) {
+                        /* duplicate signal */
+                        duplicate_signal = true;
+                        break;
+                    }
+                }
+
+                if (!duplicate_signal) {
+                    orte_ess_hnp_forward_signals[orte_ess_hnp_forward_signals_count++] = forward_signal;
+                } else {
+                    opal_show_help ("help-ess-hnp.txt", "duplicate_signal", true, signals[i]);
+                }
+            } else {
+                opal_show_help ("help-ess-hnp.txt", "invalid_signal", true, signals[i]);
+            }
+        }
+
+        opal_argv_free (signals);
+    }
+
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -205,8 +205,8 @@ static int rte_init(void)
             setup_sighandler(sig->signal, forward_signals_events + idx, signal_forward_callback);
             ++idx;
         }
-        signals_set = true;
     }
+    signals_set = true;
 
     /* get the local topology */
     if (NULL == opal_hwloc_topology) {

--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -119,7 +119,7 @@ static bool forcibly_die=false;
 static opal_event_t term_handler;
 static opal_event_t epipe_handler;
 static int term_pipe[2];
-static opal_event_t forward_signals_events[ORTE_ESS_HNP_MAX_FORWARD_SIGNALS];
+static opal_event_t *forward_signals_events = NULL;
 
 static void abort_signal_callback(int signal);
 static void clean_abort(int fd, short flags, void *arg);
@@ -149,6 +149,7 @@ static int rte_init(void)
     int idx;
     orte_topology_t *t;
     opal_list_t transports;
+    ess_hnp_signal_t *sig;
 
     /* run the prolog */
     if (ORTE_SUCCESS != (ret = orte_ess_base_std_prolog())) {
@@ -191,12 +192,21 @@ static int rte_init(void)
     signal(SIGINT, abort_signal_callback);
     signal(SIGHUP, abort_signal_callback);
 
-    /** setup callbacks for signals we should foward */
-
-    for (unsigned int i = 0 ; i < orte_ess_hnp_forward_signals_count ; ++i) {
-      setup_sighandler (orte_ess_hnp_forward_signals[i], forward_signals_events + i, signal_forward_callback);
+    /** setup callbacks for signals we should forward */
+    if (0 < (idx = opal_list_get_size(&mca_ess_hnp_component.signals))) {
+        forward_signals_events = (opal_event_t*)malloc(sizeof(opal_event_t) * idx);
+        if (NULL == forward_signals_events) {
+            ret = ORTE_ERR_OUT_OF_RESOURCE;
+            error = "unable to malloc";
+            goto error;
+        }
+        idx = 0;
+        OPAL_LIST_FOREACH(sig, &mca_ess_hnp_component.signals, ess_hnp_signal_t) {
+            setup_sighandler(sig->signal, forward_signals_events + idx, signal_forward_callback);
+            ++idx;
+        }
+        signals_set = true;
     }
-    signals_set = true;
 
     /* get the local topology */
     if (NULL == opal_hwloc_topology) {
@@ -780,6 +790,8 @@ static int rte_finalize(void)
     char *contact_path;
     orte_job_t *jdata;
     uint32_t key;
+    ess_hnp_signal_t *sig;
+    unsigned int i;
 
     if (signals_set) {
         /* Remove the epipe handler */
@@ -787,9 +799,13 @@ static int rte_finalize(void)
         /* remove the term handler */
         opal_event_del(&term_handler);
         /** Remove the USR signal handlers */
-        for (unsigned int i = 0 ; i < orte_ess_hnp_forward_signals_count ; ++i) {
+        i = 0;
+        OPAL_LIST_FOREACH(sig, &mca_ess_hnp_component.signals, ess_hnp_signal_t) {
             opal_event_signal_del(forward_signals_events + i);
+            ++i;
         }
+        free (forward_signals_events);
+        forward_signals_events = NULL;
         signals_set = false;
     }
 


### PR DESCRIPTION
This commit adds support to the hnp ess module to forward additional
signals beyond the default SIGUSR1, SIGUSR2, SIGSTP, and SIGCONT.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>