### PR TITLE
Notify all event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,6 +320,17 @@ opal/mca/pmix/pmix2x/pmix/include/pmix_rename.h
 opal/mca/pmix/pmix2x/pmix/include/pmix_version.h
 opal/mca/pmix/pmix2x/pmix/src/util/keyval/keyval_lex.c
 opal/mca/pmix/pmix2x/pmix/src/util/show_help_lex.c
+opal/mca/pmix/pmix2x/pmix/examples/alloc
+opal/mca/pmix/pmix2x/pmix/examples/client
+opal/mca/pmix/pmix2x/pmix/examples/debugger
+opal/mca/pmix/pmix2x/pmix/examples/debuggerd
+opal/mca/pmix/pmix2x/pmix/examples/dmodex
+opal/mca/pmix/pmix2x/pmix/examples/dynamic
+opal/mca/pmix/pmix2x/pmix/examples/fault
+opal/mca/pmix/pmix2x/pmix/examples/jctrl
+opal/mca/pmix/pmix2x/pmix/examples/pub
+opal/mca/pmix/pmix2x/pmix/examples/server
+opal/mca/pmix/pmix2x/pmix/examples/tool
 
 opal/tools/opal-checkpoint/opal-checkpoint
 opal/tools/opal-checkpoint/opal-checkpoint.1

--- a/opal/mca/pmix/pmix2x/pmix/src/event/pmix_event_notification.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/event/pmix_event_notification.c
@@ -788,8 +788,10 @@ static void _notify_client_event(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix_server: _notify_error notifying clients of error %s",
-                        PMIx_Error_string(cd->status));
+                        "pmix_server: _notify_client_event notifying clients of event %s range %s type %s",
+                        PMIx_Error_string(cd->status),
+                        PMIx_Data_range_string(cd->range),
+                        cd->nondefault ? "NONDEFAULT" : "OPEN");
 
     /* we cannot know if everyone who wants this notice has had a chance
      * to register for it - the notice may be coming too early. So cache

--- a/opal/mca/pmix/pmix2x/pmix2x_server_south.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_south.c
@@ -546,9 +546,9 @@ int pmix2x_server_notify_event(int status,
 
 
     rc = pmix2x_convert_opalrc(status);
-    /* the range is irrelevant here as the server is passing
+    /* the range must be nonlocal so the server will pass
      * the event down to its local clients */
-    rc = PMIx_Notify_event(rc, &op->p, PMIX_RANGE_LOCAL,
+    rc = PMIx_Notify_event(rc, &op->p, PMIX_RANGE_SESSION,
                            pinfo, sz, opcbfunc, op);
     if (PMIX_SUCCESS != rc) {
         OBJ_RELEASE(op);

--- a/orte/mca/state/base/state_base_fns.c
+++ b/orte/mca/state/base/state_base_fns.c
@@ -547,8 +547,8 @@ static void _send_notification(int status,
     }
 
     if (OPAL_ERR_PROC_ABORTED == status) {
-        /* we will pass four opal_value_t's */
-        rc = 4;
+        /* we will pass three opal_value_t's */
+        rc = 3;
         if (ORTE_SUCCESS != (rc = opal_dss.pack(buf, &rc, 1, OPAL_INT))) {
             ORTE_ERROR_LOG(rc);
             OBJ_RELEASE(buf);
@@ -569,8 +569,8 @@ static void _send_notification(int status,
         }
         OBJ_DESTRUCT(&kv);
     } else {
-        /* we are going to pass three opal_value_t's */
-        rc = 3;
+        /* we are going to pass two opal_value_t's */
+        rc = 2;
         if (ORTE_SUCCESS != (rc = opal_dss.pack(buf, &rc, 1, OPAL_INT))) {
             ORTE_ERROR_LOG(rc);
             OBJ_RELEASE(buf);
@@ -599,20 +599,6 @@ static void _send_notification(int status,
     kv.type = OPAL_NAME;
     kv.data.name.jobid = target->jobid;
     kv.data.name.vpid = target->vpid;
-    kvptr = &kv;
-    if (ORTE_SUCCESS != (rc = opal_dss.pack(buf, &kvptr, 1, OPAL_VALUE))) {
-        ORTE_ERROR_LOG(rc);
-        OBJ_DESTRUCT(&kv);
-        OBJ_RELEASE(buf);
-        return;
-    }
-    OBJ_DESTRUCT(&kv);
-
-    /* mark this as intended for non-default event handlers */
-    OBJ_CONSTRUCT(&kv, opal_value_t);
-    kv.key = strdup(OPAL_PMIX_EVENT_NON_DEFAULT);
-    kv.type = OPAL_BOOL;
-    kv.data.flag = true;
     kvptr = &kv;
     if (ORTE_SUCCESS != (rc = opal_dss.pack(buf, &kvptr, 1, OPAL_VALUE))) {
         ORTE_ERROR_LOG(rc);


### PR DESCRIPTION
The local PMIx server is notifying its clients of all events, but for some reason I don't recall, the broadcast notification was marked for delivery only to non-default event handlers. This creates a discrepancy between the two behaviors, so don't restrict the broadcast notifications.

Fixes #4117

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit d515f4888544553a0ea8df69ebfa79ef68133dae)