### PR TITLE
config: Remove support for big endian PPC, XL compiler older than 13.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,7 +14,7 @@ Copyright (c) 2006      Sun Microsystems, Inc.  All rights reserved.
                         Use is subject to license terms.
 Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
                         reserved.
-Copyright (c) 2010-2012 IBM Corporation.  All rights reserved.
+Copyright (c) 2010-2017 IBM Corporation.  All rights reserved.
 Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
 Copyright (c) 2012      University of Houston. All rights reserved.
@@ -71,6 +71,8 @@ Master (not on release branches yet)
   true when using SLURM, as it improves interoperability with SLURM's signal
   propagation tools.  By default it is set to false, except for Cray XC systems.
 - Remove IB XRC support from the OpenIB BTL due to lack of support.
+- Remove support for big endian PowerPC.
+- Remove support for XL compilers older than v13.1
 
 3.0.0 -- July, 2017
 -------------------

--- a/config/opal_check_vendor.m4
+++ b/config/opal_check_vendor.m4
@@ -12,6 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved
+dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -114,6 +115,18 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
           [OPAL_IF_IFELSE([defined(__FUJITSU)],
                [opal_check_compiler_vendor_result="fujitsu"])])
 
+    # IBM XL C/C++
+    AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
+          [OPAL_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__)],
+               [opal_check_compiler_vendor_result="ibm"
+                xlc_major_version=`$CC -qversion 2>&1 | tail -n 1 | cut -d ' ' -f 2 | cut -d '.' -f 1`
+                xlc_minor_version=`$CC -qversion 2>&1 | tail -n 1 | cut -d ' ' -f 2 | cut -d '.' -f 2`
+                AS_IF([ (test "$xlc_major_version" -lt "13" ) || (test "$xlc_major_version" -eq "13" && test "$xlc_minor_version" -lt "1" )],
+                    [AC_MSG_ERROR(["XL Compiler versions less than 13.1 not supported. Detected $xlc_major_version.$xlc_minor_version"])])
+               ],
+               [OPAL_IF_IFELSE([defined(_AIX) && !defined(__GNUC__)],
+                    [opal_check_compiler_vendor_result="ibm"])])])
+
     # GNU
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
           [OPAL_IFDEF_IFELSE([__GNUC__],
@@ -131,7 +144,7 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
                    AC_MSG_WARN([Detected gccfss being used to compile Open MPI.])
                    AC_MSG_WARN([Because of several issues Open MPI does not support])
                    AC_MSG_WARN([the gccfss compiler.  Please use a different compiler.])
-                   AC_MSG_WARN([If you didn't think you used gccfss you may want to])
+                   AC_MSG_WARN([If you did not think you used gccfss you may want to])
                    AC_MSG_WARN([check to see if the compiler you think you used is])
                    AC_MSG_WARN([actually a link to gccfss.])
                    AC_MSG_ERROR([Cannot continue])
@@ -180,13 +193,6 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
           [OPAL_IF_IFELSE([defined(__HP_cc) || defined(__HP_aCC)],
                [opal_check_compiler_vendor_result="hp"])])
-
-    # IBM XL C/C++
-    AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
-          [OPAL_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__)],
-               [opal_check_compiler_vendor_result="ibm"],
-               [OPAL_IF_IFELSE([defined(_AIX) && !defined(__GNUC__)],
-                    [opal_check_compiler_vendor_result="ibm"])])])
 
     # KAI C++ (rest in peace)
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,18 @@ AS_IF([test "$host" != "$target"],
       [AC_MSG_WARN([Cross-compile detected])
        AC_MSG_WARN([Cross-compiling is only partially supported])
        AC_MSG_WARN([Proceed at your own risk!])])
+# Check for architectures that we explicitly no longer support
+case "${host}" in
+    powerpc-*|powerpc64-*|ppc-*)
+        AC_MSG_ERROR([Big endian PPC is no longer supported.])
+        ;;
+esac
+case "${target}" in
+    powerpc-*|powerpc64-*|ppc-*)
+        AC_MSG_ERROR([Big endian PPC is no longer supported.])
+        ;;
+esac
+
 # AC_USE_SYSTEM_EXTENSIONS alters CFLAGS (e.g., adds -g -O2)
 OPAL_VAR_SCOPE_PUSH([CFLAGS_save])
 CFLAGS_save=$CFLAGS


### PR DESCRIPTION
 * Removes support for big endian PPC
 * Removes support for XL compiler older than 13.1
 * Fixes #4053