### PR TITLE
configure: add --en|disable-show-load-errors-by-default

### DIFF
--- a/README
+++ b/README
@@ -838,6 +838,33 @@ INSTALLATION OPTIONS
   are build as static or dynamic via --enable|disable-static and
   --enable|disable-shared.
 
+--disable-show-load-errors-by-default
+  Set the default value of the mca_base_component_show_load_errors MCA
+  variable: the --enable form of this option sets the MCA variable to
+  true, the --disable form sets the MCA variable to false.  The MCA
+  mca_base_component_show_load_errors variable can still be overridden
+  at run time via the usual MCA-variable-setting mechanisms; this
+  configure option simply sets the default value.
+
+  The --disable form of this option is intended for Open MPI packagers
+  who tend to enable support for many different types of networks and
+  systems in their packages.  For example, consider a packager who
+  includes support for both the FOO and BAR networks in their Open MPI
+  package, both of which require support libraries (libFOO.so and
+  libBAR.so).  If an end user only has BAR hardware, they likely only
+  have libBAR.so available on their systems -- not libFOO.so.
+  Disabling load errors by default will prevent the user from seeing
+  potentially confusing warnings about the FOO components failing to
+  load because libFOO.so is not available on their systems.
+
+  Conversely, system administrators tend to build an Open MPI that is
+  targeted at their specific environment, and contains few (if any)
+  components that are not needed.  In such cases, they might want
+  their users to be warned that the FOO network components failed to
+  load (e.g., if libFOO.so was mistakenly unavailable), because Open
+  MPI may otherwise silently failover to a slower network path for MPI
+  traffic.
+
 --with-platform=FILE
   Load configure options for the build from FILE.  Options on the
   command line that are not in FILE are also used.  Options on the

--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
@@ -285,6 +285,34 @@ else
 fi
 AC_DEFINE_UNQUOTED(OPAL_ENABLE_DLOPEN_SUPPORT, $OPAL_ENABLE_DLOPEN_SUPPORT,
     [Whether we want to enable dlopen support])
+
+
+#
+# Do we want to show component load error messages by default?
+#
+
+AC_MSG_CHECKING([for default value of mca_base_component_show_load_errors])
+AC_ARG_ENABLE([show-load-errors-by-default],
+    [AC_HELP_STRING([--enable-show-load-errors-by-default],
+                    [Set the default value for the MCA parameter
+                     mca_base_component_show_load_errors (but can be
+                     overridden at run time by the usual
+                     MCA-variable-setting mechansism).  This MCA variable
+                     controls whether warnings are displayed when an MCA
+                     component fails to load at run time due to an error.
+                     (default: enabled, meaning that
+                      mca_base_component_show_load_errors is enabled
+                      by default])])
+if test "$enable_show_load_errors_by_default" = "no" ; then
+    OPAL_SHOW_LOAD_ERRORS_DEFAULT=0
+    AC_MSG_RESULT([disabled by default])
+else
+    OPAL_SHOW_LOAD_ERRORS_DEFAULT=1
+    AC_MSG_RESULT([enabled by default])
+fi
+AC_DEFINE_UNQUOTED(OPAL_SHOW_LOAD_ERRORS_DEFAULT, $OPAL_SHOW_LOAD_ERRORS_DEFAULT,
+                   [Default value for mca_base_component_show_load_errors MCA variable])
+
 
 #
 # Heterogeneous support

--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
@@ -48,7 +48,8 @@ char *mca_base_component_path = NULL;
 int mca_base_opened = 0;
 char *mca_base_system_default_path = NULL;
 char *mca_base_user_default_path = NULL;
-bool mca_base_component_show_load_errors = true;
+bool mca_base_component_show_load_errors =
+    (bool) OPAL_SHOW_LOAD_ERRORS_DEFAULT;
 bool mca_base_component_track_load_errors = false;
 bool mca_base_component_disable_dlopen = false;
 
@@ -102,7 +103,8 @@ int mca_base_open(void)
                                          MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     free(value);
 
-    mca_base_component_show_load_errors = true;
+    mca_base_component_show_load_errors =
+        (bool) OPAL_SHOW_LOAD_ERRORS_DEFAULT;
     var_id = mca_base_var_register("opal", "mca", "base", "component_show_load_errors",
                                    "Whether to show errors for components that failed to load or not",
                                    MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,


### PR DESCRIPTION
Give packagers a configure CLI option to set the value of the MCA variable `mca_base_component_show_load_errors`.

The `--disable` form of this option is intended for Open MPI packagers who tend to enable support for many different types of networks and systems in their packages.  For example, consider a packager who includes support for both the FOO and BAR networks in their Open MPI package, both of which require support libraries (`libFOO.so` and `libBAR.so`).  If an end user only has BAR hardware, they likely only have `libBAR.so` available on their systems -- not `libFOO.so`.  Disabling load errors by default will prevent the user from seeing potentially confusing warnings about the FOO components failing to load because `libFOO.so` is not available on their systems.

Conversely, system administrators tend to build an Open MPI that is targeted at their specific environment, and contains few (if any) components that are not needed.  In such cases, they might want their users to be warned that the FOO network components failed to load (e.g., if `libFOO.so` was mistakenly unavailable), because Open MPI may otherwise silently failover to a slower network path for MPI traffic.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

I'm labeling this as both a bug and an enhancement.  Technically, it's an enhancement (because it's a new feature), but it enables functionality that prevents downstream packagers from having to patch Open MPI.  So from that perspective, you could consider it a bug.

And if we consider it a bug, we should probably consider bringing this to all release branches (or perhaps at least to v3.0.x and v3.1.x).

Refs #4306