### PR TITLE
Extend options for stddiag routing

### DIFF
--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -121,7 +122,13 @@ int mca_base_open(void)
                                          MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     /* What verbosity level do we want for the default 0 stream? */
-    mca_base_verbose = "stderr";
+    char *str = getenv("OPAL_OUTPUT_INTERNAL_TO_STDOUT");
+    if (NULL != str && str[0] == '1') {
+        mca_base_verbose = "stdout";
+    }
+    else {
+        mca_base_verbose = "stderr";
+    }
     var_id = mca_base_var_register("opal", "mca", "base", "verbose",
                                    "Specifies where the default error output stream goes (this is separate from distinct help messages).  Accepts a comma-delimited list of: stderr, stdout, syslog, syslogpri:<notice|info|debug>, syslogid:<str> (where str is the prefix string for all syslog notices), file[:filename] (if filename is not specified, a default filename is used), fileappend (if not specified, the file is opened for truncation), level[:N] (if specified, integer verbose level; otherwise, 0 is implied)",
                                    MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,

--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -174,7 +175,13 @@ bool opal_output_init(void)
         verbose.lds_want_stderr = false;
         verbose.lds_want_stdout = false;
     } else {
-        verbose.lds_want_stderr = true;
+        str = getenv("OPAL_OUTPUT_INTERNAL_TO_STDOUT");
+        if (NULL != str && str[0] == '1') {
+            verbose.lds_want_stdout = true;
+        }
+        else {
+            verbose.lds_want_stderr = true;
+        }
     }
     gethostname(hostname, sizeof(hostname));
     asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid());

--- a/orte/mca/iof/base/base.h
+++ b/orte/mca/iof/base/base.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,6 +137,7 @@ struct orte_iof_base_t {
     char                    *input_files;
     orte_iof_sink_t         *iof_write_stdout;
     orte_iof_sink_t         *iof_write_stderr;
+    bool                    redirect_app_stderr_to_stdout;
 };
 typedef struct orte_iof_base_t orte_iof_base_t;
 

--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,6 +79,15 @@ static int orte_iof_base_register(mca_base_register_flag_t flags)
                                  OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &orte_iof_base.input_files);
+
+    /* Redirect application stderr to stdout (at source) */
+    orte_iof_base.redirect_app_stderr_to_stdout = false;
+    (void) mca_base_var_register("orte", "iof","base", "redirect_app_stderr_to_stdout",
+                                 "Redirect application stderr to stdout at source (default: false)",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &orte_iof_base.redirect_app_stderr_to_stdout);
 
     return ORTE_SUCCESS;
 }

--- a/orte/mca/iof/base/iof_base_setup.c
+++ b/orte/mca/iof/base/iof_base_setup.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -183,7 +184,7 @@ orte_iof_base_setup_child(orte_iof_base_io_conf_t *opts, char ***env)
         close(opts->p_stderr[1]);
     }
 
-    if (!orte_map_stddiag_to_stderr) {
+    if (!orte_map_stddiag_to_stderr && !orte_map_stddiag_to_stdout ) {
         /* Set an environment variable that the new child process can use
            to get the fd of the pipe connected to the INTERNAL IOF tag. */
         asprintf(&str, "%d", opts->p_internal[1]);
@@ -191,6 +192,9 @@ orte_iof_base_setup_child(orte_iof_base_io_conf_t *opts, char ***env)
             opal_setenv("OPAL_OUTPUT_STDERR_FD", str, true, env);
             free(str);
         }
+    }
+    else if( orte_map_stddiag_to_stdout ) {
+        opal_setenv("OPAL_OUTPUT_INTERNAL_TO_STDOUT", "1", true, env);
     }
 
     return ORTE_SUCCESS;

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1364,6 +1364,11 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
         opal_argv_append(argc, argv, "orte_map_stddiag_to_stderr");
         opal_argv_append(argc, argv, "1");
     }
+    else if (orte_map_stddiag_to_stdout) {
+        opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
+        opal_argv_append(argc, argv, "orte_map_stddiag_to_stdout");
+        opal_argv_append(argc, argv, "1");
+    }
 
     /* the following is not an mca param */
     if (NULL != getenv("ORTE_TEST_ORTED_SUICIDE")) {

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -184,6 +185,7 @@ char **orte_forwarded_envars = NULL;
 
 /* map stddiag output to stderr so it isn't forwarded to mpirun */
 bool orte_map_stddiag_to_stderr = false;
+bool orte_map_stddiag_to_stdout = false;
 
 /* maximum size of virtual machine - used to subdivide allocation */
 int orte_max_vm_size = -1;

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -564,6 +565,7 @@ ORTE_DECLSPEC extern char **orte_forwarded_envars;
 
 /* map stddiag output to stderr so it isn't forwarded to mpirun */
 ORTE_DECLSPEC extern bool orte_map_stddiag_to_stderr;
+ORTE_DECLSPEC extern bool orte_map_stddiag_to_stdout;
 
 /* maximum size of virtual machine - used to subdivide allocation */
 ORTE_DECLSPEC extern int orte_max_vm_size;

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -544,6 +545,18 @@ int orte_register_params(void)
                                   MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                   OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
                                   &orte_map_stddiag_to_stderr);
+
+    /* whether or not to map stddiag to stderr */
+    orte_map_stddiag_to_stdout = false;
+    (void) mca_base_var_register ("orte", "orte", NULL, "map_stddiag_to_stdout",
+                                  "Map output from opal_output to stdout of the local process [default: no]",
+                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                  &orte_map_stddiag_to_stdout);
+    if( orte_map_stddiag_to_stderr && orte_map_stddiag_to_stdout ) {
+        opal_output(0, "The options \"orte_map_stddiag_to_stderr\" and \"orte_map_stddiag_to_stdout\" are mutually exclusive. They cannot both be set to true.");
+        return ORTE_ERROR;
+    }
 
     /* generate new terminal windows to display output from specified ranks */
     orte_xterm = NULL;


### PR DESCRIPTION
* Add an MCA parameter to combine stdout and stderr at the source
    - `iof_base_redirect_app_stderr_to_stdout`
* Aids in user debugging when using libraries that mix stderr with stdout
* Similar to `orte_map_stddiag_to_stderr` except it redirects `stddiag` to `stdout` instead of `stderr`.
* Add protection so that the user canot supply both:
   - `orte_map_stddiag_to_stderr`
   - `orte_map_stddiag_to_stdout`