### PR TITLE
v2.x: pmix/pmix112: Correct `--enable-pmix-dstore` option

### DIFF
--- a/opal/mca/pmix/pmix112/configure.m4
+++ b/opal/mca/pmix/pmix112/configure.m4
@@ -43,7 +43,7 @@ AC_DEFUN([MCA_opal_pmix_pmix112_CONFIG],[
                   [AC_HELP_STRING([--enable-pmix-dstore],
                                   [Enable PMIx shared memory data store (default: disabled)])])
     AC_MSG_CHECKING([if PMIx shared memory data store is enabled])
-    if test "$enable_pmix3_dstore" == "yes"; then
+    if test "$enable_pmix_dstore" = "yes"; then
         AC_MSG_RESULT([yes])
         opal_pmix_pmix_sm_flag=--enable-dstore
     else


### PR DESCRIPTION
@jjhursey This is the intended option, right?

The Open MPI `configure` option to enable PMIx shared meory dstore
is now `--enable-pmix-dstore`, not `--enable-pmix3-dstore`.
Without this fix, The `--disable-dstore` is always passed to PMIx
`configure` regardless of the Open MPI `configure` option.

And, `==` is bash extention.

This bug exists only in v2.x branch. No master and v2.0.x.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>
