### PR TITLE
mpi/info_delete: fix return code

### DIFF
--- a/ompi/mpi/c/info_delete.c
+++ b/ompi/mpi/c/info_delete.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,5 +79,14 @@ int MPI_Info_delete(MPI_Info info, const char *key) {
     OPAL_CR_ENTER_LIBRARY();
 
     err = ompi_info_delete (info, key);
+
+    // Note that ompi_info_delete() (i.e., opal_info_delete()) will
+    // return OPAL_ERR_NOT_FOUND if there was no corresponding key to
+    // delete.  Per MPI-3.1, we need to convert that to
+    // MPI_ERR_INFO_NOKEY.
+    if (OPAL_ERR_NOT_FOUND == err) {
+        err = MPI_ERR_INFO_NOKEY;
+    }
+
     OMPI_ERRHANDLER_RETURN(err, MPI_COMM_WORLD, err, FUNC_NAME);
 }


### PR DESCRIPTION
Per MPI-3.1, ensure to raise an MPI exception with value MPI_ERR_INFO_NOKEY if we try to MPI_INFO_DELETE a key that does not exist.  Thanks to @dalcinl (Lisando Dalcin) for raising the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #4126.  Once this PR is merged, need to PR to v3.0.x branch.