### PR TITLE
Fix OFI MTL to recognize correct CQ empty scenario

### DIFF
--- a/ompi/mca/mtl/ofi/help-mtl-ofi.txt
+++ b/ompi/mca/mtl/ofi/help-mtl-ofi.txt
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-# Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved
 #
 # $COPYRIGHT$
 #
@@ -8,3 +8,9 @@
 #
 # $HEADER$
 #
+[OFI call fail]
+Open MPI failed an OFI Libfabric library call (%s).This is highly unusual;
+your job may behave unpredictably (and/or abort) after this.
+  Local host: %s
+  Location: %s:%d
+  Error: %s (%zd)

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved
  *
  * $COPYRIGHT$
  *
@@ -14,6 +14,7 @@
 #include "ompi/mca/mtl/mtl.h"
 #include "ompi/mca/mtl/base/base.h"
 #include "opal/datatype/opal_convertor.h"
+#include "opal/util/show_help.h"
 
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
@@ -79,13 +80,14 @@ ompi_mtl_ofi_progress(void)
                 assert(ofi_req);
                 ret = ofi_req->event_callback(&wc, ofi_req);
                 if (OMPI_SUCCESS != ret) {
-                    opal_output(ompi_mtl_base_framework.framework_output,
-                                "Error returned by request event callback: %zd",
-                                ret);
-                    abort();
+                    opal_output(0, "%s:%d: Error returned by request event callback: %zd.\n"
+                                   "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                                   __FILE__, __LINE__, ret);
+                    fflush(stderr);
+                    exit(1);
                 }
             }
-        } else if (ret == -FI_EAVAIL) {
+        } else if (OPAL_UNLIKELY(ret == -FI_EAVAIL)) {
             /**
              * An error occured and is being reported via the CQ.
              * Read the error and forward it to the upper layer.
@@ -94,9 +96,11 @@ ompi_mtl_ofi_progress(void)
                                 &error,
                                 0);
             if (0 > ret) {
-                opal_output(ompi_mtl_base_framework.framework_output,
-                            "Error returned from fi_cq_readerr: %zd", ret);
-                abort();
+                opal_output(0, "%s:%d: Error returned from fi_cq_readerr: %s(%zd).\n"
+                               "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                               __FILE__, __LINE__, fi_strerror(-ret), ret);
+                fflush(stderr);
+                exit(1);
             }
 
             assert(error.op_context);
@@ -104,16 +108,22 @@ ompi_mtl_ofi_progress(void)
             assert(ofi_req);
             ret = ofi_req->error_callback(&error, ofi_req);
             if (OMPI_SUCCESS != ret) {
-                opal_output(ompi_mtl_base_framework.framework_output,
-                        "Error returned by request error callback: %zd",
-                        ret);
-                abort();
+                    opal_output(0, "%s:%d: Error returned by request error callback: %zd.\n"
+                                   "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                                   __FILE__, __LINE__, ret);
+                fflush(stderr);
+                exit(1);
             }
         } else {
-            /**
-             * The CQ is empty. Return.
-             */
-            break;
+            if (ret == -FI_EAGAIN) {
+                break;
+            } else {
+                opal_output(0, "%s:%d: Error returned from fi_cq_read: %s(%zd).\n"
+                               "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                               __FILE__, __LINE__, fi_strerror(-ret), ret);
+                fflush(stderr);
+                exit(1);
+            }
         }
     }
     return count;


### PR DESCRIPTION
Currently, the progress function is incorrectly interpreting any error
value other than a positive value or -FI_EAVAIL to mean CQ is empty. This is
incorrect. CQ is empty only if fi_cq_read() call returned -EAGAIN error
code. Fixing that here

Signed-off-by: Aravind Gopalakrishnan <Aravind.Gopalakrishnan@intel.com>