### PR TITLE
group: Fix `ompi_group_have_remote_peers` (2nd try)

### DIFF
--- a/ompi/group/group.c
+++ b/ompi/group/group.c
@@ -563,10 +563,13 @@ bool ompi_group_have_remote_peers (ompi_group_t *group)
 #if OMPI_GROUP_SPARSE
         proc = ompi_group_peer_lookup (group, i);
 #else
-        if (ompi_proc_is_sentinel (group->grp_proc_pointers[i])) {
+        proc = ompi_group_get_proc_ptr_raw (group, i);
+        if (ompi_proc_is_sentinel (proc)) {
+            /* the proc must be stored in the group or cached in the proc
+             * hash table if the process resides in the local node
+             * (see ompi_proc_complete_init) */
             return true;
         }
-        proc = group->grp_proc_pointers[i];
 #endif
         if (!OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)) {
             return true;


### PR DESCRIPTION
2nd try of #3410.

Difference from #3410 is that a returned value of `ompi_group_get_proc_ptr_raw` is checked with `ompi_proc_is_sentinel` instead of `NULL`.

I'll create PRs against v3.0, v2.x, and v2.0.x if MTT doesn't show an error.

Original PR description of #3410:

`ompi_group_t::grp_proc_pointers[i]` may have sentinel values even for processes which reside in the local node because the array for `MPI_COMM_WORLD` is set up before `ompi_proc_complete_init`, which allocates `ompi_proc_t` objects for processes reside in the local node, is called in `MPI_INIT`. So using `ompi_proc_is_sentinel` against `ompi_group_t::grp_proc_pointers[i]` in order to determine whether the process resides in a remote node is not appropriate.

This bug sometimes causes an `MPI_ERR_RMA_SHARED` error when `MPI_WIN_ALLOCATE_SHARED` is called, where sm OSC uses `ompi_group_have_remote_peers`.

Bug reproducer program:

```c
// run as "mpiexec -n 2 --host localhost,localhost a.out" (all processes in one node)

#include <mpi.h>
int main(int argc, char *argv[])
{
    void *base;
    MPI_Win win;
    MPI_Init(&argc, &argv);
    MPI_Win_allocate_shared(8, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &base, &win);
    MPI_Win_free(&win);
    MPI_Finalize();
    return 0;
}
```

This is a regression introduced in v2.0 (dynamic add_procs enhancement).
