### PR TITLE
Fix libevent configure.ac

### DIFF
--- a/opal/mca/event/libevent2022/libevent/configure.ac
+++ b/opal/mca/event/libevent2022/libevent/configure.ac
@@ -610,8 +610,6 @@ if test "$enable_epoll" != "no" ; then
 AC_INCLUDES_DEFAULT
 #include <sys/epoll.h>
 ],[[
-int main(int argc, char **argv)
-{
     struct epoll_event epevin;
     struct epoll_event epevout;
     int res;
@@ -639,7 +637,6 @@ int main(int argc, char **argv)
         }
     }
     /* SUCCESS */
-}
 ]])],
         [haveepoll=yes
         # OMPI: Don't use AC_LIBOBJ

--- a/opal/mca/event/libevent2022/libevent/configure.ac
+++ b/opal/mca/event/libevent2022/libevent/configure.ac
@@ -668,9 +668,6 @@ AC_INCLUDES_DEFAULT
 #include <sys/syscall.h>
 #include <sys/epoll.h>
 ],[[
-int
-main(int argc, char **argv)
-{
     struct epoll_event epevin;
     struct epoll_event epevout;
     int res;
@@ -699,7 +696,6 @@ main(int argc, char **argv)
         }
     }
     /* SUCCESS */
-}
 ]])],
         [haveepollsyscall=yes
         # OMPI: don't use AC_LIBOBJ


### PR DESCRIPTION
These changes are required to correctly detect `epoll` support with XL compilers.

References PR #2788 and PR #2792 from `master`