### PR TITLE
VERSION update for 3.0.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -82,17 +82,17 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=0:0:0
-libmpi_cxx_so_version=0:0:0
-libmpi_mpifh_so_version=0:0:0
-libmpi_usempi_tkr_so_version=0:0:0
-libmpi_usempi_ignore_tkr_so_version=0:0:0
-libmpi_usempif08_so_version=0:0:0
-libopen_rte_so_version=0:0:0
-libopen_pal_so_version=0:0:0
-libmpi_java_so_version=0:0:0
-liboshmem_so_version=0:0:0
-libompitrace_so_version=0:0:0
+libmpi_so_version=40:0:0
+libmpi_cxx_so_version=40:0:0
+libmpi_mpifh_so_version=40:0:0
+libmpi_usempi_tkr_so_version=40:0:0
+libmpi_usempi_ignore_tkr_so_version=40:0:0
+libmpi_usempif08_so_version=40:0:0
+libopen_rte_so_version=40:0:0
+libopen_pal_so_version=40:0:0
+libmpi_java_so_version=40:0:0
+liboshmem_so_version=40:0:0
+libompitrace_so_version=40:0:0
 
 # "Common" components install standalone libraries that are run-time
 # linked by one or more components.  So they need to be versioned as
@@ -100,14 +100,14 @@ libompitrace_so_version=0:0:0
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=0:0:0
+libmca_ompi_common_ompio_so_version=40:0:0
 
 # ORTE layer
-libmca_orte_common_alps_so_version=0:0:0
+libmca_orte_common_alps_so_version=40:0:0
 
 # OPAL layer
-libmca_opal_common_cuda_so_version=0:0:0
-libmca_opal_common_libfabric_so_version=0:0:0
-libmca_opal_common_sm_so_version=0:0:0
-libmca_opal_common_ugni_so_version=0:0:0
-libmca_opal_common_verbs_so_version=0:0:0
+libmca_opal_common_cuda_so_version=40:0:0
+libmca_opal_common_libfabric_so_version=40:0:0
+libmca_opal_common_sm_so_version=40:0:0
+libmca_opal_common_ugni_so_version=40:0:0
+libmca_opal_common_verbs_so_version=40:0:0


### PR DESCRIPTION
up the current to 40 and drop age to 0
for all *.so’s

Signed-off-by: Howard Pritchard <howardp@lanl.gov>