### PR TITLE
README: Update F08 language about IBM XL compiler

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006-2011 Mellanox Technologies. All rights reserved.
 Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2007      Myricom, Inc.  All rights reserved.
-Copyright (c) 2008      IBM Corporation.  All rights reserved.
+Copyright (c) 2008-2017 IBM Corporation.  All rights reserved.
 Copyright (c) 2010      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2011      University of Houston. All rights reserved.
 Copyright (c) 2013-2015 Intel, Inc. All rights reserved
@@ -180,8 +180,13 @@ Compiler Notes
   source directory path names that was resolved in 9.0-4 (9.0-3 is
   known to be broken in this regard).
 
-- IBM's xlf compilers: NO known good version that can build/link
-  the MPI f08 bindings or build/link the OSHMEM Fortran bindings.
+- OpenSHMEM Fortran bindings do not support the `no underscore` Fortran
+  symbol convention. IBM's xlf compilers build in that mode by default.
+  As such, IBM's xlf compilers cannot build/link the OpenSHMEM Fortran
+  bindings by default. A workaround is to pass FC="xlf -qextname" at
+  configure time to force a trailing underscore. See the issue below
+  for more details:
+  https://github.com/open-mpi/ompi/issues/3612
 
 - On NetBSD-6 (at least AMD64 and i386), and possibly on OpenBSD,
   libtool misidentifies properties of f95/g95, leading to obscure


### PR DESCRIPTION
 - MPI bindings build/link correctly, so remove note about that.
 - OpenSHMEM bindings do not build/link correctly by default.
   - Note the workaround and the issue on GitHub for users.
 - Related to Issue #3612

[skip ci] bot:notest
