### PR TITLE
v2.x: dl/dlopen: add libs to wrapper LIBS

### DIFF
--- a/opal/mca/dl/dlopen/configure.m4
+++ b/opal/mca/dl/dlopen/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
 #
 # $COPYRIGHT$
 #
@@ -47,7 +47,8 @@ AC_DEFUN([MCA_opal_dl_dlopen_CONFIG],[
           ])
 
     AS_IF([test "$opal_dl_dlopen_happy" = "yes"],
-          [opal_dl_dlopen_ADD_LIBS=$opal_dl_dlopen_LIBS
+          [dl_dlopen_ADD_LIBS=$opal_dl_dlopen_LIBS
+           dl_dlopen_WRAPPER_EXTRA_LIBS=$opal_dl_dlopen_LIBS
            $1],
           [$2])
 


### PR DESCRIPTION
With this, libs (e.g., "-ldl") are not added to the wrapper LIBS
flags.  This may work on some platforms, but on at least RHEL 7.3, it
does not (i.e., compiling MPI applications fails because it can't find
dlopen).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit a0543616ee2be5c9facbfeadcc48ac6a54f411b3)

@rhc54 please review