### PR TITLE
spml_ucx: fix typo in shmem_quiet() error message.

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -595,7 +595,7 @@ int mca_spml_ucx_quiet(void)
 
     err = ucp_worker_flush(mca_spml_ucx.ucp_worker);
     if (UCS_OK != err) {
-         SPML_ERROR("fence failed: %s", ucs_status_string(err));
+         SPML_ERROR("quiet failed: %s", ucs_status_string(err));
          oshmem_shmem_abort(-1);
          return OSHMEM_ERROR;
     }


### PR DESCRIPTION
picked from #4258
fixes #3996