### PR TITLE
yalla with irregular contig datatype -- Fixes 3566

### DIFF
--- a/ompi/mca/pml/yalla/pml_yalla_datatype.h
+++ b/ompi/mca/pml/yalla/pml_yalla_datatype.h
@@ -3,6 +3,7 @@
  * Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,8 +30,7 @@ OBJ_CLASS_DECLARATION(mca_pml_yalla_convertor_t);
         ptrdiff_t lb; \
         \
         if (opal_datatype_is_contiguous_memory_layout(&(_dtype)->super, _count)) { \
-            ompi_datatype_type_size(_dtype, &size); \
-            ompi_datatype_type_lb(_dtype, &lb); \
+            ompi_datatype_get_true_extent(_dtype, &lb, &size); \
             (_req_base)->data_type          = MXM_REQ_DATA_BUFFER; \
             (_req_base)->data.buffer.ptr    = (char *)_buf + lb; \
             (_req_base)->data.buffer.length = size * (_count); \


### PR DESCRIPTION
Yalla has a macro PML_YALLA_INIT_MXM_REQ_DATA that checks if a datatype
is contiguous via opal_datatype_is_contiguous_memory_layout(dt,count)
and if so it selects a size and lb that presumably is what will rdma, as
            ompi_datatype_type_size(_dtype, &size); \
            ompi_datatype_type_lb(_dtype, &lb); \

This failed when I gave it a datatype constructed as [ ...] with extent 4.
What I mean by that datatype is
    lens[0] = 3;
    disps[0] = 1;
    types[0] = MPI_CHAR;
    MPI_Type_struct(1, lens, disps, types, &tmpdt);
    MPI_Type_create_resized(tmpdt, 0, 4, &mydt);
So there are 3 chars at offset 1, and the LB is 0 and the UB is 4.

So that macro decides that size=4 and lb=0 and later I suppose size is getting
updated to 3 for the final rdma, and so a send of a buffer
[ 0 1 2 3 ] gets recved as [ 0 1 2 _ ]. I think it should use the true lb
and the true extent.

For "regular" contig datatypes it would be the same, and for the irregular
ones that are still deemed contiguous by that utility function it should
still be the right thing to use.

Signed-off-by: Mark Allen <markalle@us.ibm.com>
(cherry picked from commit 36f51bca26fbbfffcac09c1a44fec1cc1faffc08)

Fixes #3566