### PR TITLE
v2.x: odls/base: fix a typo in orte_odls_base_default_kill_local_procs()

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -1546,7 +1546,7 @@ int orte_odls_base_default_kill_local_procs(opal_pointer_array_t *procs,
             OPAL_OUTPUT_VERBOSE((5, orte_odls_base_framework.framework_output,
                                  "%s SENDING SIGTERM TO %s",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                 ORTE_NAME_PRINT(&child->name)));
+                                 ORTE_NAME_PRINT(&cd->child->name)));
             kill_local(cd->child->pid, SIGTERM);
         }
         /* wait a little again */
@@ -1556,7 +1556,7 @@ int orte_odls_base_default_kill_local_procs(opal_pointer_array_t *procs,
             OPAL_OUTPUT_VERBOSE((5, orte_odls_base_framework.framework_output,
                                  "%s SENDING SIGKILL TO %s",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                 ORTE_NAME_PRINT(&child->name)));
+                                 ORTE_NAME_PRINT(&cd->child->name)));
             kill_local(cd->child->pid, SIGKILL);
             /* indicate the waitpid fired as this is effectively what
              * has happened


### PR DESCRIPTION
These bits were backported from open-mpi/ompi@884fb7fcf264dd558708b8a773df6e7d93ef03e7

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>