### PR TITLE
libevent2021: Fix broken configure AC_LANG_PROGRAM

### DIFF
--- a/opal/mca/event/libevent2021/libevent/configure.ac
+++ b/opal/mca/event/libevent2021/libevent/configure.ac
@@ -610,8 +610,6 @@ if test "$enable_epoll" != "no" ; then
 AC_INCLUDES_DEFAULT
 #include <sys/epoll.h>
 ],[[
-int main(int argc, char **argv)
-{
     struct epoll_event epevin;
     struct epoll_event epevout;
     int res;
@@ -639,7 +637,6 @@ int main(int argc, char **argv)
         }
     }
     /* SUCCESS */
-}
 ]])],
         [haveepoll=yes
         # OMPI: Don't use AC_LIBOBJ
@@ -671,9 +668,6 @@ AC_INCLUDES_DEFAULT
 #include <sys/syscall.h>
 #include <sys/epoll.h>
 ],[[
-int
-main(int argc, char **argv)
-{
     struct epoll_event epevin;
     struct epoll_event epevout;
     int res;
@@ -702,7 +696,6 @@ main(int argc, char **argv)
         }
     }
     /* SUCCESS */
-}
 ]])],
         [haveepollsyscall=yes
         # OMPI: don't use AC_LIBOBJ


### PR DESCRIPTION
 * The AC_LANG_PROGRAM macro adds the `main()` so it is erroneous
   to add it to the test program.
 * This was detected with the XL compilers which will fail to
   build the program in this situation. The GNU compiler does not
   error out or warn, but successfully compiles the program.