### PR TITLE
Add PMIx commit that disables build of pmi-1 and pmi-2 backward compa…

### DIFF
--- a/opal/mca/pmix/pmix112/README
+++ b/opal/mca/pmix/pmix112/README
@@ -1,4 +1,5 @@
 Copyright (c) 2017      IBM Corporation.  All rights reserved.
+Copyright (c) 2017      Intel, Inc. All rights reserved.
 $COPYRIGHT$
 
 Additional copyrights may follow
@@ -8,8 +9,9 @@ $HEADER$
 ===========================================================================
 This internal component includes PMIx v1.2.1 plus following commits
 cherry-picked from the PMIx v1.2 branch (which will be included in the
-eventual PMIx v1.2.2 release). Newer patches at top.
+eventual PMIx v1.2.3 release). Newer patches at top.
 
+ * https://github.com/pmix/pmix/commit/29825cad8b5e9d80e8b41f77a901055333ea6590
  * https://github.com/pmix/pmix/commit/1b86a6e7ee99fc5969a0789a9905a4a2159a6dc0
  * https://github.com/pmix/pmix/commit/14f865c4b631827fb99779d42eaf0567f117a76f
  * https://github.com/pmix/pmix/commit/4269e8484bd883523ae485bf2e1b7bbc0719c494

--- a/opal/mca/pmix/pmix112/configure.m4
+++ b/opal/mca/pmix/pmix112/configure.m4
@@ -13,7 +13,7 @@
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2015-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -51,7 +51,7 @@ AC_DEFUN([MCA_opal_pmix_pmix112_CONFIG],[
         opal_pmix_pmix_sm_flag=--disable-dstore
     fi
 
-    opal_pmix_pmix112_args="--enable-embedded-mode --with-pmix-symbol-prefix=opal_pmix_pmix112_ $opal_pmix_pmix_sm_flag --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --with-hwloc-header=\\\"$opal_hwloc_base_include\\\""
+    opal_pmix_pmix112_args="--enable-embedded-mode --disable-pmix-backward-compatibility --with-pmix-symbol-prefix=opal_pmix_pmix112_ $opal_pmix_pmix_sm_flag --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --with-hwloc-header=\\\"$opal_hwloc_base_include\\\""
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix112_args="--enable-debug $opal_pmix_pmix112_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],

--- a/opal/mca/pmix/pmix112/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix112/pmix/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+dnl Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -844,6 +844,21 @@ fi
 AC_DEFINE_UNQUOTED([PMIX_ENABLE_TIMING], [$WANT_TIMING],
                    [Whether we want developer-level timing support or not])
 
+#
+# Install backward compatibility support for PMI-1 and PMI-2
+#
+AC_MSG_CHECKING([if want backward compatibility for PMI-1 and PMI-2])
+AC_ARG_ENABLE(pmix-backward-compatibility,
+              AC_HELP_STRING([--enable-pmix-backward-compatibility],
+                             [enable PMIx support for PMI-1 and PMI-2 (default: enabled)]))
+if test "$enable_pmix_backward_compatibility" = "no"; then
+    AC_MSG_RESULT([no])
+    WANT_PMIX_BACKWARD=0
+else
+    AC_MSG_RESULT([yes])
+    WANT_PMIX_BACKWARD=1
+fi
+
 ])dnl
 
 # Specify the symbol prefix
@@ -860,7 +875,7 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([PMIX_WANT_MUNGE], [test "$pmix_munge_support" = "1"])
         AM_CONDITIONAL([PMIX_WANT_SASL], [test "$pmix_sasl_support" = "1"])
         AM_CONDITIONAL([WANT_DSTORE],[test "x$enable_dstore" != "xno"])
+        AM_CONDITIONAL(WANT_PMIX_BACKWARD, test "$WANT_PMIX_BACKWARD" = 1)
     ])
     pmix_did_am_conditionals=yes
 ])dnl
-

--- a/opal/mca/pmix/pmix112/pmix/include/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/include/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
@@ -16,9 +16,13 @@ if ! PMIX_EMBEDDED_MODE
 include_HEADERS = \
         include/pmix.h \
         include/pmix_server.h \
-        include/pmi.h \
-        include/pmi2.h \
         include/pmix_version.h.in
+
+if WANT_PMIX_BACKWARD
+include_HEADERS += \
+        include/pmi.h \
+        include/pmi2.h
+endif
 
 include_pmixdir = $(includedir)/pmix
 include_pmix_HEADERS = \

--- a/opal/mca/pmix/pmix112/pmix/src/client/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/src/client/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
 #                         All rights reserved.
 # $COPYRIGHT$
@@ -20,7 +20,7 @@ sources += \
         src/client/pmix_client_spawn.c \
         src/client/pmix_client_connect.c
 
-if !PMIX_EMBEDDED_MODE
+if WANT_PMIX_BACKWARD
 sources += \
         src/client/pmi1.c \
         src/client/pmi2.c

--- a/opal/mca/pmix/pmix112/pmix/test/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/test/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,8 +31,14 @@ headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
+noinst_PROGRAMS =
+
 noinst_SCRIPTS = pmix_client_otheruser.sh
-noinst_PROGRAMS = pmi_client pmi2_client
+
+if WANT_PMIX_BACKWARD
+noinst_PROGRAMS += pmi_client pmi2_client
+endif
+
 if !WANT_HIDDEN
 noinst_PROGRAMS += pmix_test pmix_client pmix_regex
 endif
@@ -43,6 +49,7 @@ pmix_test_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_test_LDADD = \
 	$(top_builddir)/libpmix.la
 
+if WANT_PMIX_BACKWARD
 pmi_client_SOURCES = $(headers) \
         pmi_client.c
 pmi_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -54,6 +61,7 @@ pmi2_client_SOURCES = $(headers) \
 pmi2_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmi2_client_LDADD = \
 	$(top_builddir)/libpmix.la
+endif
 
 pmix_client_SOURCES = $(headers) \
         pmix_client.c test_fence.c test_common.c test_publish.c test_spawn.c \


### PR DESCRIPTION
…tiblity support, and update OPAL pmix112 configure.m4 to set that option

Signed-off-by: Ralph Castain <rhc@open-mpi.org>