### PR TITLE
Update the scaling script to avoid use of "system" command

### DIFF
--- a/orte/tools/prun/prun.c
+++ b/orte/tools/prun/prun.c
@@ -781,7 +781,8 @@ static int create_app(int argc, char* argv[],
     /* Grab all MCA environment variables */
     app->env = opal_argv_copy(*app_env);
     for (i=0; NULL != environ[i]; i++) {
-        if (0 == strncmp("PMIX_", environ[i], 5)) {
+        if (0 == strncmp("PMIX_", environ[i], 5) ||
+            0 == strncmp("OMPI_", environ[i], 5)) {
             /* check for duplicate in app->env - this
              * would have been placed there by the
              * cmd line processor. By convention, we


### PR DESCRIPTION
Update the scaling script to avoid use of "system" command, thus ensuring that each command sees the same environment. Fix prun to pickup and propagate OMPI MCA params

Signed-off-by: Ralph Castain <rhc@open-mpi.org>