### PR TITLE
VERSION: stupid mistake with revision vs age

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -84,17 +84,17 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=30:1:11
+libmpi_so_version=30:2:10
 libmpi_cxx_so_version=30:0:10
-libmpi_mpifh_so_version=31:0:12
-libmpi_usempi_tkr_so_version=30:0:11
-libmpi_usempi_ignore_tkr_so_version=30:0:11
-libmpi_usempif08_so_version=30:0:11
+libmpi_mpifh_so_version=31:1:11
+libmpi_usempi_tkr_so_version=30:1:10
+libmpi_usempi_ignore_tkr_so_version=30:1:10
+libmpi_usempif08_so_version=30:1:10
 
-libopen_rte_so_version=30:1:11
-libopen_pal_so_version=30:1:11
+libopen_rte_so_version=30:2:10
+libopen_pal_so_version=30:2:10
 libmpi_java_so_version=30:0:10
-liboshmem_so_version=30:1:11
+liboshmem_so_version=30:2:10
 libompitrace_so_version=30:0:10
 
 # "Common" components install standalone libraries that are run-time


### PR DESCRIPTION
thank goodness for the release checklist!
Caught this while grinding through the backward compatibility part of the checklist.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>