### PR TITLE
config: remove erroneous define

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -207,9 +207,6 @@ __atomic_add_fetch(&tmp64, 1, __ATOMIC_RELAXED);],
     [AC_MSG_RESULT([no])
      $2])
 
-  AC_DEFINE_UNQUOTED([OPAL_ASM_SYNC_HAVE_64BIT],[$opal_asm_sync_have_64bit],
-		     [Whether 64-bit is supported by the __sync builtin atomics])
-
   # Check for 128-bit support
   OPAL_CHECK_GCC_BUILTIN_CSWAP_INT128
 ])


### PR DESCRIPTION
This removes a copy-and-paste error where we were setting the
OPAL_ASM_SYNC_HAVE_64BIT more than once.

References #3993. Close when on master and v3.0.x.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 35c9b93754ceb73decb3b0ff716b33a8d6861f45)
Signed-off-by: Nathan Hjelm <hjelmn@me.com>