### PR TITLE
Add support for GPU buffers for PSM2 MTL

### DIFF
--- a/ompi/mca/mtl/mtl.h
+++ b/ompi/mca/mtl/mtl.h
@@ -5,6 +5,7 @@
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,6 +62,9 @@ typedef struct mca_mtl_request_t mca_mtl_request_t;
  * MTL module flags
  */
 #define MCA_MTL_BASE_FLAG_REQUIRE_WORLD 0x00000001
+#if OPAL_CUDA_SUPPORT
+#define MCA_MTL_BASE_FLAG_CUDA_INIT_DISABLE 0x00000002
+#endif
 
 /**
  * Initialization routine for MTL component

--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      QLogic Corporation. All rights reserved.
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -98,6 +98,9 @@ int ompi_mtl_psm2_module_init(int local_rank, int num_local_procs) {
     char *generated_key;
     char env_string[256];
     int rc;
+#if OPAL_CUDA_SUPPORT
+    char *cuda_env;
+#endif
 
     generated_key = getenv("OMPI_MCA_orte_precondition_transports");
     memset(uu, 0, sizeof(psm2_uuid_t));
@@ -170,6 +173,15 @@ int ompi_mtl_psm2_module_init(int local_rank, int num_local_procs) {
 
     /* register the psm2 progress function */
     opal_progress_register(ompi_mtl_psm2_progress);
+
+#if OPAL_CUDA_SUPPORT
+    ompi_mtl_psm2.super.mtl_flags |= MCA_MTL_BASE_FLAG_CUDA_INIT_DISABLE;
+
+    cuda_env = getenv("PSM2_CUDA");
+    if (!cuda_env || ( strcmp(cuda_env, "0") == 0) )
+        opal_output(0, "Warning: If running with device buffers, there is a"
+                    " chance the application might fail. Try setting PSM2_CUDA=1.\n");
+#endif
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/pml/cm/pml_cm_recvreq.h
+++ b/ompi/mca/pml/cm/pml_cm_recvreq.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,7 +93,8 @@ do {                                                                           \
                                            src,                         \
                                            datatype,                    \
                                            addr,                        \
-                                           count )                      \
+                                           count,                       \
+					   flags )                      \
 do {                                                                    \
     OMPI_REQUEST_INIT(&(request)->req_base.req_ompi, false);            \
     (request)->req_base.req_ompi.req_mpi_object.comm = comm;            \
@@ -108,12 +110,13 @@ do {                                                                    \
     } else {                                                            \
         ompi_proc = ompi_comm_peer_lookup( comm, src );                 \
     }                                                                   \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
     opal_convertor_copy_and_prepare_for_recv(                           \
                                   ompi_proc->super.proc_convertor,      \
                                   &(datatype->super),                   \
                                   count,                                \
                                   addr,                                 \
-                                  0,                                    \
+                                  flags,                                    \
                                   &(request)->req_base.req_convertor ); \
 } while(0)
 #else
@@ -123,7 +126,8 @@ do {                                                                    \
                                            src,                         \
                                            datatype,                    \
                                            addr,                        \
-                                           count )                      \
+                                           count,                       \
+					   flags )                      \
 do {                                                                    \
     OMPI_REQUEST_INIT(&(request)->req_base.req_ompi, false);            \
     (request)->req_base.req_ompi.req_mpi_object.comm = comm;            \
@@ -134,12 +138,13 @@ do {                                                                    \
     OBJ_RETAIN(comm);                                                   \
     OBJ_RETAIN(datatype);                                               \
                                                                         \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
     opal_convertor_copy_and_prepare_for_recv(                           \
         ompi_mpi_local_convertor,                                       \
         &(datatype->super),                                             \
         count,                                                          \
         addr,                                                           \
-        0,                                                              \
+        flags,                                                              \
         &(request)->req_base.req_convertor );                           \
 } while(0)
 #endif
@@ -153,6 +158,7 @@ do {                                                                    \
                                           datatype,                     \
                                           addr,                         \
                                           count,                        \
+					  flags,                        \
                                           persistent)                   \
 do {                                                                    \
     OMPI_REQUEST_INIT(&(request)->req_base.req_ompi, persistent);       \
@@ -173,12 +179,13 @@ do {                                                                    \
     } else {                                                            \
         ompi_proc = ompi_comm_peer_lookup( comm, src );                 \
     }                                                                   \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
     opal_convertor_copy_and_prepare_for_recv(                           \
                                   ompi_proc->super.proc_convertor,      \
                                   &(datatype->super),                   \
                                   count,                                \
                                   addr,                                 \
-                                  0,                                    \
+                                  flags,                                \
                                   &(request)->req_base.req_convertor ); \
  } while(0)
 #else
@@ -190,6 +197,7 @@ do {                                                                    \
                                           datatype,                     \
                                           addr,                         \
                                           count,                        \
+					  flags,                        \
                                           persistent)                   \
 do {                                                                    \
     OMPI_REQUEST_INIT(&(request)->req_base.req_ompi, persistent);       \
@@ -205,12 +213,13 @@ do {                                                                    \
     OBJ_RETAIN(comm);                                                   \
     OBJ_RETAIN(datatype);                                               \
                                                                         \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
     opal_convertor_copy_and_prepare_for_recv(                           \
         ompi_mpi_local_convertor,                                       \
         &(datatype->super),                                             \
         count,                                                          \
         addr,                                                           \
-        0,                                                              \
+        flags,                                                              \
         &(request)->req_base.req_convertor );                           \
  } while(0)
 #endif

--- a/ompi/mca/pml/cm/pml_cm_request.h
+++ b/ompi/mca/pml/cm/pml_cm_request.h
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,5 +53,21 @@ struct mca_pml_cm_request_t {
 };
 typedef struct mca_pml_cm_request_t mca_pml_cm_request_t;
 OBJ_CLASS_DECLARATION(mca_pml_cm_request_t);
+
+/*
+ * Avoid CUDA convertor inits only for contiguous memory and if indicated by
+ * the MTL. For non-contiguous memory, do not skip CUDA convertor init phases.
+ */
+#if OPAL_CUDA_SUPPORT
+#define MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count)            \
+    {                                                                           \
+        if (opal_datatype_is_contiguous_memory_layout(&datatype->super, count)  \
+            && (ompi_mtl->mtl_flags & MCA_MTL_BASE_FLAG_CUDA_INIT_DISABLE)) {   \
+            flags |= CONVERTOR_SKIP_CUDA_INIT;                                  \
+        }                                                                       \
+    }
+#else
+#define MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count)
+#endif
 
 #endif

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -125,18 +126,20 @@ do {                                                                    \
                                             datatype,                   \
                                             sendmode,                   \
                                             buf,                        \
-                                            count)                      \
+                                            count,                      \
+					    flags )                     \
 {                                                                       \
     OBJ_RETAIN(comm);                                                   \
     OBJ_RETAIN(datatype);                                               \
     (req_send)->req_base.req_comm = comm;                               \
     (req_send)->req_base.req_datatype = datatype;                       \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
     opal_convertor_copy_and_prepare_for_send(                           \
                                              ompi_proc->super.proc_convertor, \
                                              &(datatype->super),        \
                                              count,                     \
                                              buf,                       \
-                                             0,                         \
+                                             flags,                         \
                                              &(req_send)->req_base.req_convertor ); \
     (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
     (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =               \
@@ -154,18 +157,20 @@ do {                                                                    \
                                             datatype,                   \
                                             sendmode,                   \
                                             buf,                        \
-                                            count)                      \
+                                            count,                      \
+					    flags )                     \
 {                                                                       \
     OBJ_RETAIN(comm);                                                   \
     OBJ_RETAIN(datatype);                                               \
     (req_send)->req_base.req_comm = comm;                               \
     (req_send)->req_base.req_datatype = datatype;                       \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
     opal_convertor_copy_and_prepare_for_send(                           \
         ompi_mpi_local_convertor,                                       \
         &(datatype->super),                                             \
         count,                                                          \
         buf,                                                            \
-        0,                                                              \
+        flags,                                                              \
         &(req_send)->req_base.req_convertor );                          \
     (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
     (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =               \
@@ -185,18 +190,20 @@ do {                                                                    \
                                             datatype,                   \
                                             sendmode,                   \
                                             buf,                        \
-                                            count)                      \
+                                            count,                      \
+					    flags )                     \
 {                                                                       \
     OBJ_RETAIN(comm);                                                   \
     OBJ_RETAIN(datatype);                                               \
     (req_send)->req_base.req_comm = comm;                               \
     (req_send)->req_base.req_datatype = datatype;                       \
+    MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);       \
     opal_convertor_copy_and_prepare_for_send(                           \
                                              ompi_proc->super.proc_convertor, \
                                              &(datatype->super),        \
                                              count,                     \
                                              buf,                       \
-                                             0,                         \
+                                             flags,                         \
                                              &(req_send)->req_base.req_convertor ); \
     (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
     (req_send)->req_base.req_ompi.req_status.MPI_SOURCE =               \
@@ -215,7 +222,8 @@ do {                                                                    \
                                             datatype,                   \
                                             sendmode,                   \
                                             buf,                        \
-                                            count)                      \
+                                            count,                      \
+					    flags )                     \
 {                                                                       \
     OBJ_RETAIN(comm);                                                   \
     OBJ_RETAIN(datatype);                                               \
@@ -235,12 +243,13 @@ do {                                                                    \
         (req_send)->req_base.req_convertor.count      = count;          \
         (req_send)->req_base.req_convertor.pDesc      = &datatype->super; \
     } else {                                                            \
+        MCA_PML_CM_SWITCH_CUDA_CONVERTOR_OFF(flags, datatype, count);   \
         opal_convertor_copy_and_prepare_for_send(                       \
             ompi_mpi_local_convertor,                                   \
             &(datatype->super),                                         \
             count,                                                      \
             buf,                                                        \
-            0,                                                          \
+            flags,                                                          \
             &(req_send)->req_base.req_convertor );                      \
     }                                                                   \
     (req_send)->req_base.req_ompi.req_mpi_object.comm = comm;           \
@@ -263,7 +272,8 @@ do {                                                                    \
                                           persistent,                   \
                                           blocking,                     \
                                           buf,                          \
-                                          count)                        \
+                                          count,                        \
+					  flags )                       \
     do {                                                                \
         OMPI_REQUEST_INIT(&(sendreq->req_send.req_base.req_ompi),       \
                           persistent);                                  \
@@ -278,7 +288,8 @@ do {                                                                    \
                                              datatype,                  \
                                              sendmode,                  \
                                              buf,                       \
-                                             count);                    \
+                                             count,                     \
+					     flags )                    \
         opal_convertor_get_packed_size(                                 \
                                        &sendreq->req_send.req_base.req_convertor, \
                                        &sendreq->req_count );           \
@@ -297,7 +308,8 @@ do {                                                                    \
                                            datatype,                    \
                                            sendmode,                    \
                                            buf,                         \
-                                           count)                       \
+                                           count,                       \
+					   flags )                      \
     do {                                                                \
         OMPI_REQUEST_INIT(&(sendreq->req_send.req_base.req_ompi),       \
                           false);                                       \
@@ -308,7 +320,8 @@ do {                                                                    \
                                              datatype,                  \
                                              sendmode,                  \
                                              buf,                       \
-                                             count);                    \
+                                             count,                     \
+                                             flags);                    \
         sendreq->req_send.req_base.req_pml_complete = false;            \
     } while(0)
 

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2013-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -552,7 +553,9 @@ int32_t opal_convertor_prepare_for_recv( opal_convertor_t* convertor,
 
     convertor->flags |= CONVERTOR_RECV;
 #if OPAL_CUDA_SUPPORT
-    mca_cuda_convertor_init(convertor, pUserBuf);
+    if (!( convertor->flags & CONVERTOR_SKIP_CUDA_INIT )) {
+        mca_cuda_convertor_init(convertor, pUserBuf);
+    }
 #endif
 
     OPAL_CONVERTOR_PREPARE( convertor, datatype, count, pUserBuf );
@@ -589,7 +592,9 @@ int32_t opal_convertor_prepare_for_send( opal_convertor_t* convertor,
 {
     convertor->flags |= CONVERTOR_SEND;
 #if OPAL_CUDA_SUPPORT
-    mca_cuda_convertor_init(convertor, pUserBuf);
+    if (!( convertor->flags & CONVERTOR_SKIP_CUDA_INIT )) {
+        mca_cuda_convertor_init(convertor, pUserBuf);
+    }
 #endif
 
     OPAL_CONVERTOR_PREPARE( convertor, datatype, count, pUserBuf );

--- a/opal/datatype/opal_convertor.h
+++ b/opal/datatype/opal_convertor.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,6 +53,7 @@ BEGIN_C_DECLS
 #define CONVERTOR_STATE_ALLOC      0x04000000
 #define CONVERTOR_COMPLETED        0x08000000
 #define CONVERTOR_CUDA_UNIFIED     0x10000000
+#define CONVERTOR_SKIP_CUDA_INIT   0x40000000
 
 union dt_elem_desc;
 typedef struct opal_convertor_t opal_convertor_t;


### PR DESCRIPTION
PSM2 enables support for GPU buffers and CUDA managed memory and it can
directly recognize GPU buffers, handle copies between HFIs and GPUs.
Therefore, it is not required for OMPI to handle GPU buffers for pt2pt cases.
In this patch, we allow the PSM2 MTL to specify when
it does not require CUDA convertor support. This allows us to skip CUDA
convertor init phases and lets PSM2 handle the memory transfers.

This translates to improvements in latency.
The patch enables blocking collectives and workloads with GPU contiguous,
GPU non-contiguous memory.

(cherry picked from commit 2e83cf15ce790f89c782b6222253ab18252a7d2f)
Signed-off-by: Aravind Gopalakrishnan <Aravind.Gopalakrishnan@intel.com>

Conflicts:
	opal/datatype/opal_convertor.h