### PR TITLE
v2.0.x: btl/tcp: get rid of the MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD macro

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -53,12 +53,6 @@
 #define MCA_BTL_TCP_STATISTICS 0
 BEGIN_C_DECLS
 
-#if (HAVE_PTHREAD_H == 1)
-#define MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD 1
-#else
-#define MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD 0
-#endif  /* (HAVE_PTHREAD_H == 1) */
-
 extern opal_event_base_t* mca_btl_tcp_event_base;
 
 #define MCA_BTL_TCP_COMPLETE_FRAG_SEND(frag)                            \
@@ -81,7 +75,6 @@ extern opal_event_base_t* mca_btl_tcp_event_base;
         }                                                               \
     } while (0)
 
-#if MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
 extern opal_list_t mca_btl_tcp_ready_frag_pending_queue;
 extern opal_mutex_t mca_btl_tcp_ready_frag_mutex;
 extern int mca_btl_tcp_pipe_to_progress[2];
@@ -103,14 +96,6 @@ extern int mca_btl_tcp_progress_thread_trigger;
             opal_event_add(event, (value));                             \
         }                                                               \
     } while (0)
-#else
-#define MCA_BTL_TCP_CRITICAL_SECTION_ENTER(name)
-#define MCA_BTL_TCP_CRITICAL_SECTION_LEAVE(name)
-#define MCA_BTL_TCP_ACTIVATE_EVENT(event, value)                    \
-    do {                                                            \
-        opal_event_add(event, (value));                             \
-    } while (0)
-#endif  /* MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD */
 
 /**
  * TCP BTL component.
@@ -158,12 +143,10 @@ struct mca_btl_tcp_component_t {
 
     int tcp_enable_progress_thread;         /** Support for tcp progress thread flag */
 
-#if MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
     opal_event_t tcp_recv_thread_async_event;
     opal_mutex_t tcp_frag_eager_mutex;
     opal_mutex_t tcp_frag_max_mutex;
     opal_mutex_t tcp_frag_user_mutex;
-#endif
     /* Do we want to use TCP_NODELAY? */
     int    tcp_not_use_nodelay;
 

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -17,7 +17,7 @@
  *                         reserved.
  * Copyright (c) 2013-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -93,13 +93,11 @@ static int mca_btl_tcp_component_open(void);
 static int mca_btl_tcp_component_close(void);
 
 opal_event_base_t* mca_btl_tcp_event_base = NULL;
-#if MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
 int mca_btl_tcp_progress_thread_trigger = -1;
 int mca_btl_tcp_pipe_to_progress[2] = { -1, -1 };
 static opal_thread_t mca_btl_tcp_progress_thread = { { 0 } };
 opal_list_t mca_btl_tcp_ready_frag_pending_queue = { { 0 } };
 opal_mutex_t mca_btl_tcp_ready_frag_mutex = OPAL_MUTEX_STATIC_INIT;
-#endif  /* MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD */
 
 mca_btl_tcp_component_t mca_btl_tcp_component = {
     .super = {
@@ -287,17 +285,6 @@ static int mca_btl_tcp_component_register(void)
     /* Check if we should support async progress */
     mca_btl_tcp_param_register_int ("progress_thread", NULL, 0, OPAL_INFO_LVL_1,
                                      &mca_btl_tcp_component.tcp_enable_progress_thread);
-#if !defined(MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD)
-    if( mca_btl_tcp_component.tcp_enable_progress_thread ) {
-        opal_show_help("help-mpi-btl-tcp.txt",
-                       "unsuported progress thread",
-                       true, "progress thread",
-                       opal_process_info.nodename,
-                       mca_btl_tcp_component.tcp_if_seq,
-                       "Progress thread support compiled out");
-     }
-#endif  /* !defined(MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD) */
-
     mca_btl_tcp_component.report_all_unfound_interfaces = false;
     (void) mca_base_component_var_register(&mca_btl_tcp_component.super.btl_version,
                                            "warn_all_unfound_interfaces",
@@ -355,13 +342,11 @@ static int mca_btl_tcp_component_open(void)
     OBJ_CONSTRUCT(&mca_btl_tcp_component.tcp_frag_user, opal_free_list_t);
     opal_proc_table_init(&mca_btl_tcp_component.tcp_procs, 16, 256);
 
-#if  MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
     OBJ_CONSTRUCT(&mca_btl_tcp_component.tcp_frag_eager_mutex, opal_mutex_t);
     OBJ_CONSTRUCT(&mca_btl_tcp_component.tcp_frag_max_mutex, opal_mutex_t);
     OBJ_CONSTRUCT(&mca_btl_tcp_component.tcp_frag_user_mutex, opal_mutex_t);
     OBJ_CONSTRUCT(&mca_btl_tcp_ready_frag_mutex, opal_mutex_t);
     OBJ_CONSTRUCT(&mca_btl_tcp_ready_frag_pending_queue, opal_list_t);
-#endif  /*  MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD */
 
     /* if_include and if_exclude need to be mutually exclusive */
     if (OPAL_SUCCESS !=
@@ -753,7 +738,6 @@ static int mca_btl_tcp_component_create_instances(void)
     return ret;
 }
 
-#if MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
 static void* mca_btl_tcp_progress_thread_engine(opal_object_t *obj)
 {
     opal_thread_t* current_thread = (opal_thread_t*)obj;
@@ -780,7 +764,6 @@ static void mca_btl_tcp_component_event_async_handler(int fd, short unused, void
         opal_event_add(event, 0);
     }
 }
-#endif
 
 /*
  * Create a listen socket and bind to all interfaces

--- a/opal/mca/btl/tcp/btl_tcp_frag.c
+++ b/opal/mca/btl/tcp/btl_tcp_frag.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -280,15 +280,6 @@ bool mca_btl_tcp_frag_recv(mca_btl_tcp_frag_t* frag, int sd)
                 frag->iov[1].iov_base = (IOVBASE_TYPE*)(frag->segments[0].seg_addr.pval);
                 frag->iov[1].iov_len = frag->hdr.size;
                 frag->iov_cnt++;
-#ifndef __sparc
-#if !MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
-                /* The following cannot be done for sparc code
-                 * because it causes alignment errors when accessing
-                 * structures later on in the btl and pml code.
-                 */
-                dont_copy_data = 1;
-#endif
-#endif
                 goto repeat;
             }
             break;

--- a/opal/mca/btl/tcp/help-mpi-btl-tcp.txt
+++ b/opal/mca/btl/tcp/help-mpi-btl-tcp.txt
@@ -4,6 +4,8 @@
 # Copyright (c) 2015-2016 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
+# Copyright (c) 2016      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -66,14 +68,6 @@ available), and may eventually timeout / abort.
   Local host: %s
   PID:        %d
   Errno:      %d (%s)
-#
-[unsuported progress thread]
-WARNING: Support for the TCP progress thread has not been compiled in.
-Fall back to the normal progress.
-
-  Local host: %s
-  Value:      %s
-  Message:    %s
 #
 [peer hung up]
 An MPI communication peer process has unexpectedly disconnected.  This


### PR DESCRIPTION
since pthreads are now mandatory, the MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
is always true and hence can be safely removed

Refs. open-mpi/ompi#2891

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@a49422fe843eec9b4d3676b30015483dbf4ebc3c)