### PR TITLE
coll/base: Allgatherv MPI_IN_PLACE Bug

### DIFF
--- a/ompi/mca/coll/base/coll_base_allgatherv.c
+++ b/ompi/mca/coll/base/coll_base_allgatherv.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -622,9 +623,7 @@ ompi_coll_base_allgatherv_intra_basic_default(const void *sbuf, int scount,
         ompi_datatype_get_extent(rdtype, &lb, &extent);
         send_type = rdtype;
         send_buf = (char*)rbuf;
-        for (i = 0; i < rank; ++i) {
-            send_buf += ((ptrdiff_t)rcounts[i] * extent);
-        }
+        send_buf += ((ptrdiff_t)disps[rank] * extent);
         scount = rcounts[rank];
     } else {
         send_buf = (char*)sbuf;


### PR DESCRIPTION
MPI_Allgatherv with MPI_IN_PLACE reads data from wrong location.

They were locating the MPI_IN_PLACE send buffer as
```c
         send_buf = (char*)rbuf;
         for (i = 0; i < rank; ++i) {
             send_buf += ((ptrdiff_t)rcounts[i] * extent);
         }
```
when it should be
```c
         send_buf = (char*)rbuf;
         send_buf += ((ptrdiff_t)disps[rank] * extent);
```
because disps[] specifies where things are in the v-style buffers.

 Refs PR #2805 