### PR TITLE
romio: disable Fortran support

### DIFF
--- a/ompi/mca/io/romio314/configure.m4
+++ b/ompi/mca/io/romio314/configure.m4
@@ -77,10 +77,10 @@ AC_DEFUN([MCA_ompi_io_romio314_CONFIG],[
                        [AS_IF([test ! -z $build], [io_romio314_flags="$io_romio314_flags --build=$build"])
                         AS_IF([test ! -z $host], [io_romio314_flags="$io_romio314_flags --host=$host"])
                         AS_IF([test ! -z $target], [io_romio314_flags="$io_romio314_flags --target=$target"])])
-                   io_romio314_flags_define="$io_romio314_flags FROM_OMPI=yes CC='$CC' CFLAGS='$CFLAGS -D__EXTENSIONS__' CPPFLAGS='$CPPFLAGS' FFLAGS='$FFLAGS' LDFLAGS='$LDFLAGS' --$io_romio314_shared-shared --$io_romio314_static-static $io_romio314_flags $io_romio314_prefix_arg --disable-aio --disable-weak-symbols --enable-strict"
+                   io_romio314_flags_define="$io_romio314_flags FROM_OMPI=yes CC='$CC' CFLAGS='$CFLAGS -D__EXTENSIONS__' CPPFLAGS='$CPPFLAGS' FFLAGS='$FFLAGS' LDFLAGS='$LDFLAGS' --$io_romio314_shared-shared --$io_romio314_static-static $io_romio314_flags $io_romio314_prefix_arg --disable-aio --disable-weak-symbols --enable-strict --disable-f77 --disable-f90"
                    AC_DEFINE_UNQUOTED([MCA_io_romio314_COMPLETE_CONFIGURE_FLAGS], ["$io_romio314_flags_define"], [Complete set of command line arguments given to ROMIOs configure script])
 
-                   io_romio314_flags="$io_romio314_flags FROM_OMPI=yes CC="'"'"$CC"'"'" CFLAGS="'"'"$CFLAGS -D__EXTENSIONS__"'"'" CPPFLAGS="'"'"$CPPFLAGS"'"'" FFLAGS="'"'"$FFLAGS"'"'" LDFLAGS="'"'"$LDFLAGS"'"'" --$io_romio314_shared-shared --$io_romio314_static-static $io_romio314_flags $io_romio314_prefix_arg --disable-aio --disable-weak-symbols --enable-strict"
+                   io_romio314_flags="$io_romio314_flags FROM_OMPI=yes CC="'"'"$CC"'"'" CFLAGS="'"'"$CFLAGS -D__EXTENSIONS__"'"'" CPPFLAGS="'"'"$CPPFLAGS"'"'" FFLAGS="'"'"$FFLAGS"'"'" LDFLAGS="'"'"$LDFLAGS"'"'" --$io_romio314_shared-shared --$io_romio314_static-static $io_romio314_flags $io_romio314_prefix_arg --disable-aio --disable-weak-symbols --enable-strict --disable-f77 --disable-f90"
 
                    opal_show_subtitle "Configuring ROMIO distribution"
                    OPAL_CONFIG_SUBDIR([ompi/mca/io/romio314/romio],


### PR DESCRIPTION
romio314 is a just a component that does not require Fortran bindings,
so simply disable Fortran support to prevent warnings about deprecated flags

Fixes open-mpi/ompi#4281

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@9492766dbd16bfcb4644102354dc80062dd700d7)