### PR TITLE
Prep for v1.10.6rc1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,7 +19,7 @@ Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
 Copyright (c) 2012      University of Houston. All rights reserved.
 Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
-Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 $COPYRIGHT$
 
 Additional copyrights may follow
@@ -52,6 +52,19 @@ included in the vX.Y.Z section and be denoted as:
 
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
+
+1.10.6 - TBD
+------
+- Fix bug in timer code that caused problems at optimization settings
+  greater than 2
+- OSHMEM: make mmap allocator the default instead of sysv or verbs
+- Support MPI_Dims_create with dimension zero
+- Update USNIC support
+- Prevent 64-bit overflow on timer counter
+- Add support for forwarding signals
+- Fix bug that caused truncated messages on large sends over TCP BTL
+- Fix potential infinite loop when printing a stacktrace
+
 
 1.10.5 - 19 Dec 2016
 ------

--- a/VERSION
+++ b/VERSION
@@ -15,7 +15,7 @@
 
 major=1
 minor=10
-release=5
+release=6
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -82,14 +82,14 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=12:5:0
+libmpi_so_version=12:6:0
 libmpi_cxx_so_version=2:3:1
 libmpi_mpifh_so_version=12:1:0
 libmpi_usempi_tkr_so_version=6:0:1
 libmpi_usempi_ignore_tkr_so_version=8:0:2
 libmpi_usempif08_so_version=12:1:1
-libopen_rte_so_version=12:3:0
-libopen_pal_so_version=13:3:0
+libopen_rte_so_version=12:4:0
+libopen_pal_so_version=13:4:0
 libmpi_java_so_version=3:0:2
 liboshmem_so_version=9:2:1
 


### PR DESCRIPTION
Add NEWS bullets for 1.10.6. Update the release number to 6. Update the revision numbers for libmpi, libopen-rte, and libopen-pal as no APIs have changed, but all three libraries had modifications to them. No other versioned libraries changed.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>