### PR TITLE
communicator: Fix uninitialized variable

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -20,6 +20,7 @@
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -210,6 +211,7 @@ static ompi_comm_cid_context_t *mca_comm_cid_context_alloc (ompi_communicator_t 
 
     context->send_first = send_first;
     context->iter = 0;
+    context->ok = 1;
 
     return context;
 }

--- a/ompi/communicator/comm_request.c
+++ b/ompi/communicator/comm_request.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -260,6 +261,7 @@ void ompi_comm_request_return (ompi_comm_request_t *request)
 {
     if (request->context) {
         OBJ_RELEASE (request->context);
+        request->context = NULL;
     }
 
     OMPI_REQUEST_FINI(&request->super);


### PR DESCRIPTION
A couple of uninitialized variables that were tripped in a debugging session.