### PR TITLE
coll/libnbc: demote progress_lock to regular flag

### DIFF
--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -75,7 +75,6 @@ struct ompi_coll_libnbc_component_t {
     opal_free_list_t requests;
     opal_list_t active_requests;
     int32_t active_comms;
-    opal_atomic_lock_t progress_lock; /* protect from recursive calls */
     opal_mutex_t lock;                /* protect access to the active_requests list */
 };
 typedef struct ompi_coll_libnbc_component_t ompi_coll_libnbc_component_t;


### PR DESCRIPTION
The LOCK COMPXCHG that grabs ```mca_coll_libnbc_component.progress_lock``` (which detects recursion and defines a critical section) has been showing up on my profiles during single-threaded runs, where there shouldn't be any contention. This PR changes the lock to an OPAL_THREAD_LOCKed boolean flag to speed up the single-thread case while keeping the critical section otherwise.

Signed-off-by: Carlos Bederián <bc@famaf.unc.edu.ar>