### PR TITLE
test: add bounds check for nfs test

### DIFF
--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -132,7 +132,7 @@ void test(char* file, bool expect)
 
 void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
 {
-#define MAX_DIR 256
+#define MAX_DIR 512
 #define SIZE 1024
     char * cmd = "mount | cut -f3,5 -d' ' > opal_path_nfs.out";
     int rc;
@@ -156,7 +156,7 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
     file = fopen("opal_path_nfs.out", "r");
     i = 0;
     rc = 4711;
-    while (NULL != fgets (buffer, SIZE, file)) {
+    while (i < MAX_DIR && NULL != fgets (buffer, SIZE, file)) {
         int mount_known;
         char fs[MAXNAMLEN];
 


### PR DESCRIPTION
The nfs test builds a list of entries for all mount points on the
system, and then checks each mount point for expected results
against the opal_path_nfs() call.  This test assumed that there
were less than 256 mount points on the system, which apparently
isn't true on some Cray systems.  This patch makes two changes:
add the proper bound check to avoid a segmentation fault and
double the list of mount points we'll return.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>