### PR TITLE
opal/stacktrace: Fix stderr target for opal_stacktrace_output

### DIFF
--- a/opal/util/stacktrace.c
+++ b/opal/util/stacktrace.c
@@ -543,7 +543,7 @@ int opal_util_register_stackhandlers (void)
         opal_stacktrace_output_fileno = fileno(stdout);
     }
     else if( 0 == strcasecmp(opal_stacktrace_output_filename, "stderr") ) {
-        opal_stacktrace_output_fileno = fileno(stdout);
+        opal_stacktrace_output_fileno = fileno(stderr);
     }
     else if( 0 == strcasecmp(opal_stacktrace_output_filename, "file" ) ||
              0 == strcasecmp(opal_stacktrace_output_filename, "file:") ) {


### PR DESCRIPTION
 * Fix a typo that prevents `-mca opal_stacktrace_output stderr` (default) option from going to `stderr`.