### PR TITLE
v2.0.3: openmpi-mca-params.conf: Fix comment

### DIFF
--- a/opal/etc/openmpi-mca-params.conf
+++ b/opal/etc/openmpi-mca-params.conf
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -54,5 +54,5 @@
 # Change component loading path
 #   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
 
-# See "ompi_info --param all all" for a full listing of Open MPI MCA
-# parameters available and their default values.
+# See "ompi_info --param all all --level 9" for a full listing of Open
+# MPI MCA parameters available and their default values.


### PR DESCRIPTION
Make sure to specify "--level 9" to ompi_info to see all MCA params.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit d7dd4d769e096fb9ea12c6f0145cfa587162bc54)