### PR TITLE
Begin cleaning up debugger support

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/orte/mca/rmaps/base/rmaps_base_support_fns.c
@@ -590,9 +590,13 @@ orte_proc_t* orte_rmaps_base_setup_proc(orte_job_t *jdata,
 
     OBJ_RETAIN(node);  /* maintain accounting on object */
     proc->node = node;
-    node->num_procs++;
-    if (node->slots_inuse < node->slots) {
-        ++node->slots_inuse;
+    /* if this is a debugger job, then it doesn't count against
+     * available slots - otherwise, it does */
+    if (!ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+        node->num_procs++;
+        if (node->slots_inuse < node->slots) {
+            ++node->slots_inuse;
+        }
     }
     if (0 > (rc = opal_pointer_array_add(node->procs, (void*)proc))) {
         ORTE_ERROR_LOG(rc);

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -95,6 +95,8 @@ int orte_rmaps_rr_byslot(orte_job_t *jdata,
             /* add this node to the map - do it only once */
             if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
                 ORTE_FLAG_SET(node, ORTE_NODE_FLAG_MAPPED);
+                OBJ_RETAIN(node);
+                opal_pointer_array_add(jdata->map->nodes, node);
                 ++(jdata->map->num_nodes);
             }
             if (NULL == (proc = orte_rmaps_base_setup_proc(jdata, node, app->idx))) {

--- a/orte/orted/pmix/pmix_server_dyn.c
+++ b/orte/orted/pmix/pmix_server_dyn.c
@@ -448,6 +448,11 @@ int pmix_server_spawn_fn(opal_process_name_t *requestor,
             orte_set_attribute(&jdata->attributes, ORTE_JOB_INDEX_ARGV,
                                ORTE_ATTR_GLOBAL, &flag, OPAL_BOOL);
 
+        /***   DEBUGGER DAEMONS   ***/
+        } else if (0 == strcmp(info->key, OPAL_PMIX_DEBUGGER_DAEMONS)) {
+            ORTE_FLAG_SET(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON);
+            ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_DEBUGGER);
+
         /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/
         } else {
             /* cache for inclusion with job info at registration */


### PR DESCRIPTION
Debugger daemons do not count against available slots. Clean up some leftover errors from the upgrade to HWLOC 2 in the mappers. Properly flag debugger jobs that come in via PMIx.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>