### PR TITLE
Enable ORTE to continue running when a node fails 

### DIFF
--- a/orte/mca/plm/slurm/plm_slurm_module.c
+++ b/orte/mca/plm/slurm/plm_slurm_module.c
@@ -267,8 +267,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
     /* start one orted on each node */
     opal_argv_append(&argc, &argv, "--ntasks-per-node=1");
 
-    /* alert us if any orteds die during startup */
-    opal_argv_append(&argc, &argv, "--kill-on-bad-exit");
+    if (!orte_enable_recovery) {
+        /* kill the job if any orteds die */
+        opal_argv_append(&argc, &argv, "--kill-on-bad-exit");
+    }
 
     /* ensure the orteds are not bound to a single processor,
      * just in case the TaskAffinity option is set by default.

--- a/orte/tools/orte-clean/orte-clean.c
+++ b/orte/tools/orte-clean/orte-clean.c
@@ -183,7 +183,7 @@ main(int argc, char *argv[])
     free(legacy);
 
     /* and finally get rid of any lingering pmix-related artifacts */
-    asprintf(&legacy, "rm -f %s/pmix*", orte_process_info.tmpdir_base);
+    asprintf(&legacy, "rm -rf %s/pmix*", orte_process_info.tmpdir_base);
     system(legacy);
     free(legacy);
 


### PR DESCRIPTION
- user takes responsibility for zombies. Minor cleanup to orte-clean

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 8a4565874e1cdedc80ae45d42ba1fdd44e67883f)