### PR TITLE
Sort directory listings

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -316,7 +316,7 @@ sub mca_process_framework {
             $mca_found->{$pname}->{$framework}->{found} = 1;
             opendir(DIR, $dir) ||
                 my_die "Can't open $dir directory";
-            foreach my $d (readdir(DIR)) {
+            foreach my $d (sort(readdir(DIR))) {
                 # Skip any non-directory, "base", or any dir that
                 # begins with "."
                 next
@@ -628,7 +628,7 @@ sub mpiext_run_global {
     my $dir = "$topdir/$ext_prefix";
     opendir(DIR, $dir) ||
         my_die "Can't open $dir directory";
-    foreach my $d (readdir(DIR)) {
+    foreach my $d (sort(readdir(DIR))) {
         # Skip any non-directory, "base", or any dir that begins with "."
         next
             if (! -d "$dir/$d" || $d eq "base" || substr($d, 0, 1) eq ".");
@@ -715,7 +715,7 @@ sub mpicontrib_run_global {
     my $dir = "$topdir/$contrib_prefix";
     opendir(DIR, $dir) ||
         my_die "Can't open $dir directory";
-    foreach my $d (readdir(DIR)) {
+    foreach my $d (sort(readdir(DIR))) {
         # Skip any non-directory, "base", or any dir that begins with "."
         next
             if (! -d "$dir/$d" || $d eq "base" || substr($d, 0, 1) eq ".");


### PR DESCRIPTION
to do builds in a more reproducible manner
indepenent of (random) filesystem ordering.

See https://reproducible-builds.org/ for why this matters.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>
(cherry picked from commit 15359e2244b58444a634cc38e4a40867620d99b1)