### PR TITLE
fortran: Fix `MPI_ARGV(S)_NULL` compilation error

### DIFF
--- a/ompi/mpi/fortran/base/gen-mpi-mangling.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-mangling.pl
@@ -77,13 +77,13 @@ $fortran->{weights_empty} = {
 $fortran->{argv_null} = {
     c_type => "char *",
     c_name => "mpi_fortran_argv_null",
-    f_type => "integer",
+    f_type => "character, dimension(1)",
     f_name => "MPI_ARGV_NULL",
 };
 $fortran->{argvs_null} = {
     c_type => "char *",
     c_name => "mpi_fortran_argvs_null",
-    f_type => "integer",
+    f_type => "character, dimension(1, 1)",
     f_name => "MPI_ARGVS_NULL",
 };
 


### PR DESCRIPTION
Fortran constants `MPI_ARGV_NULL` and `MPI_ARGVS_NULL` are defined in MPI-3.1 p.680 as below.

> `MPI_ARGVS_NULL`
>   2-dim. array of `CHARACTER*(*)`
> `MPI_ARGV_NULL`
>   array of `CHARACTER*(*)`

`MPI_ARGV_NULL` and `MPI_ARGVS_NULL` are used as an argument of `MPI_COMM_SPAWN` and `MPI_COMM_SPAWN_MULTIPLE` respectively and their argument `argv` and `array_of_argv` are defined as below for `USE mpi_f08` binding in MPI-3.1.

```Fortran
CHARACTER(LEN=*), INTENT(IN) :: argv(*)
CHARACTER(LEN=*), INTENT(IN) :: array_of_argv(count, *)
```

Defining them as `INTEGER` in `mpi_f08` module will cause a compilation error of user programs like "There is no specific subroutine for the generic 'mpi_comm_spawn'".

@ggouaillardet @jsquyres I'm not so familiar with Fortran and I don't know whether they are intentionally defined as `INTEGER` in 9c77c6b. Could you confirm my change?

`USE mpi` and `include 'mpif.h'` bindings use `ompi/include/mpif-sentinels.h` and the two variables are defined correctly:

```Frotran
!     Making MPI_ARGV_NULL be the same type as the parameter that is
!     exepected in the F90 binding for MPI_COMM_SPAWN means that we
!     don't need another interface for MPI_COMM_SPAWN.
      character mpi_argv_null(1)
!     Ditto for MPI_ARGVS_NULL / MPI_COMM_SPAWN_MULTIPLE.
      character mpi_argvs_null(1, 1)
```

This commit may break ABI compatibility. But it affects only Fortran `mpi_f08` module and `MPI_ARGV_NULL` and `MPI_ARGVS_NULL` with `mpi_f08` have not been able to use for their purpose (argument of `MPI_COMM_SPAWN(_MULTIPLE)`) ever. So I'll create PRs for release branches.
