### PR TITLE
Add some debug code for detecting leaking file descriptors. 

### DIFF
--- a/orte/mca/state/base/state_base_frame.c
+++ b/orte/mca/state/base/state_base_frame.c
@@ -4,6 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +42,20 @@
  * Globals
  */
 orte_state_base_module_t orte_state = {0};
+bool orte_state_base_run_fdcheck = false;
+
+static int orte_state_base_register(mca_base_register_flag_t flags)
+{
+    orte_state_base_run_fdcheck = false;
+    mca_base_var_register("orte", "state", "base", "check_fds",
+                          "Daemons should check fds for leaks after each job completes",
+                          MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                          OPAL_INFO_LVL_9,
+                          MCA_BASE_VAR_SCOPE_READONLY,
+                          &orte_state_base_run_fdcheck);
+
+    return ORTE_SUCCESS;
+}
 
 static int orte_state_base_close(void)
 {
@@ -62,7 +77,8 @@ static int orte_state_base_open(mca_base_open_flag_t flags)
     return mca_base_framework_components_open(&orte_state_base_framework, flags);
 }
 
-MCA_BASE_FRAMEWORK_DECLARE(orte, state, "ORTE State Machine", NULL,
+MCA_BASE_FRAMEWORK_DECLARE(orte, state, "ORTE State Machine",
+                           orte_state_base_register,
                            orte_state_base_open, orte_state_base_close,
                            mca_state_base_static_components, 0);
 
@@ -95,4 +111,3 @@ OBJ_CLASS_INSTANCE(orte_state_caddy_t,
                    opal_object_t,
                    orte_state_caddy_construct,
                    orte_state_caddy_destruct);
-

--- a/orte/mca/state/base/state_private.h
+++ b/orte/mca/state/base/state_private.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,6 +32,7 @@
 
 BEGIN_C_DECLS
 
+extern bool orte_state_base_run_fdcheck;
 /*
  * Base functions
  */
@@ -75,7 +77,7 @@ ORTE_DECLSPEC void orte_state_base_cleanup_job(int fd, short argc, void *cbdata)
 ORTE_DECLSPEC void orte_state_base_report_progress(int fd, short argc, void *cbdata);
 ORTE_DECLSPEC void orte_state_base_track_procs(int fd, short argc, void *cbdata);
 ORTE_DECLSPEC void orte_state_base_check_all_complete(int fd, short args, void *cbdata);
-
+ORTE_DECLSPEC void orte_state_base_check_fds(orte_job_t *jdata);
 
 END_C_DECLS
 #endif

--- a/orte/mca/state/orted/state_orted.c
+++ b/orte/mca/state/orted/state_orted.c
@@ -484,6 +484,11 @@ static void track_procs(int fd, short argc, void *cbdata)
                 jdata->map = NULL;
             }
 
+            /* if requested, check fd status for leaks */
+            if (orte_state_base_run_fdcheck) {
+                orte_state_base_check_fds(jdata);
+            }
+
             /* cleanup the job info */
             opal_hash_table_set_value_uint32(orte_job_data, jdata->jobid, NULL);
             OBJ_RELEASE(jdata);


### PR DESCRIPTION
At the end of each job (and if MCA param is set), have each daemon compute the number of open fds and their characteristics and print a summary

Signed-off-by: Ralph Castain <rhc@open-mpi.org>