### PR TITLE
Fix the embedded hwloc configure to always disable cuda support

### DIFF
--- a/opal/mca/hwloc/external/external.h
+++ b/opal/mca/hwloc/external/external.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +41,11 @@ BEGIN_C_DECLS
 #    else
 #        error Tried to include hwloc verbs helper file, but hwloc was compiled with no OpenFabrics support
 #    endif
+#endif
+
+#if HWLOC_API_VERSION < 0x00010b00
+#define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
+#define HWLOC_OBJ_PACKAGE HWLOC_OBJ_SOCKET
 #endif
 
 END_C_DECLS

--- a/opal/mca/hwloc/hwloc2a/configure.m4
+++ b/opal/mca/hwloc/hwloc2a/configure.m4
@@ -122,35 +122,9 @@ AC_DEFUN([MCA_opal_hwloc_hwloc2a_CONFIG],[
     enable_gl=no
     enable_opencl=no
 
-    # Per https://github.com/open-mpi/ompi/issues/4219, if
-    # --without-cuda was specified, be sure to disable it in hwloc,
-    # too.  Note that hwloc uses --disable-cuda (i.e., a yes or no
-    # value), whereas we use --with-cuda here in Open MPI (i.e., a
-    # yes, no, or path value).  Need to translate appropriately.
-    #
-    # Set enable_cuda to yes if:
-    #
-    # 1. --with-cuda was specified (i.e., a human specifically asked
-    # for it)
-    # 2. --with-cuda=blah was specified (i.e., a human specifically
-    # asked for it)
-    # 3. --with-cuda was not specified, but Open MPI is building CUDA
-    # support
-    #
-    # Set enable_cuda to no in all other cases.  This logic could be
-    # compressed into a smaller set of if tests, but for readability /
-    # clarity, I left it expanded.
-    AC_MSG_CHECKING([for hwloc --enable-cuda value])
+    # Per https://github.com/open-mpi/ompi/pull/4257, ALWAYS
+    # disable cuda support
     enable_cuda=no
-    AS_IF([test "$with_cuda" = "yes"],
-          [enable_cuda=yes],
-          [AS_IF([test -n "$with_cuda" && test "$with_cuda" != "no"],
-                 [enable_cuda=yes],
-                 [AS_IF([test "$opal_check_cuda_happy" = "yes"],
-                        [enable_cuda=yes])
-                 ])
-          ])
-    AC_MSG_RESULT(["$enable_cuda"])
 
     # Open MPI currently does not use hwloc's NVML support
     enable_nvml=no


### PR DESCRIPTION
Add definitions for updated hwloc objects when old external versions are used

Signed-off-by: Ralph Castain <rhc@open-mpi.org>