### PR TITLE
osc/rdma: rework locking code to improve behavior of unlock

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_types.h
+++ b/ompi/mca/osc/rdma/osc_rdma_types.h
@@ -205,6 +205,19 @@ typedef struct ompi_osc_rdma_aggregation_t ompi_osc_rdma_aggregation_t;
 
 OBJ_CLASS_DECLARATION(ompi_osc_rdma_aggregation_t);
 
+struct ompi_osc_rdma_pending_op_t {
+    opal_list_item_t super;
+    struct ompi_osc_rdma_frag_t *op_frag;
+    void *op_buffer;
+    void *op_result;
+    size_t op_size;
+    volatile bool op_complete;
+};
+
+typedef struct ompi_osc_rdma_pending_op_t ompi_osc_rdma_pending_op_t;
+
+OBJ_CLASS_DECLARATION(ompi_osc_rdma_pending_op_t);
+
 #define OSC_RDMA_VERBOSE(x, ...) OPAL_OUTPUT_VERBOSE((x, ompi_osc_base_framework.framework_output, __VA_ARGS__))
 
 #endif /* OMPI_OSC_RDMA_TYPES_H */


### PR DESCRIPTION
This commit changes the locking code to allow the lock release to be
non-blocking. This helps with releasing the accumulate lock which may
occur in a BTL callback.

Fixes #3616

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 022c658bbf36f7ad1ab09caed7623e5d9f9e6723)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>