### PR TITLE
usnic: ensure to set the iov_limit to 1

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1552,6 +1552,8 @@ static int create_ep(opal_btl_usnic_module_t* module,
 
     hint->rx_attr->size = channel->chan_rd_num;
     hint->tx_attr->size = channel->chan_sd_num;
+    hint->tx_attr->iov_limit = 1;
+    hint->rx_attr->iov_limit = 1;
 
     /* specific ports requested? */
     sin = hint->src_addr;


### PR DESCRIPTION
The usNIC BTL does not use more than 1 iov, so be sure to set it to 1 so that we don't allocate cq/rq/sq entries based on a default (i.e., >1) number of iovs per entry.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>