### PR TITLE
.mailmap: Remove accent from Aurelein's name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -98,7 +98,7 @@ Annapurna Dasari <annapurna.dasari@intel.com> <annapurna.dasari@intel.com>
 
 L. R. Rajeshnarayanan <l.r.rajeshnarayanan@intel.com> <l.r.rajeshnarayanan@intel.com>
 
-Aurélien Bouteiller <bouteill@icl.utk.edu> <bouteill@icl.utk.edu>
-Aurélien Bouteiller <bouteill@icl.utk.edu> <darter4.nics.utk.edu>
+Aurelien Bouteiller <bouteill@icl.utk.edu> <bouteill@icl.utk.edu>
+Aurelien Bouteiller <bouteill@icl.utk.edu> <darter4.nics.utk.edu>
 
 Alex Mikheev <alexm@mellanox.com> <alexm@mellanox.com>


### PR DESCRIPTION
This was per request of Aurelein.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

[skip ci]
bot:notest