### PR TITLE
opal: use opal_list_t convienience macros

### DIFF
--- a/opal/mca/btl/openib/btl_openib_ini.c
+++ b/opal/mca/btl/openib/btl_openib_ini.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008      Mellanox Technologies. All rights reserved.
- * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved
  * Copyright (c) 2014-2015 Research Organization for Information Science
@@ -160,7 +160,6 @@ int opal_btl_openib_ini_query(uint32_t vendor_id, uint32_t vendor_part_id,
 {
     int ret;
     device_values_t *h;
-    opal_list_item_t *item;
 
     if (!initialized) {
         if (OPAL_SUCCESS != (ret = opal_btl_openib_ini_init())) {
@@ -176,10 +175,7 @@ int opal_btl_openib_ini_query(uint32_t vendor_id, uint32_t vendor_part_id,
     reset_values(values);
 
     /* Iterate over all the saved devices */
-    for (item = opal_list_get_first(&devices);
-         item != opal_list_get_end(&devices);
-         item = opal_list_get_next(item)) {
-        h = (device_values_t*) item;
+    OPAL_LIST_FOREACH(h, &devices, device_values_t) {
         if (vendor_id == h->vendor_id &&
             vendor_part_id == h->vendor_part_id) {
             /* Found it! */
@@ -208,15 +204,8 @@ int opal_btl_openib_ini_query(uint32_t vendor_id, uint32_t vendor_part_id,
  */
 int opal_btl_openib_ini_finalize(void)
 {
-    opal_list_item_t *item;
-
     if (initialized) {
-        for (item = opal_list_remove_first(&devices);
-             NULL != item;
-             item = opal_list_remove_first(&devices)) {
-            OBJ_RELEASE(item);
-        }
-        OBJ_DESTRUCT(&devices);
+        OPAL_LIST_DESTRUCT(&devices);
         initialized = true;
     }
 
@@ -524,7 +513,6 @@ static void reset_values(opal_btl_openib_ini_values_t *v)
 static int save_section(parsed_section_values_t *s)
 {
     int i, j;
-    opal_list_item_t *item;
     device_values_t *h;
     bool found;
 
@@ -541,10 +529,7 @@ static int save_section(parsed_section_values_t *s)
             found = false;
 
             /* Iterate over all the saved devices */
-            for (item = opal_list_get_first(&devices);
-                 item != opal_list_get_end(&devices);
-                 item = opal_list_get_next(item)) {
-                h = (device_values_t*) item;
+            OPAL_LIST_FOREACH(h, &devices, device_values_t) {
                 if (s->vendor_ids[i] == h->vendor_id &&
                     s->vendor_part_ids[j] == h->vendor_part_id) {
                     /* Found a match.  Update any newly-set values. */

--- a/opal/mca/btl/openib/btl_openib_proc.c
+++ b/opal/mca/btl/openib/btl_openib_proc.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
- * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -96,12 +96,7 @@ void mca_btl_openib_proc_destruct(mca_btl_openib_proc_t* ib_proc)
     }
     OBJ_DESTRUCT(&ib_proc->proc_lock);
 
-    elem = (mca_btl_openib_proc_btlptr_t*)opal_list_remove_first(&ib_proc->openib_btls);
-    while( NULL != elem ){
-            OBJ_RELEASE(elem);
-            elem = (mca_btl_openib_proc_btlptr_t*)opal_list_remove_first(&ib_proc->openib_btls);
-    }
-    OBJ_DESTRUCT(&ib_proc->openib_btls);
+    OPAL_LIST_DESTRUCT(&ib_proc->openib_btls);
 }
 
 
@@ -113,11 +108,7 @@ static mca_btl_openib_proc_t* ibproc_lookup_no_lock(opal_proc_t* proc)
 {
     mca_btl_openib_proc_t* ib_proc;
 
-    for(ib_proc = (mca_btl_openib_proc_t*)
-            opal_list_get_first(&mca_btl_openib_component.ib_procs);
-            ib_proc != (mca_btl_openib_proc_t*)
-            opal_list_get_end(&mca_btl_openib_component.ib_procs);
-            ib_proc  = (mca_btl_openib_proc_t*)opal_list_get_next(ib_proc)) {
+    OPAL_LIST_FOREACH(ib_proc, &mca_btl_openib_component.ib_procs, mca_btl_openib_proc_t) {
         if(ib_proc->proc_opal == proc) {
             return ib_proc;
         }
@@ -398,10 +389,7 @@ int mca_btl_openib_proc_reg_btl(mca_btl_openib_proc_t* ib_proc,
 {
     mca_btl_openib_proc_btlptr_t* elem;
 
-
-    for(elem = (mca_btl_openib_proc_btlptr_t*)opal_list_get_first(&ib_proc->openib_btls);
-            elem != (mca_btl_openib_proc_btlptr_t*)opal_list_get_end(&ib_proc->openib_btls);
-            elem  = (mca_btl_openib_proc_btlptr_t*)opal_list_get_next(elem)) {
+    OPAL_LIST_FOREACH(elem, &ib_proc->openib_btls, mca_btl_openib_proc_btlptr_t) {
         if(elem->openib_btl == openib_btl) {
             /* this is normal return meaning that this BTL has already touched this ib_proc */
             return OPAL_ERR_RESOURCE_BUSY;

--- a/opal/mca/btl/openib/connect/btl_openib_connect_rdmacm.c
+++ b/opal/mca/btl/openib/connect/btl_openib_connect_rdmacm.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2008      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2009      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2012-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
  * Copyright (c) 2014      The University of Tennessee and The University
@@ -1879,7 +1879,7 @@ static int ipaddrcheck(id_context_t *context,
     rdmacm_contents_t *server = context->contents;
     uint32_t ipaddr;
     bool already_exists = false;
-    opal_list_item_t *item;
+    rdmacm_contents_t *contents;
     int server_tcp_port = rdma_get_src_port(context->id);
     char *str;
 
@@ -1908,10 +1908,7 @@ static int ipaddrcheck(id_context_t *context,
 
     /* Ok, we found the IP address of this device/port.  Have we
        already see this IP address/TCP port before? */
-    for (item = opal_list_get_first(&server_listener_list);
-         item != opal_list_get_end(&server_listener_list);
-         item = opal_list_get_next(item)) {
-        rdmacm_contents_t *contents = (rdmacm_contents_t *)item;
+    OPAL_LIST_FOREACH(contents, &server_listener_list, rdmacm_contents_t) {
         BTL_VERBOSE(("paddr = %x, ipaddr addr = %x",
                      contents->ipaddr, ipaddr));
         if (contents->ipaddr == ipaddr &&

--- a/opal/mca/btl/sm/btl_sm.c
+++ b/opal/mca/btl/sm/btl_sm.c
@@ -1289,17 +1289,13 @@ void mca_btl_sm_dump(struct mca_btl_base_module_t* btl,
                      struct mca_btl_base_endpoint_t* endpoint,
                      int verbose)
 {
-    opal_list_item_t *item;
     mca_btl_sm_frag_t* frag;
 
     if( NULL != endpoint ) {
         mca_btl_base_err("BTL SM %p endpoint %p [smp_rank %d] [peer_rank %d]\n",
                          (void*) btl, (void*) endpoint,
                          endpoint->my_smp_rank, endpoint->peer_smp_rank);
-        for(item =  opal_list_get_first(&endpoint->pending_sends);
-            item != opal_list_get_end(&endpoint->pending_sends);
-            item = opal_list_get_next(item)) {
-            frag = (mca_btl_sm_frag_t*)item;
+        OPAL_LIST_FOREACH(frag, &endpoint->pending_sends, mca_btl_sm_frag_t) {
             mca_btl_base_err(" |  frag %p size %lu (hdr frag %p len %lu rank %d tag %d)\n",
                              (void*) frag, frag->size, (void*) frag->hdr->frag,
                              frag->hdr->len, frag->hdr->my_smp_rank,

--- a/opal/mca/btl/smcuda/btl_smcuda.c
+++ b/opal/mca/btl/smcuda/btl_smcuda.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2010-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
@@ -1266,17 +1266,13 @@ void mca_btl_smcuda_dump(struct mca_btl_base_module_t* btl,
                      struct mca_btl_base_endpoint_t* endpoint,
                      int verbose)
 {
-    opal_list_item_t *item;
     mca_btl_smcuda_frag_t* frag;
 
     mca_btl_base_err("BTL SM %p endpoint %p [smp_rank %d] [peer_rank %d]\n",
                      (void*) btl, (void*) endpoint,
                      endpoint->my_smp_rank, endpoint->peer_smp_rank);
     if( NULL != endpoint ) {
-        for(item =  opal_list_get_first(&endpoint->pending_sends);
-            item != opal_list_get_end(&endpoint->pending_sends);
-            item = opal_list_get_next(item)) {
-            frag = (mca_btl_smcuda_frag_t*)item;
+        OPAL_LIST_FOREACH(frag, &endpoint->pending_sends, mca_btl_smcuda_frag_t) {
             mca_btl_base_err(" |  frag %p size %lu (hdr frag %p len %lu rank %d tag %d)\n",
                              (void*) frag, frag->size, (void*) frag->hdr->frag,
                              frag->hdr->len, frag->hdr->my_smp_rank,

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2012-2015 Los Alamos National Security, LLC.
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -830,7 +830,6 @@ unsigned int opal_hwloc_base_get_nbobjs_by_type(hwloc_topology_t topo,
 {
     unsigned int num_objs, idx;
     hwloc_obj_t obj;
-    opal_list_item_t *item;
     opal_hwloc_summary_t *sum;
     opal_hwloc_topo_data_t *data;
     int rc;
@@ -866,10 +865,7 @@ unsigned int opal_hwloc_base_get_nbobjs_by_type(hwloc_topology_t topo,
         data = OBJ_NEW(opal_hwloc_topo_data_t);
         obj->userdata = (void*)data;
     } else {
-        for (item = opal_list_get_first(&data->summaries);
-             item != opal_list_get_end(&data->summaries);
-             item = opal_list_get_next(item)) {
-            sum = (opal_hwloc_summary_t*)item;
+        OPAL_LIST_FOREACH(sum, &data->summaries, opal_hwloc_summary_t) {
             if (target == sum->type &&
                 cache_level == sum->cache_level &&
                 rtype == sum->rtype) {
@@ -2098,7 +2094,6 @@ static int find_devices(hwloc_topology_t topo, char** device_name)
 int opal_hwloc_get_sorted_numa_list(hwloc_topology_t topo, char* device_name, opal_list_t *sorted_list)
 {
     hwloc_obj_t obj;
-    opal_list_item_t *item;
     opal_hwloc_summary_t *sum;
     opal_hwloc_topo_data_t *data;
     opal_rmaps_numa_node_t *numa, *copy_numa;
@@ -2110,10 +2105,7 @@ int opal_hwloc_get_sorted_numa_list(hwloc_topology_t topo, char* device_name, op
     /* we call opal_hwloc_base_get_nbobjs_by_type() before it to fill summary object so it should exist*/
     data = (opal_hwloc_topo_data_t*)obj->userdata;
     if (NULL != data) {
-        for (item = opal_list_get_first(&data->summaries);
-                item != opal_list_get_end(&data->summaries);
-                item = opal_list_get_next(item)) {
-            sum = (opal_hwloc_summary_t*)item;
+        OPAL_LIST_FOREACH(sum, &data->summaries, opal_hwloc_summary_t) {
             if (HWLOC_OBJ_NODE == sum->type) {
                 if (opal_list_get_size(&sum->sorted_by_dist_list) > 0) {
                     OPAL_LIST_FOREACH(numa, &(sum->sorted_by_dist_list), opal_rmaps_numa_node_t) {

--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -556,10 +556,9 @@ char *opal_cmd_line_get_usage_msg(opal_cmd_line_t *cmd)
         opal_mutex_unlock(&cmd->lcl_mutex);
         return NULL;
     }
-    for (i = 0, item = opal_list_get_first(&cmd->lcl_options);
-         opal_list_get_end(&cmd->lcl_options) != item;
-         ++i, item = opal_list_get_next(item)) {
-        sorted[i] = (cmd_line_option_t *) item;
+    i = 0;
+    OPAL_LIST_FOREACH(item, &cmd->lcl_options, opal_list_item_t) {
+        sorted[i++] = (cmd_line_option_t *) item;
     }
     qsort(sorted, i, sizeof(cmd_line_option_t*), qsort_callback);
 
@@ -762,7 +761,6 @@ bool opal_cmd_line_is_taken(opal_cmd_line_t *cmd, const char *opt)
 int opal_cmd_line_get_ninsts(opal_cmd_line_t *cmd, const char *opt)
 {
     int ret;
-    opal_list_item_t *item;
     cmd_line_param_t *param;
     cmd_line_option_t *option;
 
@@ -776,10 +774,7 @@ int opal_cmd_line_get_ninsts(opal_cmd_line_t *cmd, const char *opt)
     ret = 0;
     option = find_option(cmd, opt);
     if (NULL != option) {
-        for (item = opal_list_get_first(&cmd->lcl_params);
-             opal_list_get_end(&cmd->lcl_params) != item;
-             item = opal_list_get_next(item)) {
-            param = (cmd_line_param_t *) item;
+        OPAL_LIST_FOREACH(param, &cmd->lcl_params, cmd_line_param_t) {
             if (param->clp_option == option) {
                 ++ret;
             }
@@ -804,7 +799,6 @@ char *opal_cmd_line_get_param(opal_cmd_line_t *cmd, const char *opt, int inst,
                               int idx)
 {
     int num_found;
-    opal_list_item_t *item;
     cmd_line_param_t *param;
     cmd_line_option_t *option;
 
@@ -823,10 +817,7 @@ char *opal_cmd_line_get_param(opal_cmd_line_t *cmd, const char *opt, int inst,
            parameter index greater than we will have */
 
         if (idx < option->clo_num_params) {
-            for (item = opal_list_get_first(&cmd->lcl_params);
-                 opal_list_get_end(&cmd->lcl_params) != item;
-                 item = opal_list_get_next(item)) {
-                param = (cmd_line_param_t *) item;
+            OPAL_LIST_FOREACH(param, &cmd->lcl_params, cmd_line_param_t) {
                 if (param->clp_argc > 0 && param->clp_option == option) {
                     if (num_found == inst) {
                         opal_mutex_unlock(&cmd->lcl_mutex);
@@ -1160,17 +1151,13 @@ static int split_shorts(opal_cmd_line_t *cmd, char *token, char **args,
 static cmd_line_option_t *find_option(opal_cmd_line_t *cmd,
                                       const char *option_name)
 {
-    opal_list_item_t *item;
     cmd_line_option_t *option;
 
     /* Iterate through the list of options hanging off the
        opal_cmd_line_t and see if we find a match in either the short
        or long names */
 
-    for (item = opal_list_get_first(&cmd->lcl_options);
-         opal_list_get_end(&cmd->lcl_options) != item;
-         item = opal_list_get_next(item)) {
-        option = (cmd_line_option_t *) item;
+    OPAL_LIST_FOREACH(option, &cmd->lcl_options, cmd_line_option_t) {
         if ((NULL != option->clo_long_name &&
              0 == strcmp(option_name, option->clo_long_name)) ||
             (NULL != option->clo_single_dash_name &&

--- a/opal/util/if.c
+++ b/opal/util/if.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -100,9 +100,7 @@ int opal_ifnametoaddr(const char* if_name, struct sockaddr* addr, int length)
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (strcmp(intf->if_name, if_name) == 0) {
             memcpy(addr, &intf->if_addr, length);
             return OPAL_SUCCESS;
@@ -121,9 +119,7 @@ int opal_ifnametoindex(const char* if_name)
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (strcmp(intf->if_name, if_name) == 0) {
             return intf->if_index;
         }
@@ -141,9 +137,7 @@ int16_t opal_ifnametokindex(const char* if_name)
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (strcmp(intf->if_name, if_name) == 0) {
             return intf->if_kernel_index;
         }
@@ -161,9 +155,7 @@ int opal_ifindextokindex(int if_index)
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (if_index == intf->if_index) {
             return intf->if_kernel_index;
         }
@@ -204,10 +196,7 @@ int opal_ifaddrtoname(const char* if_addr, char* if_name, int length)
     }
 
     for (r = res; r != NULL; r = r->ai_next) {
-        for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-            intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-            intf =  (opal_if_t*)opal_list_get_next(intf)) {
-
+        OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
             if (AF_INET == r->ai_family) {
                 struct sockaddr_in ipv4;
                 struct sockaddr_in *inaddr;
@@ -335,9 +324,7 @@ int opal_ifnext(int if_index)
 {
     opal_if_t *intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             do {
                 opal_if_t* if_next = (opal_if_t*)opal_list_get_next(intf);
@@ -363,9 +350,7 @@ int opal_ifindextoaddr(int if_index, struct sockaddr* if_addr, unsigned int leng
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-         intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-         intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             memcpy(if_addr, &intf->if_addr, MIN(length, sizeof (intf->if_addr)));
             return OPAL_SUCCESS;
@@ -383,9 +368,7 @@ int opal_ifkindextoaddr(int if_kindex, struct sockaddr* if_addr, unsigned int le
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-         intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-         intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_kernel_index == if_kindex) {
             memcpy(if_addr, &intf->if_addr, MIN(length, sizeof (intf->if_addr)));
             return OPAL_SUCCESS;
@@ -404,9 +387,7 @@ int opal_ifindextomask(int if_index, uint32_t* if_mask, int length)
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             memcpy(if_mask, &intf->if_mask, length);
             return OPAL_SUCCESS;
@@ -424,9 +405,7 @@ int opal_ifindextomac(int if_index, uint8_t mac[6])
 {
     opal_if_t* intf;
 
-    for (intf = (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf = (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             memcpy(mac, &intf->if_mac, 6);
             return OPAL_SUCCESS;
@@ -444,9 +423,7 @@ int opal_ifindextomtu(int if_index, int *mtu)
 {
     opal_if_t* intf;
 
-    for (intf = (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf = (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             *mtu = intf->ifmtu;
             return OPAL_SUCCESS;
@@ -464,9 +441,7 @@ int opal_ifindextoflags(int if_index, uint32_t* if_flags)
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             memcpy(if_flags, &intf->if_flags, sizeof(uint32_t));
             return OPAL_SUCCESS;
@@ -486,9 +461,7 @@ int opal_ifindextoname(int if_index, char* if_name, int length)
 {
     opal_if_t *intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             strncpy(if_name, intf->if_name, length);
             return OPAL_SUCCESS;
@@ -507,9 +480,7 @@ int opal_ifkindextoname(int if_kindex, char* if_name, int length)
 {
     opal_if_t *intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_kernel_index == if_kindex) {
             strncpy(if_name, intf->if_name, length);
             return OPAL_SUCCESS;
@@ -639,9 +610,7 @@ bool opal_ifisloopback(int if_index)
 {
     opal_if_t* intf;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         if (intf->if_index == if_index) {
             if ((intf->if_flags & IFF_LOOPBACK) != 0) {
                 return true;
@@ -715,9 +684,7 @@ void opal_ifgetaliases(char ***aliases)
     /* set default answer */
     *aliases = NULL;
 
-    for (intf =  (opal_if_t*)opal_list_get_first(&opal_if_list);
-        intf != (opal_if_t*)opal_list_get_end(&opal_if_list);
-        intf =  (opal_if_t*)opal_list_get_next(intf)) {
+    OPAL_LIST_FOREACH(intf, &opal_if_list, opal_if_t) {
         addr = (struct sockaddr_in*) &intf->if_addr;
         /* ignore purely loopback interfaces */
         if ((intf->if_flags & IFF_LOOPBACK) != 0) {

--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -83,22 +83,18 @@ OBJ_CLASS_INSTANCE(opal_info_entry_t,
 int opal_info_dup (opal_info_t *info, opal_info_t **newinfo)
 {
     int err;
-    opal_list_item_t *item;
     opal_info_entry_t *iterator;
 
     OPAL_THREAD_LOCK(info->i_lock);
-    for (item = opal_list_get_first(&(info->super));
-         item != opal_list_get_end(&(info->super));
-         item = opal_list_get_next(iterator)) {
-         iterator = (opal_info_entry_t *) item;
-         err = opal_info_set(*newinfo, iterator->ie_key, iterator->ie_value);
-         if (MPI_SUCCESS != err) {
+    OPAL_LIST_FOREACH(iterator, &info->super, opal_info_entry_t) {
+        err = opal_info_set(*newinfo, iterator->ie_key, iterator->ie_value);
+        if (MPI_SUCCESS != err) {
             OPAL_THREAD_UNLOCK(info->i_lock);
             return err;
-         }
+        }
      }
     OPAL_THREAD_UNLOCK(info->i_lock);
-     return MPI_SUCCESS;
+    return MPI_SUCCESS;
 }
 
 /*
@@ -118,7 +114,6 @@ int opal_info_dup_mode (opal_info_t *info, opal_info_t **newinfo,
     int show_modifications)     // (pick v from k/v or __IN_k/v)
 {
     int err, flag;
-    opal_list_item_t *item;
     opal_info_entry_t *iterator;
     char savedkey[MPI_MAX_INFO_KEY];
     char savedval[MPI_MAX_INFO_VAL];
@@ -127,11 +122,7 @@ int opal_info_dup_mode (opal_info_t *info, opal_info_t **newinfo,
     int exists_IN_key, exists_reg_key;
 
     OPAL_THREAD_LOCK(info->i_lock);
-    for (item = opal_list_get_first(&(info->super));
-         item != opal_list_get_end(&(info->super));
-         item = opal_list_get_next(iterator)) {
-         iterator = (opal_info_entry_t *) item;
-
+    OPAL_LIST_FOREACH(iterator, &info->super, opal_info_entry_t) {
 // If we see an __IN_<key> key but no <key>, decide what to do based on mode.
 // If we see an __IN_<key> and a <key>, skip since it'll be handled when
 // we process <key>.
@@ -543,9 +534,7 @@ static opal_info_entry_t *info_find_key (opal_info_t *info, const char *key)
      * return immediately. Else, the loop will fall of the edge
      * and NULL is returned
      */
-    for (iterator = (opal_info_entry_t *)opal_list_get_first(&(info->super));
-         opal_list_get_end(&(info->super)) != (opal_list_item_t*) iterator;
-         iterator = (opal_info_entry_t *)opal_list_get_next(iterator)) {
+    OPAL_LIST_FOREACH(iterator, &info->super, opal_info_entry_t) {
         if (0 == strcmp(key, iterator->ie_key)) {
             return iterator;
         }


### PR DESCRIPTION
This commit cleans up code in opal to use OPAL_LIST_FOREACH(_SAFE),
OPAL_LIST_DESTRUCT, and OPAL_LIST_RELEASE.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>