### PR TITLE
v3.0.x: hwloc: re-enable use of autogen.pl in a tarball

### DIFF
--- a/opal/mca/hwloc/Makefile.am
+++ b/opal/mca/hwloc/Makefile.am
@@ -9,6 +9,8 @@
 # $HEADER$
 #
 
+EXTRA_DIST = autogen.options
+
 # main library setup
 noinst_LTLIBRARIES = libmca_hwloc.la
 libmca_hwloc_la_SOURCES =


### PR DESCRIPTION
Commit fec519a793a2afcfd1ebcb3fa7c151bd30893835 broke the ability to run autogen.pl in a distribution tarball (in master).  This commit restores that ability by also distributing opal/mca/hwloc/autogen.options in the tarball.

Skipping CI because CI does not test this functionality:

[skip ci]
bot:notest

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

(cherry picked from commit b8dfd49e976b6c5864274008f7f72c7e55754a89)

@bwbarrett This is why Cisco's MTT v3.0 build that runs autogen in the tarball has been broken (e.g., https://mtt.open-mpi.org/index.php?do_redir=2451).