### PR TITLE
orte: minor tweaks to run-as-root message

### DIFF
--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -322,18 +322,22 @@ int orte_submit_init(int argc, char *argv[],
      * exit with a giant warning flag
      */
     if (0 == geteuid() && !orte_cmd_options.run_as_root) {
+        /* show_help is not yet available, so print an error manually */
         fprintf(stderr, "--------------------------------------------------------------------------\n");
         if (orte_cmd_options.help) {
-            fprintf(stderr, "%s cannot provide the help message when run as root.\n", orte_basename);
+            fprintf(stderr, "%s cannot provide the help message when run as root.\n\n", orte_basename);
         } else {
-            /* show_help is not yet available, so print an error manually */
-            fprintf(stderr, "%s has detected an attempt to run as root.\n", orte_basename);
+            fprintf(stderr, "%s has detected an attempt to run as root.\n\n", orte_basename);
         }
-        fprintf(stderr, "Running as root is *strongly* discouraged as any mistake (e.g., in\n");
+
+        fprintf(stderr, "Running at root is *strongly* discouraged as any mistake (e.g., in\n");
         fprintf(stderr, "defining TMPDIR) or bug can result in catastrophic damage to the OS\n");
         fprintf(stderr, "file system, leaving your system in an unusable state.\n\n");
+
+        fprintf(stderr, "We strongly suggest that you run %s as a non-root user.\n\n", orte_basename);
+
         fprintf(stderr, "You can override this protection by adding the --allow-run-as-root\n");
-        fprintf(stderr, "option to your cmd line. However, we reiterate our strong advice\n");
+        fprintf(stderr, "option to your command line.  However, we reiterate our strong advice\n");
         fprintf(stderr, "against doing so - please do so at your own risk.\n");
         fprintf(stderr, "--------------------------------------------------------------------------\n");
         exit(1);

--- a/orte/tools/orte-dvm/orte-dvm.c
+++ b/orte/tools/orte-dvm/orte-dvm.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -221,18 +221,22 @@ int main(int argc, char *argv[])
      * exit with a giant warning flag
      */
     if (0 == geteuid() && !myglobals.run_as_root) {
+        /* show_help is not yet available, so print an error manually */
         fprintf(stderr, "--------------------------------------------------------------------------\n");
         if (myglobals.help) {
-            fprintf(stderr, "%s cannot provide the help message when run as root\n", orte_basename);
+            fprintf(stderr, "%s cannot provide the help message when run as root.\n\n", orte_basename);
         } else {
-            /* show_help is not yet available, so print an error manually */
-            fprintf(stderr, "%s has detected an attempt to run as root.\n", orte_basename);
+            fprintf(stderr, "%s has detected an attempt to run as root.\n\n", orte_basename);
         }
-        fprintf(stderr, " This is *strongly* discouraged as any mistake (e.g., in defining TMPDIR) or bug can\n");
-        fprintf(stderr, "result in catastrophic damage to the OS file system, leaving\n");
-        fprintf(stderr, "your system in an unusable state.\n\n");
+
+        fprintf(stderr, "Running at root is *strongly* discouraged as any mistake (e.g., in\n");
+        fprintf(stderr, "defining TMPDIR) or bug can result in catastrophic damage to the OS\n");
+        fprintf(stderr, "file system, leaving your system in an unusable state.\n\n");
+
+        fprintf(stderr, "We strongly suggest that you run %s as a non-root user.\n\n", orte_basename);
+
         fprintf(stderr, "You can override this protection by adding the --allow-run-as-root\n");
-        fprintf(stderr, "option to your cmd line. However, we reiterate our strong advice\n");
+        fprintf(stderr, "option to your command line.  However, we reiterate our strong advice\n");
         fprintf(stderr, "against doing so - please do so at your own risk.\n");
         fprintf(stderr, "--------------------------------------------------------------------------\n");
         exit(1);

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -130,29 +130,9 @@ int orterun(int argc, char *argv[])
 {
     orte_submit_status_t launchst, completest;
 
+    /* orte_submit_init() will also check if the user is running as
+       root (and may issue a warning/exit). */
     if (ORTE_SUCCESS != orte_submit_init(argc, argv, NULL)) {
-        exit(1);
-    }
-
-    /* check if we are running as root - if we are, then only allow
-     * us to proceed if the allow-run-as-root flag was given. Otherwise,
-     * exit with a giant warning flag
-     */
-    if (0 == geteuid() && !orte_cmd_options.run_as_root) {
-        fprintf(stderr, "--------------------------------------------------------------------------\n");
-        if (orte_cmd_options.help) {
-            fprintf(stderr, "%s cannot provide the help message when run as root.\n", orte_basename);
-        } else {
-            /* show_help is not yet available, so print an error manually */
-            fprintf(stderr, "%s has detected an attempt to run as root.\n", orte_basename);
-        }
-        fprintf(stderr, "Running at root is *strongly* discouraged as any mistake (e.g., in\n");
-        fprintf(stderr, "defining TMPDIR) or bug can result in catastrophic damage to the OS\n");
-        fprintf(stderr, "file system, leaving your system in an unusable state.\n\n");
-        fprintf(stderr, "You can override this protection by adding the --allow-run-as-root\n");
-        fprintf(stderr, "option to your cmd line. However, we reiterate our strong advice\n");
-        fprintf(stderr, "against doing so - please do so at your own risk.\n");
-        fprintf(stderr, "--------------------------------------------------------------------------\n");
         exit(1);
     }
 


### PR DESCRIPTION
Two updates:

1. Remove the "run as root" error message from orterun.c, because that functionality is now in orted_submit.c (although it is still required in orte-dvm.c -- so sync the message in orted_submit.c and orte-dvm.c to be identical).
2. Slightly tweak the text of the "run as root" error message to explicitly state that we (strongly) suggest running as a non-root user (and add a little whitespace).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@rhc54 This is a minor tweak after a user sent me a question this morning asking what to do when shown the "do not run as root" message.  It occurred to me that we don't explicitly state "Try running as another user," so I figured I'd tweak the message.