### PR TITLE
Ensure we properly cleanup on termination, including when terminating due to ctrl-c

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -1256,8 +1256,10 @@ static void pmix2x_query(opal_list_t *queries,
     OPAL_PMIX_ACQUIRE_THREAD(&opal_pmix_base.lock);
     if (0 >= opal_pmix_base.initialized) {
         OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);
-        rc = OPAL_ERR_NOT_INITIALIZED;
-        goto CLEANUP;
+        if (NULL != cbfunc) {
+            cbfunc(OPAL_ERR_NOT_INITIALIZED, NULL, cbdata, NULL, NULL);
+        }
+        return;
     }
     OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);
 
@@ -1323,8 +1325,10 @@ static void pmix2x_log(opal_list_t *info,
     OPAL_PMIX_ACQUIRE_THREAD(&opal_pmix_base.lock);
     if (0 >= opal_pmix_base.initialized) {
         OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);
-        rc = OPAL_ERR_NOT_INITIALIZED;
-        goto CLEANUP;
+        if (NULL != cbfunc) {
+            cbfunc(OPAL_ERR_NOT_INITIALIZED, cbdata);
+        }
+        return;
     }
     OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);
 

--- a/opal/mca/pmix/pmix2x/pmix2x_client.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_client.c
@@ -312,7 +312,7 @@ int pmix2x_fence(opal_list_t *procs, int collect_data)
     pmix_status_t rc;
     opal_namelist_t *ptr;
     char *nsptr;
-    size_t cnt, n;
+    size_t cnt = 0, n;
     pmix_proc_t *parray = NULL;
     pmix_info_t info, *iptr;
 
@@ -725,7 +725,7 @@ int pmix2x_lookup(opal_list_t *data, opal_list_t *info)
     pmix_pdata_t *pdata;
     pmix_info_t *pinfo = NULL;
     pmix_status_t rc;
-    size_t cnt, n, sz;
+    size_t cnt, n, sz = 0;
     opal_value_t *iptr;
     opal_pmix2x_jobid_trkr_t *jptr, *job;
 
@@ -993,7 +993,7 @@ int pmix2x_spawn(opal_list_t *job_info, opal_list_t *apps, opal_jobid_t *jobid)
     pmix_status_t rc;
     pmix_info_t *info = NULL;
     pmix_app_t *papps;
-    size_t ninfo, napps, n, m;
+    size_t ninfo = 0, napps, n, m;
     opal_value_t *ival;
     opal_pmix_app_t *app;
     char nspace[PMIX_MAX_NSLEN+1];

--- a/orte/mca/ess/base/ess_base_std_app.c
+++ b/orte/mca/ess/base/ess_base_std_app.c
@@ -342,6 +342,8 @@ int orte_ess_base_app_finalize(void)
     (void) mca_base_framework_close(&orte_state_base_framework);
 
     orte_session_dir_finalize(ORTE_PROC_MY_NAME);
+    /* cleanup the process info */
+    orte_proc_info_finalize();
 
     return ORTE_SUCCESS;
 }

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -933,6 +933,10 @@ int orte_daemon(int argc, char *argv[])
     orte_finalize();
     opal_finalize_util();
 
+    orte_session_dir_cleanup(ORTE_JOBID_WILDCARD);
+    /* cleanup the process info */
+    orte_proc_info_finalize();
+
     if (orte_debug_flag) {
         fprintf(stderr, "exiting with status %d\n", orte_exit_status);
     }

--- a/orte/runtime/orte_finalize.c
+++ b/orte/runtime/orte_finalize.c
@@ -39,6 +39,7 @@
 #include "orte/runtime/orte_locks.h"
 #include "orte/util/listener.h"
 #include "orte/util/name_fns.h"
+#include "orte/util/proc_info.h"
 #include "orte/util/show_help.h"
 
 int orte_finalize(void)
@@ -90,6 +91,9 @@ int orte_finalize(void)
     if (NULL != orte_fork_agent) {
         opal_argv_free(orte_fork_agent);
     }
+
+    /* destruct our process info */
+    OBJ_DESTRUCT(&orte_process_info.super);
 
     /* finalize the opal utilities */
     rc = opal_finalize();

--- a/orte/runtime/orte_finalize.c
+++ b/orte/runtime/orte_finalize.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -83,9 +83,6 @@ int orte_finalize(void)
     /* finalize and close schizo */
     orte_schizo.finalize();
     (void) mca_base_framework_close(&orte_schizo_base_framework);
-
-    /* cleanup the process info */
-    orte_proc_info_finalize();
 
     /* Close the general debug stream */
     opal_output_close(orte_debug_output);

--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -86,6 +86,7 @@
 #include "orte/mca/rml/rml.h"
 #include "orte/mca/state/state.h"
 #include "orte/util/proc_info.h"
+#include "orte/util/session_dir.h"
 #include "orte/util/show_help.h"
 #include "orte/util/threads.h"
 
@@ -222,6 +223,9 @@ int orterun(int argc, char *argv[])
     /* cleanup and leave */
     orte_submit_finalize();
     orte_finalize();
+    orte_session_dir_cleanup(ORTE_JOBID_WILDCARD);
+    /* cleanup the process info */
+    orte_proc_info_finalize();
 
     if (orte_debug_flag) {
         fprintf(stderr, "exiting with status %d\n", orte_exit_status);

--- a/orte/util/proc_info.c
+++ b/orte/util/proc_info.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -69,7 +69,6 @@ ORTE_DECLSPEC orte_proc_info_t orte_process_info = {
     .aliases =                         NULL,
     .pid =                             0,
     .proc_type =                       ORTE_PROC_TYPE_NONE,
-    .sync_buf =                        NULL,
     .my_port =                         0,
     .num_restarts =                    0,
     .my_node_rank =                    ORTE_NODE_RANK_INVALID,
@@ -265,9 +264,6 @@ int orte_proc_info(void)
                                   &orte_ess_node_rank);
     orte_process_info.my_node_rank = (orte_node_rank_t) orte_ess_node_rank;
 
-    /* setup the sync buffer */
-    orte_process_info.sync_buf = OBJ_NEW(opal_buffer_t);
-
     return ORTE_SUCCESS;
 }
 
@@ -329,9 +325,6 @@ int orte_proc_info_finalize(void)
     }
 
     orte_process_info.proc_type = ORTE_PROC_TYPE_NONE;
-
-    OBJ_RELEASE(orte_process_info.sync_buf);
-    orte_process_info.sync_buf = NULL;
 
     OBJ_DESTRUCT(&orte_process_info.super);
 

--- a/orte/util/proc_info.c
+++ b/orte/util/proc_info.c
@@ -326,8 +326,6 @@ int orte_proc_info_finalize(void)
 
     orte_process_info.proc_type = ORTE_PROC_TYPE_NONE;
 
-    OBJ_DESTRUCT(&orte_process_info.super);
-
     opal_argv_free(orte_process_info.aliases);
 
     init = false;

--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
@@ -99,7 +99,6 @@ struct orte_proc_info_t {
     char **aliases;                     /**< aliases for this node */
     pid_t pid;                          /**< Local process ID for this process */
     orte_proc_type_t proc_type;         /**< Type of process */
-    opal_buffer_t *sync_buf;            /**< buffer to store sync response */
     uint16_t my_port;                   /**< TCP port for out-of-band comm */
     int num_restarts;                   /**< number of times this proc has restarted */
     orte_node_rank_t my_node_rank;      /**< node rank */


### PR DESCRIPTION
@jjhursey We aren't correctly cleaning up when aborting - this fixes the problem.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 38636f4f0acd59e65ffc76966f90f6f6c2278288)