### PR TITLE
Fix linking of libpmix when emitted

### DIFF
--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -56,7 +56,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
           [opal_pmix_pmix2x_args="--disable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
     AS_IF([test "$with_devel_headers" = "yes"],
-          [AS_IF([test "$enable_dlopen" = "yes"],
+          [AS_IF([test "$enable_dlopen" != "no"],
                  [opal_pmix_pmix2x_args="--with-pmix-extra-lib=$OPAL_TOP_BUILDDIR/opal/lib${OPAL_LIB_PREFIX}open-pal.la $opal_pmix_pmix2x_args"])
            opal_pmix_pmix2x_args="--with-devel-headers  $opal_pmix_pmix2x_args"])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -56,7 +56,9 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
           [opal_pmix_pmix2x_args="--disable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
     AS_IF([test "$with_devel_headers" = "yes"],
-          [opal_pmix_pmix2x_args="--with-devel-headers --with-pmix-extra-lib=$OPAL_TOP_BUILDDIR/opal/lib${OPAL_LIB_PREFIX}open-pal.la $opal_pmix_pmix2x_args"])
+          [AS_IF([test "$enable_dlopen" = "yes"],
+                 [opal_pmix_pmix2x_args="--with-pmix-extra-lib=$OPAL_TOP_BUILDDIR/opal/lib${OPAL_LIB_PREFIX}open-pal.la $opal_pmix_pmix2x_args"])
+           opal_pmix_pmix2x_args="--with-devel-headers  $opal_pmix_pmix2x_args"])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"
 
     OPAL_CONFIG_SUBDIR([$opal_pmix_pmix2x_basedir/pmix],

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -28,7 +28,7 @@
 AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
     AC_CONFIG_FILES([opal/mca/pmix/pmix2x/Makefile])
 
-    OPAL_VAR_SCOPE_PUSH([PMIX_VERSION opal_pmix_pmix2x_save_CPPFLAGS opal_pmix_pmix2_save_CFLAGS opal_pmix_pmix2x_save_LDFLAGS opal_pmix_pmix2x_save_LIBS opal_pmix_pmix2x_basedir opal_pmix_pmix2x_args opal_pmix_pmix2x_happy opal_pmix_pmix2x_sm_flag pmix_pmix2x_status_filename])
+    OPAL_VAR_SCOPE_PUSH([PMIX_VERSION opal_pmix_pmix2x_save_CPPFLAGS opal_pmix_pmix2_save_CFLAGS opal_pmix_pmix2x_save_LDFLAGS opal_pmix_pmix2x_save_LIBS opal_pmix_pmix2x_basedir opal_pmix_pmix2x_args opal_pmix_pmix2x_happy  pmix_pmix2x_status_filename])
 
     opal_pmix_pmix2x_basedir=opal/mca/pmix/pmix2x
 
@@ -36,18 +36,6 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
     opal_pmix_pmix2x_save_CPPFLAGS=$CPPFLAGS
     opal_pmix_pmix2x_save_LDFLAGS=$LDFLAGS
     opal_pmix_pmix2x_save_LIBS=$LIBS
-
-    AC_ARG_ENABLE([pmix-dstore],
-                  [AC_HELP_STRING([--enable-pmix-dstore],
-                                  [Enable PMIx shared memory data store (default: enabled)])])
-    AC_MSG_CHECKING([if PMIx shared memory data store is enabled])
-    if test "$enable_pmix_dstore" != "no"; then
-        AC_MSG_RESULT([yes])
-        opal_pmix_pmix2x_sm_flag=--enable-dstore
-    else
-        AC_MSG_RESULT([no (disabled)])
-        opal_pmix_pmix2x_sm_flag=--disable-dstore
-    fi
 
     AC_ARG_ENABLE([pmix-timing],
                   [AC_HELP_STRING([--enable-pmix-timing],
@@ -61,15 +49,14 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
         opal_pmix_pmix2x_timing_flag=--disable-pmix-timing
     fi
 
-    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_sm_flag $opal_pmix_pmix2x_timing_flag --without-tests-examples --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-mode"
+    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_timing_flag --without-tests-examples --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-mode"
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix2x_args="--enable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
           [opal_pmix_pmix2x_args="--disable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
     AS_IF([test "$with_devel_headers" = "yes"],
-          [opal_pmix_pmix2x_args="--with-devel-headers $opal_pmix_pmix2x_args"],
-          [opal_pmix_pmix2x_args=$opal_pmix_pmix2x_args])
+          [opal_pmix_pmix2x_args="--with-devel-headers --with-pmix-extra-lib=$OPAL_TOP_BUILDDIR/opal/lib${OPAL_LIB_PREFIX}open-pal.la $opal_pmix_pmix2x_args"])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"
 
     OPAL_CONFIG_SUBDIR([$opal_pmix_pmix2x_basedir/pmix],

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
@@ -156,6 +156,18 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_SUBST(PMIX_RENAME)
     AC_CONFIG_FILES(pmix_config_prefix[include/pmix_rename.h])
 
+    # Add any extra lib?
+    AC_ARG_WITH([pmix-extra-lib],
+                AC_HELP_STRING([--with-pmix-extra-lib=LIB],
+                               [Link the output PMIx library to this extra lib (used in embedded mode)]))
+    AC_MSG_CHECKING([for extra lib])
+    AS_IF([test ! -z "$with_pmix_extra_lib"],
+          [AC_MSG_RESULT([$with_pmix_extra_lib])
+           PMIX_EXTRA_LIB=$with_pmix_extra_lib],
+          [AC_MSG_RESULT([no])
+           PMIX_EXTRA_LIB=])
+    AC_SUBST(PMIX_EXTRA_LIB)
+
     # GCC specifics.
     if test "x$GCC" = "xyes"; then
         PMIX_GCC_CFLAGS="-Wall -Wmissing-prototypes -Wundef"

--- a/opal/mca/pmix/pmix2x/pmix/src/Makefile.am
+++ b/opal/mca/pmix/pmix2x/pmix/src/Makefile.am
@@ -47,7 +47,8 @@ dist_pmixdata_DATA =
 
 libpmix_la_LIBADD = \
 	mca/base/libpmix_mca_base.la \
-	$(MCA_pmix_FRAMEWORK_LIBS)
+	$(MCA_pmix_FRAMEWORK_LIBS) \
+	$(PMIX_EXTRA_LIB)
 libpmix_la_DEPENDENCIES = $(libpmix_la_LIBADD)
 
 if PMIX_EMBEDDED_MODE


### PR DESCRIPTION
When we specify --with-devel-headers, we also emit a copy of libpmix. However, that library was built against the OPAL libevent component, which means all the libevent functions are prefixed with OPAL names. So ensure that the emitted libpmix is linked back against libopen-pal so those symbols will be resolved.

Fixes #4045

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit d593e5a4cee4684e74ecfd758781b77a84caf593)