### PR TITLE
orte/iof: Address the case when output is a regular file

### DIFF
--- a/opal/util/fd.c
+++ b/opal/util/fd.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009 Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -10,6 +11,14 @@
  */
 
 #include "opal_config.h"
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -89,3 +98,31 @@ int opal_fd_set_cloexec(int fd)
 
     return OPAL_SUCCESS;
 }
+
+bool opal_fd_is_regular(int fd)
+{
+    struct stat buf;
+    if (fstat(fd, &buf)) {
+        return false;
+    }
+    return S_ISREG(buf.st_mode);
+}
+
+bool opal_fd_is_chardev(int fd)
+{
+    struct stat buf;
+    if (fstat(fd, &buf)) {
+        return false;
+    }
+    return S_ISCHR(buf.st_mode);
+}
+
+bool opal_fd_is_blkdev(int fd)
+{
+    struct stat buf;
+    if (fstat(fd, &buf)) {
+        return false;
+    }
+    return S_ISBLK(buf.st_mode);
+}
+

--- a/opal/util/fd.h
+++ b/opal/util/fd.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009 Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -62,6 +63,37 @@ OPAL_DECLSPEC int opal_fd_write(int fd, int len, const void *buffer);
  * to setting a file descriptor to be close-on-exec.
  */
 OPAL_DECLSPEC int opal_fd_set_cloexec(int fd);
+
+/**
+ * Convenience function to check if fd point to an accessible regular file.
+ *
+ * @param fd File descriptor
+ *
+ * @returns true if "fd" points to a regular file.
+ * @returns false otherwise.
+ */
+OPAL_DECLSPEC bool opal_fd_is_regular(int fd);
+
+/**
+ * Convenience function to check if fd point to an accessible character device.
+ *
+ * @param fd File descriptor
+ *
+ * @returns true if "fd" points to a regular file.
+ * @returns false otherwise.
+ */
+OPAL_DECLSPEC bool opal_fd_is_chardev(int fd);
+
+/**
+ * Convenience function to check if fd point to an accessible block device.
+ *
+ * @param fd File descriptor
+ *
+ * @returns true if "fd" points to a regular file.
+ * @returns false otherwise.
+ */
+OPAL_DECLSPEC bool opal_fd_is_blkdev(int fd);
+
 
 END_C_DECLS
 

--- a/orte/mca/iof/base/base.h
+++ b/orte/mca/iof/base/base.h
@@ -14,6 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +49,7 @@
 #include "opal/class/opal_bitmap.h"
 #include "orte/mca/mca.h"
 #include "opal/mca/event/event.h"
+#include "opal/util/fd.h"
 
 #include "orte/mca/iof/iof.h"
 #include "orte/runtime/orte_globals.h"
@@ -84,6 +86,7 @@ ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_iof_job_t);
 typedef struct {
     opal_list_item_t super;
     bool pending;
+    bool always_writable;
     opal_event_t *ev;
     int fd;
     opal_list_t outputs;
@@ -157,6 +160,9 @@ typedef struct orte_iof_base_t orte_iof_base_t;
         ep->tag = (tg);                                             \
         if (0 <= (fid)) {                                           \
             ep->wev->fd = (fid);                                    \
+            ep->wev->always_writable = opal_fd_is_regular(fid) ||   \
+                                       opal_fd_is_chardev(fid) ||   \
+                                       opal_fd_is_blkdev(fid);      \
             opal_event_set(orte_event_base,                         \
                            ep->wev->ev, ep->wev->fd,                \
                            OPAL_EV_WRITE,                           \

--- a/orte/mca/iof/base/base.h
+++ b/orte/mca/iof/base/base.h
@@ -55,6 +55,7 @@
 #include "orte/runtime/orte_globals.h"
 #include "orte/mca/rml/rml_types.h"
 #include "orte/util/threads.h"
+#include "orte/mca/errmgr/errmgr.h"
 
 BEGIN_C_DECLS
 
@@ -88,6 +89,7 @@ typedef struct {
     bool pending;
     bool always_writable;
     opal_event_t *ev;
+    struct timeval tv;
     int fd;
     opal_list_t outputs;
 } orte_iof_write_event_t;
@@ -109,9 +111,11 @@ typedef struct {
     opal_object_t super;
     struct orte_iof_proc_t *proc;
     opal_event_t *ev;
+    struct timeval tv;
     int fd;
     orte_iof_tag_t tag;
     bool active;
+    bool always_readable;
     orte_iof_sink_t *sink;
 } orte_iof_read_event_t;
 ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_iof_read_event_t);
@@ -145,33 +149,84 @@ struct orte_iof_base_t {
 };
 typedef struct orte_iof_base_t orte_iof_base_t;
 
+/* Write event macro's */
+
+static inline bool
+orte_iof_base_fd_always_ready(int fd)
+{
+    return opal_fd_is_regular(fd) ||
+           (opal_fd_is_chardev(fd) && !isatty(fd)) ||
+           opal_fd_is_blkdev(fd);
+}
+
+#define ORTE_IOF_SINK_BLOCKSIZE (1024)
+
+#define ORTE_IOF_SINK_ACTIVATE(wev)                                     \
+    do {                                                                \
+        struct timeval *tv = NULL;                                      \
+        wev->pending = true;                                            \
+        ORTE_POST_OBJECT(wev);                                          \
+        if (wev->always_writable) {                                     \
+            /* Regular is always write ready. Use timer to activate */  \
+            tv = &wev->tv;                                        \
+        }                                                               \
+        if (opal_event_add(wev->ev, tv)) {                              \
+            ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);                         \
+        }                                                               \
+    } while(0);
+
 
 /* define an output "sink", adding it to the provided
  * endpoint list for this proc */
-#define ORTE_IOF_SINK_DEFINE(snk, nm, fid, tg, wrthndlr)            \
-    do {                                                            \
-        orte_iof_sink_t *ep;                                        \
-        OPAL_OUTPUT_VERBOSE((1, orte_iof_base_framework.framework_output,           \
-                            "defining endpt: file %s line %d fd %d",\
-                            __FILE__, __LINE__, (fid)));            \
-        ep = OBJ_NEW(orte_iof_sink_t);                              \
-        ep->name.jobid = (nm)->jobid;                               \
-        ep->name.vpid = (nm)->vpid;                                 \
-        ep->tag = (tg);                                             \
-        if (0 <= (fid)) {                                           \
-            ep->wev->fd = (fid);                                    \
-            ep->wev->always_writable = opal_fd_is_regular(fid) ||   \
-                                       opal_fd_is_chardev(fid) ||   \
-                                       opal_fd_is_blkdev(fid);      \
-            opal_event_set(orte_event_base,                         \
-                           ep->wev->ev, ep->wev->fd,                \
-                           OPAL_EV_WRITE,                           \
-                           wrthndlr, ep);                           \
-            opal_event_set_priority(ep->wev->ev, ORTE_MSG_PRI);     \
-        }                                                           \
-        *(snk) = ep;                                                \
-        ORTE_POST_OBJECT(ep);                                       \
+#define ORTE_IOF_SINK_DEFINE(snk, nm, fid, tg, wrthndlr)                \
+    do {                                                                \
+        orte_iof_sink_t *ep;                                            \
+        OPAL_OUTPUT_VERBOSE((1,                                         \
+                            orte_iof_base_framework.framework_output,   \
+                            "defining endpt: file %s line %d fd %d",    \
+                            __FILE__, __LINE__, (fid)));                \
+        ep = OBJ_NEW(orte_iof_sink_t);                                  \
+        ep->name.jobid = (nm)->jobid;                                   \
+        ep->name.vpid = (nm)->vpid;                                     \
+        ep->tag = (tg);                                                 \
+        if (0 <= (fid)) {                                               \
+            ep->wev->fd = (fid);                                        \
+            ep->wev->always_writable =                                  \
+                    orte_iof_base_fd_always_ready(fid);                 \
+            if(ep->wev->always_writable) {                              \
+                opal_event_evtimer_set(orte_event_base,                 \
+                                       ep->wev->ev,  wrthndlr, ep);     \
+            } else {                                                    \
+                opal_event_set(orte_event_base,                         \
+                               ep->wev->ev, ep->wev->fd,                \
+                               OPAL_EV_WRITE,                           \
+                               wrthndlr, ep);                           \
+            }                                                           \
+            opal_event_set_priority(ep->wev->ev, ORTE_MSG_PRI);         \
+        }                                                               \
+        *(snk) = ep;                                                    \
+        ORTE_POST_OBJECT(ep);                                           \
     } while(0);
+
+/* Read event macro's */
+#define ORTE_IOF_READ_ADDEV(rev)                                \
+    do {                                                        \
+        struct timeval *tv = NULL;                              \
+        if (rev->always_readable) {                             \
+            tv = &rev->tv;                                      \
+        }                                                       \
+        if (opal_event_add(rev->ev, tv)) {                      \
+            ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);                 \
+        }                                                       \
+    } while(0);
+
+#define ORTE_IOF_READ_ACTIVATE(rev)                             \
+    do {                                                        \
+        rev->active = true;                                     \
+        ORTE_POST_OBJECT(rev);                                  \
+        ORTE_IOF_READ_ADDEV(rev);                               \
+    } while(0);
+
 
 /* add list of structs that has name of proc + orte_iof_tag_t - when
  * defining a read event, search list for proc, add flag to the tag.
@@ -179,30 +234,35 @@ typedef struct orte_iof_base_t orte_iof_base_t;
  * when all flags = 0, then iof is complete - set message event to
  * daemon processor indicating proc iof is terminated
  */
-#define ORTE_IOF_READ_EVENT(rv, p, fid, tg, cbfunc, actv)           \
-    do {                                                            \
-        orte_iof_read_event_t *rev;                                 \
-        OPAL_OUTPUT_VERBOSE((1, orte_iof_base_framework.framework_output,           \
-                            "%s defining read event for %s: %s %d", \
-                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),     \
-                            ORTE_NAME_PRINT(&(p)->name),            \
-                            __FILE__, __LINE__));                   \
-        rev = OBJ_NEW(orte_iof_read_event_t);                       \
-        OBJ_RETAIN((p));                                            \
-        rev->proc = (struct orte_iof_proc_t*)(p);                   \
-        rev->tag = (tg);                                            \
-        rev->fd = (fid);                                            \
-        *(rv) = rev;                                                \
-        opal_event_set(orte_event_base,                             \
-                       rev->ev, (fid),                              \
-                       OPAL_EV_READ,                                \
-                       (cbfunc), rev);                              \
-        opal_event_set_priority(rev->ev, ORTE_MSG_PRI);             \
-        if ((actv)) {                                               \
-            rev->active = true;                                     \
-            ORTE_POST_OBJECT(rev);                                  \
-            opal_event_add(rev->ev, 0);                             \
-        }                                                           \
+#define ORTE_IOF_READ_EVENT(rv, p, fid, tg, cbfunc, actv)               \
+    do {                                                                \
+        orte_iof_read_event_t *rev;                                     \
+        OPAL_OUTPUT_VERBOSE((1,                                         \
+                            orte_iof_base_framework.framework_output,   \
+                            "%s defining read event for %s: %s %d",     \
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),         \
+                            ORTE_NAME_PRINT(&(p)->name),                \
+                            __FILE__, __LINE__));                       \
+        rev = OBJ_NEW(orte_iof_read_event_t);                           \
+        OBJ_RETAIN((p));                                                \
+        rev->proc = (struct orte_iof_proc_t*)(p);                       \
+        rev->tag = (tg);                                                \
+        rev->fd = (fid);                                                \
+        rev->always_readable = orte_iof_base_fd_always_ready(fid);      \
+        *(rv) = rev;                                                    \
+        if(rev->always_readable) {                                      \
+            opal_event_evtimer_set(orte_event_base,                     \
+                                   rev->ev, (cbfunc), rev);             \
+        } else {                                                        \
+            opal_event_set(orte_event_base,                             \
+                           rev->ev, (fid),                              \
+                           OPAL_EV_READ,                                \
+                           (cbfunc), rev);                              \
+        }                                                               \
+        opal_event_set_priority(rev->ev, ORTE_MSG_PRI);                 \
+        if ((actv)) {                                                   \
+            ORTE_IOF_READ_ACTIVATE(rev)                                 \
+        }                                                               \
     } while(0);
 
 

--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -298,6 +299,7 @@ OBJ_CLASS_INSTANCE(orte_iof_read_event_t,
 static void orte_iof_base_write_event_construct(orte_iof_write_event_t* wev)
 {
     wev->pending = false;
+    wev->always_writable = false;
     wev->fd = -1;
     OBJ_CONSTRUCT(&wev->outputs, opal_list_t);
     wev->ev = opal_event_alloc();

--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -270,6 +270,8 @@ static void orte_iof_base_read_event_construct(orte_iof_read_event_t* rev)
     rev->active = false;
     rev->ev = opal_event_alloc();
     rev->sink = NULL;
+    rev->tv.tv_sec = 0;
+    rev->tv.tv_usec = 0;
 }
 static void orte_iof_base_read_event_destruct(orte_iof_read_event_t* rev)
 {
@@ -303,6 +305,8 @@ static void orte_iof_base_write_event_construct(orte_iof_write_event_t* wev)
     wev->fd = -1;
     OBJ_CONSTRUCT(&wev->outputs, opal_list_t);
     wev->ev = opal_event_alloc();
+    wev->tv.tv_sec = 0;
+    wev->tv.tv_usec = 0;
 }
 static void orte_iof_base_write_event_destruct(orte_iof_write_event_t* wev)
 {

--- a/orte/mca/iof/hnp/iof_hnp_receive.c
+++ b/orte/mca/iof/hnp/iof_hnp_receive.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,9 +82,7 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
         if (NULL != mca_iof_hnp_component.stdinev &&
             !orte_job_term_ordered &&
             !mca_iof_hnp_component.stdinev->active) {
-            mca_iof_hnp_component.stdinev->active = true;
-            ORTE_POST_OBJECT(mca_iof_hnp_component.stdinev);
-            opal_event_add(mca_iof_hnp_component.stdinev->ev, 0);
+            ORTE_IOF_READ_ACTIVATE(mca_iof_hnp_component.stdinev);
         }
         goto CLEAN_RETURN;
     } else if (ORTE_IOF_XOFF & stream) {


### PR DESCRIPTION
Regular files are always write-ready, so non-blocking I/O does not
give any benefits for them.
More than that - if libevent is using "epoll" to track fd events,
epoll_ctl will refuse attempt to add an fd pointing to a regular
file descriptor with EPERM.
This fix checks the object referenced by fd and avoids event_add
using event_active instead.

In the original configuration that uncovered this issue "epoll"
was used in libevent, it was triggering the following warning
message:
"[warn] Epoll ADD(1) on fd 0 failed.  Old events were 0; read
change was 1 (add); write change was 0 (none): Operation not
permitted"
And the side effect was accumulation of all output in mpirun
memory and actually writing it only at mpirun exit.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>

P.S. For the reference:
https://bugzilla.kernel.org/show_bug.cgi?id=15272