### PR TITLE
SLURM: launch all processes via slurmd

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,7 +57,6 @@ included in the vX.Y.Z section and be denoted as:
 ------------------------
 
 Bug fixes/minor improvements:
-
 - Update internal PMIx version to 1.2.3.
 - Fix some problems when using the NAG Fortran compiler to build Open MPI
   and when using the compiler wrappers.  Thanks to Neil Carlson for reporting.
@@ -94,6 +93,11 @@ Bug fixes/minor improvements:
 - Enable use of the head node of a SLURM allocation on Cray XC systems.
 - Fix a problem with synchronous sends when using the UCX PML.
 - Use default socket buffer size to improve TCP BTL performance.
+- Add a mca parameter ras_base_launch_orted_on_hn to allow for launching
+  MPI processes on the same node where mpirun is executing using a separate
+  orte daemon, rather than the mpirun process.   This may be useful to set to
+  true when using SLURM, as it improves interoperability with SLURM's signal
+  propagation tools.  By default it is set to false, except for Cray XC systems.
 - Remove support for big endian PowerPC.
 - Remove support for XL compilers older than v13.1
 - Remove IB XRC support from the OpenIB BTL due to loss of maintainer.

--- a/orte/mca/ras/base/base.h
+++ b/orte/mca/ras/base/base.h
@@ -49,6 +49,7 @@ typedef struct orte_ras_base_t {
     bool allocation_read;
     orte_ras_base_module_t *active_module;
     int total_slots_alloc;
+    bool launch_orted_on_hn;
 } orte_ras_base_t;
 
 ORTE_DECLSPEC extern orte_ras_base_t orte_ras_base;

--- a/orte/mca/ras/base/ras_base_node.c
+++ b/orte/mca/ras/base/ras_base_node.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2011-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -97,33 +97,24 @@ int orte_ras_base_node_insert(opal_list_t* nodes, orte_job_t *jdata)
 
     /* get the hnp node's info */
     hnp_node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, 0);
-#if SLURM_CRAY_ENV
-    /* if we are in a Cray-SLURM environment, then we cannot
-     * launch procs local to the HNP. The problem
-     * is the MPI processes launched on the head node (where the
-     * ORTE_PROC_IS_HNP evalues to true) get launched by a daemon
-     * (mpirun) which is not a child of a slurmd daemon.  This
-     * means that any RDMA credentials obtained via the odls/alps
-     * local launcher are incorrect. Test for this condition. If
-     * found, then take steps to ensure we launch a daemon on
-     * the same node as mpirun and that it gets used to fork
-     * local procs instead of mpirun so they get the proper
-     * credential */
-    if (NULL != hnp_node) {
-        OPAL_LIST_FOREACH(node, nodes, orte_node_t) {
-            if (orte_ifislocal(node->name)) {
-                orte_hnp_is_allocated = true;
-                break;
+
+    if ((orte_ras_base.launch_orted_on_hn == true) &&
+        (orte_managed_allocation)) {
+        if (NULL != hnp_node) {
+            OPAL_LIST_FOREACH(node, nodes, orte_node_t) {
+                if (orte_ifislocal(node->name)) {
+                    orte_hnp_is_allocated = true;
+                    break;
+                }
+            }
+            if (orte_hnp_is_allocated && !(ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping) &
+                ORTE_MAPPING_NO_USE_LOCAL)) {
+                hnp_node->name = strdup("mpirun");
+                skiphnp = true;
+                ORTE_SET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping, ORTE_MAPPING_NO_USE_LOCAL);
             }
         }
-        if (orte_hnp_is_allocated && !(ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping) & ORTE_MAPPING_NO_USE_LOCAL)) {
-            hnp_node->name = strdup("mpirun");
-            skiphnp = true;
-            ORTE_SET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping, ORTE_MAPPING_NO_USE_LOCAL);
-        }
     }
-#endif
-
 
     /* cycle through the list */
     while (NULL != (item = opal_list_remove_first(nodes))) {


### PR DESCRIPTION
It turns out that the approach of having the HNP do the
fork/exec of MPI ranks on the head node in a SLURM environment
introduces problems when users/sysadmins want to use the SLURM
scancl tool or sbatch --signal option to signal a job.

This commit disables use of the HNP fork/exec procedure when
a job is launched into a SLURM controlled allocation.

update NEWS with a blurb about new ras framework mca parameter.

related to #3998

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
(cherry picked from commit d08be7457318dfcaba59c84ceadec1166f601a40)

Conflicts:
	NEWS
	orte/mca/ras/base/base.h
	orte/mca/ras/base/ras_base_frame.c