### PR TITLE
Btl tcp: Improved diagnostic output and failure mode

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -536,9 +536,13 @@ void mca_btl_tcp_dump(struct mca_btl_base_module_t* base_btl,
 
 
 /*
- * A blocking recv on a non-blocking socket. Used to receive the small
- * amount of connection information that identifies the endpoints
- * endpoint.
+ * A blocking recv for both blocking and non-blocking socket. 
+ * Used to receive the small amount of connection information 
+ * that identifies the endpoints
+ * 
+ * when the socket is blocking (the caller introduces timeout) 
+ * which happens during initial handshake otherwise socket is 
+ * non-blocking most of the time.
  */
 
 int mca_btl_tcp_recv_blocking(int sd, void* data, size_t size)

--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -31,11 +31,13 @@
 #include "opal/mca/mpool/base/base.h"
 #include "opal/mca/mpool/mpool.h"
 #include "opal/mca/btl/base/btl_base_error.h"
+#include "opal/opal_socket_errno.h"
 
 #include "btl_tcp.h"
 #include "btl_tcp_frag.h"
 #include "btl_tcp_proc.h"
 #include "btl_tcp_endpoint.h"
+
 
 mca_btl_tcp_module_t mca_btl_tcp_module = {
     .super = {
@@ -530,4 +532,65 @@ void mca_btl_tcp_dump(struct mca_btl_base_module_t* base_btl,
         OPAL_THREAD_UNLOCK(&btl->tcp_endpoints_mutex);
     }
 #endif /* OPAL_ENABLE_DEBUG && WANT_PEER_DUMP */
+}
+
+
+/*
+ * A blocking recv on a non-blocking socket. Used to receive the small
+ * amount of connection information that identifies the endpoints
+ * endpoint.
+ */
+
+int mca_btl_tcp_recv_blocking(int sd, void* data, size_t size)
+{
+    unsigned char* ptr = (unsigned char*)data;
+    size_t cnt = 0;
+    while (cnt < size) {
+        int retval = recv(sd, ((char *)ptr) + cnt, size - cnt, 0);
+        /* remote closed connection */
+        if (0 == retval) {
+            BTL_ERROR(("remote peer unexpectedly closed connection while I was waiting for blocking message"));
+            return -1;
+        }
+
+        /* socket is non-blocking so handle errors */
+        if (retval < 0) {
+            if (opal_socket_errno != EINTR &&
+                opal_socket_errno != EAGAIN &&
+                opal_socket_errno != EWOULDBLOCK) {
+                BTL_ERROR(("recv(%d) failed: %s (%d)", sd, strerror(opal_socket_errno), opal_socket_errno));
+                return -1;
+            }
+            continue;
+        }
+        cnt += retval;
+    }
+    return cnt;
+}
+
+
+/*
+ * A blocking send on a non-blocking socket. Used to send the small
+ * amount of connection information that identifies the endpoints
+ * endpoint.
+ */
+
+int mca_btl_tcp_send_blocking(int sd, const void* data, size_t size)
+{
+    unsigned char* ptr = (unsigned char*)data;
+    size_t cnt = 0;
+    while(cnt < size) {
+        int retval = send(sd, ((const char *)ptr) + cnt, size - cnt, 0);
+        if (retval < 0) {
+            if (opal_socket_errno != EINTR &&
+                opal_socket_errno != EAGAIN &&
+                opal_socket_errno != EWOULDBLOCK) {
+                BTL_ERROR(("send() failed: %s (%d)", strerror(opal_socket_errno), opal_socket_errno));
+                return -1;
+            }
+            continue;
+        }
+        cnt += retval;
+    }
+    return cnt;
 }

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -359,9 +359,13 @@ int mca_btl_tcp_ft_event(int state);
 int mca_btl_tcp_send_blocking(int sd, const void* data, size_t size);
 
 /*
- * A blocking recv on a non-blocking socket. Used to receive the small
- * amount of connection information that identifies the endpoints
- * endpoint.
+ * A blocking recv for both blocking and non-blocking socket.
+ * Used to receive the small amount of connection information
+ * that identifies the endpoints
+ *
+ * when the socket is blocking (the caller introduces timeout)
+ * which happens during initial handshake otherwise socket is
+ * non-blocking most of the time.
  */
 int mca_btl_tcp_recv_blocking(int sd, void* data, size_t size);
 

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -351,5 +351,19 @@ mca_btl_tcp_dump(struct mca_btl_base_module_t* btl,
   */
 int mca_btl_tcp_ft_event(int state);
 
+/*
+ * A blocking send on a non-blocking socket. Used to send the small
+ * amount of connection information that identifies the endpoints
+ * endpoint.
+ */
+int mca_btl_tcp_send_blocking(int sd, const void* data, size_t size);
+
+/*
+ * A blocking recv on a non-blocking socket. Used to receive the small
+ * amount of connection information that identifies the endpoints
+ * endpoint.
+ */
+int mca_btl_tcp_recv_blocking(int sd, void* data, size_t size);
+
 END_C_DECLS
 #endif

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -729,7 +729,9 @@ static int mca_btl_tcp_component_create_instances(void)
         char* if_name = *argv;
         int if_index = opal_ifnametokindex(if_name);
         if(if_index < 0) {
-            BTL_ERROR(("invalid interface \"%s\"", if_name));
+            opal_show_help("help-mpi-btl-tcp.txt", "invalid if_inexclude",
+                           true, "include", opal_process_info.nodename,
+                           if_name, "Unknown interface name");
             ret = OPAL_ERR_NOT_FOUND;
             goto cleanup;
         }
@@ -960,15 +962,20 @@ static int mca_btl_tcp_component_create_listen(uint16_t af_family)
 
     /* set socket up to be non-blocking, otherwise accept could block */
     if((flags = fcntl(sd, F_GETFL, 0)) < 0) {
-        BTL_ERROR(("fcntl(F_GETFL) failed: %s (%d)",
-                   strerror(opal_socket_errno), opal_socket_errno));
+        opal_show_help("help-mpi-btl-tcp.txt", "socket flag fail",
+                       true, opal_process_info.nodename,
+                       getpid(), "fcntl(sd, F_GETFL, 0)",
+                       strerror(opal_socket_errno), opal_socket_errno);
         CLOSE_THE_SOCKET(sd);
         return OPAL_ERROR;
     } else {
         flags |= O_NONBLOCK;
         if(fcntl(sd, F_SETFL, flags) < 0) {
-            BTL_ERROR(("fcntl(F_SETFL) failed: %s (%d)",
-                       strerror(opal_socket_errno), opal_socket_errno));
+            opal_show_help("help-mpi-btl-tcp.txt", "socket flag fail",
+                           true, opal_process_info.nodename,
+                           getpid(),
+                           "fcntl(sd, F_SETFL, flags & O_NONBLOCK)",
+                           strerror(opal_socket_errno), opal_socket_errno);
             CLOSE_THE_SOCKET(sd);
             return OPAL_ERROR;
         }

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.h
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.h
@@ -26,7 +26,7 @@
 BEGIN_C_DECLS
 
 #define MCA_BTL_TCP_ENDPOINT_CACHE 1
-
+#define MCA_BTL_TCP_MAGIC_STRING_LENGTH 16
 /**
  * State of TCP endpoint connection.
  */
@@ -76,7 +76,12 @@ typedef mca_btl_base_endpoint_t  mca_btl_tcp_endpoint_t;
 OBJ_CLASS_DECLARATION(mca_btl_tcp_endpoint_t);
 
 /* Magic socket handshake string */
-extern const char mca_btl_tcp_magic_id_string[];
+extern const char mca_btl_tcp_magic_id_string[MCA_BTL_TCP_MAGIC_STRING_LENGTH];
+
+typedef struct { 
+    opal_process_name_t guid;
+    char magic_id[MCA_BTL_TCP_MAGIC_STRING_LENGTH];
+} mca_btl_tcp_endpoint_hs_msg_t;
 
 void mca_btl_tcp_set_socket_options(int sd);
 void mca_btl_tcp_endpoint_close(mca_btl_base_endpoint_t*);

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.h
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.h
@@ -75,6 +75,9 @@ typedef struct mca_btl_base_endpoint_t mca_btl_base_endpoint_t;
 typedef mca_btl_base_endpoint_t  mca_btl_tcp_endpoint_t;
 OBJ_CLASS_DECLARATION(mca_btl_tcp_endpoint_t);
 
+/* Magic socket handshake string */
+extern const char mca_btl_tcp_magic_id_string[];
+
 void mca_btl_tcp_set_socket_options(int sd);
 void mca_btl_tcp_endpoint_close(mca_btl_base_endpoint_t*);
 int  mca_btl_tcp_endpoint_send(mca_btl_base_endpoint_t*, struct mca_btl_tcp_frag_t*);

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -509,10 +509,7 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
         default:
             opal_output(0, "unknown address family for tcp: %d\n",
                         endpoint_addr_ss.ss_family);
-            /*
-             * return OPAL_UNREACH or some error, as this is not
-             * good
-             */
+            return OPAL_ERR_UNREACH;
         }
     }
 
@@ -554,14 +551,26 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
             if(NULL != proc_data->local_interfaces[i]->ipv4_address &&
                NULL != peer_interfaces[j]->ipv4_address) {
 
+                /* Convert the IPv4 addresses into nicely-printable strings for verbose debugging output */
+                inet_ntop(AF_INET, &(((struct sockaddr_in*) proc_data->local_interfaces[i]->ipv4_address))->sin_addr,
+                          str_local, sizeof(str_local));
+                inet_ntop(AF_INET, &(((struct sockaddr_in*) peer_interfaces[j]->ipv4_address))->sin_addr,
+                          str_remote, sizeof(str_remote));
+
                 if(opal_net_addr_isipv4public((struct sockaddr*) local_interface->ipv4_address) &&
                    opal_net_addr_isipv4public((struct sockaddr*) peer_interfaces[j]->ipv4_address)) {
                     if(opal_net_samenetwork((struct sockaddr*) local_interface->ipv4_address,
                                             (struct sockaddr*) peer_interfaces[j]->ipv4_address,
                                             local_interface->ipv4_netmask)) {
                         proc_data->weights[i][j] = CQ_PUBLIC_SAME_NETWORK;
+                        opal_output_verbose(20, opal_btl_base_framework.framework_output,
+                                            "btl:tcp: path from %s to %s: IPV4 PUBLIC SAME NETWORK",
+                                            str_local, str_remote);
                     } else {
                         proc_data->weights[i][j] = CQ_PUBLIC_DIFFERENT_NETWORK;
+                        opal_output_verbose(20, opal_btl_base_framework.framework_output,
+                                            "btl:tcp: path from %s to %s: IPV4 PUBLIC DIFFERENT NETWORK",
+                                            str_local, str_remote);
                     }
                     proc_data->best_addr[i][j] = peer_interfaces[j]->ipv4_endpoint_addr;
                     continue;
@@ -570,8 +579,14 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
                                         (struct sockaddr*) peer_interfaces[j]->ipv4_address,
                                         local_interface->ipv4_netmask)) {
                     proc_data->weights[i][j] = CQ_PRIVATE_SAME_NETWORK;
+                    opal_output_verbose(20, opal_btl_base_framework.framework_output,
+                                       "btl:tcp: path from %s to %s: IPV4 PRIVATE SAME NETWORK",
+                                       str_local, str_remote);
                 } else {
                     proc_data->weights[i][j] = CQ_PRIVATE_DIFFERENT_NETWORK;
+                    opal_output_verbose(20, opal_btl_base_framework.framework_output,
+                                       "btl:tcp: path from %s to %s: IPV4 PRIVATE DIFFERENT NETWORK",
+                                       str_local, str_remote);
                 }
                 proc_data->best_addr[i][j] = peer_interfaces[j]->ipv4_endpoint_addr;
                 continue;
@@ -673,6 +688,12 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
             rc = OPAL_SUCCESS;
         }
     }
+    if (OPAL_ERR_UNREACH == rc) {
+        opal_output_verbose(10, opal_btl_base_framework.framework_output,
+                            "btl:tcp: host %s, process %s UNREACHABLE",
+                            proc_hostname,
+                            OPAL_NAME_PRINT(btl_proc->proc_opal->proc_name));
+    }
 
     for(i = 0; i < perm_size; ++i) {
         free(proc_data->weights[i]);
@@ -729,7 +750,7 @@ int mca_btl_tcp_proc_remove(mca_btl_tcp_proc_t* btl_proc, mca_btl_base_endpoint_
                     OBJ_RELEASE(btl_proc);
                     return OPAL_SUCCESS;
                 }
-                /* The endpoint_addr may still be NULL if this enpoint is
+                /* The endpoint_addr may still be NULL if this endpoint is
                    being removed early in the wireup sequence (e.g., if it
                    is unreachable by all other procs) */
                 if (NULL != btl_endpoint->endpoint_addr) {

--- a/opal/mca/btl/tcp/help-mpi-btl-tcp.txt
+++ b/opal/mca/btl/tcp/help-mpi-btl-tcp.txt
@@ -100,3 +100,68 @@ hopefully be able to continue).
   Peer hostname:       %s (%s)
   Source IP of socket: %s
   Known IPs of peer:   %s
+#
+[socket flag fail]
+WARNING: Open MPI failed to set flags on a TCP socket.  This should
+not happen.  It is likely that your MPI job will now fail.
+
+  Local host: %s
+  PID:        %d
+  Flag:       %s
+  Error:      %s (%d)
+#
+[server did not get guid]
+WARNING: Open MPI accepted a TCP connection from what appears to be a
+another Open MPI process but the peer process did not complete the
+initial handshake properly.  This should not happen.
+
+This attempted connection will be ignored; your MPI job may or may not
+continue properly.
+
+  Local host: %s
+  PID:        %d
+#
+[server accept cannot find guid]
+WARNING: Open MPI accepted a TCP connection from what appears to be a
+another Open MPI process but cannot find a corresponding process
+entry for that peer.
+
+This attempted connection will be ignored; your MPI job may or may not
+continue properly.
+
+  Local host: %s
+  PID:        %d
+#
+[server getpeername failed]
+WARNING: Open MPI failed to look up the peer IP address information of
+a TCP connection that it just accepted.  This should not happen.
+
+This attempted connection will be ignored; your MPI job may or may not
+continue properly.
+
+  Local host: %s
+  PID:        %d
+  Error:      %s (%d)
+#
+[server cannot find endpoint]
+WARNING: Open MPI accepted a TCP connection from what appears to be a
+valid peer Open MPI process but cannot find a corresponding endpoint
+entry for that peer.  This should not happen.
+
+This attempted connection will be ignored; your MPI job may or may not
+continue properly.
+
+  Local host: %s
+  PID:        %d
+#
+[client connect fail]
+WARNING: Open MPI failed to TCP connect to a peer MPI process via
+TCP.  This should not happen.
+
+Your Open MPI job may now fail.
+
+  Local host: %s
+  PID:        %d
+  Message:    %s
+  Error:      %s (%d)
+#


### PR DESCRIPTION
This PR handles issue https://github.com/open-mpi/ompi/issues/85 As part of this PR we focus on improving Btl tcp verbose, help and failure mode. 

Overview of changes:
1. Moved non-blocking send/receive function to btl_tcp will help reusing these function wherever needed. In this case we plan to reuse receive function to retrieve magic string to validate established connection is from mpi process.
2. Used magic string to verify mpi connection. In case if there is mismatch or missing magic string we can identify that we are trying to connect with some other process.
3. Moved few BTL_ERROR to show_help and also update the function behaviour of
mca_btl_tcp_endpoint_complete_connect to return SUCCESS and ERROR cases.
4. Improved debugging and verbose around tcp btl.

Code sourced from https://bitbucket.org/jsquyres/tcp-debug-printf/commits/9efe756cda30/




 