### PR TITLE
btl/usnic : changed fi_ep_bind flags for AV from NULL to 0.

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1659,7 +1659,7 @@ static int create_ep(opal_btl_usnic_module_t* module,
                        rc, fi_strerror(-rc));
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-    rc = fi_ep_bind(channel->ep, &module->av->fid, NULL);
+    rc = fi_ep_bind(channel->ep, &module->av->fid, 0);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
                        "internal error during init",


### PR DESCRIPTION
This patch fixed the compiler warning generated by earlier commit. ddbe1726c5d19cddbb5754a6d4a20bf2a5966654

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>