### PR TITLE
Fix --without-lsf and LSF in default search path

### DIFF
--- a/config/opal_check_withdir.m4
+++ b/config/opal_check_withdir.m4
@@ -8,6 +8,7 @@ dnl                         reserved.
 dnl Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -19,17 +20,21 @@ dnl
 # ----------------------------------------------------
 AC_DEFUN([OPAL_CHECK_WITHDIR],[
     AC_MSG_CHECKING([--with-$1 value])
-    AS_IF([test "$2" = "yes" || test "$2" = "no" || test "x$2" = "x"],
-          [AC_MSG_RESULT([simple ok (unspecified)])],
-          [AS_IF([test ! -d "$2"],
-                 [AC_MSG_RESULT([not found])
-                  AC_MSG_WARN([Directory $2 not found])
-                  AC_MSG_ERROR([Cannot continue])],
-                 [AS_IF([test "x`ls $2/$3 2> /dev/null`" = "x"],
+    AS_IF([test "$2" = "no" ],
+          [AC_MSG_RESULT([simple no (specified --without-$1)])],
+          [AS_IF([test "$2" = "yes" || test "x$2" = "x"],
+                 [AC_MSG_RESULT([simple ok (unspecified value)])],
+                 [AS_IF([test ! -d "$2"],
                         [AC_MSG_RESULT([not found])
-                         AC_MSG_WARN([Expected file $2/$3 not found])
+                         AC_MSG_WARN([Directory $2 not found])
                          AC_MSG_ERROR([Cannot continue])],
-                        [AC_MSG_RESULT([sanity check ok ($2)])]
+                        [AS_IF([test "x`ls $2/$3 2> /dev/null`" = "x"],
+                               [AC_MSG_RESULT([not found])
+                                AC_MSG_WARN([Expected file $2/$3 not found])
+                                AC_MSG_ERROR([Cannot continue])],
+                               [AC_MSG_RESULT([sanity check ok ($2)])]
+                              )
+                        ]
                        )
                  ]
                 )

--- a/config/orte_check_lsf.m4
+++ b/config/orte_check_lsf.m4
@@ -15,6 +15,7 @@ dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -26,7 +27,7 @@ dnl
 # ORTE_CHECK_LSF(prefix, [action-if-found], [action-if-not-found])
 # --------------------------------------------------------
 AC_DEFUN([ORTE_CHECK_LSF],[
-    if test -z "$orte_check_lsf_happy" ; then
+    AS_IF([test -z "$orte_check_lsf_happy"],[
        AC_ARG_WITH([lsf],
                [AC_HELP_STRING([--with-lsf(=DIR)],
                        [Build LSF support])])
@@ -36,103 +37,106 @@ AC_DEFUN([ORTE_CHECK_LSF],[
                        [Search for LSF libraries in DIR])])
        OPAL_CHECK_WITHDIR([lsf-libdir], [$with_lsf_libdir], [libbat.*])
 
-       # Defaults
-       orte_check_lsf_dir_msg="compiler default"
-       orte_check_lsf_libdir_msg="linker default"
+       AS_IF([test "$with_lsf" != "no"],[
+          # Defaults
+          orte_check_lsf_dir_msg="compiler default"
+          orte_check_lsf_libdir_msg="linker default"
 
-       # Save directory names if supplied
-       AS_IF([test ! -z "$with_lsf" && test "$with_lsf" != "yes"],
-                 [orte_check_lsf_dir="$with_lsf"
-                  orte_check_lsf_dir_msg="$orte_check_lsf_dir (from --with-lsf)"])
-       AS_IF([test ! -z "$with_lsf_libdir" && test "$with_lsf_libdir" != "yes"],
-                 [orte_check_lsf_libdir="$with_lsf_libdir"
-                  orte_check_lsf_libdir_msg="$orte_check_lsf_libdir (from --with-lsf-libdir)"])
+          # Save directory names if supplied
+          AS_IF([test ! -z "$with_lsf" && test "$with_lsf" != "yes"],
+                    [orte_check_lsf_dir="$with_lsf"
+                     orte_check_lsf_dir_msg="$orte_check_lsf_dir (from --with-lsf)"])
+          AS_IF([test ! -z "$with_lsf_libdir" && test "$with_lsf_libdir" != "yes"],
+                    [orte_check_lsf_libdir="$with_lsf_libdir"
+                     orte_check_lsf_libdir_msg="$orte_check_lsf_libdir (from --with-lsf-libdir)"])
 
-       # If no directories were specified, look for LSF_LIBDIR,
-       # LSF_INCLUDEDIR, and/or LSF_ENVDIR.
-       AS_IF([test -z "$orte_check_lsf_dir" && test -z "$orte_check_lsf_libdir"],
-                 [AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_LIBDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
-                        [LSF_LIBDIR=`egrep ^LSF_LIBDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
-                  AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_INCLUDEDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
-                        [LSF_INCLUDEDIR=`egrep ^LSF_INCLUDEDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
-                  AS_IF([test ! -z "$LSF_LIBDIR"],
-                        [orte_check_lsf_libdir=$LSF_LIBDIR
-                         orte_check_lsf_libdir_msg="$LSF_LIBDIR (from \$LSF_LIBDIR)"])
-                  AS_IF([test ! -z "$LSF_INCLUDEDIR"],
-                        [orte_check_lsf_dir=`dirname $LSF_INCLUDEDIR`
-                         orte_check_lsf_dir_msg="$orte_check_lsf_dir (from \$LSF_INCLUDEDIR)"])])
+          # If no directories were specified, look for LSF_LIBDIR,
+          # LSF_INCLUDEDIR, and/or LSF_ENVDIR.
+          AS_IF([test -z "$orte_check_lsf_dir" && test -z "$orte_check_lsf_libdir"],
+                    [AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_LIBDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
+                           [LSF_LIBDIR=`egrep ^LSF_LIBDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
+                     AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_INCLUDEDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
+                           [LSF_INCLUDEDIR=`egrep ^LSF_INCLUDEDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
+                     AS_IF([test ! -z "$LSF_LIBDIR"],
+                           [orte_check_lsf_libdir=$LSF_LIBDIR
+                            orte_check_lsf_libdir_msg="$LSF_LIBDIR (from \$LSF_LIBDIR)"])
+                     AS_IF([test ! -z "$LSF_INCLUDEDIR"],
+                           [orte_check_lsf_dir=`dirname $LSF_INCLUDEDIR`
+                            orte_check_lsf_dir_msg="$orte_check_lsf_dir (from \$LSF_INCLUDEDIR)"])])
 
-       AS_IF([test "$with_lsf" = "no"],
-                 [orte_check_lsf_happy="no"],
-                 [orte_check_lsf_happy="yes"])
+          AS_IF([test "$with_lsf" = "no"],
+                    [orte_check_lsf_happy="no"],
+                    [orte_check_lsf_happy="yes"])
 
-       orte_check_lsf_$1_save_CPPFLAGS="$CPPFLAGS"
-       orte_check_lsf_$1_save_LDFLAGS="$LDFLAGS"
-       orte_check_lsf_$1_save_LIBS="$LIBS"
+          orte_check_lsf_$1_save_CPPFLAGS="$CPPFLAGS"
+          orte_check_lsf_$1_save_LDFLAGS="$LDFLAGS"
+          orte_check_lsf_$1_save_LIBS="$LIBS"
 
-       # liblsf requires yp_all, yp_get_default_domain, and ypprot_err
-       # on Linux, Solaris, NEC, and Sony NEWSs these are found in libnsl
-       # on AIX it should be in libbsd
-       # on HP-UX it should be in libBSD
-       # on IRIX < 6 it should be in libsun (IRIX 6 and later it is in libc)
-       OPAL_SEARCH_LIBS_COMPONENT([yp_all_nsl], [yp_all], [nsl bsd BSD sun],
-                      [yp_all_nsl_happy="yes"],
-                      [yp_all_nsl_happy="no"])
+          # liblsf requires yp_all, yp_get_default_domain, and ypprot_err
+          # on Linux, Solaris, NEC, and Sony NEWSs these are found in libnsl
+          # on AIX it should be in libbsd
+          # on HP-UX it should be in libBSD
+          # on IRIX < 6 it should be in libsun (IRIX 6 and later it is in libc)
+          OPAL_SEARCH_LIBS_COMPONENT([yp_all_nsl], [yp_all], [nsl bsd BSD sun],
+                         [yp_all_nsl_happy="yes"],
+                         [yp_all_nsl_happy="no"])
 
-       AS_IF([test "$yp_all_nsl_happy" = "no"],
-                 [orte_check_lsf_happy="no"],
-                 [orte_check_lsf_happy="yes"])
+          AS_IF([test "$yp_all_nsl_happy" = "no"],
+                    [orte_check_lsf_happy="no"],
+                    [orte_check_lsf_happy="yes"])
 
-       # liblsb requires liblsf - using ls_info as a test for liblsf presence
-       OPAL_CHECK_PACKAGE([ls_info_lsf],
-                  [lsf/lsf.h],
-                  [lsf],
-                  [ls_info],
-                  [$yp_all_nsl_LIBS],
-                  [$orte_check_lsf_dir],
-                  [$orte_check_lsf_libdir],
-                  [ls_info_lsf_happy="yes"],
-                  [ls_info_lsf_happy="no"])
-
-       AS_IF([test "$ls_info_lsf_happy" = "no"],
-                 [orte_check_lsf_happy="no"],
-                 [orte_check_lsf_happy="yes"])
-
-       # test function of liblsb LSF package
-       AS_IF([test "$orte_check_lsf_happy" = "yes"],
-                 [AC_MSG_CHECKING([for LSF dir])
-                  AC_MSG_RESULT([$orte_check_lsf_dir_msg])
-                  AC_MSG_CHECKING([for LSF library dir])
-                  AC_MSG_RESULT([$orte_check_lsf_libdir_msg])
-                  AC_MSG_CHECKING([for liblsf function])
-                  AC_MSG_RESULT([$ls_info_lsf_happy])
-                  AC_MSG_CHECKING([for liblsf yp requirements])
-                  AC_MSG_RESULT([$yp_all_nsl_happy])
-                  OPAL_CHECK_PACKAGE([orte_check_lsf],
-                     [lsf/lsbatch.h],
-                     [bat],
-                     [lsb_launch],
-                     [$ls_info_lsf_LIBS $yp_all_nsl_LIBS],
+          # liblsb requires liblsf - using ls_info as a test for liblsf presence
+          OPAL_CHECK_PACKAGE([ls_info_lsf],
+                     [lsf/lsf.h],
+                     [lsf],
+                     [ls_info],
+                     [$yp_all_nsl_LIBS],
                      [$orte_check_lsf_dir],
                      [$orte_check_lsf_libdir],
-                     [orte_check_lsf_happy="yes"],
-                     [orte_check_lsf_happy="no"])])
+                     [ls_info_lsf_happy="yes"],
+                     [ls_info_lsf_happy="no"])
 
-       CPPFLAGS="$orte_check_lsf_$1_save_CPPFLAGS"
-       LDFLAGS="$orte_check_lsf_$1_save_LDFLAGS"
-       LIBS="$orte_check_lsf_$1_save_LIBS"
+          AS_IF([test "$ls_info_lsf_happy" = "no"],
+                    [orte_check_lsf_happy="no"],
+                    [orte_check_lsf_happy="yes"])
+
+          # test function of liblsb LSF package
+          AS_IF([test "$orte_check_lsf_happy" = "yes"],
+                    [AC_MSG_CHECKING([for LSF dir])
+                     AC_MSG_RESULT([$orte_check_lsf_dir_msg])
+                     AC_MSG_CHECKING([for LSF library dir])
+                     AC_MSG_RESULT([$orte_check_lsf_libdir_msg])
+                     AC_MSG_CHECKING([for liblsf function])
+                     AC_MSG_RESULT([$ls_info_lsf_happy])
+                     AC_MSG_CHECKING([for liblsf yp requirements])
+                     AC_MSG_RESULT([$yp_all_nsl_happy])
+                     OPAL_CHECK_PACKAGE([orte_check_lsf],
+                        [lsf/lsbatch.h],
+                        [bat],
+                        [lsb_launch],
+                        [$ls_info_lsf_LIBS $yp_all_nsl_LIBS],
+                        [$orte_check_lsf_dir],
+                        [$orte_check_lsf_libdir],
+                        [orte_check_lsf_happy="yes"],
+                        [orte_check_lsf_happy="no"])])
+
+          CPPFLAGS="$orte_check_lsf_$1_save_CPPFLAGS"
+          LDFLAGS="$orte_check_lsf_$1_save_LDFLAGS"
+          LIBS="$orte_check_lsf_$1_save_LIBS"
+
+       ],[orte_check_lsf_happy=no])
 
        OPAL_SUMMARY_ADD([[Resource Managers]],[[LSF]],[$1],[$orte_check_lsf_happy])
-    fi
+    ])
 
     AS_IF([test "$orte_check_lsf_happy" = "yes"],
           [$1_LIBS="[$]$1_LIBS $orte_check_lsf_LIBS"
-       $1_LDFLAGS="[$]$1_LDFLAGS $orte_check_lsf_LDFLAGS"
-       $1_CPPFLAGS="[$]$1_CPPFLAGS $orte_check_lsf_CPPFLAGS"
-       # add the LSF libraries to static builds as they are required
-       $1_WRAPPER_EXTRA_LDFLAGS=[$]$1_LDFLAGS
-       $1_WRAPPER_EXTRA_LIBS=[$]$1_LIBS
-       $2],
+           $1_LDFLAGS="[$]$1_LDFLAGS $orte_check_lsf_LDFLAGS"
+           $1_CPPFLAGS="[$]$1_CPPFLAGS $orte_check_lsf_CPPFLAGS"
+           # add the LSF libraries to static builds as they are required
+           $1_WRAPPER_EXTRA_LDFLAGS=[$]$1_LDFLAGS
+           $1_WRAPPER_EXTRA_LIBS=[$]$1_LIBS
+           $2],
           [AS_IF([test ! -z "$with_lsf" && test "$with_lsf" != "no"],
                  [AC_MSG_WARN([LSF support requested (via --with-lsf) but not found.])
                   AC_MSG_ERROR([Aborting.])])

--- a/config/orte_check_lsf.m4
+++ b/config/orte_check_lsf.m4
@@ -27,112 +27,112 @@ dnl
 # --------------------------------------------------------
 AC_DEFUN([ORTE_CHECK_LSF],[
     if test -z "$orte_check_lsf_happy" ; then
-	AC_ARG_WITH([lsf],
-		    [AC_HELP_STRING([--with-lsf(=DIR)],
-				    [Build LSF support])])
-	OPAL_CHECK_WITHDIR([lsf], [$with_lsf], [include/lsf/lsbatch.h])
-	AC_ARG_WITH([lsf-libdir],
-		    [AC_HELP_STRING([--with-lsf-libdir=DIR],
-				    [Search for LSF libraries in DIR])])
-	OPAL_CHECK_WITHDIR([lsf-libdir], [$with_lsf_libdir], [libbat.*])
+       AC_ARG_WITH([lsf],
+               [AC_HELP_STRING([--with-lsf(=DIR)],
+                       [Build LSF support])])
+       OPAL_CHECK_WITHDIR([lsf], [$with_lsf], [include/lsf/lsbatch.h])
+       AC_ARG_WITH([lsf-libdir],
+               [AC_HELP_STRING([--with-lsf-libdir=DIR],
+                       [Search for LSF libraries in DIR])])
+       OPAL_CHECK_WITHDIR([lsf-libdir], [$with_lsf_libdir], [libbat.*])
 
-	# Defaults
-	orte_check_lsf_dir_msg="compiler default"
-	orte_check_lsf_libdir_msg="linker default"
+       # Defaults
+       orte_check_lsf_dir_msg="compiler default"
+       orte_check_lsf_libdir_msg="linker default"
 
-	# Save directory names if supplied
-	AS_IF([test ! -z "$with_lsf" && test "$with_lsf" != "yes"],
-              [orte_check_lsf_dir="$with_lsf"
-               orte_check_lsf_dir_msg="$orte_check_lsf_dir (from --with-lsf)"])
-	AS_IF([test ! -z "$with_lsf_libdir" && test "$with_lsf_libdir" != "yes"],
-              [orte_check_lsf_libdir="$with_lsf_libdir"
-               orte_check_lsf_libdir_msg="$orte_check_lsf_libdir (from --with-lsf-libdir)"])
+       # Save directory names if supplied
+       AS_IF([test ! -z "$with_lsf" && test "$with_lsf" != "yes"],
+                 [orte_check_lsf_dir="$with_lsf"
+                  orte_check_lsf_dir_msg="$orte_check_lsf_dir (from --with-lsf)"])
+       AS_IF([test ! -z "$with_lsf_libdir" && test "$with_lsf_libdir" != "yes"],
+                 [orte_check_lsf_libdir="$with_lsf_libdir"
+                  orte_check_lsf_libdir_msg="$orte_check_lsf_libdir (from --with-lsf-libdir)"])
 
-	# If no directories were specified, look for LSF_LIBDIR,
-	# LSF_INCLUDEDIR, and/or LSF_ENVDIR.
-	AS_IF([test -z "$orte_check_lsf_dir" && test -z "$orte_check_lsf_libdir"],
-              [AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_LIBDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
-                     [LSF_LIBDIR=`egrep ^LSF_LIBDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
-               AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_INCLUDEDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
-                     [LSF_INCLUDEDIR=`egrep ^LSF_INCLUDEDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
-               AS_IF([test ! -z "$LSF_LIBDIR"],
-                     [orte_check_lsf_libdir=$LSF_LIBDIR
-                      orte_check_lsf_libdir_msg="$LSF_LIBDIR (from \$LSF_LIBDIR)"])
-               AS_IF([test ! -z "$LSF_INCLUDEDIR"],
-                     [orte_check_lsf_dir=`dirname $LSF_INCLUDEDIR`
-                      orte_check_lsf_dir_msg="$orte_check_lsf_dir (from \$LSF_INCLUDEDIR)"])])
+       # If no directories were specified, look for LSF_LIBDIR,
+       # LSF_INCLUDEDIR, and/or LSF_ENVDIR.
+       AS_IF([test -z "$orte_check_lsf_dir" && test -z "$orte_check_lsf_libdir"],
+                 [AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_LIBDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
+                        [LSF_LIBDIR=`egrep ^LSF_LIBDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
+                  AS_IF([test ! -z "$LSF_ENVDIR" && test -z "$LSF_INCLUDEDIR" && test -f "$LSF_ENVDIR/lsf.conf"],
+                        [LSF_INCLUDEDIR=`egrep ^LSF_INCLUDEDIR= $LSF_ENVDIR/lsf.conf | cut -d= -f2-`])
+                  AS_IF([test ! -z "$LSF_LIBDIR"],
+                        [orte_check_lsf_libdir=$LSF_LIBDIR
+                         orte_check_lsf_libdir_msg="$LSF_LIBDIR (from \$LSF_LIBDIR)"])
+                  AS_IF([test ! -z "$LSF_INCLUDEDIR"],
+                        [orte_check_lsf_dir=`dirname $LSF_INCLUDEDIR`
+                         orte_check_lsf_dir_msg="$orte_check_lsf_dir (from \$LSF_INCLUDEDIR)"])])
 
-	AS_IF([test "$with_lsf" = "no"],
-              [orte_check_lsf_happy="no"],
-              [orte_check_lsf_happy="yes"])
+       AS_IF([test "$with_lsf" = "no"],
+                 [orte_check_lsf_happy="no"],
+                 [orte_check_lsf_happy="yes"])
 
-	orte_check_lsf_$1_save_CPPFLAGS="$CPPFLAGS"
-	orte_check_lsf_$1_save_LDFLAGS="$LDFLAGS"
-	orte_check_lsf_$1_save_LIBS="$LIBS"
+       orte_check_lsf_$1_save_CPPFLAGS="$CPPFLAGS"
+       orte_check_lsf_$1_save_LDFLAGS="$LDFLAGS"
+       orte_check_lsf_$1_save_LIBS="$LIBS"
 
-	# liblsf requires yp_all, yp_get_default_domain, and ypprot_err
-	# on Linux, Solaris, NEC, and Sony NEWSs these are found in libnsl
-	# on AIX it should be in libbsd
-	# on HP-UX it should be in libBSD
-	# on IRIX < 6 it should be in libsun (IRIX 6 and later it is in libc)
-	OPAL_SEARCH_LIBS_COMPONENT([yp_all_nsl], [yp_all], [nsl bsd BSD sun],
-				   [yp_all_nsl_happy="yes"],
-				   [yp_all_nsl_happy="no"])
+       # liblsf requires yp_all, yp_get_default_domain, and ypprot_err
+       # on Linux, Solaris, NEC, and Sony NEWSs these are found in libnsl
+       # on AIX it should be in libbsd
+       # on HP-UX it should be in libBSD
+       # on IRIX < 6 it should be in libsun (IRIX 6 and later it is in libc)
+       OPAL_SEARCH_LIBS_COMPONENT([yp_all_nsl], [yp_all], [nsl bsd BSD sun],
+                      [yp_all_nsl_happy="yes"],
+                      [yp_all_nsl_happy="no"])
 
-	AS_IF([test "$yp_all_nsl_happy" = "no"],
-              [orte_check_lsf_happy="no"],
-              [orte_check_lsf_happy="yes"])
+       AS_IF([test "$yp_all_nsl_happy" = "no"],
+                 [orte_check_lsf_happy="no"],
+                 [orte_check_lsf_happy="yes"])
 
-	# liblsb requires liblsf - using ls_info as a test for liblsf presence
-	OPAL_CHECK_PACKAGE([ls_info_lsf],
-			   [lsf/lsf.h],
-			   [lsf],
-			   [ls_info],
-			   [$yp_all_nsl_LIBS],
-			   [$orte_check_lsf_dir],
-			   [$orte_check_lsf_libdir],
-			   [ls_info_lsf_happy="yes"],
-			   [ls_info_lsf_happy="no"])
+       # liblsb requires liblsf - using ls_info as a test for liblsf presence
+       OPAL_CHECK_PACKAGE([ls_info_lsf],
+                  [lsf/lsf.h],
+                  [lsf],
+                  [ls_info],
+                  [$yp_all_nsl_LIBS],
+                  [$orte_check_lsf_dir],
+                  [$orte_check_lsf_libdir],
+                  [ls_info_lsf_happy="yes"],
+                  [ls_info_lsf_happy="no"])
 
-	AS_IF([test "$ls_info_lsf_happy" = "no"],
-              [orte_check_lsf_happy="no"],
-              [orte_check_lsf_happy="yes"])
+       AS_IF([test "$ls_info_lsf_happy" = "no"],
+                 [orte_check_lsf_happy="no"],
+                 [orte_check_lsf_happy="yes"])
 
-	# test function of liblsb LSF package
-	AS_IF([test "$orte_check_lsf_happy" = "yes"],
-              [AC_MSG_CHECKING([for LSF dir])
-               AC_MSG_RESULT([$orte_check_lsf_dir_msg])
-               AC_MSG_CHECKING([for LSF library dir])
-               AC_MSG_RESULT([$orte_check_lsf_libdir_msg])
-               AC_MSG_CHECKING([for liblsf function])
-               AC_MSG_RESULT([$ls_info_lsf_happy])
-               AC_MSG_CHECKING([for liblsf yp requirements])
-               AC_MSG_RESULT([$yp_all_nsl_happy])
-               OPAL_CHECK_PACKAGE([orte_check_lsf],
-				  [lsf/lsbatch.h],
-				  [bat],
-				  [lsb_launch],
-				  [$ls_info_lsf_LIBS $yp_all_nsl_LIBS],
-				  [$orte_check_lsf_dir],
-				  [$orte_check_lsf_libdir],
-				  [orte_check_lsf_happy="yes"],
-				  [orte_check_lsf_happy="no"])])
+       # test function of liblsb LSF package
+       AS_IF([test "$orte_check_lsf_happy" = "yes"],
+                 [AC_MSG_CHECKING([for LSF dir])
+                  AC_MSG_RESULT([$orte_check_lsf_dir_msg])
+                  AC_MSG_CHECKING([for LSF library dir])
+                  AC_MSG_RESULT([$orte_check_lsf_libdir_msg])
+                  AC_MSG_CHECKING([for liblsf function])
+                  AC_MSG_RESULT([$ls_info_lsf_happy])
+                  AC_MSG_CHECKING([for liblsf yp requirements])
+                  AC_MSG_RESULT([$yp_all_nsl_happy])
+                  OPAL_CHECK_PACKAGE([orte_check_lsf],
+                     [lsf/lsbatch.h],
+                     [bat],
+                     [lsb_launch],
+                     [$ls_info_lsf_LIBS $yp_all_nsl_LIBS],
+                     [$orte_check_lsf_dir],
+                     [$orte_check_lsf_libdir],
+                     [orte_check_lsf_happy="yes"],
+                     [orte_check_lsf_happy="no"])])
 
-	CPPFLAGS="$orte_check_lsf_$1_save_CPPFLAGS"
-	LDFLAGS="$orte_check_lsf_$1_save_LDFLAGS"
-	LIBS="$orte_check_lsf_$1_save_LIBS"
+       CPPFLAGS="$orte_check_lsf_$1_save_CPPFLAGS"
+       LDFLAGS="$orte_check_lsf_$1_save_LDFLAGS"
+       LIBS="$orte_check_lsf_$1_save_LIBS"
 
-	OPAL_SUMMARY_ADD([[Resource Managers]],[[LSF]],[$1],[$orte_check_lsf_happy])
+       OPAL_SUMMARY_ADD([[Resource Managers]],[[LSF]],[$1],[$orte_check_lsf_happy])
     fi
 
     AS_IF([test "$orte_check_lsf_happy" = "yes"],
           [$1_LIBS="[$]$1_LIBS $orte_check_lsf_LIBS"
-	   $1_LDFLAGS="[$]$1_LDFLAGS $orte_check_lsf_LDFLAGS"
-	   $1_CPPFLAGS="[$]$1_CPPFLAGS $orte_check_lsf_CPPFLAGS"
-	   # add the LSF libraries to static builds as they are required
-	   $1_WRAPPER_EXTRA_LDFLAGS=[$]$1_LDFLAGS
-	   $1_WRAPPER_EXTRA_LIBS=[$]$1_LIBS
-	   $2],
+       $1_LDFLAGS="[$]$1_LDFLAGS $orte_check_lsf_LDFLAGS"
+       $1_CPPFLAGS="[$]$1_CPPFLAGS $orte_check_lsf_CPPFLAGS"
+       # add the LSF libraries to static builds as they are required
+       $1_WRAPPER_EXTRA_LDFLAGS=[$]$1_LDFLAGS
+       $1_WRAPPER_EXTRA_LIBS=[$]$1_LIBS
+       $2],
           [AS_IF([test ! -z "$with_lsf" && test "$with_lsf" != "no"],
                  [AC_MSG_WARN([LSF support requested (via --with-lsf) but not found.])
                   AC_MSG_ERROR([Aborting.])])


### PR DESCRIPTION
 * A fix for Issue #3546
 * Include a clarification to `OPAL_CHECK_WITHDIR`