### PR TITLE
configury: fix handling of --with-zlib=DIR and --with-zlib-libdir=DIR…

### DIFF
--- a/config/opal_setup_zlib.m4
+++ b/config/opal_setup_zlib.m4
@@ -15,7 +15,7 @@
 # MCA_zlib_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([OPAL_ZLIB_CONFIG],[
-    OPAL_VAR_SCOPE_PUSH([opal_zlib_dir opal_zlib_libdir])
+    OPAL_VAR_SCOPE_PUSH([opal_zlib_dir opal_zlib_libdir opal_zlib_standard_header_location opal_zlib_standard_lib_location])
 
     AC_ARG_WITH([zlib],
                 [AC_HELP_STRING([--with-zlib=DIR],
@@ -29,7 +29,6 @@ AC_DEFUN([OPAL_ZLIB_CONFIG],[
     if test "$with_zlib" != "no"; then
         AC_MSG_CHECKING([for zlib in])
         if test ! -z "$with_zlib" && test "$with_zlib" != "yes"; then
-            AC_MSG_RESULT([$with_zlib])
             opal_zlib_dir=$with_zlib
             opal_zlib_standard_header_location=no
             opal_zlib_standard_lib_location=no

--- a/config/opal_setup_zlib.m4
+++ b/config/opal_setup_zlib.m4
@@ -3,6 +3,8 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,25 +29,29 @@ AC_DEFUN([OPAL_ZLIB_CONFIG],[
     if test "$with_zlib" != "no"; then
         AC_MSG_CHECKING([for zlib in])
         if test ! -z "$with_zlib" && test "$with_zlib" != "yes"; then
+            AC_MSG_RESULT([$with_zlib])
             opal_zlib_dir=$with_zlib
             opal_zlib_standard_header_location=no
-            if test -d $with_zlib/lib; then
-                opal_zlib_libdir=$with_zlib/lib
-            elif test -d $with_zlib/lib64; then
-                opal_zlib_libdir=$with_zlib/lib64
-            else
-                AC_MSG_RESULT([Could not find $with_zlib/lib or $with_zlib/lib64])
-                AC_MSG_ERROR([Can not continue])
-            fi
-            AC_MSG_RESULT([$opal_zlib_dir and $opal_zlib_libdir])
+            opal_zlib_standard_lib_location=no
+            AS_IF([test -z "$with_zlib_libdir" || test "$with_zlib_libdir" = "yes"],
+                  [if test -d $with_zlib/lib; then
+                       opal_zlib_libdir=$with_zlib/lib
+                   elif test -d $with_zlib/lib64; then
+                       opal_zlib_libdir=$with_zlib/lib64
+                   else
+                       AC_MSG_RESULT([Could not find $with_zlib/lib or $with_zlib/lib64])
+                       AC_MSG_ERROR([Can not continue])
+                   fi
+                   AC_MSG_RESULT([$opal_zlib_dir and $opal_zlib_libdir])],
+                  [AC_MSG_RESULT([$with_zlib_libdir])])
         else
             AC_MSG_RESULT([(default search paths)])
             opal_zlib_standard_header_location=yes
+            opal_zlib_standard_lib_location=yes
         fi
         AS_IF([test ! -z "$with_zlib_libdir" && test "$with_zlib_libdir" != "yes"],
               [opal_zlib_libdir="$with_zlib_libdir"
-               opal_zlib_standard_lib_location=no],
-              [opal_zlib_standard_lib_location=yes])
+               opal_zlib_standard_lib_location=no])
 
         OPAL_CHECK_PACKAGE([opal_zlib],
                            [zlib.h],


### PR DESCRIPTION
… option

 - if --with-zlib=DIR --with-zlib-libdir=LIBDIR are given, do not search
   libs in DIR/lib[64], and do not abort if libs are not there
 - if --with-zlib=DIR is given but not --with-zlib-libdir, then do append
   -LDIR/lib[64] to LDFLAGS

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@5a816a98dffaa898c870c912d6c4b09d374804ed)