### PR TITLE
configury: add option to disable enable-new-dtags

### DIFF
--- a/README
+++ b/README
@@ -796,6 +796,10 @@ INSTALLATION OPTIONS
   This rpath/runpath behavior can be disabled via
   --disable-wrapper-rpath.
 
+  If you would like to keep the rpath option, but not enable runpath
+  a different configure option is avalabile
+  --disable-wrapper-runpath.
+
 --enable-dlopen
   Build all of Open MPI's components as standalone Dynamic Shared
   Objects (DSO's) that are loaded at run-time (this is the default).


### PR DESCRIPTION
The --enable-new-dtags option for the compiler wrappers is
often great, but for some particular install/usage scenarios
causes issues.

This commit provides a new configury option to use of rpath
in the compiler wrappers, but disables the
use of --enable-new-dtags in the link line.

To disable use of --enable-new-dtags in the Open MPI compiler
wrappers, add the following to the Open MPI configury line

--disable-wrapper-runpath

Fixes #1089

Filer of issue verified the fix works for him.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>