### PR TITLE
pmix: configure.ac: fix setup order

### DIFF
--- a/opal/mca/pmix/pmix112/pmix/configure.ac
+++ b/opal/mca/pmix/pmix112/pmix/configure.ac
@@ -155,16 +155,6 @@ PMIX_BASIC_SETUP
 AS_IF([test "$pmix_debug" = "1"],
       [CFLAGS="$CFLAGS -g"])
 
-############################################################################
-# Setup the core
-############################################################################
-
-# Setup the pmix core
-PMIX_SETUP_CORE([])
-
-# Run the AM_CONDITIONALs
-PMIX_DO_AM_CONDITIONALS
-
 ####################################################################
 # Setup C compiler
 ####################################################################
@@ -179,6 +169,17 @@ AS_IF([test -z "$CC_FOR_BUILD"],[
 ])
 
 PMIX_SETUP_CC
+
+############################################################################
+# Setup the core
+############################################################################
+
+# Setup the pmix core
+PMIX_SETUP_CORE([])
+
+# Run the AM_CONDITIONALs
+PMIX_DO_AM_CONDITIONALS
+
 
 #
 # Delayed the substitution of CFLAGS and CXXFLAGS until now because


### PR DESCRIPTION
AC_PROG_CC needs to be called before PMIX_SETUP_CORE to avoid fatal
error when using some versions of autools:
  configure.ac:173: error: AC_PROG_CC cannot be called after AM_PROG_CC_C_O

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>