### PR TITLE
Cleanup launch

### DIFF
--- a/orte/mca/oob/base/base.h
+++ b/orte/mca/oob/base/base.h
@@ -126,7 +126,7 @@ ORTE_DECLSPEC void orte_oob_base_send_nb(int fd, short args, void *cbdata);
                        orte_oob_base_send_nb, cd);                      \
         opal_event_set_priority(&cd->ev, ORTE_MSG_PRI);                 \
         opal_event_active(&cd->ev, OPAL_EV_WRITE, 1);                   \
-    }while(0);
+    }while(0)
 
 /* Our contact info is actually subject to change as transports
  * can fail at any time. So a request to obtain our URI requires
@@ -175,12 +175,9 @@ OBJ_CLASS_DECLARATION(mca_oob_uri_req_t);
         mca_oob_uri_req_t *rq;                                  \
         rq = OBJ_NEW(mca_oob_uri_req_t);                        \
         rq->uri = strdup((u));                                  \
-        opal_event_set(orte_oob_base.ev_base, &(rq)->ev, -1,    \
-                       OPAL_EV_WRITE,                           \
-                       orte_oob_base_set_addr, (rq));           \
-        opal_event_set_priority(&(rq)->ev, ORTE_MSG_PRI);       \
-        opal_event_active(&(rq)->ev, OPAL_EV_WRITE, 1);         \
-    }while(0);
+        orte_oob_base_set_addr(0, 0, (void*)rq);    \
+    }while(0)
+
 ORTE_DECLSPEC void orte_oob_base_set_addr(int fd, short args, void *cbdata);
 
 

--- a/orte/mca/oob/base/oob_base_frame.c
+++ b/orte/mca/oob/base/oob_base_frame.c
@@ -109,12 +109,6 @@ static int orte_oob_base_close(void)
 
     OBJ_DESTRUCT(&orte_oob_base.peers);
 
-    if (ORTE_PROC_IS_APP || ORTE_PROC_IS_TOOL) {
-        opal_progress_thread_finalize(NULL);
-    } else {
-        opal_progress_thread_finalize("OOB-BASE");
-    }
-
     OPAL_TIMING_EVENT((&tm_oob, "Finish"));
     OPAL_TIMING_REPORT(orte_oob_base.timing, &tm_oob);
 
@@ -133,11 +127,7 @@ static int orte_oob_base_open(mca_base_open_flag_t flags)
     opal_hash_table_init(&orte_oob_base.peers, 128);
     OBJ_CONSTRUCT(&orte_oob_base.actives, opal_list_t);
 
-    if (ORTE_PROC_IS_APP || ORTE_PROC_IS_TOOL) {
-        orte_oob_base.ev_base = opal_progress_thread_init(NULL);
-    } else {
-        orte_oob_base.ev_base = opal_progress_thread_init("OOB-BASE");
-    }
+    orte_oob_base.ev_base = orte_event_base;
 
 
 #if OPAL_ENABLE_FT_CR == 1

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -761,8 +761,10 @@ int orte_daemon(int argc, char *argv[])
 
         /* if we are rank=1, then send our topology back - otherwise, mpirun
          * will request it if necessary */
-        if (ORTE_SUCCESS != (ret = opal_dss.pack(buffer, &opal_hwloc_topology, 1, OPAL_HWLOC_TOPO))) {
-            ORTE_ERROR_LOG(ret);
+        if (1 == ORTE_PROC_MY_NAME->vpid) {
+            if (ORTE_SUCCESS != (ret = opal_dss.pack(buffer, &opal_hwloc_topology, 1, OPAL_HWLOC_TOPO))) {
+                ORTE_ERROR_LOG(ret);
+            }
         }
 
         /* send to the HNP's callback - will be routed if routes are available */

--- a/orte/util/nidmap.c
+++ b/orte/util/nidmap.c
@@ -516,9 +516,9 @@ int orte_util_encode_nodemap(opal_buffer_t *buffer)
 /* decode a nodemap for a daemon */
 int orte_util_decode_daemon_nodemap(opal_buffer_t *buffer)
 {
-    int k, m, n, rc, start, endpt;
+    int m, n, rc;
     orte_node_t *node;
-    size_t num_nodes;
+    size_t k, num_nodes, endpt;
     orte_job_t *daemons;
     orte_proc_t *dptr;
     char **nodes, *indices, *dvpids;
@@ -601,16 +601,16 @@ int orte_util_decode_daemon_nodemap(opal_buffer_t *buffer)
     for (n=0; NULL != tmp[n]; n++) {
         /* convert the number - since it might be a range,
          * save the remainder pointer */
-        nodeids[k] = strtoul(tmp[n], &rmndr, 10);
+        nodeids[k++] = strtoul(tmp[n], &rmndr, 10);
         if (NULL != rmndr) {
             /* it must be a range - find the endpoint */
             ++rmndr;
+            m = nodeids[k-1] + 1;
             endpt = strtoul(rmndr, NULL, 10);
-            start = nodeids[k] + 1;
-            for (m=0; m < endpt; m++) {
-                ++k;
-                nodeids[k] = start + m;
+            while (k <= endpt && k < num_nodes) {
+                nodeids[k++] = m++;
             }
+            --k;  // step back to compensate for later increment
         }
         ++k;
     }
@@ -624,16 +624,16 @@ int orte_util_decode_daemon_nodemap(opal_buffer_t *buffer)
     for (n=0; NULL != tmp[n]; n++) {
         /* convert the number - since it might be a range,
          * save the remainder pointer */
-        dids[k] = strtoul(tmp[n], &rmndr, 10);
+        dids[k++] = strtoul(tmp[n], &rmndr, 10);
         if (NULL != rmndr) {
             /* it must be a range - find the endpoint */
             ++rmndr;
             endpt = strtoul(rmndr, NULL, 10);
-            start = dids[k] + 1;
-            for (m=0; m < endpt; m++) {
-                ++k;
-                dids[k] = start + m;
+            m = dids[k-1] + 1;
+            while (k <= endpt && k < num_nodes) {
+                dids[k++] = m++;
             }
+            --k;  // step back to compensate for later increment
         }
         ++k;
     }


### PR DESCRIPTION
Given that we only set OOB contact info from inside of events, or before we begin threaded operations (e.g., in the ess), allow set_contact_info to directly update the oob/base framework globals.

Correct the nidmap regex decompression routine.

Ensure that rank=1 daemon always sends back its topology as this is the most common use-case.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>