### PR TITLE
bump version to 2.1.2

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -17,7 +17,7 @@
 
 major=2
 minor=1
-release=1
+release=2
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -26,7 +26,7 @@ release=1
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
[skip ci]
bot:notest

Signed-off-by: Howard Pritchard <howardp@lanl.gov>