### PR TITLE
opal: rename opal_atomic_init to opal_atomic_lock_init

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -322,7 +322,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 
     *base = module->bases[ompi_comm_rank(module->comm)];
 
-    opal_atomic_init(&module->my_node_state->accumulate_lock, OPAL_ATOMIC_UNLOCKED);
+    opal_atomic_lock_init(&module->my_node_state->accumulate_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
 
     /* share everyone's displacement units. */
     module->disp_units = malloc(sizeof(int) * comm_size);

--- a/opal/class/opal_object.c
+++ b/opal/class/opal_object.c
@@ -55,7 +55,7 @@ int opal_class_init_epoch = 1;
 /*
  * Local variables
  */
-static opal_atomic_lock_t class_lock = { { OPAL_ATOMIC_UNLOCKED } };
+static opal_atomic_lock_t class_lock = { { OPAL_ATOMIC_LOCK_UNLOCKED } };
 static void** classes = NULL;
 static int num_classes = 0;
 static int max_classes = 0;

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -129,8 +129,8 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
  * Enumeration of lock states
  */
 enum {
-    OPAL_ATOMIC_UNLOCKED = 0,
-    OPAL_ATOMIC_LOCKED = 1
+    OPAL_ATOMIC_LOCK_UNLOCKED = 0,
+    OPAL_ATOMIC_LOCK_LOCKED = 1
 };
 
 /**********************************************************************
@@ -277,7 +277,7 @@ void opal_atomic_wmb(void);
 #if OPAL_HAVE_ATOMIC_SPINLOCKS == 0
 static inline
 #endif
-void opal_atomic_init(opal_atomic_lock_t* lock, int32_t value);
+void opal_atomic_lock_init(opal_atomic_lock_t* lock, int32_t value);
 
 
 /**

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -401,7 +401,7 @@ static inline int32_t opal_atomic_sub_ptr( volatile void* addr,
  * Lock initialization function. It set the lock to UNLOCKED.
  */
 static inline void
-opal_atomic_init( opal_atomic_lock_t* lock, int32_t value )
+opal_atomic_lock_init( opal_atomic_lock_t* lock, int32_t value )
 {
    lock->u.lock = value;
 }
@@ -411,7 +411,7 @@ static inline int
 opal_atomic_trylock(opal_atomic_lock_t *lock)
 {
     int ret = opal_atomic_cmpset_acq_32( &(lock->u.lock),
-                                         OPAL_ATOMIC_UNLOCKED, OPAL_ATOMIC_LOCKED);
+                                         OPAL_ATOMIC_LOCK_UNLOCKED, OPAL_ATOMIC_LOCK_LOCKED);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -420,8 +420,8 @@ static inline void
 opal_atomic_lock(opal_atomic_lock_t *lock)
 {
    while( !opal_atomic_cmpset_acq_32( &(lock->u.lock),
-                                      OPAL_ATOMIC_UNLOCKED, OPAL_ATOMIC_LOCKED) ) {
-      while (lock->u.lock == OPAL_ATOMIC_LOCKED) {
+                                      OPAL_ATOMIC_LOCK_UNLOCKED, OPAL_ATOMIC_LOCK_LOCKED) ) {
+      while (lock->u.lock == OPAL_ATOMIC_LOCK_LOCKED) {
          /* spin */ ;
       }
    }
@@ -432,7 +432,7 @@ static inline void
 opal_atomic_unlock(opal_atomic_lock_t *lock)
 {
    opal_atomic_wmb();
-   lock->u.lock=OPAL_ATOMIC_UNLOCKED;
+   lock->u.lock=OPAL_ATOMIC_LOCK_UNLOCKED;
 }
 
 #endif /* OPAL_HAVE_ATOMIC_SPINLOCKS */

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -186,16 +186,16 @@ static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
 
 #define OPAL_HAVE_ATOMIC_SPINLOCKS 1
 
-static inline void opal_atomic_init (opal_atomic_lock_t* lock, int32_t value)
+static inline void opal_atomic_lock_init (opal_atomic_lock_t* lock, int32_t value)
 {
    lock->u.lock = value;
 }
 
 static inline int opal_atomic_trylock(opal_atomic_lock_t *lock)
 {
-    int ret = __atomic_exchange_n (&lock->u.lock, OPAL_ATOMIC_LOCKED,
+    int ret = __atomic_exchange_n (&lock->u.lock, OPAL_ATOMIC_LOCK_LOCKED,
                                    __ATOMIC_ACQUIRE | __ATOMIC_HLE_ACQUIRE);
-    if (OPAL_ATOMIC_LOCKED == ret) {
+    if (OPAL_ATOMIC_LOCK_LOCKED == ret) {
         /* abort the transaction */
         _mm_pause ();
         return 1;
@@ -206,7 +206,7 @@ static inline int opal_atomic_trylock(opal_atomic_lock_t *lock)
 
 static inline void opal_atomic_lock (opal_atomic_lock_t *lock)
 {
-    while (OPAL_ATOMIC_LOCKED == __atomic_exchange_n (&lock->u.lock, OPAL_ATOMIC_LOCKED,
+    while (OPAL_ATOMIC_LOCK_LOCKED == __atomic_exchange_n (&lock->u.lock, OPAL_ATOMIC_LOCK_LOCKED,
                                                       __ATOMIC_ACQUIRE | __ATOMIC_HLE_ACQUIRE)) {
         /* abort the transaction */
         _mm_pause ();
@@ -215,7 +215,7 @@ static inline void opal_atomic_lock (opal_atomic_lock_t *lock)
 
 static inline void opal_atomic_unlock (opal_atomic_lock_t *lock)
 {
-    __atomic_store_n (&lock->u.lock, OPAL_ATOMIC_UNLOCKED,
+    __atomic_store_n (&lock->u.lock, OPAL_ATOMIC_LOCK_UNLOCKED,
                        __ATOMIC_RELEASE | __ATOMIC_HLE_RELEASE);
 }
 

--- a/opal/mca/btl/smcuda/btl_smcuda.h
+++ b/opal/mca/btl/smcuda/btl_smcuda.h
@@ -269,8 +269,8 @@ static inline int sm_fifo_init(int fifo_size, mca_mpool_base_module_t *mpool,
     fifo->queue = (volatile void **) VIRTUAL2RELATIVE(fifo->queue_recv);
 
     /* initialize the locks */
-    opal_atomic_init(&(fifo->head_lock), OPAL_ATOMIC_UNLOCKED);
-    opal_atomic_init(&(fifo->tail_lock), OPAL_ATOMIC_UNLOCKED);
+    opal_atomic_lock_init(&(fifo->head_lock), OPAL_ATOMIC_LOCK_UNLOCKED);
+    opal_atomic_lock_init(&(fifo->tail_lock), OPAL_ATOMIC_LOCK_UNLOCKED);
     opal_atomic_unlock(&(fifo->head_lock));  /* should be unnecessary */
     opal_atomic_unlock(&(fifo->tail_lock));  /* should be unnecessary */
 

--- a/opal/mca/common/sm/common_sm.c
+++ b/opal/mca/common/sm/common_sm.c
@@ -122,7 +122,7 @@ attach_and_init(opal_shmem_ds_t *shmem_bufp,
         /* initialize some segment information */
         size_t mem_offset = map->module_data_addr -
                             (unsigned char *)map->module_seg;
-        opal_atomic_init(&map->module_seg->seg_lock, OPAL_ATOMIC_UNLOCKED);
+        opal_atomic_lock_init(&map->module_seg->seg_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
         map->module_seg->seg_inited = 0;
         map->module_seg->seg_num_procs_inited = 0;
         map->module_seg->seg_offset = mem_offset;

--- a/opal/mca/shmem/mmap/shmem_mmap_module.c
+++ b/opal/mca/shmem/mmap/shmem_mmap_module.c
@@ -427,7 +427,7 @@ segment_create(opal_shmem_ds_t *ds_buf,
         opal_atomic_rmb();
 
         /* init segment lock */
-        opal_atomic_init(&seg_hdrp->lock, OPAL_ATOMIC_UNLOCKED);
+        opal_atomic_lock_init(&seg_hdrp->lock, OPAL_ATOMIC_LOCK_UNLOCKED);
         /* i was the creator of this segment, so note that fact */
         seg_hdrp->cpid = my_pid;
 

--- a/opal/mca/shmem/posix/shmem_posix_module.c
+++ b/opal/mca/shmem/posix/shmem_posix_module.c
@@ -227,7 +227,7 @@ segment_create(opal_shmem_ds_t *ds_buf,
         opal_atomic_rmb();
 
         /* init segment lock */
-        opal_atomic_init(&seg_hdrp->lock, OPAL_ATOMIC_UNLOCKED);
+        opal_atomic_lock_init(&seg_hdrp->lock, OPAL_ATOMIC_LOCK_UNLOCKED);
         /* i was the creator of this segment, so note that fact */
         seg_hdrp->cpid = my_pid;
 

--- a/opal/mca/shmem/sysv/shmem_sysv_module.c
+++ b/opal/mca/shmem/sysv/shmem_sysv_module.c
@@ -232,7 +232,7 @@ segment_create(opal_shmem_ds_t *ds_buf,
         opal_atomic_rmb();
 
         /* init segment lock */
-        opal_atomic_init(&seg_hdrp->lock, OPAL_ATOMIC_UNLOCKED);
+        opal_atomic_lock_init(&seg_hdrp->lock, OPAL_ATOMIC_LOCK_UNLOCKED);
         /* i was the creator of this segment, so note that fact */
         seg_hdrp->cpid = my_pid;
 

--- a/opal/memoryhooks/memory.c
+++ b/opal/memoryhooks/memory.c
@@ -60,7 +60,7 @@ opal_mem_hooks_init(void)
 {
     OBJ_CONSTRUCT(&release_cb_list, opal_list_t);
 
-    opal_atomic_init(&release_lock, OPAL_ATOMIC_UNLOCKED);
+    opal_atomic_lock_init(&release_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
 
     /* delay running callbacks until there is something in the
        registration */

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -102,7 +102,7 @@ int
 opal_progress_init(void)
 {
     /* reentrant issues */
-    opal_atomic_init(&progress_lock, OPAL_ATOMIC_UNLOCKED);
+    opal_atomic_lock_init(&progress_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
 
     /* set the event tick rate */
     opal_progress_set_event_poll_rate(10000);

--- a/opal/threads/mutex.c
+++ b/opal/threads/mutex.c
@@ -58,7 +58,7 @@ static void opal_mutex_construct(opal_mutex_t *m)
 #endif /* OPAL_ENABLE_DEBUG */
 
 #if OPAL_HAVE_ATOMIC_SPINLOCKS
-    opal_atomic_init( &m->m_lock_atomic, OPAL_ATOMIC_UNLOCKED );
+    opal_atomic_lock_init( &m->m_lock_atomic, OPAL_ATOMIC_LOCK_UNLOCKED );
 #endif
 }
 
@@ -89,7 +89,7 @@ static void opal_recursive_mutex_construct(opal_recursive_mutex_t *m)
     pthread_mutexattr_destroy(&attr);
 
 #if OPAL_HAVE_ATOMIC_SPINLOCKS
-    opal_atomic_init( &m->m_lock_atomic, OPAL_ATOMIC_UNLOCKED );
+    opal_atomic_lock_init( &m->m_lock_atomic, OPAL_ATOMIC_LOCK_UNLOCKED );
 #endif
 }
 

--- a/opal/threads/mutex_unix.h
+++ b/opal/threads/mutex_unix.h
@@ -76,14 +76,14 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_recursive_mutex_t);
         .m_lock_debug = 0,                                              \
         .m_lock_file = NULL,                                            \
         .m_lock_line = 0,                                               \
-        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_UNLOCKED } },     \
+        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_LOCK_UNLOCKED } },     \
     }
 #else
 #define OPAL_MUTEX_STATIC_INIT                                          \
     {                                                                   \
         .super = OPAL_OBJ_STATIC_INIT(opal_mutex_t),                    \
         .m_lock_pthread = PTHREAD_MUTEX_INITIALIZER,                    \
-        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_UNLOCKED } },     \
+        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_LOCK_UNLOCKED } },     \
     }
 #endif
 
@@ -97,14 +97,14 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_recursive_mutex_t);
         .m_lock_debug = 0,                                              \
         .m_lock_file = NULL,                                            \
         .m_lock_line = 0,                                               \
-        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_UNLOCKED } },     \
+        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_LOCK_UNLOCKED } },     \
     }
 #else
 #define OPAL_RECURSIVE_MUTEX_STATIC_INIT                                \
     {                                                                   \
         .super = OPAL_OBJ_STATIC_INIT(opal_mutex_t),                    \
         .m_lock_pthread = OPAL_PTHREAD_RECURSIVE_MUTEX_INITIALIZER,     \
-        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_UNLOCKED } },     \
+        .m_lock_atomic = { .u = { .lock = OPAL_ATOMIC_LOCK_UNLOCKED } },     \
     }
 #endif
 

--- a/orte/runtime/orte_locks.c
+++ b/orte/runtime/orte_locks.c
@@ -35,12 +35,12 @@ opal_atomic_lock_t orte_quit_lock = {{0}};
 int orte_locks_init(void)
 {
     /* for everyone */
-    opal_atomic_init(&orte_finalize_lock, OPAL_ATOMIC_UNLOCKED);
+    opal_atomic_lock_init(&orte_finalize_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
 
     /* for HNPs */
-    opal_atomic_init(&orte_abort_inprogress_lock, OPAL_ATOMIC_UNLOCKED);
-    opal_atomic_init(&orte_jobs_complete_lock, OPAL_ATOMIC_UNLOCKED);
-    opal_atomic_init(&orte_quit_lock, OPAL_ATOMIC_UNLOCKED);
+    opal_atomic_lock_init(&orte_abort_inprogress_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
+    opal_atomic_lock_init(&orte_jobs_complete_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
+    opal_atomic_lock_init(&orte_quit_lock, OPAL_ATOMIC_LOCK_UNLOCKED);
 
     return ORTE_SUCCESS;
 }

--- a/test/asm/atomic_spinlock.c
+++ b/test/asm/atomic_spinlock.c
@@ -123,7 +123,7 @@ main(int argc, char *argv[])
     }
     num_threads = atoi(argv[1]);
 
-    opal_atomic_init(&lock, OPAL_ATOMIC_UNLOCKED);
+    opal_atomic_lock_init(&lock, OPAL_ATOMIC_LOCK_UNLOCKED);
     ret = atomic_spinlock_test_th(&lock, TEST_REPS, 0, num_threads);
 
     return ret;


### PR DESCRIPTION
This function is used to initalize and opal atomic lock. The old name
was confusing.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>