### PR TITLE
Cleanup a typo that can cause a segfault

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server_ops.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server_ops.c
@@ -1634,7 +1634,7 @@ static void lmcon(pmix_dmdx_local_t *p)
 static void lmdes(pmix_dmdx_local_t *p)
 {
     PMIX_INFO_FREE(p->info, p->ninfo);
-    PMIX_DESTRUCT(&p->loc_reqs);
+    PMIX_LIST_DESTRUCT(&p->loc_reqs);
 }
 PMIX_CLASS_INSTANCE(pmix_dmdx_local_t,
                     pmix_list_item_t,


### PR DESCRIPTION
use a local variable name different than the one passed into the function

Fixes #2863 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>