### PR TITLE
coll/hcoll: performance bugfix

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll.h
@@ -312,6 +312,25 @@ int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
 
 int mca_coll_hcoll_progress(void);
 void mca_coll_hcoll_mem_release_cb(void *buf, size_t length, void *cbdata, bool from_alloc);
+
+extern int mca_coll_hcoll_progress_registered;
+
+static inline void
+mca_coll_hcoll_progress_unregister(void) {
+    if (mca_coll_hcoll_progress_registered) {
+        opal_progress_unregister(mca_coll_hcoll_progress);
+        mca_coll_hcoll_progress_registered = 0;
+    }
+}
+
+static inline void
+mca_coll_hcoll_progress_register(void) {
+    if (!mca_coll_hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        mca_coll_hcoll_progress_registered = 1;
+    }
+}
+
 END_C_DECLS
 
 #endif

--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -288,7 +288,7 @@ static int hcoll_close(void)
     HCOL_VERBOSE(5,"HCOLL FINALIZE");
     rc = hcoll_finalize();
     OBJ_DESTRUCT(&cm->dtypes);
-    opal_progress_unregister(mca_coll_hcoll_progress);
+    mca_coll_hcoll_progress_unregister();
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(1,"Hcol library finalize failed");
         return OMPI_ERROR;

--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -286,7 +286,10 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
            mxm bcol in libhcoll needs world_group fully functional during init
            world_group, i.e. ompi_comm_world, is not ready at hcoll component open
            call */
-        opal_progress_register(mca_coll_hcoll_progress);
+#if HCOLL_API < HCOLL_VERSION(3,8)
+        mca_coll_hcoll_progress_register();
+#endif
+
 
         HCOL_VERBOSE(10,"Calling hcoll_init();");
 #if HCOLL_API >= HCOLL_VERSION(3,2)
@@ -303,7 +306,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
 
         if (HCOLL_SUCCESS != rc){
             cm->hcoll_enable = 0;
-            opal_progress_unregister(mca_coll_hcoll_progress);
+            mca_coll_hcoll_progress_unregister();
             HCOL_ERROR("Hcol library init failed");
             return NULL;
         }
@@ -324,7 +327,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
         if (OMPI_SUCCESS != err) {
             cm->hcoll_enable = 0;
             hcoll_finalize();
-            opal_progress_unregister(mca_coll_hcoll_progress);
+            mca_coll_hcoll_progress_unregister();
             HCOL_ERROR("Hcol comm keyval create failed");
             return NULL;
         }
@@ -336,7 +339,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
             if (OMPI_SUCCESS != err) {
                 cm->hcoll_enable = 0;
                 hcoll_finalize();
-                opal_progress_unregister(mca_coll_hcoll_progress);
+                mca_coll_hcoll_progress_unregister();
                 HCOL_ERROR("Hcol type keyval create failed");
                 return NULL;
             }
@@ -353,7 +356,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
         if (!cm->libhcoll_initialized) {
             cm->hcoll_enable = 0;
             hcoll_finalize();
-            opal_progress_unregister(mca_coll_hcoll_progress);
+            mca_coll_hcoll_progress_unregister();
         }
         return NULL;
     }
@@ -372,7 +375,7 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
         if (!cm->libhcoll_initialized) {
             cm->hcoll_enable = 0;
             hcoll_finalize();
-            opal_progress_unregister(mca_coll_hcoll_progress);
+            mca_coll_hcoll_progress_unregister();
         }
         return NULL;
     }

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -15,6 +15,7 @@
 #include "hcoll/api/hcoll_constants.h"
 #include "coll_hcoll_dtypes.h"
 #include "hcoll/api/hcoll_dte.h"
+int mca_coll_hcoll_progress_registered = 0;
 int mca_coll_hcoll_barrier(struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module){
     int rc;
@@ -405,6 +406,7 @@ int mca_coll_hcoll_ibarrier(struct ompi_communicator_t *comm,
     HCOL_VERBOSE(20,"RUNNING HCOL NON-BLOCKING BARRIER");
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     rt_handle = (void**) request;
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_ibarrier(hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK NON-BLOCKING BARRIER");
@@ -435,6 +437,7 @@ int mca_coll_hcoll_ibcast(void *buff, int count,
                                          comm, request, hcoll_module->previous_ibcast_module);
         return rc;
     }
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_ibcast(buff, count, dtype, root, rt_handle, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK NON-BLOCKING BCAST");
@@ -475,6 +478,7 @@ int mca_coll_hcoll_iallgather(void *sbuf, int scount,
                                              hcoll_module->previous_iallgather_module);
         return rc;
     }
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_iallgather(sbuf, scount, stype, rbuf, rcount, rtype, hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK NON-BLOCKING ALLGATHER");
@@ -521,6 +525,7 @@ int mca_coll_hcoll_iallgatherv(const void *sbuf, int scount,
                                              hcoll_module->previous_iallgatherv_module);
         return rc;
     }
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_iallgatherv((void *)sbuf,scount,stype,rbuf,rcount,displs,rtype,
             hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
@@ -576,6 +581,7 @@ int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
         return rc;
     }
 
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_iallreduce(sbuf, rbuf, count, Dtype, Op, hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK NON-BLOCKING ALLREDUCE");
@@ -628,7 +634,7 @@ int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
                                              hcoll_module->previous_ireduce_module);
         return rc;
     }
-
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_ireduce((void *)sbuf,rbuf,count,Dtype,Op,root,hcoll_module->hcoll_context,rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK NON-BLOCKING REDUCE");
@@ -673,6 +679,7 @@ int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
                                            hcoll_module->previous_igatherv_module);
         return rc;
     }
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_igatherv(sbuf,scount,stype,rbuf,rcounts,displs, rtype, root, hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK IGATHERV");
@@ -711,6 +718,7 @@ int mca_coll_hcoll_ialltoallv(void *sbuf, int *scounts, int *sdisps,
                                                comm, request, hcoll_module->previous_alltoallv_module);
         return rc;
     }
+    mca_coll_hcoll_progress_register();
     rc = hcoll_collectives.coll_ialltoallv((void *)sbuf, (int *)scounts, (int *)sdisps, stype,
                                            rbuf, (int *)rcounts, (int *)rdisps, rtype,
                                            hcoll_module->hcoll_context, (void**)request);


### PR DESCRIPTION
    Don't register mca_coll_hcoll_progress to opal_progress until
    the first call to hcoll non-blocking collective.

    v.2.0.x version of #3371 
 Signed-off-by: Valentin Petrov <valentinp@mellanox.com>