### PR TITLE
v2.0.x: CMA: Fixing logic for CMA system call detection

### DIFF
--- a/opal/mca/btl/sm/btl_sm.c
+++ b/opal/mca/btl/sm/btl_sm.c
@@ -19,6 +19,7 @@
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      ARM, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +42,7 @@
 #include <sys/mman.h>
 #endif  /* HAVE_SYS_MMAN_H */
 
-#if OPAL_BTL_SM_HAVE_CMA && defined(OPAL_CMA_NEED_SYSCALL_DEFS)
+#if OPAL_BTL_SM_HAVE_CMA && OPAL_CMA_NEED_SYSCALL_DEFS
 #include "opal/sys/cma.h"
 #endif /* OPAL_CMA_NEED_SYSCALL_DEFS */
 


### PR DESCRIPTION
The OPAL_CMA_NEED_SYSCALL_DEFS is always defined/set to 0 or 1. Therefore instead of checking if the macro is defined, we have to look at the value itself.

(cherry picked from commit d984b4b3f9f18a4dfae9a1ef3e9e7f2fbd1f0e33)

Refs: #4122
