### PR TITLE
Additional mpirun --help changes

### DIFF
--- a/opal/mca/base/mca_base_cmd_line.c
+++ b/opal/mca/base/mca_base_cmd_line.c
@@ -67,7 +67,8 @@ int mca_base_cmd_line_setup(opal_cmd_line_t *cmd)
         opal_cmd_line_init_t entry =
             {"mca_base_param_file_prefix", '\0', "am", NULL, 1,
              NULL, OPAL_CMD_LINE_TYPE_STRING,
-             "Aggregate MCA parameter set file list"
+             "Aggregate MCA parameter set file list",
+             OPAL_CMD_LINE_OTYPE_LAUNCH
             };
         ret = opal_cmd_line_make_opt_mca(cmd, entry);
         if (OPAL_SUCCESS != ret) {
@@ -79,7 +80,8 @@ int mca_base_cmd_line_setup(opal_cmd_line_t *cmd)
         opal_cmd_line_init_t entry =
             {"mca_base_envar_file_prefix", '\0', "tune", NULL, 1,
              NULL, OPAL_CMD_LINE_TYPE_STRING,
-             "Application profile options file list"
+             "Application profile options file list",
+             OPAL_CMD_LINE_OTYPE_DEBUG
             };
         ret = opal_cmd_line_make_opt_mca(cmd, entry);
         if (OPAL_SUCCESS != ret) {

--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -726,6 +726,11 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
             }
         }
     }
+    if(otype == OPAL_CMD_LINE_OTYPE_NULL || otype == OPAL_CMD_LINE_OTYPE_GENERAL) {
+        char *argument_line = "\nFor additional mpirun arguments, run 'mpirun --help <category>'\n\nThe following categories exist: general (Defaults to this option), debug,\n    output, input, mapping, ranking, binding, devel (arguments useful to OMPI\n    Developers), compatibility (arguments supported for backwards compatibility),\n    launch (arguments to modify launch options), and dvm (Distributed Virtual\n    Machine arguments).";
+
+        opal_argv_append(&argc, &argv, argument_line);
+    }
     if (NULL != argv) {
         ret = opal_argv_join(argv, '\n');
         opal_argv_free(argv);

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -77,7 +77,7 @@ static opal_cmd_line_init_t cmd_line_init[] = {
     /* Various "obvious" options */
     { NULL, 'h', NULL, "help", 1,
       &orte_cmd_options.help, OPAL_CMD_LINE_TYPE_STRING,
-      "Help  messages.  Argument options are: general (Defaults to this option), debug, output, input, mapping, ranking, binding, devel (arguments usefull to OMPI Developers), compatibility (arguments supported for backwards compatibility) launch (arguments to modify launch options), and dvm (Distributed Virtual Machine arguments", OPAL_CMD_LINE_OTYPE_GENERAL },
+      "This help message", OPAL_CMD_LINE_OTYPE_GENERAL },
     { NULL, 'V', NULL, "version", 0,
       &orte_cmd_options.version, OPAL_CMD_LINE_TYPE_BOOL,
       "Print version and exit", OPAL_CMD_LINE_OTYPE_GENERAL },
@@ -90,11 +90,11 @@ static opal_cmd_line_init_t cmd_line_init[] = {
     { NULL, '\0', "report-pid", "report-pid", 1,
       &orte_cmd_options.report_pid, OPAL_CMD_LINE_TYPE_STRING,
       "Printout pid on stdout [-], stderr [+], or a file [anything else]",
-      OPAL_CMD_LINE_OTYPE_GENERAL },
+      OPAL_CMD_LINE_OTYPE_DEBUG },
     { NULL, '\0', "report-uri", "report-uri", 1,
       &orte_cmd_options.report_uri, OPAL_CMD_LINE_TYPE_STRING,
       "Printout URI on stdout [-], stderr [+], or a file [anything else]",
-      OPAL_CMD_LINE_OTYPE_GENERAL },
+      OPAL_CMD_LINE_OTYPE_DEBUG },
 
     /* testing options */
     { NULL, '\0', "timeout", "timeout", 1,
@@ -190,7 +190,7 @@ static opal_cmd_line_init_t cmd_line_init[] = {
     { NULL, '\0', NULL, "app", 1,
       &orte_cmd_options.appfile, OPAL_CMD_LINE_TYPE_STRING,
       "Provide an appfile; ignore all other command line options",
-      OPAL_CMD_LINE_OTYPE_GENERAL },
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
 
     /* Number of processes; -c, -n, --n, -np, and --np are all
        synonyms */
@@ -238,7 +238,7 @@ static opal_cmd_line_init_t cmd_line_init[] = {
        so it does not make sense to set into a variable */
     { NULL, 'x', NULL, NULL, 1,
       NULL, OPAL_CMD_LINE_TYPE_NULL,
-      "Export an environment variable, optionally specifying a value (e.g., \"-x foo\" exports the environment variable foo and takes its value from the current environment; \"-x foo=bar\" exports the environment variable name foo and sets its value to \"bar\" in the started processes)", OPAL_CMD_LINE_OTYPE_GENERAL },
+      "Export an environment variable, optionally specifying a value (e.g., \"-x foo\" exports the environment variable foo and takes its value from the current environment; \"-x foo=bar\" exports the environment variable name foo and sets its value to \"bar\" in the started processes)", OPAL_CMD_LINE_OTYPE_LAUNCH },
 
       /* Mapping controls */
     { "rmaps_base_display_map", '\0', "display-map", "display-map", 0,
@@ -307,8 +307,8 @@ static opal_cmd_line_init_t cmd_line_init[] = {
       OPAL_CMD_LINE_OTYPE_COMPAT },
     { "rmaps_ppr_n_pernode", '\0', "N", NULL, 1,
       &orte_cmd_options.npernode, OPAL_CMD_LINE_TYPE_INT,
-      "Launch n processes per node on all allocated nodes (synonym for npernode)",
-      OPAL_CMD_LINE_OTYPE_GENERAL },
+      "Launch n processes per node on all allocated nodes (synonym for 'map-by node')",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
 
     /* declare hardware threads as independent cpus */
     { "hwloc_base_use_hwthreads_as_cpus", '\0', "use-hwthread-cpus", "use-hwthread-cpus", 0,
@@ -510,7 +510,8 @@ static opal_cmd_line_init_t cmd_line_init[] = {
     /* fwd mpirun port */
     { "orte_fwd_mpirun_port", '\0', "fwd-mpirun-port", "fwd-mpirun-port", 0,
       NULL, OPAL_CMD_LINE_TYPE_BOOL,
-      "Forward mpirun port to compute node daemons so all will use it" },
+      "Forward mpirun port to compute node daemons so all will use it",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
 
     /* End of list */
     { NULL, '\0', NULL, NULL, 0,

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -331,7 +331,7 @@ int orte_submit_init(int argc, char *argv[],
             fprintf(stderr, "%s has detected an attempt to run as root.\n\n", orte_basename);
         }
 
-        fprintf(stderr, "Running at root is *strongly* discouraged as any mistake (e.g., in\n");
+        fprintf(stderr, "Running as root is *strongly* discouraged as any mistake (e.g., in\n");
         fprintf(stderr, "defining TMPDIR) or bug can result in catastrophic damage to the OS\n");
         fprintf(stderr, "file system, leaving your system in an unusable state.\n\n");
 


### PR DESCRIPTION
This commit recategorizes several mpirun arguments,
and moves the information for mpirun --help arguments
to the bottom of the general help message.  I also
added the OPAL_CMD_LINE_OTYPE field to two commands
that were missed initially because they were not
in the same area as the others.

Signed-off-by: Nathaniel Graham <ngraham@lanl.gov>

@jsquyres Here are the changes.  It turns out -am and -tune were completely missed in the first pass because they were in a different location.  Any opal_cmd_line_init_t that does not have its opal_cmd_line_otype_t set will end up in general information.