### PR TITLE
check for negative ranks in ompi_win_peer_invalid

### DIFF
--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -162,7 +162,7 @@ static inline int ompi_win_invalid(ompi_win_t *win) {
 }
 
 static inline int ompi_win_peer_invalid(ompi_win_t *win, int peer) {
-    if (win->w_group->grp_proc_count <= peer) return true;
+    if (win->w_group->grp_proc_count <= peer || peer < 0) return true;
     return false;
 }
 


### PR DESCRIPTION
resolves #3326 (https://github.com/open-mpi/ompi/issues/3326)