### PR TITLE
pmix/pmix112: Enable PMIx shared memory dstore by default

### DIFF
--- a/opal/mca/pmix/pmix112/configure.m4
+++ b/opal/mca/pmix/pmix112/configure.m4
@@ -41,9 +41,9 @@ AC_DEFUN([MCA_opal_pmix_pmix112_CONFIG],[
 
     AC_ARG_ENABLE([pmix-dstore],
                   [AC_HELP_STRING([--enable-pmix-dstore],
-                                  [Enable PMIx shared memory data store (default: disabled)])])
+                                  [Enable PMIx shared memory data store (default: enabled)])])
     AC_MSG_CHECKING([if PMIx shared memory data store is enabled])
-    if test "$enable_pmix_dstore" = "yes"; then
+    if test "$enable_pmix_dstore" != "no"; then
         AC_MSG_RESULT([yes])
         opal_pmix_pmix_sm_flag=--enable-dstore
     else


### PR DESCRIPTION
The problem of PMIx shared memory dstore + MPI singleton is fixed now. See #2859 and #2909. We need PMIx shared memory dstore in v2.1.x.

The master branch had this change long ago and the commit includes many changes so this commit is a direct commit (no cherry-pick).

@jjhursey Please review.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>
