### PR TITLE
Fix path separator for PMIX config

### DIFF
--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -401,7 +401,7 @@ int mca_base_var_cache_files(bool rel_path_search)
 #if OPAL_WANT_HOME_CONFIG_FILES
     asprintf(&mca_base_var_files, "%s"OPAL_PATH_SEP".openmpi" OPAL_PATH_SEP
              "mca-params.conf%c%s" OPAL_PATH_SEP "openmpi-mca-params.conf",
-             home, OPAL_ENV_SEP, opal_install_dirs.sysconfdir);
+             home, ',', opal_install_dirs.sysconfdir);
 #else
     asprintf(&mca_base_var_files, "%s" OPAL_PATH_SEP "openmpi-mca-params.conf",
              opal_install_dirs.sysconfdir);
@@ -517,7 +517,7 @@ int mca_base_var_cache_files(bool rel_path_search)
     if (NULL != mca_base_var_file_prefix) {
        resolve_relative_paths(&mca_base_var_file_prefix, mca_base_param_file_path, rel_path_search, &mca_base_var_files, OPAL_ENV_SEP);
     }
-    read_files (mca_base_var_files, &mca_base_var_file_values, OPAL_ENV_SEP);
+    read_files (mca_base_var_files, &mca_base_var_file_values, ',');
 
     if (NULL != mca_base_envar_file_prefix) {
        resolve_relative_paths(&mca_base_envar_file_prefix, mca_base_param_file_path, rel_path_search, &mca_base_envar_files, ',');

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/base/pmix_mca_base_var.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/base/pmix_mca_base_var.c
@@ -436,7 +436,7 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
 #if PMIX_WANT_HOME_CONFIG_FILES
     ret = asprintf(&pmix_mca_base_var_files, "%s"PMIX_PATH_SEP".pmix" PMIX_PATH_SEP
                    "mca-params.conf%c%s" PMIX_PATH_SEP "pmix-mca-params.conf",
-                   home, PMIX_ENV_SEP, pmix_pinstall_dirs.sysconfdir);
+                   home, ',', pmix_pinstall_dirs.sysconfdir);
 #else
     ret = asprintf(&pmix_mca_base_var_files, "%s" PMIX_PATH_SEP "pmix-mca-params.conf",
                    pmix_pinstall_dirs.sysconfdir);


### PR DESCRIPTION
When creating a list of PMIX configuration files the list building code was using PMIX_ENV_SEP (':') instead of the idiomatic ','. This change fixes the list building and path parsing to match each other.