### PR TITLE
Next step in reducing launch time

### DIFF
--- a/orte/mca/grpcomm/direct/grpcomm_direct.c
+++ b/orte/mca/grpcomm/direct/grpcomm_direct.c
@@ -374,33 +374,16 @@ static void xcast_recv(int status, orte_process_name_t* sender,
                 orte_orteds_term_ordered = true;
             } else if (ORTE_DAEMON_ADD_LOCAL_PROCS == command ||
                        ORTE_DAEMON_DVM_NIDMAP_CMD == command) {
-                /* extract the byte object holding the daemonmap */
-                cnt=1;
-                if (ORTE_SUCCESS != (ret = opal_dss.unpack(data, &bo, &cnt, OPAL_BYTE_OBJECT))) {
+                /* update our local nidmap, if required - the decode function
+                 * knows what to do
+                 */
+                OPAL_OUTPUT_VERBOSE((5, orte_grpcomm_base_framework.framework_output,
+                                     "%s grpcomm:direct:xcast updating daemon nidmap",
+                                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+
+                if (ORTE_SUCCESS != (ret = orte_util_decode_daemon_nodemap(data))) {
                     ORTE_ERROR_LOG(ret);
                     goto relay;
-                }
-
-                /* update our local nidmap, if required - the decode function
-                 * knows what to do - it will also free the bytes in the byte object
-                 */
-                if (ORTE_PROC_IS_HNP) {
-                    /* no need - already have the info */
-                    if (NULL != bo) {
-                        if (NULL != bo->bytes) {
-                            free(bo->bytes);
-                        }
-                        free(bo);
-                    }
-                } else {
-                    OPAL_OUTPUT_VERBOSE((5, orte_grpcomm_base_framework.framework_output,
-                                         "%s grpcomm:direct:xcast updating daemon nidmap",
-                                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
-
-                    if (ORTE_SUCCESS != (ret = orte_util_decode_daemon_nodemap(bo))) {
-                        ORTE_ERROR_LOG(ret);
-                        goto relay;
-                    }
                 }
 
                 /* update the routing plan */

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -77,7 +77,6 @@
 #include "orte/util/session_dir.h"
 #include "orte/util/proc_info.h"
 #include "orte/util/nidmap.h"
-#include "orte/util/regex.h"
 #include "orte/util/show_help.h"
 #include "orte/runtime/orte_globals.h"
 #include "orte/runtime/orte_wait.h"
@@ -138,20 +137,11 @@ int orte_odls_base_default_get_add_procs_data(opal_buffer_t *buffer,
         return rc;
     }
 
-    /* construct a nodemap - only want updated items */
-    if (ORTE_SUCCESS != (rc = orte_util_encode_nodemap(&bo, true))) {
+    /* construct a nodemap of the daemons */
+    if (ORTE_SUCCESS != (rc = orte_util_encode_nodemap(buffer))) {
         ORTE_ERROR_LOG(rc);
         return rc;
     }
-
-    /* store it */
-    boptr = &bo;
-    if (ORTE_SUCCESS != (rc = opal_dss.pack(buffer, &boptr, 1, OPAL_BYTE_OBJECT))) {
-        ORTE_ERROR_LOG(rc);
-        return rc;
-    }
-    /* release the data since it has now been copied into our buffer */
-    free(bo.bytes);
 
     /* if we are not using static ports, we need to send the wireup info */
     if (!orte_static_ports) {

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1059,41 +1059,12 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
                                  "%s plm:base:orted_report_launch attempting to assign daemon %s to node %s",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                                  ORTE_NAME_PRINT(&dname), nodename));
-            for (idx=0; idx < orte_node_pool->size; idx++) {
-                if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, idx))) {
-                    continue;
-                }
-                if (ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_LOC_VERIFIED)) {
-                    /* already assigned */
-                    continue;
-                }
-                if (0 == strcmp(nodename, node->name)) {
-                    /* flag that we verified the location */
-                    ORTE_FLAG_SET(node, ORTE_NODE_FLAG_LOC_VERIFIED);
-                    if (node == daemon->node) {
-                        /* it wound up right where it should */
-                        break;
-                    }
-                    /* remove the prior association */
-                    if (NULL != daemon->node) {
-                        OBJ_RELEASE(daemon->node);
-                    }
-                    if (NULL != node->daemon) {
-                        OBJ_RELEASE(node->daemon);
-                    }
-                    /* associate this daemon with the node */
-                    node->daemon = daemon;
-                    OBJ_RETAIN(daemon);
-                    /* associate this node with the daemon */
-                    daemon->node = node;
-                    OBJ_RETAIN(node);
-                    OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                                         "%s plm:base:orted_report_launch assigning daemon %s to node %s",
-                                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                         ORTE_NAME_PRINT(&daemon->name), node->name));
-                    break;
-                }
-            }
+            /* to "relocate" the daemon, we just update the name of
+             * the node object pointed to by this daemon */
+            free(daemon->node->name);
+            daemon->node->name = strdup(nodename);
+            /* mark that it was verified */
+            ORTE_FLAG_SET(node, ORTE_NODE_FLAG_LOC_VERIFIED);
         }
 
         node = daemon->node;

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -260,21 +260,11 @@ static void vm_ready(int fd, short args, void *cbdata)
             return;
         }
         /* construct a nodemap with everything in it */
-        if (ORTE_SUCCESS != (rc = orte_util_encode_nodemap(&bo, false))) {
+        if (ORTE_SUCCESS != (rc = orte_util_encode_nodemap(buf))) {
             ORTE_ERROR_LOG(rc);
             OBJ_RELEASE(buf);
             return;
         }
-
-        /* store it */
-        boptr = &bo;
-        if (ORTE_SUCCESS != (rc = opal_dss.pack(buf, &boptr, 1, OPAL_BYTE_OBJECT))) {
-            ORTE_ERROR_LOG(rc);
-            OBJ_RELEASE(buf);
-            return;
-        }
-        /* release the data since it has now been copied into our buffer */
-        free(bo.bytes);
 
         /* pack a flag indicating wiring info is provided */
         flag = 1;

--- a/orte/util/nidmap.h
+++ b/orte/util/nidmap.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,8 +41,13 @@ BEGIN_C_DECLS
 #define ORTE_CONTIG_NODE_CMD        0x01
 #define ORTE_NON_CONTIG_NODE_CMD    0x02
 
-ORTE_DECLSPEC int orte_util_encode_nodemap(opal_byte_object_t *boptr, bool update);
-ORTE_DECLSPEC int orte_util_decode_daemon_nodemap(opal_byte_object_t *bo);
+/* create a regular expression describing the nodes in the
+ * allocation */
+ORTE_DECLSPEC int orte_util_encode_nodemap(opal_buffer_t *buffer);
+
+/* decode a regular expression created by the encode function
+ * into the orte_node_pool array */
+ORTE_DECLSPEC int orte_util_decode_daemon_nodemap(opal_buffer_t *buffer);
 
 ORTE_DECLSPEC int orte_util_build_daemon_nidmap(char **nodes);
 

--- a/orte/util/regex.c
+++ b/orte/util/regex.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/orte/util/regex.h
+++ b/orte/util/regex.h
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2017      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow


### PR DESCRIPTION
Begin reducing the size of the launch message itself. Start by expressing the daemon map as a set of three regular expression strings. On an 8k cluster, this reduces the nidmap contribution from over 200kBytes to 21 bytes in size.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>