### PR TITLE
AUTHORS: update for 2.0.4

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,8 @@ Brice Goglin, INRIA
   brice.goglin@inria.fr
 Camille Coti, University of Tennessee-Knoxville, INRIA
   ccoti@icl.utk.edu
+Carlos Bederián, CONICET, Universidad Nacional de Cordoba
+  bc@famaf.unc.edu.ar
 Christian Bell, QLogic
   christian.bell@qlogic.com
 Christoph Niethammer, High Performance Computing Center, Stuttgart
@@ -322,6 +324,8 @@ Weikuan Yu, Los Alamos National Laboratory
   yuw@lanl.gov
 Wesley Bland, University of Tennessee-Knoxville
   wbland@icl.utk.edu
+William LePera, IBM
+  lepera@us.ibm.com
 William Throwe, Individual
   wtt6@cornell.edu
 Yael Dayan, Mellanox


### PR DESCRIPTION
[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>