### PR TITLE
v2.0.x: hwloc: re-enable use of autogen.pl in a tarball

### DIFF
--- a/opal/mca/hwloc/Makefile.am
+++ b/opal/mca/hwloc/Makefile.am
@@ -9,6 +9,8 @@
 # $HEADER$
 #
 
+EXTRA_DIST = autogen.options
+
 # main library setup
 noinst_LTLIBRARIES = libmca_hwloc.la
 libmca_hwloc_la_SOURCES =


### PR DESCRIPTION
Commit fec519a793a2afcfd1ebcb3fa7c151bd30893835 on master broke the ability to run autogen.pl in a distribution tarball.  This commit restores that ability by also distributing opal/mca/hwloc/autogen.options in the tarball.

Skipping CI because CI does not test this functionality:

[skip ci]
bot:notest

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit b8dfd49e976b6c5864274008f7f72c7e55754a89)

@hppritcha This was causing failures in Cisco's MTT, such as https://mtt.open-mpi.org/index.php?do_redir=2407 (I have an MPI install that invokes `autogen.pl` in the tarball before the normal `configure; make install`).  This regression is not in a released tarball yet.  It was merged in #3066 on v2.x after v2.0.2 and before v2.0.3.  The regression came in while fixing `--with-hwloc=external`, which was fec519a793a2afcfd1ebcb3fa7c151bd30893835 on master, and #3066 / commit 40e6b1feebed54036eaae0c793a9ebc3e7095031 on v2.x.