### PR TITLE
Update the RML/OFI component

### DIFF
--- a/orte/mca/rml/ofi/rml_ofi_component.c
+++ b/orte/mca/rml/ofi/rml_ofi_component.c
@@ -970,7 +970,6 @@ static orte_rml_base_module_t* open_conduit(opal_list_t *attributes)
         return NULL;
     }
 
-
     /* someone may require this specific component, so look for "ofi" */
     if (orte_get_attribute(attributes, ORTE_RML_INCLUDE_COMP_ATTRIB, (void**)&comp_attrib, OPAL_STRING) &&
         NULL != comp_attrib) {
@@ -998,17 +997,23 @@ static orte_rml_base_module_t* open_conduit(opal_list_t *attributes)
             }
         }
     }
-
     /*[Debug] to check for daemon commn over ofi-ethernet, enable the default conduit  ORTE_MGMT_CONDUIT over ofi */
     if (orte_get_attribute(attributes, ORTE_RML_TRANSPORT_TYPE, (void**)&comp_attrib, OPAL_STRING) &&
         NULL != comp_attrib) {
             opal_output_verbose(20,orte_rml_base_framework.framework_output,
-                    "%s - Forcibly returning ofi socket provider for ethernet transport request",
-                    ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+                    "%s - ORTE_RML_TRANSPORT_TYPE = %s ",
+                    ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), comp_attrib);
         comps = opal_argv_split(comp_attrib, ',');
         for (i=0; NULL != comps[i]; i++) {
-            if (0 == strcmp(comps[i], "ethernet")) {
+            /* changing below to check for oob, as trying to use ofi for only mgmt conduit */
+            if (0 == strcmp(comps[i], "oob")) {
+            /* changing below to check for fabric, as trying to use ofi for only coll conduit
+            if (0 == strcmp(comps[i], "fabric")) { */
+            /*if (0 == strcmp(comps[i], "ethernet")) { */
                 /* we are a candidate,  */
+            opal_output_verbose(20,orte_rml_base_framework.framework_output,
+                    "%s - Forcibly returning ofi socket provider for ethernet transport request",
+                    ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
                 opal_argv_free(comps);
                 OBJ_CONSTRUCT(&provider, opal_list_t);
                 orte_set_attribute(&provider, ORTE_RML_PROVIDER_ATTRIB,
@@ -1018,7 +1023,7 @@ static orte_rml_base_module_t* open_conduit(opal_list_t *attributes)
         }
         opal_argv_free(comps);
     }
-    /*[Debug] */
+    /* end [Debug] */
 
     /* Alternatively, check the attributes to see if we qualify - we only handle
      * "pt2pt" */
@@ -1241,6 +1246,7 @@ void convert_to_sockaddr( char *ofiuri, struct sockaddr_in* ep_sockaddr)
     ep_sockaddr->sin_family = atoi( sin_fly );
     port = atoi( sin_port);
     ep_sockaddr->sin_port   = htons(port);
+    ep_sockaddr->sin_addr.s_addr = inet_addr(sin_addr);
     opal_output_verbose(1,orte_rml_base_framework.framework_output,
                         "%s OFI convert_to_sockaddr() port = 0x%x decimal-%d, InternetAddr = %s  ",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),ntohs(ep_sockaddr->sin_port),ntohs(ep_sockaddr->sin_port),

--- a/orte/mca/rml/ofi/rml_ofi_send.c
+++ b/orte/mca/rml/ofi/rml_ofi_send.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,7 +71,6 @@ static void ofi_recv_msg_queue_des(ofi_recv_msg_queue_t *ptr)
 OBJ_CLASS_INSTANCE(ofi_recv_msg_queue_t,
                    opal_list_item_t,
                    ofi_recv_msg_queue_cons, ofi_recv_msg_queue_des);
-
 
 static void send_self_exe(int fd, short args, void* data)
 {
@@ -523,7 +522,7 @@ static void send_msg(int fd, short args, void *cbdata)
       }
    }
     if ( OPAL_SUCCESS == ret) {
-           //Anandhi added for debug purpose
+           //[Debug] printing additional info of IP
             switch ( orte_rml_ofi.ofi_prov[ofi_prov_id].fabric_info->addr_format)
             {
                 case  FI_SOCKADDR_IN :
@@ -531,14 +530,14 @@ static void send_msg(int fd, short args, void *cbdata)
                     /*[debug] - print the sockaddr - port and s_addr */
                     ep_sockaddr = (struct sockaddr_in*)dest_ep_name;
                     opal_output_verbose(1,orte_rml_base_framework.framework_output,
-                            "%s peer %s epnamelen is %lu, port = %d (or) 0x%x, InternetAddr = 0x%s  ",
+                            "%s peer %s epnamelen is %d, port = %d (or) 0x%x, InternetAddr = 0x%s  ",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),ORTE_NAME_PRINT(peer),
                             orte_rml_ofi.ofi_prov[ofi_prov_id].epnamelen,ntohs(ep_sockaddr->sin_port),
                             ntohs(ep_sockaddr->sin_port),inet_ntoa(ep_sockaddr->sin_addr));
                     /*[end debug]*/
                     break;
             }
-            //Anandhi end debug
+            //[Debug] end debug
         opal_output_verbose(10, orte_rml_base_framework.framework_output,
                          "%s OPAL_MODEX_RECV succeded, %s peer ep name obtained. length=%lu",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
@@ -552,6 +551,7 @@ static void send_msg(int fd, short args, void *cbdata)
             snd->status = ORTE_ERR_ADDRESSEE_UNKNOWN;
 
                 ORTE_RML_SEND_COMPLETE(snd);
+
                 return;
         }
     } else {


### PR DESCRIPTION
Combine a whole lot of commits from @anandhis branch to make just one that has been signed off. This updates the RML/OFI component to make it operational, leaving the opal_ignore in place

Signed-off-by: Ralph Castain <rhc@open-mpi.org>