### PR TITLE
rcache/vma: do not release vma stuctures in vma_tree_delete

### DIFF
--- a/opal/mca/rcache/vma/rcache_vma.h
+++ b/opal/mca/rcache/vma/rcache_vma.h
@@ -13,7 +13,7 @@
  *
  * Copyright (c) 2006      Voltaire. All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -40,6 +40,7 @@ struct mca_rcache_vma_module_t {
     mca_rcache_base_module_t base;
     opal_rb_tree_t rb_tree;
     opal_list_t vma_list;
+    opal_list_t vma_gc_list;
     size_t reg_cur_cache_size;
 };
 typedef struct mca_rcache_vma_module_t mca_rcache_vma_module_t;


### PR DESCRIPTION
This commit fixes a deadlock that can occur when the libc version
holds a lock when calling munmap. In this case we could end up calling
free() from vma_tree_delete which would in turn try to obtain the lock
in libc. To avoid the issue put any deleted vma's in a new list on the
vma module and release them on the next call to vma_tree_insert. This
should be safe as this function is not called from the memory hooks.

Backported from 79cabc92fd0bc5307649597f5ef9c6006d193f5d

Fixes #1654

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>