### PR TITLE
Alltoallv small to medium size messages desync, if used in gather-alike manner #3255

### DIFF
--- a/ompi/mca/coll/sync/Makefile.am
+++ b/ompi/mca/coll/sync/Makefile.am
@@ -32,7 +32,8 @@ sources = \
         coll_sync_reduce_scatter.c \
         coll_sync_scan.c \
         coll_sync_scatter.c \
-        coll_sync_scatterv.c
+        coll_sync_scatterv.c \
+        coll_sync_alltoallv.c
 
 if MCA_BUILD_ompi_coll_sync_DSO
 component_noinst =

--- a/ompi/mca/coll/sync/coll_sync.h
+++ b/ompi/mca/coll/sync/coll_sync.h
@@ -46,6 +46,15 @@ mca_coll_base_module_t
 int mca_coll_sync_module_enable(mca_coll_base_module_t *module,
                                 struct ompi_communicator_t *comm);
 
+int mca_coll_sync_alltoallv(void *sbuf, const int *scounts,
+                            const int *sdisps,
+                            struct ompi_datatype_t *sdtype,
+                            void *rbuf, const int *rcounts,
+                            const int *rdisps,
+                            struct ompi_datatype_t *rdtype,
+                            struct ompi_communicator_t *comm,
+                            mca_coll_base_module_t *module);
+
 int mca_coll_sync_barrier(struct ompi_communicator_t *comm,
                           mca_coll_base_module_t *module);
 
@@ -130,6 +139,12 @@ typedef struct mca_coll_sync_module_t {
     /* How many ops we've executed (it's easier to have 2) */
     int after_num_operations;
 
+    /* How many ops we've executed */
+    int before_num_operations_alltoallv;
+
+    /* How many ops we've executed (it's easier to have 2) */
+    int after_num_operations_alltoallv;
+
     /* Avoid recursion of syncs */
     bool in_operation;
 } mca_coll_sync_module_t;
@@ -146,9 +161,12 @@ typedef struct mca_coll_sync_component_t {
 
     /* Do a sync *before* each Nth collective */
     int barrier_before_nops;
+    int barrier_before_nops_alltoallv;
 
     /* Do a sync *after* each Nth collective */
     int barrier_after_nops;
+    int barrier_after_nops_alltoallv;
+
 } mca_coll_sync_component_t;
 
 /* Globally exported variables */

--- a/ompi/mca/coll/sync/coll_sync_alltoallv.c
+++ b/ompi/mca/coll/sync/coll_sync_alltoallv.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "coll_sync.h"
+
+
+/*
+ *	gatherv
+ *
+ *	Function:	- gatherv
+ *	Accepts:	- same arguments as MPI_Alltoallv()
+ *	Returns:	- MPI_SUCCESS or error code
+ */
+int mca_coll_sync_alltoallv(void *sbuf, const int *scounts,
+                            const int *sdisps,
+                            struct ompi_datatype_t *sdtype,
+                            void *rbuf, const int *rcounts,
+                            const int *rdisps,
+                            struct ompi_datatype_t *rdtype,
+                            struct ompi_communicator_t *comm,
+                            mca_coll_base_module_t *module)
+{
+    mca_coll_sync_module_t *s = (mca_coll_sync_module_t*) module;
+
+    if (s->in_operation) {
+        return s->c_coll.coll_alltoallv(sbuf, scounts, sdisps, sdtype,
+                                        rbuf, rcounts, rdisps, rdtype, comm,
+                                        s->c_coll.coll_alltoallv_module);
+    } else {
+        do {
+            int err = MPI_SUCCESS;
+            s->in_operation = true;
+            if (OPAL_UNLIKELY(++(s->before_num_operations_alltoallv) ==
+                              mca_coll_sync_component.barrier_before_nops_alltoallv ||
+                              ++(s->before_num_operations) ==
+                              mca_coll_sync_component.barrier_before_nops)) {
+                s->before_num_operations = 0;
+                s->before_num_operations_alltoallv = 0;
+                err = s->c_coll.coll_barrier(comm, s->c_coll.coll_barrier_module);
+            }
+            if (OPAL_LIKELY(MPI_SUCCESS == err))
+                err = s->c_coll.coll_alltoallv(sbuf, scounts, sdisps, sdtype,
+                                               rbuf, rcounts, rdisps, rdtype, comm,
+                                               s->c_coll.coll_alltoallv_module);
+            if (OPAL_UNLIKELY(++(s->after_num_operations_alltoallv) ==
+                              mca_coll_sync_component.barrier_after_nops_alltoallv ||
+                              ++(s->after_num_operations) ==
+                              mca_coll_sync_component.barrier_after_nops)) {
+                s->after_num_operations = 0;
+                s->after_num_operations_alltoallv = 0;
+                err = s->c_coll.coll_barrier(comm, s->c_coll.coll_barrier_module);
+            }
+            s->in_operation = false;
+            return err;
+        } while(0);
+    }
+}

--- a/ompi/mca/coll/sync/coll_sync_component.c
+++ b/ompi/mca/coll/sync/coll_sync_component.c
@@ -92,6 +92,16 @@ static int sync_register(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_coll_sync_component.barrier_before_nops);
 
+    mca_coll_sync_component.barrier_before_nops_alltoallv = 0;
+    (void) mca_base_component_var_register(c, "barrier_before_alltoallv",
+                                           "Do a synchronization before each Nth alltoallv",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_sync_component.barrier_before_nops_alltoallv);
+
+
+
     mca_coll_sync_component.barrier_after_nops = 0;
     (void) mca_base_component_var_register(c, "barrier_after",
                                            "Do a synchronization after each Nth collective",
@@ -99,6 +109,14 @@ static int sync_register(void)
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_coll_sync_component.barrier_after_nops);
+
+    mca_coll_sync_component.barrier_after_nops_alltoallv = 0;
+    (void) mca_base_component_var_register(c, "barrier_after_alltoallv",
+                                           "Do a synchronization before each Nth alltoallv",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_sync_component.barrier_before_nops_alltoallv);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
Refers to Issue:
Alltoallv small to medium size messages desync, if used in gather-alike manner #3255

alltoallv desync fix via coll.sync component

Adds alltoallv to coll.sync analogous to other collectives.
Two additional control variables: barrier_before_alltoallv and
barrier_after_alltoallv analogous to barrier_before and barrier_after,
respectively. This way sync may be activated for alltoallv only.
However calls to alltoallv also increment the other counters.

Signed-off-by: Harald Braun harald.braun@atos.net