### PR TITLE
pmix/cray: fix handling of multiple finis

### DIFF
--- a/opal/mca/pmix/cray/pmix_cray.c
+++ b/opal/mca/pmix/cray/pmix_cray.c
@@ -558,17 +558,22 @@ static int cray_fini(void) {
     }
 
     if (0 == --pmix_init_count) {
+
+        opal_output_verbose(10, opal_pmix_base_framework.framework_output,
+                        "%s pmix:cray: calling PMI2_Finalize",
+                        OPAL_NAME_PRINT(pmix_pname));
+
         PMI2_Finalize();
-    }
 
-    if (NULL != pmix_kvs_name) {
-        free(pmix_kvs_name);
-        pmix_kvs_name = NULL;
-    }
+        if (NULL != pmix_kvs_name) {
+            free(pmix_kvs_name);
+            pmix_kvs_name = NULL;
+        }
 
-    if (NULL != pmix_lranks) {
-        free(pmix_lranks);
-        pmix_lranks = NULL;
+        if (NULL != pmix_lranks) {
+            free(pmix_lranks);
+            pmix_lranks = NULL;
+        }
     }
 
     return OPAL_SUCCESS;


### PR DESCRIPTION
The fini code for cray pmix wasn't correct.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 1f2f3db553b412e9e2267df389e700712b7a03cb)
(cherry picked from commit 26a8142c97f738add1d069734d63437e1f798bd8)