### PR TITLE
tcp btl: Fix multiple-link connection establishment.

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -486,10 +486,10 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
         }
 
         /*
-         * in case one of the peer addresses is already in use,
+         * in case the peer address has created all intended connections,
          * mark the complete peer interface as 'not available'
          */
-        if(endpoint_addr->addr_inuse) {
+        if(endpoint_addr->addr_inuse >=  mca_btl_tcp_component.tcp_num_links) {
             peer_interfaces[index]->inuse = 1;
         }
 
@@ -813,7 +813,7 @@ void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t* btl_proc, struct sockaddr* addr
     for( size_t i = 0; i < btl_proc->proc_endpoint_count; i++ ) {
         mca_btl_base_endpoint_t* btl_endpoint = btl_proc->proc_endpoints[i];
         /* Check all conditions before going to try to accept the connection. */
-        if( btl_endpoint->endpoint_addr->addr_family != addr->sa_family ) {
+        if( btl_endpoint->endpoint_addr->addr_family != addr->sa_family || btl_endpoint->endpoint_state != MCA_BTL_TCP_CLOSED ) {
             continue;
         }
         switch (addr->sa_family) {
@@ -855,6 +855,8 @@ void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t* btl_proc, struct sockaddr* addr
             ;
         }
 
+        /* Setting the connection state here to avoid a race condition when multiple tcp links are being added */
+        btl_endpoint->endpoint_state = MCA_BTL_TCP_CONNECTING;
         (void)mca_btl_tcp_endpoint_accept(btl_endpoint, addr, sd);
         OPAL_THREAD_UNLOCK(&btl_proc->proc_lock);
         return;


### PR DESCRIPTION
Fix case where the btl_tcp_links MCA parameter is used to create multiple TCP connections between peers.
Two issues were resulting in hangs during large message transfer:
  * The 2nd..btl_tcp_link connections were dropped during establishment because the per-process
    address check was binary, rather than a count
  * The accept handler would not skip a btl module that was already in use, resulting in all
    connections for a given address being vectored to a single btl

Signed-off-by: Jordan Cherry <cherryj@amazon.com>