### PR TITLE
single_predefined_type with MPI_LB/UB

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -837,16 +838,19 @@ ompi_datatype_t* ompi_datatype_get_single_predefined_type_from_args( ompi_dataty
                 return NULL;
             }
         }
-        if( NULL == predef ) {  /* This is the first iteration */
-            predef = current_predef;
-        } else {
-            /**
-             *  What exactly should we consider as identical types? If they are
-             * the same MPI level type, or if they map to the same OPAL datatype?
-             * In other words, MPI_FLOAT and MPI_REAL4 are they identical?
-             */
-            if( predef != current_predef ) {
-                return NULL;
+        if (current_predef != MPI_LB && current_predef != MPI_UB) {
+            if( NULL == predef ) {  /* This is the first iteration */
+                predef = current_predef;
+            } else {
+                /**
+                 *  What exactly should we consider as identical types?
+                 *  If they are the same MPI level type, or if they map
+                 *  to the same OPAL datatype? In other words, MPI_FLOAT
+                 *  and MPI_REAL4 are they identical?
+                 */
+                if( predef != current_predef ) {
+                    return NULL;
+                }
             }
         }
     }


### PR DESCRIPTION
The ompi_datatype_get_single_predefined_type_from_args() recurses down
into a constructed type to identify what base datatype it's built from
if it's built from a single type.  But if the type has MPI_LB/MPI_UB,
for example
    lens[0] = 1;
    lens[1] = 1;
    disps[0] = 0;
    disps[1] = 0;
    types[0] = MPI_LB;
    types[1] = MPI_INT;
    MPI_Type_create_struct(2, lens, disps, types, &mydt);
then this function will see the base type MPI_LB as differing from MPI_INT
and will identify mydt as not being constructed from a single base type, so
the type will be rejected for calls like MPI_Accumulate.

I think those "meta data" types shouldn't result in rejection like that, and
the above mydt should still be identified as having a single base type
of MPI_INT.

Addition: boslica wanted another change discussed here
    https://github.com/open-mpi/ompi/pull/3609
relating to the calculation for "count" after identifying the
predefined_type that was being used.

Signed-off-by: Mark Allen <markalle@us.ibm.com>
(cherry picked from commit e24d5ccb7e2bae7183acc2bc05d7a28e57d55e1d)
Signed-off-by: Mark Allen <markalle@us.ibm.com>