### PR TITLE
pmix: fix zlib protection macro usage

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/util/compress.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/util/compress.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +22,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/util/compress.h"
 
-#ifdef HAVE_ZLIB_H
+#if PMIX_HAVE_ZLIB
 bool pmix_util_compress_string(char *instring,
                                uint8_t **outbytes,
                                size_t *nbytes)


### PR DESCRIPTION
It's possible that we can have zlib.h but still not have zlib support. Use the correct macro to protect the usage of calling zlib functions.

This fixes 32-bit MTT builds at Cisco (e.g., https://mtt.open-mpi.org/index.php?do_redir=2389).

Submitted upstream to PMIX: https://github.com/pmix/master/pull/290

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>