### PR TITLE
v1.10: btl/openib: Fix openib memory registration limit calculation if cutoff = 0.

### DIFF
--- a/ompi/mca/btl/openib/btl_openib.c
+++ b/ompi/mca/btl/openib/btl_openib.c
@@ -1074,7 +1074,7 @@ int mca_btl_openib_add_procs(
     }
 
     openib_btl->local_procs += local_procs;
-    openib_btl->device->mem_reg_max /= openib_btl->local_procs;
+    openib_btl->device->mem_reg_max = openib_btl->device->mem_reg_max_total / openib_btl->local_procs;
 
     return mca_btl_openib_size_queues(openib_btl, nprocs);
 }

--- a/ompi/mca/btl/openib/btl_openib.h
+++ b/ompi/mca/btl/openib/btl_openib.h
@@ -417,7 +417,7 @@ typedef struct mca_btl_openib_device_t {
     /* Maximum value supported by this device for max_inline_data */
     uint32_t max_inline_data;
     /* Registration limit and current count */
-    uint64_t mem_reg_max, mem_reg_active;
+    uint64_t mem_reg_max, mem_reg_max_total, mem_reg_active;
     /* Device is ready for use */
     bool ready_for_use;
 } mca_btl_openib_device_t;

--- a/ompi/mca/btl/openib/btl_openib_component.c
+++ b/ompi/mca/btl/openib/btl_openib_component.c
@@ -1549,7 +1549,8 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
     }
 
     device->mem_reg_active = 0;
-    device->mem_reg_max    = calculate_max_reg(ibv_get_device_name(ib_dev));
+    device->mem_reg_max_total = calculate_max_reg(ibv_get_device_name(ib_dev));
+    device->mem_reg_max = device->mem_reg_max_total;
 
     device->ib_dev = ib_dev;
     device->ib_dev_context = dev_context;


### PR DESCRIPTION
Thanks to Marcin Krotkiewski for reporting the issue against v1.10.x.
See https://mail-archive.com/devel@lists.open-mpi.org/msg20044.html

(back-ported from commit 0951a34e95a506a9975878743994fd0762af0450)

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>

The original fix 0951a34 was cherry-picked to v2.x and v2.0.x, but not back-ported to v1.10 yet.
Though I don't know whether v1.10.7 will be released, I put this PR for someone who need this fix.

@artpol84 Please review. This fix was originally written by you against master. It has `opal` -> `ompi` change.
