### PR TITLE
mca: Dynamic components link against project lib

### DIFF
--- a/contrib/libadd_mca_comp_update.py
+++ b/contrib/libadd_mca_comp_update.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2017      IBM Corporation. All rights reserved.
+# $COPYRIGHT$
+#
+
+import glob, os, re, shutil
+
+projects= {'opal' : ["$(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la"],
+           'orte' : ["$(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la"],
+           'ompi' : ["$(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la"],
+           'oshmem' : ["$(top_builddir)/oshmem/liboshmem.la"],
+          }
+
+no_anchor_file = []
+missing_files = []
+skipped_files = []
+partly_files = []
+updated_files = []
+
+#
+# Check of all of the libadd fields are accounted for in the LIBADD
+# Return a list indicating which are missing (positional)
+#
+def check_libadd(content, libadd_field, project):
+    global projects
+
+    libadd_list = projects[project]
+    libadd_missing = [True] * len(libadd_list)
+
+    on_libadd = False
+    for line in content:
+        # First libadd line
+        if re.search( r"^\s*"+libadd_field, line):
+            # If line continuation, then keep searching after this point
+            if line[-2] == '\\':
+                on_libadd = True
+
+            for idx, lib in enumerate(libadd_list):
+                if True == libadd_missing[idx]:
+                    if 0 <= line.find(lib):
+                        libadd_missing[idx] = False
+
+        # Line continuation
+        elif True == on_libadd:
+            for idx, lib in enumerate(libadd_list):
+                if True == libadd_missing[idx]:
+                    if 0 <= line.find(lib):
+                        libadd_missing[idx] = False
+
+            # No more line continuations, so stop processing
+            if line[-2] != '\\':
+                on_libadd = False
+                break
+
+    return libadd_missing
+
+#
+# Update all of the Makefile.am's with the proper LIBADD additions
+#
+def update_makefile_ams():
+    global projects
+    global no_anchor_file
+    global missing_files
+    global skipped_files
+    global partly_files
+    global updated_files
+
+    for project, libadd_list in projects.items():
+        libadd_str = " \\\n\t".join(libadd_list)
+
+        print("="*40)
+        print("Project: "+project)
+        print("LIBADD:\n"+libadd_str)
+        print("="*40)
+
+        #
+        # Walk the directory structure
+        #
+        for root, dirs, files in os.walk(project+"/mca"):
+            parts = root.split("/")
+            if len(parts) != 4:
+                continue
+            if parts[-1] == ".libs" or parts[-1] == ".deps" or parts[-1] == "base":
+                continue
+            if parts[2] == "common":
+                continue
+
+            print("Processing: "+root)
+
+            #
+            # Find Makefile.am
+            #
+            make_filename = os.path.join(root, "Makefile.am")
+            if False == os.path.isfile( make_filename ):
+                missing_files.append("Missing: "+make_filename)
+                print("  ---> Error: "+make_filename+" is not present in this directory")
+                continue
+
+            #
+            # Stearching for: mca_FRAMEWORK_COMPONENT_la_{LIBADD|LDFLAGS}
+            # First scan file to see if it has an LIBADD / LDFLAGS
+            #
+            libadd_field  = "mca_"+parts[2]+"_"+parts[3]+"_la_LIBADD"
+            ldflags_field = "mca_"+parts[2]+"_"+parts[3]+"_la_LDFLAGS"
+            has_ldflags = False
+            has_libadd  = False
+
+            r_fd = open(make_filename, 'r')
+            orig_content = r_fd.readlines()
+            r_fd.close()
+            libadd_missing = []
+
+            for line in orig_content:
+                if re.search( r"^\s*"+ldflags_field, line):
+                    has_ldflags = True
+                elif re.search( r"^\s*"+libadd_field, line):
+                    has_libadd = True
+
+            if True == has_libadd:
+                libadd_missing = check_libadd(orig_content, libadd_field, project)
+
+            #
+            # Sanity Check: Was there an anchor field.
+            # If not skip, we might need to manually update or it might be a
+            # static component.
+            #
+            if False == has_ldflags and False == has_libadd:
+                no_anchor_file.append("No anchor ("+ldflags_field+"): "+make_filename)
+                print("  ---> Error: Makefile.am does not contain necessary anchor")
+                continue
+
+            #
+            # Sanity Check: This file does not need to be updated.
+            #
+            if True == has_libadd and all(False == v for v in libadd_missing):
+                skipped_files.append("Skip: "+make_filename)
+                print("       Skip: Already updated Makefile.am")
+                continue
+
+            #
+            # Now go though and create a new version of the Makefile.am
+            #
+            r_fd = open(make_filename, 'r')
+            w_fd = open(make_filename+".mod", 'w')
+
+            num_libadds=0
+            for line in r_fd:
+                # LDFLAGS anchor
+                if re.search( r"^\s*"+ldflags_field, line):
+                    w_fd.write(line)
+                    # If there is no LIBADD, then put it after the LDFLAGS
+                    if False == has_libadd:
+                        w_fd.write(libadd_field+" = "+libadd_str+"\n")
+                # Existing LIBADD field to extend
+                elif 0 == num_libadds and re.search( r"^\s*"+libadd_field, line):
+                    parts = line.partition("=")
+                    num_libadds += 1
+
+                    if parts[0][-1] == '+':
+                        w_fd.write(libadd_field+" += ")
+                    else:
+                        w_fd.write(libadd_field+" = ")
+
+                    # If all libs are missing, then add the full string
+                    # Otherwise only add the missing items
+                    if all(True == v for v in libadd_missing):
+                        w_fd.write(libadd_str)
+                        # Only add a continuation if there is something to continue
+                        if 0 != len(parts[2].strip()):
+                            w_fd.write(" \\")
+                        w_fd.write("\n")
+                    else:
+                        partly_files.append("Partly updated: "+make_filename)
+                        for idx, lib in enumerate(libadd_list):
+                            if True == libadd_missing[idx]:
+                                w_fd.write(lib+" \\\n")
+
+                    # Original content (unless it's just a line continuation)
+                    if 0 != len(parts[2].strip()) and parts[2].strip() != "\\":
+                        w_fd.write("\t"+parts[2].lstrip())
+
+                # Non matching line, just echo
+                else:
+                    w_fd.write(line)
+
+            r_fd.close()
+            w_fd.close()
+
+            #
+            # Replace the original with the updated version
+            #
+            shutil.move(make_filename+".mod", make_filename)
+            updated_files.append(make_filename)
+
+
+if __name__ == "__main__":
+
+    update_makefile_ams()
+
+    print("")
+
+    print("="*40);
+    print("{:>3} : Files skipped".format(len(skipped_files)))
+    print("="*40);
+
+    print("="*40);
+    print("{:>3} : Files updated, but had some libs already in place.".format(len(partly_files)))
+    print("="*40);
+    for fn in partly_files:
+        print(fn)
+
+    print("="*40);
+    print("{:>3} : Files fully updated".format(len(updated_files)))
+    print("="*40);
+    for fn in updated_files:
+        print(fn)
+
+    print("="*40);
+    print("{:>3} : Missing Makefile.am".format(len(missing_files)))
+    print("="*40);
+    for err in missing_files:
+        print(err)
+
+    print("="*40);
+    print("{:>3} : Missing Anchor for parsing (might be static-only components)".format(len(no_anchor_file)))
+    print("="*40);
+    for err in no_anchor_file:
+        print(err)
+

--- a/ompi/mca/bml/r2/Makefile.am
+++ b/ompi/mca/bml/r2/Makefile.am
@@ -8,6 +8,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #						 All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +38,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_bml_r2_la_SOURCES = $(r2_sources)
 mca_bml_r2_la_LDFLAGS = -module -avoid-version
+mca_bml_r2_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_bml_r2_la_SOURCES = $(r2_sources)

--- a/ompi/mca/coll/basic/Makefile.am
+++ b/ompi/mca/coll/basic/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -63,6 +64,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_basic_la_SOURCES = $(sources)
 mca_coll_basic_la_LDFLAGS = -module -avoid-version
+mca_coll_basic_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_basic_la_SOURCES =$(sources)

--- a/ompi/mca/coll/cuda/Makefile.am
+++ b/ompi/mca/coll/cuda/Makefile.am
@@ -3,6 +3,7 @@
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,6 +32,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_cuda_la_SOURCES = $(sources)
 mca_coll_cuda_la_LDFLAGS = -module -avoid-version
+mca_coll_cuda_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_cuda_la_SOURCES =$(sources)

--- a/ompi/mca/coll/demo/Makefile.am
+++ b/ompi/mca/coll/demo/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -56,6 +57,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_demo_la_SOURCES = $(sources)
 mca_coll_demo_la_LDFLAGS = -module -avoid-version
+mca_coll_demo_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_demo_la_SOURCES = $(sources)

--- a/ompi/mca/coll/fca/Makefile.am
+++ b/ompi/mca/coll/fca/Makefile.am
@@ -2,6 +2,7 @@
 #
 #
 # Copyright (c) 2011 Mellanox Technologies. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,7 +38,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_fca_la_SOURCES = $(coll_fca_sources)
-mca_coll_fca_la_LIBADD = $(coll_fca_LIBS)
+mca_coll_fca_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(coll_fca_LIBS)
 mca_coll_fca_la_LDFLAGS = -module -avoid-version $(coll_fca_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/coll/hcoll/Makefile.am
+++ b/ompi/mca/coll/hcoll/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (c) 2011 Mellanox Technologies. All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,7 +39,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES  = $(component_install)
 mca_coll_hcoll_la_SOURCES = $(coll_hcoll_sources)
-mca_coll_hcoll_la_LIBADD  = $(coll_hcoll_LIBS)
+mca_coll_hcoll_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(coll_hcoll_LIBS)
 mca_coll_hcoll_la_LDFLAGS = -module -avoid-version $(coll_hcoll_LDFLAGS)
 
 noinst_LTLIBRARIES           = $(component_noinst)

--- a/ompi/mca/coll/inter/Makefile.am
+++ b/ompi/mca/coll/inter/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,6 +33,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_inter_la_SOURCES = $(sources)
 mca_coll_inter_la_LDFLAGS = -module -avoid-version
+mca_coll_inter_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_inter_la_SOURCES = $(sources)

--- a/ompi/mca/coll/libnbc/Makefile.am
+++ b/ompi/mca/coll/libnbc/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -70,6 +71,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_libnbc_la_SOURCES = $(sources)
 mca_coll_libnbc_la_LDFLAGS = -module -avoid-version
+mca_coll_libnbc_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_libnbc_la_SOURCES =$(sources)

--- a/ompi/mca/coll/portals4/Makefile.am
+++ b/ompi/mca/coll/portals4/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2013-2015 Sandia National Laboratories. All rights reserved.
 # Copyright (c) 2015      Bull SAS.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,7 +33,8 @@ AM_CPPFLAGS = $(coll_portals4_CPPFLAGS)
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_portals4_la_SOURCES = $(local_sources)
-mca_coll_portals4_la_LIBADD = $(coll_portals4_LIBS)
+mca_coll_portals4_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(coll_portals4_LIBS)
 mca_coll_portals4_la_LDFLAGS = -module -avoid-version $(coll_portals4_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/coll/self/Makefile.am
+++ b/ompi/mca/coll/self/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -54,6 +55,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_self_la_SOURCES = $(sources)
 mca_coll_self_la_LDFLAGS = -module -avoid-version
+mca_coll_self_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_self_la_SOURCES =$(sources)

--- a/ompi/mca/coll/sm/Makefile.am
+++ b/ompi/mca/coll/sm/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -61,7 +62,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_sm_la_SOURCES = $(sources)
 mca_coll_sm_la_LDFLAGS = -module -avoid-version
-mca_coll_sm_la_LIBADD = \
+mca_coll_sm_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
         $(OMPI_TOP_BUILDDIR)/opal/mca/common/sm/lib@OPAL_LIB_PREFIX@mca_common_sm.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/coll/sync/Makefile.am
+++ b/ompi/mca/coll/sync/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc. All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,6 +47,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_sync_la_SOURCES = $(sources)
 mca_coll_sync_la_LDFLAGS = -module -avoid-version
+mca_coll_sync_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_sync_la_SOURCES =$(sources)

--- a/ompi/mca/coll/tuned/Makefile.am
+++ b/ompi/mca/coll/tuned/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -55,6 +56,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_coll_tuned_la_SOURCES = $(sources)
 mca_coll_tuned_la_LDFLAGS = -module -avoid-version
+mca_coll_tuned_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_coll_tuned_la_SOURCES =$(sources)

--- a/ompi/mca/crcp/bkmrk/Makefile.am
+++ b/ompi/mca/crcp/bkmrk/Makefile.am
@@ -8,6 +8,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_crcp_bkmrk_la_SOURCES = $(sources)
 mca_crcp_bkmrk_la_LDFLAGS = -module -avoid-version
+mca_crcp_bkmrk_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_crcp_bkmrk_la_SOURCES = $(sources)

--- a/ompi/mca/fbtl/plfs/Makefile.am
+++ b/ompi/mca/fbtl/plfs/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2011 University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -45,7 +46,8 @@ AM_CPPFLAGS = $(fbtl_plfs_CPPFLAGS)
 mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fbtl_plfs_la_SOURCES = $(fbtl_plfs_sources)
-mca_fbtl_plfs_la_LIBADD = $(fbtl_plfs_LIBS)
+mca_fbtl_plfs_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(fbtl_plfs_LIBS)
 mca_fbtl_plfs_la_LDFLAGS = -module -avoid-version $(fbtl_plfs_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/fbtl/posix/Makefile.am
+++ b/ompi/mca/fbtl/posix/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2011 University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fbtl_posix_la_SOURCES = $(sources)
 mca_fbtl_posix_la_LDFLAGS = -module -avoid-version
+mca_fbtl_posix_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fbtl_posix_la_SOURCES = $(sources)

--- a/ompi/mca/fbtl/pvfs2/Makefile.am
+++ b/ompi/mca/fbtl/pvfs2/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2011 University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -45,7 +46,8 @@ AM_CPPFLAGS = $(fbtl_pvfs2_CPPFLAGS)
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fbtl_pvfs2_la_SOURCES = $(fbtl_pvfs2_sources)
-mca_fbtl_pvfs2_la_LIBADD = $(fbtl_pvfs2_LIBS)
+mca_fbtl_pvfs2_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(fbtl_pvfs2_LIBS)
 mca_fbtl_pvfs2_la_LDFLAGS = -module -avoid-version $(fbtl_pvfs2_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/fcoll/dynamic/Makefile.am
+++ b/ompi/mca/fcoll/dynamic/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
 # Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_dynamic_la_SOURCES = $(sources)
 mca_fcoll_dynamic_la_LDFLAGS = -module -avoid-version
+mca_fcoll_dynamic_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_dynamic_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/dynamic_gen2/Makefile.am
+++ b/ompi/mca/fcoll/dynamic_gen2/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
 # Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_dynamic_gen2_la_SOURCES = $(sources)
 mca_fcoll_dynamic_gen2_la_LDFLAGS = -module -avoid-version
+mca_fcoll_dynamic_gen2_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_dynamic_gen2_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/individual/Makefile.am
+++ b/ompi/mca/fcoll/individual/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
 # Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_individual_la_SOURCES = $(sources)
 mca_fcoll_individual_la_LDFLAGS = -module -avoid-version
+mca_fcoll_individual_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_individual_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/static/Makefile.am
+++ b/ompi/mca/fcoll/static/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
 # Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_static_la_SOURCES = $(sources)
 mca_fcoll_static_la_LDFLAGS = -module -avoid-version
+mca_fcoll_static_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_static_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/two_phase/Makefile.am
+++ b/ompi/mca/fcoll/two_phase/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
 # Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,6 +43,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_two_phase_la_SOURCES = $(sources)
 mca_fcoll_two_phase_la_LDFLAGS = -module -avoid-version
+mca_fcoll_two_phase_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_two_phase_la_SOURCES =$(sources)

--- a/ompi/mca/fs/lustre/Makefile.am
+++ b/ompi/mca/fs/lustre/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2011 University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -47,7 +48,8 @@ AM_CPPFLAGS = $(fs_lustre_CPPFLAGS)
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fs_lustre_la_SOURCES = $(fs_lustre_sources)
-mca_fs_lustre_la_LIBADD = $(fs_lustre_LIBS)
+mca_fs_lustre_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(fs_lustre_LIBS)
 mca_fs_lustre_la_LDFLAGS = -module -avoid-version $(fs_lustre_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/fs/plfs/Makefile.am
+++ b/ompi/mca/fs/plfs/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2014 University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -47,7 +48,8 @@ AM_CPPFLAGS = $(fs_plfs_CPPFLAGS)
 mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fs_plfs_la_SOURCES = $(fs_plfs_sources)
-mca_fs_plfs_la_LIBADD = $(fs_plfs_LIBS)
+mca_fs_plfs_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(fs_plfs_LIBS)
 mca_fs_plfs_la_LDFLAGS = -module -avoid-version $(fs_plfs_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/fs/pvfs2/Makefile.am
+++ b/ompi/mca/fs/pvfs2/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2011 University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -47,7 +48,8 @@ AM_CPPFLAGS = $(fs_pvfs2_CPPFLAGS)
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fs_pvfs2_la_SOURCES = $(fs_pvfs2_sources)
-mca_fs_pvfs2_la_LIBADD = $(fs_pvfs2_LIBS)
+mca_fs_pvfs2_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(fs_pvfs2_LIBS)
 mca_fs_pvfs2_la_LDFLAGS = -module -avoid-version $(fs_pvfs2_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/fs/ufs/Makefile.am
+++ b/ompi/mca/fs/ufs/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2011 University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fs_ufs_la_SOURCES = $(sources)
 mca_fs_ufs_la_LDFLAGS = -module -avoid-version
+mca_fs_ufs_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fs_ufs_la_SOURCES = $(sources)

--- a/ompi/mca/io/ompio/Makefile.am
+++ b/ompi/mca/io/ompio/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2012 University of Houston. All rights reserved.
-# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +34,8 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_io_ompio_la_SOURCES = $(headers) $(sources)
 mca_io_ompio_la_LDFLAGS = -module -avoid-version
-mca_io_ompio_la_LIBADD = $(io_ompio_LIBS) \
+mca_io_ompio_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(io_ompio_LIBS) \
     $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/io/romio314/Makefile.am
+++ b/ompi/mca/io/romio314/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -49,7 +50,8 @@ libs = romio/libromio_dist.la
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_io_romio314_la_SOURCES = $(component_sources)
-mca_io_romio314_la_LIBADD = $(libs)
+mca_io_romio314_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(libs)
 mca_io_romio314_la_DEPENDENCIES = $(libs)
 mca_io_romio314_la_LDFLAGS = -module -avoid-version
 

--- a/ompi/mca/mtl/mxm/Makefile.am
+++ b/ompi/mca/mtl/mxm/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,7 +41,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_mtl_mxm_la_SOURCES = $(mtl_mxm_sources)
-mca_mtl_mxm_la_LIBADD = $(mtl_mxm_LIBS)
+mca_mtl_mxm_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(mtl_mxm_LIBS)
 mca_mtl_mxm_la_LDFLAGS = -module -avoid-version $(mtl_mxm_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/mtl/ofi/Makefile.am
+++ b/ompi/mca/mtl/ofi/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2013-2015 Intel, Inc. All rights reserved
 #
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,7 +44,8 @@ mca_mtl_ofi_la_SOURCES = $(mtl_ofi_sources)
 mca_mtl_ofi_la_LDFLAGS = \
         $(ompi_mtl_ofi_LDFLAGS) \
         -module -avoid-version
-mca_mtl_ofi_la_LIBADD = $(ompi_mtl_ofi_LIBS) \
+mca_mtl_ofi_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(ompi_mtl_ofi_LIBS) \
         $(OPAL_TOP_BUILDDIR)/opal/mca/common/libfabric/lib@OPAL_LIB_PREFIX@mca_common_libfabric.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/mtl/portals4/Makefile.am
+++ b/ompi/mca/mtl/portals4/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2012 Sandia National Laboratories.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -59,7 +60,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_mtl_portals4_la_SOURCES = $(local_sources)
-mca_mtl_portals4_la_LIBADD = $(mtl_portals4_LIBS)
+mca_mtl_portals4_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(mtl_portals4_LIBS)
 mca_mtl_portals4_la_LDFLAGS = -module -avoid-version $(mtl_portals4_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/mtl/psm/Makefile.am
+++ b/ompi/mca/mtl/psm/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2006 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -51,7 +52,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_mtl_psm_la_SOURCES = $(mtl_psm_sources)
-mca_mtl_psm_la_LIBADD = $(mtl_psm_LIBS)
+mca_mtl_psm_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(mtl_psm_LIBS)
 mca_mtl_psm_la_LDFLAGS = -module -avoid-version $(mtl_psm_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/mtl/psm2/Makefile.am
+++ b/ompi/mca/mtl/psm2/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -52,7 +53,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_mtl_psm2_la_SOURCES = $(mtl_psm2_sources)
-mca_mtl_psm2_la_LIBADD = $(mtl_psm2_LIBS)
+mca_mtl_psm2_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(mtl_psm2_LIBS)
 mca_mtl_psm2_la_LDFLAGS = -module -avoid-version $(mtl_psm2_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/op/example/Makefile.am
+++ b/ompi/mca/op/example/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -70,6 +71,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_op_example_la_SOURCES = $(component_sources)
 mca_op_example_la_LDFLAGS = -module -avoid-version
+mca_op_example_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 # Specific information for static builds.
 #

--- a/ompi/mca/osc/portals4/Makefile.am
+++ b/ompi/mca/osc/portals4/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2011      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,7 +36,8 @@ endif
 mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_osc_portals4_la_SOURCES = $(portals4_sources)
-mca_osc_portals4_la_LIBADD =  $(osc_portals4_LIBS)
+mca_osc_portals4_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(osc_portals4_LIBS)
 mca_osc_portals4_la_LDFLAGS = -module -avoid-version $(osc_portals4_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/osc/pt2pt/Makefile.am
+++ b/ompi/mca/osc/pt2pt/Makefile.am
@@ -11,6 +11,7 @@
 # Copyright (c) 2014      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -52,6 +53,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_osc_pt2pt_la_SOURCES = $(pt2pt_sources)
 mca_osc_pt2pt_la_LDFLAGS = -module -avoid-version
+mca_osc_pt2pt_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_osc_pt2pt_la_SOURCES = $(pt2pt_sources)

--- a/ompi/mca/osc/rdma/Makefile.am
+++ b/ompi/mca/osc/rdma/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -58,6 +59,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_osc_rdma_la_SOURCES = $(rdma_sources)
 mca_osc_rdma_la_LDFLAGS = -module -avoid-version
+mca_osc_rdma_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_osc_rdma_la_SOURCES = $(rdma_sources)

--- a/ompi/mca/osc/sm/Makefile.am
+++ b/ompi/mca/osc/sm/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2011      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,7 +34,8 @@ endif
 mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_osc_sm_la_SOURCES = $(sm_sources)
-mca_osc_sm_la_LIBADD =  $(osc_sm_LIBS)
+mca_osc_sm_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(osc_sm_LIBS)
 mca_osc_sm_la_LDFLAGS = -module -avoid-version $(osc_sm_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/pml/bfo/Makefile.am
+++ b/ompi/mca/pml/bfo/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 #
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -70,6 +71,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_bfo_la_SOURCES = $(bfo_sources)
 mca_pml_bfo_la_LDFLAGS = -module -avoid-version
+mca_pml_bfo_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pml_bfo_la_SOURCES = $(bfo_sources)

--- a/ompi/mca/pml/cm/Makefile.am
+++ b/ompi/mca/pml/cm/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (c) 2009      High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,7 +43,8 @@ local_sources = \
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_cm_la_SOURCES = $(local_sources)
-mca_pml_cm_la_LIBADD = $(pml_cm_LIBS)
+mca_pml_cm_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(pml_cm_LIBS)
 mca_pml_cm_la_LDFLAGS = -module -avoid-version $(pml_cm_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/pml/crcpw/Makefile.am
+++ b/ompi/mca/pml/crcpw/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,6 +37,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_crcpw_la_SOURCES = $(crcpw_sources)
 mca_pml_crcpw_la_LDFLAGS = -module -avoid-version
+mca_pml_crcpw_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pml_crcpw_la_SOURCES = $(crcpw_sources)

--- a/ompi/mca/pml/example/Makefile.am
+++ b/ompi/mca/pml/example/Makefile.am
@@ -8,6 +8,7 @@
 # Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -52,6 +53,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_example_la_SOURCES = $(local_sources)
 mca_pml_example_la_LDFLAGS = -module -avoid-version
+mca_pml_example_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pml_example_la_SOURCES = $(local_sources)

--- a/ompi/mca/pml/monitoring/Makefile.am
+++ b/ompi/mca/pml/monitoring/Makefile.am
@@ -3,6 +3,7 @@
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2013-2015 Inria.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,6 +33,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_monitoring_la_SOURCES = $(monitoring_sources)
 mca_pml_monitoring_la_LDFLAGS = -module -avoid-version
+mca_pml_monitoring_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pml_monitoring_la_SOURCES = $(monitoring_sources)

--- a/ompi/mca/pml/ob1/Makefile.am
+++ b/ompi/mca/pml/ob1/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -68,7 +69,7 @@ mca_pml_ob1_la_SOURCES = $(ob1_sources)
 mca_pml_ob1_la_LDFLAGS = -module -avoid-version
 
 if OPAL_cuda_support
-mca_pml_ob1_la_LIBADD = \
+mca_pml_ob1_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
     $(OMPI_TOP_BUILDDIR)/opal/mca/common/cuda/lib@OPAL_LIB_PREFIX@mca_common_cuda.la
 endif
 

--- a/ompi/mca/pml/ucx/Makefile.am
+++ b/ompi/mca/pml/ucx/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2001-2017 Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,7 +37,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_ucx_la_SOURCES = $(local_sources)
-mca_pml_ucx_la_LIBADD = $(pml_ucx_LIBS)
+mca_pml_ucx_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(pml_ucx_LIBS)
 mca_pml_ucx_la_LDFLAGS = -module -avoid-version $(pml_ucx_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/pml/v/Makefile.am
+++ b/ompi/mca/pml/v/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,6 +32,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_v_la_SOURCES = $(local_sources)
 mca_pml_v_la_LDFLAGS = -module -avoid-version
+mca_pml_v_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pml_v_la_SOURCES = $(local_sources)

--- a/ompi/mca/pml/yalla/Makefile.am
+++ b/ompi/mca/pml/yalla/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2001-2014 Mellanox Technologies Ltd. ALL RIGHTS RESERVED.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,7 +38,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pml_yalla_la_SOURCES = $(local_sources)
-mca_pml_yalla_la_LIBADD = $(pml_yalla_LIBS)
+mca_pml_yalla_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+	$(pml_yalla_LIBS)
 mca_pml_yalla_la_LDFLAGS = -module -avoid-version $(pml_yalla_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/ompi/mca/sharedfp/individual/Makefile.am
+++ b/ompi/mca/sharedfp/individual/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008      University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sharedfp_individual_la_SOURCES = $(sources)
 mca_sharedfp_individual_la_LDFLAGS = -module -avoid-version
+mca_sharedfp_individual_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sharedfp_individual_la_SOURCES = $(sources)

--- a/ompi/mca/sharedfp/lockedfile/Makefile.am
+++ b/ompi/mca/sharedfp/lockedfile/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008      University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sharedfp_lockedfile_la_SOURCES = $(sources)
 mca_sharedfp_lockedfile_la_LDFLAGS = -module -avoid-version
+mca_sharedfp_lockedfile_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sharedfp_lockedfile_la_SOURCES = $(sources)

--- a/ompi/mca/sharedfp/sm/Makefile.am
+++ b/ompi/mca/sharedfp/sm/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008      University of Houston. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sharedfp_sm_la_SOURCES = $(sources)
 mca_sharedfp_sm_la_LDFLAGS = -module -avoid-version
+mca_sharedfp_sm_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sharedfp_sm_la_SOURCES = $(sources)

--- a/ompi/mca/topo/basic/Makefile.am
+++ b/ompi/mca/topo/basic/Makefile.am
@@ -5,6 +5,7 @@
 # Copyright (c) 2011-2013 INRIA.  All rights reserved.
 # Copyright (c) 2011-2013 Université Bordeaux 1
 # Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,6 +37,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_topo_basic_la_SOURCES = $(component_sources)
 mca_topo_basic_la_LDFLAGS = -module -avoid-version
+mca_topo_basic_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_topo_basic_la_SOURCES = $(lib_sources)

--- a/ompi/mca/topo/example/Makefile.am
+++ b/ompi/mca/topo/example/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -45,6 +46,7 @@ mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_topo_example_la_SOURCES = $(component_sources)
 mca_topo_example_la_LDFLAGS = -module -avoid-version
+mca_topo_example_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_topo_example_la_SOURCES = $(lib_sources)

--- a/ompi/mca/topo/treematch/Makefile.am
+++ b/ompi/mca/topo/treematch/Makefile.am
@@ -4,6 +4,7 @@
 #                         reserved.
 # Copyright (c) 2011-2015 INRIA.  All rights reserved.
 # Copyright (c) 2011-2015 Université Bordeaux 1
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -55,6 +56,7 @@ mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_topo_treematch_la_SOURCES = $(component_sources)
 mca_topo_treematch_la_LDFLAGS = -module -avoid-version
+mca_topo_treematch_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_topo_treematch_la_SOURCES = $(lib_sources)

--- a/ompi/mca/vprotocol/example/Makefile.am
+++ b/ompi/mca/vprotocol/example/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,7 +37,7 @@ local_sources = \
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_vprotocol_example_la_SOURCES = $(local_sources)
-mca_vprotocol_example_la_LIBADD =
+mca_vprotocol_example_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 mca_vprotocol_example_la_CFLAGS =
 mca_vprotocol_example_la_LDFLAGS = -module -avoid-version
 

--- a/ompi/mca/vprotocol/pessimist/Makefile.am
+++ b/ompi/mca/vprotocol/pessimist/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2004-2007 The Trustees of the University of Tennessee.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -49,6 +50,7 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_vprotocol_pessimist_la_SOURCES = $(local_sources)
 mca_vprotocol_pessimist_la_LDFLAGS = -module -avoid-version
+mca_vprotocol_pessimist_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_vprotocol_pessimist_la_SOURCES = $(local_sources)

--- a/opal/mca/allocator/basic/Makefile.am
+++ b/opal/mca/allocator/basic/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +38,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_allocator_basic_la_SOURCES = $(sources)
 mca_allocator_basic_la_LDFLAGS = -module -avoid-version
+mca_allocator_basic_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_allocator_basic_la_SOURCES = $(sources)

--- a/opal/mca/allocator/bucket/Makefile.am
+++ b/opal/mca/allocator/bucket/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_allocator_bucket_la_SOURCES = $(sources)
 mca_allocator_bucket_la_LDFLAGS = -module -avoid-version
+mca_allocator_bucket_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_allocator_bucket_la_SOURCES = $(sources)

--- a/opal/mca/btl/openib/Makefile.am
+++ b/opal/mca/btl/openib/Makefile.am
@@ -17,6 +17,7 @@
 # Copyright (c) 2013      Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -113,7 +114,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_btl_openib_la_SOURCES = $(component_sources)
 mca_btl_openib_la_LDFLAGS = -module -avoid-version $(btl_openib_LDFLAGS)
-mca_btl_openib_la_LIBADD = $(btl_openib_LIBS) \
+mca_btl_openib_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(btl_openib_LIBS) \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/verbs/lib@OPAL_LIB_PREFIX@mca_common_verbs.la
 if OPAL_cuda_support
 mca_btl_openib_la_LIBADD += \

--- a/opal/mca/btl/portals4/Makefile.am
+++ b/opal/mca/btl/portals4/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2012 Sandia National Laboratories.  All rights reserved.
 # Copyright (c) 2014      Bull SAS.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -47,7 +48,7 @@ local_sources = \
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_portals4_la_SOURCES = $(local_sources)
-mca_btl_portals4_la_LIBADD = \
+mca_btl_portals4_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
     $(btl_portals4_LIBS)
 mca_btl_portals4_la_LDFLAGS = -module -avoid-version $(btl_portals4_LDFLAGS)
 

--- a/opal/mca/btl/scif/Makefile.am
+++ b/opal/mca/btl/scif/Makefile.am
@@ -39,7 +39,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_scif_la_SOURCES = $(scif_SOURCES)
 nodist_mca_btl_scif_la_SOURCES = $(scif_nodist_SOURCES)
-mca_btl_scif_la_LIBADD = $(btl_scif_LIBS)
+mca_btl_scif_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(btl_scif_LIBS)
 mca_btl_scif_la_LDFLAGS = -module -avoid-version $(btl_scif_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/opal/mca/btl/self/Makefile.am
+++ b/opal/mca/btl/self/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,6 +41,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_self_la_SOURCES = $(libmca_btl_self_la_sources)
 mca_btl_self_la_LDFLAGS = -module -avoid-version
+mca_btl_self_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_btl_self_la_SOURCES = $(libmca_btl_self_la_sources)

--- a/opal/mca/btl/sm/Makefile.am
+++ b/opal/mca/btl/sm/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_sm_la_SOURCES = $(libmca_btl_sm_la_sources)
 mca_btl_sm_la_LDFLAGS = -module -avoid-version
+mca_btl_sm_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 mca_btl_sm_la_CPPFLAGS = $(btl_sm_CPPFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/opal/mca/btl/smcuda/Makefile.am
+++ b/opal/mca/btl/smcuda/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -48,7 +49,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_smcuda_la_SOURCES = $(libmca_btl_smcuda_la_sources)
 mca_btl_smcuda_la_LDFLAGS = -module -avoid-version
-mca_btl_smcuda_la_LIBADD = \
+mca_btl_smcuda_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/sm/lib@OPAL_LIB_PREFIX@mca_common_sm.la
 mca_btl_smcuda_la_CPPFLAGS = $(btl_smcuda_CPPFLAGS)
 if OPAL_cuda_support

--- a/opal/mca/btl/tcp/Makefile.am
+++ b/opal/mca/btl/tcp/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -56,7 +57,7 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_btl_tcp_la_SOURCES = $(component_sources)
 mca_btl_tcp_la_LDFLAGS = -module -avoid-version
 if OPAL_cuda_support
-mca_btl_tcp_la_LIBADD = \
+mca_btl_tcp_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/cuda/lib@OPAL_LIB_PREFIX@mca_common_cuda.la
 endif
 

--- a/opal/mca/btl/template/Makefile.am
+++ b/opal/mca/btl/template/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -51,6 +52,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_btl_template_la_SOURCES = $(component_sources)
 mca_btl_template_la_LDFLAGS = -module -avoid-version
+mca_btl_template_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_btl_template_la_SOURCES = $(lib_sources)

--- a/opal/mca/btl/ugni/Makefile.am
+++ b/opal/mca/btl/ugni/Makefile.am
@@ -48,7 +48,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_ugni_la_SOURCES = $(ugni_SOURCES)
 nodist_mca_btl_ugni_la_SOURCES = $(ugni_nodist_SOURCES)
-mca_btl_ugni_la_LIBADD = $(btl_ugni_LIBS)
+mca_btl_ugni_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(btl_ugni_LIBS)
 mca_btl_ugni_la_LDFLAGS = -module -avoid-version $(btl_ugni_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/opal/mca/btl/usnic/Makefile.am
+++ b/opal/mca/btl/usnic/Makefile.am
@@ -13,7 +13,7 @@
 #                         reserved.
 # Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
-# Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -90,7 +90,7 @@ mca_btl_usnic_la_SOURCES = $(component_sources)
 mca_btl_usnic_la_LDFLAGS = \
         $(opal_btl_usnic_LDFLAGS) \
         -module -avoid-version
-mca_btl_usnic_la_LIBADD = \
+mca_btl_usnic_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(OPAL_TOP_BUILDDIR)/opal/mca/common/libfabric/lib@OPAL_LIB_PREFIX@mca_common_libfabric.la
 
 noinst_LTLIBRARIES = $(lib)

--- a/opal/mca/btl/vader/Makefile.am
+++ b/opal/mca/btl/vader/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -57,7 +58,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_btl_vader_la_SOURCES = $(libmca_btl_vader_la_sources)
 mca_btl_vader_la_LDFLAGS = -module -avoid-version $(btl_vader_LDFLAGS)
-mca_btl_vader_la_LIBADD = $(btl_vader_LIBS)
+mca_btl_vader_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(btl_vader_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_btl_vader_la_SOURCES = $(libmca_btl_vader_la_sources)

--- a/opal/mca/compress/bzip/Makefile.am
+++ b/opal/mca/compress/bzip/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2004-2010 The Trustees of Indiana University.
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +31,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_compress_bzip_la_SOURCES = $(sources)
 mca_compress_bzip_la_LDFLAGS = -module -avoid-version
+mca_compress_bzip_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_compress_bzip_la_SOURCES = $(sources)

--- a/opal/mca/compress/gzip/Makefile.am
+++ b/opal/mca/compress/gzip/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2004-2010 The Trustees of Indiana University.
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +31,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_compress_gzip_la_SOURCES = $(sources)
 mca_compress_gzip_la_LDFLAGS = -module -avoid-version
+mca_compress_gzip_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_compress_gzip_la_SOURCES = $(sources)

--- a/opal/mca/crs/blcr/Makefile.am
+++ b/opal/mca/crs/blcr/Makefile.am
@@ -8,6 +8,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,7 +42,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_crs_blcr_la_SOURCES  = $(sources)
 mca_crs_blcr_la_LDFLAGS  = -module -avoid-version $(crs_blcr_LDFLAGS)
-mca_crs_blcr_la_LIBADD = $(crs_blcr_LIBS)
+mca_crs_blcr_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(crs_blcr_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_crs_blcr_la_SOURCES = $(sources)

--- a/opal/mca/crs/criu/Makefile.am
+++ b/opal/mca/crs/criu/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Hochschule Esslingen.  All rights reserved.
 #
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,7 +42,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_crs_criu_la_SOURCES  = $(sources)
 mca_crs_criu_la_LDFLAGS  = -module -avoid-version $(crs_criu_LDFLAGS)
-mca_crs_criu_la_LIBADD = $(crs_criu_LIBS)
+mca_crs_criu_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(crs_criu_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_crs_criu_la_SOURCES = $(sources)

--- a/opal/mca/crs/dmtcp/Makefile.am
+++ b/opal/mca/crs/dmtcp/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c)      2010 The Trustees of Indiana University.
 #                         All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,7 +34,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_crs_dmtcp_la_SOURCES  = $(sources)
 mca_crs_dmtcp_la_LDFLAGS  = -module -avoid-version $(crs_dmtcp_LDFLAGS)
-mca_crs_dmtcp_la_LIBADD = $(crs_dmtcp_LIBS)
+mca_crs_dmtcp_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(crs_dmtcp_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_crs_dmtcp_la_SOURCES = $(sources)

--- a/opal/mca/crs/none/Makefile.am
+++ b/opal/mca/crs/none/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (c) 2009      High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,6 +35,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_crs_none_la_SOURCES = $(sources)
 mca_crs_none_la_LDFLAGS = -module -avoid-version
+mca_crs_none_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_crs_none_la_SOURCES = $(sources)

--- a/opal/mca/crs/self/Makefile.am
+++ b/opal/mca/crs/self/Makefile.am
@@ -8,6 +8,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_crs_self_la_SOURCES = $(sources)
 mca_crs_self_la_LDFLAGS = -module -avoid-version
+mca_crs_self_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_crs_self_la_SOURCES = $(sources)

--- a/opal/mca/memchecker/valgrind/Makefile.am
+++ b/opal/mca/memchecker/valgrind/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,7 +32,7 @@ mcacomponentdir = $(libdir)/openmpi
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_memchecker_valgrind_la_SOURCES = $(sources)
 mca_memchecker_valgrind_la_LDFLAGS = -module -avoid-version
-mca_memchecker_valgrind_la_LIBADD = \
+mca_memchecker_valgrind_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(OPAL_TOP_BUILDDIR)/opal/libopal.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/opal/mca/mpool/hugepage/Makefile.am
+++ b/opal/mca/mpool/hugepage/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,7 +45,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_mpool_hugepage_la_SOURCES = $(sources)
 mca_mpool_hugepage_la_LDFLAGS = -module -avoid-version
-mca_mpool_hugepage_la_LIBADD = $(mpool_hugepage_LIBS)
+mca_mpool_hugepage_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(mpool_hugepage_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_mpool_hugepage_la_SOURCES = $(sources)

--- a/opal/mca/mpool/memkind/Makefile.am
+++ b/opal/mca/mpool/memkind/Makefile.am
@@ -31,7 +31,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_mpool_memkind_la_SOURCES = $(memkind_SOURCES)
 nodist_mca_mpool_memkind_la_SOURCES = $(memkind_nodist_SOURCES)
-mca_mpool_memkind_la_LIBADD = $(mpool_memkind_LIBS)
+mca_mpool_memkind_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(mpool_memkind_LIBS)
 mca_mpool_memkind_la_LDFLAGS = -module -avoid-version $(mpool_memkind_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/opal/mca/patcher/linux/Makefile.am
+++ b/opal/mca/patcher/linux/Makefile.am
@@ -14,6 +14,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +40,7 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_patcher_linux_la_SOURCES = $(linux_SOURCES)
 nodist_mca_patcher_linux_la_SOURCES = $(linux_nodist_SOURCES)
 mca_patcher_linux_la_LDFLAGS = -module -avoid-version
+mca_patcher_linux_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_patcher_linux_la_SOURCES = $(linux_SOURCES)

--- a/opal/mca/patcher/overwrite/Makefile.am
+++ b/opal/mca/patcher/overwrite/Makefile.am
@@ -14,6 +14,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +40,7 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_patcher_overwrite_la_SOURCES = $(overwrite_SOURCES)
 nodist_mca_patcher_overwrite_la_SOURCES = $(overwrite_nodist_SOURCES)
 mca_patcher_overwrite_la_LDFLAGS = -module -avoid-version
+mca_patcher_overwrite_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_patcher_overwrite_la_SOURCES = $(overwrite_SOURCES)

--- a/opal/mca/pmix/cray/Makefile.am
+++ b/opal/mca/pmix/cray/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,7 +36,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_cray_la_SOURCES = $(sources)
 mca_pmix_cray_la_CPPFLAGS = $(pmix_cray_CPPFLAGS) $(pmix_alps_CPPFLAGS)
 mca_pmix_cray_la_LDFLAGS = -module -avoid-version $(pmix_cray_LDFLAGS) $(pmix_alps_LDFLAGS)
-mca_pmix_cray_la_LIBADD = $(pmix_cray_LIBS) $(pmix_alps_LIBS)
+mca_pmix_cray_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(pmix_cray_LIBS) $(pmix_alps_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_cray_la_SOURCES =$(sources)

--- a/opal/mca/pmix/ext1x/Makefile.am
+++ b/opal/mca/pmix/ext1x/Makefile.am
@@ -5,6 +5,7 @@
 #                         All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,7 +39,8 @@ mca_pmix_ext1x_la_SOURCES = $(sources)
 mca_pmix_ext1x_la_CFLAGS =
 mca_pmix_ext1x_la_CPPFLAGS = $(opal_pmix_ext1x_CPPFLAGS)
 mca_pmix_ext1x_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext1x_LDFLAGS)
-mca_pmix_ext1x_la_LIBADD = $(opal_pmix_ext1x_LIBS)
+mca_pmix_ext1x_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(opal_pmix_ext1x_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_ext1x_la_SOURCES =$(sources)

--- a/opal/mca/pmix/ext2x/Makefile.am
+++ b/opal/mca/pmix/ext2x/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,7 +37,8 @@ mca_pmix_ext2x_la_SOURCES = $(sources)
 mca_pmix_ext2x_la_CFLAGS = $(opal_pmix_ext2x_CFLAGS)
 mca_pmix_ext2x_la_CPPFLAGS =$(opal_pmix_ext2x_CPPFLAGS)
 mca_pmix_ext2x_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext2x_LDFLAGS)
-mca_pmix_ext2x_la_LIBADD = $(opal_pmix_ext2x_LIBS)
+mca_pmix_ext2x_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(opal_pmix_ext2x_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_ext2x_la_SOURCES =$(sources)

--- a/opal/mca/pmix/flux/Makefile.am
+++ b/opal/mca/pmix/flux/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,7 +30,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_flux_la_SOURCES = $(sources)
 mca_pmix_flux_la_CPPFLAGS = $(FLUX_PMI_CFLAGS)
 mca_pmix_flux_la_LDFLAGS = -module -avoid-version
-mca_pmix_flux_la_LIBADD = $(FLUX_PMI_LIBS)
+mca_pmix_flux_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(FLUX_PMI_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_flux_la_SOURCES =$(sources)

--- a/opal/mca/pmix/isolated/Makefile.am
+++ b/opal/mca/pmix/isolated/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_isolated_la_SOURCES = $(sources)
 mca_pmix_isolated_la_LDFLAGS = -module -avoid-version
+mca_pmix_isolated_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_isolated_la_SOURCES =$(sources)

--- a/opal/mca/pmix/pmix2x/Makefile.am
+++ b/opal/mca/pmix/pmix2x/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,7 +44,8 @@ mca_pmix_pmix2x_la_CFLAGS = $(opal_pmix_pmix2x_CFLAGS)
 mca_pmix_pmix2x_la_CPPFLAGS = \
         -I$(srcdir)/pmix/include $(opal_pmix_pmix2x_CPPFLAGS)
 mca_pmix_pmix2x_la_LDFLAGS = -module -avoid-version $(opal_pmix_pmix2x_LDFLAGS)
-mca_pmix_pmix2x_la_LIBADD = $(opal_pmix_pmix2x_LIBS)
+mca_pmix_pmix2x_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(opal_pmix_pmix2x_LIBS)
 mca_pmix_pmix2x_la_DEPENDENCIES = $(opal_pmix_pmix2x_DEPENDENCIES)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/opal/mca/pmix/s1/Makefile.am
+++ b/opal/mca/pmix/s1/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,7 +30,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_s1_la_SOURCES = $(sources)
 mca_pmix_s1_la_CPPFLAGS = $(opal_pmi1_CPPFLAGS)
 mca_pmix_s1_la_LDFLAGS = -module -avoid-version $(opal_pmi1_LDFLAGS)
-mca_pmix_s1_la_LIBADD = $(opal_pmi1_LIBS)
+mca_pmix_s1_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(opal_pmi1_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_s1_la_SOURCES =$(sources)

--- a/opal/mca/pmix/s2/Makefile.am
+++ b/opal/mca/pmix/s2/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,7 +32,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_s2_la_SOURCES = $(sources)
 mca_pmix_s2_la_CPPFLAGS = $(opal_pmi2_CPPFLAGS)
 mca_pmix_s2_la_LDFLAGS = -module -avoid-version $(opal_pmi2_LDFLAGS)
-mca_pmix_s2_la_LIBADD = $(opal_pmi2_LIBS)
+mca_pmix_s2_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(opal_pmi2_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_s2_la_SOURCES =$(sources)

--- a/opal/mca/pstat/linux/Makefile.am
+++ b/opal/mca/pstat/linux/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pstat_linux_la_SOURCES = $(sources)
 mca_pstat_linux_la_LDFLAGS = -module -avoid-version
+mca_pstat_linux_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pstat_linux_la_SOURCES =$(sources)

--- a/opal/mca/pstat/test/Makefile.am
+++ b/opal/mca/pstat/test/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pstat_test_la_SOURCES = $(sources)
 mca_pstat_test_la_LDFLAGS = -module -avoid-version
+mca_pstat_test_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pstat_test_la_SOURCES =$(sources)

--- a/opal/mca/rcache/gpusm/Makefile.am
+++ b/opal/mca/rcache/gpusm/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -47,7 +48,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rcache_gpusm_la_SOURCES = $(sources)
 mca_rcache_gpusm_la_LDFLAGS = -module -avoid-version
-mca_rcache_gpusm_la_LIBADD = $(rcache_gpusm_LIBS)
+mca_rcache_gpusm_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(rcache_gpusm_LIBS)
 if OPAL_cuda_support
 mca_rcache_gpusm_la_LIBADD += \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/cuda/lib@OPAL_LIB_PREFIX@mca_common_cuda.la

--- a/opal/mca/rcache/grdma/Makefile.am
+++ b/opal/mca/rcache/grdma/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,7 +47,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rcache_grdma_la_SOURCES = $(sources)
 mca_rcache_grdma_la_LDFLAGS = -module -avoid-version
-mca_rcache_grdma_la_LIBADD = $(rcache_grdma_LIBS)
+mca_rcache_grdma_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(rcache_grdma_LIBS)
 if OPAL_cuda_support
 mca_rcache_grdma_la_LIBADD += \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/cuda/lib@OPAL_LIB_PREFIX@mca_common_cuda.la

--- a/opal/mca/rcache/rgpusm/Makefile.am
+++ b/opal/mca/rcache/rgpusm/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -45,7 +46,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rcache_rgpusm_la_SOURCES = $(sources)
 mca_rcache_rgpusm_la_LDFLAGS = -module -avoid-version
-mca_rcache_rgpusm_la_LIBADD = $(rcache_rgpusm_LIBS)
+mca_rcache_rgpusm_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(rcache_rgpusm_LIBS)
 if OPAL_cuda_support
 mca_rcache_rgpusm_la_LIBADD += \
     $(OPAL_TOP_BUILDDIR)/opal/mca/common/cuda/lib@OPAL_LIB_PREFIX@mca_common_cuda.la

--- a/opal/mca/rcache/udreg/Makefile.am
+++ b/opal/mca/rcache/udreg/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,7 +45,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rcache_udreg_la_SOURCES = $(sources)
 mca_rcache_udreg_la_LDFLAGS = -module -avoid-version $(rcache_udreg_LDFLAGS)
-mca_rcache_udreg_la_LIBADD = $(rcache_udreg_LIBS)
+mca_rcache_udreg_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(rcache_udreg_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rcache_udreg_la_SOURCES = $(sources)

--- a/opal/mca/reachable/netlink/Makefile.am
+++ b/opal/mca/reachable/netlink/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,7 +39,8 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_reachable_netlink_la_SOURCES = $(sources)
 mca_reachable_netlink_la_LDFLAGS = -module -avoid-version
-mca_reachable_netlink_la_LIBADD = $(opal_reachable_netlink_LIBS)
+mca_reachable_netlink_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(opal_reachable_netlink_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_reachable_netlink_la_SOURCES =$(sources)

--- a/opal/mca/reachable/weighted/Makefile.am
+++ b/opal/mca/reachable/weighted/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_reachable_weighted_la_SOURCES = $(sources)
 mca_reachable_weighted_la_LDFLAGS = -module -avoid-version
+mca_reachable_weighted_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_reachable_weighted_la_SOURCES =$(sources)

--- a/opal/mca/shmem/mmap/Makefile.am
+++ b/opal/mca/shmem/mmap/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2011 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,6 +44,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_shmem_mmap_la_SOURCES = $(sources)
 mca_shmem_mmap_la_LDFLAGS = -module -avoid-version
+mca_shmem_mmap_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_shmem_mmap_la_SOURCES =$(sources)

--- a/opal/mca/shmem/posix/Makefile.am
+++ b/opal/mca/shmem/posix/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2011 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_shmem_posix_la_SOURCES = $(sources)
 mca_shmem_posix_la_LDFLAGS = -module -avoid-version
+mca_shmem_posix_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_shmem_posix_la_SOURCES = $(sources)

--- a/opal/mca/shmem/sysv/Makefile.am
+++ b/opal/mca/shmem/sysv/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2010-2011 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +40,7 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_shmem_sysv_la_SOURCES = $(sources)
 mca_shmem_sysv_la_LDFLAGS = -module -avoid-version
+mca_shmem_sysv_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_shmem_sysv_la_SOURCES = $(sources)

--- a/orte/mca/dfs/app/Makefile.am
+++ b/orte/mca/dfs/app/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2012      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_dfs_app_la_SOURCES = $(sources)
 mca_dfs_app_la_LDFLAGS = -module -avoid-version
+mca_dfs_app_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_dfs_app_la_SOURCES =$(sources)

--- a/orte/mca/dfs/orted/Makefile.am
+++ b/orte/mca/dfs/orted/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2012      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_dfs_orted_la_SOURCES = $(sources)
 mca_dfs_orted_la_LDFLAGS = -module -avoid-version
+mca_dfs_orted_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_dfs_orted_la_SOURCES =$(sources)

--- a/orte/mca/dfs/test/Makefile.am
+++ b/orte/mca/dfs/test/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2012      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_dfs_test_la_SOURCES = $(sources)
 mca_dfs_test_la_LDFLAGS = -module -avoid-version
+mca_dfs_test_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_dfs_test_la_SOURCES =$(sources)

--- a/orte/mca/errmgr/default_app/Makefile.am
+++ b/orte/mca/errmgr/default_app/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_errmgr_default_app_la_SOURCES = $(sources)
 mca_errmgr_default_app_la_LDFLAGS = -module -avoid-version
+mca_errmgr_default_app_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_errmgr_default_app_la_SOURCES =$(sources)

--- a/orte/mca/errmgr/default_hnp/Makefile.am
+++ b/orte/mca/errmgr/default_hnp/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_errmgr_default_hnp_la_SOURCES = $(sources)
 mca_errmgr_default_hnp_la_LDFLAGS = -module -avoid-version
+mca_errmgr_default_hnp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_errmgr_default_hnp_la_SOURCES =$(sources)

--- a/orte/mca/errmgr/default_orted/Makefile.am
+++ b/orte/mca/errmgr/default_orted/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_errmgr_default_orted_la_SOURCES = $(sources)
 mca_errmgr_default_orted_la_LDFLAGS = -module -avoid-version
+mca_errmgr_default_orted_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_errmgr_default_orted_la_SOURCES =$(sources)

--- a/orte/mca/errmgr/default_tool/Makefile.am
+++ b/orte/mca/errmgr/default_tool/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2013      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_errmgr_default_tool_la_SOURCES = $(sources)
 mca_errmgr_default_tool_la_LDFLAGS = -module -avoid-version
+mca_errmgr_default_tool_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_errmgr_default_tool_la_SOURCES =$(sources)

--- a/orte/mca/errmgr/dvm/Makefile.am
+++ b/orte/mca/errmgr/dvm/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +30,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_errmgr_dvm_la_SOURCES = $(sources)
 mca_errmgr_dvm_la_LDFLAGS = -module -avoid-version
+mca_errmgr_dvm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_errmgr_dvm_la_SOURCES =$(sources)

--- a/orte/mca/ess/alps/Makefile.am
+++ b/orte/mca/ess/alps/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,7 +41,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_alps_la_SOURCES = $(sources)
 mca_ess_alps_la_CPPFLAGS = $(ess_alps_CPPFLAGS)
 mca_ess_alps_la_LDFLAGS = -module -avoid-version $(ess_alps_LDFLAGS)
-mca_ess_alps_la_LIBADD = $(ess_alps_LDFLAGS) \
+mca_ess_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ess_alps_LDFLAGS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/ess/env/Makefile.am
+++ b/orte/mca/ess/env/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_env_la_SOURCES = $(sources)
 mca_ess_env_la_LDFLAGS = -module -avoid-version
+mca_ess_env_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_env_la_SOURCES =$(sources)

--- a/orte/mca/ess/hnp/Makefile.am
+++ b/orte/mca/ess/hnp/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2017      Los Alamos National Security, LLC. All rights
 #                         reseved.
 # Copyright (c) 2017      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_hnp_la_SOURCES = $(sources)
 mca_ess_hnp_la_LDFLAGS = -module -avoid-version
+mca_ess_hnp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_hnp_la_SOURCES =$(sources)

--- a/orte/mca/ess/lsf/Makefile.am
+++ b/orte/mca/ess/lsf/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,7 +41,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_lsf_la_SOURCES = $(sources)
 mca_ess_lsf_la_LDFLAGS = -module -avoid-version $(ess_lsf_LDFLAGS)
-mca_ess_lsf_la_LIBADD = $(ess_lsf_LIBS)
+mca_ess_lsf_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ess_lsf_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_lsf_la_SOURCES =$(sources)

--- a/orte/mca/ess/pmi/Makefile.am
+++ b/orte/mca/ess/pmi/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,7 +34,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_pmi_la_SOURCES = $(sources)
 mca_ess_pmi_la_LDFLAGS = -module -avoid-version $(ess_pmi_LDFLAGS)
-mca_ess_pmi_la_LIBADD = $(ess_pmi_LIBS)
+mca_ess_pmi_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ess_pmi_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_pmi_la_SOURCES =$(sources)

--- a/orte/mca/ess/singleton/Makefile.am
+++ b/orte/mca/ess/singleton/Makefile.am
@@ -9,6 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +38,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_singleton_la_SOURCES = $(sources)
 mca_ess_singleton_la_LDFLAGS = -module -avoid-version
+mca_ess_singleton_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_singleton_la_SOURCES =$(sources)

--- a/orte/mca/ess/slurm/Makefile.am
+++ b/orte/mca/ess/slurm/Makefile.am
@@ -9,6 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +38,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_slurm_la_SOURCES = $(sources)
 mca_ess_slurm_la_LDFLAGS = -module -avoid-version
+mca_ess_slurm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_slurm_la_SOURCES =$(sources)

--- a/orte/mca/ess/tm/Makefile.am
+++ b/orte/mca/ess/tm/Makefile.am
@@ -9,6 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +38,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_tm_la_SOURCES = $(sources)
 mca_ess_tm_la_LDFLAGS = -module -avoid-version
+mca_ess_tm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_tm_la_SOURCES =$(sources)

--- a/orte/mca/ess/tool/Makefile.am
+++ b/orte/mca/ess/tool/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,6 +39,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_tool_la_SOURCES = $(sources)
 mca_ess_tool_la_LDFLAGS = -module -avoid-version
+mca_ess_tool_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_tool_la_SOURCES =$(sources)

--- a/orte/mca/filem/raw/Makefile.am
+++ b/orte/mca/filem/raw/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, LLC.
 #                         All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,6 +41,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_filem_raw_la_SOURCES = $(sources)
 mca_filem_raw_la_LDFLAGS = -module -avoid-version
+mca_filem_raw_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_filem_raw_la_SOURCES = $(sources)

--- a/orte/mca/grpcomm/brucks/Makefile.am
+++ b/orte/mca/grpcomm/brucks/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_grpcomm_brucks_la_SOURCES = $(sources)
 mca_grpcomm_brucks_la_LDFLAGS = -module -avoid-version
+mca_grpcomm_brucks_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_grpcomm_brucks_la_SOURCES =$(sources)

--- a/orte/mca/grpcomm/direct/Makefile.am
+++ b/orte/mca/grpcomm/direct/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_grpcomm_direct_la_SOURCES = $(sources)
 mca_grpcomm_direct_la_LDFLAGS = -module -avoid-version
+mca_grpcomm_direct_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_grpcomm_direct_la_SOURCES =$(sources)

--- a/orte/mca/grpcomm/rcd/Makefile.am
+++ b/orte/mca/grpcomm/rcd/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,6 +34,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_grpcomm_rcd_la_SOURCES = $(sources)
 mca_grpcomm_rcd_la_LDFLAGS = -module -avoid-version
+mca_grpcomm_rcd_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_grpcomm_rcd_la_SOURCES =$(sources)

--- a/orte/mca/iof/hnp/Makefile.am
+++ b/orte/mca/iof/hnp/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_iof_hnp_la_SOURCES = $(hnp_SOURCES)
 mca_iof_hnp_la_LDFLAGS = -module -avoid-version
+mca_iof_hnp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_iof_hnp_la_SOURCES = $(hnp_SOURCES)

--- a/orte/mca/iof/orted/Makefile.am
+++ b/orte/mca/iof/orted/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,6 +41,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_iof_orted_la_SOURCES = $(orted_SOURCES)
 mca_iof_orted_la_LDFLAGS = -module -avoid-version
+mca_iof_orted_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_iof_orted_la_SOURCES = $(orted_SOURCES)

--- a/orte/mca/iof/tool/Makefile.am
+++ b/orte/mca/iof/tool/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +40,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_iof_tool_la_SOURCES = $(tool_SOURCES)
 mca_iof_tool_la_LDFLAGS = -module -avoid-version
+mca_iof_tool_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_iof_tool_la_SOURCES = $(tool_SOURCES)

--- a/orte/mca/notifier/smtp/Makefile.am
+++ b/orte/mca/notifier/smtp/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2009-2010 Cisco Systems, Inc. All rights reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,7 +45,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_notifier_smtp_la_SOURCES = $(sources)
 mca_notifier_smtp_la_LDFLAGS = -module -avoid-version $(notifier_smtp_LDFLAGS)
-mca_notifier_smtp_la_LIBADD = $(notifier_smtp_LIBS)
+mca_notifier_smtp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(notifier_smtp_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_notifier_smtp_la_SOURCES =$(sources)

--- a/orte/mca/notifier/syslog/Makefile.am
+++ b/orte/mca/notifier/syslog/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +40,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_notifier_syslog_la_SOURCES = $(sources)
 mca_notifier_syslog_la_LDFLAGS = -module -avoid-version
+mca_notifier_syslog_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_notifier_syslog_la_SOURCES =$(sources)

--- a/orte/mca/odls/alps/Makefile.am
+++ b/orte/mca/odls/alps/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Los Alamos National Security, LLC.  All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,7 +45,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_odls_alps_la_SOURCES = $(sources)
 mca_odls_alps_la_CPPFLAGS = $(odls_alps_CPPFLAGS)
 mca_odls_alps_la_LDFLAGS = -module -avoid-version $(odls_alps_LDFLAGS)
-mca_odls_alps_la_LIBADD = $(odls_alps_LIBS) \
+mca_odls_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(odls_alps_LIBS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/odls/default/Makefile.am
+++ b/orte/mca/odls/default/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,6 +41,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_odls_default_la_SOURCES = $(sources)
 mca_odls_default_la_LDFLAGS = -module -avoid-version
+mca_odls_default_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_odls_default_la_SOURCES =$(sources)

--- a/orte/mca/oob/alps/Makefile.am
+++ b/orte/mca/oob/alps/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012-2015 Los Alamos National Security, LLC.
 #                         All rights reserved
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,7 +36,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_oob_alps_la_SOURCES = $(sources)
 mca_oob_alps_la_LDFLAGS = -module -avoid-version
-mca_oob_alps_la_LIBADD = $(ooob_alps_LIBS) \
+mca_oob_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ooob_alps_LIBS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 

--- a/orte/mca/oob/tcp/Makefile.am
+++ b/orte/mca/oob/tcp/Makefile.am
@@ -13,6 +13,7 @@
 # Copyright (c) 2012-2013 Los Alamos National Security, LLC.
 #                         All rights reserved
 # Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -54,6 +55,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_oob_tcp_la_SOURCES = $(sources)
 mca_oob_tcp_la_LDFLAGS = -module -avoid-version
+mca_oob_tcp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_oob_tcp_la_SOURCES = $(sources)

--- a/orte/mca/oob/ud/Makefile.am
+++ b/orte/mca/oob/ud/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -55,7 +56,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_oob_ud_la_SOURCES = $(sources)
 mca_oob_ud_la_LDFLAGS = -module -avoid-version $(orte_oob_ud_LDFLAGS)
-mca_oob_ud_la_LIBADD = $(orte_oob_ud_LIBS) \
+mca_oob_ud_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(orte_oob_ud_LIBS) \
 					   $(OPAL_TOP_BUILDDIR)/opal/mca/common/verbs/lib@OPAL_LIB_PREFIX@mca_common_verbs.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/plm/alps/Makefile.am
+++ b/orte/mca/plm/alps/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
 #                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,7 +44,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_alps_la_SOURCES = $(sources)
 mca_plm_alps_la_CPPFLAGS = $(plm_alps_CPPFLAGS)
 mca_plm_alps_la_LDFLAGS = -module -avoid-version $(plm_alps_LDFLAGS)
-mca_plm_alps_la_LIBADD = $(plm_alps_LIBS) \
+mca_plm_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(plm_alps_LIBS) \
     $(ORTE_TOP_BUILDDIR)/orte/mca/common/alps/lib@ORTE_LIB_PREFIX@mca_common_alps.la
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/plm/isolated/Makefile.am
+++ b/orte/mca/plm/isolated/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +40,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_isolated_la_SOURCES = $(sources)
 mca_plm_isolated_la_LDFLAGS = -module -avoid-version
+mca_plm_isolated_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_isolated_la_SOURCES =$(sources)

--- a/orte/mca/plm/lsf/Makefile.am
+++ b/orte/mca/plm/lsf/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008      Institut National de Recherche en Informatique
 #                         et Automatique. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,7 +45,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_lsf_la_SOURCES = $(sources)
 mca_plm_lsf_la_LDFLAGS = -module -avoid-version $(plm_lsf_LDFLAGS)
-mca_plm_lsf_la_LIBADD = $(plm_lsf_LIBS)
+mca_plm_lsf_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(plm_lsf_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_lsf_la_SOURCES = $(sources)

--- a/orte/mca/plm/rsh/Makefile.am
+++ b/orte/mca/plm/rsh/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,6 +41,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_rsh_la_SOURCES = $(sources)
 mca_plm_rsh_la_LDFLAGS = -module -avoid-version
+mca_plm_rsh_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_rsh_la_SOURCES =$(sources)

--- a/orte/mca/plm/slurm/Makefile.am
+++ b/orte/mca/plm/slurm/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,6 +41,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plm_slurm_la_SOURCES = $(sources)
 mca_plm_slurm_la_LDFLAGS = -module -avoid-version
+mca_plm_slurm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plm_slurm_la_SOURCES =$(sources)

--- a/orte/mca/plm/tm/Makefile.am
+++ b/orte/mca/plm/tm/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,7 +47,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_plm_tm_la_SOURCES = $(component_sources)
 mca_plm_tm_la_LDFLAGS = -module -avoid-version $(plm_tm_LDFLAGS)
-mca_plm_tm_la_LIBADD = $(plm_tm_LIBS)
+mca_plm_tm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(plm_tm_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_plm_tm_la_SOURCES = $(lib_sources)

--- a/orte/mca/ras/alps/Makefile.am
+++ b/orte/mca/ras/alps/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008      UT-Battelle, LLC
 # Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -52,7 +53,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_alps_la_SOURCES = $(component_sources)
 mca_ras_alps_la_LDFLAGS = -module -avoid-version $(ras_alps_LDFLAGS)
-mca_ras_alps_la_LIBADD = $(ras_alps_LIBS)
+mca_ras_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ras_alps_LIBS)
 mca_ras_alps_la_CPPFLAGS = $(ras_alps_CPPFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/orte/mca/ras/gridengine/Makefile.am
+++ b/orte/mca/ras/gridengine/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2006      Sun Microsystems, Inc.  All rights reserved.
 #                         Use is subject to license terms.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,6 +43,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ras_gridengine_la_SOURCES = $(sources)
 mca_ras_gridengine_la_LDFLAGS = -module -avoid-version
+mca_ras_gridengine_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ras_gridengine_la_SOURCES =$(sources)

--- a/orte/mca/ras/lsf/Makefile.am
+++ b/orte/mca/ras/lsf/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,7 +42,8 @@ proxy_SOURCES = \
 mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ras_lsf_la_SOURCES = $(proxy_SOURCES)
-mca_ras_lsf_la_LIBADD = $(ras_lsf_LIBS)
+mca_ras_lsf_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ras_lsf_LIBS)
 mca_ras_lsf_la_LDFLAGS = -module -avoid-version $(ras_lsf_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/orte/mca/ras/simulator/Makefile.am
+++ b/orte/mca/ras/simulator/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,6 +35,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_simulator_la_SOURCES = $(component_sources)
 mca_ras_simulator_la_LDFLAGS = -module -avoid-version
+mca_ras_simulator_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_simulator_la_SOURCES = $(lib_sources)

--- a/orte/mca/ras/slurm/Makefile.am
+++ b/orte/mca/ras/slurm/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -47,7 +48,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_slurm_la_SOURCES = $(component_sources)
 mca_ras_slurm_la_LDFLAGS = -module -avoid-version $(ras_slurm_LDFLAGS)
-mca_ras_slurm_la_LIBADD = $(ras_slurm_LIBS)
+mca_ras_slurm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ras_slurm_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_slurm_la_SOURCES = $(lib_sources)

--- a/orte/mca/ras/tm/Makefile.am
+++ b/orte/mca/ras/tm/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -50,7 +51,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_tm_la_SOURCES = $(component_sources)
 mca_ras_tm_la_LDFLAGS = -module -avoid-version $(ras_tm_LDFLAGS)
-mca_ras_tm_la_LIBADD = $(ras_tm_LIBS)
+mca_ras_tm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(ras_tm_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_tm_la_SOURCES = $(lib_sources)

--- a/orte/mca/rmaps/mindist/Makefile.am
+++ b/orte/mca/rmaps/mindist/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rmaps_mindist_la_SOURCES = $(sources)
 mca_rmaps_mindist_la_LDFLAGS = -module -avoid-version
+mca_rmaps_mindist_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rmaps_mindist_la_SOURCES =$(sources)

--- a/orte/mca/rmaps/ppr/Makefile.am
+++ b/orte/mca/rmaps/ppr/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +31,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rmaps_ppr_la_SOURCES = $(sources)
 mca_rmaps_ppr_la_LDFLAGS = -module -avoid-version
+mca_rmaps_ppr_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rmaps_ppr_la_SOURCES =$(sources)

--- a/orte/mca/rmaps/rank_file/Makefile.am
+++ b/orte/mca/rmaps/rank_file/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -48,6 +49,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rmaps_rank_file_la_SOURCES = $(sources)
 mca_rmaps_rank_file_la_LDFLAGS = -module -avoid-version
+mca_rmaps_rank_file_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rmaps_rank_file_la_SOURCES =$(sources)

--- a/orte/mca/rmaps/resilient/Makefile.am
+++ b/orte/mca/rmaps/resilient/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
 #
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,6 +32,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rmaps_resilient_la_SOURCES = $(sources)
 mca_rmaps_resilient_la_LDFLAGS = -module -avoid-version
+mca_rmaps_resilient_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rmaps_resilient_la_SOURCES =$(sources)

--- a/orte/mca/rmaps/round_robin/Makefile.am
+++ b/orte/mca/rmaps/round_robin/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,6 +44,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rmaps_round_robin_la_SOURCES = $(sources)
 mca_rmaps_round_robin_la_LDFLAGS = -module -avoid-version
+mca_rmaps_round_robin_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rmaps_round_robin_la_SOURCES =$(sources)

--- a/orte/mca/rmaps/seq/Makefile.am
+++ b/orte/mca/rmaps/seq/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,6 +41,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rmaps_seq_la_SOURCES = $(sources)
 mca_rmaps_seq_la_LDFLAGS = -module -avoid-version
+mca_rmaps_seq_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rmaps_seq_la_SOURCES =$(sources)

--- a/orte/mca/rml/oob/Makefile.am
+++ b/orte/mca/rml/oob/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      Intel, Inc. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +40,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rml_oob_la_SOURCES = $(sources)
 mca_rml_oob_la_LDFLAGS = -module -avoid-version
+mca_rml_oob_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rml_oob_la_SOURCES = $(sources)

--- a/orte/mca/routed/binomial/Makefile.am
+++ b/orte/mca/routed/binomial/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (c) 2009      High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,6 +33,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_routed_binomial_la_SOURCES = $(sources)
 mca_routed_binomial_la_LDFLAGS = -module -avoid-version
+mca_routed_binomial_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_routed_binomial_la_SOURCES = $(sources)

--- a/orte/mca/routed/debruijn/Makefile.am
+++ b/orte/mca/routed/debruijn/Makefile.am
@@ -4,6 +4,7 @@
 # Copyright (c) 2009      High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,6 +33,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_routed_debruijn_la_SOURCES = $(sources)
 mca_routed_debruijn_la_LDFLAGS = -module -avoid-version
+mca_routed_debruijn_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_routed_debruijn_la_SOURCES = $(sources)

--- a/orte/mca/routed/direct/Makefile.am
+++ b/orte/mca/routed/direct/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2007      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +31,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_routed_direct_la_SOURCES = $(sources)
 mca_routed_direct_la_LDFLAGS = -module -avoid-version
+mca_routed_direct_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_routed_direct_la_SOURCES = $(sources)

--- a/orte/mca/routed/radix/Makefile.am
+++ b/orte/mca/routed/radix/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2007      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +31,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_routed_radix_la_SOURCES = $(sources)
 mca_routed_radix_la_LDFLAGS = -module -avoid-version
+mca_routed_radix_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_routed_radix_la_SOURCES = $(sources)

--- a/orte/mca/rtc/hwloc/Makefile.am
+++ b/orte/mca/rtc/hwloc/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2014      Intel, Inc. All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rtc_hwloc_la_SOURCES = $(sources)
 mca_rtc_hwloc_la_LDFLAGS = -module -avoid-version
+mca_rtc_hwloc_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rtc_hwloc_la_SOURCES =$(sources)

--- a/orte/mca/schizo/alps/Makefile.am
+++ b/orte/mca/schizo/alps/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_schizo_alps_la_SOURCES = $(sources)
 mca_schizo_alps_la_LDFLAGS = -module -avoid-version
+mca_schizo_alps_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_schizo_alps_la_SOURCES = $(sources)

--- a/orte/mca/schizo/flux/Makefile.am
+++ b/orte/mca/schizo/flux/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_schizo_flux_la_SOURCES = $(sources)
 mca_schizo_flux_la_LDFLAGS = -module -avoid-version
+mca_schizo_flux_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_schizo_flux_la_SOURCES = $(sources)

--- a/orte/mca/schizo/moab/Makefile.am
+++ b/orte/mca/schizo/moab/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +31,8 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_schizo_moab_la_SOURCES = $(sources)
 mca_schizo_moab_la_LDFLAGS = -module -avoid-version $(schizo_moab_LDFLAGS)
-mca_schizo_moab_la_LIBADD = $(schizo_moab_LIBS)
+mca_schizo_moab_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(schizo_moab_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_schizo_moab_la_SOURCES = $(sources)

--- a/orte/mca/schizo/ompi/Makefile.am
+++ b/orte/mca/schizo/ompi/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2015      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_schizo_ompi_la_SOURCES = $(sources)
 mca_schizo_ompi_la_LDFLAGS = -module -avoid-version
+mca_schizo_ompi_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_schizo_ompi_la_SOURCES = $(sources)

--- a/orte/mca/schizo/orte/Makefile.am
+++ b/orte/mca/schizo/orte/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_schizo_orte_la_SOURCES = $(sources)
 mca_schizo_orte_la_LDFLAGS = -module -avoid-version
+mca_schizo_orte_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_schizo_orte_la_SOURCES = $(sources)

--- a/orte/mca/schizo/singularity/Makefile.am
+++ b/orte/mca/schizo/singularity/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_schizo_singularity_la_SOURCES = $(sources)
 mca_schizo_singularity_la_LDFLAGS = -module -avoid-version
+mca_schizo_singularity_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_schizo_singularity_la_SOURCES = $(sources)

--- a/orte/mca/schizo/slurm/Makefile.am
+++ b/orte/mca/schizo/slurm/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_schizo_slurm_la_SOURCES = $(sources)
 mca_schizo_slurm_la_LDFLAGS = -module -avoid-version
+mca_schizo_slurm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_schizo_slurm_la_SOURCES = $(sources)

--- a/orte/mca/snapc/full/Makefile.am
+++ b/orte/mca/snapc/full/Makefile.am
@@ -8,6 +8,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +42,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_snapc_full_la_SOURCES = $(sources)
 mca_snapc_full_la_LDFLAGS = -module -avoid-version
+mca_snapc_full_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_snapc_full_la_SOURCES = $(sources)

--- a/orte/mca/sstore/central/Makefile.am
+++ b/orte/mca/sstore/central/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c)      2010 The Trustees of Indiana University.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,6 +35,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sstore_central_la_SOURCES = $(sources)
 mca_sstore_central_la_LDFLAGS = -module -avoid-version
+mca_sstore_central_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sstore_central_la_SOURCES = $(sources)

--- a/orte/mca/sstore/stage/Makefile.am
+++ b/orte/mca/sstore/stage/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c)      2010 The Trustees of Indiana University.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,6 +35,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sstore_stage_la_SOURCES = $(sources)
 mca_sstore_stage_la_LDFLAGS = -module -avoid-version
+mca_sstore_stage_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sstore_stage_la_SOURCES = $(sources)

--- a/orte/mca/state/app/Makefile.am
+++ b/orte/mca/state/app/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2011      Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +30,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_state_app_la_SOURCES = $(sources)
 mca_state_app_la_LDFLAGS = -module -avoid-version
+mca_state_app_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_state_app_la_SOURCES =$(sources)

--- a/orte/mca/state/dvm/Makefile.am
+++ b/orte/mca/state/dvm/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_state_dvm_la_SOURCES = $(sources)
 mca_state_dvm_la_LDFLAGS = -module -avoid-version
+mca_state_dvm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_state_dvm_la_SOURCES =$(sources)

--- a/orte/mca/state/hnp/Makefile.am
+++ b/orte/mca/state/hnp/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2011      Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +30,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_state_hnp_la_SOURCES = $(sources)
 mca_state_hnp_la_LDFLAGS = -module -avoid-version
+mca_state_hnp_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_state_hnp_la_SOURCES =$(sources)

--- a/orte/mca/state/novm/Makefile.am
+++ b/orte/mca/state/novm/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2011-2012 Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +30,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_state_novm_la_SOURCES = $(sources)
 mca_state_novm_la_LDFLAGS = -module -avoid-version
+mca_state_novm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_state_novm_la_SOURCES =$(sources)

--- a/orte/mca/state/orted/Makefile.am
+++ b/orte/mca/state/orted/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2011      Los Alamos National Security, LLC.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +30,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_state_orted_la_SOURCES = $(sources)
 mca_state_orted_la_LDFLAGS = -module -avoid-version
+mca_state_orted_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_state_orted_la_SOURCES =$(sources)

--- a/orte/mca/state/tool/Makefile.am
+++ b/orte/mca/state/tool/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2013      Intel, Inc. All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +29,7 @@ mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_state_tool_la_SOURCES = $(sources)
 mca_state_tool_la_LDFLAGS = -module -avoid-version
+mca_state_tool_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_state_tool_la_SOURCES =$(sources)

--- a/oshmem/mca/atomic/basic/Makefile.am
+++ b/oshmem/mca/atomic/basic/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,6 +33,7 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_atomic_basic_la_SOURCES = $(sources)
 mca_atomic_basic_la_LDFLAGS = -module -avoid-version
+mca_atomic_basic_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_atomic_basic_la_SOURCES =$(sources)

--- a/oshmem/mca/atomic/mxm/Makefile.am
+++ b/oshmem/mca/atomic/mxm/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -33,7 +34,8 @@ endif
 mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_atomic_mxm_la_SOURCES = $(mxm_sources)
-mca_atomic_mxm_la_LIBADD = $(atomic_mxm_LIBS)
+mca_atomic_mxm_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(atomic_mxm_LIBS)
 mca_atomic_mxm_la_LDFLAGS = -module -avoid-version $(atomic_mxm_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/atomic/ucx/Makefile.am
+++ b/oshmem/mca/atomic/ucx/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -33,7 +34,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_atomic_ucx_la_SOURCES = $(ucx_sources)
-mca_atomic_ucx_la_LIBADD = $(atomic_ucx_LIBS)
+mca_atomic_ucx_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(atomic_ucx_LIBS)
 mca_atomic_ucx_la_LDFLAGS = -module -avoid-version $(atomic_ucx_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/memheap/buddy/Makefile.am
+++ b/oshmem/mca/memheap/buddy/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +30,7 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_memheap_buddy_la_SOURCES = $(buddy_sources)
 mca_memheap_buddy_la_LDFLAGS = -module -avoid-version
+mca_memheap_buddy_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la
 
 #noinst_LTLIBRARIES = $(lib)
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/memheap/ptmalloc/Makefile.am
+++ b/oshmem/mca/memheap/ptmalloc/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,6 +32,7 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_memheap_ptmalloc_la_SOURCES = $(ptmalloc_sources)
 mca_memheap_ptmalloc_la_LDFLAGS = -module -avoid-version
+mca_memheap_ptmalloc_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la
 
 #noinst_LTLIBRARIES = $(lib)
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/scoll/basic/Makefile.am
+++ b/oshmem/mca/scoll/basic/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2013-2016 Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -35,6 +36,7 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_scoll_basic_la_SOURCES = $(sources)
 mca_scoll_basic_la_LDFLAGS = -module -avoid-version
+mca_scoll_basic_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_scoll_basic_la_SOURCES =$(sources)

--- a/oshmem/mca/scoll/fca/Makefile.am
+++ b/oshmem/mca/scoll/fca/Makefile.am
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2013-2015 Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 #  Additional copyrights may follow
@@ -33,7 +34,8 @@ endif
 mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_scoll_fca_la_SOURCES = $(scoll_fca_sources)
-mca_scoll_fca_la_LIBADD = $(scoll_fca_LIBS)
+mca_scoll_fca_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(scoll_fca_LIBS)
 mca_scoll_fca_la_LDFLAGS = -module -avoid-version $(scoll_fca_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/scoll/mpi/Makefile.am
+++ b/oshmem/mca/scoll/mpi/Makefile.am
@@ -1,5 +1,6 @@
 # Copyright (c) 2013-2015 Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 #  Additional copyrights may follow
@@ -29,7 +30,8 @@ endif
 mcacomponentdir = $(pkglibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_scoll_mpi_la_SOURCES = $(scoll_mpi_sources)
-mca_scoll_mpi_la_LIBADD = $(scoll_mpi_LIBS)
+mca_scoll_mpi_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(scoll_mpi_LIBS)
 mca_scoll_mpi_la_LDFLAGS = -module -avoid-version $(scoll_mpi_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/spml/ikrit/Makefile.am
+++ b/oshmem/mca/spml/ikrit/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 #
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,7 +32,8 @@ endif
 mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_spml_ikrit_la_SOURCES = $(ikrit_sources)
-mca_spml_ikrit_la_LIBADD = $(spml_ikrit_LIBS)
+mca_spml_ikrit_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(spml_ikrit_LIBS)
 mca_spml_ikrit_la_LDFLAGS = -module -avoid-version $(spml_ikrit_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/spml/ucx/Makefile.am
+++ b/oshmem/mca/spml/ucx/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2015      Mellanox Technologies, Inc.
 #                         All rights reserved.
 #
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -32,7 +33,8 @@ endif
 mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_spml_ucx_la_SOURCES = $(ucx_sources)
-mca_spml_ucx_la_LIBADD = $(spml_ucx_LIBS)
+mca_spml_ucx_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(spml_ucx_LIBS)
 mca_spml_ucx_la_LDFLAGS = -module -avoid-version $(spml_ucx_LDFLAGS)
 
 noinst_LTLIBRARIES = $(component_noinst)

--- a/oshmem/mca/sshmem/mmap/Makefile.am
+++ b/oshmem/mca/sshmem/mmap/Makefile.am
@@ -1,5 +1,6 @@
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +31,7 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sshmem_mmap_la_SOURCES = $(sources)
 mca_sshmem_mmap_la_LDFLAGS = -module -avoid-version
+mca_sshmem_mmap_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sshmem_mmap_la_SOURCES =$(sources)

--- a/oshmem/mca/sshmem/sysv/Makefile.am
+++ b/oshmem/mca/sshmem/sysv/Makefile.am
@@ -1,6 +1,7 @@
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,6 +32,7 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sshmem_sysv_la_SOURCES = $(sources)
 mca_sshmem_sysv_la_LDFLAGS = -module -avoid-version
+mca_sshmem_sysv_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sshmem_sysv_la_SOURCES = $(sources)

--- a/oshmem/mca/sshmem/ucx/Makefile.am
+++ b/oshmem/mca/sshmem/ucx/Makefile.am
@@ -1,5 +1,6 @@
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,7 +33,8 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sshmem_ucx_la_SOURCES = $(sources)
 mca_sshmem_ucx_la_LDFLAGS = -module -avoid-version $(sshmem_ucx_LDFLAGS)
-mca_sshmem_ucx_la_LIBADD = $(sshmem_ucx_LIBS)
+mca_sshmem_ucx_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(sshmem_ucx_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sshmem_ucx_la_SOURCES =$(sources)

--- a/oshmem/mca/sshmem/verbs/Makefile.am
+++ b/oshmem/mca/sshmem/verbs/Makefile.am
@@ -1,5 +1,6 @@
 # Copyright (c) 2014      Mellanox Technologies, Inc.
 #                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +31,8 @@ mcacomponentdir = $(oshmemlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sshmem_verbs_la_SOURCES = $(sources)
 mca_sshmem_verbs_la_LDFLAGS = -module -avoid-version $(oshmem_verbs_LDFLAGS)
-mca_sshmem_verbs_la_LIBADD  = $(oshmem_verbs_LIBS) \
+mca_sshmem_verbs_la_LIBADD = $(top_builddir)/oshmem/liboshmem.la \
+	$(oshmem_verbs_LIBS) \
 							  $(OPAL_TOP_BUILDDIR)/opal/mca/common/verbs/lib@OPAL_LIB_PREFIX@mca_common_verbs.la
 
 noinst_LTLIBRARIES = $(component_noinst)


### PR DESCRIPTION
 * Resolves #3705
 * Ref PR #4121 for `master`
 * Components should link against the project level library to better
   support `dlopen` with `RTLD_LOCAL`.
 * Different project levels link to different sets of libraries by
   using the `mca_FRAMEWORK_COMPONENT_la_LIBADD` in the `Makefile.am`.
```
MCA components in ompi/
       $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
MCA components in orte/
       $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
MCA components in opal/
       $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
```

Note: The changes in this commit were automated. Some components
were not included because they are statically built only.