### PR TITLE
opal/mca: Fix mca_base_verbose file suffix processing

### DIFF
--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -214,12 +214,12 @@ static void parse_verbose(char *e, opal_output_stream_t *lds)
             have_output = true;
         }
 
-        else if (strcasecmp(ptr, "file") == 0) {
+        else if (strcasecmp(ptr, "file") == 0 || strcasecmp(ptr, "file:") == 0) {
             lds->lds_want_file = true;
             have_output = true;
         } else if (strncasecmp(ptr, "file:", 5) == 0) {
             lds->lds_want_file = true;
-            lds->lds_file_suffix = ptr + 5;
+            lds->lds_file_suffix = strdup(ptr + 5);
             have_output = true;
         } else if (strcasecmp(ptr, "fileappend") == 0) {
             lds->lds_want_file = true;

--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -87,6 +87,7 @@ typedef struct {
  * Private functions
  */
 static void construct(opal_object_t *stream);
+static void destruct(opal_object_t *stream);
 static int do_open(int output_id, opal_output_stream_t * lds);
 static int open_file(int i);
 static void free_descriptor(int output_id);
@@ -120,7 +121,7 @@ static bool syslog_opened = false;
 #endif
 static char *redirect_syslog_ident = NULL;
 
-OBJ_CLASS_INSTANCE(opal_output_stream_t, opal_object_t, construct, NULL);
+OBJ_CLASS_INSTANCE(opal_output_stream_t, opal_object_t, construct, destruct);
 
 /*
  * Setup the output stream infrastructure
@@ -529,6 +530,15 @@ static void construct(opal_object_t *obj)
     stream->lds_want_file = false;
     stream->lds_want_file_append = false;
     stream->lds_file_suffix = NULL;
+}
+static void destruct(opal_object_t *obj)
+{
+    opal_output_stream_t *stream = (opal_output_stream_t*) obj;
+
+    if( NULL != stream->lds_file_suffix ) {
+        free(stream->lds_file_suffix);
+        stream->lds_file_suffix = NULL;
+    }
 }
 
 /*


### PR DESCRIPTION
 * `-mca mca_base_verbose file:foo` should create an output file with
    the suffix `foo`. But since we free the pointer at the end of this
    function then by the time we use it it is pointing to invalid memory.
 * This commit fixes that corruption
 * This commit also fixes the behavior of `file:` with no suffix.
   Makes it the same as `file` without the colon.