### PR TITLE
pmix/pmix2x: fix errors in event abstration

### DIFF
--- a/opal/mca/event/libevent2022/libevent2022.h
+++ b/opal/mca/event/libevent2022/libevent2022.h
@@ -110,6 +110,8 @@ OPAL_DECLSPEC int opal_event_finalize(void);
 
 #define opal_event_set(b, x, fd, fg, cb, arg) event_assign((x), (b), (fd), (fg), (event_callback_fn) (cb), (arg))
 
+#define opal_event_assign(x, b, fd, fg, cb, arg) event_assign((x), (b), (fd), (fg), (event_callback_fn) (cb), (arg))
+
 #define opal_event_add(ev, tv) event_add((ev), (tv))
 
 #define opal_event_del(ev) event_del((ev))

--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -308,9 +310,9 @@ void pmix2x_event_hdlr(size_t evhdlr_registration_id,
     }
 
     /* now push it into the local thread */
-    event_assign(&cd->ev, opal_pmix_base.evbase,
-                 -1, EV_WRITE, _event_hdlr, cd);
-    event_active(&cd->ev, EV_WRITE, 1);
+    opal_event_assign(&cd->ev, opal_pmix_base.evbase,
+                      -1, EV_WRITE, _event_hdlr, cd);
+    opal_event_active(&cd->ev, EV_WRITE, 1);
 }
 
 opal_vpid_t pmix2x_convert_rank(pmix_rank_t rank)

--- a/opal/mca/pmix/pmix2x/pmix2x.h
+++ b/opal/mca/pmix/pmix2x/pmix2x.h
@@ -1,9 +1,12 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -151,9 +154,9 @@ OBJ_CLASS_DECLARATION(pmix2x_threadshift_t);
         _cd->handler = (e);                                 \
         _cd->opcbfunc = (cb);                               \
         _cd->cbdata = (cd);                                 \
-        event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
-                     -1, EV_WRITE, (fn), (_cd));            \
-        event_active(&((_cd)->ev), EV_WRITE, 1);            \
+        opal_event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
+                          -1, EV_WRITE, (fn), (_cd));            \
+        opal_event_active(&((_cd)->ev), EV_WRITE, 1);            \
     } while(0)
 
 #define OPAL_PMIX_THREADSHIFT(e, i, eh, fn, cb, cd)         \
@@ -165,9 +168,9 @@ OBJ_CLASS_DECLARATION(pmix2x_threadshift_t);
         _cd->evhandler = (eh);                              \
         _cd->cbfunc = (cb);                                 \
         _cd->cbdata = (cd);                                 \
-        event_assign(&((_cd)->ev), opal_pmix_base.evbase,   \
-                     -1, EV_WRITE, (fn), (_cd));            \
-        event_active(&((_cd)->ev), EV_WRITE, 1);            \
+        opal_event_assign(&((_cd)->ev), opal_pmix_base.evbase,  \
+                          -1, EV_WRITE, (fn), (_cd));           \
+        opal_event_active(&((_cd)->ev), EV_WRITE, 1);           \
     } while(0)
 
 #define OPAL_PMIX_NOTIFY_THREADSHIFT(s, sr, r, i, fn, cb, cd)   \
@@ -180,9 +183,9 @@ OBJ_CLASS_DECLARATION(pmix2x_threadshift_t);
         _cd->info = (i);                                        \
         _cd->opcbfunc = (cb);                                   \
         _cd->cbdata = (cd);                                     \
-        event_assign(&((_cd)->ev), opal_pmix_base.evbase,       \
+        opal_event_assign(&((_cd)->ev), opal_pmix_base.evbase,  \
                      -1, EV_WRITE, (fn), (_cd));                \
-        event_active(&((_cd)->ev), EV_WRITE, 1);                \
+        opal_event_active(&((_cd)->ev), EV_WRITE, 1);           \
     } while(0)
 
 /****  CLIENT FUNCTIONS  ****/

--- a/opal/mca/pmix/pmix2x/pmix2x_server_south.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_south.c
@@ -7,6 +7,8 @@
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -297,9 +299,9 @@ int pmix2x_server_register_nspace(opal_jobid_t jobid,
     if (NULL == cbfunc) {
         _reg_nspace(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
-                     -1, EV_WRITE, _reg_nspace, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+        opal_event_assign(&cd->ev, opal_pmix_base.evbase,
+                          -1, EV_WRITE, _reg_nspace, cd);
+        opal_event_active(&cd->ev, EV_WRITE, 1);
     }
 
     return OPAL_SUCCESS;
@@ -357,9 +359,9 @@ void pmix2x_server_deregister_nspace(opal_jobid_t jobid,
     if (NULL == cbfunc) {
         _dereg_nspace(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
+        opal_event_assign(&cd->ev, opal_pmix_base.evbase,
                      -1, EV_WRITE, _dereg_nspace, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+        opal_event_active(&cd->ev, EV_WRITE, 1);
     }
 }
 
@@ -427,9 +429,9 @@ void pmix2x_server_deregister_client(const opal_process_name_t *proc,
     if (NULL == cbfunc) {
         _dereg_client(0, 0, cd);
     } else {
-        event_assign(&cd->ev, opal_pmix_base.evbase,
+        opal_event_assign(&cd->ev, opal_pmix_base.evbase,
                      -1, EV_WRITE, _dereg_client, cd);
-        event_active(&cd->ev, EV_WRITE, 1);
+        opal_event_active(&cd->ev, EV_WRITE, 1);
     }
 }
 


### PR DESCRIPTION
Parts of the pmix2x component called the event_* functions directly
instead of the opal_event_* wrappers. This is fine as long as we are
using libevent but becomes a problem with other event libraries.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>