### PR TITLE
Control distribution of signals to children vs grandchildren

### DIFF
--- a/orte/mca/odls/base/odls_base_frame.c
+++ b/orte/mca/odls/base/odls_base_frame.c
@@ -86,6 +86,15 @@ static int orte_odls_base_register(mca_base_register_flag_t flags)
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &orte_odls_globals.num_threads);
 
+    orte_odls_globals.signal_direct_children_only = false;
+    (void) mca_base_var_register("orte", "odls", "base", "signal_direct_children_only",
+                                 "Whether to restrict signals (e.g., SIGTERM) to direct children, or "
+                                 "to apply them as well to any children spawned by those processes",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &orte_odls_globals.signal_direct_children_only);
+
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/odls/base/odls_private.h
+++ b/orte/mca/odls/base/odls_private.h
@@ -62,6 +62,7 @@ typedef struct {
     opal_event_base_t **ev_bases;   // event base array for progress threads
     char** ev_threads;              // event progress thread names
     int next_base;                  // counter to load-level thread use
+    bool signal_direct_children_only;
 } orte_odls_globals_t;
 
 ORTE_DECLSPEC extern orte_odls_globals_t orte_odls_globals;

--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -644,9 +644,22 @@ int orte_odls_default_launch_local_procs(opal_buffer_t *data)
  * Send a signal to a pid.  Note that if we get an error, we set the
  * return value and let the upper layer print out the message.
  */
-static int send_signal(pid_t pid, int signal)
+static int send_signal(pid_t pd, int signal)
 {
     int rc = ORTE_SUCCESS;
+    pid_t pid;
+
+    if (orte_odls_globals.signal_direct_children_only) {
+        pid = pd;
+    } else {
+#if HAVE_SETPGID
+        /* send to the process group so that any children of our children
+         * also receive the signal*/
+        pid = -pd;
+#else
+        pid = pd;
+#endif
+    }
 
     OPAL_OUTPUT_VERBOSE((1, orte_odls_base_framework.framework_output,
                          "%s sending signal %d to pid %ld",


### PR DESCRIPTION
By default, apply signals to all direct children _and_ any children they might have spawned (so long as they remain in the same process group). Provide an MCA param (odls_base_signal_direct_children_only) to indicate that the signal is to go _only_ to our direct children, and not be delivered to any children spawned by those procs.

Refs https://www.mail-archive.com/users@lists.open-mpi.org/msg31221.html

Signed-off-by: Ralph Castain <rhc@open-mpi.org>