### PR TITLE
pml_yalla/mtl_mxm/hcoll: open memory component to activate memory hooks.

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll.h
@@ -17,6 +17,7 @@
 #include "mpi.h"
 #include "ompi/mca/mca.h"
 #include "opal/memoryhooks/memory.h"
+#include "opal/mca/memory/base/base.h"
 #include "ompi/mca/coll/coll.h"
 #include "ompi/request/request.h"
 #include "ompi/mca/pml/pml.h"

--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -251,6 +251,8 @@ static int hcoll_open(void)
 
     cm->libhcoll_initialized = false;
 
+    (void)mca_base_framework_open(&opal_memory_base_framework, 0);
+
     /* Register memory hooks */
     if ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) ==
         ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) &
@@ -293,5 +295,8 @@ static int hcoll_close(void)
         HCOL_VERBOSE(1,"Hcol library finalize failed");
         return OMPI_ERROR;
     }
+
+    mca_base_framework_close(&opal_memory_base_framework);
+
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/mtl/mxm/mtl_mxm_component.c
+++ b/ompi/mca/mtl/mxm/mtl_mxm_component.c
@@ -16,6 +16,7 @@
 #include "opal/util/show_help.h"
 #include "ompi/proc/proc.h"
 #include "opal/memoryhooks/memory.h"
+#include "opal/mca/memory/base/base.h"
 #include "ompi/runtime/mpiruntime.h"
 
 #include "mtl_mxm.h"
@@ -200,6 +201,7 @@ static int ompi_mtl_mxm_component_open(void)
     }
 
 #if MXM_API >= MXM_VERSION(2,0)
+    (void)mca_base_framework_open(&opal_memory_base_framework, 0);
     /* Register memory hooks */
     if ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) ==
         ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) &
@@ -281,6 +283,7 @@ static int ompi_mtl_mxm_component_close(void)
 #if MXM_API >= MXM_VERSION(2,0)
         mxm_config_free_ep_opts(ompi_mtl_mxm.mxm_ep_opts);
         mxm_config_free_context_opts(ompi_mtl_mxm.mxm_ctx_opts);
+        mca_base_framework_close(&opal_memory_base_framework);
 #else
         mxm_config_free(ompi_mtl_mxm.mxm_ep_opts);
         mxm_config_free(ompi_mtl_mxm.mxm_ctx_opts);

--- a/ompi/mca/pml/yalla/pml_yalla.c
+++ b/ompi/mca/pml/yalla/pml_yalla.c
@@ -21,6 +21,7 @@
 #include "opal/runtime/opal.h"
 #include "opal/memoryhooks/memory.h"
 #include "opal/util/opal_environ.h"
+#include "opal/mca/memory/base/base.h"
 #include "opal/mca/pmix/pmix.h"
 #include "ompi/mca/pml/base/pml_base_bsend.h"
 #include "ompi/message/message.h"
@@ -112,6 +113,8 @@ int mca_pml_yalla_open(void)
 
     PML_YALLA_VERBOSE(1, "mca_pml_yalla_open");
 
+    (void)mca_base_framework_open(&opal_memory_base_framework, 0);
+
     /* Set memory hooks */
     if ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) ==
         ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) &
@@ -156,6 +159,7 @@ int mca_pml_yalla_close(void)
         mxm_cleanup(ompi_pml_yalla.mxm_context);
         ompi_pml_yalla.mxm_context = NULL;
     }
+    mca_base_framework_close(&opal_memory_base_framework);
     return 0;
 }
 


### PR DESCRIPTION
 Memory hooks are now set-up on demand. pml/yalla, mtl/mxm and
coll/hcoll need the memory hooks, so make sure those are installed.

picked from master #3071
Signed-off-by: Yossi Itigin <yosefe@mellanox.com>