### PR TITLE
oshmem: fix issue with shmem_g c11 generics

### DIFF
--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -298,7 +298,7 @@ OSHMEM_DECLSPEC  long long shmem_longlong_g(const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double shmem_longdouble_g(const long double* addr, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_g(addr, pe)                                    \
-    _Generic(&*(dst),                                        \
+    _Generic(&*(addr),                                        \
             char*:        shmem_char_g,                      \
             short*:       shmem_short_g,                     \
             int*:         shmem_int_g,                       \


### PR DESCRIPTION
There was a typo in the shmem_g c11 generic interface
in shmem.h.in

Thanks to @nspark for reporting the problem and
specifying the fix.

Fixes #3968

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
(cherry picked from commit 1d612da1cbc5f5355fdd4a17ccd5d56fe718a406)