### PR TITLE
ompi/mpi: Fixes for `mpi_type_create_f90_(real|complex)`

### DIFF
--- a/ompi/mpi/c/type_create_f90_complex.c
+++ b/ompi/mpi/c/type_create_f90_complex.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,8 +107,8 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
         snprintf(datatype->name, MPI_MAX_OBJECT_NAME, "COMBINER %s",
                  (*newtype)->name);
 
-        a_i[0] = &r;
-        a_i[1] = &p;
+        a_i[0] = &p;
+        a_i[1] = &r;
         ompi_datatype_set_args( datatype, 2, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_COMPLEX );
 
         rc = opal_hash_table_set_value_uint64( &ompi_mpi_f90_complex_hashtable, key, datatype );

--- a/ompi/mpi/c/type_create_f90_complex.c
+++ b/ompi/mpi/c/type_create_f90_complex.c
@@ -46,6 +46,7 @@ static const char FUNC_NAME[] = "MPI_Type_create_f90_complex";
 int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
 {
     uint64_t key;
+    int p_key, r_key;
 
     OPAL_CR_NOOP_PROGRESS();
 
@@ -65,8 +66,10 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
     /* if the user does not care about p or r set them to 0 so the
      * test associate with them will always succeed.
      */
-    if( MPI_UNDEFINED == p ) p = 0;
-    if( MPI_UNDEFINED == r ) r = 0;
+    p_key = p;
+    r_key = r;
+    if( MPI_UNDEFINED == p ) p_key = 0;
+    if( MPI_UNDEFINED == r ) r_key = 0;
 
     /**
      * With respect to the MPI standard, MPI-2.0 Sect. 10.2.5, MPI_TYPE_CREATE_F90_xxxx,
@@ -87,7 +90,7 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
         const int* a_i[2];
         int rc;
 
-        key = (((uint64_t)p) << 32) | ((uint64_t)r);
+        key = (((uint64_t)p_key) << 32) | ((uint64_t)r_key);
         if( OPAL_SUCCESS == opal_hash_table_get_value_uint64( &ompi_mpi_f90_complex_hashtable,
                                                               key, (void**)newtype ) ) {
             return MPI_SUCCESS;

--- a/ompi/mpi/c/type_create_f90_real.c
+++ b/ompi/mpi/c/type_create_f90_real.c
@@ -46,6 +46,7 @@ static const char FUNC_NAME[] = "MPI_Type_create_f90_real";
 int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
 {
     uint64_t key;
+    int p_key, r_key;
 
     OPAL_CR_NOOP_PROGRESS();
 
@@ -65,8 +66,10 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
     /* if the user does not care about p or r set them to 0 so the
      * test associate with them will always succeed.
      */
-    if( MPI_UNDEFINED == p ) p = 0;
-    if( MPI_UNDEFINED == r ) r = 0;
+    p_key = p;
+    r_key = r;
+    if( MPI_UNDEFINED == p ) p_key = 0;
+    if( MPI_UNDEFINED == r ) r_key = 0;
 
     /**
      * With respect to the MPI standard, MPI-2.0 Sect. 10.2.5, MPI_TYPE_CREATE_F90_xxxx,
@@ -87,7 +90,7 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
         const int* a_i[2] = {&p, &r};
         int rc;
 
-        key = (((uint64_t)p) << 32) | ((uint64_t)r);
+        key = (((uint64_t)p_key) << 32) | ((uint64_t)r_key);
         if( OPAL_SUCCESS == opal_hash_table_get_value_uint64( &ompi_mpi_f90_real_hashtable,
                                                               key, (void**)newtype ) ) {
             return MPI_SUCCESS;

--- a/ompi/mpi/c/type_create_f90_real.c
+++ b/ompi/mpi/c/type_create_f90_real.c
@@ -16,6 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,7 +84,7 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
 
     if( *newtype != &ompi_mpi_datatype_null.dt ) {
         ompi_datatype_t* datatype;
-        const int* a_i[2] = {&r, &p};
+        const int* a_i[2] = {&p, &r};
         int rc;
 
         key = (((uint64_t)p) << 32) | ((uint64_t)r);


### PR DESCRIPTION
 * Preserve parameter order of `(p,r)` so that a following `MPI_TYPE_GET_ENVELOPE` and `MPI_TYPE_GET_CONTENTS` see these parameters in the same order as they are supplied to `MPI_TYPE_CREATE_F90_(real|complex)`.
 * Adjust the handling of `MPI_UNDEFINED` so that a subsequent call to `MPI_TYPE_GET_ENVELOPE` and `MPI_TYPE_GET_CONTENTS` on the datatype will get `MPI_UNDEFINED` instead of `0` for the respective parameter.

Note I'll post a PR to `ompi-tests` with a test case for this to help illustrate the problem.