### PR TITLE
v2.0.3: configury: consider double _Complex as a candidate for the C equivale…

### DIFF
--- a/config/ompi_setup_mpi_fortran.m4
+++ b/config/ompi_setup_mpi_fortran.m4
@@ -15,7 +15,7 @@ dnl Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2006-2007 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
-dnl Copyright (c) 2014-2015 Research Organization for Information Science
+dnl Copyright (c) 2014-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -187,7 +187,7 @@ AC_DEFUN([OMPI_SETUP_MPI_FORTRAN],[
     OMPI_FORTRAN_CHECK([DOUBLE PRECISION], [yes],
                    [float, double, long double], [-1], [yes])
 
-    OMPI_FORTRAN_CHECK([COMPLEX], [yes], [float _Complex], [-1], [no])
+    OMPI_FORTRAN_CHECK([COMPLEX], [yes], [float _Complex, double _Complex], [-1], [no])
 
     # The complex*N tests are a bit different (note: the complex tests are
     # the same as all the rest, because complex is a composite of two


### PR DESCRIPTION
…nt of Fortran COMPLEX

this is necessary when -d8 flag is passed to Fortran compiler

(cherry picked from commit 529ab559d443cb73831bf4ff42d7f56d5e8dc675)

Thanks to Alexander Klein for pointing out that we neglected to bring
this fix to the release branches.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>