### PR TITLE
osc/base: Detect unsupported data types and abort

### DIFF
--- a/ompi/mca/osc/base/Makefile.am
+++ b/ompi/mca/osc/base/Makefile.am
@@ -7,12 +7,15 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2017 IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+dist_ompidata_DATA = base/help-mca-osc-base.txt
 
 headers += \
         base/base.h \

--- a/ompi/mca/osc/base/help-mca-osc-base.txt
+++ b/ompi/mca/osc/base/help-mca-osc-base.txt
@@ -1,0 +1,18 @@
+# -*- text -*-
+#
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for Open MPI MCA osc-specific
+# error messages.
+#
+[unsupported-dt]
+Unsupported datatype and op combination used in a one-sided operation.
+
+ Datatype : %s
+ Operation: %s
+ Rank     : %d

--- a/ompi/mca/osc/base/osc_base_obj_convert.c
+++ b/ompi/mca/osc/base/osc_base_obj_convert.c
@@ -78,21 +78,20 @@ int ompi_osc_base_process_op (void *outbuf, void *inbuf, size_t inbuflen,
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
-    /* TODO: Remove the following check when ompi adds support */
+    /* TODO: Remove the following check when support is added.
+     * See the following issue for the current state:
+     *   https://github.com/open-mpi/ompi/issues/1666
+     */
     if(MPI_MINLOC == op || MPI_MAXLOC == op) {
         if(MPI_SHORT_INT == datatype ||
            MPI_DOUBLE_INT == datatype ||
            MPI_LONG_INT == datatype ||
            MPI_LONG_DOUBLE_INT == datatype) {
            ompi_communicator_t *comm = &ompi_mpi_comm_world.comm;
-           opal_output(0, "Error: %s datatype is currently "
-                       "unsupported for MPI_MINLOC/MPI_MAXLOC "
-                       "operation\n", datatype->name);
-           opal_show_help("help-mpi-api.txt", "mpi-abort", true,
-                          comm->c_my_rank,
-                          ('\0' != comm->c_name[0]) ? comm->c_name : "<Unknown>",
-                          -1);
-
+           opal_show_help("help-mca-osc-base.txt", "unsupported-dt", true,
+                          datatype->name,
+                          op->o_name,
+                          comm->c_my_rank);
            ompi_mpi_abort(comm, -1);
         }
     }

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,6 +15,7 @@
 #include "osc_rdma_accumulate.h"
 #include "osc_rdma_request.h"
 #include "osc_rdma_comm.h"
+#include "opal/util/show_help.h"
 
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
 
@@ -1024,6 +1026,46 @@ int ompi_osc_rdma_rget_accumulate_internal (ompi_osc_rdma_sync_t *sync, const vo
         }
 
         return OMPI_SUCCESS;
+    }
+
+    /* TODO: Remove the following check when support is added.
+     * See the following issue for the current state:
+     *   https://github.com/open-mpi/ompi/issues/1666
+     */
+    if(MPI_MINLOC == op || MPI_MAXLOC == op) {
+        if(MPI_SHORT_INT == origin_datatype ||
+           MPI_DOUBLE_INT == origin_datatype ||
+           MPI_LONG_INT == origin_datatype ||
+           MPI_LONG_DOUBLE_INT == origin_datatype) {
+           ompi_communicator_t *comm = &ompi_mpi_comm_world.comm;
+           opal_show_help("help-mca-osc-base.txt", "unsupported-dt", true,
+                          origin_datatype->name,
+                          op->o_name,
+                          comm->c_my_rank);
+           ompi_mpi_abort(comm, -1);
+        }
+        if(MPI_SHORT_INT == result_datatype ||
+           MPI_DOUBLE_INT == result_datatype ||
+           MPI_LONG_INT == result_datatype ||
+           MPI_LONG_DOUBLE_INT == result_datatype) {
+           ompi_communicator_t *comm = &ompi_mpi_comm_world.comm;
+           opal_show_help("help-mca-osc-base.txt", "unsupported-dt", true,
+                          result_datatype->name,
+                          op->o_name,
+                          comm->c_my_rank);
+           ompi_mpi_abort(comm, -1);
+        }
+        if(MPI_SHORT_INT == target_datatype ||
+           MPI_DOUBLE_INT == target_datatype ||
+           MPI_LONG_INT == target_datatype ||
+           MPI_LONG_DOUBLE_INT == target_datatype) {
+           ompi_communicator_t *comm = &ompi_mpi_comm_world.comm;
+           opal_show_help("help-mca-osc-base.txt", "unsupported-dt", true,
+                          target_datatype->name,
+                          op->o_name,
+                          comm->c_my_rank);
+           ompi_mpi_abort(comm, -1);
+        }
     }
 
     (void) ompi_datatype_get_extent (origin_datatype, &lb, &extent);


### PR DESCRIPTION
Using MPI_MINLOC or MPI_MAXLOC with the following data types
leads to data corruption:
 * MPI_DOUBLE_INT
 * MPI_LONG_INT
 * MPI_SHORT_INT
 * MPI_LONG_DOUBLE_INT

Detect this print a error message and abort.
This workaround should be removed once the following issue is resolved:
 * https://github.com/open-mpi/ompi/issues/1666

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit 94f92f6b49212545355123d711abc91af9647d8e)
Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>