### PR TITLE
v2.0.x: mtl-portals4: in rendezvous, reissue PtlGet() if it fails

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -71,6 +71,9 @@ struct mca_mtl_portals4_module_t {
     /* free list of message for matched probe */
     opal_free_list_t fl_message;
 
+    /* free list of rendezvous get fragments */
+    opal_free_list_t fl_rndv_get_frag;
+
     /** Network interface handle for matched interface */
     ptl_handle_ni_t ni_h;
     /** Limit given by portals after NIInit */

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -83,6 +83,26 @@ struct ompi_mtl_portals4_recv_request_t {
 };
 typedef struct ompi_mtl_portals4_recv_request_t ompi_mtl_portals4_recv_request_t;
 
+struct ompi_mtl_portals4_rndv_get_frag_t {
+    opal_free_list_item_t super;
+    /* the recv request that's composed of these frags */
+    ompi_mtl_portals4_recv_request_t *request;
+    /* info extracted from the put_overflow event that is required to retry the rndv-get */
+    void            *frag_start;
+    ptl_size_t       frag_length;
+    ptl_process_t    frag_target;
+    ptl_hdr_data_t   frag_match_bits;
+    ptl_size_t       frag_remote_offset;
+
+    int (*event_callback)(ptl_event_t *ev, struct ompi_mtl_portals4_rndv_get_frag_t*);
+
+#if OPAL_ENABLE_DEBUG
+    uint32_t frag_num;
+#endif
+};
+typedef struct ompi_mtl_portals4_rndv_get_frag_t ompi_mtl_portals4_rndv_get_frag_t;
+OBJ_CLASS_DECLARATION(ompi_mtl_portals4_rndv_get_frag_t);
+
 
 struct ompi_mtl_portals4_recv_short_request_t {
     ompi_mtl_portals4_base_request_t super;


### PR DESCRIPTION
This PR fixes a race condition in the rendezvous protocol.  The
race occurs because the sender does not wait for the link event on the
send buffer.  Even though this has not been seen in the wild, it is
possible for the receiver to issue the PtlGet() before the ME is
linked which causes a NAK at the receiver.  This PR resolves this
race by reissuing the PtlGet() when a NAK occurs.

(cherry picked from commit 27ee862964f7a1f4fa1b40c476200d2dacbb5658)

Signed-off-by: Todd Kordenbrock <thkgcode@gmail.com>
