### PR TITLE
configury: do not add -I/usr/include -L/usr/lib[64] when UCX is insta…

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -1,7 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (C) 2015      Mellanox Technologies Ltd. ALL RIGHTS RESERVED.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
@@ -34,21 +34,20 @@ AC_DEFUN([OMPI_CHECK_UCX],[
 	ompi_check_ucx_$1_save_LIBS="$LIBS"
 
 	AS_IF([test "$with_ucx" != "no"],
-              [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "yes"],
-                     [
-			 ompi_check_ucx_dir="$with_ucx"
-			 ompi_check_ucx_libdir="$with_ucx/lib"
-                     ])
-               AS_IF([test ! -z "$with_ucx_libdir" && test "$with_ucx_libdir" != "yes"],
+              [AS_IF([test -n "$with_ucx" && test "$with_ucx" != "yes"],
+                     [ompi_check_ucx_dir="$with_ucx"
+                      files=`ls $ompi_check_ucx_dir/lib64/libucp.* 2> /dev/null | wc -l`
+                      AS_IF([test "$files" -gt 0],
+                            [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib64],
+                            [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib])])
+               AS_IF([test -n "$with_ucx_libdir" && test "$with_ucx_libdir" != "yes"],
                      [ompi_check_ucx_libdir="$with_ucx_libdir"])
-
-               ompi_check_ucx_extra_libs="-L$ompi_check_ucx_libdir"
 
                OPAL_CHECK_PACKAGE([ompi_check_ucx],
 				  [ucp/api/ucp.h],
 				  [ucp],
 				  [ucp_cleanup],
-				  [$ompi_check_ucx_extra_libs],
+				  [],
 				  [$ompi_check_ucx_dir],
 				  [$ompi_check_ucx_libdir],
 				  [ompi_check_ucx_happy="yes"],
@@ -64,7 +63,8 @@ AC_DEFUN([OMPI_CHECK_UCX],[
 	AC_MSG_CHECKING(for UCX version compatibility)
 	AC_REQUIRE_CPP
 	old_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"
+        AS_IF([test -n "$ompi_check_ucx_dir"],
+              [CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"])
 	AC_COMPILE_IFELSE(
             [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],
 			     [[


### PR DESCRIPTION
…lled in /usr

Fixes open-mpi/ompi#4345

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@af03f55aa87b6c97c8a0b3375e97cc8aa7eb3539)