### PR TITLE
coll/basic: Expand check for negative input values

### DIFF
--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -187,6 +188,7 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
 
     indegree = dist_graph->indegree;
     outdegree = dist_graph->outdegree;
+    if( 0 == (indegree + outdegree) ) return OMPI_SUCCESS;
 
     inedges = dist_graph->in;
     outedges = dist_graph->out;

--- a/ompi/mpi/c/ineighbor_allgather.c
+++ b/ompi/mpi/c/ineighbor_allgather.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -91,6 +94,28 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
             OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            int indegree  = dist_graph->indegree;
+            int outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
     }
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/ineighbor_allgatherv.c
+++ b/ompi/mpi/c/ineighbor_allgatherv.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -113,6 +116,28 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
 
         if (NULL == displs) {
           return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_BUFFER, FUNC_NAME);
+        }
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            int indegree  = dist_graph->indegree;
+            int outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
         }
     }
 

--- a/ompi/mpi/c/ineighbor_alltoallv.c
+++ b/ompi/mpi/c/ineighbor_alltoallv.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -111,6 +114,28 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
         for (i = 0; i < indegree; ++i) {
             OMPI_CHECK_DATATYPE_FOR_RECV(err, recvtype, recvcounts[i]);
             OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+        }
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            indegree  = dist_graph->indegree;
+            outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
         }
     }
 

--- a/ompi/mpi/c/ineighbor_alltoallw.c
+++ b/ompi/mpi/c/ineighbor_alltoallw.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -109,6 +112,28 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
         for (i = 0; i < indegree; ++i) {
             OMPI_CHECK_DATATYPE_FOR_RECV(err, recvtypes[i], recvcounts[i]);
             OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+        }
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            indegree  = dist_graph->indegree;
+            outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
         }
     }
 

--- a/ompi/mpi/c/neighbor_allgather.c
+++ b/ompi/mpi/c/neighbor_allgather.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -90,6 +93,28 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
             OMPI_CHECK_DATATYPE_FOR_SEND(err, sendtype, sendcount);
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            int indegree  = dist_graph->indegree;
+            int outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
     }
 
     /* Do we need to do anything?  Everyone had to give the same send

--- a/ompi/mpi/c/neighbor_allgatherv.c
+++ b/ompi/mpi/c/neighbor_allgatherv.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -113,6 +116,28 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
 
         if (NULL == displs) {
           return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_BUFFER, FUNC_NAME);
+        }
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            int indegree  = dist_graph->indegree;
+            int outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
         }
     }
 

--- a/ompi/mpi/c/neighbor_alltoall.c
+++ b/ompi/mpi/c/neighbor_alltoall.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,6 +32,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -90,6 +93,28 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
             ompi_datatype_type_size(recvtype, &recvtype_size);
             if ((sendtype_size*sendcount) != (recvtype_size*recvcount)) {
                 return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_TRUNCATE, FUNC_NAME);
+            }
+        }
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            int indegree  = dist_graph->indegree;
+            int outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
             }
         }
     }

--- a/ompi/mpi/c/neighbor_alltoallv.c
+++ b/ompi/mpi/c/neighbor_alltoallv.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
 #include "ompi/communicator/comm_helpers.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -117,6 +120,28 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
         for (i = 0; i < indegree; ++i) {
             OMPI_CHECK_DATATYPE_FOR_RECV(err, recvtype, recvcounts[i]);
             OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+        }
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            indegree  = dist_graph->indegree;
+            outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
         }
     }
 

--- a/ompi/mpi/c/neighbor_alltoallw.c
+++ b/ompi/mpi/c/neighbor_alltoallw.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,8 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
 #include "ompi/communicator/comm_helpers.h"
+#include "ompi/mca/topo/topo.h"
+#include "ompi/mca/topo/base/base.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -113,6 +116,28 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
         for (i = 0; i < indegree; ++i) {
             OMPI_CHECK_DATATYPE_FOR_RECV(err, recvtypes[i], recvcounts[i]);
             OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
+        }
+
+        if( OMPI_COMM_IS_CART(comm) ) {
+            const mca_topo_base_comm_cart_2_2_0_t *cart = comm->c_topo->mtc.cart;
+            if( 0 > cart->ndims ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_GRAPH(comm) ) {
+            int degree;
+            mca_topo_base_graph_neighbors_count(comm, ompi_comm_rank(comm), &degree);
+            if( 0 > degree ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
+        }
+        else if( OMPI_COMM_IS_DIST_GRAPH(comm) ) {
+            const mca_topo_base_comm_dist_graph_2_2_0_t *dist_graph = comm->c_topo->mtc.dist_graph;
+            indegree  = dist_graph->indegree;
+            outdegree = dist_graph->outdegree;
+            if( indegree <  0 || outdegree <  0 ) {
+                return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG, FUNC_NAME);
+            }
         }
     }
 


### PR DESCRIPTION
 * Negative values are parameter errors for neighborhood collectives
   - Add checks to the mpi/c interface `MPI_PARAM_CHECK`
 * Fix a success check for neighbor_alltoallw with dist_graph

PR #2812 (`master`)