### PR TITLE
optionally passive wait when the progress loop is idle for a while

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2016 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies Ltd. All rights reserved.
  *
@@ -284,6 +284,7 @@ opal_list_t ompi_registered_datareps = {{0}};
 
 bool ompi_enable_timing = false;
 extern bool ompi_mpi_yield_when_idle;
+extern uint32_t ompi_mpi_sleep_when_idle_threshold;
 extern int ompi_mpi_event_tick_rate;
 
 /**
@@ -970,6 +971,9 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
 
     /* see if yield_when_idle was specified - if so, use it */
     opal_progress_set_yield_when_idle(ompi_mpi_yield_when_idle);
+
+    /* set the threshold to start sleeping when idle */
+    opal_progress_set_sleep_when_idle_threshold(ompi_mpi_sleep_when_idle_threshold);
 
     /* negative value means use default - just don't do anything */
     if (ompi_mpi_event_tick_rate >= 0) {

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      Research Organization for Information Science
+ * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -63,6 +63,7 @@ bool ompi_have_sparse_group_storage = OPAL_INT_TO_BOOL(OMPI_GROUP_SPARSE);
 bool ompi_use_sparse_group_storage = OPAL_INT_TO_BOOL(OMPI_GROUP_SPARSE);
 
 bool ompi_mpi_yield_when_idle = false;
+int ompi_mpi_sleep_when_idle_threshold = -1;
 int ompi_mpi_event_tick_rate = -1;
 char *ompi_mpi_show_mca_params_string = NULL;
 bool ompi_mpi_have_sparse_group_storage = !!(OMPI_GROUP_SPARSE);
@@ -109,11 +110,19 @@ int ompi_mpi_register_params(void)
        exactly/under-subscribed, or 1 when oversubscribed */
     ompi_mpi_yield_when_idle = false;
     (void) mca_base_var_register("ompi", "mpi", NULL, "yield_when_idle",
-                                 "Yield the processor when waiting for MPI communication (for MPI processes, will default to 1 when oversubscribing nodes)",
+                                 "Yield the processor when waiting for communication (for MPI processes, will default to 1 when oversubscribing nodes)",
                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                 OPAL_INFO_LVL_9,
+                                 OPAL_INFO_LVL_6,
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &ompi_mpi_yield_when_idle);
+
+    ompi_mpi_sleep_when_idle_threshold = -1;
+    (void) mca_base_var_register("ompi", "mpi", NULL, "sleep_when_idle_threshold",
+                                 "Sleep after waiting for communication too long",
+                                 MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                 OPAL_INFO_LVL_6,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &ompi_mpi_sleep_when_idle_threshold);
 
     ompi_mpi_event_tick_rate = -1;
     (void) mca_base_var_register("ompi", "mpi", NULL, "event_tick_rate",

--- a/opal/runtime/opal_progress.h
+++ b/opal/runtime/opal_progress.h
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -113,17 +115,33 @@ OPAL_DECLSPEC void opal_progress_event_users_decrement(void);
 /**
  * Set whether opal_progress() should yield when idle
  *
- * Set whether opal_progress() should yield the processor (either by
- * sched_yield() or SwitchToThread()) if no events were progressed
- * during the progress loop.  The return value of the callback
- * functions is used to determine whether or not yielding is required.
+ * Set whether opal_progress() should yield the processor by
+ * sched_yield() no events were progressed during the progress loop.
+ * The return value of the callback functions is used to determine
+ * whether or not yielding is required.
  * By default, the event loop will yield when the progress function is
- * idle.
+ * idle only when oversubscription.
  *
  * @param   yieldopt  Whether to yield when idle.
  * @return         Previous value of the yield_when_idle option.
  */
 OPAL_DECLSPEC bool opal_progress_set_yield_when_idle(bool yieldopt);
+
+
+/**
+ * Set whether opal_progress() should sleep when idle for a while
+ *
+ * Set whether opal_progress() should sleep if no events were progressed
+ * during the progress loop for some time.  The return value of the callback
+ * functions is used to determine whether or not sleeping is required.
+ * By default, the event loop will not sleep when the progress function is
+ * idle.
+ * -1 means no sleeping and 0 means always sleep.
+ *
+ * @param   thresholdopt  The threshold to start sleeping.
+ * @return         Previous value of the sleep_threshold option.
+ */
+OPAL_DECLSPEC int opal_progress_set_sleep_when_idle_threshold(int thresholdopt);
 
 
 /**


### PR DESCRIPTION
Add the new mpi_poll_when_idle and mpi_poll_threhold MCA parameters to
control if and when the progress loop should poll() when idle and
when polling should start.

The default is not to poll when idle.

Thanks Paul Kapinos for bringing this to our attention

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>