### PR TITLE
v2.x: check for negative ranks in ompi_win_peer_invalid

### DIFF
--- a/ompi/mpi/c/win_lock.c
+++ b/ompi/mpi/c/win_lock.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -60,9 +60,6 @@ int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win)
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_RMA_SYNC, FUNC_NAME);
         }
     }
-
-    /* NTH: do not bother keeping track of locking MPI_PROC_NULL. */
-    if (MPI_PROC_NULL == rank) return MPI_SUCCESS;
 
     rc = win->w_osc_module->osc_lock(lock_type, rank, assert, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);

--- a/ompi/mpi/c/win_shared_query.c
+++ b/ompi/mpi/c/win_shared_query.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012-2013 Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -39,7 +39,7 @@ int MPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, 
 
         if (ompi_win_invalid(win)) {
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_WIN, FUNC_NAME);
-         } else if (ompi_win_peer_invalid(win, rank)) {
+         } else if (MPI_PROC_NULL != rank && ompi_win_peer_invalid(win, rank)) {
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_RANK, FUNC_NAME);
          }
     }

--- a/ompi/mpi/c/win_unlock.c
+++ b/ompi/mpi/c/win_unlock.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -53,9 +53,6 @@ int MPI_Win_unlock(int rank, MPI_Win win)
             return OMPI_ERRHANDLER_INVOKE(win, MPI_ERR_RANK, FUNC_NAME);
         }
     }
-
-    /* NTH: do not bother keeping track of unlocking MPI_PROC_NULL. */
-    if (MPI_PROC_NULL == rank) return MPI_SUCCESS;
 
     rc = win->w_osc_module->osc_unlock(rank, win);
     OMPI_ERRHANDLER_RETURN(rc, win, rc, FUNC_NAME);

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -162,7 +162,7 @@ static inline int ompi_win_invalid(ompi_win_t *win) {
 }
 
 static inline int ompi_win_peer_invalid(ompi_win_t *win, int peer) {
-    if (win->w_group->grp_proc_count <= peer) return true;
+    if (win->w_group->grp_proc_count <= peer || peer < 0) return true;
     return false;
 }
 


### PR DESCRIPTION
resolves #3326 (https://github.com/open-mpi/ompi/issues/3326)

Signed-off-by: jeff.r.hammond@intel.com

(cherry picked from commit open-mpi/ompi@b3a20100d3d31e4937a5b23d012c8ae9b22e0cd3)