### PR TITLE
Improve launch performance

### DIFF
--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -348,7 +348,11 @@ int orte_ess_base_orted_setup(char **hosts)
     node->name = strdup(orte_process_info.nodename);
     node->index = opal_pointer_array_set_item(orte_node_pool, ORTE_PROC_MY_NAME->vpid, node);
     /* point our topology to the one detected locally */
-    node->topology = opal_hwloc_topology;
+    node->topology = OBJ_NEW(orte_topology_t);
+    node->topology->sig = strdup(orte_topo_signature);
+    node->topology->topo = opal_hwloc_topology;
+    /* add it to the array of known ones */
+    opal_pointer_array_add(orte_node_topologies, node->topology);
 
     /* create and store a proc object for us */
     proc = OBJ_NEW(orte_proc_t);

--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -208,14 +208,6 @@ static int rte_init(void)
             goto error;
         }
     }
-    /* generate the signature */
-    orte_topo_signature = opal_hwloc_base_get_topo_signature(opal_hwloc_topology);
-
-    if (15 < opal_output_get_verbosity(orte_ess_base_framework.framework_output)) {
-        opal_output(0, "%s Topology Info:", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
-        opal_dss.dump(0, opal_hwloc_topology, OPAL_HWLOC_TOPO);
-    }
-
 
     /* if we are using xml for output, put an mpirun start tag */
     if (orte_xml_output) {
@@ -404,12 +396,6 @@ static int rte_init(void)
     node->name = strdup(orte_process_info.nodename);
     node->index = opal_pointer_array_set_item(orte_node_pool, 0, node);
 
-    /* add it to the array of known topologies */
-    t = OBJ_NEW(orte_topology_t);
-    t->topo = opal_hwloc_topology;
-    t->sig = strdup(orte_topo_signature);
-    opal_pointer_array_add(orte_node_topologies, t);
-
     /* create and store a proc object for us */
     proc = OBJ_NEW(orte_proc_t);
     proc->name.jobid = ORTE_PROC_MY_NAME->jobid;
@@ -523,7 +509,18 @@ static int rte_init(void)
      * will have reset our topology. Ensure we always get the right
      * one by setting our node topology afterwards
      */
-    node->topology = opal_hwloc_topology;
+    /* add it to the array of known topologies */
+    t = OBJ_NEW(orte_topology_t);
+    t->topo = opal_hwloc_topology;
+    /* generate the signature */
+    orte_topo_signature = opal_hwloc_base_get_topo_signature(opal_hwloc_topology);
+    t->sig = strdup(orte_topo_signature);
+    opal_pointer_array_add(orte_node_topologies, t);
+    node->topology = t;
+    if (15 < opal_output_get_verbosity(orte_ess_base_framework.framework_output)) {
+        opal_output(0, "%s Topology Info:", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+        opal_dss.dump(0, opal_hwloc_topology, OPAL_HWLOC_TOPO);
+    }
 
     /* init the hash table, if necessary */
     if (NULL == orte_coprocessors) {

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -239,7 +239,6 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *data,
     orte_proc_t *pptr, *dmn;
     opal_buffer_t *bptr;
     orte_app_context_t *app;
-    bool found;
     orte_node_t *node;
     bool newmap = false;
 
@@ -436,18 +435,9 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *data,
         opal_pointer_array_add(dmn->node->procs, pptr);
 
         /* add the node to the map, if not already there */
-        found = false;
-        for (k=0; k < jdata->map->nodes->size; k++) {
-            if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, k))) {
-                continue;
-            }
-            if (node->daemon == dmn) {
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
+        if (!ORTE_FLAG_TEST(dmn->node, ORTE_NODE_FLAG_MAPPED)) {
             OBJ_RETAIN(dmn->node);
+            ORTE_FLAG_SET(dmn->node, ORTE_NODE_FLAG_MAPPED);
             opal_pointer_array_add(jdata->map->nodes, dmn->node);
             if (newmap) {
                 jdata->map->num_nodes++;
@@ -478,6 +468,12 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *data,
             /* mark that this app_context is being used on this node */
             app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, pptr->app_idx);
             ORTE_FLAG_SET(app, ORTE_APP_FLAG_USED_ON_NODE);
+        }
+    }
+    /* reset the node map flags we used so the next job will start clean */
+    for (n=0; n < jdata->map->nodes->size; n++) {
+        if (NULL != (node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, n))) {
+            ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
         }
     }
 

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.

--- a/orte/mca/odls/odls_types.h
+++ b/orte/mca/odls/odls_types.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014      Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,6 +76,9 @@ typedef uint8_t orte_daemon_cmd_flag_t;
 
 /* new daemon collective id */
 #define ORTE_DAEMON_NEW_COLL_ID             (orte_daemon_cmd_flag_t) 29
+
+/* request full topology string */
+#define ORTE_DAEMON_REPORT_TOPOLOGY_CMD     (orte_daemon_cmd_flag_t) 33
 
 
 /* for debug purposes, get stack traces from all application procs */

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2009      Institut National de Recherche en Informatique
  *                         et Automatique. All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -80,7 +80,7 @@
 void orte_plm_base_daemons_reported(int fd, short args, void *cbdata)
 {
     orte_state_caddy_t *caddy = (orte_state_caddy_t*)cbdata;
-    hwloc_topology_t t;
+    orte_topology_t *t;
     orte_job_t *jdata;
     orte_node_t *node;
     orte_proc_t *dmn1;
@@ -149,26 +149,26 @@ void orte_plm_base_daemons_reported(int fd, short args, void *cbdata)
                                          "%s plm:base:setting slots for node %s by %s",
                                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), node->name, orte_set_slots));
                     if (0 == strncmp(orte_set_slots, "cores", strlen(orte_set_slots))) {
-                        node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology,
+                        node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                                          HWLOC_OBJ_CORE, 0,
                                                                          OPAL_HWLOC_LOGICAL);
                     } else if (0 == strncmp(orte_set_slots, "sockets", strlen(orte_set_slots))) {
-                        if (0 == (node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology,
+                        if (0 == (node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                                                    HWLOC_OBJ_SOCKET, 0,
                                                                                    OPAL_HWLOC_LOGICAL))) {
                             /* some systems don't report sockets - in this case,
                              * use numanodes
                              */
-                            node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology,
+                            node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                                              HWLOC_OBJ_NODE, 0,
                                                                              OPAL_HWLOC_LOGICAL);
                         }
                     } else if (0 == strncmp(orte_set_slots, "numas", strlen(orte_set_slots))) {
-                        node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology,
+                        node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                                          HWLOC_OBJ_NODE, 0,
                                                                          OPAL_HWLOC_LOGICAL);
                     } else if (0 == strncmp(orte_set_slots, "hwthreads", strlen(orte_set_slots))) {
-                        node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology,
+                        node->slots = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                                          HWLOC_OBJ_PU, 0,
                                                                          OPAL_HWLOC_LOGICAL);
                     } else {
@@ -767,6 +767,161 @@ void orte_plm_base_registered(int fd, short args, void *cbdata)
 static bool orted_failed_launch;
 static orte_job_t *jdatorted=NULL;
 
+/* callback for topology reports */
+void orte_plm_base_daemon_topology(int status, orte_process_name_t* sender,
+                                   opal_buffer_t *buffer,
+                                   orte_rml_tag_t tag, void *cbdata)
+{
+    hwloc_topology_t topo;
+    int rc, idx;
+    char *sig, *coprocessors, **sns;
+    orte_proc_t *daemon=NULL;
+    orte_topology_t *t, *t2;
+    int i;
+    uint32_t h;
+    orte_job_t *jdata;
+
+    OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
+                         "%s plm:base:daemon_topology for daemon %s",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(sender)));
+
+    /* get the daemon job, if necessary */
+    if (NULL == jdatorted) {
+        jdatorted = orte_get_job_data_object(ORTE_PROC_MY_NAME->jobid);
+    }
+    if (NULL == (daemon = (orte_proc_t*)opal_pointer_array_get_item(jdatorted->procs, sender->vpid))) {
+        ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
+        orted_failed_launch = true;
+        goto CLEANUP;
+    }
+
+    /* unpack the topology signature for this node */
+    idx=1;
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &sig, &idx, OPAL_STRING))) {
+        ORTE_ERROR_LOG(rc);
+        orted_failed_launch = true;
+        goto CLEANUP;
+    }
+    /* find it in the array */
+    t = NULL;
+    for (i=0; i < orte_node_topologies->size; i++) {
+        if (NULL == (t2 = (orte_topology_t*)opal_pointer_array_get_item(orte_node_topologies, i))) {
+            continue;
+        }
+        /* just check the signature */
+        if (0 == strcmp(sig, t2->sig)) {
+            t = t2;
+            break;
+        }
+    }
+    if (NULL == t) {
+        /* should never happen */
+        ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
+        orted_failed_launch = true;
+        goto CLEANUP;
+    }
+
+    /* unpack the topology */
+    idx=1;
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &topo, &idx, OPAL_HWLOC_TOPO))) {
+        ORTE_ERROR_LOG(rc);
+        orted_failed_launch = true;
+        goto CLEANUP;
+    }
+    /* filter the topology as we'll need it that way later */
+    opal_hwloc_base_filter_cpus(topo);
+    /* record the final topology */
+    t->topo = topo;
+
+    /* unpack any coprocessors */
+    idx=1;
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &coprocessors, &idx, OPAL_STRING))) {
+        ORTE_ERROR_LOG(rc);
+        orted_failed_launch = true;
+        goto CLEANUP;
+    }
+    if (NULL != coprocessors) {
+        /* init the hash table, if necessary */
+        if (NULL == orte_coprocessors) {
+            orte_coprocessors = OBJ_NEW(opal_hash_table_t);
+            opal_hash_table_init(orte_coprocessors, orte_process_info.num_procs);
+        }
+        /* separate the serial numbers of the coprocessors
+         * on this host
+         */
+        sns = opal_argv_split(coprocessors, ',');
+        for (idx=0; NULL != sns[idx]; idx++) {
+            /* compute the hash */
+            OPAL_HASH_STR(sns[idx], h);
+            /* mark that this coprocessor is hosted by this node */
+            opal_hash_table_set_value_uint32(orte_coprocessors, h, (void*)&daemon->name.vpid);
+        }
+        opal_argv_free(sns);
+        free(coprocessors);
+        orte_coprocessors_detected = true;
+    }
+    /* see if this daemon is on a coprocessor */
+    idx=1;
+    if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &coprocessors, &idx, OPAL_STRING))) {
+        ORTE_ERROR_LOG(rc);
+        orted_failed_launch = true;
+        goto CLEANUP;
+    }
+    if (NULL != coprocessors) {
+        if (orte_get_attribute(&daemon->node->attributes, ORTE_NODE_SERIAL_NUMBER, NULL, OPAL_STRING)) {
+            /* this is not allowed - a coprocessor cannot be host
+             * to another coprocessor at this time
+             */
+            ORTE_ERROR_LOG(ORTE_ERR_NOT_SUPPORTED);
+            orted_failed_launch = true;
+            free(coprocessors);
+            goto CLEANUP;
+        }
+        orte_set_attribute(&daemon->node->attributes, ORTE_NODE_SERIAL_NUMBER, ORTE_ATTR_LOCAL, coprocessors, OPAL_STRING);
+        free(coprocessors);
+        orte_coprocessors_detected = true;
+    }
+
+  CLEANUP:
+    OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
+                         "%s plm:base:orted_report_launch %s for daemon %s",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         orted_failed_launch ? "failed" : "completed",
+                         ORTE_NAME_PRINT(sender)));
+
+    if (orted_failed_launch) {
+        ORTE_ACTIVATE_JOB_STATE(jdatorted, ORTE_JOB_STATE_FAILED_TO_START);
+        return;
+    } else {
+        jdatorted->num_reported++;
+        OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
+                             "%s plm:base:orted_report_launch recvd %d of %d reported daemons",
+                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                             jdatorted->num_reported, jdatorted->num_procs));
+        if (jdatorted->num_procs == jdatorted->num_reported) {
+            bool dvm = true;
+            jdatorted->state = ORTE_JOB_STATE_DAEMONS_REPORTED;
+            /* activate the daemons_reported state for all jobs
+             * whose daemons were launched
+             */
+            for (idx=1; idx < orte_job_data->size; idx++) {
+                if (NULL == (jdata = (orte_job_t*)opal_pointer_array_get_item(orte_job_data, idx))) {
+                    continue;
+                }
+                dvm = false;
+                if (ORTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
+                    ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_DAEMONS_REPORTED);
+                }
+            }
+            if (dvm) {
+                /* must be launching a DVM - activate the state */
+                ORTE_ACTIVATE_JOB_STATE(jdatorted, ORTE_JOB_STATE_DAEMONS_REPORTED);
+            }
+        }
+    }
+}
+
 void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
                                    opal_buffer_t *buffer,
                                    orte_rml_tag_t tag, void *cbdata)
@@ -779,13 +934,11 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
     orte_job_t *jdata;
     orte_process_name_t dname;
     opal_buffer_t *relay;
-    char *coprocessors, **sns, *sig;
-    uint32_t h;
-    hwloc_topology_t topo;
+    char *sig;
     orte_topology_t *t;
     int i;
     bool found;
-    uint8_t tflag;
+    orte_daemon_cmd_flag_t cmd = ORTE_DAEMON_REPORT_TOPOLOGY_CMD;
 
     /* get the daemon job, if necessary */
     if (NULL == jdatorted) {
@@ -850,42 +1003,13 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
                                  "%s plm:base:orted_report_launch attempting to assign daemon %s to node %s",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                                  ORTE_NAME_PRINT(&dname), nodename));
-            for (idx=0; idx < orte_node_pool->size; idx++) {
-                if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, idx))) {
-                    continue;
-                }
-                if (ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_LOC_VERIFIED)) {
-                    /* already assigned */
-                    continue;
-                }
-                if (0 == strcmp(nodename, node->name)) {
-                    /* flag that we verified the location */
-                    ORTE_FLAG_SET(node, ORTE_NODE_FLAG_LOC_VERIFIED);
-                    if (node == daemon->node) {
-                        /* it wound up right where it should */
-                        break;
-                    }
-                    /* remove the prior association */
-                    if (NULL != daemon->node) {
-                        OBJ_RELEASE(daemon->node);
-                    }
-                    if (NULL != node->daemon) {
-                        OBJ_RELEASE(node->daemon);
-                    }
-                    /* associate this daemon with the node */
-                    node->daemon = daemon;
-                    OBJ_RETAIN(daemon);
-                    /* associate this node with the daemon */
-                    daemon->node = node;
-                    OBJ_RETAIN(node);
-                    OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                                         "%s plm:base:orted_report_launch assigning daemon %s to node %s",
-                                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                         ORTE_NAME_PRINT(&daemon->name), node->name));
-                    break;
-                }
-            }
-        }
+            /* to "relocate" the daemon, we just update the name of
+             * the node object pointed to by this daemon */
+            free(daemon->node->name);
+            daemon->node->name = strdup(nodename);
+            /* mark that it was verified */
+            ORTE_FLAG_SET(node, ORTE_NODE_FLAG_LOC_VERIFIED);
+       }
 
         node = daemon->node;
         if (NULL == node) {
@@ -935,126 +1059,62 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
             free(alias);
         }
 
-        /* store the local resources for that node */
+        /* unpack the topology signature for that node */
         idx=1;
-        if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &tflag, &idx, OPAL_UINT8))) {
+        if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &sig, &idx, OPAL_STRING))) {
             ORTE_ERROR_LOG(rc);
             orted_failed_launch = true;
             goto CLEANUP;
         }
-        if (1 == tflag) {
-            idx=1;
-            if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &sig, &idx, OPAL_STRING))) {
-                ORTE_ERROR_LOG(rc);
-                orted_failed_launch = true;
-                goto CLEANUP;
+        OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
+                             "%s RECEIVED TOPOLOGY SIG %s FROM NODE %s",
+                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), sig, nodename));
+        /* do we already have this topology from some other node? */
+        found = false;
+        for (i=0; i < orte_node_topologies->size; i++) {
+            if (NULL == (t = (orte_topology_t*)opal_pointer_array_get_item(orte_node_topologies, i))) {
+                continue;
             }
-            idx=1;
-            if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &topo, &idx, OPAL_HWLOC_TOPO))) {
-                ORTE_ERROR_LOG(rc);
-                orted_failed_launch = true;
-                goto CLEANUP;
-            }
-            OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                                 "%s RECEIVED TOPOLOGY FROM NODE %s",
-                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), nodename));
-            if (10 < opal_output_get_verbosity(orte_plm_base_framework.framework_output)) {
-                opal_dss.dump(0, topo, OPAL_HWLOC_TOPO);
-            }
-            if (1 == dname.vpid || orte_hetero_nodes) {
-                /* the user has told us that something is different, so just store it */
+            /* just check the signature */
+            if (0 == strcmp(sig, t->sig)) {
                 OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                                     "%s ADDING TOPOLOGY PER USER REQUEST TO NODE %s",
-                                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), node->name));
-                t = OBJ_NEW(orte_topology_t);
-                /* filter the topology as we'll need it that way later */
-                opal_hwloc_base_filter_cpus(topo);
-                t->topo = topo;
-                t->sig = sig;
-                opal_pointer_array_add(orte_node_topologies, t);
-                node->topology = topo;
-            } else {
-                /* do we already have this topology from some other node? */
-                found = false;
-                for (i=0; i < orte_node_topologies->size; i++) {
-                    if (NULL == (t = (orte_topology_t*)opal_pointer_array_get_item(orte_node_topologies, i))) {
-                        continue;
-                    }
-                    /* just check the signature */
-                    if (0 == strcmp(sig, t->sig)) {
-                        OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                                             "%s TOPOLOGY ALREADY RECORDED",
-                                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
-                        found = true;
-                        node->topology = t->topo;
-                        hwloc_topology_destroy(topo);
-                        free(sig);
-                        break;
-                    }
-                }
-                if (!found) {
-                    /* nope - add it */
-                    OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                                         "%s NEW TOPOLOGY - ADDING",
-                                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
-                    t = OBJ_NEW(orte_topology_t);
-                    /* filter the topology as we'll need it that way later */
-                    opal_hwloc_base_filter_cpus(topo);
-                    t->topo = topo;
-                    t->sig = sig;
-                    opal_pointer_array_add(orte_node_topologies, t);
-                    node->topology = topo;
-                }
+                                     "%s TOPOLOGY ALREADY RECORDED",
+                                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                found = true;
+                node->topology = t;
+                free(sig);
+                break;
             }
         }
-
-        /* unpack any coprocessors */
-        idx=1;
-        if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &coprocessors, &idx, OPAL_STRING))) {
-            ORTE_ERROR_LOG(rc);
-            orted_failed_launch = true;
-            goto CLEANUP;
-        }
-        if (NULL != coprocessors) {
-            /* init the hash table, if necessary */
-            if (NULL == orte_coprocessors) {
-                orte_coprocessors = OBJ_NEW(opal_hash_table_t);
-                opal_hash_table_init(orte_coprocessors, orte_process_info.num_procs);
-            }
-            /* separate the serial numbers of the coprocessors
-             * on this host
-             */
-            sns = opal_argv_split(coprocessors, ',');
-            for (idx=0; NULL != sns[idx]; idx++) {
-                /* compute the hash */
-                OPAL_HASH_STR(sns[idx], h);
-                /* mark that this coprocessor is hosted by this node */
-                opal_hash_table_set_value_uint32(orte_coprocessors, h, (void*)&node->daemon->name.vpid);
-            }
-            opal_argv_free(sns);
-            free(coprocessors);
-            orte_coprocessors_detected = true;
-        }
-        /* see if this daemon is on a coprocessor */
-        idx=1;
-        if (OPAL_SUCCESS != (rc = opal_dss.unpack(buffer, &coprocessors, &idx, OPAL_STRING))) {
-            ORTE_ERROR_LOG(rc);
-            orted_failed_launch = true;
-            goto CLEANUP;
-        }
-        if (NULL != coprocessors) {
-            if (orte_get_attribute(&node->attributes, ORTE_NODE_SERIAL_NUMBER, NULL, OPAL_STRING)) {
-                /* this is not allowed - a coprocessor cannot be host
-                 * to another coprocessor at this time
-                 */
-                ORTE_ERROR_LOG(ORTE_ERR_NOT_SUPPORTED);
+        if (!found) {
+            /* nope - save the signature and request the complete topology from that node */
+            OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
+                                 "%s NEW TOPOLOGY - ADDING",
+                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+            t = OBJ_NEW(orte_topology_t);
+            t->sig = sig;
+            opal_pointer_array_add(orte_node_topologies, t);
+            node->topology = t;
+            /* construct the request */
+            relay = OBJ_NEW(opal_buffer_t);
+            if (OPAL_SUCCESS != (rc = opal_dss.pack(relay, &cmd, 1, ORTE_DAEMON_CMD))) {
+                ORTE_ERROR_LOG(rc);
+                OBJ_RELEASE(relay);
                 orted_failed_launch = true;
-                free(coprocessors);
                 goto CLEANUP;
             }
-            orte_set_attribute(&node->attributes, ORTE_NODE_SERIAL_NUMBER, ORTE_ATTR_LOCAL, coprocessors, OPAL_STRING);
-            free(coprocessors);
-            orte_coprocessors_detected = true;
+            /* send it */
+            orte_rml.send_buffer_nb(sender, relay,
+                                    ORTE_RML_TAG_DAEMON,
+                                    orte_rml_send_callback, NULL);
+            /* we will count this node as completed
+             * when we get the full topology back */
+            if (NULL != nodename) {
+                free(nodename);
+                nodename = NULL;
+            }
+            idx = 1;
+            continue;
         }
 
     CLEANUP:

--- a/orte/mca/plm/base/plm_base_receive.c
+++ b/orte/mca/plm/base/plm_base_receive.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -85,6 +85,10 @@ int orte_plm_base_comm_start(void)
                                 ORTE_RML_TAG_REPORT_REMOTE_LAUNCH,
                                 ORTE_RML_PERSISTENT,
                                 orte_plm_base_daemon_failed, NULL);
+        orte_rml.recv_buffer_nb(ORTE_NAME_WILDCARD,
+                                ORTE_RML_TAG_TOPOLOGY_REPORT,
+                                ORTE_RML_PERSISTENT,
+                                orte_plm_base_daemon_topology, NULL);
     }
     recv_issued = true;
 
@@ -105,6 +109,8 @@ int orte_plm_base_comm_stop(void)
     orte_rml.recv_cancel(ORTE_NAME_WILDCARD, ORTE_RML_TAG_PLM);
     if (ORTE_PROC_IS_HNP) {
         orte_rml.recv_cancel(ORTE_NAME_WILDCARD, ORTE_RML_TAG_ORTED_CALLBACK);
+        orte_rml.recv_cancel(ORTE_NAME_WILDCARD, ORTE_RML_TAG_REPORT_REMOTE_LAUNCH);
+        orte_rml.recv_cancel(ORTE_NAME_WILDCARD, ORTE_RML_TAG_TOPOLOGY_REPORT);
     }
     recv_issued = false;
 

--- a/orte/mca/plm/base/plm_private.h
+++ b/orte/mca/plm/base/plm_private.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2017      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -79,6 +80,9 @@ ORTE_DECLSPEC void orte_plm_base_daemon_callback(int status, orte_process_name_t
 ORTE_DECLSPEC void orte_plm_base_daemon_failed(int status, orte_process_name_t* sender,
                                                opal_buffer_t *buffer,
                                                orte_rml_tag_t tag, void *cbdata);
+ORTE_DECLSPEC void orte_plm_base_daemon_topology(int status, orte_process_name_t* sender,
+                                                 opal_buffer_t *buffer,
+                                                 orte_rml_tag_t tag, void *cbdata);
 
 ORTE_DECLSPEC int orte_plm_base_create_jobid(orte_job_t *jdata);
 ORTE_DECLSPEC int orte_plm_base_set_hnp_name(void);

--- a/orte/mca/ras/simulator/ras_sim_module.c
+++ b/orte/mca/ras/simulator/ras_sim_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -266,7 +266,8 @@ static int allocate(orte_job_t *jdata, opal_list_t *nodes)
                 obj = hwloc_get_root_obj(topo);
                 node->slots = opal_hwloc_base_get_npus(topo, obj);
             }
-            node->topology = topo;
+            node->topology = OBJ_NEW(orte_topology_t);
+            node->topology->topo = topo;
             opal_output_verbose(1, orte_ras_base_framework.framework_output,
                                 "Created Node <%10s> [%3d : %3d]",
                                 node->name, node->slots, node->slots_max);

--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -66,7 +66,7 @@ static void reset_usage(orte_node_t *node, orte_jobid_t jobid)
                         node->name, node->num_procs);
 
     /* start by clearing any existing info */
-    opal_hwloc_base_clear_usage(node->topology);
+    opal_hwloc_base_clear_usage(node->topology->topo);
 
     /* cycle thru the procs on the node and record
      * their usage in the topology
@@ -176,7 +176,7 @@ static int bind_upwards(orte_job_t *jdata,
                     continue;
                 }
                 /* get its index */
-                if (UINT_MAX == (idx = opal_hwloc_base_get_obj_idx(node->topology, obj, OPAL_HWLOC_AVAILABLE))) {
+                if (UINT_MAX == (idx = opal_hwloc_base_get_obj_idx(node->topology->topo, obj, OPAL_HWLOC_AVAILABLE))) {
                     ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
                     return ORTE_ERR_SILENT;
                 }
@@ -184,7 +184,7 @@ static int bind_upwards(orte_job_t *jdata,
                 data = (opal_hwloc_obj_data_t*)obj->userdata;
                 data->num_bound++;
                 /* get the number of cpus under this location */
-                if (0 == (ncpus = opal_hwloc_base_get_npus(node->topology, obj))) {
+                if (0 == (ncpus = opal_hwloc_base_get_npus(node->topology->topo, obj))) {
                     orte_show_help("help-orte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
                     return ORTE_ERR_SILENT;
                 }
@@ -210,7 +210,7 @@ static int bind_upwards(orte_job_t *jdata,
                     }
                 }
                 /* bind it here */
-                cpus = opal_hwloc_base_get_available_cpus(node->topology, obj);
+                cpus = opal_hwloc_base_get_available_cpus(node->topology->topo, obj);
                 hwloc_bitmap_list_asprintf(&cpu_bitmap, cpus);
                 orte_set_attribute(&proc->attributes, ORTE_PROC_CPU_BITMAP, ORTE_ATTR_GLOBAL, cpu_bitmap, OPAL_STRING);
                 /* record the location */
@@ -287,7 +287,7 @@ static int bind_downwards(orte_job_t *jdata,
          * or if it is some depth below it, so we have to conduct a bit
          * of a search. Let hwloc find the min usage one for us.
          */
-        trg_obj = opal_hwloc_base_find_min_bound_target_under_obj(node->topology, locale,
+        trg_obj = opal_hwloc_base_find_min_bound_target_under_obj(node->topology->topo, locale,
                                                                   target, cache_level);
         if (NULL == trg_obj) {
             /* there aren't any such targets under this object */
@@ -310,7 +310,7 @@ static int bind_downwards(orte_job_t *jdata,
             }
             trg_obj = nxt_obj;
             /* get the number of cpus under this location */
-            ncpus = opal_hwloc_base_get_npus(node->topology, trg_obj);
+            ncpus = opal_hwloc_base_get_npus(node->topology->topo, trg_obj);
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                 "%s GOT %d CPUS",
                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), ncpus);
@@ -344,7 +344,7 @@ static int bind_downwards(orte_job_t *jdata,
                 }
             }
             /* bind the proc here */
-            cpus = opal_hwloc_base_get_available_cpus(node->topology, trg_obj);
+            cpus = opal_hwloc_base_get_available_cpus(node->topology->topo, trg_obj);
             hwloc_bitmap_or(totalcpuset, totalcpuset, cpus);
             /* track total #cpus */
             total_cpus += ncpus;
@@ -363,13 +363,13 @@ static int bind_downwards(orte_job_t *jdata,
         if (4 < opal_output_get_verbosity(orte_rmaps_base_framework.framework_output)) {
             char tmp1[1024], tmp2[1024];
             if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2str(tmp1, sizeof(tmp1),
-                                                               node->topology, totalcpuset)) {
+                                                               node->topology->topo, totalcpuset)) {
                 opal_output(orte_rmaps_base_framework.framework_output,
                             "%s PROC %s ON %s IS NOT BOUND",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                             ORTE_NAME_PRINT(&proc->name), node->name);
             } else {
-                opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), node->topology, totalcpuset);
+                opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), node->topology->topo, totalcpuset);
                 opal_output(orte_rmaps_base_framework.framework_output,
                             "%s BOUND PROC %s[%s] TO %s: %s",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
@@ -418,7 +418,7 @@ static int bind_in_place(orte_job_t *jdata,
             /* if we don't want to launch, then we are just testing the system,
              * so ignore questions about support capabilities
              */
-            support = (struct hwloc_topology_support*)hwloc_topology_get_support(node->topology);
+            support = (struct hwloc_topology_support*)hwloc_topology_get_support(node->topology->topo);
             /* check if topology supports cpubind - have to be careful here
              * as Linux doesn't currently support thread-level binding. This
              * may change in the future, though, and it isn't clear how hwloc
@@ -461,7 +461,7 @@ static int bind_in_place(orte_job_t *jdata,
          * on this node, just silently skip it - we will not bind
          */
         if (!OPAL_BINDING_POLICY_IS_SET(map->binding) &&
-            HWLOC_TYPE_DEPTH_UNKNOWN == hwloc_get_type_depth(node->topology, HWLOC_OBJ_CORE)) {
+            HWLOC_TYPE_DEPTH_UNKNOWN == hwloc_get_type_depth(node->topology->topo, HWLOC_OBJ_CORE)) {
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                 "Unable to bind-to core by default on node %s as no cores detected",
                                 node->name);
@@ -489,13 +489,13 @@ static int bind_in_place(orte_job_t *jdata,
                 return ORTE_ERR_SILENT;
             }
             /* get the index of this location */
-            if (UINT_MAX == (idx = opal_hwloc_base_get_obj_idx(node->topology, locale, OPAL_HWLOC_AVAILABLE))) {
+            if (UINT_MAX == (idx = opal_hwloc_base_get_obj_idx(node->topology->topo, locale, OPAL_HWLOC_AVAILABLE))) {
                 ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
                 return ORTE_ERR_SILENT;
             }
             data = (opal_hwloc_obj_data_t*)locale->userdata;
             /* get the number of cpus under this location */
-            if (0 == (ncpus = opal_hwloc_base_get_npus(node->topology, locale))) {
+            if (0 == (ncpus = opal_hwloc_base_get_npus(node->topology->topo, locale))) {
                 orte_show_help("help-orte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
                 return ORTE_ERR_SILENT;
             }
@@ -510,7 +510,7 @@ static int bind_in_place(orte_job_t *jdata,
                 found = false;
                 while (NULL != (sib = sib->next_cousin)) {
                     data = (opal_hwloc_obj_data_t*)sib->userdata;
-                    ncpus = opal_hwloc_base_get_npus(node->topology, sib);
+                    ncpus = opal_hwloc_base_get_npus(node->topology->topo, sib);
                     if (data->num_bound < ncpus) {
                         found = true;
                         locale = sib;
@@ -525,7 +525,7 @@ static int bind_in_place(orte_job_t *jdata,
                     sib = locale;
                     while (NULL != (sib = sib->prev_cousin)) {
                         data = (opal_hwloc_obj_data_t*)sib->userdata;
-                        ncpus = opal_hwloc_base_get_npus(node->topology, sib);
+                        ncpus = opal_hwloc_base_get_npus(node->topology->topo, sib);
                         if (data->num_bound < ncpus) {
                             found = true;
                             locale = sib;
@@ -562,7 +562,7 @@ static int bind_in_place(orte_job_t *jdata,
                                 ORTE_NAME_PRINT(&proc->name),
                                 hwloc_obj_type_string(locale->type), idx);
             /* bind the proc here */
-            cpus = opal_hwloc_base_get_available_cpus(node->topology, locale);
+            cpus = opal_hwloc_base_get_available_cpus(node->topology->topo, locale);
             hwloc_bitmap_list_asprintf(&cpu_bitmap, cpus);
             orte_set_attribute(&proc->attributes, ORTE_PROC_CPU_BITMAP, ORTE_ATTR_GLOBAL, cpu_bitmap, OPAL_STRING);
             /* update the location, in case it changed */
@@ -609,7 +609,7 @@ static int bind_to_cpuset(orte_job_t *jdata)
             /* if we don't want to launch, then we are just testing the system,
              * so ignore questions about support capabilities
              */
-            support = (struct hwloc_topology_support*)hwloc_topology_get_support(node->topology);
+            support = (struct hwloc_topology_support*)hwloc_topology_get_support(node->topology->topo);
             /* check if topology supports cpubind - have to be careful here
              * as Linux doesn't currently support thread-level binding. This
              * may change in the future, though, and it isn't clear how hwloc
@@ -642,7 +642,7 @@ static int bind_to_cpuset(orte_job_t *jdata)
                 }
             }
         }
-        root = hwloc_get_root_obj(node->topology);
+        root = hwloc_get_root_obj(node->topology->topo);
         if (NULL == root->userdata) {
             /* something went wrong */
             ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
@@ -845,7 +845,7 @@ int orte_rmaps_base_compute_bindings(orte_job_t *jdata)
             /* if we don't want to launch, then we are just testing the system,
              * so ignore questions about support capabilities
              */
-            support = (struct hwloc_topology_support*)hwloc_topology_get_support(node->topology);
+            support = (struct hwloc_topology_support*)hwloc_topology_get_support(node->topology->topo);
             /* check if topology supports cpubind - have to be careful here
              * as Linux doesn't currently support thread-level binding. This
              * may change in the future, though, and it isn't clear how hwloc
@@ -888,7 +888,7 @@ int orte_rmaps_base_compute_bindings(orte_job_t *jdata)
          * on this node, just silently skip it - we will not bind
          */
         if (!OPAL_BINDING_POLICY_IS_SET(jdata->map->binding) &&
-            HWLOC_TYPE_DEPTH_UNKNOWN == hwloc_get_type_depth(node->topology, HWLOC_OBJ_CORE)) {
+            HWLOC_TYPE_DEPTH_UNKNOWN == hwloc_get_type_depth(node->topology->topo, HWLOC_OBJ_CORE)) {
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                 "Unable to bind-to core by default on node %s as no cores detected",
                                 node->name);
@@ -912,9 +912,9 @@ int orte_rmaps_base_compute_bindings(orte_job_t *jdata)
                 /* must use a unique function because blasted hwloc
                  * just doesn't deal with caches very well...sigh
                  */
-                bind_depth = hwloc_get_cache_type_depth(node->topology, clvl, -1);
+                bind_depth = hwloc_get_cache_type_depth(node->topology->topo, clvl, -1);
             } else {
-                bind_depth = hwloc_get_type_depth(node->topology, hwb);
+                bind_depth = hwloc_get_type_depth(node->topology->topo, hwb);
             }
             if (0 > bind_depth) {
                 /* didn't find such an object */
@@ -926,9 +926,9 @@ int orte_rmaps_base_compute_bindings(orte_job_t *jdata)
                 /* must use a unique function because blasted hwloc
                  * just doesn't deal with caches very well...sigh
                  */
-                map_depth = hwloc_get_cache_type_depth(node->topology, clvm, -1);
+                map_depth = hwloc_get_cache_type_depth(node->topology->topo, clvm, -1);
             } else {
-                map_depth = hwloc_get_type_depth(node->topology, hwm);
+                map_depth = hwloc_get_type_depth(node->topology->topo, hwm);
             }
             if (0 > map_depth) {
                 /* didn't find such an object */

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -307,7 +307,7 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
      */
     if (orte_do_not_launch) {
         orte_node_t *node;
-        hwloc_topology_t t0;
+        orte_topology_t *t0;
         int i;
         if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, 0))) {
             ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
@@ -445,7 +445,7 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     if (NULL == bd) {
                         (void)strncpy(tmp1, "UNBOUND", strlen("UNBOUND"));
                     } else {
-                        if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(tmp1, sizeof(tmp1), node->topology, bd->cpuset)) {
+                        if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(tmp1, sizeof(tmp1), node->topology->topo, bd->cpuset)) {
                             (void)strncpy(tmp1, "UNBOUND", strlen("UNBOUND"));
                         }
                     }
@@ -470,7 +470,7 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 }
                 procbitmap = NULL;
                 orte_get_attribute(&proc->attributes, ORTE_PROC_CPU_BITMAP, (void**)&procbitmap, OPAL_STRING);
-                locality = opal_hwloc_base_get_relative_locality(node->topology,
+                locality = opal_hwloc_base_get_relative_locality(node->topology->topo,
                                                                  p0bitmap,
                                                                  procbitmap);
                 opal_output(orte_clean_output, "\t\t<rank=%s rank=%s locality=%s>",

--- a/orte/mca/rmaps/base/rmaps_base_ranking.c
+++ b/orte/mca/rmaps/base/rmaps_base_ranking.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -93,7 +93,7 @@ static int rank_span(orte_job_t *jdata,
              item = opal_list_get_next(item)) {
             node = (orte_node_t*)item;
             /* get the number of objects - only consider those we can actually use */
-            num_objs = opal_hwloc_base_get_nbobjs_by_type(node->topology, target,
+            num_objs = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, target,
                                                           cache_level, OPAL_HWLOC_AVAILABLE);
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                 "mca:rmaps:rank_span: found %d objects on node %s with %d procs",
@@ -104,7 +104,7 @@ static int rank_span(orte_job_t *jdata,
 
             /* for each object */
             for (i=0; i < num_objs && cnt < app->num_procs; i++) {
-                obj = opal_hwloc_base_get_obj_by_type(node->topology, target,
+                obj = opal_hwloc_base_get_obj_by_type(node->topology->topo, target,
                                                       cache_level, i, OPAL_HWLOC_AVAILABLE);
 
                 opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
@@ -206,7 +206,7 @@ static int rank_fill(orte_job_t *jdata,
          item = opal_list_get_next(item)) {
         node = (orte_node_t*)item;
         /* get the number of objects - only consider those we can actually use */
-        num_objs = opal_hwloc_base_get_nbobjs_by_type(node->topology, target,
+        num_objs = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, target,
                                                       cache_level, OPAL_HWLOC_AVAILABLE);
         opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                             "mca:rmaps:rank_fill: found %d objects on node %s with %d procs",
@@ -217,7 +217,7 @@ static int rank_fill(orte_job_t *jdata,
 
         /* for each object */
         for (i=0; i < num_objs && cnt < app->num_procs; i++) {
-            obj = opal_hwloc_base_get_obj_by_type(node->topology, target,
+            obj = opal_hwloc_base_get_obj_by_type(node->topology->topo, target,
                                                   cache_level, i, OPAL_HWLOC_AVAILABLE);
 
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
@@ -327,7 +327,7 @@ static int rank_by(orte_job_t *jdata,
          item = opal_list_get_next(item)) {
         node = (orte_node_t*)item;
         /* get the number of objects - only consider those we can actually use */
-        num_objs = opal_hwloc_base_get_nbobjs_by_type(node->topology, target,
+        num_objs = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, target,
                                                       cache_level, OPAL_HWLOC_AVAILABLE);
         opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                             "mca:rmaps:rank_by: found %d objects on node %s with %d procs",
@@ -337,7 +337,7 @@ static int rank_by(orte_job_t *jdata,
         }
         /* collect all the objects */
         for (i=0; i < num_objs; i++) {
-            obj = opal_hwloc_base_get_obj_by_type(node->topology, target,
+            obj = opal_hwloc_base_get_obj_by_type(node->topology->topo, target,
                                                   cache_level, i, OPAL_HWLOC_AVAILABLE);
             opal_pointer_array_set_item(&objs, i, obj);
         }

--- a/orte/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/orte/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -196,7 +196,7 @@ static int mindist_map(orte_job_t *jdata)
                 item = opal_list_get_next(item)) {
             node = (orte_node_t*)item;
 
-            if (NULL == node->topology) {
+            if (NULL == node->topology || NULL == node->topology->topo) {
                 orte_show_help("help-orte-rmaps-base.txt", "rmaps:no-topology",
                         true, node->name);
                 rc = ORTE_ERR_SILENT;
@@ -205,7 +205,7 @@ static int mindist_map(orte_job_t *jdata)
             /* get the root object as we are not assigning
              * locale except at the node level
              */
-            obj = hwloc_get_root_obj(node->topology);
+            obj = hwloc_get_root_obj(node->topology->topo);
             if (NULL == obj) {
                 orte_show_help("help-orte-rmaps-base.txt", "rmaps:no-topology",
                         true, node->name);
@@ -215,9 +215,9 @@ static int mindist_map(orte_job_t *jdata)
 
             /* get the number of available pus */
             if (opal_hwloc_use_hwthreads_as_cpus) {
-                total_npus = opal_hwloc_base_get_nbobjs_by_type(node->topology, HWLOC_OBJ_PU, 0, OPAL_HWLOC_AVAILABLE);
+                total_npus = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_PU, 0, OPAL_HWLOC_AVAILABLE);
             } else {
-                total_npus = opal_hwloc_base_get_nbobjs_by_type(node->topology, HWLOC_OBJ_CORE, 0, OPAL_HWLOC_AVAILABLE);
+                total_npus = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_CORE, 0, OPAL_HWLOC_AVAILABLE);
             }
             if (bynode) {
                 if (total_npus < num_procs_to_assign * orte_rmaps_base.cpus_per_rank) {
@@ -235,9 +235,9 @@ static int mindist_map(orte_job_t *jdata)
             }
             /* first we need to fill summary object for root with information about nodes
              * so we call opal_hwloc_base_get_nbobjs_by_type */
-            opal_hwloc_base_get_nbobjs_by_type(node->topology, HWLOC_OBJ_NODE, 0, OPAL_HWLOC_AVAILABLE);
+            opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NODE, 0, OPAL_HWLOC_AVAILABLE);
             OBJ_CONSTRUCT(&numa_list, opal_list_t);
-            ret = opal_hwloc_get_sorted_numa_list(node->topology, orte_rmaps_base.device, &numa_list);
+            ret = opal_hwloc_get_sorted_numa_list(node->topology->topo, orte_rmaps_base.device, &numa_list);
             if (ret > 1) {
                 orte_show_help("help-orte-rmaps-md.txt", "orte-rmaps-mindist:several-devices",
                                true, orte_rmaps_base.device, ret, node->name);
@@ -256,11 +256,11 @@ static int mindist_map(orte_job_t *jdata)
                 required = 0;
                 OPAL_LIST_FOREACH(numa, &numa_list, opal_rmaps_numa_node_t) {
                     /* get the hwloc object for this numa */
-                    if (NULL == (obj = opal_hwloc_base_get_obj_by_type(node->topology, HWLOC_OBJ_NODE, 0, numa->index, OPAL_HWLOC_AVAILABLE))) {
+                    if (NULL == (obj = opal_hwloc_base_get_obj_by_type(node->topology->topo, HWLOC_OBJ_NODE, 0, numa->index, OPAL_HWLOC_AVAILABLE))) {
                         ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
                         return ORTE_ERR_NOT_FOUND;
                     }
-                    npus = opal_hwloc_base_get_npus(node->topology, obj);
+                    npus = opal_hwloc_base_get_npus(node->topology->topo, obj);
                     if (bynode) {
                         required = ((num_procs_to_assign-j) > npus/orte_rmaps_base.cpus_per_rank) ? (npus/orte_rmaps_base.cpus_per_rank) : (num_procs_to_assign-j);
                     } else {
@@ -295,7 +295,7 @@ static int mindist_map(orte_job_t *jdata)
                             j, node->name);
                 }
             } else {
-                if (hwloc_get_nbobjs_by_type(node->topology, HWLOC_OBJ_SOCKET) > 1) {
+                if (hwloc_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_SOCKET) > 1) {
                     /* don't have info about pci locality */
                     orte_show_help("help-orte-rmaps-md.txt", "orte-rmaps-mindist:no-pci-locality-info",
                             true, node->name);
@@ -353,12 +353,12 @@ static int mindist_map(orte_job_t *jdata)
                         "mca:rmaps:mindist: second pass assigning %d extra procs to node %s",
                         (int)num_procs_to_assign, node->name);
                 OBJ_CONSTRUCT(&numa_list, opal_list_t);
-                opal_hwloc_get_sorted_numa_list(node->topology, orte_rmaps_base.device, &numa_list);
+                opal_hwloc_get_sorted_numa_list(node->topology->topo, orte_rmaps_base.device, &numa_list);
                 if (opal_list_get_size(&numa_list) > 0) {
                     numa_item = opal_list_get_first(&numa_list);
                     k = 0;
-                    obj = hwloc_get_obj_by_type(node->topology, HWLOC_OBJ_NODE,((opal_rmaps_numa_node_t*)numa_item)->index);
-                    npus = opal_hwloc_base_get_npus(node->topology, obj);
+                    obj = hwloc_get_obj_by_type(node->topology->topo, HWLOC_OBJ_NODE,((opal_rmaps_numa_node_t*)numa_item)->index);
+                    npus = opal_hwloc_base_get_npus(node->topology->topo, obj);
                     for (j = 0; j < (int)num_procs_to_assign && nprocs_mapped < (int)app->num_procs; j++) {
                         if (NULL == (proc = orte_rmaps_base_setup_proc(jdata, node, i))) {
                             rc = ORTE_ERR_OUT_OF_RESOURCE;
@@ -372,8 +372,8 @@ static int mindist_map(orte_job_t *jdata)
                             if (numa_item == opal_list_get_end(&numa_list)) {
                                 numa_item = opal_list_get_first(&numa_list);
                             }
-                            obj = hwloc_get_obj_by_type(node->topology, HWLOC_OBJ_NODE,((opal_rmaps_numa_node_t*)numa_item)->index);
-                            npus = opal_hwloc_base_get_npus(node->topology, obj);
+                            obj = hwloc_get_obj_by_type(node->topology->topo, HWLOC_OBJ_NODE,((opal_rmaps_numa_node_t*)numa_item)->index);
+                            npus = opal_hwloc_base_get_npus(node->topology->topo, obj);
                             k = 0;
                         }
                     }

--- a/orte/mca/rmaps/ppr/rmaps_ppr.c
+++ b/orte/mca/rmaps/ppr/rmaps_ppr.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -263,7 +263,7 @@ static int ppr_mapper(orte_job_t *jdata)
              item = opal_list_get_next(item)) {
             node = (orte_node_t*)item;
             /* bozo check */
-            if (NULL == node->topology) {
+            if (NULL == node->topology || NULL == node->topology->topo) {
                 orte_show_help("help-orte-rmaps-ppr.txt", "ppr-topo-missing",
                                true, node->name);
                 rc = ORTE_ERR_SILENT;
@@ -283,7 +283,7 @@ static int ppr_mapper(orte_job_t *jdata)
              * that many procs on this node
              */
             if (OPAL_HWLOC_NODE_LEVEL == start) {
-                obj = hwloc_get_root_obj(node->topology);
+                obj = hwloc_get_root_obj(node->topology->topo);
                 for (j=0; j < ppr[start] && nprocs_mapped < total_procs; j++) {
                     if (NULL == (proc = orte_rmaps_base_setup_proc(jdata, node, idx))) {
                         rc = ORTE_ERR_OUT_OF_RESOURCE;
@@ -294,7 +294,7 @@ static int ppr_mapper(orte_job_t *jdata)
                 }
             } else {
                 /* get the number of lowest resources on this node */
-                nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology,
+                nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                            lowest, cache_level,
                                                            OPAL_HWLOC_AVAILABLE);
 
@@ -302,7 +302,7 @@ static int ppr_mapper(orte_job_t *jdata)
                  * recording the locale of each proc so we know its cpuset
                  */
                 for (i=0; i < nobjs; i++) {
-                    obj = opal_hwloc_base_get_obj_by_type(node->topology,
+                    obj = opal_hwloc_base_get_obj_by_type(node->topology->topo,
                                                           lowest, cache_level,
                                                           i, OPAL_HWLOC_AVAILABLE);
                     for (j=0; j < ppr[start] && nprocs_mapped < total_procs; j++) {
@@ -483,7 +483,7 @@ static void prune(orte_jobid_t jobid,
     }
 
     /* get the number of resources at this level on this node */
-    nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology,
+    nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                lvl, cache_level,
                                                OPAL_HWLOC_AVAILABLE);
 
@@ -491,11 +491,11 @@ static void prune(orte_jobid_t jobid,
      * underneath it and check against the limit
      */
     for (i=0; i < nobjs; i++) {
-        obj = opal_hwloc_base_get_obj_by_type(node->topology,
+        obj = opal_hwloc_base_get_obj_by_type(node->topology->topo,
                                               lvl, cache_level,
                                               i, OPAL_HWLOC_AVAILABLE);
         /* get the available cpuset */
-        avail = opal_hwloc_base_get_available_cpus(node->topology, obj);
+        avail = opal_hwloc_base_get_available_cpus(node->topology->topo, obj);
 
         /* look at the intersection of this object's cpuset and that
          * of each proc in the job/app - if they intersect, then count this proc
@@ -515,7 +515,7 @@ static void prune(orte_jobid_t jobid,
                 ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
                 return;
             }
-            cpus = opal_hwloc_base_get_available_cpus(node->topology, locale);
+            cpus = opal_hwloc_base_get_available_cpus(node->topology->topo, locale);
             if (hwloc_bitmap_intersects(avail, cpus)) {
                 nprocs++;
             }
@@ -541,7 +541,7 @@ static void prune(orte_jobid_t jobid,
              * have only one child, then return this
              * object
              */
-            top = find_split(node->topology, obj);
+            top = find_split(node->topology->topo, obj);
             hwloc_obj_type_snprintf(dang, 64, top, 1);
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                                 "mca:rmaps:ppr: SPLIT AT LEVEL %s", dang);
@@ -553,7 +553,7 @@ static void prune(orte_jobid_t jobid,
             /* find the child with the most procs underneath it */
             for (k=0; k < top->arity && limit < nprocs; k++) {
                 /* get this object's available cpuset */
-                childcpus = opal_hwloc_base_get_available_cpus(node->topology, top->children[k]);
+                childcpus = opal_hwloc_base_get_available_cpus(node->topology->topo, top->children[k]);
                 nunder = 0;
                 pptr = NULL;
                 for (n=0; n < node->procs->size; n++) {
@@ -569,7 +569,7 @@ static void prune(orte_jobid_t jobid,
                         ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
                         return;
                     }
-                    cpus = opal_hwloc_base_get_available_cpus(node->topology, locale);
+                    cpus = opal_hwloc_base_get_available_cpus(node->topology->topo, locale);
                     if (hwloc_bitmap_intersects(childcpus, cpus)) {
                         nunder++;
                         if (NULL == pptr) {

--- a/orte/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/orte/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Voltaire. All rights reserved
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -308,7 +308,7 @@ static int orte_rmaps_rf_map(orte_job_t *jdata)
                 /* setup the bitmap */
                 hwloc_cpuset_t bitmap;
                 char *cpu_bitmap;
-                if (NULL == node->topology) {
+                if (NULL == node->topology || NULL == node->topology->topo) {
                     /* not allowed - for rank-file, we must have
                      * the topology info
                      */
@@ -318,7 +318,7 @@ static int orte_rmaps_rf_map(orte_job_t *jdata)
                 }
                 bitmap = hwloc_bitmap_alloc();
                 /* parse the slot_list to find the socket and core */
-                if (ORTE_SUCCESS != (rc = opal_hwloc_base_slot_list_parse(slots, node->topology, rtype, bitmap))) {
+                if (ORTE_SUCCESS != (rc = opal_hwloc_base_slot_list_parse(slots, node->topology->topo, rtype, bitmap))) {
                     ORTE_ERROR_LOG(rc);
                     hwloc_bitmap_free(bitmap);
                     goto error;

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -76,8 +76,8 @@ int orte_rmaps_rr_byslot(orte_job_t *jdata,
         /* get the root object as we are not assigning
          * locale here except at the node level
          */
-        if (NULL != node->topology) {
-            obj = hwloc_get_root_obj(node->topology);
+        if (NULL != node->topology && NULL != node->topology->topo) {
+            obj = hwloc_get_root_obj(node->topology->topo);
         }
         if (node->slots <= node->slots_inuse) {
             opal_output_verbose(2, orte_rmaps_base_framework.framework_output,
@@ -146,8 +146,8 @@ int orte_rmaps_rr_byslot(orte_job_t *jdata,
         /* get the root object as we are not assigning
          * locale except at the node level
          */
-        if (NULL != node->topology) {
-            obj = hwloc_get_root_obj(node->topology);
+        if (NULL != node->topology && NULL != node->topology->topo) {
+            obj = hwloc_get_root_obj(node->topology->topo);
         }
 
         /* add this node to the map - do it only once */
@@ -290,8 +290,8 @@ int orte_rmaps_rr_bynode(orte_job_t *jdata,
             /* get the root object as we are not assigning
              * locale except at the node level
              */
-            if (NULL != node->topology) {
-                obj = hwloc_get_root_obj(node->topology);
+            if (NULL != node->topology && NULL != node->topology->topo) {
+                obj = hwloc_get_root_obj(node->topology->topo);
             }
             /* add this node to the map, but only do so once */
             if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
@@ -403,8 +403,8 @@ int orte_rmaps_rr_bynode(orte_job_t *jdata,
             /* get the root object as we are not assigning
              * locale except at the node level
              */
-            if (NULL != node->topology) {
-                obj = hwloc_get_root_obj(node->topology);
+            if (NULL != node->topology && NULL != node->topology->topo) {
+                obj = hwloc_get_root_obj(node->topology->topo);
             }
 
            OPAL_OUTPUT_VERBOSE((20, orte_rmaps_base_framework.framework_output,
@@ -507,14 +507,14 @@ int orte_rmaps_rr_byobj(orte_job_t *jdata,
     do {
         add_one = false;
         OPAL_LIST_FOREACH(node, node_list, orte_node_t) {
-            if (NULL == node->topology) {
+            if (NULL == node->topology || NULL == node->topology->topo) {
                 orte_show_help("help-orte-rmaps-ppr.txt", "ppr-topo-missing",
                                true, node->name);
                 return ORTE_ERR_SILENT;
             }
             start = 0;
             /* get the number of objects of this type on this node */
-            nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology, target, cache_level, OPAL_HWLOC_AVAILABLE);
+            nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, target, cache_level, OPAL_HWLOC_AVAILABLE);
             if (0 == nobjs) {
                 continue;
             }
@@ -564,13 +564,13 @@ int orte_rmaps_rr_byobj(orte_job_t *jdata,
                     opal_output_verbose(20, orte_rmaps_base_framework.framework_output,
                                         "mca:rmaps:rr: assigning proc to object %d", (i+start) % nobjs);
                     /* get the hwloc object */
-                    if (NULL == (obj = opal_hwloc_base_get_obj_by_type(node->topology, target, cache_level, (i+start) % nobjs, OPAL_HWLOC_AVAILABLE))) {
+                    if (NULL == (obj = opal_hwloc_base_get_obj_by_type(node->topology->topo, target, cache_level, (i+start) % nobjs, OPAL_HWLOC_AVAILABLE))) {
                         ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
                         return ORTE_ERR_NOT_FOUND;
                     }
-                    if (orte_rmaps_base.cpus_per_rank > (int)opal_hwloc_base_get_npus(node->topology, obj)) {
+                    if (orte_rmaps_base.cpus_per_rank > (int)opal_hwloc_base_get_npus(node->topology->topo, obj)) {
                         orte_show_help("help-orte-rmaps-base.txt", "mapping-too-low", true,
-                                       orte_rmaps_base.cpus_per_rank, opal_hwloc_base_get_npus(node->topology, obj),
+                                       orte_rmaps_base.cpus_per_rank, opal_hwloc_base_get_npus(node->topology->topo, obj),
                                        orte_rmaps_base_print_mapping(orte_rmaps_base.mapping));
                         return ORTE_ERR_SILENT;
                     }
@@ -662,13 +662,13 @@ static int byobj_span(orte_job_t *jdata,
      */
     nobjs = 0;
     OPAL_LIST_FOREACH(node, node_list, orte_node_t) {
-        if (NULL == node->topology) {
+        if (NULL == node->topology || NULL == node->topology->topo) {
             orte_show_help("help-orte-rmaps-ppr.txt", "ppr-topo-missing",
                            true, node->name);
             return ORTE_ERR_SILENT;
         }
         /* get the number of objects of this type on this node */
-        nobjs += opal_hwloc_base_get_nbobjs_by_type(node->topology, target, cache_level, OPAL_HWLOC_AVAILABLE);
+        nobjs += opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, target, cache_level, OPAL_HWLOC_AVAILABLE);
     }
 
     if (0 == nobjs) {
@@ -707,19 +707,19 @@ static int byobj_span(orte_job_t *jdata,
             ++(jdata->map->num_nodes);
         }
         /* get the number of objects of this type on this node */
-        nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology, target, cache_level, OPAL_HWLOC_AVAILABLE);
+        nobjs = opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, target, cache_level, OPAL_HWLOC_AVAILABLE);
         opal_output_verbose(2, orte_rmaps_base_framework.framework_output,
                             "mca:rmaps:rr:byobj: found %d objs on node %s", nobjs, node->name);
         /* loop through the number of objects */
         for (i=0; i < (int)nobjs && nprocs_mapped < (int)app->num_procs; i++) {
             /* get the hwloc object */
-            if (NULL == (obj = opal_hwloc_base_get_obj_by_type(node->topology, target, cache_level, i, OPAL_HWLOC_AVAILABLE))) {
+            if (NULL == (obj = opal_hwloc_base_get_obj_by_type(node->topology->topo, target, cache_level, i, OPAL_HWLOC_AVAILABLE))) {
                 ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
                 return ORTE_ERR_NOT_FOUND;
             }
-            if (orte_rmaps_base.cpus_per_rank > (int)opal_hwloc_base_get_npus(node->topology, obj)) {
+            if (orte_rmaps_base.cpus_per_rank > (int)opal_hwloc_base_get_npus(node->topology->topo, obj)) {
                 orte_show_help("help-orte-rmaps-base.txt", "mapping-too-low", true,
-                               orte_rmaps_base.cpus_per_rank, opal_hwloc_base_get_npus(node->topology, obj),
+                               orte_rmaps_base.cpus_per_rank, opal_hwloc_base_get_npus(node->topology->topo, obj),
                                orte_rmaps_base_print_mapping(orte_rmaps_base.mapping));
                 return ORTE_ERR_SILENT;
             }

--- a/orte/mca/rmaps/seq/rmaps_seq.c
+++ b/orte/mca/rmaps/seq/rmaps_seq.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -437,7 +437,7 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
             if (NULL != sq->cpuset) {
                 hwloc_cpuset_t bitmap;
                 char *cpu_bitmap;
-                if (NULL == node->topology) {
+                if (NULL == node->topology || NULL == node->topology->topo) {
                     /* not allowed - for sequential cpusets, we must have
                      * the topology info
                      */
@@ -455,7 +455,7 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
                     /* setup the bitmap */
                     bitmap = hwloc_bitmap_alloc();
                     /* parse the slot_list to find the socket and core */
-                    if (ORTE_SUCCESS != (rc = opal_hwloc_base_slot_list_parse(sq->cpuset, node->topology, rtype, bitmap))) {
+                    if (ORTE_SUCCESS != (rc = opal_hwloc_base_slot_list_parse(sq->cpuset, node->topology->topo, rtype, bitmap))) {
                         ORTE_ERROR_LOG(rc);
                         hwloc_bitmap_free(bitmap);
                         goto error;
@@ -485,8 +485,8 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
                 /* assign the locale - okay for the topo to be null as
                  * it just means it wasn't returned
                  */
-                if (NULL != node->topology) {
-                    locale = hwloc_get_root_obj(node->topology);
+                if (NULL != node->topology && NULL != node->topology->topo) {
+                    locale = hwloc_get_root_obj(node->topology->topo);
                     orte_set_attribute(&proc->attributes, ORTE_PROC_HWLOC_LOCALE,
                                        ORTE_ATTR_LOCAL, locale, OPAL_PTR);
                 }

--- a/orte/mca/rml/rml_types.h
+++ b/orte/mca/rml/rml_types.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -167,6 +167,9 @@ BEGIN_C_DECLS
 
 /* stacktrace for debug */
 #define ORTE_RML_TAG_STACK_TRACE            60
+
+/* topology report */
+#define ORTE_RML_TAG_TOPOLOGY_REPORT        62
 
 #define ORTE_RML_TAG_MAX                   100
 

--- a/orte/mca/state/novm/state_novm.c
+++ b/orte/mca/state/novm/state_novm.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -222,7 +222,7 @@ static void allocation_complete(int fd, short args, void *cbdata)
         if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, i))) {
             continue;
         }
-        node->topology = t->topo;
+        node->topology = t;
     }
 
     /* move to the map stage */

--- a/orte/runtime/data_type_support/orte_dt_print_fns.c
+++ b/orte/runtime/data_type_support/orte_dt_print_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -477,10 +477,10 @@ int orte_dt_print_proc(char **output, char *prefix, orte_proc_t *src, opal_data_
             NULL != src->node->topology) {
             mycpus = hwloc_bitmap_alloc();
             hwloc_bitmap_list_sscanf(mycpus, cpu_bitmap);
-            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2str(tmp1, sizeof(tmp1), src->node->topology, mycpus)) {
+            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2str(tmp1, sizeof(tmp1), src->node->topology->topo, mycpus)) {
                 str = strdup("UNBOUND");
             } else {
-                opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), src->node->topology, mycpus);
+                opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), src->node->topology->topo, mycpus);
                 asprintf(&str, "%s:%s", tmp1, tmp2);
             }
             hwloc_bitmap_free(mycpus);
@@ -515,7 +515,7 @@ int orte_dt_print_proc(char **output, char *prefix, orte_proc_t *src, opal_data_
 
     if (orte_get_attribute(&src->attributes, ORTE_PROC_HWLOC_LOCALE, (void**)&loc, OPAL_PTR)) {
         if (NULL != loc) {
-            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(locale, sizeof(locale), src->node->topology, loc->cpuset)) {
+            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(locale, sizeof(locale), src->node->topology->topo, loc->cpuset)) {
                 strcpy(locale, "NODE");
             }
         } else {
@@ -526,7 +526,7 @@ int orte_dt_print_proc(char **output, char *prefix, orte_proc_t *src, opal_data_
     }
     if (orte_get_attribute(&src->attributes, ORTE_PROC_HWLOC_BOUND, (void**)&bd, OPAL_PTR)) {
         if (NULL != bd) {
-            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(bind, sizeof(bind), src->node->topology, bd->cpuset)) {
+            if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(bind, sizeof(bind), src->node->topology->topo, bd->cpuset)) {
                 strcpy(bind, "UNBOUND");
             }
         } else {

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -490,6 +490,7 @@ char* orte_get_proc_hostname(orte_process_name_t *proc)
     }
 
     /* if we are an app, get the data from the modex db */
+    hostname = NULL;
     OPAL_MODEX_RECV_VALUE(rc, OPAL_PMIX_HOSTNAME,
                           (opal_process_name_t*)proc,
                           &hostname, OPAL_STRING);
@@ -514,6 +515,7 @@ orte_node_rank_t orte_get_proc_node_rank(orte_process_name_t *proc)
     }
 
     /* if we are an app, get the value from the modex db */
+    noderank = NULL;
     OPAL_MODEX_RECV_VALUE(rc, OPAL_PMIX_NODE_RANK,
                           (opal_process_name_t*)proc,
                           &noderank, ORTE_NODE_RANK);
@@ -792,7 +794,9 @@ static void orte_node_destruct(orte_node_t* node)
     }
     OBJ_RELEASE(node->procs);
 
-    /* do NOT destroy the topology */
+    if (NULL != node->topology) {
+        OBJ_RELEASE(node->topology);
+    }
 
     /* release the attributes */
     OPAL_LIST_DESTRUCT(&node->attributes);
@@ -920,7 +924,7 @@ static void tcon(orte_topology_t *t)
 }
 static void tdes(orte_topology_t *t)
 {
-    if (NULL != t->topo) {
+    if (NULL != t->topo && opal_hwloc_topology != t->topo) {
         hwloc_topology_destroy(t->topo);
     }
     if (NULL != t->sig) {

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -253,6 +253,13 @@ typedef struct {
 
 ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_app_context_t);
 
+/* define an object for storing node topologies */
+typedef struct {
+    opal_object_t super;
+    hwloc_topology_t topo;
+    char *sig;
+} orte_topology_t;
+ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_topology_t);
 
 typedef struct {
     /** Base object so this can be put on a list */
@@ -291,7 +298,7 @@ typedef struct {
         may want to allow up to four processes but no more. */
     orte_std_cntr_t slots_max;
     /* system topology for this node */
-    hwloc_topology_t topology;
+    orte_topology_t *topology;
     /* flags */
     orte_node_flags_t flags;
     /* list of orte_attribute_t */
@@ -403,14 +410,6 @@ struct orte_proc_t {
 };
 typedef struct orte_proc_t orte_proc_t;
 ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_proc_t);
-
-/* define an object for storing node topologies */
-typedef struct {
-    opal_object_t super;
-    hwloc_topology_t topo;
-    char *sig;
-} orte_topology_t;
-ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_topology_t);
 
 /**
  * Get a job data object


### PR DESCRIPTION
Improve launch performance by:

eliminating nested loop - use the "node mapped" flag to determine if a node needs to be added to the job map, and then clear all the used nodes' flags after completing the assignments.

eliminating the return of local node topology unless mpirun detects a different signature that it hasn't seen before

Signed-off-by: Ralph Castain rhc@open-mpi.org
