### PR TITLE
v3.0.x: usnic: ensure to set the iov_limit to 1

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_component.c
+++ b/opal/mca/btl/usnic/btl_usnic_component.c
@@ -704,6 +704,8 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
     struct fi_info hints = {0};
     struct fi_ep_attr ep_attr = {0};
     struct fi_fabric_attr fabric_attr = {0};
+    struct fi_rx_attr rx_attr = {0};
+    struct fi_tx_attr tx_attr = {0};
 
     /* We only want providers named "usnic" that are of type EP_DGRAM */
     fabric_attr.prov_name = "usnic";
@@ -714,6 +716,11 @@ static mca_btl_base_module_t** usnic_component_init(int* num_btl_modules,
     hints.addr_format = FI_SOCKADDR;
     hints.ep_attr = &ep_attr;
     hints.fabric_attr = &fabric_attr;
+    hints.tx_attr = &tx_attr;
+    hints.rx_attr = &rx_attr;
+
+    tx_attr.iov_limit = 1;
+    rx_attr.iov_limit = 1;
 
     ret = fi_getinfo(libfabric_api, NULL, 0, 0, &hints, &info_list);
     if (0 != ret) {

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1552,8 +1552,6 @@ static int create_ep(opal_btl_usnic_module_t* module,
 
     hint->rx_attr->size = channel->chan_rd_num;
     hint->tx_attr->size = channel->chan_sd_num;
-    hint->tx_attr->iov_limit = 1;
-    hint->rx_attr->iov_limit = 1;
 
     /* specific ports requested? */
     sin = hint->src_addr;

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1552,6 +1552,8 @@ static int create_ep(opal_btl_usnic_module_t* module,
 
     hint->rx_attr->size = channel->chan_rd_num;
     hint->tx_attr->size = channel->chan_sd_num;
+    hint->tx_attr->iov_limit = 1;
+    hint->rx_attr->iov_limit = 1;
 
     /* specific ports requested? */
     sin = hint->src_addr;


### PR DESCRIPTION
The usNIC BTL does not use more than 1 iov, so be sure to set it to 1 so that we don't allocate cq/rq/sq entries based on a default (i.e., >1) number of iovs per entry.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 7bd2de9960419422a4591f4b5d286f1f911a0a47)