### PR TITLE
README: qualify ARM support (lightly) for v2.0.x

### DIFF
--- a/README
+++ b/README
@@ -135,7 +135,8 @@ General notes
 
 - Other systems have been lightly (but not fully tested):
   - Cygwin 32 & 64 bit with gcc
-  - ARMv4, ARMv5, ARMv6, ARMv7, ARMv8
+  - ARMv6, ARMv7, ARMv8 (aarch64).  aarch64 requires configure option 
+    --enable-builtin-atomics with this release.
   - Other 64 bit platforms (e.g., Linux on PPC64)
   - Oracle Solaris 10 and 11, 32 and 64 bit (SPARC, i386, x86_64),
     with Oracle Solaris Studio 12.5


### PR DESCRIPTION
Per discussions at the OMPI devel f2f 7/17, update
support for ARM (aarch64).  Note that --enable-builtin-atomics
is a required configure option for aarch64.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>