### PR TITLE
 mpi/c: Force wtick/wtime to use gettimeofday

### DIFF
--- a/ompi/mpi/c/wtick.c
+++ b/ompi/mpi/c/wtick.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,6 +41,12 @@ double MPI_Wtick(void)
 {
     OPAL_CR_NOOP_PROGRESS();
 
+    /*
+     * See https://github.com/open-mpi/ompi/issues/3003
+     * For now we are forcing the use of gettimeofday() until we find a
+     * more portable solution.
+     */
+#if 0
 #if OPAL_TIMER_CYCLE_NATIVE
     {
         opal_timer_t freq = opal_timer_base_get_freq();
@@ -52,6 +59,7 @@ double MPI_Wtick(void)
     }
 #elif OPAL_TIMER_USEC_NATIVE
     return 0.000001;
+#endif
 #else
     /* Otherwise, we already return usec precision. */
     return 0.000001;

--- a/ompi/mpi/c/wtime.c
+++ b/ompi/mpi/c/wtime.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,10 +41,17 @@ double MPI_Wtime(void)
 {
     double wtime;
 
+    /*
+     * See https://github.com/open-mpi/ompi/issues/3003
+     * For now we are forcing the use of gettimeofday() until we find a
+     * more portable solution.
+     */
+#if 0
 #if OPAL_TIMER_CYCLE_NATIVE
     wtime = ((double) opal_timer_base_get_cycles()) / opal_timer_base_get_freq();
 #elif OPAL_TIMER_USEC_NATIVE
     wtime = ((double) opal_timer_base_get_usec()) / 1000000.0;
+#endif
 #else
     /* Fall back to gettimeofday() if we have nothing else */
     struct timeval tv;

--- a/opal/mca/timer/linux/timer_linux.h
+++ b/opal/mca/timer/linux/timer_linux.h
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,8 +22,6 @@
 
 #include "opal_config.h"
 #include <opal/sys/timer.h>
-
-OPAL_DECLSPEC extern opal_timer_t opal_timer_linux_freq;
 
 OPAL_DECLSPEC extern opal_timer_t (*opal_timer_base_get_cycles)(void);
 OPAL_DECLSPEC extern opal_timer_t (*opal_timer_base_get_usec)(void);

--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -14,7 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2016 Broadcom Limited. All rights reserved.
  * $COPYRIGHT$
  *
@@ -49,7 +49,7 @@ opal_timer_t (*opal_timer_base_get_cycles)(void) = opal_timer_base_get_cycles_sy
 opal_timer_t (*opal_timer_base_get_usec)(void) = opal_timer_base_get_usec_sys_timer;
 #endif  /* OPAL_HAVE_CLOCK_GETTIME */
 
-opal_timer_t opal_timer_linux_freq = {0};
+static opal_timer_t opal_timer_linux_freq = {0};
 
 static int opal_timer_linux_open(void);
 

--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -33,20 +33,25 @@
 #include "opal/constants.h"
 #include "opal/util/show_help.h"
 
-static opal_timer_t opal_timer_base_get_cycles_sys_timer(void);
-static opal_timer_t opal_timer_base_get_usec_sys_timer(void);
+static opal_timer_t opal_timer_linux_get_cycles_sys_timer(void);
+static opal_timer_t opal_timer_linux_get_usec_sys_timer(void);
 
 /**
  * Define some sane defaults until we call the _init function.
  */
 #if OPAL_HAVE_CLOCK_GETTIME
-static opal_timer_t opal_timer_base_get_cycles_clock_gettime(void);
-static opal_timer_t opal_timer_base_get_usec_clock_gettime(void);
-opal_timer_t (*opal_timer_base_get_cycles)(void) = opal_timer_base_get_cycles_clock_gettime;
-opal_timer_t (*opal_timer_base_get_usec)(void) = opal_timer_base_get_usec_clock_gettime;
+static opal_timer_t opal_timer_linux_get_cycles_clock_gettime(void);
+static opal_timer_t opal_timer_linux_get_usec_clock_gettime(void);
+
+opal_timer_t (*opal_timer_base_get_cycles)(void) =
+    opal_timer_linux_get_cycles_clock_gettime;
+opal_timer_t (*opal_timer_base_get_usec)(void) =
+    opal_timer_linux_get_usec_clock_gettime;
 #else
-opal_timer_t (*opal_timer_base_get_cycles)(void) = opal_timer_base_get_cycles_sys_timer;
-opal_timer_t (*opal_timer_base_get_usec)(void) = opal_timer_base_get_usec_sys_timer;
+opal_timer_t (*opal_timer_base_get_cycles)(void) =
+    opal_timer_linux_get_cycles_sys_timer;
+opal_timer_t (*opal_timer_base_get_usec)(void) =
+    opal_timer_linux_get_usec_sys_timer;
 #endif  /* OPAL_HAVE_CLOCK_GETTIME */
 
 static opal_timer_t opal_timer_linux_freq = {0};
@@ -171,8 +176,8 @@ int opal_timer_linux_open(void)
         struct timespec res;
         if( 0 == clock_getres(CLOCK_MONOTONIC, &res)) {
             opal_timer_linux_freq = 1.e3;
-            opal_timer_base_get_cycles = opal_timer_base_get_cycles_clock_gettime;
-            opal_timer_base_get_usec = opal_timer_base_get_usec_clock_gettime;
+            opal_timer_base_get_cycles = opal_timer_linux_get_cycles_clock_gettime;
+            opal_timer_base_get_usec = opal_timer_linux_get_usec_clock_gettime;
             return ret;
         }
 #else
@@ -181,13 +186,13 @@ int opal_timer_linux_open(void)
 #endif  /* OPAL_HAVE_CLOCK_GETTIME && (0 == OPAL_TIMER_MONOTONIC) */
     }
     ret = opal_timer_linux_find_freq();
-    opal_timer_base_get_cycles = opal_timer_base_get_cycles_sys_timer;
-    opal_timer_base_get_usec = opal_timer_base_get_usec_sys_timer;
+    opal_timer_base_get_cycles = opal_timer_linux_get_cycles_sys_timer;
+    opal_timer_base_get_usec = opal_timer_linux_get_usec_sys_timer;
     return ret;
 }
 
 #if OPAL_HAVE_CLOCK_GETTIME
-opal_timer_t opal_timer_base_get_usec_clock_gettime(void)
+opal_timer_t opal_timer_linux_get_usec_clock_gettime(void)
 {
     struct timespec tp = {.tv_sec = 0, .tv_nsec = 0};
 
@@ -196,7 +201,7 @@ opal_timer_t opal_timer_base_get_usec_clock_gettime(void)
     return (tp.tv_sec * 1e6 + tp.tv_nsec/1000);
 }
 
-opal_timer_t opal_timer_base_get_cycles_clock_gettime(void)
+opal_timer_t opal_timer_linux_get_cycles_clock_gettime(void)
 {
     struct timespec tp = {.tv_sec = 0, .tv_nsec = 0};
 
@@ -206,7 +211,7 @@ opal_timer_t opal_timer_base_get_cycles_clock_gettime(void)
 }
 #endif  /* OPAL_HAVE_CLOCK_GETTIME */
 
-opal_timer_t opal_timer_base_get_cycles_sys_timer(void)
+opal_timer_t opal_timer_linux_get_cycles_sys_timer(void)
 {
 #if OPAL_HAVE_SYS_TIMER_GET_CYCLES
     return opal_sys_timer_get_cycles();
@@ -216,7 +221,7 @@ opal_timer_t opal_timer_base_get_cycles_sys_timer(void)
 }
 
 
-opal_timer_t opal_timer_base_get_usec_sys_timer(void)
+opal_timer_t opal_timer_linux_get_usec_sys_timer(void)
 {
 #if OPAL_HAVE_SYS_TIMER_GET_CYCLES
     /* freq is in MHz, so this gives usec */
@@ -230,5 +235,3 @@ opal_timer_t opal_timer_base_get_freq(void)
 {
     return opal_timer_linux_freq * 1000000;
 }
-
-


### PR DESCRIPTION
Workaround for Issue #3003
 * Some relatively minor changes to the timer/linux component
 * Force `wtick`/`wtime` to use `gettimeofday` instead of the high precision timers until we figure out a portable way to calibrate them.