### PR TITLE
Choosing the ofi provider when opening conduit and sending message to peer

### DIFF
--- a/orte/mca/rml/ofi/rml_ofi.h
+++ b/orte/mca/rml/ofi/rml_ofi.h
@@ -158,10 +158,17 @@ typedef struct {
 } ;
 typedef struct orte_rml_ofi_module_t orte_rml_ofi_module_t;
 
+/* For every first send initiated to new peer 
+ * select the peer provider, peer ep-addr, 
+ * local provider and populate in orte_rml_ofi_peer_t instance.
+ * Insert this in hash table.
+ * */
 typedef struct {
     opal_object_t super;
-    void*   ofi_ep;
-    size_t  ofi_ep_len;
+    char*   ofi_prov_name;   /* peer (dest) provider chosen */
+    void*   ofi_ep;          /* peer (dest) ep chosen */
+    size_t  ofi_ep_len;      /* peer (dest) ep length */
+    uint8_t src_prov_id;     /* index of the local (src) provider used for this peer */
 } orte_rml_ofi_peer_t;
 OBJ_CLASS_DECLARATION(orte_rml_ofi_peer_t);
 
@@ -200,6 +207,7 @@ int orte_rml_ofi_error_callback(struct fi_cq_err_entry *error,
 /* OFI Recv handler */
 int orte_rml_ofi_recv_handler(struct fi_cq_data_entry *wc, uint8_t ofi_prov_id);
 
+bool user_override(void);
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
When opening conduit, checking for the transport preference in below order -
(1) rml_ofi_transports mca parameter.  This parameter should have the list of transports (currently ethernet,fabric are valid). Fabric is higher priority if provided.
(2) ORTE_RML_TRANSPORT_TYPE key with values "ethernet" or "fabric". "fabric" is higher priority.
If specific provider is required use ORTE_RML_OFI_PROV_NAME key with values "socket" or "OPA" or any other supported in system.

On send_msg choose the provider on local and peer to follow below rules -
(1) if the user specified the transport for this conduit (even giving us a prioritized list of candidates), then the one we selected is the _only_ one we will use. If the remote peer has a matching endpoint, then we use it - otherwise, we error out
(2) if the user didn't specify a transport, then we look for matches against _all_ of our available transports, starting with fabric and then going to Ethernet, taking the first one that matches.
(3) if we can't find any match, then we error out

Signed-off-by: Anandhi Jayakumar