### PR TITLE
VERSION: add missing "#" on a comment line

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -5,7 +5,7 @@
 #                         All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
-                          reserved.
+#                          reserved.
 
 # This is the VERSION file for Open MPI, describing the precise
 # version of Open MPI in this distribution.  The various components of


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Thanks to @rhc54 reporting the issue.  Looks like a comment line was accidentally left without a `#` prefix, which causes this errant output when you run `configure`:

```
*** Checking versions
checking for repo version... v2.1.1-68-g86ded841dc
checking Open MPI version... 2.1.2a1
checking Open MPI release date... Unreleased developer copy
...
checking Open Portable Access Layer repository version... v2.1.1-68-g86ded841dc
./VERSION: line 8: reserved.: command not found
```

It doesn't cause a *problem*, per se, but it is definitely a bug.  Trivial to fix.

This bug was first introduced in the v2.1.1 release.