### PR TITLE
osc/rdma: fix typo in ompi_osc_rdma_lock_acquire_exclusive

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_lock.h
+++ b/ompi/mca/osc/rdma/osc_rdma_lock.h
@@ -311,7 +311,7 @@ static inline int ompi_osc_rdma_lock_acquire_exclusive (ompi_osc_rdma_module_t *
 {
     int ret;
 
-    while (1 != (ret = ompi_osc_rdma_lock_try_acquire_exclusive (module, peer, offset))) {
+    while (1 == (ret = ompi_osc_rdma_lock_try_acquire_exclusive (module, peer, offset))) {
         ompi_osc_rdma_progress (module);
     }
 


### PR DESCRIPTION
Fixes #3571

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit b83c5dbee512e40566e45742909149777c71768f)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>