### PR TITLE
AUTHORS: Update for upcoming v2.0.3 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,6 +132,8 @@ Igor Ivanov, Mellanox
   igor.ivanov@itseez.com
 Igor Usarov, Mellanox
   igoru@mellanox.com
+Jeff Hammond, Individual
+  jeff.science@gmail.com
 Jeff Squyres, University of Indiana, Cisco
   jeff@squyres.com
   jsquyres@cisco.com
@@ -161,6 +163,8 @@ Karol Mroz, University of British Columbia
   mroz.karol@gmail.com
 Kenneth Matney, Oak Ridge National Laboratory
   matneykdsr@ornl.gov
+Kevin Buckley, Individual
+  kevin.buckley.ecs.vuw.ac.nz@gmail.com
 L. R. Rajeshnarayanan, Intel
   l.r.rajeshnarayanan@intel.com
 LANL OMPI Bot, Los Alamos National Laboratory
@@ -215,6 +219,8 @@ Nicolas Chevalier, Bull
   nicolas.chevalier@bull.net
 Nysal Jan K A, IBM
   jnysal@in.ibm.com
+Omri Mor, Individual
+  omri50@gmail.com
 Orion Poplawski, Individual
   orion@cora.nwra.com
 Oscar Vega-Gisbert, Universitat Politecnica de Valencia


### PR DESCRIPTION
Generated by running contrib/dist/make-authors.pl

[skip ci]
bot:notest

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>