### PR TITLE
WIP: consolidate some version checking code

### DIFF
--- a/contrib/dist/make_dist_tarball
+++ b/contrib/dist/make_dist_tarball
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2016      Intel, Inc. All rights reserved
 # $COPYRIGHT$
 #
@@ -258,10 +258,17 @@ make_tarball() {
     #
     echo "*** Running autogen $autogen_args..."
     rm -f success
+
+    strict="--autotools-eq"
+    if test $highok -eq 0; then
+        strict="--autotools-ge"
+    fi
+    strict="$strict ac:$AC_TARGET_VERSION,am:$AM_TARGET_VERSION,lt:$LT_TARGET_VERSION"
+
     if test "$want_ompi" = "1" ; then
-        (./autogen.pl --force $autogen_args 2>&1 && touch success) | tee auto.out
+        (./autogen.pl $strict --force $autogen_args 2>&1 && touch success) | tee auto.out
     else
-        (./autogen.pl --force --no-ompi $autogen_args 2>&1 && touch success) | tee auto.out
+        (./autogen.pl $strict --force --no-ompi $autogen_args 2>&1 && touch success) | tee auto.out
     fi
     if test ! -f success; then
         echo "Autogen failed.  Aborting"


### PR DESCRIPTION
Based on conversations week of 29 May 2017:

- we note that there's 2 separate autogen version checking codes: in autogen.pl and make_dist_tarball
- regardless of decisions about what to do w.r.t. minimum enforced versions, it would be good to consolidate these codes together
- autogen.pl currently checks for versions in a "greater than or equal to" manner, make_dist_tarball checks for "exactly equal to".  So the  consolidated code will need to be able to handle both.

This first cut is a WIP.  I'm not 100% happy with it yet, but I'm out of time for this window, and need to save it somewhere to return to it later.

I added --autotools-eq=X and --autotools-ge=X options to autogen.pl, which take an arg of the form "ac:X,am:X,lt:X" where you specify the versions you want checked.  The thought was that make_dist_tarball could sepcify -eq or -ge (depending on whether --highok was specified or not) and specify the exact versions that it was looking for.

This commit does *not* adjust the default versions that autogen.pl is looking for, nor does it change the default "greater than or equal to" behavior.

I put a comment in autogen.pl about what might be a better set of CLI options.  I made an obvious syntax error after the comment so that Future Jeff will be forced to find the comment and pick up from there.  :-)

Note that the current stuff I added in this commit does not check for m4 and flex versions in autogen.pl -- but make_dist_tarball checks for these things (the flex version was quite important to distribution tarballs over time).  Need to expand to include those checks (not sure why we're checking for m4 versions, though...?  That sort of thing should be covered by Automake).

Note that it is a separate question as to whether we want make_dist_tarball and autogen.pl to -- by default -- look for the same versions (i.e., and therefore potentially only have the versions listed in one place, not two).  If the versions in one are updated to match the other, note that it would probably be good to put comments in both places reminding Future Editors to change *both* places. 

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>