### PR TITLE
de-ORTEfy the ompi tree

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1768,8 +1768,8 @@ int ompi_comm_determine_first ( ompi_communicator_t *intercomm, int high )
         theirproc = ompi_group_peer_lookup(intercomm->c_remote_group,0);
 
         mask = OMPI_RTE_CMP_JOBID | OMPI_RTE_CMP_VPID;
-        rc = ompi_rte_compare_name_fields(mask, (const orte_process_name_t*)&(ourproc->super.proc_name),
-                                                (const orte_process_name_t*)&(theirproc->super.proc_name));
+        rc = ompi_rte_compare_name_fields(mask, (const ompi_process_name_t*)&(ourproc->super.proc_name),
+                                                (const ompi_process_name_t*)&(theirproc->super.proc_name));
         if ( 0 > rc ) {
             flag = true;
         }

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -158,8 +158,8 @@ int ompi_dpm_connect_accept(ompi_communicator_t *comm, int root,
                                               sizeof(ompi_proc_t *));
             for (i=0 ; i<group->grp_proc_count ; i++) {
                 if (NULL == (proc_list[i] = ompi_group_peer_lookup(group,i))) {
-                    ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
-                    rc = ORTE_ERR_NOT_FOUND;
+                    OMPI_ERROR_LOG(OMPI_ERR_NOT_FOUND);
+                    rc = OMPI_ERR_NOT_FOUND;
                     free(proc_list);
                     goto exit;
                 }
@@ -665,10 +665,10 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
     for (i = 0; i < count; ++i) {
         app = OBJ_NEW(opal_pmix_app_t);
         if (NULL == app) {
-            ORTE_ERROR_LOG(ORTE_ERR_OUT_OF_RESOURCE);
+            OMPI_ERROR_LOG(OMPI_ERR_OUT_OF_RESOURCE);
             OPAL_LIST_DESTRUCT(&apps);
             opal_progress_event_users_decrement();
-            return ORTE_ERR_OUT_OF_RESOURCE;
+            return OMPI_ERR_OUT_OF_RESOURCE;
         }
         /* add the app to the job data */
         opal_list_append(&apps, &app->super);
@@ -893,9 +893,9 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
             ompi_info_get (array_of_info[i], "ompi_stdin_target", sizeof(stdin_target) - 1, stdin_target, &flag);
             if ( flag ) {
                 if (0 == strcmp(stdin_target, "all")) {
-                    ui32 = ORTE_VPID_WILDCARD;
+                    ui32 = OPAL_VPID_WILDCARD;
                 } else if (0 == strcmp(stdin_target, "none")) {
-                    ui32 = ORTE_VPID_INVALID;
+                    ui32 = OPAL_VPID_INVALID;
                 } else {
                     ui32 = strtoul(stdin_target, NULL, 10);
                 }
@@ -911,7 +911,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
          */
         if ( !have_wdir ) {
             if (OMPI_SUCCESS != (rc = opal_getcwd(cwd, OPAL_PATH_MAX))) {
-                ORTE_ERROR_LOG(rc);
+                OMPI_ERROR_LOG(rc);
                 OPAL_LIST_DESTRUCT(&apps);
                 opal_progress_event_users_decrement();
                 return rc;

--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -888,16 +888,16 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
         kv.type = OPAL_STRING;
         kv.data.string = strdup(set_as_string);
 
-        (void)opal_pmix.store_local((opal_process_name_t*)ORTE_PROC_MY_NAME, &kv);
+        (void)opal_pmix.store_local((opal_process_name_t*)OMPI_PROC_MY_NAME, &kv);
         OBJ_DESTRUCT(&kv);
 
         locality = opal_hwloc_base_get_relative_locality(opal_hwloc_topology,
-                                                         orte_process_info.cpuset,set_as_string);
+                                                         ompi_process_info.cpuset,set_as_string);
         OBJ_CONSTRUCT(&kv, opal_value_t);
         kv.key = strdup(OPAL_PMIX_LOCALITY);
         kv.type = OPAL_UINT16;
         kv.data.uint16 = locality;
-        (void)opal_pmix.store_local((opal_process_name_t*)ORTE_PROC_MY_NAME, &kv);
+        (void)opal_pmix.store_local((opal_process_name_t*)OMPI_PROC_MY_NAME, &kv);
         OBJ_DESTRUCT(&kv);
 
         if( OMPI_SUCCESS != (err = ompi_comm_create(comm_old,


### PR DESCRIPTION
The ompi tree should be runtime independent, but over time a few
ORTE depedent definitions and functions have escaped into the ompi
tree. I'm working on my own runtime so I've used this as an opportunity
to get rid of ORTE dependencies in the ompi/ tree. I still need to go
back and change orte to conform to the new world and these changes are
untested, but I can now compile (but not link) without orte so I'm
commiting this changeset.


Signed-off-by: Noah Evans <noah.evans@gmail.com>