### PR TITLE
configure: add an option to set wrapper CC

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2007-2009 Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2012      Los Alamos National Security, LLC. All rights
+dnl Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
@@ -35,11 +35,6 @@ AC_DEFUN([OPAL_SETUP_CC],[
     AC_REQUIRE([_OPAL_START_SETUP_CC])
     AC_REQUIRE([_OPAL_PROG_CC])
     AC_REQUIRE([AM_PROG_CC_C_O])
-
-    # AC_PROG_CC_C99 changes CC (instead of CFLAGS) so save CC (without c99
-    # flags) for use in our wrappers.
-    WRAPPER_CC="$CC"
-    AC_SUBST([WRAPPER_CC])
 
     # From Open MPI 1.7 on we require a C99 compiant compiler
     AC_PROG_CC_C99

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -15,6 +15,8 @@ dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -75,6 +77,22 @@ AC_DEFUN([OPAL_WRAPPER_FLAGS_ADD], [
 #     <flag>_prefix, configure is not.  There's no known use case for
 #     doing so, and we'd like to force the issue.
 AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
+    AC_ARG_WITH([wrapper-cc],
+                [AC_HELP_STRING([--with-wrapper-cc],
+                                [C compiler to use when using mpicc])])
+
+    AS_IF([test "$with_wrapper_cc" = "yes" || test "$with_wrapper_cc" = "no"],
+          [AC_MSG_ERROR([--with-wrapper-cc must have an argument.])])
+    if test -n "$with_wrapper_cc" ; then
+        WRAPPER_CC="$with_wrapper_cc"
+    else
+        # Just grab the compiler. If the user wants to also set CFLAGS there
+        # is an option for that.
+        WRAPPER_CC=$(echo "$CC" | cut -d' ' -f1)
+    fi
+
+    AC_SUBST([WRAPPER_CC])
+
     AC_ARG_WITH([wrapper-cflags],
                 [AC_HELP_STRING([--with-wrapper-cflags],
                                 [Extra flags to add to CFLAGS when using mpicc])])


### PR DESCRIPTION
This commit adds a new configure option: --with-wrapper-cc. This
option can be used to set which C compiler is invoked by mpicc. The
feature is necessary when building for compiler suites that do not
support C11 (Ex: icc). A version of Open MPI that is set up for these
compilers can be built with:

./configure --with-wrapper-cc=icc CC=gcc FC=ifort CXX=icpc

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>