### PR TITLE
Pr/sharedfp append fix v2.0.x

### DIFF
--- a/ompi/mca/fs/ufs/fs_ufs_file_open.c
+++ b/ompi/mca/fs/ufs/fs_ufs_file_open.c
@@ -71,10 +71,12 @@ mca_fs_ufs_file_open (struct ompi_communicator_t *comm,
 
     if ( 0 == rank ) {
 	/* MODE_CREATE and MODE_EXCL can only be set by one process */
-	if ( access_mode & MPI_MODE_CREATE )
-	    amode = amode | O_CREAT;
-	if (access_mode & MPI_MODE_EXCL)
-	    amode = amode | O_EXCL;
+        if ( !(fh->f_flags & OMPIO_SHAREDFP_IS_SET)) {
+            if ( access_mode & MPI_MODE_CREATE )
+                amode = amode | O_CREAT;
+            if (access_mode & MPI_MODE_EXCL)
+                amode = amode | O_EXCL;
+        }
 	fh->fd = open (filename, amode, perm);
 	ret = fh->fd;
     }

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -49,7 +49,7 @@ int mca_io_ompio_bytes_per_agg = OMPIO_PREALLOC_MAX_BUF_SIZE;
 int mca_io_ompio_num_aggregators = -1;
 int mca_io_ompio_record_offset_info = 0;
 int mca_io_ompio_coll_timing_info = 0;
-int mca_io_ompio_sharedfp_lazy_open = 1;
+int mca_io_ompio_sharedfp_lazy_open = 0;
 
 int mca_io_ompio_grouping_option=5;
 
@@ -206,7 +206,7 @@ static int register_component(void)
                                            &mca_io_ompio_num_aggregators);
 
 
-    mca_io_ompio_sharedfp_lazy_open = 1;
+    mca_io_ompio_sharedfp_lazy_open = 0;
     (void) mca_base_component_var_register(&mca_io_ompio_component.io_version,
                                            "sharedfp_lazy_open",
                                            "lazy allocation of internal shared file pointer structures",

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2016 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2017 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
@@ -197,14 +197,8 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
 	}
 
 	/* open the file once more for the shared file pointer if required.
-	** Per default, the shared file pointer specific actions are however
-	** only performed on first access of the shared file pointer, except
-	** for the addproc sharedfp component.
-	**
-	** Lazy open does not work for the addproc sharedfp
-	** component since it starts by spawning a process using MPI_Comm_spawn.
-	** For this, the first operation has to be collective which we can
-	** not guarantuee outside of the MPI_File_open operation.
+        ** Can be disabled by the user if no shared file pointer operations
+        ** are used by his application.
 	*/
 	if ( NULL != ompio_fh->f_sharedfp &&
 	     true == use_sharedfp &&
@@ -250,10 +244,27 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
        file pointer of OMPIO to the very end of the file. */
     if ( ompio_fh->f_amode & MPI_MODE_APPEND ) {
         OMPI_MPI_OFFSET_TYPE current_size;
+        mca_sharedfp_base_module_t * shared_fp_base_module;
 
         ompio_fh->f_fs->fs_file_get_size( ompio_fh,
                                           &current_size);
         ompi_io_ompio_set_explicit_offset (ompio_fh, current_size);
+        if ( true == use_sharedfp ) {
+            if ( NULL != ompio_fh->f_sharedfp &&
+                 (!mca_io_ompio_sharedfp_lazy_open ||
+                  !strcmp (ompio_fh->f_sharedfp_component->mca_component_name,
+                           "addproc")               )) {
+                
+                shared_fp_base_module = ompio_fh->f_sharedfp;
+                ret = shared_fp_base_module->sharedfp_seek(ompio_fh,current_size, MPI_SEEK_SET);
+            }
+            else {
+                opal_output(1, "mca_common_ompio_file_open: Could not adjust position of "
+                            "shared file pointer whith MPI_MODE_APPEND\n");
+                ret = MPI_ERR_OTHER;
+                goto fn_fail;
+            }
+        }
     }
 
 

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -114,7 +114,6 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
 	/* No need to duplicate the communicator if the file_open is called
 	   from the sharedfp component, since the comm used as an input
 	   is already a dup of the user level comm. */
-	ompio_fh->f_flags |= OMPIO_SHAREDFP_IS_SET;
 	ompio_fh->f_comm = comm;
     }
 
@@ -195,26 +194,9 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
 	    ** function will return an error code.
 	    */
 	}
-
-	/* open the file once more for the shared file pointer if required.
-        ** Can be disabled by the user if no shared file pointer operations
-        ** are used by his application.
-	*/
-	if ( NULL != ompio_fh->f_sharedfp &&
-	     true == use_sharedfp &&
-	     (!mca_io_ompio_sharedfp_lazy_open ||
-	      !strcmp (ompio_fh->f_sharedfp_component->mca_component_name,
-		       "addproc")               )) {
-	    ret = ompio_fh->f_sharedfp->sharedfp_file_open(comm,
-							   filename,
-							   amode,
-							   info,
-							   ompio_fh);
-
-	    if ( OMPI_SUCCESS != ret ) {
-		goto fn_fail;
-	    }
-	}
+    }
+    else {
+	ompio_fh->f_flags |= OMPIO_SHAREDFP_IS_SET;
     }
 
      /*Determine topology information if set*/
@@ -231,14 +213,30 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
 					info,
 					ompio_fh);
 
-
-
-
     if ( OMPI_SUCCESS != ret ) {
 	ret = MPI_ERR_FILE;
         goto fn_fail;
     }
 
+
+    if ( true == use_sharedfp ) {
+        /* open the file once more for the shared file pointer if required.           
+        ** Can be disabled by the user if no shared file pointer operations
+        ** are used by his application.
+        */
+        if ( NULL != ompio_fh->f_sharedfp &&
+             !mca_io_ompio_sharedfp_lazy_open ) {
+            ret = ompio_fh->f_sharedfp->sharedfp_file_open(comm,
+                                                           filename,
+                                                           amode,
+                                                           info,
+                                                           ompio_fh);
+
+            if ( OMPI_SUCCESS != ret ) {
+                goto fn_fail;
+            }
+        }
+    }
 
     /* If file has been opened in the append mode, move the internal
        file pointer of OMPIO to the very end of the file. */
@@ -251,16 +249,14 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
         ompi_io_ompio_set_explicit_offset (ompio_fh, current_size);
         if ( true == use_sharedfp ) {
             if ( NULL != ompio_fh->f_sharedfp &&
-                 (!mca_io_ompio_sharedfp_lazy_open ||
-                  !strcmp (ompio_fh->f_sharedfp_component->mca_component_name,
-                           "addproc")               )) {
+                 !mca_io_ompio_sharedfp_lazy_open ) {
                 
                 shared_fp_base_module = ompio_fh->f_sharedfp;
                 ret = shared_fp_base_module->sharedfp_seek(ompio_fh,current_size, MPI_SEEK_SET);
             }
             else {
                 opal_output(1, "mca_common_ompio_file_open: Could not adjust position of "
-                            "shared file pointer whith MPI_MODE_APPEND\n");
+                            "shared file pointer with MPI_MODE_APPEND\n");
                 ret = MPI_ERR_OTHER;
                 goto fn_fail;
             }
@@ -412,7 +408,7 @@ ompio_io_ompio_file_close (mca_io_ompio_file_t *ompio_fh)
     }
 
 
-    if (MPI_COMM_NULL != ompio_fh->f_comm && (ompio_fh->f_flags & OMPIO_SHAREDFP_IS_SET) )  {
+    if (MPI_COMM_NULL != ompio_fh->f_comm && !(ompio_fh->f_flags & OMPIO_SHAREDFP_IS_SET) )  {
         ompi_comm_free (&ompio_fh->f_comm);
     }
 

--- a/ompi/mca/io/ompio/io_ompio_file_set_view.c
+++ b/ompi/mca/io/ompio/io_ompio_file_set_view.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2016 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2017 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *  $COPYRIGHT$
@@ -98,8 +98,12 @@ int mca_io_ompio_set_view_internal(mca_io_ompio_file_t *fh,
     }
 
     /* Reset the flags first */
-    fh->f_flags = 0;
-
+    if ( fh->f_flags & OMPIO_CONTIGUOUS_FVIEW ) {
+        fh->f_flags &= ~OMPIO_CONTIGUOUS_FVIEW;
+    }
+    if ( fh->f_flags & OMPIO_UNIFORM_FVIEW ) {
+        fh->f_flags &= ~OMPIO_UNIFORM_FVIEW;
+    }
     fh->f_flags |= OMPIO_FILE_VIEW_IS_SET;
     fh->f_datarep = strdup (datarep);
     datatype_duplicate (filetype, &fh->f_orig_filetype );


### PR DESCRIPTION
Fixes a bug reported on the mailing list. ompio did only reposition the individual
file pointer when the file was opened in append mode. Set the shared file
pointer also to point to the end of the file, similarly to the individual
file pointer.

This is the equivalent to commit d3a8d38
on master, cannot be cherry-picked because of differences in the organization
of the ompio files ( usage of mca/common/ompio on master).
