### PR TITLE
Don't remove the IOF framework's tracking info for a proc until the state machine tells it to do so.

### DIFF
--- a/orte/mca/iof/hnp/iof_hnp_read.c
+++ b/orte/mca/iof/hnp/iof_hnp_read.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2016 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -262,9 +262,7 @@ void orte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
             NULL == proct->revstderr &&
             NULL == proct->revstddiag) {
             /* this proc's iof is complete */
-            opal_list_remove_item(&mca_iof_hnp_component.procs, &proct->super);
             ORTE_ACTIVATE_PROC_STATE(&proct->name, ORTE_PROC_STATE_IOF_COMPLETE);
-            OBJ_RELEASE(proct);
         }
         return;
     }

--- a/orte/mca/iof/iof_types.h
+++ b/orte/mca/iof/iof_types.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,6 +40,7 @@ typedef uint16_t orte_iof_tag_t;
 #define ORTE_IOF_STDMERGE   0x0006
 #define ORTE_IOF_STDDIAG    0x0008
 #define ORTE_IOF_STDOUTALL  0x000e
+#define ORTE_IOF_STDALL     0x000f
 #define ORTE_IOF_EXCLUSIVE  0x0100
 
 /* flow control flags */

--- a/orte/mca/iof/orted/iof_orted_read.c
+++ b/orte/mca/iof/orted/iof_orted_read.c
@@ -167,9 +167,7 @@ void orte_iof_orted_read_handler(int fd, short event, void *cbdata)
         NULL == proct->revstderr &&
         NULL == proct->revstddiag) {
         /* this proc's iof is complete */
-        opal_list_remove_item(&mca_iof_orted_component.procs, &proct->super);
         ORTE_ACTIVATE_PROC_STATE(&proct->name, ORTE_PROC_STATE_IOF_COMPLETE);
-        OBJ_RELEASE(proct);
     }
     if (NULL != buf) {
         OBJ_RELEASE(buf);

--- a/orte/mca/state/base/state_base_fns.c
+++ b/orte/mca/state/base/state_base_fns.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -632,13 +632,9 @@ void orte_state_base_track_procs(int fd, short argc, void *cbdata)
         if (pdata->state < ORTE_PROC_STATE_TERMINATED) {
             pdata->state = state;
         }
-        /* Release only the stdin IOF file descriptor for this child, if one
-         * was defined. File descriptors for the other IOF channels - stdout,
-         * stderr, and stddiag - were released when their associated pipes
-         * were cleared and closed due to termination of the process
-         */
+        /* Release the IOF file descriptors */
         if (NULL != orte_iof.close) {
-            orte_iof.close(proc, ORTE_IOF_STDIN);
+            orte_iof.close(proc, ORTE_IOF_STDALL);
         }
         ORTE_FLAG_SET(pdata, ORTE_PROC_FLAG_IOF_COMPLETE);
         if (ORTE_FLAG_TEST(pdata, ORTE_PROC_FLAG_WAITPID)) {


### PR DESCRIPTION
This plugs leaked file descriptors as we were losing track prior to destructing the resources.

Fixes #2691

Signed-off-by: Ralph Castain <rhc@open-mpi.org>