### PR TITLE
osc/rdma: cleanup local peer setup and fix a bug

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -128,6 +128,9 @@ struct ompi_osc_rdma_module_t {
     /** value of same_size info key for this window */
     bool same_size;
 
+    /** CPU atomics can be used */
+    bool use_cpu_atomics;
+
     /** passive-target synchronization will not be used in this window */
     bool no_locks;
 


### PR DESCRIPTION
The data endpoint was not being set correctly for local peers in some
cases. This commit fixes the bug and cleans the associated code to
simplify the logic.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>