### PR TITLE
SPML_UCX: use ompi_proc_world_size() to set the estimated_num_eps value

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -128,7 +128,7 @@ static int mca_spml_ucx_component_open(void)
     memset(&params, 0, sizeof(params));
     params.field_mask = UCP_PARAM_FIELD_FEATURES|UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
     params.features   = UCP_FEATURE_RMA|UCP_FEATURE_AMO32|UCP_FEATURE_AMO64;
-    params.estimated_num_eps = oshmem_num_procs();
+    params.estimated_num_eps = ompi_proc_world_size();
 
     err = ucp_init(&params, ucp_config, &mca_spml_ucx.ucp_context);
     ucp_config_release(ucp_config);


### PR DESCRIPTION
before this fix, mca_spml_ucx_component_open was using
oshmem_num_procs() to set the value of params.estimated_num_eps for UCX.
The oshmem_num_procs() function uses oshmem_group_all which will be
initialized after the call to mca_spml_ucx_component_open and therefore,
cannot be used there.

Signed-off-by: Alina Sklarevich <alinas@mellanox.com>
(cherry picked from commit 007b1803ec94621d28c72bbb1db1c87b67e51296)