### PR TITLE
Fix a threadlock when notifying clients of failures

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -240,9 +240,9 @@ void pmix2x_event_hdlr(size_t evhdlr_registration_id,
     size_t n;
     opal_pmix2x_event_t *event;
 
-     opal_output_verbose(2, opal_pmix_base_framework.framework_output,
-                         "%s RECEIVED NOTIFICATION OF STATUS %d",
-                         OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status);
+    opal_output_verbose(2, opal_pmix_base_framework.framework_output,
+                        "%s RECEIVED NOTIFICATION OF STATUS %d",
+                        OPAL_NAME_PRINT(OPAL_PROC_MY_NAME), status);
 
     OPAL_PMIX_ACQUIRE_THREAD(&opal_pmix_base.lock);
 

--- a/opal/mca/pmix/pmix2x/pmix2x_server_south.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_south.c
@@ -410,9 +410,11 @@ void pmix2x_server_deregister_client(const opal_process_name_t *proc,
             (void)strncpy(p.nspace, jptr->nspace, PMIX_MAX_NSLEN);
             p.rank = pmix2x_convert_opalrank(proc->vpid);
             OPAL_PMIX_CONSTRUCT_LOCK(&lock);
+            OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);
             PMIx_server_deregister_client(&p, lkcbfunc, (void*)&lock);
             OPAL_PMIX_WAIT_THREAD(&lock);
             OPAL_PMIX_DESTRUCT_LOCK(&lock);
+            OPAL_PMIX_ACQUIRE_THREAD(&opal_pmix_base.lock);
             break;
         }
     }


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit d619de4f4ccf7c309b6476a1b8b44595da9d1131)