### PR TITLE
opal/threads: protect opal_tsd_keys_destruct() to fix Java bindings.

### DIFF
--- a/opal/threads/thread.c
+++ b/opal/threads/thread.c
@@ -117,6 +117,7 @@ int opal_tsd_keys_destruct()
         if(OPAL_SUCCESS == opal_tsd_getspecific(opal_tsd_key_values[i].key, &ptr)) {
             if (NULL != opal_tsd_key_values[i].destructor) {
                 opal_tsd_key_values[i].destructor(ptr);
+                opal_tsd_setspecific(opal_tsd_key_values[i].key, NULL);
             }
         }
     }


### PR DESCRIPTION
When Java bindings are used, MPI_Init() is not invoked
by the main thread, and this causes some keys being destructed twice.
Reset the per thread values to NULL in order to correctly handle this

Fixes open-mpi/ompi#2811

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>