### PR TITLE
v3.x: usNIC: fix fi_ep_bind flag. FI_RECV should not be associated with av.

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1659,7 +1659,7 @@ static int create_ep(opal_btl_usnic_module_t* module,
                        rc, fi_strerror(-rc));
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-    rc = fi_ep_bind(channel->ep, &module->av->fid, NULL);
+    rc = fi_ep_bind(channel->ep, &module->av->fid, 0);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
                        "internal error during init",

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1659,7 +1659,7 @@ static int create_ep(opal_btl_usnic_module_t* module,
                        rc, fi_strerror(-rc));
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-    rc = fi_ep_bind(channel->ep, &module->av->fid, FI_RECV);
+    rc = fi_ep_bind(channel->ep, &module->av->fid, NULL);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
                        "internal error during init",


### PR DESCRIPTION
(cherry-picked from commit : a705f2cf7b9fd7dce9a61f3338ebf047f41834d6)

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>