### PR TITLE
Fix total_slots_allocated computation

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -150,6 +150,7 @@ void orte_plm_base_daemons_reported(int fd, short args, void *cbdata)
     if (!orte_managed_allocation) {
         if (NULL != orte_set_slots &&
             0 != strncmp(orte_set_slots, "none", strlen(orte_set_slots))) {
+            caddy->jdata->total_slots_alloc = 0;
             for (i=0; i < orte_node_pool->size; i++) {
                 if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, i))) {
                     continue;
@@ -160,6 +161,7 @@ void orte_plm_base_daemons_reported(int fd, short args, void *cbdata)
                                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), node->name, orte_set_slots));
                     orte_plm_base_set_slots(node);
                 }
+                caddy->jdata->total_slots_alloc += node->slots;
             }
         }
     }

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -520,7 +520,9 @@ void orte_rmaps_base_display_map(orte_job_t *jdata)
             }
         }
     } else {
-        opal_output(orte_clean_output, " Data for JOB %s offset %s", ORTE_JOBID_PRINT(jdata->jobid), ORTE_VPID_PRINT(jdata->offset));
+        opal_output(orte_clean_output, " Data for JOB %s offset %s Total slots allocated %lu",
+                    ORTE_JOBID_PRINT(jdata->jobid), ORTE_VPID_PRINT(jdata->offset),
+                    (long unsigned)jdata->total_slots_alloc);
         opal_dss.print(&output, NULL, jdata->map, ORTE_JOB_MAP);
         if (orte_xml_output) {
             fprintf(orte_xml_fp, "%s\n", output);


### PR DESCRIPTION
On unmanaged allocations, we need to update the total_slots_allocated once the daemons have been launched and "discovered" their topology

Signed-off-by: Ralph Castain <rhc@open-mpi.org>