### PR TITLE
orte/pmix: Do not set orted exit status to one from proc abort

### DIFF
--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014      Mellanox Technologies, Inc.
+ * Copyright (c) 2014-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -187,8 +187,6 @@ static void _client_abort(int sd, short args, void *cbdata)
         p->exit_code = cd->status;
         ORTE_ACTIVATE_PROC_STATE(&p->name, ORTE_PROC_STATE_CALLED_ABORT);
     }
-
-    ORTE_UPDATE_EXIT_STATUS(cd->status);
 
     /* release the caller */
     if (NULL != cd->cbfunc) {


### PR DESCRIPTION
The fact that application proc called Abort (read failed) doesn't
mean that ORTE subsystem has failed - vice versa it does it's work
to gracefuly exit the whole application.

orted exiting with non-zero status creates a problem for at least
plm/slurm environments where orteds are launched via `srun` with
"--kill-on-bad-exit" flag. If one of orteds has exited with non-
zero status slurm will immediately kill all other orteds. As the
result we see a lot of leftover in the `/tmp` directory.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>
(cherry picked from commit 4af7a0827fa0bfc2d7d22016edd2ed3347fdd5ab)