### PR TITLE
io/ompio: fix grouping option

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_aggregators.c
+++ b/ompi/mca/io/ompio/io_ompio_aggregators.c
@@ -1286,15 +1286,11 @@ int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
                                        fh->f_comm);   
 
 exit:
-    if (NULL != aggr_bytes_per_group_tmp) {
-        free(aggr_bytes_per_group_tmp);
-    }
-    if (NULL != start_offsets_lens_tmp) {
-        free(start_offsets_lens_tmp);
-    }
-    if (NULL != end_offsets_tmp) {
-        free(end_offsets_tmp);
-    }
+    /* Do not free aggr_bytes_per_group_tmp, 
+    ** start_offsets_lens_tmp, and end_offsets_tmp
+    ** here. The memory is released in the layer above.
+    */
+
 
     return ret;
 }


### PR DESCRIPTION
changing the value of mca_io_ompio_grouping_option lead to a segfault due to
a double-free problem. Remove the erroneous free statements that have been introduced
and add a note ensuring that we are not re-adding them back at that spot.

fixes issue #3903

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>