### PR TITLE
v3.x: compiler warning fixes

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -153,7 +154,6 @@ int ompi_osc_pt2pt_frag_flush_pending_all (ompi_osc_pt2pt_module_t *module)
 int ompi_osc_pt2pt_frag_flush_target (ompi_osc_pt2pt_module_t *module, int target)
 {
     ompi_osc_pt2pt_peer_t *peer = ompi_osc_pt2pt_peer_lookup (module, target);
-    ompi_osc_pt2pt_frag_t *frag;
     int ret = OMPI_SUCCESS;
 
     OPAL_OUTPUT_VERBOSE((50, ompi_osc_base_framework.framework_output,

--- a/ompi/mca/topo/treematch/treematch/tm_kpartitioning.c
+++ b/ompi/mca/topo/treematch/treematch/tm_kpartitioning.c
@@ -15,8 +15,9 @@ static int verbose_level = ERROR;
 #define MAX_TRIALS 10
 #define USE_KL_STRATEGY 1
 
-
+#if !defined(MIN)
 #define MIN(a,b) ((a)<(b)?(a):(b))
+#endif
 
 
 int  fill_tab(int **,int *,int,int,int,int);

--- a/ompi/mca/topo/treematch/treematch/tm_tree.c
+++ b/ompi/mca/topo/treematch/treematch/tm_tree.c
@@ -12,8 +12,12 @@
 #include "tm_thread_pool.h"
 
 
+#if !defined(MIN)
 #define MIN(a,b) ((a)<(b)?(a):(b))
+#endif
+#if !defined(MAX)
 #define MAX(a,b) ((a)>(b)?(a):(b))
+#endif
 
 #ifndef __CHARMC__
 #define __CHARMC__ 0


### PR DESCRIPTION
All cherry-picked from master; this is the v3.x version of https://github.com/open-mpi/ompi/pull/3185.