### PR TITLE
symbol name pollution

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@
 # Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -1407,6 +1407,7 @@ AC_CONFIG_FILES([
     test/support/Makefile
     test/threads/Makefile
     test/util/Makefile
+    test/symbol_name/Makefile
 ])
 m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile])])
 m4_ifdef([project_ompi], [

--- a/contrib/update-my-copyright.pl
+++ b/contrib/update-my-copyright.pl
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2017      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 
@@ -66,6 +67,7 @@ my $HELP = 0;
 # Defaults
 my $my_search_name = "Cisco";
 my $my_formal_name = "Cisco Systems, Inc.  All rights reserved.";
+my $my_manual_list = "";
 
 # Protected directories
 my @protected = qw(
@@ -80,6 +82,8 @@ $my_search_name = $ENV{OMPI_COPYRIGHT_SEARCH_NAME}
     if (defined($ENV{OMPI_COPYRIGHT_SEARCH_NAME}));
 $my_formal_name = $ENV{OMPI_COPYRIGHT_FORMAL_NAME}
     if (defined($ENV{OMPI_COPYRIGHT_FORMAL_NAME}));
+$my_manual_list = $ENV{OMPI_COPYRIGHT_MANUAL_LIST}
+    if (defined($ENV{OMPI_COPYRIGHT_MANUAL_LIST}));
 
 GetOptions(
     "help" => \$HELP,
@@ -87,6 +91,7 @@ GetOptions(
     "check-only" => \$CHECK_ONLY,
     "search-name=s" => \$my_search_name,
     "formal-name=s" => \$my_formal_name,
+    "manual-list=s" => \$my_manual_list,
 ) or die "unable to parse options, stopped";
 
 if ($HELP) {
@@ -98,6 +103,7 @@ $0 [options]
 --check-only         exit(111) if there are files with copyrights to edit
 --search-name=NAME   Set search name to NAME
 --formal-same=NAME   Set formal name to NAME
+--manual-list=FNAME  Use specified file as list of files to mod copyright
 EOT
     exit(0);
 }
@@ -143,6 +149,8 @@ $vcs = "hg"
     if (-d "$top/.hg");
 $vcs = "svn"
     if (-d "$top/.svn");
+$vcs = "manual"
+    if ("$my_manual_list" ne "");
 
 my @files = find_modified_files($vcs);
 
@@ -362,6 +370,9 @@ sub find_modified_files {
             }
         }
         close(CMD);
+    }
+    elsif ($vcs eq "manual") {
+        @files = split(/\n/, `cat $my_manual_list`);
     }
     else {
         die "unknown VCS '$vcs', stopped";

--- a/ompi/mca/coll/base/coll_base_alltoall.c
+++ b/ompi/mca/coll/base/coll_base_alltoall.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -390,7 +391,7 @@ int ompi_coll_base_alltoall_intra_linear_sync(const void *sbuf, int scount,
                     (max_outstanding_reqs <= 0)) ?
                    (size - 1) : (max_outstanding_reqs));
     if (0 < total_reqs) {
-        reqs = coll_base_comm_get_reqs(module->base_data, 2 * total_reqs);
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, 2 * total_reqs);
         if (NULL == reqs) { error = -1; line = __LINE__; goto error_hndl; }
     }
 
@@ -613,7 +614,7 @@ int ompi_coll_base_alltoall_intra_basic_linear(const void *sbuf, int scount,
 
     /* Initiate all send/recv to/from others. */
 
-    req = rreq = coll_base_comm_get_reqs(data, (size - 1) * 2);
+    req = rreq = ompi_coll_base_comm_get_reqs(data, (size - 1) * 2);
     if (NULL == req) { err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto err_hndl; }
 
     prcv = (char *) rbuf;

--- a/ompi/mca/coll/base/coll_base_alltoallv.c
+++ b/ompi/mca/coll/base/coll_base_alltoallv.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -231,7 +232,7 @@ ompi_coll_base_alltoallv_intra_basic_linear(const void *sbuf, const int *scounts
 
     /* Now, initiate all send/recv to/from others. */
     nreqs = 0;
-    reqs = preq = coll_base_comm_get_reqs(data, 2 * size);
+    reqs = preq = ompi_coll_base_comm_get_reqs(data, 2 * size);
     if( NULL == reqs ) { err = OMPI_ERR_OUT_OF_RESOURCE; goto err_hndl; }
 
     /* Post all receives first */

--- a/ompi/mca/coll/base/coll_base_barrier.c
+++ b/ompi/mca/coll/base/coll_base_barrier.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -342,7 +343,7 @@ int ompi_coll_base_barrier_intra_basic_linear(struct ompi_communicator_t *comm,
     /* The root collects and broadcasts the messages. */
 
     else {
-        requests = coll_base_comm_get_reqs(module->base_data, size);
+        requests = ompi_coll_base_comm_get_reqs(module->base_data, size);
         if( NULL == requests ) { err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto err_hndl; }
 
         for (i = 1; i < size; ++i) {

--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,7 +69,7 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
     tmpbuf = (char *) buffer;
 
     if( tree->tree_nextsize != 0 ) {
-        send_reqs = coll_base_comm_get_reqs(module->base_data, tree->tree_nextsize);
+        send_reqs = ompi_coll_base_comm_get_reqs(module->base_data, tree->tree_nextsize);
         if( NULL == send_reqs ) { err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto error_hndl; }
     }
 
@@ -628,7 +629,7 @@ ompi_coll_base_bcast_intra_basic_linear(void *buff, int count,
     }
 
     /* Root sends data to all others. */
-    preq = reqs = coll_base_comm_get_reqs(module->base_data, size-1);
+    preq = reqs = ompi_coll_base_comm_get_reqs(module->base_data, size-1);
     if( NULL == reqs ) { err = OMPI_ERR_OUT_OF_RESOURCE; goto err_hndl; }
 
     for (i = 0; i < size; ++i) {

--- a/ompi/mca/coll/base/coll_base_frame.c
+++ b/ompi/mca/coll/base/coll_base_frame.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,7 +110,7 @@ coll_base_comm_destruct(mca_coll_base_comm_t *data)
 OBJ_CLASS_INSTANCE(mca_coll_base_comm_t, opal_object_t,
                    coll_base_comm_construct, coll_base_comm_destruct);
 
-ompi_request_t** coll_base_comm_get_reqs(mca_coll_base_comm_t* data, int nreqs)
+ompi_request_t** ompi_coll_base_comm_get_reqs(mca_coll_base_comm_t* data, int nreqs)
 {
     if( 0 == nreqs ) return NULL;
 

--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -455,6 +455,6 @@ static inline void ompi_coll_base_free_reqs(ompi_request_t **reqs, int count)
  * Return the array of requests on the data. If the array was not initialized
  * or if it's size was too small, allocate it to fit the requested size.
  */
-ompi_request_t** coll_base_comm_get_reqs(mca_coll_base_comm_t* data, int nreqs);
+ompi_request_t** ompi_coll_base_comm_get_reqs(mca_coll_base_comm_t* data, int nreqs);
 
 #endif /* MCA_COLL_BASE_EXPORT_H */

--- a/ompi/mca/coll/base/coll_base_gather.c
+++ b/ompi/mca/coll/base/coll_base_gather.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -267,7 +268,7 @@ ompi_coll_base_gather_intra_linear_sync(const void *sbuf, int scount,
         */
         char *ptmp;
         ompi_request_t *first_segment_req;
-        reqs = coll_base_comm_get_reqs(module->base_data, size);
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, size);
         if (NULL == reqs) { ret = -1; line = __LINE__; goto error_hndl; }
 
         ompi_datatype_type_size(rdtype, &typelng);

--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -287,7 +287,7 @@ int ompi_coll_base_reduce_generic( const void* sendbuf, void* recvbuf, int origi
 
             int creq = 0;
 
-            sreq = coll_base_comm_get_reqs(module->base_data, max_outstanding_reqs);
+            sreq = ompi_coll_base_comm_get_reqs(module->base_data, max_outstanding_reqs);
             if (NULL == sreq) { line = __LINE__; ret = -1; goto error_hndl; }
 
             /* post first group of requests */

--- a/ompi/mca/coll/basic/coll_basic_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_allgather.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,7 +79,7 @@ mca_coll_basic_allgather_inter(const void *sbuf, int scount,
         if (OMPI_SUCCESS != err) { line = __LINE__; goto exit; }
 
         /* Get a requests arrays of the right size */
-        reqs = coll_base_comm_get_reqs(module->base_data, rsize + 1);
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, rsize + 1);
         if( NULL == reqs ) { line = __LINE__; err = OMPI_ERR_OUT_OF_RESOURCE; goto exit; }
 
         /* Do a send-recv between the two root procs. to avoid deadlock */

--- a/ompi/mca/coll/basic/coll_basic_allreduce.c
+++ b/ompi/mca/coll/basic/coll_basic_allreduce.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,7 +110,7 @@ mca_coll_basic_allreduce_inter(const void *sbuf, void *rbuf, int count,
         pml_buffer = tmpbuf - gap;
 
         if (rsize > 1) {
-            reqs = coll_base_comm_get_reqs(module->base_data, rsize - 1);
+            reqs = ompi_coll_base_comm_get_reqs(module->base_data, rsize - 1);
             if( NULL == reqs ) { err = OMPI_ERR_OUT_OF_RESOURCE; line = __LINE__; goto exit; }
         }
 

--- a/ompi/mca/coll/basic/coll_basic_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoall.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,7 +78,7 @@ mca_coll_basic_alltoall_inter(const void *sbuf, int scount,
 
     /* Initiate all send/recv to/from others. */
     nreqs = size * 2;
-    req = rreq = coll_base_comm_get_reqs( module->base_data, nreqs);
+    req = rreq = ompi_coll_base_comm_get_reqs( module->base_data, nreqs);
     if( NULL == req ) { return OMPI_ERR_OUT_OF_RESOURCE; }
     sreq = rreq + size;
 

--- a/ompi/mca/coll/basic/coll_basic_alltoallv.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoallv.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2013      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,7 +69,7 @@ mca_coll_basic_alltoallv_inter(const void *sbuf, const int *scounts, const int *
 
     /* Initiate all send/recv to/from others. */
     nreqs = rsize * 2;
-    preq = coll_base_comm_get_reqs(module->base_data, nreqs);
+    preq = ompi_coll_base_comm_get_reqs(module->base_data, nreqs);
     if( NULL == preq ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* Post all receives first  */

--- a/ompi/mca/coll/basic/coll_basic_alltoallw.c
+++ b/ompi/mca/coll/basic/coll_basic_alltoallw.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -179,7 +180,7 @@ mca_coll_basic_alltoallw_intra(const void *sbuf, const int *scounts, const int *
     /* Initiate all send/recv to/from others. */
 
     nreqs = 0;
-    reqs = preq = coll_base_comm_get_reqs(module->base_data, 2 * size);
+    reqs = preq = ompi_coll_base_comm_get_reqs(module->base_data, 2 * size);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* Post all receives first -- a simple optimization */
@@ -269,7 +270,7 @@ mca_coll_basic_alltoallw_inter(const void *sbuf, const int *scounts, const int *
 
     /* Initiate all send/recv to/from others. */
     nreqs = 0;
-    reqs = preq = coll_base_comm_get_reqs(module->base_data, 2 * size);
+    reqs = preq = ompi_coll_base_comm_get_reqs(module->base_data, 2 * size);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* Post all receives first -- a simple optimization */

--- a/ompi/mca/coll/basic/coll_basic_bcast.c
+++ b/ompi/mca/coll/basic/coll_basic_bcast.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,7 +82,7 @@ mca_coll_basic_bcast_log_intra(void *buff, int count,
 
     /* Send data to the children. */
 
-    reqs = coll_base_comm_get_reqs(module->base_data, size);
+    reqs = ompi_coll_base_comm_get_reqs(module->base_data, size);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     err = MPI_SUCCESS;
@@ -156,7 +157,7 @@ mca_coll_basic_bcast_lin_inter(void *buff, int count,
                                 MCA_COLL_BASE_TAG_BCAST, comm,
                                 MPI_STATUS_IGNORE));
     } else {
-        reqs = coll_base_comm_get_reqs(module->base_data, rsize);
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, rsize);
         if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
         /* root section */

--- a/ompi/mca/coll/basic/coll_basic_gatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_gatherv.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -142,7 +143,7 @@ mca_coll_basic_gatherv_inter(const void *sbuf, int scount,
             return OMPI_ERROR;
         }
 
-        reqs = coll_base_comm_get_reqs(module->base_data, size);
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, size);
         if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
         for (i = 0; i < size; ++i) {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgather.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,7 +53,7 @@ mca_coll_basic_neighbor_allgather_cart(const void *sbuf, int scount,
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
 
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* The ordering is defined as -1 then +1 in each dimension in
@@ -139,7 +140,7 @@ mca_coll_basic_neighbor_allgather_graph(const void *sbuf, int scount,
     }
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 2 * degree);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     for (neighbor = 0; neighbor < degree ; ++neighbor) {
@@ -190,7 +191,7 @@ mca_coll_basic_neighbor_allgather_dist_graph(const void *sbuf, int scount,
     outedges = dist_graph->out;
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     for (neighbor = 0; neighbor < indegree ; ++neighbor) {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_allgatherv.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_allgatherv.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,7 +52,7 @@ mca_coll_basic_neighbor_allgatherv_cart(const void *sbuf, int scount, struct omp
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
 
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* The ordering is defined as -1 then +1 in each dimension in
@@ -126,7 +127,7 @@ mca_coll_basic_neighbor_allgatherv_graph(const void *sbuf, int scount, struct om
     }
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 2 * degree);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     for (neighbor = 0; neighbor < degree ; ++neighbor) {
@@ -175,7 +176,7 @@ mca_coll_basic_neighbor_allgatherv_dist_graph(const void *sbuf, int scount, stru
     outedges = dist_graph->out;
 
     ompi_datatype_get_extent(rdtype, &lb, &extent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     for (neighbor = 0; neighbor < indegree ; ++neighbor) {

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoall.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,7 +51,7 @@ mca_coll_basic_neighbor_alltoall_cart(const void *sbuf, int scount, struct ompi_
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post receives first */
@@ -157,7 +158,7 @@ mca_coll_basic_neighbor_alltoall_graph(const void *sbuf, int scount, struct ompi
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 2 * degree);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post receives first */
@@ -215,7 +216,7 @@ mca_coll_basic_neighbor_alltoall_dist_graph(const void *sbuf, int scount,struct 
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post receives first */

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallv.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallv.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,7 +52,7 @@ mca_coll_basic_neighbor_alltoallv_cart(const void *sbuf, const int scounts[], co
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post receives first */
@@ -144,7 +145,7 @@ mca_coll_basic_neighbor_alltoallv_graph(const void *sbuf, const int scounts[], c
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree );
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 2 * degree );
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post all receives first */
@@ -201,7 +202,7 @@ mca_coll_basic_neighbor_alltoallv_dist_graph(const void *sbuf, const int scounts
 
     ompi_datatype_get_extent(rdtype, &lb, &rdextent);
     ompi_datatype_get_extent(sdtype, &lb, &sdextent);
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, indegree + outdegree);
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post all receives first */

--- a/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
+++ b/ompi/mca/coll/basic/coll_basic_neighbor_alltoallw.c
@@ -49,7 +49,7 @@ mca_coll_basic_neighbor_alltoallw_cart(const void *sbuf, const int scounts[], co
 
     if (0 == cart->ndims) return OMPI_SUCCESS;
 
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 4 * cart->ndims );
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post receives first */
@@ -134,7 +134,7 @@ mca_coll_basic_neighbor_alltoallw_graph(const void *sbuf, const int scounts[], c
     mca_topo_base_graph_neighbors_count (comm, rank, &degree);
     if (0 == degree) return OMPI_SUCCESS;
 
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, 2 * degree );
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, 2 * degree );
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     edges = graph->edges;
@@ -195,7 +195,7 @@ mca_coll_basic_neighbor_alltoallw_dist_graph(const void *sbuf, const int scounts
 
     if (0 == indegree+outdegree) return OMPI_SUCCESS;
 
-    reqs = preqs = coll_base_comm_get_reqs( module->base_data, indegree + outdegree );
+    reqs = preqs = ompi_coll_base_comm_get_reqs( module->base_data, indegree + outdegree );
     if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
     /* post all receives first */

--- a/ompi/mca/coll/basic/coll_basic_scatter.c
+++ b/ompi/mca/coll/basic/coll_basic_scatter.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,7 +69,7 @@ mca_coll_basic_scatter_inter(const void *sbuf, int scount,
             return OMPI_ERROR;
         }
 
-        reqs = coll_base_comm_get_reqs(module->base_data, size);
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, size);
         if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
         incr *= scount;

--- a/ompi/mca/coll/basic/coll_basic_scatterv.c
+++ b/ompi/mca/coll/basic/coll_basic_scatterv.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -144,7 +145,7 @@ mca_coll_basic_scatterv_inter(const void *sbuf, const int *scounts,
             return OMPI_ERROR;
         }
 
-        reqs = coll_base_comm_get_reqs(module->base_data, size);
+        reqs = ompi_coll_base_comm_get_reqs(module->base_data, size);
         if( NULL == reqs ) { return OMPI_ERR_OUT_OF_RESOURCE; }
 
         for (i = 0; i < size; ++i) {

--- a/ompi/mca/fcoll/base/base.h
+++ b/ompi/mca/fcoll/base/base.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,7 +48,7 @@ OMPI_DECLSPEC int mca_fcoll_base_find_available(bool enable_progress_threads,
 OMPI_DECLSPEC int mca_fcoll_base_init_file (struct mca_io_ompio_file_t *file);
 
 OMPI_DECLSPEC int mca_fcoll_base_get_param (struct mca_io_ompio_file_t *file, int keyval);
-OMPI_DECLSPEC int fcoll_base_sort_iovec (struct iovec *iov, int num_entries, int *sorted);
+OMPI_DECLSPEC int ompi_fcoll_base_sort_iovec (struct iovec *iov, int num_entries, int *sorted);
 
 /*
  * Globals

--- a/ompi/mca/fcoll/base/fcoll_base_coll_array.c
+++ b/ompi/mca/fcoll/base/fcoll_base_coll_array.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +35,7 @@
 #include "ompi/mca/common/ompio/common_ompio.h"
 
 
-int fcoll_base_coll_allgatherv_array (void *sbuf,
+int ompi_fcoll_base_coll_allgatherv_array (void *sbuf,
                                       int scount,
                                       ompi_datatype_t *sdtype,
                                       void *rbuf,
@@ -76,7 +77,7 @@ int fcoll_base_coll_allgatherv_array (void *sbuf,
         send_type = sdtype;
     }
 
-    err = fcoll_base_coll_gatherv_array (send_buf,
+    err = ompi_fcoll_base_coll_gatherv_array (send_buf,
                                          rcounts[j],
                                          send_type,
                                          rbuf,
@@ -104,7 +105,7 @@ int fcoll_base_coll_allgatherv_array (void *sbuf,
         return err;
     }
     
-    fcoll_base_coll_bcast_array (rbuf,
+    ompi_fcoll_base_coll_bcast_array (rbuf,
                                  1,
                                  newtype,
                                  root_index,
@@ -117,7 +118,7 @@ int fcoll_base_coll_allgatherv_array (void *sbuf,
     return OMPI_SUCCESS;
 }
 
-int fcoll_base_coll_gatherv_array (void *sbuf,
+int ompi_fcoll_base_coll_gatherv_array (void *sbuf,
                                    int scount,
                                    ompi_datatype_t *sdtype,
                                    void *rbuf,
@@ -206,7 +207,7 @@ int fcoll_base_coll_gatherv_array (void *sbuf,
     return err;
 }
 
-int fcoll_base_coll_scatterv_array (void *sbuf,
+int ompi_fcoll_base_coll_scatterv_array (void *sbuf,
                                     int *scounts,
                                     int *disps,
                                     ompi_datatype_t *sdtype,
@@ -296,7 +297,7 @@ int fcoll_base_coll_scatterv_array (void *sbuf,
     return err;
 }
 
-int fcoll_base_coll_allgather_array (void *sbuf,
+int ompi_fcoll_base_coll_allgather_array (void *sbuf,
                                      int scount,
                                      ompi_datatype_t *sdtype,
                                      void *rbuf,
@@ -324,7 +325,7 @@ int fcoll_base_coll_allgather_array (void *sbuf,
     }
 
     /* Gather and broadcast. */
-    err = fcoll_base_coll_gather_array (sbuf,
+    err = ompi_fcoll_base_coll_gather_array (sbuf,
                                         scount,
                                         sdtype,
                                         rbuf,
@@ -336,7 +337,7 @@ int fcoll_base_coll_allgather_array (void *sbuf,
                                         comm);
     
     if (OMPI_SUCCESS == err) {
-        err = fcoll_base_coll_bcast_array (rbuf,
+        err = ompi_fcoll_base_coll_bcast_array (rbuf,
                                            rcount * procs_per_group,
                                            rdtype,
                                            root_index,
@@ -349,7 +350,7 @@ int fcoll_base_coll_allgather_array (void *sbuf,
     return err;
 }
 
-int fcoll_base_coll_gather_array (void *sbuf,
+int ompi_fcoll_base_coll_gather_array (void *sbuf,
                                   int scount,
                                   ompi_datatype_t *sdtype,
                                   void *rbuf,
@@ -439,7 +440,7 @@ int fcoll_base_coll_gather_array (void *sbuf,
     return err;
 }
 
-int fcoll_base_coll_bcast_array (void *buff,
+int ompi_fcoll_base_coll_bcast_array (void *buff,
                                  int count,
                                  ompi_datatype_t *datatype,
                                  int root_index,

--- a/ompi/mca/fcoll/base/fcoll_base_coll_array.h
+++ b/ompi/mca/fcoll/base/fcoll_base_coll_array.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +42,7 @@
  * Modified versions of Collective operations
  * Based on an array of procs in group
  */
-OMPI_DECLSPEC int fcoll_base_coll_gatherv_array (void *sbuf,
+OMPI_DECLSPEC int ompi_fcoll_base_coll_gatherv_array (void *sbuf,
                                                  int scount,
                                                  ompi_datatype_t *sdtype,
                                                  void *rbuf,
@@ -52,7 +53,7 @@ OMPI_DECLSPEC int fcoll_base_coll_gatherv_array (void *sbuf,
                                                  int *procs_in_group,
                                                  int procs_per_group,
                                                  ompi_communicator_t *comm);
-OMPI_DECLSPEC int fcoll_base_coll_scatterv_array (void *sbuf,
+OMPI_DECLSPEC int ompi_fcoll_base_coll_scatterv_array (void *sbuf,
                                                   int *scounts,
                                                   int *disps,
                                                   ompi_datatype_t *sdtype,
@@ -63,7 +64,7 @@ OMPI_DECLSPEC int fcoll_base_coll_scatterv_array (void *sbuf,
                                                   int *procs_in_group,
                                                   int procs_per_group,
                                                   ompi_communicator_t *comm);
-OMPI_DECLSPEC int fcoll_base_coll_allgather_array (void *sbuf,
+OMPI_DECLSPEC int ompi_fcoll_base_coll_allgather_array (void *sbuf,
                                                    int scount,
                                                    ompi_datatype_t *sdtype,
                                                    void *rbuf,
@@ -74,7 +75,7 @@ OMPI_DECLSPEC int fcoll_base_coll_allgather_array (void *sbuf,
                                                    int procs_per_group,
                                                    ompi_communicator_t *comm);
 
-OMPI_DECLSPEC int fcoll_base_coll_allgatherv_array (void *sbuf,
+OMPI_DECLSPEC int ompi_fcoll_base_coll_allgatherv_array (void *sbuf,
                                                     int scount,
                                                     ompi_datatype_t *sdtype,
                                                     void *rbuf,
@@ -85,7 +86,7 @@ OMPI_DECLSPEC int fcoll_base_coll_allgatherv_array (void *sbuf,
                                                     int *procs_in_group,
                                                     int procs_per_group,
                                                     ompi_communicator_t *comm);
-OMPI_DECLSPEC int fcoll_base_coll_gather_array (void *sbuf,
+OMPI_DECLSPEC int ompi_fcoll_base_coll_gather_array (void *sbuf,
                                                 int scount,
                                                 ompi_datatype_t *sdtype,
                                                 void *rbuf,
@@ -95,7 +96,7 @@ OMPI_DECLSPEC int fcoll_base_coll_gather_array (void *sbuf,
                                                 int *procs_in_group,
                                                 int procs_per_group,
                                                 ompi_communicator_t *comm);
-OMPI_DECLSPEC int fcoll_base_coll_bcast_array (void *buff,
+OMPI_DECLSPEC int ompi_fcoll_base_coll_bcast_array (void *buff,
                                                int count,
                                                ompi_datatype_t *datatype,
                                                int root_index,

--- a/ompi/mca/fcoll/base/fcoll_base_sort.c
+++ b/ompi/mca/fcoll/base/fcoll_base_sort.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +24,7 @@
 #include "ompi/mca/common/ompio/common_ompio.h"
 
 
-int fcoll_base_sort_iovec (struct iovec *iov,
+int ompi_fcoll_base_sort_iovec (struct iovec *iov,
                            int num_entries,
                            int *sorted)
 {

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_read_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_read_all.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,7 +165,7 @@ mca_fcoll_dynamic_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rcomm_time = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&max_data,
+    ret = ompi_fcoll_base_coll_allgather_array (&max_data,
                                            1,
                                            MPI_LONG,
                                            total_bytes_per_process,
@@ -216,7 +217,7 @@ mca_fcoll_dynamic_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rcomm_time = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&local_count,
+    ret = ompi_fcoll_base_coll_allgather_array (&local_count,
                                            1,
                                            MPI_INT,
                                            fview_count,
@@ -274,7 +275,7 @@ mca_fcoll_dynamic_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rcomm_time = MPI_Wtime();
 #endif
-    ret =  fcoll_base_coll_allgatherv_array (local_iov_array,
+    ret =  ompi_fcoll_base_coll_allgatherv_array (local_iov_array,
                                              local_count,
                                              fh->f_iov_type,
                                              global_iov_array,
@@ -309,7 +310,7 @@ mca_fcoll_dynamic_file_read_all (mca_io_ompio_file_t *fh,
             ret = OMPI_ERR_OUT_OF_RESOURCE;
             goto exit;
         }
-        fcoll_base_sort_iovec (global_iov_array, total_fview_count, sorted);
+        ompi_fcoll_base_sort_iovec (global_iov_array, total_fview_count, sorted);
     }
 
     if (NULL != local_iov_array) {

--- a/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic/fcoll_dynamic_file_write_all.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -168,7 +169,7 @@ mca_fcoll_dynamic_file_write_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_comm_time = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&max_data,
+    ret = ompi_fcoll_base_coll_allgather_array (&max_data,
                                            1,
                                            MPI_LONG,
                                            total_bytes_per_process,
@@ -231,7 +232,7 @@ mca_fcoll_dynamic_file_write_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_comm_time = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&local_count,
+    ret = ompi_fcoll_base_coll_allgather_array (&local_count,
                                            1,
                                            MPI_INT,
                                            fview_count,
@@ -293,7 +294,7 @@ mca_fcoll_dynamic_file_write_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_comm_time = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgatherv_array (local_iov_array,
+    ret = ompi_fcoll_base_coll_allgatherv_array (local_iov_array,
                                             local_count,
                                             fh->f_iov_type,
                                             global_iov_array,
@@ -327,7 +328,7 @@ mca_fcoll_dynamic_file_write_all (mca_io_ompio_file_t *fh,
             ret = OMPI_ERR_OUT_OF_RESOURCE;
 	    goto exit;
         }
-	fcoll_base_sort_iovec (global_iov_array, total_fview_count, sorted);
+	ompi_fcoll_base_sort_iovec (global_iov_array, total_fview_count, sorted);
     }
 
     if (NULL != local_iov_array){

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_read_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_read_all.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2015 University of Houston. All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,7 +165,7 @@ mca_fcoll_dynamic_gen2_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rcomm_time = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&max_data,
+    ret = ompi_fcoll_base_coll_allgather_array (&max_data,
                                            1,
                                            MPI_LONG,
                                            total_bytes_per_process,
@@ -216,7 +217,7 @@ mca_fcoll_dynamic_gen2_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rcomm_time = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&local_count,
+    ret = ompi_fcoll_base_coll_allgather_array (&local_count,
                                            1,
                                            MPI_INT,
                                            fview_count,
@@ -274,7 +275,7 @@ mca_fcoll_dynamic_gen2_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rcomm_time = MPI_Wtime();
 #endif
-    ret =  fcoll_base_coll_allgatherv_array (local_iov_array,
+    ret =  ompi_fcoll_base_coll_allgatherv_array (local_iov_array,
                                              local_count,
                                              fh->f_iov_type,
                                              global_iov_array,
@@ -309,7 +310,7 @@ mca_fcoll_dynamic_gen2_file_read_all (mca_io_ompio_file_t *fh,
             ret = OMPI_ERR_OUT_OF_RESOURCE;
             goto exit;
         }
-        fcoll_base_sort_iovec (global_iov_array, total_fview_count, sorted);
+        ompi_fcoll_base_sort_iovec (global_iov_array, total_fview_count, sorted);
     }
 
     if (NULL != local_iov_array) {

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -274,7 +275,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
                                                  fh->f_comm->c_coll->coll_allgather_module);
     }
     else {
-        ret = fcoll_base_coll_allgather_array (broken_total_lengths,
+        ret = ompi_fcoll_base_coll_allgather_array (broken_total_lengths,
                                                dynamic_gen2_num_io_procs,
                                                MPI_LONG,
                                                total_bytes_per_process,
@@ -333,7 +334,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
                                                 fh->f_comm->c_coll->coll_allgather_module);            
     }
     else {
-        ret = fcoll_base_coll_allgather_array (broken_counts,
+        ret = ompi_fcoll_base_coll_allgather_array (broken_counts,
                                                dynamic_gen2_num_io_procs,
                                                MPI_INT,
                                                result_counts,
@@ -420,7 +421,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
                                                       fh->f_comm->c_coll->coll_allgatherv_module );
         }
         else {
-            ret = fcoll_base_coll_allgatherv_array (broken_iov_arrays[i],
+            ret = ompi_fcoll_base_coll_allgatherv_array (broken_iov_arrays[i],
                                                     broken_counts[i],
                                                     fh->f_iov_type,
                                                     aggr_data[i]->global_iov_array,
@@ -455,7 +456,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (mca_io_ompio_file_t *fh,
                 ret = OMPI_ERR_OUT_OF_RESOURCE;
                 goto exit;
             }
-            fcoll_base_sort_iovec (aggr_data[i]->global_iov_array, total_fview_count, aggr_data[i]->sorted);
+            ompi_fcoll_base_sort_iovec (aggr_data[i]->global_iov_array, total_fview_count, aggr_data[i]->sorted);
         }
         
         if (NULL != local_iov_array){

--- a/ompi/mca/fcoll/static/fcoll_static_file_read_all.c
+++ b/ompi/mca/fcoll/static/fcoll_static_file_read_all.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -294,7 +295,7 @@ mca_fcoll_static_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rexch = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&iov_size,
+    ret = ompi_fcoll_base_coll_allgather_array (&iov_size,
                                            1,
                                            MPI_INT,
                                            iovec_count_per_process,
@@ -337,7 +338,7 @@ mca_fcoll_static_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rexch = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_gatherv_array (local_iov_array,
+    ret = ompi_fcoll_base_coll_gatherv_array (local_iov_array,
                                          iov_size,
                                          io_array_type,
                                          global_iov_array,
@@ -496,7 +497,7 @@ mca_fcoll_static_file_read_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_rexch = MPI_Wtime();
 #endif
-        fcoll_base_coll_gather_array (&bytes_to_read_in_cycle,
+        ompi_fcoll_base_coll_gather_array (&bytes_to_read_in_cycle,
                                       1,
                                       MPI_INT,
                                       bytes_per_process,

--- a/ompi/mca/fcoll/static/fcoll_static_file_write_all.c
+++ b/ompi/mca/fcoll/static/fcoll_static_file_write_all.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -295,7 +296,7 @@ mca_fcoll_static_file_write_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_exch = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_allgather_array (&iov_size,
+    ret = ompi_fcoll_base_coll_allgather_array (&iov_size,
                                            1,
                                            MPI_INT,
                                            iovec_count_per_process,
@@ -339,7 +340,7 @@ mca_fcoll_static_file_write_all (mca_io_ompio_file_t *fh,
 #if OMPIO_FCOLL_WANT_TIME_BREAKDOWN
     start_exch = MPI_Wtime();
 #endif
-    ret = fcoll_base_coll_gatherv_array (local_iov_array,
+    ret = ompi_fcoll_base_coll_gatherv_array (local_iov_array,
                                          iov_size,
                                          io_array_type,
                                          global_iov_array,
@@ -500,7 +501,7 @@ mca_fcoll_static_file_write_all (mca_io_ompio_file_t *fh,
         start_exch = MPI_Wtime();
 #endif
         /* gather from each process how many bytes each will be sending */
-        ret = fcoll_base_coll_gather_array (&bytes_to_write_in_cycle,
+        ret = ompi_fcoll_base_coll_gather_array (&bytes_to_write_in_cycle,
                                             1,
                                             MPI_INT,
                                             bytes_per_process,

--- a/ompi/mca/io/ompio/io_ompio_aggregators.c
+++ b/ompi/mca/io/ompio/io_ompio_aggregators.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -921,7 +922,7 @@ int mca_io_ompio_merge_groups(mca_io_ompio_file_t *fh,
 
     //merge_aggrs[0] is considered the new aggregator
     //New aggregator collects group sizes of the groups to be merged
-    ret = fcoll_base_coll_allgather_array (&fh->f_init_procs_per_group,
+    ret = ompi_fcoll_base_coll_allgather_array (&fh->f_init_procs_per_group,
                                            1,
                                            MPI_INT,
                                            sizes_old_group,
@@ -957,7 +958,7 @@ int mca_io_ompio_merge_groups(mca_io_ompio_file_t *fh,
     //New aggregator also collects the grouping distribution
     //This is the actual merge
     //use allgatherv array
-    ret = fcoll_base_coll_allgatherv_array (fh->f_init_procs_in_group,
+    ret = ompi_fcoll_base_coll_allgatherv_array (fh->f_init_procs_in_group,
                                             fh->f_init_procs_per_group,
                                             MPI_INT,
                                             fh->f_procs_in_group,
@@ -1140,7 +1141,7 @@ int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
     }
 
     //Gather start offsets across processes in a group on aggregator
-    ret = fcoll_base_coll_allgather_array (start_offset_len,
+    ret = ompi_fcoll_base_coll_allgather_array (start_offset_len,
                                            3,
                                            OMPI_OFFSET_DATATYPE,
                                            start_offsets_lens_tmp,
@@ -1151,7 +1152,7 @@ int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
                                            fh->f_init_procs_per_group,
                                            fh->f_comm);
     if ( OMPI_SUCCESS != ret ) {
-        opal_output (1, "mca_io_ompio_prepare_to_grou[: error in fcoll_base_coll_allgather_array\n");
+        opal_output (1, "mca_io_ompio_prepare_to_grou[: error in ompi_fcoll_base_coll_allgather_array\n");
         goto exit;
     }
     end_offsets_tmp = (OMPI_MPI_OFFSET_TYPE* )malloc (fh->f_init_procs_per_group * sizeof(OMPI_MPI_OFFSET_TYPE));
@@ -1191,7 +1192,7 @@ int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
         goto exit;
     }
     //Communicate bytes per group between all aggregators
-    ret = fcoll_base_coll_allgather_array (bytes_per_group,
+    ret = ompi_fcoll_base_coll_allgather_array (bytes_per_group,
                                            1,
                                            OMPI_OFFSET_DATATYPE,
                                            aggr_bytes_per_group_tmp,
@@ -1202,7 +1203,7 @@ int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
                                            fh->f_init_num_aggrs,
                                            fh->f_comm);
     if ( OMPI_SUCCESS != ret ) {
-        opal_output (1, "mca_io_ompio_prepare_to_grou[: error in fcoll_base_coll_allgather_array 2\n");
+        opal_output (1, "mca_io_ompio_prepare_to_grou[: error in ompi_fcoll_base_coll_allgather_array 2\n");
         free(decision_list_tmp);
         goto exit;
     }
@@ -1276,7 +1277,7 @@ int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
     *decision_list = &decision_list_tmp[0];
     }
     //Communicate flag to all group members
-    ret = fcoll_base_coll_bcast_array (ompio_grouping_flag,
+    ret = ompi_fcoll_base_coll_bcast_array (ompio_grouping_flag,
                                        1,
                                        MPI_INT,
                                        0,

--- a/ompi/mca/pml/v/pml_v_component.c
+++ b/ompi/mca/pml/v/pml_v_component.c
@@ -7,6 +7,7 @@
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,7 +101,7 @@ static int mca_pml_v_component_register(void)
 static int mca_pml_v_component_open(void)
 {
     int rc;
-    pml_v_output_open(ompi_pml_v_output, ompi_pml_v_verbose);
+    ompi_pml_v_output_open(ompi_pml_v_output, ompi_pml_v_verbose);
 
     V_OUTPUT_VERBOSE(500, "loaded");
 
@@ -111,7 +112,7 @@ static int mca_pml_v_component_open(void)
     }
 
     if( NULL == mca_vprotocol_base_include_list ) {
-        pml_v_output_close();
+        ompi_pml_v_output_close();
         return mca_base_framework_close(&ompi_vprotocol_base_framework);
     }
 
@@ -136,7 +137,7 @@ static int mca_pml_v_component_close(void)
     }
 
     /* Make sure to close out output even if vprotocol isn't in use */
-    pml_v_output_close ();
+    ompi_pml_v_output_close ();
 
     /* Mark that we have changed something */
     snprintf(mca_pml_base_selected_component.pmlm_version.mca_component_name,
@@ -188,7 +189,7 @@ static int mca_pml_v_component_parasite_close(void)
     mca_pml_base_selected_component = mca_pml_v.host_pml_component;
 
     (void) mca_base_framework_close(&ompi_vprotocol_base_framework);
-    pml_v_output_close();
+    ompi_pml_v_output_close();
 
     mca_pml.pml_enable = mca_pml_v.host_pml.pml_enable;
     /* don't need to call the host component's close: pml_base will do it */

--- a/ompi/mca/pml/v/pml_v_output.c
+++ b/ompi/mca/pml/v/pml_v_output.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
  *                         All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +20,7 @@
 #endif
 #include <string.h>
 
-int pml_v_output_open(char *output, int verbosity) {
+int ompi_pml_v_output_open(char *output, int verbosity) {
     opal_output_stream_t lds;
     char hostname[OPAL_MAXHOSTNAMELEN] = "NA";
 
@@ -49,7 +50,7 @@ int pml_v_output_open(char *output, int verbosity) {
     return mca_pml_v.output;
 }
 
-void pml_v_output_close(void) {
+void ompi_pml_v_output_close(void) {
     opal_output_close(mca_pml_v.output);
     mca_pml_v.output = -1;
 }

--- a/ompi/mca/pml/v/pml_v_output.h
+++ b/ompi/mca/pml/v/pml_v_output.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
  *                         All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,8 +19,8 @@
 
 BEGIN_C_DECLS
 
-int pml_v_output_open(char *output, int verbosity);
-void pml_v_output_close(void);
+int ompi_pml_v_output_open(char *output, int verbosity);
+void ompi_pml_v_output_close(void);
 
 static inline void V_OUTPUT_ERR(const char *fmt, ... ) __opal_attribute_format__(__printf__, 1, 2);
 static inline void V_OUTPUT_ERR(const char *fmt, ... )

--- a/ompi/mpi/fortran/mpif-h/register_datarep_f.c
+++ b/ompi/mpi/fortran/mpif-h/register_datarep_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,12 +96,12 @@ typedef struct intercept_extra_state {
     ompi_mpi2_fortran_datarep_conversion_fn_t *write_fn_f77;
     ompi_mpi2_fortran_datarep_extent_fn_t *extent_fn_f77;
     MPI_Aint *extra_state_f77;
-} intercept_extra_state_t;
+} ompi_intercept_extra_state_t;
 
-OBJ_CLASS_DECLARATION(intercept_extra_state_t);
+OBJ_CLASS_DECLARATION(ompi_intercept_extra_state_t);
 
 #if !OMPI_BUILD_MPI_PROFILING || OPAL_HAVE_WEAK_SYMBOLS
-static void intercept_extra_state_constructor(intercept_extra_state_t *obj)
+static void intercept_extra_state_constructor(ompi_intercept_extra_state_t *obj)
 {
     obj->read_fn_f77 = NULL;
     obj->write_fn_f77 = NULL;
@@ -108,7 +109,7 @@ static void intercept_extra_state_constructor(intercept_extra_state_t *obj)
     obj->extra_state_f77 = NULL;
 }
 
-OBJ_CLASS_INSTANCE(intercept_extra_state_t,
+OBJ_CLASS_INSTANCE(ompi_intercept_extra_state_t,
                    opal_list_item_t,
                    intercept_extra_state_constructor, NULL);
 #endif  /* !OMPI_BUILD_MPI_PROFILING */
@@ -137,10 +138,10 @@ void ompi_register_datarep_f(char *datarep,
     char *c_datarep;
     int c_ierr, ret;
     MPI_Datarep_conversion_function *read_fn_c, *write_fn_c;
-    intercept_extra_state_t *intercept;
+    ompi_intercept_extra_state_t *intercept;
 
     /* Malloc space for the intercept callback data */
-    intercept = OBJ_NEW(intercept_extra_state_t);
+    intercept = OBJ_NEW(ompi_intercept_extra_state_t);
     if (NULL == intercept) {
         c_ierr = OMPI_ERRHANDLER_INVOKE(MPI_FILE_NULL,
                                         OMPI_ERR_OUT_OF_RESOURCE, FUNC_NAME);
@@ -210,8 +211,8 @@ static int read_intercept_fn(void *userbuf, MPI_Datatype type_c, int count_c,
 {
     MPI_Fint ierr, count_f77 = OMPI_FINT_2_INT(count_c);
     MPI_Fint type_f77 = PMPI_Type_c2f(type_c);
-    intercept_extra_state_t *intercept_data =
-        (intercept_extra_state_t*) extra_state;
+    ompi_intercept_extra_state_t *intercept_data =
+        (ompi_intercept_extra_state_t*) extra_state;
 
     intercept_data->read_fn_f77((char *) userbuf, &type_f77, &count_f77, (char *) filebuf,
                                 &position, intercept_data->extra_state_f77,
@@ -228,8 +229,8 @@ static int write_intercept_fn(void *userbuf, MPI_Datatype type_c, int count_c,
 {
     MPI_Fint ierr, count_f77 = OMPI_FINT_2_INT(count_c);
     MPI_Fint type_f77 = PMPI_Type_c2f(type_c);
-    intercept_extra_state_t *intercept_data =
-        (intercept_extra_state_t*) extra_state;
+    ompi_intercept_extra_state_t *intercept_data =
+        (ompi_intercept_extra_state_t*) extra_state;
 
     intercept_data->write_fn_f77((char *) userbuf, &type_f77, &count_f77, (char *) filebuf,
                                  &position, intercept_data->extra_state_f77,
@@ -244,8 +245,8 @@ static int extent_intercept_fn(MPI_Datatype type_c, MPI_Aint *file_extent_f77,
                                void *extra_state)
 {
     MPI_Fint ierr, type_f77 = PMPI_Type_c2f(type_c);
-    intercept_extra_state_t *intercept_data =
-        (intercept_extra_state_t*) extra_state;
+    ompi_intercept_extra_state_t *intercept_data =
+        (ompi_intercept_extra_state_t*) extra_state;
 
     intercept_data->extent_fn_f77(&type_f77, file_extent_f77,
                                  intercept_data->extra_state_f77, &ierr);

--- a/ompi/mpi/tool/category_changed.c
+++ b/ompi/mpi/tool/category_changed.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,9 +28,9 @@ int MPI_T_category_changed(int *stamp)
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
     *stamp = mca_base_var_group_get_stamp ();
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/category_get_categories.c
+++ b/ompi/mpi/tool/category_get_categories.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@ int MPI_T_category_get_categories(int cat_index, int len, int indices[])
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         rc = mca_base_var_group_get (cat_index, &group);
@@ -49,7 +50,7 @@ int MPI_T_category_get_categories(int cat_index, int len, int indices[])
         }
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/category_get_cvars.c
+++ b/ompi/mpi/tool/category_get_cvars.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@ int MPI_T_category_get_cvars(int cat_index, int len, int indices[])
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         rc = mca_base_var_group_get (cat_index, &group);
@@ -49,7 +50,7 @@ int MPI_T_category_get_cvars(int cat_index, int len, int indices[])
         }
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/category_get_index.c
+++ b/ompi/mpi/tool/category_get_index.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,9 +34,9 @@ int MPI_T_category_get_index (const char *name, int *category_index)
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
     ret = mca_base_var_group_find_by_name (name, category_index);
-    mpit_unlock ();
+    ompi_mpit_unlock ();
     if (OPAL_SUCCESS != ret) {
         return MPI_T_ERR_INVALID_NAME;
     }

--- a/ompi/mpi/tool/category_get_info.c
+++ b/ompi/mpi/tool/category_get_info.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@ int MPI_T_category_get_info(int cat_index, char *name, int *name_len,
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         rc = mca_base_var_group_get (cat_index, &group);
@@ -57,7 +58,7 @@ int MPI_T_category_get_info(int cat_index, char *name, int *name_len,
         mpit_copy_string (desc, desc_len, group->group_description);
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/category_get_num.c
+++ b/ompi/mpi/tool/category_get_num.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,9 +32,9 @@ int MPI_T_category_get_num (int *num_cat)
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
     *num_cat = mca_base_var_group_get_count ();
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/category_get_pvars.c
+++ b/ompi/mpi/tool/category_get_pvars.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-213 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@ int MPI_T_category_get_pvars(int cat_index, int len, int indices[])
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         rc = mca_base_var_group_get (cat_index, &group);
@@ -49,7 +50,7 @@ int MPI_T_category_get_pvars(int cat_index, int len, int indices[])
         }
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/cvar_get_index.c
+++ b/ompi/mpi/tool/cvar_get_index.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,9 +34,9 @@ int MPI_T_cvar_get_index (const char *name, int *cvar_index)
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
     ret = mca_base_var_find_by_name (name, cvar_index);
-    mpit_unlock ();
+    ompi_mpit_unlock ();
     if (OPAL_SUCCESS != ret) {
         return MPI_T_ERR_INVALID_NAME;
     }

--- a/ompi/mpi/tool/cvar_get_info.c
+++ b/ompi/mpi/tool/cvar_get_info.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@ int MPI_T_cvar_get_info(int cvar_index, char *name, int *name_len, int *verbosit
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         rc = mca_base_var_get (cvar_index, &var);
@@ -69,7 +70,7 @@ int MPI_T_cvar_get_info(int cvar_index, char *name, int *name_len, int *verbosit
         }
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/cvar_get_num.c
+++ b/ompi/mpi/tool/cvar_get_num.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,9 +31,9 @@ int MPI_T_cvar_get_num (int *num_cvar) {
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
     *num_cvar = mca_base_var_get_count();
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/cvar_handle_alloc.c
+++ b/ompi/mpi/tool/cvar_handle_alloc.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@ int MPI_T_cvar_handle_alloc (int cvar_index, void *obj_handle,
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     *handle = NULL;
 
@@ -68,7 +69,7 @@ int MPI_T_cvar_handle_alloc (int cvar_index, void *obj_handle,
         *handle = (MPI_T_cvar_handle) new_handle;
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/cvar_read.c
+++ b/ompi/mpi/tool/cvar_read.c
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@ int MPI_T_cvar_read (MPI_T_cvar_handle handle, void *buf)
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         rc = mca_base_var_get_value(handle->var->mbv_index, &value, NULL, NULL);
@@ -78,7 +79,7 @@ int MPI_T_cvar_read (MPI_T_cvar_handle handle, void *buf)
         }
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/cvar_write.c
+++ b/ompi/mpi/tool/cvar_write.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +34,7 @@ int MPI_T_cvar_write (MPI_T_cvar_handle handle, const void *buf)
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         if (MCA_BASE_VAR_SCOPE_CONSTANT == handle->var->mbv_scope ||
@@ -53,7 +54,7 @@ int MPI_T_cvar_write (MPI_T_cvar_handle handle, const void *buf)
         }
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/enum_get_info.c
+++ b/ompi/mpi/tool/enum_get_info.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +30,7 @@ int MPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *name, int *name_len
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         if (num) {
@@ -43,7 +44,7 @@ int MPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *name, int *name_len
         mpit_copy_string (name, name_len, enumtype->enum_name);
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/enum_get_item.c
+++ b/ompi/mpi/tool/enum_get_item.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +32,7 @@ int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name,
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         rc = enumtype->get_count (enumtype, &count);
@@ -54,7 +55,7 @@ int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name,
         mpit_copy_string(name, name_len, tmp);
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/finalize.c
+++ b/ompi/mpi/tool/finalize.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,14 +29,14 @@
 
 int MPI_T_finalize (void)
 {
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     if (!mpit_is_initialized ()) {
-        mpit_unlock ();
+        ompi_mpit_unlock ();
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    if (0 == --mpit_init_count) {
+    if (0 == --ompi_mpit_init_count) {
         (void) ompi_info_close_components ();
 
         if ((!ompi_mpi_initialized || ompi_mpi_finalized) &&
@@ -49,7 +50,7 @@ int MPI_T_finalize (void)
         (void) opal_finalize_util ();
     }
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/tool/init_thread.c
+++ b/ompi/mpi/tool/init_thread.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,9 +25,9 @@
 #include "ompi/mpi/tool/profile/defines.h"
 #endif
 
-extern opal_mutex_t mpit_big_lock;
+extern opal_mutex_t ompi_mpit_big_lock;
 
-extern volatile uint32_t mpit_init_count;
+extern volatile uint32_t ompi_mpit_init_count;
 extern volatile int32_t initted;
 
 
@@ -34,10 +35,10 @@ int MPI_T_init_thread (int required, int *provided)
 {
     int rc = MPI_SUCCESS;
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
-        if (0 != mpit_init_count++) {
+        if (0 != ompi_mpit_init_count++) {
             break;
         }
 
@@ -60,7 +61,7 @@ int MPI_T_init_thread (int required, int *provided)
         ompi_mpi_thread_level (required, provided);
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return rc;
 }

--- a/ompi/mpi/tool/mpit-internal.h
+++ b/ompi/mpi/tool/mpit-internal.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2011      UT-Battelle, LLC. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,17 +32,17 @@ typedef struct ompi_mpit_cvar_handle_t {
     void           *bound_object;
 } ompi_mpit_cvar_handle_t;
 
-void mpit_lock (void);
-void mpit_unlock (void);
+void ompi_mpit_lock (void);
+void ompi_mpit_unlock (void);
 
-extern volatile uint32_t mpit_init_count;
+extern volatile uint32_t ompi_mpit_init_count;
 
 int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype);
 int ompit_opal_to_mpit_error (int rc);
 
 static inline int mpit_is_initialized (void)
 {
-    return !!mpit_init_count;
+    return !!ompi_mpit_init_count;
 }
 
 static inline void mpit_copy_string (char *dest, int *len, const char *source)

--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,18 +14,18 @@
 
 #include "ompi/mpi/tool/mpit-internal.h"
 
-opal_mutex_t mpit_big_lock = OPAL_MUTEX_STATIC_INIT;
+opal_mutex_t ompi_mpit_big_lock = OPAL_MUTEX_STATIC_INIT;
 
-volatile uint32_t mpit_init_count = 0;
+volatile uint32_t ompi_mpit_init_count = 0;
 
-void mpit_lock (void)
+void ompi_mpit_lock (void)
 {
-    opal_mutex_lock (&mpit_big_lock);
+    opal_mutex_lock (&ompi_mpit_big_lock);
 }
 
-void mpit_unlock (void)
+void ompi_mpit_unlock (void)
 {
-    opal_mutex_unlock (&mpit_big_lock);
+    opal_mutex_unlock (&ompi_mpit_big_lock);
 }
 
 int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype)

--- a/ompi/mpi/tool/pvar_get_index.c
+++ b/ompi/mpi/tool/pvar_get_index.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,9 +34,9 @@ int MPI_T_pvar_get_index (const char *name, int var_class, int *pvar_index)
         return MPI_ERR_ARG;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
     ret = mca_base_pvar_find_by_name (name, var_class, pvar_index);
-    mpit_unlock ();
+    ompi_mpit_unlock ();
     if (OPAL_SUCCESS != ret) {
         return MPI_T_ERR_INVALID_NAME;
     }

--- a/ompi/mpi/tool/pvar_get_info.c
+++ b/ompi/mpi/tool/pvar_get_info.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +34,7 @@ int MPI_T_pvar_get_info(int pvar_index, char *name, int *name_len,
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         /* Find the performance variable. mca_base_pvar_get() handles the
@@ -88,7 +89,7 @@ int MPI_T_pvar_get_info(int pvar_index, char *name, int *name_len,
         }
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ret;
 }

--- a/ompi/mpi/tool/pvar_handle_alloc.c
+++ b/ompi/mpi/tool/pvar_handle_alloc.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +32,7 @@ int MPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index,
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         /* Find the performance variable. mca_base_pvar_get() handles the
@@ -52,7 +53,7 @@ int MPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index,
                                           handle, count);
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ompit_opal_to_mpit_error(ret);
 }

--- a/ompi/mpi/tool/pvar_handle_free.c
+++ b/ompi/mpi/tool/pvar_handle_free.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +30,7 @@ int MPI_T_pvar_handle_free(MPI_T_pvar_session session, MPI_T_pvar_handle *handle
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     do {
         /* Check that this is a valid handle */
@@ -49,7 +50,7 @@ int MPI_T_pvar_handle_free(MPI_T_pvar_session session, MPI_T_pvar_handle *handle
         *handle = MPI_T_PVAR_HANDLE_NULL;
     } while (0);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ret;
 }

--- a/ompi/mpi/tool/pvar_read.c
+++ b/ompi/mpi/tool/pvar_read.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,11 +35,11 @@ int MPI_T_pvar_read(MPI_T_pvar_session session, MPI_T_pvar_handle handle,
         return MPI_T_ERR_INVALID_HANDLE;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     ret = mca_base_pvar_handle_read_value (handle, buf);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ompit_opal_to_mpit_error (ret);
 }

--- a/ompi/mpi/tool/pvar_reset.c
+++ b/ompi/mpi/tool/pvar_reset.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +30,7 @@ int MPI_T_pvar_reset(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     if (MPI_T_PVAR_ALL_HANDLES == handle) {
         OPAL_LIST_FOREACH(handle, &session->handles, mca_base_pvar_handle_t) {
@@ -44,7 +45,7 @@ int MPI_T_pvar_reset(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
         ret = mca_base_pvar_handle_reset (handle);
     }
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ompit_opal_to_mpit_error (ret);
 }

--- a/ompi/mpi/tool/pvar_session_create.c
+++ b/ompi/mpi/tool/pvar_session_create.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,14 +30,14 @@ int MPI_T_pvar_session_create(MPI_T_pvar_session *session)
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     *session = OBJ_NEW(mca_base_pvar_session_t);
     if (NULL == *session) {
         ret = MPI_ERR_NO_MEM;
     }
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ret;
 }

--- a/ompi/mpi/tool/pvar_start.c
+++ b/ompi/mpi/tool/pvar_start.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +39,7 @@ int MPI_T_pvar_start(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     if (MPI_T_PVAR_ALL_HANDLES == handle) {
         OPAL_LIST_FOREACH(handle, &session->handles, mca_base_pvar_handle_t) {
@@ -53,7 +54,7 @@ int MPI_T_pvar_start(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
         ret = pvar_handle_start (handle);
     }
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ompit_opal_to_mpit_error (ret);
 }

--- a/ompi/mpi/tool/pvar_stop.c
+++ b/ompi/mpi/tool/pvar_stop.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +39,7 @@ int MPI_T_pvar_stop(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
         return MPI_T_ERR_NOT_INITIALIZED;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     if (MPI_T_PVAR_ALL_HANDLES == handle) {
         OPAL_LIST_FOREACH(handle, &session->handles, mca_base_pvar_handle_t) {
@@ -55,7 +56,7 @@ int MPI_T_pvar_stop(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
         ret = pvar_handle_stop (handle);
     }
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ompit_opal_to_mpit_error (ret);
 }

--- a/ompi/mpi/tool/pvar_write.c
+++ b/ompi/mpi/tool/pvar_write.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,11 +35,11 @@ int MPI_T_pvar_write(MPI_T_pvar_session session, MPI_T_pvar_handle handle,
         return MPI_T_ERR_INVALID_HANDLE;
     }
 
-    mpit_lock ();
+    ompi_mpit_lock ();
 
     ret = mca_base_pvar_handle_write_value (handle, buf);
 
-    mpit_unlock ();
+    ompi_mpit_unlock ();
 
     return ompit_opal_to_mpit_error (ret);
 }

--- a/ompi/patterns/comm/allgather.c
+++ b/ompi/patterns/comm/allgather.c
@@ -5,6 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +28,7 @@
 /**
  * All-reduce - subgroup in communicator
  */
-OMPI_DECLSPEC int comm_allgather_pml(void *src_buf, void *dest_buf, int count,
+OMPI_DECLSPEC int ompi_comm_allgather_pml(void *src_buf, void *dest_buf, int count,
         ompi_datatype_t *dtype, int my_rank_in_group,
         int n_peers, int *ranks_in_comm,ompi_communicator_t *comm)
 {
@@ -76,7 +77,7 @@ OMPI_DECLSPEC int comm_allgather_pml(void *src_buf, void *dest_buf, int count,
 
     /* get my reduction communication pattern */
     memset(&my_exchange_node, 0, sizeof(netpatterns_pair_exchange_node_t));
-    rc = netpatterns_setup_recursive_doubling_tree_node(n_peers,
+    rc = ompi_netpatterns_setup_recursive_doubling_tree_node(n_peers,
             my_rank_in_group, &my_exchange_node);
     if(OMPI_SUCCESS != rc){
         return rc;
@@ -283,7 +284,7 @@ OMPI_DECLSPEC int comm_allgather_pml(void *src_buf, void *dest_buf, int count,
         }
     }
 
-    netpatterns_cleanup_recursive_doubling_tree_node(&my_exchange_node);
+    ompi_netpatterns_cleanup_recursive_doubling_tree_node(&my_exchange_node);
 
     /* return */
     return OMPI_SUCCESS;

--- a/ompi/patterns/comm/allreduce.c
+++ b/ompi/patterns/comm/allreduce.c
@@ -5,6 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +30,7 @@
 /**
  * All-reduce for contigous primitive types
  */
-OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
+OMPI_DECLSPEC int ompi_comm_allreduce_pml(void *sbuf, void *rbuf, int count,
         ompi_datatype_t *dtype, int my_rank_in_group,
         struct ompi_op_t *op, int n_peers,int *ranks_in_comm,
         ompi_communicator_t *comm)
@@ -79,7 +80,7 @@ OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
 
     /* get my reduction communication pattern */
     memset(&my_exchange_node, 0, sizeof(netpatterns_pair_exchange_node_t));
-    rc = netpatterns_setup_recursive_doubling_tree_node(n_peers,
+    rc = ompi_netpatterns_setup_recursive_doubling_tree_node(n_peers,
             my_rank_in_group, &my_exchange_node);
     if(OMPI_SUCCESS != rc){
         return rc;
@@ -118,7 +119,7 @@ OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
                             -OMPI_COMMON_TAG_ALLREDUCE, comm,
                             MPI_STATUSES_IGNORE));
                 if( 0 > rc ) {
-                    fprintf(stderr,"  first recv failed in comm_allreduce_pml \n");
+                    fprintf(stderr,"  first recv failed in ompi_comm_allreduce_pml \n");
                     fflush(stderr);
                     goto  Error;
                 }
@@ -144,7 +145,7 @@ OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
                             -OMPI_COMMON_TAG_ALLREDUCE, MCA_PML_BASE_SEND_STANDARD,
                             comm));
                 if( 0 > rc ) {
-                    fprintf(stderr,"  first send failed in comm_allreduce_pml \n");
+                    fprintf(stderr,"  first send failed in ompi_comm_allreduce_pml \n");
                     fflush(stderr);
                     goto  Error;
                 }
@@ -173,7 +174,7 @@ OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
                                               -OMPI_COMMON_TAG_ALLREDUCE,
                                               comm, MPI_STATUS_IGNORE);
             if( 0 > rc ) {
-                fprintf(stderr,"  irecv failed in  comm_allreduce_pml at iterations %d \n",
+                fprintf(stderr,"  irecv failed in  ompi_comm_allreduce_pml at iterations %d \n",
                         exchange);
                 fflush(stderr);
                 goto Error;
@@ -205,7 +206,7 @@ OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
                             -OMPI_COMMON_TAG_ALLREDUCE, comm,
                             MPI_STATUSES_IGNORE));
                 if( 0 > rc ) {
-                    fprintf(stderr,"  last recv failed in comm_allreduce_pml \n");
+                    fprintf(stderr,"  last recv failed in ompi_comm_allreduce_pml \n");
                     fflush(stderr);
                     goto  Error;
                 }
@@ -223,7 +224,7 @@ OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
                             -OMPI_COMMON_TAG_ALLREDUCE, MCA_PML_BASE_SEND_STANDARD,
                             comm));
                 if( 0 > rc ) {
-                    fprintf(stderr,"  last send failed in comm_allreduce_pml \n");
+                    fprintf(stderr,"  last send failed in ompi_comm_allreduce_pml \n");
                     fflush(stderr);
                     goto  Error;
                 }
@@ -238,7 +239,7 @@ OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
         count_processed += count_this_stripe;
     }
 
-    netpatterns_cleanup_recursive_doubling_tree_node(&my_exchange_node);
+    ompi_netpatterns_cleanup_recursive_doubling_tree_node(&my_exchange_node);
 
     /* return */
     return OMPI_SUCCESS;

--- a/ompi/patterns/comm/bcast.c
+++ b/ompi/patterns/comm/bcast.c
@@ -5,6 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +30,7 @@
  *  This is a very simple algorithm - binary tree, transmitting the full
  *  message at each step.
  */
-OMPI_DECLSPEC int comm_bcast_pml(void *buffer, int root, int count,
+OMPI_DECLSPEC int ompi_comm_bcast_pml(void *buffer, int root, int count,
         ompi_datatype_t *dtype, int my_rank_in_group,
         int n_peers, int *ranks_in_comm,ompi_communicator_t *comm)
 {
@@ -47,7 +48,7 @@ OMPI_DECLSPEC int comm_bcast_pml(void *buffer, int root, int count,
     /*
      * compute my communication pattern - binary tree
      */
-    rc=netpatterns_setup_narray_tree(2, node_rank, n_peers,
+    rc=ompi_netpatterns_setup_narray_tree(2, node_rank, n_peers,
             &node_data);
     if( OMPI_SUCCESS != rc ) {
         goto Error;

--- a/ompi/patterns/comm/coll_ops.h
+++ b/ompi/patterns/comm/coll_ops.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,14 +27,14 @@ BEGIN_C_DECLS
 
 
 
-OMPI_DECLSPEC int comm_allgather_pml(void *src_buf, void *dest_buf, int count,
+OMPI_DECLSPEC int ompi_comm_allgather_pml(void *src_buf, void *dest_buf, int count,
         ompi_datatype_t *dtype, int my_rank_in_group, int n_peers,
         int *ranks_in_comm,ompi_communicator_t *comm);
-OMPI_DECLSPEC int comm_allreduce_pml(void *sbuf, void *rbuf, int count,
+OMPI_DECLSPEC int ompi_comm_allreduce_pml(void *sbuf, void *rbuf, int count,
         ompi_datatype_t *dtype, int my_rank_in_group,
         struct ompi_op_t *op, int n_peers,int *ranks_in_comm,
         ompi_communicator_t *comm);
-OMPI_DECLSPEC int comm_bcast_pml(void *buffer, int root, int count,
+OMPI_DECLSPEC int ompi_comm_bcast_pml(void *buffer, int root, int count,
         ompi_datatype_t *dtype, int my_rank_in_group,
         int n_peers, int *ranks_in_comm,ompi_communicator_t
         *comm);

--- a/ompi/patterns/net/allreduce.c
+++ b/ompi/patterns/net/allreduce.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -152,7 +153,7 @@ comm_allreduce(void *sbuf, void *rbuf, int count, opal_datatype_t *dtype,
     }
 
     /* get my reduction communication pattern */
-    ret=netpatterns_setup_recursive_doubling_tree_node(n_peers,my_rank,&my_exchange_node);
+    ret=ompi_netpatterns_setup_recursive_doubling_tree_node(n_peers,my_rank,&my_exchange_node);
     if(OMPI_SUCCESS != ret){
         return ret;
     }

--- a/ompi/patterns/net/netpatterns.h
+++ b/ompi/patterns/net/netpatterns.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
+  * Copyright (c) 2017      IBM Corporation. All rights reserved.
   * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,21 +21,21 @@
 
 BEGIN_C_DECLS
 
-int netpatterns_base_err(const char* fmt, ...);
-int netpatterns_register_mca_params(void);
+int ompi_netpatterns_base_err(const char* fmt, ...);
+int ompi_netpatterns_register_mca_params(void);
 
 #if OPAL_ENABLE_DEBUG
-extern int netpatterns_base_verbose; /* disabled by default */
-OMPI_DECLSPEC extern int netpatterns_base_err(const char*, ...) __opal_attribute_format__(__printf__, 1, 2);
+extern int ompi_netpatterns_base_verbose; /* disabled by default */
+OMPI_DECLSPEC extern int ompi_netpatterns_base_err(const char*, ...) __opal_attribute_format__(__printf__, 1, 2);
 #define NETPATTERNS_VERBOSE(args)                                \
     do {                                                         \
-        if(netpatterns_base_verbose > 0) {           \
-            netpatterns_base_err("[%s]%s[%s:%d:%s] ",\
+        if(ompi_netpatterns_base_verbose > 0) {           \
+            ompi_netpatterns_base_err("[%s]%s[%s:%d:%s] ",\
                     ompi_process_info.nodename,                  \
                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),          \
                     __FILE__, __LINE__, __func__);               \
-            netpatterns_base_err args;               \
-            netpatterns_base_err("\n");              \
+            ompi_netpatterns_base_err args;               \
+            ompi_netpatterns_base_err("\n");              \
         }                                                        \
     } while(0);
 #else
@@ -121,24 +122,24 @@ netpatterns_narray_knomial_tree_node_t;
 
 
 /* Init code for common_netpatterns */
-OMPI_DECLSPEC int netpatterns_init(void);
+OMPI_DECLSPEC int ompi_netpatterns_init(void);
 
 /* setup an n-array tree */
-OMPI_DECLSPEC int netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_nodes,
+OMPI_DECLSPEC int ompi_netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_nodes,
         netpatterns_tree_node_t *my_node);
 /* setup an n-array tree with k-nomial levels */
-OMPI_DECLSPEC int netpatterns_setup_narray_knomial_tree( int tree_order, int my_rank, int num_nodes,
+OMPI_DECLSPEC int ompi_netpatterns_setup_narray_knomial_tree( int tree_order, int my_rank, int num_nodes,
         netpatterns_narray_knomial_tree_node_t *my_node);
 /* cleanup an n-array tree setup by the above function */
-OMPI_DECLSPEC void netpatterns_cleanup_narray_knomial_tree (netpatterns_narray_knomial_tree_node_t *my_node);
+OMPI_DECLSPEC void ompi_netpatterns_cleanup_narray_knomial_tree (netpatterns_narray_knomial_tree_node_t *my_node);
 
 /* setup an multi-nomial tree - for each node in the tree
  *  this returns it's parent, and it's children
  */
-OMPI_DECLSPEC int netpatterns_setup_multinomial_tree(int tree_order, int num_nodes,
+OMPI_DECLSPEC int ompi_netpatterns_setup_multinomial_tree(int tree_order, int num_nodes,
         netpatterns_tree_node_t *tree_nodes);
 
-OMPI_DECLSPEC int netpatterns_setup_narray_tree_contigous_ranks(int tree_order,
+OMPI_DECLSPEC int ompi_netpatterns_setup_narray_tree_contigous_ranks(int tree_order,
         int num_nodes, netpatterns_tree_node_t **tree_nodes);
 
 /* calculate the nearest power of radix that is equal to or greater

--- a/ompi/patterns/net/netpatterns_base.c
+++ b/ompi/patterns/net/netpatterns_base.c
@@ -2,6 +2,7 @@
  *
  * Copyright (c) 2009-2012 Mellanox Technologies.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,22 +14,22 @@
 #include "ompi/include/ompi/constants.h"
 #include "netpatterns.h"
 
-int netpatterns_base_verbose = 0; /* disabled by default */
+int ompi_netpatterns_base_verbose = 0; /* disabled by default */
 
-int netpatterns_register_mca_params(void)
+int ompi_netpatterns_register_mca_params(void)
 {
-    netpatterns_base_verbose = 0;
+    ompi_netpatterns_base_verbose = 0;
     mca_base_var_register("ompi", "common", "netpatterns", "base_verbose",
                           "Verbosity level of the NETPATTERNS framework",
                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                           OPAL_INFO_LVL_9,
                           MCA_BASE_VAR_SCOPE_READONLY,
-                          &netpatterns_base_verbose);
+                          &ompi_netpatterns_base_verbose);
 
     return OMPI_SUCCESS;
 }
 
-int netpatterns_base_err(const char* fmt, ...)
+int ompi_netpatterns_base_err(const char* fmt, ...)
 {
     va_list list;
     int ret;
@@ -39,16 +40,16 @@ int netpatterns_base_err(const char* fmt, ...)
     return ret;
 }
 
-int netpatterns_init(void)
+int ompi_netpatterns_init(void)
 {
 /* There is no component for common_netpatterns so every component that uses it
-   should call netpatterns_init, still we want to run it only once */
+   should call ompi_netpatterns_init, still we want to run it only once */
 static int was_called = 0;
 
     if (0 == was_called) {
         was_called = 1;
 
-        return netpatterns_register_mca_params();
+        return ompi_netpatterns_register_mca_params();
     }
 
     return OMPI_SUCCESS;

--- a/ompi/patterns/net/netpatterns_knomial_tree.c
+++ b/ompi/patterns/net/netpatterns_knomial_tree.c
@@ -6,6 +6,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +34,7 @@
 
 /* setup recursive doubleing tree node */
 
-OMPI_DECLSPEC int netpatterns_setup_recursive_knomial_allgather_tree_node(
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_allgather_tree_node(
         int num_nodes, int node_rank, int tree_order, int *hier_ranks,
         netpatterns_k_exchange_node_t *exchange_node)
 {
@@ -52,7 +53,7 @@ OMPI_DECLSPEC int netpatterns_setup_recursive_knomial_allgather_tree_node(
 
 
     NETPATTERNS_VERBOSE(
-            ("Enter netpatterns_setup_recursive_knomial_tree_node(num_nodes=%d, node_rank=%d, tree_order=%d)",
+            ("Enter ompi_netpatterns_setup_recursive_knomial_tree_node(num_nodes=%d, node_rank=%d, tree_order=%d)",
                 num_nodes, node_rank, tree_order));
 
     assert(num_nodes > 1);
@@ -504,7 +505,7 @@ Error:
     return OMPI_ERROR;
 }
 
-OMPI_DECLSPEC void netpatterns_cleanup_recursive_knomial_allgather_tree_node(
+OMPI_DECLSPEC void ompi_netpatterns_cleanup_recursive_knomial_allgather_tree_node(
         netpatterns_k_exchange_node_t *exchange_node)
 {
     int i;
@@ -531,7 +532,7 @@ OMPI_DECLSPEC void netpatterns_cleanup_recursive_knomial_allgather_tree_node(
     free(exchange_node->payload_info);
 }
 
-OMPI_DECLSPEC int netpatterns_setup_recursive_knomial_tree_node(
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_tree_node(
         int num_nodes, int node_rank, int tree_order,
         netpatterns_k_exchange_node_t *exchange_node)
 {
@@ -541,7 +542,7 @@ OMPI_DECLSPEC int netpatterns_setup_recursive_knomial_tree_node(
     int k_base, kpow_num, peer;
 
     NETPATTERNS_VERBOSE(
-            ("Enter netpatterns_setup_recursive_knomial_tree_node(num_nodes=%d, node_rank=%d, tree_order=%d)",
+            ("Enter ompi_netpatterns_setup_recursive_knomial_tree_node(num_nodes=%d, node_rank=%d, tree_order=%d)",
                 num_nodes, node_rank, tree_order));
 
     assert(num_nodes > 1);
@@ -669,13 +670,13 @@ OMPI_DECLSPEC int netpatterns_setup_recursive_knomial_tree_node(
 
 Error:
 
-    netpatterns_cleanup_recursive_knomial_tree_node (exchange_node);
+    ompi_netpatterns_cleanup_recursive_knomial_tree_node (exchange_node);
 
     /* error return */
     return OMPI_ERROR;
 }
 
-OMPI_DECLSPEC void netpatterns_cleanup_recursive_knomial_tree_node(
+OMPI_DECLSPEC void ompi_netpatterns_cleanup_recursive_knomial_tree_node(
         netpatterns_k_exchange_node_t *exchange_node)
 {
     int i;
@@ -697,7 +698,7 @@ OMPI_DECLSPEC void netpatterns_cleanup_recursive_knomial_tree_node(
 }
 
 #if 1
-OMPI_DECLSPEC int netpatterns_setup_recursive_doubling_n_tree_node(int num_nodes, int node_rank, int tree_order,
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_doubling_n_tree_node(int num_nodes, int node_rank, int tree_order,
         netpatterns_pair_exchange_node_t *exchange_node)
 {
     /* local variables */
@@ -705,7 +706,7 @@ OMPI_DECLSPEC int netpatterns_setup_recursive_doubling_n_tree_node(int num_nodes
     int n_levels;
     int shift, mask;
 
-    NETPATTERNS_VERBOSE(("Enter netpatterns_setup_recursive_doubling_n_tree_node(num_nodes=%d, node_rank=%d, tree_order=%d)", num_nodes, node_rank, tree_order));
+    NETPATTERNS_VERBOSE(("Enter ompi_netpatterns_setup_recursive_doubling_n_tree_node(num_nodes=%d, node_rank=%d, tree_order=%d)", num_nodes, node_rank, tree_order));
 
     assert(num_nodes > 1);
     while (tree_order > num_nodes) {
@@ -838,7 +839,7 @@ Error:
     return OMPI_ERROR;
 }
 
-OMPI_DECLSPEC void netpatterns_cleanup_recursive_doubling_tree_node(
+OMPI_DECLSPEC void ompi_netpatterns_cleanup_recursive_doubling_tree_node(
     netpatterns_pair_exchange_node_t *exchange_node)
 {
     NETPATTERNS_VERBOSE(("About to release rank_extra_sources_array and rank_exchanges"));
@@ -852,15 +853,15 @@ OMPI_DECLSPEC void netpatterns_cleanup_recursive_doubling_tree_node(
 }
 #endif
 
-OMPI_DECLSPEC int netpatterns_setup_recursive_doubling_tree_node(int num_nodes, int node_rank,
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_doubling_tree_node(int num_nodes, int node_rank,
         netpatterns_pair_exchange_node_t *exchange_node)
 {
-    return netpatterns_setup_recursive_doubling_n_tree_node(num_nodes, node_rank, 2, exchange_node);
+    return ompi_netpatterns_setup_recursive_doubling_n_tree_node(num_nodes, node_rank, 2, exchange_node);
 }
 
 #if 0
 /*OMPI_DECLSPEC int old_netpatterns_setup_recursive_doubling_tree_node(int num_nodes, int node_rank,*/
-OMPI_DECLSPEC int netpatterns_setup_recursive_doubling_n_tree_node(int num_nodes, int node_rank,int tree_order,
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_doubling_n_tree_node(int num_nodes, int node_rank,int tree_order,
         netpatterns_pair_exchange_node_t *exchange_node)
 {
     /* local variables */

--- a/ompi/patterns/net/netpatterns_knomial_tree.h
+++ b/ompi/patterns/net/netpatterns_knomial_tree.h
@@ -5,6 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,27 +111,27 @@ struct netpatterns_k_exchange_node_t {
 typedef struct netpatterns_k_exchange_node_t
                netpatterns_k_exchange_node_t;
 
-OMPI_DECLSPEC int netpatterns_setup_recursive_doubling_n_tree_node(int num_nodes, int node_rank, int tree_order,
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_doubling_n_tree_node(int num_nodes, int node_rank, int tree_order,
     netpatterns_pair_exchange_node_t *exchange_node);
 
-OMPI_DECLSPEC void netpatterns_cleanup_recursive_doubling_tree_node(
+OMPI_DECLSPEC void ompi_netpatterns_cleanup_recursive_doubling_tree_node(
     netpatterns_pair_exchange_node_t *exchange_node);
 
-OMPI_DECLSPEC int netpatterns_setup_recursive_doubling_tree_node(int num_nodes, int node_rank,
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_doubling_tree_node(int num_nodes, int node_rank,
     netpatterns_pair_exchange_node_t *exchange_node);
 
-OMPI_DECLSPEC int netpatterns_setup_recursive_knomial_tree_node(
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_tree_node(
    int num_nodes, int node_rank, int tree_order,
    netpatterns_k_exchange_node_t *exchange_node);
 
-OMPI_DECLSPEC void netpatterns_cleanup_recursive_knomial_tree_node(
+OMPI_DECLSPEC void ompi_netpatterns_cleanup_recursive_knomial_tree_node(
    netpatterns_k_exchange_node_t *exchange_node);
 
-OMPI_DECLSPEC int netpatterns_setup_recursive_knomial_allgather_tree_node(
+OMPI_DECLSPEC int ompi_netpatterns_setup_recursive_knomial_allgather_tree_node(
         int num_nodes, int node_rank, int tree_order, int *hier_ranks,
         netpatterns_k_exchange_node_t *exchange_node);
 
-OMPI_DECLSPEC void netpatterns_cleanup_recursive_knomial_allgather_tree_node(
+OMPI_DECLSPEC void ompi_netpatterns_cleanup_recursive_knomial_allgather_tree_node(
         netpatterns_k_exchange_node_t *exchange_node);
 
 /* Input: k_exchange_node structure

--- a/ompi/patterns/net/netpatterns_multinomial_tree.c
+++ b/ompi/patterns/net/netpatterns_multinomial_tree.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2009-2012 Mellanox Technologies.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +27,7 @@
 /* setup an multi-nomial tree - for each node in the tree
  *  this returns it's parent, and it's children */
 
-OMPI_DECLSPEC int netpatterns_setup_multinomial_tree(int tree_order, int num_nodes,
+OMPI_DECLSPEC int ompi_netpatterns_setup_multinomial_tree(int tree_order, int num_nodes,
         netpatterns_tree_node_t *tree_nodes)
 {
     /* local variables */

--- a/ompi/patterns/net/netpatterns_nary_tree.c
+++ b/ompi/patterns/net/netpatterns_nary_tree.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2009-2012 Oak Ridge National Laboratory.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +33,7 @@
 
 /* setup an n-array tree */
 
-int netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_nodes,
+int ompi_netpatterns_setup_narray_tree(int tree_order, int my_rank, int num_nodes,
         netpatterns_tree_node_t *my_node)
 {
     /* local variables */
@@ -159,7 +160,7 @@ Error:
     return OMPI_ERROR;
 }
 
-void netpatterns_cleanup_narray_knomial_tree (netpatterns_narray_knomial_tree_node_t *my_node)
+void ompi_netpatterns_cleanup_narray_knomial_tree (netpatterns_narray_knomial_tree_node_t *my_node)
 {
     if (my_node->children_ranks) {
 	free (my_node->children_ranks);
@@ -167,11 +168,11 @@ void netpatterns_cleanup_narray_knomial_tree (netpatterns_narray_knomial_tree_no
     }
 
     if (0 != my_node->my_rank) {
-	netpatterns_cleanup_recursive_knomial_tree_node (&my_node->k_node);
+	ompi_netpatterns_cleanup_recursive_knomial_tree_node (&my_node->k_node);
     }
 }
 
-int netpatterns_setup_narray_knomial_tree(
+int ompi_netpatterns_setup_narray_knomial_tree(
         int tree_order, int my_rank, int num_nodes,
         netpatterns_narray_knomial_tree_node_t *my_node)
 {
@@ -231,7 +232,7 @@ int netpatterns_setup_narray_knomial_tree(
             my_rank-cum_cnt;
         my_node->level_size = cnt;
 
-        rc = netpatterns_setup_recursive_knomial_tree_node(
+        rc = ompi_netpatterns_setup_recursive_knomial_tree_node(
                 my_node->level_size, my_node->rank_on_level,
                 tree_order, &my_node->k_node);
         if (OMPI_SUCCESS != rc) {
@@ -430,7 +431,7 @@ error:
  * ranks may be rotated based on who the actual root is, to obtain the
  * appropriate communication pattern for such roots.
  */
-OMPI_DECLSPEC int netpatterns_setup_narray_tree_contigous_ranks(
+OMPI_DECLSPEC int ompi_netpatterns_setup_narray_tree_contigous_ranks(
         int tree_order, int num_nodes,
         netpatterns_tree_node_t **tree_nodes)
 {

--- a/opal/dss/dss_open_close.c
+++ b/opal/dss/dss_open_close.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +44,7 @@ static opal_dss_buffer_type_t default_buf_type = OPAL_DSS_BUFFER_NON_DESC;
 /* variable group id */
 static int opal_dss_group_id = -1;
 
-mca_base_var_enum_value_t buffer_type_values[] = {
+static mca_base_var_enum_value_t buffer_type_values[] = {
     {OPAL_DSS_BUFFER_NON_DESC, "non-described"},
     {OPAL_DSS_BUFFER_FULLY_DESC, "described"},
     {0, NULL}

--- a/opal/mca/base/mca_base_pvar.c
+++ b/opal/mca/base/mca_base_pvar.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2015      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -148,7 +149,7 @@ static int mca_base_pvar_default_get_value (const mca_base_pvar_t *pvar, void *v
     /* not used */
     (void) obj_handle;
 
-    memmove (value, pvar->ctx, var_type_sizes[pvar->type]);
+    memmove (value, pvar->ctx, ompi_var_type_sizes[pvar->type]);
 
     return OPAL_SUCCESS;
 }
@@ -158,7 +159,7 @@ static int mca_base_pvar_default_set_value (mca_base_pvar_t *pvar, const void *v
     /* not used */
     (void) obj_handle;
 
-    memmove (pvar->ctx, value, var_type_sizes[pvar->type]);
+    memmove (pvar->ctx, value, ompi_var_type_sizes[pvar->type]);
 
     return OPAL_SUCCESS;
 }
@@ -481,7 +482,7 @@ int mca_base_pvar_handle_alloc (mca_base_pvar_session_t *session, int index, voi
 
         /* get the size of this datatype since read functions will expect an
            array of datatype not mca_base_pvar_value_t's. */
-        datatype_size = var_type_sizes[pvar->type];
+        datatype_size = ompi_var_type_sizes[pvar->type];
         if (0 == datatype_size) {
             ret = OPAL_ERROR;
             break;
@@ -689,7 +690,7 @@ int mca_base_pvar_handle_read_value (mca_base_pvar_handle_t *handle, void *value
     if (mca_base_pvar_is_sum (handle->pvar) || mca_base_pvar_is_watermark (handle->pvar) ||
         !mca_base_pvar_handle_is_running (handle)) {
         /* read the value cached in the handle. */
-        memmove (value, handle->current_value, handle->count * var_type_sizes[handle->pvar->type]);
+        memmove (value, handle->current_value, handle->count * ompi_var_type_sizes[handle->pvar->type]);
     } else {
         /* read the value directly from the variable. */
         ret = handle->pvar->get_value (handle->pvar, value, handle->obj_handle);
@@ -718,7 +719,7 @@ int mca_base_pvar_handle_write_value (mca_base_pvar_handle_t *handle, const void
         return ret;
     }
 
-    memmove (handle->current_value, value, handle->count * var_type_sizes[handle->pvar->type]);
+    memmove (handle->current_value, value, handle->count * ompi_var_type_sizes[handle->pvar->type]);
     /* read the value directly from the variable. */
     ret = handle->pvar->set_value (handle->pvar, value, handle->obj_handle);
 
@@ -799,7 +800,7 @@ int mca_base_pvar_handle_reset (mca_base_pvar_handle_t *handle)
     /* reset this handle to a state analagous to when it was created */
     if (mca_base_pvar_is_sum (handle->pvar)) {
         /* reset the running sum to 0 */
-        memset (handle->current_value, 0, handle->count * var_type_sizes[handle->pvar->type]);
+        memset (handle->current_value, 0, handle->count * ompi_var_type_sizes[handle->pvar->type]);
 
         if (mca_base_pvar_handle_is_running (handle)) {
             ret = handle->pvar->get_value (handle->pvar, handle->last_value, handle->obj_handle);
@@ -879,7 +880,7 @@ int mca_base_pvar_dump(int index, char ***out, mca_base_var_dump_type_t output_t
             }
         }
 
-        (void)asprintf(out[0] + line++, "%stype:%s", tmp, var_type_names[pvar->type]);
+        (void)asprintf(out[0] + line++, "%stype:%s", tmp, ompi_var_type_names[pvar->type]);
         free(tmp);  // release tmp storage
     } else {
         /* there will be at most three lines in the pretty print case */
@@ -889,7 +890,7 @@ int mca_base_pvar_dump(int index, char ***out, mca_base_var_dump_type_t output_t
         }
 
         (void)asprintf (out[0] + line++, "performance \"%s\" (type: %s, class: %s)", full_name,
-                        var_type_names[pvar->type], pvar_class_names[pvar->var_class]);
+                        ompi_var_type_names[pvar->type], pvar_class_names[pvar->var_class]);
 
         if (pvar->description) {
             (void)asprintf(out[0] + line++, "%s", pvar->description);

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -79,7 +79,7 @@ static int mca_base_var_count = 0;
 
 static opal_hash_table_t mca_base_var_index_hash;
 
-const char *var_type_names[] = {
+const char *ompi_var_type_names[] = {
     "int",
     "unsigned_int",
     "unsigned_long",
@@ -91,7 +91,7 @@ const char *var_type_names[] = {
     "double"
 };
 
-const size_t var_type_sizes[] = {
+const size_t ompi_var_type_sizes[] = {
     sizeof (int),
     sizeof (unsigned),
     sizeof (unsigned long),
@@ -771,7 +771,7 @@ int mca_base_var_set_value (int vari, const void *value, size_t size, mca_base_v
     }
 
     if (MCA_BASE_VAR_TYPE_STRING != var->mbv_type && MCA_BASE_VAR_TYPE_VERSION_STRING != var->mbv_type) {
-        memmove (var->mbv_storage, value, var_type_sizes[var->mbv_type]);
+        memmove (var->mbv_storage, value, ompi_var_type_sizes[var->mbv_type]);
     } else {
         var_set_string (var, (char *) value);
     }
@@ -2118,7 +2118,7 @@ int mca_base_var_dump(int vari, char ***out, mca_base_var_dump_type_t output_typ
         /* Is this variable deprecated? */
         asprintf(out[0] + line++, "%sdeprecated:%s", tmp, VAR_IS_DEPRECATED(var[0]) ? "yes" : "no");
 
-        asprintf(out[0] + line++, "%stype:%s", tmp, var_type_names[var->mbv_type]);
+        asprintf(out[0] + line++, "%stype:%s", tmp, ompi_var_type_names[var->mbv_type]);
 
         /* Does this parameter have any synonyms or is it a synonym? */
         if (VAR_IS_SYNONYM(var[0])) {
@@ -2149,7 +2149,7 @@ int mca_base_var_dump(int vari, char ***out, mca_base_var_dump_type_t output_typ
         asprintf (out[0], "%s \"%s\" (current value: \"%s\", data source: %s, level: %d %s, type: %s",
                   VAR_IS_DEFAULT_ONLY(var[0]) ? "informational" : "parameter",
                   full_name, value_string, source_string, var->mbv_info_lvl + 1,
-                  info_lvl_strings[var->mbv_info_lvl], var_type_names[var->mbv_type]);
+                  info_lvl_strings[var->mbv_info_lvl], ompi_var_type_names[var->mbv_type]);
 
         tmp = out[0][0];
         if (VAR_IS_DEPRECATED(var[0])) {

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -102,7 +103,7 @@ const size_t var_type_sizes[] = {
     sizeof (double)
 };
 
-const char *var_source_names[] = {
+static const char *var_source_names[] = {
     "default",
     "command line",
     "environment",

--- a/opal/mca/base/mca_base_var.h
+++ b/opal/mca/base/mca_base_var.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,7 +96,7 @@ typedef enum {
     MCA_BASE_VAR_TYPE_MAX
 } mca_base_var_type_t;
 
-extern const char *var_type_names[];
+extern const char *ompi_var_type_names[];
 
 /**
  * Source of an MCA variable's value

--- a/opal/mca/base/mca_base_var_enum.c
+++ b/opal/mca/base/mca_base_var_enum.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +41,7 @@ OBJ_CLASS_INSTANCE(mca_base_var_enum_t, opal_object_t, mca_base_var_enum_constru
 
 static void mca_base_var_enum_flag_constructor (mca_base_var_enum_flag_t *enumerator);
 static void mca_base_var_enum_flag_destructor (mca_base_var_enum_flag_t *enumerator);
-OBJ_CLASS_INSTANCE(mca_base_var_enum_flag_t, opal_object_t, mca_base_var_enum_flag_constructor,
+static OBJ_CLASS_INSTANCE(mca_base_var_enum_flag_t, opal_object_t, mca_base_var_enum_flag_constructor,
                    mca_base_var_enum_flag_destructor);
 
 static int enum_dump (mca_base_var_enum_t *self, char **out);

--- a/opal/mca/base/mca_base_vari.h
+++ b/opal/mca/base/mca_base_vari.h
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,8 +72,8 @@ typedef enum {
 #define VAR_IS_SETTABLE(var) (!!((var).mbv_flags & MCA_BASE_VAR_FLAG_SETTABLE))
 #define VAR_IS_DEPRECATED(var) (!!((var).mbv_flags & MCA_BASE_VAR_FLAG_DEPRECATED))
 
-extern const char *var_type_names[];
-extern const size_t var_type_sizes[];
+extern const char *ompi_var_type_names[];
+extern const size_t ompi_var_type_sizes[];
 extern bool mca_base_var_initialized;
 
 /**

--- a/opal/mca/crs/base/base.h
+++ b/opal/mca/crs/base/base.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Evergrid, Inc. All rights reserved.
  *
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -120,9 +121,9 @@ BEGIN_C_DECLS
     typedef int (*opal_crs_base_self_restart_fn_t)(void);
     typedef int (*opal_crs_base_self_continue_fn_t)(void);
 
-    extern opal_crs_base_self_checkpoint_fn_t crs_base_self_checkpoint_fn;
-    extern opal_crs_base_self_restart_fn_t    crs_base_self_restart_fn;
-    extern opal_crs_base_self_continue_fn_t   crs_base_self_continue_fn;
+    extern opal_crs_base_self_checkpoint_fn_t ompi_crs_base_self_checkpoint_fn;
+    extern opal_crs_base_self_restart_fn_t    ompi_crs_base_self_restart_fn;
+    extern opal_crs_base_self_continue_fn_t   ompi_crs_base_self_continue_fn;
 
     OPAL_DECLSPEC int opal_crs_base_self_register_checkpoint_callback
                       (opal_crs_base_self_checkpoint_fn_t  function);

--- a/opal/mca/crs/base/crs_base_fns.c
+++ b/opal/mca/crs/base/crs_base_fns.c
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,9 +48,9 @@
 #include "opal/mca/crs/crs.h"
 #include "opal/mca/crs/base/base.h"
 
-opal_crs_base_self_checkpoint_fn_t crs_base_self_checkpoint_fn = NULL;
-opal_crs_base_self_restart_fn_t    crs_base_self_restart_fn = NULL;
-opal_crs_base_self_continue_fn_t   crs_base_self_continue_fn = NULL;
+opal_crs_base_self_checkpoint_fn_t ompi_crs_base_self_checkpoint_fn = NULL;
+opal_crs_base_self_restart_fn_t    ompi_crs_base_self_restart_fn = NULL;
+opal_crs_base_self_continue_fn_t   ompi_crs_base_self_continue_fn = NULL;
 
 /******************
  * Local Functions
@@ -330,19 +331,19 @@ int opal_crs_base_clear_options(opal_crs_base_ckpt_options_t *target)
 
 int opal_crs_base_self_register_checkpoint_callback(opal_crs_base_self_checkpoint_fn_t  function)
 {
-    crs_base_self_checkpoint_fn = function;
+    ompi_crs_base_self_checkpoint_fn = function;
     return OPAL_SUCCESS;
 }
 
 int opal_crs_base_self_register_restart_callback(opal_crs_base_self_restart_fn_t  function)
 {
-    crs_base_self_restart_fn = function;
+    ompi_crs_base_self_restart_fn = function;
     return OPAL_SUCCESS;
 }
 
 int opal_crs_base_self_register_continue_callback(opal_crs_base_self_continue_fn_t  function)
 {
-    crs_base_self_continue_fn = function;
+    ompi_crs_base_self_continue_fn = function;
     return OPAL_SUCCESS;
 }
 

--- a/opal/mca/crs/blcr/crs_blcr_module.c
+++ b/opal/mca/crs/blcr/crs_blcr_module.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2007      Evergrid, Inc. All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  *
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -640,7 +641,7 @@ static int opal_crs_blcr_thread_callback(void *arg) {
     else
 #endif
     {
-        if(OPAL_SUCCESS != (ret = trigger_user_inc_callback(OPAL_CR_INC_CRS_PRE_CKPT,
+        if(OPAL_SUCCESS != (ret = ompi_trigger_user_inc_callback(OPAL_CR_INC_CRS_PRE_CKPT,
                                                             OPAL_CR_INC_STATE_PREPARE)) ) {
             ;
         }
@@ -665,7 +666,7 @@ static int opal_crs_blcr_thread_callback(void *arg) {
         blcr_current_state = OPAL_CRS_CONTINUE;
     }
 
-    if( OPAL_SUCCESS != (ret = trigger_user_inc_callback(OPAL_CR_INC_CRS_POST_CKPT,
+    if( OPAL_SUCCESS != (ret = ompi_trigger_user_inc_callback(OPAL_CR_INC_CRS_POST_CKPT,
                                                          (blcr_current_state == OPAL_CRS_CONTINUE ?
                                                           OPAL_CR_INC_STATE_CONTINUE :
                                                           OPAL_CR_INC_STATE_RESTART))) ) {

--- a/opal/mca/event/external/event_external_component.c
+++ b/opal/mca/event/external/event_external_component.c
@@ -35,7 +35,7 @@ const char *opal_event_external_component_version_string =
 static int event_external_open(void);
 static int event_external_register (void);
 
-char *event_module_include = NULL;
+char *ompi_event_module_include = NULL;
 
 /*
  * Instantiate the public struct with all of our public information
@@ -82,9 +82,9 @@ static int event_external_register (void) {
     all_available_eventops = event_get_supported_methods();
 
 #ifdef __APPLE__
-    event_module_include ="select";
+    ompi_event_module_include ="select";
 #else
-    event_module_include = "poll";
+    ompi_event_module_include = "poll";
 #endif
 
     avail = opal_argv_join((char**)all_available_eventops, ',');
@@ -99,7 +99,7 @@ static int event_external_register (void) {
                                            MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_3,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
-                                           &event_module_include);
+                                           &ompi_event_module_include);
     free(help_msg);  /* release the help message */
     free(avail);
     avail = NULL;

--- a/opal/mca/event/external/event_external_module.c
+++ b/opal/mca/event/external/event_external_module.c
@@ -17,7 +17,7 @@
 
 #include "opal/util/argv.h"
 
-extern char *event_module_include;
+extern char *ompi_event_module_include;
 static struct event_config *config = NULL;
 
 opal_event_base_t* opal_event_base_create(void)
@@ -45,11 +45,11 @@ int opal_event_init(void)
 
     all_available_eventops = event_get_supported_methods();
 
-    if (NULL == event_module_include) {
+    if (NULL == ompi_event_module_include) {
         /* Shouldn't happen, but... */
-        event_module_include = strdup("select");
+        ompi_event_module_include = strdup("select");
     }
-    includes = opal_argv_split(event_module_include,',');
+    includes = opal_argv_split(ompi_event_module_include,',');
 
     /* get a configuration object */
     config = event_config_new();

--- a/opal/mca/event/libevent2022/libevent/event-internal.h
+++ b/opal/mca/event/libevent2022/libevent/event-internal.h
@@ -161,8 +161,8 @@ struct event_changelist {
 
 #ifndef _EVENT_DISABLE_DEBUG_MODE
 /* Global internal flag: set to one if debug mode is on. */
-extern int _event_debug_mode_on;
-#define EVENT_DEBUG_MODE_IS_ON() (_event_debug_mode_on)
+extern int ompi__event_debug_mode_on;
+#define EVENT_DEBUG_MODE_IS_ON() (ompi__event_debug_mode_on)
 #else
 #define EVENT_DEBUG_MODE_IS_ON() (0)
 #endif

--- a/opal/mca/event/libevent2022/libevent/evmap-internal.h
+++ b/opal/mca/event/libevent2022/libevent/evmap-internal.h
@@ -51,7 +51,7 @@ void evmap_signal_clear(struct event_signal_map* ctx);
 
 /** Add an IO event (some combination of EV_READ or EV_WRITE) to an
     event_base's list of events on a given file descriptor, and tell the
-    underlying eventops about the fd if its state has changed.
+    underlying ompi_eventops about the fd if its state has changed.
 
     Requires that ev is not already added.
 
@@ -62,7 +62,7 @@ void evmap_signal_clear(struct event_signal_map* ctx);
 int evmap_io_add(struct event_base *base, evutil_socket_t fd, struct event *ev);
 /** Remove an IO event (some combination of EV_READ or EV_WRITE) to an
     event_base's list of events on a given file descriptor, and tell the
-    underlying eventops about the fd if its state has changed.
+    underlying ompi_eventops about the fd if its state has changed.
 
     @param base the event_base to operate on.
     @param fd the file descriptor corresponding to ev.

--- a/opal/mca/event/libevent2022/libevent/evutil.c
+++ b/opal/mca/event/libevent2022/libevent/evutil.c
@@ -2113,7 +2113,7 @@ _evutil_weakrand(void)
  * Volatile pointer to memset: we use this to keep the compiler from
  * eliminating our call to memset.
  */
-void * (*volatile evutil_memset_volatile_)(void *, int, size_t) = memset;
+static void * (*volatile evutil_memset_volatile_)(void *, int, size_t) = memset;
 
 void
 evutil_memclear_(void *mem, size_t len)

--- a/opal/mca/event/libevent2022/libevent/log-internal.h
+++ b/opal/mca/event/libevent2022/libevent/log-internal.h
@@ -57,7 +57,7 @@ void _event_debugx(const char *fmt, ...) EV_CHECK_FMT(1,2);
 #undef EV_CHECK_FMT
 
 /****    OMPI CHANGE    ****/
-extern int event_enable_debug_output;
+extern int ompi_event_enable_debug_output;
 /**** END OMPI CHANGE  ****/
 
 #endif

--- a/opal/mca/event/libevent2022/libevent/log.c
+++ b/opal/mca/event/libevent2022/libevent/log.c
@@ -64,7 +64,7 @@ static void event_exit(int errcode) EV_NORETURN;
 static event_fatal_cb fatal_fn = NULL;
 
 /****    OMPI CHANGE    ****/
-int event_enable_debug_output = 0;
+int ompi_event_enable_debug_output = 0;
 /****  END OMPI CHANGE  ****/
 
 void

--- a/opal/mca/event/libevent2022/libevent/test/regress.c
+++ b/opal/mca/event/libevent2022/libevent/test/regress.c
@@ -814,7 +814,7 @@ end:
 #ifndef WIN32
 static void signal_cb(evutil_socket_t fd, short event, void *arg);
 
-#define current_base event_global_current_base_
+#define current_base ompi_event_global_current_base_
 extern struct event_base *current_base;
 
 static void

--- a/opal/mca/event/libevent2022/libevent2022_component.c
+++ b/opal/mca/event/libevent2022/libevent2022_component.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  *
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@ const char *opal_event_libevent2022_component_version_string =
 /*
  * MCA variables
  */
-char *event_module_include = NULL;
+char *ompi_event_module_include = NULL;
 
 /* copied from event.c */
 #if defined(_EVENT_HAVE_EVENT_PORTS) && _EVENT_HAVE_EVENT_PORTS
@@ -61,7 +62,7 @@ extern const struct eventop win32ops;
 #endif
 
 /* Array of backends in order of preference. */
-const struct eventop *eventops[] = {
+const struct eventop *ompi_eventops[] = {
 #if defined(_EVENT_HAVE_EVENT_PORTS) && _EVENT_HAVE_EVENT_PORTS
 	&evportops,
 #endif
@@ -122,7 +123,7 @@ const opal_event_component_t mca_event_libevent2022_component = {
 
 static int libevent2022_register (void)
 {
-    const struct eventop** _eventop = eventops;
+    const struct eventop** _eventop = ompi_eventops;
     char available_eventops[BUFSIZ] = "none";
     char *help_msg = NULL;
     int ret;
@@ -156,18 +157,18 @@ static int libevent2022_register (void)
         const int len = sizeof (available_eventops);
         int cur_len = snprintf (available_eventops, len, "%s", (*(_eventop++))->name);
 
-        for (int i = 1 ; eventops[i] && cur_len < len ; ++i) {
+        for (int i = 1 ; ompi_eventops[i] && cur_len < len ; ++i) {
             cur_len += snprintf (available_eventops + cur_len, len - cur_len, ", %s",
-                                 eventops[i]->name);
+                                 ompi_eventops[i]->name);
         }
         /* ensure the available_eventops string is always NULL-terminated  */
         available_eventops[len - 1] = '\0';
     }
 
 #ifdef __APPLE__
-    event_module_include ="select";
+    ompi_event_module_include ="select";
 #else
-    event_module_include = "poll";
+    ompi_event_module_include = "poll";
 #endif
 
     asprintf( &help_msg,
@@ -181,7 +182,7 @@ static int libevent2022_register (void)
                                            MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_3,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
-                                           &event_module_include);
+                                           &ompi_event_module_include);
     free(help_msg);  /* release the help message */
 
     if (0 > ret) {

--- a/opal/mca/event/libevent2022/libevent2022_module.c
+++ b/opal/mca/event/libevent2022/libevent2022_module.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,8 +68,8 @@
 #include "opal/mca/event/event.h"
 
 static struct event_config *config=NULL;
-extern char *event_module_include;
-extern const struct eventop *eventops[];
+extern char *ompi_event_module_include;
+extern const struct eventop *ompi_eventops[];
 
 opal_event_base_t* opal_event_base_create(void)
 {
@@ -93,29 +94,29 @@ int opal_event_init(void)
         dumpit = true;
     }
 
-    if (NULL == event_module_include) {
+    if (NULL == ompi_event_module_include) {
         /* Shouldn't happen, but... */
-        event_module_include = strdup("select");
+        ompi_event_module_include = strdup("select");
     }
-    includes = opal_argv_split(event_module_include,',');
+    includes = opal_argv_split(ompi_event_module_include,',');
 
     /* get a configuration object */
     config = event_config_new();
     /* cycle thru the available subsystems */
-    for (i = 0 ; NULL != eventops[i] ; ++i) {
+    for (i = 0 ; NULL != ompi_eventops[i] ; ++i) {
         /* if this module isn't included in the given ones,
          * then exclude it
          */
         dumpit = true;
         for (j=0; NULL != includes[j]; j++) {
             if (0 == strcmp("all", includes[j]) ||
-                0 == strcmp(eventops[i]->name, includes[j])) {
+                0 == strcmp(ompi_eventops[i]->name, includes[j])) {
                 dumpit = false;
                 break;
             }
         }
         if (dumpit) {
-            event_config_avoid_method(config, eventops[i]->name);
+            event_config_avoid_method(config, ompi_eventops[i]->name);
         }
     }
     opal_argv_free(includes);

--- a/opal/mca/pmix/pmix2x/pmix/src/threads/wait_sync.h
+++ b/opal/mca/pmix/pmix2x/pmix/src/threads/wait_sync.h
@@ -9,6 +9,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +41,7 @@ typedef struct pmix_wait_sync_t {
 #define REQUEST_PENDING        (void*)0L
 #define REQUEST_COMPLETED      (void*)1L
 
-#define PMIX_SYNC_WAIT(sync)    sync_wait_mt (sync)
+#define PMIX_SYNC_WAIT(sync)    ompi_sync_wait_mt (sync)
 
 /* The loop in release handles a race condition between the signaling
  * thread and the destruction of the condition variable. The signaling

--- a/opal/runtime/opal_cr.c
+++ b/opal/runtime/opal_cr.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2012-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -620,7 +621,7 @@ int opal_cr_inc_core_prep(void)
     /*
      * Call User Level INC
      */
-    if(OPAL_SUCCESS != (ret = trigger_user_inc_callback(OPAL_CR_INC_PRE_CRS_PRE_MPI,
+    if(OPAL_SUCCESS != (ret = ompi_trigger_user_inc_callback(OPAL_CR_INC_PRE_CRS_PRE_MPI,
                                                         OPAL_CR_INC_STATE_PREPARE)) ) {
         return ret;
     }
@@ -640,7 +641,7 @@ int opal_cr_inc_core_prep(void)
     /*
      * Call User Level INC
      */
-    if(OPAL_SUCCESS != (ret = trigger_user_inc_callback(OPAL_CR_INC_PRE_CRS_POST_MPI,
+    if(OPAL_SUCCESS != (ret = ompi_trigger_user_inc_callback(OPAL_CR_INC_PRE_CRS_POST_MPI,
                                                         OPAL_CR_INC_STATE_PREPARE)) ) {
         return ret;
     }
@@ -728,7 +729,7 @@ int opal_cr_inc_core_recover(int state)
         cb_state = OPAL_CR_INC_STATE_ERROR;
     }
 
-    if(OPAL_SUCCESS != (ret = trigger_user_inc_callback(OPAL_CR_INC_POST_CRS_PRE_MPI,
+    if(OPAL_SUCCESS != (ret = ompi_trigger_user_inc_callback(OPAL_CR_INC_POST_CRS_PRE_MPI,
                                                         cb_state)) ) {
         return ret;
     }
@@ -745,7 +746,7 @@ int opal_cr_inc_core_recover(int state)
         return ret;
     }
 
-    if(OPAL_SUCCESS != (ret = trigger_user_inc_callback(OPAL_CR_INC_POST_CRS_POST_MPI,
+    if(OPAL_SUCCESS != (ret = ompi_trigger_user_inc_callback(OPAL_CR_INC_POST_CRS_POST_MPI,
                                                         cb_state)) ) {
         return ret;
     }
@@ -881,7 +882,7 @@ int opal_cr_user_inc_register_callback(opal_cr_user_inc_callback_event_t event,
     return OPAL_SUCCESS;
 }
 
-int trigger_user_inc_callback(opal_cr_user_inc_callback_event_t event,
+int ompi_trigger_user_inc_callback(opal_cr_user_inc_callback_event_t event,
                               opal_cr_user_inc_callback_state_t state)
 {
     if( NULL == cur_user_coord_callback[event] ) {

--- a/opal/runtime/opal_cr.h
+++ b/opal/runtime/opal_cr.h
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -329,7 +330,7 @@ typedef enum opal_cr_ckpt_cmd_state_t opal_cr_ckpt_cmd_state_t;
                        opal_cr_user_inc_callback_fn_t  function,
                        opal_cr_user_inc_callback_fn_t  *prev_function);
 
-    OPAL_DECLSPEC int trigger_user_inc_callback(opal_cr_user_inc_callback_event_t event,
+    OPAL_DECLSPEC int ompi_trigger_user_inc_callback(opal_cr_user_inc_callback_event_t event,
                                                 opal_cr_user_inc_callback_state_t state);
 
 

--- a/opal/runtime/opal_info_support.c
+++ b/opal/runtime/opal_info_support.c
@@ -593,7 +593,7 @@ void opal_info_do_type(opal_cmd_line_t *opal_info_cmd_line)
             if (OPAL_SUCCESS != ret) {
                 continue;
             }
-            if (0 == strcmp(type, var_type_names[var->mbv_type]) && (var->mbv_info_lvl <= max_level)) {
+            if (0 == strcmp(type, ompi_var_type_names[var->mbv_type]) && (var->mbv_info_lvl <= max_level)) {
                 ret = mca_base_var_dump(var->mbv_index, &strings, !opal_info_pretty ? MCA_BASE_VAR_DUMP_PARSABLE : MCA_BASE_VAR_DUMP_READABLE);
                 if (OPAL_SUCCESS != ret) {
                     continue;

--- a/opal/threads/wait_sync.c
+++ b/opal/threads/wait_sync.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +24,7 @@ static ompi_wait_sync_t* wait_sync_list = NULL;
         pthread_mutex_unlock( &(who)->lock);           \
     } while(0)
 
-int sync_wait_mt(ompi_wait_sync_t *sync)
+int ompi_sync_wait_mt(ompi_wait_sync_t *sync)
 {
     /* Don't stop if the waiting synchronization is completed. We avoid the
      * race condition around the release of the synchronization using the

--- a/opal/threads/wait_sync.h
+++ b/opal/threads/wait_sync.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +38,7 @@ typedef struct ompi_wait_sync_t {
 #define REQUEST_PENDING        (void*)0L
 #define REQUEST_COMPLETED      (void*)1L
 
-#define SYNC_WAIT(sync)                 (opal_using_threads() ? sync_wait_mt (sync) : sync_wait_st (sync))
+#define SYNC_WAIT(sync)                 (opal_using_threads() ? ompi_sync_wait_mt (sync) : sync_wait_st (sync))
 
 /* The loop in release handles a race condition between the signaling
  * thread and the destruction of the condition variable. The signaling
@@ -75,7 +76,7 @@ typedef struct ompi_wait_sync_t {
         (sync)->signaling = false;                    \
 }
 
-OPAL_DECLSPEC int sync_wait_mt(ompi_wait_sync_t *sync);
+OPAL_DECLSPEC int ompi_sync_wait_mt(ompi_wait_sync_t *sync);
 static inline int sync_wait_st (ompi_wait_sync_t *sync)
 {
     while (sync->count > 0) {

--- a/opal/util/cmd_line.h
+++ b/opal/util/cmd_line.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -134,7 +135,7 @@ BEGIN_C_DECLS
         /** Thread safety */
         opal_recursive_mutex_t lcl_mutex;
 
-        /** List of cmd_line_option_t's (defined internally) */
+        /** List of ompi_cmd_line_option_t's (defined internally) */
         opal_list_t lcl_options;
 
         /** Duplicate of argc from opal_cmd_line_parse() */
@@ -142,7 +143,7 @@ BEGIN_C_DECLS
         /** Duplicate of argv from opal_cmd_line_parse() */
         char **lcl_argv;
 
-        /** Parsed output; list of cmd_line_param_t's (defined internally) */
+        /** Parsed output; list of ompi_cmd_line_param_t's (defined internally) */
         opal_list_t lcl_params;
 
         /** List of tail (unprocessed) arguments */

--- a/opal/util/error.c
+++ b/opal/util/error.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,7 +49,7 @@ struct converter_info_t {
 typedef struct converter_info_t converter_info_t;
 
 /* all default to NULL */
-converter_info_t converters[MAX_CONVERTERS] = {{0}};
+static converter_info_t converters[MAX_CONVERTERS] = {{0}};
 
 static int
 opal_strerror_int(int errnum, const char **str)

--- a/orte/mca/errmgr/default_orted/errmgr_default_orted.c
+++ b/orte/mca/errmgr/default_orted/errmgr_default_orted.c
@@ -9,6 +9,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -411,7 +412,7 @@ static void proc_errors(int fd, short args, void *cbdata)
                 goto cleanup;
             }
             /* leave the exit code alone - process this as a waitpid */
-            odls_base_default_wait_local_proc(child, NULL);
+            ompi_odls_base_default_wait_local_proc(child, NULL);
             goto cleanup;
         }
         OPAL_OUTPUT_VERBOSE((2, orte_errmgr_base_framework.framework_output,

--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,7 +90,7 @@ static opal_event_t int_handler;
 static opal_event_t epipe_handler;
 static opal_event_t sigusr1_handler;
 static opal_event_t sigusr2_handler;
-char *log_path = NULL;
+static char *log_path = NULL;
 static void shutdown_signal(int fd, short flags, void *arg);
 static void signal_callback(int fd, short flags, void *arg);
 static void epipe_signal_callback(int fd, short flags, void *arg);

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1111,7 +1112,7 @@ void orte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             /* set the waitpid callback here for thread protection and
              * to ensure we can capture the callback on shortlived apps */
             ORTE_FLAG_SET(child, ORTE_PROC_FLAG_ALIVE);
-            orte_wait_cb(child, odls_base_default_wait_local_proc, NULL);
+            orte_wait_cb(child, ompi_odls_base_default_wait_local_proc, NULL);
 
             /* dispatch this child to the next available launch thread */
             cd = OBJ_NEW(orte_odls_spawn_caddy_t);
@@ -1245,7 +1246,7 @@ int orte_odls_base_default_signal_local_procs(const orte_process_name_t *proc, i
  *  Wait for a callback indicating the child has completed.
  */
 
-void odls_base_default_wait_local_proc(orte_proc_t *proc, void* cbdata)
+void ompi_odls_base_default_wait_local_proc(orte_proc_t *proc, void* cbdata)
 {
     int i;
     orte_job_t *jobdat;
@@ -1825,7 +1826,7 @@ int orte_odls_base_default_restart_proc(orte_proc_t *child,
             goto CLEANUP;
         }
     }
-    orte_wait_cb(child, odls_base_default_wait_local_proc, NULL);
+    orte_wait_cb(child, ompi_odls_base_default_wait_local_proc, NULL);
 
     ++orte_odls_globals.next_base;
     if (orte_odls_globals.num_threads <= orte_odls_globals.next_base) {

--- a/orte/mca/odls/base/odls_private.h
+++ b/orte/mca/odls/base/odls_private.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2011      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,7 +127,7 @@ OBJ_CLASS_DECLARATION(orte_odls_launch_local_t);
 
 ORTE_DECLSPEC void orte_odls_base_default_launch_local(int fd, short sd, void *cbdata);
 
-ORTE_DECLSPEC void odls_base_default_wait_local_proc(orte_proc_t *proc, void* cbdata);
+ORTE_DECLSPEC void ompi_odls_base_default_wait_local_proc(orte_proc_t *proc, void* cbdata);
 
 /* define a function type to signal a local proc */
 typedef int (*orte_odls_base_signal_local_fn_t)(pid_t pid, int signum);

--- a/orte/util/show_help.c
+++ b/orte/util/show_help.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,7 +84,7 @@ typedef struct {
 
 static void tuple_list_item_constructor(tuple_list_item_t *obj);
 static void tuple_list_item_destructor(tuple_list_item_t *obj);
-OBJ_CLASS_INSTANCE(tuple_list_item_t, opal_list_item_t,
+static OBJ_CLASS_INSTANCE(tuple_list_item_t, opal_list_item_t,
                    tuple_list_item_constructor,
                    tuple_list_item_destructor);
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
 # Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,7 +22,7 @@
 #
 
 # support needs to be first for dependencies
-SUBDIRS = support asm class threads datatype util dss
+SUBDIRS = support asm class threads datatype util dss symbol_name
 if PROJECT_OMPI
 SUBDIRS += monitoring
 endif

--- a/test/symbol_name/Makefile.am
+++ b/test/symbol_name/Makefile.am
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2017      IBM Corporation. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# Note: the Jenkins tests on LANL-distcheck and travis-ci keep
+# failing when I write this Makefile.am in the "obvious" way.
+# The test ends up running in $PWD
+#     /path/to/openmpi-gitclone/_build/test/symbol_name/
+# while files like nmcheck_prefix and nmcheck_prefix.pl are in
+#     /path/to/openmpi-gitclone/test/symbol_name/
+# and can be located with the env var $srcdir
+#
+# I tried putting nmchec_prefix.pl in check_SCRIPTS and that does
+# cause a "make nmcheck_prefix.pl" step, but it then says there's
+# no rule to make that target.
+#
+# Since I don't know what is the "correct" way to access the extra file
+# nmcheck_prefix.pl, what I'm doing for now is using $srcdir to
+# find it.
+
+TESTS = nmcheck_prefix
+
+EXTRA_DIST = nmcheck_prefix nmcheck_prefix.pl
+
+AM_TESTS_ENVIRONMENT = MYBASE='$(top_builddir)'; OMPI_LIBMPI_NAME=@OMPI_LIBMPI_NAME@; export MYBASE OMPI_LIBMPI_NAME;
+
+export VERBOSE=yes

--- a/test/symbol_name/nmcheck_prefix
+++ b/test/symbol_name/nmcheck_prefix
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Copyright (c) 2017      IBM Corporation. All rights reserved.
+
+
+# if there's no perl, skip the test
+perl -v > /dev/null 2>&1
+if [ $? -ne 0 ] ; then exit 77 ; fi
+
+# I wrote more in Makedefs.am about why I'm using ${srcdir} here. I suspect
+# there's a more correct way to set up automake so the file is available,
+# but nothing else has worked for me yet.
+
+perl ${srcdir}/nmcheck_prefix.pl

--- a/test/symbol_name/nmcheck_prefix.pl
+++ b/test/symbol_name/nmcheck_prefix.pl
@@ -1,0 +1,174 @@
+#!/usr/bin/env perl
+
+# Copyright (c) 2017      IBM Corporation. All rights reserved.
+
+sub main {
+    if (!$ENV{MYBASE}) {
+        print "Test expects env var MYBASE set to base dir\n";
+        print "(where ompi/ opal/ orte/ test/ etc live)\n";
+        print "And optionally OMPI_LIBMPI_NAME should be set\n";
+        print "if MPI is configured with some name other than\n";
+        print "\"mpi\" for that.\n";
+        exit -1;
+    }
+
+# env var MYBASE should be the top dir where ompi/ opal/ orte/ test/ etc live.
+# env var OMPI_LIBMPI_NAME should be @OMPI_LIBMPI_NAME@ from automake
+#
+# Most likely the libs we want to check are
+#     ompi/.libs/lib<mpi>.so
+#     ompi/mpi/fortran/mpif-h/.libs/lib<mpi>_mpifh.so
+#     ompi/mpi/fortran/use-mpi-tkr/.libs/lib<mpi>_usempi.so
+#     orte/.libs/libopen-rte.so
+#     opal/.libs/libopen-pal.so
+# but I hate to assume those are the locations, so I'll use 'find' and
+# test whatever ".so"s are found.
+
+    @libs = ();
+    $mpi = "mpi";
+    if ($ENV{OMPI_LIBMPI_NAME}) {
+        $mpi = $ENV{OMPI_LIBMPI_NAME};
+    }
+    for $name (
+        "lib${mpi}.so",
+        "lib${mpi}_mpifh.so",
+        "lib${mpi}_usempi.so",
+        "libopen-rte.so",
+        "libopen-pal.so" )
+    {
+        for $loc (split(/\n/, `find $ENV{MYBASE} -name $name`)) {
+            if ($loc !~ /openmpi-gitclone/) {
+                push @libs, $loc;
+            }
+        }
+    }
+
+    @mca_symbols = lookup_mca_symbols();
+
+    print "Checking for bad symbol names in the main libs:\n";
+    $isbad = 0;
+    for $lib (@libs) {
+        print "checking $lib\n";
+        check_lib_for_bad_exports($lib);
+    }
+    if ($isbad) { exit(-1); }
+}
+
+# Find libraries with names of the form  libmca_coll_basic.a etc
+# and presume those to be MCAs that are being built into libmpi.so etc
+# rather than the usual case where it becomes mca_coll_basic.so.
+#
+# When name pollution occurs in an MCA .so we don't care about it.
+# When it's an MCA built into libmpi.so we care a little, but aren't
+# going to make this testcase fail over it.
+sub lookup_mca_symbols {
+    my @list;
+    my $lib;
+
+    @list = ();
+    for $lib (split(/\n/, `find $ENV{MYBASE} -name libmca_[a-zA-Z0-9_-]*\\.a`))
+    {
+        if ($lib !~ /openmpi-gitclone/) {
+            print "NOTE: found static $lib\n";
+            push @list, get_nm($lib, 'all');
+        }
+    }
+
+    return @list;
+}
+
+sub check_lib_for_bad_exports {
+    my $lib = $_[0];
+    my @symbols;
+    my $s;
+
+    @symbols = get_nm($lib, 'all');
+
+    # grep to get rid of symbol prefixes that are considered acceptable,
+    # leaving behind anything bad:
+    @symbols = grep(!/^ompi_/i, @symbols);
+    @symbols = grep(!/^opal_/i, @symbols);
+    @symbols = grep(!/^orte_/i, @symbols);
+    @symbols = grep(!/^orted_/i, @symbols);
+    @symbols = grep(!/^oshmem_/i, @symbols);
+    @symbols = grep(!/^mpi_/i, @symbols);
+    @symbols = grep(!/^pmpi_/i, @symbols);
+    @symbols = grep(!/^pmix_/i, @symbols);
+    @symbols = grep(!/^pmix2x_/i, @symbols);
+    @symbols = grep(!/^PMI_/i, @symbols);
+    @symbols = grep(!/^PMI2_/i, @symbols);
+    @symbols = grep(!/^MPIR_/, @symbols);
+    @symbols = grep(!/^MPIX_/, @symbols);
+    @symbols = grep(!/^mpidbg_dll_locations$/, @symbols);
+    @symbols = grep(!/^mpimsgq_dll_locations$/, @symbols);
+    @symbols = grep(!/^ompit_/i, @symbols);
+    @symbols = grep(!/^ADIO_/i, @symbols);
+    @symbols = grep(!/^ADIOI_/i, @symbols);
+    @symbols = grep(!/^MPIO_/i, @symbols);
+    @symbols = grep(!/^MPIOI_/i, @symbols);
+    @symbols = grep(!/^MPIU_/i, @symbols);
+    @symbols = grep(!/^NBC_/i, @symbols);
+    @symbols = grep(!/^mca_/, @symbols);
+
+    @symbols = grep(!/^_fini$/, @symbols);
+    @symbols = grep(!/^_init$/, @symbols);
+    @symbols = grep(!/^_edata$/, @symbols);
+    @symbols = grep(!/^_end$/, @symbols);
+    @symbols = grep(!/^__bss_start$/, @symbols);
+    @symbols = grep(!/^__malloc_initialize_hook$/, @symbols);
+
+    # The symbols can now be split into two groups: fatal and warning.
+    # The warnings will be for symbols that appear to be from MCAs that
+    # this build has placed into a main lib, but which would normally
+    # be segregated into some mca_*.so
+    # for the fatal ones.
+    @warning_symbols = @fatal_symbols = ();
+    if (scalar(@mca_symbols) > 0) {
+        %whash = ();
+        for $s (@mca_symbols) {
+            $whash{$s} = 1;
+        }
+        for $s (@symbols) {
+            if ($whash{$s}) {
+                push @warning_symbols, $s;
+            } else {
+                push @fatal_symbols, $s;
+            }
+        }
+    } else {
+        @fatal_symbols = @symbols;
+    }
+
+    for $s (@fatal_symbols) {
+        print "    [error]   $s\n";
+        $isbad = 1;
+    }
+    for $s (@warning_symbols) {
+        print "    [warning] $s \n";
+    }
+}
+
+# get_nm /path/to/some/libfoo.so <func|wfunc|all>
+
+sub get_nm {
+    my $lib = $_[0];
+    my $mode = $_[1];
+    my $pattern;
+    my $cmd;
+    my @tmp;
+
+    $pattern = " [TWBCDVR] ";
+    if ($mode eq 'func') { $pattern = " [T] "; }
+    if ($mode eq 'wfunc') { $pattern = " [W] "; }
+
+    $cmd = "nm $lib";
+    $cmd = "$cmd | grep \"$pattern\"";
+    $cmd = "$cmd | sed -e 's/  *\$//' -e 's/.* //'";
+
+    @tmp = split(/\n/, qx#$cmd#);
+    @tmp = sort(@tmp);
+
+    return(@tmp);
+}
+
+main();


### PR DESCRIPTION
Adding a test into "make check" that uses "nm" to look at the symbol names in the main libraries (libmpi, libmpi_fh, libmpi_usempi, libopen-rte, libopen-pal) that user apps are directly/indirectly linked against. It expects everything to have some prefix like ompi_, opal_, orte_ etc.

The second commit in this pull request adds "ompi_" onto a handful of symbols the test identified as bad. There are still a couple categories I didn't change that I found iffy:  mca_*, netpatterns_*, and a few that seem related to libevent. I left those pieces untouched and for now have them being accepted by the testcase.

The third commit is just a minor enhancement to update-my-copyright.pl to add a --manual-list=file option.