### PR TITLE
oshmem: add C++ wrappers

### DIFF
--- a/config/oshmem_config_files.m4
+++ b/config/oshmem_config_files.m4
@@ -2,7 +2,9 @@
 #
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,6 +25,7 @@ AC_DEFUN([OSHMEM_CONFIG_FILES],[
     oshmem/tools/oshmem_info/Makefile
     oshmem/tools/wrappers/Makefile
     oshmem/tools/wrappers/shmemcc-wrapper-data.txt
+    oshmem/tools/wrappers/shmemc++-wrapper-data.txt
     oshmem/tools/wrappers/shmemfort-wrapper-data.txt
     ])
 ])

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -13,6 +13,8 @@
 # Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,6 +32,7 @@ CCC = mpic++
 FC = mpifort
 JAVAC = mpijavac
 SHMEMCC = shmemcc
+SHMEMCXX = shmemc++
 SHMEMFC = shmemfort
 
 # Using -g is not necessary, but it is helpful for example programs,
@@ -51,6 +54,7 @@ EXAMPLES = \
 	 hello_usempi \
 	 hello_usempif08 \
 	 hello_oshmem \
+	 hello_oshmemcxx \
 	 hello_oshmemfh \
 	 Hello.class \
 	 ring_c \
@@ -105,6 +109,7 @@ mpi:
 oshmem:
 	@ if oshmem_info --parsable | grep oshmem:bindings:c:yes >/dev/null; then \
 	    $(MAKE) hello_oshmem; \
+	    $(MAKE) hello_oshmemcxx; \
 	    $(MAKE) ring_oshmem; \
 	    $(MAKE) oshmem_shmalloc; \
 	    $(MAKE) oshmem_circular_shift; \
@@ -146,6 +151,8 @@ Ring.class: Ring.java
 
 hello_oshmem: hello_oshmem_c.c
 	$(SHMEMCC) $(CFLAGS) $? -o $@
+hello_oshmemcxx: hello_oshmem_cxx.cc
+	$(SHMEMCXX) $(CXXFLAGS) $? -o $@
 hello_oshmemfh: hello_oshmemfh.f90
 	$(SHMEMFC) $(FCFLAGS) $? -o $@
 

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -14,6 +14,8 @@
 # Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +41,7 @@ EXTRA_DIST += \
         examples/hello_usempi.f90 \
         examples/hello_usempif08.f90 \
         examples/hello_oshmem_c.c \
+        examples/hello_oshmem_cxx.cc \
         examples/hello_oshmemfh.f90 \
         examples/ring_c.c \
         examples/ring_cxx.cc \

--- a/examples/hello_oshmem_cxx.cc
+++ b/examples/hello_oshmem_cxx.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <iostream>
+#include "shmem.h"
+
+#if !defined(OSHMEM_SPEC_VERSION) || OSHMEM_SPEC_VERSION < 10200
+#error This application uses API 1.2 and up
+#endif
+
+int main(int argc, char* argv[])
+{
+    int proc, nproc;
+    char name[SHMEM_MAX_NAME_LEN];
+    int major, minor;
+
+    shmem_init();
+    nproc = shmem_n_pes();
+    proc = shmem_my_pe();
+    shmem_info_get_name(name);
+    shmem_info_get_version(&major, &minor);
+
+    std::cout << "Hello, world, I am " << proc << " of " << nproc << ": " << name
+              << " (version: " << major << "." << minor << ")" << std::endl;
+
+    shmem_finalize();
+
+    return 0;
+}

--- a/oshmem/tools/wrappers/Makefile.am
+++ b/oshmem/tools/wrappers/Makefile.am
@@ -2,7 +2,7 @@
 #                         All rights reserved.
 # Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc.  All rights reserved.
-# Copyright (c) 2014      Research Organization for Information Science
+# Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
@@ -12,41 +12,87 @@
 
 include $(top_srcdir)/Makefile.ompi-rules
 
-man_pages = oshcc.1 shmemcc.1 oshfort.1 shmemfort.1 oshrun.1 shmemrun.1
+man_pages = oshcc.1 shmemcc.1 oshc++.1 shmemc++.1 oshcxx.1 shmemcxx.1 oshfort.1 shmemfort.1 oshrun.1 shmemrun.1
 
 if PROJECT_OSHMEM
 man_MANS = $(man_pages)
 
 nodist_oshmemdata_DATA =  \
 	shmemcc-wrapper-data.txt \
+	shmemc++-wrapper-data.txt \
 	shmemfort-wrapper-data.txt
 
 # Only install / uninstall if we're building oshmem
-install-exec-hook:
+install-exec-hook-always:
 	test -z "$(bindir)" || $(mkdir_p) "$(DESTDIR)$(bindir)"
 	(cd $(DESTDIR)$(bindir); rm -f shmemrun$(EXEEXT); $(LN_S) mpirun$(EXEEXT) shmemrun$(EXEEXT))
 	(cd $(DESTDIR)$(bindir); rm -f oshrun$(EXEEXT); $(LN_S) mpirun$(EXEEXT) oshrun$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f shmemcc$(EXEEXT); $(LN_S) mpicc$(EXEEXT) shmemcc$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f oshcc$(EXEEXT); $(LN_S) mpicc$(EXEEXT) oshcc$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f shmemfort$(EXEEXT); $(LN_S) mpifort$(EXEEXT) shmemfort$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f oshfort$(EXEEXT); $(LN_S) mpifort$(EXEEXT) oshfort$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemcc$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemcc$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshcc$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshcc$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemc++$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemc++$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemcxx$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemcxx$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshc++$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshc++$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshcxx$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshcxx$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f shmemfort$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemfort$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshfort$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshfort$(EXEEXT))
 
-install-data-hook:
+install-data-hook-always:
 	(cd $(DESTDIR)$(pkgdatadir); rm -f oshcc-wrapper-data.txt; $(LN_S) shmemcc-wrapper-data.txt oshcc-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f shmemcxx-wrapper-data.txt; $(LN_S) shmemc++-wrapper-data.txt shmemcxx-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f oshc++-wrapper-data.txt; $(LN_S) shmemc++-wrapper-data.txt oshc++-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f oshcxx-wrapper-data.txt; $(LN_S) shmemc++-wrapper-data.txt oshcxx-wrapper-data.txt)
 	(cd $(DESTDIR)$(pkgdatadir); rm -f oshfort-wrapper-data.txt; $(LN_S) shmemfort-wrapper-data.txt oshfort-wrapper-data.txt)
 
-uninstall-local:
+uninstall-local-always:
 	rm -f $(DESTDIR)$(bindir)/shmemrun$(EXEEXT) \
 	$(DESTDIR)$(bindir)/oshrun$(EXEEXT) \
 	$(DESTDIR)$(bindir)/shmemcc$(EXEEXT) \
 	$(DESTDIR)$(bindir)/oshcc$(EXEEXT) \
+	$(DESTDIR)$(bindir)/shmemcxx$(EXEEXT) \
+	$(DESTDIR)$(bindir)/oshcxx$(EXEEXT) \
 	$(DESTDIR)$(bindir)/shmemfort$(EXEEXT) \
 	$(DESTDIR)$(bindir)/oshfort$(EXEEXT) \
 	$(DESTDIR)$(pkgdatadir)/shmemcc-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/oshcc-wrapper-data.txt \
+	$(DESTDIR)$(pkgdatadir)/shmemcxx-wrapper-data.txt \
+	$(DESTDIR)$(pkgdatadir)/oshcxx-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/shmemfort-wrapper-data.txt \
 	$(DESTDIR)$(pkgdatadir)/oshfort-wrapper-data.txt
 
+
+if CASE_SENSITIVE_FS
+man_MANS += oshCC.1 shmemCC.1
+
+install-exec-hook: install-exec-hook-always
+	(cd $(DESTDIR)$(bindir); rm -f shmemCC$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) shmemCC$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f oshCC$(EXEEXT); $(LN_S) opal_wrapper$(EXEEXT) oshCC$(EXEEXT))
+
+install-data-hook: install-data-hook-always
+	(cd $(DESTDIR)$(pkgdatadir); rm -f shmemCC-wrapper-data.txt; $(LN_S) shmemcxx-wrapper-data.txt shmemCC-wrapper-data.txt)
+	(cd $(DESTDIR)$(pkgdatadir); rm -f oshCC-wrapper-data.txt; $(LN_S) oshcxx-wrapper-data.txt oshCC-wrapper-data.txt)
+
+uninstall-local: uninstall-local-always
+	rm -f $(DESTDIR)$(bindir)/shmemCC$(EXEEXT) \
+	$(DESTDIR)$(mandir)/man1/shmemCC.1 \
+	$(DESTDIR)$(pkgdatadir)/shmemCC-wrapper-data.txt
+	rm -f $(DESTDIR)$(bindir)/oshCC$(EXEEXT) \
+	$(DESTDIR)$(mandir)/man1/oshCC.1 \
+	$(DESTDIR)$(pkgdatadir)/oshCC-wrapper-data.txt
+
+oshCC.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshCC.1
+	sed -e 's/#COMMAND#/oshCC/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshCC.1
+
+shmemCC.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemCC.1
+	sed -e 's/#COMMAND#/shmemCC/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemCC.1
+
+else # CASE_SENSITIVE_FS
+install-exec-hook: install-exec-hook-always
+install-data-hook: install-data-hook-always
+uninstall-local: uninstall-local-always
+
+endif # CASE_SENSITIVE_FS
 
 ########################################################
 #
@@ -54,7 +100,7 @@ uninstall-local:
 #
 ########################################################
 distclean-local:
-	rm -f $(man_pages)
+	rm -f $(man_MANS)
 
 $(top_builddir)/opal/tools/wrappers/generic_wrapper.1:
 	(cd $(top_builddir)/opal/tools/wrappers && $(MAKE) $(AM_MAKEFLAGS) generic_wrapper.1)
@@ -66,6 +112,22 @@ oshcc.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
 shmemcc.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
 	rm -f shmemcc.1
 	sed -e 's/#COMMAND#/shmemcc/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemcc.1
+
+oshc++.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshc++.1
+	sed -e 's/#COMMAND#/oshc++/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshc++.1
+
+shmemc++.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemc++.1
+	sed -e 's/#COMMAND#/shmemc++/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemc++.1
+
+oshcxx.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f oshcxx.1
+	sed -e 's/#COMMAND#/oshcxx/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > oshcxx.1
+
+shmemcxx.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
+	rm -f shmemcxx.1
+	sed -e 's/#COMMAND#/shmemcxx/g' -e 's/#PROJECT#/Open SHMEM/g' -e 's/#PROJECT_SHORT#/OSHMEM/g' -e 's/#LANGUAGE#/C++/g' < $(top_builddir)/opal/tools/wrappers/generic_wrapper.1 > shmemcxx.1
 
 oshfort.1: $(top_builddir)/opal/tools/wrappers/generic_wrapper.1
 	rm -f oshfort.1

--- a/oshmem/tools/wrappers/shmemc++-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemc++-wrapper-data.txt.in
@@ -1,0 +1,37 @@
+# Copyright (c) 2013      Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# There can be multiple blocks of configuration data, chosen by
+# compiler flags (using the compiler_args key to chose which block
+# should be activated.  This can be useful for multilib builds.  See the
+# multilib page at:
+#    https://github.com/open-mpi/ompi/wiki/compilerwrapper3264
+# for more information.
+
+project=Open SHMEM
+project_short=OSHMEM
+version=@OSHMEM_VERSION@
+language=C++
+compiler_env=CXX
+compiler_flags_env=CXXFLAGS
+compiler=@CXX@
+preprocessor_flags=@OMPI_WRAPPER_EXTRA_CPPFLAGS@
+compiler_flags=@OMPI_WRAPPER_EXTRA_CXXFLAGS@
+linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
+# Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
+# intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
+# etc. are pulled in implicitly) because we intend SHMEM/MPI
+# applications to only use the SHMEM and MPI APIs.
+libs=-loshmem -lmpi
+libs_static=-loshmem -lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
+static_lib_file=liboshmem.a
+required_file=
+includedir=${includedir}
+libdir=${libdir}


### PR DESCRIPTION
though there are no C++ bindings for oshmem, we need C++ wrappers
since a C compiler might not be able to compile a C++ source.
the C++ wrappers are :
- shmemc++ / oshc++
- shmemcxx / oshcxx
- shmemCC / oshCC (on case sensitive filesystems)

also add the examples/hello_oshmem_cxx.cc example

Thanks Bert Wesarg for bringing this to our attention

Fixes open-mpi/ompi#2097

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@d1740a679c27603632d7f9d690339837018c404e)