### PR TITLE
util: Fix graph allocation size

### DIFF
--- a/opal/util/bipartite_graph.c
+++ b/opal/util/bipartite_graph.c
@@ -914,7 +914,7 @@ int opal_bp_graph_solve_bipartite_assignment(const opal_bp_graph_t *g,
         goto out;
     }
 
-    *match_edges_out = malloc(*num_match_edges_out * sizeof(*match_edges_out));
+    *match_edges_out = malloc(*num_match_edges_out * 2 * sizeof(int));
     if (NULL == *match_edges_out) {
         *num_match_edges_out = 0;
         OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);


### PR DESCRIPTION
Fix an allocation bug that could occur on non-LP64 platforms.
match_edges_out is an array of integers representing the
edges of the graph (where vertices are ints), with two ints
for every edge.  The previous code allocated enough space
for num_dges * sizeof(int*), which happens to be the same
as num_edges * 2 * sizeof(int) on LP64 platforms, but would
be wrong on all other platforms.

Fixes: CID 1417754

Signed-off-by: Brian Barrett <bbarrett@amazon.com>