### PR TITLE
Add some missing qualifiers to the wrapper compilers for -lopen-rte and -lopen-pal

### DIFF
--- a/orte/tools/wrappers/orte.pc.in
+++ b/orte/tools/wrappers/orte.pc.in
@@ -15,8 +15,8 @@ pkgincludedir=@opalincludedir@
 # static linking (they're pulled in by libopen-rte.so's implicit
 # dependencies), so only list these in Libs.private.
 #
-Libs: -L${libdir} @ORTE_PKG_CONFIG_LDFLAGS@ -lopen-rte
-Libs.private: -lopen-pal @ORTE_WRAPPER_EXTRA_LIBS@
+Libs: -L${libdir} @ORTE_PKG_CONFIG_LDFLAGS@ -l@ORTE_LIB_PREFIX@open-rte
+Libs.private: -l@OPAL_LIB_PREFIX@open-pal @ORTE_WRAPPER_EXTRA_LIBS@
 #
 # It is safe to hard-wire the -I before the EXTRA_INCLUDES because we
 # will not be installing this .pc file unless --enable-devel-headers is

--- a/orte/tools/wrappers/ortecc-wrapper-data.txt.in
+++ b/orte/tools/wrappers/ortecc-wrapper-data.txt.in
@@ -20,10 +20,10 @@ linker_flags=@ORTE_WRAPPER_EXTRA_LDFLAGS@
 # intentionally always link in open-pal and open-rte in
 # ortecc/ortec++ because we intend ORTE applications to use both the
 # ORTE and OPAL APIs.
-libs=-lopen-rte -lopen-pal
-libs_static=-lopen-rte -lopen-pal @ORTE_WRAPPER_EXTRA_LIBS@
-dyn_lib_file=libopen-rte.@OPAL_DYN_LIB_SUFFIX@
-static_lib_file=libopen-rte.a
+libs=-l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal
+libs_static=-l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @ORTE_WRAPPER_EXTRA_LIBS@
+dyn_lib_file=lib@ORTE_LIB_PREFIX@open-rte.@OPAL_DYN_LIB_SUFFIX@
+static_lib_file=lib@ORTE_LIB_PREFIX@open-rte.a
 required_file=
 includedir=${includedir}
 libdir=${libdir}


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>