### PR TITLE
v3.0.x: Add volatile to the pointer in the list_item structure. (#3468)

### DIFF
--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -48,7 +48,7 @@ union opal_counted_pointer_t {
         /** update counter used when cmpset_128 is available */
         uint64_t counter;
         /** list item pointer */
-        opal_list_item_t *item;
+        volatile opal_list_item_t * volatile item;
     } data;
 #if OPAL_HAVE_ATOMIC_CMPSET_128 && HAVE_OPAL_INT128_T
     /** used for atomics when there is a cmpset that can operate on
@@ -138,14 +138,14 @@ static inline opal_list_item_t *opal_lifo_push_atomic (opal_lifo_t *lifo,
  */
 static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
 {
+    opal_counted_pointer_t old_head;
     opal_list_item_t *item;
 
     do {
-        opal_counted_pointer_t old_head;
 
         old_head.data.counter = lifo->opal_lifo_head.data.counter;
         opal_atomic_rmb ();
-        item = old_head.data.item = lifo->opal_lifo_head.data.item;
+        old_head.data.item = item = (opal_list_item_t*)lifo->opal_lifo_head.data.item;
 
         if (item == &lifo->opal_lifo_ghost) {
             return NULL;

--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -103,9 +103,9 @@ struct opal_list_item_t
 {
     opal_object_t super;
     /**< Generic parent class for all Open MPI objects */
-    volatile struct opal_list_item_t *opal_list_next;
+    volatile struct opal_list_item_t * volatile opal_list_next;
     /**< Pointer to next list item */
-    volatile struct opal_list_item_t *opal_list_prev;
+    volatile struct opal_list_item_t * volatile opal_list_prev;
     /**< Pointer to previous list item */
     int32_t item_free;
 


### PR DESCRIPTION
This change has the side effect of improving the performance of all atomic data structures (in addition to making the code correct under a certain interpretation of the volatile usage).

Original issue: #3450
Master PR: #3468
Fixes #3478 (v3.0.x tracking issue)

Has been approved by @hjelmn @bwbarrett @bosilca on master.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit d7ebcca93fc86796e0d43997935539b1e922a1f1)
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>