### PR TITLE
verbs: remove extra event user increment/decrement operation

### DIFF
--- a/opal/mca/btl/openib/btl_openib_endpoint.c
+++ b/opal/mca/btl/openib/btl_openib_endpoint.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2006-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006-2007 Voltaire All rights reserved.
  * Copyright (c) 2006-2009 Mellanox Technologies, Inc.  All rights reserved.
@@ -641,10 +641,6 @@ void mca_btl_openib_endpoint_connected(mca_btl_openib_endpoint_t *endpoint)
 
     endpoint->endpoint_state = MCA_BTL_IB_CONNECTED;
     endpoint->endpoint_btl->device->non_eager_rdma_endpoints++;
-
-    /* The connection is correctly setup. Now we can decrease the
-       event trigger. */
-    opal_progress_event_users_decrement();
 
     if(MCA_BTL_XRC_ENABLED) {
         if (master) {

--- a/opal/mca/btl/openib/btl_openib_endpoint.h
+++ b/opal/mca/btl/openib/btl_openib_endpoint.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006-2007 Voltaire All rights reserved.
  * Copyright (c) 2007-2009 Mellanox Technologies.  All rights reserved.
@@ -501,13 +501,6 @@ static inline int check_endpoint_state(mca_btl_openib_endpoint_t *ep,
             if (OPAL_SUCCESS == rc) {
                 rc = OPAL_ERR_RESOURCE_BUSY;
             }
-            /*
-             * As long as we expect a message from the peer (in order
-             * to setup the connection) let the event engine pool the
-             * OOB events. Note: we increment it once peer active
-             * connection.
-             */
-            opal_progress_event_users_increment();
             /* fall through */
         default:
             opal_list_append(pending_list, (opal_list_item_t *)des);

--- a/orte/mca/oob/ud/oob_ud_event.c
+++ b/orte/mca/oob/ud/oob_ud_event.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2011-2012 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *               2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -53,9 +53,6 @@ static bool event_completed_set = false;
 void mca_oob_ud_event_start_monitor (mca_oob_ud_device_t *device)
 {
     if (!event_started) {
-#if !OPAL_ENABLE_PROGRESS_THREADS
-        opal_progress_event_users_increment ();
-#endif
         opal_event_set (orte_event_base, &device->event, device->ib_channel->fd,
                         OPAL_EV_READ, mca_oob_ud_event_dispatch, (void *) device);
         opal_event_add (&device->event, NULL);
@@ -66,9 +63,6 @@ void mca_oob_ud_event_start_monitor (mca_oob_ud_device_t *device)
 void mca_oob_ud_event_stop_monitor (mca_oob_ud_device_t *device)
 {
     if (event_started) {
-#if !OPAL_ENABLE_PROGRESS_THREADS
-        opal_progress_event_users_decrement ();
-#endif
         opal_event_del (&device->event);
         mca_oob_ud_stop_events (device);
         event_started = false;


### PR DESCRIPTION
Since the oob and connections systems do not work the same way they
did in older versions of Open MPI these operations are no longer
necessary. At best they do nothing and at worst they hurt performance
by making us enter the event library more often in opal_progress().

Fixes #2839

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>