### PR TITLE
man: fix a typo in MPI_Win_get_name()

### DIFF
--- a/ompi/mpi/man/man3/MPI_Win_get_name.3in
+++ b/ompi/mpi/man/man3/MPI_Win_get_name.3in
@@ -39,7 +39,7 @@ Window whose name is to be returned (handle).
 .ft R
 .TP 1i
 win_name
-the Tame previously stored on the window, or an empty string if no such name exists (string). 
+the name previously stored on the window, or an empty string if no such name exists (string).
 .TP 1i
 resultlen
 Length of returned name (integer). 


### PR DESCRIPTION
Thanks Nicolas Joly for the report

Fixes open-mpi/ompi#2782

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@6f2ca5809b1aa6332946d1652e0b19cc9f2a9853)