### PR TITLE
Lustre configure fixes

### DIFF
--- a/config/ompi_check_lustre.m4
+++ b/config/ompi_check_lustre.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2008-2012 University of Houston. All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
@@ -46,7 +46,7 @@ AC_DEFUN([OMPI_CHECK_LUSTRE],[
              [Build Lustre support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     OPAL_CHECK_WITHDIR([lustre], [$with_lustre], [include/lustre/liblustreapi.h])
 
-    AS_IF([test -z "$with_lustre"],
+    AS_IF([test -z "$with_lustre" || test "$with_lustre" = "yes"],
           [ompi_check_lustre_dir="/usr"],
           [ompi_check_lustre_dir="$with_lustre"])
 

--- a/config/ompi_check_lustre.m4
+++ b/config/ompi_check_lustre.m4
@@ -39,7 +39,6 @@ AC_DEFUN([OMPI_CHECK_LUSTRE],[
     check_lustre_configuration="none"
     ompi_check_lustre_happy="yes"
 
-
     # Get some configuration information
     AC_ARG_WITH([lustre],
         [AC_HELP_STRING([--with-lustre(=DIR)],
@@ -48,7 +47,7 @@ AC_DEFUN([OMPI_CHECK_LUSTRE],[
 
     AS_IF([test -z "$with_lustre" || test "$with_lustre" = "yes"],
           [ompi_check_lustre_dir="/usr"],
-          [ompi_check_lustre_dir="$with_lustre"])
+          [ompi_check_lustre_dir=$with_lustre])
 
     if test -e "$ompi_check_lustre_dir/lib64" ; then
         ompi_check_lustre_libdir="$ompi_check_lustre_dir/lib64"

--- a/config/ompi_check_lustre.m4
+++ b/config/ompi_check_lustre.m4
@@ -87,6 +87,6 @@ OPAL_LOG_COMMAND(
     AS_IF([test "$ompi_check_lustre_happy" = "yes"],
           [$2],
           [AS_IF([test ! -z "$with_lustre" && test "$with_lustre" != "no"],
-                  [echo LUSTRE support not found])
-              $3])
+                 [AC_MSG_ERROR([Lustre support requested but not found.  Aborting])])
+           $3])
 ])

--- a/ompi/mca/fs/lustre/configure.m4
+++ b/ompi/mca/fs/lustre/configure.m4
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2008-2012 University of Houston. All rights reserved.
 # $COPYRIGHT$
 #
@@ -33,12 +33,6 @@ AC_DEFUN([MCA_ompi_fs_lustre_CONFIG],[
     AS_IF([test "$fs_lustre_happy" = "yes"],
           [$1],
           [$2])
-
-#    AC_CHECK_HEADERS([lustre/liblustreapi.h], [],
-#                      [AC_CHECK_HEADERS([lustre/liblustreapi.h], [], [$2],
-#                          [AC_INCLUDES_DEFAULT])],
-#                      [AC_INCLUDES_DEFAULT])
-
 
     # substitute in the things needed to build lustre
     AC_SUBST([fs_lustre_CPPFLAGS])


### PR DESCRIPTION
@edgargabriel This PR is a few commits to update/fix Lustre `configure.m4`:

1. Ensure that `--with-lustre` doesn't cause a compile fail (per #3447)
1. Ensure that if the user does `--with-lustre` and we can't find Lustre support, abort
1. Remove some dead code
1. Trivial style updates

Fixes #3447.

Can you review?  If it's good, I'll PR to the various 2.x/3.x branches.