### PR TITLE
v2.1.1: update the VERSION file

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -4,6 +4,8 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
+                          reserved.
 
 # This is the VERSION file for Open MPI, describing the precise
 # version of Open MPI in this distribution.  The various components of
@@ -24,7 +26,7 @@ release=1
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=a1
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -82,17 +84,17 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=30:0:10
+libmpi_so_version=30:1:10
 libmpi_cxx_so_version=30:0:10
-libmpi_mpifh_so_version=30:0:10
+libmpi_mpifh_so_version=31:0:11
 libmpi_usempi_tkr_so_version=30:0:10
 libmpi_usempi_ignore_tkr_so_version=30:0:10
 libmpi_usempif08_so_version=30:0:10
 
-libopen_rte_so_version=30:0:10
-libopen_pal_so_version=30:0:10
+libopen_rte_so_version=30:1:10
+libopen_pal_so_version=30:1:10
 libmpi_java_so_version=30:0:10
-liboshmem_so_version=30:0:10
+liboshmem_so_version=30:1:10
 libompitrace_so_version=30:0:10
 
 # "Common" components install standalone libraries that are run-time
@@ -108,6 +110,6 @@ libmca_orte_common_alps_so_version=30:0:10
 # OPAL layer
 libmca_opal_common_cuda_so_version=30:0:10
 libmca_opal_common_libfabric_so_version=30:0:10
-libmca_opal_common_sm_so_version=30:0:10
+libmca_opal_common_sm_so_version=30:1:10
 libmca_opal_common_ugni_so_version=30:0:10
 libmca_opal_common_verbs_so_version=30:0:10


### PR DESCRIPTION
the upping of age and rev for libmpi.so/libmpif owes
to additions to the mpi.h and mpif.h include files.

[ci skip]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>