### PR TITLE
v2.0.x: create_tarball: read $debug from environment

### DIFF
--- a/contrib/nightly/create_tarball.sh
+++ b/contrib/nightly/create_tarball.sh
@@ -34,7 +34,7 @@ gitbranch=$5
 
 # Set this to any value for additional output; typically only when
 # debugging
-debug=1
+: ${debug:=}
 
 # do you want a success mail?
 want_success_mail=1


### PR DESCRIPTION
If $debug is set in the environment, use that.  This allows enabling
debug mode without requiring an edit to the script.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>