### PR TITLE
v2.0.x: Add volatile to the pointer in the list_item structure.

### DIFF
--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -101,9 +101,9 @@ struct opal_list_item_t
 {
     opal_object_t super;
     /**< Generic parent class for all Open MPI objects */
-    volatile struct opal_list_item_t *opal_list_next;
+    volatile struct opal_list_item_t * volatile opal_list_next;
     /**< Pointer to next list item */
-    volatile struct opal_list_item_t *opal_list_prev;
+    volatile struct opal_list_item_t * volatile opal_list_prev;
     /**< Pointer to previous list item */
     int32_t item_free;
 


### PR DESCRIPTION
This change has the side effect of improving the performance of all atomic data structures (in addition to making the code correct under a certain interpretation of the volatile usage).

Original issue: #3450
Master PR: #3468
Fixes #3476 (v2.0.x tracking issue)

Has been approved by @hjelmn @bwbarrett @bosilca on master.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit d7ebcca93fc86796e0d43997935539b1e922a1f1)
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>