### PR TITLE
Add access() calls to ensure fopen(...,"r") doesn't segfault

### DIFF
--- a/ompi/debuggers/dlopen_test.c
+++ b/ompi/debuggers/dlopen_test.c
@@ -65,12 +65,17 @@ static int do_test(void)
 
     /* Double check that the .la file is there that we expect; if it's
        not, skip this test. */
+    if (!access(full_filename, F_OK)) {
+      fprintf(stderr,
+              "File %s.la doesn't seem to exist; skipping this test\n",
+              full_filename);
+      exit(77);
+    }
     fp = fopen(full_filename, "r");
-    if (NULL == fp) {
-        fprintf(stderr,
-                "File %s.la doesn't seem to exist; skipping this test\n",
-                full_filename);
-        exit(77);
+    if (fp == NULL) {
+      fprintf(stderr, "File %s.la fopen failed; skipping this test\n",
+              full_filename);
+      exit(77);
     }
     /* We know the .la file is there, so read it, looking for the
        dlopen value.  If the dlopen value is '' (i.e., empty), then

--- a/ompi/debuggers/ompi_debuggers.c
+++ b/ompi/debuggers/ompi_debuggers.c
@@ -148,7 +148,7 @@ static void check(char *dir, char *file, char **locations)
         FILE *fp;
 
         /* Just try to open the file */
-        if (NULL != (fp = fopen(str, "r"))) {
+        if (access(str, F_OK) && (NULL != (fp = fopen(str, "r"))) {
             fclose(fp);
             opal_argv_append_nosize(&locations, file);
         }

--- a/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
+++ b/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
@@ -88,6 +88,10 @@ int ompi_coll_tuned_read_rules_config_file (char *fname, ompi_coll_alg_rule_t** 
         return (-3);
     }
 
+    if (!access(fname, F_OK)) {
+        OPAL_OUTPUT((ompi_coll_tuned_stream,"rules file does not exist [%s]\n", fname));
+        goto on_file_error;
+    }
     fptr = fopen (fname, "r");
     if (!fptr) {
         OPAL_OUTPUT((ompi_coll_tuned_stream,"cannot read rules file [%s]\n", fname));

--- a/ompi/mca/topo/treematch/treematch/tm_mapping.c
+++ b/ompi/mca/topo/treematch/treematch/tm_mapping.c
@@ -73,6 +73,12 @@ int nb_lines(char *filename)
   char line[LINE_SIZE];
   int N = 0;
 
+  if(!access(filename, F_OK)) {
+    if(tm_get_verbose_level() >= CRITICAL)
+      fprintf(stderr,"%s does not exist\n",filename);
+    exit(-1);
+  }
+
   if(!(pf = fopen(filename,"r"))){
     if(tm_get_verbose_level() >= CRITICAL)
       fprintf(stderr,"Cannot open %s\n",filename);
@@ -97,6 +103,11 @@ void init_mat(char *filename,int N, double **mat, double *sum_row)
   int i,j;
   unsigned int vl = tm_get_verbose_level();
 
+  if(!access(filename, F_OK)) {
+    if(tm_get_verbose_level() >= CRITICAL)
+      fprintf(stderr,"%s does not exist\n",filename);
+    exit(-1);
+  }
 
   if(!(pf=fopen(filename,"r"))){
     if(vl >= CRITICAL)

--- a/ompi/mca/topo/treematch/treematch/tm_topology.c
+++ b/ompi/mca/topo/treematch/treematch/tm_topology.c
@@ -481,6 +481,11 @@ int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology
   int i,n;
   unsigned int vl = tm_get_verbose_level();
 
+  if (!access(constraints_filename, F_OK)) {
+    if(tm_get_verbose_level() >= CRITICAL)
+      fprintf(stderr,"%s does not exist\n",constraints_filename);
+    exit(-1);
+  }
 
   if (!(pf = fopen(constraints_filename,"r"))) {
     if(vl >= CRITICAL)

--- a/opal/mca/btl/openib/btl_openib_ini.c
+++ b/opal/mca/btl/openib/btl_openib_ini.c
@@ -229,9 +229,17 @@ static int parse_file(char *filename)
 
     /* Open the file */
     ini_filename = filename;
+
+    if (!access(filename, F_OK)) {
+        opal_show_help("help-mpi-btl-openib.txt", "ini file:file not found",
+                       true, filename);
+        ret = OPAL_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
     btl_openib_ini_yyin = fopen(filename, "r");
     if (NULL == btl_openib_ini_yyin) {
-        opal_show_help("help-mpi-btl-openib.txt", "ini file:file not found",
+        opal_show_help("help-mpi-btl-openib.txt", "ini file:could not open",
                        true, filename);
         ret = OPAL_ERR_NOT_FOUND;
         goto cleanup;

--- a/opal/mca/btl/ugni/btl_ugni_init.c
+++ b/opal/mca/btl/ugni/btl_ugni_init.c
@@ -264,12 +264,13 @@ int mca_btl_ugni_init (void)
         mca_btl_ugni_component.virtual_device_count = MCA_BTL_UGNI_MAX_DEV_HANDLES;
     }
 
-    fh = fopen ("/proc/sys/kernel/pid_max", "r");
-    if (NULL != fh) {
-        fscanf (fh, "%d", &pid_max);
-        fclose (fh);
+    if (access("/proc/sys/kernel/pid_max", F_OK)) {
+        fh = fopen ("/proc/sys/kernel/pid_max", "r");
+        if (NULL != fh) {
+            fscanf (fh, "%d", &pid_max);
+            fclose (fh);
+        }
     }
-
     /* Use pid to generate the cdm_id.  Although its not stated in the uGNI
      * documentation, the cdm_id only needs to be unique within a node for a
      * given ptag/cookie tuple */

--- a/opal/mca/crs/blcr/crs_blcr_module.c
+++ b/opal/mca/crs/blcr/crs_blcr_module.c
@@ -739,6 +739,14 @@ static int blcr_cold_start(opal_crs_blcr_snapshot_t *snapshot) {
      * Find the snapshot directory, read the metadata file
      */
     if( NULL == snapshot->super.metadata ) {
+        if(access(snapshot->super.metadata_filename, F_OK) {
+            opal_output(mca_crs_blcr_component.super.output_handle,
+                        "crs:blcr: checkpoint(): Error: %s does not exist",
+                        snapshot->super.metadata_filename);
+            exit_status = OPAL_ERROR;
+            goto cleanup;
+        }
+
         if (NULL == (snapshot->super.metadata = fopen(snapshot->super.metadata_filename, "r")) ) {
             opal_output(mca_crs_blcr_component.super.output_handle,
                         "crs:blcr: checkpoint(): Error: Unable to open the file (%s)",

--- a/opal/mca/crs/dmtcp/crs_dmtcp_module.c
+++ b/opal/mca/crs/dmtcp/crs_dmtcp_module.c
@@ -477,13 +477,14 @@ static int dmtcp_cold_start(opal_crs_dmtcp_snapshot_t *snapshot) {
     char **tmp_argv = NULL;
     char * component_name = NULL;
     int prev_pid;
-
+    char *smfname;
     /*
      * Find the snapshot directory, read the metadata file for
      * component name and previous pid
      */
     if( NULL == snapshot->super.metadata ) {
-        if (NULL == (snapshot->super.metadata = fopen(snapshot->super.metadata_filename, "r")) ) {
+        smfname = snapshot->super.metadata_filename;
+        if (!access(smfname, F_OK) || NULL == (snapshot->super.metadata = fopen(smfname, "r")) ) {
             opal_output(mca_crs_dmtcp_component.super.output_handle,
                         "crs:dmtcp: dmtcp_cold_start(): Error: Unable to open the file (%s)",
                         snapshot->super.metadata_filename);

--- a/opal/mca/if/linux_ipv6/if_linux_ipv6.c
+++ b/opal/mca/if/linux_ipv6/if_linux_ipv6.c
@@ -95,7 +95,8 @@ static int if_linux_ipv6_open(void)
 {
 #if OPAL_ENABLE_IPV6
     FILE *f;
-    if ((f = fopen("/proc/net/if_inet6", "r"))) {
+    if (access("/proc/net/if_inet6", F_OK) &&
+        (f = fopen("/proc/net/if_inet6", "r"))) {
         char ifname[IF_NAMESIZE];
         unsigned int idx, pfxlen, scope, dadstat;
         struct in6_addr a6;

--- a/opal/mca/pmix/cray/pmix_cray_component.c
+++ b/opal/mca/pmix/cray/pmix_cray_component.c
@@ -114,16 +114,18 @@ static int pmix_cray_component_query(mca_base_module_t **module, int *priority)
 
     /* disqualify ourselves if not running in a Cray PAGG container, or we
        were launched by the orte/mpirun launcher */
-    fd = fopen(proc_job_file, "r");
-    if ((fd == NULL) || (getenv("OMPI_NO_USE_CRAY_PMI") != NULL)) {
+    if (!access(proc_job_file, F_OK) ||
+        fd = fopen(proc_job_file, "r") == NULL ||
+        (getenv("OMPI_NO_USE_CRAY_PMI") != NULL)) {
         *priority = 0;
         *module = NULL;
         rc = OPAL_ERROR;
     } else {
         snprintf(task_is_app_fname,sizeof(task_is_app_fname),
                  "/proc/self/task/%ld/task_is_app",syscall(SYS_gettid));
-        fd_task_is_app = fopen(task_is_app_fname, "r");
-        if (fd_task_is_app != NULL) {   /* okay we're in a PAGG container,
+        if(access(fd_task_is_app, F_OK) &&
+           NULL != fd_task_is_app = fopen(task_is_app_fname, "r") {
+                                        /* okay we're in a PAGG container,
                                            and we are an app task (not just a process
                                            running on a mom node, for example),
                                            so we should give cray pmi a shot. */

--- a/opal/mca/pmix/pmix3x/pmix/contrib/perf_tools/pmi_intra_perf.c
+++ b/opal/mca/pmix/pmix3x/pmix/contrib/perf_tools/pmi_intra_perf.c
@@ -129,7 +129,7 @@ int get_mem_usage(double *_pss, double *_rss) {
     memset(data, 0, sizeof(data));
     snprintf(data, sizeof(data), "/proc/%d/smaps", pid);
 
-    if (NULL == (smaps = fopen(data, "r"))) {
+    if (!access(data, F_OK) || NULL == (smaps = fopen(data, "r"))) {
         return -1;
     }
 

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -94,7 +94,7 @@ pmix_pif_base_component_t mca_pif_linux_ipv6_component = {
 static int if_linux_ipv6_open(void)
 {
     FILE *f;
-    if ((f = fopen("/proc/net/if_inet6", "r"))) {
+    if (access("/proc/net/if_inet6", F_OK) && NULL != (f = fopen("/proc/net/if_inet6", "r"))) {
         char ifname[IF_NAMESIZE];
         unsigned int idx, pfxlen, scope, dadstat;
         struct in6_addr a6;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp.c
@@ -471,8 +471,7 @@ static pmix_status_t parse_uri_file(char *filename,
     struct timeval tv;
     int retries;
 
-    fp = fopen(filename, "r");
-    if (NULL == fp) {
+    if (!access(filename, F_OK) || NULL == (fp = fopen(filename, "r"))) {
         /* if we cannot open the file, then the server must not
          * be configured to support tool connections, or this
          * user isn't authorized to access it - or it may just
@@ -495,8 +494,7 @@ static pmix_status_t parse_uri_file(char *filename,
                     pmix_event_evtimer_add(&ev, &tv);
                     PMIX_WAIT_THREAD(&lock);
                     PMIX_DESTRUCT_LOCK(&lock);
-                    fp = fopen(filename, "r");
-                    if (NULL != fp) {
+                    if (access(filename, F_OK) && NULL != (fp = fopen(filename, "r"))) {
                         /* we found it! */
                         goto process;
                     }

--- a/opal/mca/pmix/pmix3x/pmix/src/util/keyval_parse.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/keyval_parse.c
@@ -28,6 +28,7 @@
 #include "src/util/output.h"
 #include <string.h>
 #include <ctype.h>
+#include <unistd.h>
 
 int pmix_util_keyval_parse_lineno = 0;
 
@@ -70,8 +71,7 @@ pmix_util_keyval_parse(const char *filename,
     keyval_callback = callback;
 
     /* Open the pmix */
-    pmix_util_keyval_yyin = fopen(keyval_filename, "r");
-    if (NULL == pmix_util_keyval_yyin) {
+    if (!access(keyval_filename, F_OK) || NULL == (pmix_util_keyval_yyin = fopen(keyval_filename, "r"))) {
         ret = PMIX_ERR_NOT_FOUND;
         goto cleanup;
     }

--- a/opal/mca/pmix/pmix3x/pmix/src/util/show_help.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/show_help.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <locale.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 #include "src/util/show_help.h"
@@ -169,6 +170,9 @@ static int open_file(const char *base, const char *topic)
                     free(filename);
                     if (0 > asprintf(&filename, "%s%s%s.txt", search_dirs[i], PMIX_PATH_SEP, base)) {
                         return PMIX_ERR_OUT_OF_RESOURCE;
+                    }
+                    if(!access(filename, F_OK)){
+                      return PMIX_ERR_NOT_FOUND;
                     }
                     pmix_show_help_yyin = fopen(filename, "r");
                 }

--- a/opal/mca/pstat/linux/pstat_linux_module.c
+++ b/opal/mca/pstat/linux/pstat_linux_module.c
@@ -289,7 +289,7 @@ static int query(pid_t pid,
             return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
         }
 
-        if (NULL == (fp = fopen(data, "r"))) {
+        if (!access(data, F_OK) || NULL == (fp = fopen(data, "r"))) {
             /* ignore this */
             return OPAL_SUCCESS;
         }
@@ -318,7 +318,7 @@ static int query(pid_t pid,
             return OPAL_ERR_VALUE_OUT_OF_BOUNDS;
         }
 
-        if (NULL == (fp = fopen(data, "r"))) {
+        if (!access(data, F_OK) || NULL == (fp = fopen(data, "r"))) {
             /* ignore this */
             return OPAL_SUCCESS;
         }
@@ -365,7 +365,7 @@ static int query(pid_t pid,
         nstats->la15 = strtof(eptr, NULL);
 
         /* see if we can open the meminfo file */
-        if (NULL == (fp = fopen("/proc/meminfo", "r"))) {
+        if (!access("/proc/meminfo", F_OK) || NULL == (fp = fopen("/proc/meminfo", "r"))) {
             /* ignore this */
             goto diskstats;
         }
@@ -398,7 +398,7 @@ static int query(pid_t pid,
 
     diskstats:
         /* look for the diskstats file */
-        if (NULL == (fp = fopen("/proc/diskstats", "r"))) {
+        if (!access("/proc/diskstats", F_OK) || NULL == (fp = fopen("/proc/diskstats", "r"))) {
             /* not an error if we don't find this one as it
              * isn't critical
              */
@@ -441,7 +441,7 @@ static int query(pid_t pid,
 
     netstats:
         /* look for the netstats file */
-        if (NULL == (fp = fopen("/proc/net/dev", "r"))) {
+        if (!access("/proc/net/dev", F_OK) || NULL == (fp = fopen("/proc/net/dev", "r"))) {
             /* not an error if we don't find this one as it
              * isn't critical
              */

--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -26,6 +26,7 @@
 #include "opal_config.h"
 
 #include <string.h>
+#include <unistd.h>
 
 #include "opal/mca/timer/timer.h"
 #include "opal/mca/timer/base/base.h"
@@ -110,6 +111,9 @@ static int opal_timer_linux_find_freq(void)
     int ret;
     char buf[1024];
 
+    if(!access("/proc/cpuinfo", F_OK)) {
+        return OPAL_ERR_IN_ERRNO;
+    }
     fp = fopen("/proc/cpuinfo", "r");
     if (NULL == fp) {
         return OPAL_ERR_IN_ERRNO;

--- a/opal/runtime/opal_cr.c
+++ b/opal/runtime/opal_cr.c
@@ -987,7 +987,7 @@ static int extract_env_vars(int prev_pid, char * file_name)
         goto cleanup;
     }
 
-    if (NULL == (env_data = fopen(file_name, "r")) ) {
+    if (!access(env_data, F_OK) || NULL == (env_data = fopen(file_name, "r")) ) {
         exit_status = OPAL_ERROR;
         goto cleanup;
     }

--- a/opal/tools/opal-restart/opal-restart.c
+++ b/opal/tools/opal-restart/opal-restart.c
@@ -214,7 +214,7 @@ main(int argc, char *argv[])
                  opal_restart_globals.snapshot_loc,
                  opal_restart_globals.snapshot_ref,
                  opal_restart_globals.snapshot_metadata);
-        if( NULL == (metadata = fopen(full_metadata_path, "r")) ) {
+        if(!access(full_metadata_path, F_OK) || NULL == (metadata = fopen(full_metadata_path, "r")) ) {
             opal_show_help("help-opal-restart.txt", "invalid_metadata", true,
                            opal_restart_globals.snapshot_metadata,
                            full_metadata_path);
@@ -657,7 +657,7 @@ static int post_env_vars(int prev_pid, opal_crs_base_snapshot_t *snapshot)
     /*
      * Any directories that need to be created
      */
-    if( NULL == (snapshot->metadata = fopen(snapshot->metadata_filename, "r")) ) {
+    if(!access(snapshot->metadata_filename, F_OK) || NULL == (snapshot->metadata = fopen(snapshot->metadata_filename, "r")) ) {
         opal_show_help("help-opal-restart.txt", "invalid_metadata", true,
                        opal_restart_globals.snapshot_metadata,
                        snapshot->metadata_filename);

--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -28,6 +28,7 @@
 #include "opal/threads/mutex.h"
 #include <string.h>
 #include <ctype.h>
+#include <unistd.h>
 
 int opal_util_keyval_parse_lineno = 0;
 
@@ -76,6 +77,10 @@ opal_util_keyval_parse(const char *filename,
     keyval_filename = filename;
     keyval_callback = callback;
 
+    if (!access(keyval_filename, F_OK)) {
+        ret = OPAL_ERR_NOT_FOUND;
+        goto cleanup;
+    }
     /* Open the opal */
     opal_util_keyval_yyin = fopen(keyval_filename, "r");
     if (NULL == opal_util_keyval_yyin) {

--- a/opal/util/show_help.c
+++ b/opal/util/show_help.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <locale.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "opal/mca/installdirs/installdirs.h"
 #include "opal/util/show_help.h"
@@ -158,13 +159,20 @@ static int open_file(const char *base, const char *topic)
          */
         for (i=0; NULL != search_dirs[i]; i++) {
             filename = opal_os_path( false, search_dirs[i], base, NULL );
+            if(!access(filename, F_OK)) {
+              goto doesntexist;
+            }
             opal_show_help_yyin = fopen(filename, "r");
             if (NULL == opal_show_help_yyin) {
+            doesntexist:
                 asprintf(&err_msg, "%s: %s", filename, strerror(errno));
                 base_len = strlen(base);
                 if (4 > base_len || 0 != strcmp(base + base_len - 4, ".txt")) {
                     free(filename);
                     asprintf(&filename, "%s%s%s.txt", search_dirs[i], OPAL_PATH_SEP, base);
+                    if(!access(filename, F_OK)) {
+                      break;
+                    }
                     opal_show_help_yyin = fopen(filename, "r");
                 }
             }

--- a/orte/mca/common/alps/common_alps.c
+++ b/orte/mca/common/alps/common_alps.c
@@ -50,12 +50,15 @@ int orte_common_alps_proc_in_pagg(bool *flag)
         return ORTE_ERR_BAD_PARAM;
     }
 
-    fd = fopen(proc_job_file, "r");
-    if (fd == NULL) {
+    if (!access(proc_job_file, F_OK) || NULL == (fd = fopen(proc_job_file, "r"));
         *flag = 0;
     } else {
         snprintf(task_is_app_fname,sizeof(task_is_app_fname),
                  "/proc/self/task/%ld/task_is_app",syscall(SYS_gettid));
+        if(!access(task_is_app_fname, F_OK)) {
+            *flag = 0;
+            return rc;
+        }
         fd_task_is_app = fopen(task_is_app_fname, "r");
         if (fd_task_is_app != NULL) {   /* okay we're in a PAGG container,
                                            and we are an app task (not just a process

--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -121,8 +121,7 @@ static int rte_init(void)
             }
 
             /* open the file and extract the uri */
-            fp = fopen(filename, "r");
-            if (NULL == fp) { /* can't find or read file! */
+            if (!access(filename, F_OK) || NULL == (fp = fopen(filename, "r"))) { /* can't find or read file! */
                 orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-access", true,
                                "singleton", mca_ess_singleton_component.server_uri);
                 return ORTE_ERROR;

--- a/orte/mca/ras/alps/ras_alps_module.c
+++ b/orte/mca/ras/alps/ras_alps_module.c
@@ -247,7 +247,7 @@ orte_ras_get_appinfo_path(void)
                             "ras:alps:allocate: Trying ALPS configuration "
                             "file: \"%s\"",
                             sysconfigs[i].path);
-        if (NULL == (fp = fopen(sysconfigs[i].path, "r"))) {
+        if (!access(sysconfigs[i].path, F_OK) || NULL == (fp = fopen(sysconfigs[i].path, "r"))) {
             int err = errno;
             opal_output_verbose(1, orte_ras_base_framework.framework_output,
                                 "ras:alps:allocate: Skipping ALPS "

--- a/orte/mca/ras/gridengine/ras_gridengine_module.c
+++ b/orte/mca/ras/gridengine/ras_gridengine_module.c
@@ -78,7 +78,7 @@ static int orte_ras_gridengine_allocate(orte_job_t *jdata, opal_list_t *nodelist
     }
 
     /* check the PE_HOSTFILE before continuing on */
-    if (!(fp = fopen(pe_hostfile, "r"))) {
+    if (!access(pe_hostfile, F_OK) || !(fp = fopen(pe_hostfile, "r"))) {
         orte_show_help("help-ras-gridengine.txt", "cannot-read-pe-hostfile",
             true, pe_hostfile, strerror(errno));
         rc = ORTE_ERROR;
@@ -166,7 +166,7 @@ static int get_slot_count(char* node_name, int* slot_cnt)
     FILE *fp;
 
     /* check the PE_HOSTFILE before continuing on */
-    if (!(fp = fopen(pe_hostfile, "r"))) {
+    if (!access(pe_hostfile, F_OK) || !(fp = fopen(pe_hostfile, "r"))) {
         orte_show_help("help-ras-gridengine.txt", "cannot-read-pe-hostfile",
             true, pe_hostfile, strerror(errno));
         ORTE_ERROR_LOG(ORTE_ERROR);

--- a/orte/mca/ras/slurm/ras_slurm_module.c
+++ b/orte/mca/ras/slurm/ras_slurm_module.c
@@ -1185,7 +1185,7 @@ static int read_ip_port(char *filename, char **ip, uint16_t *port)
     bool found_port = false;
     bool found_ip = false;
 
-    if (NULL == (fp = fopen(filename, "r"))) {
+    if (!access(filename, F_OK) || NULL == (fp = fopen(filename, "r"))) {
         orte_show_help("help-ras-slurm.txt", "config-file-not-found", true, filename);
         return ORTE_ERR_SILENT;
     }

--- a/orte/mca/rmaps/seq/rmaps_seq.c
+++ b/orte/mca/rmaps/seq/rmaps_seq.c
@@ -162,8 +162,8 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
     if (NULL != orte_default_hostfile) {
         char *hstname = NULL;
         /* open the file */
-        fp = fopen(orte_default_hostfile, "r");
-        if (NULL == fp) {
+        if (!access(orte_default_hostfile, F_OK) ||
+		NULL == (fp = fopen(orte_default_hostfile, "r"))) {
             ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
             rc = ORTE_ERR_NOT_FOUND;
             goto error;
@@ -269,8 +269,8 @@ static int orte_rmaps_seq_map(orte_job_t *jdata)
                                 "mca:rmaps:seq: using hostfile %s nodes on app %s", hosts, app->app);
             OBJ_CONSTRUCT(&sq_list, opal_list_t);
             /* open the file */
-            fp = fopen(hosts, "r");
-            if (NULL == fp) {
+            if(!access(hosts, F_OK) || 
+            		NULL == (fp = fopen(hosts, "r"))) {
                 ORTE_ERROR_LOG(ORTE_ERR_NOT_FOUND);
                 rc = ORTE_ERR_NOT_FOUND;
                 OBJ_DESTRUCT(&sq_list);

--- a/orte/mca/rtc/hwloc/rtc_hwloc.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.c
@@ -113,6 +113,9 @@ static int init(void)
                                         &shmemaddr, shmemsize))) {
         /* we couldn't find a hole, so don't use the shmem support */
         if (4 < opal_output_get_verbosity(orte_rtc_base_framework.framework_output)) {
+            if (!access("/proc/self/maps", F_OK)) {
+                return ORTE_SUCCESS;
+            }
             FILE *file = fopen("/proc/self/maps", "r");
             if (file) {
                 char line[256];
@@ -572,6 +575,9 @@ static int find_hole(orte_rtc_hwloc_vm_hole_kind_t hkind,
     FILE *file;
     char line[96];
 
+    if (!access("/proc/self/maps", F_OK)) {
+      return ORTE_ERROR;
+    }
     file = fopen("/proc/self/maps", "r");
     if (!file) {
         return ORTE_ERROR;

--- a/orte/mca/sstore/base/sstore_base_fns.c
+++ b/orte/mca/sstore/base/sstore_base_fns.c
@@ -581,6 +581,7 @@ int orte_sstore_base_extract_global_metadata(orte_sstore_base_global_snapshot_in
     orte_process_name_t proc;
     opal_list_item_t* item = NULL;
     orte_sstore_base_local_snapshot_info_t *vpid_snapshot = NULL;
+    char *mdfname = global_snapshot->metadata_filename;
 
     /*
      * Cleanup the structure a bit, so we can refresh it below
@@ -602,7 +603,7 @@ int orte_sstore_base_extract_global_metadata(orte_sstore_base_global_snapshot_in
     /*
      * Open the metadata file
      */
-    if (NULL == (metadata = fopen(global_snapshot->metadata_filename, "r")) ) {
+    if (!access(mdfname, F_OK) || NULL == (metadata = fopen(mdfname, "r")) ) {
         opal_output(orte_sstore_base_framework.framework_output,
                     "sstore:base:extract_global_metadata() Unable to open the file (%s)\n",
                     global_snapshot->metadata_filename);
@@ -699,13 +700,14 @@ int orte_sstore_base_find_largest_seq_num(orte_sstore_base_global_snapshot_info_
     int exit_status = ORTE_SUCCESS;
     FILE *metadata = NULL;
     int tmp_seq_num = -1;
+    char *mdfname = global_snapshot->metadata_filename;
 
     *seq_num = -1;
 
     /*
      * Open the metadata file
      */
-    if (NULL == (metadata = fopen(global_snapshot->metadata_filename, "r")) ) {
+    if (!access(mdfname, F_OK) || NULL == (metadata = fopen(mdfname, "r")) ) {
         opal_output(orte_sstore_base_framework.framework_output,
                     "sstore:base:find_largest_seq_num() Unable to open the file (%s)\n",
                     global_snapshot->metadata_filename);
@@ -739,6 +741,7 @@ int orte_sstore_base_find_all_seq_nums(orte_sstore_base_global_snapshot_info_t *
     FILE *metadata = NULL;
     int tmp_seq_num = -1;
     char * tmp_str = NULL;
+    char *mdfname = global_snapshot->metadata_filename;
 
     *num_seq = 0;
     *seq_list = NULL;
@@ -746,7 +749,7 @@ int orte_sstore_base_find_all_seq_nums(orte_sstore_base_global_snapshot_info_t *
     /*
      * Open the metadata file
      */
-    if (NULL == (metadata = fopen(global_snapshot->metadata_filename, "r")) ) {
+    if (!access(mdfname, F_OK) || NULL == (metadata = fopen(mdfname, "r")) ) {
         opal_output(orte_sstore_base_framework.framework_output,
                     "sstore:base:find_all_seq_nums() Unable to open the file (%s)\n",
                     global_snapshot->metadata_filename);

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -393,10 +393,13 @@ int orte_submit_init(int argc, char *argv[],
                 orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-bad", true, "uri", orte_cmd_options.hnp);
                 exit(1);
             }
-
+            if (!access(filename, F_OK)) { /* can't find file! */
+                orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-access", true, orte_cmd_options.hnp);
+                exit(1);
+            }
             /* open the file and extract the uri */
             fp = fopen(filename, "r");
-            if (NULL == fp) { /* can't find or read file! */
+            if (NULL == fp) { /* can't read file! */
                 orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-access", true, orte_cmd_options.hnp);
                 exit(1);
             }
@@ -1884,7 +1887,11 @@ static int parse_appfile(orte_job_t *jdata, char *filename, char ***env)
     }
 
     /* Try to open the file */
-
+    if (!access(filename, F_OK)) {
+        orte_show_help("help-orterun.txt", "orterun:appfile-not-found", true,
+                       filename);
+        return ORTE_ERR_NOT_FOUND;
+    }
     fp = fopen(filename, "r");
     if (NULL == fp) {
         orte_show_help("help-orterun.txt", "orterun:appfile-not-found", true,

--- a/orte/orted/pmix/pmix_server_pub.c
+++ b/orte/orted/pmix/pmix_server_pub.c
@@ -82,9 +82,14 @@ static int init_server(void)
                 return ORTE_ERR_BAD_PARAM;
             }
 
+            if (!access(filename, F_OK)) { /* can't find file! */
+              orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-access", true,
+                             orte_basename, orte_data_server_uri);
+              return ORTE_ERR_BAD_PARAM;
+            }
             /* open the file and extract the uri */
             fp = fopen(filename, "r");
-            if (NULL == fp) { /* can't find or read file! */
+            if (NULL == fp) { /* can't read file! */
                 orte_show_help("help-orterun.txt", "orterun:ompi-server-filename-access", true,
                                orte_basename, orte_data_server_uri);
                 return ORTE_ERR_BAD_PARAM;

--- a/orte/test/mpi/pconnect.c
+++ b/orte/test/mpi/pconnect.c
@@ -41,8 +41,18 @@ int main(int argc, char* argv[])
 
     MPI_Init(&argc, &argv);
 
+    if (!access(argv[1], F_OK)) {
+      fprintf(stderr, "file %s not found\n", argv[1]);
+      exit(1);
+    }
+
     /* read the file */
     fp = fopen(argv[1], "r");
+    if(NULL == fp) {
+      fprintf(stderr, "could not open %s for reading\n", argv[1]);
+      exit(1);
+    }
+
     fgets(port, 1024, fp);
     port[strlen(port)-1] = '\0';  /* remove newline */
     fclose(fp);

--- a/orte/tools/orte-top/orte-top.c
+++ b/orte/tools/orte-top/orte-top.c
@@ -322,9 +322,14 @@ main(int argc, char *argv[])
                 exit(1);
             }
 
+            if (!access(filename, F_OK)) { /* can't find file! */
+                orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-access", true, filename);
+                orte_finalize();
+                exit(1);
+            }
             /* open the file and extract the pid */
             fp = fopen(filename, "r");
-            if (NULL == fp) { /* can't find or read file! */
+            if (NULL == fp) { /* can't read file! */
                 orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-access", true, filename);
                 orte_finalize();
                 exit(1);
@@ -399,9 +404,14 @@ main(int argc, char *argv[])
                 exit(1);
             }
 
+            if(!access(filename, F_OK)) { /* can't find file! */
+                orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-access", true, filename);
+                orte_finalize();
+                exit(1);
+            }
             /* open the file and extract the uri */
             fp = fopen(filename, "r");
-            if (NULL == fp) { /* can't find or read file! */
+            if (NULL == fp) { /* can't read file! */
                 orte_show_help("help-orte-top.txt", "orte-top:hnp-filename-access", true, filename);
                 orte_finalize();
                 exit(1);

--- a/orte/util/hnp_contact.c
+++ b/orte/util/hnp_contact.c
@@ -108,13 +108,16 @@ int orte_read_hnp_contact_file(char *filename, orte_hnp_contact_t *hnp, bool con
     int rc;
     opal_value_t val;
 
+    if (!access(filename, F_OK))
+      /* failed on first access - wait and try again */
+      sleep(1);
+    if (!access(filename, F_OK))
+      /* failed twice - give up */
+      return ORTE_ERR_FILE_OPEN_FAILURE;
+
     fp = fopen(filename, "r");
-    if (NULL == fp) { /* failed on first read - wait and try again */
-        fp = fopen(filename, "r");
-        if (NULL == fp) { /* failed twice - give up */
-            return ORTE_ERR_FILE_OPEN_FAILURE;
-        }
-    }
+    if (NULL == fp)
+      return ORTE_ERR_FILE_OPEN_FAILURE;
 
     hnp_uri = orte_getline(fp);
     if (NULL == hnp_uri) {

--- a/orte/util/hostfile/hostfile.c
+++ b/orte/util/hostfile/hostfile.c
@@ -454,8 +454,11 @@ static int hostfile_parse(const char *hostfile, opal_list_t* updates,
     cur_hostfile_name = hostfile;
 
     orte_util_hostfile_done = false;
+    if (!access(hostfile, F_OK))
+      goto errpath;
     orte_util_hostfile_in = fopen(hostfile, "r");
     if (NULL == orte_util_hostfile_in) {
+errpath:
         if (NULL == orte_default_hostfile ||
             0 != strcmp(orte_default_hostfile, hostfile)) {
             /* not the default hostfile, so not finding it

--- a/oshmem/mca/memheap/base/memheap_base_static.c
+++ b/oshmem/mca/memheap/base/memheap_base_static.c
@@ -176,12 +176,15 @@ static int _load_segments(void)
 
     memheap_context.n_segments = 0;
     /* FIXME!!! Linux specific code */
+    if (!access("/proc/self/maps", F_OK)) {
+        MEMHEAP_ERROR("Cannot access /proc/self/maps");
+        return OSHMEM_ERROR;
+    }
     fp = fopen("/proc/self/maps", "r");
-    if (NULL == fp) {
+    if (fp == NULL) {
         MEMHEAP_ERROR("Failed to open /proc/self/maps");
         return OSHMEM_ERROR;
     }
-
     while (NULL != fgets(line, sizeof(line), fp)) {
         memset(&seg, 0, sizeof(seg));
         if (3 > sscanf(line,

--- a/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
+++ b/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
@@ -306,7 +306,7 @@ size_t sshmem_sysv_gethugepagesize(void)
     FILE *f;
 
     /* Cache the huge page size value */
-    if (huge_page_size == 0) {
+    if (huge_page_size == 0 && access("/proc/meminfo", F_OK)) {
         f = fopen("/proc/meminfo", "r");
         if (f != NULL) {
             while (fgets(buf, sizeof(buf), f)) {

--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -156,6 +156,8 @@ void get_mounts (int * num_dirs, char ** dirs[], bool * nfs[])
        because we would run this test on a system with a larger number
        of mount points than the array.  So just count and make sure to
        have an array large enough. */
+    if(!access("opal_path_nfs.out", F_OK))
+        goto out;
     file = fopen("opal_path_nfs.out", "r");
     int count = 0;
     while (NULL != fgets (buffer, SIZE, file)) {


### PR DESCRIPTION
One of the invariants of the fopen() function called with the "r"
option is that the file exist before the function is called. If
this is not the case behavior is undefined (in the case of glibc
on some Crays and Redhat machines this means you get a segfault
in fileno_unlocked()). This commit is a first attempt at ensuring
this invariant holds when calls to fopen() are made.