### PR TITLE
pml/ob1: do not access fragment after calling btl rget

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2015 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2012      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
@@ -753,13 +753,14 @@ void mca_pml_ob1_recv_request_progress_rget( mca_pml_ob1_recv_request_t* recvreq
             frag->rdma_length = bytes_remaining;
         }
 
+        prev_sent = frag->rdma_length;
+
         /* NTH: TODO -- handle error conditions gracefully */
         rc = mca_pml_ob1_recv_request_get_frag(frag);
         if (OMPI_SUCCESS != rc) {
             break;
         }
 
-        prev_sent = frag->rdma_length;
         bytes_remaining -= prev_sent;
         offset += prev_sent;
     }


### PR DESCRIPTION
This commit fixes a bug that occurs when the btl callback happens before
the rget returns. In this case the fragment has been returned and is no
longer valid. This commit saves the size before calling rget. This is
valid since the BTL is not allowed to change the read size.

Fixes #3821

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>