### PR TITLE
osc/rdma: fix typo in atomic code

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_lock.h
+++ b/ompi/mca/osc/rdma/osc_rdma_lock.h
@@ -68,7 +68,7 @@ static inline int ompi_osc_rdma_lock_btl_fop (ompi_osc_rdma_module_t *module, om
     }
 
     if (NULL != frag) {
-        if (*result) {
+        if (result) {
             *result = *temp;
         }
         ompi_osc_rdma_frag_complete (frag);


### PR DESCRIPTION
Fixes #3267

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit fad0803920f7089987085040603dc9b90d566c1f)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>