### PR TITLE
v2.x: fix duplication of stdin into --output-filename files

### DIFF
--- a/orte/mca/iof/orted/iof_orted_receive.c
+++ b/orte/mca/iof/orted/iof_orted_receive.c
@@ -136,6 +136,10 @@ void orte_iof_orted_recv(int status, orte_process_name_t* sender,
          item = opal_list_get_next(item)) {
         orte_iof_sink_t* sink = (orte_iof_sink_t*)item;
 
+        /* is this sink for stdin? it could be for writing a file from stdout/err */
+        if (!(ORTE_IOF_STDIN & sink->tag))
+            continue;
+
         /* is this intended for this jobid? */
         if (target.jobid == sink->name.jobid) {
             /* yes - is this intended for all vpids or this vpid? */


### PR DESCRIPTION
Looks like the stdin stream was being written to all sinks, even the ones meant for stdout/err/diag.  Fixes open-mpi/ompi#3392

3.x and master appear from the code like they might not suffer from the same issue.

Signed-off-by: Tim Burgess <ozburgess@gmail.com>