### PR TITLE
MPI_Sendreceive_replace data error with > 2k msg

### DIFF
--- a/ompi/mpi/c/sendrecv_replace.c
+++ b/ompi/mpi/c/sendrecv_replace.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -116,6 +117,7 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
             rc = OMPI_ERR_OUT_OF_RESOURCE;
             goto cleanup_and_return;
         }
+        iov.iov_len = packed_size;
     }
     max_data = packed_size;
     iov_count = 1;


### PR DESCRIPTION
Signed-off-by: William LePera <lepera@us.ibm.com>

This bug was found during a run of the MPICH test case allpairf, which reported invalid data when using MPI_Sendreceive_replace with a buffer of 666 reals, starting with the 513th index (the first 512 were correct).  The problem occurred because MPI_Sendreceive_replace was setting the length of the receive buffer at 2048, even if it dynamically allocated a larger buffer size.