### PR TITLE
btl/openib: disable XRC in OpenIB BTL

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -53,6 +53,12 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
+2.1.2 -- August, 2017
+--------------------
+
+Bug fixes/minor improvements:
+- Remove IB XRC support from the OpenIB BTL due to lack of support.
+
 2.1.1 -- April, 2017
 --------------------
 

--- a/config/opal_check_openfabrics.m4
+++ b/config/opal_check_openfabrics.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2006-2016 Los Alamos National Security, LLC.  All rights
+# Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2006-2009 Mellanox Technologies. All rights reserved.
 # Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
@@ -301,12 +301,13 @@ AC_DEFUN([OPAL_CHECK_OPENFABRICS],[
 
 AC_DEFUN([OPAL_CHECK_OPENFABRICS_CM_ARGS],[
     #
-    # ConnectX XRC support
+    # ConnectX XRC support - disabled see issue #3890
     #
-    AC_ARG_ENABLE([openib-connectx-xrc],
-        [AC_HELP_STRING([--enable-openib-connectx-xrc],
-                        [Enable ConnectX XRC support in the openib BTL. If you do not have InfiniBand ConnectX adapters, you may disable the ConnectX XRC support. If you do not know which InfiniBand adapter is installed on your cluster, leave this option enabled (default: enabled)])],
-                        [enable_connectx_xrc="$enableval"], [enable_connectx_xrc="yes"])
+dnl    AC_ARG_ENABLE([openib-connectx-xrc],
+dnl        [AC_HELP_STRING([--enable-openib-connectx-xrc],
+dnl                        [Enable ConnectX XRC support in the openib BTL. (default: disabled)])],
+dnl                        [enable_connectx_xrc="$enableval"], [enable_connectx_xrc="no"])
+    enable_connectx_xrc="no"
     #
     # Unconnect Datagram (UD) based connection manager
     #


### PR DESCRIPTION
disable XRC in OpenIB BTL due to lack of support.

Related to #3890
Fixes #3969

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 8223d4cba0f77fb25315eb5afcc070f46666d3d7)

Conflicts:
	NEWS