### PR TITLE
VERSION: roll to v2.1.3a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -17,7 +17,7 @@
 
 major=2
 minor=1
-release=2
+release=3
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -26,7 +26,7 @@ release=2
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc4
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
on to v2.1.3a1. Intentionally don't skip CI.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>