### PR TITLE
io/ompio: remove fucntion call to cart_based_grouping

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -199,14 +199,6 @@ ompio_io_ompio_file_open (ompi_communicator_t *comm,
 	ompio_fh->f_flags |= OMPIO_SHAREDFP_IS_SET;
     }
 
-     /*Determine topology information if set*/
-    if (ompio_fh->f_comm->c_flags & OMPI_COMM_CART){
-        ret = mca_io_ompio_cart_based_grouping(ompio_fh);
-	if(OMPI_SUCCESS != ret ){
-	    ret = MPI_ERR_FILE;
-	}
-    }
-
     ret = ompio_fh->f_fs->fs_file_open (comm,
 					filename,
 					amode,


### PR DESCRIPTION
the cart_based_grouping aggregator strategy was not correctly updated
during the last major rewrite of the aggregator selection algorithm.
It is also not supposed to be called from file_open (but from
file_set_view).

fixes issue  #3695

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>