### PR TITLE
usNIC: fix fi_ep_bind flag. FI_RECV should not be associated with address vector.

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1659,7 +1659,7 @@ static int create_ep(opal_btl_usnic_module_t* module,
                        rc, fi_strerror(-rc));
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-    rc = fi_ep_bind(channel->ep, &module->av->fid, FI_RECV);
+    rc = fi_ep_bind(channel->ep, &module->av->fid, NULL);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
                        "internal error during init",


### PR DESCRIPTION
FI_RECV is not a valid flag for address vector. This is a bug where usNIC libfabric provider does not validate the flag. There will be fix coming up from libfabric side for OMPI reverse compatibility.

Signed-off-by: Thananon Patinyasakdikul <tpatinya@utk.edu>