### PR TITLE
Fix yalla PML: MPI_Recv does not return MPI_ERR_TRUNCATE upon overflow

### DIFF
--- a/ompi/mca/pml/yalla/pml_yalla.c
+++ b/ompi/mca/pml/yalla/pml_yalla.c
@@ -372,6 +372,7 @@ int mca_pml_yalla_recv(void *buf, size_t count, ompi_datatype_t *datatype, int s
 {
     mxm_recv_req_t rreq;
     mxm_error_t error;
+    int rc;
 
     PML_YALLA_INIT_MXM_RECV_REQ(&rreq, buf, count, datatype, src, tag, comm, recv);
     PML_YALLA_INIT_BLOCKING_MXM_RECV_REQ(&rreq);
@@ -390,10 +391,10 @@ int mca_pml_yalla_recv(void *buf, size_t count, ompi_datatype_t *datatype, int s
                       rreq.completion.sender_imm, rreq.completion.sender_tag,
                       rreq.tag, rreq.tag_mask,
                       rreq.completion.actual_len);
-    PML_YALLA_SET_RECV_STATUS(&rreq, rreq.completion.actual_len, status);
+    rc = PML_YALLA_SET_RECV_STATUS(&rreq, rreq.completion.actual_len, status);
     PML_YALLA_FREE_BLOCKING_MXM_REQ(&rreq.base);
 
-    return OMPI_SUCCESS;
+    return rc;
 }
 
 int mca_pml_yalla_isend_init(const void *buf, size_t count, ompi_datatype_t *datatype,
@@ -681,8 +682,7 @@ int mca_pml_yalla_mrecv(void *buf, size_t count, ompi_datatype_t *datatype,
                       rreq.completion.sender_imm, rreq.completion.sender_tag,
                       rreq.tag, rreq.tag_mask,
                       rreq.completion.actual_len);
-    PML_YALLA_SET_RECV_STATUS(&rreq, rreq.completion.actual_len, status);
-    return OMPI_SUCCESS;
+    return PML_YALLA_SET_RECV_STATUS(&rreq, rreq.completion.actual_len, status);
 }
 
 int mca_pml_yalla_start(size_t count, ompi_request_t** requests)

--- a/ompi/mca/pml/yalla/pml_yalla_request.h
+++ b/ompi/mca/pml/yalla/pml_yalla_request.h
@@ -176,30 +176,39 @@ void mca_pml_yalla_init_reqs(void);
         } \
     }
 
-#define PML_YALLA_SET_RECV_STATUS(_rreq, _length, _mpi_status) \
-    { \
-        if ((_mpi_status) != MPI_STATUS_IGNORE) { \
-            switch ((_rreq)->base.error) { \
-            case MXM_OK: \
-                (_mpi_status)->MPI_ERROR  = OMPI_SUCCESS; \
-                break; \
-            case MXM_ERR_CANCELED: \
-                (_mpi_status)->MPI_ERROR  = OMPI_SUCCESS; \
-                (_mpi_status)->_cancelled = true; \
-                break; \
-            case MXM_ERR_MESSAGE_TRUNCATED: \
-                (_mpi_status)->MPI_ERROR  = MPI_ERR_TRUNCATE; \
-                break; \
-            default: \
-                (_mpi_status)->MPI_ERROR  = MPI_ERR_INTERN; \
-                break; \
-            } \
-            \
-            (_mpi_status)->MPI_TAG    = (_rreq)->completion.sender_tag; \
-            (_mpi_status)->MPI_SOURCE = (_rreq)->completion.sender_imm; \
-            (_mpi_status)->_ucount    = (_length); \
-        } \
+static inline int PML_YALLA_SET_RECV_STATUS(mxm_recv_req_t *_rreq,
+                                            size_t _length,
+                                            ompi_status_public_t *_mpi_status)
+{
+    int rc;
+
+    switch (_rreq->base.error) {
+    case MXM_OK:
+        rc = OMPI_SUCCESS;
+        break;
+    case MXM_ERR_CANCELED:
+        rc = OMPI_SUCCESS;
+        break;
+    case MXM_ERR_MESSAGE_TRUNCATED:
+        rc = MPI_ERR_TRUNCATE;
+        break;
+    default:
+        rc = MPI_ERR_INTERN;
+        break;
     }
+
+    /* If status is not ignored, fill what is needed */
+    if (_mpi_status != MPI_STATUS_IGNORE) {
+        _mpi_status->MPI_ERROR  = rc;
+        if (MXM_ERR_CANCELED == _rreq->base.error) {
+            _mpi_status->_cancelled = true;
+        }
+        _mpi_status->MPI_TAG    = _rreq->completion.sender_tag;
+        _mpi_status->MPI_SOURCE = _rreq->completion.sender_imm;
+        _mpi_status->_ucount    = _length;
+    }
+    return rc;
+}
 
 #define PML_YALLA_SET_MESSAGE(_rreq, _comm, _mxm_msg, _message) \
     { \


### PR DESCRIPTION
Applies commit from PR #3260 to v2.x
Signed-off-by: Nadia Derbey <Nadia.Derbey@atos.net>