### PR TITLE
datatype: Fix darray MPI_ACCUMULATE bug

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -758,12 +758,12 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( int32_t* i, MPI_Aint* 
         /******************************************************************/
     case MPI_COMBINER_DARRAY:
         ompi_datatype_create_darray( i[0] /* size */, i[1] /* rank */, i[2] /* ndims */,
-                                     &i[3 + 0 * i[0]], &i[3 + 1 * i[0]],
-                                     &i[3 + 2 * i[0]], &i[3 + 3 * i[0]],
-                                     i[3 + 4 * i[0]], d[0], &datatype );
+                                     &i[3 + 0 * i[2]], &i[3 + 1 * i[2]],
+                                     &i[3 + 2 * i[2]], &i[3 + 3 * i[2]],
+                                     i[3 + 4 * i[2]], d[0], &datatype );
         {
-            const int* a_i[8] = {&i[0], &i[1], &i[2], &i[3 + 0 * i[0]], &i[3 + 1 * i[0]], &i[3 + 2 * i[0]],
-                                 &i[3 + 3 * i[0]], &i[3 + 4 * i[0]]};
+            const int* a_i[8] = {&i[0], &i[1], &i[2], &i[3 + 0 * i[2]], &i[3 + 1 * i[2]], &i[3 + 2 * i[2]],
+                                 &i[3 + 3 * i[2]], &i[3 + 4 * i[2]]};
             ompi_datatype_set_args( datatype, 4 * i[2] + 4, a_i, 0, NULL, 1, d, MPI_COMBINER_DARRAY);
         }
         break;


### PR DESCRIPTION
Array sizes of `array_of_gsizes`, `array_of_distribs`, `array_of_dargs`, and `array_of_psizes` parameters of the `ompi_datatype_create_darray` function (and `MPI_TYPE_CREATE_DARRAY`) are all `ndims`. `ndims` are `i[2]`, not `i[0]`. See MPI-3.1 p.122.

Because this function `__ompi_datatype_create_from_args` is used by pt2pt OSC, using a datatype created by `MPI_TYPE_CREATE_DARRAY` for `MPI_(R)(GET_)ACCUMULATE` caused a segmentation fault or something on a target process.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>

Needs PR to v2.1, v2.0, and possibly 1.10.
