### PR TITLE
configury: do not use libnl-3 when it is half broken

### DIFF
--- a/config/opal_check_libnl.m4
+++ b/config/opal_check_libnl.m4
@@ -301,7 +301,11 @@ AC_DEFUN([OPAL_CHECK_LIBNL_V3],[
     AS_IF([test $opal_libnlv3_happy -eq 1],
           [$2_LIBS="-lnl-3 -lnl-route-3"
            OPAL_HAVE_LIBNL3=1],
-          [$2_LIBS=""])
+          [# OPAL_CHECK_PACKAGE(...,nl_recvmsgs_report,...) might have set the variables below
+           # so reset them if libnl v3 cannot be used
+           $2_CPPFLAGS=""
+           $2_LDFLAGS=""
+           $2_LIBS=""])
 
    OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_check_libnl.m4
+++ b/config/opal_check_libnl.m4
@@ -1,6 +1,6 @@
 dnl -*- shell-script -*-
 dnl
-dnl Copyright (c) 2015-2016 Research Organization for Information Science
+dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
@@ -300,7 +300,8 @@ AC_DEFUN([OPAL_CHECK_LIBNL_V3],[
     # If we found everything
     AS_IF([test $opal_libnlv3_happy -eq 1],
           [$2_LIBS="-lnl-3 -lnl-route-3"
-           OPAL_HAVE_LIBNL3=1])
+           OPAL_HAVE_LIBNL3=1],
+          [$2_LIBS=""])
 
    OPAL_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
Fixes open-mpi/ompi#4211

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@94747a1d283c249f92c5505076bac35fa5785585)