### PR TITLE
test: Update nmcheck_prefix.pl

### DIFF
--- a/test/symbol_name/nmcheck_prefix.pl
+++ b/test/symbol_name/nmcheck_prefix.pl
@@ -33,6 +33,7 @@ sub main {
         "lib${mpi}.so",
         "lib${mpi}_mpifh.so",
         "lib${mpi}_usempi.so",
+        "lib${mpi}_usempi_ignore_tkr.so",
         "libopen-rte.so",
         "libopen-pal.so" )
     {
@@ -113,8 +114,9 @@ sub check_lib_for_bad_exports {
     @symbols = grep(!/^_fini$/, @symbols);
     @symbols = grep(!/^_init$/, @symbols);
     @symbols = grep(!/^_edata$/, @symbols);
-    @symbols = grep(!/^_end$/, @symbols);
-    @symbols = grep(!/^__bss_start$/, @symbols);
+    @symbols = grep(!/^_+end_*$/, @symbols);
+    @symbols = grep(!/^_+bss_start_*$/, @symbols);
+    @symbols = grep(!/^_+bss_end_*$/, @symbols);
     @symbols = grep(!/^__malloc_initialize_hook$/, @symbols);
 
     # The symbols can now be split into two groups: fatal and warning.


### PR DESCRIPTION
The linker of Linux/AArch64 (at least) generates `__bss_start__`, `__bss_end__`, `_bss_end__`, and `__end__` symbols. Without this change, `make check` will fail.
    
`libmpi_usempi_ignore_tkr.so` is added but `libmpi_usempif08.so` is not added because `use-mpi-f08` has `contains` statements in modules and compilers automatically generate compiler-specific symbols for them. For example, gfortran 4.9 generates `__mpi_f08_callbacks_MOD_mpi_comm_dup_fn` etc.

This commit does not need to be merged into release branches because no release branches have this file.
