### PR TITLE
You cannot include both pmi.h and pmi2.h as they have conflicting defines in them.

### DIFF
--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC. All
  *                         rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -30,7 +30,6 @@
 #include "pmi2_pmap_parser.h"
 
 #include <string.h>
-#include <pmi.h>
 #include <pmi2.h>
 
 #include "opal/mca/pmix/base/base.h"


### PR DESCRIPTION


Thanks to Kilian Cavalotti for pointing it out

Signed-off-by: Ralph Castain <rhc@open-mpi.org>