### PR TITLE
updating nmcheck_prefix.pl to accept some more compiler-generated names

### DIFF
--- a/test/symbol_name/nmcheck_prefix.pl
+++ b/test/symbol_name/nmcheck_prefix.pl
@@ -111,6 +111,15 @@ sub check_lib_for_bad_exports {
     @symbols = grep(!/^NBC_/i, @symbols);
     @symbols = grep(!/^mca_/, @symbols);
 
+# in libmpi_usempi_ignore_tkr.so someone posted an MTT test where
+# the compiler produced symbols like
+#   [error]   MPI
+#   [error]   _Cmpi_fortran_status_ignore
+#   [error]   _Cmpi_fortran_statuses_ignore
+# which we shouldn't identify as bad:
+    @symbols = grep(!/^MPI$/, @symbols);
+    @symbols = grep(!/^_Cmpi_$/, @symbols);
+
     @symbols = grep(!/^_fini$/, @symbols);
     @symbols = grep(!/^_init$/, @symbols);
     @symbols = grep(!/^_edata$/, @symbols);


### PR DESCRIPTION
Someone posted an MTT test where libmpi_usempi_ignore_tkr.so ended
up with symbols like these being identifed as errors:
    [error]   MPI
    [error]   _Cmpi_fortran_status_ignore
    [error]   _Cmpi_fortran_statuses_ignore
those must be compiler-generated names so we shouldn't identify them
as problematic.