### PR TITLE
Fix PMIX_DECLSPEC conversions to PMIX_EXPORT, and fix unused var warning

### DIFF
--- a/opal/mca/pmix/pmix112/pmix/include/pmix/autogen/pmix_config_bottom.h
+++ b/opal/mca/pmix/pmix112/pmix/include/pmix/autogen/pmix_config_bottom.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -343,26 +343,14 @@
 #    define __pmix_attribute_destructor__
 #endif
 
-#ifndef PMIX_DECLSPEC
-# define PMIX_DECLSPEC
 #ifdef PMIX_C_HAVE_VISIBILITY
 # if PMIX_C_HAVE_VISIBILITY
-#  define PMIX_EXPORT __attribute__((__visibility__("default")))
+#  define PMIX_EXPORT           __pmix_attribute_visibility__("default")
 # else
 #  define PMIX_EXPORT
 # endif
 #else
 # define PMIX_EXPORT
-#endif
-#endif
-
-#ifndef PMIX_DECLSPEC
-#define PMIX_DECLSPEC
-#  if PMIX_C_HAVE_VISIBILITY
-#    define PMIX_EXPORT           __pmix_attribute_visibility__("default")
-#  else
-#    define PMIX_EXPORT
-#  endif
 #endif
 
 /*
@@ -402,11 +390,11 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 #include <sys/param.h>
 #endif
 #if defined(PATH_MAX)
-#define PMIX_PATH_MAX	(PATH_MAX + 1)
+#define PMIX_PATH_MAX   (PATH_MAX + 1)
 #elif defined(_POSIX_PATH_MAX)
-#define PMIX_PATH_MAX	(_POSIX_PATH_MAX + 1)
+#define PMIX_PATH_MAX   (_POSIX_PATH_MAX + 1)
 #else
-#define PMIX_PATH_MAX	256
+#define PMIX_PATH_MAX   256
 #endif
 
 #if defined(MAXHOSTNAMELEN)
@@ -590,4 +578,3 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 
 #endif /* PMIX_BUILDING */
 #endif /* PMIX_CONFIG_BOTTOM_H */
-

--- a/opal/mca/pmix/pmix112/pmix/src/buffer_ops/buffer_ops.h
+++ b/opal/mca/pmix/pmix112/pmix/src/buffer_ops/buffer_ops.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -44,12 +44,12 @@ BEGIN_C_DECLS
  * of places throughout the code base - transferring a value to
  * another pmix_value_t structure
  */
-PMIX_DECLSPEC pmix_status_t pmix_value_xfer(pmix_value_t *kv, pmix_value_t *src);
-PMIX_DECLSPEC void pmix_value_load(pmix_value_t *v, void *data,
-                                   pmix_data_type_t type);
-PMIX_DECLSPEC pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data,
-                                              size_t *sz, pmix_data_type_t type);
-PMIX_DECLSPEC bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1);
+PMIX_EXPORT pmix_status_t pmix_value_xfer(pmix_value_t *kv, pmix_value_t *src);
+PMIX_EXPORT void pmix_value_load(pmix_value_t *v, void *data,
+                                 pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data,
+                                            size_t *sz, pmix_data_type_t type);
+PMIX_EXPORT bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1);
 
 
 #define PMIX_LOAD_BUFFER(b, d, s)                       \
@@ -247,12 +247,12 @@ typedef pmix_status_t (*pmix_bfrop_copy_payload_fn_t)(pmix_buffer_t *dest,
  * structure gets loaded, so we provide an "open" call that is
  * executed as part of the program startup.
  */
-PMIX_DECLSPEC pmix_status_t pmix_bfrop_open(void);
+PMIX_EXPORT pmix_status_t pmix_bfrop_open(void);
 
 /**
  * BFROP finalize function
  */
-PMIX_DECLSPEC pmix_status_t pmix_bfrop_close(void);
+PMIX_EXPORT pmix_status_t pmix_bfrop_close(void);
 
 
 /**
@@ -308,7 +308,7 @@ struct pmix_bfrop_t {
 };
 typedef struct pmix_bfrop_t pmix_bfrop_t;
 
-PMIX_DECLSPEC extern pmix_bfrop_t pmix_bfrop;  /* holds bfrop function pointers */
+PMIX_EXPORT extern pmix_bfrop_t pmix_bfrop;  /* holds bfrop function pointers */
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/buffer_ops/internal.h
+++ b/opal/mca/pmix/pmix112/pmix/src/buffer_ops/internal.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -189,7 +189,7 @@ typedef struct {
     /** print function */
     pmix_bfrop_print_fn_t odti_print_fn;
 } pmix_bfrop_type_info_t;
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_bfrop_type_info_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_bfrop_type_info_t);
 
 /*
  * globals needed within bfrop
@@ -235,10 +235,10 @@ extern pmix_data_type_t pmix_bfrop_num_reg_types;
 /*
  * Specialized functions
  */
-PMIX_DECLSPEC    pmix_status_t pmix_bfrop_pack_buffer(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT    pmix_status_t pmix_bfrop_pack_buffer(pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
 
-PMIX_DECLSPEC    pmix_status_t pmix_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst,
+PMIX_EXPORT    pmix_status_t pmix_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst,
                                                         int32_t *num_vals, pmix_data_type_t type);
 
 /*

--- a/opal/mca/pmix/pmix112/pmix/src/buffer_ops/types.h
+++ b/opal/mca/pmix/pmix112/pmix/src/buffer_ops/types.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,7 +78,7 @@ typedef struct {
         including overhead -- packed in the buffer) */
     size_t bytes_used;
 } pmix_buffer_t;
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION (pmix_buffer_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION (pmix_buffer_t);
 
 /* these classes are required by the regex code shared
  * between the client and server implementations - it
@@ -88,7 +88,7 @@ typedef struct {
     int start;
     int cnt;
 } pmix_regex_range_t;
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_regex_range_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_regex_range_t);
 
 typedef struct {
     /* list object */
@@ -98,7 +98,7 @@ typedef struct {
     int num_digits;
     pmix_list_t ranges;
 } pmix_regex_value_t;
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_regex_value_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_regex_value_t);
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/class/pmix_hash_table.h
+++ b/opal/mca/pmix/pmix112/pmix/src/class/pmix_hash_table.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -47,7 +47,7 @@
 
 BEGIN_C_DECLS
 
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_hash_table_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_hash_table_t);
 
 struct pmix_hash_table_t
 {
@@ -73,12 +73,12 @@ typedef struct pmix_hash_table_t pmix_hash_table_t;
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_init(pmix_hash_table_t* ht, size_t table_size);
+PMIX_EXPORT pmix_status_t pmix_hash_table_init(pmix_hash_table_t* ht, size_t table_size);
 
 /**
  * Alternative form
  */
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_init2(pmix_hash_table_t* ht, size_t estimated_max_size,
+PMIX_EXPORT pmix_status_t pmix_hash_table_init2(pmix_hash_table_t* ht, size_t estimated_max_size,
                                         int density_numer, int density_denom,
                                         int growth_numer, int growth_denom);
 
@@ -103,7 +103,7 @@ static inline size_t pmix_hash_table_get_size(pmix_hash_table_t *ht)
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_all(pmix_hash_table_t *ht);
+PMIX_EXPORT pmix_status_t pmix_hash_table_remove_all(pmix_hash_table_t *ht);
 
 /**
  *  Retrieve value via uint32_t key.
@@ -118,8 +118,8 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_all(pmix_hash_table_t *ht);
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_value_uint32(pmix_hash_table_t* table, uint32_t key,
-						             void** ptr);
+PMIX_EXPORT pmix_status_t pmix_hash_table_get_value_uint32(pmix_hash_table_t* table, uint32_t key,
+                                                             void** ptr);
 
 /**
  *  Set value based on uint32_t key.
@@ -131,7 +131,7 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_value_uint32(pmix_hash_table_t* 
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_set_value_uint32(pmix_hash_table_t* table, uint32_t key, void* value);
+PMIX_EXPORT pmix_status_t pmix_hash_table_set_value_uint32(pmix_hash_table_t* table, uint32_t key, void* value);
 
 /**
  *  Remove value based on uint32_t key.
@@ -142,7 +142,7 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_set_value_uint32(pmix_hash_table_t* 
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_value_uint32(pmix_hash_table_t* table, uint32_t key);
+PMIX_EXPORT pmix_status_t pmix_hash_table_remove_value_uint32(pmix_hash_table_t* table, uint32_t key);
 
 /**
  *  Retrieve value via uint64_t key.
@@ -157,8 +157,8 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_value_uint32(pmix_hash_table_
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_value_uint64(pmix_hash_table_t *table, uint64_t key,
-						             void **ptr);
+PMIX_EXPORT pmix_status_t pmix_hash_table_get_value_uint64(pmix_hash_table_t *table, uint64_t key,
+                                                             void **ptr);
 
 /**
  *  Set value based on uint64_t key.
@@ -170,7 +170,7 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_value_uint64(pmix_hash_table_t *
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_set_value_uint64(pmix_hash_table_t *table, uint64_t key, void* value);
+PMIX_EXPORT pmix_status_t pmix_hash_table_set_value_uint64(pmix_hash_table_t *table, uint64_t key, void* value);
 
 /**
  *  Remove value based on uint64_t key.
@@ -181,7 +181,7 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_set_value_uint64(pmix_hash_table_t *
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_value_uint64(pmix_hash_table_t *table, uint64_t key);
+PMIX_EXPORT pmix_status_t pmix_hash_table_remove_value_uint64(pmix_hash_table_t *table, uint64_t key);
 
 /**
  *  Retrieve value via arbitrary length binary key.
@@ -196,8 +196,8 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_value_uint64(pmix_hash_table_
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_value_ptr(pmix_hash_table_t *table, const void* key,
-						          size_t keylen, void **ptr);
+PMIX_EXPORT pmix_status_t pmix_hash_table_get_value_ptr(pmix_hash_table_t *table, const void* key,
+                                                          size_t keylen, void **ptr);
 
 /**
  *  Set value based on arbitrary length binary key.
@@ -209,7 +209,7 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_value_ptr(pmix_hash_table_t *tab
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_set_value_ptr(pmix_hash_table_t *table, const void* key, size_t keylen, void* value);
+PMIX_EXPORT pmix_status_t pmix_hash_table_set_value_ptr(pmix_hash_table_t *table, const void* key, size_t keylen, void* value);
 
 /**
  *  Remove value based on arbitrary length binary key.
@@ -220,7 +220,7 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_set_value_ptr(pmix_hash_table_t *tab
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_value_ptr(pmix_hash_table_t *table, const void* key, size_t keylen);
+PMIX_EXPORT pmix_status_t pmix_hash_table_remove_value_ptr(pmix_hash_table_t *table, const void* key, size_t keylen);
 
 
 /** The following functions are only for allowing iterating through
@@ -245,8 +245,8 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_remove_value_ptr(pmix_hash_table_t *
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_first_key_uint32(pmix_hash_table_t *table, uint32_t *key,
-					                         void **value, void **node);
+PMIX_EXPORT pmix_status_t pmix_hash_table_get_first_key_uint32(pmix_hash_table_t *table, uint32_t *key,
+                                                                 void **value, void **node);
 
 
 /**
@@ -263,9 +263,9 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_first_key_uint32(pmix_hash_table
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_next_key_uint32(pmix_hash_table_t *table, uint32_t *key,
-				                                void **value, void *in_node,
-				                                void **out_node);
+PMIX_EXPORT pmix_status_t pmix_hash_table_get_next_key_uint32(pmix_hash_table_t *table, uint32_t *key,
+                                                                void **value, void *in_node,
+                                                                void **out_node);
 
 
 /**
@@ -281,8 +281,8 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_next_key_uint32(pmix_hash_table_
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_first_key_uint64(pmix_hash_table_t *table, uint64_t *key,
-				                                 void **value, void **node);
+PMIX_EXPORT pmix_status_t pmix_hash_table_get_first_key_uint64(pmix_hash_table_t *table, uint64_t *key,
+                                                                 void **value, void **node);
 
 
 /**
@@ -299,9 +299,9 @@ PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_first_key_uint64(pmix_hash_table
  *
  */
 
-PMIX_DECLSPEC pmix_status_t pmix_hash_table_get_next_key_uint64(pmix_hash_table_t *table, uint64_t *key,
-				                                void **value, void *in_node,
-				                                void **out_node);
+PMIX_EXPORT pmix_status_t pmix_hash_table_get_next_key_uint64(pmix_hash_table_t *table, uint64_t *key,
+                                                                void **value, void *in_node,
+                                                                void **out_node);
 
 /**
  * @brief Returns next power-of-two of the given value.

--- a/opal/mca/pmix/pmix112/pmix/src/class/pmix_list.h
+++ b/opal/mca/pmix/pmix112/pmix/src/class/pmix_list.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,13 +83,13 @@ BEGIN_C_DECLS
  *
  * The class for the list container.
  */
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_list_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_list_t);
 /**
  * \internal
  *
  * Base class for items that are put in list (pmix_list_t) containers.
  */
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_list_item_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_list_item_t);
 
 
 /**
@@ -807,7 +807,7 @@ static inline void pmix_list_insert_pos(pmix_list_t *list, pmix_list_item_t *pos
    * If index is greater than the length of the list, no action is
    * performed and false is returned.
    */
-  PMIX_DECLSPEC bool pmix_list_insert(pmix_list_t *list, pmix_list_item_t *item,
+  PMIX_EXPORT bool pmix_list_insert(pmix_list_t *list, pmix_list_item_t *item,
                                       long long idx);
 
 
@@ -828,7 +828,7 @@ static inline void pmix_list_insert_pos(pmix_list_t *list, pmix_list_item_t *pos
      * containers remain valid, including those that point to elements
      * in \c xlist.
      */
-    PMIX_DECLSPEC void pmix_list_join(pmix_list_t *thislist, pmix_list_item_t *pos,
+    PMIX_EXPORT void pmix_list_join(pmix_list_t *thislist, pmix_list_item_t *pos,
                                       pmix_list_t *xlist);
 
 
@@ -855,7 +855,7 @@ static inline void pmix_list_insert_pos(pmix_list_t *list, pmix_list_item_t *pos
      * This is an O(N) operation because the length of both lists must
      * be recomputed.
      */
-    PMIX_DECLSPEC void pmix_list_splice(pmix_list_t *thislist, pmix_list_item_t *pos,
+    PMIX_EXPORT void pmix_list_splice(pmix_list_t *thislist, pmix_list_item_t *pos,
                                         pmix_list_t *xlist, pmix_list_item_t *first,
                                         pmix_list_item_t *last);
 
@@ -902,7 +902,7 @@ static inline void pmix_list_insert_pos(pmix_list_t *list, pmix_list_item_t *pos
      * whatever the underlying type is).  See the documentation of
      * pmix_list_item_compare_fn_t for an example).
      */
-    PMIX_DECLSPEC int pmix_list_sort(pmix_list_t* list, pmix_list_item_compare_fn_t compare);
+    PMIX_EXPORT int pmix_list_sort(pmix_list_t* list, pmix_list_item_compare_fn_t compare);
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/class/pmix_object.h
+++ b/opal/mca/pmix/pmix112/pmix/src/class/pmix_object.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -378,7 +378,7 @@ do {                                                            \
 } while (0)
 #endif
 
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_object_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_object_t);
 
 /* declarations *******************************************************/
 
@@ -390,7 +390,7 @@ PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_object_t);
  *
  * @param class    Pointer to class descriptor
  */
-PMIX_DECLSPEC void pmix_class_initialize(pmix_class_t *);
+PMIX_EXPORT void pmix_class_initialize(pmix_class_t *);
 
 /**
  * Shut down the class system and release all memory
@@ -401,7 +401,7 @@ PMIX_DECLSPEC void pmix_class_initialize(pmix_class_t *);
  * tools like valgrind and purify don't report still-reachable memory
  * upon process termination.
  */
-PMIX_DECLSPEC int pmix_class_finalize(void);
+PMIX_EXPORT int pmix_class_finalize(void);
 
 /**
  * Run the hierarchy of class constructors for this object, in a
@@ -498,4 +498,3 @@ static inline int pmix_obj_update(pmix_object_t *object, int inc)
 END_C_DECLS
 
 #endif
-

--- a/opal/mca/pmix/pmix112/pmix/src/class/pmix_pointer_array.h
+++ b/opal/mca/pmix/pmix112/pmix/src/class/pmix_pointer_array.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -63,7 +63,7 @@ typedef struct pmix_pointer_array_t pmix_pointer_array_t;
 /**
  * Class declaration
  */
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_pointer_array_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pointer_array_t);
 
 /**
  * Initialize the pointer array with an initial size of initial_allocation.
@@ -79,7 +79,7 @@ PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_pointer_array_t);
  * @return PMIX_SUCCESS if all initializations were succesfull. Otherwise,
  *  the error indicate what went wrong in the function.
  */
-PMIX_DECLSPEC pmix_status_t pmix_pointer_array_init(pmix_pointer_array_t* array,
+PMIX_EXPORT pmix_status_t pmix_pointer_array_init(pmix_pointer_array_t* array,
                                                     int initial_allocation,
                                                     int max_size, int block_size );
 
@@ -92,7 +92,7 @@ PMIX_DECLSPEC pmix_status_t pmix_pointer_array_init(pmix_pointer_array_t* array,
  * @return Index of inserted array element.  Return value of
  *  (-1) indicates an error.
  */
-PMIX_DECLSPEC int pmix_pointer_array_add(pmix_pointer_array_t *array, void *ptr);
+PMIX_EXPORT int pmix_pointer_array_add(pmix_pointer_array_t *array, void *ptr);
 
 /**
  * Set the value of an element in array
@@ -104,7 +104,7 @@ PMIX_DECLSPEC int pmix_pointer_array_add(pmix_pointer_array_t *array, void *ptr)
  * @return PMIX_SUCCESS if item was inserted. Otherwise,
  *  the error indicate what went wrong in the function.
  */
-PMIX_DECLSPEC pmix_status_t pmix_pointer_array_set_item(pmix_pointer_array_t *array,
+PMIX_EXPORT pmix_status_t pmix_pointer_array_set_item(pmix_pointer_array_t *array,
                                                         int index, void *value);
 
 /**
@@ -157,7 +157,7 @@ static inline int pmix_pointer_array_get_size(pmix_pointer_array_t *array)
  * Simple function to set the size of the array in order to
  * hide the member field from external users.
  */
-PMIX_DECLSPEC pmix_status_t pmix_pointer_array_set_size(pmix_pointer_array_t *array, int size);
+PMIX_EXPORT pmix_status_t pmix_pointer_array_set_size(pmix_pointer_array_t *array, int size);
 
 /**
  * Test whether a certain element is already in use. If not yet
@@ -173,7 +173,7 @@ PMIX_DECLSPEC pmix_status_t pmix_pointer_array_set_size(pmix_pointer_array_t *ar
  * In contrary to array_set, this function does not allow to overwrite
  * a value, unless the previous value is NULL ( equiv. to free ).
  */
-PMIX_DECLSPEC bool pmix_pointer_array_test_and_set_item (pmix_pointer_array_t *table,
+PMIX_EXPORT bool pmix_pointer_array_test_and_set_item (pmix_pointer_array_t *table,
                                           int index,
                                           void *value);
 

--- a/opal/mca/pmix/pmix112/pmix/src/sec/pmix_sec.h
+++ b/opal/mca/pmix/pmix112/pmix/src/sec/pmix_sec.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -132,11 +132,11 @@ typedef struct {
     pmix_sec_base_module_server_hndshk_fn_t  server_handshake;
 } pmix_sec_base_module_t;
 
-PMIX_DECLSPEC extern pmix_sec_base_module_t pmix_sec;
+PMIX_EXPORT extern pmix_sec_base_module_t pmix_sec;
 
 /* initialize and finalize the security system */
-PMIX_DECLSPEC int pmix_sec_init(void);
-PMIX_DECLSPEC void pmix_sec_finalize(void);
+PMIX_EXPORT int pmix_sec_init(void);
+PMIX_EXPORT void pmix_sec_finalize(void);
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/util/argv.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/argv.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire. All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -74,7 +74,7 @@ BEGIN_C_DECLS
    * value into the argv array; there is no need to keep the original
    * string (i.e., the arg parameter) after invoking this function.
    */
-PMIX_DECLSPEC  pmix_status_t pmix_argv_append(int *argc, char ***argv, const char *arg) __pmix_attribute_nonnull__(1) __pmix_attribute_nonnull__(3);
+PMIX_EXPORT  pmix_status_t pmix_argv_append(int *argc, char ***argv, const char *arg) __pmix_attribute_nonnull__(1) __pmix_attribute_nonnull__(3);
 
   /**
    * Append to an argv-style array, but ignore the size of the array.
@@ -91,7 +91,7 @@ PMIX_DECLSPEC  pmix_status_t pmix_argv_append(int *argc, char ***argv, const cha
    * argv-style arrays that do not have integers that are actively
    * maintaing their sizes.
    */
-PMIX_DECLSPEC  pmix_status_t pmix_argv_append_nosize(char ***argv, const char *arg);
+PMIX_EXPORT  pmix_status_t pmix_argv_append_nosize(char ***argv, const char *arg);
 
 /**
  * Insert the provided arg at the beginning of the array
@@ -102,7 +102,7 @@ PMIX_DECLSPEC  pmix_status_t pmix_argv_append_nosize(char ***argv, const char *a
  * @retval PMIX_SUCCESS On success
  * @retval PMIX_ERROR On failure
  */
-PMIX_DECLSPEC pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg);
+PMIX_EXPORT pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg);
 
 /**
  * Append to an argv-style array, but only if the provided argument
@@ -119,7 +119,7 @@ PMIX_DECLSPEC pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *a
  * except that it only appends the provided argument if it does not already
  * exist in the provided array, or overwrites it if it is.
  */
-PMIX_DECLSPEC  pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool overwrite);
+PMIX_EXPORT  pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool overwrite);
 
 /**
    * Free a NULL-terminated argv array.
@@ -134,7 +134,7 @@ PMIX_DECLSPEC  pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const 
    * not safe to invoke this function with a non-NULL-terminated argv
    * array.
    */
-PMIX_DECLSPEC  void pmix_argv_free(char **argv);
+PMIX_EXPORT  void pmix_argv_free(char **argv);
 
   /**
    * Split a string into a NULL-terminated argv array. Do not include empty
@@ -151,7 +151,7 @@ PMIX_DECLSPEC  void pmix_argv_free(char **argv);
    * argument (i.e., it can be freed after calling this function
    * without invalidating the output argv).
    */
-PMIX_DECLSPEC  char **pmix_argv_split(const char *src_string, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT  char **pmix_argv_split(const char *src_string, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
   /**
    * Split a string into a NULL-terminated argv array. Include empty
@@ -168,7 +168,7 @@ PMIX_DECLSPEC  char **pmix_argv_split(const char *src_string, int delimiter) __p
    * argument (i.e., it can be freed after calling this function
    * without invalidating the output argv).
    */
-PMIX_DECLSPEC  char **pmix_argv_split_with_empty(const char *src_string, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT  char **pmix_argv_split_with_empty(const char *src_string, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
   /**
    * Return the length of a NULL-terminated argv array.
@@ -180,7 +180,7 @@ PMIX_DECLSPEC  char **pmix_argv_split_with_empty(const char *src_string, int del
    *
    * The argv array must be NULL-terminated.
    */
-PMIX_DECLSPEC  int pmix_argv_count(char **argv);
+PMIX_EXPORT  int pmix_argv_count(char **argv);
 
   /**
    * Join all the elements of an argv array into a single
@@ -198,9 +198,9 @@ PMIX_DECLSPEC  int pmix_argv_count(char **argv);
    *
    * It is the callers responsibility to free the returned string.
    */
-PMIX_DECLSPEC  char *pmix_argv_join(char **argv, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT  char *pmix_argv_join(char **argv, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
-PMIX_DECLSPEC  char *pmix_argv_join_range(char **argv, size_t start, size_t end, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT  char *pmix_argv_join_range(char **argv, size_t start, size_t end, int delimiter) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
   /**
    * Return the number of bytes consumed by an argv array.
@@ -211,7 +211,7 @@ PMIX_DECLSPEC  char *pmix_argv_join_range(char **argv, size_t start, size_t end,
    * array.  This includes the number of bytes used by each of the
    * strings as well as the pointers used in the argv array.
    */
-PMIX_DECLSPEC  size_t pmix_argv_len(char **argv);
+PMIX_EXPORT  size_t pmix_argv_len(char **argv);
 
   /**
    * Copy a NULL-terminated argv array.
@@ -225,7 +225,7 @@ PMIX_DECLSPEC  size_t pmix_argv_len(char **argv);
    * Specifically, the output argv will be an array of the same length
    * as the input argv, and strcmp(argv_in[i], argv_out[i]) will be 0.
    */
-PMIX_DECLSPEC  char **pmix_argv_copy(char **argv) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT  char **pmix_argv_copy(char **argv) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
     /**
      * Delete one or more tokens from the middle of an argv.
@@ -252,7 +252,7 @@ PMIX_DECLSPEC  char **pmix_argv_copy(char **argv) __pmix_attribute_malloc__ __pm
      * free()ed (it is assumed that the argv "owns" the memory that
      * the pointer points to).
      */
-PMIX_DECLSPEC  pmix_status_t pmix_argv_delete(int *argc, char ***argv,
+PMIX_EXPORT  pmix_status_t pmix_argv_delete(int *argc, char ***argv,
                                               int start, int num_to_delete);
 
     /**
@@ -276,7 +276,7 @@ PMIX_DECLSPEC  pmix_status_t pmix_argv_delete(int *argc, char ***argv,
      * source points to are strdup'ed into the new locations in
      * target).
      */
-PMIX_DECLSPEC  pmix_status_t pmix_argv_insert(char ***target, int start, char **source);
+PMIX_EXPORT  pmix_status_t pmix_argv_insert(char ***target, int start, char **source);
 
 /**
  * Insert one argv element in front of a specific position in an array
@@ -299,7 +299,7 @@ PMIX_DECLSPEC  pmix_status_t pmix_argv_insert(char ***target, int start, char **
  * source points to is strdup'ed into the new location in
  * target).
  */
-PMIX_DECLSPEC  pmix_status_t pmix_argv_insert_element(char ***target, int location, char *source);
+PMIX_EXPORT  pmix_status_t pmix_argv_insert_element(char ***target, int location, char *source);
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/util/basename.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/basename.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,7 +68,7 @@ BEGIN_C_DECLS
  *
  * The caller is responsible for freeing the returned string.
  */
-PMIX_DECLSPEC char *pmix_basename(const char* filename) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT char *pmix_basename(const char* filename) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
 /**
  * Return the dirname of a filename.
@@ -107,7 +107,7 @@ PMIX_DECLSPEC char *pmix_basename(const char* filename) __pmix_attribute_malloc_
  *
  * The caller is responsible for freeing the returned string.
  */
-PMIX_DECLSPEC char *pmix_dirname(const char* filename) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT char *pmix_dirname(const char* filename) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/util/crc.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/crc.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +42,7 @@ BEGIN_C_DECLS
 #define PMIX_CSUM_ZERO  0
 
 
-PMIX_DECLSPEC unsigned long
+PMIX_EXPORT unsigned long
 pmix_bcopy_csum_partial(
     const void *  source,
     void *  destination,
@@ -65,7 +65,7 @@ pmix_bcopy_csum (
     return pmix_bcopy_csum_partial(source, destination, copylen, csumlen, &plong, &plength);
 }
 
-PMIX_DECLSPEC unsigned int
+PMIX_EXPORT unsigned int
 pmix_bcopy_uicsum_partial (
     const void *  source,
     void *  destination,
@@ -88,7 +88,7 @@ pmix_bcopy_uicsum (
     return pmix_bcopy_uicsum_partial(source, destination, copylen, csumlen, &pint, &plength);
 }
 
-PMIX_DECLSPEC unsigned long
+PMIX_EXPORT unsigned long
 pmix_csum_partial (
     const void *  source,
     size_t csumlen,
@@ -114,7 +114,7 @@ pmix_csum16 (const void *  source, size_t csumlen)
     register uint32_t csum = 0;
 
     while (csumlen > 1) {
-	    csum += *src++;
+            csum += *src++;
         csumlen -= 2;
     }
     /* Add leftover byte, if any */
@@ -127,7 +127,7 @@ pmix_csum16 (const void *  source, size_t csumlen)
     return csum;
 }
 
-PMIX_DECLSPEC unsigned int
+PMIX_EXPORT unsigned int
 pmix_uicsum_partial (
     const void *  source,
     size_t csumlen,
@@ -149,7 +149,7 @@ pmix_uicsum(const void *  source, size_t csumlen)
 
 void pmix_initialize_crc_table(void);
 
-PMIX_DECLSPEC unsigned int
+PMIX_EXPORT unsigned int
 pmix_bcopy_uicrc_partial(
     const void *  source,
     void *  destination,
@@ -167,7 +167,7 @@ pmix_bcopy_uicrc(
     return pmix_bcopy_uicrc_partial(source, destination, copylen, crclen, CRC_INITIAL_REGISTER);
 }
 
-PMIX_DECLSPEC unsigned int
+PMIX_EXPORT unsigned int
 pmix_uicrc_partial(
     const void *  source,
     size_t crclen,
@@ -183,4 +183,3 @@ pmix_uicrc(const void *  source, size_t crclen)
 END_C_DECLS
 
 #endif
-

--- a/opal/mca/pmix/pmix112/pmix/src/util/error.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/error.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,16 +54,16 @@ pmix_status_t pmix_remove_errhandler(int errhandler_ref);
 
 void pmix_get_errorgroup(pmix_status_t status, char *pmix_error_group);
 
-PMIX_DECLSPEC pmix_status_t pmix_lookup_errhandler(pmix_notification_fn_t err,
+PMIX_EXPORT pmix_status_t pmix_lookup_errhandler(pmix_notification_fn_t err,
                                                    int *index);
 
-PMIX_DECLSPEC pmix_status_t pmix_add_errhandler(pmix_notification_fn_t err,
+PMIX_EXPORT pmix_status_t pmix_add_errhandler(pmix_notification_fn_t err,
                                                 pmix_info_t *info, int ninfo,
                                                 int *index);
 
-PMIX_DECLSPEC pmix_status_t pmix_remove_errhandler(int errhandler_ref);
+PMIX_EXPORT pmix_status_t pmix_remove_errhandler(int errhandler_ref);
 
-PMIX_DECLSPEC void pmix_get_errorgroup ( pmix_status_t status, char *pmix_error_group);
+PMIX_EXPORT void pmix_get_errorgroup ( pmix_status_t status, char *pmix_error_group);
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/util/fd.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/fd.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -36,7 +36,7 @@ BEGIN_C_DECLS
  * Loop over reading from the fd until len bytes are read or an error
  * occurs.  EAGAIN and EINTR are transparently handled.
  */
-PMIX_DECLSPEC pmix_status_t pmix_fd_read(int fd, int len, void *buffer);
+PMIX_EXPORT pmix_status_t pmix_fd_read(int fd, int len, void *buffer);
 
 /**
  * Write a complete buffer to a file descriptor.
@@ -51,7 +51,7 @@ PMIX_DECLSPEC pmix_status_t pmix_fd_read(int fd, int len, void *buffer);
  * Loop over writing to the fd until len bytes are written or an error
  * occurs.  EAGAIN and EINTR are transparently handled.
  */
-PMIX_DECLSPEC pmix_status_t pmix_fd_write(int fd, int len, const void *buffer);
+PMIX_EXPORT pmix_status_t pmix_fd_write(int fd, int len, const void *buffer);
 
 /**
  * Convenience function to set a file descriptor to be close-on-exec.
@@ -65,7 +65,7 @@ PMIX_DECLSPEC pmix_status_t pmix_fd_write(int fd, int len, const void *buffer);
  * This is simply a convenience function because there's a few steps
  * to setting a file descriptor to be close-on-exec.
  */
-PMIX_DECLSPEC pmix_status_t pmix_fd_set_cloexec(int fd);
+PMIX_EXPORT pmix_status_t pmix_fd_set_cloexec(int fd);
 
 END_C_DECLS
 

--- a/opal/mca/pmix/pmix112/pmix/src/util/os_path.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/os_path.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,7 +65,7 @@ BEGIN_C_DECLS
  * appropriate to the local operating system. The path_name string has been malloc'd
  * and therefore the user is responsible for free'ing the field.
 */
-PMIX_DECLSPEC char *pmix_os_path(bool relative, ...) __pmix_attribute_malloc__ __pmix_attribute_sentinel__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT char *pmix_os_path(bool relative, ...) __pmix_attribute_malloc__ __pmix_attribute_sentinel__ __pmix_attribute_warn_unused_result__;
 
 /**
  * Convert the path to be OS friendly. On UNIX this function will

--- a/opal/mca/pmix/pmix112/pmix/src/util/output.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/output.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,8 +94,8 @@ BEGIN_C_DECLS
  * subsystem to tell it to dump any collected output directly to
  * syslog instead of forwarding it to another location.
  */
-PMIX_DECLSPEC extern bool pmix_output_redirected_to_syslog;
-PMIX_DECLSPEC extern int pmix_output_redirected_syslog_pri;
+PMIX_EXPORT extern bool pmix_output_redirected_to_syslog;
+PMIX_EXPORT extern int pmix_output_redirected_syslog_pri;
 
 /**
  * \class pmix_output_stream_t
@@ -266,7 +266,7 @@ struct pmix_output_stream_t {
      * By definition, the default verbose stream has a handle ID of 0,
      * and has a verbose level of 0.
      */
-    PMIX_DECLSPEC bool pmix_output_init(void);
+    PMIX_EXPORT bool pmix_output_init(void);
 
     /**
      * Shut down the output stream system.
@@ -274,7 +274,7 @@ struct pmix_output_stream_t {
      * Shut down the output stream system, including the default verbose
      * stream.
      */
-    PMIX_DECLSPEC void pmix_output_finalize(void);
+    PMIX_EXPORT void pmix_output_finalize(void);
 
     /**
      * Opens an output stream.
@@ -298,7 +298,7 @@ struct pmix_output_stream_t {
      * when open_open() / pmix_output() is directed to send output to a
      * file but the process session directory does not yet exist.
      */
-    PMIX_DECLSPEC int pmix_output_open(pmix_output_stream_t *lds);
+    PMIX_EXPORT int pmix_output_open(pmix_output_stream_t *lds);
 
     /**
      * Re-opens / redirects an output stream.
@@ -312,7 +312,7 @@ struct pmix_output_stream_t {
      * passed is invalid, this call is effectively the same as opening a
      * new stream with a specific stream handle.
      */
-    PMIX_DECLSPEC int pmix_output_reopen(int output_id, pmix_output_stream_t *lds);
+    PMIX_EXPORT int pmix_output_reopen(int output_id, pmix_output_stream_t *lds);
 
     /**
      * Enables and disables output streams.
@@ -331,7 +331,7 @@ struct pmix_output_stream_t {
      * to the stream via PMIX_OUTPUT() or pmix_output() until the output
      * is re-enabled.
      */
-    PMIX_DECLSPEC bool pmix_output_switch(int output_id, bool enable);
+    PMIX_EXPORT bool pmix_output_switch(int output_id, bool enable);
 
     /**
      * \internal
@@ -342,7 +342,7 @@ struct pmix_output_stream_t {
      * typically only invoked after a restart (i.e., in a new process)
      * where output streams need to be re-initialized.
      */
-    PMIX_DECLSPEC void pmix_output_reopen_all(void);
+    PMIX_EXPORT void pmix_output_reopen_all(void);
 
     /**
      * Close an output stream.
@@ -354,7 +354,7 @@ struct pmix_output_stream_t {
      * re-used; it is possible that after a stream is closed, if another
      * stream is opened, it will get the same handle value.
      */
-    PMIX_DECLSPEC void pmix_output_close(int output_id);
+    PMIX_EXPORT void pmix_output_close(int output_id);
 
     /**
      * Main function to send output to a stream.
@@ -381,7 +381,7 @@ struct pmix_output_stream_t {
      * created, pmix_output() will automatically create the file and
      * writing to it.
      */
-    PMIX_DECLSPEC void pmix_output(int output_id, const char *format, ...) __pmix_attribute_format__(__printf__, 2, 3);
+    PMIX_EXPORT void pmix_output(int output_id, const char *format, ...) __pmix_attribute_format__(__printf__, 2, 3);
 
     /**
      * Send output to a stream only if the passed verbosity level is
@@ -411,13 +411,13 @@ struct pmix_output_stream_t {
      *
      * @see pmix_output_set_verbosity()
      */
-    PMIX_DECLSPEC void pmix_output_verbose(int verbose_level, int output_id,
+    PMIX_EXPORT void pmix_output_verbose(int verbose_level, int output_id,
                                            const char *format, ...) __pmix_attribute_format__(__printf__, 3, 4);
 
    /**
     * Same as pmix_output_verbose(), but takes a va_list form of varargs.
     */
-    PMIX_DECLSPEC void pmix_output_vverbose(int verbose_level, int output_id,
+    PMIX_EXPORT void pmix_output_vverbose(int verbose_level, int output_id,
                                             const char *format, va_list ap) __pmix_attribute_format__(__printf__, 3, 0);
 
     /**
@@ -434,13 +434,13 @@ struct pmix_output_stream_t {
      * level is not high enough, NULL is returned.  The caller is
      * responsible for free()'ing the returned string.
      */
-    PMIX_DECLSPEC char *pmix_output_string(int verbose_level, int output_id,
+    PMIX_EXPORT char *pmix_output_string(int verbose_level, int output_id,
                                            const char *format, ...) __pmix_attribute_format__(__printf__, 3, 4);
 
    /**
     * Same as pmix_output_string, but accepts a va_list form of varargs.
     */
-    PMIX_DECLSPEC char *pmix_output_vstring(int verbose_level, int output_id,
+    PMIX_EXPORT char *pmix_output_vstring(int verbose_level, int output_id,
                                             const char *format, va_list ap) __pmix_attribute_format__(__printf__, 3, 0);
 
     /**
@@ -452,7 +452,7 @@ struct pmix_output_stream_t {
      * This function sets the verbosity level on a given stream.  It
      * will be used for all future invocations of pmix_output_verbose().
      */
-    PMIX_DECLSPEC void pmix_output_set_verbosity(int output_id, int level);
+    PMIX_EXPORT void pmix_output_set_verbosity(int output_id, int level);
 
     /**
      * Get the verbosity level for a stream
@@ -460,7 +460,7 @@ struct pmix_output_stream_t {
      * @param output_id Stream id returned from pmix_output_open()
      * @returns Verbosity of stream
      */
-    PMIX_DECLSPEC int pmix_output_get_verbosity(int output_id);
+    PMIX_EXPORT int pmix_output_get_verbosity(int output_id);
 
     /**
      * Set characteristics for output files.
@@ -502,7 +502,7 @@ struct pmix_output_stream_t {
      * this function affects both new streams \em and any stream that
      * was previously opened but had not yet output anything.
      */
-    PMIX_DECLSPEC void pmix_output_set_output_file_info(const char *dir,
+    PMIX_EXPORT void pmix_output_set_output_file_info(const char *dir,
                                                         const char *prefix,
                                                         char **olddir,
                                                         char **oldprefix);
@@ -510,7 +510,7 @@ struct pmix_output_stream_t {
     /**
      * Same as pmix_output_verbose(), but pointer to buffer and size.
      */
-    PMIX_DECLSPEC void pmix_output_hexdump(int verbose_level, int output_id,
+    PMIX_EXPORT void pmix_output_hexdump(int verbose_level, int output_id,
                                            void *ptr, int buflen);
 
 #if PMIX_ENABLE_DEBUG
@@ -559,9 +559,8 @@ struct pmix_output_stream_t {
  * The intended usage is to invoke the constructor and then enable
  * the output fields that you want.
  */
-PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_output_stream_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_output_stream_t);
 
 END_C_DECLS
 
 #endif /* PMIX_OUTPUT_H_ */
-

--- a/opal/mca/pmix/pmix112/pmix/src/util/pmix_environ.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/pmix_environ.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -65,7 +65,7 @@ BEGIN_C_DECLS
  * one of the two is NULL, the other list is simply copied to the
  * output.  If both are NULL, NULL is returned.
  */
-PMIX_DECLSPEC char **pmix_environ_merge(char **minor, char **major) __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT char **pmix_environ_merge(char **minor, char **major) __pmix_attribute_warn_unused_result__;
 
 /**
  * Portable version of setenv(3), allowing editing of any
@@ -113,7 +113,7 @@ PMIX_DECLSPEC char **pmix_environ_merge(char **minor, char **major) __pmix_attri
  *   pmix_setenv("foo", "bar", true, &my_env);
  * \endcode
  */
-PMIX_DECLSPEC pmix_status_t pmix_setenv(const char *name, const char *value,
+PMIX_EXPORT pmix_status_t pmix_setenv(const char *name, const char *value,
                               bool overwrite, char ***env) __pmix_attribute_nonnull__(1);
 
 /**
@@ -130,20 +130,20 @@ PMIX_DECLSPEC pmix_status_t pmix_setenv(const char *name, const char *value,
  * If \em name is found in \em env, the string corresponding to
  * that entry is freed and its entry is eliminated from the array.
  */
-PMIX_DECLSPEC pmix_status_t pmix_unsetenv(const char *name, char ***env) __pmix_attribute_nonnull__(1);
+PMIX_EXPORT pmix_status_t pmix_unsetenv(const char *name, char ***env) __pmix_attribute_nonnull__(1);
 
 /* A consistent way to retrieve the home and tmp directory on all supported
  * platforms.
  */
-PMIX_DECLSPEC const char* pmix_home_directory( void );
-PMIX_DECLSPEC const char* pmix_tmp_directory( void );
+PMIX_EXPORT const char* pmix_home_directory( void );
+PMIX_EXPORT const char* pmix_tmp_directory( void );
 
 /* Some care is needed with environ on OS X when dealing with shared
    libraries.  Handle that care here... */
 #ifdef HAVE__NSGETENVIRON
 #define environ (*_NSGetEnviron())
 #else
-PMIX_DECLSPEC extern char **environ;
+PMIX_EXPORT extern char **environ;
 #endif
 
 END_C_DECLS

--- a/opal/mca/pmix/pmix112/pmix/src/util/printf.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/printf.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,7 +53,7 @@ BEGIN_C_DECLS
  *
  * THIS IS A PORTABILITY FEATURE: USE snprintf() in CODE.
  */
-PMIX_DECLSPEC int  pmix_snprintf(char *str, size_t size, const char *fmt, ...) __pmix_attribute_format__(__printf__, 3, 4);
+PMIX_EXPORT int  pmix_snprintf(char *str, size_t size, const char *fmt, ...) __pmix_attribute_format__(__printf__, 3, 4);
 
 
 /**
@@ -78,7 +78,7 @@ PMIX_DECLSPEC int  pmix_snprintf(char *str, size_t size, const char *fmt, ...) _
  *
  * THIS IS A PORTABILITY FEATURE: USE vsnprintf() in CODE.
  */
-PMIX_DECLSPEC int  pmix_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) __pmix_attribute_format__(__printf__, 3, 0);
+PMIX_EXPORT int  pmix_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) __pmix_attribute_format__(__printf__, 3, 0);
 
 /**
  * Allocates and writes to a string under the control of a format
@@ -99,7 +99,7 @@ PMIX_DECLSPEC int  pmix_vsnprintf(char *str, size_t size, const char *fmt, va_li
  *
  * THIS IS A PORTABILITY FEATURE: USE asprintf() in CODE.
  */
-PMIX_DECLSPEC int  pmix_asprintf(char **ptr, const char *fmt, ...) __pmix_attribute_format__(__printf__, 2, 3);
+PMIX_EXPORT int  pmix_asprintf(char **ptr, const char *fmt, ...) __pmix_attribute_format__(__printf__, 2, 3);
 
 
 /**
@@ -123,10 +123,9 @@ PMIX_DECLSPEC int  pmix_asprintf(char **ptr, const char *fmt, ...) __pmix_attrib
  *
  * THIS IS A PORTABILITY FEATURE: USE vasprintf() in CODE.
  */
-PMIX_DECLSPEC int  pmix_vasprintf(char **ptr, const char *fmt, va_list ap) __pmix_attribute_format__(__printf__, 2, 0);
+PMIX_EXPORT int  pmix_vasprintf(char **ptr, const char *fmt, va_list ap) __pmix_attribute_format__(__printf__, 2, 0);
 
 
 END_C_DECLS
 
 #endif /* PMIX_PRINTF_H */
-

--- a/opal/mca/pmix/pmix112/pmix/src/util/progress_threads.h
+++ b/opal/mca/pmix/pmix112/pmix/src/util/progress_threads.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
@@ -24,11 +24,11 @@
  * will also create a pipe so that libevent has something to block
  * against, thus keeping the thread from free-running
  */
-PMIX_DECLSPEC pmix_event_base_t* pmix_start_progress_thread(void);
+PMIX_EXPORT pmix_event_base_t* pmix_start_progress_thread(void);
 
 /* stop the progress thread of the provided name. This function will
  * also cleanup the blocking pipes and release the event base if
  * the cleanup param is true */
-PMIX_DECLSPEC void pmix_stop_progress_thread(pmix_event_base_t *ev_base);
+PMIX_EXPORT void pmix_stop_progress_thread(pmix_event_base_t *ev_base);
 
 #endif

--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
@@ -81,9 +81,7 @@ static bool signals_set=false;
 static opal_event_t term_handler;
 static opal_event_t int_handler;
 static opal_event_t epipe_handler;
-static opal_event_t sigusr1_handler;
-static opal_event_t sigusr2_handler;
-char *log_path = NULL;
+static char *log_path = NULL;
 static void shutdown_signal(int fd, short flags, void *arg);
 static void epipe_signal_callback(int fd, short flags, void *arg);
 static void signal_forward_callback(int fd, short event, void *arg);


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>