### PR TITLE
pml/base: Expose some bsend varaibles so PMLs may reference them

### DIFF
--- a/ompi/mca/pml/base/pml_base_bsend.c
+++ b/ompi/mca/pml/base/pml_base_bsend.c
@@ -15,6 +15,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,9 +44,9 @@ static opal_condition_t mca_pml_bsend_condition;  /* condition variable to block
 static mca_allocator_base_component_t* mca_pml_bsend_allocator_component;
 static mca_allocator_base_module_t* mca_pml_bsend_allocator;  /* sub-allocator to manage users buffer */
 static size_t           mca_pml_bsend_usersize;   /* user provided buffer size */
-static unsigned char   *mca_pml_bsend_userbase;   /* user provided buffer base */
-static unsigned char   *mca_pml_bsend_base;       /* adjusted base of user buffer */
-static unsigned char   *mca_pml_bsend_addr;       /* current offset into user buffer */
+unsigned char          *mca_pml_bsend_userbase;   /* user provided buffer base */
+unsigned char          *mca_pml_bsend_base;       /* adjusted base of user buffer */
+unsigned char          *mca_pml_bsend_addr;       /* current offset into user buffer */
 static size_t           mca_pml_bsend_size;       /* adjusted size of user buffer */
 static size_t           mca_pml_bsend_count;      /* number of outstanding requests */
 static size_t           mca_pml_bsend_pagesz;     /* mmap page size */

--- a/ompi/mca/pml/base/pml_base_bsend.h
+++ b/ompi/mca/pml/base/pml_base_bsend.h
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +36,10 @@ OMPI_DECLSPEC int mca_pml_base_bsend_request_start(ompi_request_t*);
 OMPI_DECLSPEC int mca_pml_base_bsend_request_fini(ompi_request_t*);
 OMPI_DECLSPEC void*  mca_pml_base_bsend_request_alloc_buf( size_t length );
 OMPI_DECLSPEC int mca_pml_base_bsend_request_free(void* addr);
+
+extern unsigned char   *mca_pml_bsend_userbase;   /* user provided buffer base */
+extern unsigned char   *mca_pml_bsend_base;       /* adjusted base of user buffer */
+extern unsigned char   *mca_pml_bsend_addr;       /* current offset into user buffer */
 
 END_C_DECLS
 


### PR DESCRIPTION
 * This was useful when trying to optimize our PML - having access to the user pointers.