### PR TITLE
cma: restore --with-cma=no configure option

### DIFF
--- a/config/opal_check_cma.m4
+++ b/config/opal_check_cma.m4
@@ -22,6 +22,10 @@ AC_DEFUN([OPAL_CHECK_CMA],[
                 [AC_HELP_STRING([--with-cma],
                                 [Build Cross Memory Attach support (default: autodetect)])])
 
+    if test "x$with_cma" = "xno" ; then
+        opal_check_cma_happy=0
+    fi
+
     # We only need to do the back-end test once
     if test -z "$opal_check_cma_happy" ; then
         OPAL_CHECK_CMA_BACKEND


### PR DESCRIPTION
This support broke when we enabled CMA by default. Addreses the issue
raised by #3270.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 533a8e6dae07c44f68659a19c2a326fc89959a04)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>