### PR TITLE
orte-clean: fix bad username/uid usage, add orte-dvm

### DIFF
--- a/config/opal_check_ps.m4
+++ b/config/opal_check_ps.m4
@@ -13,6 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2017      UT-Battelle, LLC. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -30,11 +31,11 @@ PS_FLAVOR="unknown"
 ps -A -o fname > /dev/null 2>&1
 
 if test "$?" = "0"; then
-     PS_FLAVOR="ps -A -o fname,pid,user"
+     PS_FLAVOR="ps -A -o fname,pid,uid"
 else
      ps -A -o command > /dev/null 2>&1
      if test "$?" = "0"; then
-         PS_FLAVOR="ps -A -o command,pid,user"
+         PS_FLAVOR="ps -A -o command,pid,uid"
      fi
 fi
 AC_MSG_RESULT([$PS_FLAVOR])


### PR DESCRIPTION
This fixes a mismatch between PS listing that returned
USERNAME but code was pruning based on UID.

This changes the OPAL_PS_FLAVOR_CHECK format to return
'uid' instead of 'user'.  (Note: Avoiding call to
getlogin_r() but assuming UID is uniform on system,
same assumption exists for session dir anyway.)

Note, still maintains behavior from man page for root
running orte-clean on node (kills all orteds).

Adds 'orte-dvm' to list of procnames that will be checked/killed.

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>