### PR TITLE
coll/libnbc: fix the red_schain algo of ireduce with MPI_IN_PLACE

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ireduce.c
+++ b/ompi/mca/coll/libnbc/nbc_ireduce.c
@@ -7,9 +7,8 @@
  *                         rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014-2016 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  *
  * Author(s): Torsten Hoefler <htor@cs.indiana.edu>
  *
@@ -426,30 +425,10 @@ static inline int red_sched_chain (int rank, int p, int root, const void *sendbu
 
     /* last node does not recv */
     if (vrank != p-1) {
-      if (vrank == 0) {
-        if (sendbuf != recvbuf) {
-          // for regular src, recv into recvbuf
-          res = NBC_Sched_recv ((char *)recvbuf+offset, false, thiscount, datatype, rpeer, schedule, true);
-        } else {
-          // but for any-src, recv into tmpbuf
-          // because for MPI_IN_PLACE if we recved into recvbuf here we'd be
-          // overwriting our sendbuf, and we use it in the operation
-          // that happens further down
-          res = NBC_Sched_recv ((char *)offset, true, thiscount, datatype, rpeer, schedule, true);
-        }
+      if (vrank == 0 && sendbuf != recvbuf) {
+        res = NBC_Sched_recv ((char *)recvbuf+offset, false, thiscount, datatype, rpeer, schedule, true);
       } else {
-        if (sendbuf != recvbuf) {
-          // for regular src, add sendbuf into recvbuf
-          // (here recvbuf holds the reduction from 1..n-1)
-          res = NBC_Sched_op ((char *) sendbuf + offset, false, (char *) recvbuf + offset, false,
-                             thiscount, datatype, op, schedule, true);
-        } else {
-          // for MPI_IN_PLACE, add tmpbuf into recvbuf
-          // (here tmpbuf holds the reduction from 1..n-1) and
-          // recvbuf is our sendbuf
-          res = NBC_Sched_op ((char *) offset, true, (char *) recvbuf + offset, false,
-                             thiscount, datatype, op, schedule, true);
-        }
+        res = NBC_Sched_recv ((char *)offset, true, thiscount, datatype, rpeer, schedule, true);
       }
       if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
         return res;
@@ -457,8 +436,13 @@ static inline int red_sched_chain (int rank, int p, int root, const void *sendbu
 
       /* root reduces into receivebuf */
       if(vrank == 0) {
-        res = NBC_Sched_op ((char *) sendbuf + offset, false, (char *) recvbuf + offset, false,
-                             thiscount, datatype, op, schedule, true);
+        if (sendbuf != recvbuf) {
+            res = NBC_Sched_op ((char *) sendbuf + offset, false, (char *) recvbuf + offset, false,
+                                 thiscount, datatype, op, schedule, true);
+        } else {
+            res = NBC_Sched_op ((char *)offset, true, (char *) recvbuf + offset, false,
+                                 thiscount, datatype, op, schedule, true);
+        }
       } else {
         res = NBC_Sched_op ((char *) sendbuf + offset, false, (char *) offset, true, thiscount,
                              datatype, op, schedule, true);


### PR DESCRIPTION
this fixes a regression introduced in open-mpi/ompi@045d0c5f4caffdf31fb2dd1cb4d7b8940c07d365

Fixes open-mpi/ompi#2879

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@9bcadbd51bbb310903232f054d514497dc1a5147)