### PR TITLE
common/ompio: fix the lazy_open flag

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -200,12 +200,12 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
                  !mca_io_ompio_sharedfp_lazy_open  ) {                
                 shared_fp_base_module = ompio_fh->f_sharedfp;
                 ret = shared_fp_base_module->sharedfp_seek(ompio_fh,current_size, MPI_SEEK_SET);
-            }
-            else {
-                opal_output(1, "mca_common_ompio_file_open: Could not adjust position of "
-                            "shared file pointer with MPI_MODE_APPEND\n");
-                ret = MPI_ERR_OTHER;
-                goto fn_fail;
+                if ( MPI_SUCCESS != ret  ) {
+                    opal_output(1, "mca_common_ompio_file_open: Could not adjust position of "
+                                "shared file pointer with MPI_MODE_APPEND\n");
+                    ret = MPI_ERR_OTHER;
+                    goto fn_fail;
+                }
             }
         }
 


### PR DESCRIPTION
fixes an erroneous error code being returned when activating
the mca_io_ompio_sharedfp_lazy_open flag with MPI_MODE_APPEND.

fixes issue #3904

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>