### PR TITLE
pmix2x: configury: do not include src/include/pmix_config.h into the …

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/include/Makefile.include
+++ b/opal/mca/pmix/pmix2x/pmix/src/include/Makefile.include
@@ -12,6 +12,8 @@
 #                         All rights reserved.
 # Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,6 +45,6 @@ headers += \
 endif ! PMIX_EMBEDDED_MODE
 
 if WANT_INSTALL_HEADERS
-headers += \
+nodist_headers += \
     include/pmix_config.h
 endif


### PR DESCRIPTION
…dist tarball

This is an automatically generated file, so it should not be included
in the dist tarball

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from upstream commit pmix/pmix@ebda03a3de0df75969beb0e4bc751ced40b199e8)