### PR TITLE
rcache/base: do not free memory with the vma lock held

### DIFF
--- a/opal/mca/rcache/base/rcache_base_vma.h
+++ b/opal/mca/rcache/base/rcache_base_vma.h
@@ -44,7 +44,7 @@ struct mca_rcache_base_vma_module_t {
     opal_object_t super;
     opal_rb_tree_t rb_tree;
     opal_list_t vma_list;
-    opal_list_t vma_gc_list;
+    opal_lifo_t vma_gc_lifo;
     size_t reg_cur_cache_size;
     opal_mutex_t vma_lock;
 };


### PR DESCRIPTION
This commit makes the vma tree garbage collection list a lifo. This
way we can avoid having to hold any lock when releasing vmas. In
theory this should finally fix the hold-and-wait deadlock detailed
in #1654.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>