### PR TITLE
Fix incorrect usage of '==' in test comparisons

### DIFF
--- a/config/opal_setup_zlib.m4
+++ b/config/opal_setup_zlib.m4
@@ -56,7 +56,7 @@ AC_DEFUN([OPAL_ZLIB_CONFIG],[
                            [$opal_zlib_libdir],
                            [opal_zlib_support=1],
                            [opal_zlib_support=0])
-        if test $opal_zlib_support == "1"; then
+        if test $opal_zlib_support = "1"; then
             LIBS="$LIBS -lz"
             if test "$opal_zlib_standard_header_location" != "yes"; then
                 CPPFLAGS="$CPPFLAGS $opal_zlib_CPPFLAGS"

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -53,7 +53,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
                   [AC_HELP_STRING([--enable-pmix-timing],
                                   [Enable PMIx timing measurements (default: disabled)])])
     AC_MSG_CHECKING([if PMIx timing is enabled])
-    if test "$enable_pmix_timing" == "yes"; then
+    if test "$enable_pmix_timing" = "yes"; then
         AC_MSG_RESULT([yes])
         opal_pmix_pmix2x_timing_flag=--enable-pmix-timing
     else

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
@@ -933,7 +933,7 @@ AC_MSG_CHECKING([if want shared memory datastore])
 AC_ARG_ENABLE([dstore],
               [AC_HELP_STRING([--disable-dstore],
                               [Using shared memory datastore (default: enabled)])])
-if test "$enable_dstore" == "no" ; then
+if test "$enable_dstore" = "no" ; then
     AC_MSG_RESULT([no])
     WANT_DSTORE=0
 else
@@ -952,7 +952,7 @@ AC_MSG_CHECKING([if want dstore pthread-based locking])
 AC_ARG_ENABLE([dstore-pthlck],
               [AC_HELP_STRING([--disable-dstore-pthlck],
                               [Disable pthread-based lockig in dstor (default: enabled)])])
-if test "$enable_dstore_pthlck" == "no" ; then
+if test "$enable_dstore_pthlck" = "no" ; then
     AC_MSG_RESULT([no])
     DSTORE_PTHREAD_LOCK="0"
 else

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix_check_lock.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix_check_lock.m4
@@ -5,6 +5,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2017      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2017      Intel, Inc. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -26,7 +27,7 @@ AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
         _x_ac_fcntl_lock_found="1"
     ], [], [#include <fcntl.h>])
 
-    if test "$DSTORE_PTHREAD_LOCK" == "1"; then
+    if test "$DSTORE_PTHREAD_LOCK" = "1"; then
         AC_CHECK_FUNC([pthread_rwlockattr_setkind_np],
             [AC_EGREP_HEADER([PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP],
                     [pthread.h],[
@@ -43,15 +44,15 @@ AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
             ])
         ])
 
-        if test "$_x_ac_pthread_lock_found" == "0"; then
-            if test "$_x_ac_fcntl_lock_found" == "1"; then
+        if test "$_x_ac_pthread_lock_found" = "0"; then
+            if test "$_x_ac_fcntl_lock_found" = "1"; then
                 AC_MSG_WARN([dstore: pthread-based locking not found, will use fcntl-based locking.])
             else
                 AC_MSG_ERROR([dstore: no available locking mechanisms was found. Can not continue. Try disabling dstore])
             fi
         fi
     else
-        if test "$_x_ac_fcntl_lock_found" == "0"; then
+        if test "$_x_ac_fcntl_lock_found" = "0"; then
             AC_MSG_ERROR([dstore: no available locking mechanisms was found. Can not continue. Try disabling dstore])
         fi
         LIBS="$orig_libs"

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix_setup_zlib.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix_setup_zlib.m4
@@ -56,7 +56,7 @@ AC_DEFUN([PMIX_ZLIB_CONFIG],[
                            [$pmix_zlib_libdir],
                            [pmix_zlib_support=1],
                            [pmix_zlib_support=0])
-        if test $pmix_zlib_support == "1"; then
+        if test $pmix_zlib_support = "1"; then
             LIBS="$LIBS -lz"
             PMIX_EMBEDDED_LIBS="$PMIX_EMBEDDED_LIBS -lz"
             if test "$pmix_zlib_standard_header_location" != "yes"; then


### PR DESCRIPTION
Fixes #3991 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit f128b4c54692e17e275f0f4542663658e52c0721)