### PR TITLE
Fix comm_spawn and orte-dvm by resetting all used "node mapped" flags after building the child list

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -408,13 +408,6 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
     if (NULL == jdata->map) {
         jdata->map = OBJ_NEW(orte_job_map_t);
         newmap = true;
-    } else if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_MAP_INITIALIZED)) {
-        /* zero all the node map flags */
-        for (n=0; n < jdata->map->nodes->size; n++) {
-            if (NULL != (node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, n))) {
-                ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
-            }
-        }
     }
 
     /* if we have a file map, then we need to load it */
@@ -494,7 +487,12 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
             app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, pptr->app_idx);
             ORTE_FLAG_SET(app, ORTE_APP_FLAG_USED_ON_NODE);
         }
-        ORTE_FLAG_SET(jdata, ORTE_JOB_FLAG_MAP_INITIALIZED);
+    }
+    /* reset the node map flags we used so the next job will start clean */
+    for (n=0; n < jdata->map->nodes->size; n++) {
+        if (NULL != (node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, n))) {
+            ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
+        }
     }
 
  COMPLETE:

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -389,8 +389,6 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
         OBJ_RELEASE(caddy);
         return;
     }
-    /* mark that nodes were assigned to this job */
-    ORTE_FLAG_SET(jdata, ORTE_JOB_FLAG_MAP_INITIALIZED);
 
     /* if any node is oversubscribed, then check to see if a binding
      * directive was given - if not, then we want to clear the default

--- a/orte/runtime/data_type_support/orte_dt_unpacking_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_unpacking_fns.c
@@ -204,8 +204,6 @@ int orte_dt_unpack_job(opal_buffer_t *buffer, void *dest,
             ORTE_ERROR_LOG(rc);
             return rc;
         }
-        /* mark the map as uninitialized as we don't pack the node map */
-        ORTE_FLAG_UNSET(jobs[i], ORTE_JOB_FLAG_MAP_INITIALIZED);
 
         /* unpack the attributes */
         n=1;

--- a/orte/util/attr.h
+++ b/orte/util/attr.h
@@ -89,7 +89,6 @@ typedef uint16_t orte_job_flags_t;
 #define ORTE_JOB_FLAG_RESTART            0x0200   //
 #define ORTE_JOB_FLAG_PROCS_MIGRATING    0x0400   // some procs in job are migrating from one node to another
 #define ORTE_JOB_FLAG_OVERSUBSCRIBED     0x0800   // at least one node in the job is oversubscribed
-#define ORTE_JOB_FLAG_MAP_INITIALIZED    0x1000   // nodes have been assigned to this job map
 
 /***   JOB ATTRIBUTE KEYS   ***/
 #define ORTE_JOB_START_KEY   ORTE_NODE_MAX_KEY


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>