### PR TITLE
mpi/java: Add missing Java binding methods

### DIFF
--- a/ompi/mpi/java/c/mpi_Comm.c
+++ b/ompi/mpi/java/c/mpi_Comm.c
@@ -13,6 +13,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -706,6 +707,13 @@ JNIEXPORT jlong JNICALL Java_mpi_Comm_getErrhandler(
     int rc = MPI_Errhandler_get((MPI_Comm)comm, &errhandler);
     ompi_java_exceptionCheck(env, rc);
     return (jlong)errhandler;
+}
+
+JNIEXPORT void JNICALL Java_mpi_Comm_callErrhandler(
+        JNIEnv *env, jobject jthis, jlong comm, jint errorCode)
+{
+    int rc = MPI_Comm_call_errhandler((MPI_Comm)comm, errorCode);
+    ompi_java_exceptionCheck(env, rc);
 }
 
 static int commCopyAttr(MPI_Comm oldcomm, int keyval, void *extraState,

--- a/ompi/mpi/java/c/mpi_File.c
+++ b/ompi/mpi/java/c/mpi_File.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -236,6 +237,20 @@ JNIEXPORT jlong JNICALL Java_mpi_File_iReadAt(
     return (jlong)request;
 }
 
+JNIEXPORT jlong JNICALL Java_mpi_File_iReadAtAll(
+        JNIEnv *env, jobject jthis, jlong fh, jlong offset,
+        jobject buf, jint count, jlong type)
+{
+    void *ptr = (*env)->GetDirectBufferAddress(env, buf);
+    MPI_Request request;
+
+    int rc = MPI_File_iread_at_all((MPI_File)fh, (MPI_Offset)offset,
+                                   ptr, count, (MPI_Datatype)type, &request);
+
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)request;
+}
+
 JNIEXPORT jlong JNICALL Java_mpi_File_iWriteAt(
         JNIEnv *env, jobject jthis, jlong fh, jlong offset,
         jobject buf, jint count, jlong type)
@@ -245,6 +260,20 @@ JNIEXPORT jlong JNICALL Java_mpi_File_iWriteAt(
 
     int rc = MPI_File_iwrite_at((MPI_File)fh, (MPI_Offset)offset,
                                 ptr, count, (MPI_Datatype)type, &request);
+
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)request;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_File_iWriteAtAll(
+        JNIEnv *env, jobject jthis, jlong fh, jlong offset,
+        jobject buf, jint count, jlong type)
+{
+    void *ptr = (*env)->GetDirectBufferAddress(env, buf);
+    MPI_Request request;
+
+    int rc = MPI_File_iwrite_at_all((MPI_File)fh, (MPI_Offset)offset,
+                                    ptr, count, (MPI_Datatype)type, &request);
 
     ompi_java_exceptionCheck(env, rc);
     return (jlong)request;
@@ -336,6 +365,20 @@ JNIEXPORT jlong JNICALL Java_mpi_File_iRead(
     return (jlong)request;
 }
 
+JNIEXPORT jlong JNICALL Java_mpi_File_iReadAll(
+        JNIEnv *env, jobject jthis, jlong fh,
+        jobject buf, jint count, jlong type)
+{
+    void *ptr = (*env)->GetDirectBufferAddress(env, buf);
+    MPI_Request request;
+
+    int rc = MPI_File_iread_all((MPI_File)fh, ptr, count,
+                                (MPI_Datatype)type, &request);
+
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)request;
+}
+
 JNIEXPORT jlong JNICALL Java_mpi_File_iWrite(
         JNIEnv *env, jobject jthis, jlong fh,
         jobject buf, jint count, jlong type)
@@ -345,6 +388,20 @@ JNIEXPORT jlong JNICALL Java_mpi_File_iWrite(
 
     int rc = MPI_File_iwrite((MPI_File)fh, ptr, count,
                              (MPI_Datatype)type, &request);
+
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)request;
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_File_iWriteAll(
+        JNIEnv *env, jobject jthis, jlong fh,
+        jobject buf, jint count, jlong type)
+{
+    void *ptr = (*env)->GetDirectBufferAddress(env, buf);
+    MPI_Request request;
+
+    int rc = MPI_File_iwrite_all((MPI_File)fh, ptr, count,
+                                 (MPI_Datatype)type, &request);
 
     ompi_java_exceptionCheck(env, rc);
     return (jlong)request;
@@ -646,9 +703,43 @@ JNIEXPORT void JNICALL Java_mpi_File_setAtomicity(
     ompi_java_exceptionCheck(env, rc);
 }
 
+JNIEXPORT jboolean JNICALL Java_mpi_File_getAtomicity(
+        JNIEnv *env, jobject jthis, jlong fh)
+{
+    int atomicity;
+    int rc = MPI_File_get_atomicity((MPI_File)fh, &atomicity);
+    ompi_java_exceptionCheck(env, rc);
+    return atomicity ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT void JNICALL Java_mpi_File_sync(
         JNIEnv *env, jobject jthis, jlong fh)
 {
     int rc = MPI_File_sync((MPI_File)fh);
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT void JNICALL Java_mpi_File_setErrhandler(
+        JNIEnv *env, jobject jthis, jlong fh, jlong errhandler)
+{
+    int rc = MPI_File_set_errhandler(
+             (MPI_File)fh, (MPI_Errhandler)errhandler);
+
+    ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_File_getErrhandler(
+        JNIEnv *env, jobject jthis, jlong fh)
+{
+    MPI_Errhandler errhandler;
+    int rc = MPI_File_get_errhandler((MPI_File)fh, &errhandler);
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)errhandler;
+}
+
+JNIEXPORT void JNICALL Java_mpi_File_callErrhandler(
+        JNIEnv *env, jobject jthis, jlong fh, jint errorCode)
+{
+    int rc = MPI_File_call_errhandler((MPI_File)fh, errorCode);
     ompi_java_exceptionCheck(env, rc);
 }

--- a/ompi/mpi/java/c/mpi_Win.c
+++ b/ompi/mpi/java/c/mpi_Win.c
@@ -222,7 +222,7 @@ JNIEXPORT void JNICALL Java_mpi_Win_setErrhandler(
         JNIEnv *env, jobject jthis, jlong win, jlong errhandler)
 {
     int rc = MPI_Win_set_errhandler(
-             (MPI_Win)win, (MPI_Errhandler)MPI_ERRORS_RETURN);
+             (MPI_Win)win, (MPI_Errhandler)errhandler);
 
     ompi_java_exceptionCheck(env, rc);
 }

--- a/ompi/mpi/java/c/mpi_Win.c
+++ b/ompi/mpi/java/c/mpi_Win.c
@@ -13,6 +13,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -224,6 +225,15 @@ JNIEXPORT void JNICALL Java_mpi_Win_setErrhandler(
              (MPI_Win)win, (MPI_Errhandler)MPI_ERRORS_RETURN);
 
     ompi_java_exceptionCheck(env, rc);
+}
+
+JNIEXPORT jlong JNICALL Java_mpi_Win_getErrhandler(
+        JNIEnv *env, jobject jthis, jlong win)
+{
+    MPI_Errhandler errhandler;
+    int rc = MPI_Win_get_errhandler((MPI_Win)win, &errhandler);
+    ompi_java_exceptionCheck(env, rc);
+    return (jlong)errhandler;
 }
 
 JNIEXPORT void JNICALL Java_mpi_Win_callErrhandler(

--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -13,6 +13,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1195,6 +1196,20 @@ public class Comm implements Freeable, Cloneable
 	}
 
 	private native long getErrhandler(long comm);
+
+	/**
+	 * Calls the error handler currently associated with the communicator.
+	 * <p>Java binding of the MPI operation {@code MPI_COMM_CALL_ERRHANDLER}.
+	 * @param errorCode error code
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public void callErrhandler(int errorCode) throws MPIException
+	{
+		callErrhandler(handle, errorCode);
+	}
+
+	private native void callErrhandler(long handle, int errorCode)
+			throws MPIException;
 
 	// Collective Communication
 

--- a/ompi/mpi/java/java/File.java
+++ b/ompi/mpi/java/java/File.java
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -406,6 +407,29 @@ public final class File
 					throws MPIException;
 
 	/**
+	 * Java binding of {@code MPI_FILE_IREAD_AT_ALL}.
+	 * @param offset file offset
+	 * @param buf    buffer
+	 * @param count  number of items in buffer
+	 * @param type   datatype of each buffer element
+	 * @return request object
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Request iReadAtAll(long offset, Buffer buf, int count, Datatype type)
+			throws MPIException
+	{
+		MPI.check();
+		assertDirectBuffer(buf);
+		Request req = new Request(iReadAtAll(handle, offset, buf, count, type.handle));
+		req.addRecvBufRef(buf);
+		return req;
+	}
+
+	private native long iReadAtAll(
+			long fh, long offset, Buffer buf, int count, long type)
+					throws MPIException;
+
+	/**
 	 * Java binding of {@code MPI_FILE_IWRITE_AT}.
 	 * @param offset file offset
 	 * @param buf    buffer
@@ -425,6 +449,29 @@ public final class File
 	}
 
 	private native long iWriteAt(
+			long fh, long offset, Buffer buf, int count, long type)
+					throws MPIException;
+
+	/**
+	 * Java binding of {@code MPI_FILE_IWRITE_AT_ALL}.
+	 * @param offset file offset
+	 * @param buf    buffer
+	 * @param count  number of items in buffer
+	 * @param type   datatype of each buffer element
+	 * @return request object
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Request iWriteAtAll(long offset, Buffer buf, int count, Datatype type)
+			throws MPIException
+	{
+		MPI.check();
+		assertDirectBuffer(buf);
+		Request req = new Request(iWriteAtAll(handle, offset, buf, count, type.handle));
+		req.addSendBufRef(buf);
+		return req;
+	}
+
+	private native long iWriteAtAll(
 			long fh, long offset, Buffer buf, int count, long type)
 					throws MPIException;
 
@@ -565,6 +612,26 @@ public final class File
 			throws MPIException;
 
 	/**
+	 * Java binding of {@code MPI_FILE_IREAD_ALL}.
+	 * @param buf   buffer
+	 * @param count number of items in buffer
+	 * @param type  datatype of each buffer element
+	 * @return request object
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Request iReadAll(Buffer buf, int count, Datatype type) throws MPIException
+	{
+		MPI.check();
+		assertDirectBuffer(buf);
+		Request req = new Request(iReadAll(handle, buf, count, type.handle));
+		req.addRecvBufRef(buf);
+		return req;
+	}
+
+	private native long iReadAll(long fh, Buffer buf, int count, long type)
+			throws MPIException;
+
+	/**
 	 * Java binding of {@code MPI_FILE_IWRITE}.
 	 * @param buf   buffer
 	 * @param count number of items in buffer
@@ -582,6 +649,26 @@ public final class File
 	}
 
 	private native long iWrite(long fh, Buffer buf, int count, long type)
+			throws MPIException;
+
+	/**
+	 * Java binding of {@code MPI_FILE_IWRITE_ALL}.
+	 * @param buf   buffer
+	 * @param count number of items in buffer
+	 * @param type  datatype of each buffer element
+	 * @return request object
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Request iWriteAll(Buffer buf, int count, Datatype type) throws MPIException
+	{
+		MPI.check();
+		assertDirectBuffer(buf);
+		Request req = new Request(iWriteAll(handle, buf, count, type.handle));
+		req.addRecvBufRef(buf);
+		return req;
+	}
+
+	private native long iWriteAll(long fh, Buffer buf, int count, long type)
 			throws MPIException;
 
 	/**
@@ -1235,6 +1322,19 @@ public final class File
 			throws MPIException;
 
 	/**
+	 * Java binding of {@code MPI_FILE_GET_ATOMICITY}.
+	 * @return current consistency of the file
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public boolean getAtomicity() throws MPIException
+	{
+		MPI.check();
+		return getAtomicity(handle);
+	}
+
+	private native boolean getAtomicity(long fh) throws MPIException;
+
+	/**
 	 * Java binding of {@code MPI_FILE_SYNC}.
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
 	 */
@@ -1245,5 +1345,45 @@ public final class File
 	}
 
 	private native void sync(long handle) throws MPIException;
+
+	/**
+	 * Java binding of the MPI operation {@code MPI_FILE_SET_ERRHANDLER}.
+	 * @param errhandler new MPI error handler for file
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public void setErrhandler(Errhandler errhandler) throws MPIException
+	{
+		MPI.check();
+		setErrhandler(handle, errhandler.handle);
+	}
+
+	private native void setErrhandler(long fh, long errhandler)
+			throws MPIException;
+
+	/**
+	 * Java binding of the MPI operation {@code MPI_FILE_GET_ERRHANDLER}.
+	 * @return MPI error handler currently associated with file
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Errhandler getErrhandler() throws MPIException
+	{
+		MPI.check();
+		return new Errhandler(getErrhandler(handle));
+	}
+
+	private native long getErrhandler(long fh);
+
+	/**
+	 * Java binding of the MPI operation {@code MPI_FILE_CALL_ERRHANDLER}.
+	 * @param errorCode error code
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public void callErrhandler(int errorCode) throws MPIException
+	{
+		callErrhandler(handle, errorCode);
+	}
+
+	private native void callErrhandler(long handle, int errorCode)
+			throws MPIException;
 
 } // File

--- a/ompi/mpi/java/java/Win.java
+++ b/ompi/mpi/java/java/Win.java
@@ -13,6 +13,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -426,6 +427,19 @@ public final class Win implements Freeable
 
 	private native void setErrhandler(long win, long errhandler)
 			throws MPIException;
+
+	/**
+	 * Java binding of the MPI operation {@code MPI_WIN_GET_ERRHANDLER}.
+	 * @return MPI error handler currently associated with window
+	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
+	 */
+	public Errhandler getErrhandler() throws MPIException
+	{
+		MPI.check();
+		return new Errhandler(getErrhandler(handle));
+	}
+
+	private native long getErrhandler(long win);
 
 	/**
 	 * Java binding of the MPI operation {@code MPI_WIN_CALL_ERRHANDLER}.


### PR DESCRIPTION
This commit add the following methods.

| Language-indep. notation | Java binding            |
| ------------------------ | ----------------------- |
| MPI_WIN_GET_ERRHANDLER   | mpi.Win.getErrhandler   |
| MPI_FILE_SET_ERRHANDLER  | mpi.File.setErrhandler  |
| MPI_FILE_GET_ERRHANDLER  | mpi.File.getErrhandler  |
| MPI_COMM_CALL_ERRHANDLER | mpi.Comm.callErrhandler |
| MPI_FILE_CALL_ERRHANDLER | mpi.File.callErrhandler |
| MPI_FILE_IREAD_AT_ALL    | mpi.File.iReadAtAll     |
| MPI_FILE_IWRITE_AT_ALL   | mpi.File.iWriteAtAll    |
| MPI_FILE_IREAD_ALL       | mpi.File.iReadAll       |
| MPI_FILE_IWRITE_ALL      | mpi.File.iWriteAll      |
| MPI_FILE_GET_ATOMICITY   | mpi.File.getAtomicity   |

`MPI_FILE_I{READ,WRITE}(_AT)_ALL` routines are added in MPI-3.1.
I don't know why other methods were missing.

Additionally, existing `mpi.Win.setErrhandler` is corrected.
