### PR TITLE
v2.1.1: compiler warning fixes

### DIFF
--- a/ompi/mca/coll/base/coll_base_allgatherv.c
+++ b/ompi/mca/coll/base/coll_base_allgatherv.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -603,7 +604,7 @@ ompi_coll_base_allgatherv_intra_basic_default(const void *sbuf, int scount,
                                               struct ompi_communicator_t *comm,
                                               mca_coll_base_module_t *module)
 {
-    int i, size, rank, err;
+    int size, rank, err;
     MPI_Aint extent, lb;
     char *send_buf = NULL;
     struct ompi_datatype_t *newtype, *send_type;

--- a/ompi/mca/coll/sync/coll_sync.h
+++ b/ompi/mca/coll/sync/coll_sync.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,7 +71,7 @@ int mca_coll_sync_gather(const void *sbuf, int scount,
 
 int mca_coll_sync_gatherv(const void *sbuf, int scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int *rcounts, int *disps,
+                          void *rbuf, const int *rcounts, const int *disps,
                           struct ompi_datatype_t *rdtype,
                           int root,
                           struct ompi_communicator_t *comm,
@@ -85,7 +85,7 @@ int mca_coll_sync_reduce(const void *sbuf, void *rbuf, int count,
                          mca_coll_base_module_t *module);
 
 int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf,
-                                 int *rcounts,
+                                 const int *rcounts,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,
@@ -105,8 +105,8 @@ int mca_coll_sync_scatter(const void *sbuf, int scount,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
-int mca_coll_sync_scatterv(const void *sbuf, int *scounts, int *disps,
-                           struct ompi_datatype_t *sdtype,
+int mca_coll_sync_scatterv(const void *sbuf, const int *scounts,
+                           const int *disps, struct ompi_datatype_t *sdtype,
                            void *rbuf, int rcount,
                            struct ompi_datatype_t *rdtype,
                            int root,

--- a/ompi/mca/coll/sync/coll_sync_gatherv.c
+++ b/ompi/mca/coll/sync/coll_sync_gatherv.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +31,7 @@
  */
 int mca_coll_sync_gatherv(const void *sbuf, int scount,
                           struct ompi_datatype_t *sdtype,
-                          void *rbuf, int *rcounts, int *disps,
+                          void *rbuf, const int *rcounts, const int *disps,
                           struct ompi_datatype_t *rdtype, int root,
                           struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module)

--- a/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
+++ b/ompi/mca/coll/sync/coll_sync_reduce_scatter.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +30,8 @@
  *	Accepts:	- same as MPI_Reduce_scatter()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf, int *rcounts,
+int mca_coll_sync_reduce_scatter(const void *sbuf, void *rbuf,
+                                 const int *rcounts,
                                  struct ompi_datatype_t *dtype,
                                  struct ompi_op_t *op,
                                  struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/sync/coll_sync_scatterv.c
+++ b/ompi/mca/coll/sync/coll_sync_scatterv.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,8 +29,8 @@
  *	Accepts:	- same arguments as MPI_Scatterv()
  *	Returns:	- MPI_SUCCESS or error code
  */
-int mca_coll_sync_scatterv(const void *sbuf, int *scounts,
-                           int *disps, struct ompi_datatype_t *sdtype,
+int mca_coll_sync_scatterv(const void *sbuf, const int *scounts,
+                           const int *disps, struct ompi_datatype_t *sdtype,
                            void *rbuf, int rcount,
                            struct ompi_datatype_t *rdtype, int root,
                            struct ompi_communicator_t *comm,

--- a/opal/class/opal_graph.c
+++ b/opal/class/opal_graph.c
@@ -337,7 +337,6 @@ void opal_graph_remove_edge (opal_graph_t *graph, opal_graph_edge_t *edge)
 void opal_graph_remove_vertex(opal_graph_t *graph, opal_graph_vertex_t *vertex)
 {
     opal_adjacency_list_t *adj_list;
-    opal_graph_edge_t *edge;
 
     /* do not need to remove all the edges of this vertex and destruct them as
      * they will be released in the destructor for adj_list */

--- a/opal/datatype/opal_datatype_pack.c
+++ b/opal/datatype/opal_datatype_pack.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -464,9 +464,7 @@ opal_pack_general_function( opal_convertor_t* pConvertor,
     unsigned char *conv_ptr, *iov_ptr;
     size_t iov_len_local;
     uint32_t iov_count;
-    int type, rc;
-    const opal_convertor_master_t* master = pConvertor->master;
-    ptrdiff_t advance;
+    int type;
 
     DO_DEBUG( opal_output( 0, "opal_convertor_general_pack( %p:%p, {%p, %lu}, %d )\n",
                            (void*)pConvertor, (void*)pConvertor->pBaseBuf,
@@ -566,7 +564,10 @@ opal_pack_general_function( opal_convertor_t* pConvertor,
                 PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_LOOP, count_desc,
                             pStack->disp + local_disp);
                 pos_desc++;
+#if 0
+            // This label currently in another if 0'ed out block
             update_loop_description:  /* update the current state */
+#endif
                 conv_ptr = pConvertor->pBaseBuf + pStack->disp;
                 UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
                 DDT_DUMP_STACK( pConvertor->pStack, pConvertor->stack_pos, pElem, "advance loop" );

--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -2506,7 +2506,7 @@ btl_openib_component_init(int *num_btl_modules,
     mca_btl_openib_frag_init_data_t *init_data;
     struct dev_distance *dev_sorted;
     float distance;
-    int index, value;
+    int index;
     bool found;
     mca_base_var_source_t source;
     int list_count = 0;
@@ -2871,8 +2871,6 @@ btl_openib_component_init(int *num_btl_modules,
         opal_argv_free(mca_btl_openib_component.if_exclude_list);
         mca_btl_openib_component.if_exclude_list = NULL;
     }
-
-    value = opal_mem_hooks_support_level();
 
 #if OPAL_CUDA_SUPPORT
    if (mca_btl_openib_component.cuda_want_gdr && (0 == opal_leave_pinned)) {

--- a/opal/mca/btl/openib/btl_openib_mca.c
+++ b/opal/mca/btl/openib/btl_openib_mca.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2006-2009 Mellanox Technologies. All rights reserved.
  * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -677,20 +677,6 @@ int btl_openib_register_mca_params(void)
                    "Allow connecting processes from different IB subnets."
                    "(0 = do not allow; 1 = allow)",
                    false, &mca_btl_openib_component.allow_different_subnets));
-
-#if MEMORY_LINUX_MALLOC_ALIGN_ENABLED
-    tmp = mca_base_var_find ("opal", "memory", "linux", "memalign");
-    if (0 <= tmp) {
-        (void) mca_base_var_register_synonym(tmp, "opal", "btl", "openib", "memalign",
-                                             MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
-    }
-
-    tmp = mca_base_var_find ("opal", "memory", "linux", "memalign_threshold");
-    if (0 <= tmp) {
-        (void) mca_base_var_register_synonym(tmp, "opal", "btl", "openib", "memalign_threshold",
-                                             MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
-    }
-#endif /* MEMORY_LINUX_MALLOC_ALIGN_ENABLED */
 
     /* Register any MCA params for the connect pseudo-components */
     if (OPAL_SUCCESS == ret) {

--- a/opal/mca/common/sm/common_sm_mpool.c
+++ b/opal/mca/common/sm/common_sm_mpool.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011-2014 NVIDIA Corporation.  All rights reserved.
@@ -51,14 +51,6 @@ static void *mca_common_sm_mpool_alloc (mca_mpool_base_module_t *mpool,
   */
 static void mca_common_sm_mpool_free(mca_mpool_base_module_t *mpool,
                                      void *addr);
-
-/**
- * Fault Tolerance Event Notification Function
- * @param state Checkpoint Stae
- * @return OPAL_SUCCESS or failure status
- */
-static int mca_common_sm_mpool_ft_event (int state);
-
 
 /*
  *  Initializes the mpool module.

--- a/opal/mca/memory/base/memory_base_open.c
+++ b/opal/mca/memory/base/memory_base_open.c
@@ -69,26 +69,9 @@ static opal_memory_base_component_2_0_0_t empty_component = {
  */
 opal_memory_base_component_2_0_0_t *opal_memory = &empty_component;
 
-#if MEMORY_LINUX_PTMALLOC2
-/*
- * Note that this is a minor abstraction violation (that has actually
- * existed for quite a long time -- it used to be up in
- * ompi_mpi_init(); yoinks!): we're including a component's header
- * file here.  This is an unfortunate necessity: the linux/ptmallox
- * system hooks in pre-main, and has to be initialized before any
- * component or module has even been created.  Sad panda.
- */
-#include "opal/mca/memory/linux/memory_linux.h"
-#endif
 
 void opal_memory_base_malloc_init_hook (void)
 {
-#if MEMORY_LINUX_PTMALLOC2
-    /* See above comment about linux/ptmalloc2 about why this
-       abstraction violation is here. */
-    opal_memory->memoryc_init_hook = opal_memory_linux_malloc_init_hook;
-#endif
-
     if (opal_memory->memoryc_init_hook) {
         opal_memory->memoryc_init_hook ();
     }
@@ -110,14 +93,6 @@ static int opal_memory_base_open(mca_base_open_flag_t flags)
         tmp = (opal_memory_base_component_2_0_0_t *) item->cli_component;
 
         ret = tmp->memoryc_query (&priority);
-#if MEMORY_LINUX_PTMALLOC2
-        /* See above comment about linux/ptmalloc2 about why this
-           abstraction violation is here. */
-        if (0 == strcmp (tmp->memoryc_version.mca_component_name, "linux")) {
-            /* if ptmalloc is enabled always use it */
-            priority = 1000000;
-        }
-#endif
         if (OPAL_SUCCESS != ret || priority < highest_priority) {
             continue;
         }

--- a/opal/util/cmd_line.h
+++ b/opal/util/cmd_line.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -566,7 +566,7 @@ BEGIN_C_DECLS
      * to opal_argv_free()) by the caller.
      */
     OPAL_DECLSPEC int opal_cmd_line_get_tail(opal_cmd_line_t *cmd, int *tailc,
-                                             char ***tailv) __opal_attribute_nonnull__(1) __opal_attribute_nonnull__(2);
+                                             char ***tailv);
 
 END_C_DECLS
 

--- a/oshmem/mca/scoll/base/scoll_base_select.c
+++ b/oshmem/mca/scoll/base/scoll_base_select.c
@@ -123,6 +123,7 @@ static int scoll_null_alltoall(struct oshmem_group_t *group,
                               const void *source,
                               ptrdiff_t dst, ptrdiff_t sst,
                               size_t nlong,
+                              size_t element_size,
                               long *pSync,
                               int alg)
 {


### PR DESCRIPTION
Similar to https://github.com/open-mpi/ompi/pull/3187, a bunch of compiler warning fixes for v2.1.1.

Some were cherry-picked from https://github.com/open-mpi/ompi/pull/3187 (not from master), and are noted in the commit messages.  A few were original to this branch.

None are critical for v2.1.0.

@hppritcha Please review.