### PR TITLE
ompi/attributes: revamp attribute handling.

### DIFF
--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -270,8 +272,8 @@ static int free_win(int keyval)
 
 static int set_f(int keyval, MPI_Fint value)
 {
-    return ompi_attr_set_fortran_mpi1(COMM_ATTR, MPI_COMM_WORLD,
-                                      &MPI_COMM_WORLD->c_keyhash,
-                                      keyval, value,
-                                      true);
+    return ompi_attr_set_fint(COMM_ATTR, MPI_COMM_WORLD,
+                              &MPI_COMM_WORLD->c_keyhash,
+                              keyval, value,
+                              true);
 }

--- a/ompi/mpi/c/add_error_class.c
+++ b/ompi/mpi/c/add_error_class.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -66,12 +66,12 @@ int MPI_Add_error_class(int *errorclass)
     ** in attribute/attribute.c and attribute/attribute_predefined.c
     ** why we have to call the fortran attr_set function
     */
-    rc  = ompi_attr_set_fortran_mpi1 (COMM_ATTR,
-				      MPI_COMM_WORLD,
-				      &MPI_COMM_WORLD->c_keyhash,
-				      MPI_LASTUSEDCODE,
-				      ompi_mpi_errcode_lastused,
-				      true);
+    rc  = ompi_attr_set_fint (COMM_ATTR,
+                              MPI_COMM_WORLD,
+                              &MPI_COMM_WORLD->c_keyhash,
+                              MPI_LASTUSEDCODE,
+                              ompi_mpi_errcode_lastused,
+                              true);
     if ( MPI_SUCCESS != rc ) {
 	return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, rc, FUNC_NAME);
     }

--- a/ompi/mpi/c/add_error_code.c
+++ b/ompi/mpi/c/add_error_code.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -73,12 +73,12 @@ int MPI_Add_error_code(int errorclass, int *errorcode)
     ** in attribute/attribute.c and attribute/attribute_predefined.c
     ** why we have to call the fortran attr_set function
     */
-    rc  = ompi_attr_set_fortran_mpi1 (COMM_ATTR,
-				      MPI_COMM_WORLD,
-				      &MPI_COMM_WORLD->c_keyhash,
-				      MPI_LASTUSEDCODE,
-				      ompi_mpi_errcode_lastused,
-				      true);
+    rc  = ompi_attr_set_fint (COMM_ATTR,
+                              MPI_COMM_WORLD,
+                              &MPI_COMM_WORLD->c_keyhash,
+                              MPI_LASTUSEDCODE,
+                              ompi_mpi_errcode_lastused,
+                              true);
     if ( MPI_SUCCESS != rc ) {
 	return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, rc, FUNC_NAME);
     }

--- a/ompi/mpi/fortran/mpif-h/attr_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/attr_get_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -77,10 +77,10 @@ void ompi_attr_get_f(MPI_Fint *comm, MPI_Fint *keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi1(c_comm->c_keyhash,
-                                        OMPI_FINT_2_INT(*keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_fint(c_comm->c_keyhash,
+                                OMPI_FINT_2_INT(*keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/attr_put_f.c
+++ b/ompi/mpi/fortran/mpif-h/attr_put_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -76,11 +76,11 @@ void ompi_attr_put_f(MPI_Fint *comm, MPI_Fint *keyval, MPI_Fint *attribute_val,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_err = ompi_attr_set_fortran_mpi1(COMM_ATTR,
-                                       c_comm,
-                                       &c_comm->c_keyhash,
-                                       OMPI_FINT_2_INT(*keyval),
-                                       *attribute_val,
-                                       false);
+    c_err = ompi_attr_set_fint(COMM_ATTR,
+                               c_comm,
+                               &c_comm->c_keyhash,
+                               OMPI_FINT_2_INT(*keyval),
+                               *attribute_val,
+                               false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_err);
 }

--- a/ompi/mpi/fortran/mpif-h/comm_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_create_keyval_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -39,7 +39,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_COMM_CREATE_KEYVAL,
                            pmpi_comm_create_keyval_,
                            pmpi_comm_create_keyval__,
                            pompi_comm_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr) )
 #endif
 #endif
@@ -59,7 +59,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_COMM_CREATE_KEYVAL,
                            mpi_comm_create_keyval_,
                            mpi_comm_create_keyval__,
                            ompi_comm_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state, ierr) )
 #else
 #define ompi_comm_create_keyval_f pompi_comm_create_keyval_f
@@ -69,8 +69,8 @@ OMPI_GENERATE_F77_BINDINGS (MPI_COMM_CREATE_KEYVAL,
 static const char FUNC_NAME[] = "MPI_Comm_create_keyval_f";
 
 
-void ompi_comm_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn,
-                              ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn,
+void ompi_comm_create_keyval_f(ompi_aint_copy_attr_function* comm_copy_attr_fn,
+                              ompi_aint_delete_attr_function* comm_delete_attr_fn,
                               MPI_Fint *comm_keyval,
                               MPI_Aint *extra_state, MPI_Fint *ierr)
 {
@@ -79,8 +79,8 @@ void ompi_comm_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* comm_copy_a
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi2_fortran_copy_fn = comm_copy_attr_fn;
-    del_fn.attr_mpi2_fortran_delete_fn = comm_delete_attr_fn;
+    copy_fn.attr_aint_copy_fn = comm_copy_attr_fn;
+    del_fn.attr_aint_delete_fn = comm_delete_attr_fn;
 
     /* Note that we only set the "F77" bit and exclude the "F77_OLD"
        bit, indicating that the callbacks should use the new MPI-2

--- a/ompi/mpi/fortran/mpif-h/comm_get_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_get_attr_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -78,10 +78,10 @@ void ompi_comm_get_attr_f(MPI_Fint *comm, MPI_Fint *comm_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi2(c_comm->c_keyhash,
-                                        OMPI_FINT_2_INT(*comm_keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_aint(c_comm->c_keyhash,
+                                OMPI_FINT_2_INT(*comm_keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/comm_set_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_set_attr_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -76,11 +76,11 @@ void ompi_comm_set_attr_f(MPI_Fint *comm, MPI_Fint *comm_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_set_fortran_mpi2(COMM_ATTR,
-                                        c_comm,
-                                        &c_comm->c_keyhash,
-                                        OMPI_FINT_2_INT(*comm_keyval),
-                                        *attribute_val,
-                                        false);
+    c_ierr = ompi_attr_set_aint(COMM_ATTR,
+                                c_comm,
+                                &c_comm->c_keyhash,
+                                OMPI_FINT_2_INT(*comm_keyval),
+                                *attribute_val,
+                                false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/keyval_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/keyval_create_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -39,7 +39,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_KEYVAL_CREATE,
                            pmpi_keyval_create_,
                            pmpi_keyval_create__,
                            pompi_keyval_create_f,
-                           (ompi_mpi1_fortran_copy_attr_function* copy_fn, ompi_mpi1_fortran_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
+                           (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
                            (copy_fn, delete_fn, keyval, extra_state, ierr) )
 #endif
 #endif
@@ -59,7 +59,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_KEYVAL_CREATE,
                            mpi_keyval_create_,
                            mpi_keyval_create__,
                            ompi_keyval_create_f,
-                           (ompi_mpi1_fortran_copy_attr_function* copy_fn, ompi_mpi1_fortran_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
+                           (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr),
                            (copy_fn, delete_fn, keyval, extra_state, ierr) )
 #else
 #define ompi_keyval_create_f pompi_keyval_create_f
@@ -68,8 +68,8 @@ OMPI_GENERATE_F77_BINDINGS (MPI_KEYVAL_CREATE,
 
 static const char FUNC_NAME[] = "MPI_keyval_create_f";
 
-void ompi_keyval_create_f(ompi_mpi1_fortran_copy_attr_function* copy_attr_fn,
-                         ompi_mpi1_fortran_delete_attr_function* delete_attr_fn,
+void ompi_keyval_create_f(ompi_fint_copy_attr_function* copy_attr_fn,
+                         ompi_fint_delete_attr_function* delete_attr_fn,
                          MPI_Fint *keyval, MPI_Fint *extra_state,
                          MPI_Fint *ierr)
 {
@@ -78,8 +78,8 @@ void ompi_keyval_create_f(ompi_mpi1_fortran_copy_attr_function* copy_attr_fn,
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi1_fortran_copy_fn = copy_attr_fn;
-    del_fn.attr_mpi1_fortran_delete_fn = delete_attr_fn;
+    copy_fn.attr_fint_copy_fn = copy_attr_fn;
+    del_fn.attr_fint_delete_fn = delete_attr_fn;
 
     /* Set the "F77_OLD" bit to denote that the callbacks should use
        the old MPI-1 INTEGER-parameter functions (as opposed to the
@@ -88,7 +88,7 @@ void ompi_keyval_create_f(ompi_mpi1_fortran_copy_attr_function* copy_attr_fn,
 
     ret = ompi_attr_create_keyval_fint(COMM_ATTR, copy_fn, del_fn,
                                        OMPI_SINGLE_NAME_CONVERT(keyval), *extra_state,
-                                       OMPI_KEYVAL_F77 | OMPI_KEYVAL_F77_MPI1,
+                                       OMPI_KEYVAL_F77,
                                        NULL);
 
     if (MPI_SUCCESS != ret) {

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2011-2013 Universite Bordeaux 1
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2016-2017 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -120,7 +122,7 @@ PN2(void, MPI_Comm_call_errhandler, mpi_comm_call_errhandler, MPI_COMM_CALL_ERRH
 PN2(void, MPI_Comm_compare, mpi_comm_compare, MPI_COMM_COMPARE, (MPI_Fint *comm1, MPI_Fint *comm2, MPI_Fint *result, MPI_Fint *ierr));
 PN2(void, MPI_Comm_connect, mpi_comm_connect, MPI_COMM_CONNECT, (char *port_name, MPI_Fint *info, MPI_Fint *root, MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr, int port_name_len));
 PN2(void, MPI_Comm_create_errhandler, mpi_comm_create_errhandler, MPI_COMM_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
-PN2(void, MPI_Comm_create_keyval, mpi_comm_create_keyval, MPI_COMM_CREATE_KEYVAL, (ompi_mpi2_fortran_copy_attr_function* comm_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Comm_create_keyval, mpi_comm_create_keyval, MPI_COMM_CREATE_KEYVAL, (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create, mpi_comm_create, MPI_COMM_CREATE, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *newcomm, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create_group, mpi_comm_create_group, MPI_COMM_CREATE_GROUP, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *tag, MPI_Fint *newcomm, MPI_Fint *ierr));
 PN2(void, MPI_Comm_delete_attr, mpi_comm_delete_attr, MPI_COMM_DELETE_ATTR, (MPI_Fint *comm, MPI_Fint *comm_keyval, MPI_Fint *ierr));
@@ -303,7 +305,7 @@ PN2(void, MPI_Irsend, mpi_irsend, MPI_IRSEND, (char *buf, MPI_Fint *count, MPI_F
 PN2(void, MPI_Isend, mpi_isend, MPI_ISEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Issend, mpi_issend, MPI_ISSEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Is_thread_main, mpi_is_thread_main, MPI_IS_THREAD_MAIN, (ompi_fortran_logical_t *flag, MPI_Fint *ierr));
-PN2(void, MPI_Keyval_create, mpi_keyval_create, MPI_KEYVAL_CREATE, (ompi_mpi1_fortran_copy_attr_function* copy_fn, ompi_mpi1_fortran_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Keyval_create, mpi_keyval_create, MPI_KEYVAL_CREATE, (ompi_fint_copy_attr_function* copy_fn, ompi_fint_delete_attr_function* delete_fn, MPI_Fint *keyval, MPI_Fint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Keyval_free, mpi_keyval_free, MPI_KEYVAL_FREE, (MPI_Fint *keyval, MPI_Fint *ierr));
 PN2(void, MPI_Lookup_name, mpi_lookup_name, MPI_LOOKUP_NAME, (char *service_name, MPI_Fint *info, char *port_name, MPI_Fint *ierr, int service_name_len, int port_name_len));
 PN2(void, MPI_Mprobe, mpi_mprobe, MPI_MPROBE, (MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *message, MPI_Fint *status, MPI_Fint *ierr));
@@ -369,7 +371,7 @@ PN2(void, MPI_Type_create_f90_integer, mpi_type_create_f90_integer, MPI_TYPE_CRE
 PN2(void, MPI_Type_create_f90_real, mpi_type_create_f90_real, MPI_TYPE_CREATE_F90_REAL, (MPI_Fint *p, MPI_Fint *r, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hindexed, mpi_type_create_hindexed, MPI_TYPE_CREATE_HINDEXED, (MPI_Fint *count, MPI_Fint *array_of_blocklengths, MPI_Aint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hvector, mpi_type_create_hvector, MPI_TYPE_CREATE_HVECTOR, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Aint *stride, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
-PN2(void, MPI_Type_create_keyval, mpi_type_create_keyval, MPI_TYPE_CREATE_KEYVAL, (ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Type_create_keyval, mpi_type_create_keyval, MPI_TYPE_CREATE_KEYVAL, (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_indexed_block, mpi_type_create_indexed_block, MPI_TYPE_CREATE_INDEXED_BLOCK, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Fint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_hindexed_block, mpi_type_create_hindexed_block, MPI_TYPE_CREATE_HINDEXED_BLOCK, (MPI_Fint *count, MPI_Fint *blocklength, MPI_Aint *array_of_displacements, MPI_Fint *oldtype, MPI_Fint *newtype, MPI_Fint *ierr));
 PN2(void, MPI_Type_create_struct, mpi_type_create_struct, MPI_TYPE_CREATE_STRUCT, (MPI_Fint *count, MPI_Fint *array_of_block_lengths, MPI_Aint *array_of_displacements, MPI_Fint *array_of_types, MPI_Fint *newtype, MPI_Fint *ierr));
@@ -417,7 +419,7 @@ PN2(void, MPI_Win_complete, mpi_win_complete, MPI_WIN_COMPLETE, (MPI_Fint *win, 
 PN2(void, MPI_Win_create, mpi_win_create, MPI_WIN_CREATE, (char *base, MPI_Aint *size, MPI_Fint *disp_unit, MPI_Fint *info, MPI_Fint *comm, MPI_Fint *win, MPI_Fint *ierr));
 PN2(void, MPI_Win_create_dynamic, mpi_win_create_dynamic, MPI_WIN_CREATE_DYNAMIC, (MPI_Fint *info, MPI_Fint *comm, MPI_Fint *win, MPI_Fint *ierr));
 PN2(void, MPI_Win_create_errhandler, mpi_win_create_errhandler, MPI_WIN_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
-PN2(void, MPI_Win_create_keyval, mpi_win_create_keyval, MPI_WIN_CREATE_KEYVAL, (ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
+PN2(void, MPI_Win_create_keyval, mpi_win_create_keyval, MPI_WIN_CREATE_KEYVAL, (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Win_delete_attr, mpi_win_delete_attr, MPI_WIN_DELETE_ATTR, (MPI_Fint *win, MPI_Fint *win_keyval, MPI_Fint *ierr));
 PN2(void, MPI_Win_detach, mpi_win_detach, MPI_WIN_DETACH, (MPI_Fint *win, char *base, MPI_Fint *ierr));
 PN2(void, MPI_Win_fence, mpi_win_fence, MPI_WIN_FENCE, (MPI_Fint *assert, MPI_Fint *win, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/type_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_keyval_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -39,7 +39,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_TYPE_CREATE_KEYVAL,
                            pmpi_type_create_keyval_,
                            pmpi_type_create_keyval__,
                            pompi_type_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr) )
 #endif
 #endif
@@ -59,7 +59,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_TYPE_CREATE_KEYVAL,
                            mpi_type_create_keyval_,
                            mpi_type_create_keyval__,
                            ompi_type_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* type_copy_attr_fn, ompi_aint_delete_attr_function* type_delete_attr_fn, MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state, ierr) )
 #else
 #define ompi_type_create_keyval_f pompi_type_create_keyval_f
@@ -68,8 +68,8 @@ OMPI_GENERATE_F77_BINDINGS (MPI_TYPE_CREATE_KEYVAL,
 
 static char FUNC_NAME[] = "MPI_Type_create_keyval_f";
 
-void ompi_type_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* type_copy_attr_fn,
-                               ompi_mpi2_fortran_delete_attr_function* type_delete_attr_fn,
+void ompi_type_create_keyval_f(ompi_aint_copy_attr_function* type_copy_attr_fn,
+                               ompi_aint_delete_attr_function* type_delete_attr_fn,
                                MPI_Fint *type_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;
@@ -77,8 +77,8 @@ void ompi_type_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* type_copy_a
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi2_fortran_copy_fn = type_copy_attr_fn;
-    del_fn.attr_mpi2_fortran_delete_fn = type_delete_attr_fn;
+    copy_fn.attr_aint_copy_fn = type_copy_attr_fn;
+    del_fn.attr_aint_delete_fn = type_delete_attr_fn;
 
     /* Note that we only set the "F77" bit and exclude the "F77_OLD"
        bit, indicating that the callbacks should use the new MPI-2

--- a/ompi/mpi/fortran/mpif-h/type_get_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_attr_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -78,10 +78,10 @@ void ompi_type_get_attr_f(MPI_Fint *type, MPI_Fint *type_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi2(c_type->d_keyhash,
-                                        OMPI_FINT_2_INT(*type_keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_aint(c_type->d_keyhash,
+                                OMPI_FINT_2_INT(*type_keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/type_set_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_set_attr_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -75,11 +75,11 @@ void ompi_type_set_attr_f(MPI_Fint *type, MPI_Fint *type_keyval, MPI_Aint *attri
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_set_fortran_mpi2(TYPE_ATTR,
-                                        c_type,
-                                        &c_type->d_keyhash,
-                                        OMPI_FINT_2_INT(*type_keyval),
-                                        *attribute_val,
-                                        false);
+    c_ierr = ompi_attr_set_aint(TYPE_ATTR,
+                                c_type,
+                                &c_type->d_keyhash,
+                                OMPI_FINT_2_INT(*type_keyval),
+                                *attribute_val,
+                                false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_create_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_create_keyval_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -39,7 +39,7 @@ OMPI_GENERATE_F77_BINDINGS (PMPI_WIN_CREATE_KEYVAL,
                            pmpi_win_create_keyval_,
                            pmpi_win_create_keyval__,
                            pompi_win_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr) )
 #endif
 #endif
@@ -59,7 +59,7 @@ OMPI_GENERATE_F77_BINDINGS (MPI_WIN_CREATE_KEYVAL,
                            mpi_win_create_keyval_,
                            mpi_win_create_keyval__,
                            ompi_win_create_keyval_f,
-                           (ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn, ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
+                           (ompi_aint_copy_attr_function* win_copy_attr_fn, ompi_aint_delete_attr_function* win_delete_attr_fn, MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr),
                            (win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state, ierr) )
 #else
 #define ompi_win_create_keyval_f pompi_win_create_keyval_f
@@ -68,8 +68,8 @@ OMPI_GENERATE_F77_BINDINGS (MPI_WIN_CREATE_KEYVAL,
 
 static char FUNC_NAME[] = "MPI_Win_create_keyval";
 
-void ompi_win_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* win_copy_attr_fn,
-                             ompi_mpi2_fortran_delete_attr_function* win_delete_attr_fn,
+void ompi_win_create_keyval_f(ompi_aint_copy_attr_function* win_copy_attr_fn,
+                             ompi_aint_delete_attr_function* win_delete_attr_fn,
                              MPI_Fint *win_keyval, MPI_Aint *extra_state, MPI_Fint *ierr)
 {
     int ret, c_ierr;
@@ -77,8 +77,8 @@ void ompi_win_create_keyval_f(ompi_mpi2_fortran_copy_attr_function* win_copy_att
     ompi_attribute_fn_ptr_union_t copy_fn;
     ompi_attribute_fn_ptr_union_t del_fn;
 
-    copy_fn.attr_mpi2_fortran_copy_fn = win_copy_attr_fn;
-    del_fn.attr_mpi2_fortran_delete_fn = win_delete_attr_fn;
+    copy_fn.attr_aint_copy_fn = win_copy_attr_fn;
+    del_fn.attr_aint_delete_fn = win_delete_attr_fn;
 
     /* Note that we only set the "F77" bit and exclude the "F77_OLD"
        bit, indicating that the callbacks should use the new MPI-2

--- a/ompi/mpi/fortran/mpif-h/win_get_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_get_attr_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -77,10 +77,10 @@ void ompi_win_get_attr_f(MPI_Fint *win, MPI_Fint *win_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_get_fortran_mpi2(c_win->w_keyhash,
-                                        OMPI_FINT_2_INT(*win_keyval),
-                                        attribute_val,
-                                        OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = ompi_attr_get_aint(c_win->w_keyhash,
+                                OMPI_FINT_2_INT(*win_keyval),
+                                attribute_val,
+                                OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     OMPI_SINGLE_INT_2_LOGICAL(flag);
 }

--- a/ompi/mpi/fortran/mpif-h/win_set_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_set_attr_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -77,11 +77,11 @@ void ompi_win_set_attr_f(MPI_Fint *win, MPI_Fint *win_keyval,
     /* This stuff is very confusing.  Be sure to see the comment at
        the top of src/attributes/attributes.c. */
 
-    c_ierr = ompi_attr_set_fortran_mpi2(WIN_ATTR,
-                                        c_win,
-                                        &c_win->w_keyhash,
-                                        OMPI_FINT_2_INT(*win_keyval),
-                                        *attribute_val,
-                                        false);
+    c_ierr = ompi_attr_set_aint(WIN_ATTR,
+                                c_win,
+                                &c_win->w_keyhash,
+                                OMPI_FINT_2_INT(*win_keyval),
+                                *attribute_val,
+                                false);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_shared_query_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_shared_query_f.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -118,7 +118,7 @@ void ompi_win_shared_query_f(MPI_Fint *win, MPI_Fint *rank, MPI_Aint *size,
     c_win = PMPI_Win_f2c(*win);
 
     c_ierr = PMPI_Win_shared_query(c_win, OMPI_FINT_2_INT(*rank), size,
-                                  OMPI_SINGLE_NAME_CONVERT(disp_unit), baseptr);
+                                   OMPI_SINGLE_NAME_CONVERT(disp_unit), baseptr);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -191,25 +191,25 @@ config_window(void *base, size_t size, int disp_unit,
                           MPI_WIN_BASE, base, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi2(WIN_ATTR, win,
-                                     &win->w_keyhash,
-                                     MPI_WIN_SIZE, size, true);
+    ret = ompi_attr_set_aint(WIN_ATTR, win,
+                             &win->w_keyhash,
+                             MPI_WIN_SIZE, size, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
-                                     &win->w_keyhash,
-                                     MPI_WIN_DISP_UNIT, disp_unit,
-                                     true);
+    ret = ompi_attr_set_int(WIN_ATTR, win,
+                            &win->w_keyhash,
+                            MPI_WIN_DISP_UNIT, disp_unit,
+                            true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
-                                     &win->w_keyhash,
-                                     MPI_WIN_CREATE_FLAVOR, flavor, true);
+    ret = ompi_attr_set_int(WIN_ATTR, win,
+                            &win->w_keyhash,
+                            MPI_WIN_CREATE_FLAVOR, flavor, true);
     if (OMPI_SUCCESS != ret) return ret;
 
-    ret = ompi_attr_set_fortran_mpi1(WIN_ATTR, win,
-                                     &win->w_keyhash,
-                                     MPI_WIN_MODEL, model, true);
+    ret = ompi_attr_set_int(WIN_ATTR, win,
+                            &win->w_keyhash,
+                            MPI_WIN_MODEL, model, true);
     if (OMPI_SUCCESS != ret) return ret;
 
     win->w_f_to_c_index = opal_pointer_array_add(&ompi_mpi_windows, win);


### PR DESCRIPTION
we now have 12 cases to deal (4 writers and 3 readers) :

1. C `void*` is written into the attribute value, and the value is read into a C `void*` (unity)
2. C `void*` is written, Fortran `INTEGER` is read
3. C `void*` is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read
4. Fortran `INTEGER` is written, C `void*` is read
5. Fortran `INTEGER` is written, Fortran `INTEGER` is read (unity)
6. Fortran `INTEGER` is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read
7. Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is written, C `void*` is read
8. Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is written, Fortran `INTEGER` is read
9. Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read (unity)
10. Intrinsic is written, C `void*` is read
11. Intrinsic is written, Fortran `INTEGER` is read
12. Intrinsic is written, Fortran `INTEGER(KIND=MPI_ADDRESS_KIND)` is read

MPI-2 Fortran "integer representation" has type `INTEGER(KIND=MPI_ADDRESS_KIND)` as clarified
at https://github.com/mpiwg-rma/rma-issues/issues/1

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@72cfbb665c3555f2db21fc31511389732c3e187f)