### PR TITLE
Fix a problem that surfaced on NetBSD/AMD64. 

### DIFF
--- a/opal/mca/pmix/pmix112/pmix/src/sm/pmix_mmap.c
+++ b/opal/mca/pmix/pmix112/pmix/src/sm/pmix_mmap.c
@@ -3,6 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,15 +63,31 @@ int _mmap_segment_create(pmix_sm_seg_t *sm_seg, const char *file_name, size_t si
     }
     /* size backing file - note the use of real_size here */
 #ifdef HAVE_POSIX_FALLOCATE
-    if (0 != posix_fallocate(sm_seg->seg_id, 0, size)) {
+    if (0 != (rc = posix_fallocate(sm_seg->seg_id, 0, size))) {
         pmix_output_verbose(2, pmix_globals.debug_output,
                 "sys call posix_fallocate(2) fail\n");
-        if (ENOSPC == errno) {
+        if ((ENOTSUP == rc)
+#ifdef EOPNOTSUPP
+                            || (EOPNOTSUPP == rc)
+#endif
+           ) {
+            /* Not supported by OS and/or filesystem.
+             * Must fall-back to ftruncate().
+             */
+            if (0 != ftruncate(sm_seg->seg_id, size)) {
+                pmix_output_verbose(2, pmix_globals.debug_output,
+                        "sys call ftruncate(2) fail\n");
+                rc = PMIX_ERROR;
+                goto out;
+            }
+            rc = PMIX_SUCCESS;
+        } else if (ENOSPC == rc) {
             rc = PMIX_ERR_OUT_OF_RESOURCE;
+            goto out;
         } else {
             rc = PMIX_ERROR;
+            goto out;
         }
-        goto out;
     }
 #else
     if (0 != ftruncate(sm_seg->seg_id, size)) {


### PR DESCRIPTION
Just because HAVE_POSIX_FALLOCATE is defined doesn't mean the function actually works, so fall back to the ftruncate code path when it fails.

Thanks to Paul Hargrove for the patch

Signed-off-by: Ralph Castain <rhc@open-mpi.org>