### PR TITLE
amd64/timer: bring timer code up to date with master

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -801,6 +801,22 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
             else
                 ompi_cv_asm_arch="AMD64"
             fi
+
+           # Check for RDTSCP support
+           result=0
+            AC_MSG_CHECKING([for RDTSCP assembly support])
+           AC_RUN_IFELSE([AC_LANG_PROGRAM([], [
+  unsigned int rax, rdx;
+  __asm__ __volatile__ ("rdtscp\n": "=a" (rax), "=d" (rdx)::);
+])],
+               [result=1
+                   AC_MSG_RESULT([yes])],
+               [AC_MSG_RESULT([no])],
+               [#cross compile not supported
+                   AC_MSG_RESULT(["no (cross compiling)"])])
+           AC_DEFINE_UNQUOTED([OPAL_ASSEMBLY_SUPPORTS_RDTSCP], [$result],
+                [Whether we have support for RDTSCP instruction])
+
             OPAL_ASM_SUPPORT_64BIT=1
             OMPI_GCC_INLINE_ASSIGN='"xaddl %1,%0" : "=m"(ret), "+r"(negone) : "m"(ret)'
             ;;

--- a/opal/include/opal/sys/amd64/timer.h
+++ b/opal/include/opal/sys/amd64/timer.h
@@ -3,24 +3,24 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. ALl rights
  *                         reserved.
  * $COPYRIGHT$
- * 
+ *
  * Additional copyrights may follow
- * 
+ *
  * $HEADER$
  */
 
-#ifndef OMPI_SYS_ARCH_TIMER_H
-#define OMPI_SYS_ARCH_TIMER_H 1
+#ifndef OPAL_SYS_ARCH_TIMER_H
+#define OPAL_SYS_ARCH_TIMER_H 1
 
 
 typedef uint64_t opal_timer_t;
@@ -29,30 +29,35 @@ typedef uint64_t opal_timer_t;
 #undef OPAL_TIMER_MONOTONIC
 #define OPAL_TIMER_MONOTONIC 0
 
-#if OMPI_GCC_INLINE_ASSEMBLY
+#if OPAL_GCC_INLINE_ASSEMBLY
 
-#if 0
+/**
+ * http://www.intel.com/content/www/us/en/intelligent-systems/embedded-systems-training/ia-32-ia-64-benchmark-code-execution-paper.html
+ */
 static inline opal_timer_t
 opal_sys_timer_get_cycles(void)
 {
-    opal_timer_t ret;
-
-    __asm__ __volatile__("rdtsc" : "=A"(ret));
-
-    return ret;
-}
-
+     unsigned l, h;
+#if !OPAL_ASSEMBLY_SUPPORTS_RDTSCP
+     __asm__ __volatile__ ("cpuid\n\t"
+                           "rdtsc\n\t"
+                           : "=a" (l), "=d" (h)
+                           :: "rbx", "rcx");
 #else
-
-static inline opal_timer_t 
-opal_sys_timer_get_cycles(void)
-{
-     unsigned a, d; 
-     __asm__ __volatile__ ("rdtsc" : "=a" (a), "=d" (d));
-     return ((opal_timer_t)a) | (((opal_timer_t)d) << 32);
-}
-
+     /* If we need higher accuracy we should implement the algorithm proposed
+      * on the Intel document referenced above. However, in the context of MPI
+      * this function will be used as the backend for MPI_Wtime and as such
+      * can afford a small inaccuracy.
+      */
+     __asm__ __volatile__ ("rdtscp\n\t"
+                           "mov %%edx, %0\n\t"
+                           "mov %%eax, %1\n\t"
+                           "cpuid\n\t"
+                           : "=r" (h), "=r" (l)
+                           :: "rax", "rbx", "rcx", "rdx");
 #endif
+     return ((opal_timer_t)l) | (((opal_timer_t)h) << 32);
+}
 
 static inline bool opal_sys_timer_is_monotonic (void)
 {
@@ -81,6 +86,6 @@ opal_timer_t opal_sys_timer_get_cycles(void);
 
 #define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1
 
-#endif /* OMPI_GCC_INLINE_ASSEMBLY */
+#endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
-#endif /* ! OMPI_SYS_ARCH_TIMER_H */
+#endif /* ! OPAL_SYS_ARCH_TIMER_H */


### PR DESCRIPTION
There is a bug with the timer code used in v1.10 that causes
MPI_Wtime() to reset more frequently than expected (~ every 8000
seconds instead of 500 years). The timer code was fixed on master but
was never fixed on v1.10.

Backport of 6772b077925f5143988457b66085685efdab73de

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>