### PR TITLE
PSM and PSM2 MTLs check on the max message size allowed by API.

### DIFF
--- a/ompi/mca/mtl/psm/help-mtl-psm.txt
+++ b/ompi/mca/mtl/psm/help-mtl-psm.txt
@@ -37,7 +37,10 @@ Unable to post application receive buffer (psm_mq_irecv).
 
   Error:      %s
   Buffer:     %p
-  Length:     %d
+  Length:     %llu
 #
 [path query mechanism unknown]
 Unknown path record query mechanism %s. Supported mechanisms are %s.
+#
+[message too big]
+Message size %llu bigger than supported by PSM API. Max = %llu

--- a/ompi/mca/mtl/psm/mtl_psm_recv.c
+++ b/ompi/mca/mtl/psm/mtl_psm_recv.c
@@ -50,6 +50,13 @@ ompi_mtl_psm_irecv(struct mca_mtl_base_module_t* mtl,
 
     if (OMPI_SUCCESS != ret) return ret;
 
+    if (length >= 1ULL << sizeof(uint32_t) * 8) {
+            opal_show_help("help-mtl-psm.txt",
+                   "message too big", false,
+                   length, 1ULL << sizeof(uint32_t) * 8);
+            return OMPI_ERROR;
+    }
+
     mtl_psm_request->length = length;
     mtl_psm_request->convertor = convertor;
     mtl_psm_request->type = OMPI_MTL_PSM_IRECV;

--- a/ompi/mca/mtl/psm/mtl_psm_send.c
+++ b/ompi/mca/mtl/psm/mtl_psm_send.c
@@ -24,6 +24,7 @@
 #include "ompi/mca/pml/pml.h"
 #include "ompi/communicator/communicator.h"
 #include "opal/datatype/opal_convertor.h"
+#include "opal/util/show_help.h"
 
 #include "mtl_psm.h"
 #include "mtl_psm_types.h"
@@ -56,12 +57,18 @@ ompi_mtl_psm_send(struct mca_mtl_base_module_t* mtl,
                                  &length,
                                  &mtl_psm_request.free_after);
 
+    if (OMPI_SUCCESS != ret) return ret;
+
+    if (length >= 1ULL << sizeof(uint32_t) * 8) {
+            opal_show_help("help-mtl-psm.txt",
+                   "message too big", false,
+                   length, 1ULL << sizeof(uint32_t) * 8);
+            return OMPI_ERROR;
+    }
 
     mtl_psm_request.length = length;
     mtl_psm_request.convertor = convertor;
     mtl_psm_request.type = OMPI_MTL_PSM_ISEND;
-
-    if (OMPI_SUCCESS != ret) return ret;
 
     if (mode == MCA_PML_BASE_SEND_SYNCHRONOUS)
 	flags |= PSM_MQ_FLAG_SENDSYNC;
@@ -109,11 +116,19 @@ ompi_mtl_psm_isend(struct mca_mtl_base_module_t* mtl,
                                  &length,
                                  &mtl_psm_request->free_after);
 
+
+    if (OMPI_SUCCESS != ret) return ret;
+
+    if (length >= 1ULL << sizeof(uint32_t) * 8) {
+            opal_show_help("help-mtl-psm.txt",
+                   "message too big", false,
+                   length, 1ULL << sizeof(uint32_t) * 8);
+            return OMPI_ERROR;
+    }
+
     mtl_psm_request->length= length;
     mtl_psm_request->convertor = convertor;
     mtl_psm_request->type = OMPI_MTL_PSM_ISEND;
-
-    if (OMPI_SUCCESS != ret) return ret;
 
     if (mode == MCA_PML_BASE_SEND_SYNCHRONOUS)
 	flags |= PSM_MQ_FLAG_SENDSYNC;

--- a/ompi/mca/mtl/psm2/help-mtl-psm2.txt
+++ b/ompi/mca/mtl/psm2/help-mtl-psm2.txt
@@ -38,7 +38,10 @@ Unable to post application receive buffer (psm2_mq_irecv or psm2_mq_imrecv).
 
   Error:      %s
   Buffer:     %p
-  Length:     %d
+  Length:     %llu
 #
 [path query mechanism unknown]
 Unknown path record query mechanism %s. Supported mechanisms are %s.
+#
+[message too big]
+Message size %llu bigger than supported by PSM2 API. Max = %llu

--- a/ompi/mca/mtl/psm2/mtl_psm2_recv.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_recv.c
@@ -52,6 +52,13 @@ ompi_mtl_psm2_irecv(struct mca_mtl_base_module_t* mtl,
 
     if (OMPI_SUCCESS != ret) return ret;
 
+    if (length >= 1ULL << sizeof(uint32_t) * 8) {
+            opal_show_help("help-mtl-psm2.txt",
+		    "message too big", false,
+		    length, 1ULL << sizeof(uint32_t) * 8);
+            return OMPI_ERROR;
+    }
+
     mtl_psm2_request->length = length;
     mtl_psm2_request->convertor = convertor;
     mtl_psm2_request->type = OMPI_mtl_psm2_IRECV;
@@ -101,6 +108,13 @@ ompi_mtl_psm2_imrecv(struct mca_mtl_base_module_t* mtl,
                                      &mtl_psm2_request->free_after);
 
     if (OMPI_SUCCESS != ret) return ret;
+
+    if (length >= 1ULL << sizeof(uint32_t) * 8) {
+            opal_show_help("help-mtl-psm2.txt",
+		    "message too big", false,
+		    length, 1ULL << sizeof(uint32_t) * 8);
+            return OMPI_ERROR;
+    }
 
     mtl_psm2_request->length = length;
     mtl_psm2_request->convertor = convertor;

--- a/ompi/mca/mtl/psm2/mtl_psm2_send.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_send.c
@@ -22,6 +22,7 @@
 #include "ompi/mca/pml/pml.h"
 #include "ompi/communicator/communicator.h"
 #include "opal/datatype/opal_convertor.h"
+#include "opal/util/show_help.h"
 
 #include "mtl_psm2.h"
 #include "mtl_psm2_types.h"
@@ -54,6 +55,12 @@ ompi_mtl_psm2_send(struct mca_mtl_base_module_t* mtl,
                                  &length,
                                  &mtl_psm2_request.free_after);
 
+    if (length >= 1ULL << sizeof(uint32_t) * 8) {
+            opal_show_help("help-mtl-psm2.txt",
+		    "message too big", false,
+		    length, 1ULL << sizeof(uint32_t) * 8);
+            return OMPI_ERROR;
+    }
 
     mtl_psm2_request.length = length;
     mtl_psm2_request.convertor = convertor;
@@ -106,6 +113,13 @@ ompi_mtl_psm2_isend(struct mca_mtl_base_module_t* mtl,
                                  &mtl_psm2_request->buf,
                                  &length,
                                  &mtl_psm2_request->free_after);
+
+    if (length >= 1ULL << sizeof(uint32_t) * 8) {
+            opal_show_help("help-mtl-psm2.txt",
+		    "message too big", false,
+		    length, 1ULL << sizeof(uint32_t) * 8);
+            return OMPI_ERROR;
+    }
 
     mtl_psm2_request->length= length;
     mtl_psm2_request->convertor = convertor;


### PR DESCRIPTION
OMPI send and receive mesages use size_t for the lenght while PSM and PSM2
psm(2)mq_send/receive use uint32_t. Type size_t is 64 bits in 64 bits arch.
Therefore, this patch adds a sanity check on the lenght of the message
and fails gracefully.

Signed-off-by: Matias Cabral <matias.a.cabral@intel.com>
(cherry picked from commit 644641d06ffedda2c798ea1fbfcc1e782ca880f6)