### PR TITLE
btl/vader: remove debug code that should not be in a release

### DIFF
--- a/opal/mca/btl/vader/btl_vader_knem.c
+++ b/opal/mca/btl/vader/btl_vader_knem.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -109,7 +109,6 @@ int mca_btl_vader_knem_init (void)
     struct knem_cmd_info knem_info;
     int rc;
 
-    signal (SIGSEGV, SIG_DFL);
     /* Open the knem device.  Try to print a helpful message if we
        fail to open it. */
     mca_btl_vader.knem_fd = open("/dev/knem", O_RDWR);


### PR DESCRIPTION
References #3902. Close when in master, v3.0.x, and v2.x.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>