### PR TITLE
osc/pt2pt: fix threading issues

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
@@ -501,6 +501,9 @@ ompi_osc_pt2pt_accumulate_w_req (const void *origin_addr, int origin_count,
 
         is_long_msg = true;
         tag = get_tag (module);
+    } else {
+        /* still need to set the tag for the active/passive logic on the target */
+        tag = !!(module->passive_target_access_epoch);
     }
 
     if (is_long_msg) {
@@ -523,6 +526,7 @@ ompi_osc_pt2pt_accumulate_w_req (const void *origin_addr, int origin_count,
     header->count = target_count;
     header->displacement = target_disp;
     header->op = op->o_f_to_c_index;
+    header->tag = tag;
     ptr += sizeof (*header);
 
     do {
@@ -565,7 +569,6 @@ ompi_osc_pt2pt_accumulate_w_req (const void *origin_addr, int origin_count,
             }
         } else {
             header->base.type = OMPI_OSC_PT2PT_HDR_TYPE_ACC_LONG;
-            header->tag = tag;
             osc_pt2pt_hton(header, proc);
 
             OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -314,12 +314,13 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
            sizeof(ompi_osc_base_module_t));
 
     /* initialize the objects, so that always free in cleanup */
-    OBJ_CONSTRUCT(&module->lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&module->lock, opal_recursive_mutex_t);
     OBJ_CONSTRUCT(&module->cond, opal_condition_t);
     OBJ_CONSTRUCT(&module->locks_pending, opal_list_t);
     OBJ_CONSTRUCT(&module->locks_pending_lock, opal_mutex_t);
     OBJ_CONSTRUCT(&module->outstanding_locks, opal_hash_table_t);
     OBJ_CONSTRUCT(&module->pending_acc, opal_list_t);
+    OBJ_CONSTRUCT(&module->pending_acc_lock, opal_mutex_t);
     OBJ_CONSTRUCT(&module->buffer_gc, opal_list_t);
     OBJ_CONSTRUCT(&module->gc_lock, opal_mutex_t);
     OBJ_CONSTRUCT(&module->all_sync, ompi_osc_pt2pt_sync_t);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
@@ -77,6 +77,7 @@ int ompi_osc_pt2pt_free(ompi_win_t *win)
     /* it is erroneous to close a window with active operations on it so we should
      * probably produce an error here instead of cleaning up */
     OPAL_LIST_DESTRUCT(&module->pending_acc);
+    OBJ_DESTRUCT(&module->pending_acc_lock);
 
     osc_pt2pt_gc_clean (module);
     OPAL_LIST_DESTRUCT(&module->buffer_gc);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
@@ -50,7 +50,7 @@ typedef struct ompi_osc_pt2pt_pending_lock_t ompi_osc_pt2pt_pending_lock_t;
 OBJ_CLASS_INSTANCE(ompi_osc_pt2pt_pending_lock_t, opal_list_item_t,
                    NULL, NULL);
 
-static int ompi_osc_activate_next_lock (ompi_osc_pt2pt_module_t *module);
+static int ompi_osc_pt2pt_activate_next_lock (ompi_osc_pt2pt_module_t *module);
 static inline int queue_lock (ompi_osc_pt2pt_module_t *module, int requestor, int lock_type, uint64_t lock_ptr);
 static int ompi_osc_pt2pt_flush_lock (ompi_osc_pt2pt_module_t *module, ompi_osc_pt2pt_sync_t *lock,
                                       int target);
@@ -100,9 +100,9 @@ static inline void ompi_osc_pt2pt_unlock_self (ompi_osc_pt2pt_module_t *module, 
 
     if (MPI_LOCK_EXCLUSIVE == lock_type) {
         OPAL_THREAD_ADD32(&module->lock_status, 1);
-        ompi_osc_activate_next_lock (module);
+        ompi_osc_pt2pt_activate_next_lock (module);
     } else if (0 == OPAL_THREAD_ADD32(&module->lock_status, -1)) {
-        ompi_osc_activate_next_lock (module);
+        ompi_osc_pt2pt_activate_next_lock (module);
     }
 
     /* need to ensure we make progress */
@@ -385,10 +385,10 @@ static int ompi_osc_pt2pt_unlock_internal (int target, ompi_win_t *win)
     OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,
                          "ompi_osc_pt2pt_unlock_internal: lock acks still expected: %d",
                          lock->sync_expected));
+    OPAL_THREAD_UNLOCK(&module->lock);
 
     /* wait until ack has arrived from target */
     ompi_osc_pt2pt_sync_wait_expected (lock);
-    OPAL_THREAD_UNLOCK(&module->lock);
 
     OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,
                          "ompi_osc_pt2pt_unlock_internal: all lock acks received"));
@@ -426,7 +426,7 @@ static int ompi_osc_pt2pt_unlock_internal (int target, ompi_win_t *win)
              * So make sure to wait for all of the fragments to arrive.
              */
             OPAL_THREAD_LOCK(&module->lock);
-            while (module->outgoing_frag_count < module->outgoing_frag_signal_count) {
+            while (module->outgoing_frag_count < 0) {
                 opal_condition_wait(&module->cond, &module->lock);
             }
             OPAL_THREAD_UNLOCK(&module->lock);
@@ -628,7 +628,7 @@ int ompi_osc_pt2pt_flush_local (int target, struct ompi_win_t *win)
 
     /* wait for all the requests */
     OPAL_THREAD_LOCK(&module->lock);
-    while (module->outgoing_frag_count != module->outgoing_frag_signal_count) {
+    while (module->outgoing_frag_count < 0) {
         opal_condition_wait(&module->cond, &module->lock);
     }
     OPAL_THREAD_UNLOCK(&module->lock);
@@ -654,7 +654,7 @@ int ompi_osc_pt2pt_flush_local_all (struct ompi_win_t *win)
 
     /* wait for all the requests */
     OPAL_THREAD_LOCK(&module->lock);
-    while (module->outgoing_frag_count != module->outgoing_frag_signal_count) {
+    while (module->outgoing_frag_count < 0) {
         opal_condition_wait(&module->cond, &module->lock);
     }
     OPAL_THREAD_UNLOCK(&module->lock);
@@ -758,7 +758,7 @@ static bool ompi_osc_pt2pt_lock_try_acquire (ompi_osc_pt2pt_module_t* module, in
     return true;
 }
 
-static int ompi_osc_activate_next_lock (ompi_osc_pt2pt_module_t *module) {
+static int ompi_osc_pt2pt_activate_next_lock (ompi_osc_pt2pt_module_t *module) {
     /* release any other pending locks we can */
     ompi_osc_pt2pt_pending_lock_t *pending_lock, *next;
     int ret = OMPI_SUCCESS;
@@ -903,9 +903,9 @@ int ompi_osc_pt2pt_process_unlock (ompi_osc_pt2pt_module_t *module, int source,
 
     if (-1 == module->lock_status) {
         OPAL_THREAD_ADD32(&module->lock_status, 1);
-        ompi_osc_activate_next_lock (module);
+        ompi_osc_pt2pt_activate_next_lock (module);
     } else if (0 == OPAL_THREAD_ADD32(&module->lock_status, -1)) {
-        ompi_osc_activate_next_lock (module);
+        ompi_osc_pt2pt_activate_next_lock (module);
     }
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_sync.h
@@ -127,18 +127,23 @@ bool ompi_osc_pt2pt_sync_pscw_peer (struct ompi_osc_pt2pt_module_t *module, int 
 /**
  * Wait for all remote peers in the synchronization to respond
  */
-static inline void ompi_osc_pt2pt_sync_wait (ompi_osc_pt2pt_sync_t *sync)
+static inline void ompi_osc_pt2pt_sync_wait_nolock (ompi_osc_pt2pt_sync_t *sync)
 {
-    OPAL_THREAD_LOCK(&sync->lock);
     while (!sync->eager_send_active) {
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                              "waiting for access epoch to start"));
         opal_condition_wait(&sync->cond, &sync->lock);
     }
-    OPAL_THREAD_UNLOCK(&sync->lock);
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                          "access epoch ready"));
+}
+
+static inline void ompi_osc_pt2pt_sync_wait (ompi_osc_pt2pt_sync_t *sync)
+{
+    OPAL_THREAD_LOCK(&sync->lock);
+    ompi_osc_pt2pt_sync_wait_nolock (sync);
+    OPAL_THREAD_UNLOCK(&sync->lock);
 }
 
 /**


### PR DESCRIPTION
This commit fixes a number of threading issues discovered in
osc/pt2pt. This includes:

 - Lock the synchronization object not the module in osc_pt2pt_start.
   This fixes a race between the start function and processing post
   messages.

 - Always lock before calling cond_broadcast. Fixes a race between
   the waiting thread and signaling thread.

 - Make all atomically updated values volatile.

 - Make the module lock recursive to protect against some deadlock
   conditions. Will roll this back once the locks have been
   re-designed.

 - Mark incoming complete *after* completing an accumulate not
   before. This was causing an incorrect answer under certain
   conditions.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>