### PR TITLE
Expose opal_set_using_threads in python bindings

### DIFF
--- a/orte/bindings/python/setup.py
+++ b/orte/bindings/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "orte-cffi",
-    version = "0.4.0",
+    version = "0.4.2",
     author = "Mark Santcroos",
     author_email = "mark.santcroos@rutgers.edu",
     description = "CFFI-based Python wrapper for Open RTE",

--- a/orte/bindings/python/src/orte-cffi/build.py
+++ b/orte/bindings/python/src/orte-cffi/build.py
@@ -8,15 +8,18 @@ import os
 
 
 #
-#
 # Get a path value from ompi_info based on key
 #
 def ompi_info_path(key):
 
     cmd = ['ompi_info', '--path', key, '--parseable']
 
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr= p.communicate()
+    try:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError:
+        raise Exception('ompi_info not found, check your path')
+
+    stdout, stderr = p.communicate()
 
     if p.returncode != 0:
         raise Exception(stderr)
@@ -129,6 +132,7 @@ int orte_submit_job(char *cmd[], int *index,
 void orte_submit_finalize(void);
 int orte_submit_cancel(int index);
 int orte_submit_halt(void);
+bool opal_set_using_threads(bool have);
 
 /* Callbacks */
 extern "Python" void launch_cb(int, orte_job_t *, int, void *);


### PR DESCRIPTION
Expose opal_set_using_threads() in python bindings so that the client can request to enable mutexes.
Improve error message on missing ompi_info while we are at it.
Increase version for pypi.

Signed-off-by: Mark Santcroos mark.santcroos@rutgers.edu