### PR TITLE
configure: add builtin asm check for s390/s390x

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -13,7 +13,7 @@ dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+dnl Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
@@ -1088,9 +1088,13 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
         # as s390 is 31bits while s390x is 64bits
         s390-*)
             opal_cv_asm_arch="S390"
+            OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"],
+              [AC_MSG_ERROR([No atomic primitives available for $host])])
             ;;
         s390x-*)
             opal_cv_asm_arch="S390X"
+            OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"],
+              [AC_MSG_ERROR([No atomic primitives available for $host])])
             ;;
         sparc*-*)
             # SPARC v9 (and above) are the only ones with 64bit support


### PR DESCRIPTION
We accepted a change that enabled CMA on s390 and s390x. This change
had the side-effect that we were no longer using the builtin atomics
for these systems. This is a problem since we do not have ASM for
s390 and s390x. This commit restores the atomics.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>