### PR TITLE
coll/libnbc: optimize zero size ialltoall{v,w}

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_ialltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallw.c
@@ -193,12 +193,14 @@ static inline int a2aw_sched_linear(int rank, int p, NBC_Schedule *schedule,
   int res;
 
   for (int i = 0; i < p; i++) {
+    ptrdiff_t gap, span;
     if (i == rank) {
       continue;
     }
 
     /* post send */
-    if (sendcounts[i] != 0) {
+    span = opal_datatype_span(&sendtypes[i]->super, sendcounts[i], &gap);
+    if (OPAL_LIKELY(0 < span)) {
       char *sbuf = (char *) sendbuf + sdispls[i];
       res = NBC_Sched_send (sbuf, false, sendcounts[i], sendtypes[i], i, schedule, false);
       if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
@@ -206,7 +208,8 @@ static inline int a2aw_sched_linear(int rank, int p, NBC_Schedule *schedule,
       }
     }
     /* post receive */
-    if (recvcounts[i] != 0) {
+    span = opal_datatype_span(&recvtypes[i]->super, recvcounts[i], &gap);
+    if (OPAL_LIKELY(0 < span)) {
       char *rbuf = (char *) recvbuf + rdispls[i];
       res = NBC_Sched_recv (rbuf, false, recvcounts[i], recvtypes[i], i, schedule, false);
       if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {

--- a/ompi/mca/coll/libnbc/nbc_ialltoallw.c
+++ b/ompi/mca/coll/libnbc/nbc_ialltoallw.c
@@ -5,7 +5,7 @@
  *                         Corporation.  All rights reserved.
  * Copyright (c) 2006      The Technical University of Chemnitz. All
  *                         rights reserved.
- * Copyright (c) 2014-2016 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -67,6 +67,11 @@ int ompi_coll_libnbc_ialltoallw(const void* sendbuf, const int *sendcounts, cons
         span = lspan;
       }
     }
+    if (OPAL_UNLIKELY(0 == span)) {
+      *request = &ompi_request_empty;
+      NBC_Return_handle (handle);
+      return OMPI_SUCCESS;
+    }
     handle->tmpbuf = malloc(span);
     if (OPAL_UNLIKELY(NULL == handle->tmpbuf)) {
       NBC_Return_handle (handle);
@@ -80,6 +85,7 @@ int ompi_coll_libnbc_ialltoallw(const void* sendbuf, const int *sendcounts, cons
     sbuf = (char *) sendbuf + sdispls[rank];
     res = NBC_Copy(sbuf, sendcounts[rank], sendtypes[rank], rbuf, recvcounts[rank], recvtypes[rank], comm);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
+      NBC_Return_handle (handle);
       return res;
     }
   }

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -14,6 +14,8 @@
  *                         reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -344,6 +346,9 @@ opal_datatype_span( const opal_datatype_t* pData, int64_t count,
 {
     OPAL_PTRDIFF_TYPE extent = (pData->ub - pData->lb);
     OPAL_PTRDIFF_TYPE true_extent = (pData->true_ub - pData->true_lb);
+    if (OPAL_UNLIKELY(0 == pData->size) || (0 == count)) {
+        return 0;
+    }
     *gap = pData->true_lb;
     return true_extent + (count - 1) * extent;
 }


### PR DESCRIPTION
Thanks Lisandro Dalcin for the report

Fixes open-mpi/ompi#2945

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>