### PR TITLE
opal/output: Make sure verbose gets updated when id 0 gets updated.

### DIFF
--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -680,6 +681,18 @@ static int do_open(int output_id, opal_output_stream_t * lds)
         }
         info[i].ldi_file_want_append = lds->lds_want_file_append;
         info[i].ldi_file_num_lines_lost = 0;
+    }
+
+    /* Special case: output_id == 0 == verbose_stream
+     * This is the verbose stream, so update the internal 'verbose_stream'
+     * to match the parameters set in the info[i]
+     */
+    if( verbose_stream == i ) {
+        verbose.lds_want_syslog     = info[i].ldi_syslog;
+        verbose.lds_syslog_priority = info[i].ldi_syslog_priority;
+        verbose.lds_syslog_ident    = info[i].ldi_syslog_ident;
+        verbose.lds_want_stdout     = info[i].ldi_stdout;
+        verbose.lds_want_stderr     = info[i].ldi_stderr;
     }
 
     /* Don't open a file in the session directory now -- do that lazily


### PR DESCRIPTION
 - This allows the following MCA option to have an impact on the
   framework verbose output as well.
   * `-mca mca_base_verbose stdout`
 - Ref PR #2809
