### PR TITLE
timer/linux: prevent 64-bit overflow

### DIFF
--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
@@ -148,6 +148,10 @@ static int opal_timer_linux_find_freq(void)
 
     fclose(fp);
 
+    /* convert the timer frequency to MHz to avoid an extra operation when
+     * converting from cycles to usec */
+    opal_timer_linux_freq /= 1000000;
+
     return OPAL_SUCCESS;
 }
 
@@ -159,7 +163,7 @@ int opal_timer_linux_open(void)
 #if OPAL_HAVE_CLOCK_GETTIME && (0 == OPAL_TIMER_MONOTONIC)
         struct timespec res;
         if( 0 == clock_getres(CLOCK_MONOTONIC, &res)) {
-            opal_timer_linux_freq = 1.e9;
+            opal_timer_linux_freq = 1.e3;
             opal_timer_base_get_cycles = opal_timer_base_get_cycles_clock_gettime;
             opal_timer_base_get_usec = opal_timer_base_get_usec_clock_gettime;
             return ret;
@@ -208,8 +212,8 @@ opal_timer_t opal_timer_base_get_cycles_sys_timer(void)
 opal_timer_t opal_timer_base_get_usec_sys_timer(void)
 {
 #if OPAL_HAVE_SYS_TIMER_GET_CYCLES
-    /* freq is in Hz, so this gives usec */
-    return opal_sys_timer_get_cycles() * 1000000  / opal_timer_linux_freq;
+    /* freq is in MHz, so this gives usec */
+    return opal_sys_timer_get_cycles()  / opal_timer_linux_freq;
 #else
     return 0;
 #endif
@@ -217,7 +221,7 @@ opal_timer_t opal_timer_base_get_usec_sys_timer(void)
 
 opal_timer_t opal_timer_base_get_freq(void)
 {
-    return opal_timer_linux_freq;
+    return opal_timer_linux_freq * 1000000;
 }
 
 


### PR DESCRIPTION
The linux timer code was multiplying the result of the x86 time stamp
counter by 1000000 before dividing by the cpu frequency. This can
cause us to overflow 64 bits if the time stamp counter grows larger
than ~ 1.8e13 (about 8400 seconds after boot). To fix the issue the
units of opal_timer_linux_freq have been changed to MHz.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 45c05880aa17cc2e26f2643b40f64392bc4f1868)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>