### PR TITLE
mtl/ofi: Fix provider selection.

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -231,7 +231,7 @@ is_in_list(char **list, char *item)
     }
 
     while (NULL != list[i]) {
-        if (0 == strncmp(item, list[i], strlen(item))) {
+        if (0 == strncmp(item, list[i], strlen(list[i]))) {
             return 1;
         } else {
             i++;


### PR DESCRIPTION
This allows mtl_ofi_provider_include to work with layered providers as well.
e.g. --mca mtl_ofi_provider_include "providerX;ofi_rxm"