### PR TITLE
Add support for the -v (verbose) option to prun and silence the "executing" and "completed" output otherwise.

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event_notification.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event_notification.c
@@ -815,7 +815,9 @@ static void _notify_client_event(int sd, short args, void *cbdata)
         /* check for caching instructions */
         for (n=0; n < cd->ninfo; n++) {
             if (0 == strncmp(cd->info[n].key, PMIX_EVENT_DO_NOT_CACHE, PMIX_MAX_KEYLEN)) {
-                holdcd = PMIX_INFO_TRUE(&cd->info[n]);
+                if (PMIX_INFO_TRUE(&cd->info[n])) {
+                    holdcd = false;
+                }
                 break;
             }
         }

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -140,7 +140,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                 }
             }
         }
-        if (!peer->finalized) {
+        if (!peer->finalized && !PMIX_PROC_IS_TOOL(peer)) {
             /* if this peer already called finalize, then
              * we are just seeing their connection go away
              * when they terminate - so do not generate

--- a/orte/mca/state/dvm/state_dvm.c
+++ b/orte/mca/state/dvm/state_dvm.c
@@ -599,19 +599,18 @@ static void dvm_notify(int sd, short args, void *cbdata)
         val->type = OPAL_STATUS;
         val->data.status = ret;
         opal_list_append(info, &val->super);
-        /* if there was a problem, we need to send the requestor more info about what happened */
-        if (ORTE_SUCCESS != ret) {
-            val = OBJ_NEW(opal_value_t);
-            val->key = strdup(OPAL_PMIX_PROCID);
-            val->type = OPAL_NAME;
-            val->data.name.jobid = jdata->jobid;
-            if (NULL != pptr) {
-                val->data.name.vpid = pptr->name.vpid;
-            } else {
-                val->data.name.vpid = ORTE_VPID_WILDCARD;
-            }
-            opal_list_append(info, &val->super);
+        /* tell the requestor which job or proc  */
+        val = OBJ_NEW(opal_value_t);
+        val->key = strdup(OPAL_PMIX_PROCID);
+        val->type = OPAL_NAME;
+        val->data.name.jobid = jdata->jobid;
+        if (NULL != pptr) {
+            val->data.name.vpid = pptr->name.vpid;
+        } else {
+            val->data.name.vpid = ORTE_VPID_WILDCARD;
         }
+        opal_list_append(info, &val->super);
+        /* setup the caddy */
         mycaddy = (mycaddy_t*)malloc(sizeof(mycaddy_t));
         mycaddy->info = info;
         OBJ_RETAIN(jdata);


### PR DESCRIPTION
Debounce "unreachable" notifications for tools when they disconnect
Enable the -x cmd line option for prun

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 0a5b36180a22959654461ac1303cec35313f8b4a)