### PR TITLE
configury: revamp ucx detection

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -20,86 +20,97 @@
 # LDFLAGS, LIBS} as needed and runs action-if-found if there is
 # support, otherwise executes action-if-not-found
 AC_DEFUN([OMPI_CHECK_UCX],[
-    if test -z "$ompi_check_ucx_happy" ; then
-	AC_ARG_WITH([ucx],
-		    [AC_HELP_STRING([--with-ucx(=DIR)],
-				    [Build with Unified Communication X library support])])
-	OPAL_CHECK_WITHDIR([ucx], [$with_ucx], [include/ucp/api/ucp.h])
-	AC_ARG_WITH([ucx-libdir],
-		    [AC_HELP_STRING([--with-ucx-libdir=DIR],
-				    [Search for Unified Communication X libraries in DIR])])
-	OPAL_CHECK_WITHDIR([ucx-libdir], [$with_ucx_libdir], [libucp.*])
+    OPAL_VAR_SCOPE_PUSH([ompi_check_ucx_dir])
 
-	AS_IF([test "$with_ucx" != "no"],
-              [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "yes"],
-                     [_x_ac_ucx_dirs="$with_ucx"],
-                     [
-                        PKG_CHECK_MODULES_STATIC([ucx],[ucx],
-                                          [_x_ac_ucx_dirs=`$PKG_CONFIG --variable=prefix ucx`],
-                                          [_x_ac_ucx_dirs="/usr /usr/local /opt/ucx"])
-                     ])
-                for ompi_check_ucx_dir in $_x_ac_ucx_dirs; do
-                    AS_IF([test ! -z "$with_ucx_libdir" && test "$with_ucx_libdir" != "yes"],
-                          [
-                            ompi_check_ucx_libdir="$with_ucx_libdir"
-                            ompi_check_ucx_extra_libs="-L$ompi_check_ucx_libdir"
-                          ],
-                          [AS_IF([test ! -z "$ompi_check_ucx_dir"],
-                                 [
-                                    ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib
-                                    ompi_check_ucx_extra_libs="-L$ompi_check_ucx_libdir"
-                                 ])])
+    AS_IF([test -z "$ompi_check_ucx_happy"],
+          [AC_ARG_WITH([ucx],
+		       [AC_HELP_STRING([--with-ucx(=DIR)],
+				       [Build with Unified Communication X library support])])
+	   OPAL_CHECK_WITHDIR([ucx], [$with_ucx], [include/ucp/api/ucp.h])
+	   AC_ARG_WITH([ucx-libdir],
+		       [AC_HELP_STRING([--with-ucx-libdir=DIR],
+				       [Search for Unified Communication X libraries in DIR])])
+	   OPAL_CHECK_WITHDIR([ucx-libdir], [$with_ucx_libdir], [libucp.*])
 
-                    ompi_check_ucx_$1_save_CPPFLAGS="$CPPFLAGS"
-                    ompi_check_ucx_$1_save_LDFLAGS="$LDFLAGS"
-                    ompi_check_ucx_$1_save_LIBS="$LIBS"
+	   AS_IF([test "$with_ucx" != "no"],
+                 [AS_IF([test -n "$with_ucx" && test "$with_ucx" != "yes"],
+                        [ompi_check_ucx_dir="$with_ucx"],
+                        [PKG_CHECK_MODULES_STATIC([ucx],[ucx],
+                                             [ompi_check_ucx_dir=`$PKG_CONFIG --variable=prefix ucx`
+                                              AS_IF([test "$ompi_check_ucx_dir" = "/usr"],
+                                                    [ompi_check_ucx_dir=])],
+                                             [true])])
+                  ompi_check_ucx_happy="no"
+                  AS_IF([test -z "$ompi_check_ucx_dir"],
+                        [OPAL_CHECK_PACKAGE([ompi_check_ucx],
+                                   [ucp/api/ucp.h],
+                                   [ucp],
+                                   [ucp_cleanup],
+                                   [],
+                                   [],
+                                   [],
+                                   [ompi_check_ucx_happy="yes"],
+                                   [ompi_check_ucx_happy="no"])
+                         AS_IF([test "$ompi_check_ucx_happy" = yes],
+                               [AC_MSG_CHECKING(for UCX version compatibility)
+                                AC_REQUIRE_CPP
+                                AC_COMPILE_IFELSE(
+                                    [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
+                                    [ompi_check_ucx_happy="yes"],
+                                    [ompi_check_ucx_happy="no"])
 
-                    OPAL_CHECK_PACKAGE([ompi_check_ucx],
-                                [ucp/api/ucp.h],
-                                [ucp],
-                                [ucp_cleanup],
-                                [$ompi_check_ucx_extra_libs],
-                                [$ompi_check_ucx_dir],
-                                [$ompi_check_ucx_libdir],
-                                [ompi_check_ucx_happy="yes"],
-                                [ompi_check_ucx_happy="no"])
-                    CPPFLAGS="$ompi_check_ucx_$1_save_CPPFLAGS"
-                    LDFLAGS="$ompi_check_ucx_$1_save_LDFLAGS"
-                    LIBS="$ompi_check_ucx_$1_save_LIBS"
+                                AC_MSG_RESULT([$ompi_check_ucx_happy])])
+                         AS_IF([test "$ompi_check_ucx_happy" = "no"],
+                               [ompi_check_ucx_dir=/opt/ucx])])
+                  AS_IF([test "$ompi_check_ucx_happy" != yes],
+                        [AS_IF([test -n "$with_ucx_libdir"],
+                               [ompi_check_ucx_libdir="$with_ucx_libdir"],
+                               [files=`ls $ompi_check_ucx_dir/lib64/libucp.* 2> /dev/null | wc -l`
+                                AS_IF([test "$files" -gt 0],
+                                      [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib64],
+                                      [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib])])
 
-                    if test "$ompi_check_ucx_happy" = no; then
-                        continue
-                    fi
+                         ompi_check_ucx_$1_save_CPPFLAGS="$CPPFLAGS"
+                         ompi_check_ucx_$1_save_LDFLAGS="$LDFLAGS"
+                         ompi_check_ucx_$1_save_LIBS="$LIBS"
 
-                    AC_MSG_CHECKING(for UCX version compatibility)
-                    AC_REQUIRE_CPP
-                    old_CPPFLAGS="$CPPFLAGS"
-                    CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"
-                    AC_COMPILE_IFELSE(
-                        [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
-                        [ompi_ucx_version_ok="yes"],
-                        [ompi_ucx_version_ok="no"])
+                         OPAL_CHECK_PACKAGE([ompi_check_ucx],
+                                            [ucp/api/ucp.h],
+                                            [ucp],
+                                            [ucp_cleanup],
+                                            [],
+                                            [$ompi_check_ucx_dir],
+                                            [$ompi_check_ucx_libdir],
+                                            [ompi_check_ucx_happy="yes"],
+                                            [ompi_check_ucx_happy="no"])
+                         CPPFLAGS="$ompi_check_ucx_$1_save_CPPFLAGS"
+                         LDFLAGS="$ompi_check_ucx_$1_save_LDFLAGS"
+                         LIBS="$ompi_check_ucx_$1_save_LIBS"
 
-                    AC_MSG_RESULT([$ompi_ucx_version_ok])
-                    CPPFLAGS=$old_CPPFLAGS
+                         AS_IF([test "$ompi_check_ucx_happy" = yes],
+                               [AC_MSG_CHECKING(for UCX version compatibility)
+                                AC_REQUIRE_CPP
+                                old_CPPFLAGS="$CPPFLAGS"
+                                CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"
+                                AC_COMPILE_IFELSE(
+                                    [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
+                                    [ompi_check_ucx_happy="yes"],
+                                    [ompi_check_ucx_happy="no"])
 
-                    AS_IF([test "$ompi_ucx_version_ok" = "no"], [ompi_check_ucx_happy="no"])
+                                AC_MSG_RESULT([$ompi_check_ucx_happy])
+                                CPPFLAGS=$old_CPPFLAGS])])
 
-                    if test "$ompi_check_ucx_happy" = yes; then
-                        break
-                    fi
-                done],
-            [ompi_check_ucx_happy="no"])
-        OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])
-    fi
+                  OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])])])
 
     AS_IF([test "$ompi_check_ucx_happy" = "yes"],
           [$1_CPPFLAGS="[$]$1_CPPFLAGS $ompi_check_ucx_CPPFLAGS"
-	   $1_LDFLAGS="[$]$1_LDFLAGS $ompi_check_ucx_LDFLAGS"
-	   $1_LIBS="[$]$1_LIBS $ompi_check_ucx_LIBS"
-	   $2],
+           $1_LDFLAGS="[$]$1_LDFLAGS $ompi_check_ucx_LDFLAGS"
+           $1_LIBS="[$]$1_LIBS $ompi_check_ucx_LIBS"
+           $2],
           [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "no"],
                  [AC_MSG_ERROR([UCX support requested but not found.  Aborting])])
            $3])
+
+    OPAL_VAR_SCOPE_POP
 ])
 


### PR DESCRIPTION
 - when --with-ucx=DIR is not set, try the default path and fallback to /opt/ucx
 - when --with-ucx-libdir is not set, try lib64 and then lib directories
 - do not handle --with-ucx-libdir (this is a user mistake, no need to over-complicate our logic)

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>