### PR TITLE
v2.0.x: usNIC: fix fi_ep_bind flag. FI_RECV should not be associated with av.

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1649,7 +1649,7 @@ static int create_ep(opal_btl_usnic_module_t* module,
                        rc, fi_strerror(-rc));
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-    rc = fi_ep_bind(channel->ep, &module->av->fid, FI_RECV);
+    rc = fi_ep_bind(channel->ep, &module->av->fid, NULL);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
                        "internal error during init",

--- a/opal/mca/btl/usnic/btl_usnic_module.c
+++ b/opal/mca/btl/usnic/btl_usnic_module.c
@@ -1649,7 +1649,7 @@ static int create_ep(opal_btl_usnic_module_t* module,
                        rc, fi_strerror(-rc));
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
-    rc = fi_ep_bind(channel->ep, &module->av->fid, NULL);
+    rc = fi_ep_bind(channel->ep, &module->av->fid, 0);
     if (0 != rc) {
         opal_show_help("help-mpi-btl-usnic.txt",
                        "internal error during init",


### PR DESCRIPTION
From PR #3539 
Cherry-picked from caacff8 and bf7534d