### PR TITLE
opal/util: initialize proc_hostname in the opal_proc_t constructor

### DIFF
--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -4,8 +4,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria.  All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
- * Copyright (c) 2014-2016 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -50,6 +50,7 @@ static void opal_proc_construct(opal_proc_t* proc)
     proc->proc_convertor = NULL;
     proc->proc_flags = 0;
     proc->proc_name = *OPAL_NAME_INVALID;
+    proc->proc_hostname  = NULL;
 }
 
 static void opal_proc_destruct(opal_proc_t* proc)


### PR DESCRIPTION
Refs open-mpi/ompi#4264

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@b3558f261b53587ec03bd430322927b8614bf22f)