### PR TITLE
Improve the opal_pointer_array & more

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -86,15 +86,15 @@ int ompi_comm_init(void)
 
     /* Setup communicator array */
     OBJ_CONSTRUCT(&ompi_mpi_communicators, opal_pointer_array_t);
-    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_mpi_communicators, 0,
+    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_mpi_communicators, 16,
                                                 OMPI_FORTRAN_HANDLE_MAX, 64) ) {
         return OMPI_ERROR;
     }
 
     /* Setup f to c table (we can no longer use the cid as the fortran handle) */
     OBJ_CONSTRUCT(&ompi_comm_f_to_c_table, opal_pointer_array_t);
-    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_comm_f_to_c_table, 0,
-                                                OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_comm_f_to_c_table, 8,
+                                                OMPI_FORTRAN_HANDLE_MAX, 32) ) {
         return OMPI_ERROR;
     }
 

--- a/ompi/datatype/ompi_datatype_internal.h
+++ b/ompi/datatype/ompi_datatype_internal.h
@@ -403,7 +403,7 @@ extern const ompi_datatype_t* ompi_datatype_basicDatatypes[OMPI_DATATYPE_MPI_MAX
 
 #define OMPI_DATATYPE_EMPTY_DATA(NAME)                                               \
     .id = OMPI_DATATYPE_MPI_ ## NAME,                                                \
-    .d_f_to_c_index = 0,                                                             \
+    .d_f_to_c_index = -1,                                                            \
     .d_keyhash = NULL,                                                               \
     .args = NULL,                                                                    \
     .packed_description = NULL,                                                      \

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -457,7 +457,7 @@ int32_t ompi_datatype_init( void )
     /* Create the f2c translation table */
     OBJ_CONSTRUCT(&ompi_datatype_f_to_c_table, opal_pointer_array_t);
     if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_datatype_f_to_c_table,
-                                                0, OMPI_FORTRAN_HANDLE_MAX, 64)) {
+                                                64, OMPI_FORTRAN_HANDLE_MAX, 32)) {
         return OMPI_ERROR;
     }
     /* All temporary datatypes created on the following statement will get registered

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2016 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -512,7 +512,6 @@ int32_t ompi_datatype_init( void )
     /* Copy the desc pointer from the <OMPI_DATATYPE_MPI_MAX_PREDEFINED datatypes to
        the synonym types */
 
-
     /* Start to populate the f2c index translation table */
 
     /* The order of the data registration should be the same as the
@@ -523,14 +522,14 @@ int32_t ompi_datatype_init( void )
     /* This macro makes everything significantly easier to read below.
        All hail the moog!  :-) */
 
-#define MOOG(name, index)                                                            \
-    {                                                                                \
-        ompi_mpi_##name.dt.d_f_to_c_index =                                          \
-            opal_pointer_array_add(&ompi_datatype_f_to_c_table, &ompi_mpi_##name);   \
+#define MOOG(name, index)                                               \
+    do {                                                                \
+        ompi_mpi_##name.dt.d_f_to_c_index =                             \
+            opal_pointer_array_add(&ompi_datatype_f_to_c_table, &ompi_mpi_##name); \
         if( ompi_datatype_number_of_predefined_data < (ompi_mpi_##name).dt.d_f_to_c_index ) \
             ompi_datatype_number_of_predefined_data = (ompi_mpi_##name).dt.d_f_to_c_index; \
-        assert( (index) == ompi_mpi_##name.dt.d_f_to_c_index );                      \
-    }
+        assert( (index) == ompi_mpi_##name.dt.d_f_to_c_index );         \
+    } while(0)
 
     /*
      * This MUST match the order of ompi/include/mpif-values.pl

--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -133,8 +133,8 @@ int ompi_mpi_errcode_init (void)
     /* Initialize the pointer array, which will hold the references to
        the error objects */
     OBJ_CONSTRUCT(&ompi_mpi_errcodes, opal_pointer_array_t);
-    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_mpi_errcodes, 0,
-                                                OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_mpi_errcodes, 64,
+                                                OMPI_FORTRAN_HANDLE_MAX, 32) ) {
         return OMPI_ERROR;
     }
 

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -83,8 +83,8 @@ int ompi_errhandler_init(void)
   /* initialize ompi_errhandler_f_to_c_table */
 
   OBJ_CONSTRUCT( &ompi_errhandler_f_to_c_table, opal_pointer_array_t);
-  if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_errhandler_f_to_c_table, 0,
-                                              OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+  if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_errhandler_f_to_c_table, 8,
+                                              OMPI_FORTRAN_HANDLE_MAX, 16) ) {
     return OMPI_ERROR;
   }
 

--- a/ompi/file/file.c
+++ b/ompi/file/file.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -73,7 +73,7 @@ int ompi_file_init(void)
 
     OBJ_CONSTRUCT(&ompi_file_f_to_c_table, opal_pointer_array_t);
     if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_file_f_to_c_table, 0,
-                                                OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+                                                OMPI_FORTRAN_HANDLE_MAX, 16) ) {
         return OMPI_ERROR;
     }
 

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -319,8 +319,8 @@ int ompi_group_init(void)
 {
     /* initialize ompi_group_f_to_c_table */
     OBJ_CONSTRUCT( &ompi_group_f_to_c_table, opal_pointer_array_t);
-    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_group_f_to_c_table, 0,
-                                                OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_group_f_to_c_table, 4,
+                                                OMPI_FORTRAN_HANDLE_MAX, 16) ) {
         return OMPI_ERROR;
     }
 

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -102,7 +102,7 @@ int ompi_info_init(void)
 
     OBJ_CONSTRUCT(&ompi_info_f_to_c_table, opal_pointer_array_t);
     if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_info_f_to_c_table, 0,
-                                                OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+                                                OMPI_FORTRAN_HANDLE_MAX, 16) ) {
         return OMPI_ERROR;
     }
 

--- a/ompi/mpi/c/type_c2f.c
+++ b/ompi/mpi/c/type_c2f.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -55,5 +55,10 @@ MPI_Fint MPI_Type_c2f(MPI_Datatype datatype)
         }
     }
 
+    /* If necessary add the datatype to the f2c translation table */
+    if( -1 == datatype->d_f_to_c_index ) {
+        datatype->d_f_to_c_index = opal_pointer_array_add(&ompi_datatype_f_to_c_table, datatype);
+        /* We don't check for error as returning a negative value is considered as an error */
+    }
     return OMPI_INT_2_FINT(datatype->d_f_to_c_index);
 }

--- a/ompi/request/request.c
+++ b/ompi/request/request.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2016 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -108,7 +108,7 @@ int ompi_request_init(void)
     OBJ_CONSTRUCT(&ompi_request_null, ompi_request_t);
     OBJ_CONSTRUCT(&ompi_request_f_to_c_table, opal_pointer_array_t);
     if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_request_f_to_c_table,
-                                                0, OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+                                                0, OMPI_FORTRAN_HANDLE_MAX, 32) ) {
         return OMPI_ERROR;
     }
     ompi_request_null.request.req_type = OMPI_REQUEST_NULL;

--- a/ompi/tools/ompi_info/ompi_info.c
+++ b/ompi/tools/ompi_info/ompi_info.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
 
     /* setup the mca_types array */
     OBJ_CONSTRUCT(&mca_types, opal_pointer_array_t);
-    opal_pointer_array_init(&mca_types, 256, INT_MAX, 128);
+    opal_pointer_array_init(&mca_types, 128, INT_MAX, 64);
 
     /* add in the opal frameworks */
     opal_info_register_types(&mca_types);
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 
     /* init the component map */
     OBJ_CONSTRUCT(&component_map, opal_pointer_array_t);
-    opal_pointer_array_init(&component_map, 256, INT_MAX, 128);
+    opal_pointer_array_init(&component_map, 64, INT_MAX, 32);
 
     /* Register OMPI's params */
     if (OMPI_SUCCESS != (ret = ompi_info_register_framework_params(&component_map))) {

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -79,8 +79,8 @@ ompi_win_init(void)
 
     /* setup window Fortran array */
     OBJ_CONSTRUCT(&ompi_mpi_windows, opal_pointer_array_t);
-    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_mpi_windows, 0,
-                                                OMPI_FORTRAN_HANDLE_MAX, 64) ) {
+    if( OPAL_SUCCESS != opal_pointer_array_init(&ompi_mpi_windows, 4,
+                                                OMPI_FORTRAN_HANDLE_MAX, 16) ) {
         return OMPI_ERROR;
     }
 

--- a/test/class/opal_pointer_array.c
+++ b/test/class/opal_pointer_array.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -109,11 +109,7 @@ static void test(bool thread_usage){
     }
 
     /* test opal_pointer_array_get_item */
-    array->number_free=array->size;
-    array->lowest_free=0;
-    for(i=0 ; i < array->size ; i++ ) {
-        array->addr[i] = NULL;
-    }
+    opal_pointer_array_remove_all(array);
     error_cnt=0;
     for(i=0 ; i < array->size ; i++ ) {
         value.ivalue = i + 2;
@@ -141,7 +137,35 @@ static void test(bool thread_usage){
         test_failure(" data check - 2nd ");
     }
 
-    free (array);
+    OBJ_RELEASE(array);
+    assert(NULL == array);
+
+    array=OBJ_NEW(opal_pointer_array_t);
+    assert(array);
+    opal_pointer_array_init(array, 0, 4, 2);
+    for( i = 0; i < 4; i++ ) {
+        value.ivalue = i + 1;
+        if( 0 > opal_pointer_array_add( array, value.cvalue ) ) {
+            test_failure("Add/Remove: failure during initial data_add ");
+        }
+    }
+    for( i = i-1; i >= 0; i-- ) {
+        if( i % 2 )
+            if( 0 != opal_pointer_array_set_item(array, i, NULL) )
+                test_failure("Add/Remove: failure during item removal ");
+    }
+    for( i = 0; i < 4; i++ ) {
+        if( !opal_pointer_array_add( array, (void*)(uintptr_t)(i+1) ) ) {
+            if( i != 2 ) {
+                test_failure("Add/Remove: failure during the readd ");
+                break;
+            }
+        }
+    }
+    opal_pointer_array_remove_all(array);
+    OBJ_RELEASE(array);
+    assert(NULL == array);
+
     free(test_data);
 }
 


### PR DESCRIPTION
This PR is related to #2426, as it originally tried to fix the performance degradation in datatype creation which was entirely due to the implementation of the opal_pointer_array. Thus, i replace the original implementation by one that in addition to the data array keeps an array of bits to find the next available items in a more compact way.

However, after the reimplementation of opal_pointer_array I also decided to remove the automatic registration of the OMPI datatype into the f2c (Fortran-to-C) translation table, and instead do the registration only when necessary (basically when we know that we will return the datatype object through the Fortran interface).

Here are some performance numbers (I could not replicate the original numbers on the #2426, but I strongly suspect they were obtained in debug mode). 

Original OMPI: 29.458 s
above + rewrite of opal_pointer_array: 0.787 s
above + not registration of the datatype: 0.581 s

The last trick (not automatically registering MPI objects) can also be used for a wide range of MPI objects: windows, files, communicators, requests, info, attributes and more.
