### PR TITLE
Add missing definition of MPI_T_PVAR_SESSION_NULL (resolve #2652)

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -776,6 +776,7 @@ enum {
  */
 #define MPI_T_PVAR_ALL_HANDLES ((MPI_T_pvar_handle) -1)
 #define MPI_T_PVAR_HANDLE_NULL ((MPI_T_pvar_handle) 0)
+#define MPI_T_PVAR_SESSION_NULL ((MPI_T_pvar_session) 0)
 #define MPI_T_CVAR_HANDLE_NULL ((MPI_T_cvar_handle) 0)
 
 /* MPI-2 specifies that the name "MPI_TYPE_NULL_DELETE_FN" (and all

--- a/ompi/mpi/tool/pvar_session_free.c
+++ b/ompi/mpi/tool/pvar_session_free.c
@@ -23,14 +23,19 @@
 
 int MPI_T_pvar_session_free(MPI_T_pvar_session *session)
 {
+    int ret = MPI_SUCCESS;
+
     if (!mpit_is_initialized ()) {
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    if (NULL != *session) {
+    /* Check that this is a valid session */
+    if (MPI_T_PVAR_SESSION_NULL == *session) {
+        ret = MPI_T_ERR_INVALID_SESSION;
+    } else {
         OBJ_RELEASE(*session);
-        *session = NULL;
+        *session = MPI_T_PVAR_SESSION_NULL;
     }
 
-    return MPI_SUCCESS;
+    return ret;
 }


### PR DESCRIPTION
This pull resolves #2652 by adding the missing definition of `MPI_T_PVAR_SESSION_NULL`. It also corrects an issue with `MPI_T_pvar_session_free()` so as to match the man page description.

The only user-visible difference of the pull is that `MPI_T_pvar_session_free()` will now correctly fail with a return value of `MPI_T_ERR_INVALID_SESSION` when the `session` parameter is not valid (that is, when `MPI_T_PVAR_SESSION_NULL  == session`.