### PR TITLE
Deregister event handlers only on final call to finalize. Ensure we pass PMIx mca params

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix2x_client.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_client.c
@@ -168,7 +168,7 @@ int pmix2x_client_finalize(void)
     OPAL_PMIX_ACQUIRE_THREAD(&opal_pmix_base.lock);
     --opal_pmix_base.initialized;
 
-    if (0 < opal_pmix_base.initialized) {
+    if (0 == opal_pmix_base.initialized) {
         /* deregister all event handlers */
         OPAL_LIST_FOREACH_SAFE(event, ev2, &mca_pmix_pmix2x_component.events, opal_pmix2x_event_t) {
             OPAL_PMIX_DESTRUCT_LOCK(&event->lock);

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -691,7 +691,8 @@ static int parse_env(char *path,
     }
 
     for (i = 0; NULL != srcenv[i]; ++i) {
-        if (0 == strncmp("OMPI_", srcenv[i], 5)) {
+        if (0 == strncmp("OMPI_", srcenv[i], 5) ||
+            0 == strncmp("PMIX_", srcenv[i], 5)) {
             /* check for duplicate in app->env - this
              * would have been placed there by the
              * cmd line processor. By convention, we


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 9178219e6b7c326cb2168c63f9344d5f2b21802e)