### PR TITLE
ras/slurm: fix compile error due to missing header

### DIFF
--- a/orte/mca/ras/slurm/ras_slurm_module.c
+++ b/orte/mca/ras/slurm/ras_slurm_module.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2011-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved.
@@ -26,6 +27,7 @@
 #include "orte/constants.h"
 #include "orte/types.h"
 
+#include <netdb.h>
 #include <unistd.h>
 #include <string.h>
 #include <ctype.h>


### PR DESCRIPTION
On some systems this component fails to build due to the missing
netdb.h header.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>