### PR TITLE
opal: do not declare static inline ... (void)

### DIFF
--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2010      ARM ltd.  All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,22 +52,22 @@
  *
  *********************************************************************/
 
-static inline void opal_atomic_mb (void)
+static inline void opal_atomic_mb ()
 {
     MB();
 }
 
-static inline void opal_atomic_rmb (void)
+static inline void opal_atomic_rmb ()
 {
     RMB();
 }
 
-static inline void opal_atomic_wmb (void)
+static inline void opal_atomic_wmb ()
 {
     WMB();
 }
 
-static inline void opal_atomic_isync (void)
+static inline void opal_atomic_isync ()
 {
     __asm__ __volatile__ ("isb");
 }

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -46,17 +46,17 @@
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
 
 
-static inline void opal_atomic_mb(void)
+static inline void opal_atomic_mb()
 {
     __atomic_thread_fence (__ATOMIC_SEQ_CST);
 }
 
-static inline void opal_atomic_rmb(void)
+static inline void opal_atomic_rmb()
 {
     __atomic_thread_fence (__ATOMIC_ACQUIRE);
 }
 
-static inline void opal_atomic_wmb(void)
+static inline void opal_atomic_wmb()
 {
     __atomic_thread_fence (__ATOMIC_RELEASE);
 }

--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2010 Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -58,24 +58,24 @@
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline void opal_atomic_mb(void)
+static inline void opal_atomic_mb()
 {
     MB();
 }
 
 
-static inline void opal_atomic_rmb(void)
+static inline void opal_atomic_rmb()
 {
     MB();
 }
 
 
-static inline void opal_atomic_wmb(void)
+static inline void opal_atomic_wmb()
 {
     MB();
 }
 
-static inline void opal_atomic_isync(void)
+static inline void opal_atomic_isync()
 {
 }
 

--- a/opal/include/opal/sys/ia64/atomic.h
+++ b/opal/include/opal/sys/ia64/atomic.h
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,24 +46,24 @@
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline void opal_atomic_mb(void)
+static inline void opal_atomic_mb()
 {
     MB();
 }
 
 
-static inline void opal_atomic_rmb(void)
+static inline void opal_atomic_rmb()
 {
     MB();
 }
 
 
-static inline void opal_atomic_wmb(void)
+static inline void opal_atomic_wmb()
 {
     MB();
 }
 
-static inline void opal_atomic_isync(void)
+static inline void opal_atomic_isync()
 {
 }
 

--- a/opal/include/opal/sys/sparcv9/atomic.h
+++ b/opal/include/opal/sys/sparcv9/atomic.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserverd.
- * Copyright (c) 2016      Research Organization for Information Science
+ * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -50,24 +50,24 @@
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline void opal_atomic_mb(void)
+static inline void opal_atomic_mb()
 {
     MEMBAR("#LoadLoad | #LoadStore | #StoreStore | #StoreLoad");
 }
 
 
-static inline void opal_atomic_rmb(void)
+static inline void opal_atomic_rmb()
 {
     MEMBAR("#LoadLoad");
 }
 
 
-static inline void opal_atomic_wmb(void)
+static inline void opal_atomic_wmb()
 {
     MEMBAR("#StoreStore");
 }
 
-static inline void opal_atomic_isync(void)
+static inline void opal_atomic_isync()
 {
 }
 

--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,17 +32,17 @@
  *********************************************************************/
 #define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
 
-static inline void opal_atomic_mb(void)
+static inline void opal_atomic_mb()
 {
     __sync_synchronize();
 }
 
-static inline void opal_atomic_rmb(void)
+static inline void opal_atomic_rmb()
 {
     __sync_synchronize();
 }
 
-static inline void opal_atomic_wmb(void)
+static inline void opal_atomic_wmb()
 {
     __sync_synchronize();
 }

--- a/opal/include/opal/sys/timer.h
+++ b/opal/include/opal/sys/timer.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2016      Broadcom Limited. All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,7 +120,7 @@ typedef long opal_timer_t;
 
 #define OPAL_HAVE_SYS_TIMER_IS_MONOTONIC 1
 
-static inline bool opal_sys_timer_is_monotonic (void)
+static inline bool opal_sys_timer_is_monotonic ()
 {
     return OPAL_TIMER_MONOTONIC;
 }

--- a/opal/include/opal/sys/x86_64/atomic.h
+++ b/opal/include/opal/sys/x86_64/atomic.h
@@ -51,24 +51,24 @@
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline void opal_atomic_mb(void)
+static inline void opal_atomic_mb()
 {
     MB();
 }
 
 
-static inline void opal_atomic_rmb(void)
+static inline void opal_atomic_rmb()
 {
     MB();
 }
 
 
-static inline void opal_atomic_wmb(void)
+static inline void opal_atomic_wmb()
 {
     MB();
 }
 
-static inline void opal_atomic_isync(void)
+static inline void opal_atomic_isync()
 {
 }
 

--- a/opal/include/opal/sys/x86_64/timer.h
+++ b/opal/include/opal/sys/x86_64/timer.h
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. ALl rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +44,7 @@ opal_sys_timer_get_cycles(void)
      return ((opal_timer_t)l) | (((opal_timer_t)h) << 32);
 }
 
-static inline bool opal_sys_timer_is_monotonic (void)
+static inline bool opal_sys_timer_is_monotonic ()
 {
     int64_t tmp;
     int32_t cpuid1, cpuid2;


### PR DESCRIPTION
just declare inline subroutines with
static inline ... ()
in order to make some compilers (xlc 12.1) happy

Thanks Paul Hargrove for the report

Refs. open-mpi/ompi#3816

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>