### PR TITLE
pml/ob1: fix mca_pml_ob1_progress_needed usage

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_progress.c
+++ b/ompi/mca/pml/ob1/pml_ob1_progress.c
@@ -10,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,8 +56,8 @@ static inline int mca_pml_ob1_process_pending_cuda_async_copies(void)
 static int mca_pml_ob1_progress_needed = 0;
 int mca_pml_ob1_enable_progress(int32_t count)
 {
-    int32_t old = OPAL_ATOMIC_ADD32(&mca_pml_ob1_progress_needed, count);
-    if( 0 != old )
+    int32_t progress_count = OPAL_ATOMIC_ADD32(&mca_pml_ob1_progress_needed, count);
+    if( 1 < progress_count )
         return 0;  /* progress was already on */
 
     opal_progress_register(mca_pml_ob1_progress);
@@ -118,7 +120,7 @@ int mca_pml_ob1_progress(void)
 
     if( 0 != completed_requests ) {
         j = OPAL_ATOMIC_ADD32(&mca_pml_ob1_progress_needed, -completed_requests);
-        if( j == completed_requests ) {
+        if( 0 == j ) {
             opal_progress_unregister(mca_pml_ob1_progress);
         }
     }


### PR DESCRIPTION
OPAL_ATOMIC_ADD32() returns the *new* value and *not* the previous one.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>