### PR TITLE
Enable full operations under SLURM on Cray systems

### DIFF
--- a/config/orte_check_slurm.m4
+++ b/config/orte_check_slurm.m4
@@ -13,6 +13,7 @@
 # Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -67,6 +68,15 @@ AC_DEFUN([ORTE_CHECK_SLURM],[
               [AC_CHECK_FUNC([setpgid],
                              [orte_check_slurm_happy="yes"],
                              [orte_check_slurm_happy="no"])])
+
+        # check to see if this is a Cray nativized slurm env.
+
+        slurm_cray_env=0
+        OPAL_CHECK_ALPS([orte_slurm_cray],
+                        [slurm_cray_env=1])
+
+        AC_DEFINE_UNQUOTED([SLURM_CRAY_ENV],[$slurm_cray_env],
+                           [defined to 1 if slurm cray env, 0 otherwise])
 
         OPAL_SUMMARY_ADD([[Resource Managers]],[[Slurm]],[$1],[$orte_check_slurm_happy])
     fi

--- a/orte/mca/plm/slurm/configure.m4
+++ b/orte/mca/plm/slurm/configure.m4
@@ -13,6 +13,7 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,12 +39,4 @@ AC_DEFUN([MCA_orte_plm_slurm_CONFIG],[
     AC_SUBST([plm_slurm_LDFLAGS])
     AC_SUBST([plm_slurm_LIBS])
 
-    # check to see if this is a Cray nativized slurm env.
-
-    slurm_cray_env=0
-    OPAL_CHECK_ALPS([plm_slurm_cray],
-                    [slurm_cray_env=1])
-
-    AC_DEFINE_UNQUOTED([SLURM_CRAY_ENV],[$slurm_cray_env],
-                       [defined to 1 if slurm cray env, 0 otherwise])
 ])dnl

--- a/orte/mca/plm/slurm/help-plm-slurm.txt
+++ b/orte/mca/plm/slurm/help-plm-slurm.txt
@@ -49,18 +49,3 @@ are running.
 
 Please consult with your system administrator about obtaining
 such support.
-[no-local-support]
-The SLURM process starter cannot start processes local to
-mpirun when executing under a Cray environment. The problem
-is that mpirun is not itself a child of a slurmd daemon. Thus,
-any processes mpirun itself starts will inherit incorrect
-RDMA credentials.
-
-Your application will be mapped and run (assuming adequate
-resources) on the remaining allocated nodes. If adequate
-resources are not available, you will need to exit and obtain
-a larger allocation.
-
-This situation will be fixed in a future release. Meantime,
-you can turn "off" this warning by setting the plm_slurm_warning
-MCA param to 0.

--- a/orte/mca/plm/slurm/plm_slurm_module.c
+++ b/orte/mca/plm/slurm/plm_slurm_module.c
@@ -193,25 +193,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
                          "%s plm:slurm: LAUNCH DAEMONS CALLED",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
 
-#if SLURM_CRAY_ENV
-        /* if we are in a Cray-SLURM environment, then we cannot
-         * launch procs local to the HNP. The problem
-         * is the MPI processes launched on the head node (where the
-         * ORTE_PROC_IS_HNP evalues to true) get launched by a daemon
-         * (mpirun) which is not a child of a slurmd daemon.  This
-         * means that any RDMA credentials obtained via the odls/alps
-         * local launcher are incorrect. So warn the user and set
-         * the envar for no_schedule_local if mpirun is not on a
-         * system management node (i.e. is part of the allocation)
-         * and the "no_use_local" flag hasn't been set */
-        if (mca_plm_slurm_component.slurm_warning_msg &&
-            (orte_hnp_is_allocated && !(ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping) & ORTE_MAPPING_NO_USE_LOCAL))) {
-            orte_show_help("help-plm-slurm.txt", "no-local-support", true);
-            ORTE_SET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping, ORTE_MAPPING_NO_USE_LOCAL);
-            mca_plm_slurm_component.slurm_warning_msg = false;  // only do this once
-        }
-#endif
-
     /* if we are launching debugger daemons, then just go
      * do it - no new daemons will be launched
      */


### PR DESCRIPTION
Enable full operations under SLURM on Cray systems by co-locating a daemon with mpirun when mpirun is executing on a compute node in that environment. This allows local application procs to inherit their security credential from the daemon as it will have been launched via SLURM

Tested on gadget

Signed-off-by: Ralph Castain <rhc@open-mpi.org>