### PR TITLE
Rework OOB and routed/radix for performance during launch

### DIFF
--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -1135,7 +1135,6 @@ void mca_oob_tcp_component_hop_unknown(int fd, short args, void *cbdata)
     snd->seq_num = mop->snd->hdr.seq_num;
     snd->data = mop->snd->data;
     snd->count = mop->snd->hdr.nbytes;
-    snd->cbfunc.iov = NULL;
     snd->cbdata = NULL;
     snd->routed = strdup(mop->snd->hdr.routed);
     /* activate the OOB send state */

--- a/orte/mca/oob/tcp/oob_tcp_sendrecv.c
+++ b/orte/mca/oob/tcp/oob_tcp_sendrecv.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,47 +75,89 @@
 #include "orte/mca/oob/tcp/oob_tcp_common.h"
 #include "orte/mca/oob/tcp/oob_tcp_connection.h"
 
-static int send_bytes(mca_oob_tcp_peer_t* peer)
+static int send_msg(mca_oob_tcp_peer_t* peer, mca_oob_tcp_send_t* msg)
 {
-    mca_oob_tcp_send_t* msg = peer->send_msg;
-    int rc;
+    struct iovec iov[2];
+    int iov_count;
+    ssize_t remain = msg->sdbytes, rc;
 
     OPAL_TIMING_EVENT((&tm_oob, "to %s %d bytes",
                        ORTE_NAME_PRINT(&(peer->name)), msg->sdbytes));
 
-    while (0 < msg->sdbytes) {
-        rc = write(peer->sd, msg->sdptr, msg->sdbytes);
-        if (rc < 0) {
-            if (opal_socket_errno == EINTR) {
-                continue;
-            } else if (opal_socket_errno == EAGAIN) {
-                /* tell the caller to keep this message on active,
-                 * but let the event lib cycle so other messages
-                 * can progress while this socket is busy
-                 */
-                return ORTE_ERR_RESOURCE_BUSY;
-            } else if (opal_socket_errno == EWOULDBLOCK) {
-                /* tell the caller to keep this message on active,
-                 * but let the event lib cycle so other messages
-                 * can progress while this socket is busy
-                 */
-                return ORTE_ERR_WOULD_BLOCK;
-            }
-            /* we hit an error and cannot progress this message */
-            opal_output(0, "%s->%s mca_oob_tcp_msg_send_bytes: write failed: %s (%d) [sd = %d]",
-                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                        ORTE_NAME_PRINT(&(peer->name)),
-                        strerror(opal_socket_errno),
-                        opal_socket_errno,
-                        peer->sd);
-            return ORTE_ERR_COMM_FAILURE;
+    iov[0].iov_base = msg->sdptr;
+    iov[0].iov_len = msg->sdbytes;
+    if (!msg->hdr_sent) {
+        if (NULL != msg->data) {
+            /* relay message - just send that data */
+            iov[1].iov_base = msg->data;
+        } else if (NULL != msg->msg->buffer) {
+            /* buffer send */
+            iov[1].iov_base = msg->msg->buffer->base_ptr;
+        } else {
+            iov[1].iov_base = msg->msg->data;
         }
-        /* update location */
-        msg->sdbytes -= rc;
-        msg->sdptr += rc;
+        iov[1].iov_len = ntohl(msg->hdr.nbytes);
+        remain += ntohl(msg->hdr.nbytes);
+        iov_count = 2;
+    } else {
+        iov_count = 1;
     }
-    /* we sent the full data block */
-    return ORTE_SUCCESS;
+
+  retry:
+    rc = writev(peer->sd, iov, iov_count);
+    if (OPAL_LIKELY(rc == remain)) {
+        /* we successfully sent the header and the msg data if any */
+        msg->hdr_sent = true;
+        msg->sdbytes = 0;
+        msg->sdptr = (char *)iov[iov_count-1].iov_base + iov[iov_count-1].iov_len;
+        return ORTE_SUCCESS;
+    } else if (rc < 0) {
+        if (opal_socket_errno == EINTR) {
+            goto retry;
+        } else if (opal_socket_errno == EAGAIN) {
+            /* tell the caller to keep this message on active,
+             * but let the event lib cycle so other messages
+             * can progress while this socket is busy
+             */
+            return ORTE_ERR_RESOURCE_BUSY;
+        } else if (opal_socket_errno == EWOULDBLOCK) {
+            /* tell the caller to keep this message on active,
+             * but let the event lib cycle so other messages
+             * can progress while this socket is busy
+             */
+            return ORTE_ERR_WOULD_BLOCK;
+        } else {
+            /* we hit an error and cannot progress this message */
+            opal_output(0, "oob:tcp: send_msg: write failed: %s (%d) [sd = %d]",
+                        strerror(opal_socket_errno),
+                        opal_socket_errno, peer->sd);
+            return ORTE_ERR_UNREACH;
+        }
+    } else {
+        /* short writev. This usually means the kernel buffer is full,
+         * so there is no point for retrying at that time.
+         * simply update the msg and return with PMIX_ERR_RESOURCE_BUSY */
+        if ((size_t)rc < msg->sdbytes) {
+            /* partial write of the header or the msg data */
+            msg->sdptr = (char *)msg->sdptr + rc;
+            msg->sdbytes -= rc;
+        } else {
+            /* header was fully written, but only a part of the msg data was written */
+            msg->hdr_sent = true;
+            rc -= msg->sdbytes;
+            if (NULL != msg->data) {
+                /* technically, this should never happen as iov_count
+                 * would be 1 for a zero-byte message, and so we cannot
+                 * have a case where we write the header and part of the
+                 * msg. However, code checkers don't know that and are
+                 * fooled by our earlier check for NULL, and so
+                 * we silence their warnings by using this check */
+                msg->sdptr = (char *)msg->data + rc;
+            }
+            msg->sdbytes = ntohl(msg->hdr.nbytes) - rc;
+        }
+        return ORTE_ERR_RESOURCE_BUSY;
+    }
 }
 
 /*
@@ -155,135 +197,74 @@ void mca_oob_tcp_send_handler(int sd, short flags, void *cbdata)
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                             (NULL == peer->send_msg) ? "NULL" : ORTE_NAME_PRINT(&peer->name));
         if (NULL != msg) {
-            /* if the header hasn't been completely sent, send it */
-            if (!msg->hdr_sent) {
-                if (ORTE_SUCCESS == (rc = send_bytes(peer))) {
-                    /* header is completely sent */
-                    msg->hdr_sent = true;
-                    /* setup to send the data */
-                    if (NULL != msg->data) {
-                        /* relay msg - send that data */
-                        msg->sdptr = msg->data;
-                        msg->sdbytes = (int)ntohl(msg->hdr.nbytes);
-                    } else if (NULL == msg->msg) {
-                        /* this was a zero-byte relay - nothing more to do */
-                        OBJ_RELEASE(msg);
-                        peer->send_msg = NULL;
-                        goto next;
-                    } else if (NULL != msg->msg->buffer) {
-                        /* send the buffer data as a single block */
-                        msg->sdptr = msg->msg->buffer->base_ptr;
-                        msg->sdbytes = msg->msg->buffer->bytes_used;
-                    } else if (NULL != msg->msg->iov) {
-                        /* start with the first iovec */
-                        msg->sdptr = msg->msg->iov[0].iov_base;
-                        msg->sdbytes = msg->msg->iov[0].iov_len;
-                        msg->iovnum = 0;
-                    } else {
-                        /* just send the data */
-                        msg->sdptr = msg->msg->data;
-                        msg->sdbytes = msg->msg->count;
-                    }
-                    /* fall thru and let the send progress */
-                } else if (ORTE_ERR_RESOURCE_BUSY == rc ||
-                           ORTE_ERR_WOULD_BLOCK == rc) {
-                    /* exit this event and let the event lib progress */
-                    return;
-                } else {
-                    // report the error
-                    opal_output(0, "%s-%s mca_oob_tcp_peer_send_handler: unable to send header",
-                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                ORTE_NAME_PRINT(&(peer->name)));
-                    opal_event_del(&peer->send_event);
-                    msg->msg->status = rc;
+            opal_output_verbose(2, orte_oob_base_framework.framework_output,
+                                "oob:tcp:send_handler SENDING MSG");
+            if (ORTE_SUCCESS == (rc = send_msg(peer, msg))) {
+                // message is complete
+                if (NULL != msg->data || NULL == msg->msg) {
+                    /* the relay is complete - release the data */
+                    opal_output_verbose(2, orte_oob_base_framework.framework_output,
+                                        "%s MESSAGE RELAY COMPLETE TO %s OF %d BYTES ON SOCKET %d",
+                                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                        ORTE_NAME_PRINT(&(peer->name)),
+                                        (int)ntohl(msg->hdr.nbytes), peer->sd);
+                    OBJ_RELEASE(msg);
+                    peer->send_msg = NULL;
+                } else if (NULL != msg->msg->buffer) {
+                    /* we are done - notify the RML */
+                    opal_output_verbose(2, orte_oob_base_framework.framework_output,
+                                        "%s MESSAGE SEND COMPLETE TO %s OF %d BYTES ON SOCKET %d",
+                                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                        ORTE_NAME_PRINT(&(peer->name)),
+                                        (int)ntohl(msg->hdr.nbytes), peer->sd);
+                    msg->msg->status = ORTE_SUCCESS;
                     ORTE_RML_SEND_COMPLETE(msg->msg);
                     OBJ_RELEASE(msg);
                     peer->send_msg = NULL;
-                    goto next;
-                }
-            }
-            /* progress the data transmission */
-            if (msg->hdr_sent) {
-                if (ORTE_SUCCESS == (rc = send_bytes(peer))) {
-                    /* this block is complete */
-                    if (NULL != msg->data || NULL == msg->msg) {
-                        /* the relay is complete - release the data */
-                        opal_output_verbose(2, orte_oob_base_framework.framework_output,
-                                            "%s MESSAGE RELAY COMPLETE TO %s OF %d BYTES ON SOCKET %d",
-                                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                            ORTE_NAME_PRINT(&(peer->name)),
-                                            (int)ntohl(msg->hdr.nbytes), peer->sd);
-                        OBJ_RELEASE(msg);
-                        peer->send_msg = NULL;
-                    } else if (NULL != msg->msg->buffer) {
-                        /* we are done - notify the RML */
-                        opal_output_verbose(2, orte_oob_base_framework.framework_output,
-                                            "%s MESSAGE SEND COMPLETE TO %s OF %d BYTES ON SOCKET %d",
-                                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                            ORTE_NAME_PRINT(&(peer->name)),
-                                            (int)ntohl(msg->hdr.nbytes), peer->sd);
-                        msg->msg->status = ORTE_SUCCESS;
-                        ORTE_RML_SEND_COMPLETE(msg->msg);
-                        OBJ_RELEASE(msg);
-                        peer->send_msg = NULL;
-                    } else if (NULL != msg->msg->data) {
-                        /* this was a relay we have now completed - no need to
-                         * notify the RML as the local proc didn't initiate
-                         * the send
-                         */
-                        opal_output_verbose(2, orte_oob_base_framework.framework_output,
-                                            "%s MESSAGE RELAY COMPLETE TO %s OF %d BYTES ON SOCKET %d",
-                                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                            ORTE_NAME_PRINT(&(peer->name)),
-                                            (int)ntohl(msg->hdr.nbytes), peer->sd);
-                        msg->msg->status = ORTE_SUCCESS;
-                        OBJ_RELEASE(msg);
-                        peer->send_msg = NULL;
-                    } else {
-                        /* rotate to the next iovec */
-                        msg->iovnum++;
-                        if (msg->iovnum < msg->msg->count) {
-                            msg->sdptr = msg->msg->iov[msg->iovnum].iov_base;
-                            msg->sdbytes = msg->msg->iov[msg->iovnum].iov_len;
-                            /* exit this event to give the event lib
-                             * a chance to progress any other pending
-                             * actions
-                             */
-                            return;
-                        } else {
-                            /* this message is complete - notify the RML */
-                            opal_output_verbose(2, orte_oob_base_framework.framework_output,
-                                                "%s MESSAGE SEND COMPLETE TO %s OF %d BYTES ON SOCKET %d",
-                                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                                ORTE_NAME_PRINT(&(peer->name)),
-                                                (int)ntohl(msg->hdr.nbytes), peer->sd);
-                            msg->msg->status = ORTE_SUCCESS;
-                            ORTE_RML_SEND_COMPLETE(msg->msg);
-                            OBJ_RELEASE(msg);
-                            peer->send_msg = NULL;
-                        }
-                    }
-                    /* fall thru to queue the next message */
-                } else if (ORTE_ERR_RESOURCE_BUSY == rc ||
-                           ORTE_ERR_WOULD_BLOCK == rc) {
-                    /* exit this event and let the event lib progress */
-                    return;
+                } else if (NULL != msg->msg->data) {
+                    /* this was a relay we have now completed - no need to
+                     * notify the RML as the local proc didn't initiate
+                     * the send
+                     */
+                    opal_output_verbose(2, orte_oob_base_framework.framework_output,
+                                        "%s MESSAGE RELAY COMPLETE TO %s OF %d BYTES ON SOCKET %d",
+                                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                        ORTE_NAME_PRINT(&(peer->name)),
+                                        (int)ntohl(msg->hdr.nbytes), peer->sd);
+                    msg->msg->status = ORTE_SUCCESS;
+                    OBJ_RELEASE(msg);
+                    peer->send_msg = NULL;
                 } else {
-                    // report the error
-                    opal_output(0, "%s-%s mca_oob_tcp_peer_send_handler: unable to send message ON SOCKET %d",
-                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                ORTE_NAME_PRINT(&(peer->name)), peer->sd);
-                    opal_event_del(&peer->send_event);
-                    msg->msg->status = rc;
+                    /* this message is complete - notify the RML */
+                    opal_output_verbose(2, orte_oob_base_framework.framework_output,
+                                        "%s MESSAGE SEND COMPLETE TO %s OF %d BYTES ON SOCKET %d",
+                                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                        ORTE_NAME_PRINT(&(peer->name)),
+                                        (int)ntohl(msg->hdr.nbytes), peer->sd);
+                    msg->msg->status = ORTE_SUCCESS;
                     ORTE_RML_SEND_COMPLETE(msg->msg);
                     OBJ_RELEASE(msg);
                     peer->send_msg = NULL;
-                    ORTE_FORCED_TERMINATE(1);
-                    return;
                 }
+                /* fall thru to queue the next message */
+            } else if (ORTE_ERR_RESOURCE_BUSY == rc ||
+                       ORTE_ERR_WOULD_BLOCK == rc) {
+                /* exit this event and let the event lib progress */
+                opal_output_verbose(2, orte_oob_base_framework.framework_output,
+                                    "oob:tcp:send_handler RES BUSY OR WOULD BLOCK");
+                return;
+            } else {
+                // report the error
+                opal_output(0, "%s-%s mca_oob_tcp_peer_send_handler: unable to send header",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                            ORTE_NAME_PRINT(&(peer->name)));
+                opal_event_del(&peer->send_event);
+                msg->msg->status = rc;
+                ORTE_RML_SEND_COMPLETE(msg->msg);
+                OBJ_RELEASE(msg);
+                peer->send_msg = NULL;
             }
 
-        next:
             /* if current message completed - progress any pending sends by
              * moving the next in the queue into the "on-deck" position. Note
              * that this doesn't mean we send the message right now - we will
@@ -575,7 +556,6 @@ void mca_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                     snd->seq_num = peer->recv_msg->hdr.seq_num;
                     snd->count = peer->recv_msg->hdr.nbytes;
                     snd->routed = strdup(peer->recv_msg->hdr.routed);
-                    snd->cbfunc.iov = NULL;
                     snd->cbdata = NULL;
                     /* activate the OOB send state */
                     ORTE_OOB_SEND(snd);
@@ -657,4 +637,3 @@ static void err_cons(mca_oob_tcp_msg_error_t *ptr)
 OBJ_CLASS_INSTANCE(mca_oob_tcp_msg_error_t,
                    opal_object_t,
                    err_cons, NULL);
-

--- a/orte/mca/oob/tcp/oob_tcp_sendrecv.h
+++ b/orte/mca/oob/tcp/oob_tcp_sendrecv.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -105,7 +105,6 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
 #define MCA_OOB_TCP_QUEUE_SEND(m, p)                                    \
     do {                                                                \
         mca_oob_tcp_send_t *msg;                                        \
-        int i;                                                          \
         opal_output_verbose(5, orte_oob_base_framework.framework_output, \
                             "%s:[%s:%d] queue send to %s",              \
                              ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),        \
@@ -127,11 +126,6 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
         /* set the total number of bytes to be sent */                  \
         if (NULL != (m)->buffer) {                                      \
             msg->hdr.nbytes = (m)->buffer->bytes_used;                  \
-        } else if (NULL != (m)->iov) {                                  \
-            msg->hdr.nbytes = 0;                                        \
-            for (i=0; i < (m)->count; i++) {                            \
-                msg->hdr.nbytes += (m)->iov[i].iov_len;                 \
-            }                                                           \
         } else {                                                        \
             msg->hdr.nbytes = (m)->count;                               \
         }                                                               \
@@ -153,7 +147,6 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
 #define MCA_OOB_TCP_QUEUE_PENDING(m, p)                                 \
     do {                                                                \
         mca_oob_tcp_send_t *msg;                                        \
-        int i;                                                          \
         opal_output_verbose(5, orte_oob_base_framework.framework_output, \
                             "%s:[%s:%d] queue pending to %s",           \
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),         \
@@ -175,11 +168,6 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
         /* set the total number of bytes to be sent */                  \
         if (NULL != (m)->buffer) {                                      \
             msg->hdr.nbytes = (m)->buffer->bytes_used;                  \
-        } else if (NULL != (m)->iov) {                                  \
-            msg->hdr.nbytes = 0;                                        \
-            for (i=0; i < (m)->count; i++) {                            \
-                msg->hdr.nbytes += (m)->iov[i].iov_len;                 \
-            }                                                           \
         } else {                                                        \
             msg->hdr.nbytes = (m)->count;                               \
         }                                                               \

--- a/orte/mca/oob/ud/oob_ud_req.c
+++ b/orte/mca/oob/ud/oob_ud_req.c
@@ -4,7 +4,7 @@
  *                         reserved.
  *               2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -334,7 +334,6 @@ void mca_oob_ud_req_complete (mca_oob_ud_req_t *req, int rc)
                 snd->data = data;
                 snd->count = req->req_data.buf.size;
             }
-            snd->cbfunc.iov = NULL;
             snd->cbdata = NULL;
             /* activate the OOB send state */
             ORTE_OOB_SEND(snd);

--- a/orte/mca/oob/ud/oob_ud_send.h
+++ b/orte/mca/oob/ud/oob_ud_send.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2014 Mellanox Technologies, Inc.
  *                    All rights reserved.
+ * Copyright (c) 2017      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,17 +18,7 @@
 
 #define min(a,b) ((a) < (b) ? (a) : (b))
 
-#define MCA_OOB_UD_IOV_SIZE(msg, size)                                  \
-    do {                                                                \
-        if (msg->iov != NULL) {                                         \
-            int i;                                                      \
-            for (i = 0, (size) = 0 ; i < (msg->count) ; ++i) {          \
-                (size) += (msg->iov)[i].iov_len;                        \
-            }                                                           \
-        } else {                                                        \
-            (size) = msg->buffer->bytes_used;                           \
-        }                                                               \
-    } while (0);
+#define MCA_OOB_UD_IOV_SIZE(msg, size) (size) = msg->buffer->bytes_used
 
 /* State machine for processing message */
 typedef struct {

--- a/orte/mca/rml/base/rml_base_frame.c
+++ b/orte/mca/rml/base/rml_base_frame.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2016 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -43,9 +43,7 @@ orte_rml_base_API_t orte_rml = {
     .get_contact_info       = orte_rml_API_get_contact_info,
     .set_contact_info       = orte_rml_API_set_contact_info,
     .ping                   = orte_rml_API_ping,
-    .send_nb                = orte_rml_API_send_nb,
     .send_buffer_nb         = orte_rml_API_send_buffer_nb,
-    .recv_nb                = orte_rml_API_recv_nb,
     .recv_buffer_nb         = orte_rml_API_recv_buffer_nb,
     .recv_cancel            = orte_rml_API_recv_cancel,
     .purge                  = orte_rml_API_purge,
@@ -254,10 +252,8 @@ void orte_rml_recv_callback(int status, orte_process_name_t* sender,
 /***   RML CLASS INSTANCES   ***/
 static void xfer_cons(orte_self_send_xfer_t *xfer)
 {
-    xfer->iov = NULL;
-    xfer->cbfunc.iov = NULL;
     xfer->buffer = NULL;
-    xfer->cbfunc.buffer = NULL;
+    xfer->cbfunc = NULL;
     xfer->cbdata = NULL;
 }
 OBJ_CLASS_INSTANCE(orte_self_send_xfer_t,
@@ -268,9 +264,9 @@ static void send_cons(orte_rml_send_t *ptr)
 {
     ptr->retries = 0;
     ptr->cbdata = NULL;
-    ptr->iov = NULL;
     ptr->buffer = NULL;
     ptr->data = NULL;
+    ptr->count = 0;
     ptr->seq_num = 0xFFFFFFFF;
     ptr->routed = NULL;
 }

--- a/orte/mca/rml/ofi/rml_ofi.h
+++ b/orte/mca/rml/ofi/rml_ofi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -174,13 +174,6 @@ int orte_rml_ofi_send_buffer_nb(struct orte_rml_base_module_t *mod,
                                 orte_rml_tag_t tag,
                                 orte_rml_buffer_callback_fn_t cbfunc,
                                 void* cbdata);
-int orte_rml_ofi_send_nb(struct orte_rml_base_module_t *mod,
-                         orte_process_name_t* peer,
-                         struct iovec* iov,
-                         int count,
-                         orte_rml_tag_t tag,
-                         orte_rml_callback_fn_t cbfunc,
-                         void* cbdata);
 
 /****************** INTERNAL OFI Functions*************/
 void free_ofi_prov_resources( int ofi_prov_id);

--- a/orte/mca/rml/ofi/rml_ofi_component.c
+++ b/orte/mca/rml/ofi/rml_ofi_component.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,7 +73,6 @@ orte_rml_ofi_module_t orte_rml_ofi = {
     .api = {
     .component = (struct orte_rml_component_t*)&mca_rml_ofi_component,
     .ping = NULL,
-    .send_nb = orte_rml_ofi_send_nb,
     .send_buffer_nb = orte_rml_ofi_send_buffer_nb,
     .purge = NULL
     }

--- a/orte/mca/rml/oob/rml_oob.h
+++ b/orte/mca/rml/oob/rml_oob.h
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,14 +47,6 @@ typedef struct {
 ORTE_MODULE_DECLSPEC extern orte_rml_component_t mca_rml_oob_component;
 
 void orte_rml_oob_fini(struct orte_rml_base_module_t *mod);
-
-int orte_rml_oob_send_nb(struct orte_rml_base_module_t *mod,
-                         orte_process_name_t* peer,
-                         struct iovec* msg,
-                         int count,
-                         orte_rml_tag_t tag,
-                         orte_rml_callback_fn_t cbfunc,
-                         void* cbdata);
 
 int orte_rml_oob_send_buffer_nb(struct orte_rml_base_module_t *mod,
                                 orte_process_name_t* peer,

--- a/orte/mca/rml/oob/rml_oob_component.c
+++ b/orte/mca/rml/oob/rml_oob_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -96,7 +96,6 @@ static orte_rml_pathway_t pathway;
 static orte_rml_base_module_t base_module = {
     .component = (struct orte_rml_component_t*)&mca_rml_oob_component,
     .ping = NULL,
-    .send_nb = orte_rml_oob_send_nb,
     .send_buffer_nb = orte_rml_oob_send_buffer_nb,
     .purge = NULL
 };

--- a/orte/mca/rml/rml.h
+++ b/orte/mca/rml/rml.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
@@ -84,38 +84,6 @@ ORTE_DECLSPEC void orte_rml_recv_callback(int status, orte_process_name_t* sende
 /*                     RML CALLBACK FUNCTION DEFINITIONS                */
 
 /**
- * Funtion prototype for callback from non-blocking iovec send and recv
- *
- * Funtion prototype for callback from non-blocking iovec send and recv.
- * On send, the iovec pointer will be the same pointer passed to
- * send_nb and count will equal the count given to send.
- *
- * On recv, the iovec pointer will be the address of a single iovec
- * allocated and owned by the RML, not the process receiving the
- * callback. Ownership of the data block can be transferred by setting
- * a user variable to point to the data block, and setting the
- * iovec->iov_base pointer to NULL.
- *
- * @note The parameter in/out parameters are relative to the user's callback
- * function.
- *
- * @param[in] status  Completion status
- * @param[in] peer    Opaque name of peer process
- * @param[in] msg     Pointer to the array of iovec that was sent
- *                    or to a single iovec that has been recvd
- * @param[in] count   Number of iovecs in the array
- * @param[in] tag     User defined tag for matching send/recv
- * @param[in] cbdata  User data passed to send_nb()
- */
-typedef void (*orte_rml_callback_fn_t)(int status,
-                                       orte_process_name_t* peer,
-                                       struct iovec* msg,
-                                       int count,
-                                       orte_rml_tag_t tag,
-                                       void* cbdata);
-
-
-/**
  * Funtion prototype for callback from non-blocking buffer send and receive
  *
  * Function prototype for callback from non-blocking buffer send and
@@ -179,38 +147,6 @@ typedef int (*orte_rml_module_ping_fn_t)(struct orte_rml_base_module_t *mod,
 
 
 /**
- * Send an iovec non-blocking message
- *
- * Send an array of iovecs to the specified peer.  The call
- * will return immediately, although the iovecs may not be modified
- * until the completion callback is triggered.  The iovecs *may* be
- * passed to another call to send_nb before the completion callback is
- * triggered.  The callback being triggered does not give any
- * indication of remote completion.
- *
- * @param[in] peer   Name of receiving process
- * @param[in] msg    Pointer to an array of iovecs to be sent
- * @param[in] count  Number of iovecs in array
- * @param[in] tag    User defined tag for matching send/recv
- * @param[in] cbfunc Callback function on message comlpetion
- * @param[in] cbdata User data to provide during completion callback
- *
- * @retval ORTE_SUCCESS The message was successfully started
- * @retval ORTE_ERR_BAD_PARAM One of the parameters was invalid
- * @retval ORTE_ERR_ADDRESSEE_UNKNOWN Contact information for the
- *                    receiving process is not available
- * @retval ORTE_ERROR  An unspecified error occurred
- */
-typedef int (*orte_rml_module_send_nb_fn_t)(struct orte_rml_base_module_t *mod,
-                                            orte_process_name_t* peer,
-                                            struct iovec* msg,
-                                            int count,
-                                            orte_rml_tag_t tag,
-                                            orte_rml_callback_fn_t cbfunc,
-                                            void* cbdata);
-
-
-/**
  * Send a buffer non-blocking message
  *
  * Send a buffer to the specified peer.  The call
@@ -258,9 +194,6 @@ typedef struct orte_rml_base_module_t {
     char                                        *routed;
     /** Ping process for connectivity check */
     orte_rml_module_ping_fn_t                    ping;
-
-    /** Send non-blocking iovec message */
-    orte_rml_module_send_nb_fn_t                 send_nb;
 
     /** Send non-blocking buffer message */
     orte_rml_module_send_buffer_nb_fn_t          send_buffer_nb;
@@ -356,38 +289,6 @@ typedef int (*orte_rml_API_ping_fn_t)(orte_rml_conduit_t conduit_id,
 
 
 /**
- * Send an iovec non-blocking message
- *
- * Send an array of iovecs to the specified peer.  The call
- * will return immediately, although the iovecs may not be modified
- * until the completion callback is triggered.  The iovecs *may* be
- * passed to another call to send_nb before the completion callback is
- * triggered.  The callback being triggered does not give any
- * indication of remote completion.
- *
- * @param[in] peer   Name of receiving process
- * @param[in] msg    Pointer to an array of iovecs to be sent
- * @param[in] count  Number of iovecs in array
- * @param[in] tag    User defined tag for matching send/recv
- * @param[in] cbfunc Callback function on message comlpetion
- * @param[in] cbdata User data to provide during completion callback
- *
- * @retval ORTE_SUCCESS The message was successfully started
- * @retval ORTE_ERR_BAD_PARAM One of the parameters was invalid
- * @retval ORTE_ERR_ADDRESSEE_UNKNOWN Contact information for the
- *                    receiving process is not available
- * @retval ORTE_ERROR  An unspecified error occurred
- */
-typedef int (*orte_rml_API_send_nb_fn_t)(orte_rml_conduit_t conduit_id,
-                                         orte_process_name_t* peer,
-                                         struct iovec* msg,
-                                         int count,
-                                         orte_rml_tag_t tag,
-                                         orte_rml_callback_fn_t cbfunc,
-                                         void* cbdata);
-
-
-/**
  * Send a buffer non-blocking message
  *
  * Send a buffer to the specified peer.  The call
@@ -422,22 +323,6 @@ typedef int (*orte_rml_API_send_buffer_nb_fn_t)(orte_rml_conduit_t conduit_id,
  * and is to be restarted
  */
 typedef void (*orte_rml_API_purge_fn_t)(orte_process_name_t *peer);
-
-/**
- * Receive an iovec non-blocking message
- *
- * @param[in]  peer    Peer process or ORTE_NAME_WILDCARD for wildcard receive
- * @param[in]  tag     User defined tag for matching send/recv
- * @param[in] persistent Boolean flag indicating whether or not this is a one-time recv
- * @param[in] cbfunc   Callback function on message comlpetion
- * @param[in] cbdata   User data to provide during completion callback
- */
-typedef void (*orte_rml_API_recv_nb_fn_t)(orte_process_name_t* peer,
-                                          orte_rml_tag_t tag,
-                                          bool persistent,
-                                          orte_rml_callback_fn_t cbfunc,
-                                          void* cbdata);
-
 
 /**
  * Receive a buffer non-blocking message
@@ -485,14 +370,9 @@ typedef struct {
     /** Ping process for connectivity check */
     orte_rml_API_ping_fn_t                      ping;
 
-    /** Send non-blocking iovec message */
-    orte_rml_API_send_nb_fn_t           send_nb;
 
     /** Send non-blocking buffer message */
     orte_rml_API_send_buffer_nb_fn_t    send_buffer_nb;
-
-    /** Receive non-blocking iovec message */
-    orte_rml_API_recv_nb_fn_t                   recv_nb;
 
     /** Receive non-blocking buffer message */
     orte_rml_API_recv_buffer_nb_fn_t            recv_buffer_nb;

--- a/orte/mca/routed/radix/routed_radix.h
+++ b/orte/mca/routed/radix/routed_radix.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2007      Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,7 +20,7 @@ BEGIN_C_DECLS
 
 typedef struct {
     orte_routed_component_t super;
-    int radix;
+    orte_vpid_t radix;
 } orte_routed_radix_component_t;
 ORTE_MODULE_DECLSPEC extern orte_routed_radix_component_t mca_routed_radix_component;
 


### PR DESCRIPTION
Remove stale iovec RML/OOB interfaces as nobody has ever used them. Update the OOB/TCP send code to use writev for speed. Fix a bug in routed_radix where it would end up sending to the wrong "parent" when phoning home if radix=1

Update the routed/radix component to make it much faster - eliminate computation of the entire placement tree in a bitmap. Instead, compute relative location of target procs based on radix search algo.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>