### PR TITLE
v3.0.x: hwloc1112: always disable building CUDA support.

### DIFF
--- a/opal/mca/hwloc/hwloc1117/configure.m4
+++ b/opal/mca/hwloc/hwloc1117/configure.m4
@@ -115,35 +115,9 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1117_CONFIG],[
     enable_gl=no
     enable_opencl=no
 
-    # Per https://github.com/open-mpi/ompi/issues/4219, if
-    # --without-cuda was specified, be sure to disable it in hwloc,
-    # too.  Note that hwloc uses --disable-cuda (i.e., a yes or no
-    # value), whereas we use --with-cuda here in Open MPI (i.e., a
-    # yes, no, or path value).  Need to translate appropriately.
-    #
-    # Set enable_cuda to yes if:
-    #
-    # 1. --with-cuda was specified (i.e., a human specifically asked
-    # for it)
-    # 2. --with-cuda=blah was specified (i.e., a human specifically
-    # asked for it)
-    # 3. --with-cuda was not specified, but Open MPI is building CUDA
-    # support
-    #
-    # Set enable_cuda to no in all other cases.  This logic could be
-    # compressed into a smaller set of if tests, but for readability /
-    # clarity, I left it expanded.
-    AC_MSG_CHECKING([for hwloc --enable-cuda value])
+    # Per https://github.com/open-mpi/ompi/pull/4257, ALWAYS
+    # disable cuda support
     enable_cuda=no
-    AS_IF([test "$with_cuda" = "yes"],
-          [enable_cuda=yes],
-          [AS_IF([test -n "$with_cuda" && test "$with_cuda" != "no"],
-                 [enable_cuda=yes],
-                 [AS_IF([test "$opal_check_cuda_happy" = "yes"],
-                        [enable_cuda=yes])
-                 ])
-          ])
-    AC_MSG_RESULT(["$enable_cuda"])
 
     # Open MPI currently does not use hwloc's NVML support
     enable_nvml=no


### PR DESCRIPTION
There is no usage of CUDA hwloc objects in the v3.0.x branch, and linking in CUDA can cause problems (per https://github.com/open-mpi/ompi/pull/4257#issuecomment-332900393).

Partially cherry-picked from c341b5347509037c145f0c3b8fd990d1511e6908.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Per https://github.com/open-mpi/ompi/issues/4248, this PR is a follow on to #4251 (which was merged before the corresponding v2.0.x / #4249 and v2.1.x / #4250 PRs were merged).  This secondary commit was added on #4249 and #4250 before they were merged.