### PR TITLE
opal/runtime: Add a hang-up detection feature

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -140,7 +140,8 @@ static int mca_pml_ob1_recv_request_cancel(struct ompi_request_t* ompi_request, 
     return OMPI_SUCCESS;
 }
 
-static int mca_pml_ob1_recv_request_dump(struct ompi_request_t* request)
+static int mca_pml_ob1_recv_request_dump(FILE* file, char* prefix,
+                                         struct ompi_request_t* request)
 {
     char crequest[64], cpeer[64], ctag[64];
     char ccomm[MPI_MAX_OBJECT_NAME+64], ctype[MPI_MAX_OBJECT_NAME+64];
@@ -149,7 +150,6 @@ static int mca_pml_ob1_recv_request_dump(struct ompi_request_t* request)
     opal_proc_t* proc = &basereq->req_proc->super;
     ompi_communicator_t* comm = basereq->req_comm;
     ompi_datatype_t* type = basereq->req_datatype;
-    FILE* stream = stderr;
 
     if( MPI_UNDEFINED == request->req_f_to_c_index ) {
         snprintf(crequest, sizeof(crequest), "(c=%p f=%s)",
@@ -187,8 +187,8 @@ static int mca_pml_ob1_recv_request_dump(struct ompi_request_t* request)
                  type->name, (void*) type, type->d_f_to_c_index, type->id);
     }
 
-    fprintf(stream,
-            "[%s:%05d] "
+    fprintf(file,
+            "%s"
             "recv request %s "
             "from rank=%s on communicator=%s with tag=%s "
             "for datatype=%s x count=%lu in addr=%p ["
@@ -206,7 +206,7 @@ static int mca_pml_ob1_recv_request_dump(struct ompi_request_t* request)
             "pending=%s "
             "ack_sent=%s "
             "match_received=%s]\n",
-            opal_process_info.nodename, (int) getpid(),
+            prefix,
             crequest,
             cpeer, ccomm, ctag,
             ctype, basereq->req_count, basereq->req_addr,

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -130,7 +130,8 @@ static int mca_pml_ob1_send_request_cancel(struct ompi_request_t* request, int c
     return OMPI_SUCCESS;
 }
 
-static int mca_pml_ob1_send_request_dump(struct ompi_request_t* request)
+static int mca_pml_ob1_send_request_dump(FILE* file, char* prefix,
+                                         struct ompi_request_t* request)
 {
     char crequest[64], cpeer[64], ctag[64];
     char ccomm[MPI_MAX_OBJECT_NAME+64], ctype[MPI_MAX_OBJECT_NAME+64];
@@ -139,7 +140,6 @@ static int mca_pml_ob1_send_request_dump(struct ompi_request_t* request)
     opal_proc_t* proc = &basereq->req_proc->super;
     ompi_communicator_t* comm = basereq->req_comm;
     ompi_datatype_t* type = basereq->req_datatype;
-    FILE* stream = stderr;
 
     if( MPI_UNDEFINED == request->req_f_to_c_index ) {
         snprintf(crequest, sizeof(crequest), "(c=%p f=%s)",
@@ -177,8 +177,8 @@ static int mca_pml_ob1_send_request_dump(struct ompi_request_t* request)
                  type->name, (void*) type, type->d_f_to_c_index, type->id);
     }
 
-    fprintf(stream,
-            "[%s:%05d] "
+    fprintf(file,
+            "%s"
             "send request %s "
             "to rank=%s on communicator=%s with tag=%s "
             "for datatype=%s x count=%lu in addr=%p ["
@@ -193,7 +193,7 @@ static int mca_pml_ob1_send_request_dump(struct ompi_request_t* request)
             "bytes_delivered=%lu "
             "rdma_cnt=%" PRIu32 " "
             "pending=%d]\n",
-            opal_process_info.nodename, (int) getpid(),
+            prefix,
             crequest,
             cpeer, ccomm, ctag,
             ctype, basereq->req_count, basereq->req_addr,

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -129,11 +130,98 @@ static int mca_pml_ob1_send_request_cancel(struct ompi_request_t* request, int c
     return OMPI_SUCCESS;
 }
 
+static int mca_pml_ob1_send_request_dump(struct ompi_request_t* request)
+{
+    char crequest[64], cpeer[64], ctag[64];
+    char ccomm[MPI_MAX_OBJECT_NAME+64], ctype[MPI_MAX_OBJECT_NAME+64];
+    mca_pml_base_request_t* basereq = (mca_pml_base_request_t*) request;
+    mca_pml_ob1_send_request_t* sendreq = (mca_pml_ob1_send_request_t*) request;
+    opal_proc_t* proc = &basereq->req_proc->super;
+    ompi_communicator_t* comm = basereq->req_comm;
+    ompi_datatype_t* type = basereq->req_datatype;
+    FILE* stream = stderr;
+
+    if( MPI_UNDEFINED == request->req_f_to_c_index ) {
+        snprintf(crequest, sizeof(crequest), "(c=%p f=%s)",
+                 (void*) request, "UNDEFINED");
+    } else {
+        snprintf(crequest, sizeof(crequest), "(c=%p f=%d)",
+                 (void*) request, request->req_f_to_c_index);
+    }
+
+    snprintf(ccomm, sizeof(ccomm), "%s (c=%p f=%d id=%" PRIu32 " my_rank=%d)",
+             comm->c_name, (void*) comm, comm->c_f_to_c_index,
+             comm->c_contextid, comm->c_my_rank);
+
+    if( OMPI_ANY_SOURCE == basereq->req_peer ) {
+        snprintf(cpeer, sizeof(cpeer), "%s", "ANY_SOURCE");
+    } else if( NULL == proc ) {
+        snprintf(cpeer, sizeof(cpeer), "%" PRId32, basereq->req_peer);
+    } else {
+        snprintf(cpeer, sizeof(cpeer),
+                 "%" PRId32 " (jobid=%" PRIu32 " vpid=%" PRIu32 ")",
+                 basereq->req_peer,
+                 proc->proc_name.jobid, proc->proc_name.vpid);
+    }
+
+    if( OMPI_ANY_TAG == basereq->req_tag ) {
+        snprintf(ctag, sizeof(ctag), "%s", "ANY_TAG");
+    } else {
+        snprintf(ctag, sizeof(ctag), "%" PRId32, basereq->req_tag);
+    }
+
+    if( 0 == basereq->req_count ) {
+        snprintf(ctype, sizeof(ctype), "N/A");
+    } else {
+        snprintf(ctype, sizeof(ctype), "%s (c=%p f=%" PRId32 " id=%" PRId32 ")",
+                 type->name, (void*) type, type->d_f_to_c_index, type->id);
+    }
+
+    fprintf(stream,
+            "[%s:%05d] "
+            "send request %s "
+            "to rank=%s on communicator=%s with tag=%s "
+            "for datatype=%s x count=%lu in addr=%p ["
+            "complete=%s state=%d "
+            "type=%d pml_complete=%s free_called=%s sequence=%" PRIu64 " "
+            "send_mode=%d "
+            "bytes_packed=%lu "
+            "recv=%p "
+            "state=%" PRId32 " "
+            "throttle_sends=%s "
+            "pipeline_depth=%lu "
+            "bytes_delivered=%lu "
+            "rdma_cnt=%" PRIu32 " "
+            "pending=%d]\n",
+            opal_process_info.nodename, (int) getpid(),
+            crequest,
+            cpeer, ccomm, ctag,
+            ctype, basereq->req_count, basereq->req_addr,
+            (request->req_complete == REQUEST_COMPLETED) ? "y" : "n",
+            (int) request->req_state,
+            (int) basereq->req_type,
+            basereq->req_pml_complete ? "y" : "n",
+            basereq->req_free_called ? "y" : "n",
+            basereq->req_sequence,
+            (int) sendreq->req_send.req_send_mode,
+            sendreq->req_send.req_bytes_packed,
+            sendreq->req_recv.pval,
+            sendreq->req_state,
+            sendreq->req_throttle_sends ? "y" : "n",
+            sendreq->req_pipeline_depth,
+            sendreq->req_bytes_delivered,
+            sendreq->req_rdma_cnt,
+            sendreq->req_pending);
+
+    return OMPI_SUCCESS;
+}
+
 static void mca_pml_ob1_send_request_construct(mca_pml_ob1_send_request_t* req)
 {
     req->req_send.req_base.req_type = MCA_PML_REQUEST_SEND;
     req->req_send.req_base.req_ompi.req_free = mca_pml_ob1_send_request_free;
     req->req_send.req_base.req_ompi.req_cancel = mca_pml_ob1_send_request_cancel;
+    req->req_send.req_base.req_ompi.req_dump = mca_pml_ob1_send_request_dump;
     req->req_rdma_cnt = 0;
     req->req_throttle_sends = false;
     req->rdma_frag = NULL;

--- a/ompi/request/request.c
+++ b/ompi/request/request.c
@@ -17,6 +17,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,6 +60,7 @@ static void ompi_request_construct(ompi_request_t* req)
     req->req_cancel       = NULL;
     req->req_complete_cb  = NULL;
     req->req_complete_cb_data = NULL;
+    req->req_dump         = NULL;
     req->req_f_to_c_index = MPI_UNDEFINED;
     req->req_mpi_object.comm = (struct ompi_communicator_t*) NULL;
 }
@@ -181,4 +183,20 @@ int ompi_request_finalize(void)
     OBJ_DESTRUCT( &ompi_request_empty );
     OBJ_DESTRUCT( &ompi_request_f_to_c_table );
     return OMPI_SUCCESS;
+}
+
+void ompi_request_dump_on_hangup(void * cbdata)
+{
+    ompi_request_t* request = (ompi_request_t*) cbdata;
+    if (request->req_complete != REQUEST_COMPLETED && request->req_dump) {
+        request->req_dump(request);
+    }
+}
+
+void ompi_request_dump_array_on_hangup(void * cbdata)
+{
+    ompi_request_array_t* array = (ompi_request_array_t*) cbdata;
+    for (size_t i = 0; i < array->count; i++) {
+        ompi_request_dump_on_hangup(array->requests[i]);
+    }
 }

--- a/ompi/request/request.c
+++ b/ompi/request/request.c
@@ -185,18 +185,18 @@ int ompi_request_finalize(void)
     return OMPI_SUCCESS;
 }
 
-void ompi_request_dump_on_hangup(void * cbdata)
+void ompi_request_dump_on_hangup(FILE * file, char * prefix, void * cbdata)
 {
     ompi_request_t* request = (ompi_request_t*) cbdata;
     if (request->req_complete != REQUEST_COMPLETED && request->req_dump) {
-        request->req_dump(request);
+        request->req_dump(file, prefix, request);
     }
 }
 
-void ompi_request_dump_array_on_hangup(void * cbdata)
+void ompi_request_dump_array_on_hangup(FILE * file, char * prefix, void * cbdata)
 {
     ompi_request_array_t* array = (ompi_request_array_t*) cbdata;
     for (size_t i = 0; i < array->count; i++) {
-        ompi_request_dump_on_hangup(array->requests[i]);
+        ompi_request_dump_on_hangup(file, prefix, array->requests[i]);
     }
 }

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -82,7 +82,8 @@ typedef int (*ompi_request_complete_fn_t)(struct ompi_request_t* request);
  * or MPI_WAIT{|ANY|ALL|SOME} function call. Implementers can dump any data
  * for debugging purposes.
  */
-typedef int (*ompi_request_dump_fn_t)(struct ompi_request_t* request);
+typedef int (*ompi_request_dump_fn_t)(FILE* file, char* prefix,
+                                      struct ompi_request_t* request);
 
 /**
  * Forward declaration
@@ -360,16 +361,20 @@ int ompi_request_finalize(void);
 /**
  * Function used for OPAL_PROGRESS_WHILE to dump one request data on hang-up.
  *
+ * @param file   File stream to output hang-up situation information.
+ * @param prefix Desired prefix for each line of hang-up situation information.
  * @param cbdata Pointer to an ompi_request_t object.
  */
-void ompi_request_dump_on_hangup(void * cbdata);
+void ompi_request_dump_on_hangup(FILE * file, char * prefix, void * cbdata);
 
 /**
  * Function used for OPAL_PROGRESS_WHILE to dump multiple request data on hang-up.
  *
+ * @param file   File stream to output hang-up situation information.
+ * @param prefix Desired prefix for each line of hang-up situation information.
  * @param cbdata Pointer to an ompi_request_array_t object.
  */
-void ompi_request_dump_array_on_hangup(void * cbdata);
+void ompi_request_dump_array_on_hangup(FILE * file, char * prefix, void * cbdata);
 
 /**
  * Cancel a pending request.

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,6 +75,15 @@ typedef int (*ompi_request_cancel_fn_t)(struct ompi_request_t* request, int flag
  */
 typedef int (*ompi_request_complete_fn_t)(struct ompi_request_t* request);
 
+/*
+ * Optional function called when a hang-up situation is detected.
+ * If this function is called with a request, it means the request has not
+ * completed within opal_progress_timeout seconds in a blocking operation
+ * or MPI_WAIT{|ANY|ALL|SOME} function call. Implementers can dump any data
+ * for debugging purposes.
+ */
+typedef int (*ompi_request_dump_fn_t)(struct ompi_request_t* request);
+
 /**
  * Forward declaration
  */
@@ -113,6 +123,7 @@ struct ompi_request_t {
     ompi_request_cancel_fn_t req_cancel;        /**< Optional function to cancel the request */
     ompi_request_complete_fn_t req_complete_cb; /**< Called when the request is MPI completed */
     void *req_complete_cb_data;
+    ompi_request_dump_fn_t req_dump;            /**< Called when a hang-up situation is detected */
     ompi_mpi_object_t req_mpi_object;           /**< Pointer to MPI object that created this request */
 };
 
@@ -313,6 +324,14 @@ typedef struct ompi_request_fns_t {
 } ompi_request_fns_t;
 
 /**
+ * Array of ompi_request_t pointers.
+ */
+typedef struct ompi_request_array_t {
+    size_t count;              /**< Number of requests */
+    ompi_request_t **requests; /**< Array of pointers of requests */
+} ompi_request_array_t;
+
+/**
  * Globals used for tracking requests and request completion.
  */
 OMPI_DECLSPEC extern opal_pointer_array_t   ompi_request_f_to_c_table;
@@ -337,6 +356,20 @@ OMPI_DECLSPEC int ompi_request_persistent_proc_null_free(ompi_request_t **reques
  * Shut down the MPI_Request subsystem; invoked during MPI_FINALIZE.
  */
 int ompi_request_finalize(void);
+
+/**
+ * Function used for OPAL_PROGRESS_WHILE to dump one request data on hang-up.
+ *
+ * @param cbdata Pointer to an ompi_request_t object.
+ */
+void ompi_request_dump_on_hangup(void * cbdata);
+
+/**
+ * Function used for OPAL_PROGRESS_WHILE to dump multiple request data on hang-up.
+ *
+ * @param cbdata Pointer to an ompi_request_array_t object.
+ */
+void ompi_request_dump_array_on_hangup(void * cbdata);
 
 /**
  * Cancel a pending request.
@@ -379,7 +412,7 @@ static inline void ompi_request_wait_completion(ompi_request_t *req)
         WAIT_SYNC_INIT(&sync, 1);
 
         if (OPAL_ATOMIC_CMPSET_PTR(&req->req_complete, REQUEST_PENDING, &sync)) {
-            SYNC_WAIT(&sync);
+            SYNC_WAIT(&sync, ompi_request_dump_on_hangup, req);
         } else {
             /* completed before we had a chance to swap in the sync object */
             WAIT_SYNC_SIGNALLED(&sync);
@@ -388,9 +421,8 @@ static inline void ompi_request_wait_completion(ompi_request_t *req)
         assert(REQUEST_COMPLETE(req));
         WAIT_SYNC_RELEASE(&sync);
     } else {
-        while(!REQUEST_COMPLETE(req)) {
-            opal_progress();
-        }
+        OPAL_PROGRESS_WHILE(!REQUEST_COMPLETE(req),
+                            true, ompi_request_dump_on_hangup, req);
     }
 }
 

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -159,6 +160,19 @@ int opal_register_params(void)
                                  OPAL_INFO_LVL_8, MCA_BASE_VAR_SCOPE_LOCAL,
                                  &opal_progress_yield_when_idle);
 #endif
+
+    ret = mca_base_var_register ("opal", "opal", "progress", "timeout",
+                                 "If nonzero, the timeout-based hang-up detection feature is enabled. "
+                                 "The absolute value is a time in seconds to wait a completion of an operation. "
+                                 "If positive, the process prints a message and aborts on the timeout. "
+                                 "If negative, the process prints a message and continues on the timeout. "
+                                 "If you want to debug a hang-up situation caused by inter-process communication, "
+                                 "setting opal_abort_delay also is recommended because peer processes also can detect "
+                                 "the hang-up situation and print useful messages before aborting the entire job. "
+                                 "This feature cannot detect all hang-up situations and may give a false-positive.",
+                                 MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                                 OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
+                                 &opal_progress_timeout);
 
 #if OPAL_ENABLE_DEBUG
     opal_progress_debug = false;

--- a/opal/runtime/opal_progress.h
+++ b/opal/runtime/opal_progress.h
@@ -202,8 +202,15 @@ static inline bool opal_progress_spin(volatile bool* complete)
 
 /**
  * typedef of callback functions which are called when hang-up is detected
+ *
+ * A typical usage is to output hang-up situation information for debugging.
+ *
+ * @param file   File stream to output hang-up situation information into.
+ * @param prefix Desired prefix for each line of hang-up situation information.
+ * @param cbdata Callback data passed with the function pointer.
  */
-typedef void (*opal_progress_hangup_callback_fn_t)(void *cbdata);
+typedef void (*opal_progress_hangup_callback_fn_t)(FILE *file, char *prefix,
+                                                   void *cbdata);
 
 /**
  * How many seconds we wait in opal_progress loop (OPAL_PROGRESS_BLOCK_WHILE)

--- a/opal/threads/condition.h
+++ b/opal/threads/condition.h
@@ -13,6 +13,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,17 +66,17 @@ static inline int opal_condition_wait(opal_condition_t *c, opal_mutex_t *m)
             opal_mutex_lock(m);
             return 0;
         }
-        while (c->c_signaled == 0) {
+        OPAL_PROGRESS_BLOCK_WHILE(c->c_signaled == 0, true, NULL, NULL, {
             opal_mutex_unlock(m);
             opal_progress();
             OPAL_CR_TEST_CHECKPOINT_READY_STALL();
             opal_mutex_lock(m);
-        }
+        });
     } else {
-        while (c->c_signaled == 0) {
+        OPAL_PROGRESS_BLOCK_WHILE(c->c_signaled == 0, true, NULL, NULL, {
             opal_progress();
             OPAL_CR_TEST_CHECKPOINT_READY_STALL();
-        }
+        });
     }
 
     c->c_signaled--;

--- a/opal/threads/wait_sync.c
+++ b/opal/threads/wait_sync.c
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,7 +24,9 @@ static ompi_wait_sync_t* wait_sync_list = NULL;
         pthread_mutex_unlock( &(who)->lock);           \
     } while(0)
 
-int sync_wait_mt(ompi_wait_sync_t *sync)
+int sync_wait_mt(ompi_wait_sync_t *sync,
+                 opal_progress_hangup_callback_fn_t hangup_cbfunc,
+                 void *hangup_cbdata)
 {
     /* Don't stop if the waiting synchronization is completed. We avoid the
      * race condition around the release of the synchronization using the
@@ -80,9 +83,9 @@ int sync_wait_mt(ompi_wait_sync_t *sync)
     }
 
     pthread_mutex_unlock(&sync->lock);
-    while(sync->count > 0) {  /* progress till completion */
-        opal_progress();  /* don't progress with the sync lock locked or you'll deadlock */
-    }
+    /* progress till completion */
+    /* don't progress with the sync lock locked or you'll deadlock */
+    OPAL_PROGRESS_WHILE(sync->count > 0, true, NULL, NULL);
     assert(sync == wait_sync_list);
 
  i_am_done:

--- a/opal/util/stacktrace.h
+++ b/opal/util/stacktrace.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,18 @@
  * is passed NULL for it's FILE file pointer.
  */
 extern int opal_stacktrace_output_fileno;
+
+/**
+ * Set the opal_stacktrace_output_filename variable.
+ *
+ * We append VPID and PID as a suffix to the filename specified by the MCA
+ * parameter opal_stacktrace_output. But since the MCA parameter registration
+ * and its parsing may be processed before setting the VPID of this process,
+ * they may not be able to determine the suffix. This function should be
+ * called before using the opal_stacktrace_output_filename variable so that
+ * the filename suffix will be set appropriately with the VPID.
+ */
+OPAL_DECLSPEC void opal_stacktrace_set_output_filename(void);
 
 /**
  * Output the current stack trace (not including the call to this


### PR DESCRIPTION
# Add a hang-up detection feature

Debugging communication deadlock of MPI processes is a difficult task. If one process stops progress for some reason, peer processes who wait the process also stop progress. And all processes in the job will stop progress. Usually, finding the causal process is not a trivial task. Sometimes, even determining whether the situation is communication deadlock or just slowdown is difficult. This commit adds a feature to detect a possible deadlock (hang-up) and output information which may be useful to analyze the deadlock.

I want to discuss this code modification at the upcoming July 2017 OMPI developer's meeting.

## Added Feature

### Detection

The logic of the deadlock detection is very simple. If a waiting operation (in `MPI_WAIT` etc.) does not complete within a certain time, we consider it as a hang-up situation. The time limit can be set by the MCA parameter `opal_progress_timeout` in seconds. I know this logic is suboptimal and there are studies about communication deadlock detection/analysis. But this logic is easy to implement and is proved to be very useful among Fujitsu MPI customers.

By default, `opal_progress_timeout` is 0 and this feature is disabled.

### Output

If a hang-up situation is detected, the following information is output at each process.

- message to indicate a possible hang-up is detected
- stack trace
- data of waiting request

An output example:

```
[dirac:19756] Possible hang-up (no progress) is detected on [[56375,1],0]
[dirac:19756] [ 0] /home/tkawa/openmpi/lib/libopen-pal.so.0(opal_progress_handle_hangup+0xc0)[0x7fa267a9a540]
[dirac:19756] [ 1] /home/tkawa/openmpi/lib/openmpi/mca_pml_ob1.so(+0x102e8)[0x7fa25c2c42e8]
[dirac:19756] [ 2] /home/tkawa/openmpi/lib/openmpi/mca_pml_ob1.so(mca_pml_ob1_send+0x599)[0x7fa25c2c6731]
[dirac:19756] [ 3] /home/tkawa/openmpi/lib/libmpi.so.0(PMPI_Send+0x2a7)[0x7fa26873995e]
[dirac:19756] [ 4] ./deadlock[0x400c7c]
[dirac:19756] [ 5] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7fa2680dcb45]
[dirac:19756] [ 6] ./deadlock[0x400a99]
[dirac:19756] send request (c=0xb6c100 f=UNDEFINED) to rank=0 (jobid=3694592001 vpid=0) on communicator=MPI_COMM_WORLD (c=0x601500 f=0 id=0 my_rank=0) with tag=0 for datatype=MPI_CHAR (c=0x601300 f=34 id=1) x count=131072 in addr=0x7ffcdd9cdb00 [complete=n state=2 type=1 pml_complete=n free_called=n sequence=1 send_mode=4 bytes_packed=131072 recv=(nil) state=0 throttle_sends=n pipeline_depth=0 bytes_delivered=0 rdma_cnt=1 pending=0]
```

Assembling output from all processes and analyzing the data will help finding the cause of the hang-up. But such script is not ready at this moment.

### Termination

By default, when hang-up is detected and information is output, the process will abort with `exit(1)`.

If one MPI process aborts, `orted` will terminates all MPI processes. But in many cases, other processes also detect hang-up and try to output information. To ensure information is output on all processes, the existing MCA parameter `opal_abort_delay` can be used. If a positive value is specified, each process sleeps for the given seconds to wait other processes to output information. If a negative value is specified, each process sleeps forever and allows attaching of a debugger.

This detection logic gives a false-positive. If the value of `opal_progress_timeout` is negative, the process does not abort. It only output information and continue progress when possible hang-up is detected.

## Similar Feature

`orterun` has the `--timeout` option and also can detect possible hang-up. Advantage of this feature is:

- The timeout of this feature is per-operation basis.
- Request data can be output.
- It can be used with resource manager other than `orted`.

## Code Modification

### Detection

`while` loops which call the `opal_progress` function are replaced with the `OPAL_PROGRESS_WHILE` macro and `OPAL_PROGRESS_BLOCK_WHILE` macro, which processes timeout. In this commit, only `while` loops in the following functions are replaced.

- `sync_wait_st`
- `sync_wait_mt`
- `opal_condition_wait`

These functions covers most of blocking MPI functions but not all. You can replace loops in other functions easily.

### Output

In this commit, output of request data is supported by only ob1 PML requests. You can support data output by setting the `req_dump` callback function of the `ompi_request_t` structure.
