### PR TITLE
predefined MPI object padding: set to fixed number of bytes

### DIFF
--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2006-2010 University of Houston.  All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
@@ -242,6 +242,15 @@ typedef struct ompi_communicator_t ompi_communicator_t;
  * the ompi_communicator_t without impacting the size of the
  * ompi_predefined_communicator_t structure for some number of additions.
  *
+ * Note: we used to define the PAD as a multiple of sizeof(void*).
+ * However, this makes a different size PAD, depending on
+ * sizeof(void*).  In some cases
+ * (https://github.com/open-mpi/ompi/issues/3610), 32 bit builds can
+ * run out of space when 64 bit builds are still ok.  So we changed to
+ * use just a naked byte size.  As a rule of thumb, however, the size
+ * should probably still be a multiple of 8 so that it has the
+ * possibility of being nicely aligned.
+ *
  * As an example:
  * If the size of ompi_communicator_t is less than the size of the _PAD then
  * the _PAD ensures that the size of the ompi_predefined_communicator_t is
@@ -258,7 +267,7 @@ typedef struct ompi_communicator_t ompi_communicator_t;
  * the PREDEFINED_COMMUNICATOR_PAD macro?
  * A: Most likely not, but it would be good to check.
  */
-#define PREDEFINED_COMMUNICATOR_PAD (sizeof(void*) * 64)
+#define PREDEFINED_COMMUNICATOR_PAD 512
 
 struct ompi_predefined_communicator_t {
     struct ompi_communicator_t comm;

--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -4,7 +4,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -95,7 +95,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_datatype_t);
 /* Using set constant for padding of the DATATYPE handles because the size of
  * base structure is very close to being the same no matter the bitness.
  */
-#define PREDEFINED_DATATYPE_PAD (512)
+#define PREDEFINED_DATATYPE_PAD 512
 
 struct ompi_predefined_datatype_t {
     struct ompi_datatype_t dt;

--- a/ompi/file/file.h
+++ b/ompi/file/file.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      University of Houston. All rights reserved.
@@ -103,7 +103,7 @@ typedef struct ompi_file_t ompi_file_t;
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
-#define PREDEFINED_FILE_PAD (sizeof(void*) * 192)
+#define PREDEFINED_FILE_PAD 1536
 
 struct ompi_predefined_file_t {
     struct ompi_file_t file;

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2007 University of Houston. All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
@@ -107,7 +107,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_group_t);
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
-#define PREDEFINED_GROUP_PAD (sizeof(void*) * 32)
+#define PREDEFINED_GROUP_PAD 256
 
 struct ompi_predefined_group_t {
     struct ompi_group_t group;

--- a/ompi/info/info.h
+++ b/ompi/info/info.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -55,7 +55,7 @@ typedef struct ompi_info_t ompi_info_t;
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
-#define PREDEFINED_INFO_PAD (sizeof(void*) * 32)
+#define PREDEFINED_INFO_PAD 256
 
 struct ompi_predefined_info_t {
     struct ompi_info_t info;

--- a/ompi/message/message.h
+++ b/ompi/message/message.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2011-2012 Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -38,7 +38,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_message_t);
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
-#define PREDEFINED_MESSAGE_PAD (sizeof(void*) * 32)
+#define PREDEFINED_MESSAGE_PAD 256
 
 struct ompi_predefined_message_t {
     struct ompi_message_t message;

--- a/ompi/op/op.h
+++ b/ompi/op/op.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      UT-Battelle, LLC
- * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -199,7 +199,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_op_t);
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
-#define PREDEFINED_OP_PAD (sizeof(void*) * 256)
+#define PREDEFINED_OP_PAD 2048
 
 struct ompi_predefined_op_t {
     struct ompi_op_t op;

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
@@ -127,7 +127,7 @@ typedef struct ompi_request_t ompi_request_t;
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
-#define PREDEFINED_REQUEST_PAD (sizeof(void*) * 32)
+#define PREDEFINED_REQUEST_PAD 256
 
 struct ompi_predefined_request_t {
     struct ompi_request_t request;

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -119,7 +119,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_win_t);
  * See ompi/communicator/communicator.h comments with struct ompi_communicator_t
  * for full explanation why we chose the following padding construct for predefines.
  */
-#define PREDEFINED_WIN_PAD (sizeof(void*) * 64)
+#define PREDEFINED_WIN_PAD 512
 
 struct ompi_predefined_win_t {
     struct ompi_win_t win;


### PR DESCRIPTION
Convert the predefined MPI object padding to a fixed number of bytes (vs. a multiple of sizeof(void*)) so that the padding is the same size between 32 and 64 bit builds.  I.e., we won't have a situation where we've run out of padding in 32 bit builds but still have more space available in 64 bit builds.

Fixes #3610

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bwbarrett @hppritcha This is an ABI-changing commit (albeit pretty low risk).  If we want this for v3.0.x, it needs to be in for v3.0.0.