### PR TITLE
atomics/powerpc: Fix WMB instruction

### DIFF
--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2010-2017 IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -29,10 +29,8 @@
 
 #define MB()  __asm__ __volatile__ ("sync" : : : "memory")
 #define RMB() __asm__ __volatile__ ("lwsync" : : : "memory")
-#define WMB() __asm__ __volatile__ ("eieio" : : : "memory")
+#define WMB() __asm__ __volatile__ ("lwsync" : : : "memory")
 #define ISYNC() __asm__ __volatile__ ("isync" : : : "memory")
-#define SMP_SYNC  "sync \n\t"
-#define SMP_ISYNC "\n\tisync"
 
 
 /**********************************************************************


### PR DESCRIPTION
 * `lwsync` is a write memory barrier.
    - `eieio` is really not meant for this type of operation.
 * References:
    - https://github.com/pmix/pmix/pull/391
    - https://github.com/open-mpi/ompi/pull/3661