### PR TITLE
You cannot include both pmi.h and pmi2.h as they have conflicting defines in them.

### DIFF
--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -30,7 +30,6 @@
 #include "pmi2_pmap_parser.h"
 
 #include <string.h>
-#include <pmi.h>
 #include <pmi2.h>
 
 #include "opal/mca/pmix/base/base.h"


### PR DESCRIPTION
Thanks to Kilian Cavalotti for pointing it out

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 4b6d220a8356693d60ee14dc9ca9dcfc2e7fb519)