### PR TITLE
v3.0.x: mtl-portals4: add timeout to rendezvous get fragments

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4.h
@@ -73,6 +73,7 @@ struct mca_mtl_portals4_module_t {
 
     /* free list of rendezvous get fragments */
     opal_free_list_t fl_rndv_get_frag;
+    int get_retransmit_timeout;
 
     /** Network interface handle for matched interface */
     ptl_handle_ni_t ni_h;

--- a/ompi/mca/mtl/portals4/mtl_portals4_component.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_component.c
@@ -202,6 +202,16 @@ ompi_mtl_portals4_component_register(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &ompi_mtl_portals4.max_msg_size_mtl);
 
+    ompi_mtl_portals4.get_retransmit_timeout=10000;
+    (void) mca_base_component_var_register(&mca_mtl_portals4_component.mtl_version,
+                                           "get_retransmit_timeout",
+                                           "PtlGET retransmission timeout in usec",
+                                           MCA_BASE_VAR_TYPE_INT,
+                                           NULL, 0, 0,
+                                           OPAL_INFO_LVL_5,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &ompi_mtl_portals4.get_retransmit_timeout);
+
     OBJ_RELEASE(new_enum);
     if (0 > ret) {
         return OMPI_ERR_NOT_SUPPORTED;

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv.c
@@ -340,6 +340,8 @@ ompi_mtl_portals4_rndv_get_frag_progress(ptl_event_t *ev,
             mtl_ptl_error(1, "PTL_EVENT_REPLY with ni_fail_type: %s"
                     " => cannot retry",
                     name_of_err[ev->ni_fail_type]);
+            ret = PTL_FAIL;
+            goto callback_error;
         }
 
         opal_timer_t time = opal_timer_base_get_usec() - rndv_get_frag->frag_start_time_usec;

--- a/ompi/mca/mtl/portals4/mtl_portals4_recv.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_recv.c
@@ -336,6 +336,12 @@ ompi_mtl_portals4_rndv_get_frag_progress(ptl_event_t *ev,
                             "%s:%d: PTL_EVENT_REPLY with ni_fail_type: %d",
                             __FILE__, __LINE__, ev->ni_fail_type);
 
+        if (OPAL_UNLIKELY(ev->ni_fail_type != PTL_NI_DROPPED)) {
+            mtl_ptl_error(1, "PTL_EVENT_REPLY with ni_fail_type: %s"
+                    " => cannot retry",
+                    name_of_err[ev->ni_fail_type]);
+        }
+
         opal_timer_t time = opal_timer_base_get_usec() - rndv_get_frag->frag_start_time_usec;
         if (time > (unsigned int) ompi_mtl_portals4.get_retransmit_timeout) {
             mtl_ptl_error(1, "timeout retrying GET");

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -94,7 +94,8 @@ struct ompi_mtl_portals4_rndv_get_frag_t {
     ptl_process_t    frag_target;
     ptl_hdr_data_t   frag_match_bits;
     ptl_size_t       frag_remote_offset;
-    opal_timer_t     frag_start_time_usec;
+    /* the absolute time at which this frag times out */
+    opal_timer_t     frag_abs_timeout_usec;
 
     int (*event_callback)(ptl_event_t *ev, struct ompi_mtl_portals4_rndv_get_frag_t*);
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_request.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_request.h
@@ -22,6 +22,7 @@
 
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/mca/mtl/mtl.h"
+#include "opal/mca/timer/base/base.h"
 
 struct ompi_mtl_portals4_message_t;
 struct ompi_mtl_portals4_pending_request_t;
@@ -93,6 +94,7 @@ struct ompi_mtl_portals4_rndv_get_frag_t {
     ptl_process_t    frag_target;
     ptl_hdr_data_t   frag_match_bits;
     ptl_size_t       frag_remote_offset;
+    opal_timer_t     frag_start_time_usec;
 
     int (*event_callback)(ptl_event_t *ev, struct ompi_mtl_portals4_rndv_get_frag_t*);
 


### PR DESCRIPTION
This PR adds a timeout to each fragment of a rendezvous get. If any fragment times out or fails, the entire receive fails.

(cherry picked from master commits 06b15ce, 99453e6, 37766d7, 5ecd905)

Signed-off-by: Todd Kordenbrock thkgcode@gmail.com
