### PR TITLE
Update to newest PMIx master (includes configuration cleanups). Silence trivial Coverity warning in hwloc base.

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -2232,6 +2232,9 @@ char* opal_hwloc_base_get_locality_string(hwloc_topology_t topo,
 
         /* get the width of the topology at this depth */
         width = hwloc_get_nbobjs_by_depth(topo, d);
+        if (0 == width) {
+            continue;
+        }
 
         /* scan all objects at this depth to see if
          * the location overlaps with them

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -49,14 +49,14 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
         opal_pmix_pmix2x_sm_flag=--disable-dstore
     fi
 
-    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_sm_flag --without-tests-examples --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
+    opal_pmix_pmix2x_args="--enable-embedded-mode --with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_sm_flag --without-tests-examples --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix2x_args="--enable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
           [opal_pmix_pmix2x_args="--disable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
     AS_IF([test "$with_devel_headers" = "yes"], [],
-          [opal_pmix_pmix2x_args="--enable-embedded-mode $opal_pmix_pmix2x_args"])
+          [opal_pmix_pmix2x_args="--with-devel-headers $opal_pmix_pmix2x_args"])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"
 
     OPAL_CONFIG_SUBDIR([$opal_pmix_pmix2x_basedir/pmix],

--- a/opal/mca/pmix/pmix2x/pmix/VERSION
+++ b/opal/mca/pmix/pmix2x/pmix/VERSION
@@ -23,14 +23,14 @@ release=0
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=gitbf86f3a
+repo_rev=git3b5c9b7
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Feb 13, 2017"
+date="Feb 14, 2017"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/opal/mca/pmix/pmix2x/pmix/include/Makefile.am
+++ b/opal/mca/pmix/pmix2x/pmix/include/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -10,7 +10,7 @@
 
 # Only install the headers if we're in standalone mode
 
-if ! PMIX_EMBEDDED_MODE
+if WANT_PRIMARY_HEADERS
 include_HEADERS = \
         pmix.h \
         pmix_common.h \
@@ -23,4 +23,4 @@ nodist_include_HEADERS = \
     pmix_version.h \
     pmix_rename.h
 
-endif ! PMIX_EMBEDDED_MODE
+endif

--- a/opal/mca/pmix/pmix2x/pmix/src/runtime/pmix_finalize.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/runtime/pmix_finalize.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -66,11 +66,6 @@ void pmix_rte_finalize(void)
             return;
         }
         return;
-    }
-
-    if (!pmix_globals.external_evbase) {
-        /* stop the progress thread */
-        (void)pmix_progress_thread_stop(NULL);
     }
 
     /* cleanup communications */

--- a/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server.c
@@ -268,6 +268,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:server finalize called");
 
+    if (!pmix_globals.external_evbase) {
+        /* stop the progress thread */
+        (void)pmix_progress_thread_stop(NULL);
+    }
+
     pmix_ptl_base_stop_listening();
 
     cleanup_server_state();

--- a/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server_ops.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server_ops.c
@@ -1636,7 +1636,9 @@ static void lmcon(pmix_dmdx_local_t *p)
 }
 static void lmdes(pmix_dmdx_local_t *p)
 {
-    PMIX_INFO_FREE(p->info, p->ninfo);
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
     PMIX_LIST_DESTRUCT(&p->loc_reqs);
 }
 PMIX_CLASS_INSTANCE(pmix_dmdx_local_t,

--- a/opal/mca/pmix/pmix2x/pmix/src/tool/pmix_tool.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/tool/pmix_tool.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -516,6 +516,11 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     PMIX_WAIT_FOR_COMPLETION(active);
     pmix_output_verbose(2, pmix_globals.debug_output,
                          "pmix:tool finalize sync received");
+
+    if (!pmix_globals.external_evbase) {
+        /* stop the progress thread */
+        (void)pmix_progress_thread_stop(NULL);
+    }
 
     /* shutdown services */
     pmix_rte_finalize();


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>