### PR TITLE
switch ADIOI_GEN_WriteStrided to ADIOI_GEN_WriteStrided_naive

### DIFF
--- a/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs.c
@@ -31,7 +31,7 @@ struct ADIOI_Fns_struct ADIO_GPFS_operations = {
     ADIOI_GEN_SetInfo, /* SetInfo for any platform besides BlueGene or PE */
 #endif
     ADIOI_GEN_ReadStrided, /* ReadStrided */
-    ADIOI_GEN_WriteStrided, /* WriteStrided */
+    ADIOI_GEN_WriteStrided_naive, /* WriteStrided_naive */
     ADIOI_GPFS_Close, /* Close */
 #ifdef ROMIO_HAVE_WORKING_AIO
 #warning Consider BG support for NFS before enabling this.

--- a/ompi/mca/io/romio314/romio/adio/ad_sfs/ad_sfs.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_sfs/ad_sfs.c
@@ -20,7 +20,7 @@ struct ADIOI_Fns_struct ADIO_SFS_operations = {
     ADIOI_SFS_Fcntl, /* Fcntl */
     ADIOI_GEN_SetInfo, /* SetInfo */
     ADIOI_GEN_ReadStrided, /* ReadStrided */
-    ADIOI_GEN_WriteStrided, /* WriteStrided */
+    ADIOI_GEN_WriteStrided_naive, /* WriteStrided_naive */
     ADIOI_GEN_Close, /* Close */
     ADIOI_FAKE_IreadContig, /* IreadContig */
     ADIOI_FAKE_IwriteContig, /* IwriteContig */

--- a/ompi/mca/io/romio314/romio/adio/ad_ufs/ad_ufs.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_ufs/ad_ufs.c
@@ -21,7 +21,7 @@ struct ADIOI_Fns_struct ADIO_UFS_operations = {
     ADIOI_GEN_Fcntl, /* Fcntl */
     ADIOI_GEN_SetInfo, /* SetInfo */
     ADIOI_GEN_ReadStrided, /* ReadStrided */
-    ADIOI_GEN_WriteStrided, /* WriteStrided */
+    ADIOI_GEN_WriteStrided_naive, /* WriteStrided_naive */
     ADIOI_GEN_Close, /* Close */
 #ifdef ROMIO_HAVE_WORKING_AIO
     ADIOI_GEN_IreadContig, /* IreadContig */


### PR DESCRIPTION
When ADIOI_GEN_WriteStrided wants to write data into a file with
a non-contiguous view, it does so with the sequence
    lock
    read
    modify
    write
    unlock

This adequately protects against other ranks executing the same
sequence. But as near as I can tell it isn't standard practice
to lock/unlock around all write calls in the entire romio product.

So the result is a very selective protection -- protection against
other ranks who happen to be doing the same operations we're doing,
but no protection against other ranks who could be doing something
else hitting one of the myriad of other write calls in romio.

The _naive version does more of a piecemeal walking of the datatype
writing each chunk. Unless we put a lock/unlock around every write
in romio, I think this is the only safe way to do it.

Signed-off-by: Mark Allen <markalle@us.ibm.com>

See bug report:
https://github.com/open-mpi/ompi/issues/4144
which includes testcase
https://gist.github.com/markalle/d7da240c19e57f095c5d1b13240dae24