### PR TITLE
v3.0.x: mpif-externals.h: add missing MPI_AINT_ADD/MPI_AINT_DIFF

### DIFF
--- a/ompi/include/mpif-externals.h
+++ b/ompi/include/mpif-externals.h
@@ -10,7 +10,7 @@
 !                         University of Stuttgart.  All rights reserved.
 ! Copyright (c) 2004-2005 The Regents of the University of California.
 !                         All rights reserved.
-! Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
 ! $COPYRIGHT$
 !
 ! Additional copyrights may follow
@@ -41,4 +41,8 @@
 !
       external MPI_WTIME, MPI_WTICK , PMPI_WTICK, PMPI_WTIME
       double precision MPI_WTIME, MPI_WTICK , PMPI_WTICK, PMPI_WTIME
-
+!
+!     address integer functions
+!
+      external MPI_AINT_ADD, MPI_AINT_DIFF
+      integer(kind=MPI_ADDRESS_KIND) MPI_AINT_ADD, MPI_AINT_DIFF


### PR DESCRIPTION
MPI_AINT_ADD and MPI_AINT_DIFF are functions and must be declared as externals with the proper return type.  This is already done properly in the mpi and mpi_f08 modules; these declarations for these functions were only missing from mpif.h (i.e., mpif-externals.h).

Thanks to Aboorva Devarajan (@AboorvaDevarajan) for the bug report.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit d32eff6ea28dff2d29f0c79eeb09c357c468feff)