### PR TITLE
orte: Fix MPI_Spawn

### DIFF
--- a/orte/orted/pmix/pmix_server_register_fns.c
+++ b/orte/orted/pmix/pmix_server_register_fns.c
@@ -74,11 +74,6 @@ int orte_pmix_server_register_nspace(orte_job_t *jdata)
                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                         ORTE_JOBID_PRINT(jdata->jobid));
 
-    /* if this job has no local procs, then no need to register them */
-    if (0 == jdata->num_local_procs) {
-        return ORTE_SUCCESS;
-    }
-
     /* setup the info list */
     info = OBJ_NEW(opal_list_t);
     uid = geteuid();


### PR DESCRIPTION
Register namespace even if there is no node-local processes that
belongs to it. We need this for the MPI_Spawn case.

Addressing https://github.com/open-mpi/ompi/issues/2920.
Was introduced in be3ef777392347aa4560fb4eaa13075d2e77ed6e.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>