### PR TITLE
pmix/configure.m4: always use embedded mode

### DIFF
--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -61,7 +61,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
         opal_pmix_pmix2x_timing_flag=--disable-pmix-timing
     fi
 
-    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_sm_flag $opal_pmix_pmix2x_timing_flag --without-tests-examples --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
+    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_sm_flag $opal_pmix_pmix2x_timing_flag --without-tests-examples --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-mode"
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix2x_args="--enable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
@@ -69,7 +69,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
     AS_IF([test "$with_devel_headers" = "yes"],
           [opal_pmix_pmix2x_args="--with-devel-headers $opal_pmix_pmix2x_args"],
-          [opal_pmix_pmix2x_args="--enable-embedded-mode $opal_pmix_pmix2x_args"])
+          [opal_pmix_pmix2x_args=$opal_pmix_pmix2x_args])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"
 
     OPAL_CONFIG_SUBDIR([$opal_pmix_pmix2x_basedir/pmix],


### PR DESCRIPTION
Looks like embedded mode was mistakenly disabled when `--with-devel-headers` was specified.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

I don't know offhand which branches this affects -- assumedly at least v3.x.  I did not check the v2.x or v2.0.x branches.