### PR TITLE
btl/usnic: restore configure usNIC summary line

### DIFF
--- a/opal/mca/btl/usnic/configure.m4
+++ b/opal/mca/btl/usnic/configure.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006      Sandia National Laboratories. All rights
 #                         reserved.
-# Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -143,5 +143,6 @@ AC_DEFUN([_OPAL_BTL_USNIC_DO_CONFIG],[
                  [$2])
           ])
 
+    OPAL_SUMMARY_ADD([[Transports]],[[Cisco usNIC]],[[btl_usnic]],[$opal_btl_usnic_happy])
     OPAL_VAR_SCOPE_POP
 ])dnl


### PR DESCRIPTION
Not sure how/when this got deleted, but put back the "Cisco usNIC" line in the transport summary at the end of configure.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>