### PR TITLE
v3.x: mca/sensor: replace OMPI macro with ORTE macro

### DIFF
--- a/orte/mca/sensor/Makefile.am
+++ b/orte/mca/sensor/Makefile.am
@@ -2,6 +2,8 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -21,7 +23,7 @@ libmca_sensor_la_SOURCES += $(headers)
 
 # Conditionally install the header files
 if WANT_INSTALL_HEADERS
-ortedir = $(ompiincludedir)/$(subdir)
+ortedir = $(orteincludedir)/$(subdir)
 nobase_orte_HEADERS = $(headers)
 endif
 

--- a/orte/mca/sensor/file/Makefile.am
+++ b/orte/mca/sensor/file/Makefile.am
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved. 
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -8,7 +10,7 @@
 # $HEADER$
 #
 
-dist_ompidata_DATA = help-orte-sensor-file.txt
+dist_ortedata_DATA = help-orte-sensor-file.txt
 
 sources = \
         sensor_file.c \
@@ -27,7 +29,7 @@ component_noinst = libmca_sensor_file.la
 component_install =
 endif
 
-mcacomponentdir = $(ompilibdir)
+mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sensor_file_la_SOURCES = $(sources)
 mca_sensor_file_la_LDFLAGS = -module -avoid-version

--- a/orte/mca/sensor/heartbeat/Makefile.am
+++ b/orte/mca/sensor/heartbeat/Makefile.am
@@ -2,6 +2,8 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved. 
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -9,7 +11,7 @@
 # $HEADER$
 #
 
-dist_ompidata_DATA = help-orte-sensor-heartbeat.txt
+dist_ortedata_DATA = help-orte-sensor-heartbeat.txt
 
 sources = \
         sensor_heartbeat.c \
@@ -28,7 +30,7 @@ component_noinst = libmca_sensor_heartbeat.la
 component_install =
 endif
 
-mcacomponentdir = $(ompilibdir)
+mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sensor_heartbeat_la_SOURCES = $(sources)
 mca_sensor_heartbeat_la_LDFLAGS = -module -avoid-version

--- a/orte/mca/sensor/resusage/Makefile.am
+++ b/orte/mca/sensor/resusage/Makefile.am
@@ -2,6 +2,8 @@
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved. 
 #
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -9,7 +11,7 @@
 # $HEADER$
 #
 
-dist_ompidata_DATA = help-orte-sensor-resusage.txt
+dist_ortedata_DATA = help-orte-sensor-resusage.txt
 
 sources = \
         sensor_resusage.c \
@@ -28,7 +30,7 @@ component_noinst = libmca_sensor_resusage.la
 component_install =
 endif
 
-mcacomponentdir = $(ompilibdir)
+mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sensor_resusage_la_SOURCES = $(sources)
 mca_sensor_resusage_la_LDFLAGS = -module -avoid-version


### PR DESCRIPTION
and keep autogen.pl --no-ompi happy

This is a one-off commit for the v3.x branch

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>