### PR TITLE
Attempt vpath inside component

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -275,8 +275,8 @@ AC_ARG_ENABLE([dlopen],
                      Disabling dlopen implies --disable-mca-dso.
                      (default: enabled)])])
 if test "$enable_dlopen" = "no" ; then
-    enable_mca_dso="no"
-    enable_mca_static="yes"
+    enable_mca_dso=no
+    enable_mca_static=yes
     OPAL_ENABLE_DLOPEN_SUPPORT=0
     AC_MSG_RESULT([no])
 else

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -173,6 +173,7 @@ AC_DEFUN([OPAL_MCA],[
     elif test "$enable_mca_dso" = "no"; then
         DSO_all=0
         msg=none
+        enable_dlopen=no
     else
         DSO_all=0
         ifs_save="$IFS"

--- a/contrib/platform/intel/bend/linux
+++ b/contrib/platform/intel/bend/linux
@@ -18,6 +18,7 @@ enable_cxx_exceptions=no
 enable_mpi_java=no
 enable_io_romio=no
 enable_contrib_no_build=libnbc
+enable_install_libpmix=yes
 with_memory_manager=no
 with_tm=no
 with_psm=no

--- a/opal/mca/pmix/pmix2x/configure.m4
+++ b/opal/mca/pmix/pmix2x/configure.m4
@@ -37,6 +37,10 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
     opal_pmix_pmix2x_save_LDFLAGS=$LDFLAGS
     opal_pmix_pmix2x_save_LIBS=$LIBS
 
+    AC_ARG_ENABLE([install-libpmix],
+                  [AC_HELP_STRING([--enable-install-libpmix],
+                                  [Enable a native PMIx library and headers in the OMPI install location (default: disabled)])])
+
     AC_ARG_ENABLE([pmix-timing],
                   [AC_HELP_STRING([--enable-pmix-timing],
                                   [Enable PMIx timing measurements (default: disabled)])])
@@ -49,16 +53,17 @@ AC_DEFUN([MCA_opal_pmix_pmix2x_CONFIG],[
         opal_pmix_pmix2x_timing_flag=--disable-pmix-timing
     fi
 
-    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_timing_flag --without-tests-examples --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --enable-embedded-mode"
+    opal_pmix_pmix2x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ $opal_pmix_pmix2x_timing_flag --without-tests-examples --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix2x_args="--enable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
           [opal_pmix_pmix2x_args="--disable-debug $opal_pmix_pmix2x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
+    AS_IF([test "$enable_install_libpmix" = "yes" && test "$enable_dlopen" != "no"],
+          [opal_pmix_pmix2x_args="--with-pmix-extra-lib=$OPAL_TOP_BUILDDIR/opal/lib${OPAL_LIB_PREFIX}open-pal.la $opal_pmix_pmix2x_args"],
+          [opal_pmix_pmix2x_args="--enable-embedded-mode $opal_pmix_pmix2x_args"])
     AS_IF([test "$with_devel_headers" = "yes"],
-          [AS_IF([test "$enable_dlopen" != "no"],
-                 [opal_pmix_pmix2x_args="--with-pmix-extra-lib=$OPAL_TOP_BUILDDIR/opal/lib${OPAL_LIB_PREFIX}open-pal.la $opal_pmix_pmix2x_args"])
-           opal_pmix_pmix2x_args="--with-devel-headers  $opal_pmix_pmix2x_args"])
+          [opal_pmix_pmix2x_args="--with-devel-headers  $opal_pmix_pmix2x_args"])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"
 
     OPAL_CONFIG_SUBDIR([$opal_pmix_pmix2x_basedir/pmix],

--- a/opal/mca/pmix/pmix2x/pmix/src/Makefile.am
+++ b/opal/mca/pmix/pmix2x/pmix/src/Makefile.am
@@ -51,19 +51,9 @@ libpmix_la_DEPENDENCIES = $(libpmix_la_LIBADD)
 
 if PMIX_EMBEDDED_MODE
 
-if WANT_INSTALL_HEADERS
-
-lib_LTLIBRARIES = libpmix.la
-libpmix_la_SOURCES = $(headers) $(sources)
-libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
-
-else
-
 noinst_LTLIBRARIES = libpmix.la
 libpmix_la_SOURCES = $(headers) $(sources)
 libpmix_la_LDFLAGS =
-
-endif
 
 else
 


### PR DESCRIPTION
Refs #4208 

The current configure logic installs a "native" version of libpmix (and its associated headers) in the OMPI install area when --with-devel-headers is given. The rationale for providing this capability was to allow users to write/test PMIx-based applications and execute them using mpirun, ensuring that the two were compatible. This is viewed as a desirable, but temporary, situation until broader PMIx support is available.

What we would like to do is separate this installation request from --with-devel-headers as the latter really was intended for another purpose. This PR adds a new --enable-install-libpmix option for this purpose. However, the symbols in the resulting libpmix are prefixed so they aren't exposed to the application that just links against OMPI libraries. As a result, we have to link the output libpmix against libopen-pal, which causes problems in certain configurations as noted in the referenced issue.

One way to resolve this, as proposed by @jsquyres, would be to build the internal pmix library twice - once with prefixed symbols (used to construct the component), and once without prefixing the symbols (used for the libpmix installation). This would involve doing VPATH builds of the library included in the component directory.

This PR contains a checkpoint of the work done to-date. I have unfortunately been unable to get the idea to work as the VPATH configure consistently fails. It first appeared that OPAL_CONFIG_SUBDIRS wasn't correctly setting the path to the configure - it would go to the correct subdirectory, but would execute "./configure" instead of "../configure", therefore errorring out due to not finding configure.

I fixed that by creating a new OPAL_CONFIG_VPATH that was a little less generalized. It now executes the correct command, and appears to be in the correct directory - but it still reports failure.

The subdirectory for the VPATH build is being created. If I manually go to that directory and execute "../configure", everything works fine. So I am unclear as to the problem.

@ggouaillardet @jsquyres Additional eyes would be much appreciated!

Signed-off-by: Ralph Castain <rhc@open-mpi.org>