### PR TITLE
reachable: Fix string length Coverity warning

### DIFF
--- a/opal/mca/reachable/netlink/reachable_netlink_module.c
+++ b/opal/mca/reachable/netlink/reachable_netlink_module.c
@@ -95,9 +95,11 @@ static int get_weights(opal_if_t *local_if, opal_if_t *remote_if)
     strncpy(str_local,
             opal_net_get_hostname((struct sockaddr *)&local_if->if_addr),
             sizeof(str_local));
+    str_local[sizeof(str_local) - 1] = '\0';
     strncpy(str_remote,
             opal_net_get_hostname((struct sockaddr *)&remote_if->if_addr),
             sizeof(str_remote));
+    str_remote[sizeof(str_remote) - 1] = '\0';
 
     /*  initially, assume no connection is possible */
     weight = calculate_weight(0, 0, CQ_NO_CONNECTION);

--- a/opal/mca/reachable/weighted/reachable_weighted.c
+++ b/opal/mca/reachable/weighted/reachable_weighted.c
@@ -121,7 +121,9 @@ static int get_weights(opal_if_t *local_if, opal_if_t *remote_if)
     /* opal_net_get_hostname returns a static buffer.  Great for
        single address printfs, need to copy in this case */
     strncpy(str_local, opal_net_get_hostname(local_sockaddr), sizeof(str_local));
+    str_local[sizeof(str_local) - 1] = '\0';
     strncpy(str_remote, opal_net_get_hostname(remote_sockaddr), sizeof(str_remote));
+    str_remote[sizeof(str_remote) - 1] = '\0';
 
     /*  initially, assume no connection is possible */
     weight = calculate_weight(0, 0, CQ_NO_CONNECTION);


### PR DESCRIPTION
Make sure hostnames are null terminated, even when they were
too long to fit in the hostname buffer.

Fixes: CID 1418232

Signed-off-by: Brian Barrett <bbarrett@amazon.com>