### PR TITLE
v2.1.x: mpi/cxx: remove nonexistent function from cxx glue

### DIFF
--- a/ompi/mpi/cxx/cxx_glue.h
+++ b/ompi/mpi/cxx/cxx_glue.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2016      Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2016-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -15,7 +15,6 @@
 #define OMPI_CXX_COMM_GLUE_H
 
 #include "ompi_config.h"
-#include "ompi/errhandler/errhandler.h"
 #include <stdlib.h>
 
 #include "mpi.h"
@@ -80,9 +79,6 @@ MPI_Errhandler ompi_cxx_errhandler_create_file (ompi_cxx_dummy_fn_t *fn);
 ompi_cxx_intercept_file_extra_state_t
 *ompi_cxx_new_intercept_state (void *read_fn_cxx, void *write_fn_cxx, void *extent_fn_cxx,
                                void *extra_state_cxx);
-
-void ompi_cxx_errhandler_set_cxx_dispatch_fn (struct ompi_errhandler_t *errhandler,
-                                              ompi_errhandler_cxx_dispatch_fn_t *dispatch_fn);
 
 void ompi_cxx_errhandler_set_callbacks (struct ompi_errhandler_t *errhandler, MPI_Comm_errhandler_function *eh_comm_fn,
                                         ompi_file_errhandler_fn *eh_file_fn, MPI_Win_errhandler_function *eh_win_fn);


### PR DESCRIPTION
This commit removes a nonexistent function that was causing build
problems under certain environments.

Reference #3442

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit ee9093c373963ed9cdf71041ff49422863b77311)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>