### PR TITLE
v3.1: Disable syslog support on OSX 10.13

### DIFF
--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -174,8 +174,10 @@ static void set_defaults(opal_output_stream_t *lds)
     /* Load up defaults */
 
     OBJ_CONSTRUCT(lds, opal_output_stream_t);
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
     lds->lds_syslog_priority = LOG_INFO;
     lds->lds_syslog_ident = "ompi";
+#endif
     lds->lds_want_stderr = true;
 }
 
@@ -205,10 +207,15 @@ static void parse_verbose(char *e, opal_output_stream_t *lds)
         }
 
         if (0 == strcasecmp(ptr, "syslog")) {
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             have_output = true;
+#else
+            opal_output(0, "syslog support requested but not available on this system");
+#endif  /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
         }
         else if (strncasecmp(ptr, "syslogpri:", 10) == 0) {
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             have_output = true;
             if (strcasecmp(ptr + 10, "notice") == 0)
@@ -217,9 +224,16 @@ static void parse_verbose(char *e, opal_output_stream_t *lds)
                 lds->lds_syslog_priority = LOG_INFO;
             else if (strcasecmp(ptr + 10, "DEBUG") == 0)
                 lds->lds_syslog_priority = LOG_DEBUG;
+#else
+            opal_output(0, "syslog support requested but not available on this system");
+#endif  /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
         } else if (strncasecmp(ptr, "syslogid:", 9) == 0) {
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             lds->lds_syslog_ident = ptr + 9;
+#else
+            opal_output(0, "syslog support requested but not available on this system");
+#endif  /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
         }
 
         else if (strcasecmp(ptr, "stdout") == 0) {

--- a/opal/mca/pmix/pmix2x/pmix/src/mca/base/pmix_mca_base_open.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/base/pmix_mca_base_open.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -171,7 +171,9 @@ static void set_defaults(pmix_output_stream_t *lds)
     /* Load up defaults */
 
     PMIX_CONSTRUCT(lds, pmix_output_stream_t);
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
     lds->lds_syslog_priority = LOG_INFO;
+#endif  /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
     lds->lds_syslog_ident = "ompi";
     lds->lds_want_stderr = true;
 }
@@ -202,10 +204,15 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds)
         }
 
         if (0 == strcasecmp(ptr, "syslog")) {
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             have_output = true;
+#else
+            pmix_output(0, "syslog support requested but not available on this system");
+#endif  /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
         }
         else if (strncasecmp(ptr, "syslogpri:", 10) == 0) {
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             have_output = true;
             if (strcasecmp(ptr + 10, "notice") == 0)
@@ -214,9 +221,16 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds)
                 lds->lds_syslog_priority = LOG_INFO;
             else if (strcasecmp(ptr + 10, "DEBUG") == 0)
                 lds->lds_syslog_priority = LOG_DEBUG;
+#else
+            pmix_output(0, "syslog support requested but not available on this system");
+#endif  /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
         } else if (strncasecmp(ptr, "syslogid:", 9) == 0) {
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             lds->lds_syslog_ident = ptr + 9;
+#else
+            pmix_output(0, "syslog support requested but not available on this system");
+#endif  /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
         }
 
         else if (strcasecmp(ptr, "stdout") == 0) {

--- a/opal/mca/pmix/pmix2x/pmix/src/util/output.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/util/output.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -143,6 +143,7 @@ bool pmix_output_init(void)
         }
     }
     str = getenv("PMIX_OUTPUT_SYSLOG_PRI");
+#ifdef HAVE_SYSLOG_H
     if (NULL != str) {
         if (0 == strcasecmp(str, "info")) {
             pmix_output_redirected_syslog_pri = LOG_INFO;
@@ -156,6 +157,7 @@ bool pmix_output_init(void)
     } else {
         pmix_output_redirected_syslog_pri = LOG_ERR;
     }
+#endif
 
     str = getenv("PMIX_OUTPUT_SYSLOG_IDENT");
     if (NULL != str) {

--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2008 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -147,6 +147,7 @@ bool opal_output_init(void)
         }
     }
     str = getenv("OPAL_OUTPUT_SYSLOG_PRI");
+#ifdef HAVE_SYSLOG_H
     if (NULL != str) {
         if (0 == strcasecmp(str, "info")) {
             opal_output_redirected_syslog_pri = LOG_INFO;
@@ -160,7 +161,7 @@ bool opal_output_init(void)
     } else {
         opal_output_redirected_syslog_pri = LOG_ERR;
     }
-
+#endif  /* HAVE_SYSLOG_H */
     str = getenv("OPAL_OUTPUT_SYSLOG_IDENT");
     if (NULL != str) {
         redirect_syslog_ident = strdup(str);
@@ -349,7 +350,7 @@ void opal_output_close(int output_id)
             }
         }
 
-#if defined(HAVE_SYSLOG)
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
         if (i >= OPAL_OUTPUT_MAX_STREAMS && syslog_opened) {
             closelog();
         }
@@ -612,7 +613,7 @@ static int do_open(int output_id, opal_output_stream_t * lds)
     info[i].ldi_verbose_level = lds->lds_verbose_level;
 
 #if USE_SYSLOG
-#if defined(HAVE_SYSLOG)
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
     if (opal_output_redirected_to_syslog) {
         info[i].ldi_syslog = true;
         info[i].ldi_syslog_priority = opal_output_redirected_syslog_pri;
@@ -629,7 +630,7 @@ static int do_open(int output_id, opal_output_stream_t * lds)
         info[i].ldi_syslog = lds->lds_want_syslog;
         if (lds->lds_want_syslog) {
 
-#if defined(HAVE_SYSLOG)
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             if (NULL != lds->lds_syslog_ident) {
                 info[i].ldi_syslog_ident = strdup(lds->lds_syslog_ident);
                 openlog(lds->lds_syslog_ident, LOG_PID, LOG_USER);
@@ -642,7 +643,7 @@ static int do_open(int output_id, opal_output_stream_t * lds)
             info[i].ldi_syslog_priority = lds->lds_syslog_priority;
         }
 
-#if defined(HAVE_SYSLOG)
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
     }
 #endif
 
@@ -951,7 +952,7 @@ static int output(int output_id, const char *format, va_list arglist)
         }
 
         /* Syslog output -- does not use the newline-appended string */
-#if defined(HAVE_SYSLOG)
+#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
         if (ldi->ldi_syslog) {
             syslog(ldi->ldi_syslog_priority, "%s", str);
         }

--- a/orte/mca/notifier/notifier.h
+++ b/orte/mca/notifier/notifier.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -68,6 +68,7 @@ ORTE_DECLSPEC extern int orte_notifier_debug_output;
 
 /* Severities */
 typedef enum {
+#ifdef HAVE_SYSLOG_H
     ORTE_NOTIFIER_EMERG = LOG_EMERG,
     ORTE_NOTIFIER_ALERT = LOG_ALERT,
     ORTE_NOTIFIER_CRIT = LOG_CRIT,
@@ -76,6 +77,16 @@ typedef enum {
     ORTE_NOTIFIER_NOTICE = LOG_NOTICE,
     ORTE_NOTIFIER_INFO = LOG_INFO,
     ORTE_NOTIFIER_DEBUG = LOG_DEBUG
+#else
+    ORTE_NOTIFIER_EMERG,
+    ORTE_NOTIFIER_ALERT,
+    ORTE_NOTIFIER_CRIT,
+    ORTE_NOTIFIER_ERROR,
+    ORTE_NOTIFIER_WARN,
+    ORTE_NOTIFIER_NOTICE,
+    ORTE_NOTIFIER_INFO,
+    ORTE_NOTIFIER_DEBUG
+#endif
 } orte_notifier_severity_t;
 
 typedef struct {

--- a/orte/mca/notifier/syslog/configure.m4
+++ b/orte/mca/notifier/syslog/configure.m4
@@ -1,0 +1,31 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2017 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_notifier_syslog_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_orte_notifier_syslog_CONFIG], [
+    AC_CONFIG_FILES([orte/mca/notifier/syslog/Makefile])
+
+    OPAL_VAR_SCOPE_PUSH([orte_notifier_syslog_happy])
+
+    # Per https://github.com/open-mpi/ompi/issues/4373 and
+    # https://github.com/open-mpi/ompi/pull/4374, we need to check
+    # that syslog.h is compilable.  If syslog.h is not compilable,
+    # disable this component.
+    AC_CHECK_HEADER([syslog.h],
+        [orte_notifier_syslog_happy=1],
+        [orte_notifier_syslog_happy=0])
+
+    AS_IF([test $orte_notifier_syslog_happy -eq 1],
+          [$1],
+          [$2])
+
+    OPAL_VAR_SCOPE_POP
+])dnl


### PR DESCRIPTION
Fix OSX 10.13 syslog.h issue with gcc 7.x
Backport 8f32b345de.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>