### PR TITLE
Revert "group: Fix `ompi_group_have_remote_peers`"

### DIFF
--- a/ompi/group/group.c
+++ b/ompi/group/group.c
@@ -563,13 +563,10 @@ bool ompi_group_have_remote_peers (ompi_group_t *group)
 #if OMPI_GROUP_SPARSE
         proc = ompi_group_peer_lookup (group, i);
 #else
-        proc = ompi_group_get_proc_ptr_raw (group, i);
-        if (NULL == proc) {
-            /* the proc must be stored in the group or cached in the proc
-             * hash table if the process resides in the local node
-             * (see ompi_proc_complete_init) */
+        if (ompi_proc_is_sentinel (group->grp_proc_pointers[i])) {
             return true;
         }
+        proc = group->grp_proc_pointers[i];
 #endif
         if (!OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
             return true;


### PR DESCRIPTION
Reverts open-mpi/ompi#3410

@rhc54 reported this commit causes a segmentation fault and I can reproduce it.
Sorry for annoying commit.
