### PR TITLE
Ensure that data from a job that was stored in ompi-server is purged once that job completes. Cleanup a few typos. Silence a Coverity warning

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -534,11 +534,8 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
 
 static int setup_path(orte_app_context_t *app, char **wdir)
 {
-    int rc;
+    int rc=ORTE_SUCCESS;
     char dir[MAXPATHLEN];
-    char **argvptr;
-    char *pathenv = NULL, *mpiexec_pathenv = NULL;
-    char *full_search;
 
     if (!orte_get_attribute(&app->attributes, ORTE_APP_SSNDIR_CWD, NULL, OPAL_BOOL)) {
         /* Try to change to the app's cwd and check that the app
@@ -570,40 +567,6 @@ static int setup_path(orte_app_context_t *app, char **wdir)
         opal_setenv(OPAL_MCA_PREFIX"initial_wdir", dir, true, &app->env);
     } else {
         *wdir = NULL;
-    }
-
-    /* Search for the OMPI_exec_path and PATH settings in the environment. */
-    for (argvptr = app->env; *argvptr != NULL; argvptr++) {
-        if (0 == strncmp("OMPI_exec_path=", *argvptr, 15)) {
-            mpiexec_pathenv = *argvptr + 15;
-        }
-        if (0 == strncmp("PATH=", *argvptr, 5)) {
-            pathenv = *argvptr + 5;
-        }
-    }
-
-    /* If OMPI_exec_path is set (meaning --path was used), then create a
-       temporary environment to be used in the search for the executable.
-       The PATH setting in this temporary environment is a combination of
-       the OMPI_exec_path and PATH values.  If OMPI_exec_path is not set,
-       then just use existing environment with PATH in it.  */
-    if (NULL != mpiexec_pathenv) {
-        argvptr = NULL;
-        if (pathenv != NULL) {
-            asprintf(&full_search, "%s:%s", mpiexec_pathenv, pathenv);
-        } else {
-            asprintf(&full_search, "%s", mpiexec_pathenv);
-        }
-        opal_setenv("PATH", full_search, true, &argvptr);
-        free(full_search);
-    } else {
-        argvptr = app->env;
-    }
-
-    rc = orte_util_check_context_app(app, argvptr);
-    /* do not ERROR_LOG - it will be reported elsewhere */
-    if (NULL != mpiexec_pathenv) {
-        opal_argv_free(argvptr);
     }
 
  CLEANUP:
@@ -662,6 +625,9 @@ void orte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
     int rc, i;
     bool found;
     orte_proc_state_t state;
+    char **argvptr;
+    char *pathenv = NULL, *mpiexec_pathenv = NULL;
+    char *full_search;
 
     /* thread-protect common values */
     cd->env = opal_argv_copy(app->env);
@@ -758,6 +724,44 @@ void orte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
      */
     if (ORTE_SUCCESS != (rc = orte_schizo.setup_child(jobdat, child, app, &cd->env))) {
         ORTE_ERROR_LOG(rc);
+        state = ORTE_PROC_STATE_FAILED_TO_LAUNCH;
+        goto errorout;
+    }
+
+    /* Search for the OMPI_exec_path and PATH settings in the environment. */
+    for (argvptr = app->env; *argvptr != NULL; argvptr++) {
+        if (0 == strncmp("OMPI_exec_path=", *argvptr, 15)) {
+            mpiexec_pathenv = *argvptr + 15;
+        }
+        if (0 == strncmp("PATH=", *argvptr, 5)) {
+            pathenv = *argvptr + 5;
+        }
+    }
+
+    /* If OMPI_exec_path is set (meaning --path was used), then create a
+       temporary environment to be used in the search for the executable.
+       The PATH setting in this temporary environment is a combination of
+       the OMPI_exec_path and PATH values.  If OMPI_exec_path is not set,
+       then just use existing environment with PATH in it.  */
+    if (NULL != mpiexec_pathenv) {
+        argvptr = NULL;
+        if (pathenv != NULL) {
+            asprintf(&full_search, "%s:%s", mpiexec_pathenv, pathenv);
+        } else {
+            asprintf(&full_search, "%s", mpiexec_pathenv);
+        }
+        opal_setenv("PATH", full_search, true, &argvptr);
+        free(full_search);
+    } else {
+        argvptr = app->env;
+    }
+
+    rc = orte_util_check_context_app(app, argvptr);
+    /* do not ERROR_LOG - it will be reported elsewhere */
+    if (NULL != mpiexec_pathenv) {
+        opal_argv_free(argvptr);
+    }
+    if (ORTE_SUCCESS != rc) {
         state = ORTE_PROC_STATE_FAILED_TO_LAUNCH;
         goto errorout;
     }

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -485,8 +485,7 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
         }
     }
 
-    if (!ORTE_PROC_IS_HNP &&
-        !orte_get_attribute(&jdata->attributes, ORTE_JOB_FULLY_DESCRIBED, NULL, OPAL_BOOL)) {
+    if (!orte_get_attribute(&jdata->attributes, ORTE_JOB_FULLY_DESCRIBED, NULL, OPAL_BOOL)) {
         /* compute and save bindings of local children */
         if (ORTE_SUCCESS != (rc = orte_rmaps_base_compute_bindings(jdata))) {
             ORTE_ERROR_LOG(rc);

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -359,7 +359,7 @@ int orte_rmaps_rr_bynode(orte_job_t *jdata,
                     return ORTE_ERR_OUT_OF_RESOURCE;
                 }
                 nprocs_mapped++;
-            orte_set_attribute(&proc->attributes, ORTE_PROC_HWLOC_LOCALE, ORTE_ATTR_LOCAL, obj, OPAL_PTR);
+                orte_set_attribute(&proc->attributes, ORTE_PROC_HWLOC_LOCALE, ORTE_ATTR_LOCAL, obj, OPAL_PTR);
             }
             /* not all nodes are equal, so only set oversubscribed for
              * this node if it is in that state

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -1207,6 +1207,11 @@ static int setup_child(orte_job_t *jdata,
         opal_setenv("PWD", param, true, env);
         /* update the initial wdir value too */
         opal_setenv("OMPI_MCA_initial_wdir", param, true, env);
+    } else if (NULL != app->cwd) {
+        /* change to it */
+        if (0 != chdir(app->cwd)) {
+            return ORTE_ERROR;
+        }
     }
     return ORTE_SUCCESS;
 }

--- a/orte/mca/state/base/state_private.h
+++ b/orte/mca/state/base/state_private.h
@@ -78,6 +78,7 @@ ORTE_DECLSPEC void orte_state_base_report_progress(int fd, short argc, void *cbd
 ORTE_DECLSPEC void orte_state_base_track_procs(int fd, short argc, void *cbdata);
 ORTE_DECLSPEC void orte_state_base_check_all_complete(int fd, short args, void *cbdata);
 ORTE_DECLSPEC void orte_state_base_check_fds(orte_job_t *jdata);
+ORTE_DECLSPEC void orte_state_base_notify_data_server(orte_process_name_t *target);
 
 END_C_DECLS
 #endif

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -80,6 +80,8 @@ static orte_job_state_t launch_states[] = {
     ORTE_JOB_STATE_DAEMONS_LAUNCHED,
     ORTE_JOB_STATE_DAEMONS_REPORTED,
     ORTE_JOB_STATE_VM_READY,
+    ORTE_JOB_STATE_MAP,
+    ORTE_JOB_STATE_MAP_COMPLETE,
     ORTE_JOB_STATE_SYSTEM_PREP,
     ORTE_JOB_STATE_LAUNCH_APPS,
     ORTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE,
@@ -98,6 +100,8 @@ static orte_state_cbfunc_t launch_callbacks[] = {
     orte_plm_base_daemons_launched,
     orte_plm_base_daemons_reported,
     vm_ready,
+    orte_rmaps_base_map_job,
+    orte_plm_base_mapping_complete,
     orte_plm_base_complete_setup,
     orte_plm_base_launch_apps,
     orte_state_base_local_launch_complete,
@@ -211,7 +215,7 @@ static void files_ready(int status, void *cbdata)
         ORTE_FORCED_TERMINATE(status);
         return;
     } else {
-        ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_SYSTEM_PREP);
+        ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_MAP);
     }
 }
 

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -1628,22 +1628,17 @@ static int create_app(int argc, char* argv[],
     app->num_procs = (orte_std_cntr_t)orte_cmd_options.num_procs;
     total_num_apps++;
 
-    /* Capture any preload flags */
-    if (orte_cmd_options.preload_binaries) {
-        orte_set_attribute(&app->attributes, ORTE_APP_PRELOAD_BIN, ORTE_ATTR_GLOBAL, NULL, OPAL_BOOL);
-    }
-    /* if we were told to cwd to the session dir and the app was given in
-     * relative syntax, then we need to preload the binary to
+    /* see if we need to preload the binary to
      * find the app - don't do this for java apps, however, as we
      * can't easily find the class on the cmd line. Java apps have to
      * preload their binary via the preload_files option
      */
-    if (!opal_path_is_absolute(app->argv[0]) &&
-        NULL == strstr(app->argv[0], "java")) {
+    if (NULL == strstr(app->argv[0], "java")) {
         if (orte_cmd_options.preload_binaries) {
             orte_set_attribute(&app->attributes, ORTE_APP_SSNDIR_CWD, ORTE_ATTR_GLOBAL, NULL, OPAL_BOOL);
-        } else if (orte_get_attribute(&app->attributes, ORTE_APP_SSNDIR_CWD, NULL, OPAL_BOOL)) {
             orte_set_attribute(&app->attributes, ORTE_APP_PRELOAD_BIN, ORTE_ATTR_GLOBAL, NULL, OPAL_BOOL);
+            /* no harm in setting this attribute twice as the function will simply ignore it */
+            orte_set_attribute(&app->attributes, ORTE_APP_SSNDIR_CWD, ORTE_ATTR_GLOBAL, NULL, OPAL_BOOL);
         }
     }
     if (NULL != orte_cmd_options.preload_files) {

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -370,7 +370,6 @@ int orte_submit_init(int argc, char *argv[],
     } else {
         orte_process_info.proc_type = ORTE_PROC_TOOL;
     }
-
     if (ORTE_PROC_IS_TOOL) {
         if (0 == strncasecmp(orte_cmd_options.hnp, "file", strlen("file"))) {
             char input[1024], *filename;

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -220,6 +220,7 @@ int pmix_server_init(void)
         return rc;
     }
     OBJ_CONSTRUCT(&orte_pmix_server_globals.notifications, opal_list_t);
+    orte_pmix_server_globals.server = *ORTE_NAME_INVALID;
 
    /* setup recv for direct modex requests */
     orte_rml.recv_buffer_nb(ORTE_NAME_WILDCARD, ORTE_RML_TAG_DIRECT_MODEX,

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -45,8 +45,9 @@
 #include "opal/util/proc.h"
 
 #include "orte/mca/grpcomm/base/base.h"
+#include "orte/runtime/orte_globals.h"
 
- BEGIN_C_DECLS
+BEGIN_C_DECLS
 
 #define ORTED_PMIX_MIN_DMX_TIMEOUT      10
 #define ORTE_ADJUST_TIMEOUT(a)                                      \
@@ -252,7 +253,6 @@ typedef struct {
     opal_hotel_t reqs;
     int num_rooms;
     int timeout;
-    char *server_uri;
     bool wait_for_server;
     orte_process_name_t server;
     opal_list_t notifications;

--- a/orte/orted/pmix/pmix_server_pub.c
+++ b/orte/orted/pmix/pmix_server_pub.c
@@ -69,7 +69,7 @@ static int init_server(void)
             if (NULL == filename) {
                 /* filename is not correctly formatted */
                 orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-bad", true,
-                               orte_basename, orte_pmix_server_globals.server_uri);
+                               orte_basename, orte_data_server_uri);
                 return ORTE_ERR_BAD_PARAM;
             }
             ++filename; /* space past the : */
@@ -77,7 +77,7 @@ static int init_server(void)
             if (0 >= strlen(filename)) {
                 /* they forgot to give us the name! */
                 orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-missing", true,
-                               orte_basename, orte_pmix_server_globals.server_uri);
+                               orte_basename, orte_data_server_uri);
                 return ORTE_ERR_BAD_PARAM;
             }
 
@@ -85,14 +85,14 @@ static int init_server(void)
             fp = fopen(filename, "r");
             if (NULL == fp) { /* can't find or read file! */
                 orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-access", true,
-                               orte_basename, orte_pmix_server_globals.server_uri);
+                               orte_basename, orte_data_server_uri);
                 return ORTE_ERR_BAD_PARAM;
             }
             if (NULL == fgets(input, 1024, fp)) {
                 /* something malformed about file */
                 fclose(fp);
                 orte_show_help("help-orterun.txt", "orterun:ompi-server-file-bad", true,
-                               orte_basename, orte_pmix_server_globals.server_uri,
+                               orte_basename, orte_data_server_uri,
                                orte_basename);
                 return ORTE_ERR_BAD_PARAM;
             }
@@ -100,7 +100,7 @@ static int init_server(void)
             input[strlen(input)-1] = '\0';  /* remove newline */
             server = strdup(input);
         } else {
-            server = strdup(orte_pmix_server_globals.server_uri);
+            server = strdup(orte_data_server_uri);
         }
         /* setup our route to the server */
         OBJ_CONSTRUCT(&buf, opal_buffer_t);
@@ -154,8 +154,8 @@ static void execute(int sd, short args, void *cbdata)
         /* we need to initialize our connection to the server */
         if (ORTE_SUCCESS != (rc = init_server())) {
             orte_show_help("help-orted.txt", "noserver", true,
-                           (NULL == orte_pmix_server_globals.server_uri) ?
-                           "NULL" : orte_pmix_server_globals.server_uri);
+                           (NULL == orte_data_server_uri) ?
+                           "NULL" : orte_data_server_uri);
             goto callback;
         }
     }

--- a/orte/runtime/orte_data_server.h
+++ b/orte/runtime/orte_data_server.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,10 +35,10 @@
 
 BEGIN_C_DECLS
 
-#define ORTE_PMIX_PUBLISH_CMD    0x01
-#define ORTE_PMIX_LOOKUP_CMD     0x02
-#define ORTE_PMIX_UNPUBLISH_CMD  0x03
-
+#define ORTE_PMIX_PUBLISH_CMD           0x01
+#define ORTE_PMIX_LOOKUP_CMD            0x02
+#define ORTE_PMIX_UNPUBLISH_CMD         0x03
+#define ORTE_PMIX_PURGE_PROC_CMD        0x04
 
 /* provide hooks to startup and finalize the data server */
 ORTE_DECLSPEC int orte_data_server_init(void);


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>