### PR TITLE
README: Add a blurb about FreeBSD 11.1

### DIFF
--- a/README
+++ b/README
@@ -144,6 +144,9 @@ General notes
   - Other 64 bit platforms (e.g., Linux on PPC64)
   - Oracle Solaris 10 and 11, 32 and 64 bit (SPARC, i386, x86_64),
     with Oracle Solaris Studio 12.5
+  - Problems have been reported when building Open MPI on FreeBSD 11.1
+    using the clang-4.0 system compiler. A workaround is to build
+    Open MPI using the GNU compiler.
 
 Compiler Notes
 --------------


### PR DESCRIPTION
The clang 4.0 compiler that ships with FreeBSD 11.1 doesn't
work well with OpenMPI.  Workaround is to use a GNU compiler.

Related to #3992.
[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 083e6e6f5e47c1b292f213ec9c4b10cbaeba815e)