### PR TITLE
Fix binding policy bug and support pe=1 modifier

### DIFF
--- a/opal/mca/hwloc/hwloc.h
+++ b/opal/mca/hwloc/hwloc.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
@@ -191,7 +191,7 @@ typedef uint16_t opal_binding_policy_t;
 #define OPAL_GET_BINDING_POLICY(pol) \
     ((pol) & 0x0fff)
 #define OPAL_SET_BINDING_POLICY(target, pol) \
-    (target) = (pol) | (((target) & 0xf000) | OPAL_BIND_GIVEN)
+    (target) = (pol) | (((target) & 0x2000) | OPAL_BIND_GIVEN)
 #define OPAL_SET_DEFAULT_BINDING_POLICY(target, pol)            \
     do {                                                        \
         if (!OPAL_BINDING_POLICY_IS_SET((target))) {            \

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -205,7 +205,7 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
             opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
                             "mca:rmaps[%d] binding policy given", __LINE__);
             jdata->map->binding = opal_hwloc_binding_policy;
-        } else if (1 < jdata->map->cpus_per_rank) {
+        } else if (0 < jdata->map->cpus_per_rank) {
             /* bind to cpus */
             if (opal_hwloc_use_hwthreads_as_cpus) {
                 /* if we are using hwthread cpus, then bind to those */

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -833,7 +833,7 @@ static void orte_job_map_construct(orte_job_map_t* map)
     map->ranking = 0;
     map->binding = 0;
     map->ppr = NULL;
-    map->cpus_per_rank = 1;
+    map->cpus_per_rank = 0;
     map->display_map = false;
     map->num_new_daemons = 0;
     map->daemon_vpid_start = ORTE_VPID_INVALID;


### PR DESCRIPTION
Allow someone to specify the "pe=N" modifier to a mapping policy when N=1. This equates to just "bind-to core", but helps people who use a script to set the PE policy. Fix a bug where setting the binding policy left a lingering "if-supported" flag that shouldn't be there.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>