### PR TITLE
v1.10: datatype: Fix darray MPI_ACCUMULATE bug

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -732,13 +732,13 @@ static ompi_datatype_t* __ompi_datatype_create_from_args( int32_t* i, MPI_Aint* 
         /******************************************************************/
     case MPI_COMBINER_DARRAY:
         ompi_datatype_create_darray( i[0] /* size */, i[1] /* rank */, i[2] /* ndims */,
-                                     &i[3 + 0 * i[0]], &i[3 + 1 * i[0]],
-                                     &i[3 + 2 * i[0]], &i[3 + 3 * i[0]],
-                                     i[3 + 4 * i[0]], d[0], &datatype );
+                                     &i[3 + 0 * i[2]], &i[3 + 1 * i[2]],
+                                     &i[3 + 2 * i[2]], &i[3 + 3 * i[2]],
+                                     i[3 + 4 * i[2]], d[0], &datatype );
         {
-            const int* a_i[8] = {&i[0], &i[1], &i[2], &i[3 + 0 * i[0]], &i[3 + 1 * i[0]], &i[3 + 2 * i[0]],
-                                 &i[3 + 3 * i[0]], &i[3 + 4 * i[0]]};
-            ompi_datatype_set_args( datatype, 4 * i[0] + 4,a_i, 0, NULL, 1, d, MPI_COMBINER_DARRAY);
+            const int* a_i[8] = {&i[0], &i[1], &i[2], &i[3 + 0 * i[2]], &i[3 + 1 * i[2]], &i[3 + 2 * i[2]],
+                                 &i[3 + 3 * i[2]], &i[3 + 4 * i[2]]};
+            ompi_datatype_set_args( datatype, 4 * i[2] + 4, a_i, 0, NULL, 1, d, MPI_COMBINER_DARRAY);
         }
         break;
         /******************************************************************/


### PR DESCRIPTION
Array sizes of `array_of_gsizes`, `array_of_distribs`, `array_of_dargs`, and `array_of_psizes` parameters of the `ompi_datatype_create_darray` function (and `MPI_TYPE_CREATE_DARRAY`) are all `ndims`. `ndims` is `i[2]`, not `i[0]`. See MPI-3.1 p.122.

Because this function `__ompi_datatype_create_from_args` is used by pt2pt OSC, using a datatype created by `MPI_TYPE_CREATE_DARRAY` for `MPI_(R)(GET_)ACCUMULATE` caused a segmentation fault or something on a target process.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>
(cherry picked from commit b4599d7bb712c51288021b9fe493cee1c21f7880)