### PR TITLE
orterun: Add parameter to control when we give up on stack traces

### DIFF
--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -128,6 +129,8 @@ float orte_max_timeout = -1.0;
 orte_timer_t *orte_mpiexec_timeout = NULL;
 
 opal_buffer_t *orte_tree_launch_cmd = NULL;
+
+int orte_stack_trace_wait_timeout = 30;
 
 /* global arrays for data storage */
 opal_pointer_array_t *orte_job_data = NULL;

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -586,6 +587,9 @@ ORTE_DECLSPEC extern char *orte_daemon_cores;
 
 /* cutoff for collective modex */
 ORTE_DECLSPEC extern uint32_t orte_direct_modex_cutoff;
+
+/* Max time to wait for stack straces to return */
+ORTE_DECLSPEC extern int orte_stack_trace_wait_timeout;
 
 END_C_DECLS
 

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -742,6 +743,15 @@ int orte_register_params(void)
                                 &orte_direct_modex_cutoff);
     /* register a synonym for old name */
     mca_base_var_register_synonym (id, "ompi", "ompi", "hostname", "cutoff", MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+
+
+    /* Amount of time to wait for a stack trace to return from the daemons */
+    orte_stack_trace_wait_timeout = 30;
+    (void) mca_base_var_register ("orte", "orte", NULL, "timeout_for_stack_trace",
+                                  "Seconds to wait for stack traces to return before terminating the job (<= 0 wait forever)",
+                                  MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                  &orte_stack_trace_wait_timeout);
 
     return ORTE_SUCCESS;
 }


### PR DESCRIPTION
 * MCA option to control how long we wait for stack traces:
   - `orte_timeout_for_stack_trace INTEGER`
     Default: 30
     Setting to <= 0 will cause it to wait forever
 * Useful when gathering stack traces from large jobs which might take
   a long time.

This is a custom patch for `v2.x` since this functionality takes a different form here than in `master`. I need to backport this to `master`.

This improves https://github.com/open-mpi/ompi-release/pull/1317