### PR TITLE
v2.0.x: README: remove references to the removed coll/hierarch module

### DIFF
--- a/README
+++ b/README
@@ -17,6 +17,9 @@ Copyright (c) 2010      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2011      University of Houston. All rights reserved.
 Copyright (c) 2013-2015 Intel, Inc. All rights reserved
 Copyright (c) 2015      NVIDIA Corporation.  All rights reserved.
+Copyright (c) 2017      Research Organization for Information Science
+                        and Technology (RIST). All rights reserved.
+
 $COPYRIGHT$
 
 Additional copyrights may follow
@@ -535,24 +538,6 @@ OSHMEM Functionality and Features
 
 MPI Collectives
 -----------
-
-- The "hierarch" coll component (i.e., an implementation of MPI
-  collective operations) attempts to discover network layers of
-  latency in order to segregate individual "local" and "global"
-  operations as part of the overall collective operation.  In this
-  way, network traffic can be reduced -- or possibly even minimized
-  (similar to MagPIe).  The current "hierarch" component only
-  separates MPI processes into on- and off-node groups.
-
-  Hierarch has had sufficient correctness testing, but has not
-  received much performance tuning.  As such, hierarch is not
-  activated by default -- it must be enabled manually by setting its
-  priority level to 100:
-
-    mpirun --mca coll_hierarch_priority 100 ...
-
-  We would appreciate feedback from the user community about how well
-  hierarch works for your applications.
 
 - The "fca" coll component: the Mellanox Fabric Collective Accelerator
   (FCA) is a solution for offloading collective operations from the


### PR DESCRIPTION
Fixes open-mpi/ompi#4005

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@2216b80b82dbf4b5e94fa49ae9daeb890649109a)