### PR TITLE
btl/vader: work around ob1 pending fragment bug

### DIFF
--- a/opal/mca/btl/vader/btl_vader_send.c
+++ b/opal/mca/btl/vader/btl_vader_send.c
@@ -49,6 +49,10 @@ int mca_btl_vader_send (struct mca_btl_base_module_t *btl,
         return 1;
     }
 
+    /* in order to work around a long standing ob1 bug (see #3845) we have to always
+     * make the callback. once this is fixed in ob1 we can restore the code below. */
+    frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
+
     /* header (+ optional inline data) */
     frag->hdr->len = total_size;
     /* type of message, pt-2-pt, one-sided, etc */
@@ -69,6 +73,9 @@ int mca_btl_vader_send (struct mca_btl_base_module_t *btl,
         return OPAL_SUCCESS;
     }
 
+    return OPAL_SUCCESS;
+
+#if 0
     if ((frag->hdr->flags & MCA_BTL_VADER_FLAG_SINGLE_COPY) ||
         !(frag->base.des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP)) {
         frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;
@@ -79,4 +86,5 @@ int mca_btl_vader_send (struct mca_btl_base_module_t *btl,
     /* data is gone (from the pml's perspective). frag callback/release will
        happen later */
     return 1;
+#endif
 }


### PR DESCRIPTION
This commit ensures that the pml callback is always made when
sending fragments. This is needed to avoid #3845. Once that is
fixed the #if 0'd code can be restored.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>