### PR TITLE
osc/sm: do not require 64-bit atomic math

### DIFF
--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -18,6 +18,20 @@
 
 #include "opal/mca/shmem/base/base.h"
 
+#if OPAL_HAVE_ATOMIC_MATH_64
+
+typedef uint64_t osc_sm_post_type_t;
+#define OSC_SM_POST_BITS 6
+#define OSC_SM_POST_MASK 0x3f
+
+#else
+
+typedef uint32_t osc_sm_post_type_t;
+#define OSC_SM_POST_BITS 5
+#define OSC_SM_POST_MASK 0x1f
+
+#endif
+
 /* data shared across all peers */
 struct ompi_osc_sm_global_state_t {
     int use_barrier_for_fence;
@@ -81,7 +95,8 @@ struct ompi_osc_sm_module_t {
     ompi_osc_sm_global_state_t *global_state;
     ompi_osc_sm_node_state_t *my_node_state;
     ompi_osc_sm_node_state_t *node_states;
-    uint64_t **posts;
+
+    osc_sm_post_type_t ** volatile posts;
 
     opal_mutex_t lock;
 };

--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -214,9 +214,9 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         if (NULL == module->global_state) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
         module->node_states = malloc(sizeof(ompi_osc_sm_node_state_t));
         if (NULL == module->node_states) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-        module->posts = calloc (1, sizeof(module->posts[0]) + sizeof (uint64_t));
+        module->posts = calloc (1, sizeof(module->posts[0]) + sizeof (module->posts[0][0]));
         if (NULL == module->posts) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
-        module->posts[0] = (uint64_t *) (module->posts + 1);
+        module->posts[0] = (osc_sm_post_type_t *) (module->posts + 1);
     } else {
         unsigned long total, *rbuf;
         int i, flag;
@@ -258,7 +258,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 	/* user opal/shmem directly to create a shared memory segment */
 	state_size = sizeof(ompi_osc_sm_global_state_t) + sizeof(ompi_osc_sm_node_state_t) * comm_size;
         state_size += OPAL_ALIGN_PAD_AMOUNT(state_size, 64);
-        posts_size = comm_size * post_size * sizeof (uint64_t);
+        posts_size = comm_size * post_size * sizeof (module->posts[0][0]);
         posts_size += OPAL_ALIGN_PAD_AMOUNT(posts_size, 64);
         if (0 == ompi_comm_rank (module->comm)) {
             char *data_file;
@@ -295,7 +295,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         if (NULL == module->posts) return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
 
         /* set module->posts[0] first to ensure 64-bit alignment */
-        module->posts[0] = (uint64_t *) (module->segment_base);
+        module->posts[0] = (osc_sm_post_type_t *) (module->segment_base);
         module->global_state = (ompi_osc_sm_global_state_t *) (module->posts[0] + comm_size * post_size);
         module->node_states = (ompi_osc_sm_node_state_t *) (module->global_state + 1);
 


### PR DESCRIPTION
This commit fixes an issue on 32-bit systems that required atomic
64-bit math in the active target path. This commit updates the code to
work correctly on 32-bit systems.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>