### PR TITLE
Fix the top_ompi_srcdir in Fortran mpiext building system

### DIFF
--- a/config/ompi_ext.m4
+++ b/config/ompi_ext.m4
@@ -7,6 +7,9 @@ dnl Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2011-2012 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2017      The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -554,17 +557,17 @@ EOF
         #
         # Include the mpif.h header if it is available.  Cannot do
         # this from inside the usempi.h since, for VPATH builds, the
-        # top_ompi_srcdir is needed to find the header.
+        # srcdir is needed to find the header.
         #
         if test "$enabled_mpifh" = 1; then
             mpifh_component_header="mpiext_${component}_mpifh.h"
             cat >> $mpiusempi_ext_h <<EOF
-      include '$top_ompi_srcdir/ompi/mpiext/$component/mpif-h/$mpifh_component_header'
+      include '${srcdir}/ompi/mpiext/$component/mpif-h/$mpifh_component_header'
 EOF
         fi
 
         cat >> $mpiusempi_ext_h <<EOF
-      include '$top_ompi_srcdir/ompi/mpiext/$component/use-mpi/$component_header'
+      include '${srcdir}/ompi/mpiext/$component/use-mpi/$component_header'
 
 EOF
     else
@@ -607,17 +610,17 @@ EOF
         #
         # Include the mpif.h header if it is available.  Cannot do
         # this from inside the usempif08.h since, for VPATH builds,
-        # the top_ompi_srcdir is needed to find the header.
+        # the srcdir is needed to find the header.
         #
         if test "$enabled_mpifh" = 1; then
             mpifh_component_header="mpiext_${component}_mpifh.h"
             cat >> $mpiusempif08_ext_h <<EOF
-      include '$top_ompi_srcdir/ompi/mpiext/$component/mpif-h/$mpifh_component_header'
+      include '${srcdir}/ompi/mpiext/$component/mpif-h/$mpifh_component_header'
 EOF
         fi
 
         cat >> $mpiusempif08_ext_h <<EOF
-      include '$top_ompi_srcdir/ompi/mpiext/$component/use-mpi-f08/$component_header'
+      include '${srcdir}/ompi/mpiext/$component/use-mpi-f08/$component_header'
 
 EOF
     else


### PR DESCRIPTION
The top_ompi_srcdir configure variable has been suppressed. This results in mpiext defining fortran 90 bindings to fail with an error 
```
make[2]: Entering directory '/global/u1/b/bouteill/cori/ulfm2/debug.build/ompi/mpi/fortran/mpiext'
  PPFC     mpi-ext-module.lo
mpi-ext-module.F90(22): error #5102: Cannot open include file '/ompi/mpiext/ftmpi/mpif-h/mpiext_ftmpi_mpifh.h'
      include '/ompi/mpiext/ftmpi/mpif-h/mpiext_ftmpi_mpifh.h'
--------------^
```
This patch replaces top_ompi_srcdir with srcdir in the configure logic directing mpiext fortran f90 mods. 

