### PR TITLE
ROMIO 3.1.4 : Add support for missing ops

### DIFF
--- a/ompi/mca/io/romio314/src/io_romio314.h
+++ b/ompi/mca/io/romio314/src/io_romio314.h
@@ -128,12 +128,24 @@ int mca_io_romio314_file_iread_at (struct ompi_file_t *fh,
                                 int count,
                                 struct ompi_datatype_t *datatype,
                                 ompi_request_t **request);
+int mca_io_romio314_file_iread_at_all (struct ompi_file_t *fh,
+                                       MPI_Offset offset,
+                                       void *buf,
+                                       int count,
+                                       struct ompi_datatype_t *datatype,
+                                       ompi_request_t **request);
 int mca_io_romio314_file_iwrite_at (struct ompi_file_t *fh,
                                  MPI_Offset offset,
                                  const void *buf,
                                  int count,
                                  struct ompi_datatype_t *datatype,
                                  ompi_request_t **request);
+int mca_io_romio314_file_iwrite_at_all (struct ompi_file_t *fh,
+                                        MPI_Offset offset,
+                                        const void *buf,
+                                        int count,
+                                        struct ompi_datatype_t *datatype,
+                                        ompi_request_t **request);
 
 /* Section 9.4.3 */
 int mca_io_romio314_file_read (struct ompi_file_t *fh,
@@ -161,11 +173,21 @@ int mca_io_romio314_file_iread (struct ompi_file_t *fh,
                              int count,
                              struct ompi_datatype_t *datatype,
                              ompi_request_t **request);
+int mca_io_romio314_file_iread_all (struct ompi_file_t *fh,
+                                    void *buf,
+                                    int count,
+                                    struct ompi_datatype_t *datatype,
+                                    ompi_request_t **request);
 int mca_io_romio314_file_iwrite (struct ompi_file_t *fh,
                               const void *buf,
                               int count,
                               struct ompi_datatype_t *datatype,
                               ompi_request_t **request);
+int mca_io_romio314_file_iwrite_all (struct ompi_file_t *fh,
+                                     const void *buf,
+                                     int count,
+                                     struct ompi_datatype_t *datatype,
+                                     ompi_request_t **request);
 int mca_io_romio314_file_seek (struct ompi_file_t *fh,
                             MPI_Offset offset,
                             int whence);

--- a/ompi/mca/io/romio314/src/io_romio314_file_read.c
+++ b/ompi/mca/io/romio314/src/io_romio314_file_read.c
@@ -9,6 +9,7 @@
  *                          University of Stuttgart.  All rights reserved.
  *  Copyright (c) 2004-2005 The Regents of the University of California.
  *                          All rights reserved.
+ *  Copyright (c) 2017      IBM Corporation.  All rights reserved.
  *  $COPYRIGHT$
  *
  *  Additional copyrights may follow
@@ -87,6 +88,33 @@ mca_io_romio314_file_iread_at (ompi_file_t *fh,
     return ret;
 }
 
+int
+mca_io_romio314_file_iread_at_all (ompi_file_t *fh,
+                                   MPI_Offset offset,
+                                   void *buf,
+                                   int count,
+                                   struct ompi_datatype_t *datatype,
+                                   ompi_request_t **request)
+{
+    int         ret;
+    mca_io_romio314_data_t *data;
+
+    data = (mca_io_romio314_data_t *) fh->f_io_selected_data;
+    OPAL_THREAD_LOCK (&mca_io_romio314_mutex);
+    // ----------------------------------------------------
+    // NOTE: If you upgrade ROMIO, replace this with the actual ROMIO call.
+    // ----------------------------------------------------
+    // No support for non-blocking collective I/O operations.
+    // Fake it with individual non-blocking I/O operations.
+    // Similar to OMPIO
+    ret =
+        ROMIO_PREFIX(MPI_File_iread_at) (data->romio_fh, offset, buf, count,
+                                         datatype, request);
+    OPAL_THREAD_UNLOCK (&mca_io_romio314_mutex);
+
+    return ret;
+}
+
 
 int
 mca_io_romio314_file_read (ompi_file_t *fh,
@@ -150,6 +178,31 @@ mca_io_romio314_file_iread (ompi_file_t *fh,
     return ret;
 }
 
+int
+mca_io_romio314_file_iread_all (ompi_file_t *fh,
+                                void *buf,
+                                int count,
+                                struct ompi_datatype_t *datatype,
+                                ompi_request_t **request)
+{
+    int         ret;
+    mca_io_romio314_data_t *data;
+
+    data = (mca_io_romio314_data_t *) fh->f_io_selected_data;
+    OPAL_THREAD_LOCK (&mca_io_romio314_mutex);
+    // ----------------------------------------------------
+    // NOTE: If you upgrade ROMIO, replace this with the actual ROMIO call.
+    // ----------------------------------------------------
+    // No support for non-blocking collective I/O operations.
+    // Fake it with individual non-blocking I/O operations.
+    // Similar to OMPIO
+    ret =
+        ROMIO_PREFIX(MPI_File_iread) (data->romio_fh, buf, count, datatype,
+                                      request);
+    OPAL_THREAD_UNLOCK (&mca_io_romio314_mutex);
+
+    return ret;
+}
 
 int
 mca_io_romio314_file_read_shared (ompi_file_t *fh,

--- a/ompi/mca/io/romio314/src/io_romio314_file_write.c
+++ b/ompi/mca/io/romio314/src/io_romio314_file_write.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,6 +93,32 @@ mca_io_romio314_file_iwrite_at (ompi_file_t *fh,
 }
 
 
+int
+mca_io_romio314_file_iwrite_at_all (ompi_file_t *fh,
+                                    MPI_Offset offset,
+                                    const void *buf,
+                                    int count,
+                                    struct ompi_datatype_t *datatype,
+                                    ompi_request_t **request)
+{
+    int         ret;
+    mca_io_romio314_data_t *data;
+
+    data = (mca_io_romio314_data_t *) fh->f_io_selected_data;
+    OPAL_THREAD_LOCK (&mca_io_romio314_mutex);
+    // ----------------------------------------------------
+    // NOTE: If you upgrade ROMIO, replace this with the actual ROMIO call.
+    // ----------------------------------------------------
+    // No support for non-blocking collective I/O operations.
+    // Fake it with individual non-blocking I/O operations.
+    // Similar to OMPIO
+    ret =
+        ROMIO_PREFIX(MPI_File_iwrite_at) (data->romio_fh, offset, buf, count,
+                                          datatype, request);
+    OPAL_THREAD_UNLOCK (&mca_io_romio314_mutex);
+
+    return ret;
+}
 
 
 
@@ -150,6 +177,32 @@ mca_io_romio314_file_iwrite (ompi_file_t *fh,
     ret =
         ROMIO_PREFIX(MPI_File_iwrite) (data->romio_fh, buf, count, datatype,
                                        request);
+    OPAL_THREAD_UNLOCK (&mca_io_romio314_mutex);
+
+    return ret;
+}
+
+int
+mca_io_romio314_file_iwrite_all (ompi_file_t *fh,
+                                const void *buf,
+                                 int count,
+                                 struct ompi_datatype_t *datatype,
+                                 ompi_request_t **request)
+{
+    int         ret;
+    mca_io_romio314_data_t *data;
+
+    data = (mca_io_romio314_data_t *) fh->f_io_selected_data;
+    OPAL_THREAD_LOCK (&mca_io_romio314_mutex);
+    // ----------------------------------------------------
+    // NOTE: If you upgrade ROMIO, replace this with the actual ROMIO call.
+    // ----------------------------------------------------
+    // No support for non-blocking collective I/O operations.
+    // Fake it with individual non-blocking I/O operations.
+    // Similar to OMPIO
+    ret =
+        ROMIO_PREFIX(MPI_File_iwrite) (data->romio_fh, buf, count, datatype,
+                                      request);
     OPAL_THREAD_UNLOCK (&mca_io_romio314_mutex);
 
     return ret;

--- a/ompi/mca/io/romio314/src/io_romio314_module.c
+++ b/ompi/mca/io/romio314/src/io_romio314_module.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,8 +60,8 @@ mca_io_base_module_2_0_0_t mca_io_romio314_module = {
     mca_io_romio314_file_write_at_all,
     mca_io_romio314_file_iread_at,
     mca_io_romio314_file_iwrite_at,
-    NULL, /* iread_at_all */
-    NULL, /* iwrite_at_all */
+    mca_io_romio314_file_iread_at_all,
+    mca_io_romio314_file_iwrite_at_all,
 
     /* non-indexed IO operations */
     mca_io_romio314_file_read,
@@ -69,8 +70,8 @@ mca_io_base_module_2_0_0_t mca_io_romio314_module = {
     mca_io_romio314_file_write_all,
     mca_io_romio314_file_iread,
     mca_io_romio314_file_iwrite,
-    NULL, /* iread_all */
-    NULL, /* iwrite_all */
+    mca_io_romio314_file_iread_all,
+    mca_io_romio314_file_iwrite_all,
 
     mca_io_romio314_file_seek,
     mca_io_romio314_file_get_position,

--- a/ompi/mpi/c/file_iread_all.c
+++ b/ompi/mpi/c/file_iread_all.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015      University of Houston.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,8 +70,13 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
-            io_module_file_iread_all(fh, buf, count, datatype, request);
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iread_all) ) {
+            rc = MPI_ERR_UNSUPPORTED_OPERATION;
+        }
+        else {
+            rc = fh->f_io_selected_module.v2_0_0.
+                io_module_file_iread_all(fh, buf, count, datatype, request);
+        }
         break;
 
     default:

--- a/ompi/mpi/c/file_iread_at_all.c
+++ b/ompi/mpi/c/file_iread_at_all.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2015      University of Houston.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,9 +70,14 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
-            io_module_file_iread_at_all(fh, offset, buf, count, datatype,
-                                        request);
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iread_at_all) ) {
+            rc = MPI_ERR_UNSUPPORTED_OPERATION;
+        }
+        else {
+            rc = fh->f_io_selected_module.v2_0_0.
+                io_module_file_iread_at_all(fh, offset, buf, count, datatype,
+                                            request);
+        }
         break;
 
     default:

--- a/ompi/mpi/c/file_iwrite_all.c
+++ b/ompi/mpi/c/file_iwrite_all.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      University of Houston.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,8 +74,13 @@ int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
-          io_module_file_iwrite_all(fh, buf, count, datatype, request);
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iwrite_all) ) {
+            rc = MPI_ERR_UNSUPPORTED_OPERATION;
+        }
+        else {
+            rc = fh->f_io_selected_module.v2_0_0.
+                io_module_file_iwrite_all(fh, buf, count, datatype, request);
+        }
         break;
 
     default:

--- a/ompi/mpi/c/file_iwrite_at_all.c
+++ b/ompi/mpi/c/file_iwrite_at_all.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      University of Houston.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,9 +75,14 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf,
     /* Call the back-end io component function */
     switch (fh->f_io_version) {
     case MCA_IO_BASE_V_2_0_0:
-        rc = fh->f_io_selected_module.v2_0_0.
-            io_module_file_iwrite_at_all(fh, offset, buf, count, datatype,
-                                         request);
+        if( OPAL_UNLIKELY(NULL == fh->f_io_selected_module.v2_0_0.io_module_file_iwrite_at_all) ) {
+            rc = MPI_ERR_UNSUPPORTED_OPERATION;
+        }
+        else {
+            rc = fh->f_io_selected_module.v2_0_0.
+                io_module_file_iwrite_at_all(fh, offset, buf, count, datatype,
+                                             request);
+        }
         break;
 
     default:


### PR DESCRIPTION
 * Add work around support for the following missing ops in ROMIO 3.1.4
    - `MPI_File_iread_at_all`
    - `MPI_File_iwrite_at_all`
    - `MPI_File_iread_all`
    - `MPI_File_iwrite_all`
 * See PR #3688
