### PR TITLE
Cleanup PMIx shutdown

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/runtime/pmix_finalize.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/runtime/pmix_finalize.c
@@ -101,10 +101,8 @@ void pmix_rte_finalize(void)
        much */
     pmix_output_finalize();
 
-#if 0
     /* close the bfrops */
-    (void)pmix_mca_base_framework_close(&pmix_bfrops_base_framework);
-#endif
+    pmix_bfrop_close();
 
     /* clean out the globals */
     PMIX_RELEASE(pmix_globals.mypeer);
@@ -117,7 +115,14 @@ void pmix_rte_finalize(void)
     }
     PMIX_DESTRUCT(&pmix_globals.events);
 
-    #if PMIX_NO_LIB_DESTRUCTOR
-        pmix_cleanup();
-    #endif
+    /* now safe to release the event base */
+    if (!pmix_globals.external_evbase) {
+        (void)pmix_progress_thread_stop(NULL);
+    }
+
+
+#if PMIX_NO_LIB_DESTRUCTOR
+    pmix_cleanup();
+#endif
+
 }

--- a/opal/mca/pmix/pmix2x/pmix/src/tool/pmix_tool.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/tool/pmix_tool.c
@@ -518,17 +518,18 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
                          "pmix:tool finalize sync received");
 
     if (!pmix_globals.external_evbase) {
-        /* stop the progress thread */
-        (void)pmix_progress_thread_stop(NULL);
+        /* stop the progress thread, but leave the event base
+         * still constructed. This will allow us to safely
+         * tear down the infrastructure, including removal
+         * of any events objects may be holding */
+        (void)pmix_progress_thread_pause(NULL);
     }
-
-    /* shutdown services */
-    pmix_rte_finalize();
 
     PMIX_DESTRUCT(&pmix_client_globals.myserver);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
 
-    pmix_class_finalize();
+    /* shutdown services */
+    pmix_rte_finalize();
 
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Instead of completely free'ing the event base, pause the PMIx progress thread before tearing down the infrastructure, and then release the event base at the end of the procedure. This allows any infrastructure objects holding events to delete them prior to free'ing the event base.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>