### PR TITLE
Use the node index to compare to daemon vpid when identifying procs t…

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -398,8 +398,9 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
                 if (!ORTE_FLAG_TEST(pptr, ORTE_PROC_FLAG_LOCAL)) {
                     /* not on the local list */
                     OPAL_OUTPUT_VERBOSE((5, orte_odls_base_framework.framework_output,
-                                         "%s adding proc %s to my local list",
+                                         "%s[%s:%d] adding proc %s to my local list",
                                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                         __FILE__, __LINE__,
                                          ORTE_NAME_PRINT(&pptr->name)));
                     /* keep tabs of the number of local procs */
                     jdata->num_local_procs++;
@@ -439,8 +440,9 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
                 if (!ORTE_FLAG_TEST(pptr, ORTE_PROC_FLAG_LOCAL)) {
                     /* not on the local list */
                     OPAL_OUTPUT_VERBOSE((5, orte_odls_base_framework.framework_output,
-                                         "%s adding proc %s to my local list",
+                                         "%s[%s:%d] adding proc %s to my local list",
                                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                         __FILE__, __LINE__,
                                          ORTE_NAME_PRINT(&pptr->name)));
                     /* keep tabs of the number of local procs */
                     jdata->num_local_procs++;

--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -843,12 +843,15 @@ int orte_rmaps_base_compute_bindings(orte_job_t *jdata)
      */
   execute:
     /* initialize */
+    opal_output_verbose(5, orte_rmaps_base_framework.framework_output,
+                        "mca:rmaps: computing bindings for job %s",
+                        ORTE_JOBID_PRINT(jdata->jobid));
 
     for (i=0; i < jdata->map->nodes->size; i++) {
         if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, i))) {
             continue;
         }
-        if (!orte_no_vm && (int)ORTE_PROC_MY_NAME->vpid != i) {
+        if (!orte_no_vm && (int)ORTE_PROC_MY_NAME->vpid != node->index) {
             continue;
         }
         if (!orte_do_not_launch) {


### PR DESCRIPTION
…o bind

Signed-off-by: Ralph Castain <rhc@open-mpi.org>

(cherry picked from commit open-mpi/ompi@bb1aaa32860eab1e0d1963fa6dbf0c38ef5f91ec)