### PR TITLE
fs/lustre: update lustre header file used in the component

### DIFF
--- a/config/ompi_check_lustre.m4
+++ b/config/ompi_check_lustre.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
-dnl Copyright (c) 2008-2012 University of Houston. All rights reserved.
+dnl Copyright (c) 2008-2017 University of Houston. All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
@@ -43,7 +43,7 @@ AC_DEFUN([OMPI_CHECK_LUSTRE],[
     AC_ARG_WITH([lustre],
         [AC_HELP_STRING([--with-lustre(=DIR)],
              [Build Lustre support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
-    OPAL_CHECK_WITHDIR([lustre], [$with_lustre], [include/lustre/liblustreapi.h])
+    OPAL_CHECK_WITHDIR([lustre], [$with_lustre], [include/lustre/lustreapi.h])
 
     AS_IF([test -z "$with_lustre" || test "$with_lustre" = "yes"],
           [ompi_check_lustre_dir="/usr"],
@@ -56,13 +56,13 @@ AC_DEFUN([OMPI_CHECK_LUSTRE],[
     fi
 
     # Add correct -I and -L flags
-    OPAL_CHECK_PACKAGE([$1], [lustre/liblustreapi.h], [lustreapi], [llapi_file_create], [],
+    OPAL_CHECK_PACKAGE([$1], [lustre/lustreapi.h], [lustreapi], [llapi_file_create], [],
                        [$ompi_check_lustre_dir], [$ompi_check_lustre_libdir], [ompi_check_lustre_happy="yes"],
                        [ompi_check_lustre_happy="no"])
 
     AC_MSG_CHECKING([for required lustre data structures])
    cat > conftest.c <<EOF
-#include "lustre/liblustreapi.h"
+#include "lustre/lustreapi.h"
 void alloc_lum()
 {
   int v1, v3;

--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2016 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2017 University of Houston. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,8 +43,6 @@
 #endif
 
 #include <sys/ioctl.h>
-#include <lustre/liblustreapi.h>
-#include <lustre/lustre_user.h>
 
 /*
  * *******************************************************************

--- a/ompi/mca/fs/lustre/fs_lustre.h
+++ b/ompi/mca/fs/lustre/fs_lustre.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2015 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2017 University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -33,7 +33,7 @@ extern int mca_fs_lustre_stripe_width;
 
 BEGIN_C_DECLS
 
-#include <lustre/liblustreapi.h>
+#include <lustre/lustreapi.h>
 #include <lustre/lustre_user.h>
 
 #ifndef LOV_MAX_STRIPE_COUNT


### PR DESCRIPTION
liblustreapi.h is at this point deprecated. Switch to lustreapi.h instead

fixes issue #3223

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>