### PR TITLE
coll/hcoll: performance bugfix

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll.h
+++ b/ompi/mca/coll/hcoll/coll_hcoll.h
@@ -313,6 +313,8 @@ int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
 
 int mca_coll_hcoll_progress(void);
 void mca_coll_hcoll_mem_release_cb(void *buf, size_t length, void *cbdata, bool from_alloc);
+
+extern int hcoll_progress_registered ;
 END_C_DECLS
 
 #endif

--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -290,7 +290,8 @@ static int hcoll_close(void)
     HCOL_VERBOSE(5,"HCOLL FINALIZE");
     rc = hcoll_finalize();
     OBJ_DESTRUCT(&cm->dtypes);
-    opal_progress_unregister(mca_coll_hcoll_progress);
+    if (hcoll_progress_registered)
+        opal_progress_unregister(mca_coll_hcoll_progress);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(1,"Hcol library finalize failed");
         return OMPI_ERROR;

--- a/ompi/mca/coll/hcoll/coll_hcoll_module.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_module.c
@@ -286,7 +286,6 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
            mxm bcol in libhcoll needs world_group fully functional during init
            world_group, i.e. ompi_comm_world, is not ready at hcoll component open
            call */
-        opal_progress_register(mca_coll_hcoll_progress);
 
         HCOL_VERBOSE(10,"Calling hcoll_init();");
 #if HCOLL_API >= HCOLL_VERSION(3,2)
@@ -303,7 +302,6 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
 
         if (HCOLL_SUCCESS != rc){
             cm->hcoll_enable = 0;
-            opal_progress_unregister(mca_coll_hcoll_progress);
             HCOL_ERROR("Hcol library init failed");
             return NULL;
         }
@@ -324,7 +322,6 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
         if (OMPI_SUCCESS != err) {
             cm->hcoll_enable = 0;
             hcoll_finalize();
-            opal_progress_unregister(mca_coll_hcoll_progress);
             HCOL_ERROR("Hcol comm keyval create failed");
             return NULL;
         }
@@ -336,7 +333,6 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
             if (OMPI_SUCCESS != err) {
                 cm->hcoll_enable = 0;
                 hcoll_finalize();
-                opal_progress_unregister(mca_coll_hcoll_progress);
                 HCOL_ERROR("Hcol type keyval create failed");
                 return NULL;
             }
@@ -353,7 +349,6 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
         if (!cm->libhcoll_initialized) {
             cm->hcoll_enable = 0;
             hcoll_finalize();
-            opal_progress_unregister(mca_coll_hcoll_progress);
         }
         return NULL;
     }
@@ -372,7 +367,6 @@ mca_coll_hcoll_comm_query(struct ompi_communicator_t *comm, int *priority)
         if (!cm->libhcoll_initialized) {
             cm->hcoll_enable = 0;
             hcoll_finalize();
-            opal_progress_unregister(mca_coll_hcoll_progress);
         }
         return NULL;
     }

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -15,6 +15,7 @@
 #include "hcoll/api/hcoll_constants.h"
 #include "coll_hcoll_dtypes.h"
 #include "hcoll/api/hcoll_dte.h"
+int hcoll_progress_registered = 0;
 int mca_coll_hcoll_barrier(struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module){
     int rc;
@@ -405,6 +406,10 @@ int mca_coll_hcoll_ibarrier(struct ompi_communicator_t *comm,
     HCOL_VERBOSE(20,"RUNNING HCOL NON-BLOCKING BARRIER");
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     rt_handle = (void**) request;
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
+    }
     rc = hcoll_collectives.coll_ibarrier(hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK NON-BLOCKING BARRIER");
@@ -434,6 +439,10 @@ int mca_coll_hcoll_ibcast(void *buff, int count,
         rc = hcoll_module->previous_ibcast(buff,count,datatype,root,
                                          comm, request, hcoll_module->previous_ibcast_module);
         return rc;
+    }
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
     }
     rc = hcoll_collectives.coll_ibcast(buff, count, dtype, root, rt_handle, hcoll_module->hcoll_context);
     if (HCOLL_SUCCESS != rc){
@@ -474,6 +483,10 @@ int mca_coll_hcoll_iallgather(void *sbuf, int scount,
                                              request,
                                              hcoll_module->previous_iallgather_module);
         return rc;
+    }
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
     }
     rc = hcoll_collectives.coll_iallgather(sbuf, scount, stype, rbuf, rcount, rtype, hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
@@ -520,6 +533,10 @@ int mca_coll_hcoll_iallgatherv(const void *sbuf, int scount,
                                              request,
                                              hcoll_module->previous_iallgatherv_module);
         return rc;
+    }
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
     }
     rc = hcoll_collectives.coll_iallgatherv((void *)sbuf,scount,stype,rbuf,rcount,displs,rtype,
             hcoll_module->hcoll_context, rt_handle);
@@ -576,6 +593,10 @@ int mca_coll_hcoll_iallreduce(const void *sbuf, void *rbuf, int count,
         return rc;
     }
 
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
+    }
     rc = hcoll_collectives.coll_iallreduce(sbuf, rbuf, count, Dtype, Op, hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK NON-BLOCKING ALLREDUCE");
@@ -628,6 +649,10 @@ int mca_coll_hcoll_ireduce(const void *sbuf, void *rbuf, int count,
                                              hcoll_module->previous_ireduce_module);
         return rc;
     }
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
+    }
 
     rc = hcoll_collectives.coll_ireduce((void *)sbuf,rbuf,count,Dtype,Op,root,hcoll_module->hcoll_context,rt_handle);
     if (HCOLL_SUCCESS != rc){
@@ -673,6 +698,10 @@ int mca_coll_hcoll_igatherv(const void* sbuf, int scount,
                                            hcoll_module->previous_igatherv_module);
         return rc;
     }
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
+    }
     rc = hcoll_collectives.coll_igatherv(sbuf,scount,stype,rbuf,rcounts,displs, rtype, root, hcoll_module->hcoll_context, rt_handle);
     if (HCOLL_SUCCESS != rc){
         HCOL_VERBOSE(20,"RUNNING FALLBACK IGATHERV");
@@ -710,6 +739,10 @@ int mca_coll_hcoll_ialltoallv(void *sbuf, int *scounts, int *sdisps,
                                                rbuf, rcounts, rdisps, rdtype,
                                                comm, request, hcoll_module->previous_alltoallv_module);
         return rc;
+    }
+    if (!hcoll_progress_registered) {
+        opal_progress_register(mca_coll_hcoll_progress);
+        hcoll_progress_registered = 1;
     }
     rc = hcoll_collectives.coll_ialltoallv((void *)sbuf, (int *)scounts, (int *)sdisps, stype,
                                            rbuf, (int *)rcounts, (int *)rdisps, rtype,


### PR DESCRIPTION
    Don't register mca_coll_hcoll_progress to opal_progress until the
    first call to hcoll non-blocking collective.

    V2.x version of #3371 
Signed-off-by: Valentin Petrov <valentinp@mellanox.com>