### PR TITLE
Attempt to detect when we are direct-launched without the necessary P…

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -944,7 +944,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
  error:
     if (ret != OMPI_SUCCESS) {
         /* Only print a message if one was not already printed */
-        if (NULL != error) {
+        if (NULL != error && OMPI_ERR_SILENT != ret) {
             const char *err_msg = opal_strerror(ret);
             opal_show_help("help-mpi-runtime.txt",
                            "mpi_init:startup:internal-failure", true,

--- a/orte/mca/ess/base/help-ess-base.txt
+++ b/orte/mca/ess/base/help-ess-base.txt
@@ -49,3 +49,43 @@ MCA parameter:
   param:  %s
 
 This is not a recognized signal value. Please fix or remove it.
+#
+[slurm-error]
+The application appears to have been direct launched using "srun",
+but OMPI was not built with SLURM's PMI support and therefore cannot
+execute. There are several options for building PMI support under
+SLURM, depending upon the SLURM version you are using:
+
+  version 16.05 or later: you can use SLURM's PMIx support. This
+  requires that you configure and build SLURM --with-pmix.
+
+  Versions earlier than 16.05: you must use either SLURM's PMI-1 or
+  PMI-2 support. SLURM builds PMI-1 by default, or you can manually
+  install PMI-2. You must then build Open MPI using --with-pmi pointing
+  to the SLURM PMI library location.
+
+Please configure as appropriate and try again.
+#
+[slurm-error2]
+The application appears to have been direct launched using "srun",
+but OMPI was not built with SLURM support. This usually happens
+when OMPI was not configured --with-slurm and we weren't able
+to discover a SLURM installation in the usual places.
+
+Please configure as appropriate and try again.
+#
+[alps-error]
+The application appears to have been direct launched using "aprun",
+but OMPI was not built with ALPS PMI support and therefore cannot
+execute. You must build Open MPI using --with-pmi pointing
+to the ALPS PMI library location.
+
+Please configure as appropriate and try again.
+#
+[alps-error2]
+The application appears to have been direct launched using "aprun",
+but OMPI was not built with ALPS support. This usually happens
+when OMPI was not configured --with-alps and we weren't able
+to discover an ALPS installation in the usual places.
+
+Please configure as appropriate and try again.

--- a/orte/mca/schizo/alps/schizo_alps.c
+++ b/orte/mca/schizo/alps/schizo_alps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,8 +65,15 @@ static orte_schizo_launch_environ_t check_launch_environment(void)
          * launch performance penalty for hwloc at high ppn on knl */
         opal_argv_append_nosize(&pushed_envs, OPAL_MCA_PREFIX "orte_bound_at_launch");
         opal_argv_append_nosize(&pushed_vals, "true");
+        /* mark that we are native */
+        opal_argv_append_nosize(&pushed_envs, "ORTE_SCHIZO_DETECTION");
+        opal_argv_append_nosize(&pushed_vals, "NATIVE");
         goto setup;
     }
+
+    /* mark that we are on ALPS */
+    opal_argv_append_nosize(&pushed_envs, "ORTE_SCHIZO_DETECTION");
+    opal_argv_append_nosize(&pushed_vals, "ALPS");
 
     /* see if we are running in a Cray PAGG container */
     fd = fopen(proc_job_file, "r");

--- a/orte/mca/schizo/orte/schizo_orte.c
+++ b/orte/mca/schizo/orte/schizo_orte.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,7 +53,7 @@ static orte_schizo_launch_environ_t check_launch_environment(void)
      * so no need to further check that here. Instead,
      * see if we were direct launched vs launched via mpirun */
     if (NULL != orte_process_info.my_daemon_uri) {
-        /* nope */
+        /* yes we were */
         myenv = ORTE_SCHIZO_NATIVE_LAUNCHED;
         opal_argv_append_nosize(&pushed_envs, OPAL_MCA_PREFIX"ess");
         opal_argv_append_nosize(&pushed_vals, "pmi");
@@ -65,6 +65,10 @@ static orte_schizo_launch_environ_t check_launch_environment(void)
     myenv = ORTE_SCHIZO_UNMANAGED_SINGLETON;
     opal_argv_append_nosize(&pushed_envs, OPAL_MCA_PREFIX"ess");
     opal_argv_append_nosize(&pushed_vals, "singleton");
+    /* mark that we are in ORTE */
+    opal_argv_append_nosize(&pushed_envs, "ORTE_SCHIZO_DETECTION");
+    opal_argv_append_nosize(&pushed_vals, "ORTE");
+
 
   setup:
     opal_output_verbose(1, orte_schizo_base_framework.framework_output,

--- a/orte/mca/schizo/slurm/schizo_slurm.c
+++ b/orte/mca/schizo/slurm/schizo_slurm.c
@@ -62,6 +62,9 @@ static orte_schizo_launch_environ_t check_launch_environment(void)
         myenv = ORTE_SCHIZO_NATIVE_LAUNCHED;
         opal_argv_append_nosize(&pushed_envs, OPAL_MCA_PREFIX"ess");
         opal_argv_append_nosize(&pushed_vals, "pmi");
+        /* mark that we are native */
+        opal_argv_append_nosize(&pushed_envs, "ORTE_SCHIZO_DETECTION");
+        opal_argv_append_nosize(&pushed_vals, "NATIVE");
         goto setup;
     }
 
@@ -71,6 +74,10 @@ static orte_schizo_launch_environ_t check_launch_environment(void)
         myenv = ORTE_SCHIZO_UNDETERMINED;
         return myenv;
     }
+
+    /* mark that we are in SLURM */
+    opal_argv_append_nosize(&pushed_envs, "ORTE_SCHIZO_DETECTION");
+    opal_argv_append_nosize(&pushed_vals, "SLURM");
 
     /* we are in an allocation, but were we direct launched
      * or are we a singleton? */


### PR DESCRIPTION
…MI support, and thus are incorrectly identified as being "singleton". Advise the user on the required PMI(x) support and error out.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit bd4a6fee22d2bf2bf455faf55404cdc452cd6bd6)