### PR TITLE
Ensure that oob/base level data is always accessed in the oob/base event thread. Make debruijn the default routed component

### DIFF
--- a/orte/mca/oob/tcp/oob_tcp_peer.h
+++ b/orte/mca/oob/tcp/oob_tcp_peer.h
@@ -76,25 +76,6 @@ typedef struct {
 } mca_oob_tcp_peer_op_t;
 OBJ_CLASS_DECLARATION(mca_oob_tcp_peer_op_t);
 
-#define ORTE_ACTIVATE_TCP_PEER_OP(p, a, n, pts, cbfunc)                 \
-    do {                                                                \
-        mca_oob_tcp_peer_op_t *pop;                                     \
-        pop = OBJ_NEW(mca_oob_tcp_peer_op_t);                           \
-        pop->peer.jobid = (p)->jobid;                                   \
-        pop->peer.vpid = (p)->vpid;                                     \
-        pop->af_family = (a);                                           \
-        if (NULL != (n)) {                                              \
-            pop->net = strdup((n));                                     \
-        }                                                               \
-        if (NULL != (pts)) {                                            \
-            pop->port = strdup((pts));                                  \
-        }                                                               \
-        opal_event_set((p)->ev_base, &pop->ev, -1,                      \
-                       OPAL_EV_WRITE, (cbfunc), pop);                   \
-        opal_event_set_priority(&pop->ev, ORTE_MSG_PRI);                \
-        opal_event_active(&pop->ev, OPAL_EV_WRITE, 1);                  \
-    } while(0);
-
 #define ORTE_ACTIVATE_TCP_CMP_OP(p, r, cbfunc)                          \
     do {                                                                \
         mca_oob_tcp_peer_op_t *pop;                                     \
@@ -106,7 +87,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_peer_op_t);
         if (NULL != proxy) {                                            \
             pop->rtmod = strdup(proxy);                                 \
         }                                                               \
-        opal_event_set((p)->ev_base, &pop->ev, -1,                      \
+        opal_event_set(orte_oob_base.ev_base, &pop->ev, -1,             \
                        OPAL_EV_WRITE, (cbfunc), pop);                   \
         opal_event_set_priority(&pop->ev, ORTE_MSG_PRI);                \
         opal_event_active(&pop->ev, OPAL_EV_WRITE, 1);                  \

--- a/orte/mca/routed/debruijn/routed_debruijn_component.c
+++ b/orte/mca/routed/debruijn/routed_debruijn_component.c
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2004-2008 The Trustees of Indiana University.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,13 +48,8 @@ static int orte_routed_debruijn_component_query(mca_base_module_t **module, int 
     /* Debruijn shall be our default, especially for large systems. For smaller
      * systems, we will allow other options that have even fewer hops to
      * support wireup
-     *
-     * XXX: set this to 0 until we can figure out what's going on with
-     * it within undersubscribed allocations. Once debruijn is fixed,
-     * revert back to priority 70. Note: this component seems to work fine within
-     * fully utilized allocations.
      */
-    *priority = 0;
+    *priority = 70;
     *module = (mca_base_module_t *) &orte_routed_debruijn_module;
     return ORTE_SUCCESS;
 }

--- a/orte/mca/routed/radix/routed_radix_component.c
+++ b/orte/mca/routed/radix/routed_radix_component.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2004-2008 The Trustees of Indiana University.
  *                         All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,7 +69,7 @@ static int orte_routed_radix_component_query(mca_base_module_t **module, int *pr
         return ORTE_ERR_BAD_PARAM;
     }
 
-    *priority = 70;
+    *priority = 50;
     *module = (mca_base_module_t *) &orte_routed_radix_module;
     return ORTE_SUCCESS;
 }


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>