### PR TITLE
Print a better error message when srun isn't found in the path. 

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -2151,11 +2151,13 @@ int orte_plm_base_setup_virtual_machine(orte_job_t *jdata)
     }
 
     /* ensure we are not on the list */
-    item = opal_list_get_first(&nodes);
-    node = (orte_node_t*)item;
-    if (0 == node->index) {
-        opal_list_remove_item(&nodes, item);
-        OBJ_RELEASE(item);
+    if (0 < opal_list_get_size(&nodes)) {
+        item = opal_list_get_first(&nodes);
+        node = (orte_node_t*)item;
+        if (0 == node->index) {
+            opal_list_remove_item(&nodes, item);
+            OBJ_RELEASE(item);
+        }
     }
 
     /* if we didn't get anything, then we are the only node in the

--- a/orte/mca/plm/slurm/help-plm-slurm.txt
+++ b/orte/mca/plm/slurm/help-plm-slurm.txt
@@ -49,3 +49,7 @@ are running.
 
 Please consult with your system administrator about obtaining
 such support.
+[no-srun]
+The SLURM process starter for OpenMPI was unable to locate a
+usable "srun" command in its path. Please check your path
+and try again.

--- a/orte/mca/plm/slurm/plm_slurm_module.c
+++ b/orte/mca/plm/slurm/plm_slurm_module.c
@@ -587,7 +587,8 @@ static int plm_slurm_start_proc(int argc, char **argv, char **env,
     orte_proc_t *dummy;
 
     if (NULL == exec_argv) {
-        return ORTE_ERR_NOT_FOUND;
+        orte_show_help("help-plm-slurm.txt", "no-srun", true);
+        return ORTE_ERR_SILENT;
     }
 
     srun_pid = fork();


### PR DESCRIPTION
Ensure we don't segfault if -host specifies a node not included in the allocation

Signed-off-by: Ralph Castain <rhc@open-mpi.org>