### PR TITLE
SLURM: launch all processes via slurmd

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -65,6 +65,11 @@ Master (not on release branches yet)
   via --enable-mpi-cxx.
 - Removed embedded VampirTrace.  It is in maintenance mode since 2013.
   Please consider Score-P (score-p.org) as an external replacement.
+- Add a mca parameter ras_base_launch_orted_on_hn to allow for launching
+  MPI processes on the same node where mpirun is executing using a separate
+  orte daemon, rather than the mpirun process.   This may be useful to set to
+  true when using SLURM, as it improves interoperability with SLURM's signal
+  propagation tools.  By default it is set to false, except for Cray XC systems.
 
 3.0.0 -- July, 2017
 -------------------

--- a/orte/mca/ras/base/base.h
+++ b/orte/mca/ras/base/base.h
@@ -51,6 +51,7 @@ typedef struct orte_ras_base_t {
     orte_ras_base_module_t *active_module;
     int total_slots_alloc;
     int multiplier;
+    bool launch_orted_on_hn;
 } orte_ras_base_t;
 
 ORTE_DECLSPEC extern orte_ras_base_t orte_ras_base;

--- a/orte/mca/ras/base/ras_base_frame.c
+++ b/orte/mca/ras/base/ras_base_frame.c
@@ -59,6 +59,31 @@ static int ras_register(mca_base_register_flag_t flags)
                           NULL, 0, 0,
                           OPAL_INFO_LVL_9,
                           MCA_BASE_VAR_SCOPE_READONLY, &orte_ras_base.multiplier);
+#if SLURM_CRAY_ENV
+    /*
+     * If we are in a Cray-SLURM environment, then we cannot
+     * launch procs local to the HNP. The problem
+     * is the MPI processes launched on the head node (where the
+     * ORTE_PROC_IS_HNP evalues to true) get launched by a daemon
+     * (mpirun) which is not a child of a slurmd daemon.  This
+     * means that any RDMA credentials obtained via the odls/alps
+     * local launcher are incorrect. Test for this condition. If
+     * found, then take steps to ensure we launch a daemon on
+     * the same node as mpirun and that it gets used to fork
+     * local procs instead of mpirun so they get the proper
+     * credential */
+
+    orte_ras_base.launch_orted_on_hn = true;
+#else
+    orte_ras_base.launch_orted_on_hn = false;
+#endif
+
+    mca_base_var_register("orte", "ras", "base", "launch_orted_on_hn",
+                          "Launch an orte daemon on the head node",
+                           MCA_BASE_VAR_TYPE_BOOL,
+                           NULL, 0, 0,
+                           OPAL_INFO_LVL_9,
+                           MCA_BASE_VAR_SCOPE_READONLY, &orte_ras_base.launch_orted_on_hn);
     return ORTE_SUCCESS;
 }
 


### PR DESCRIPTION
It turns out that the approach of having the HNP do the
fork/exec of MPI ranks on the head node in a SLURM environment
introduces problems when users/sysadmins want to use the SLURM
scancl tool or sbatch --signal option to signal a job.

This commit disables use of the HNP fork/exec procedure when
a job is launched into a SLURM controlled allocation.

related to #3998

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>