### PR TITLE
opal/pmix112: Sync with PMIx v1.2.3

### DIFF
--- a/opal/mca/pmix/pmix112/pmix/VERSION
+++ b/opal/mca/pmix/pmix112/pmix/VERSION
@@ -24,7 +24,7 @@ release=3
 # The only requirement is that it must be entirely printable ASCII
 # characters and have no white space.
 
-greek=rc1
+greek=
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
 * Matches official PMIx v1.2.3 release
   - https://github.com/pmix/pmix/releases/tag/v1.2.3

[skip ci] bot:notest
