### PR TITLE
v2.0.3: compiler warning fixes

### DIFF
--- a/ompi/mca/coll/base/coll_base_allgatherv.c
+++ b/ompi/mca/coll/base/coll_base_allgatherv.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -603,7 +604,7 @@ ompi_coll_base_allgatherv_intra_basic_default(const void *sbuf, int scount,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
 {
-    int i, size, rank, err;
+    int size, rank, err;
     MPI_Aint extent, lb;
     char *send_buf = NULL;
     struct ompi_datatype_t *newtype, *send_type;

--- a/ompi/mca/coll/sync/coll_sync.h
+++ b/ompi/mca/coll/sync/coll_sync.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,7 +71,7 @@ int mca_coll_sync_gather(const void *sbuf, int scount,
 
 int mca_coll_sync_gatherv(const void *sbuf, int scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int *rcounts, int *disps,
+                          void *rbuf, const int *rcounts, const int *disps,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
@@ -85,7 +85,7 @@ int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
                          mca_coll_base_module_t *module);
 
 int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf,
-                                 int *rcounts,
+                                 const int *rcounts,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,
@@ -105,8 +105,8 @@ int mca_coll_sync_scatter(const void *sbuf, int scount,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_sync_scatterv(const void *sbuf, int *scounts, int *disps,
-                           struct ompi_datatype_t *sdtype,
+int mca_coll_sync_scatterv(const void *sbuf, const int *scounts,
+                           const int *disps, struct ompi_datatype_t *sdtype,
                            void *rbuf, int rcount,
                            struct ompi_datatype_t *rdtype,
                            int root,

--- a/ompi/mca/coll/sync/coll_sync_gatherv.c
+++ b/ompi/mca/coll/sync/coll_sync_gatherv.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +31,7 @@
  */
 int mca_coll_sync_gatherv(const void *sbuf, int scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int *rcounts, int *disps,
+                          void *rbuf, const int *rcounts, const int *disps,
                           struct ompi_datatype_t *rdtype, int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
+++ b/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +30,8 @@
  *	Accepts:	- same as MPI_Reduce_scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf, int *rcounts,
+int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf,
+                                 const int *rcounts,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_scatterv.c
+++ b/ompi/mca/coll/sync/coll_sync_scatterv.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,8 +29,8 @@
  *	Accepts:	- same arguments as MPI_Scatterv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_scatterv(const void *sbuf, int *scounts,
-                           int *disps, struct ompi_datatype_t *sdtype,
+int mca_coll_sync_scatterv(const void *sbuf, const int *scounts,
+                           const int *disps, struct ompi_datatype_t *sdtype,
                            void *rbuf, int rcount,
                            struct ompi_datatype_t *rdtype, int root,
                            struct ompi_communicator_t *comm,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -10,7 +10,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -669,7 +669,6 @@ static inline void osc_pt2pt_copy_for_send (void *target, size_t target_len, con
  */
 static inline void osc_pt2pt_gc_clean (ompi_osc_pt2pt_module_t *module)
 {
-    ompi_request_t *request;
     opal_list_item_t *item;
 
     OPAL_THREAD_LOCK(&module->gc_lock);

--- a/opal/datatype/opal_datatype_pack.c
+++ b/opal/datatype/opal_datatype_pack.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -464,9 +464,7 @@ opal_pack_general_function( opal_convertor_t* pConvertor,
     unsigned char *conv_ptr, *iov_ptr;
     size_t iov_len_local;
     uint32_t iov_count;
-    int type, rc;
-    const opal_convertor_master_t* master = pConvertor->master;
-    ptrdiff_t advance;
+    int type;
 
     DO_DEBUG( opal_output( 0, "opal_convertor_general_pack( %p:%p, {%p, %lu}, %d )\n",
                            (void*)pConvertor, (void*)pConvertor->pBaseBuf,
@@ -566,7 +564,10 @@ opal_pack_general_function( opal_convertor_t* pConvertor,
                 PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_LOOP, count_desc,
                             pStack->disp + local_disp);
                 pos_desc++;
+#if 0
+            // This label currently in another if 0'ed out block
             update_loop_description:  /* update the current state */
+#endif
                 conv_ptr = pConvertor->pBaseBuf + pStack->disp;
                 UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
                 DDT_DUMP_STACK( pConvertor->pStack, pConvertor->stack_pos, pElem, "advance loop" );

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Laboratory
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
@@ -408,40 +408,6 @@ static int mca_btl_tcp_component_close(void)
 #if OPAL_CUDA_SUPPORT
     mca_common_cuda_fini();
 #endif /* OPAL_CUDA_SUPPORT */
-
-#if MCA_BTL_TCP_SUPPORT_PROGRESS_THREAD
-    OBJ_DESTRUCT(&mca_btl_tcp_component.tcp_frag_eager_mutex);
-    OBJ_DESTRUCT(&mca_btl_tcp_component.tcp_frag_max_mutex);
-
-    if( (NULL != mca_btl_tcp_event_base) &&
-        (mca_btl_tcp_event_base != opal_sync_event_base) ) {
-        /* Turn of the progress thread before moving forward */
-        if( -1 != mca_btl_tcp_progress_thread_trigger ) {
-            mca_btl_tcp_progress_thread_trigger = 0;
-            /* Let the progress thread know that we're going away */
-            if( -1 != mca_btl_tcp_pipe_to_progress[1] ) {
-                close(mca_btl_tcp_pipe_to_progress[1]);
-                mca_btl_tcp_pipe_to_progress[1] = -1;
-            }
-            while( -1 != mca_btl_tcp_progress_thread_trigger ) {
-                /*event_base_loopbreak(mca_btl_tcp_event_base);*/
-                sched_yield();
-                usleep(100); /* give app a chance to re-enter library */
-             }
-        }
-        opal_event_del(&mca_btl_tcp_component.tcp_recv_thread_async_event);
-        opal_event_base_free(mca_btl_tcp_event_base);
-        mca_btl_tcp_event_base = NULL;
-
-        /* Close the remaining pipes */
-        if( -1 != mca_btl_tcp_pipe_to_progress[0] ) {
-            close(mca_btl_tcp_pipe_to_progress[0]);
-            mca_btl_tcp_pipe_to_progress[0] = -1;
-        }
-    }
-    OBJ_DESTRUCT(&mca_btl_tcp_ready_frag_mutex);
-    OBJ_DESTRUCT(&mca_btl_tcp_ready_frag_pending_queue);
-#endif
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -763,7 +763,6 @@ mca_btl_tcp_proc_t* mca_btl_tcp_proc_lookup(const opal_process_name_t *name)
     if (OPAL_UNLIKELY(NULL == proc)) {
         mca_btl_base_endpoint_t *endpoint;
         opal_proc_t *opal_proc;
-        int rc;
 
         BTL_VERBOSE(("adding tcp proc for unknown peer {.jobid = 0x%x, .vpid = 0x%x}",
                      name->jobid, name->vpid));

--- a/opal/util/cmd_line.h
+++ b/opal/util/cmd_line.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -566,7 +566,7 @@ BEGIN_C_DECLS
      * to opal_argv_free()) by the caller.
      */
     OPAL_DECLSPEC int opal_cmd_line_get_tail(opal_cmd_line_t *cmd, int *tailc,
-                                             char ***tailv) __opal_attribute_nonnull__(1) __opal_attribute_nonnull__(2);
+                                             char ***tailv);
 
 END_C_DECLS
 


### PR DESCRIPTION
A variety of compiler warning fixes, most of which are unique to the v2.0.x branch.

At least one was in common with master (the memory/patcher fix), which was cherry picked from a commit in https://github.com/open-mpi/ompi/pull/3185.

I did not check to see if there were commits on master that fixed the other warnings; I just fixed them directly here on v2.0.x (it did not seem worth the spelunking effort).

@hppritcha Please review.