### PR TITLE
Fix plm/rsh runtime check

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -1165,7 +1165,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
             }
         }
         /* we need mpirun to be the first node on this list */
-        if (0 != strcmp(nodelist[0], orte_process_info.nodename)) {
+        if (NULL == nodelist ||
+            0 != strcmp(nodelist[0], orte_process_info.nodename)) {
             opal_argv_prepend_nosize(&nodelist, orte_process_info.nodename);
         }
         nlistflat = opal_argv_join(nodelist, ',');


### PR DESCRIPTION
Fix the check for rsh/ssh so we allow the check for SGE and LoadLeveler to occur if user doesn't specify their own launch agent. Fix a Coverity warning

Signed-off-by: Ralph Castain <rhc@open-mpi.org>