### PR TITLE
v3.x: check for negative ranks in ompi_win_peer_invalid

### DIFF
--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -162,7 +162,7 @@ static inline int ompi_win_invalid(ompi_win_t *win) {
 }
 
 static inline int ompi_win_peer_invalid(ompi_win_t *win, int peer) {
-    if (win->w_group->grp_proc_count <= peer) return true;
+    if (win->w_group->grp_proc_count <= peer || peer < 0) return true;
     return false;
 }
 


### PR DESCRIPTION
resolves #3326 (https://github.com/open-mpi/ompi/issues/3326)

Signed-off-by: jeff.r.hammond@intel.com

(cherry picked from commit open-mpi/ompi@b3a20100d3d31e4937a5b23d012c8ae9b22e0cd3)