### PR TITLE
Pr/sharedfp append fix v2.x

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -49,7 +49,7 @@ int mca_io_ompio_bytes_per_agg = OMPIO_PREALLOC_MAX_BUF_SIZE;
 int mca_io_ompio_num_aggregators = -1;
 int mca_io_ompio_record_offset_info = 0;
 int mca_io_ompio_coll_timing_info = 0;
-int mca_io_ompio_sharedfp_lazy_open = 1;
+int mca_io_ompio_sharedfp_lazy_open = 0;
 
 int mca_io_ompio_grouping_option=5;
 
@@ -206,7 +206,7 @@ static int register_component(void)
                                            &mca_io_ompio_num_aggregators);
 
 
-    mca_io_ompio_sharedfp_lazy_open = 1;
+    mca_io_ompio_sharedfp_lazy_open = 0;
     (void) mca_base_component_var_register(&mca_io_ompio_component.io_version,
                                            "sharedfp_lazy_open",
                                            "lazy allocation of internal shared file pointer structures",

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2016 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2017 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
@@ -197,14 +197,8 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
 	}
 
 	/* open the file once more for the shared file pointer if required.
-	** Per default, the shared file pointer specific actions are however
-	** only performed on first access of the shared file pointer, except
-	** for the addproc sharedfp component.
-	**
-	** Lazy open does not work for the addproc sharedfp
-	** component since it starts by spawning a process using MPI_Comm_spawn.
-	** For this, the first operation has to be collective which we can
-	** not guarantuee outside of the MPI_File_open operation.
+        ** Can be disabled by the user if no shared file pointer operations
+        ** are used by his application.
 	*/
 	if ( NULL != ompio_fh->f_sharedfp &&
 	     true == use_sharedfp &&
@@ -250,10 +244,27 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
        file pointer of OMPIO to the very end of the file. */
     if ( ompio_fh->f_amode & MPI_MODE_APPEND ) {
         OMPI_MPI_OFFSET_TYPE current_size;
+        mca_sharedfp_base_module_t * shared_fp_base_module;
 
         ompio_fh->f_fs->fs_file_get_size( ompio_fh,
                                           &current_size);
         ompi_io_ompio_set_explicit_offset (ompio_fh, current_size);
+        if ( true == use_sharedfp ) {
+            if ( NULL != ompio_fh->f_sharedfp &&
+                 (!mca_io_ompio_sharedfp_lazy_open ||
+                  !strcmp (ompio_fh->f_sharedfp_component->mca_component_name,
+                           "addproc")               )) {
+                
+                shared_fp_base_module = ompio_fh->f_sharedfp;
+                ret = shared_fp_base_module->sharedfp_seek(ompio_fh,current_size, MPI_SEEK_SET);
+            }
+            else {
+                opal_output(1, "mca_common_ompio_file_open: Could not adjust position of "
+                            "shared file pointer whith MPI_MODE_APPEND\n");
+                ret = MPI_ERR_OTHER;
+                goto fn_fail;
+            }
+        }
     }
 
 


### PR DESCRIPTION
Fixes a bug reported on the mailing list. ompio did only reposition the individual
file pointer when the file was opened in append mode. Set the shared file
pointer also to point to the end of the file, similarly to the individual
file pointer.

This is the equivalent to commit d3a8d38
on master, cannot be cherry-picked because of differences in the organization
of the ompio files ( usage of mca/common/ompio on master).