### PR TITLE
OSHMEM/CONFIGURE: Check for the presence of ibv_exp_reg_shared_mr.

### DIFF
--- a/oshmem/mca/sshmem/verbs/configure.m4
+++ b/oshmem/mca/sshmem/verbs/configure.m4
@@ -76,6 +76,26 @@ AC_DEFUN([MCA_oshmem_sshmem_verbs_CONFIG],[
     exp_reg_mr_happy=0
     AS_IF([test "$oshmem_have_mpage" = "3"],
             [
+                oshmem_verbs_save_CFLAGS="$CFLAGS"
+                CFLAGS="$CFLAGS -Wno-strict-prototypes -Werror"
+
+                AC_COMPILE_IFELSE(
+                         [AC_LANG_PROGRAM([[#include <infiniband/verbs_exp.h>]],
+                                           [[
+                                             struct ibv_exp_reg_shared_mr_in in_smr;
+                                             uint64_t access_flags = IBV_EXP_ACCESS_SHARED_MR_USER_READ   |
+                                                                     IBV_EXP_ACCESS_SHARED_MR_USER_WRITE  |
+                                                                     IBV_EXP_ACCESS_SHARED_MR_GROUP_READ  |
+                                                                     IBV_EXP_ACCESS_SHARED_MR_GROUP_WRITE |
+                                                                     IBV_EXP_ACCESS_SHARED_MR_OTHER_READ  |
+                                                                     IBV_EXP_ACCESS_SHARED_MR_OTHER_WRITE;
+                                             in_smr.exp_access = access_flags;
+                                             ibv_exp_reg_shared_mr(&in_smr);
+                                          ]])], [],
+                          [oshmem_verbs_sm_build_verbs=0])
+
+                CFLAGS="$oshmem_verbs_save_CFLAGS"
+
               AC_CHECK_MEMBER([struct ibv_exp_reg_shared_mr_in.exp_access],
                 [exp_access_happy=1],
                 [],
@@ -90,8 +110,7 @@ AC_DEFUN([MCA_oshmem_sshmem_verbs_CONFIG],[
     AC_DEFINE_UNQUOTED(MPAGE_HAVE_IBV_EXP_REG_MR_CREATE_FLAGS, $exp_reg_mr_happy, [create_flags field is part of ibv_exp_reg_mr_in])
 
     AS_IF([test "$enable_verbs_sshmem" = "yes" && test "$oshmem_verbs_sm_build_verbs" = "0"],
-          [AC_MSG_WARN([VERBS shared memory support requested but not found])
-           AC_MSG_ERROR([Cannot continue])])
+          [AC_MSG_WARN([VERBS shared memory support requested but not found])])
 
     AS_IF([test "$oshmem_verbs_sm_build_verbs" = "1"], [$1], [$2])
 


### PR DESCRIPTION
+ The sshmem verbs component will disqualify itself if this verb isn't
present on the build host.
+ In case where support was requested but not found, don't stop the
build - continue without this component.

Signed-off-by: Alina Sklarevich <alinas@mellanox.com>