### PR TITLE
mpool/memkind: add a missing include file

### DIFF
--- a/opal/mca/mpool/memkind/mpool_memkind_component.c
+++ b/opal/mca/mpool/memkind/mpool_memkind_component.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2010-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +35,7 @@
 #include <memkind.h>
 #include "opal/mca/base/base.h"
 #include "opal/mca/allocator/base/base.h"
+#include "opal/util/argv.h"
 #include "mpool_memkind.h"
 
 


### PR DESCRIPTION
unfortunately v2.x can't compile using GCC 7.1.0
without this patch.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit 3d0541f2bf1b418b7afc74c6f2ea5321a9e22806)