### PR TITLE
pml/bfo: Correct a function name and header filenames

### DIFF
--- a/ompi/mca/pml/bfo/pml_bfo_start.c
+++ b/ompi/mca/pml/bfo/pml_bfo_start.c
@@ -20,13 +20,13 @@
 
 #include "ompi_config.h"
 
-#include "pml_ob1.h"
-#include "pml_ob1_recvreq.h"
-#include "pml_ob1_sendreq.h"
+#include "pml_bfo.h"
+#include "pml_bfo_recvreq.h"
+#include "pml_bfo_sendreq.h"
 #include "ompi/memchecker.h"
 
 
-int mca_pml_ob1_start(size_t count, ompi_request_t** requests)
+int mca_pml_bfo_start(size_t count, ompi_request_t** requests)
 {
     int rc;
     size_t i;


### PR DESCRIPTION
These lines were incorrectly modified in 90f2940.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>

This commit was a part of PR #2758 but it is not specific to #2758. So I created a separate PR.
Because bfo PML is unmaintained these days, no need to merge into v2.0.x and v2.x.
