### PR TITLE
v3.0.x: hwloc/base: fix info message for opal_hwloc_base_binding_policy

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -120,7 +120,7 @@ static int opal_hwloc_base_register(mca_base_register_flag_t flags)
     (void) mca_base_var_register("opal", "hwloc", "base", "binding_policy",
                                  "Policy for binding processes. Allowed values: none, hwthread, core, l1cache, l2cache, "
                                  "l3cache, socket, numa, board (\"none\" is the default when oversubscribed, \"core\" is "
-                                 "the default when np<=2, and \"socket\" is the default when np>2). Allowed qualifiers: "
+                                 "the default when np<=2, and \"numa\" is the default when np>2). Allowed qualifiers: "
                                  "overload-allowed, if-supported",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY, &opal_hwloc_base_binding_policy);


### PR DESCRIPTION
if np > 2, the default binding is now "numa"

Thanks Dave Love for the report.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@825116044e362b25e4edac5778702e5f26154281)