### PR TITLE
odls/base: Fix abormal cleanup when app is wrapped

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1609,11 +1610,24 @@ int orte_odls_base_default_kill_local_procs(opal_pointer_array_t *procs,
                                  "%s SENDING SIGKILL TO %s",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                                  ORTE_NAME_PRINT(&cd->child->name)));
-            kill_local(cd->child->pid, SIGKILL);
+
+            /* Send signal to the negative of the PID to send the signal to all
+             * of the children of that PID - the process group under it.
+             * Otherwise it is delivered to only that PID.
+             */
+            kill_local(cd->child->pid * -1, SIGKILL);
+
             /* indicate the waitpid fired as this is effectively what
              * has happened
              */
             ORTE_FLAG_SET(cd->child, ORTE_PROC_FLAG_WAITPID);
+
+            /* Since we are not going to wait for this process, make sure
+             * we mark it as not-alive so that we don't wait for it
+             * in orted_cmd
+             */
+            ORTE_FLAG_UNSET(cd->child, ORTE_PROC_FLAG_ALIVE);
+
             cd->child->pid = 0;
 
             /* mark the child as "killed" */


### PR DESCRIPTION
 * The scenario is that we have a wrapper process placed before the MPI application:
```shell
 mpirun -np 2 wrapper ./hello_c
```
 * Wrapper can be as simple as:
```bash
#!/bin/bash -e
eval "$@"
exit 0
```
 * If `hello_c` crashes and `wrapper` detects it, then `wrapper` will
   exit with a non-zero exit status. The orted will notice that and
   start a kill process for all local processes.
   - The orted will send `SIGKILL` to the `wrapper` process, and that
     process will terminate and leave the `hello_c` running. The `hello_c`
     will continue to run (in this test case will wait in `MPI_Finalize`)
     and the job will seem to hang.
 * This commit does two things each will fix this scenario.
   1. After killing the process mark it as not alive since we are not
      going to wait on it. This prevents orted_cmd from seeing the process
      as alive and waiting for it to complete (note that the pid is set
      to `0` so we wouldn't be able to mark it correctly later even if
      we did get a notice.
   2. Instead of sending the `SIGKILL` signal to just the `PID` of `wrapper`
      send it to `-PID` so that the kernel will send the signal to the
      whole process group under `wrapper` as well. This will case the
      `hello_c` program to terminate as well.