### PR TITLE
Create a Github issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,29 @@
+Thank you for taking the time to submit an issue!
+
+## Background information
+
+### What version of Open MPI are you using? (e.g., v1.10.3, v2.1.0, git branch name and hash, etc.)
+
+
+
+### Describe how Open MPI was installed (e.g., from a source/distribution tarball, from a git clone, from an operating system distribution package, etc.)
+
+
+
+### Please describe the system on which you are running
+
+* Operating system/version: 
+* Computer hardware: 
+* Network type: 
+
+-----------------------------
+
+## Details of the problem
+
+Please describe, in detail, the problem that you are having, including the behavior you expect to see, the actual behavior that you are seeing, steps to reproduce the problem, etc.  It is most helpful if you can attach a small program that a developer can use to reproduce your problem.
+
+**Note**: If you include verbatim output (or a code block), please use a [GitHub Markdown](https://help.github.com/articles/creating-and-highlighting-code-blocks/) code block like below:
+```shell
+shell$ mpirun -np 2 ./hello_world
+```
+


### PR DESCRIPTION
It seems like we keep getting bug reports where the first questions we have to ask are always the same (E.g., "what version of Open MPI are you using?").

Per https://help.github.com/articles/creating-an-issue-template-for-your-repository/, perhaps we should have an github issue template for Open MPI.

If you're a community developer and want to make a free-form issue, it's easy enough to select-all/delete and write whatever you want.  But having this template may be helpful for newbies -- it may cause a little introspection during the bug reporting process, which is usually a Good Thing.

I tentatively put together a few questions and format.  I'm not tied to this at all -- I'm very open to suggestions and comments.

[skip ci]
bot:notest