### PR TITLE
java: Detect `javadoc` path and improve `mpijavac` man page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,7 @@ ompi/tools/wrappers/mpicc.1
 ompi/tools/wrappers/mpic++.1
 ompi/tools/wrappers/mpicxx.1
 ompi/tools/wrappers/mpifort.1
+ompi/tools/wrappers/mpijavac.1
 ompi/tools/wrappers/ompi_wrapper_script
 ompi/tools/wrappers/ompi.pc
 ompi/tools/wrappers/ompi-c.pc

--- a/config/opal_setup_java.m4
+++ b/config/opal_setup_java.m4
@@ -17,6 +17,7 @@ dnl Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013      Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -162,10 +163,11 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
             AC_PATH_PROG(JAVAC, javac)
             AC_PATH_PROG(JAVAH, javah)
             AC_PATH_PROG(JAR, jar)
+            AC_PATH_PROG(JAVADOC, javadoc)
             PATH=$opal_java_PATH_save
 
-            # Check to see if we have all 3 programs.
-            AS_IF([test -z "$JAVAC" || test -z "$JAVAH" || test -z "$JAR"],
+            # Check to see if we have all 4 programs.
+            AS_IF([test -z "$JAVAC" || test -z "$JAVAH" || test -z "$JAR" || test -z "$JAVADOC"],
                   [opal_java_happy=no
                    HAVE_JAVA_SUPPORT=0],
                   [opal_java_happy=yes

--- a/ompi/mpi/java/java/Makefile.am
+++ b/ompi/mpi/java/java/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -179,7 +180,7 @@ jdoc: doc
 # mpi.jar is ever rebuilt, then also make the docs eligible to be
 # rebuilt.
 doc: mpi/MPI.class
-	$(OMPI_V_JAVADOC) javadoc $(OMPI_V_JAVADOC_QUIET) -d doc $(srcdir)/*.java
+	$(OMPI_V_JAVADOC) $(JAVADOC) $(OMPI_V_JAVADOC_QUIET) -d doc $(srcdir)/*.java
 	@touch doc
 
 jdoc-install: doc

--- a/ompi/tools/wrappers/Makefile.am
+++ b/ompi/tools/wrappers/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2013      Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,13 +25,14 @@
 include $(top_srcdir)/Makefile.ompi-rules
 
 generated_man_pages = mpicc.1 mpic++.1 mpicxx.1 mpifort.1 mpif77.1 mpif90.1
-man_pages = $(generated_man_pages)
-
-EXTRA_DIST = mpif77.1in mpijavac.1 mpijavac.pl.in
 
 if OMPI_WANT_JAVA_BINDINGS
-man_pages += mpijavac.1
+generated_man_pages += mpijavac.1
 endif
+
+man_pages = $(generated_man_pages)
+
+EXTRA_DIST = mpif77.1in mpijavac.1in mpijavac.pl.in
 
 if OPAL_WANT_SCRIPT_WRAPPER_COMPILERS
 

--- a/ompi/tools/wrappers/mpijavac.1in
+++ b/ompi/tools/wrappers/mpijavac.1in
@@ -1,5 +1,6 @@
 .\" Copyright (c) 2012      Los Alamos National Security, LLC.  All rights reserved.
-.TH mpijava 1 "Unreleased developer copy" "1.7a1r25839M" "Open MPI"
+.\" Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+.TH mpijava 1 "#OPAL_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
 .
 .SH NAME
 mpijava -- Open MPI Java wrapper compiler


### PR DESCRIPTION
- Detect the path of the `javadoc` command in `configure` (no user-visible change)
- Correct hardcorded date and version in  `mpijavac` man page
