### PR TITLE
ess: add missing <signal.h> header

### DIFF
--- a/orte/mca/ess/base/ess_base_frame.c
+++ b/orte/mca/ess/base/ess_base_frame.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -21,6 +21,8 @@
 
 #include "orte_config.h"
 #include "orte/constants.h"
+
+#include <signal.h>
 
 #include "orte/mca/mca.h"
 #include "opal/util/output.h"


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit af9565ec250f80c018e65727bf6cdd1c3a4aac3a)

This fixes an Absoft compile error on MTT (https://mtt.open-mpi.org/index.php?do_redir=2460).

@rhc54 Please review -- trivial (just bringing over an additional commit from master, from pr #3649).