### PR TITLE
v1.10: opal/stacktace: Raise the signal after processing

### DIFF
--- a/opal/util/stacktrace.c
+++ b/opal/util/stacktrace.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  * 
  * Additional copyrights may follow
@@ -348,6 +349,14 @@ static void show_stackframe (int signo, siginfo_t * info, void * p)
     } else {
         write(fileno(stderr), unable_to_print_msg, strlen(unable_to_print_msg));
     }
+
+    /* Raise the signal again, so we don't accidentally mask critical signals.
+     * For critical signals, it is preferred that we call 'raise' instead of
+     * 'exit' or 'abort' so that the return status is set properly for this
+     * process.
+     */
+    signal(signo, SIG_DFL);
+    raise(signo);
 }
 
 #endif /* OPAL_WANT_PRETTY_PRINT_STACKTRACE && ! defined(__WINDOWS__) */


### PR DESCRIPTION
 - This prevents us for accidentally masking a signal that was meant to
   terminate the application.
 - Refs PR #2772 

Refs #2801