### PR TITLE
mca/base: add new base enumerator (auto_bool)

### DIFF
--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -117,6 +117,96 @@ mca_base_var_enum_t mca_base_var_enum_bool = {
     .dump      = mca_base_var_enum_bool_dump
 };
 
+static int mca_base_var_enum_auto_bool_get_count (mca_base_var_enum_t *enumerator, int *count)
+{
+    *count = 3;
+    return OPAL_SUCCESS;
+}
+
+static int mca_base_var_enum_auto_bool_get_value (mca_base_var_enum_t *self, int index,
+                                                  int *value, const char **string_value)
+{
+    const int values[3] = {0, 1, -1};
+    const char *strings[3] = {"false", "true", "auto"};
+
+    if (2 < index) {
+        return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    *value = values[index];
+    *string_value = strings[index];
+
+    return OPAL_SUCCESS;
+}
+
+static int mca_base_var_enum_auto_bool_vfs (mca_base_var_enum_t *self, const char *string_value,
+                                            int *value)
+{
+    char *tmp;
+    int v;
+
+    /* skip whitespace */
+    string_value += strspn (string_value, " \t\n\v\f\r");
+
+    v = strtol (string_value, &tmp, 10);
+    if (*tmp != '\0') {
+        if (0 == strcasecmp (string_value, "true") || 0 == strcasecmp (string_value, "t") ||
+            0 == strcasecmp (string_value, "enabled") || 0 == strcasecmp (string_value, "yes")) {
+            v = 1;
+        } else if (0 == strcasecmp (string_value, "false") || 0 == strcasecmp (string_value, "f") ||
+                   0 == strcasecmp (string_value, "disabled") || 0 == strcasecmp (string_value, "no")) {
+            v = 0;
+        } else if (0 == strcasecmp (string_value, "auto")) {
+            v = -1;
+        } else {
+            return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
+        }
+    }
+
+    if (v > 1) {
+        *value = 1;
+    } else if (v < -1) {
+        *value = -1;
+    } else {
+        *value = v;
+    }
+
+    return OPAL_SUCCESS;
+}
+
+static int mca_base_var_enum_auto_bool_sfv (mca_base_var_enum_t *self, const int value,
+                                            char **string_value)
+{
+    if (string_value) {
+        if (value < 0) {
+            *string_value = strdup ("auto");
+        } else if (value > 0) {
+            *string_value = strdup ("true");
+        } else {
+            *string_value = strdup ("false");
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
+static int mca_base_var_enum_auto_bool_dump (mca_base_var_enum_t *self, char **out)
+{
+    *out = strdup ("-1: auto, 0: f|false|disabled|no, 1: t|true|enabled|yes");
+    return *out ? OPAL_SUCCESS : OPAL_ERR_OUT_OF_RESOURCE;
+}
+
+mca_base_var_enum_t mca_base_var_enum_auto_bool = {
+    .super     = OPAL_OBJ_STATIC_INIT(opal_object_t),
+    .enum_is_static = true,
+    .enum_name = "auto_boolean",
+    .get_count = mca_base_var_enum_auto_bool_get_count,
+    .get_value = mca_base_var_enum_auto_bool_get_value,
+    .value_from_string = mca_base_var_enum_auto_bool_vfs,
+    .string_from_value = mca_base_var_enum_auto_bool_sfv,
+    .dump      = mca_base_var_enum_auto_bool_dump
+};
+
 /* verbosity enumerator */
 static mca_base_var_enum_value_t verbose_values[] = {
     {MCA_BASE_VERBOSE_NONE,      "none"},

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -67,7 +67,7 @@ static int mca_base_var_enum_bool_vfs (mca_base_var_enum_t *self, const char *st
                                        int *value)
 {
     char *tmp;
-    int v;
+    long v;
 
     /* skip whitespace */
     string_value += strspn (string_value, " \t\n\v\f\r");
@@ -75,10 +75,12 @@ static int mca_base_var_enum_bool_vfs (mca_base_var_enum_t *self, const char *st
     v = strtol (string_value, &tmp, 10);
     if (*tmp != '\0') {
         if (0 == strcmp (string_value, "true") || 0 == strcmp (string_value, "t") ||
-            0 == strcmp (string_value, "enabled") || 0 == strcmp (string_value, "yes")) {
+            0 == strcmp (string_value, "enabled") || 0 == strcmp (string_value, "yes") ||
+            0 == strcmp (string_value, "y")) {
             v = 1;
         } else if (0 == strcmp (string_value, "false") || 0 == strcmp (string_value, "f") ||
-                   0 == strcmp (string_value, "disabled") || 0 == strcmp (string_value, "no")) {
+                   0 == strcmp (string_value, "disabled") || 0 == strcmp (string_value, "no") ||
+                   0 == strcmp (string_value, "n")) {
             v = 0;
         } else {
             return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
@@ -102,7 +104,7 @@ static int mca_base_var_enum_bool_sfv (mca_base_var_enum_t *self, const int valu
 
 static int mca_base_var_enum_bool_dump (mca_base_var_enum_t *self, char **out)
 {
-    *out = strdup ("0: f|false|disabled|no, 1: t|true|enabled|yes");
+    *out = strdup ("0: f|false|disabled|no|n, 1: t|true|enabled|yes|y");
     return *out ? OPAL_SUCCESS : OPAL_ERR_OUT_OF_RESOURCE;
 }
 
@@ -143,7 +145,7 @@ static int mca_base_var_enum_auto_bool_vfs (mca_base_var_enum_t *self, const cha
                                             int *value)
 {
     char *tmp;
-    int v;
+    long v;
 
     /* skip whitespace */
     string_value += strspn (string_value, " \t\n\v\f\r");
@@ -151,10 +153,12 @@ static int mca_base_var_enum_auto_bool_vfs (mca_base_var_enum_t *self, const cha
     v = strtol (string_value, &tmp, 10);
     if (*tmp != '\0') {
         if (0 == strcasecmp (string_value, "true") || 0 == strcasecmp (string_value, "t") ||
-            0 == strcasecmp (string_value, "enabled") || 0 == strcasecmp (string_value, "yes")) {
+            0 == strcasecmp (string_value, "enabled") || 0 == strcasecmp (string_value, "yes") ||
+            0 == strcasecmp (string_value, "y")) {
             v = 1;
         } else if (0 == strcasecmp (string_value, "false") || 0 == strcasecmp (string_value, "f") ||
-                   0 == strcasecmp (string_value, "disabled") || 0 == strcasecmp (string_value, "no")) {
+                   0 == strcasecmp (string_value, "disabled") || 0 == strcasecmp (string_value, "no") ||
+                   0 == strcasecmp (string_value, "n")) {
             v = 0;
         } else if (0 == strcasecmp (string_value, "auto")) {
             v = -1;
@@ -168,7 +172,7 @@ static int mca_base_var_enum_auto_bool_vfs (mca_base_var_enum_t *self, const cha
     } else if (v < -1) {
         *value = -1;
     } else {
-        *value = v;
+        *value = (int) v;
     }
 
     return OPAL_SUCCESS;
@@ -192,7 +196,7 @@ static int mca_base_var_enum_auto_bool_sfv (mca_base_var_enum_t *self, const int
 
 static int mca_base_var_enum_auto_bool_dump (mca_base_var_enum_t *self, char **out)
 {
-    *out = strdup ("-1: auto, 0: f|false|disabled|no, 1: t|true|enabled|yes");
+    *out = strdup ("-1: auto, 0: f|false|disabled|no|n, 1: t|true|enabled|yes|y");
     return *out ? OPAL_SUCCESS : OPAL_ERR_OUT_OF_RESOURCE;
 }
 

--- a/opal/mca/base/mca_base_var_enum.h
+++ b/opal/mca/base/mca_base_var_enum.h
@@ -238,6 +238,16 @@ OPAL_DECLSPEC int mca_base_var_enum_create_flag (const char *name, const mca_bas
 extern mca_base_var_enum_t mca_base_var_enum_bool;
 
 /**
+ * Extended boolean enumerator
+ *
+ * This enumerator maps:
+ *   positive integer, true, yes, enabled, t -> 1
+ *   0, false, no, disabled, f -> 0
+ *   auto -> -1
+ */
+extern mca_base_var_enum_t mca_base_var_enum_auto_bool;
+
+/**
  * Verbosity level enumerator
  */
 extern mca_base_var_enum_t mca_base_var_enum_verbose;

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -233,10 +233,9 @@ int opal_register_params(void)
     /* Leave pinned parameter */
     opal_leave_pinned = -1;
     ret = mca_base_var_register("ompi", "mpi", NULL, "leave_pinned",
-                                "Whether to use the \"leave pinned\" protocol or not.  Enabling this setting can help bandwidth performance when repeatedly sending and receiving large messages with the same buffers over RDMA-based networks (0 = do not use \"leave pinned\" protocol, 1 = use \"leave pinned\" protocol, -1 = allow network to choose at runtime).",
-                                MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                OPAL_INFO_LVL_9,
-                                MCA_BASE_VAR_SCOPE_READONLY,
+                                "Whether to use the \"leave pinned\" protocol or not.  Enabling this setting can help bandwidth performance when repeatedly sending and receiving large messages with the same buffers over RDMA-based networks (false = do not use \"leave pinned\" protocol, true = use \"leave pinned\" protocol, auto = allow network to choose at runtime).",
+                                MCA_BASE_VAR_TYPE_INT, &mca_base_var_enum_auto_bool, 0, 0,
+                                OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
                                 &opal_leave_pinned);
     mca_base_var_register_synonym(ret, "opal", "opal", NULL, "leave_pinned",
                                   MCA_BASE_VAR_SYN_FLAG_DEPRECATED);


### PR DESCRIPTION
This commit adds a new base enumerator type for variables that take of
the values -1, 0, and 1. These values are mapped to the strings auto,
false, true. This commit updates the mpi_leave_pinned MCA variable to
use the new enumerator.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 9e692ce26406f1bd3b27684b5197b260dabcec5d)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>