### PR TITLE
coll/spacc: Add Alltoallv implementation

### DIFF
--- a/ompi/mca/coll/spacc/Makefile.am
+++ b/ompi/mca/coll/spacc/Makefile.am
@@ -11,6 +11,7 @@ sources = \
         coll_spacc_component.c \
         coll_spacc_module.c \
         coll_spacc_allreduce.c \
+        coll_spacc_alltoallv.c \
         coll_spacc_reduce.c
 
 # Make the output library in this directory, and name it either

--- a/ompi/mca/coll/spacc/coll_spacc.h
+++ b/ompi/mca/coll/spacc/coll_spacc.h
@@ -20,6 +20,7 @@ BEGIN_C_DECLS
 extern int mca_coll_spacc_stream;
 extern int mca_coll_spacc_priority;
 extern int mca_coll_spacc_verbose;
+extern int mca_coll_spacc_alltoallv_block_size;
 
 /* API functions */
 
@@ -30,6 +31,12 @@ mca_coll_base_module_t
 
 int mca_coll_spacc_module_enable(mca_coll_base_module_t *module,
                                  struct ompi_communicator_t *comm);
+
+int mca_coll_spacc_alltoallv_intra_block(
+    const void *sbuf, const int *scounts, const int *sdisps,
+    struct ompi_datatype_t *sdtype, void *rbuf, const int *rcounts,
+    const int *rdisps, struct ompi_datatype_t *rdtype,
+    struct ompi_communicator_t *comm, mca_coll_base_module_t *module);
 
 int mca_coll_spacc_allreduce_intra_redscat_allgather(
     const void *sbuf, void *rbuf, int count, struct ompi_datatype_t *dtype,

--- a/ompi/mca/coll/spacc/coll_spacc_allreduce.c
+++ b/ompi/mca/coll/spacc/coll_spacc_allreduce.c
@@ -296,7 +296,7 @@ int mca_coll_spacc_allreduce_intra_redscat_allgather(
          * to recursive doubling (previous step).
          */
 
-        step--;
+        step = nsteps - 1;
 
         for (int mask = nprocs_pof2 >> 1; mask > 0; mask >>= 1) {
             int vdest = vrank ^ mask;

--- a/ompi/mca/coll/spacc/coll_spacc_alltoallv.c
+++ b/ompi/mca/coll/spacc/coll_spacc_alltoallv.c
@@ -1,0 +1,124 @@
+/*
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "coll_spacc.h"
+
+#include "mpi.h"
+#include "ompi/constants.h"
+#include "opal/util/bit_ops.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/base/coll_base_functions.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/coll/base/coll_base_util.h"
+#include "ompi/mca/pml/pml.h"
+
+/*
+ * mca_coll_spacc_alltoallv_intra_block
+ *
+ * Function:  Alltoallv using pairwise exchange algorithm
+ * Accepts:   Same arguments as MPI_Alltoallv
+ * Parameters: mca_coll_spacc_block_size
+ * Returns:   MPI_SUCCESS or error code
+ *
+ * This algorithm posts all irecvs and isends in comm_size / block_size steps
+ * and takes into account zero values in scounts[] and rcounts[].
+ *
+ * Limitations:
+ *   for MPI_IN_PLACE we switch to the linear algorithm
+ *   intra-communicators only
+ *
+ * Memory requirements (per process):
+ *   2 * block_size * sizeof(request)
+ */
+int mca_coll_spacc_alltoallv_intra_block(
+    const void *sbuf, const int *scounts, const int *sdisps,
+    struct ompi_datatype_t *sdtype, void *rbuf, const int *rcounts,
+    const int *rdisps, struct ompi_datatype_t *rdtype,
+    struct ompi_communicator_t *comm, mca_coll_base_module_t *module)
+{
+    int i, j, nops, comm_size, rank, remote, err, nreqs;
+    int block_size = mca_coll_spacc_alltoallv_block_size;
+    char *psend, *precv;
+    ptrdiff_t sdtype_ext, rdtype_ext;
+    ompi_request_t **reqs;
+
+    if (MPI_IN_PLACE == sbuf) {
+        return mca_coll_base_alltoallv_intra_basic_inplace(rbuf, rcounts, rdisps,
+                                                           rdtype, comm, module);
+    }
+
+    comm_size = ompi_comm_size(comm);
+    rank = ompi_comm_rank(comm);
+    opal_output_verbose(30, mca_coll_spacc_stream,
+                        "coll:spacc:alltoallv: rank %d/%d", rank, comm_size);
+
+    ompi_datatype_type_extent(sdtype, &sdtype_ext);
+    ompi_datatype_type_extent(rdtype, &rdtype_ext);
+
+    if (0 != scounts[rank]) {
+        psend = (char *)sbuf + (ptrdiff_t)sdisps[rank] * sdtype_ext;
+        precv = (char *)rbuf + (ptrdiff_t)rdisps[rank] * rdtype_ext;
+        err = ompi_datatype_sndrcv(psend, scounts[rank], sdtype,
+                                   precv, rcounts[rank], rdtype);
+        if (MPI_SUCCESS != err)
+            return err;
+    }
+
+    if (1 == comm_size)
+        return MPI_SUCCESS;
+
+    if (block_size <= 0 || block_size > comm_size) {
+        opal_output_verbose(30, mca_coll_spacc_stream,
+                            "coll:spacc:alltoallv: invalid block_size %d, replace to %d",
+                            block_size, comm_size);
+        block_size = comm_size;
+    }
+    reqs = malloc(sizeof(*reqs) * 2 * block_size);
+    if (NULL == reqs) {
+        err = OMPI_ERR_OUT_OF_RESOURCE;
+        goto err_hndl;
+    }
+
+    for (i = 0; i < comm_size; i += block_size) {
+        nreqs = 0;
+        nops = comm_size - i < block_size ? comm_size - i : block_size;
+        /* Post nops irecvs and isends */
+        for (j = 0; j < nops; j++) {
+            remote = (rank + i + j) % comm_size;
+            if (rcounts[remote] <= 0 || rank == remote)
+                continue;
+            precv = ((char *)rbuf) + (ptrdiff_t)rdisps[remote] * rdtype_ext;
+            err = MCA_PML_CALL(irecv_init(precv, rcounts[remote], rdtype,
+                                          remote, MCA_COLL_BASE_TAG_ALLTOALLV,
+                                          comm, &reqs[nreqs]));
+            if (MPI_SUCCESS != err) { goto err_hndl; }
+            nreqs++;
+        }
+        for (j = 0; j < nops; j++) {
+            remote = (rank - i - j + comm_size) % comm_size;
+            if (scounts[remote] <= 0 || rank == remote)
+                continue;
+            psend = ((char *)sbuf) + (ptrdiff_t)sdisps[remote] * sdtype_ext;
+            err = MCA_PML_CALL(isend_init(psend, scounts[remote], sdtype,
+                                      remote, MCA_COLL_BASE_TAG_ALLTOALLV,
+                                      MCA_PML_BASE_SEND_STANDARD, comm,
+                                      &reqs[nreqs]));
+            if (MPI_SUCCESS != err) { goto err_hndl; }
+            nreqs++;
+        }
+        MCA_PML_CALL(start(nreqs, reqs));
+        err = ompi_request_wait_all(nreqs, reqs, MPI_STATUSES_IGNORE);
+    }
+
+ err_hndl:
+    free(reqs);
+    return err;
+}

--- a/ompi/mca/coll/spacc/coll_spacc_component.c
+++ b/ompi/mca/coll/spacc/coll_spacc_component.c
@@ -24,6 +24,7 @@ const char *ompi_coll_spacc_component_version_string =
 int mca_coll_spacc_priority = 5;
 int mca_coll_spacc_stream = -1;
 int mca_coll_spacc_verbose = 0;
+int mca_coll_spacc_alltoallv_block_size = 4;
 
 /*
  * Local function
@@ -82,6 +83,12 @@ static int spacc_register(void)
                                           OPAL_INFO_LVL_9,
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_coll_spacc_verbose);
+    (void)mca_base_component_var_register(&mca_coll_spacc_component.super.collm_version,
+                                          "alltoallv_block_size", "Alltoallv block size",
+                                          MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                          OPAL_INFO_LVL_9,
+                                          MCA_BASE_VAR_SCOPE_READONLY,
+                                          &mca_coll_spacc_alltoallv_block_size);
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/coll/spacc/coll_spacc_module.c
+++ b/ompi/mca/coll/spacc/coll_spacc_module.c
@@ -11,6 +11,7 @@
 #include "mpi.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/base/coll_base_functions.h"
 #include "ompi/mca/coll/coll.h"
 #include "coll_spacc.h"
 
@@ -63,7 +64,7 @@ mca_coll_base_module_t *ompi_coll_spacc_comm_query(
     spacc_module->super.coll_allgatherv = NULL;
     spacc_module->super.coll_allreduce  = mca_coll_spacc_allreduce_intra_redscat_allgather;
     spacc_module->super.coll_alltoall   = NULL;
-    spacc_module->super.coll_alltoallv  = NULL;
+    spacc_module->super.coll_alltoallv  = mca_coll_spacc_alltoallv_intra_block;
     spacc_module->super.coll_alltoallw  = NULL;
     spacc_module->super.coll_barrier    = NULL;
     spacc_module->super.coll_bcast      = NULL;
@@ -87,6 +88,10 @@ static int spacc_module_enable(mca_coll_base_module_t *module,
                                struct ompi_communicator_t *comm)
 {
     opal_output_verbose(30, mca_coll_spacc_stream, "coll:spacc:module_enable called");
+    /* prepare the placeholder for the array of request* */
+    module->base_data = OBJ_NEW(mca_coll_base_comm_t);
+    if (NULL == module->base_data)
+        return OMPI_ERROR;
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
1. Add pairwise exchange algorithm for Alltoallv. This algorithm takes into account
   zero values in `scounts[]` and `rcouns[]`.

2. Fix: prepare the placeholder for the array of `request*` (for using linear allreduce).

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>