### PR TITLE
opal/atomic: always inline load-link store-conditional

### DIFF
--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reseved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -204,8 +204,10 @@ static inline void _opal_lifo_release_cpu (void)
  */
 static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
 {
-    opal_list_item_t *item, *next;
-    int attempt = 0;
+    register opal_list_item_t volatile * volatile * head = &lifo->opal_lifo_head.data.item;
+    register opal_list_item_t *ghost = &lifo->opal_lifo_ghost;
+    register opal_list_item_t *item, *next;
+    int attempt = 0, ret;
 
     do {
         if (++attempt == 5) {
@@ -215,13 +217,14 @@ static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
             attempt = 0;
         }
 
-        item = (opal_list_item_t *) opal_atomic_ll_ptr (&lifo->opal_lifo_head.data.item);
-        if (&lifo->opal_lifo_ghost == item) {
+        opal_atomic_ll_ptr(head, item);
+        next = (opal_list_item_t *) item->opal_list_next;
+        if (ghost == item) {
             return NULL;
         }
 
-        next = (opal_list_item_t *) item->opal_list_next;
-    } while (!opal_atomic_sc_ptr (&lifo->opal_lifo_head.data.item, next));
+        opal_atomic_sc_ptr(head, next, ret);
+    } while (!ret);
 
     opal_atomic_wmb ();
 

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -278,15 +278,15 @@ static inline int opal_atomic_cmpset_rel_ptr(volatile void* addr,
 
 #if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_LLSC_32
 
-#define opal_atomic_ll_ptr(addr) (void *) opal_atomic_ll_32((int32_t *) addr)
-#define opal_atomic_sc_ptr(addr, newval) opal_atomic_sc_32((int32_t *) addr, (int32_t) newval)
+#define opal_atomic_ll_ptr opal_atomic_ll_32
+#define opal_atomic_sc_ptr opal_atomic_sc_32
 
 #define OPAL_HAVE_ATOMIC_LLSC_PTR 1
 
 #elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_LLSC_64
 
-#define opal_atomic_ll_ptr(addr) (void *) opal_atomic_ll_64((int64_t *) addr)
-#define opal_atomic_sc_ptr(addr, newval) opal_atomic_sc_64((int64_t *) addr, (int64_t) newval)
+#define opal_atomic_ll_ptr opal_atomic_ll_64
+#define opal_atomic_sc_ptr opal_atomic_sc_64
 
 #define OPAL_HAVE_ATOMIC_LLSC_PTR 1
 


### PR DESCRIPTION
Enabling debugging can cause the load-link store-conditional
atomic operations to hit a live-lock condition. To prevent the
live-lock always inline these atomics.

Fixes #3697

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>