### PR TITLE
libevent2022: Fix broken configure AC_LANG_PROGRAM

### DIFF
--- a/opal/mca/event/libevent2022/libevent/configure.ac
+++ b/opal/mca/event/libevent2022/libevent/configure.ac
@@ -670,9 +670,6 @@ AC_INCLUDES_DEFAULT
 #include <sys/syscall.h>
 #include <sys/epoll.h>
 ],[[
-int
-main(int argc, char **argv)
-{
     struct epoll_event epevin;
     struct epoll_event epevout;
     int res;
@@ -701,7 +698,6 @@ main(int argc, char **argv)
         }
     }
     /* SUCCESS */
-}
 ]])],
         [haveepollsyscall=yes
         # OMPI: don't use AC_LIBOBJ


### PR DESCRIPTION
 * Similar to commit https://github.com/open-mpi/ompi/commit/029964a748230475bc4c950334bd85d593e2352e This removes an extra `int main` during configure.
 * This commit should have been included in the previous PR.