### PR TITLE
AUTHORS: update for 3.0.0 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -149,6 +149,8 @@ Igor Ivanov, Mellanox
   igor.ivanov@itseez.com
 Igor Usarov, Mellanox
   igoru@mellanox.com
+Jeff Hammond
+  jeff.science@gmail.com
 Jeff Squyres, University of Indiana, Cisco
   jeff@squyres.com
   jsquyres@cisco.com
@@ -181,6 +183,8 @@ Karol Mroz, University of British Columbia
   mroz.karol@gmail.com
 Kenneth Matney, Oak Ridge National Laboratory
   matneykdsr@ornl.gov
+Kevin Buckley
+  kevin.buckley.ecs.vuw.ac.nz@gmail.com
 L. R. Rajeshnarayanan, Intel
   l.r.rajeshnarayanan@intel.com
 LANL OMPI Bot, Los Alamos National Laboratory
@@ -238,6 +242,8 @@ Nick Papior Andersen, Individual
   nickpapior@gmail.com
 Nicolas Chevalier, Bull
   nicolas.chevalier@bull.net
+Nicolas Morey-Chaisemartin
+  nmoreychaisemartin@suse.com
 Nysal Jan K A, IBM
   jnysal@gmail.com
   jnysal@in.ibm.com


### PR DESCRIPTION
[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>