### PR TITLE
v2.x: opal: add support for s390 and s390x architectures

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -1085,7 +1085,12 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
             fi
             OPAL_GCC_INLINE_ASSIGN='"1: li %0,0" : "=&r"(ret)'
             ;;
-
+        s390-*)
+            opal_cv_asm_arch="S390"
+            ;;
+        s390x-*)
+            opal_cv_asm_arch="S390X"
+            ;;
         sparc*-*)
             # SPARC v9 (and above) are the only ones with 64bit support
             # if compiling 32 bit, see if we are v9 (aka v8plus) or

--- a/opal/include/opal/sys/architecture.h
+++ b/opal/include/opal/sys/architecture.h
@@ -42,6 +42,8 @@
 #define OPAL_MIPS           0070
 #define OPAL_ARM            0100
 #define OPAL_ARM64          0101
+#define OPAL_S390           0110
+#define OPAL_S390X          0111
 #define OPAL_BUILTIN_SYNC   0200
 #define OPAL_BUILTIN_OSX    0201
 #define OPAL_BUILTIN_GCC    0202

--- a/opal/include/opal/sys/cma.h
+++ b/opal/include/opal/sys/cma.h
@@ -87,6 +87,16 @@
 
 #endif
 
+#elif OPAL_ASSEMBLY_ARCH == OPAL_S390
+
+#define __NR_process_vm_readv	340
+#define __NR_process_vm_writev	341
+
+#elif OPAL_ASSEMBLY_ARCH == OPAL_S390X
+
+#define __NR_process_vm_readv	340
+#define __NR_process_vm_writev	341
+
 #else
 #error "Unsupported architecture for process_vm_readv and process_vm_writev syscalls"
 #endif


### PR DESCRIPTION
Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>