### PR TITLE
Address external libevent once again

### DIFF
--- a/opal/mca/event/external/configure.m4
+++ b/opal/mca/event/external/configure.m4
@@ -99,13 +99,23 @@ AC_DEFUN([MCA_opal_event_external_CONFIG],[
                   OPAL_CHECK_WITHDIR([libevent], [$opal_event_dir],
                                      [include/event.h])
                   AS_IF([test -z "$with_libevent_libdir" || test "$with_libevent_libdir" = "yes"],
-                        [AS_IF([test -d "$with_libevent/lib64"],
+                        [AC_MSG_CHECKING([for $with_libevent/lib64])
+                         AS_IF([test -d "$with_libevent/lib64"],
+                               [opal_event_libdir_found=yes
+                                AC_MSG_RESULT([found])],
+                               [opal_event_libdir_found=no
+                                AC_MSG_RESULT([not found])])
+                         AS_IF([test "$opal_event_libdir_found" = "yes"],
                                [opal_event_libdir="$with_libevent/lib64"],
-                               [AS_IF([test -d "$with_libevent/lib"],
-                                      [opal_event_libdir="$with_libevent/lib"],
-                                      [AC_MSG_WARN([libevent library were neither found under:])
+                               [AC_MSG_CHECKING([for $with_libevent/lib])
+                                AS_IF([test -d "$with_libevent/lib"],
+                                      [AC_MSG_RESULT([found])
+                                       opal_event_libdir="$with_libevent/lib"],
+                                      [AC_MSG_RESULT([not found])
+                                       AC_MSG_WARN([Library directories were not found:])
                                        AC_MSG_WARN([    $with_libevent/lib64])
                                        AC_MSG_WARN([    $with_libevent/lib])
+                                       AC_MSG_WARN([Please use --with-libevent-libdir to identify it.])
                                        AC_MSG_ERROR([Cannot continue])])])])],
                  [AC_MSG_RESULT([(default search paths)])])
            AS_IF([test ! -z "$with_libevent_libdir" && test "$with_libevent_libdir" != "yes"],
@@ -136,6 +146,7 @@ AC_DEFUN([MCA_opal_event_external_CONFIG],[
                          AC_MSG_WARN([Open MPI requires libevent to be compiled with])
                          AC_MSG_WARN([thread support enabled])
                          AC_MSG_ERROR([Cannot continue])])
+
            AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
                         [],
                         [AC_MSG_WARN([External libevent does not have thread support])

--- a/opal/mca/pmix/pmix3x/configure.m4
+++ b/opal/mca/pmix/pmix3x/configure.m4
@@ -59,14 +59,11 @@ AC_DEFUN([MCA_opal_pmix_pmix3x_CONFIG],[
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
           [opal_pmix_pmix3x_args="--disable-debug $opal_pmix_pmix3x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
+    AC_MSG_CHECKING([if want to install standalone libpmix])
     AS_IF([test "$enable_install_libpmix" == "yes"],
-          [AS_IF([test "$opal_event_external_want" != "yes"],
-                 [AC_MSG_WARN([Installing the embedded PMIx library as a separate])
-                  AC_MSG_WARN([standalone library requires that OMPI be configured])
-                  AC_MSG_WARN([against an external version of libevent.])
-                  AC_MSG_ERROR([Cannot continue])])
-           opal_pmix_pmix3x_args="--with-pmix-extra-lib=\"$opal_event_libdir/libevent.la $opal_event_libdir/libevent_pthreads.la\" $opal_pmix_pmix3x_args"],
-          [opal_pmix_pmix3x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX2X_ --enable-embedded-mode $opal_pmix_pmix3x_args"])
+          [AC_MSG_RESULT([yes])],
+          [AC_MSG_RESULT([no])
+           opal_pmix_pmix3x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX3X_ --enable-embedded-mode $opal_pmix_pmix3x_args"])
     AS_IF([test "$with_devel_headers" = "yes"],
           [opal_pmix_pmix3x_args="--with-devel-headers  $opal_pmix_pmix3x_args"])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"


### PR DESCRIPTION
Assume that a user has both a lib64 and lib directory under the location of $with_libevent. However, libevent itself was installed in the lib directory, not lib64. Assume also that $with_libevent/lib is in the default LD_LIBRARY_PATH.

We need the configury to be smart enough to see that lib64 exists, but that libevent isn't in it so that it moves along and finds libevent in the correct place. I'm not wild about this solution, but I found that just running AC_CHECK_LIB always succeeded with -L$with_libevent/lib64. I'm open to alternative solutions.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>