### PR TITLE
LANL/platform: disable use of XRC recv bufs

### DIFF
--- a/contrib/platform/lanl/toss/optimized-mlx.conf
+++ b/contrib/platform/lanl/toss/optimized-mlx.conf
@@ -88,7 +88,7 @@ btl = vader,openib,self
 
 ## Setup OpenIB - just in case
 btl_openib_want_fork_support = 0
-btl_openib_receive_queues = X,4096,1024:X,12288,512:X,65536,512
+btl_openib_receive_queues = S,4096,1024:S,12288,512:S,65536,512
 
 ## Disable MXM
 pml = ob1


### PR DESCRIPTION
Forgot as part of #3970 to disable use of XRC
recv bufs by default in LANL platform config
file.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>