### PR TITLE
README: update for v2.1.2 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -217,9 +217,11 @@ Nick Papior Andersen, Individual
   nickpapior@gmail.com
 Nicolas Chevalier, Bull
   nicolas.chevalier@bull.net
+Nicolas Morey-Chaisemartin, SUSE
+  nmoreychaisemartin@suse.com
 Nysal Jan K A, IBM
   jnysal@in.ibm.com
-Omri Mor
+Omri Mor,
   omri50@gmail.com
 Orion Poplawski, Individual
   orion@cora.nwra.com
@@ -299,6 +301,8 @@ Thomas Herault, University of Tennessee-Knoxville
   herault@icl.utk.edu
 Thomas Naughton, Oak Ridge National Laboratory
   naughtont@ornl.gov
+Tim Burgess,
+  timb@dugeo.com
 Tim Mattox, Indiana University, Cisco, Individual
   tmattox@gmail.com
 Tim Prins, Indiana University, Los Alamos National Laboratory
@@ -324,6 +328,8 @@ Weikuan Yu, Los Alamos National Laboratory
   yuw@lanl.gov
 Wesley Bland, University of Tennessee-Knoxville
   wbland@icl.utk.edu
+William LePera, IBM
+  lepera@us.ibm.com
 William Throwe, Individual
   wtt6@cornell.edu
 Yael Dayan, Mellanox

--- a/README
+++ b/README
@@ -68,7 +68,7 @@ Much, much more information is also available in the Open MPI FAQ:
 ===========================================================================
 
 The following abbreviated list of release notes applies to this code
-base as of this writing (March 2017):
+base as of this writing (August 2017):
 
 General notes
 -------------


### PR DESCRIPTION
Update README and AUTHORS for v2.1.2 release.
[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>