### PR TITLE
mpit: Fix MPI_T_pvar_get_index

### DIFF
--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -60,6 +60,7 @@ int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype
 
         break;
     case MCA_BASE_VAR_TYPE_STRING:
+    case MCA_BASE_VAR_TYPE_VERSION_STRING:
         *datatype = MPI_CHAR;
         break;
     case MCA_BASE_VAR_TYPE_BOOL:

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -179,7 +179,7 @@ int mca_base_pvar_register (const char *project, const char *framework, const ch
                             int bind, mca_base_pvar_flag_t flags, mca_base_get_value_fn_t get_value,
                             mca_base_set_value_fn_t set_value, mca_base_notify_fn_t notify, void *ctx)
 {
-    int ret, group_index;
+    int ret, group_index, pvar_index;
     mca_base_pvar_t *pvar;
 
     /* assert on usage errors */
@@ -284,15 +284,18 @@ int mca_base_pvar_register (const char *project, const char *framework, const ch
                 }
             }
 
-            /* add this performance variable to the MCA variable group */
-            ret = mca_base_var_group_add_pvar (group_index, pvar_count);
-            if (0 > ret) {
+            pvar_index = opal_pointer_array_add (&registered_pvars, pvar);
+            if (0 > pvar_index) {
                 break;
             }
+            pvar->pvar_index = pvar_index;
 
-            ret = opal_pointer_array_add (&registered_pvars, pvar);
-            if (0 > ret) {
-                break;
+            /* add this performance variable to the MCA variable group */
+            if (0 <= group_index) {
+                ret = mca_base_var_group_add_pvar (group_index, pvar_index);
+                if (0 > ret) {
+                    break;
+                }
             }
 
             opal_hash_table_set_value_ptr (&mca_base_pvar_index_hash, pvar->name, strlen (pvar->name),


### PR DESCRIPTION
MPI_T_pvar_get_index was returning an incorrect index. The index
was never set correctly while registering the performance variables.
Additionally fix a missing case in the mca_base_var_type_t to MPI
datatype conversion. This type is currently used for control variables
registered by mxm, fca and hcoll components.

 * Moving PR #2421 from `master`