### PR TITLE
Provide better help when forced_terminate is invoked

### DIFF
--- a/orte/mca/errmgr/base/help-errmgr-base.txt
+++ b/orte/mca/errmgr/base/help-errmgr-base.txt
@@ -98,3 +98,10 @@ then it could be an internal programming error that should be
 reported to the developers. In the meantime, a workaround may
 be to set the MCA param routed=direct on the command line or
 in your environment.
+#
+[simple-message]
+An internal error has occurred in ORTE:
+
+%s
+
+This is something that should be reported to the developers.

--- a/orte/mca/grpcomm/direct/grpcomm_direct.c
+++ b/orte/mca/grpcomm/direct/grpcomm_direct.c
@@ -528,7 +528,8 @@ static void xcast_recv(int status, orte_process_name_t* sender,
                 OBJ_RELEASE(item);
                 continue;
             }
-            if (ORTE_PROC_STATE_RUNNING < rec->state ||
+            if ((ORTE_PROC_STATE_RUNNING < rec->state &&
+                ORTE_PROC_STATE_CALLED_ABORT != rec->state) ||
                 !ORTE_FLAG_TEST(rec, ORTE_PROC_FLAG_ALIVE)) {
                 opal_output(0, "%s grpcomm:direct:send_relay proc %s not running - cannot relay",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), ORTE_NAME_PRINT(&nm->name));

--- a/orte/mca/state/state.h
+++ b/orte/mca/state/state.h
@@ -48,6 +48,7 @@
 #include "opal/class/opal_list.h"
 #include "opal/mca/event/event.h"
 
+#include "orte/mca/errmgr/errmgr.h"
 #include "orte/mca/plm/plm_types.h"
 #include "orte/runtime/orte_globals.h"
 
@@ -64,42 +65,40 @@ ORTE_DECLSPEC extern mca_base_framework_t orte_state_base_framework;
 /* For ease in debugging the state machine, it is STRONGLY recommended
  * that the functions be accessed using the following macros
  */
-#define ORTE_FORCED_TERMINATE(x)                                        \
-    do {                                                                \
-        if (!orte_abnormal_term_ordered) {                              \
-            opal_output_verbose(1, orte_state_base_framework.framework_output, \
-                                "%s FORCE-TERMINATE AT %s:%d",          \
-                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),     \
-                                __FILE__, __LINE__);                    \
-            ORTE_UPDATE_EXIT_STATUS(x);                                 \
-            ORTE_ACTIVATE_JOB_STATE(NULL, ORTE_JOB_STATE_FORCED_EXIT);  \
-        }                                                               \
+#define ORTE_FORCED_TERMINATE(x)                                                    \
+    do {                                                                            \
+        if (!orte_abnormal_term_ordered) {                                          \
+            orte_errmgr.abort((x), "%s FORCE-TERMINATE AT %s:%d - error %s(%d)",    \
+                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),                 \
+                                ORTE_ERROR_NAME((x)), (x),                          \
+                                __FILE__, __LINE__);                                \
+        }                                                                           \
     } while(0);
 
-#define ORTE_ACTIVATE_JOB_STATE(j, s)                                   \
-    do {                                                                \
-        orte_job_t *shadow=(j);                                         \
-        opal_output_verbose(1, orte_state_base_framework.framework_output, \
-                            "%s ACTIVATE JOB %s STATE %s AT %s:%d",	\
-                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),         \
-                            (NULL == shadow) ? "NULL" :                 \
-                            ORTE_JOBID_PRINT(shadow->jobid),		\
-                            orte_job_state_to_str((s)),                 \
-                            __FILE__, __LINE__);			\
-        orte_state.activate_job_state(shadow, (s));                     \
+#define ORTE_ACTIVATE_JOB_STATE(j, s)                                       \
+    do {                                                                    \
+        orte_job_t *shadow=(j);                                             \
+        opal_output_verbose(1, orte_state_base_framework.framework_output,  \
+                            "%s ACTIVATE JOB %s STATE %s AT %s:%d",         \
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),             \
+                            (NULL == shadow) ? "NULL" :                     \
+                            ORTE_JOBID_PRINT(shadow->jobid),                \
+                            orte_job_state_to_str((s)),                     \
+                            __FILE__, __LINE__);                            \
+        orte_state.activate_job_state(shadow, (s));                         \
     } while(0);
 
-#define ORTE_ACTIVATE_PROC_STATE(p, s)                                  \
-    do {                                                                \
-        orte_process_name_t *shadow=(p);                                \
-	    opal_output_verbose(1, orte_state_base_framework.framework_output, \
-                            "%s ACTIVATE PROC %s STATE %s AT %s:%d",	\
-                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),         \
-                            (NULL == shadow) ? "NULL" :                 \
-                            ORTE_NAME_PRINT(shadow),			\
-                            orte_proc_state_to_str((s)),		\
-                            __FILE__, __LINE__);			\
-        orte_state.activate_proc_state(shadow, (s));                    \
+#define ORTE_ACTIVATE_PROC_STATE(p, s)                                      \
+    do {                                                                    \
+        orte_process_name_t *shadow=(p);                                    \
+        opal_output_verbose(1, orte_state_base_framework.framework_output,  \
+                            "%s ACTIVATE PROC %s STATE %s AT %s:%d",        \
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),             \
+                            (NULL == shadow) ? "NULL" :                     \
+                            ORTE_NAME_PRINT(shadow),                        \
+                            orte_proc_state_to_str((s)),                    \
+                            __FILE__, __LINE__);                            \
+        orte_state.activate_proc_state(shadow, (s));                        \
     } while(0);
 
 /**


### PR DESCRIPTION
Instead of "forced_terminate" just quietly causing the daemon to disappear, let's at least attempt to let the user know where the problem occurred.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>