### PR TITLE
libevent2022: Fix broken configure AC_LANG_PROGRAM

### DIFF
--- a/opal/mca/event/libevent2022/libevent/configure.ac
+++ b/opal/mca/event/libevent2022/libevent/configure.ac
@@ -611,8 +611,6 @@ if test "$enable_epoll" != "no" ; then
 AC_INCLUDES_DEFAULT
 #include <sys/epoll.h>
 ],[[
-int main(int argc, char **argv)
-{
     struct epoll_event epevin;
     struct epoll_event epevout;
     int res;
@@ -640,7 +638,6 @@ int main(int argc, char **argv)
         }
     }
     /* SUCCESS */
-}
 ]])],
         [haveepoll=yes
         # OMPI: Don't use AC_LIBOBJ


### PR DESCRIPTION
 * The AC_LANG_PROGRAM macro adds the `main()` so it is erroneous
   to add it to the test program.
 * This was detected with the XL compilers which will fail to
   build the program in this situation. The GNU compiler does not
   error out or warn, but successfully compiles the program.

The resulting test program looked like
```c
int
main()
{
  int main(int argc, char **argv)
  {
  // ...
  }
}
```

And XL complained with
```shell
error: function definition is not allowed here
```