### PR TITLE
PML/UCX/YALLA: Fix the message release call.

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx_request.h
+++ b/ompi/mca/pml/ucx/pml_ucx_request.h
@@ -89,7 +89,7 @@ enum {
 #define PML_UCX_MESSAGE_RELEASE(_message) \
     { \
         ompi_message_return(*(_message)); \
-        *(_message) = NULL; \
+        *(_message) = MPI_MESSAGE_NULL; \
     }
 
 

--- a/ompi/mca/pml/yalla/pml_yalla_request.h
+++ b/ompi/mca/pml/yalla/pml_yalla_request.h
@@ -213,7 +213,7 @@ void mca_pml_yalla_init_reqs(void);
 #define PML_YALLA_MESSAGE_RELEASE(_message) \
     { \
         ompi_message_return(*(_message)); \
-        *(_message) = NULL; \
+        *(_message) = MPI_MESSAGE_NULL; \
     }
 
 #endif /* PML_YALLA_REQUEST_H_ */


### PR DESCRIPTION
Set message to MPI_MESSAGE_NULL.

Signed-off-by: Alina Sklarevich <alinas@mellanox.com>
(cherry picked from commit eec310c99c8014a797a04376105792eb6c22a1bb)