### PR TITLE
Revert MPI_SIZEOF fix for gfortran 4.8

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,6 @@ Copyright (c) 2013-2015 Intel, Inc. All rights reserved
 Copyright (c) 2015      NVIDIA Corporation.  All rights reserved.
 Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
                         reserved.
-Copyright (c) 2017      IBM Corporation. All rights reserved                        
 
 $COPYRIGHT$
 
@@ -371,7 +370,8 @@ Compiler Notes
   - All Fortran compilers support the mpif.h/shmem.fh-based bindings,
     with one exception: the MPI_SIZEOF interfaces will only be present
     when Open MPI is built with a Fortran compiler that support the
-    INTERFACE keyword and ISO_FORTRAN_ENV.
+    INTERFACE keyword and ISO_FORTRAN_ENV.  Most notably, this
+    excludes the GNU Fortran compiler suite before version 4.9.
 
   - The level of support provided by the mpi module is based on your
     Fortran compiler.

--- a/README
+++ b/README
@@ -373,12 +373,6 @@ Compiler Notes
     when Open MPI is built with a Fortran compiler that support the
     INTERFACE keyword and ISO_FORTRAN_ENV.
 
-    *** The Open MPI team has not tested to determine exactly which
-        version of the GNU Fortran compiler suite started supporting
-        what is required for MPI_SIZEOF.  We know that gfortran v4.8
-        (bundled in RHEL 7.x) supports the MPI_SIZEOF interfaces.
-        However, gfortran 4.4 (bundled in RHEL 6.x) does not.
-
   - The level of support provided by the mpi module is based on your
     Fortran compiler.
 

--- a/config/ompi_fortran_check_storage_size.m4
+++ b/config/ompi_fortran_check_storage_size.m4
@@ -11,7 +11,6 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2017      IBM Corporation. All rights reserved. 
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -62,7 +61,7 @@ SUBROUTINE storage_size_complex32_r1(x, size)
     COMPLEX(REAL32), DIMENSION(*)::x
     INTEGER, INTENT(OUT) :: size
 
-    size = storage_size(x(1)) / 8
+    size = storage_size(x) / 8
 END SUBROUTINE storage_size_complex32_r1
 
 SUBROUTINE storage_size_int32_scalar(x, size)
@@ -78,7 +77,7 @@ SUBROUTINE storage_size_int32_r1(x, size)
     INTEGER(INT32), DIMENSION(*)::x
     INTEGER, INTENT(OUT) :: size
 
-    size = storage_size(x(1)) / 8
+    size = storage_size(x) / 8
 END SUBROUTINE storage_size_int32_r1
 
 SUBROUTINE storage_size_real32_scalar(x, size)
@@ -94,7 +93,7 @@ SUBROUTINE storage_size_real32_r1(x, size)
     REAL(REAL32), DIMENSION(*)::x
     INTEGER, INTENT(OUT) :: size
 
-    size = storage_size(x(1)) / 8
+    size = storage_size(x) / 8
 END SUBROUTINE storage_size_real32_r1
 ]])],
              [AS_VAR_SET(fortran_storage_size_var, yes)],

--- a/config/ompi_fortran_check_storage_size.m4
+++ b/config/ompi_fortran_check_storage_size.m4
@@ -11,6 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -27,6 +28,17 @@ dnl
 AC_DEFUN([OMPI_FORTRAN_CHECK_STORAGE_SIZE],[
     AS_VAR_PUSHDEF([fortran_storage_size_var], [ompi_cv_fortran_have_storage_size])
 
+    # Re PR: https://github.com/open-mpi/ompi/pull/3822
+    # We explored correcting the following syntax to compile with gfortran 4.8
+    #   -    size = storage_size(x) / 8
+    #   +    size = storage_size(x(1)) / 8
+    # That allowed gfortran 4.8 to pass this configure test, but fail to
+    # correctly handle mpi_sizeof due to the weak test for INTERFACE in
+    # ompi_fortran_check_interface.m4. Until we can strengthen that configure
+    # check we reverted the commit from PR #3822 to keep the old logic here
+    # so that gfortran 4.8 will disqualify itself correctly for mpi_sizeof()
+    # support.
+    #
     AC_CACHE_CHECK([if Fortran compiler supports STORAGE_SIZE for relevant types],
        fortran_storage_size_var,
        [AC_LANG_PUSH([Fortran])

--- a/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-sizeof.pl
@@ -3,7 +3,6 @@
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2017      IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 # Script to generate the overloaded MPI_SIZEOF interfaces and
@@ -98,7 +97,7 @@ sub queue_sub {
 ${indent}  INTEGER, INTENT(OUT) :: size
 ${indent}  INTEGER$optional_ierror_param, INTENT(OUT) :: ierror";
     $subr->{start} = $start;
-    $subr->{middle} = "${indent}  size = storage_size(xSUBSCRIPT) / 8
+    $subr->{middle} = "${indent}  size = storage_size(x) / 8
 ${indent}  ${optional_ierror_statement}ierror = 0";
     $subr->{end} = "${indent}END SUBROUTINE ^PREFIX^$sub_name^RANK^";
 
@@ -127,7 +126,6 @@ sub generate {
     if (0 == $rank) {
         $str =~ s/\^RANK\^/_scalar/g;
         $str =~ s/\^DIMENSION\^//;
-        $str =~ s/SUBSCRIPT//;
     } else {
         $str =~ s/\^RANK\^/_r$rank/g;
         my $dim;
@@ -137,7 +135,6 @@ sub generate {
             --$d;
         }
         $str =~ s/\^DIMENSION\^/, DIMENSION($dim*)/;
-        $str =~ s/SUBSCRIPT/($dim 1)/;
     }
 
     # All done


### PR DESCRIPTION
 * Reverts PR #3822 
 * Add comment in the code about why. Enough of a breadcrumb for us to follow up on.