### PR TITLE
MPI_Wtick: may return a higher resolution than 10e-6 these days

### DIFF
--- a/ompi/mpi/man/man3/MPI_Wtick.3in
+++ b/ompi/mpi/man/man3/MPI_Wtick.3in
@@ -1,6 +1,7 @@
 .\" -*- nroff -*-
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
+.\" Copyright (c) 2017 Cisco Systems, Inc.
 .\" $COPYRIGHT$
 .TH MPI_Wtick 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .SH NAME
@@ -37,9 +38,6 @@ returns, as a double-precision value, the number of seconds between
 successive clock ticks. For example, if the clock is implemented by
 the hardware as a counter that is incremented every millisecond, the
 value returned by MPI_Wtick should be 10^-3.
-.PP
-Note that on POSIX platforms, Open MPI should always return 10^-6 for
-MPI_Wtick.  The returned value may be different on Windows platforms.
 .PP
 
 .SH NOTE


### PR DESCRIPTION
Thanks to Mark Dixon (@ccaamad) for reporting the error.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit dc53cd5f74182a7113ff1b89435b66b9ad136d98)

@hppritcha I marked this as v2.1.1.  It's zero risk for v2.1.0, but just on the principle of "let's stop shoving things into v2.1.0 so that we can get it out the door", I pushed it off to v2.1.1.  But I don't feel strongly either way.

[skip ci]
bot:notest