### PR TITLE
Fix MPI_SIZEOF for gfortran 4.8

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,7 @@ Copyright (c) 2013-2015 Intel, Inc. All rights reserved
 Copyright (c) 2015      NVIDIA Corporation.  All rights reserved.
 Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
                         reserved.
+Copyright (c) 2017      IBM Corporation. All rights reserved                        
 
 $COPYRIGHT$
 
@@ -365,8 +366,7 @@ Compiler Notes
   - All Fortran compilers support the mpif.h/shmem.fh-based bindings,
     with one exception: the MPI_SIZEOF interfaces will only be present
     when Open MPI is built with a Fortran compiler that support the
-    INTERFACE keyword and ISO_FORTRAN_ENV.  Most notably, this
-    excludes the GNU Fortran compiler suite before version 4.9.
+    INTERFACE keyword and ISO_FORTRAN_ENV.
 
   - The level of support provided by the mpi module is based on your
     Fortran compiler.

--- a/config/ompi_fortran_check_storage_size.m4
+++ b/config/ompi_fortran_check_storage_size.m4
@@ -11,6 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2017      IBM Corporation. All rights reserved. 
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -61,7 +62,7 @@ SUBROUTINE storage_size_complex32_r1(x, size)
     COMPLEX(REAL32), DIMENSION(*)::x
     INTEGER, INTENT(OUT) :: size
 
-    size = storage_size(x) / 8
+    size = storage_size(x(1)) / 8
 END SUBROUTINE storage_size_complex32_r1
 
 SUBROUTINE storage_size_int32_scalar(x, size)
@@ -77,7 +78,7 @@ SUBROUTINE storage_size_int32_r1(x, size)
     INTEGER(INT32), DIMENSION(*)::x
     INTEGER, INTENT(OUT) :: size
 
-    size = storage_size(x) / 8
+    size = storage_size(x(1)) / 8
 END SUBROUTINE storage_size_int32_r1
 
 SUBROUTINE storage_size_real32_scalar(x, size)
@@ -93,7 +94,7 @@ SUBROUTINE storage_size_real32_r1(x, size)
     REAL(REAL32), DIMENSION(*)::x
     INTEGER, INTENT(OUT) :: size
 
-    size = storage_size(x) / 8
+    size = storage_size(x(1)) / 8
 END SUBROUTINE storage_size_real32_r1
 ]])],
              [AS_VAR_SET(fortran_storage_size_var, yes)],

--- a/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -3,6 +3,7 @@
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 # Script to generate the overloaded MPI_SIZEOF interfaces and
@@ -97,7 +98,7 @@ sub queue_sub {
 ${indent}  INTEGER, INTENT(OUT) :: size
 ${indent}  INTEGER$optional_ierror_param, INTENT(OUT) :: ierror";
     $subr->{start} = $start;
-    $subr->{middle} = "${indent}  size = storage_size(x) / 8
+    $subr->{middle} = "${indent}  size = storage_size(xSUBSCRIPT) / 8
 ${indent}  ${optional_ierror_statement}ierror = 0";
     $subr->{end} = "${indent}END SUBROUTINE ^PREFIX^$sub_name^RANK^";
 
@@ -126,6 +127,7 @@ sub generate {
     if (0 == $rank) {
         $str =~ s/\^RANK\^/_scalar/g;
         $str =~ s/\^DIMENSION\^//;
+        $str =~ s/SUBSCRIPT//;
     } else {
         $str =~ s/\^RANK\^/_r$rank/g;
         my $dim;
@@ -135,6 +137,7 @@ sub generate {
             --$d;
         }
         $str =~ s/\^DIMENSION\^/, DIMENSION($dim*)/;
+        $str =~ s/SUBSCRIPT/($dim 1)/;
     }
 
     # All done


### PR DESCRIPTION
MPI_SIZEOF gets disabled by the configure stage of OMPI when used with gfortran 4.8.5 . This is because the following syntax
    size = storage_size(x)
isn't recognised by the compiler for x which is an array.
Converting this to
    size = storage_size(x(1))
passes the configuration stage, and making a corresponding change to gen-mpi-sizeof.pl causes the generated code to be acceptable to gfortran (and hopefully also to the other fortran compilers which accept the base syntax).


