### PR TITLE
hwloc: re-enable use of autogen.pl in a tarball

### DIFF
--- a/opal/mca/hwloc/Makefile.am
+++ b/opal/mca/hwloc/Makefile.am
@@ -9,6 +9,8 @@
 # $HEADER$
 #
 
+EXTRA_DIST = autogen.options
+
 # main library setup
 noinst_LTLIBRARIES = libmca_hwloc.la
 libmca_hwloc_la_SOURCES =


### PR DESCRIPTION
Commit fec519a793a2afcfd1ebcb3fa7c151bd30893835 broke the ability to run autogen.pl in a distribution tarball.  This commit restores that ability by also distributing opal/mca/hwloc/autogen.options in the tarball.

Skipping CI because CI does not test this functionality:

[skip ci]
bot:notest

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>