### PR TITLE
v2.0.x: btl/usnic: assign the number of send credit correctly.

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_proc.c
+++ b/opal/mca/btl/usnic/btl_usnic_proc.c
@@ -741,6 +741,7 @@ opal_btl_usnic_create_endpoint(opal_btl_usnic_module_t *module,
     endpoint->endpoint_module = module;
     assert(modex_index >= 0 && modex_index < (int)proc->proc_modex_count);
     endpoint->endpoint_remote_modex = proc->proc_modex[modex_index];
+    endpoint->endpoint_send_credits = module->sd_num;
 
     /* Start creating destinations; one for each channel.  These
        progress in the background.a */


### PR DESCRIPTION
usnic endpoints was always created with default send credit value of 8. This commit assign the correct number from the hardware instead.

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>
(cherry picked from commit 68658e4bab1c9d7143370ca3793ebdf6c9b98cf2)
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Written by @thananon, reviewed by @jsquyres