### PR TITLE
README: Add a blurb about FreeBSD 11.1

### DIFF
--- a/README
+++ b/README
@@ -136,6 +136,9 @@ General notes
     with Oracle Solaris Studio 12.5
   - OpenBSD.  Requires configure options --enable-mca-no-build=patcher
     and --disable-slopen with this release.
+  - Problems have been reported when building Open MPI on FreeBSD 11.1
+    using the clang-4.0 system compiler. A workaround is to build
+    Open MPI using the GNU compiler.
 
 Platform Notes
 --------------


### PR DESCRIPTION
The clang 4.0 compiler that ships with FreeBSD 11.1 doesn't
work well with OpenMPI.  Workaround is to use a GNU compiler.

Related to #3992.
[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 083e6e6f5e47c1b292f213ec9c4b10cbaeba815e)