### PR TITLE
io/ompio: add a new grouping option avoiding communication

### DIFF
--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -111,7 +111,7 @@ OMPI_DECLSPEC extern int mca_io_ompio_coll_timing_info;
 #define OPTIMIZE_GROUPING               4
 #define SIMPLE                          5
 #define NO_REFINEMENT                   6
-
+#define SIMPLE_PLUS                     7
 
 #define OMPIO_UNIFORM_DIST_THRESHOLD     0.5
 #define OMPIO_CONTG_THRESHOLD        1048576

--- a/ompi/mca/io/ompio/io_ompio_aggregators.c
+++ b/ompi/mca/io/ompio/io_ompio_aggregators.c
@@ -497,8 +497,9 @@ int mca_io_ompio_set_aggregator_props (struct mca_io_ompio_file_t *fh,
     fh->f_flags |= OMPIO_AGGREGATOR_IS_SET;
 
     if (-1 == num_aggregators) {
-        if ( SIMPLE == mca_io_ompio_grouping_option ||
-            NO_REFINEMENT == mca_io_ompio_grouping_option ) {
+        if ( SIMPLE        == mca_io_ompio_grouping_option ||
+             NO_REFINEMENT == mca_io_ompio_grouping_option ||
+             SIMPLE_PLUS   == mca_io_ompio_grouping_option ) {
             fh->f_aggregator_index = 0;
             fh->f_final_num_aggrs  = fh->f_init_num_aggrs;
             fh->f_procs_per_group  = fh->f_init_procs_per_group;

--- a/ompi/mca/io/ompio/io_ompio_component.c
+++ b/ompi/mca/io/ompio/io_ompio_component.c
@@ -212,7 +212,7 @@ static int register_component(void)
                                            "Option for grouping of processes in the aggregator selection "
                                            "1: Data volume based grouping 2: maximizing group size uniformity 3: maximimze "
                                            "data contiguity 4: hybrid optimization  5: simple (default) "
-                                           "6: skip refinement step",
+                                           "6: skip refinement step 7: simple+: grouping based on default file view",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                            OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_READONLY,


### PR DESCRIPTION
the new grouping option simple+ performs all calculations used
for the aggregator selection as if the default file view would be used,
thus avoiding communication in file_set_view all together. This mode
is useful for applications that do not set a file view, but use
explicit offset operations on the default file view.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>