### PR TITLE
v2.1.0: help btl base: tell how to disable the warning

### DIFF
--- a/opal/mca/btl/base/help-mpi-btl-base.txt
+++ b/opal/mca/btl/base/help-mpi-btl-base.txt
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,3 +26,6 @@ Module: %s
 
 Another transport will be used instead, although this may result in
 lower performance.
+
+NOTE: You can disable this warning by setting the MCA parameter
+btl_base_warn_component_unused to 0.


### PR DESCRIPTION
As reported in
https://www.mail-archive.com/users@lists.open-mpi.org/msg30607.html,
give instructions in the show_help message how to disable the
warning.  Thanks to Susan Schwarz for reporting the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

(cherry picked from commit e272250531fcec7bb1510a2a171fea3a56b915d9)