### PR TITLE
build: Fix platform detection on FreeBSD

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -44,6 +44,8 @@ Copyright (c) 2010      ARM ltd.  All rights reserved.
 Copyright (c) 2010-2011 Alex Brick <bricka@ccs.neu.edu>.  All rights reserved.
 Copyright (c) 2013-2014 Intel, Inc. All rights reserved.
 Copyright (c) 2011-2014 NVIDIA Corporation.  All rights reserved.
+Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+                        reserved.
 
 $COPYRIGHT$
 

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -11,6 +11,8 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+dnl Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl 
 dnl Additional copyrights may follow
@@ -795,7 +797,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
         OMPI_GCC_INLINE_ASSIGN=""
         OPAL_ASM_SUPPORT_64BIT=0
         case "${host}" in
-        i?86-*|x86_64*)
+        i?86-*|x86_64*|amd64*)
             if test "$ac_cv_sizeof_long" = "4" ; then
                 ompi_cv_asm_arch="IA32"
             else


### PR DESCRIPTION
Look for amd64 in addition to x86_64 as the platform
type for x86_64 assembly.  The FreeBSD-packaged
Autoconf package has a patch to return
amd64-unknown-freebsd11.0 instead of the
x86_64-unknown-freebsd11.0 that a stock Autoconf
package would return.  Since we want to run Jenkins
builds on FreeBSD, working around the FreeBSD patch
is probably the easiest thing.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>