### PR TITLE
util: move graph solver from usnic to util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -681,3 +681,4 @@ test/util/opal_sos
 test/util/opal_path_nfs
 test/util/opal_path_nfs.out
 test/util/opal_bit_ops
+test/util/bipartite_graph

--- a/opal/mca/btl/usnic/Makefile.am
+++ b/opal/mca/btl/usnic/Makefile.am
@@ -31,8 +31,7 @@ dist_opaldata_DATA = \
     help-mpi-btl-usnic.txt
 
 test_sources = \
-    test/btl_usnic_component_test.h \
-    test/btl_usnic_graph_test.h
+    test/btl_usnic_component_test.h
 
 sources = \
     btl_usnic_compat.h \
@@ -50,8 +49,6 @@ sources = \
     btl_usnic_endpoint.h \
     btl_usnic_frag.c \
     btl_usnic_frag.h \
-    btl_usnic_graph.h \
-    btl_usnic_graph.c \
     btl_usnic_hwloc.c \
     btl_usnic_hwloc.h \
     btl_usnic_map.c \

--- a/opal/mca/btl/usnic/btl_usnic_compat.h
+++ b/opal/mca/btl/usnic/btl_usnic_compat.h
@@ -149,8 +149,6 @@ usnic_compat_proc_name_compare(opal_process_name_t a,
 #  define opal_btl_usnic_ack_segment_t ompi_btl_usnic_ack_segment_t
 #  define opal_btl_usnic_ack_segment_t_class ompi_btl_usnic_ack_segment_t_class
 
-#  define opal_btl_usnic_graph_t ompi_btl_usnic_graph_t
-
 #  define opal_btl_usnic_run_tests ompi_btl_usnic_run_tests
 
 #  define USNIC_SEND_LOCAL        des_src

--- a/opal/util/Makefile.am
+++ b/opal/util/Makefile.am
@@ -42,6 +42,8 @@ headers = \
         arch.h \
         argv.h \
         basename.h \
+	bipartite_graph.h \
+	bipartite_graph_internal.h \
         bit_ops.h \
         cmd_line.h \
         crc.h \
@@ -81,6 +83,7 @@ libopalutil_la_SOURCES = \
         arch.c \
         argv.c \
         basename.c \
+	bipartite_graph.c \
         cmd_line.c \
         crc.c \
         daemon_init.c \

--- a/opal/util/bipartite_graph.h
+++ b/opal/util/bipartite_graph.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,23 +17,21 @@
  * that complicates other pieces of the implementation (specifically, adding
  * and removing edges). */
 
-#ifndef BTL_USNIC_GRAPH_H
-#define BTL_USNIC_GRAPH_H
+#ifndef OPAL_BP_GRAPH_H
+#define OPAL_BP_GRAPH_H
 
-#include "opal_config.h"
+struct opal_bp_graph_vertex_t;
+struct opal_bp_graph_edge_t;
+struct opal_bp_graph_t;
 
-struct opal_btl_usnic_vertex_t;
-struct opal_btl_usnic_edge_t;
-struct opal_btl_usnic_graph_t;
-
-typedef struct opal_btl_usnic_vertex_t opal_btl_usnic_vertex_t;
-typedef struct opal_btl_usnic_edge_t opal_btl_usnic_edge_t;
-typedef struct opal_btl_usnic_graph_t opal_btl_usnic_graph_t;
+typedef struct opal_bp_graph_vertex_t opal_bp_graph_vertex_t;
+typedef struct opal_bp_graph_edge_t opal_bp_graph_edge_t;
+typedef struct opal_bp_graph_t opal_bp_graph_t;
 
 /**
  * callback function pointer type for cleaning up user data associated with a
  * vertex or edge */
-typedef void (*opal_btl_usnic_cleanup_fn_t)(void *user_data);
+typedef void (*opal_bp_graph_cleanup_fn_t)(void *user_data);
 
 /**
  * create a new empty graph
@@ -44,9 +44,9 @@ typedef void (*opal_btl_usnic_cleanup_fn_t)(void *user_data);
  *
  * @returns OPAL_SUCCESS or an OMPI error code
  */
-int opal_btl_usnic_gr_create(opal_btl_usnic_cleanup_fn_t v_data_cleanup_fn,
-                             opal_btl_usnic_cleanup_fn_t e_data_cleanup_fn,
-                             opal_btl_usnic_graph_t **g_out);
+int opal_bp_graph_create(opal_bp_graph_cleanup_fn_t v_data_cleanup_fn,
+			 opal_bp_graph_cleanup_fn_t e_data_cleanup_fn,
+			 opal_bp_graph_t **g_out);
 
 /**
  * free the given graph
@@ -56,7 +56,7 @@ int opal_btl_usnic_gr_create(opal_btl_usnic_cleanup_fn_t v_data_cleanup_fn,
  *
  * @returns OPAL_SUCCESS or an OMPI error code
  */
-int opal_btl_usnic_gr_free(opal_btl_usnic_graph_t *g);
+int opal_bp_graph_free(opal_bp_graph_t *g);
 
 /**
  * clone (deep copy) the given graph
@@ -70,9 +70,9 @@ int opal_btl_usnic_gr_free(opal_btl_usnic_graph_t *g);
  * @param[in] g_clone_out     the resulting cloned graph
  * @returns OPAL_SUCCESS or an OMPI error code
  */
-int opal_btl_usnic_gr_clone(const opal_btl_usnic_graph_t *g,
-                            bool copy_user_data,
-                            opal_btl_usnic_graph_t **g_clone_out);
+int opal_bp_graph_clone(const opal_bp_graph_t *g,
+			bool copy_user_data,
+			opal_bp_graph_t **g_clone_out);
 
 /**
  * return the number of edges for which this vertex is a destination
@@ -81,8 +81,8 @@ int opal_btl_usnic_gr_clone(const opal_btl_usnic_graph_t *g,
  * @param[in] vertex  the vertex id to query
  * @returns the number of edges for which this vertex is a destination
  */
-int opal_btl_usnic_gr_indegree(const opal_btl_usnic_graph_t *g,
-                               int vertex);
+int opal_bp_graph_indegree(const opal_bp_graph_t *g,
+			   int vertex);
 
 /**
  * return the number of edges for which this vertex is a source
@@ -91,8 +91,8 @@ int opal_btl_usnic_gr_indegree(const opal_btl_usnic_graph_t *g,
  * @param[in] vertex  the vertex id to query
  * @returns the number of edges for which this vertex is a source
  */
-int opal_btl_usnic_gr_outdegree(const opal_btl_usnic_graph_t *g,
-                                int vertex);
+int opal_bp_graph_outdegree(const opal_bp_graph_t *g,
+			    int vertex);
 
 /**
  * add an edge to the given graph
@@ -106,12 +106,12 @@ int opal_btl_usnic_gr_outdegree(const opal_btl_usnic_graph_t *g,
  *
  * @returns OPAL_SUCCESS or an OMPI error code
  */
-int opal_btl_usnic_gr_add_edge(opal_btl_usnic_graph_t *g,
-                               int from,
-                               int to,
-                               int64_t cost,
-                               int capacity,
-                               void *e_data);
+int opal_bp_graph_add_edge(opal_bp_graph_t *g,
+			   int from,
+			   int to,
+			   int64_t cost,
+			   int capacity,
+			   void *e_data);
 
 /**
  * add a vertex to the given graph
@@ -122,16 +122,16 @@ int opal_btl_usnic_gr_add_edge(opal_btl_usnic_graph_t *g,
  *
  * @returns OPAL_SUCCESS or an OMPI error code
  */
-int opal_btl_usnic_gr_add_vertex(opal_btl_usnic_graph_t *g,
-                                 void *v_data,
-                                 int *index_out);
+int opal_bp_graph_add_vertex(opal_bp_graph_t *g,
+			     void *v_data,
+			     int *index_out);
 
 /**
  * compute the order of a graph (number of vertices)
  *
  * @param[in] g the graph to query
  */
-int opal_btl_usnic_gr_order(const opal_btl_usnic_graph_t *g);
+int opal_bp_graph_order(const opal_bp_graph_t *g);
 
 /**
  * This function solves the "assignment problem":
@@ -157,7 +157,8 @@ int opal_btl_usnic_gr_order(const opal_btl_usnic_graph_t *g);
  *
  * @returns OPAL_SUCCESS or an OMPI error code
  */
-int opal_btl_usnic_solve_bipartite_assignment(const opal_btl_usnic_graph_t *g,
-                                              int *num_match_edges_out,
-                                              int **match_edges_out);
-#endif /* BTL_USNIC_GRAPH_H */
+int opal_bp_graph_solve_bipartite_assignment(const opal_bp_graph_t *g,
+					     int *num_match_edges_out,
+					     int **match_edges_out);
+
+#endif /* OPAL_BP_GRAPH_H */

--- a/opal/util/bipartite_graph_internal.h
+++ b/opal/util/bipartite_graph_internal.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * This file defines a number of internal structures to the BP graph
+ * code which need to be exposed only for unit testing.  This file
+ * should not be included in code that uses the BP graph interface.
+ */
+
+#ifndef BIPARTITE_GRAPH_INTERNAL
+#define BIPARTITE_GRAPH_INTERNAL 1
+
+struct opal_bp_graph_edge_t {
+    opal_object_t super;
+
+    opal_list_item_t outbound_li;
+    opal_list_item_t inbound_li;
+
+    /** source of this edge */
+    int source;
+
+    /** v_index of target of this edge */
+    int target;
+
+    /** cost (weight) of this edge */
+    int64_t cost;
+
+    /**
+     * (flow-network) capacity of this edge.  Zero-capacity edges essentially do
+     * not exist and will be ignored by most of the algorithms implemented here.
+     */
+    int capacity;
+
+    /** any other information associated with this edge */
+    void *e_data;
+};
+
+struct opal_bp_graph_vertex_t {
+    /** index in the graph's array of vertices */
+    int v_index;
+
+    /** any other information associated with the vertex */
+    void *v_data;
+
+    /** linked list of edges for which this vertex is a source */
+    opal_list_t out_edges;
+
+    /** linked list of edges for which this vertex is a target */
+    opal_list_t in_edges;
+};
+
+struct opal_bp_graph_t {
+    /** number of vertices currently in this graph */
+    int num_vertices;
+
+    /** vertices in this graph (with number of set elements == num_vertices) */
+    opal_pointer_array_t vertices;
+
+    /** index of the source vertex, or -1 if not present */
+    int source_idx;
+
+    /** index of the sink vertex, or -1 if not present */
+    int sink_idx;
+
+    /** user callback to clean up the v_data */
+    opal_bp_graph_cleanup_fn_t v_data_cleanup_fn;
+
+    /** user callback to clean up the e_data */
+    opal_bp_graph_cleanup_fn_t e_data_cleanup_fn;
+};
+
+
+#define LIST_FOREACH_CONTAINED(item, list, type, member)		\
+    for (item = container_of( (list)->opal_list_sentinel.opal_list_next, type, member ); \
+	 &item->member != &(list)->opal_list_sentinel;			\
+	 item = container_of(						\
+			     ((opal_list_item_t *) (&item->member))->opal_list_next, type, member ))
+
+#define LIST_FOREACH_SAFE_CONTAINED(item, next, list, type, member)	\
+    for (item = container_of( (list)->opal_list_sentinel.opal_list_next, type, member ), \
+	     next = container_of(					\
+				 ((opal_list_item_t *) (&item->member))->opal_list_next, type, member ); \
+	 &item->member != &(list)->opal_list_sentinel;			\
+	 item = next,							\
+	     next = container_of(					\
+				 ((opal_list_item_t *) (&item->member))->opal_list_next, type, member ))
+
+#define NUM_VERTICES(g) (g->num_vertices)
+
+#define CHECK_VERTEX_RANGE(g,v)			\
+    do {					\
+        if ((v) < 0 ||				\
+            (v) >= NUM_VERTICES(g)) {		\
+            return OPAL_ERR_BAD_PARAM;		\
+        }					\
+    } while (0)
+
+/* cast away any constness of &g->vertices b/c the opal_pointer_array API is
+ * not const-correct */
+#define V_ID_TO_PTR(g, v_id)						\
+    ((opal_bp_graph_vertex_t *)						\
+     opal_pointer_array_get_item((opal_pointer_array_t *)&g->vertices, v_id))
+
+#define FOREACH_OUT_EDGE(g,v_id,e_ptr)				\
+    LIST_FOREACH_CONTAINED(e_ptr,				\
+                           &(V_ID_TO_PTR(g, v_id)->out_edges),	\
+                           opal_bp_graph_edge_t,		\
+                           outbound_li)
+
+#define FOREACH_IN_EDGE(g,v_id,e_ptr)				\
+    LIST_FOREACH_CONTAINED(e_ptr,				\
+                           &(V_ID_TO_PTR(g, v_id)->in_edges),	\
+                           opal_bp_graph_edge_t,		\
+                           inbound_li)
+
+
+/* Iterate over (u,v) edge pairs along the given path, where path is defined
+ * by the predecessor array "pred".  Stops when a -1 predecessor is
+ * encountered.  Note: because it is a *predecessor* array, the traversal
+ * starts at the sink and progresses towards the source. */
+#define FOREACH_UV_ON_PATH(pred, source, sink, u, v)		\
+    for (u = pred[sink], v = sink; u != -1; v = u, u = pred[u])
+
+
+bool opal_bp_graph_bellman_ford(opal_bp_graph_t *gx,
+				int source,
+				int target,
+				int *pred);
+
+int opal_bp_graph_bipartite_to_flow(opal_bp_graph_t *g);
+
+#endif

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -34,7 +34,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/support
 
 
 check_PROGRAMS = \
-	opal_bit_ops opal_path_nfs
+	opal_bit_ops \
+	opal_path_nfs \
+	bipartite_graph
 
 TESTS = \
 	$(check_PROGRAMS)
@@ -73,7 +75,6 @@ opal_bit_ops_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
         $(top_builddir)/test/support/libsupport.a
 opal_bit_ops_DEPENDENCIES = $(opal_path_nfs_LDADD)
-
 
 opal_path_nfs_SOURCES = opal_path_nfs.c
 opal_path_nfs_LDADD = \
@@ -117,6 +118,12 @@ opal_path_nfs_DEPENDENCIES = $(opal_path_nfs_LDADD)
 #        $(top_builddir)/orte/libopen-rte.la \
 #        $(top_builddir)/test/support/libsupport.a
 #orte_universe_setup_file_io_DEPENDENCIES = $(orte_universe_setup_file_io_LDADD)
+
+bipartite_graph_SOURCES = bipartite_graph.c
+bipartite_graph_LDADD = \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
+        $(top_builddir)/test/support/libsupport.a
+bipartite_graph_DEPENDENCIES = $(bipartite_graph_LDADD)
 
 clean-local:
 	rm -f test_session_dir_out test-file opal_path_nfs.out

--- a/test/util/bipartite_graph.c
+++ b/test/util/bipartite_graph.c
@@ -7,26 +7,67 @@
  * $HEADER$
  */
 
-#ifndef BTL_USNIC_GRAPH_TEST_H
-#define BTL_USNIC_GRAPH_TEST_H
-
-#if OPAL_BTL_USNIC_UNIT_TESTS
+#include "opal_config.h"
 
 #include <stdlib.h>
 #include <sys/time.h>
-#include "btl_usnic_test.h"
+
+#include "opal/constants.h"
+#include "opal/class/opal_list.h"
+#include "opal/class/opal_pointer_array.h"
+#include "opal/util/bipartite_graph.h"
+#include "opal/util/bipartite_graph_internal.h"
+
+#  define test_out(...) fprintf(stderr, __VA_ARGS__)
+#  define check(a)                                                           \
+    do {                                                                     \
+        if (!(a)) {                                                          \
+            test_out("%s:%d: check failed, '%s'\n", __func__, __LINE__, #a); \
+            return 1;                                              \
+        }                                                                    \
+    } while (0)
+#  define check_str_eq(a,b)                                     \
+    do {                                                        \
+        const char *a_ = (a);                                   \
+        const char *b_ = (b);                                   \
+        if (0 != strcmp(a_,b_)) {                               \
+            test_out("%s:%d: check failed, \"%s\" != \"%s\"\n", \
+                     __func__, __LINE__, a_, b_);               \
+            return 1;                                 \
+        }                                                       \
+    } while (0)
+#  define check_int_eq(got, expected)                                   \
+    do {                                                                \
+        if ((got) != (expected)) {                                      \
+            test_out("%s:%d: check failed, \"%s\" != \"%s\", got %d\n", \
+                     __func__, __LINE__, #got, #expected, (got));       \
+            return 1;                                         \
+        }                                                               \
+    } while (0)
+/* just use check_int_eq for now, no public error code to string routine
+ * exists (opal_err2str is static) */
+#  define check_err_code(got, expected)                                 \
+    check_int_eq(got, expected)
+#  define check_msg(a, msg)                                \
+    do {                                                   \
+        if (!(a)) {                                        \
+            test_out("%s:%d: check failed, \"%s\" (%s)\n", \
+                     __func__, __LINE__, #a, (msg));       \
+            return 1;                            \
+        }                                                  \
+    } while (0)
 
 #define check_graph_is_consistent(g)                                         \
     do {                                                                     \
-        check(NUM_VERTICES(g) <= opal_pointer_array_get_size(&g->vertices)); \
-        check(g->source_idx >= -1 || g->source_idx < NUM_VERTICES(g));       \
-        check(g->sink_idx >= -1 || g->sink_idx < NUM_VERTICES(g));           \
+        check(opal_bp_graph_order(g) <= opal_pointer_array_get_size(&g->vertices)); \
+        check(g->source_idx >= -1 || g->source_idx < opal_bp_graph_order(g));       \
+        check(g->sink_idx >= -1 || g->sink_idx < opal_bp_graph_order(g));           \
     } while (0)
 
 #define check_has_in_out_degree(g, u, expected_indegree, expected_outdegree)   \
     do {                                                                       \
-        check_int_eq(opal_btl_usnic_gr_indegree(g, (u)), expected_indegree);   \
-        check_int_eq(opal_btl_usnic_gr_outdegree(g, (u)), expected_outdegree); \
+        check_int_eq(opal_bp_graph_indegree(g, (u)), expected_indegree);   \
+        check_int_eq(opal_bp_graph_outdegree(g, (u)), expected_outdegree); \
     } while (0)
 
 /* Check the given path for sanity and that it does not have a cycle.  Uses
@@ -65,7 +106,7 @@ static void e_cleanup(void *e_data)
 }
 
 /* a utility function for comparing integer pairs, useful for sorting the edge
- * list returned by opal_btl_usnic_solve_bipartite_assignment */
+ * list returned by opal_bp_graph_solve_bipartite_assignment */
 static int cmp_int_pair(const void *a, const void *b)
 {
     int *ia = (int *)a;
@@ -105,7 +146,7 @@ static double gettime(void)
 
 static int test_graph_create(void *ctx)
 {
-    opal_btl_usnic_graph_t *g;
+    opal_bp_graph_t *g;
     int i;
     int err;
     int user_data;
@@ -113,62 +154,62 @@ static int test_graph_create(void *ctx)
 
     /* TEST CASE: check zero-vertex case */
     g = NULL;
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
-    check(opal_btl_usnic_gr_order(g) == 0);
+    check(opal_bp_graph_order(g) == 0);
     check_graph_is_consistent(g);
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
     /* TEST CASE: check nonzero-vertex case with no cleanup routines */
     g = NULL;
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
     check_graph_is_consistent(g);
     for (i = 0; i < 4; ++i) {
         index = -1;
-        err = opal_btl_usnic_gr_add_vertex(g, &user_data, &index);
+        err = opal_bp_graph_add_vertex(g, &user_data, &index);
         check_err_code(err, OPAL_SUCCESS);
         check(index == i);
     }
-    check(opal_btl_usnic_gr_order(g) == 4);
+    check(opal_bp_graph_order(g) == 4);
     check_graph_is_consistent(g);
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
     /* TEST CASE: make sure cleanup routines are invoked properly */
     g = NULL;
     v_cleanup_count = 0;
     e_cleanup_count = 0;
-    err = opal_btl_usnic_gr_create(&v_cleanup, &e_cleanup, &g);
+    err = opal_bp_graph_create(&v_cleanup, &e_cleanup, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
     check_graph_is_consistent(g);
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, &user_data, &index);
+        err = opal_bp_graph_add_vertex(g, &user_data, &index);
         check_err_code(err, OPAL_SUCCESS);
         check(index == i);
     }
-    check(opal_btl_usnic_gr_order(g) == 5);
+    check(opal_bp_graph_order(g) == 5);
     check_graph_is_consistent(g);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/1,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/1,
                                      /*capacity=*/2, &user_data);
     check_graph_is_consistent(g);
     check(v_cleanup_count == 0);
     check(e_cleanup_count == 0);
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
     check(v_cleanup_count == 5);
     check(e_cleanup_count == 1);
 
-    return TEST_PASSED;
+    return 0;
 }
 
 static int test_graph_clone(void *ctx)
 {
-    opal_btl_usnic_graph_t *g, *gx;
+    opal_bp_graph_t *g, *gx;
     int i;
     int err;
     int user_data;
@@ -178,92 +219,92 @@ static int test_graph_clone(void *ctx)
     g = NULL;
     v_cleanup_count = 0;
     e_cleanup_count = 0;
-    err = opal_btl_usnic_gr_create(&v_cleanup, &e_cleanup, &g);
+    err = opal_bp_graph_create(&v_cleanup, &e_cleanup, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
     check_graph_is_consistent(g);
 
     /* add 5 edges */
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, &user_data, &index);
+        err = opal_bp_graph_add_vertex(g, &user_data, &index);
         check_err_code(err, OPAL_SUCCESS);
     }
-    check(opal_btl_usnic_gr_order(g) == 5);
+    check(opal_bp_graph_order(g) == 5);
     check_graph_is_consistent(g);
 
     /* and two edges */
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/1,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/1,
                                      /*capacity=*/2, &user_data);
     check_err_code(err, OPAL_SUCCESS);
     check_graph_is_consistent(g);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/3, /*v=*/1, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/3, /*v=*/1, /*cost=*/2,
                                      /*capacity=*/100, &user_data);
     check_err_code(err, OPAL_SUCCESS);
     check_graph_is_consistent(g);
 
     /* now clone it and ensure that we get the same kind of graph */
     gx = NULL;
-    err = opal_btl_usnic_gr_clone(g, /*copy_user_data=*/false, &gx);
+    err = opal_bp_graph_clone(g, /*copy_user_data=*/false, &gx);
     check_err_code(err, OPAL_SUCCESS);
     check(gx != NULL);
 
     /* double check that cleanups still happen as expected after cloning */
-    err = opal_btl_usnic_gr_free(gx);
+    err = opal_bp_graph_free(gx);
     check_err_code(err, OPAL_SUCCESS);
     check(v_cleanup_count == 0);
     check(e_cleanup_count == 0);
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
     check(v_cleanup_count == 5);
     check(e_cleanup_count == 2);
 
-    return TEST_PASSED;
+    return 0;
 }
 
 static int test_graph_accessors(void *ctx)
 {
-    opal_btl_usnic_graph_t *g;
+    opal_bp_graph_t *g;
     int i;
     int err;
 
     /* TEST CASE: check _indegree/_outdegree/_order work correctly */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 4; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
 
-        check(opal_btl_usnic_gr_indegree(g, i) == 0);
-        check(opal_btl_usnic_gr_outdegree(g, i) == 0);
+        check(opal_bp_graph_indegree(g, i) == 0);
+        check(opal_bp_graph_outdegree(g, i) == 0);
     }
 
-    check(opal_btl_usnic_gr_order(g) == 4);
+    check(opal_bp_graph_order(g) == 4);
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/2,
                                      /*capacity=*/1, NULL);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/1, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/1, /*cost=*/2,
                                      /*capacity=*/1, NULL);
 
-    check(opal_btl_usnic_gr_indegree(g,  0) == 0);
-    check(opal_btl_usnic_gr_outdegree(g, 0) == 2);
-    check(opal_btl_usnic_gr_indegree(g,  1) == 1);
-    check(opal_btl_usnic_gr_outdegree(g, 1) == 0);
-    check(opal_btl_usnic_gr_indegree(g,  2) == 1);
-    check(opal_btl_usnic_gr_outdegree(g, 2) == 0);
-    check(opal_btl_usnic_gr_indegree(g,  3) == 0);
-    check(opal_btl_usnic_gr_outdegree(g, 3) == 0);
+    check(opal_bp_graph_indegree(g,  0) == 0);
+    check(opal_bp_graph_outdegree(g, 0) == 2);
+    check(opal_bp_graph_indegree(g,  1) == 1);
+    check(opal_bp_graph_outdegree(g, 1) == 0);
+    check(opal_bp_graph_indegree(g,  2) == 1);
+    check(opal_bp_graph_outdegree(g, 2) == 0);
+    check(opal_bp_graph_indegree(g,  3) == 0);
+    check(opal_bp_graph_outdegree(g, 3) == 0);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
-    return TEST_PASSED;
+    return 0;
 }
 
 static int test_graph_assignment_solver(void *ctx)
 {
-    opal_btl_usnic_graph_t *g;
+    opal_bp_graph_t *g;
     int i;
     int err;
     int nme;
@@ -276,22 +317,22 @@ static int test_graph_assignment_solver(void *ctx)
      * 0 --> 2
      * 1 --> 3
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 4; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
                                      /*capacity=*/1, NULL);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/2,
                                      /*capacity=*/1, NULL);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -301,7 +342,7 @@ static int test_graph_assignment_solver(void *ctx)
     check(me[0] == 0 && me[1] == 2);
     check(me[2] == 1 && me[3] == 3);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
 
@@ -311,27 +352,27 @@ static int test_graph_assignment_solver(void *ctx)
      * 1 --> 4
      * 2 --> 4
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -342,7 +383,7 @@ static int test_graph_assignment_solver(void *ctx)
     check(me[2] == 2 && me[3] == 4);
     free(me);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
 
@@ -353,27 +394,27 @@ static int test_graph_assignment_solver(void *ctx)
      *
      * make sure that 0-->2 & 1-->3 get chosen.
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 4; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/1,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/5,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/5,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -384,7 +425,7 @@ static int test_graph_assignment_solver(void *ctx)
     check(me[2] == 1 && me[3] == 3);
     free(me);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
     /* Also need to do this version of it to be safe:
@@ -394,27 +435,27 @@ static int test_graph_assignment_solver(void *ctx)
      *
      * Should choose 0-->2 & 1-->3 here too.
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 4; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/2, /*cost=*/1,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/2, /*cost=*/1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/5,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/5,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -425,7 +466,7 @@ static int test_graph_assignment_solver(void *ctx)
     check(me[2] == 1 && me[3] == 3);
     free(me);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
     /* TEST CASE: test Christian's case with negative weights:
@@ -435,27 +476,27 @@ static int test_graph_assignment_solver(void *ctx)
      *
      * make sure that 0-->2 & 1-->3 get chosen.
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 4; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-1,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/-5,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/-5,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -466,7 +507,7 @@ static int test_graph_assignment_solver(void *ctx)
     check(me[2] == 1 && me[3] == 3);
     free(me);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
 
@@ -478,27 +519,27 @@ static int test_graph_assignment_solver(void *ctx)
      *
      * make sure that 0-->2 & 1-->3 get chosen.
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-1,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/-5,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/-5,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -509,7 +550,7 @@ static int test_graph_assignment_solver(void *ctx)
     check(me[2] == 1 && me[3] == 3);
     free(me);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
     /* TEST CASE: sample UDP graph from bldsb005 + bldsb007
@@ -520,30 +561,30 @@ static int test_graph_assignment_solver(void *ctx)
      *
      * Make sure that either (0-->2 && 1-->3) or (0-->3 && 1-->2) get chosen.
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 4; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-4294967296,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-4294967296,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/2, /*cost=*/-4294967296,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/2, /*cost=*/-4294967296,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-4294967296,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-4294967296,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/-4294967296,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/-4294967296,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -559,7 +600,7 @@ static int test_graph_assignment_solver(void *ctx)
     }
     free(me);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
 
@@ -568,22 +609,22 @@ static int test_graph_assignment_solver(void *ctx)
      * 0 --> 2
      * 1 --> 2
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 3; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-100,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/-100,
                                      /*capacity=*/1, NULL);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/2, /*cost=*/-100,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/2, /*cost=*/-100,
                                      /*capacity=*/1, NULL);
 
     me = NULL;
-    err = opal_btl_usnic_solve_bipartite_assignment(g,
+    err = opal_bp_graph_solve_bipartite_assignment(g,
                                                     &nme,
                                                     &me);
     check_err_code(err, OPAL_SUCCESS);
@@ -592,7 +633,7 @@ static int test_graph_assignment_solver(void *ctx)
     qsort(me, nme, 2*sizeof(int), &cmp_int_pair);
     check((me[0] == 0 || me[0] == 1) && me[1] == 2);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
 
@@ -607,27 +648,27 @@ static int test_graph_assignment_solver(void *ctx)
 #define NUM_ITER (10000)
     start = gettime();
     for (iter = 0; iter < NUM_ITER; ++iter) {
-        err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+        err = opal_bp_graph_create(NULL, NULL, &g);
         check_err_code(err, OPAL_SUCCESS);
         check(g != NULL);
 
         for (i = 0; i < 5; ++i) {
-            err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+            err = opal_bp_graph_add_vertex(g, NULL, NULL);
             check_err_code(err, OPAL_SUCCESS);
         }
 
-        err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
+        err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
                                         /*capacity=*/1, NULL);
         check_err_code(err, OPAL_SUCCESS);
-        err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
+        err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
                                         /*capacity=*/1, NULL);
         check_err_code(err, OPAL_SUCCESS);
-        err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
+        err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
                                         /*capacity=*/1, NULL);
         check_err_code(err, OPAL_SUCCESS);
 
         me = NULL;
-        err = opal_btl_usnic_solve_bipartite_assignment(g,
+        err = opal_bp_graph_solve_bipartite_assignment(g,
                                                         &nme,
                                                         &me);
         check_err_code(err, OPAL_SUCCESS);
@@ -638,7 +679,7 @@ static int test_graph_assignment_solver(void *ctx)
         check(me[2] == 2 && me[3] == 4);
         free(me);
 
-        err = opal_btl_usnic_gr_free(g);
+        err = opal_bp_graph_free(g);
         check_err_code(err, OPAL_SUCCESS);
     }
     end = gettime();
@@ -649,12 +690,12 @@ static int test_graph_assignment_solver(void *ctx)
             NUM_ITER, end - start, (end - start) / NUM_ITER);
 #endif
 
-    return TEST_PASSED;
+    return 0;
 }
 
 static int test_graph_bellman_ford(void *ctx)
 {
-    opal_btl_usnic_graph_t *g;
+    opal_bp_graph_t *g;
     int i;
     int err;
     bool path_found;
@@ -669,37 +710,37 @@ static int test_graph_bellman_ford(void *ctx)
      *
      * should yield the path 5,1,3,6 (see costs in code below)
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 6; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/2, /*cost=*/10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/3, /*cost=*/2,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/4, /*v=*/0, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/4, /*v=*/0, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/4, /*v=*/1, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/4, /*v=*/1, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/5, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/5, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/3, /*v=*/5, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/3, /*v=*/5, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
     pred = malloc(6*sizeof(*pred));
     check(pred != NULL);
-    path_found = bellman_ford(g, /*source=*/4, /*target=*/5, pred);
+    path_found = opal_bp_graph_bellman_ford(g, /*source=*/4, /*target=*/5, pred);
     check(path_found);
     check_path_cycle(6, /*source=*/4, /*target=*/5, pred);
     check_int_eq(pred[5], 3);
@@ -707,7 +748,7 @@ static int test_graph_bellman_ford(void *ctx)
     check_int_eq(pred[1], 4);
     free(pred);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
 
@@ -718,31 +759,31 @@ static int test_graph_bellman_ford(void *ctx)
      * 1 --> 4
      * 2 --> 4
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
-    err = bipartite_to_flow(g);
+    err = opal_bp_graph_bipartite_to_flow(g);
     check_err_code(err, OPAL_SUCCESS);
 
     pred = malloc(7*sizeof(*pred));
     check(pred != NULL);
-    path_found = bellman_ford(g, /*source=*/5, /*target=*/6, pred);
+    path_found = opal_bp_graph_bellman_ford(g, /*source=*/5, /*target=*/6, pred);
     check(path_found);
     check_int_eq(g->source_idx, 5);
     check_int_eq(g->sink_idx, 6);
@@ -752,7 +793,7 @@ static int test_graph_bellman_ford(void *ctx)
     check_int_eq(pred[2], 5);
     free(pred);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
     /* TEST CASE: same as previous, but with very large cost values (try to
@@ -762,31 +803,31 @@ static int test_graph_bellman_ford(void *ctx)
      * 1 --> 4
      * 2 --> 4
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/INT32_MAX+10LL,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/INT32_MAX+10LL,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/INT32_MAX+2LL,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/INT32_MAX+2LL,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/INT32_MAX+1LL,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/INT32_MAX+1LL,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
-    err = bipartite_to_flow(g);
+    err = opal_bp_graph_bipartite_to_flow(g);
     check_err_code(err, OPAL_SUCCESS);
 
     pred = malloc(7*sizeof(*pred));
     check(pred != NULL);
-    path_found = bellman_ford(g, /*source=*/5, /*target=*/6, pred);
+    path_found = opal_bp_graph_bellman_ford(g, /*source=*/5, /*target=*/6, pred);
     check(path_found);
     check_int_eq(g->source_idx, 5);
     check_int_eq(g->sink_idx, 6);
@@ -796,7 +837,7 @@ static int test_graph_bellman_ford(void *ctx)
     check_int_eq(pred[2], 5);
     free(pred);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
     /* TEST CASE: left side has more vertices than the right side, then
@@ -807,31 +848,31 @@ static int test_graph_bellman_ford(void *ctx)
      * 1 --> 4
      * 2 --> 4
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-1,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/-1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/-2,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/-2,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/-10,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/-10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
-    err = bipartite_to_flow(g);
+    err = opal_bp_graph_bipartite_to_flow(g);
     check_err_code(err, OPAL_SUCCESS);
 
     pred = malloc(7*sizeof(*pred));
     check(pred != NULL);
-    path_found = bellman_ford(g, /*source=*/5, /*target=*/6, pred);
+    path_found = opal_bp_graph_bellman_ford(g, /*source=*/5, /*target=*/6, pred);
     check(path_found);
     check_int_eq(g->source_idx, 5);
     check_int_eq(g->sink_idx, 6);
@@ -841,15 +882,15 @@ static int test_graph_bellman_ford(void *ctx)
     check_int_eq(pred[2], 5);
     free(pred);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
-    return TEST_PASSED;
+    return 0;
 }
 
 static int test_graph_flow_conversion(void *ctx)
 {
-    opal_btl_usnic_graph_t *g;
+    opal_bp_graph_t *g;
     int i;
     int err;
 
@@ -860,26 +901,26 @@ static int test_graph_flow_conversion(void *ctx)
      * 1 --> 4
      * 2 --> 4
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     for (i = 0; i < 5; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
+    err = opal_bp_graph_add_edge(g, /*u=*/0, /*v=*/3, /*cost=*/10,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
+    err = opal_bp_graph_add_edge(g, /*u=*/1, /*v=*/4, /*cost=*/2,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
-    check_int_eq(opal_btl_usnic_gr_order(g), 5);
+    check_int_eq(opal_bp_graph_order(g), 5);
     check_has_in_out_degree(g, 0, /*exp_indeg=*/0, /*exp_outdeg=*/1);
     check_has_in_out_degree(g, 1, /*exp_indeg=*/0, /*exp_outdeg=*/1);
     check_has_in_out_degree(g, 2, /*exp_indeg=*/0, /*exp_outdeg=*/1);
@@ -887,10 +928,10 @@ static int test_graph_flow_conversion(void *ctx)
     check_has_in_out_degree(g, 4, /*exp_indeg=*/2, /*exp_outdeg=*/0);
 
     /* this should add two nodes and a bunch of edges */
-    err = bipartite_to_flow(g);
+    err = opal_bp_graph_bipartite_to_flow(g);
     check_err_code(err, OPAL_SUCCESS);
 
-    check_int_eq(opal_btl_usnic_gr_order(g), 7);
+    check_int_eq(opal_bp_graph_order(g), 7);
     check_has_in_out_degree(g, 0, /*exp_indeg=*/2, /*exp_outdeg=*/2);
     check_has_in_out_degree(g, 1, /*exp_indeg=*/2, /*exp_outdeg=*/2);
     check_has_in_out_degree(g, 2, /*exp_indeg=*/2, /*exp_outdeg=*/2);
@@ -899,7 +940,7 @@ static int test_graph_flow_conversion(void *ctx)
     check_has_in_out_degree(g, 5, /*exp_indeg=*/3, /*exp_outdeg=*/3);
     check_has_in_out_degree(g, 6, /*exp_indeg=*/2, /*exp_outdeg=*/2);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
 
@@ -908,74 +949,74 @@ static int test_graph_flow_conversion(void *ctx)
      * there's no reason that the code should bother to support this, it's not
      * useful
      */
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
-    check_int_eq(opal_btl_usnic_gr_order(g), 0);
-    err = bipartite_to_flow(g);
+    check_int_eq(opal_bp_graph_order(g), 0);
+    err = opal_bp_graph_bipartite_to_flow(g);
     check_err_code(err, OPAL_ERR_BAD_PARAM);
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
-    return TEST_PASSED;
+    return 0;
 }
 
 static int test_graph_param_checking(void *ctx)
 {
-    opal_btl_usnic_graph_t *g;
+    opal_bp_graph_t *g;
     int i;
     int err;
 
-    err = opal_btl_usnic_gr_create(NULL, NULL, &g);
+    err = opal_bp_graph_create(NULL, NULL, &g);
     check_err_code(err, OPAL_SUCCESS);
     check(g != NULL);
 
     /* try with no vertices */
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/3, /*v=*/5, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/3, /*v=*/5, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_ERR_BAD_PARAM);
 
     for (i = 0; i < 6; ++i) {
-        err = opal_btl_usnic_gr_add_vertex(g, NULL, NULL);
+        err = opal_bp_graph_add_vertex(g, NULL, NULL);
         check_err_code(err, OPAL_SUCCESS);
     }
 
     /* try u out of range */
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/9, /*v=*/5, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/9, /*v=*/5, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_ERR_BAD_PARAM);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/6, /*v=*/5, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/6, /*v=*/5, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_ERR_BAD_PARAM);
 
     /* try v out of range */
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/8, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/8, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_ERR_BAD_PARAM);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/6, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/6, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_ERR_BAD_PARAM);
 
     /* try adding an edge that already exists */
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/0,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/4, /*cost=*/0,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_EXISTS);
 
     /* try an edge with an out of range cost */
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/3, /*cost=*/INT64_MAX,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/3, /*cost=*/INT64_MAX,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_ERR_BAD_PARAM);
-    err = opal_btl_usnic_gr_add_edge(g, /*u=*/2, /*v=*/3, /*cost=*/INT64_MAX-1,
+    err = opal_bp_graph_add_edge(g, /*u=*/2, /*v=*/3, /*cost=*/INT64_MAX-1,
                                      /*capacity=*/1, NULL);
     check_err_code(err, OPAL_SUCCESS);
 
-    err = opal_btl_usnic_gr_free(g);
+    err = opal_bp_graph_free(g);
     check_err_code(err, OPAL_SUCCESS);
 
-    return TEST_PASSED;
+    return 0;
 }
 
 static int test_graph_helper_macros(void *ctx)
@@ -1053,18 +1094,19 @@ static int test_graph_helper_macros(void *ctx)
     pair2[0] = 1; pair2[1] = 0;
     check(cmp_int_pair(pair1, pair2) > 0);
 
-    return TEST_PASSED;
+    return 0;
 }
 
-USNIC_REGISTER_TEST("test_graph_create", test_graph_create, NULL)
-USNIC_REGISTER_TEST("test_graph_clone", test_graph_clone, NULL)
-USNIC_REGISTER_TEST("test_graph_accessors", test_graph_accessors, NULL)
-USNIC_REGISTER_TEST("test_graph_assignment_solver", test_graph_assignment_solver, NULL)
-USNIC_REGISTER_TEST("test_graph_bellman_ford", test_graph_bellman_ford, NULL)
-USNIC_REGISTER_TEST("test_graph_flow_conversion", test_graph_flow_conversion, NULL)
-USNIC_REGISTER_TEST("test_graph_param_checking", test_graph_param_checking, NULL)
-USNIC_REGISTER_TEST("test_graph_helper_macros", test_graph_helper_macros, NULL)
+int main(int argc, char *argv[])
+{
+    check(test_graph_create(NULL) == 0);
+    check(test_graph_clone(NULL) == 0);
+    check(test_graph_accessors(NULL) == 0);
+    check(test_graph_assignment_solver(NULL) == 0);
+    check(test_graph_bellman_ford(NULL) == 0);
+    check(test_graph_flow_conversion(NULL) == 0);
+    check(test_graph_param_checking(NULL) == 0);
+    check(test_graph_helper_macros(NULL) == 0);
 
-#endif /* OPAL_BTL_USNIC_UNIT_TESTS */
-
-#endif /* BTL_USNIC_GRAPH_TEST_H */
+    return 0;
+}


### PR DESCRIPTION
Cisco wrote a bipartite graph solver to properly solve
interface pair selection for usNIC.  Using the reachable
framework, the TCP BTL (and possibly the runtime network
code can use the graph solver to make more optimal pair
selection.  Jeff was happy to have the code more broadly
used, but didn't have time to do the move, hence this
commit.

There are a couple of minor changes to the code compared
to the usNIC version.  Obviously, the functions have
been renamed to match naming convention for their new
home.  Since it's easier to write unit tests for
util/ code, the unit tests have been made first class
tests run at "make check" time.  This last bit required
moving some of the definitions into a new header,
bipartite_graph_internal.h, so that they could be
included in both the library code and the test code.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>