### PR TITLE
Add a new launcher "prun" for starting applications against the ORTE DVM.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -520,6 +520,8 @@ orte/tools/orted/orted
 orte/tools/orted/orted.1
 orte/tools/orterun/orterun
 orte/tools/orterun/orterun.1
+orte/tools/prun/prun
+orte/tools/prun/prun.1
 orte/tools/wrappers/ortecc-wrapper-data.txt
 orte/tools/wrappers/ortec++-wrapper-data.txt
 orte/tools/wrappers/ortecc.1

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -13,7 +13,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -240,9 +240,11 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
            AC_MSG_ERROR([Cannot continue])])
 
     AC_MSG_CHECKING([if user requested external PMIx support($with_pmix)])
+    opal_prun_happy=no
     AS_IF([test -z "$with_pmix" || test "$with_pmix" = "yes" || test "$with_pmix" = "internal"],
           [AC_MSG_RESULT([no])
-           opal_external_pmix_happy=no],
+           opal_external_pmix_happy=no
+           opal_prun_happy=yes],
 
           [AC_MSG_RESULT([yes])
            # check for external pmix lib */
@@ -295,7 +297,8 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
                                                       ], [])],
                                     [AC_MSG_RESULT([found])
                                      opal_external_pmix_version=2x
-                                     opal_external_pmix_version_found=1],
+                                     opal_external_pmix_version_found=1
+                                     opal_prun_happy=yes],
                                     [AC_MSG_RESULT([not found])])])
 
            AS_IF([test "$opal_external_pmix_version_found" = "0"],
@@ -326,5 +329,6 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
            opal_external_pmix_LIBS=-lpmix
            opal_external_pmix_happy=yes])
 
+    AM_CONDITIONAL([OPAL_WANT_PRUN], [test "$opal_prun_happy" = "yes"])
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/orte_config_files.m4
+++ b/config/orte_config_files.m4
@@ -6,7 +6,7 @@
 #                         Corporation.  All rights reserved.
 # Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
 #                         reserved.
-# Copyright (c) 2015-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,5 +34,6 @@ AC_DEFUN([ORTE_CONFIG_FILES],[
         orte/tools/orte-info/Makefile
         orte/tools/orte-server/Makefile
         orte/tools/orte-dvm/Makefile
+        orte/tools/prun/Makefile
     ])
 ])

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -88,7 +88,7 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
            opal_pmix_pmix2x_CPPFLAGS="-I$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix/include -I$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix -I$OPAL_TOP_SRCDIR/$opal_pmix_pmix2x_basedir/pmix/include -I$OPAL_TOP_SRCDIR/$opal_pmix_pmix2x_basedir/pmix"
            opal_pmix_pmix2x_DEPENDENCIES="$OPAL_TOP_BUILDDIR/$opal_pmix_pmix2x_basedir/pmix/src/libpmix.la"
            # and the flags for prun
-           OPAL_PMIX_CPPFLAGS="-I$opal_pmix_pmix2x_CPPFLAGS"
+           OPAL_PMIX_CPPFLAGS="$opal_pmix_pmix2x_CPPFLAGS"
            AC_SUBST(OPAL_PMIX_CPPFLAGS)
            OPAL_PMIX_LDADD=$opal_pmix_pmix2x_LIBS
            AC_SUBST(OPAL_PMIX_LDADD)

--- a/opal/mca/pmix/pmix2x/pmix2x.h
+++ b/opal/mca/pmix/pmix2x/pmix2x.h
@@ -256,6 +256,12 @@ OPAL_MODULE_DECLSPEC int pmix2x_disconnectnb(opal_list_t *procs,
 OPAL_MODULE_DECLSPEC int pmix2x_resolve_peers(const char *nodename, opal_jobid_t jobid,
                                              opal_list_t *procs);
 OPAL_MODULE_DECLSPEC int pmix2x_resolve_nodes(opal_jobid_t jobid, char **nodelist);
+OPAL_MODULE_DECLSPEC int pmix2x_allocate(opal_pmix_alloc_directive_t directive,
+                                         opal_list_t *info,
+                                         opal_pmix_info_cbfunc_t cbfunc, void *cbdata);
+OPAL_MODULE_DECLSPEC int pmix2x_job_control(opal_list_t *targets,
+                                            opal_list_t *directives,
+                                            opal_pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /****  TOOL FUNCTIONS  ****/
 OPAL_MODULE_DECLSPEC int pmix2x_tool_init(opal_list_t *info);

--- a/opal/mca/pmix/pmix2x/pmix2x_server_north.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_north.c
@@ -670,6 +670,9 @@ static pmix_status_t server_spawn_fn(const pmix_proc_t *p,
         if (NULL != apps[n].env) {
             app->env = opal_argv_copy(apps[n].env);
         }
+        if (NULL != apps[n].cwd) {
+            app->cwd = strdup(apps[n].cwd);
+        }
         app->maxprocs = apps[n].maxprocs;
         for (k=0; k < apps[n].ninfo; k++) {
             oinfo = OBJ_NEW(opal_value_t);

--- a/orte/tools/Makefile.am
+++ b/orte/tools/Makefile.am
@@ -13,7 +13,7 @@
 # Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
 #                         reserved.
-# Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -50,5 +50,10 @@ DIST_SUBDIRS += \
         tools/orte-info \
         tools/orte-migrate \
         tools/orte-server \
-        tools/orte-dvm
+        tools/orte-dvm \
+        tools/prun
 
+if OPAL_WANT_PRUN
+SUBDIRS += \
+	tools/prun
+endif

--- a/orte/tools/prun/Makefile.am
+++ b/orte/tools/prun/Makefile.am
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This is not quite in the Automake spirit, but we have to do it.
+# Since the totalview portion of the library must be built with -g, we
+# must eliminate the CFLAGS that are passed in here by default (which
+# may already have debugging and/or optimization flags).  We use
+# post-processed forms of the CFLAGS in the library targets down
+# below.
+
+AM_CPPFLAGS = $(OPAL_PMIX_CPPFLAGS)
+
+CFLAGS = $(CFLAGS_WITHOUT_OPTFLAGS) $(DEBUGGER_CFLAGS)
+AM_LDFLAGS = $(OPAL_PMIX_LDFLAGS)
+
+include $(top_srcdir)/Makefile.ompi-rules
+
+man_pages = prun.1
+EXTRA_DIST = $(man_pages:.1=.1in)
+
+if OPAL_INSTALL_BINARIES
+
+bin_PROGRAMS = prun
+
+nodist_man_MANS = $(man_pages)
+
+# Ensure that the man pages are rebuilt if the opal_config.h file
+# changes; a "good enough" way to know if configure was run again (and
+# therefore the release date or version may have changed)
+$(nodist_man_MANS): $(top_builddir)/opal/include/opal_config.h
+
+endif # OPAL_INSTALL_BINARIES
+
+prun_SOURCES = \
+        main.c \
+        prun.c \
+        prun.h
+
+prun_LDADD = \
+	$(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+	$(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+	$(OPAL_PMIX_LDADD)
+
+prun_LIBS = $(OPAL_PMIX_LIBS)
+
+distclean-local:
+	rm -f $(man_pages)

--- a/orte/tools/prun/main.c
+++ b/orte/tools/prun/main.c
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *                                                                         *
+ *          Open MPI: Open Source High Performance Computing               *
+ *                                                                         *
+ *                   http://www.open-mpi.org/                              *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "prun.h"
+
+int main(int argc, char *argv[])
+{
+    return prun(argc, argv);
+}
+
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */

--- a/orte/tools/prun/prun.1in
+++ b/orte/tools/prun/prun.1in
@@ -1,0 +1,1597 @@
+.\" -*- nroff -*-
+.\" Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
+.\" Copyright (c) 2017      Intel, Inc.  All rights reserved.
+.\" Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
+.\"                         reserved.
+.\" $COPYRIGHT$
+.\"
+.\" Man page for PSRVR's prun command
+.\"
+.\" .TH name     section center-footer   left-footer  center-header
+.TH PRUN 1 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.\" **************************
+.\"    Name Section
+.\" **************************
+.SH NAME
+.
+prun \- Execute serial and parallel jobs with the PMIx Reference Server.
+
+.
+.\" **************************
+.\"    Synopsis Section
+.\" **************************
+.SH SYNOPSIS
+.
+.PP
+Single Process Multiple Data (SPMD) Model:
+
+.B prun
+[ options ]
+.B <program>
+[ <args> ]
+.P
+
+Multiple Instruction Multiple Data (MIMD) Model:
+
+.B prun
+[ global_options ]
+       [ local_options1 ]
+.B <program1>
+[ <args1> ] :
+       [ local_options2 ]
+.B <program2>
+[ <args2> ] :
+       ... :
+       [ local_optionsN ]
+.B <programN>
+[ <argsN> ]
+.P
+
+Note that in both models, invoking \fIprun\fP via an absolute path
+name is equivalent to specifying the \fI--prefix\fP option with a
+\fI<dir>\fR value equivalent to the directory where \fIprun\fR
+resides, minus its last subdirectory.  For example:
+
+    \fB%\fP /usr/local/bin/prun ...
+
+is equivalent to
+
+    \fB%\fP prun --prefix /usr/local
+
+.
+.\" **************************
+.\"    Quick Summary Section
+.\" **************************
+.SH QUICK SUMMARY
+.
+If you are simply looking for how to run an application, you
+probably want to use a command line of the following form:
+
+    \fB%\fP prun [ -np X ] [ --hostfile <filename> ]  <program>
+
+This will run X copies of \fI<program>\fR in your current run-time
+environment (if running under a supported resource manager, PSRVR's
+\fIprun\fR will usually automatically use the corresponding resource manager
+process starter, as opposed to, for example, \fIrsh\fR or \fIssh\fR,
+which require the use of a hostfile, or will default to running all X
+copies on the localhost), scheduling (by default) in a round-robin fashion by
+CPU slot.  See the rest of this page for more details.
+.P
+Please note that prun automatically binds processes. Three binding patterns are used in the absence of any further directives:
+.TP 18
+.B Bind to core:
+when the number of processes is <= 2
+.
+.
+.TP
+.B Bind to socket:
+when the number of processes is > 2
+.
+.
+.TP
+.B Bind to none:
+when oversubscribed
+.
+.
+.P
+If your application uses threads, then you probably want to ensure that you are
+either not bound at all (by specifying --bind-to none), or bound to multiple cores
+using an appropriate binding level or specific number of processing elements per
+application process.
+.
+.\" **************************
+.\"    Options Section
+.\" **************************
+.SH OPTIONS
+.
+.I prun
+will send the name of the directory where it was invoked on the local
+node to each of the remote nodes, and attempt to change to that
+directory.  See the "Current Working Directory" section below for further
+details.
+.\"
+.\" Start options listing
+.\"    Indent 10 characters from start of first column to start of second column
+.TP 10
+.B <program>
+The program executable. This is identified as the first non-recognized argument
+to prun.
+.
+.
+.TP
+.B <args>
+Pass these run-time arguments to every new process.  These must always
+be the last arguments to \fIprun\fP. If an app context file is used,
+\fI<args>\fP will be ignored.
+.
+.
+.TP
+.B -h\fR,\fP --help
+Display help for this command
+.
+.
+.TP
+.B -q\fR,\fP --quiet
+Suppress informative messages from prun during application execution.
+.
+.
+.TP
+.B -v\fR,\fP --verbose
+Be verbose
+.
+.
+.TP
+.B -V\fR,\fP --version
+Print version number.  If no other arguments are given, this will also
+cause prun to exit.
+.
+.
+.TP
+.B -N \fR<num>\fP
+.br
+Launch num processes per node on all allocated nodes (synonym for npernode).
+.
+.
+.
+.TP
+.B -display-map\fR,\fP --display-map
+Display a table showing the mapped location of each process prior to launch.
+.
+.
+.
+.TP
+.B -display-allocation\fR,\fP --display-allocation
+Display the detected resource allocation.
+.
+.
+.
+.TP
+.B -output-proctable\fR,\fP --output-proctable
+Output the debugger proctable after launch.
+.
+.
+.
+.TP
+.B -max-vm-size\fR,\fP --max-vm-size \fR<size>\fP
+Number of processes to run.
+.
+.
+.
+.TP
+.B -novm\fR,\fP --novm
+Execute without creating an allocation-spanning virtual machine (only start
+daemons on nodes hosting application procs).
+.
+.
+.
+.TP
+.B -hnp\fR,\fP --hnp \fR<arg0>\fP
+Specify the URI of the \fRpsrvr\fP process, or the name of the file (specified as
+file:filename) that contains that info.
+.
+.
+.
+.P
+Use one of the following options to specify which hosts (nodes) within the \fRpsrvr\fP to run on.
+.
+.
+.TP
+.B -H\fR,\fP -host\fR,\fP --host \fR<host1,host2,...,hostN>\fP
+List of hosts on which to invoke processes.
+.
+.
+.TP
+.B -hostfile\fR,\fP --hostfile \fR<hostfile>\fP
+Provide a hostfile to use.
+.\" JJH - Should have man page for how to format a hostfile properly.
+.
+.
+.TP
+.B -default-hostfile\fR,\fP --default-hostfile \fR<hostfile>\fP
+Provide a default hostfile.
+.
+.
+.TP
+.B -machinefile\fR,\fP --machinefile \fR<machinefile>\fP
+Synonym for \fI-hostfile\fP.
+.
+.
+.
+.
+.TP
+.B -cpu-set\fR,\fP --cpu-set \fR<list>\fP
+Restrict launched processes to the specified logical cpus on each node (comma-separated
+list). Note that the binding options will still apply within the specified envelope - e.g.,
+you can elect to bind each process to only one cpu within the specified cpu set.
+.
+.
+.
+.P
+The following options specify the number of processes to launch. Note that none
+of the options imply a particular binding policy - e.g., requesting N processes
+for each socket does not imply that the processes will be bound to the socket.
+.
+.
+.TP
+.B -c\fR,\fP -n\fR,\fP --n\fR,\fP -np \fR<#>\fP
+Run this many copies of the program on the given nodes.  This option
+indicates that the specified file is an executable program and not an
+application context. If no value is provided for the number of copies to
+execute (i.e., neither the "-np" nor its synonyms are provided on the command
+line), prun will automatically execute a copy of the program on
+each process slot (see below for description of a "process slot"). This
+feature, however, can only be used in the SPMD model and will return an
+error (without beginning execution of the application) otherwise.
+.
+.
+.TP
+.B —map-by ppr:N:<object>
+Launch N times the number of objects of the specified type on each node.
+.
+.
+.TP
+.B -npersocket\fR,\fP --npersocket \fR<#persocket>\fP
+On each node, launch this many processes times the number of processor
+sockets on the node.
+The \fI-npersocket\fP option also turns on the \fI-bind-to-socket\fP option.
+(deprecated in favor of --map-by ppr:n:socket)
+.
+.
+.TP
+.B -npernode\fR,\fP --npernode \fR<#pernode>\fP
+On each node, launch this many processes.
+(deprecated in favor of --map-by ppr:n:node)
+.
+.
+.TP
+.B -pernode\fR,\fP --pernode
+On each node, launch one process -- equivalent to \fI-npernode\fP 1.
+(deprecated in favor of --map-by ppr:1:node)
+.
+.
+.
+.
+.P
+To map processes:
+.
+.
+.TP
+.B --map-by \fR<foo>\fP
+Map to the specified object, defaults to \fIsocket\fP. Supported options
+include slot, hwthread, core, L1cache, L2cache, L3cache, socket, numa,
+board, node, sequential, distance, and ppr. Any object can include
+modifiers by adding a \fR:\fP and any combination of PE=n (bind n
+processing elements to each proc), SPAN (load
+balance the processes across the allocation), OVERSUBSCRIBE (allow
+more processes on a node than processing elements), and NOOVERSUBSCRIBE.
+This includes PPR, where the pattern would be terminated by another colon
+to separate it from the modifiers.
+.
+.TP
+.B -bycore\fR,\fP --bycore
+Map processes by core (deprecated in favor of --map-by core)
+.
+.TP
+.B -byslot\fR,\fP --byslot
+Map and rank processes round-robin by slot.
+.
+.TP
+.B -nolocal\fR,\fP --nolocal
+Do not run any copies of the launched application on the same node as
+prun is running.  This option will override listing the localhost
+with \fB--host\fR or any other host-specifying mechanism.
+.
+.TP
+.B -nooversubscribe\fR,\fP --nooversubscribe
+Do not oversubscribe any nodes; error (without starting any processes)
+if the requested number of processes would cause oversubscription.
+This option implicitly sets "max_slots" equal to the "slots" value for
+each node. (Enabled by default).
+.
+.TP
+.B -oversubscribe\fR,\fP --oversubscribe
+Nodes are allowed to be oversubscribed, even on a managed system, and
+overloading of processing elements.
+.
+.TP
+.B -bynode\fR,\fP --bynode
+Launch processes one per node, cycling by node in a round-robin
+fashion.  This spreads processes evenly among nodes and assigns
+ranks in a round-robin, "by node" manner.
+.
+.TP
+.B -cpu-list\fR,\fP --cpu-list \fR<cpus>\fP
+List of processor IDs to bind processes to [default=NULL].
+.
+.
+.
+.
+.P
+To order processes' ranks:
+.
+.
+.TP
+.B --rank-by \fR<foo>\fP
+Rank in round-robin fashion according to the specified object,
+defaults to \fIslot\fP. Supported options
+include slot, hwthread, core, L1cache, L2cache, L3cache,
+socket, numa, board, and node.
+.
+.
+.
+.
+.P
+For process binding:
+.
+.TP
+.B --bind-to \fR<foo>\fP
+Bind processes to the specified object, defaults to \fIcore\fP. Supported options
+include slot, hwthread, core, l1cache, l2cache, l3cache, socket, numa, board, and none.
+.
+.TP
+.B -cpus-per-proc\fR,\fP --cpus-per-proc \fR<#perproc>\fP
+Bind each process to the specified number of cpus.
+(deprecated in favor of --map-by <obj>:PE=n)
+.
+.TP
+.B -cpus-per-rank\fR,\fP --cpus-per-rank \fR<#perrank>\fP
+Alias for \fI-cpus-per-proc\fP.
+(deprecated in favor of --map-by <obj>:PE=n)
+.
+.TP
+.B -bind-to-core\fR,\fP --bind-to-core
+Bind processes to cores (deprecated in favor of --bind-to core)
+.
+.TP
+.B -bind-to-socket\fR,\fP --bind-to-socket
+Bind processes to processor sockets  (deprecated in favor of --bind-to socket)
+.
+.TP
+.B -report-bindings\fR,\fP --report-bindings
+Report any bindings for launched processes.
+.
+.
+.
+.
+.P
+For rankfiles:
+.
+.
+.TP
+.B -rf\fR,\fP --rankfile \fR<rankfile>\fP
+Provide a rankfile file.
+.
+.
+.
+.
+.P
+To manage standard I/O:
+.
+.
+.TP
+.B -output-filename\fR,\fP --output-filename \fR<filename>\fP
+Redirect the stdout, stderr, and stddiag of all processes to a process-unique version of
+the specified filename. Any directories in the filename will automatically be created.
+Each output file will consist of filename.id, where the id will be the
+processes' rank, left-filled with
+zero's for correct ordering in listings.
+.
+.
+.TP
+.B -stdin\fR,\fP --stdin\fR <rank> \fP
+The rank of the process that is to receive stdin. The
+default is to forward stdin to rank 0, but this option
+can be used to forward stdin to any process. It is also acceptable to
+specify \fInone\fP, indicating that no processes are to receive stdin.
+.
+.
+.TP
+.B -merge-stderr-to-stdout\fR,\fP --merge-stderr-to-stdout
+Merge stderr to stdout for each process.
+.
+.
+.TP
+.B -tag-output\fR,\fP --tag-output
+Tag each line of output to stdout, stderr, and stddiag with \fB[jobid, MCW_rank]<stdxxx>\fP
+indicating the process jobid and rank of the process that generated the output,
+and the channel which generated it.
+.
+.
+.TP
+.B -timestamp-output\fR,\fP --timestamp-output
+Timestamp each line of output to stdout, stderr, and stddiag.
+.
+.
+.TP
+.B -xml\fR,\fP --xml
+Provide all output to stdout, stderr, and stddiag in an xml format.
+.
+.
+.TP
+.B -xml-file\fR,\fP --xml-file \fR<filename>\fP
+Provide all output in XML format to the specified file.
+.
+.
+.TP
+.B -xterm\fR,\fP --xterm \fR<ranks>\fP
+Display the output from the processes identified by their ranks in separate xterm windows. The ranks are specified
+as a comma-separated list of ranges, with a -1 indicating all. A separate
+window will be created for each specified process.
+.B Note:
+xterm will normally terminate the window upon termination of the process running
+within it. However, by adding a "!" to the end of the list of specified ranks,
+the proper options will be provided to ensure that xterm keeps the window open
+\fIafter\fP the process terminates, thus allowing you to see the process' output.
+Each xterm window will subsequently need to be manually closed.
+.B Note:
+In some environments, xterm may require that the executable be in the user's
+path, or be specified in absolute or relative terms. Thus, it may be necessary
+to specify a local executable as "./foo" instead of just "foo". If xterm fails to
+find the executable, prun will hang, but still respond correctly to a ctrl-c.
+If this happens, please check that the executable is being specified correctly
+and try again.
+.
+.
+.
+.
+.P
+To manage files and runtime environment:
+.
+.
+.TP
+.B -path\fR,\fP --path \fR<path>\fP
+<path> that will be used when attempting to locate the requested
+executables.  This is used prior to using the local PATH setting.
+.
+.
+.TP
+.B --prefix \fR<dir>\fP
+Prefix directory that will be used to set the \fIPATH\fR and
+\fILD_LIBRARY_PATH\fR on the remote node before invoking
+the target process.  See the "Remote Execution" section, below.
+.
+.
+.TP
+.B --noprefix
+Disable the automatic --prefix behavior
+.
+.
+.TP
+.B -s\fR,\fP --preload-binary
+Copy the specified executable(s) to remote machines prior to starting remote processes. The
+executables will be copied to the session directory and will be deleted upon
+completion of the job.
+.
+.
+.TP
+.B --preload-files \fR<files>\fP
+Preload the comma separated list of files to the current working directory of the remote
+machines where processes will be launched prior to starting those processes.
+.
+.
+.TP
+.B -set-cwd-to-session-dir\fR,\fP --set-cwd-to-session-dir
+Set the working directory of the started processes to their session directory.
+.
+.
+.TP
+.B -wd \fR<dir>\fP
+Synonym for \fI-wdir\fP.
+.
+.
+.TP
+.B -wdir \fR<dir>\fP
+Change to the directory <dir> before the user's program executes.
+See the "Current Working Directory" section for notes on relative paths.
+.B Note:
+If the \fI-wdir\fP option appears both on the command line and in an
+application context, the context will take precedence over the command
+line. Thus, if the path to the desired wdir is different
+on the backend nodes, then it must be specified as an absolute path that
+is correct for the backend node.
+.
+.
+.TP
+.B -x \fR<env>\fP
+Export the specified environment variables to the remote nodes before
+executing the program.  Only one environment variable can be specified
+per \fI-x\fP option.  Existing environment variables can be specified
+or new variable names specified with corresponding values.  For
+example:
+    \fB%\fP prun -x DISPLAY -x OFILE=/tmp/out ...
+
+The parser for the \fI-x\fP option is not very sophisticated; it does
+not even understand quoted values.  Users are advised to set variables
+in the environment, and then use \fI-x\fP to export (not define) them.
+.
+.
+.
+.
+.P
+Setting MCA parameters:
+.
+.
+.TP
+.B -gpmca\fR,\fP --gpmca \fR<key> <value>\fP
+Pass global MCA parameters that are applicable to all contexts. \fI<key>\fP is
+the parameter name; \fI<value>\fP is the parameter value.
+.
+.
+.TP
+.B -pmca\fR,\fP --pmca \fR<key> <value>\fP
+Send arguments to various MCA modules.  See the "MCA" section, below.
+.
+.
+.TP
+.B -am \fR<arg0>\fP
+Aggregate MCA parameter set file list.
+.
+.
+.TP
+.B -tune\fR,\fP --tune \fR<tune_file>\fP
+Specify a tune file to set arguments for various MCA modules and environment variables.
+See the "Setting MCA parameters and environment variables from file" section, below.
+.
+.
+.
+.
+.P
+For debugging:
+.
+.
+.TP
+.B -debug\fR,\fP --debug
+Invoke the user-level debugger indicated by the \fIorte_base_user_debugger\fP
+MCA parameter.
+.
+.
+.TP
+.B --get-stack-traces
+When paired with the
+.B --timeout
+option,
+.I prun
+will obtain and print out stack traces from all launched processes
+that are still alive when the timeout expires.  Note that obtaining
+stack traces can take a little time and produce a lot of output,
+especially for large process-count jobs.
+.
+.
+.TP
+.B -debugger\fR,\fP --debugger \fR<args>\fP
+Sequence of debuggers to search for when \fI--debug\fP is used (i.e.
+a synonym for \fIorte_base_user_debugger\fP MCA parameter).
+.
+.
+.TP
+.B --timeout \fR<seconds>
+The maximum number of seconds that
+.I prun
+will run.  After this many seconds,
+.I prun
+will abort the launched job and exit with a non-zero exit status.
+Using
+.B --timeout
+can be also useful when combined with the
+.B --get-stack-traces
+option.
+.
+.
+.TP
+.B -tv\fR,\fP --tv
+Launch processes under the TotalView debugger.
+Deprecated backwards compatibility flag. Synonym for \fI--debug\fP.
+.
+.
+.
+.
+.P
+There are also other options:
+.
+.
+.TP
+.B --allow-run-as-root
+Allow
+.I prun
+to run when executed by the root user
+.RI ( prun
+defaults to aborting when launched as the root user).
+.
+.
+.TP
+.B --app \fR<appfile>\fP
+Provide an appfile, ignoring all other command line options.
+.
+.
+.TP
+.B -cf\fR,\fP --cartofile \fR<cartofile>\fP
+Provide a cartography file.
+.
+.
+.TP
+.B -continuous\fR,\fP --continuous
+Job is to run until explicitly terminated.
+.
+.
+.TP
+.B -disable-recovery\fR,\fP --disable-recovery
+Disable recovery (resets all recovery options to off).
+.
+.
+.TP
+.B -do-not-launch\fR,\fP --do-not-launch
+Perform all necessary operations to prepare to launch the application, but do not actually launch it.
+.
+.
+.TP
+.B -do-not-resolve\fR,\fP --do-not-resolve
+Do not attempt to resolve interfaces.
+.
+.
+.TP
+.B -enable-recovery\fR,\fP --enable-recovery
+Enable recovery from process failure [Default = disabled].
+.
+.
+.TP
+.B -index-argv-by-rank\fR,\fP --index-argv-by-rank
+Uniquely index argv[0] for each process using its rank.
+.
+.
+.TP
+.B -max-restarts\fR,\fP --max-restarts \fR<num>\fP
+Max number of times to restart a failed process.
+.
+.
+.TP
+.B --ppr \fR<list>\fP
+Comma-separated list of number of processes on a given resource type [default: none].
+.
+.
+.TP
+.B -report-child-jobs-separately\fR,\fP --report-child-jobs-separately
+Return the exit status of the primary job only.
+.
+.
+.TP
+.B -report-events\fR,\fP --report-events \fR<URI>\fP
+Report events to a tool listening at the specified URI.
+.
+.
+.TP
+.B -report-pid\fR,\fP --report-pid \fR<channel>\fP
+Print out prun's PID during startup. The channel must be either a '-' to indicate
+that the pid is to be output to stdout, a '+' to indicate that the pid is to be
+output to stderr, or a filename to which the pid is to be written.
+.
+.
+.TP
+.B -report-uri\fR,\fP --report-uri \fR<channel>\fP
+Print out prun's URI during startup. The channel must be either a '-' to indicate
+that the URI is to be output to stdout, a '+' to indicate that the URI is to be
+output to stderr, or a filename to which the URI is to be written.
+.
+.
+.TP
+.B -show-progress\fR,\fP --show-progress
+Output a brief periodic report on launch progress.
+.
+.
+.TP
+.B -terminate\fR,\fP --terminate
+Terminate the DVM.
+.
+.
+.TP
+.B -use-hwthread-cpus\fR,\fP --use-hwthread-cpus
+Use hardware threads as independent cpus.
+.
+.
+.TP
+.B -use-regexp\fR,\fP --use-regexp
+Use regular expressions for launch.
+.
+.
+.
+.
+.P
+The following options are useful for developers; they are not generally
+useful to most users:
+.
+.TP
+.B -d\fR,\fP --debug-devel
+Enable debugging. This is not generally useful for most users.
+.
+.
+.TP
+.B -display-devel-allocation\fR,\fP --display-devel-allocation
+Display a detailed list of the allocation being used by this job.
+.
+.
+.TP
+.B -display-devel-map\fR,\fP --display-devel-map
+Display a more detailed table showing the mapped location of each process prior to launch.
+.
+.
+.TP
+.B -display-diffable-map\fR,\fP --display-diffable-map
+Display a diffable process map just before launch.
+.
+.
+.TP
+.B -display-topo\fR,\fP --display-topo
+Display the topology as part of the process map just before launch.
+.
+.
+.TP
+.B --report-state-on-timeout
+When paired with the
+.B --timeout
+command line option, report the run-time subsystem state of each
+process when the timeout expires.
+.
+.
+.P
+There may be other options listed with \fIprun --help\fP.
+.
+.
+.\" **************************
+.\"    Description Section
+.\" **************************
+.SH DESCRIPTION
+.
+One invocation of \fIprun\fP starts an application running under PSRVR. If the application is single process multiple data (SPMD), the application
+can be specified on the \fIprun\fP command line.
+
+If the application is multiple instruction multiple data (MIMD), comprising of
+multiple programs, the set of programs and argument can be specified in one of
+two ways: Extended Command Line Arguments, and Application Context.
+.PP
+An application context describes the MIMD program set including all arguments
+in a separate file.
+.\" See appcontext(5) for a description of the application context syntax.
+This file essentially contains multiple \fIprun\fP command lines, less the
+command name itself.  The ability to specify different options for different
+instantiations of a program is another reason to use an application context.
+.PP
+Extended command line arguments allow for the description of the application
+layout on the command line using colons (\fI:\fP) to separate the specification
+of programs and arguments. Some options are globally set across all specified
+programs (e.g. --hostfile), while others are specific to a single program
+(e.g. -np).
+.
+.
+.
+.SS Specifying Host Nodes
+.
+Host nodes can be identified on the \fIprun\fP command line with the \fI-host\fP
+option or in a hostfile.
+.
+.PP
+For example,
+.
+.TP 4
+prun -H aa,aa,bb ./a.out
+launches two processes on node aa and one on bb.
+.
+.PP
+Or, consider the hostfile
+.
+
+   \fB%\fP cat myhostfile
+   aa slots=2
+   bb slots=2
+   cc slots=2
+
+.
+.PP
+Here, we list both the host names (aa, bb, and cc) but also how many "slots"
+there are for each.  Slots indicate how many processes can potentially execute
+on a node.  For best performance, the number of slots may be chosen to be the
+number of cores on the node or the number of processor sockets.  If the hostfile
+does not provide slots information, PSRVR will attempt to discover the number
+of cores (or hwthreads, if the use-hwthreads-as-cpus option is set) and set the
+number of slots to that value. This default behavior also occurs when specifying
+the \fI-host\fP option with a single hostname. Thus, the command
+.
+.TP 4
+prun -H aa ./a.out
+launches a number of processes equal to the number of cores on node aa.
+.
+.PP
+.
+.TP 4
+prun -hostfile myhostfile ./a.out
+will launch two processes on each of the three nodes.
+.
+.TP 4
+prun -hostfile myhostfile -host aa ./a.out
+will launch two processes, both on node aa.
+.
+.TP 4
+prun -hostfile myhostfile -host dd ./a.out
+will find no hosts to run on and abort with an error.
+That is, the specified host dd is not in the specified hostfile.
+.
+.PP
+When running under resource managers (e.g., SLURM, Torque, etc.),
+PSRVR will obtain both the hostnames and the number of slots directly
+from the resource manger.
+.
+.SS Specifying Number of Processes
+.
+As we have just seen, the number of processes to run can be set using the
+hostfile.  Other mechanisms exist.
+.
+.PP
+The number of processes launched can be specified as a multiple of the
+number of nodes or processor sockets available.  For example,
+.
+.TP 4
+prun -H aa,bb -npersocket 2 ./a.out
+launches processes 0-3 on node aa and process 4-7 on node bb,
+where aa and bb are both dual-socket nodes.
+The \fI-npersocket\fP option also turns on the \fI-bind-to-socket\fP option,
+which is discussed in a later section.
+.
+.TP 4
+prun -H aa,bb -npernode 2 ./a.out
+launches processes 0-1 on node aa and processes 2-3 on node bb.
+.
+.TP 4
+prun -H aa,bb -npernode 1 ./a.out
+launches one process per host node.
+.
+.TP 4
+prun -H aa,bb -pernode ./a.out
+is the same as \fI-npernode\fP 1.
+.
+.
+.PP
+Another alternative is to specify the number of processes with the
+\fI-np\fP option.  Consider now the hostfile
+.
+
+   \fB%\fP cat myhostfile
+   aa slots=4
+   bb slots=4
+   cc slots=4
+
+.
+.PP
+Now,
+.
+.TP 4
+prun -hostfile myhostfile -np 6 ./a.out
+will launch processes 0-3 on node aa and processes 4-5 on node bb.  The remaining
+slots in the hostfile will not be used since the \fI-np\fP option indicated
+that only 6 processes should be launched.
+.
+.SS Mapping Processes to Nodes:  Using Policies
+.
+The examples above illustrate the default mapping of process processes
+to nodes.  This mapping can also be controlled with various
+\fIprun\fP options that describe mapping policies.
+.
+.
+.PP
+Consider the same hostfile as above, again with \fI-np\fP 6:
+.
+
+                          node aa      node bb      node cc
+
+  prun                  0 1 2 3      4 5
+
+  prun --map-by node    0 3          1 4          2 5
+
+  prun -nolocal                      0 1 2 3      4 5
+.
+.PP
+The \fI--map-by node\fP option will load balance the processes across
+the available nodes, numbering each process in a round-robin fashion.
+.
+.PP
+The \fI-nolocal\fP option prevents any processes from being mapped onto the
+local host (in this case node aa).  While \fIprun\fP typically consumes
+few system resources, \fI-nolocal\fP can be helpful for launching very
+large jobs where \fIprun\fP may actually need to use noticeable amounts
+of memory and/or processing time.
+.
+.PP
+Just as \fI-np\fP can specify fewer processes than there are slots, it can
+also oversubscribe the slots.  For example, with the same hostfile:
+.
+.TP 4
+prun -hostfile myhostfile -np 14 ./a.out
+will launch processes 0-3 on node aa, 4-7 on bb, and 8-11 on cc.  It will
+then add the remaining two processes to whichever nodes it chooses.
+.
+.PP
+One can also specify limits to oversubscription.  For example, with the same
+hostfile:
+.
+.TP 4
+prun -hostfile myhostfile -np 14 -nooversubscribe ./a.out
+will produce an error since \fI-nooversubscribe\fP prevents oversubscription.
+.
+.PP
+Limits to oversubscription can also be specified in the hostfile itself:
+.
+ % cat myhostfile
+ aa slots=4 max_slots=4
+ bb         max_slots=4
+ cc slots=4
+.
+.PP
+The \fImax_slots\fP field specifies such a limit.  When it does, the
+\fIslots\fP value defaults to the limit.  Now:
+.
+.TP 4
+prun -hostfile myhostfile -np 14 ./a.out
+causes the first 12 processes to be launched as before, but the remaining
+two processes will be forced onto node cc.  The other two nodes are
+protected by the hostfile against oversubscription by this job.
+.
+.PP
+Using the \fI--nooversubscribe\fR option can be helpful since PSRVR
+currently does not get "max_slots" values from the resource manager.
+.
+.PP
+Of course, \fI-np\fP can also be used with the \fI-H\fP or \fI-host\fP
+option.  For example,
+.
+.TP 4
+prun -H aa,bb -np 8 ./a.out
+launches 8 processes.  Since only two hosts are specified, after the first
+two processes are mapped, one to aa and one to bb, the remaining processes
+oversubscribe the specified hosts.
+.
+.PP
+And here is a MIMD example:
+.
+.TP 4
+prun -H aa -np 1 hostname : -H bb,cc -np 2 uptime
+will launch process 0 running \fIhostname\fP on node aa and processes 1 and 2
+each running \fIuptime\fP on nodes bb and cc, respectively.
+.
+.SS Mapping, Ranking, and Binding: Oh My!
+.
+PSRVR employs a three-phase procedure for assigning process locations and
+ranks:
+.
+.TP 10
+\fBmapping\fP
+Assigns a default location to each process
+.
+.TP 10
+\fBranking\fP
+Assigns a rank value to each process
+.
+.TP 10
+\fBbinding\fP
+Constrains each process to run on specific processors
+.
+.PP
+The \fImapping\fP step is used to assign a default location to each process
+based on the mapper being employed. Mapping by slot, node, and sequentially results
+in the assignment of the processes to the node level. In contrast, mapping by object, allows
+the mapper to assign the process to an actual object on each node.
+.
+.PP
+\fBNote:\fP the location assigned to the process is independent of where it will be bound - the
+assignment is used solely as input to the binding algorithm.
+.
+.PP
+The mapping of process processes to nodes can be defined not just
+with general policies but also, if necessary, using arbitrary mappings
+that cannot be described by a simple policy.  One can use the "sequential
+mapper," which reads the hostfile line by line, assigning processes
+to nodes in whatever order the hostfile specifies.  Use the
+\fI-pmca rmaps seq\fP option.  For example, using the same hostfile
+as before:
+.
+.PP
+prun -hostfile myhostfile -pmca rmaps seq ./a.out
+.
+.PP
+will launch three processes, one on each of nodes aa, bb, and cc, respectively.
+The slot counts don't matter;  one process is launched per line on
+whatever node is listed on the line.
+.
+.PP
+Another way to specify arbitrary mappings is with a rankfile, which
+gives you detailed control over process binding as well.  Rankfiles
+are discussed below.
+.
+.PP
+The second phase focuses on the \fIranking\fP of the process within
+the job.  PSRVR
+separates this from the mapping procedure to allow more flexibility in the
+relative placement of processes. This is best illustrated by considering the
+following two cases where we used the —map-by ppr:2:socket option:
+.
+.PP
+                          node aa       node bb
+
+    rank-by core         0 1 ! 2 3     4 5 ! 6 7
+
+   rank-by socket        0 2 ! 1 3     4 6 ! 5 7
+
+   rank-by socket:span   0 4 ! 1 5     2 6 ! 3 7
+.
+.PP
+Ranking by core and by slot provide the identical result - a simple
+progression of ranks across each node. Ranking by
+socket does a round-robin ranking within each node until all processes
+have been assigned a rank, and then progresses to the next
+node. Adding the \fIspan\fP modifier to the ranking directive causes
+the ranking algorithm to treat the entire allocation as a single
+entity - thus, the MCW ranks are assigned across all sockets before
+circling back around to the beginning.
+.
+.PP
+The \fIbinding\fP phase actually binds each process to a given set of processors. This can
+improve performance if the operating system is placing processes
+suboptimally.  For example, it might oversubscribe some multi-core
+processor sockets, leaving other sockets idle;  this can lead
+processes to contend unnecessarily for common resources.  Or, it
+might spread processes out too widely;  this can be suboptimal if
+application performance is sensitive to interprocess communication
+costs.  Binding can also keep the operating system from migrating
+processes excessively, regardless of how optimally those processes
+were placed to begin with.
+.
+.PP
+The processors to be used for binding can be identified in terms of
+topological groupings - e.g., binding to an l3cache will bind each
+process to all processors within the scope of a single L3 cache within
+their assigned location. Thus, if a process is assigned by the mapper
+to a certain socket, then a \fI—bind-to l3cache\fP directive will
+cause the process to be bound to the processors that share a single L3
+cache within that socket.
+.
+.PP
+To help balance loads, the binding directive uses a round-robin method when binding to
+levels lower than used in the mapper. For example, consider the case where a job is
+mapped to the socket level, and then bound to core. Each socket will have multiple cores,
+so if multiple processes are mapped to a given socket, the binding algorithm will assign
+each process located to a socket to a unique core in a round-robin manner.
+.
+.PP
+Alternatively, processes mapped by l2cache and then bound to socket will simply be bound
+to all the processors in the socket where they are located. In this manner, users can
+exert detailed control over relative MCW rank location and binding.
+.
+.PP
+Finally, \fI--report-bindings\fP can be used to report bindings.
+.
+.PP
+As an example, consider a node with two processor sockets, each comprising
+four cores.  We run \fIprun\fP with \fI-np 4 --report-bindings\fP and
+the following additional options:
+.
+
+ % prun ... --map-by core --bind-to core
+ [...] ... binding child [...,0] to cpus 0001
+ [...] ... binding child [...,1] to cpus 0002
+ [...] ... binding child [...,2] to cpus 0004
+ [...] ... binding child [...,3] to cpus 0008
+
+ % prun ... --map-by socket --bind-to socket
+ [...] ... binding child [...,0] to socket 0 cpus 000f
+ [...] ... binding child [...,1] to socket 1 cpus 00f0
+ [...] ... binding child [...,2] to socket 0 cpus 000f
+ [...] ... binding child [...,3] to socket 1 cpus 00f0
+
+ % prun ... --map-by core:PE=2 --bind-to core
+ [...] ... binding child [...,0] to cpus 0003
+ [...] ... binding child [...,1] to cpus 000c
+ [...] ... binding child [...,2] to cpus 0030
+ [...] ... binding child [...,3] to cpus 00c0
+
+ % prun ... --bind-to none
+.
+.PP
+Here, \fI--report-bindings\fP shows the binding of each process as a mask.
+In the first case, the processes bind to successive cores as indicated by
+the masks 0001, 0002, 0004, and 0008.  In the second case, processes bind
+to all cores on successive sockets as indicated by the masks 000f and 00f0.
+The processes cycle through the processor sockets in a round-robin fashion
+as many times as are needed.  In the third case, the masks show us that
+2 cores have been bound per process.  In the fourth case, binding is
+turned off and no bindings are reported.
+.
+.PP
+PSRVR's support for process binding depends on the underlying
+operating system.  Therefore, certain process binding options may not be available
+on every system.
+.
+.PP
+Process binding can also be set with MCA parameters.
+Their usage is less convenient than that of \fIprun\fP options.
+On the other hand, MCA parameters can be set not only on the \fIprun\fP
+command line, but alternatively in a system or user mca-params.conf file
+or as environment variables, as described in the MCA section below.
+Some examples include:
+.
+.PP
+    prun option          MCA parameter key         value
+
+  --map-by core          rmaps_base_mapping_policy   core
+  --map-by socket        rmaps_base_mapping_policy   socket
+  --rank-by core         rmaps_base_ranking_policy   core
+  --bind-to core         hwloc_base_binding_policy   core
+  --bind-to socket       hwloc_base_binding_policy   socket
+  --bind-to none         hwloc_base_binding_policy   none
+.
+.
+.SS Rankfiles
+.
+Rankfiles are text files that specify detailed information about how
+individual processes should be mapped to nodes, and to which
+processor(s) they should be bound.  Each line of a rankfile specifies
+the location of one process.  The general form of each line in the
+rankfile is:
+.
+
+    rank <N>=<hostname> slot=<slot list>
+.
+.PP
+For example:
+.
+
+    $ cat myrankfile
+    rank 0=aa slot=1:0-2
+    rank 1=bb slot=0:0,1
+    rank 2=cc slot=1-2
+    $ prun -H aa,bb,cc,dd -rf myrankfile ./a.out
+.
+.PP
+Means that
+.
+
+  Rank 0 runs on node aa, bound to logical socket 1, cores 0-2.
+  Rank 1 runs on node bb, bound to logical socket 0, cores 0 and 1.
+  Rank 2 runs on node cc, bound to logical cores 1 and 2.
+.
+.PP
+Rankfiles can alternatively be used to specify \fIphysical\fP processor
+locations. In this case, the syntax is somewhat different. Sockets are
+no longer recognized, and the slot number given must be the number of
+the physical PU as most OS's do not assign a unique physical identifier
+to each core in the node. Thus, a proper physical rankfile looks something
+like the following:
+.
+
+    $ cat myphysicalrankfile
+    rank 0=aa slot=1
+    rank 1=bb slot=8
+    rank 2=cc slot=6
+.
+.PP
+This means that
+.
+
+  Rank 0 will run on node aa, bound to the core that contains physical PU 1
+  Rank 1 will run on node bb, bound to the core that contains physical PU 8
+  Rank 2 will run on node cc, bound to the core that contains physical PU 6
+.
+.PP
+Rankfiles are treated as \fIlogical\fP by default, and the MCA parameter
+rmaps_rank_file_physical must be set to 1 to indicate that the rankfile
+is to be considered as \fIphysical\fP.
+.
+.PP
+The hostnames listed above are "absolute," meaning that actual
+resolveable hostnames are specified.  However, hostnames can also be
+specified as "relative," meaning that they are specified in relation
+to an externally-specified list of hostnames (e.g., by prun's --host
+argument, a hostfile, or a job scheduler).
+.
+.PP
+The "relative" specification is of the form "+n<X>", where X is an
+integer specifying the Xth hostname in the set of all available
+hostnames, indexed from 0.  For example:
+.
+
+    $ cat myrankfile
+    rank 0=+n0 slot=1:0-2
+    rank 1=+n1 slot=0:0,1
+    rank 2=+n2 slot=1-2
+    $ prun -H aa,bb,cc,dd -rf myrankfile ./a.out
+.
+.PP
+All socket/core slot locations are be
+specified as
+.I logical
+indexes.  You can use tools such as HWLOC's "lstopo" to find the
+logical indexes of socket and cores.
+.
+.
+.SS Application Context or Executable Program?
+.
+To distinguish the two different forms, \fIprun\fP
+looks on the command line for \fI--app\fP option.  If
+it is specified, then the file named on the command line is
+assumed to be an application context.  If it is not
+specified, then the file is assumed to be an executable program.
+.
+.
+.
+.SS Locating Files
+.
+If no relative or absolute path is specified for a file, prun will first look for files by searching the directories specified
+by the \fI--path\fP option.  If there is no \fI--path\fP option set or
+if the file is not found at the \fI--path\fP location, then prun
+will search the user's PATH environment variable as defined on the
+source node(s).
+.PP
+If a relative directory is specified, it must be relative to the initial
+working directory determined by the specific starter used. For example when
+using the rsh or ssh starters, the initial directory is $HOME by default. Other
+starters may set the initial directory to the current working directory from
+the invocation of \fIprun\fP.
+.
+.
+.
+.SS Current Working Directory
+.
+The \fI\-wdir\fP prun option (and its synonym, \fI\-wd\fP) allows
+the user to change to an arbitrary directory before the program is
+invoked.  It can also be used in application context files to specify
+working directories on specific nodes and/or for specific
+applications.
+.PP
+If the \fI\-wdir\fP option appears both in a context file and on the
+command line, the context file directory will override the command
+line value.
+.PP
+If the \fI-wdir\fP option is specified, prun will attempt to
+change to the specified directory on all of the remote nodes. If this
+fails, \fIprun\fP will abort.
+.PP
+If the \fI-wdir\fP option is \fBnot\fP specified, prun will send
+the directory name where \fIprun\fP was invoked to each of the
+remote nodes. The remote nodes will try to change to that
+directory. If they are unable (e.g., if the directory does not exist on
+that node), then prun will use the default directory determined by
+the starter.
+.PP
+All directory changing occurs before the user's program is invoked.
+.
+.
+.
+.SS Standard I/O
+.
+PSRVR directs UNIX standard input to /dev/null on all processes
+except the rank 0 process. The rank 0 process
+inherits standard input from \fIprun\fP.
+.B Note:
+The node that invoked \fIprun\fP need not be the same as the node where the
+rank 0 process resides. PSRVR handles the redirection of
+\fIprun\fP's standard input to the rank 0 process.
+.PP
+PSRVR directs UNIX standard output and error from remote nodes to the node
+that invoked \fIprun\fP and prints it on the standard output/error of
+\fIprun\fP.
+Local processes inherit the standard output/error of \fIprun\fP and transfer
+to it directly.
+.PP
+Thus it is possible to redirect standard I/O for applications by
+using the typical shell redirection procedure on \fIprun\fP.
+
+      \fB%\fP prun -np 2 my_app < my_input > my_output
+
+Note that in this example \fIonly\fP the rank 0 process will
+receive the stream from \fImy_input\fP on stdin.  The stdin on all the other
+nodes will be tied to /dev/null.  However, the stdout from all nodes will
+be collected into the \fImy_output\fP file.
+.
+.
+.
+.SS Signal Propagation
+.
+When prun receives a SIGTERM and SIGINT, it will attempt to kill
+the entire job by sending all processes in the job a SIGTERM, waiting
+a small number of seconds, then sending all processes in the job a
+SIGKILL.
+.
+.PP
+SIGUSR1 and SIGUSR2 signals received by prun are propagated to
+all processes in the job.
+.
+.PP
+A SIGTSTOP signal to prun will cause a SIGSTOP signal to be sent
+to all of the programs started by prun and likewise a SIGCONT signal
+to prun will cause a SIGCONT sent.
+.
+.PP
+Other signals are not currently propagated
+by prun.
+.
+.
+.SS Process Termination / Signal Handling
+.
+During the run of an application, if any process dies abnormally
+(either exiting before invoking \fIPMIx_Finalize\fP, or dying as the result of a
+signal), \fIprun\fP will print out an error message and kill the rest of the
+application.
+.PP
+.
+.
+.SS Process Environment
+.
+Processes in the application inherit their environment from the
+PSRVR daemon upon the node on which they are running.  The
+environment is typically inherited from the user's shell.  On remote
+nodes, the exact environment is determined by the boot MCA module
+used.  The \fIrsh\fR launch module, for example, uses either
+\fIrsh\fR/\fIssh\fR to launch the PSRVR daemon on remote nodes, and
+typically executes one or more of the user's shell-setup files before
+launching the daemon.  When running dynamically linked
+applications which require the \fILD_LIBRARY_PATH\fR environment
+variable to be set, care must be taken to ensure that it is correctly
+set when booting PSRVR.
+.PP
+See the "Remote Execution" section for more details.
+.
+.
+.SS Remote Execution
+.
+PSRVR requires that the \fIPATH\fR environment variable be set to
+find executables on remote nodes (this is typically only necessary in
+\fIrsh\fR- or \fIssh\fR-based environments -- batch/scheduled
+environments typically copy the current environment to the execution
+of remote jobs, so if the current environment has \fIPATH\fR and/or
+\fILD_LIBRARY_PATH\fR set properly, the remote nodes will also have it
+set properly).  If PSRVR was compiled with shared library support,
+it may also be necessary to have the \fILD_LIBRARY_PATH\fR environment
+variable set on remote nodes as well (especially to find the shared
+libraries required to run user applications).
+.PP
+However, it is not always desirable or possible to edit shell
+startup files to set \fIPATH\fR and/or \fILD_LIBRARY_PATH\fR.  The
+\fI--prefix\fR option is provided for some simple configurations where
+this is not possible.
+.PP
+The \fI--prefix\fR option takes a single argument: the base directory
+on the remote node where PSRVR is installed.  PSRVR will use
+this directory to set the remote \fIPATH\fR and \fILD_LIBRARY_PATH\fR
+before executing any user applications.  This allows
+running jobs without having pre-configured the \fIPATH\fR and
+\fILD_LIBRARY_PATH\fR on the remote nodes.
+.PP
+PSRVR adds the basename of the current
+node's "bindir" (the directory where PSRVR's executables are
+installed) to the prefix and uses that to set the \fIPATH\fR on the
+remote node.  Similarly, PSRVR adds the basename of the current
+node's "libdir" (the directory where PSRVR's libraries are
+installed) to the prefix and uses that to set the
+\fILD_LIBRARY_PATH\fR on the remote node.  For example:
+.TP 15
+Local bindir:
+/local/node/directory/bin
+.TP
+Local libdir:
+/local/node/directory/lib64
+.PP
+If the following command line is used:
+
+    \fB%\fP prun --prefix /remote/node/directory
+
+PSRVR will add "/remote/node/directory/bin" to the \fIPATH\fR
+and "/remote/node/directory/lib64" to the \fLD_LIBRARY_PATH\fR on the
+remote node before attempting to execute anything.
+.PP
+The \fI--prefix\fR option is not sufficient if the installation paths
+on the remote node are different than the local node (e.g., if "/lib"
+is used on the local node, but "/lib64" is used on the remote node),
+or if the installation paths are something other than a subdirectory
+under a common prefix.
+.PP
+Note that executing \fIprun\fR via an absolute pathname is
+equivalent to specifying \fI--prefix\fR without the last subdirectory
+in the absolute pathname to \fIprun\fR.  For example:
+
+    \fB%\fP /usr/local/bin/prun ...
+
+is equivalent to
+
+    \fB%\fP prun --prefix /usr/local
+.
+.
+.
+.SS Exported Environment Variables
+.
+All environment variables that are named in the form PMIX_* will automatically
+be exported to new processes on the local and remote nodes. Environmental
+parameters can also be set/forwarded to the new processes using the MCA
+parameter \fImca_base_env_list\fP. While the syntax of the \fI\-x\fP option and MCA param
+allows the definition of new variables, note that the parser
+for these options are currently not very sophisticated - it does not even
+understand quoted values.  Users are advised to set variables in the
+environment and use the option to export them; not to define them.
+.
+.
+.
+.SS Setting MCA Parameters
+.
+The \fI-pmca\fP switch allows the passing of parameters to various MCA
+(Modular Component Architecture) modules.
+.\" PSRVR's MCA modules are described in detail in psrvrmca(7).
+MCA modules have direct impact on programs because they allow tunable
+parameters to be set at run time (such as which BTL communication device driver
+to use, what parameters to pass to that BTL, etc.).
+.PP
+The \fI-pmca\fP switch takes two arguments: \fI<key>\fP and \fI<value>\fP.
+The \fI<key>\fP argument generally specifies which MCA module will receive the value.
+For example, the \fI<key>\fP "btl" is used to select which BTL to be used for
+transporting messages.  The \fI<value>\fP argument is the value that is
+passed.
+For example:
+.
+.TP 4
+prun -pmca btl tcp,self -np 1 foo
+Tells PSRVR to use the "tcp" and "self" BTLs, and to run a single copy of
+"foo" on an allocated node.
+.
+.TP
+prun -pmca btl self -np 1 foo
+Tells PSRVR to use the "self" BTL, and to run a single copy of "foo" on an
+allocated node.
+.\" And so on.  PSRVR's BTL MCA modules are described in psrvrmca_btl(7).
+.PP
+The \fI-pmca\fP switch can be used multiple times to specify different
+\fI<key>\fP and/or \fI<value>\fP arguments.  If the same \fI<key>\fP is
+specified more than once, the \fI<value>\fPs are concatenated with a comma
+(",") separating them.
+.PP
+Note that the \fI-pmca\fP switch is simply a shortcut for setting environment variables.
+The same effect may be accomplished by setting corresponding environment
+variables before running \fIprun\fP.
+The form of the environment variables that PSRVR sets is:
+
+      PMIX_MCA_<key>=<value>
+.PP
+Thus, the \fI-pmca\fP switch overrides any previously set environment
+variables.  The \fI-pmca\fP settings similarly override MCA parameters set
+in the
+$OPAL_PREFIX/etc/psrvr-mca-params.conf or $HOME/.psrvr/mca-params.conf
+file.
+.
+.PP
+Unknown \fI<key>\fP arguments are still set as
+environment variable -- they are not checked (by \fIprun\fP) for correctness.
+Illegal or incorrect \fI<value>\fP arguments may or may not be reported -- it
+depends on the specific MCA module.
+.PP
+To find the available component types under the MCA architecture, or to find the
+available parameters for a specific component, use the \fIpinfo\fP command.
+See the \fIpinfo(1)\fP man page for detailed information on the command.
+.
+.
+.
+.SS Setting MCA parameters and environment variables from file.
+The \fI-tune\fP command line option and its synonym \fI-pmca mca_base_envar_file_prefix\fP allows a user
+to set mca parameters and environment variables with the syntax described below.
+This option requires a single file or list of files separated by "," to follow.
+.PP
+A valid line in the file may contain zero or many "-x", "-pmca", or “--pmca” arguments.
+The following patterns are supported: -pmca var val -pmca var "val" -x var=val -x var.
+If any argument is duplicated in the file, the last value read will be used.
+.PP
+MCA parameters and environment specified on the command line have higher precedence than variables specified in the file.
+.
+.
+.
+.SS Running as root
+.
+The PSRVR team strongly advises against executing
+.I prun
+as the root user. Applications should be run as regular
+(non-root) users.
+.
+.PP
+Reflecting this advice, prun will refuse to run as root by default.
+To override this default, you can add the
+.I --allow-run-as-root
+option to the
+.I prun
+command line.
+.
+.SS Exit status
+.
+There is no standard definition for what \fIprun\fP should return as an exit
+status. After considerable discussion, we settled on the following method for
+assigning the \fIprun\fP exit status (note: in the following description,
+the "primary" job is the initial application started by prun - all jobs that
+are spawned by that job are designated "secondary" jobs):
+.
+.IP \[bu] 2
+if all processes in the primary job normally terminate with exit status 0, we return 0
+.IP \[bu]
+if one or more processes in the primary job normally terminate with non-zero exit status,
+we return the exit status of the process with the lowest rank to have a non-zero status
+.IP \[bu]
+if all processes in the primary job normally terminate with exit status 0, and one or more
+processes in a secondary job normally terminate with non-zero exit status, we (a) return
+the exit status of the process with the lowest rank in the lowest jobid to have a non-zero
+status, and (b) output a message summarizing the exit status of the primary and all secondary jobs.
+.IP \[bu]
+if the cmd line option --report-child-jobs-separately is set, we will return -only- the
+exit status of the primary job. Any non-zero exit status in secondary jobs will be
+reported solely in a summary print statement.
+.
+.PP
+By default, PSRVR records and notes that processes exited with non-zero termination status.
+This is generally not considered an "abnormal termination" - i.e., PSRVR will not abort a
+job if one or more processes return a non-zero status. Instead, the default behavior simply
+reports the number of processes terminating with non-zero status upon completion of the job.
+.PP
+However, in some cases it can be desirable to have the job abort when any process terminates
+with non-zero status. For example, a non-PMIx job might detect a bad result from a calculation
+and want to abort, but doesn't want to generate a core file. Or a PMIx job might continue past
+a call to PMIx_Finalize, but indicate that all processes should abort due to some post-PMIx result.
+.PP
+It is not anticipated that this situation will occur frequently. However, in the interest of
+serving the broader community, PSRVR now has a means for allowing users to direct that jobs be
+aborted upon any process exiting with non-zero status. Setting the MCA parameter
+"orte_abort_on_non_zero_status" to 1 will cause PSRVR to abort all processes once any process
+ exits with non-zero status.
+.PP
+Terminations caused in this manner will be reported on the console as an "abnormal termination",
+with the first process to so exit identified along with its exit status.
+.PP
+.\" **************************
+.\"    Return Value Section
+.\" **************************
+.
+.SH RETURN VALUE
+.
+\fIprun\fP returns 0 if all processes started by \fIprun\fP exit after calling
+PMIx_Finalize.  A non-zero value is returned if an internal error occurred in
+prun, or one or more processes exited before calling PMIx_Finalize.  If an
+internal error occurred in prun, the corresponding error code is returned.
+In the event that one or more processes exit before calling PMIx_Finalize, the
+return value of the rank of the process that \fIprun\fP first notices died
+before calling PMIx_Finalize will be returned.  Note that, in general, this will
+be the first process that died but is not guaranteed to be so.
+.
+.PP
+If the
+.B --timeout
+command line option is used and the timeout expires before the job
+completes (thereby forcing
+.I prun
+to kill the job)
+.I prun
+will return an exit status equivalent to the value of
+.B ETIMEDOUT
+(which is typically 110 on Linux and OS X systems).
+
+.
+.\" **************************
+.\"    See Also Section
+.\" **************************
+.

--- a/orte/tools/prun/prun.c
+++ b/orte/tools/prun/prun.c
@@ -1,0 +1,1205 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2008 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
+ * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "orte_config.h"
+#include "orte/constants.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#ifdef HAVE_STRINGS_H
+#include <strings.h>
+#endif  /* HAVE_STRINGS_H */
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#include <errno.h>
+#include <signal.h>
+#include <ctype.h>
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif  /* HAVE_SYS_TYPES_H */
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif  /* HAVE_SYS_WAIT_H */
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif  /* HAVE_SYS_TIME_H */
+#include <fcntl.h>
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+
+#include "opal/mca/event/event.h"
+#include "opal/mca/installdirs/installdirs.h"
+#include "opal/mca/pmix/base/base.h"
+#include "opal/mca/base/base.h"
+#include "opal/util/argv.h"
+#include "opal/util/output.h"
+#include "opal/util/basename.h"
+#include "opal/util/cmd_line.h"
+#include "opal/util/opal_environ.h"
+#include "opal/util/opal_getcwd.h"
+#include "opal/util/show_help.h"
+#include "opal/util/fd.h"
+#include "opal/sys/atomic.h"
+#if OPAL_ENABLE_FT_CR == 1
+#include "opal/runtime/opal_cr.h"
+#endif
+
+#include "opal/version.h"
+#include "opal/runtime/opal.h"
+#include "opal/runtime/opal_info_support.h"
+#include "opal/util/os_path.h"
+#include "opal/util/path.h"
+#include "opal/class/opal_pointer_array.h"
+#include "opal/dss/dss.h"
+
+/* ensure I can behave like a daemon */
+#include "prun.h"
+#include <include/pmix.h>
+#include <include/pmix_tool.h>
+
+/**
+ * Global struct for caching orte command line options.
+ */
+struct orte_cmd_options_t {
+    char *help;
+    bool version;
+    bool verbose;
+    char *report_pid;
+    char *report_uri;
+    bool terminate;
+    bool debugger;
+    int num_procs;
+    char *appfile;
+    char *wdir;
+    bool set_cwd_to_session_dir;
+    char *path;
+    char *preload_files;
+    bool sleep;
+    char *stdin_target;
+    char *prefix;
+    char *path_to_mpirun;
+    bool disable_recovery;
+    bool preload_binaries;
+    bool index_argv;
+    bool run_as_root;
+    char *personality;
+    bool create_dvm;
+    bool terminate_dvm;
+    bool nolocal;
+    bool no_oversubscribe;
+    bool oversubscribe;
+    int cpus_per_proc;
+    bool pernode;
+    int npernode;
+    bool use_hwthreads_as_cpus;
+    int npersocket;
+    char *mapping_policy;
+    char *ranking_policy;
+    char *binding_policy;
+    bool report_bindings;
+    char *cpu_list;
+    bool debug;
+    bool tag_output;
+    bool timestamp_output;
+    char *output_filename;
+    bool merge;
+    bool continuous;
+    char *hnp;
+    bool staged_exec;
+    int timeout;
+    bool report_state_on_timeout;
+    bool get_stack_traces;
+};
+typedef struct orte_cmd_options_t orte_cmd_options_t;
+static orte_cmd_options_t orte_cmd_options = {0};
+static opal_cmd_line_t *orte_cmd_line = NULL;
+static opal_list_t job_info;
+static opal_pmix_lock_t globallock;
+
+static int create_app(int argc, char* argv[],
+                      opal_list_t *jdata,
+                      opal_pmix_app_t **app,
+                      bool *made_app, char ***app_env);
+static int parse_locals(opal_list_t *jdata, int argc, char* argv[]);
+static void set_classpath_jar_file(opal_pmix_app_t *app, int index, char *jarfile);
+
+
+static opal_cmd_line_init_t cmd_line_init[] = {
+    /* Various "obvious" options */
+    { NULL, 'h', NULL, "help", 1,
+      &orte_cmd_options.help, OPAL_CMD_LINE_TYPE_STRING,
+      "This help message", OPAL_CMD_LINE_OTYPE_GENERAL },
+    { NULL, 'V', NULL, "version", 0,
+      &orte_cmd_options.version, OPAL_CMD_LINE_TYPE_BOOL,
+      "Print version and exit", OPAL_CMD_LINE_OTYPE_GENERAL },
+    { "orte_execute_quiet", 'q', NULL, "quiet", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Suppress helpful messages", OPAL_CMD_LINE_OTYPE_GENERAL },
+
+    /* exit status reporting */
+    { "orte_report_child_jobs_separately", '\0', "report-child-jobs-separately", "report-child-jobs-separately", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Return the exit status of the primary job only", OPAL_CMD_LINE_OTYPE_OUTPUT },
+
+    /* select XML output */
+    { "orte_xml_output", '\0', "xml", "xml", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Provide all output in XML format", OPAL_CMD_LINE_OTYPE_OUTPUT },
+    { "orte_xml_file", '\0', "xml-file", "xml-file", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Provide all output in XML format to the specified file", OPAL_CMD_LINE_OTYPE_OUTPUT },
+
+    /* tag output */
+    { "orte_tag_output", '\0', "tag-output", "tag-output", 0,
+      &orte_cmd_options.tag_output, OPAL_CMD_LINE_TYPE_BOOL,
+      "Tag all output with [job,rank]", OPAL_CMD_LINE_OTYPE_OUTPUT },
+    { "orte_timestamp_output", '\0', "timestamp-output", "timestamp-output", 0,
+      &orte_cmd_options.timestamp_output, OPAL_CMD_LINE_TYPE_BOOL,
+      "Timestamp all application process output", OPAL_CMD_LINE_OTYPE_OUTPUT },
+    { "orte_output_filename", '\0', "output-filename", "output-filename", 1,
+      &orte_cmd_options.output_filename, OPAL_CMD_LINE_TYPE_STRING,
+      "Redirect output from application processes into filename/job/rank/std[out,err,diag]",
+      OPAL_CMD_LINE_OTYPE_OUTPUT },
+    { NULL, '\0', "merge-stderr-to-stdout", "merge-stderr-to-stdout", 0,
+      &orte_cmd_options.merge, OPAL_CMD_LINE_TYPE_BOOL,
+      "Merge stderr to stdout for each process", OPAL_CMD_LINE_OTYPE_OUTPUT },
+    { "orte_xterm", '\0', "xterm", "xterm", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Create a new xterm window and display output from the specified ranks there",
+      OPAL_CMD_LINE_OTYPE_OUTPUT },
+
+    /* select stdin option */
+    { NULL, '\0', "stdin", "stdin", 1,
+      &orte_cmd_options.stdin_target, OPAL_CMD_LINE_TYPE_STRING,
+      "Specify procs to receive stdin [rank, all, none] (default: 0, indicating rank 0)",
+      OPAL_CMD_LINE_OTYPE_INPUT },
+
+    /* request that argv[0] be indexed */
+    { NULL, '\0', "index-argv-by-rank", "index-argv-by-rank", 0,
+      &orte_cmd_options.index_argv, OPAL_CMD_LINE_TYPE_BOOL,
+      "Uniquely index argv[0] for each process using its rank",
+      OPAL_CMD_LINE_OTYPE_INPUT },
+
+    /* Specify the launch agent to be used */
+    { "orte_launch_agent", '\0', "launch-agent", "launch-agent", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Command used to start processes on remote nodes (default: orted)",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+
+    /* Preload the binary on the remote machine */
+    { NULL, 's', NULL, "preload-binary", 0,
+      &orte_cmd_options.preload_binaries, OPAL_CMD_LINE_TYPE_BOOL,
+      "Preload the binary on the remote machine before starting the remote process.",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+
+    /* Preload files on the remote machine */
+    { NULL, '\0', NULL, "preload-files", 1,
+      &orte_cmd_options.preload_files, OPAL_CMD_LINE_TYPE_STRING,
+      "Preload the comma separated list of files to the remote machines current working directory before starting the remote process.",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+
+    /* Use an appfile */
+    { NULL, '\0', NULL, "app", 1,
+      &orte_cmd_options.appfile, OPAL_CMD_LINE_TYPE_STRING,
+      "Provide an appfile; ignore all other command line options",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+
+    /* Number of processes; -c, -n, --n, -np, and --np are all
+       synonyms */
+    { NULL, 'c', "np", "np", 1,
+      &orte_cmd_options.num_procs, OPAL_CMD_LINE_TYPE_INT,
+      "Number of processes to run", OPAL_CMD_LINE_OTYPE_GENERAL },
+    { NULL, '\0', "n", "n", 1,
+      &orte_cmd_options.num_procs, OPAL_CMD_LINE_TYPE_INT,
+      "Number of processes to run", OPAL_CMD_LINE_OTYPE_GENERAL },
+
+    /* Set a hostfile */
+    { NULL, '\0', "hostfile", "hostfile", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Provide a hostfile", OPAL_CMD_LINE_OTYPE_LAUNCH },
+    { NULL, '\0', "machinefile", "machinefile", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Provide a hostfile", OPAL_CMD_LINE_OTYPE_LAUNCH },
+    { "orte_default_hostfile", '\0', "default-hostfile", "default-hostfile", 1,
+        NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Provide a default hostfile", OPAL_CMD_LINE_OTYPE_LAUNCH },
+    { "opal_if_do_not_resolve", '\0', "do-not-resolve", "do-not-resolve", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Do not attempt to resolve interfaces", OPAL_CMD_LINE_OTYPE_DEVEL },
+
+    { "orte_rankfile", '\0', "rf", "rankfile", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Provide a rankfile file", OPAL_CMD_LINE_OTYPE_MAPPING },
+
+    /* Export environment variables; potentially used multiple times,
+       so it does not make sense to set into a variable */
+    { NULL, 'x', NULL, NULL, 1,
+      NULL, OPAL_CMD_LINE_TYPE_NULL,
+      "Export an environment variable, optionally specifying a value (e.g., \"-x foo\" exports the environment variable foo and takes its value from the current environment; \"-x foo=bar\" exports the environment variable name foo and sets its value to \"bar\" in the started processes)", OPAL_CMD_LINE_OTYPE_LAUNCH },
+
+      /* Mapping controls */
+    { "rmaps_base_display_map", '\0', "display-map", "display-map", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Display the process map just before launch", OPAL_CMD_LINE_OTYPE_DEBUG },
+    { "rmaps_base_display_devel_map", '\0', "display-devel-map", "display-devel-map", 0,
+       NULL, OPAL_CMD_LINE_TYPE_BOOL,
+       "Display a detailed process map (mostly intended for developers) just before launch",
+       OPAL_CMD_LINE_OTYPE_DEVEL },
+    { "rmaps_base_display_topo_with_map", '\0', "display-topo", "display-topo", 0,
+       NULL, OPAL_CMD_LINE_TYPE_BOOL,
+       "Display the topology as part of the process map (mostly intended for developers) just before launch",
+       OPAL_CMD_LINE_OTYPE_DEVEL },
+    { "rmaps_base_display_diffable_map", '\0', "display-diffable-map", "display-diffable-map", 0,
+       NULL, OPAL_CMD_LINE_TYPE_BOOL,
+       "Display a diffable process map (mostly intended for developers) just before launch",
+       OPAL_CMD_LINE_OTYPE_DEVEL },
+    { NULL, 'H', "host", "host", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "List of hosts to invoke processes on",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+    { "rmaps_base_no_schedule_local", '\0', "nolocal", "nolocal", 0,
+      &orte_cmd_options.nolocal, OPAL_CMD_LINE_TYPE_BOOL,
+      "Do not run any MPI applications on the local node",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+    { "rmaps_base_no_oversubscribe", '\0', "nooversubscribe", "nooversubscribe", 0,
+      &orte_cmd_options.no_oversubscribe, OPAL_CMD_LINE_TYPE_BOOL,
+      "Nodes are not to be oversubscribed, even if the system supports such operation",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+    { "rmaps_base_oversubscribe", '\0', "oversubscribe", "oversubscribe", 0,
+      &orte_cmd_options.oversubscribe, OPAL_CMD_LINE_TYPE_BOOL,
+      "Nodes are allowed to be oversubscribed, even on a managed system, and overloading of processing elements",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+    { "rmaps_base_cpus_per_rank", '\0', "cpus-per-proc", "cpus-per-proc", 1,
+      &orte_cmd_options.cpus_per_proc, OPAL_CMD_LINE_TYPE_INT,
+      "Number of cpus to use for each process [default=1]",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+    { "rmaps_base_cpus_per_rank", '\0', "cpus-per-rank", "cpus-per-rank", 1,
+      &orte_cmd_options.cpus_per_proc, OPAL_CMD_LINE_TYPE_INT,
+      "Synonym for cpus-per-proc", OPAL_CMD_LINE_OTYPE_MAPPING },
+
+    /* backward compatiblity */
+    { "rmaps_base_bycore", '\0', "bycore", "bycore", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Whether to map and rank processes round-robin by core",
+      OPAL_CMD_LINE_OTYPE_COMPAT },
+    { "rmaps_base_bynode", '\0', "bynode", "bynode", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Whether to map and rank processes round-robin by node",
+      OPAL_CMD_LINE_OTYPE_COMPAT },
+    { "rmaps_base_byslot", '\0', "byslot", "byslot", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Whether to map and rank processes round-robin by slot",
+      OPAL_CMD_LINE_OTYPE_COMPAT },
+
+    /* Nperxxx options that do not require topology and are always
+     * available - included for backwards compatibility
+     */
+    { "rmaps_ppr_pernode", '\0', "pernode", "pernode", 0,
+      &orte_cmd_options.pernode, OPAL_CMD_LINE_TYPE_BOOL,
+      "Launch one process per available node",
+      OPAL_CMD_LINE_OTYPE_COMPAT },
+    { "rmaps_ppr_n_pernode", '\0', "npernode", "npernode", 1,
+      &orte_cmd_options.npernode, OPAL_CMD_LINE_TYPE_INT,
+      "Launch n processes per node on all allocated nodes",
+      OPAL_CMD_LINE_OTYPE_COMPAT },
+    { "rmaps_ppr_n_pernode", '\0', "N", NULL, 1,
+      &orte_cmd_options.npernode, OPAL_CMD_LINE_TYPE_INT,
+      "Launch n processes per node on all allocated nodes (synonym for 'map-by node')",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+
+    /* declare hardware threads as independent cpus */
+    { "hwloc_base_use_hwthreads_as_cpus", '\0', "use-hwthread-cpus", "use-hwthread-cpus", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Use hardware threads as independent cpus", OPAL_CMD_LINE_OTYPE_MAPPING },
+
+    /* include npersocket for backwards compatibility */
+    { "rmaps_ppr_n_persocket", '\0', "npersocket", "npersocket", 1,
+      &orte_cmd_options.npersocket, OPAL_CMD_LINE_TYPE_INT,
+      "Launch n processes per socket on all allocated nodes",
+      OPAL_CMD_LINE_OTYPE_COMPAT },
+
+    /* Mapping options */
+    { "rmaps_base_mapping_policy", '\0', NULL, "map-by", 1,
+      &orte_cmd_options.mapping_policy, OPAL_CMD_LINE_TYPE_STRING,
+      "Mapping Policy [slot | hwthread | core | socket (default) | numa | board | node]",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+
+      /* Ranking options */
+    { "rmaps_base_ranking_policy", '\0', NULL, "rank-by", 1,
+      &orte_cmd_options.ranking_policy, OPAL_CMD_LINE_TYPE_STRING,
+      "Ranking Policy [slot (default) | hwthread | core | socket | numa | board | node]",
+      OPAL_CMD_LINE_OTYPE_RANKING },
+
+      /* Binding options */
+    { "hwloc_base_binding_policy", '\0', NULL, "bind-to", 1,
+      &orte_cmd_options.binding_policy, OPAL_CMD_LINE_TYPE_STRING,
+      "Policy for binding processes. Allowed values: none, hwthread, core, l1cache, l2cache, l3cache, socket, numa, board (\"none\" is the default when oversubscribed, \"core\" is the default when np<=2, and \"socket\" is the default when np>2). Allowed qualifiers: overload-allowed, if-supported", OPAL_CMD_LINE_OTYPE_BINDING },
+
+    /* backward compatiblity */
+    { "hwloc_base_bind_to_core", '\0', "bind-to-core", "bind-to-core", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Bind processes to cores", OPAL_CMD_LINE_OTYPE_COMPAT },
+    { "hwloc_base_bind_to_socket", '\0', "bind-to-socket", "bind-to-socket", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Bind processes to sockets", OPAL_CMD_LINE_OTYPE_COMPAT },
+
+    { "hwloc_base_report_bindings", '\0', "report-bindings", "report-bindings", 0,
+      &orte_cmd_options.report_bindings, OPAL_CMD_LINE_TYPE_BOOL,
+      "Whether to report process bindings to stderr",
+      OPAL_CMD_LINE_OTYPE_BINDING },
+
+    /* slot list option */
+    { "hwloc_base_cpu_list", '\0', "cpu-list", "cpu-list", 1,
+      &orte_cmd_options.cpu_list, OPAL_CMD_LINE_TYPE_STRING,
+      "List of processor IDs to bind processes to [default=NULL]",
+      OPAL_CMD_LINE_OTYPE_BINDING },
+
+    /* generalized pattern mapping option */
+    { "rmaps_ppr_pattern", '\0', NULL, "ppr", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Comma-separated list of number of processes on a given resource type [default: none]",
+      OPAL_CMD_LINE_OTYPE_MAPPING },
+
+    /* Allocation options */
+    { "orte_display_alloc", '\0', "display-allocation", "display-allocation", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Display the allocation being used by this job", OPAL_CMD_LINE_OTYPE_DEBUG },
+    { "orte_display_devel_alloc", '\0', "display-devel-allocation", "display-devel-allocation", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Display a detailed list (mostly intended for developers) of the allocation being used by this job",
+      OPAL_CMD_LINE_OTYPE_DEVEL },
+    { "hwloc_base_cpu_set", '\0', "cpu-set", "cpu-set", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Comma-separated list of ranges specifying logical cpus allocated to this job [default: none]",
+      OPAL_CMD_LINE_OTYPE_DEBUG },
+
+    /* mpiexec-like arguments */
+    { NULL, '\0', "wdir", "wdir", 1,
+      &orte_cmd_options.wdir, OPAL_CMD_LINE_TYPE_STRING,
+      "Set the working directory of the started processes",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+    { NULL, '\0', "wd", "wd", 1,
+      &orte_cmd_options.wdir, OPAL_CMD_LINE_TYPE_STRING,
+      "Synonym for --wdir", OPAL_CMD_LINE_OTYPE_LAUNCH },
+    { NULL, '\0', "set-cwd-to-session-dir", "set-cwd-to-session-dir", 0,
+      &orte_cmd_options.set_cwd_to_session_dir, OPAL_CMD_LINE_TYPE_BOOL,
+      "Set the working directory of the started processes to their session directory",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+    { NULL, '\0', "path", "path", 1,
+      &orte_cmd_options.path, OPAL_CMD_LINE_TYPE_STRING,
+      "PATH to be used to look for executables to start processes",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+
+    /* User-level debugger arguments */
+    { NULL, '\0', "tv", "tv", 0,
+      &orte_cmd_options.debugger, OPAL_CMD_LINE_TYPE_BOOL,
+      "Deprecated backwards compatibility flag; synonym for \"--debug\"",
+      OPAL_CMD_LINE_OTYPE_DEBUG },
+    { NULL, '\0', "debug", "debug", 0,
+      &orte_cmd_options.debugger, OPAL_CMD_LINE_TYPE_BOOL,
+      "Invoke the user-level debugger indicated by the orte_base_user_debugger MCA parameter",
+      OPAL_CMD_LINE_OTYPE_DEBUG },
+    { "orte_base_user_debugger", '\0', "debugger", "debugger", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Sequence of debuggers to search for when \"--debug\" is used",
+      OPAL_CMD_LINE_OTYPE_DEBUG },
+    { "orte_output_debugger_proctable", '\0', "output-proctable", "output-proctable", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Output the debugger proctable after launch",
+      OPAL_CMD_LINE_OTYPE_DEBUG },
+
+    { "orte_report_events", '\0', "report-events", "report-events", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Report events to a tool listening at the specified URI", OPAL_CMD_LINE_OTYPE_DEBUG },
+
+    { "orte_enable_recovery", '\0', "enable-recovery", "enable-recovery", 0,
+      NULL, OPAL_CMD_LINE_TYPE_BOOL,
+      "Enable recovery from process failure [Default = disabled]",
+      OPAL_CMD_LINE_OTYPE_UNSUPPORTED },
+
+    { "orte_max_restarts", '\0', "max-restarts", "max-restarts", 1,
+      NULL, OPAL_CMD_LINE_TYPE_INT,
+      "Max number of times to restart a failed process",
+      OPAL_CMD_LINE_OTYPE_UNSUPPORTED },
+
+    { NULL, '\0', "continuous", "continuous", 0,
+      &orte_cmd_options.continuous, OPAL_CMD_LINE_TYPE_BOOL,
+      "Job is to run until explicitly terminated", OPAL_CMD_LINE_OTYPE_DEBUG },
+
+    { NULL, '\0', "disable-recovery", "disable-recovery", 0,
+      &orte_cmd_options.disable_recovery, OPAL_CMD_LINE_TYPE_BOOL,
+      "Disable recovery (resets all recovery options to off)",
+      OPAL_CMD_LINE_OTYPE_UNSUPPORTED },
+
+    { NULL, '\0', "personality", "personality", 1,
+      &orte_cmd_options.personality, OPAL_CMD_LINE_TYPE_STRING,
+      "Comma-separated list of programming model, languages, and containers being used (default=\"ompi\")",
+      OPAL_CMD_LINE_OTYPE_LAUNCH },
+
+    /* tell the dvm to terminate */
+    { NULL, '\0', "terminate", "terminate", 0,
+      &orte_cmd_options.terminate_dvm, OPAL_CMD_LINE_TYPE_BOOL,
+      "Terminate the DVM", OPAL_CMD_LINE_OTYPE_DVM },
+
+    /* End of list */
+    { NULL, '\0', NULL, NULL, 0,
+      NULL, OPAL_CMD_LINE_TYPE_NULL, NULL }
+};
+
+
+static void infocb(pmix_status_t status,
+                   pmix_info_t *info, size_t ninfo,
+                   void *cbdata,
+                   pmix_release_cbfunc_t release_fn,
+                   void *release_cbdata)
+{
+    opal_pmix_lock_t *lock = (opal_pmix_lock_t*)cbdata;
+    OPAL_ACQUIRE_OBJECT(lock);
+
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    OPAL_PMIX_WAKEUP_THREAD(lock);
+}
+
+static void regcbfunc(pmix_status_t status, size_t ref, void *cbdata)
+{
+    opal_pmix_lock_t *lock = (opal_pmix_lock_t*)cbdata;
+    OPAL_ACQUIRE_OBJECT(lock);
+    OPAL_PMIX_WAKEUP_THREAD(lock);
+}
+
+static void evhandler(size_t evhdlr_registration_id,
+                      pmix_status_t status,
+                      const pmix_proc_t *source,
+                      pmix_info_t info[], size_t ninfo,
+                      pmix_info_t *results, size_t nresults,
+                      pmix_event_notification_cbfunc_fn_t cbfunc,
+                      void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+    OPAL_ACQUIRE_OBJECT(&globallock);
+    OPAL_PMIX_WAKEUP_THREAD(&globallock);
+}
+
+
+int prun(int argc, char *argv[])
+{
+    int rc, i;
+    char *param;
+    opal_pmix_lock_t lock;
+    opal_list_t apps;
+    opal_value_t *val;
+    opal_pmix_app_t *app;
+    pmix_status_t code;
+    char nspace[PMIX_MAX_NSLEN+1];
+    pmix_info_t info;
+    pmix_proc_t myproc;
+    size_t asz, jsz;
+    pmix_app_t *papps = NULL;
+    pmix_info_t *pinfo = NULL;
+
+    /* init the globals */
+    memset(&orte_cmd_options, 0, sizeof(orte_cmd_options));
+    OBJ_CONSTRUCT(&job_info, opal_list_t);
+    OBJ_CONSTRUCT(&apps, opal_list_t);
+
+    /* search the argv for MCA params */
+    for (i=0; NULL != argv[i]; i++) {
+        if (':' == argv[i][0] ||
+            NULL == argv[i+1] || NULL == argv[i+2]) {
+            break;
+        }
+        if (0 == strncmp(argv[i], "-"OPAL_MCA_CMD_LINE_ID, strlen("-"OPAL_MCA_CMD_LINE_ID)) ||
+            0 == strncmp(argv[i], "--"OPAL_MCA_CMD_LINE_ID, strlen("--"OPAL_MCA_CMD_LINE_ID)) ||
+            0 == strncmp(argv[i], "-g"OPAL_MCA_CMD_LINE_ID, strlen("-g"OPAL_MCA_CMD_LINE_ID)) ||
+            0 == strncmp(argv[i], "--g"OPAL_MCA_CMD_LINE_ID, strlen("--g"OPAL_MCA_CMD_LINE_ID))) {
+            (void) mca_base_var_env_name (argv[i+1], &param);
+            opal_setenv(param, argv[i+2], true, &environ);
+            free(param);
+        } else if (0 == strcmp(argv[i], "-am") ||
+                   0 == strcmp(argv[i], "--am")) {
+            (void)mca_base_var_env_name("mca_base_param_file_prefix", &param);
+            opal_setenv(param, argv[i+1], true, &environ);
+            free(param);
+        } else if (0 == strcmp(argv[i], "-tune") ||
+                   0 == strcmp(argv[i], "--tune")) {
+            (void)mca_base_var_env_name("mca_base_envar_file_prefix", &param);
+            opal_setenv(param, argv[i+1], true, &environ);
+            free(param);
+        }
+    }
+
+    /* init only the util portion of OPAL */
+    if (OPAL_SUCCESS != (rc = opal_init_util(&argc, &argv))) {
+        return rc;
+    }
+
+    /* setup our cmd line */
+    orte_cmd_line = OBJ_NEW(opal_cmd_line_t);
+    if (OPAL_SUCCESS != (rc = opal_cmd_line_add(orte_cmd_line, cmd_line_init))) {
+        return rc;
+    }
+
+    /* now that options have been defined, finish setup */
+    mca_base_cmd_line_setup(orte_cmd_line);
+
+    /* parse the result to get values */
+    if (OPAL_SUCCESS != (rc = opal_cmd_line_parse(orte_cmd_line,
+                                                  true, false, argc, argv)) ) {
+        if (OPAL_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+                    opal_strerror(rc));
+        }
+        return rc;
+    }
+
+    /* see if print version is requested. Do this before
+     * check for help so that --version --help works as
+     * one might expect. */
+     if (orte_cmd_options.version) {
+        char *str;
+        str = opal_info_make_version_str("all",
+                                         OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+                                         OPAL_RELEASE_VERSION,
+                                         OPAL_GREEK_VERSION,
+                                         OPAL_REPO_REV);
+        if (NULL != str) {
+            fprintf(stdout, "%s (%s) %s\n\nReport bugs to %s\n",
+                    "prun", "PMIx Reference Server", str, PACKAGE_BUGREPORT);
+            free(str);
+        }
+        exit(0);
+    }
+
+    /* check if we are running as root - if we are, then only allow
+     * us to proceed if the allow-run-as-root flag was given. Otherwise,
+     * exit with a giant warning flag
+     */
+    if (0 == geteuid() && !orte_cmd_options.run_as_root) {
+        /* show_help is not yet available, so print an error manually */
+        fprintf(stderr, "--------------------------------------------------------------------------\n");
+        if (orte_cmd_options.help) {
+            fprintf(stderr, "prun cannot provide the help message when run as root.\n\n");
+        } else {
+            fprintf(stderr, "prun has detected an attempt to run as root.\n\n");
+        }
+
+        fprintf(stderr, "Running as root is *strongly* discouraged as any mistake (e.g., in\n");
+        fprintf(stderr, "defining TMPDIR) or bug can result in catastrophic damage to the OS\n");
+        fprintf(stderr, "file system, leaving your system in an unusable state.\n\n");
+
+        fprintf(stderr, "We strongly suggest that you run prun as a non-root user.\n\n");
+
+        fprintf(stderr, "You can override this protection by adding the --allow-run-as-root\n");
+        fprintf(stderr, "option to your command line.  However, we reiterate our strong advice\n");
+        fprintf(stderr, "against doing so - please do so at your own risk.\n");
+        fprintf(stderr, "--------------------------------------------------------------------------\n");
+        exit(1);
+    }
+
+    /* process any mca params */
+    rc = mca_base_cmd_line_process_args(orte_cmd_line, &environ, &environ);
+    if (ORTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    /* use the system connection first, if available */
+    PMIX_INFO_LOAD(&info, OPAL_PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    /* init as a tool */
+    if (OPAL_SUCCESS != PMIx_tool_init(&myproc, &info, 1)) {
+        fprintf(stderr, "Unable to init as tool\n");
+        exit(1);
+    }
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* if the user just wants us to terminate a DVM, then do so */
+    if (orte_cmd_options.terminate_dvm) {
+        PMIX_INFO_LOAD(&info, OPAL_PMIX_JOB_CTRL_TERMINATE, NULL, PMIX_BOOL);
+        fprintf(stderr, "TERMINATING DVM...");
+        OPAL_PMIX_CONSTRUCT_LOCK(&lock);
+        rc = PMIx_Job_control_nb(NULL, 0, &info, 1, infocb, (void*)&lock);
+        OPAL_PMIX_WAIT_THREAD(&lock);
+        OPAL_PMIX_DESTRUCT_LOCK(&lock);
+        PMIX_INFO_DESTRUCT(&info);
+        fprintf(stderr, "DONE\n");
+        goto DONE;
+    }
+
+    /* get here if they want to run an application, so let's parse
+     * the cmd line to get it */
+
+    if (OPAL_SUCCESS != parse_locals(&apps, argc, argv)) {
+        opal_output(0, "[%s:%d] SOMETHING WRONG", __FILE__, __LINE__);
+        OPAL_LIST_DESTRUCT(&apps);
+        goto DONE;
+    }
+
+    /* bozo check */
+    if (0 == (asz = opal_list_get_size(&apps))) {
+        opal_output(0, "[%s:%d] SOMETHING WRONG", __FILE__, __LINE__);
+        goto DONE;
+    }
+
+    /* register for job terminations so we get notified when
+     * our job completes */
+    OPAL_PMIX_CONSTRUCT_LOCK(&lock);
+    code = PMIX_ERR_JOB_TERMINATED;
+    PMIx_Register_event_handler(&code, 1, NULL, 0, evhandler, regcbfunc, &lock);
+    OPAL_PMIX_WAIT_THREAD(&lock);
+    OPAL_PMIX_DESTRUCT_LOCK(&lock);
+
+    /* convert the job info and apps to PMIx arrays */
+    if (0 < (jsz = opal_list_get_size(&job_info))) {
+        PMIX_INFO_CREATE(pinfo, jsz);
+        i=0;
+        OPAL_LIST_FOREACH(val, &job_info, opal_value_t) {
+            (void)strncpy(pinfo[i].key, val->key, PMIX_MAX_KEYLEN);
+            /* we only have bool and string types here */
+            if (OPAL_BOOL == val->type) {
+                pinfo[i].value.type = PMIX_BOOL;
+                pinfo[i].value.data.flag = val->data.flag;
+            } else if (OPAL_STRING == val->type) {
+                pinfo[i].value.type = PMIX_STRING;
+                pinfo[i].value.data.string = strdup(val->data.string);
+            } else {
+                opal_output(0, "UNSUPPORTED TYPE %d", val->type);
+            }
+            ++i;
+        }
+    }
+    OPAL_LIST_DESTRUCT(&job_info);
+
+    PMIX_APP_CREATE(papps, asz);
+    i=0;
+    OPAL_LIST_FOREACH(app, &apps, opal_pmix_app_t) {
+        papps[i].cmd = strdup(app->cmd);
+        papps[i].argv = opal_argv_copy(app->argv);
+        papps[i].env = opal_argv_copy(app->env);
+        if (NULL != app->cwd) {
+            papps[i].cwd = strdup(app->cwd);
+        }
+        papps[i].maxprocs = app->maxprocs;
+        ++i;
+    }
+    OPAL_LIST_DESTRUCT(&apps);
+
+    OPAL_PMIX_CONSTRUCT_LOCK(&globallock);
+    if (PMIX_SUCCESS != PMIx_Spawn(pinfo, jsz, papps, asz, nspace)) {
+        opal_output(0, "[%s:%d] SOMETHING WRONG", __FILE__, __LINE__);
+        OPAL_PMIX_DESTRUCT_LOCK(&globallock);
+        goto DONE;
+    }
+    opal_output(0, "JOB %s EXECUTING", nspace);
+    OPAL_PMIX_WAIT_THREAD(&globallock);
+    OPAL_PMIX_DESTRUCT_LOCK(&globallock);
+    if (NULL != pinfo) {
+        PMIX_INFO_FREE(pinfo, jsz);
+    }
+    if (NULL != papps) {
+        PMIX_APP_FREE(papps, asz);
+    }
+
+ DONE:
+    /* cleanup and leave */
+    PMIx_tool_finalize();
+    opal_finalize();
+    return 0;
+}
+
+static int parse_locals(opal_list_t *jdata, int argc, char* argv[])
+{
+    int i, rc;
+    int temp_argc;
+    char **temp_argv, **env;
+    opal_pmix_app_t *app;
+    bool made_app;
+
+    /* Make the apps */
+    temp_argc = 0;
+    temp_argv = NULL;
+    opal_argv_append(&temp_argc, &temp_argv, argv[0]);
+
+    /* NOTE: This bogus env variable is necessary in the calls to
+       create_app(), below.  See comment immediately before the
+       create_app() function for an explanation. */
+
+    env = NULL;
+    for (i = 1; i < argc; ++i) {
+        if (0 == strcmp(argv[i], ":")) {
+            /* Make an app with this argv */
+            if (opal_argv_count(temp_argv) > 1) {
+                if (NULL != env) {
+                    opal_argv_free(env);
+                    env = NULL;
+                }
+                app = NULL;
+                rc = create_app(temp_argc, temp_argv, jdata, &app, &made_app, &env);
+                if (OPAL_SUCCESS != rc) {
+                    /* Assume that the error message has already been
+                       printed; no need to cleanup -- we can just
+                       exit */
+                    exit(1);
+                }
+                if (made_app) {
+                    opal_list_append(jdata, &app->super);
+                }
+
+                /* Reset the temps */
+
+                temp_argc = 0;
+                temp_argv = NULL;
+                opal_argv_append(&temp_argc, &temp_argv, argv[0]);
+            }
+        } else {
+            opal_argv_append(&temp_argc, &temp_argv, argv[i]);
+        }
+    }
+
+    if (opal_argv_count(temp_argv) > 1) {
+        app = NULL;
+        rc = create_app(temp_argc, temp_argv, jdata, &app, &made_app, &env);
+        if (ORTE_SUCCESS != rc) {
+            /* Assume that the error message has already been printed;
+               no need to cleanup -- we can just exit */
+            exit(1);
+        }
+        if (made_app) {
+            opal_list_append(jdata, &app->super);
+        }
+    }
+    if (NULL != env) {
+        opal_argv_free(env);
+    }
+    opal_argv_free(temp_argv);
+
+    /* All done */
+
+    return ORTE_SUCCESS;
+}
+
+
+/*
+ * This function takes a "char ***app_env" parameter to handle the
+ * specific case:
+ *
+ *   orterun --mca foo bar -app appfile
+ *
+ * That is, we'll need to keep foo=bar, but the presence of the app
+ * file will cause an invocation of parse_appfile(), which will cause
+ * one or more recursive calls back to create_app().  Since the
+ * foo=bar value applies globally to all apps in the appfile, we need
+ * to pass in the "base" environment (that contains the foo=bar value)
+ * when we parse each line in the appfile.
+ *
+ * This is really just a special case -- when we have a simple case like:
+ *
+ *   orterun --mca foo bar -np 4 hostname
+ *
+ * Then the upper-level function (parse_locals()) calls create_app()
+ * with a NULL value for app_env, meaning that there is no "base"
+ * environment that the app needs to be created from.
+ */
+static int create_app(int argc, char* argv[],
+                      opal_list_t *jdata,
+                      opal_pmix_app_t **app_ptr,
+                      bool *made_app, char ***app_env)
+{
+    char cwd[OPAL_PATH_MAX];
+    int i, j, count, rc;
+    char *param, *value;
+    opal_pmix_app_t *app = NULL;
+    bool found = false;
+    char *appname = NULL;
+    opal_value_t *val;
+
+    *made_app = false;
+
+    /* parse the cmd line - do this every time thru so we can
+     * repopulate the globals */
+    if (OPAL_SUCCESS != (rc = opal_cmd_line_parse(orte_cmd_line, true, false,
+                                                  argc, argv)) ) {
+        if (OPAL_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+                    opal_strerror(rc));
+        }
+        return rc;
+    }
+
+    /* Setup application context */
+    app = OBJ_NEW(opal_pmix_app_t);
+    opal_cmd_line_get_tail(orte_cmd_line, &count, &app->argv);
+
+    /* See if we have anything left */
+    if (0 == count) {
+        opal_show_help("help-orterun.txt", "orterun:executable-not-specified",
+                       true, "prun", "prun");
+        rc = OPAL_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* Grab all MCA environment variables */
+    app->env = opal_argv_copy(*app_env);
+    for (i=0; NULL != environ[i]; i++) {
+        if (0 == strncmp("PMIX_", environ[i], 5)) {
+            /* check for duplicate in app->env - this
+             * would have been placed there by the
+             * cmd line processor. By convention, we
+             * always let the cmd line override the
+             * environment
+             */
+            param = strdup(environ[i]);
+            value = strchr(param, '=');
+            *value = '\0';
+            value++;
+            opal_setenv(param, value, false, &app->env);
+            free(param);
+        }
+    }
+
+    /* Did the user request a specific wdir? */
+
+    if (NULL != orte_cmd_options.wdir) {
+        /* if this is a relative path, convert it to an absolute path */
+        if (opal_path_is_absolute(orte_cmd_options.wdir)) {
+            app->cwd = strdup(orte_cmd_options.wdir);
+        } else {
+            /* get the cwd */
+            if (OPAL_SUCCESS != (rc = opal_getcwd(cwd, sizeof(cwd)))) {
+                opal_show_help("help-orterun.txt", "orterun:init-failure",
+                               true, "get the cwd", rc);
+                goto cleanup;
+            }
+            /* construct the absolute path */
+            app->cwd = opal_os_path(false, cwd, orte_cmd_options.wdir, NULL);
+        }
+    } else if (orte_cmd_options.set_cwd_to_session_dir) {
+        val = OBJ_NEW(opal_value_t);
+        val->key = strdup(OPAL_PMIX_SET_SESSION_CWD);
+        val->type = OPAL_BOOL;
+        val->data.flag = true;
+        opal_list_append(&job_info, &val->super);
+    } else {
+        if (OPAL_SUCCESS != (rc = opal_getcwd(cwd, sizeof(cwd)))) {
+            opal_show_help("help-orterun.txt", "orterun:init-failure",
+                           true, "get the cwd", rc);
+            goto cleanup;
+        }
+        app->cwd = strdup(cwd);
+    }
+
+    /* Did the user specify a hostfile. Need to check for both
+     * hostfile and machine file.
+     * We can only deal with one hostfile per app context, otherwise give an error.
+     */
+    found = false;
+    if (0 < (j = opal_cmd_line_get_ninsts(orte_cmd_line, "hostfile"))) {
+        if (1 < j) {
+            opal_show_help("help-orterun.txt", "orterun:multiple-hostfiles",
+                           true, "prun", NULL);
+            return ORTE_ERR_FATAL;
+        } else {
+            value = opal_cmd_line_get_param(orte_cmd_line, "hostfile", 0, 0);
+            val = OBJ_NEW(opal_value_t);
+            val->key = strdup(OPAL_PMIX_HOSTFILE);
+            val->type = OPAL_STRING;
+            val->data.string = value;
+            opal_list_append(&job_info, &val->super);
+            found = true;
+        }
+    }
+    if (0 < (j = opal_cmd_line_get_ninsts(orte_cmd_line, "machinefile"))) {
+        if (1 < j || found) {
+            opal_show_help("help-orterun.txt", "orterun:multiple-hostfiles",
+                           true, "prun", NULL);
+            return ORTE_ERR_FATAL;
+        } else {
+            value = opal_cmd_line_get_param(orte_cmd_line, "machinefile", 0, 0);
+            val = OBJ_NEW(opal_value_t);
+            val->key = strdup(OPAL_PMIX_HOSTFILE);
+            val->type = OPAL_STRING;
+            val->data.string = value;
+            opal_list_append(&job_info, &val->super);
+        }
+    }
+
+    /* Did the user specify any hosts? */
+    if (0 < (j = opal_cmd_line_get_ninsts(orte_cmd_line, "host"))) {
+        char **targ=NULL, *tval;
+        for (i = 0; i < j; ++i) {
+            value = opal_cmd_line_get_param(orte_cmd_line, "host", i, 0);
+            opal_argv_append_nosize(&targ, value);
+        }
+        tval = opal_argv_join(targ, ',');
+        val = OBJ_NEW(opal_value_t);
+        val->key = strdup(OPAL_PMIX_HOST);
+        val->type = OPAL_STRING;
+        val->data.string = tval;
+        opal_list_append(&job_info, &val->super);
+    }
+
+    /* check for bozo error */
+    if (0 > orte_cmd_options.num_procs) {
+        opal_show_help("help-orterun.txt", "orterun:negative-nprocs",
+                       true, "prun", app->argv[0],
+                       orte_cmd_options.num_procs, NULL);
+        return ORTE_ERR_FATAL;
+    }
+
+    app->maxprocs = orte_cmd_options.num_procs;
+
+    /* see if we need to preload the binary to
+     * find the app - don't do this for java apps, however, as we
+     * can't easily find the class on the cmd line. Java apps have to
+     * preload their binary via the preload_files option
+     */
+    if (NULL == strstr(app->argv[0], "java")) {
+        if (orte_cmd_options.preload_binaries) {
+            val = OBJ_NEW(opal_value_t);
+            val->key = strdup(OPAL_PMIX_SET_SESSION_CWD);
+            val->type = OPAL_BOOL;
+            val->data.flag = true;
+            opal_list_append(&job_info, &val->super);
+            val = OBJ_NEW(opal_value_t);
+            val->key = strdup(OPAL_PMIX_PRELOAD_BIN);
+            val->type = OPAL_BOOL;
+            val->data.flag = true;
+            opal_list_append(&job_info, &val->super);
+        }
+    }
+    if (NULL != orte_cmd_options.preload_files) {
+        val = OBJ_NEW(opal_value_t);
+        val->key = strdup(OPAL_PMIX_PRELOAD_FILES);
+        val->type = OPAL_BOOL;
+        val->data.flag = true;
+        opal_list_append(&job_info, &val->super);
+    }
+
+    /* Do not try to find argv[0] here -- the starter is responsible
+       for that because it may not be relevant to try to find it on
+       the node where orterun is executing.  So just strdup() argv[0]
+       into app. */
+
+    app->cmd = strdup(app->argv[0]);
+    if (NULL == app->cmd) {
+        opal_show_help("help-orterun.txt", "orterun:call-failed",
+                       true, "prun", "library", "strdup returned NULL", errno);
+        rc = ORTE_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* if this is a Java application, we have a bit more work to do. Such
+     * applications actually need to be run under the Java virtual machine
+     * and the "java" command will start the "executable". So we need to ensure
+     * that all the proper java-specific paths are provided
+     */
+    appname = opal_basename(app->cmd);
+    if (0 == strcmp(appname, "java")) {
+        /* see if we were given a library path */
+        found = false;
+        for (i=1; NULL != app->argv[i]; i++) {
+            if (NULL != strstr(app->argv[i], "java.library.path")) {
+                char *dptr;
+                /* find the '=' that delineates the option from the path */
+                if (NULL == (dptr = strchr(app->argv[i], '='))) {
+                    /* that's just wrong */
+                    rc = ORTE_ERR_BAD_PARAM;
+                    goto cleanup;
+                }
+                /* step over the '=' */
+                ++dptr;
+                /* yep - but does it include the path to the mpi libs? */
+                found = true;
+                if (NULL == strstr(app->argv[i], opal_install_dirs.libdir)) {
+                    /* doesn't appear to - add it to be safe */
+                    if (':' == app->argv[i][strlen(app->argv[i]-1)]) {
+                        asprintf(&value, "-Djava.library.path=%s%s", dptr, opal_install_dirs.libdir);
+                    } else {
+                        asprintf(&value, "-Djava.library.path=%s:%s", dptr, opal_install_dirs.libdir);
+                    }
+                    free(app->argv[i]);
+                    app->argv[i] = value;
+                }
+                break;
+            }
+        }
+        if (!found) {
+            /* need to add it right after the java command */
+            asprintf(&value, "-Djava.library.path=%s", opal_install_dirs.libdir);
+            opal_argv_insert_element(&app->argv, 1, value);
+            free(value);
+        }
+
+        /* see if we were given a class path */
+        found = false;
+        for (i=1; NULL != app->argv[i]; i++) {
+            if (NULL != strstr(app->argv[i], "cp") ||
+                NULL != strstr(app->argv[i], "classpath")) {
+                /* yep - but does it include the path to the mpi libs? */
+                found = true;
+                /* check if mpi.jar exists - if so, add it */
+                value = opal_os_path(false, opal_install_dirs.libdir, "mpi.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    set_classpath_jar_file(app, i+1, "mpi.jar");
+                }
+                free(value);
+                /* check for oshmem support */
+                value = opal_os_path(false, opal_install_dirs.libdir, "shmem.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    set_classpath_jar_file(app, i+1, "shmem.jar");
+                }
+                free(value);
+                /* always add the local directory */
+                asprintf(&value, "%s:%s", app->cwd, app->argv[i+1]);
+                free(app->argv[i+1]);
+                app->argv[i+1] = value;
+                break;
+            }
+        }
+        if (!found) {
+            /* check to see if CLASSPATH is in the environment */
+            found = false;  // just to be pedantic
+            for (i=0; NULL != environ[i]; i++) {
+                if (0 == strncmp(environ[i], "CLASSPATH", strlen("CLASSPATH"))) {
+                    value = strchr(environ[i], '=');
+                    ++value; /* step over the = */
+                    opal_argv_insert_element(&app->argv, 1, value);
+                    /* check for mpi.jar */
+                    value = opal_os_path(false, opal_install_dirs.libdir, "mpi.jar", NULL);
+                    if (access(value, F_OK ) != -1) {
+                        set_classpath_jar_file(app, 1, "mpi.jar");
+                    }
+                    free(value);
+                    /* check for shmem.jar */
+                    value = opal_os_path(false, opal_install_dirs.libdir, "shmem.jar", NULL);
+                    if (access(value, F_OK ) != -1) {
+                        set_classpath_jar_file(app, 1, "shmem.jar");
+                    }
+                    free(value);
+                    /* always add the local directory */
+                    (void)asprintf(&value, "%s:%s", app->cwd, app->argv[1]);
+                    free(app->argv[1]);
+                    app->argv[1] = value;
+                    opal_argv_insert_element(&app->argv, 1, "-cp");
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                /* need to add it right after the java command - have
+                 * to include the working directory and trust that
+                 * the user set cwd if necessary
+                 */
+                char *str, *str2;
+                /* always start with the working directory */
+                str = strdup(app->cwd);
+                /* check for mpi.jar */
+                value = opal_os_path(false, opal_install_dirs.libdir, "mpi.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    (void)asprintf(&str2, "%s:%s", str, value);
+                    free(str);
+                    str = str2;
+                }
+                free(value);
+                /* check for shmem.jar */
+                value = opal_os_path(false, opal_install_dirs.libdir, "shmem.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    asprintf(&str2, "%s:%s", str, value);
+                    free(str);
+                    str = str2;
+                }
+                free(value);
+                opal_argv_insert_element(&app->argv, 1, str);
+                free(str);
+                opal_argv_insert_element(&app->argv, 1, "-cp");
+            }
+        }
+        /* try to find the actual command - may not be perfect */
+        for (i=1; i < opal_argv_count(app->argv); i++) {
+            if (NULL != strstr(app->argv[i], "java.library.path")) {
+                continue;
+            } else if (NULL != strstr(app->argv[i], "cp") ||
+                       NULL != strstr(app->argv[i], "classpath")) {
+                /* skip the next field */
+                i++;
+                continue;
+            }
+            /* declare this the winner */
+            opal_setenv("OMPI_COMMAND", app->argv[i], true, &app->env);
+            /* collect everything else as the cmd line */
+            if ((i+1) < opal_argv_count(app->argv)) {
+                value = opal_argv_join(&app->argv[i+1], ' ');
+                opal_setenv("OMPI_ARGV", value, true, &app->env);
+                free(value);
+            }
+            break;
+        }
+    } else {
+        /* add the cmd to the environment for MPI_Info to pickup */
+        opal_setenv("OMPI_COMMAND", appname, true, &app->env);
+        if (1 < opal_argv_count(app->argv)) {
+            value = opal_argv_join(&app->argv[1], ' ');
+            opal_setenv("OMPI_ARGV", value, true, &app->env);
+            free(value);
+        }
+    }
+
+    *app_ptr = app;
+    app = NULL;
+    *made_app = true;
+
+    /* All done */
+
+ cleanup:
+    if (NULL != app) {
+        OBJ_RELEASE(app);
+    }
+    if (NULL != appname) {
+        free(appname);
+    }
+    return rc;
+}
+
+static void set_classpath_jar_file(opal_pmix_app_t *app, int index, char *jarfile)
+{
+    if (NULL == strstr(app->argv[index], jarfile)) {
+        /* nope - need to add it */
+        char *fmt = ':' == app->argv[index][strlen(app->argv[index]-1)]
+                    ? "%s%s/%s" : "%s:%s/%s";
+        char *str;
+        asprintf(&str, fmt, app->argv[index], opal_install_dirs.libdir, jarfile);
+        free(app->argv[index]);
+        app->argv[index] = str;
+    }
+}

--- a/orte/tools/prun/prun.h
+++ b/orte/tools/prun/prun.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRUN_H
+#define PRUN_H
+
+#include "orte_config.h"
+
+BEGIN_C_DECLS
+
+/**
+ * Main body of prun functionality
+ */
+int prun(int argc, char *argv[]);
+
+END_C_DECLS
+
+#endif /* ORTERUN_ORTERUN_H */


### PR DESCRIPTION
Unlike "orterun", "prun" is a PMIx-only program that discovers the DVM connection instead of requiring that we explicitly provide it. Only build "prun" if PMIx v2.x is available.

This gets the DVM working again, but still is showing problems for multiple executions. I'll detail those in a separate issue. Thus, the DVM should still be considered "broken".

Signed-off-by: Ralph Castain <rhc@open-mpi.org>