### PR TITLE
v2.x: fortran: Fix `MPI_ARGV(S)_NULL` compilation error

### DIFF
--- a/ompi/mpi/fortran/base/gen-mpi-mangling.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-mangling.pl
@@ -77,13 +77,13 @@ $fortran->{weights_empty} = {
 $fortran->{argv_null} = {
     c_type => "char *",
     c_name => "mpi_fortran_argv_null",
-    f_type => "integer",
+    f_type => "character, dimension(1)",
     f_name => "MPI_ARGV_NULL",
 };
 $fortran->{argvs_null} = {
     c_type => "char *",
     c_name => "mpi_fortran_argvs_null",
-    f_type => "integer",
+    f_type => "character, dimension(1, 1)",
     f_name => "MPI_ARGVS_NULL",
 };
 


### PR DESCRIPTION
@ggouaillardet Could you review?

Corresponding master PR: #3401

(cherry picked from commit 0fcd964)
