### PR TITLE
v2.0.x: configury: check for more __sync builtins

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -88,7 +88,9 @@ AC_DEFUN([OPAL_CHECK_SYNC_BUILTIN_CSWAP_INT128], [
 AC_DEFUN([OPAL_CHECK_SYNC_BUILTINS], [
   AC_MSG_CHECKING([for __sync builtin atomics])
 
-  AC_TRY_COMPILE([], [__sync_synchronize()],
+  AC_TRY_LINK([long tmp;], [__sync_synchronize();
+__sync_bool_compare_and_swap(&tmp, 0, 1);
+__sync_add_and_fetch(&tmp, 1);],
     [AC_MSG_RESULT([yes])
      $1],
     [AC_MSG_RESULT([no])


### PR DESCRIPTION
This commit updates the check for __sync builtin atomics to see if the
compiler supports both __sync_bool_compare_and_swap and
__sync_add_and_fetch. If either of these functions are not available
then we can't use the __sync builtins.

Fixes #1487

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>

(back-ported from commit open-mpi/ompi@98ce659e0b4492c67023fb0429b6a1fdf1980b87)