### PR TITLE
configure: detect UCX support by default

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -1,6 +1,7 @@
 # -*- shell-script -*-
 #
-# Copyright (C) 2015      Mellanox Technologies Ltd. ALL RIGHTS RESERVED.
+# Copyright (C) 2015-2017 Mellanox Technologies, Inc.
+#                         All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -20,6 +21,7 @@
 # support, otherwise executes action-if-not-found
 AC_DEFUN([OMPI_CHECK_UCX],[
     if test -z "$ompi_check_ucx_happy" ; then
+        _x_ac_ucx_dirs="/usr /usr/local /opt/ucx"
 	AC_ARG_WITH([ucx],
 		    [AC_HELP_STRING([--with-ucx(=DIR)],
 				    [Build with Unified Communication X library support])])
@@ -29,57 +31,63 @@ AC_DEFUN([OMPI_CHECK_UCX],[
 				    [Search for Unified Communication X libraries in DIR])])
 	OPAL_CHECK_WITHDIR([ucx-libdir], [$with_ucx_libdir], [libucp.*])
 
-	ompi_check_ucx_$1_save_CPPFLAGS="$CPPFLAGS"
-	ompi_check_ucx_$1_save_LDFLAGS="$LDFLAGS"
-	ompi_check_ucx_$1_save_LIBS="$LIBS"
-
 	AS_IF([test "$with_ucx" != "no"],
               [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "yes"],
-                     [
-			 ompi_check_ucx_dir="$with_ucx"
-			 ompi_check_ucx_libdir="$with_ucx/lib"
-                     ])
-               AS_IF([test ! -z "$with_ucx_libdir" && test "$with_ucx_libdir" != "yes"],
-                     [ompi_check_ucx_libdir="$with_ucx_libdir"])
+                     [_x_ac_ucx_dirs="$with_ucx"])
+                for ompi_check_ucx_dir in $_x_ac_ucx_dirs; do
+                    AS_IF([test ! -z "$with_ucx_libdir" && test "$with_ucx_libdir" != "yes"],
+                          [
+                            ompi_check_ucx_libdir="$with_ucx_libdir"
+                            ompi_check_ucx_extra_libs="-L$ompi_check_ucx_libdir"
+                          ],
+                          [AS_IF([test ! -z "$ompi_check_ucx_dir"],
+                                 [
+                                    ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib
+                                    ompi_check_ucx_extra_libs="-L$ompi_check_ucx_libdir"
+                                 ])])
 
-               ompi_check_ucx_extra_libs="-L$ompi_check_ucx_libdir"
+                    ompi_check_ucx_$1_save_CPPFLAGS="$CPPFLAGS"
+                    ompi_check_ucx_$1_save_LDFLAGS="$LDFLAGS"
+                    ompi_check_ucx_$1_save_LIBS="$LIBS"
 
-               OPAL_CHECK_PACKAGE([ompi_check_ucx],
-				  [ucp/api/ucp.h],
-				  [ucp],
-				  [ucp_cleanup],
-				  [$ompi_check_ucx_extra_libs],
-				  [$ompi_check_ucx_dir],
-				  [$ompi_check_ucx_libdir],
-				  [ompi_check_ucx_happy="yes"],
-				  [ompi_check_ucx_happy="no"])],
-              [ompi_check_ucx_happy="no"])
+                    OPAL_CHECK_PACKAGE([ompi_check_ucx],
+                                [ucp/api/ucp.h],
+                                [ucp],
+                                [ucp_cleanup],
+                                [$ompi_check_ucx_extra_libs],
+                                [$ompi_check_ucx_dir],
+                                [$ompi_check_ucx_libdir],
+                                [ompi_check_ucx_happy="yes"],
+                                [ompi_check_ucx_happy="no"])
+                    CPPFLAGS="$ompi_check_ucx_$1_save_CPPFLAGS"
+                    LDFLAGS="$ompi_check_ucx_$1_save_LDFLAGS"
+                    LIBS="$ompi_check_ucx_$1_save_LIBS"
 
+                    if test "$ompi_check_ucx_happy" = no; then
+                        continue
+                    fi
 
+                    AC_MSG_CHECKING(for UCX version compatibility)
+                    AC_REQUIRE_CPP
+                    old_CPPFLAGS="$CPPFLAGS"
+                    CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"
+                    AC_COMPILE_IFELSE(
+                        [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
+                        [ompi_ucx_version_ok="yes"],
+                        [ompi_ucx_version_ok="no"])
 
-	CPPFLAGS="$ompi_check_ucx_$1_save_CPPFLAGS"
-	LDFLAGS="$ompi_check_ucx_$1_save_LDFLAGS"
-	LIBS="$ompi_check_ucx_$1_save_LIBS"
+                    AC_MSG_RESULT([$ompi_ucx_version_ok])
+                    CPPFLAGS=$old_CPPFLAGS
 
-	AC_MSG_CHECKING(for UCX version compatibility)
-	AC_REQUIRE_CPP
-	old_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"
-	AC_COMPILE_IFELSE(
-            [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],
-			     [[
-			     ]])],
-            [ompi_ucx_version_ok="yes"],
-            [ompi_ucx_version_ok="no"])
+                    AS_IF([test "$ompi_ucx_version_ok" = "no"], [ompi_check_ucx_happy="no"])
 
-	AC_MSG_RESULT([$ompi_ucx_version_ok])
-	CPPFLAGS=$old_CPPFLAGS
-
-	AS_IF([test "$ompi_ucx_version_ok" = "no"], [ompi_check_ucx_happy="no"])
-
-	OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])
+                    if test "$ompi_check_ucx_happy" = yes; then
+                        break
+                    fi
+                done],
+            [ompi_check_ucx_happy="no"])
+        OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])
     fi
-
 
     AS_IF([test "$ompi_check_ucx_happy" = "yes"],
           [$1_CPPFLAGS="[$]$1_CPPFLAGS $ompi_check_ucx_CPPFLAGS"

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -21,7 +21,6 @@
 # support, otherwise executes action-if-not-found
 AC_DEFUN([OMPI_CHECK_UCX],[
     if test -z "$ompi_check_ucx_happy" ; then
-        _x_ac_ucx_dirs="/usr /usr/local /opt/ucx"
 	AC_ARG_WITH([ucx],
 		    [AC_HELP_STRING([--with-ucx(=DIR)],
 				    [Build with Unified Communication X library support])])
@@ -33,7 +32,12 @@ AC_DEFUN([OMPI_CHECK_UCX],[
 
 	AS_IF([test "$with_ucx" != "no"],
               [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "yes"],
-                     [_x_ac_ucx_dirs="$with_ucx"])
+                     [_x_ac_ucx_dirs="$with_ucx"],
+                     [
+                        PKG_CHECK_MODULES_STATIC([ucx],[ucx],
+                                          [_x_ac_ucx_dirs=`$PKG_CONFIG --variable=prefix ucx`],
+                                          [_x_ac_ucx_dirs="/usr /usr/local /opt/ucx"])
+                     ])
                 for ompi_check_ucx_dir in $_x_ac_ucx_dirs; do
                     AS_IF([test ! -z "$with_ucx_libdir" && test "$with_ucx_libdir" != "yes"],
                           [

--- a/ompi/mca/pml/ucx/Makefile.am
+++ b/ompi/mca/pml/ucx/Makefile.am
@@ -1,5 +1,6 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2015.  ALL RIGHTS RESERVED.
+# Copyright (C) 2001-2017 Mellanox Technologies, Inc.
+#                         All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,10 +37,10 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_ucx_la_SOURCES = $(local_sources)
 mca_pml_ucx_la_LIBADD = $(pml_ucx_LIBS)
-mca_pml_ucx_la_LDFLAGS = -module -avoid-version
+mca_pml_ucx_la_LDFLAGS = -module -avoid-version $(pml_ucx_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pml_ucx_la_SOURCES = $(local_sources)
 libmca_pml_ucx_la_LIBADD = $(pml_ucx_LIBS)
-libmca_pml_ucx_la_LDFLAGS = -module -avoid-version
+libmca_pml_ucx_la_LDFLAGS = -module -avoid-version $(pml_ucx_LDFLAGS)
 


### PR DESCRIPTION
Adds detecting UCX from following paths: "/usr /usr/local /opt/ucx"

Signed-off-by: Boris Karasev <karasev.b@gmail.com>