### PR TITLE
Cleanup the os_dirpath logic

### DIFF
--- a/opal/util/help-opal-util.txt
+++ b/opal/util/help-opal-util.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2009 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -93,3 +94,23 @@ resource:
   Limit:     %s
 
 Please correct the request and try again.
+#
+[dir-mode]
+While working through a directory tree, we were unable to set
+a directory to the desired mode:
+
+  Directory:  %s
+  Mode:       %0x
+  Error:      %s
+
+Please check to ensure you have adequate permissions to perform
+the desired operation.
+#
+[mkdir-failed]
+A call to mkdir was unable to create the desired directory:
+
+  Directory: %s
+  Error:     %s
+
+Please check to ensure you have adequate permissions to perform
+the desired operation.

--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -113,10 +113,11 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
         }
 
         /* Now that we have the name, try to create it */
-        ret = mkdir(tmp, mode);
+        mkdir(tmp, mode);
+        ret = errno;  // save the errno for an error msg, if needed
         if (0 != stat(tmp, &buf)) {
             opal_show_help("help-opal-util.txt", "mkdir-failed", true,
-                        tmp, strerror(errno));
+                        tmp, strerror(ret));
             opal_argv_free(parts);
             free(tmp);
             return OPAL_ERROR;

--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
@@ -121,6 +121,12 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
             opal_argv_free(parts);
             free(tmp);
             return OPAL_ERROR;
+        } else if (i == (len-1) && (mode != (mode & buf.st_mode)) && (0 > chmod(tmp, (buf.st_mode | mode)))) {
+            opal_show_help("help-opal-util.txt", "dir-mode", true,
+                           tmp, mode, strerror(errno));
+            opal_argv_free(parts);
+            free(tmp);
+            return(OPAL_ERR_PERM); /* can't set correct mode */
         }
     }
 

--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,6 +40,7 @@
 
 #include "opal/util/output.h"
 #include "opal/util/os_dirpath.h"
+#include "opal/util/show_help.h"
 #include "opal/util/argv.h"
 #include "opal/util/os_path.h"
 #include "opal/constants.h"
@@ -63,11 +65,9 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
         if (0 == (ret = chmod(path, (buf.st_mode | mode)))) { /* successfully change mode */
             return(OPAL_SUCCESS);
         }
-        opal_output(0,
-                    "opal_os_dirpath_create: "
-                    "Error: Unable to create directory (%s), unable to set the correct mode [%d]\n",
-                    path, ret);
-        return(OPAL_ERROR); /* can't set correct mode */
+        opal_show_help("help-opal-util.txt", "dir-mode", true,
+                    path, mode, strerror(errno));
+        return(OPAL_ERR_PERM); /* can't set correct mode */
     }
 
     /* quick -- try to make directory */
@@ -112,14 +112,11 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
             strcat(tmp, parts[i]);
         }
 
-        /* Now that we finally have the name to check, check it.
-           Create it if it doesn't exist. */
+        /* Now that we have the name, try to create it */
         ret = mkdir(tmp, mode);
-        if ((0 > ret && EEXIST != errno) || 0 != stat(tmp, &buf)) {
-            opal_output(0,
-                        "opal_os_dirpath_create: "
-                        "Error: Unable to create the sub-directory (%s) of (%s), mkdir failed [%d]\n",
-                        tmp, path, ret);
+        if (0 != stat(tmp, &buf)) {
+            opal_show_help("help-opal-util.txt", "mkdir-failed", true,
+                        tmp, strerror(errno));
             opal_argv_free(parts);
             free(tmp);
             return OPAL_ERROR;
@@ -263,19 +260,19 @@ bool opal_os_dirpath_is_empty(const char *path ) {
     struct dirent *ep;
 
     if (NULL != path) {  /* protect against error */
-    	dp = opendir(path);
-    	if (NULL != dp) {
-    	    while ((ep = readdir(dp))) {
-        		if ((0 != strcmp(ep->d_name, ".")) &&
-        		    (0 != strcmp(ep->d_name, ".."))) {
+        dp = opendir(path);
+        if (NULL != dp) {
+            while ((ep = readdir(dp))) {
+                        if ((0 != strcmp(ep->d_name, ".")) &&
+                            (0 != strcmp(ep->d_name, ".."))) {
                             closedir(dp);
-        		    return false;
-        		}
-    	    }
-    	    closedir(dp);
-    	    return true;
-    	}
-    	return false;
+                            return false;
+                        }
+            }
+            closedir(dp);
+            return true;
+        }
+        return false;
     }
 
     return true;
@@ -306,4 +303,3 @@ int opal_os_dirpath_access(const char *path, const mode_t in_mode ) {
         return( OPAL_ERR_NOT_FOUND );
     }
 }
-


### PR DESCRIPTION
Cleanup the os_dirpath logic so it doesn't error out if the directory actually gets created (regardless of what mkdir returns), and pretty-prints the error if it does error out.

Fixes #2754 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit b257c32d2c264f78897e24c6952ea5297709e44c)