### PR TITLE
Move coll structure outside of the communicator

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -591,8 +591,8 @@ static int ompi_comm_allreduce_intra_nb (int *inbuf, int *outbuf, int count, str
 {
     ompi_communicator_t *comm = context->comm;
 
-    return comm->c_coll.coll_iallreduce (inbuf, outbuf, count, MPI_INT, op, comm,
-                                         req, comm->c_coll.coll_iallreduce_module);
+    return comm->c_coll->coll_iallreduce (inbuf, outbuf, count, MPI_INT, op, comm,
+                                         req, comm->c_coll->coll_iallreduce_module);
 }
 
 /* Non-blocking version of ompi_comm_allreduce_inter */
@@ -641,9 +641,9 @@ static int ompi_comm_allreduce_inter_nb (int *inbuf, int *outbuf,
 
     /* Execute the inter-allreduce: the result from the local will be in the buffer of the remote group
      * and vise-versa. */
-    rc = intercomm->c_local_comm->c_coll.coll_ireduce (inbuf, context->tmpbuf, count, MPI_INT, op, 0,
+    rc = intercomm->c_local_comm->c_coll->coll_ireduce (inbuf, context->tmpbuf, count, MPI_INT, op, 0,
                                                        intercomm->c_local_comm, &subreq,
-                                                       intercomm->c_local_comm->c_coll.coll_ireduce_module);
+                                                       intercomm->c_local_comm->c_coll->coll_ireduce_module);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
         ompi_comm_request_return (request);
         return rc;
@@ -704,8 +704,8 @@ static int ompi_comm_allreduce_inter_bcast (ompi_comm_request_t *request)
     int rc;
 
     /* both roots have the same result. broadcast to the local group */
-    rc = comm->c_coll.coll_ibcast (context->outbuf, context->count, MPI_INT, 0, comm,
-                                   &subreq, comm->c_coll.coll_ibcast_module);
+    rc = comm->c_coll->coll_ibcast (context->outbuf, context->count, MPI_INT, 0, comm,
+                                   &subreq, comm->c_coll->coll_ibcast_module);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
         return rc;
     }
@@ -720,9 +720,9 @@ static int ompi_comm_allreduce_bridged_schedule_bcast (ompi_comm_request_t *requ
     ompi_request_t *subreq;
     int rc;
 
-    rc = comm->c_coll.coll_ibcast (context->outbuf, context->count, MPI_INT,
+    rc = comm->c_coll->coll_ibcast (context->outbuf, context->count, MPI_INT,
                                    context->cid_context->local_leader, comm,
-                                   &subreq, comm->c_coll.coll_ibcast_module);
+                                   &subreq, comm->c_coll->coll_ibcast_module);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
         return rc;
     }
@@ -803,9 +803,9 @@ static int ompi_comm_allreduce_intra_bridge_nb (int *inbuf, int *outbuf,
     }
 
     /* step 1: reduce to the local leader */
-    rc = comm->c_coll.coll_ireduce (inbuf, context->tmpbuf, count, MPI_INT, op,
+    rc = comm->c_coll->coll_ireduce (inbuf, context->tmpbuf, count, MPI_INT, op,
                                     cid_context->local_leader, comm, &subreq,
-                                    comm->c_coll.coll_ireduce_module);
+                                    comm->c_coll->coll_ireduce_module);
     if ( OMPI_SUCCESS != rc ) {
         ompi_comm_request_return (request);
         return rc;
@@ -955,9 +955,9 @@ static int ompi_comm_allreduce_intra_pmix_nb (int *inbuf, int *outbuf,
     request->context = &context->super;
 
     /* comm is an intra-communicator */
-    rc = comm->c_coll.coll_ireduce (inbuf, context->tmpbuf, count, MPI_INT, op,
+    rc = comm->c_coll->coll_ireduce (inbuf, context->tmpbuf, count, MPI_INT, op,
                                     cid_context->local_leader, comm,
-                                    &subreq, comm->c_coll.coll_ireduce_module);
+                                    &subreq, comm->c_coll->coll_ireduce_module);
     if ( OMPI_SUCCESS != rc ) {
         ompi_comm_request_return (request);
         return rc;

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -353,6 +353,7 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
     comm->error_handler  = NULL;
     comm->c_pml_comm     = NULL;
     comm->c_topo         = NULL;
+    comm->c_coll         = NULL;
 
     /* A keyhash will be created if/when an attribute is cached on
        this communicator */
@@ -362,12 +363,6 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
 #ifdef OMPI_WANT_PERUSE
     comm->c_peruse_handles = NULL;
 #endif
-
-    /* Need to zero out the collectives module because we sometimes
-       call coll_unselect without a matching call to coll_select, and
-       we need an easy way for the coll base code to realize we've
-       done this. */
-    memset(&comm->c_coll, 0, sizeof(mca_coll_base_comm_coll_t));
 }
 
 static void ompi_comm_destruct(ompi_communicator_t* comm)
@@ -379,7 +374,7 @@ static void ompi_comm_destruct(ompi_communicator_t* comm)
 
     /* Release the collective module */
 
-    if ( MPI_COMM_NULL != comm ) {
+    if ( NULL != comm->c_coll ) {
         mca_coll_base_comm_unselect(comm);
     }
 

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -169,7 +169,7 @@ struct ompi_communicator_t {
     struct mca_pml_comm_t  *c_pml_comm;
 
     /* Collectives module interface and data */
-    mca_coll_base_comm_coll_t c_coll;
+    mca_coll_base_comm_coll_t *c_coll;
 };
 typedef struct ompi_communicator_t ompi_communicator_t;
 
@@ -256,7 +256,7 @@ typedef struct ompi_communicator_t ompi_communicator_t;
  * the PREDEFINED_COMMUNICATOR_PAD macro?
  * A: Most likely not, but it would be good to check.
  */
-#define PREDEFINED_COMMUNICATOR_PAD (sizeof(void*) * 192)
+#define PREDEFINED_COMMUNICATOR_PAD (sizeof(void*) * 64)
 
 struct ompi_predefined_communicator_t {
     struct ompi_communicator_t comm;

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -229,8 +229,8 @@ int ompi_dpm_connect_accept(ompi_communicator_t *comm, int root,
      * side's participants */
 
     /* bcast the list-length to all processes in the local comm */
-    rc = comm->c_coll.coll_bcast(&rportlen, 1, MPI_INT, root, comm,
-                                 comm->c_coll.coll_bcast_module);
+    rc = comm->c_coll->coll_bcast(&rportlen, 1, MPI_INT, root, comm,
+                                 comm->c_coll->coll_bcast_module);
     if (OMPI_SUCCESS != rc) {
         free(rport);
         goto exit;
@@ -245,8 +245,8 @@ int ompi_dpm_connect_accept(ompi_communicator_t *comm, int root,
         }
     }
     /* now share the list of remote participants */
-    rc = comm->c_coll.coll_bcast(rport, rportlen, MPI_BYTE, root, comm,
-                                 comm->c_coll.coll_bcast_module);
+    rc = comm->c_coll->coll_bcast(rport, rportlen, MPI_BYTE, root, comm,
+                                 comm->c_coll->coll_bcast_module);
     if (OMPI_SUCCESS != rc) {
         free(rport);
         goto exit;

--- a/ompi/include/ompi/memchecker.h
+++ b/ompi/include/ompi/memchecker.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
- * Copyright (c) 2010-2013 The University of Tennessee and The University
+ * Copyright (c) 2010-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
@@ -224,24 +224,24 @@ static inline int memchecker_comm(MPI_Comm comm)
     opal_memchecker_base_isdefined (&comm->errhandler_type, sizeof(ompi_errhandler_type_t));
     opal_memchecker_base_isdefined (&comm->c_pml_comm, sizeof(struct mca_pml_comm_t *));
     /* c_coll */
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_module_init, sizeof(mca_coll_base_module_init_1_0_0_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_module_finalize, sizeof(mca_coll_base_module_finalize_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_allgather, sizeof(mca_coll_base_module_allgather_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_allgatherv, sizeof(mca_coll_base_module_allgatherv_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_allreduce, sizeof(mca_coll_base_module_allreduce_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_alltoall, sizeof(mca_coll_base_module_alltoall_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_alltoallv, sizeof(mca_coll_base_module_alltoallv_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_alltoallw, sizeof(mca_coll_base_module_alltoallw_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_barrier, sizeof(mca_coll_base_module_barrier_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_bcast, sizeof(mca_coll_base_module_bcast_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_exscan, sizeof(mca_coll_base_module_exscan_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_gather, sizeof(mca_coll_base_module_gather_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_gatherv, sizeof(mca_coll_base_module_gatherv_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_reduce, sizeof(mca_coll_base_module_reduce_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_reduce_scatter, sizeof(mca_coll_base_module_reduce_scatter_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_scan, sizeof(mca_coll_base_module_scan_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_scatter, sizeof(mca_coll_base_module_scatter_fn_t));
-    opal_memchecker_base_isdefined (&comm->c_coll.coll_scatterv, sizeof(mca_coll_base_module_scatterv_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_module_init, sizeof(mca_coll_base_module_init_1_0_0_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_module_finalize, sizeof(mca_coll_base_module_finalize_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_allgather, sizeof(mca_coll_base_module_allgather_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_allgatherv, sizeof(mca_coll_base_module_allgatherv_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_allreduce, sizeof(mca_coll_base_module_allreduce_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_alltoall, sizeof(mca_coll_base_module_alltoall_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_alltoallv, sizeof(mca_coll_base_module_alltoallv_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_alltoallw, sizeof(mca_coll_base_module_alltoallw_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_barrier, sizeof(mca_coll_base_module_barrier_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_bcast, sizeof(mca_coll_base_module_bcast_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_exscan, sizeof(mca_coll_base_module_exscan_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_gather, sizeof(mca_coll_base_module_gather_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_gatherv, sizeof(mca_coll_base_module_gatherv_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_reduce, sizeof(mca_coll_base_module_reduce_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_reduce_scatter, sizeof(mca_coll_base_module_reduce_scatter_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_scan, sizeof(mca_coll_base_module_scan_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_scatter, sizeof(mca_coll_base_module_scatter_fn_t));
+    opal_memchecker_base_isdefined (&comm->c_coll->coll_scatterv, sizeof(mca_coll_base_module_scatterv_fn_t));
 
     opal_memchecker_base_isdefined (&comm->c_coll_selected_component, sizeof(const mca_coll_base_component_2_0_0_t *));
     opal_memchecker_base_isdefined (&comm->c_coll_selected_module, sizeof(const mca_coll_base_module_1_0_0_t *));

--- a/ompi/mca/coll/base/coll_base_allgather.c
+++ b/ompi/mca/coll/base/coll_base_allgather.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -718,20 +718,20 @@ ompi_coll_base_allgather_intra_basic_linear(const void *sbuf, int scount,
 
     /* Gather and broadcast. */
 
-    err = comm->c_coll.coll_gather(sbuf, scount, sdtype,
+    err = comm->c_coll->coll_gather(sbuf, scount, sdtype,
                                    rbuf, rcount, rdtype,
-                                   0, comm, comm->c_coll.coll_gather_module);
+                                   0, comm, comm->c_coll->coll_gather_module);
     if (MPI_SUCCESS == err) {
         size_t length = (ptrdiff_t)rcount * ompi_comm_size(comm);
         if( length < (size_t)INT_MAX ) {
-            err = comm->c_coll.coll_bcast(rbuf, (ptrdiff_t)rcount * ompi_comm_size(comm), rdtype,
-                                          0, comm, comm->c_coll.coll_bcast_module);
+            err = comm->c_coll->coll_bcast(rbuf, (ptrdiff_t)rcount * ompi_comm_size(comm), rdtype,
+                                          0, comm, comm->c_coll->coll_bcast_module);
         } else {
             ompi_datatype_t* temptype;
             ompi_datatype_create_contiguous(ompi_comm_size(comm), rdtype, &temptype);
             ompi_datatype_commit(&temptype);
-            err = comm->c_coll.coll_bcast(rbuf, rcount, temptype,
-                                          0, comm, comm->c_coll.coll_bcast_module);
+            err = comm->c_coll->coll_bcast(rbuf, rcount, temptype,
+                                          0, comm, comm->c_coll->coll_bcast_module);
             ompi_datatype_destroy(&temptype);
         }
     }

--- a/ompi/mca/coll/base/coll_base_allgatherv.c
+++ b/ompi/mca/coll/base/coll_base_allgatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -623,10 +623,10 @@ ompi_coll_base_allgatherv_intra_basic_default(const void *sbuf, int scount,
         send_type = sdtype;
     }
 
-    err = comm->c_coll.coll_gatherv(send_buf,
+    err = comm->c_coll->coll_gatherv(send_buf,
                                     scount, send_type,rbuf,
                                     rcounts, disps, rdtype, 0,
-                                    comm, comm->c_coll.coll_gatherv_module);
+                                    comm, comm->c_coll->coll_gatherv_module);
     if (MPI_SUCCESS != err) {
         return err;
     }
@@ -653,8 +653,8 @@ ompi_coll_base_allgatherv_intra_basic_default(const void *sbuf, int scount,
         return err;
     }
 
-    comm->c_coll.coll_bcast(rbuf, 1, newtype, 0, comm,
-                            comm->c_coll.coll_bcast_module);
+    comm->c_coll->coll_bcast(rbuf, 1, newtype, 0, comm,
+                            comm->c_coll->coll_bcast_module);
 
     ompi_datatype_destroy (&newtype);
 

--- a/ompi/mca/coll/base/coll_base_allreduce.c
+++ b/ompi/mca/coll/base/coll_base_allreduce.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -65,22 +65,22 @@ ompi_coll_base_allreduce_intra_nonoverlapping(const void *sbuf, void *rbuf, int 
 
     if (MPI_IN_PLACE == sbuf) {
         if (0 == rank) {
-            err = comm->c_coll.coll_reduce (MPI_IN_PLACE, rbuf, count, dtype,
-                                            op, 0, comm, comm->c_coll.coll_reduce_module);
+            err = comm->c_coll->coll_reduce (MPI_IN_PLACE, rbuf, count, dtype,
+                                            op, 0, comm, comm->c_coll->coll_reduce_module);
         } else {
-            err = comm->c_coll.coll_reduce (rbuf, NULL, count, dtype, op, 0,
-                                            comm, comm->c_coll.coll_reduce_module);
+            err = comm->c_coll->coll_reduce (rbuf, NULL, count, dtype, op, 0,
+                                            comm, comm->c_coll->coll_reduce_module);
         }
     } else {
-        err = comm->c_coll.coll_reduce (sbuf, rbuf, count, dtype, op, 0,
-                                        comm, comm->c_coll.coll_reduce_module);
+        err = comm->c_coll->coll_reduce (sbuf, rbuf, count, dtype, op, 0,
+                                        comm, comm->c_coll->coll_reduce_module);
     }
     if (MPI_SUCCESS != err) {
         return err;
     }
 
-    return comm->c_coll.coll_bcast (rbuf, count, dtype, 0, comm,
-                                    comm->c_coll.coll_bcast_module);
+    return comm->c_coll->coll_bcast (rbuf, count, dtype, 0, comm,
+                                    comm->c_coll->coll_bcast_module);
 }
 
 /*

--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -85,17 +85,17 @@ static OBJ_CLASS_INSTANCE(avail_coll_t, opal_list_item_t, NULL, NULL);
 #define COPY(module, comm, func)                                        \
     do {                                                                \
         if (NULL != module->coll_ ## func) {                            \
-            if (NULL != comm->c_coll.coll_ ## func ## _module) {        \
-                OBJ_RELEASE(comm->c_coll.coll_ ## func ## _module);     \
+            if (NULL != comm->c_coll->coll_ ## func ## _module) {       \
+                OBJ_RELEASE(comm->c_coll->coll_ ## func ## _module);    \
             }                                                           \
-            comm->c_coll.coll_ ## func = module->coll_ ## func;         \
-            comm->c_coll.coll_ ## func ## _module = module;             \
+            comm->c_coll->coll_ ## func = module->coll_ ## func;        \
+            comm->c_coll->coll_ ## func ## _module = module;            \
             OBJ_RETAIN(module);                                         \
         }                                                               \
     } while (0)
 
 #define CHECK_NULL(what, comm, func)                                    \
-  ( (what) = # func , NULL == (comm)->c_coll.coll_ ## func)
+  ( (what) = # func , NULL == (comm)->c_coll->coll_ ## func)
 
 /*
  * This function is called at the initialization time of every
@@ -118,7 +118,7 @@ int mca_coll_base_comm_select(ompi_communicator_t * comm)
 
     /* Initialize all the relevant pointers, since they're used as
      * sentinel values */
-    memset(&comm->c_coll, 0, sizeof(mca_coll_base_comm_coll_t));
+    comm->c_coll = (mca_coll_base_comm_coll_t*)calloc(1, sizeof(mca_coll_base_comm_coll_t));
 
     opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                         "coll:base:comm_select: Checking all available modules");

--- a/ompi/mca/coll/base/coll_base_comm_unselect.c
+++ b/ompi/mca/coll/base/coll_base_comm_unselect.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -34,19 +34,17 @@
 #include "ompi/communicator/communicator.h"
 #include "ompi/mca/coll/base/base.h"
 
-#define CLOSE(comm, func)                                       \
-    do {                                                        \
-        if (NULL != comm->c_coll.coll_ ## func ## _module) {    \
-            if (NULL != comm->c_coll.coll_ ## func ## _module-> \
-                coll_module_disable) {                          \
-                comm->c_coll.coll_ ## func ## _module->         \
-                coll_module_disable(                            \
-                comm->c_coll.coll_ ## func ## _module, comm);   \
-            }                                                   \
-            OBJ_RELEASE(comm->c_coll.coll_ ## func ## _module); \
-            comm->c_coll.coll_## func = NULL;                   \
-            comm->c_coll.coll_## func ## _module = NULL;        \
-        }                                                       \
+#define CLOSE(comm, func)                                        \
+    do {                                                         \
+        if (NULL != comm->c_coll->coll_ ## func ## _module) {    \
+            if (NULL != comm->c_coll->coll_ ## func ## _module->coll_module_disable) { \
+                comm->c_coll->coll_ ## func ## _module->coll_module_disable(           \
+                              comm->c_coll->coll_ ## func ## _module, comm);           \
+            }                                                    \
+            OBJ_RELEASE(comm->c_coll->coll_ ## func ## _module); \
+            comm->c_coll->coll_## func = NULL;                   \
+            comm->c_coll->coll_## func ## _module = NULL;        \
+        }                                                        \
     } while (0)
 
 int mca_coll_base_comm_unselect(ompi_communicator_t * comm)
@@ -101,6 +99,10 @@ int mca_coll_base_comm_unselect(ompi_communicator_t * comm)
 
     CLOSE(comm, reduce_local);
 
+    free(comm->c_coll);
+    comm->c_coll = NULL;
+
     /* All done */
     return OMPI_SUCCESS;
 }
+

--- a/ompi/mca/coll/base/coll_base_reduce_scatter.c
+++ b/ompi/mca/coll/base/coll_base_reduce_scatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -66,11 +66,11 @@ int ompi_coll_base_reduce_scatter_intra_nonoverlapping(const void *sbuf, void *r
     if (MPI_IN_PLACE == sbuf) {
         /* rbuf on root (0) is big enough to hold whole data */
         if (root == rank) {
-            err = comm->c_coll.coll_reduce (MPI_IN_PLACE, tmprbuf, total_count,
-                                            dtype, op, root, comm, comm->c_coll.coll_reduce_module);
+            err = comm->c_coll->coll_reduce (MPI_IN_PLACE, tmprbuf, total_count,
+                                            dtype, op, root, comm, comm->c_coll->coll_reduce_module);
         } else {
-            err = comm->c_coll.coll_reduce(tmprbuf, NULL, total_count,
-                                           dtype, op, root, comm, comm->c_coll.coll_reduce_module);
+            err = comm->c_coll->coll_reduce(tmprbuf, NULL, total_count,
+                                           dtype, op, root, comm, comm->c_coll->coll_reduce_module);
         }
     } else {
         if (root == rank) {
@@ -82,8 +82,8 @@ int ompi_coll_base_reduce_scatter_intra_nonoverlapping(const void *sbuf, void *r
             tmprbuf_free = (char*) malloc(dsize);
             tmprbuf = tmprbuf_free - gap;
         }
-        err = comm->c_coll.coll_reduce (sbuf, tmprbuf, total_count,
-                                        dtype, op, root, comm, comm->c_coll.coll_reduce_module);
+        err = comm->c_coll->coll_reduce (sbuf, tmprbuf, total_count,
+                                        dtype, op, root, comm, comm->c_coll->coll_reduce_module);
     }
     if (MPI_SUCCESS != err) {
         if (NULL != tmprbuf_free) free(tmprbuf_free);
@@ -96,13 +96,13 @@ int ompi_coll_base_reduce_scatter_intra_nonoverlapping(const void *sbuf, void *r
         displs[i] = displs[i-1] + rcounts[i-1];
     }
     if (MPI_IN_PLACE == sbuf && root == rank) {
-        err =  comm->c_coll.coll_scatterv (tmprbuf, rcounts, displs, dtype,
+        err =  comm->c_coll->coll_scatterv (tmprbuf, rcounts, displs, dtype,
                                            MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                                           root, comm, comm->c_coll.coll_scatterv_module);
+                                           root, comm, comm->c_coll->coll_scatterv_module);
     } else {
-        err =  comm->c_coll.coll_scatterv (tmprbuf, rcounts, displs, dtype,
+        err =  comm->c_coll->coll_scatterv (tmprbuf, rcounts, displs, dtype,
                                            rbuf, rcounts[rank], dtype,
-                                           root, comm, comm->c_coll.coll_scatterv_module);
+                                           root, comm, comm->c_coll->coll_scatterv_module);
     }
     free(displs);
     if (NULL != tmprbuf_free) free(tmprbuf_free);

--- a/ompi/mca/coll/basic/coll_basic_allgatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_allgatherv.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -61,9 +61,9 @@ mca_coll_basic_allgatherv_inter(const void *sbuf, int scount,
         sdisps[i] = 0;
     }
 
-    err = comm->c_coll.coll_alltoallv(sbuf, scounts, sdisps, sdtype,
+    err = comm->c_coll->coll_alltoallv(sbuf, scounts, sdisps, sdtype,
                                       rbuf, rcounts, disps, rdtype, comm,
-                                      comm->c_coll.coll_alltoallv_module);
+                                      comm->c_coll->coll_alltoallv_module);
 
     if (NULL != scounts) {
         free(scounts);

--- a/ompi/mca/coll/basic/coll_basic_allreduce.c
+++ b/ompi/mca/coll/basic/coll_basic_allreduce.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -51,18 +51,18 @@ mca_coll_basic_allreduce_intra(const void *sbuf, void *rbuf, int count,
 
     if (MPI_IN_PLACE == sbuf) {
         if (0 == ompi_comm_rank(comm)) {
-            err = comm->c_coll.coll_reduce(MPI_IN_PLACE, rbuf, count, dtype, op, 0, comm, comm->c_coll.coll_reduce_module);
+            err = comm->c_coll->coll_reduce(MPI_IN_PLACE, rbuf, count, dtype, op, 0, comm, comm->c_coll->coll_reduce_module);
         } else {
-            err = comm->c_coll.coll_reduce(rbuf, NULL, count, dtype, op, 0, comm, comm->c_coll.coll_reduce_module);
+            err = comm->c_coll->coll_reduce(rbuf, NULL, count, dtype, op, 0, comm, comm->c_coll->coll_reduce_module);
         }
     } else {
-        err = comm->c_coll.coll_reduce(sbuf, rbuf, count, dtype, op, 0, comm, comm->c_coll.coll_reduce_module);
+        err = comm->c_coll->coll_reduce(sbuf, rbuf, count, dtype, op, 0, comm, comm->c_coll->coll_reduce_module);
     }
     if (MPI_SUCCESS != err) {
         return err;
     }
 
-    return comm->c_coll.coll_bcast(rbuf, count, dtype, 0, comm, comm->c_coll.coll_bcast_module);
+    return comm->c_coll->coll_bcast(rbuf, count, dtype, 0, comm, comm->c_coll->coll_bcast_module);
 }
 
 

--- a/ompi/mca/coll/basic/coll_basic_barrier.c
+++ b/ompi/mca/coll/basic/coll_basic_barrier.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -127,6 +127,6 @@ mca_coll_basic_barrier_inter_lin(struct ompi_communicator_t *comm,
     int result;
 
     rank = ompi_comm_rank(comm);
-    return comm->c_coll.coll_allreduce(&rank, &result, 1, MPI_INT, MPI_MAX,
-                                       comm, comm->c_coll.coll_allreduce_module);
+    return comm->c_coll->coll_allreduce(&rank, &result, 1, MPI_INT, MPI_MAX,
+                                       comm, comm->c_coll->coll_allreduce_module);
 }

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -331,14 +331,14 @@ mca_coll_basic_reduce_scatter_intra(const void *sbuf, void *rbuf, const int *rco
 
         /* reduction */
         err =
-            comm->c_coll.coll_reduce(sbuf, recv_buf, count, dtype, op, 0,
-                                     comm, comm->c_coll.coll_reduce_module);
+            comm->c_coll->coll_reduce(sbuf, recv_buf, count, dtype, op, 0,
+                                     comm, comm->c_coll->coll_reduce_module);
 
         /* scatter */
         if (MPI_SUCCESS == err) {
-            err = comm->c_coll.coll_scatterv(recv_buf, rcounts, disps, dtype,
+            err = comm->c_coll->coll_scatterv(recv_buf, rcounts, disps, dtype,
                                              rbuf, rcounts[rank], dtype, 0,
-                                             comm, comm->c_coll.coll_scatterv_module);
+                                             comm, comm->c_coll->coll_scatterv_module);
         }
     }
 
@@ -469,10 +469,10 @@ mca_coll_basic_reduce_scatter_inter(const void *sbuf, void *rbuf, const int *rco
     }
 
     /* Now do a scatterv on the local communicator */
-    err = comm->c_local_comm->c_coll.coll_scatterv(lbuf, rcounts, disps, dtype,
+    err = comm->c_local_comm->c_coll->coll_scatterv(lbuf, rcounts, disps, dtype,
                                                    rbuf, rcounts[rank], dtype, 0,
                                                    comm->c_local_comm,
-                                                   comm->c_local_comm->c_coll.coll_scatterv_module);
+                                                   comm->c_local_comm->c_coll->coll_scatterv_module);
 
   exit:
     if (NULL != tmpbuf) {

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -92,14 +92,14 @@ mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, int rcou
 
     /* reduction */
     err =
-        comm->c_coll.coll_reduce(sbuf, recv_buf, count, dtype, op, 0,
-                                 comm, comm->c_coll.coll_reduce_module);
+        comm->c_coll->coll_reduce(sbuf, recv_buf, count, dtype, op, 0,
+                                 comm, comm->c_coll->coll_reduce_module);
 
     /* scatter */
     if (MPI_SUCCESS == err) {
-        err = comm->c_coll.coll_scatter(recv_buf, rcount, dtype,
+        err = comm->c_coll->coll_scatter(recv_buf, rcount, dtype,
                                         rbuf, rcount, dtype, 0,
-                                        comm, comm->c_coll.coll_scatter_module);
+                                        comm, comm->c_coll->coll_scatter_module);
     }
 
  cleanup:
@@ -211,10 +211,10 @@ mca_coll_basic_reduce_scatter_block_inter(const void *sbuf, void *rbuf, int rcou
     }
 
     /* Now do a scatterv on the local communicator */
-    err = comm->c_local_comm->c_coll.coll_scatter(lbuf, rcount, dtype,
+    err = comm->c_local_comm->c_coll->coll_scatter(lbuf, rcount, dtype,
 				   rbuf, rcount, dtype, 0,
 				   comm->c_local_comm,
-				   comm->c_local_comm->c_coll.coll_scatter_module);
+				   comm->c_local_comm->c_coll->coll_scatter_module);
 
   exit:
     if (NULL != tmpbuf) {

--- a/ompi/mca/coll/cuda/coll_cuda_allreduce.c
+++ b/ompi/mca/coll/cuda/coll_cuda_allreduce.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 The University of Tennessee and The University
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
@@ -36,7 +36,6 @@ mca_coll_cuda_allreduce(const void *sbuf, void *rbuf, int count,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
-    const char *sbuf2;
     size_t bufsize;
     int rc;
 
@@ -48,7 +47,6 @@ mca_coll_cuda_allreduce(const void *sbuf, void *rbuf, int count,
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
         opal_cuda_memcpy_sync(sbuf1, sbuf, bufsize);
-        sbuf2 = sbuf; /* save away original buffer */
         sbuf = sbuf1 - gap;
     }
 

--- a/ompi/mca/coll/cuda/coll_cuda_exscan.c
+++ b/ompi/mca/coll/cuda/coll_cuda_exscan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 The University of Tennessee and The University
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
@@ -28,7 +28,6 @@ int mca_coll_cuda_exscan(const void *sbuf, void *rbuf, int count,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
-    const char *sbuf2;
     size_t bufsize;
     int rc;
 
@@ -40,7 +39,6 @@ int mca_coll_cuda_exscan(const void *sbuf, void *rbuf, int count,
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
         opal_cuda_memcpy_sync(sbuf1, sbuf, bufsize);
-        sbuf2 = sbuf; /* save away original buffer */
         sbuf = sbuf1 - gap;
     }
 

--- a/ompi/mca/coll/cuda/coll_cuda_module.c
+++ b/ompi/mca/coll/cuda/coll_cuda_module.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014      The University of Tennessee and The University
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
@@ -122,14 +122,14 @@ int mca_coll_cuda_module_enable(mca_coll_base_module_t *module,
     char *msg = NULL;
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
 
-#define CHECK_AND_RETAIN(src, dst, name)               \
-    if (NULL == (src)->c_coll.coll_ ## name ## _module) {   \
-        good = false; \
-        msg = #name; \
-    } else if (good) { \
-        (dst)->c_coll.coll_ ## name ## _module = (src)->c_coll.coll_ ## name ## _module;\
-        (dst)->c_coll.coll_ ## name = (src)->c_coll.coll_ ## name ; \
-        OBJ_RETAIN((src)->c_coll.coll_ ## name ## _module); \
+#define CHECK_AND_RETAIN(src, dst, name)                                                   \
+    if (NULL == (src)->c_coll->coll_ ## name ## _module) {                                 \
+        good = false;                                                                      \
+        msg = #name;                                                                       \
+    } else if (good) {                                                                     \
+        (dst)->c_coll.coll_ ## name ## _module = (src)->c_coll->coll_ ## name ## _module;  \
+        (dst)->c_coll.coll_ ## name = (src)->c_coll->coll_ ## name;                        \
+        OBJ_RETAIN((src)->c_coll->coll_ ## name ## _module);                               \
     }
 
     CHECK_AND_RETAIN(comm, s, allreduce);
@@ -145,11 +145,10 @@ int mca_coll_cuda_module_enable(mca_coll_base_module_t *module,
     /* All done */
     if (good) {
         return OMPI_SUCCESS;
-    } else {
-        orte_show_help("help-mpi-coll-cuda.txt", "missing collective", true,
-                       orte_process_info.nodename,
-                       mca_coll_cuda_component.priority, msg);
-        return OMPI_ERR_NOT_FOUND;
     }
+    orte_show_help("help-mpi-coll-cuda.txt", "missing collective", true,
+                   orte_process_info.nodename,
+                   mca_coll_cuda_component.priority, msg);
+    return OMPI_ERR_NOT_FOUND;
 }
 

--- a/ompi/mca/coll/cuda/coll_cuda_reduce_scatter_block.c
+++ b/ompi/mca/coll/cuda/coll_cuda_reduce_scatter_block.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 The University of Tennessee and The University
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
@@ -40,7 +40,6 @@ mca_coll_cuda_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
-    const char *sbuf2;
     size_t sbufsize, rbufsize;
     int rc;
 
@@ -54,7 +53,6 @@ mca_coll_cuda_reduce_scatter_block(const void *sbuf, void *rbuf, int rcount,
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
         opal_cuda_memcpy_sync(sbuf1, sbuf, sbufsize);
-        sbuf2 = sbuf; /* save away original buffer */
         sbuf = sbuf1 - gap;
     }
 

--- a/ompi/mca/coll/cuda/coll_cuda_scan.c
+++ b/ompi/mca/coll/cuda/coll_cuda_scan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 The University of Tennessee and The University
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2014-2015 NVIDIA Corporation.  All rights reserved.
@@ -35,7 +35,6 @@ int mca_coll_cuda_scan(const void *sbuf, void *rbuf, int count,
     mca_coll_cuda_module_t *s = (mca_coll_cuda_module_t*) module;
     ptrdiff_t gap;
     char *rbuf1 = NULL, *sbuf1 = NULL, *rbuf2 = NULL;
-    const char *sbuf2;
     size_t bufsize;
     int rc;
 
@@ -47,7 +46,6 @@ int mca_coll_cuda_scan(const void *sbuf, void *rbuf, int count,
             return OMPI_ERR_OUT_OF_RESOURCE;
         }
         opal_cuda_memcpy_sync(sbuf1, sbuf, bufsize);
-        sbuf2 = sbuf; /* save away original buffer */
         sbuf = sbuf1 - gap;
     }
 

--- a/ompi/mca/coll/demo/coll_demo_module.c
+++ b/ompi/mca/coll/demo/coll_demo_module.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -166,8 +166,8 @@ mca_coll_demo_comm_query(struct ompi_communicator_t *comm, int *priority)
 
 #define COPY(comm, module, func)                                        \
     do {                                                                \
-        module->underlying.coll_ ## func  = comm->c_coll.coll_ ## func; \
-        module->underlying.coll_ ## func  = comm->c_coll.coll_ ## func; \
+        module->underlying.coll_ ## func  = comm->c_coll->coll_ ## func; \
+        module->underlying.coll_ ## func  = comm->c_coll->coll_ ## func; \
         if (NULL != module->underlying.coll_ ## func ## _module) {      \
             OBJ_RETAIN(module->underlying.coll_ ## func ## _module);    \
         }                                                               \

--- a/ompi/mca/coll/fca/coll_fca_module.c
+++ b/ompi/mca/coll/fca/coll_fca_module.c
@@ -2,6 +2,9 @@
  * Copyright (c) 2011      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,8 +121,8 @@ static int __fca_comm_new(mca_coll_fca_module_t *fca_module)
     }
 
     /* Get all rank info sizes using MPI_Gather */
-    rc = comm->c_coll.coll_gather(&info_size, 1, MPI_INT, rcounts, 1, MPI_INT, 0,
-                                  comm, comm->c_coll.coll_gather_module);
+    rc = comm->c_coll->coll_gather(&info_size, 1, MPI_INT, rcounts, 1, MPI_INT, 0,
+                                  comm, comm->c_coll->coll_gather_module);
     if (rc != OMPI_SUCCESS)
         return rc;
 
@@ -144,9 +147,9 @@ static int __fca_comm_new(mca_coll_fca_module_t *fca_module)
     }
 
     /* Send all node managers information to rank0 using MPI_Gatherv */
-    rc = comm->c_coll.coll_gatherv(my_info, info_size, MPI_BYTE,
+    rc = comm->c_coll->coll_gatherv(my_info, info_size, MPI_BYTE,
                                    all_info, rcounts, displs, MPI_BYTE, 0,
-                                   comm, comm->c_coll.coll_gather_module);
+                                   comm, comm->c_coll->coll_gather_module);
     if (rc != OMPI_SUCCESS) {
         FCA_ERROR("Failed to gather rank information to rank0: %d", rc);
         return rc;
@@ -284,7 +287,7 @@ static int __create_fca_comm(mca_coll_fca_module_t *fca_module)
                 }
 
                 part_of_hash_index = modular_pow(cm->fca_primes[grank % cm->fca_number_of_primes], grank, cm->fca_hash_size);
-                rc = comm->c_coll.coll_allreduce(&part_of_hash_index, &hash_index, 1, MPI_INT, MPI_SUM, comm, comm->c_coll.coll_allreduce_module);
+                rc = comm->c_coll->coll_allreduce(&part_of_hash_index, &hash_index, 1, MPI_INT, MPI_SUM, comm, comm->c_coll->coll_allreduce_module);
                 if (rc != OMPI_SUCCESS) {
                     FCA_ERROR("Failed to reduce hash_index: %d", rc);
                     return rc;
@@ -448,9 +451,9 @@ static void __destroy_fca_comm(mca_coll_fca_module_t *fca_module)
 }
 
 #define FCA_SAVE_PREV_COLL_API(__api) do {\
-    fca_module->previous_ ## __api            = comm->c_coll.coll_ ## __api;\
-    fca_module->previous_ ## __api ## _module = comm->c_coll.coll_ ## __api ## _module;\
-    if (!comm->c_coll.coll_ ## __api || !comm->c_coll.coll_ ## __api ## _module) {\
+    fca_module->previous_ ## __api            = comm->c_coll->coll_ ## __api;\
+    fca_module->previous_ ## __api ## _module = comm->c_coll->coll_ ## __api ## _module;\
+    if (!comm->c_coll->coll_ ## __api || !comm->c_coll->coll_ ## __api ## _module) {\
         FCA_VERBOSE(1, "(%d/%s): no underlying " # __api"; disqualifying myself",\
                     comm->c_contextid, comm->c_name);\
         return OMPI_ERROR;\

--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -1,11 +1,14 @@
 /**
-  Copyright (c) 2011 Mellanox Technologies. All rights reserved.
-  Copyright (c) 2016      IBM Corporation.  All rights reserved.
-  $COPYRIGHT$
-
-  Additional copyrights may follow
-
- $HEADER$
+ * Copyright (c) 2011 Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
  */
 
 #include "ompi_config.h"
@@ -149,9 +152,9 @@ static void mca_coll_hcoll_module_destruct(mca_coll_hcoll_module_t *hcoll_module
 }
 
 #define HCOL_SAVE_PREV_COLL_API(__api) do {\
-    hcoll_module->previous_ ## __api            = comm->c_coll.coll_ ## __api;\
-    hcoll_module->previous_ ## __api ## _module = comm->c_coll.coll_ ## __api ## _module;\
-    if (!comm->c_coll.coll_ ## __api || !comm->c_coll.coll_ ## __api ## _module) {\
+    hcoll_module->previous_ ## __api            = comm->c_coll->coll_ ## __api;\
+    hcoll_module->previous_ ## __api ## _module = comm->c_coll->coll_ ## __api ## _module;\
+    if (!comm->c_coll->coll_ ## __api || !comm->c_coll->coll_ ## __api ## _module) {\
         return OMPI_ERROR;\
     }\
     OBJ_RETAIN(hcoll_module->previous_ ## __api ## _module);\

--- a/ompi/mca/coll/inter/coll_inter_allgather.c
+++ b/ompi/mca/coll/inter/coll_inter_allgather.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -66,10 +66,10 @@ mca_coll_inter_allgather_inter(const void *sbuf, int scount,
 	}
         ptmp = ptmp_free - gap;
 
-	err = comm->c_local_comm->c_coll.coll_gather(sbuf, scount, sdtype,
+	err = comm->c_local_comm->c_coll->coll_gather(sbuf, scount, sdtype,
 						     ptmp, scount, sdtype,
 						     0, comm->c_local_comm,
-						     comm->c_local_comm->c_coll.coll_gather_module);
+						     comm->c_local_comm->c_coll->coll_gather_module);
 	if (OMPI_SUCCESS != err) {
 	    goto exit;
 	}
@@ -99,9 +99,9 @@ mca_coll_inter_allgather_inter(const void *sbuf, int scount,
     }
     /* bcast the message to all the local processes */
     if ( rcount > 0 ) {
-	err = comm->c_local_comm->c_coll.coll_bcast(rbuf, rcount*rsize, rdtype,
+	err = comm->c_local_comm->c_coll->coll_bcast(rbuf, rcount*rsize, rdtype,
 						    root, comm->c_local_comm,
-						    comm->c_local_comm->c_coll.coll_bcast_module);
+						    comm->c_local_comm->c_coll->coll_bcast_module);
 	if (OMPI_SUCCESS != err) {
 	    goto exit;
 	}

--- a/ompi/mca/coll/inter/coll_inter_allgatherv.c
+++ b/ompi/mca/coll/inter/coll_inter_allgatherv.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -66,10 +66,10 @@ mca_coll_inter_allgatherv_inter(const void *sbuf, int scount,
 	}
     }
     /* Local gather to get the scount of each process */
-    err = comm->c_local_comm->c_coll.coll_gather(&scount, 1, MPI_INT,
+    err = comm->c_local_comm->c_coll->coll_gather(&scount, 1, MPI_INT,
 						 count, 1, MPI_INT,
 						 0, comm->c_local_comm,
-                                                 comm->c_local_comm->c_coll.coll_gather_module);
+                                                 comm->c_local_comm->c_coll->coll_gather_module);
     if (OMPI_SUCCESS != err) {
         goto exit;
     }
@@ -93,10 +93,10 @@ mca_coll_inter_allgatherv_inter(const void *sbuf, int scount,
             ptmp = ptmp_free - gap;
 	}
     }
-    err = comm->c_local_comm->c_coll.coll_gatherv(sbuf, scount, sdtype,
+    err = comm->c_local_comm->c_coll->coll_gatherv(sbuf, scount, sdtype,
 						  ptmp, count, displace,
 						  sdtype,0, comm->c_local_comm,
-                                                  comm->c_local_comm->c_coll.coll_gatherv_module);
+                                                  comm->c_local_comm->c_coll->coll_gatherv_module);
     if (OMPI_SUCCESS != err) {
         goto exit;
     }
@@ -128,9 +128,9 @@ mca_coll_inter_allgatherv_inter(const void *sbuf, int scount,
     }
 
     /* bcast the message to all the local processes */
-    err = comm->c_local_comm->c_coll.coll_bcast(rbuf, 1, ndtype,
+    err = comm->c_local_comm->c_coll->coll_bcast(rbuf, 1, ndtype,
 						0, comm->c_local_comm,
-                                                comm->c_local_comm->c_coll.coll_bcast_module);
+                                                comm->c_local_comm->c_coll->coll_bcast_module);
   exit:
     if( NULL != ndtype ) {
         ompi_datatype_destroy(&ndtype);

--- a/ompi/mca/coll/inter/coll_inter_allreduce.c
+++ b/ompi/mca/coll/inter/coll_inter_allreduce.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -63,10 +63,10 @@ mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, int count,
     }
     pml_buffer = tmpbuf - gap;
 
-    err = comm->c_local_comm->c_coll.coll_reduce(sbuf, pml_buffer, count,
+    err = comm->c_local_comm->c_coll->coll_reduce(sbuf, pml_buffer, count,
 						 dtype, op, root,
 						 comm->c_local_comm,
-                                                 comm->c_local_comm->c_coll.coll_reduce_module);
+                                                 comm->c_local_comm->c_coll->coll_reduce_module);
     if (OMPI_SUCCESS != err) {
 	goto exit;
     }
@@ -95,9 +95,9 @@ mca_coll_inter_allreduce_inter(const void *sbuf, void *rbuf, int count,
     }
 
     /* bcast the message to all the local processes */
-    err = comm->c_local_comm->c_coll.coll_bcast(rbuf, count, dtype,
+    err = comm->c_local_comm->c_coll->coll_bcast(rbuf, count, dtype,
 						root, comm->c_local_comm,
-                                                comm->c_local_comm->c_coll.coll_bcast_module);
+                                                comm->c_local_comm->c_coll->coll_bcast_module);
     if (OMPI_SUCCESS != err) {
             goto exit;
     }

--- a/ompi/mca/coll/inter/coll_inter_bcast.c
+++ b/ompi/mca/coll/inter/coll_inter_bcast.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -60,9 +60,9 @@ mca_coll_inter_bcast_inter(void *buff, int count,
                 return err;
             }
 	}
-	err = comm->c_local_comm->c_coll.coll_bcast(buff, count, datatype, 0,
+	err = comm->c_local_comm->c_coll->coll_bcast(buff, count, datatype, 0,
                                                     comm->c_local_comm,
-                                                    comm->c_local_comm->c_coll.coll_bcast_module);
+                                                    comm->c_local_comm->c_coll->coll_bcast_module);
     } else {
         /* root section, send to the first process of the remote group */
 	err = MCA_PML_CALL(send(buff, count, datatype, 0,

--- a/ompi/mca/coll/inter/coll_inter_gather.c
+++ b/ompi/mca/coll/inter/coll_inter_gather.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -70,10 +70,10 @@ mca_coll_inter_gather_inter(const void *sbuf, int scount,
         }
         ptmp = ptmp_free - gap;
 
-	err = comm->c_local_comm->c_coll.coll_gather(sbuf, scount, sdtype,
+	err = comm->c_local_comm->c_coll->coll_gather(sbuf, scount, sdtype,
 						     ptmp, scount, sdtype,
 						     0, comm->c_local_comm,
-                                                     comm->c_local_comm->c_coll.coll_gather_module);
+                                                     comm->c_local_comm->c_coll->coll_gather_module);
 	if (0 == rank) {
 	    /* First process sends data to the root */
 	    err = MCA_PML_CALL(send(ptmp, scount*size_local, sdtype, root,

--- a/ompi/mca/coll/inter/coll_inter_gatherv.c
+++ b/ompi/mca/coll/inter/coll_inter_gatherv.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -76,10 +76,10 @@ mca_coll_inter_gatherv_inter(const void *sbuf, int scount,
         }
     }
 
-    err = comm->c_local_comm->c_coll.coll_gather(&scount, 1, MPI_INT,
+    err = comm->c_local_comm->c_coll->coll_gather(&scount, 1, MPI_INT,
                                                  count, 1, MPI_INT,
                                                  0, comm->c_local_comm,
-                                                 comm->c_local_comm->c_coll.coll_gather_module);
+                                                 comm->c_local_comm->c_coll->coll_gather_module);
     if (OMPI_SUCCESS != err) {
         goto exit;
     }
@@ -103,10 +103,10 @@ mca_coll_inter_gatherv_inter(const void *sbuf, int scount,
             ptmp = ptmp_free - gap;
         }
     }
-    err = comm->c_local_comm->c_coll.coll_gatherv(sbuf, scount, sdtype,
+    err = comm->c_local_comm->c_coll->coll_gatherv(sbuf, scount, sdtype,
                                                   ptmp, count, displace,
                                                   sdtype,0, comm->c_local_comm,
-                                                  comm->c_local_comm->c_coll.coll_gatherv_module);
+                                                  comm->c_local_comm->c_coll->coll_gatherv_module);
     if (OMPI_SUCCESS != err) {
         goto exit;
     }

--- a/ompi/mca/coll/inter/coll_inter_reduce.c
+++ b/ompi/mca/coll/inter/coll_inter_reduce.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -68,9 +68,9 @@ mca_coll_inter_reduce_inter(const void *sbuf, void *rbuf, int count,
 	}
 	pml_buffer = free_buffer - gap;
 
-	err = comm->c_local_comm->c_coll.coll_reduce(sbuf, pml_buffer, count,
+	err = comm->c_local_comm->c_coll->coll_reduce(sbuf, pml_buffer, count,
 						     dtype, op, 0, comm->c_local_comm,
-                                                     comm->c_local_comm->c_coll.coll_reduce_module);
+                                                     comm->c_local_comm->c_coll->coll_reduce_module);
 	if (0 == rank) {
 	    /* First process sends the result to the root */
 	    err = MCA_PML_CALL(send(pml_buffer, count, dtype, root,

--- a/ompi/mca/coll/inter/coll_inter_scatter.c
+++ b/ompi/mca/coll/inter/coll_inter_scatter.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -77,10 +77,10 @@ mca_coll_inter_scatter_inter(const void *sbuf, int scount,
             }
 	}
 	/* Perform the scatter locally with the first process as root */
-	err = comm->c_local_comm->c_coll.coll_scatter(ptmp, rcount, rdtype,
+	err = comm->c_local_comm->c_coll->coll_scatter(ptmp, rcount, rdtype,
 						      rbuf, rcount, rdtype,
 						      0, comm->c_local_comm,
-                                                      comm->c_local_comm->c_coll.coll_scatter_module);
+                                                      comm->c_local_comm->c_coll->coll_scatter_module);
 	if (NULL != ptmp_free) {
 	    free(ptmp_free);
 	}

--- a/ompi/mca/coll/inter/coll_inter_scatterv.c
+++ b/ompi/mca/coll/inter/coll_inter_scatterv.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -96,10 +96,10 @@ mca_coll_inter_scatterv_inter(const void *sbuf, const int *scounts,
 	    }
 	}
 	/* perform the scatterv locally */
-	err = comm->c_local_comm->c_coll.coll_scatterv(ptmp, counts, displace,
+	err = comm->c_local_comm->c_coll->coll_scatterv(ptmp, counts, displace,
 						       rdtype, rbuf, rcount,
 						       rdtype, 0, comm->c_local_comm,
-                                                       comm->c_local_comm->c_coll.coll_scatterv_module);
+                                                       comm->c_local_comm->c_coll->coll_scatterv_module);
 	if (OMPI_SUCCESS != err) {
 	    return err;
 	}

--- a/ompi/mca/coll/portals4/coll_portals4_component.c
+++ b/ompi/mca/coll/portals4/coll_portals4_component.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -123,9 +123,9 @@ ptl_datatype_t ompi_coll_portals4_atomic_datatype [OMPI_DATATYPE_MPI_MAX_PREDEFI
 
 #define PORTALS4_SAVE_PREV_COLL_API(__module, __comm, __api)                                \
     do {                                                                                    \
-        __module->previous_ ## __api            = __comm->c_coll.coll_ ## __api;            \
-        __module->previous_ ## __api ## _module = __comm->c_coll.coll_ ## __api ## _module; \
-        if (!comm->c_coll.coll_ ## __api || !comm->c_coll.coll_ ## __api ## _module) {      \
+        __module->previous_ ## __api            = __comm->c_coll->coll_ ## __api;            \
+        __module->previous_ ## __api ## _module = __comm->c_coll->coll_ ## __api ## _module; \
+        if (!comm->c_coll->coll_ ## __api || !comm->c_coll->coll_ ## __api ## _module) {      \
             opal_output_verbose(1, ompi_coll_base_framework.framework_output,               \
                     "(%d/%s): no underlying " # __api"; disqualifying myself",              \
                     __comm->c_contextid, __comm->c_name);                                   \

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -224,8 +224,8 @@ mca_coll_sm_comm_query(struct ompi_communicator_t *comm, int *priority)
 static int sm_module_enable(mca_coll_base_module_t *module,
                             struct ompi_communicator_t *comm)
 {
-    if (NULL == comm->c_coll.coll_reduce ||
-        NULL == comm->c_coll.coll_reduce_module) {
+    if (NULL == comm->c_coll->coll_reduce ||
+        NULL == comm->c_coll->coll_reduce_module) {
         opal_output_verbose(10, ompi_coll_base_framework.framework_output,
                             "coll:sm:enable (%d/%s): no underlying reduce; disqualifying myself",
                             comm->c_contextid, comm->c_name);
@@ -458,8 +458,8 @@ int ompi_coll_sm_lazy_enable(mca_coll_base_module_t *module,
     }
 
     /* Save previous component's reduce information */
-    sm_module->previous_reduce = comm->c_coll.coll_reduce;
-    sm_module->previous_reduce_module = comm->c_coll.coll_reduce_module;
+    sm_module->previous_reduce = comm->c_coll->coll_reduce;
+    sm_module->previous_reduce_module = comm->c_coll->coll_reduce_module;
     OBJ_RETAIN(sm_module->previous_reduce_module);
 
     /* Indicate that we have successfully attached and setup */

--- a/ompi/mca/coll/sync/coll_sync_bcast.c
+++ b/ompi/mca/coll/sync/coll_sync_bcast.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
@@ -40,8 +40,7 @@ int mca_coll_sync_bcast(void *buff, int count,
     if (s->in_operation) {
         return s->c_coll.coll_bcast(buff, count, datatype, root, comm,
                                     s->c_coll.coll_bcast_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_bcast(buff, count, datatype, root, comm,
-                                          s->c_coll.coll_bcast_module));
     }
+    COLL_SYNC(s, s->c_coll.coll_bcast(buff, count, datatype, root, comm,
+                                      s->c_coll.coll_bcast_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_exscan.c
+++ b/ompi/mca/coll/sync/coll_sync_exscan.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -40,8 +40,7 @@ int mca_coll_sync_exscan(const void *sbuf, void *rbuf, int count,
     if (s->in_operation) {
         return s->c_coll.coll_exscan(sbuf, rbuf, count, dtype, op, comm,
                                        s->c_coll.coll_exscan_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_exscan(sbuf, rbuf, count, dtype, op, comm,
-                                           s->c_coll.coll_exscan_module));
     }
+    COLL_SYNC(s, s->c_coll.coll_exscan(sbuf, rbuf, count, dtype, op, comm,
+                                       s->c_coll.coll_exscan_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_gather.c
+++ b/ompi/mca/coll/sync/coll_sync_gather.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -40,11 +40,10 @@ int mca_coll_sync_gather(const void *sbuf, int scount,
 
     if (s->in_operation) {
         return s->c_coll.coll_gather(sbuf, scount, sdtype,
-                                    rbuf, rcount, rdtype, root, comm,
-                                    s->c_coll.coll_gather_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_gather(sbuf, scount, sdtype,
-                                           rbuf, rcount, rdtype, root, comm,
-                                           s->c_coll.coll_gather_module));
+                                     rbuf, rcount, rdtype, root, comm,
+                                     s->c_coll.coll_gather_module);
     }
+    COLL_SYNC(s, s->c_coll.coll_gather(sbuf, scount, sdtype,
+                                       rbuf, rcount, rdtype, root, comm,
+                                       s->c_coll.coll_gather_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_gatherv.c
+++ b/ompi/mca/coll/sync/coll_sync_gatherv.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -40,12 +40,11 @@ int mca_coll_sync_gatherv(const void *sbuf, int scount,
 
     if (s->in_operation) {
         return s->c_coll.coll_gatherv(sbuf, scount, sdtype,
-                                     rbuf, rcounts, disps, rdtype, root, comm,
-                                     s->c_coll.coll_gatherv_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_gatherv(sbuf, scount, sdtype,
-                                            rbuf, rcounts, disps, rdtype,
-                                            root, comm,
-                                            s->c_coll.coll_gatherv_module));
+                                      rbuf, rcounts, disps, rdtype, root, comm,
+                                      s->c_coll.coll_gatherv_module);
     }
+    COLL_SYNC(s, s->c_coll.coll_gatherv(sbuf, scount, sdtype,
+                                        rbuf, rcounts, disps, rdtype,
+                                        root, comm,
+                                        s->c_coll.coll_gatherv_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_module.c
+++ b/ompi/mca/coll/sync/coll_sync_module.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -146,14 +146,14 @@ int mca_coll_sync_module_enable(mca_coll_base_module_t *module,
     mca_coll_sync_module_t *s = (mca_coll_sync_module_t*) module;
 
     /* Save the prior layer of coll functions */
-    s->c_coll = comm->c_coll;
+    s->c_coll = *comm->c_coll;
 
-#define CHECK_AND_RETAIN(name) \
-    if (NULL == s->c_coll.coll_ ## name ## _module) { \
-        good = false; \
-        msg = #name; \
-    } else if (good) { \
-        OBJ_RETAIN(s->c_coll.coll_ ## name ## _module); \
+#define CHECK_AND_RETAIN(name)                           \
+    if (NULL == s->c_coll.coll_ ## name ## _module) {    \
+        good = false;                                    \
+        msg = #name;                                     \
+    } else if (good) {                                   \
+        OBJ_RETAIN(s->c_coll.coll_ ## name ## _module);  \
     }
 
     CHECK_AND_RETAIN(bcast);
@@ -172,12 +172,11 @@ int mca_coll_sync_module_enable(mca_coll_base_module_t *module,
     /* All done */
     if (good) {
         return OMPI_SUCCESS;
-    } else {
-        orte_show_help("help-coll-sync.txt", "missing collective", true,
-                       orte_process_info.nodename,
-                       mca_coll_sync_component.priority, msg);
-        return OMPI_ERR_NOT_FOUND;
     }
+    orte_show_help("help-coll-sync.txt", "missing collective", true,
+                   orte_process_info.nodename,
+                   mca_coll_sync_component.priority, msg);
+    return OMPI_ERR_NOT_FOUND;
 }
 
 

--- a/ompi/mca/coll/sync/coll_sync_reduce.c
+++ b/ompi/mca/coll/sync/coll_sync_reduce.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -38,10 +38,9 @@ int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
 
     if (s->in_operation) {
         return s->c_coll.coll_reduce(sbuf, rbuf, count, dtype, op, root, comm,
-                                    s->c_coll.coll_reduce_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_reduce(sbuf, rbuf, count, dtype,
-                                           op, root, comm,
-                                           s->c_coll.coll_reduce_module));
+                                     s->c_coll.coll_reduce_module);
     }
+    COLL_SYNC(s, s->c_coll.coll_reduce(sbuf, rbuf, count, dtype,
+                                       op, root, comm,
+                                       s->c_coll.coll_reduce_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
+++ b/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -40,11 +40,10 @@ int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf, const int *rcount
 
     if (s->in_operation) {
         return s->c_coll.coll_reduce_scatter(sbuf, rbuf, rcounts,
-                                            dtype, op, comm,
-                                            s->c_coll.coll_reduce_scatter_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_reduce_scatter(sbuf, rbuf, rcounts,
-                                                   dtype, op, comm,
-                                                   s->c_coll.coll_reduce_scatter_module));
+                                             dtype, op, comm,
+                                             s->c_coll.coll_reduce_scatter_module);
     }
+    COLL_SYNC(s, s->c_coll.coll_reduce_scatter(sbuf, rbuf, rcounts,
+                                               dtype, op, comm,
+                                               s->c_coll.coll_reduce_scatter_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_scan.c
+++ b/ompi/mca/coll/sync/coll_sync_scan.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -38,9 +38,8 @@ int mca_coll_sync_scan(const void *sbuf, void *rbuf, int count,
 
     if (s->in_operation) {
         return s->c_coll.coll_scan(sbuf, rbuf, count, dtype, op, comm,
-                                  s->c_coll.coll_scan_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_scan(sbuf, rbuf, count, dtype, op, comm,
-                                         s->c_coll.coll_scan_module));
+                                   s->c_coll.coll_scan_module);
     }
+    COLL_SYNC(s, s->c_coll.coll_scan(sbuf, rbuf, count, dtype, op, comm,
+                                     s->c_coll.coll_scan_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_scatter.c
+++ b/ompi/mca/coll/sync/coll_sync_scatter.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -40,11 +40,10 @@ int mca_coll_sync_scatter(const void *sbuf, int scount,
 
     if (s->in_operation) {
         return s->c_coll.coll_scatter(sbuf, scount, sdtype,
-                                     rbuf, rcount, rdtype, root, comm,
-                                     s->c_coll.coll_scatter_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_scatter(sbuf, scount, sdtype,
-                                            rbuf, rcount, rdtype, root, comm,
-                                            s->c_coll.coll_scatter_module));
+                                      rbuf, rcount, rdtype, root, comm,
+                                      s->c_coll.coll_scatter_module);
     }
+    COLL_SYNC(s, s->c_coll.coll_scatter(sbuf, scount, sdtype,
+                                        rbuf, rcount, rdtype, root, comm,
+                                        s->c_coll.coll_scatter_module));
 }

--- a/ompi/mca/coll/sync/coll_sync_scatterv.c
+++ b/ompi/mca/coll/sync/coll_sync_scatterv.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -40,11 +40,10 @@ int mca_coll_sync_scatterv(const void *sbuf, const int *scounts,
 
     if (s->in_operation) {
         return s->c_coll.coll_scatterv(sbuf, scounts, disps, sdtype,
-                                      rbuf, rcount, rdtype, root, comm,
-                                      s->c_coll.coll_scatterv_module);
-    } else {
-        COLL_SYNC(s, s->c_coll.coll_scatterv(sbuf, scounts, disps, sdtype,
-                                             rbuf, rcount, rdtype, root, comm,
-                                             s->c_coll.coll_scatterv_module));
+                                       rbuf, rcount, rdtype, root, comm,
+                                       s->c_coll.coll_scatterv_module);
     }
+    COLL_SYNC(s, s->c_coll.coll_scatterv(sbuf, scounts, disps, sdtype,
+                                         rbuf, rcount, rdtype, root, comm,
+                                         s->c_coll.coll_scatterv_module));
 }

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -236,7 +236,7 @@ int mca_common_ompio_file_close (mca_io_ompio_file_t *ompio_fh)
     int delete_flag = 0;
     char name[256];
 
-    ret = ompio_fh->f_comm->c_coll.coll_barrier ( ompio_fh->f_comm, ompio_fh->f_comm->c_coll.coll_barrier_module);
+    ret = ompio_fh->f_comm->c_coll->coll_barrier ( ompio_fh->f_comm, ompio_fh->f_comm->c_coll->coll_barrier_module);
     if ( OMPI_SUCCESS != ret ) {
         /* Not sure what to do */
         opal_output (1,"mca_common_ompio_file_close: error in Barrier \n");

--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -238,13 +238,13 @@ OMPI_MPI_OFFSET_TYPE get_contiguous_chunk_size (mca_io_ompio_file_t *fh)
     avg[1] = (OMPI_MPI_OFFSET_TYPE) fh->f_iov_count;
     avg[2] = (OMPI_MPI_OFFSET_TYPE) uniform;
 
-    fh->f_comm->c_coll.coll_allreduce (avg,
+    fh->f_comm->c_coll->coll_allreduce (avg,
                                        global_avg,
                                        3,
                                        OMPI_OFFSET_DATATYPE,
                                        MPI_SUM,
                                        fh->f_comm,
-                                       fh->f_comm->c_coll.coll_allreduce_module);
+                                       fh->f_comm->c_coll->coll_allreduce_module);
     global_avg[0] = global_avg[0]/fh->f_size;
     global_avg[1] = global_avg[1]/fh->f_size;
 
@@ -265,13 +265,13 @@ OMPI_MPI_OFFSET_TYPE get_contiguous_chunk_size (mca_io_ompio_file_t *fh)
     /* second confirmation round to see whether all processes agree
     ** on having a uniform file view or not
     */
-    fh->f_comm->c_coll.coll_allreduce (&uniform,
+    fh->f_comm->c_coll->coll_allreduce (&uniform,
 				       &global_uniform,
 				       1,
 				       MPI_INT,
 				       MPI_MAX,
 				       fh->f_comm,
-				       fh->f_comm->c_coll.coll_allreduce_module);
+				       fh->f_comm->c_coll->coll_allreduce_module);
 
     if ( 0 == global_uniform  ){
 	/* yes, everybody agrees on having a uniform file view */

--- a/ompi/mca/common/ompio/common_ompio_print_queue.c
+++ b/ompi/mca/common/ompio/common_ompio_print_queue.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -157,7 +157,7 @@ int mca_common_ompio_print_time_info( struct mca_common_ompio_print_queue *q,
 	}
     }
 
-    ret = fh->f_comm->c_coll.coll_gather(time_details,
+    ret = fh->f_comm->c_coll->coll_gather(time_details,
                                          4,
                                          MPI_DOUBLE,
                                          final_time_details,
@@ -165,7 +165,7 @@ int mca_common_ompio_print_time_info( struct mca_common_ompio_print_queue *q,
                                          MPI_DOUBLE,
                                          0,
                                          fh->f_comm,
-                                         fh->f_comm->c_coll.coll_gather_module);
+                                         fh->f_comm->c_coll->coll_gather_module);
     
     if ( OMPI_SUCCESS != ret ) {
     }

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -264,14 +264,14 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
     start_comm_time = MPI_Wtime();
 #endif
     if ( 1 == mca_fcoll_dynamic_gen2_num_groups ) {
-        ret = fh->f_comm->c_coll.coll_allgather (broken_total_lengths,
+        ret = fh->f_comm->c_coll->coll_allgather (broken_total_lengths,
                                                  dynamic_gen2_num_io_procs,
                                                  MPI_LONG,
                                                  total_bytes_per_process,
                                                  dynamic_gen2_num_io_procs,
                                                  MPI_LONG,
                                                  fh->f_comm,
-                                                 fh->f_comm->c_coll.coll_allgather_module);
+                                                 fh->f_comm->c_coll->coll_allgather_module);
     }
     else {
         ret = fcoll_base_coll_allgather_array (broken_total_lengths,
@@ -323,14 +323,14 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
     start_comm_time = MPI_Wtime();
 #endif
     if ( 1 == mca_fcoll_dynamic_gen2_num_groups ) {
-        ret = fh->f_comm->c_coll.coll_allgather(broken_counts,
+        ret = fh->f_comm->c_coll->coll_allgather(broken_counts,
                                                 dynamic_gen2_num_io_procs,
                                                 MPI_INT,
                                                 result_counts,
                                                 dynamic_gen2_num_io_procs,
                                                 MPI_INT,
                                                 fh->f_comm,
-                                                fh->f_comm->c_coll.coll_allgather_module);            
+                                                fh->f_comm->c_coll->coll_allgather_module);            
     }
     else {
         ret = fcoll_base_coll_allgather_array (broken_counts,
@@ -409,7 +409,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
         start_comm_time = MPI_Wtime();
 #endif
         if ( 1 == mca_fcoll_dynamic_gen2_num_groups ) {
-            ret = fh->f_comm->c_coll.coll_allgatherv (broken_iov_arrays[i],
+            ret = fh->f_comm->c_coll->coll_allgatherv (broken_iov_arrays[i],
                                                       broken_counts[i],
                                                       fh->f_iov_type,
                                                       aggr_data[i]->global_iov_array,
@@ -417,7 +417,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
                                                       displs,
                                                       fh->f_iov_type,
                                                       fh->f_comm,
-                                                      fh->f_comm->c_coll.coll_allgatherv_module );
+                                                      fh->f_comm->c_coll->coll_allgatherv_module );
         }
         else {
             ret = fcoll_base_coll_allgatherv_array (broken_iov_arrays[i],

--- a/ompi/mca/fcoll/static/fcoll_static_file_read_all.c
+++ b/ompi/mca/fcoll/static/fcoll_static_file_read_all.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -213,13 +213,13 @@ mca_fcoll_static_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rexch = MPI_Wtime();
 #endif
-    ret = fh->f_comm->c_coll.coll_allreduce (&local_cycles,
+    ret = fh->f_comm->c_coll->coll_allreduce (&local_cycles,
                                              &cycles,
                                              1,
                                              MPI_INT,
                                              MPI_MAX,
                                              fh->f_comm,
-                                             fh->f_comm->c_coll.coll_allreduce_module);
+                                             fh->f_comm->c_coll->coll_allreduce_module);
 
     if (OMPI_SUCCESS != ret){
         goto exit;

--- a/ompi/mca/fcoll/static/fcoll_static_file_write_all.c
+++ b/ompi/mca/fcoll/static/fcoll_static_file_write_all.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -207,13 +207,13 @@ mca_fcoll_static_file_write_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_exch = MPI_Wtime();
 #endif
-    ret = fh->f_comm->c_coll.coll_allreduce (&local_cycles,
+    ret = fh->f_comm->c_coll->coll_allreduce (&local_cycles,
                                              &cycles,
                                              1,
                                              MPI_INT,
                                              MPI_MAX,
                                              fh->f_comm,
-                                             fh->f_comm->c_coll.coll_allreduce_module);
+                                             fh->f_comm->c_coll->coll_allreduce_module);
 
     if (OMPI_SUCCESS != ret){
         fprintf(stderr,"local cycles allreduce!\n");

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -220,13 +220,13 @@ mca_fcoll_two_phase_file_read_all (mca_io_ompio_file_t *fh,
     }
 
     long_max_data = (long) max_data;
-    ret = fh->f_comm->c_coll.coll_allreduce (&long_max_data,
+    ret = fh->f_comm->c_coll->coll_allreduce (&long_max_data,
 					     &long_total_bytes,
 					     1,
 					     MPI_LONG,
 					     MPI_SUM,
 					     fh->f_comm,
-					     fh->f_comm->c_coll.coll_allreduce_module);
+					     fh->f_comm->c_coll->coll_allreduce_module);
 
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
@@ -334,27 +334,27 @@ mca_fcoll_two_phase_file_read_all (mca_io_ompio_file_t *fh,
 	goto exit;
     }
 
-    ret = fh->f_comm->c_coll.coll_allgather(&start_offset,
+    ret = fh->f_comm->c_coll->coll_allgather(&start_offset,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    start_offsets,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    fh->f_comm,
-					    fh->f_comm->c_coll.coll_allgather_module);
+					    fh->f_comm->c_coll->coll_allgather_module);
 
     if ( OMPI_SUCCESS != ret ){
 	goto exit;
     }
 
-    ret = fh->f_comm->c_coll.coll_allgather(&end_offset,
+    ret = fh->f_comm->c_coll->coll_allgather(&end_offset,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    end_offsets,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    fh->f_comm,
-					    fh->f_comm->c_coll.coll_allgather_module);
+					    fh->f_comm->c_coll->coll_allgather_module);
 
 
     if ( OMPI_SUCCESS != ret ){
@@ -573,13 +573,13 @@ static int two_phase_read_and_exch(mca_io_ompio_file_t *fh,
 	ntimes = 0;
     }
 
-    fh->f_comm->c_coll.coll_allreduce (&ntimes,
+    fh->f_comm->c_coll->coll_allreduce (&ntimes,
 				       &max_ntimes,
 				       1,
 				       MPI_INT,
 				       MPI_MAX,
 				       fh->f_comm,
-				       fh->f_comm->c_coll.coll_allreduce_module);
+				       fh->f_comm->c_coll->coll_allreduce_module);
 
     if (ntimes){
 	read_buf = (char *) calloc (two_phase_cycle_buffer_size, sizeof(char));
@@ -837,14 +837,14 @@ static int two_phase_exchange_data(mca_io_ompio_file_t *fh,
     start_rcomm_time = MPI_Wtime();
 #endif
 
-    ret = fh->f_comm->c_coll.coll_alltoall (send_size,
+    ret = fh->f_comm->c_coll->coll_alltoall (send_size,
 					    1,
 					    MPI_INT,
 					    recv_size,
 					    1,
 					    MPI_INT,
 					    fh->f_comm,
-					    fh->f_comm->c_coll.coll_alltoall_module);
+					    fh->f_comm->c_coll->coll_alltoall_module);
 
     if ( OMPI_SUCCESS != ret ){
 	goto exit;

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -264,13 +264,13 @@ mca_fcoll_two_phase_file_write_all (mca_io_ompio_file_t *fh,
     }
 
     long_max_data = (long) max_data;
-    ret = fh->f_comm->c_coll.coll_allreduce (&long_max_data,
+    ret = fh->f_comm->c_coll->coll_allreduce (&long_max_data,
 					     &long_total_bytes,
 					     1,
 					     MPI_LONG,
 					     MPI_SUM,
 					     fh->f_comm,
-					     fh->f_comm->c_coll.coll_allreduce_module);
+					     fh->f_comm->c_coll->coll_allreduce_module);
 
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
@@ -392,28 +392,28 @@ mca_fcoll_two_phase_file_write_all (mca_io_ompio_file_t *fh,
     }
 
 
-    ret = fh->f_comm->c_coll.coll_allgather(&start_offset,
+    ret = fh->f_comm->c_coll->coll_allgather(&start_offset,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    start_offsets,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    fh->f_comm,
-					    fh->f_comm->c_coll.coll_allgather_module);
+					    fh->f_comm->c_coll->coll_allgather_module);
 
     if ( OMPI_SUCCESS != ret ){
 	goto exit;
     }
 
 
-    ret = fh->f_comm->c_coll.coll_allgather(&end_offset,
+    ret = fh->f_comm->c_coll->coll_allgather(&end_offset,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    end_offsets,
 					    1,
 					    OMPI_OFFSET_DATATYPE,
 					    fh->f_comm,
-					    fh->f_comm->c_coll.coll_allgather_module);
+					    fh->f_comm->c_coll->coll_allgather_module);
 
 
     if ( OMPI_SUCCESS != ret ){
@@ -642,13 +642,13 @@ static int two_phase_exch_and_write(mca_io_ompio_file_t *fh,
 	ntimes = 0;
     }
 
-    fh->f_comm->c_coll.coll_allreduce (&ntimes,
+    fh->f_comm->c_coll->coll_allreduce (&ntimes,
 				       &max_ntimes,
 				       1,
 				       MPI_INT,
 				       MPI_MAX,
 				       fh->f_comm,
-				       fh->f_comm->c_coll.coll_allreduce_module);
+				       fh->f_comm->c_coll->coll_allreduce_module);
 
     if (ntimes){
 	write_buf = (char *) malloc (two_phase_cycle_buffer_size);
@@ -945,14 +945,14 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_comm_time = MPI_Wtime();
 #endif
-    ret = fh->f_comm->c_coll.coll_alltoall (recv_size,
+    ret = fh->f_comm->c_coll->coll_alltoall (recv_size,
 					    1,
 					    MPI_INT,
 					    send_size,
 					    1,
 					    MPI_INT,
 					    fh->f_comm,
-					    fh->f_comm->c_coll.coll_alltoall_module);
+					    fh->f_comm->c_coll->coll_alltoall_module);
 
     if ( OMPI_SUCCESS != ret ){
 	return ret;

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_support_fns.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_support_fns.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -212,14 +212,14 @@ int mca_fcoll_two_phase_calc_others_requests(mca_io_ompio_file_t *fh,
     }
 
     /* Change it to the ompio specific alltoall in coll module : VVN*/
-    ret =  fh->f_comm->c_coll.coll_alltoall (count_my_req_per_proc,
+    ret =  fh->f_comm->c_coll->coll_alltoall (count_my_req_per_proc,
 					     1,
 					     MPI_INT,
 					     count_others_req_per_proc,
 					     1,
 					     MPI_INT,
 					     fh->f_comm,
-					     fh->f_comm->c_coll.coll_alltoall_module);
+					     fh->f_comm->c_coll->coll_alltoall_module);
     if ( OMPI_SUCCESS != ret ) {
 	return ret;
     }

--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -92,12 +92,12 @@ mca_fs_lustre_component_file_query (mca_io_ompio_file_t *fh, int *priority)
         if (OMPIO_ROOT == fh->f_rank) {
             fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
         }
-	fh->f_comm->c_coll.coll_bcast (&(fh->f_fstype),
+	fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
 				       1,
 				       MPI_INT,
 				       OMPIO_ROOT,
 				       fh->f_comm,
-				       fh->f_comm->c_coll.coll_bcast_module);
+				       fh->f_comm->c_coll->coll_bcast_module);
     }
     else {
 	if (!strncmp(fh->f_filename, "lustre:", 7) ||

--- a/ompi/mca/fs/lustre/fs_lustre_file_close.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_close.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -37,8 +37,8 @@
 int
 mca_fs_lustre_file_close (mca_io_ompio_file_t *fh)
 {
-    fh->f_comm->c_coll.coll_barrier (fh->f_comm,
-                                     fh->f_comm->c_coll.coll_barrier_module);
+    fh->f_comm->c_coll->coll_barrier (fh->f_comm,
+                                     fh->f_comm->c_coll->coll_barrier_module);
     close (fh->fd);
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -129,8 +129,8 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
             }
             close (fh->fd);
         }
-        fh->f_comm->c_coll.coll_barrier (fh->f_comm,
-                                         fh->f_comm->c_coll.coll_barrier_module);
+        fh->f_comm->c_coll->coll_barrier (fh->f_comm,
+                                         fh->f_comm->c_coll->coll_barrier_module);
     }
 
     fh->fd = open (filename, amode, perm);

--- a/ompi/mca/fs/lustre/fs_lustre_file_set_size.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_set_size.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -40,12 +40,12 @@ mca_fs_lustre_file_set_size (mca_io_ompio_file_t *fh,
 
     err = ftruncate(fh->fd, size);
 
-    fh->f_comm->c_coll.coll_bcast (&err,
+    fh->f_comm->c_coll->coll_bcast (&err,
                                    1,
                                    MPI_INT,
                                    OMPIO_ROOT,
                                    fh->f_comm,
-                                   fh->f_comm->c_coll.coll_bcast_module);
+                                   fh->f_comm->c_coll->coll_bcast_module);
     if (-1 == err) {
         return OMPI_ERROR;
     }

--- a/ompi/mca/fs/plfs/fs_plfs.c
+++ b/ompi/mca/fs/plfs/fs_plfs.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -107,12 +107,12 @@ mca_fs_plfs_component_file_query (mca_io_ompio_file_t *fh, int *priority)
 	        fh->f_fstype = PLFS;
             }
 	}
-	fh->f_comm->c_coll.coll_bcast (&(fh->f_fstype),
+	fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
 				       1,
 				       MPI_INT,
 				       OMPIO_ROOT,
 				       fh->f_comm,
-				       fh->f_comm->c_coll.coll_bcast_module);
+				       fh->f_comm->c_coll->coll_bcast_module);
     }
     else {
 	if (!strncmp(fh->f_filename, "plfs:", 7) ||

--- a/ompi/mca/fs/plfs/fs_plfs_file_close.c
+++ b/ompi/mca/fs/plfs/fs_plfs_file_close.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -43,8 +43,8 @@ mca_fs_plfs_file_close (mca_io_ompio_file_t *fh)
     int amode;
     char wpath[1024];
 
-    fh->f_comm->c_coll.coll_barrier (fh->f_comm,
-                                     fh->f_comm->c_coll.coll_barrier_module);
+    fh->f_comm->c_coll->coll_barrier (fh->f_comm,
+                                     fh->f_comm->c_coll->coll_barrier_module);
 
     getcwd( wpath, sizeof(wpath) );
     sprintf( wpath,"%s/%s",wpath,fh->f_filename );

--- a/ompi/mca/fs/plfs/fs_plfs_file_open.c
+++ b/ompi/mca/fs/plfs/fs_plfs_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -91,7 +91,7 @@ mca_fs_plfs_file_open (struct ompi_communicator_t *comm,
 	fh->f_fs_ptr = pfd;
     }
 
-    comm->c_coll.coll_bcast ( &plfs_ret, 1, MPI_INT, 0, comm, comm->c_coll.coll_bcast_module);
+    comm->c_coll->coll_bcast ( &plfs_ret, 1, MPI_INT, 0, comm, comm->c_coll->coll_bcast_module);
     if ( PLFS_SUCCESS != plfs_ret ) {
         return OMPI_ERROR;
     }

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -95,12 +95,12 @@ mca_fs_pvfs2_component_file_query (mca_io_ompio_file_t *fh, int *priority)
         if (OMPIO_ROOT == fh->f_rank) {
             fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
 	}
-	fh->f_comm->c_coll.coll_bcast (&(fh->f_fstype),
+	fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
 				       1,
 				       MPI_INT,
 				       OMPIO_ROOT,
 				       fh->f_comm,
-				       fh->f_comm->c_coll.coll_bcast_module);
+				       fh->f_comm->c_coll->coll_bcast_module);
     }
     else {
         if (!strncmp(fh->f_filename, "pvfs2:", 6) ||

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_close.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_close.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -46,8 +46,8 @@ mca_fs_pvfs2_file_close (mca_io_ompio_file_t *fh)
         fh->f_fs_ptr = NULL;
     }
     /*
-    fh->f_comm->c_coll.coll_barrier (fh->f_comm,
-                                     fh->f_comm->c_coll.coll_barrier_module);
+    fh->f_comm->c_coll->coll_barrier (fh->f_comm,
+                                     fh->f_comm->c_coll->coll_barrier_module);
     close (fh->fd);
     */
     return OMPI_SUCCESS;

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -153,12 +153,12 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
     ompi_datatype_create_struct (2, lens, offsets, types, &open_status_type);
     ompi_datatype_commit (&open_status_type);
 
-    fh->f_comm->c_coll.coll_bcast (MPI_BOTTOM,
+    fh->f_comm->c_coll->coll_bcast (MPI_BOTTOM,
                                    1,
                                    open_status_type,
                                    OMPIO_ROOT,
                                    fh->f_comm,
-                                   fh->f_comm->c_coll.coll_bcast_module);
+                                   fh->f_comm->c_coll->coll_bcast_module);
 
     ompi_datatype_destroy (&open_status_type);
 

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_set_size.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_set_size.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -48,20 +48,20 @@ mca_fs_pvfs2_file_set_size (mca_io_ompio_file_t *fh,
     if (OMPIO_ROOT == fh->f_rank) {
         ret = PVFS_sys_truncate(pvfs2_fs->object_ref,
                                 size, &(pvfs2_fs->credentials));
-        fh->f_comm->c_coll.coll_bcast (&ret,
+        fh->f_comm->c_coll->coll_bcast (&ret,
                                        1,
                                        MPI_INT,
                                        OMPIO_ROOT,
                                        fh->f_comm,
-                                       fh->f_comm->c_coll.coll_bcast_module);
+                                       fh->f_comm->c_coll->coll_bcast_module);
     }
     else {
-        fh->f_comm->c_coll.coll_bcast (&ret,
+        fh->f_comm->c_coll->coll_bcast (&ret,
                                        1,
                                        MPI_INT,
                                        OMPIO_ROOT,
                                        fh->f_comm,
-                                       fh->f_comm->c_coll.coll_bcast_module);
+                                       fh->f_comm->c_coll->coll_bcast_module);
     }
 
     if (ret != 0) {

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_sync.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_sync.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -50,12 +50,12 @@ mca_fs_pvfs2_file_sync (mca_io_ompio_file_t *fh)
         ret = PVFS_sys_flush(pvfs2_fs->object_ref, &(pvfs2_fs->credentials));
     }
 
-    fh->f_comm->c_coll.coll_bcast (&ret,
+    fh->f_comm->c_coll->coll_bcast (&ret,
                                    1,
                                    MPI_INT,
                                    OMPIO_ROOT,
                                    fh->f_comm,
-                                   fh->f_comm->c_coll.coll_bcast_module);
+                                   fh->f_comm->c_coll->coll_bcast_module);
 
     if (0 != ret) {
         return OMPI_ERROR;

--- a/ompi/mca/fs/ufs/fs_ufs_file_close.c
+++ b/ompi/mca/fs/ufs/fs_ufs_file_close.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -37,8 +37,8 @@
 int
 mca_fs_ufs_file_close (mca_io_ompio_file_t *fh)
 {
-    fh->f_comm->c_coll.coll_barrier (fh->f_comm,
-                                     fh->f_comm->c_coll.coll_barrier_module);
+    fh->f_comm->c_coll->coll_barrier (fh->f_comm,
+                                     fh->f_comm->c_coll->coll_barrier_module);
     /*    close (*(int *)fh->fd);*/
     close (fh->fd);
     /*    if (NULL != fh->fd)

--- a/ompi/mca/fs/ufs/fs_ufs_file_open.c
+++ b/ompi/mca/fs/ufs/fs_ufs_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -81,7 +81,7 @@ mca_fs_ufs_file_open (struct ompi_communicator_t *comm,
 	ret = fh->fd;
     }
 
-    comm->c_coll.coll_bcast ( &ret, 1, MPI_INT, 0, comm, comm->c_coll.coll_bcast_module);
+    comm->c_coll->coll_bcast ( &ret, 1, MPI_INT, 0, comm, comm->c_coll->coll_bcast_module);
     if ( -1 == ret ) {
 	fh->fd = ret;
 	return OMPI_ERROR;

--- a/ompi/mca/fs/ufs/fs_ufs_file_set_size.c
+++ b/ompi/mca/fs/ufs/fs_ufs_file_set_size.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -42,12 +42,12 @@ mca_fs_ufs_file_set_size (mca_io_ompio_file_t *fh,
 
     err = ftruncate(fh->fd, size);
 
-    fh->f_comm->c_coll.coll_bcast (&err,
+    fh->f_comm->c_coll->coll_bcast (&err,
                                    1,
                                    MPI_INT,
                                    OMPIO_ROOT,
                                    fh->f_comm,
-                                   fh->f_comm->c_coll.coll_bcast_module);
+                                   fh->f_comm->c_coll->coll_bcast_module);
     if (-1 == err) {
         return OMPI_ERROR;
     }

--- a/ompi/mca/io/ompio/io_ompio.c
+++ b/ompi/mca/io/ompio/io_ompio.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -142,7 +142,7 @@ int ompi_io_ompio_generate_current_file_view (struct mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
 	}
 
-        fh->f_comm->c_coll.coll_gather (&k,
+        fh->f_comm->c_coll->coll_gather (&k,
                                         1,
                                         MPI_INT,
                                         recvcounts,
@@ -150,7 +150,7 @@ int ompi_io_ompio_generate_current_file_view (struct mca_io_ompio_file_t *fh,
 					MPI_INT,
                                         OMPIO_ROOT,
                                         fh->f_comm,
-                                        fh->f_comm->c_coll.coll_gather_module);
+                                        fh->f_comm->c_coll->coll_gather_module);
 
         per_process = (mca_io_ompio_offlen_array_t *)
 	    malloc (k * sizeof(mca_io_ompio_offlen_array_t));
@@ -248,7 +248,7 @@ int ompi_io_ompio_generate_current_file_view (struct mca_io_ompio_file_t *fh,
                 }
             }
 	}
-	fh->f_comm->c_coll.coll_gatherv (per_process,
+	fh->f_comm->c_coll->coll_gatherv (per_process,
 					 k,
 					 io_array_type,
 					 all_process,
@@ -257,7 +257,7 @@ int ompi_io_ompio_generate_current_file_view (struct mca_io_ompio_file_t *fh,
 					 io_array_type,
 					 OMPIO_ROOT,
 					 fh->f_comm,
-					 fh->f_comm->c_coll.coll_gatherv_module);
+					 fh->f_comm->c_coll->coll_gatherv_module);
 
 	ompi_datatype_destroy(&io_array_type);
 

--- a/ompi/mca/io/ompio/io_ompio_aggregators.c
+++ b/ompi/mca/io/ompio/io_ompio_aggregators.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -133,14 +133,14 @@ int mca_io_ompio_fview_based_grouping(mca_io_ompio_file_t *fh,
     }
     
     //Allgather start offsets across processes in a group on aggregator
-    ret = fh->f_comm->c_coll.coll_allgather (start_offset_len,
+    ret = fh->f_comm->c_coll->coll_allgather (start_offset_len,
                                              3,
                                              OMPI_OFFSET_DATATYPE,
                                              start_offsets_lens,
                                              3,
                                              OMPI_OFFSET_DATATYPE,
                                              fh->f_comm,
-                                             fh->f_comm->c_coll.coll_allgather_module);
+                                             fh->f_comm->c_coll->coll_allgather_module);
     if ( OMPI_SUCCESS != ret ) {
         goto exit;
     }
@@ -493,13 +493,13 @@ int mca_io_ompio_create_groups(mca_io_ompio_file_t *fh,
     if(fh->f_rank == fh->f_procs_in_group[fh->f_aggregator_index]){
 	   final_aggr = 1;
     }
-    ret = fh->f_comm->c_coll.coll_allreduce (&final_aggr,
+    ret = fh->f_comm->c_coll->coll_allreduce (&final_aggr,
                                              &final_num_aggrs,
                                              1,
                                              MPI_INT,
                                              MPI_SUM,
                                              fh->f_comm,
-                                             fh->f_comm->c_coll.coll_allreduce_module);
+                                             fh->f_comm->c_coll->coll_allreduce_module);
     if ( OMPI_SUCCESS != ret ) {
         opal_output (1, "mca_io_ompio_create_groups: error in allreduce\n");
     }

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -140,12 +140,12 @@ int mca_io_ompio_file_preallocate (ompi_file_t *fh,
     OPAL_THREAD_LOCK(&fh->f_mutex);
     tmp = diskspace;
 
-    ret = data->ompio_fh.f_comm->c_coll.coll_bcast (&tmp,
+    ret = data->ompio_fh.f_comm->c_coll->coll_bcast (&tmp,
                                                     1,
                                                     OMPI_OFFSET_DATATYPE,
                                                     OMPIO_ROOT,
                                                     data->ompio_fh.f_comm,
-                                                    data->ompio_fh.f_comm->c_coll.coll_bcast_module);
+                                                    data->ompio_fh.f_comm->c_coll->coll_bcast_module);
     if ( OMPI_SUCCESS != ret ) {
         OPAL_THREAD_UNLOCK(&fh->f_mutex);
         return OMPI_ERROR;
@@ -234,8 +234,8 @@ int mca_io_ompio_file_preallocate (ompi_file_t *fh,
 
 exit:     
     free ( buf );
-    fh->f_comm->c_coll.coll_bcast ( &ret, 1, MPI_INT, OMPIO_ROOT, fh->f_comm,
-                                   fh->f_comm->c_coll.coll_bcast_module);
+    fh->f_comm->c_coll->coll_bcast ( &ret, 1, MPI_INT, OMPIO_ROOT, fh->f_comm,
+                                   fh->f_comm->c_coll->coll_bcast_module);
     
     if ( diskspace > current_size ) {
         data->ompio_fh.f_fs->fs_file_set_size (&data->ompio_fh, diskspace);
@@ -256,12 +256,12 @@ int mca_io_ompio_file_set_size (ompi_file_t *fh,
 
     tmp = size;
     OPAL_THREAD_LOCK(&fh->f_mutex);
-    ret = data->ompio_fh.f_comm->c_coll.coll_bcast (&tmp,
+    ret = data->ompio_fh.f_comm->c_coll->coll_bcast (&tmp,
                                                     1,
                                                     OMPI_OFFSET_DATATYPE,
                                                     OMPIO_ROOT,
                                                     data->ompio_fh.f_comm,
-                                                    data->ompio_fh.f_comm->c_coll.coll_bcast_module);
+                                                    data->ompio_fh.f_comm->c_coll->coll_bcast_module);
     if ( OMPI_SUCCESS != ret ) {
         opal_output(1, ",mca_io_ompio_file_set_size: error in bcast\n");
         OPAL_THREAD_UNLOCK(&fh->f_mutex);
@@ -281,8 +281,8 @@ int mca_io_ompio_file_set_size (ompi_file_t *fh,
         return ret;
     }
     
-    ret = data->ompio_fh.f_comm->c_coll.coll_barrier (data->ompio_fh.f_comm,
-                                                      data->ompio_fh.f_comm->c_coll.coll_barrier_module);
+    ret = data->ompio_fh.f_comm->c_coll->coll_barrier (data->ompio_fh.f_comm,
+                                                      data->ompio_fh.f_comm->c_coll->coll_barrier_module);
     if ( OMPI_SUCCESS != ret ) {
         opal_output(1, ",mca_io_ompio_file_set_size: error in barrier\n");
         OPAL_THREAD_UNLOCK(&fh->f_mutex);
@@ -382,12 +382,12 @@ int mca_io_ompio_file_set_atomicity (ompi_file_t *fh,
 
     /* check if the atomicity flag is the same on all processes */
     tmp = flag;
-    data->ompio_fh.f_comm->c_coll.coll_bcast (&tmp,
+    data->ompio_fh.f_comm->c_coll->coll_bcast (&tmp,
                                               1,
                                               MPI_INT,
                                               OMPIO_ROOT,
                                               data->ompio_fh.f_comm,
-                                              data->ompio_fh.f_comm->c_coll.coll_bcast_module);
+                                              data->ompio_fh.f_comm->c_coll->coll_bcast_module);
 
     if (tmp != flag) {
         OPAL_THREAD_UNLOCK(&fh->f_mutex);

--- a/ompi/mca/osc/portals4/osc_portals4_active_target.c
+++ b/ompi/mca/osc/portals4/osc_portals4_active_target.c
@@ -1,5 +1,8 @@
 /*
  * Copyright (c) 2011      Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,8 +33,8 @@ ompi_osc_portals4_fence(int assert, struct ompi_win_t *win)
 
     comm_ret = ompi_osc_portals4_complete_all(module);
 
-    ret = module->comm->c_coll.coll_barrier(module->comm,
-                                            module->comm->c_coll.coll_barrier_module);
+    ret = module->comm->c_coll->coll_barrier(module->comm,
+                                            module->comm->c_coll->coll_barrier_module);
 
     return (OMPI_SUCCESS == comm_ret) ? ret : comm_ret;
 }

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -5,6 +5,9 @@
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -443,9 +446,9 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     /* share everyone's displacement units. Only do an allgather if
        strictly necessary, since it requires O(p) state. */
     tmp = disp_unit;
-    ret = module->comm->c_coll.coll_bcast(&tmp, 1, MPI_INT, 0,
+    ret = module->comm->c_coll->coll_bcast(&tmp, 1, MPI_INT, 0,
                                           module->comm,
-                                          module->comm->c_coll.coll_bcast_module);
+                                          module->comm->c_coll->coll_bcast_module);
     if (OMPI_SUCCESS != ret) {
         opal_output_verbose(1, ompi_osc_base_framework.framework_output,
                             "%s:%d: MPI_Bcast failed: %d\n",
@@ -453,8 +456,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         goto error;
     }
     tmp = (tmp == disp_unit) ? 1 : 0;
-    ret = module->comm->c_coll.coll_allreduce(MPI_IN_PLACE, &tmp, 1, MPI_INT, MPI_LAND,
-                                              module->comm, module->comm->c_coll.coll_allreduce_module);
+    ret = module->comm->c_coll->coll_allreduce(MPI_IN_PLACE, &tmp, 1, MPI_INT, MPI_LAND,
+                                              module->comm, module->comm->c_coll->coll_allreduce_module);
     if (OMPI_SUCCESS != ret) goto error;
     if (tmp == 1) {
         module->disp_unit = disp_unit;
@@ -462,10 +465,10 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     } else {
         module->disp_unit = -1;
         module->disp_units = malloc(sizeof(int) * ompi_comm_size(module->comm));
-        ret = module->comm->c_coll.coll_allgather(&disp_unit, 1, MPI_INT,
+        ret = module->comm->c_coll->coll_allgather(&disp_unit, 1, MPI_INT,
                                                   module->disp_units, 1, MPI_INT,
                                                   module->comm,
-                                                  module->comm->c_coll.coll_allgather_module);
+                                                  module->comm->c_coll->coll_allgather_module);
         if (OMPI_SUCCESS != ret) goto error;
     }
 
@@ -608,8 +611,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     }
     OPAL_THREAD_UNLOCK(&mca_osc_portals4_component.lock);
 
-    module->comm->c_coll.coll_barrier(module->comm,
-                                      module->comm->c_coll.coll_barrier_module);
+    module->comm->c_coll->coll_barrier(module->comm,
+                                      module->comm->c_coll->coll_barrier_module);
 
     return OMPI_SUCCESS;
 
@@ -648,8 +651,8 @@ ompi_osc_portals4_free(struct ompi_win_t *win)
     int ret = OMPI_SUCCESS;
 
     /* synchronize */
-    module->comm->c_coll.coll_barrier(module->comm,
-                                      module->comm->c_coll.coll_barrier_module);
+    module->comm->c_coll->coll_barrier(module->comm,
+                                      module->comm->c_coll->coll_barrier_module);
 
     /* cleanup */
     PtlMEUnlink(module->control_me_h);
@@ -687,8 +690,8 @@ ompi_osc_portals4_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
         (ompi_osc_portals4_module_t*) win->w_osc_module;
 
     /* enforce collectiveness... */
-    return module->comm->c_coll.coll_barrier(module->comm,
-                                             module->comm->c_coll.coll_barrier_module);
+    return module->comm->c_coll->coll_barrier(module->comm,
+                                             module->comm->c_coll->coll_barrier_module);
 }
 
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_active_target.c
@@ -14,6 +14,9 @@
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -147,7 +150,7 @@ int ompi_osc_pt2pt_fence(int assert, ompi_win_t *win)
 
     /* short-circuit the noprecede case */
     if (0 != (assert & MPI_MODE_NOPRECEDE)) {
-        module->comm->c_coll.coll_barrier (module->comm,  module->comm->c_coll.coll_barrier_module);
+        module->comm->c_coll->coll_barrier (module->comm,  module->comm->c_coll->coll_barrier_module);
         OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,
                              "osc pt2pt: fence end (short circuit)"));
         return ret;
@@ -163,10 +166,10 @@ int ompi_osc_pt2pt_fence(int assert, ompi_win_t *win)
                          "osc pt2pt: fence done sending"));
 
     /* find out how much data everyone is going to send us.  */
-    ret = module->comm->c_coll.coll_reduce_scatter_block (module->epoch_outgoing_frag_count,
+    ret = module->comm->c_coll->coll_reduce_scatter_block (module->epoch_outgoing_frag_count,
                                                           &incoming_reqs, 1, MPI_UINT32_T,
                                                           MPI_SUM, module->comm,
-                                                          module->comm->c_coll.coll_reduce_scatter_block_module);
+                                                          module->comm->c_coll->coll_reduce_scatter_block_module);
     if (OMPI_SUCCESS != ret) {
         return ret;
     }
@@ -196,7 +199,7 @@ int ompi_osc_pt2pt_fence(int assert, ompi_win_t *win)
     module->all_sync.epoch_active = false;
     OPAL_THREAD_UNLOCK(&module->lock);
 
-    module->comm->c_coll.coll_barrier (module->comm, module->comm->c_coll.coll_barrier_module);
+    module->comm->c_coll->coll_barrier (module->comm, module->comm->c_coll->coll_barrier_module);
 
     OPAL_OUTPUT_VERBOSE((25, ompi_osc_base_framework.framework_output,
                          "osc pt2pt: fence end: %d", ret));

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University.
  *                         All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -414,8 +414,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 
     /* barrier to prevent arrival of lock requests before we're
        fully created */
-    ret = module->comm->c_coll.coll_barrier(module->comm,
-                                            module->comm->c_coll.coll_barrier_module);
+    ret = module->comm->c_coll->coll_barrier(module->comm,
+                                            module->comm->c_coll->coll_barrier_module);
     if (OMPI_SUCCESS != ret) goto cleanup;
 
     if (!mca_osc_pt2pt_component.progress_enable) {
@@ -448,8 +448,8 @@ ompi_osc_pt2pt_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
         (ompi_osc_pt2pt_module_t*) win->w_osc_module;
 
     /* enforce collectiveness... */
-    return module->comm->c_coll.coll_barrier(module->comm,
-                                             module->comm->c_coll.coll_barrier_module);
+    return module->comm->c_coll->coll_barrier(module->comm,
+                                             module->comm->c_coll->coll_barrier_module);
 }
 
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_module.c
@@ -13,6 +13,9 @@
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +58,8 @@ int ompi_osc_pt2pt_free(ompi_win_t *win)
 
         /* finish with a barrier */
         if (ompi_group_size(win->w_group) > 1) {
-            (void) module->comm->c_coll.coll_barrier (module->comm,
-                                                      module->comm->c_coll.coll_barrier_module);
+            (void) module->comm->c_coll->coll_barrier (module->comm,
+                                                      module->comm->c_coll->coll_barrier_module);
         }
 
         /* remove from component information */

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -13,6 +13,9 @@
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -617,7 +620,7 @@ int ompi_osc_rdma_fence_atomic (int assert, ompi_win_t *win)
         OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "fence complete (short circuit)");
         /* no communication can occur until a peer has entered the same fence epoch. for now
          * a barrier is used to ensure this is the case. */
-        ret = module->comm->c_coll.coll_barrier(module->comm, module->comm->c_coll.coll_barrier_module);
+        ret = module->comm->c_coll->coll_barrier(module->comm, module->comm->c_coll->coll_barrier_module);
         OPAL_THREAD_UNLOCK(&module->lock);
         return ret;
     }
@@ -625,7 +628,7 @@ int ompi_osc_rdma_fence_atomic (int assert, ompi_win_t *win)
     ompi_osc_rdma_sync_rdma_complete (&module->all_sync);
 
     /* ensure all writes to my memory are complete */
-    ret = module->comm->c_coll.coll_barrier(module->comm, module->comm->c_coll.coll_barrier_module);
+    ret = module->comm->c_coll->coll_barrier(module->comm, module->comm->c_coll->coll_barrier_module);
 
     if (assert & MPI_MODE_NOSUCCEED) {
         /* as specified in MPI-3 p 438 3-5 the fence can end an epoch. it isn't explicitly

--- a/ompi/mca/osc/rdma/osc_rdma_module.c
+++ b/ompi/mca/osc/rdma/osc_rdma_module.c
@@ -11,6 +11,9 @@
  * Copyright (c) 2007-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +58,8 @@ int ompi_osc_rdma_free(ompi_win_t *win)
 
         /* finish with a barrier */
         if (ompi_group_size(win->w_group) > 1) {
-            (void) module->comm->c_coll.coll_barrier (module->comm,
-                                                      module->comm->c_coll.coll_barrier_module);
+            (void) module->comm->c_coll->coll_barrier (module->comm,
+                                                      module->comm->c_coll->coll_barrier_module);
         }
 
         /* remove from component information */

--- a/ompi/mca/osc/sm/osc_sm_active_target.c
+++ b/ompi/mca/osc/sm/osc_sm_active_target.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014      The University of Tennessee and The University
+ * Copyright (c) 2014-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -101,8 +101,8 @@ ompi_osc_sm_fence(int assert, struct ompi_win_t *win)
     opal_atomic_mb();
 
     if (module->global_state->use_barrier_for_fence) {
-        return module->comm->c_coll.coll_barrier(module->comm,
-                                                 module->comm->c_coll.coll_barrier_module);
+        return module->comm->c_coll->coll_barrier(module->comm,
+                                                 module->comm->c_coll->coll_barrier_module);
     } else {
         module->my_sense = !module->my_sense;
         pthread_mutex_lock(&module->global_state->mtx);

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -7,6 +7,9 @@
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -234,10 +237,10 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         } else {
             total = size;
         }
-        ret = module->comm->c_coll.coll_allgather(&total, 1, MPI_UNSIGNED_LONG,
+        ret = module->comm->c_coll->coll_allgather(&total, 1, MPI_UNSIGNED_LONG,
                                                   rbuf, 1, MPI_UNSIGNED_LONG,
                                                   module->comm,
-                                                  module->comm->c_coll.coll_allgather_module);
+                                                  module->comm->c_coll->coll_allgather_module);
         if (OMPI_SUCCESS != ret) return ret;
 
         total = 0;
@@ -266,8 +269,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
             }
         }
 
-	ret = module->comm->c_coll.coll_bcast (&module->seg_ds, sizeof (module->seg_ds), MPI_BYTE, 0,
-					       module->comm, module->comm->c_coll.coll_bcast_module);
+	ret = module->comm->c_coll->coll_bcast (&module->seg_ds, sizeof (module->seg_ds), MPI_BYTE, 0,
+					       module->comm, module->comm->c_coll->coll_bcast_module);
 	if (OMPI_SUCCESS != ret) {
 	    goto error;
 	}
@@ -316,10 +319,10 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 
     /* share everyone's displacement units. */
     module->disp_units = malloc(sizeof(int) * comm_size);
-    ret = module->comm->c_coll.coll_allgather(&disp_unit, 1, MPI_INT,
+    ret = module->comm->c_coll->coll_allgather(&disp_unit, 1, MPI_INT,
                                               module->disp_units, 1, MPI_INT,
                                               module->comm,
-                                              module->comm->c_coll.coll_allgather_module);
+                                              module->comm->c_coll->coll_allgather_module);
     if (OMPI_SUCCESS != ret) goto error;
 
     module->start_group = NULL;
@@ -375,8 +378,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 #endif
     }
 
-    ret = module->comm->c_coll.coll_barrier(module->comm,
-                                            module->comm->c_coll.coll_barrier_module);
+    ret = module->comm->c_coll->coll_barrier(module->comm,
+                                            module->comm->c_coll->coll_barrier_module);
     if (OMPI_SUCCESS != ret) goto error;
 
     *model = MPI_WIN_UNIFIED;
@@ -462,8 +465,8 @@ ompi_osc_sm_free(struct ompi_win_t *win)
     /* free memory */
     if (NULL != module->segment_base) {
         /* synchronize */
-        module->comm->c_coll.coll_barrier(module->comm,
-                                          module->comm->c_coll.coll_barrier_module);
+        module->comm->c_coll->coll_barrier(module->comm,
+                                          module->comm->c_coll->coll_barrier_module);
 
         if (0 == ompi_comm_rank (module->comm)) {
             opal_shmem_unlink (&module->seg_ds);
@@ -500,8 +503,8 @@ ompi_osc_sm_set_info(struct ompi_win_t *win, struct ompi_info_t *info)
         (ompi_osc_sm_module_t*) win->w_osc_module;
 
     /* enforce collectiveness... */
-    return module->comm->c_coll.coll_barrier(module->comm,
-                                             module->comm->c_coll.coll_barrier_module);
+    return module->comm->c_coll->coll_barrier(module->comm,
+                                             module->comm->c_coll->coll_barrier_module);
 }
 
 

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc_file_open.c
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -148,7 +148,7 @@ int mca_sharedfp_addproc_file_close (mca_io_ompio_file_t *fh)
     /* Make sure that all processes are ready to release the
     ** shared file pointer resources
     */
-    sh->comm->c_coll.coll_barrier(sh->comm, sh->comm->c_coll.coll_barrier_module );
+    sh->comm->c_coll->coll_barrier(sh->comm, sh->comm->c_coll->coll_barrier_module );
 
     addproc_data = (struct mca_sharedfp_addproc_data*)(sh->selected_module_data);
 

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc_iread.c
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc_iread.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -114,9 +114,9 @@ int mca_sharedfp_addproc_read_ordered_begin(mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather( &sendBuff, 1, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_gather( &sendBuff, 1, OMPI_OFFSET_DATATYPE,
 					buff, 1, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					sh->comm->c_coll.coll_gather_module);
+					sh->comm->c_coll->coll_gather_module);
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }
@@ -163,9 +163,9 @@ int mca_sharedfp_addproc_read_ordered_begin(mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, 1, OMPI_OFFSET_DATATYPE, &offsetBuff,
+    ret = sh->comm->c_coll->coll_scatter ( buff, 1, OMPI_OFFSET_DATATYPE, &offsetBuff,
 					  1, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					  sh->comm->c_coll.coll_scatter_module );
+					  sh->comm->c_coll->coll_scatter_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc_iwrite.c
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc_iwrite.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -115,9 +115,9 @@ int mca_sharedfp_addproc_write_ordered_begin(mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff,
 					 recvcnt, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					 sh->comm->c_coll.coll_gather_module);
+					 sh->comm->c_coll->coll_gather_module);
     if( OMPI_SUCCESS != ret ){
 	goto exit;
     }
@@ -159,9 +159,9 @@ int mca_sharedfp_addproc_write_ordered_begin(mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE, &offsetBuff,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE, &offsetBuff,
 					  recvcnt, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					  sh->comm->c_coll.coll_scatter_module );
+					  sh->comm->c_coll->coll_scatter_module );
     if( OMPI_SUCCESS != ret ){
 	goto exit;
     }

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc_read.c
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc_read.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -106,9 +106,9 @@ int mca_sharedfp_addproc_read_ordered (mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather( &sendBuff, 1, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_gather( &sendBuff, 1, OMPI_OFFSET_DATATYPE,
 					buff, 1, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					sh->comm->c_coll.coll_gather_module);
+					sh->comm->c_coll->coll_gather_module);
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }
@@ -155,9 +155,9 @@ int mca_sharedfp_addproc_read_ordered (mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, 1, OMPI_OFFSET_DATATYPE, &offsetBuff,
+    ret = sh->comm->c_coll->coll_scatter ( buff, 1, OMPI_OFFSET_DATATYPE, &offsetBuff,
 					  1, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					  sh->comm->c_coll.coll_scatter_module );
+					  sh->comm->c_coll->coll_scatter_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc_seek.c
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc_seek.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -63,7 +63,7 @@ mca_sharedfp_addproc_seek (mca_io_ompio_file_t *fh,
 	}
 
     }
-    ret = sh->comm->c_coll.coll_barrier(sh->comm, sh->comm->c_coll.coll_barrier_module);
+    ret = sh->comm->c_coll->coll_barrier(sh->comm, sh->comm->c_coll->coll_barrier_module);
 
     return ret;
 }

--- a/ompi/mca/sharedfp/addproc/sharedfp_addproc_write.c
+++ b/ompi/mca/sharedfp/addproc/sharedfp_addproc_write.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -111,9 +111,9 @@ int mca_sharedfp_addproc_write_ordered (mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff,
 					 recvcnt, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					 sh->comm->c_coll.coll_gather_module);
+					 sh->comm->c_coll->coll_gather_module);
     if( OMPI_SUCCESS != ret ){
 	goto exit;
     }
@@ -155,9 +155,9 @@ int mca_sharedfp_addproc_write_ordered (mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE, &offsetBuff,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE, &offsetBuff,
 					  recvcnt, OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					  sh->comm->c_coll.coll_scatter_module );
+					  sh->comm->c_coll->coll_scatter_module );
     if( OMPI_SUCCESS != ret ){
 	goto exit;
     }

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_collaborate_data.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_collaborate_data.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -92,9 +92,9 @@ int mca_sharedfp_individual_collaborate_data(struct mca_sharedfp_base_data_t *sh
 	goto exit;
     }
 
-    comm->c_coll.coll_allgather ( &nodesoneachprocess, 1, MPI_INT,
+    comm->c_coll->coll_allgather ( &nodesoneachprocess, 1, MPI_INT,
 				  countbuff, 1, MPI_INT, comm,
-				  comm->c_coll.coll_allgather_module );
+				  comm->c_coll->coll_allgather_module );
 
     if ( mca_sharedfp_individual_verbose) {
 	for (i = 0; i < size ; i++) {
@@ -137,16 +137,16 @@ int mca_sharedfp_individual_collaborate_data(struct mca_sharedfp_base_data_t *sh
 	goto exit;
     }
 
-    ret = comm->c_coll.coll_allgatherv ( ind_ts, countbuff[rank], MPI_DOUBLE,
+    ret = comm->c_coll->coll_allgatherv ( ind_ts, countbuff[rank], MPI_DOUBLE,
 					 timestampbuff, countbuff, displ, MPI_DOUBLE,
-					 comm, comm->c_coll.coll_allgatherv_module );
+					 comm, comm->c_coll->coll_allgatherv_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }
 
-    ret = comm->c_coll.coll_allgatherv ( ind_recordlength, countbuff[rank], OMPI_OFFSET_DATATYPE,
+    ret = comm->c_coll->coll_allgatherv ( ind_recordlength, countbuff[rank], OMPI_OFFSET_DATATYPE,
 					 offsetbuff, countbuff, displ, OMPI_OFFSET_DATATYPE,
-					 comm, comm->c_coll.coll_allgatherv_module );
+					 comm, comm->c_coll->coll_allgatherv_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_iwrite.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_iwrite.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -159,9 +159,9 @@ int mca_sharedfp_individual_write_ordered_begin(mca_io_ompio_file_t *fh,
     }
 
     /*collect the total bytes to be written*/
-    sh->comm->c_coll.coll_gather ( &totalbytes, 1, OMPI_OFFSET_DATATYPE,
+    sh->comm->c_coll->coll_gather ( &totalbytes, 1, OMPI_OFFSET_DATATYPE,
 				   offbuff, 1, OMPI_OFFSET_DATATYPE, 0,
-				   sh->comm, sh->comm->c_coll.coll_gather_module );
+				   sh->comm, sh->comm->c_coll->coll_gather_module );
 
     if ( 0 == rank ) {
         prev_offset = offbuff[0];
@@ -180,16 +180,16 @@ int mca_sharedfp_individual_write_ordered_begin(mca_io_ompio_file_t *fh,
 
 
     /* Scatter the results to the other processes */
-    ret = sh->comm->c_coll.coll_scatter ( offbuff, 1, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( offbuff, 1, OMPI_OFFSET_DATATYPE,
 					  &offset, 1, OMPI_OFFSET_DATATYPE, 0,
-					  sh->comm, sh->comm->c_coll.coll_scatter_module );
+					  sh->comm, sh->comm->c_coll->coll_scatter_module );
     if ( OMPI_SUCCESS != ret )  {
 	opal_output(0,"sharedfp_individual_write_ordered_begin: Error in scattering offsets \n");
 	goto exit;
     }
 
-    ret = sh->comm->c_coll.coll_bcast ( &global_offset, 1, OMPI_OFFSET_DATATYPE,
-                                        0, sh->comm, sh->comm->c_coll.coll_bcast_module );
+    ret = sh->comm->c_coll->coll_bcast ( &global_offset, 1, OMPI_OFFSET_DATATYPE,
+                                        0, sh->comm, sh->comm->c_coll->coll_bcast_module );
     if ( OMPI_SUCCESS != ret )  {
 	opal_output(0,"sharedfp_individual_write_ordered_begin: Error while bcasting global offset \n");
 	goto exit;

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -152,9 +152,9 @@ int mca_sharedfp_individual_write_ordered (mca_io_ompio_file_t *fh,
     }
 
     /*collect the total bytes to be written*/
-    sh->comm->c_coll.coll_gather ( &totalbytes, 1, OMPI_OFFSET_DATATYPE,
+    sh->comm->c_coll->coll_gather ( &totalbytes, 1, OMPI_OFFSET_DATATYPE,
 				   offbuff, 1, OMPI_OFFSET_DATATYPE, 0,
-				   sh->comm, sh->comm->c_coll.coll_gather_module );
+				   sh->comm, sh->comm->c_coll->coll_gather_module );
 
     if ( 0 == rank ) {
         prev_offset = offbuff[0];
@@ -173,16 +173,16 @@ int mca_sharedfp_individual_write_ordered (mca_io_ompio_file_t *fh,
 
 
     /* Scatter the results to the other processes */
-    ret = sh->comm->c_coll.coll_scatter ( offbuff, 1, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( offbuff, 1, OMPI_OFFSET_DATATYPE,
 					  &offset, 1, OMPI_OFFSET_DATATYPE, 0,
-					  sh->comm, sh->comm->c_coll.coll_scatter_module );
+					  sh->comm, sh->comm->c_coll->coll_scatter_module );
     if ( OMPI_SUCCESS != ret )  {
 	opal_output(0,"sharedfp_individual_write_ordered: Error in scattering offsets \n");
 	goto exit;
     }
 
-    ret = sh->comm->c_coll.coll_bcast ( &global_offset, 1, OMPI_OFFSET_DATATYPE,
-				  0, sh->comm, sh->comm->c_coll.coll_bcast_module );
+    ret = sh->comm->c_coll->coll_bcast ( &global_offset, 1, OMPI_OFFSET_DATATYPE,
+				  0, sh->comm, sh->comm->c_coll->coll_bcast_module );
     if ( OMPI_SUCCESS != ret )  {
 	opal_output(0,"sharedfp_individual_write_ordered: Error while bcasting global offset \n");
 	goto exit;

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -115,7 +115,7 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
 	write ( handle, &position, sizeof(OMPI_MPI_OFFSET_TYPE) );
 	close ( handle );
     }
-    comm->c_coll.coll_barrier ( comm, comm->c_coll.coll_barrier_module );
+    comm->c_coll->coll_barrier ( comm, comm->c_coll->coll_barrier_module );
 
     handle = open ( lockedfilename, O_RDWR, 0644  );
     if ( -1 == handle ) {
@@ -133,7 +133,7 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
     /*remember the shared file handle*/
     fh->f_sharedfp_data = sh;
 
-    comm->c_coll.coll_barrier ( comm, comm->c_coll.coll_barrier_module );
+    comm->c_coll->coll_barrier ( comm, comm->c_coll->coll_barrier_module );
 
     return err;
 }

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iread.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iread.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -149,9 +149,9 @@ int mca_sharedfp_lockedfile_read_ordered_begin(mca_io_ompio_file_t *fh,
 	}
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff, recvcnt,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff, recvcnt,
 					 OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					 sh->comm->c_coll.coll_gather_module );
+					 sh->comm->c_coll->coll_gather_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }
@@ -189,9 +189,9 @@ int mca_sharedfp_lockedfile_read_ordered_begin(mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
 					 &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					 sh->comm, sh->comm->c_coll.coll_scatter_module );
+					 sh->comm, sh->comm->c_coll->coll_scatter_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iwrite.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_iwrite.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -148,9 +148,9 @@ int mca_sharedfp_lockedfile_write_ordered_begin(mca_io_ompio_file_t *fh,
 	}
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff, recvcnt,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff, recvcnt,
 					 OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					 sh->comm->c_coll.coll_gather_module );
+					 sh->comm->c_coll->coll_gather_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }
@@ -188,9 +188,9 @@ int mca_sharedfp_lockedfile_write_ordered_begin(mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
 					 &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					 sh->comm, sh->comm->c_coll.coll_scatter_module );
+					 sh->comm, sh->comm->c_coll->coll_scatter_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_read.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_read.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -137,9 +137,9 @@ int mca_sharedfp_lockedfile_read_ordered (mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
 					 buff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					 sh->comm, sh->comm->c_coll.coll_gather_module );
+					 sh->comm, sh->comm->c_coll->coll_gather_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }
@@ -178,9 +178,9 @@ int mca_sharedfp_lockedfile_read_ordered (mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
 					  &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					  sh->comm, sh->comm->c_coll.coll_scatter_module );
+					  sh->comm, sh->comm->c_coll->coll_scatter_module );
 
     /*Each process now has its own individual offset in recvBUFF*/
     offset = offsetBuff - sendBuff;

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_seek.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_seek.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -160,6 +160,6 @@ mca_sharedfp_lockedfile_seek (mca_io_ompio_file_t *fh,
         }
     }
 
-    sh->comm->c_coll.coll_barrier ( sh->comm , sh->comm->c_coll.coll_barrier_module );
+    sh->comm->c_coll->coll_barrier ( sh->comm , sh->comm->c_coll->coll_barrier_module );
     return ret;
 }

--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_write.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_write.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -142,9 +142,9 @@ int mca_sharedfp_lockedfile_write_ordered (mca_io_ompio_file_t *fh,
 	}
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff, recvcnt,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE, buff, recvcnt,
 					 OMPI_OFFSET_DATATYPE, 0, sh->comm,
-					 sh->comm->c_coll.coll_gather_module );
+					 sh->comm->c_coll->coll_gather_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }
@@ -182,9 +182,9 @@ int mca_sharedfp_lockedfile_write_ordered (mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
 					 &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					 sh->comm, sh->comm->c_coll.coll_scatter_module );
+					 sh->comm, sh->comm->c_coll->coll_scatter_module );
     if ( OMPI_SUCCESS != ret ) {
 	goto exit;
     }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -161,7 +161,7 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
         memset ( &sm_offset, 0, sizeof (struct mca_sharedfp_sm_offset ));
         write ( sm_fd, &sm_offset, sizeof(struct mca_sharedfp_sm_offset));
     }
-    comm->c_coll.coll_barrier (comm, comm->c_coll.coll_barrier_module );
+    comm->c_coll->coll_barrier (comm, comm->c_coll->coll_barrier_module );
 
     /*the file has been written to, now we can map*/
     sm_offset_ptr = mmap(NULL, sizeof(struct mca_sharedfp_sm_offset), PROT_READ | PROT_WRITE,
@@ -223,7 +223,7 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
         err = OMPI_ERROR;
     }
 
-    comm->c_coll.coll_barrier (comm, comm->c_coll.coll_barrier_module );
+    comm->c_coll->coll_barrier (comm, comm->c_coll->coll_barrier_module );
 
     return err;
 }
@@ -249,7 +249,7 @@ int mca_sharedfp_sm_file_close (mca_io_ompio_file_t *fh)
      * all processes are ready to release the
      * shared file pointer resources
      */
-    sh->comm->c_coll.coll_barrier (sh->comm, sh->comm->c_coll.coll_barrier_module );
+    sh->comm->c_coll->coll_barrier (sh->comm, sh->comm->c_coll->coll_barrier_module );
 
     file_data = (sm_data*)(sh->selected_module_data);
     if (file_data)  {

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_iread.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_iread.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -143,9 +143,9 @@ int mca_sharedfp_sm_read_ordered_begin(mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
 					 buff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					 sh->comm, sh->comm->c_coll.coll_gather_module );
+					 sh->comm, sh->comm->c_coll->coll_gather_module );
     if( OMPI_SUCCESS != ret){
 	goto exit;
     }
@@ -185,9 +185,9 @@ int mca_sharedfp_sm_read_ordered_begin(mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
 					  &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					  sh->comm, sh->comm->c_coll.coll_scatter_module );
+					  sh->comm, sh->comm->c_coll->coll_scatter_module );
     if( OMPI_SUCCESS != ret){
 	goto exit;
     }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_iwrite.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_iwrite.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -146,9 +146,9 @@ int mca_sharedfp_sm_write_ordered_begin(mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
 					 buff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					 sh->comm, sh->comm->c_coll.coll_gather_module );
+					 sh->comm, sh->comm->c_coll->coll_gather_module );
     if( OMPI_SUCCESS != ret){
 	goto exit;
     }
@@ -188,9 +188,9 @@ int mca_sharedfp_sm_write_ordered_begin(mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
 					  &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-					  sh->comm, sh->comm->c_coll.coll_scatter_module );
+					  sh->comm, sh->comm->c_coll->coll_scatter_module );
     if( OMPI_SUCCESS != ret){
 	goto exit;
     }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_read.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_read.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -137,9 +137,9 @@ int mca_sharedfp_sm_read_ordered (mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
                                          buff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-                                         sh->comm, sh->comm->c_coll.coll_gather_module );
+                                         sh->comm, sh->comm->c_coll->coll_gather_module );
     if( OMPI_SUCCESS != ret){
         goto exit;
     }
@@ -178,9 +178,9 @@ int mca_sharedfp_sm_read_ordered (mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
                                           &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-                                          sh->comm, sh->comm->c_coll.coll_scatter_module );
+                                          sh->comm, sh->comm->c_coll->coll_scatter_module );
     if( OMPI_SUCCESS != ret){
         goto exit;
     }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_seek.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_seek.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -146,7 +146,7 @@ mca_sharedfp_sm_seek (mca_io_ompio_file_t *fh,
     /* since we are only letting process 0, update the current pointer
      * all of the other processes need to wait before proceeding.
      */
-    sh->comm->c_coll.coll_barrier ( sh->comm, sh->comm->c_coll.coll_barrier_module );
+    sh->comm->c_coll->coll_barrier ( sh->comm, sh->comm->c_coll->coll_barrier_module );
 
     return ret;
 }

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_write.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -144,9 +144,9 @@ int mca_sharedfp_sm_write_ordered (mca_io_ompio_file_t *fh,
             return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    ret = sh->comm->c_coll.coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_gather ( &sendBuff, sendcnt, OMPI_OFFSET_DATATYPE,
                                    buff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-                                   sh->comm, sh->comm->c_coll.coll_gather_module );
+                                   sh->comm, sh->comm->c_coll->coll_gather_module );
     if ( OMPI_SUCCESS != ret ) {
         goto exit;
     }
@@ -185,9 +185,9 @@ int mca_sharedfp_sm_write_ordered (mca_io_ompio_file_t *fh,
     }
 
     /* Scatter the results to the other processes*/
-    ret = sh->comm->c_coll.coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
+    ret = sh->comm->c_coll->coll_scatter ( buff, sendcnt, OMPI_OFFSET_DATATYPE,
                                           &offsetBuff, recvcnt, OMPI_OFFSET_DATATYPE, 0,
-                                          sh->comm, sh->comm->c_coll.coll_scatter_module );
+                                          sh->comm, sh->comm->c_coll->coll_scatter_module );
 
     if ( OMPI_SUCCESS != ret ) {
         goto exit;

--- a/ompi/mca/topo/base/topo_base_dist_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create.c
@@ -3,7 +3,7 @@
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2011-2013 The University of Tennessee and The University
+ * Copyright (c) 2011-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
@@ -114,9 +114,9 @@ int mca_topo_base_dist_graph_distribute(mca_topo_base_module_t* module,
         }
     }
 
-    err = comm->c_coll.coll_reduce_scatter_block( MPI_IN_PLACE, idx, 2,
+    err = comm->c_coll->coll_reduce_scatter_block( MPI_IN_PLACE, idx, 2,
                                                   (ompi_datatype_t*)&ompi_mpi_int, MPI_SUM, comm,
-                                                  comm->c_coll.coll_reduce_scatter_block_module);
+                                                  comm->c_coll->coll_reduce_scatter_block_module);
     /**
      * At this point in the indexes array we have:
      * - idx[0].in  total number of IN  edges

--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2011-2015 The University of Tennessee and The University
+ * Copyright (c) 2011-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2011-2015 INRIA.  All rights reserved.
@@ -105,9 +105,9 @@ static int check_oversubscribing(int rank,
                 return err;
     }
 
-    if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_bcast(&oversubscribed, 1,
+    if (OMPI_SUCCESS != (err = comm_old->c_coll->coll_bcast(&oversubscribed, 1,
                                                            MPI_INT, 0, comm_old,
-                                                           comm_old->c_coll.coll_bcast_module)))
+                                                           comm_old->c_coll->coll_bcast_module)))
         return err;
 
     return oversubscribed;
@@ -416,10 +416,10 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
                     local_pattern[topo->in[i]] += topo->inw[i];
                 for(i = 0; i < topo->outdegree ; i++)
                     local_pattern[topo->out[i]] += topo->outw[i];
-                if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_gather(MPI_IN_PLACE, size, MPI_DOUBLE,
+                if (OMPI_SUCCESS != (err = comm_old->c_coll->coll_gather(MPI_IN_PLACE, size, MPI_DOUBLE,
                                                                         local_pattern, size, MPI_DOUBLE,
                                                                         0, comm_old,
-                                                                        comm_old->c_coll.coll_gather_module)))
+                                                                        comm_old->c_coll->coll_gather_module)))
                     return err;
             }
         } else {
@@ -429,10 +429,10 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
                     local_pattern[topo->in[i]] += topo->inw[i];
                 for(i = 0; i < topo->outdegree ; i++)
                     local_pattern[topo->out[i]] += topo->outw[i];
-                if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_gather(local_pattern, size, MPI_DOUBLE,
+                if (OMPI_SUCCESS != (err = comm_old->c_coll->coll_gather(local_pattern, size, MPI_DOUBLE,
                                                                         NULL,0,0,
                                                                         0, comm_old,
-                                                                        comm_old->c_coll.coll_gather_module)))
+                                                                        comm_old->c_coll->coll_gather_module)))
                     return err;
             }
         }
@@ -692,9 +692,9 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
 
         /* Todo : Bcast + group creation */
         /* scatter the ranks */
-        if (OMPI_SUCCESS != (err = comm_old->c_coll.coll_scatter(k, 1, MPI_INT,
+        if (OMPI_SUCCESS != (err = comm_old->c_coll->coll_scatter(k, 1, MPI_INT,
                                                                  &newrank, 1, MPI_INT,
-                                                                 0, comm_old,comm_old->c_coll.coll_scatter_module)))
+                                                                 0, comm_old,comm_old->c_coll->coll_scatter_module)))
             ERR_EXIT(err);
 
         if ( 0 == rank )
@@ -729,10 +729,10 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
         for(i = 0 ; i < size ; i++)
             grank_to_lrank[i] = -1;
 
-        if (OMPI_SUCCESS != (err = localcomm->c_coll.coll_allgather(&rank,1,MPI_INT,
+        if (OMPI_SUCCESS != (err = localcomm->c_coll->coll_allgather(&rank,1,MPI_INT,
                                                                     lrank_to_grank,1,MPI_INT,
                                                                     localcomm,
-                                                                    localcomm->c_coll.coll_allgather_module)))
+                                                                    localcomm->c_coll->coll_allgather_module)))
             return err;
 
         for(i = 0 ; i < num_procs_in_node ; i++)
@@ -759,10 +759,10 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
                 for(i = 0; i < topo->outdegree ; i++)
                     if (grank_to_lrank[topo->out[i]] != -1)
                         local_pattern[grank_to_lrank[topo->out[i]]] += topo->outw[i];
-                if (OMPI_SUCCESS != (err = localcomm->c_coll.coll_gather(MPI_IN_PLACE, num_procs_in_node, MPI_DOUBLE,
+                if (OMPI_SUCCESS != (err = localcomm->c_coll->coll_gather(MPI_IN_PLACE, num_procs_in_node, MPI_DOUBLE,
                                                                          local_pattern, num_procs_in_node, MPI_DOUBLE,
                                                                          0,localcomm,
-                                                                         localcomm->c_coll.coll_gather_module)))
+                                                                         localcomm->c_coll->coll_gather_module)))
                     ERR_EXIT(err);
             }
 
@@ -853,17 +853,17 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
                 for(i = 0; i < topo->outdegree ; i++)
                     if (grank_to_lrank[topo->out[i]] != -1)
                         local_pattern[grank_to_lrank[topo->out[i]]] += topo->outw[i];
-                if (OMPI_SUCCESS != (err = localcomm->c_coll.coll_gather(local_pattern, num_procs_in_node, MPI_DOUBLE,
+                if (OMPI_SUCCESS != (err = localcomm->c_coll->coll_gather(local_pattern, num_procs_in_node, MPI_DOUBLE,
                                                                          NULL,0,0,
                                                                          0,localcomm,
-                                                                         localcomm->c_coll.coll_gather_module)))
+                                                                         localcomm->c_coll->coll_gather_module)))
                     ERR_EXIT(err);
             }
         }
 
-        if (OMPI_SUCCESS != (err = localcomm->c_coll.coll_bcast(matching, num_procs_in_node,
+        if (OMPI_SUCCESS != (err = localcomm->c_coll->coll_bcast(matching, num_procs_in_node,
                                                                 MPI_INT,0,localcomm,
-                                                                localcomm->c_coll.coll_bcast_module)))
+                                                                localcomm->c_coll->coll_bcast_module)))
             ERR_EXIT(err);
 
         object = hwloc_get_obj_by_depth(opal_hwloc_topology,

--- a/ompi/mpi/c/allgather.c
+++ b/ompi/mpi/c/allgather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -119,9 +119,9 @@ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
     /* Invoke the coll component to perform the back-end operation */
 
-    err = comm->c_coll.coll_allgather(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_allgather(sendbuf, sendcount, sendtype,
                                       recvbuf, recvcount, recvtype, comm,
-                                      comm->c_coll.coll_allgather_module);
+                                      comm->c_coll->coll_allgather_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/allgatherv.c
+++ b/ompi/mpi/c/allgatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -140,10 +140,10 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_allgatherv(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_allgatherv(sendbuf, sendcount, sendtype,
                                        recvbuf, (int *) recvcounts,
                                        (int *) displs, recvtype, comm,
-                                       comm->c_coll.coll_allgatherv_module);
+                                       comm->c_coll->coll_allgatherv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/allreduce.c
+++ b/ompi/mpi/c/allreduce.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -107,9 +107,9 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_allreduce(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_allreduce(sendbuf, recvbuf, count,
                                       datatype, op, comm,
-                                      comm->c_coll.coll_allreduce_module);
+                                      comm->c_coll->coll_allreduce_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/alltoall.c
+++ b/ompi/mpi/c/alltoall.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -104,9 +104,9 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_alltoall(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_alltoall(sendbuf, sendcount, sendtype,
                                      recvbuf, recvcount, recvtype,
-                                     comm, comm->c_coll.coll_alltoall_module);
+                                     comm, comm->c_coll->coll_alltoall_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/alltoallv.c
+++ b/ompi/mpi/c/alltoallv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -123,9 +123,9 @@ int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
+    err = comm->c_coll->coll_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
                                       recvbuf, recvcounts, rdispls, recvtype,
-                                      comm, comm->c_coll.coll_alltoallv_module);
+                                      comm, comm->c_coll->coll_alltoallv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/alltoallw.c
+++ b/ompi/mpi/c/alltoallw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -118,9 +118,9 @@ int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_alltoallw(sendbuf, sendcounts, sdispls, (ompi_datatype_t **) sendtypes,
+    err = comm->c_coll->coll_alltoallw(sendbuf, sendcounts, sdispls, (ompi_datatype_t **) sendtypes,
                                       recvbuf, recvcounts, rdispls, (ompi_datatype_t **) recvtypes,
-                                      comm, comm->c_coll.coll_alltoallw_module);
+                                      comm, comm->c_coll->coll_alltoallw_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/barrier.c
+++ b/ompi/mpi/c/barrier.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -60,7 +60,7 @@ int MPI_Barrier(MPI_Comm comm)
 
   if (OMPI_COMM_IS_INTRA(comm)) {
     if (ompi_comm_size(comm) > 1) {
-      err = comm->c_coll.coll_barrier(comm, comm->c_coll.coll_barrier_module);
+      err = comm->c_coll->coll_barrier(comm, comm->c_coll->coll_barrier_module);
     }
   }
 
@@ -68,7 +68,7 @@ int MPI_Barrier(MPI_Comm comm)
      there's always at least 2 processes in an intercommunicator. */
 
   else {
-      err = comm->c_coll.coll_barrier(comm, comm->c_coll.coll_barrier_module);
+      err = comm->c_coll->coll_barrier(comm, comm->c_coll->coll_barrier_module);
   }
 
   /* All done */

--- a/ompi/mpi/c/bcast.c
+++ b/ompi/mpi/c/bcast.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -108,7 +108,7 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
 
     /* Invoke the coll component to perform the back-end operation */
 
-    err = comm->c_coll.coll_bcast(buffer, count, datatype, root, comm,
-                                  comm->c_coll.coll_bcast_module);
+    err = comm->c_coll->coll_bcast(buffer, count, datatype, root, comm,
+                                  comm->c_coll->coll_bcast_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/comm_disconnect.c
+++ b/ompi/mpi/c/comm_disconnect.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -69,7 +69,7 @@ int MPI_Comm_disconnect(MPI_Comm *comm)
         }
     }
     else {
-        (*comm)->c_coll.coll_barrier(*comm, (*comm)->c_coll.coll_barrier_module);
+        (*comm)->c_coll->coll_barrier(*comm, (*comm)->c_coll->coll_barrier_module);
     }
 
     ompi_comm_free(comm);

--- a/ompi/mpi/c/exscan.c
+++ b/ompi/mpi/c/exscan.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -88,9 +88,9 @@ int MPI_Exscan(const void *sendbuf, void *recvbuf, int count,
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_exscan(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_exscan(sendbuf, recvbuf, count,
                                    datatype, op, comm,
-                                   comm->c_coll.coll_exscan_module);
+                                   comm->c_coll->coll_exscan_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/gather.c
+++ b/ompi/mpi/c/gather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -178,8 +178,8 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_gather(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_gather(sendbuf, sendcount, sendtype, recvbuf,
                                    recvcount, recvtype, root, comm,
-                                   comm->c_coll.coll_gather_module);
+                                   comm->c_coll->coll_gather_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/gatherv.c
+++ b/ompi/mpi/c/gatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -190,9 +190,9 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_gatherv(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_gatherv(sendbuf, sendcount, sendtype, recvbuf,
                                     recvcounts, displs,
                                     recvtype, root, comm,
-                                    comm->c_coll.coll_gatherv_module);
+                                    comm->c_coll->coll_gatherv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/iallgather.c
+++ b/ompi/mpi/c/iallgather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -96,9 +96,9 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_iallgather(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_iallgather(sendbuf, sendcount, sendtype,
                                        recvbuf, recvcount, recvtype, comm,
-                                       request, comm->c_coll.coll_iallgather_module);
+                                       request, comm->c_coll->coll_iallgather_module);
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/iallgatherv.c
+++ b/ompi/mpi/c/iallgatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -119,10 +119,10 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_iallgatherv(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_iallgatherv(sendbuf, sendcount, sendtype,
                                         recvbuf, recvcounts, displs,
                                         recvtype, comm, request,
-                                        comm->c_coll.coll_iallgatherv_module);
+                                        comm->c_coll->coll_iallgatherv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/iallreduce.c
+++ b/ompi/mpi/c/iallreduce.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -110,8 +110,8 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_iallreduce(sendbuf, recvbuf, count, datatype,
-                                       op, comm, request, comm->c_coll.coll_iallreduce_module);
+    err = comm->c_coll->coll_iallreduce(sendbuf, recvbuf, count, datatype,
+                                       op, comm, request, comm->c_coll->coll_iallreduce_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ialltoall.c
+++ b/ompi/mpi/c/ialltoall.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -95,8 +95,8 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ialltoall(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_ialltoall(sendbuf, sendcount, sendtype,
                                       recvbuf, recvcount, recvtype, comm,
-                                      request, comm->c_coll.coll_ialltoall_module);
+                                      request, comm->c_coll->coll_ialltoall_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ialltoallv.c
+++ b/ompi/mpi/c/ialltoallv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -124,9 +124,9 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ialltoallv(sendbuf, sendcounts, sdispls,
+    err = comm->c_coll->coll_ialltoallv(sendbuf, sendcounts, sdispls,
                                        sendtype, recvbuf, recvcounts, rdispls,
-                                       recvtype, comm, request, comm->c_coll.coll_ialltoallv_module);
+                                       recvtype, comm, request, comm->c_coll->coll_ialltoallv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/ialltoallw.c
+++ b/ompi/mpi/c/ialltoallw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -120,10 +120,10 @@ int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispl
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ialltoallw(sendbuf, sendcounts, sdispls,
+    err = comm->c_coll->coll_ialltoallw(sendbuf, sendcounts, sdispls,
                                        sendtypes, recvbuf, recvcounts,
                                        rdispls, recvtypes, comm, request,
-                                       comm->c_coll.coll_ialltoallw_module);
+                                       comm->c_coll->coll_ialltoallw_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/ibarrier.c
+++ b/ompi/mpi/c/ibarrier.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -57,7 +57,7 @@ int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request)
 
     OPAL_CR_ENTER_LIBRARY();
 
-    err = comm->c_coll.coll_ibarrier(comm, request, comm->c_coll.coll_ibarrier_module);
+    err = comm->c_coll->coll_ibarrier(comm, request, comm->c_coll->coll_ibarrier_module);
 
     /* All done */
 

--- a/ompi/mpi/c/ibcast.c
+++ b/ompi/mpi/c/ibcast.c
@@ -1,7 +1,10 @@
 /*
- * Copyright (c)      2012 Oak Rigde National Laboratory. All rights reserved.
+ * Copyright (c) 2012      Oak Rigde National Laboratory. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,8 +80,8 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype,
 
     /* Invoke the coll component to perform the back-end operation */
 
-    err = comm->c_coll.coll_ibcast(buffer, count, datatype, root, comm,
+    err = comm->c_coll->coll_ibcast(buffer, count, datatype, root, comm,
                                   request,
-                                  comm->c_coll.coll_ibcast_module);
+                                  comm->c_coll->coll_ibcast_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/iexscan.c
+++ b/ompi/mpi/c/iexscan.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -80,9 +80,9 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count,
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_iexscan(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_iexscan(sendbuf, recvbuf, count,
                                     datatype, op, comm, request,
-                                    comm->c_coll.coll_iexscan_module);
+                                    comm->c_coll->coll_iexscan_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/igather.c
+++ b/ompi/mpi/c/igather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -167,8 +167,8 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_igather(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_igather(sendbuf, sendcount, sendtype, recvbuf,
                                     recvcount, recvtype, root, comm, request,
-                                    comm->c_coll.coll_igather_module);
+                                    comm->c_coll->coll_igather_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/igatherv.c
+++ b/ompi/mpi/c/igatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -190,8 +190,8 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_igatherv(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_igatherv(sendbuf, sendcount, sendtype, recvbuf,
                                      recvcounts, displs, recvtype,
-                                     root, comm, request, comm->c_coll.coll_igatherv_module);
+                                     root, comm, request, comm->c_coll->coll_igatherv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ineighbor_allgather.c
+++ b/ompi/mpi/c/ineighbor_allgather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -122,9 +122,9 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf,
                                                 recvcount, recvtype, comm, request,
-                                                comm->c_coll.coll_ineighbor_allgather_module);
+                                                comm->c_coll->coll_ineighbor_allgather_module);
 
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ineighbor_allgatherv.c
+++ b/ompi/mpi/c/ineighbor_allgatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -144,10 +144,10 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ineighbor_allgatherv(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_ineighbor_allgatherv(sendbuf, sendcount, sendtype,
                                                  recvbuf, (int *) recvcounts, (int *) displs,
                                                  recvtype, comm, request,
-                                                 comm->c_coll.coll_ineighbor_allgatherv_module);
+                                                 comm->c_coll->coll_ineighbor_allgatherv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/ineighbor_alltoall.c
+++ b/ompi/mpi/c/ineighbor_alltoall.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -118,8 +118,8 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ineighbor_alltoall(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_ineighbor_alltoall(sendbuf, sendcount, sendtype,
                                                recvbuf, recvcount, recvtype, comm,
-                                               request, comm->c_coll.coll_ineighbor_alltoall_module);
+                                               request, comm->c_coll->coll_ineighbor_alltoall_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ineighbor_alltoallv.c
+++ b/ompi/mpi/c/ineighbor_alltoallv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -142,9 +142,9 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ineighbor_alltoallv(sendbuf, sendcounts, sdispls,
+    err = comm->c_coll->coll_ineighbor_alltoallv(sendbuf, sendcounts, sdispls,
                                                 sendtype, recvbuf, recvcounts, rdispls,
-                                                recvtype, comm, request, comm->c_coll.coll_ineighbor_alltoallv_module);
+                                                recvtype, comm, request, comm->c_coll->coll_ineighbor_alltoallv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/ineighbor_alltoallw.c
+++ b/ompi/mpi/c/ineighbor_alltoallw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -142,9 +142,9 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
+    err = comm->c_coll->coll_ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
                                                 recvbuf, recvcounts, rdispls, recvtypes, comm, request,
-                                                comm->c_coll.coll_ineighbor_alltoallw_module);
+                                                comm->c_coll->coll_ineighbor_alltoallw_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/intercomm_create.c
+++ b/ompi/mpi/c/intercomm_create.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -130,9 +130,9 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
     }
 
     /* bcast size and list of remote processes to all processes in local_comm */
-    rc = local_comm->c_coll.coll_bcast ( &rsize, 1, MPI_INT, lleader,
+    rc = local_comm->c_coll->coll_bcast ( &rsize, 1, MPI_INT, lleader,
                                          local_comm,
-                                         local_comm->c_coll.coll_bcast_module);
+                                         local_comm->c_coll->coll_bcast_module);
     if ( rc != MPI_SUCCESS ) {
         goto err_exit;
     }

--- a/ompi/mpi/c/ireduce.c
+++ b/ompi/mpi/c/ireduce.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -134,9 +134,9 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count,
 
     /* Invoke the coll component to perform the back-end operation */
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_ireduce(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_ireduce(sendbuf, recvbuf, count,
                                     datatype, op, root, comm, request,
-                                    comm->c_coll.coll_ireduce_module);
+                                    comm->c_coll->coll_ireduce_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ireduce_scatter.c
+++ b/ompi/mpi/c/ireduce_scatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -131,9 +131,9 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_ireduce_scatter(sendbuf, recvbuf, recvcounts,
+    err = comm->c_coll->coll_ireduce_scatter(sendbuf, recvbuf, recvcounts,
                                             datatype, op, comm, request,
-                                            comm->c_coll.coll_ireduce_scatter_module);
+                                            comm->c_coll->coll_ireduce_scatter_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/ireduce_scatter_block.c
+++ b/ompi/mpi/c/ireduce_scatter_block.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -98,9 +98,9 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_ireduce_scatter_block(sendbuf, recvbuf, recvcount,
+    err = comm->c_coll->coll_ireduce_scatter_block(sendbuf, recvbuf, recvcount,
                                                   datatype, op, comm, request,
-                                                  comm->c_coll.coll_ireduce_scatter_block_module);
+                                                  comm->c_coll->coll_ireduce_scatter_block_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/iscan.c
+++ b/ompi/mpi/c/iscan.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -94,10 +94,10 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count,
     /* Call the coll component to actually perform the allgather */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_iscan(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_iscan(sendbuf, recvbuf, count,
                                   datatype, op, comm,
                                   request,
-                                  comm->c_coll.coll_iscan_module);
+                                  comm->c_coll->coll_iscan_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/iscatter.c
+++ b/ompi/mpi/c/iscatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -150,8 +150,8 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_iscatter(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_iscatter(sendbuf, sendcount, sendtype, recvbuf,
                                      recvcount, recvtype, root, comm, request,
-                                     comm->c_coll.coll_iscatter_module);
+                                     comm->c_coll->coll_iscatter_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/iscatterv.c
+++ b/ompi/mpi/c/iscatterv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -190,8 +190,8 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_iscatterv(sendbuf, sendcounts, displs,
+    err = comm->c_coll->coll_iscatterv(sendbuf, sendcounts, displs,
                                       sendtype, recvbuf, recvcount, recvtype, root, comm,
-                                      request, comm->c_coll.coll_iscatterv_module);
+                                      request, comm->c_coll->coll_iscatterv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/neighbor_allgather.c
+++ b/ompi/mpi/c/neighbor_allgather.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -129,9 +129,9 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_neighbor_allgather(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_neighbor_allgather(sendbuf, sendcount, sendtype,
                                                recvbuf, recvcount, recvtype, comm,
-                                               comm->c_coll.coll_neighbor_allgather_module);
+                                               comm->c_coll->coll_neighbor_allgather_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/neighbor_allgatherv.c
+++ b/ompi/mpi/c/neighbor_allgatherv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -165,9 +165,9 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_neighbor_allgatherv(sendbuf, sendcount, sendtype,
+    err = comm->c_coll->coll_neighbor_allgatherv(sendbuf, sendcount, sendtype,
                                                 recvbuf, recvcounts, displs,
-                                                recvtype, comm, comm->c_coll.coll_neighbor_allgatherv_module);
+                                                recvtype, comm, comm->c_coll->coll_neighbor_allgatherv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/neighbor_alltoall.c
+++ b/ompi/mpi/c/neighbor_alltoall.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -126,9 +126,9 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_neighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_neighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf,
                                               recvcount, recvtype, comm,
-                                              comm->c_coll.coll_neighbor_alltoall_module);
+                                              comm->c_coll->coll_neighbor_alltoall_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/neighbor_alltoallv.c
+++ b/ompi/mpi/c/neighbor_alltoallv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -142,9 +142,9 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_neighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
+    err = comm->c_coll->coll_neighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
                                                recvbuf, recvcounts, rdispls, recvtype,
-                                               comm, comm->c_coll.coll_neighbor_alltoallv_module);
+                                               comm, comm->c_coll->coll_neighbor_alltoallv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/neighbor_alltoallw.c
+++ b/ompi/mpi/c/neighbor_alltoallw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -138,9 +138,9 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_neighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
+    err = comm->c_coll->coll_neighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes,
                                                recvbuf, recvcounts, rdispls, recvtypes,
-                                               comm, comm->c_coll.coll_neighbor_alltoallw_module);
+                                               comm, comm->c_coll->coll_neighbor_alltoallw_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }
 

--- a/ompi/mpi/c/reduce.c
+++ b/ompi/mpi/c/reduce.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -133,9 +133,9 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_reduce(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_reduce(sendbuf, recvbuf, count,
                                    datatype, op, root, comm,
-                                   comm->c_coll.coll_reduce_module);
+                                   comm->c_coll->coll_reduce_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/reduce_local.c
+++ b/ompi/mpi/c/reduce_local.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -82,8 +82,8 @@ int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count,
     // Since there is no 'comm' parameter to this interface use 'self' since
     // this is a local operation to this process.
     ompi_communicator_t *comm = &ompi_mpi_comm_self.comm;
-    err = comm->c_coll.coll_reduce_local(inbuf, inoutbuf, count, datatype, op,
-                                         comm->c_coll.coll_reduce_local_module);
+    err = comm->c_coll->coll_reduce_local(inbuf, inoutbuf, count, datatype, op,
+                                         comm->c_coll->coll_reduce_local_module);
     OBJ_RELEASE(datatype);
     OBJ_RELEASE(op);
 

--- a/ompi/mpi/c/reduce_scatter.c
+++ b/ompi/mpi/c/reduce_scatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -128,9 +128,9 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_reduce_scatter(sendbuf, recvbuf, recvcounts,
+    err = comm->c_coll->coll_reduce_scatter(sendbuf, recvbuf, recvcounts,
                                            datatype, op, comm,
-                                           comm->c_coll.coll_reduce_scatter_module);
+                                           comm->c_coll->coll_reduce_scatter_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/reduce_scatter_block.c
+++ b/ompi/mpi/c/reduce_scatter_block.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -97,9 +97,9 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
     /* Invoke the coll component to perform the back-end operation */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_reduce_scatter_block(sendbuf, recvbuf, recvcount,
+    err = comm->c_coll->coll_reduce_scatter_block(sendbuf, recvbuf, recvcount,
                                                  datatype, op, comm,
-                                                 comm->c_coll.coll_reduce_scatter_block_module);
+                                                 comm->c_coll->coll_reduce_scatter_block_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/scan.c
+++ b/ompi/mpi/c/scan.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -102,9 +102,9 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count,
     /* Call the coll component to actually perform the allgather */
 
     OBJ_RETAIN(op);
-    err = comm->c_coll.coll_scan(sendbuf, recvbuf, count,
+    err = comm->c_coll->coll_scan(sendbuf, recvbuf, count,
                                  datatype, op, comm,
-                                 comm->c_coll.coll_scan_module);
+                                 comm->c_coll->coll_scan_module);
     OBJ_RELEASE(op);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/scatter.c
+++ b/ompi/mpi/c/scatter.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -161,8 +161,8 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_scatter(sendbuf, sendcount, sendtype, recvbuf,
+    err = comm->c_coll->coll_scatter(sendbuf, sendcount, sendtype, recvbuf,
                                     recvcount, recvtype, root, comm,
-                                    comm->c_coll.coll_scatter_module);
+                                    comm->c_coll->coll_scatter_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/mpi/c/scatterv.c
+++ b/ompi/mpi/c/scatterv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2012 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -190,8 +190,8 @@ int MPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[]
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */
-    err = comm->c_coll.coll_scatterv(sendbuf, sendcounts, displs,
+    err = comm->c_coll->coll_scatterv(sendbuf, sendcounts, displs,
                                      sendtype, recvbuf, recvcount, recvtype, root, comm,
-                                     comm->c_coll.coll_scatterv_module);
+                                     comm->c_coll->coll_scatterv_module);
     OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
 }

--- a/ompi/runtime/ompi_cr.c
+++ b/ompi/runtime/ompi_cr.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -99,7 +99,7 @@ int ompi_cr_verbosity = 0;
         bool found = false;                                     \
         int k;                                                  \
         mca_coll_base_module_t *my_module =                     \
-            comm->c_coll.coll_ ## func ## _module;              \
+            comm->c_coll->coll_ ## func ## _module;             \
         if (NULL != my_module) {                                \
             for (k = 0 ; k < highest_module ; ++k) {            \
                 if (my_module == modules[k]) found = true;      \

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -268,7 +268,7 @@ int ompi_mpi_finalize(void)
              * reasons cited above), followed by a blocking PMIx fence
              * (which does not call opal_progress()). */
             ompi_communicator_t *comm = &ompi_mpi_comm_world.comm;
-            comm->c_coll.coll_barrier(comm, comm->c_coll.coll_barrier_module);
+            comm->c_coll->coll_barrier(comm, comm->c_coll->coll_barrier_module);
 
             opal_pmix.fence(NULL, 0);
         }

--- a/oshmem/mca/scoll/mpi/scoll_mpi_ops.c
+++ b/oshmem/mca/scoll/mpi/scoll_mpi_ops.c
@@ -1,5 +1,6 @@
 /**
   Copyright (c) 2011 Mellanox Technologies. All rights reserved.
+  Copyright (c) 2017      IBM Corporation.  All rights reserved.
   $COPYRIGHT$
 
   Additional copyrights may follow
@@ -21,7 +22,7 @@ int mca_scoll_mpi_barrier(struct oshmem_group_t *group, long *pSync, int alg)
     MPI_COLL_VERBOSE(20,"RUNNING MPI BARRIER");
     mpi_module = (mca_scoll_mpi_module_t *) group->g_scoll.scoll_barrier_module;
 
-    rc = mpi_module->comm->c_coll.coll_barrier(mpi_module->comm, mpi_module->comm->c_coll.coll_barrier_module);
+    rc = mpi_module->comm->c_coll->coll_barrier(mpi_module->comm, mpi_module->comm->c_coll->coll_barrier_module);
     if (OMPI_SUCCESS != rc){
         MPI_COLL_VERBOSE(20,"RUNNING FALLBACK BARRIER");
         PREVIOUS_SCOLL_FN(mpi_module, barrier, group,
@@ -71,9 +72,9 @@ int mca_scoll_mpi_broadcast(struct oshmem_group_t *group,
                 SCOLL_DEFAULT_ALG);
         return rc;
     }
-    rc = mpi_module->comm->c_coll.coll_bcast(buf, (int)nlong, dtype, root, mpi_module->comm, mpi_module->comm->c_coll.coll_bcast_module);
+    rc = mpi_module->comm->c_coll->coll_bcast(buf, (int)nlong, dtype, root, mpi_module->comm, mpi_module->comm->c_coll->coll_bcast_module);
 #else
-    rc = mpi_module->comm->c_coll.coll_bcast(buf, nlong, dtype, root, mpi_module->comm, mpi_module->comm->c_coll.coll_bcast_module);
+    rc = mpi_module->comm->c_coll->coll_bcast(buf, nlong, dtype, root, mpi_module->comm, mpi_module->comm->c_coll->coll_bcast_module);
 #endif
     if (OMPI_SUCCESS != rc){
         MPI_COLL_VERBOSE(20,"RUNNING FALLBACK BCAST");
@@ -126,9 +127,9 @@ int mca_scoll_mpi_collect(struct oshmem_group_t *group,
                     SCOLL_DEFAULT_ALG);
             return rc;
         }
-        rc = mpi_module->comm->c_coll.coll_allgather(sbuf, (int)nlong, stype, rbuf, (int)nlong, rtype, mpi_module->comm, mpi_module->comm->c_coll.coll_allgather_module);
+        rc = mpi_module->comm->c_coll->coll_allgather(sbuf, (int)nlong, stype, rbuf, (int)nlong, rtype, mpi_module->comm, mpi_module->comm->c_coll->coll_allgather_module);
 #else
-        rc = mpi_module->comm->c_coll.coll_allgather(sbuf, nlong, stype, rbuf, nlong, rtype, mpi_module->comm, mpi_module->comm->c_coll.coll_allgather_module);
+        rc = mpi_module->comm->c_coll->coll_allgather(sbuf, nlong, stype, rbuf, nlong, rtype, mpi_module->comm, mpi_module->comm->c_coll->coll_allgather_module);
 #endif
         if (OMPI_SUCCESS != rc){
             MPI_COLL_VERBOSE(20,"RUNNING FALLBACK FCOLLECT");
@@ -195,9 +196,9 @@ int mca_scoll_mpi_reduce(struct oshmem_group_t *group,
                 SCOLL_DEFAULT_ALG);
         return rc;
     }
-    rc = mpi_module->comm->c_coll.coll_allreduce(sbuf, rbuf, (int)count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll.coll_allreduce_module);
+    rc = mpi_module->comm->c_coll->coll_allreduce(sbuf, rbuf, (int)count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll->coll_allreduce_module);
 #else
-    rc = mpi_module->comm->c_coll.coll_allreduce(sbuf, rbuf, count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll.coll_allreduce_module);
+    rc = mpi_module->comm->c_coll->coll_allreduce(sbuf, rbuf, count, dtype, h_op, mpi_module->comm, mpi_module->comm->c_coll->coll_allreduce_module);
 #endif
     if (OMPI_SUCCESS != rc){
         MPI_COLL_VERBOSE(20,"RUNNING FALLBACK REDUCE");


### PR DESCRIPTION
As we changed the ABI (forcing a major release), we can limit
the size of the predefined communicators by moving the collective
structure outside the communicator. This might have a minimal,
but unnoticeable, impact on performance. This approach has been
discussed during the January 2017 devel meeting.