### PR TITLE
Fix pmix configury so that libpmix is still emitted when --with-devel-headers is given, even under static builds

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/Makefile.am
+++ b/opal/mca/pmix/pmix2x/pmix/src/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -49,9 +49,21 @@ libpmix_la_LIBADD = \
 libpmix_la_DEPENDENCIES = $(libpmix_la_LIBADD)
 
 if PMIX_EMBEDDED_MODE
+
+if WANT_INSTALL_HEADERS
+
+# retain output of pmix library
+lib_LTLIBRARIES = libpmix.la
+libpmix_la_SOURCES = $(headers) $(sources)
+libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
+
+else
+
 noinst_LTLIBRARIES = libpmix.la
 libpmix_la_SOURCES = $(headers) $(sources)
 libpmix_la_LDFLAGS =
+
+endif
 
 else
 


### PR DESCRIPTION
Refs https://github.com/open-mpi/ompi/commit/af336ac0e80440871479bd1f33aa2184d15bb1dc

Signed-off-by: Ralph Castain <rhc@open-mpi.org>