### PR TITLE
fix for buffer length check (rdma osc w/ odd datatypes)

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -793,7 +794,14 @@ static inline int ompi_osc_rdma_put_w_req (ompi_osc_rdma_sync_t *sync, const voi
         return OMPI_SUCCESS;
     }
 
-    ret = osc_rdma_get_remote_segment (module, peer, target_disp, target_datatype->super.size * target_count,
+    ptrdiff_t len, offset;
+    // a buffer defined by (buf, count, dt)
+    // will have data starting at buf+offset and ending len bytes later:
+    len = opal_datatype_span(&target_datatype->super, target_count, &offset);
+
+    // the below function wants arg4 to be the number of bytes after
+    // source_disp that the data ends, which is offset+len
+    ret = osc_rdma_get_remote_segment (module, peer, target_disp, offset+len,
                                        &target_address, &target_handle);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
         return ret;


### PR DESCRIPTION
The osc_rdma_get_remote_segment() has the 3rd and 4th args as
* target_disp
* length
which it uses to determine if the rdma falls within the bounds of
the window or not (actually it only checks the upper bound, but I'm
okay with that).

Anyway the caller previously was passing in the length argument as
    target_datatype->super.size * target_count
which which doesn't really represent the number of bytes after target_disp
for which data exists. In particular I could create a datatype as
    { disp -4, len 4 } and use target_disp 4
and that would be bytes 0-3 of the window where the original code
would think it was bytes 4-7 and could abort at the range check.

Ive changed it to use the opal_datatype_span() function.

Fixes 3576

Signed-off-by: Mark Allen <markalle@us.ibm.com>