### PR TITLE
build: Fix platform detection on FreeBSD

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -53,6 +53,8 @@ Copyright (c) 2014-2015 Hewlett-Packard Development Company, LP.  All
                         rights reserved.
 Copyright (c) 2013-2017 Research Organization for Information Science (RIST).
                         All rights reserved.
+Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+                        reserved.
 
 $COPYRIGHT$
 

--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -15,6 +15,8 @@ dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -1002,7 +1004,7 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
         OPAL_GCC_INLINE_ASSIGN=""
         OPAL_ASM_SUPPORT_64BIT=0
         case "${host}" in
-        i?86-*|x86_64*)
+        i?86-*|x86_64*|amd64*)
             if test "$ac_cv_sizeof_long" = "4" ; then
                 opal_cv_asm_arch="IA32"
             else


### PR DESCRIPTION
Look for amd64 in addition to x86_64 as the platform
type for x86_64 assembly.  The FreeBSD-packaged
Autoconf package has a patch to return
amd64-unknown-freebsd11.0 instead of the
x86_64-unknown-freebsd11.0 that a stock Autoconf
package would return.  Since we want to run Jenkins
builds on FreeBSD, working around the FreeBSD patch
is probably the easiest thing.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>