### PR TITLE
ess/alps: fix problem in makefile

### DIFF
--- a/orte/mca/ess/alps/Makefile.am
+++ b/orte/mca/ess/alps/Makefile.am
@@ -35,7 +35,7 @@ component_noinst = libmca_ess_alps.la
 component_install =
 endif
 
-mcacomponentdir = $(ompilibdir)
+mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_alps_la_SOURCES = $(sources)
 mca_ess_alps_la_CPPFLAGS = $(ess_alps_CPPFLAGS)


### PR DESCRIPTION
./autogen.pl --no-ompi doesn't work without this
fix when alps can be configured.

@rhc54 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>