### PR TITLE
We cannot use OFI to determine when daemons can finalize as we don't …

### DIFF
--- a/orte/mca/errmgr/default_hnp/errmgr_default_hnp.c
+++ b/orte/mca/errmgr/default_hnp/errmgr_default_hnp.c
@@ -136,8 +136,16 @@ static void hnp_abort(int error_code, char *fmt, ...)
     char *outmsg = NULL;
     orte_timer_t *timer;
 
+    /* only do this once */
+    if (orte_abnormal_term_ordered) {
+        return;
+    }
+
     /* ensure we exit with non-zero status */
     ORTE_UPDATE_EXIT_STATUS(error_code);
+
+    /* set the aborting flag */
+    orte_abnormal_term_ordered = true;
 
     /* If there was a message, construct it */
     va_start(arglist, fmt);

--- a/orte/mca/rml/base/base.h
+++ b/orte/mca/rml/base/base.h
@@ -202,9 +202,9 @@ OBJ_CLASS_DECLARATION(orte_self_send_xfer_t);
     do {                                                                \
         orte_rml_recv_t *msg;                                           \
         opal_output_verbose(5, orte_rml_base_framework.framework_output, \
-                            "%s Message posted at %s:%d",               \
+                            "%s Message posted at %s:%d for tag %d",    \
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),         \
-                            __FILE__, __LINE__);                        \
+                            __FILE__, __LINE__, (t));                   \
         msg = OBJ_NEW(orte_rml_recv_t);                                 \
         msg->sender.jobid = (p)->jobid;                                 \
         msg->sender.vpid = (p)->vpid;                                   \

--- a/orte/mca/rml/oob/rml_oob_component.c
+++ b/orte/mca/rml/oob/rml_oob_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -207,7 +207,8 @@ static orte_rml_base_module_t* open_conduit(opal_list_t *attributes)
         NULL != comp_attrib) {
         comps = opal_argv_split(comp_attrib, ',');
         for (i=0; NULL != comps[i]; i++) {
-            if (0 == strcasecmp(comps[i], "Ethernet")) {
+            if (0 == strcasecmp(comps[i], "Ethernet") ||
+                0 == strcasecmp(comps[i], "oob")) {
                 /* we are a candidate */
                 opal_argv_free(comps);
                 md = make_module();
@@ -254,7 +255,14 @@ static orte_rml_base_module_t* open_conduit(opal_list_t *attributes)
         opal_argv_free(comps);
         free(comp_attrib);
         return NULL;
+    }
 
+    /* if they didn't specify a protocol or a transport, then we can be considered */
+    if (!orte_get_attribute(attributes, ORTE_RML_TRANSPORT_TYPE, NULL, OPAL_STRING) ||
+        !orte_get_attribute(attributes, ORTE_RML_PROTOCOL_TYPE, NULL, OPAL_STRING)) {
+        md = make_module();
+        md->routed = orte_routed.assign_module(NULL);
+        return md;
     }
 
     /* if we get here, we cannot handle it */

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -768,7 +768,7 @@ int orte_register_params(void)
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY, &orte_coll_transport);
 
-    orte_mgmt_transport = "oob,ethernet";
+    orte_mgmt_transport = "oob";
     (void) mca_base_var_register("orte", "orte", "mgmt", "transports",
                                  "Comma-separated list of transports to use for ORTE management messages",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,


### PR DESCRIPTION
…see the "sockets" go away. So always use the OOB for the mgmt conduit - this provides the necessary termination signal AND ensures that IOF and other mgmt messages go solely across TCP.

Cleanup the way we look for matching OFI addresses by using the opal_net_samenetwork helper function. This now works for multi-network environments, but only using the socket provider

Signed-off-by: Ralph Castain <rhc@open-mpi.org>