### PR TITLE
orte_data_server: fix a typo in ORTE_PMIX_PUBLISH_CMD handling

### DIFF
--- a/orte/runtime/orte_data_server.c
+++ b/orte/runtime/orte_data_server.c
@@ -351,8 +351,8 @@ void orte_data_server(int status, orte_process_name_t* sender,
                     OPAL_OUTPUT_VERBOSE((1, orte_data_server_output,
                                         "%s NOT STORING DATA FROM %s AT INDEX %d",
                                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                        ORTE_NAME_PRINT(&data->owner), data->index);
-                    opal_pointer_array_set_item(&orte_data_server_store, data->index, NULL));
+                                        ORTE_NAME_PRINT(&data->owner), data->index));
+                    opal_pointer_array_set_item(&orte_data_server_store, data->index, NULL);
                     OBJ_RELEASE(data);
                     goto release;
                 }


### PR DESCRIPTION
correctly balance some parenthesis ...

Fixes open-mpi/ompi#4153

Thanks Austen Lauria for the report

This is a one-off commit for the v3.0.x branch, master was fixed as part of a larger commit,
and the v2 branches are unaffected.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>