### PR TITLE
Fully support OMPI spawn options. 

### DIFF
--- a/opal/dss/dss.h
+++ b/opal/dss/dss.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +32,16 @@
 #include "opal/dss/dss_types.h"
 
 BEGIN_C_DECLS
+
+/* Provide a macro for determining the bool value of an opal_value_t */
+#define OPAL_CHECK_BOOL(v, p)           \
+    do {                                \
+        if (OPAL_UNDEF == (v)->type) {  \
+            (p) = true;                 \
+        } else {                        \
+            (p) = (v)->data.flag;       \
+        }                               \
+    } while(0)
 
 /* A non-API function for something that happens in a number
  * of places throughout the code base - loading a value into

--- a/opal/mca/pmix/pmix2x/pmix/include/pmix_common.h
+++ b/opal/mca/pmix/pmix2x/pmix/include/pmix_common.h
@@ -344,6 +344,21 @@ typedef uint32_t pmix_rank_t;
                                                                     //        job - i.e., not part of the "comm_world" of the job
 #define PMIX_SET_SESSION_CWD                "pmix.ssncwd"           // (bool) set the application's current working directory to
                                                                     //        the session working directory assigned by the RM
+#define PMIX_TAG_OUTPUT                     "pmix.tagout"           // (bool) tag application output with the ID of the source
+#define PMIX_TIMESTAMP_OUTPUT               "pmix.tsout"            // (bool) timestamp output from applications
+#define PMIX_MERGE_STDERR_STDOUT            "pmix.mergeerrout"      // (bool) merge stdout and stderr streams from application procs
+#define PMIX_OUTPUT_TO_FILE                 "pmix.outfile"          // (char*) output application output to given file
+#define PMIX_INDEX_ARGV                     "pmix.indxargv"         // (bool) mark the argv with the rank of the proc
+#define PMIX_CPUS_PER_PROC                  "pmix.cpuperproc"       // (uint32_t) #cpus to assign to each rank
+#define PMIX_NO_PROCS_ON_HEAD               "pmix.nolocal"          // (bool) do not place procs on the head node
+#define PMIX_NO_OVERSUBSCRIBE               "pmix.noover"           // (bool) do not oversubscribe the cpus
+#define PMIX_REPORT_BINDINGS                "pmix.repbind"          // (bool) report bindings of the individual procs
+#define PMIX_CPU_LIST                       "pmix.cpulist"          // (char*) list of cpus to use for this job
+#define PMIX_JOB_RECOVERABLE                "pmix.recover"          // (bool) application supports recoverable operations
+#define PMIX_JOB_CONTINUOUS                 "pmix.continuous"       // (bool) application is continuous, all failed procs should
+                                                                        //        be immediately restarted
+#define PMIX_MAX_RESTARTS                   "pmix.maxrestarts"      // (uint32_t) max number of times to restart a job
+
 
 /* query attributes */
 #define PMIX_QUERY_NAMESPACES               "pmix.qry.ns"           // (char*) request a comma-delimited list of active nspaces

--- a/opal/mca/pmix/pmix2x/pmix/src/mca/ptl/tcp/ptl_tcp.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/ptl/tcp/ptl_tcp.c
@@ -471,7 +471,7 @@ static pmix_status_t parse_uri_file(char *filename,
          * user isn't authorized to access it - or it may just
          * not exist yet! Check for existence */
         if (0 != access(filename, R_OK)) {
-            if (ENOENT == errno) {
+            if (ENOENT == errno && 0 < mca_ptl_tcp_component.wait_to_connect) {
                 /* the file does not exist, so give it
                  * a little time to see if the server
                  * is still starting up */
@@ -979,6 +979,7 @@ static pmix_status_t df_search(char *dirname, char *prefix,
         }
         newdir = pmix_os_path(false, dirname, dir_entry->d_name, NULL);
         if (-1 == stat(newdir, &buf)) {
+            free(newdir);
             continue;
         }
         /* if it is a directory, down search */

--- a/opal/mca/pmix/pmix2x/pmix2x_server_south.c
+++ b/opal/mca/pmix/pmix2x/pmix2x_server_south.c
@@ -343,10 +343,12 @@ void pmix2x_server_deregister_nspace(opal_jobid_t jobid,
         if (jptr->jobid == jobid) {
             /* found it - tell the server to deregister */
             OPAL_PMIX_CONSTRUCT_LOCK(&lock);
+            OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);
             PMIx_server_deregister_nspace(jptr->nspace, lkcbfunc, (void*)&lock);
             OPAL_PMIX_WAIT_THREAD(&lock);
             OPAL_PMIX_DESTRUCT_LOCK(&lock);
             /* now get rid of it from our list */
+            OPAL_PMIX_ACQUIRE_THREAD(&opal_pmix_base.lock);
             opal_list_remove_item(&mca_pmix_pmix2x_component.jobids, &jptr->super);
             OBJ_RELEASE(jptr);
             break;

--- a/opal/mca/pmix/pmix_types.h
+++ b/opal/mca/pmix/pmix_types.h
@@ -259,6 +259,21 @@ BEGIN_C_DECLS
                                                                         //        job - i.e., not part of the "comm_world" of the job
 #define OPAL_PMIX_SET_SESSION_CWD               "pmix.ssncwd"           // (bool) set the application's current working directory to
                                                                         //        the session working directory assigned by the RM
+#define OPAL_PMIX_TAG_OUTPUT                    "pmix.tagout"           // (bool) tag application output with the ID of the source
+#define OPAL_PMIX_TIMESTAMP_OUTPUT              "pmix.tsout"            // (bool) timestamp output from applications
+#define OPAL_PMIX_MERGE_STDERR_STDOUT           "pmix.mergeerrout"      // (bool) merge stdout and stderr streams from application procs
+#define OPAL_PMIX_OUTPUT_TO_FILE                "pmix.outfile"          // (char*) output application output to given file
+#define OPAL_PMIX_INDEX_ARGV                    "pmix.indxargv"         // (bool) mark the argv with the rank of the proc
+#define OPAL_PMIX_CPUS_PER_PROC                 "pmix.cpuperproc"       // (uint32_t) #cpus to assign to each rank
+#define OPAL_PMIX_NO_PROCS_ON_HEAD              "pmix.nolocal"          // (bool) do not place procs on the head node
+#define OPAL_PMIX_NO_OVERSUBSCRIBE              "pmix.noover"           // (bool) do not oversubscribe the cpus
+#define OPAL_PMIX_REPORT_BINDINGS               "pmix.repbind"          // (bool) report bindings of the individual procs
+#define OPAL_PMIX_CPU_LIST                      "pmix.cpulist"          // (char*) list of cpus to use for this job
+#define OPAL_PMIX_JOB_RECOVERABLE               "pmix.recover"          // (bool) application supports recoverable operations
+#define OPAL_PMIX_JOB_CONTINUOUS                "pmix.continuous"       // (bool) application is continuous, all failed procs should
+                                                                        //        be immediately restarted
+#define OPAL_PMIX_MAX_RESTARTS                  "pmix.maxrestarts"      // (uint32_t) max number of times to restart a job
+
 
 /* query attributes */
 #define OPAL_PMIX_QUERY_NAMESPACES              "pmix.qry.ns"           // (char*) request a comma-delimited list of active nspaces
@@ -281,6 +296,7 @@ BEGIN_C_DECLS
                                                                         //         is being requested
 #define OPAL_PMIX_TIME_REMAINING                "pmix.time.remaining"   // (char*) query number of seconds (uint32_t) remaining in allocation
                                                                         //         for the specified nspace
+
 
 /* log attributes */
 #define OPAL_PMIX_LOG_STDERR                    "pmix.log.stderr"       // (char*) log string to stderr

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -96,7 +96,7 @@ static int
 opal_err2str(int errnum, const char **errmsg)
 {
     const char *retval;
-opal_output(0, "OPAL ERR2STR %d", errnum);
+
     switch (errnum) {
     case OPAL_SUCCESS:
         retval = "Success";

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -145,6 +145,8 @@ int orte_rmaps_rr_byslot(orte_job_t *jdata,
         /* add this node to the map - do it only once */
         if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
             ORTE_FLAG_SET(node, ORTE_NODE_FLAG_MAPPED);
+            OBJ_RETAIN(node);
+            opal_pointer_array_add(jdata->map->nodes, node);
             ++(jdata->map->num_nodes);
         }
         if (add_one) {
@@ -284,6 +286,8 @@ int orte_rmaps_rr_bynode(orte_job_t *jdata,
             /* add this node to the map, but only do so once */
             if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
                 ORTE_FLAG_SET(node, ORTE_NODE_FLAG_MAPPED);
+                OBJ_RETAIN(node);
+                opal_pointer_array_add(jdata->map->nodes, node);
                 ++(jdata->map->num_nodes);
             }
             if (oversubscribed) {
@@ -532,6 +536,8 @@ int orte_rmaps_rr_byobj(orte_job_t *jdata,
             /* add this node to the map, if reqd */
             if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
                 ORTE_FLAG_SET(node, ORTE_NODE_FLAG_MAPPED);
+                OBJ_RETAIN(node);
+                opal_pointer_array_add(jdata->map->nodes, node);
                 ++(jdata->map->num_nodes);
             }
             nmapped = 0;
@@ -678,6 +684,8 @@ static int byobj_span(orte_job_t *jdata,
         /* add this node to the map, if reqd */
         if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
             ORTE_FLAG_SET(node, ORTE_NODE_FLAG_MAPPED);
+            OBJ_RETAIN(node);
+            opal_pointer_array_add(jdata->map->nodes, node);
             ++(jdata->map->num_nodes);
         }
         /* get the number of objects of this type on this node */

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -502,11 +502,6 @@ static opal_cmd_line_init_t cmd_line_init[] = {
       "Create a persistent distributed virtual machine (DVM)",
       OPAL_CMD_LINE_OTYPE_DVM },
 
-    /* tell the dvm to terminate */
-    { NULL, '\0', "terminate", "terminate", 0,
-      &orte_cmd_options.terminate_dvm, OPAL_CMD_LINE_TYPE_BOOL,
-      "Terminate the DVM", OPAL_CMD_LINE_OTYPE_DVM },
-
     /* fwd mpirun port */
     { "orte_fwd_mpirun_port", '\0', "fwd-mpirun-port", "fwd-mpirun-port", 0,
       NULL, OPAL_CMD_LINE_TYPE_BOOL,

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -450,7 +450,7 @@ static void check_complete(int fd, short args, void *cbdata)
      * we call the errmgr so that any attempt to restart the job will
      * avoid doing so in the exact same place as the current job
      */
-    if (NULL != jdata->map && jdata->state == ORTE_JOB_STATE_TERMINATED) {
+    if (NULL != jdata->map) {
         map = jdata->map;
         for (index = 0; index < map->nodes->size; index++) {
             if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(map->nodes, index))) {

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -820,7 +820,6 @@ int orte_submit_job(char *argv[], int *index,
         orte_set_attribute(&jdata->attributes, ORTE_JOB_MERGE_STDERR_STDOUT, ORTE_ATTR_GLOBAL, NULL, OPAL_BOOL);
     }
 
-
     /* check what user wants us to do with stdin */
     if (NULL != orte_cmd_options.stdin_target) {
         if (0 == strcmp(orte_cmd_options.stdin_target, "all")) {
@@ -902,7 +901,7 @@ int orte_submit_job(char *argv[], int *index,
         ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_NO_USE_LOCAL);
     }
     if (orte_cmd_options.no_oversubscribe) {
-        ORTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_NO_OVERSUBSCRIBE);
+        ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_NO_OVERSUBSCRIBE);
     }
     if (orte_cmd_options.oversubscribe) {
         ORTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_NO_OVERSUBSCRIBE);

--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -785,10 +785,12 @@ static void _toolconn(int sd, short args, void *cbdata)
         OBJ_RETAIN(node);
         opal_pointer_array_add(jdata->map->nodes, node);
         jdata->map->num_nodes++;
-        /* and it obviously is on the node */
+        /* and it obviously is on the node - note that
+         * we do _not_ increment the #procs on the node
+         * as the tool doesn't count against the slot
+         * allocation */
         OBJ_RETAIN(proc);
         opal_pointer_array_add(node->procs, proc);
-        node->num_procs++;
         /* set the trivial */
         proc->local_rank = 0;
         proc->node_rank = 0;


### PR DESCRIPTION
Fix a bug in the round-robin mappers where we weren't adding nodes to the job map node array, and so resources were not released

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 285d8cfef74ffc899e9c51e1d9c597b7fb2ceb89)