### PR TITLE
contrib: Fix mellanox platform defaults (btl/sm -> btl/vader)

### DIFF
--- a/contrib/platform/mellanox/optimized.conf
+++ b/contrib/platform/mellanox/optimized.conf
@@ -61,7 +61,7 @@ scoll_fca_enable = 0
 #rmaps_base_mapping_policy = dist:auto
 coll = ^ml
 hwloc_base_binding_policy = core
-btl = sm,openib,self
+btl = vader,openib,self
 # Basic behavior to smooth startup
 mca_base_component_show_load_errors = 0
 orte_abort_timeout = 10


### PR DESCRIPTION
Signed-off-by: Artem Polyakov <artpol84@gmail.com>
(cherry picked from commit 35f15a0ba595afb64ece2af9419be9ea2d1e0f41)