### PR TITLE
Update and cleanup os_dirpath

### DIFF
--- a/opal/util/help-opal-util.txt
+++ b/opal/util/help-opal-util.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -93,3 +94,23 @@ resource:
   Limit:     %s
 
 Please correct the request and try again.
+#
+[dir-mode]
+While working through a directory tree, we were unable to set
+a directory to the desired mode:
+
+  Directory:  %s
+  Mode:       %0x
+  Error:      %s
+
+Please check to ensure you have adequate permissions to perform
+the desired operation.
+#
+[mkdir-failed]
+A call to mkdir was unable to create the desired directory:
+
+  Directory: %s
+  Error:     %s
+
+Please check to ensure you have adequate permissions to perform
+the desired operation.

--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -117,15 +117,10 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
            Create it if it doesn't exist. */
         ret = mkdir(tmp, mode);
         if ((0 > ret && EEXIST != errno) || 0 != stat(tmp, &buf)) {
-            if (0 > ret && EEXIST != errno) {
-                opal_output(0, "opal_os_dirpath_create: "
-                               "Error: Unable to create the sub-directory (%s) of (%s), mkdir failed [%d] (%s)]\n",
-                        tmp, path, errno, strerror(errno));
-            } else {
-                opal_output(0, "opal_os_dirpath_create: "
-                               "Error: Unable to stat the sub-directory (%s) of (%s), mkdir failed [%d] (%s)]\n",
-                        tmp, path, errno, strerror(errno));
-            }
+            opal_output(0,
+                        "opal_os_dirpath_create: "
+                        "Error: Unable to create the sub-directory (%s) of (%s), mkdir failed [%d]\n",
+                        tmp, path, ret);
             opal_argv_free(parts);
             free(tmp);
             return OPAL_ERROR;


### PR DESCRIPTION
A prior commit was made to the 2.x series that didn't get into master, so bring that forward. Further improve on it by cleaning up the logic so it only errors out if the directory doesn't actually get made, and pretty-prints the associated error message.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
