### PR TITLE
Correct the path to the ORTE data dir - allows master to be built with --no-ompi

### DIFF
--- a/orte/mca/ras/alps/Makefile.am
+++ b/orte/mca/ras/alps/Makefile.am
@@ -24,7 +24,7 @@ dist_ortedata_DATA = help-ras-alps.txt \
 		  ras-alps-command.sh
 
 install-data-hook:
-	chmod +x $(DESTDIR)$(pkgdatadir)/ras-alps-command.sh
+	chmod +x $(ortedatadir)/ras-alps-command.sh
 
 sources = \
         ras_alps.h \


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>