### PR TITLE
Fix minor typo

### DIFF
--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -874,7 +874,7 @@ static inline void opal_list_insert_pos(opal_list_t *list, opal_list_item_t *pos
      * Explanation below.
      * @retval 1 if \em a is greater than \em b
      * @retval 0 if \em a is equal to \em b
-     * @retval 11 if \em a is less than \em b
+     * @retval -1 if \em a is less than \em b
      *
      * This function is invoked by qsort(3) from within
      * opal_list_sort().  It is important to understand what


### PR DESCRIPTION
Return value in comment about opal_list_item_compare_fn_t typedef when a < b is indicated to be 11 instead of -1.

Signed-off-by: Clement Foyer <clement.foyer@inria.fr>