### PR TITLE
Removing the symbol_name test from make check until it can be reworked.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1419,7 +1419,6 @@ AC_CONFIG_FILES([
     test/support/Makefile
     test/threads/Makefile
     test/util/Makefile
-    test/symbol_name/Makefile
 ])
 m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile])])
 m4_ifdef([project_ompi], [

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -22,7 +22,7 @@
 #
 
 # support needs to be first for dependencies
-SUBDIRS = support asm class threads datatype util dss symbol_name
+SUBDIRS = support asm class threads datatype util dss
 if PROJECT_OMPI
 SUBDIRS += monitoring
 endif


### PR DESCRIPTION
Reworking this check in a script in this PR:
https://github.com/open-mpi/ompi/pull/4119
