### PR TITLE
Roll up to PMIx v1.2.5

### DIFF
--- a/opal/mca/pmix/pmix112/pmix/Makefile.am
+++ b/opal/mca/pmix/pmix112/pmix/Makefile.am
@@ -77,6 +77,15 @@ else
 lib_LTLIBRARIES = libpmix.la
 libpmix_la_SOURCES = $(headers) $(sources)
 libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
+
+if WANT_PMI_BACKWARD
+lib_LTLIBRARIES += libpmi.la libpmi2.la
+libpmi_la_SOURCES = $(headers) $(sources)
+libpmi_la_LDFLAGS = -version-info $(libpmi_so_version)
+libpmi2_la_SOURCES = $(headers) $(sources)
+libpmi2_la_LDFLAGS = -version-info $(libpmi2_so_version)
+endif
+
 SUBDIRS = . test examples
 endif
 

--- a/opal/mca/pmix/pmix112/pmix/NEWS
+++ b/opal/mca/pmix/pmix112/pmix/NEWS
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
 Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
 $COPYRIGHT$
 
@@ -20,8 +20,17 @@ other, a single NEWS-worthy item might apply to different series. For
 example, a bug might be fixed in the master, and then moved to the
 current release as well as the "stable" bug fix release branch.
 
-1.2.4 -- TBD
+1.2.5 -- TBD
 ----------------------
+
+
+1.2.4 -- 13 Oct. 2017
+----------------------
+- Silence some unnecessary warning messages (PR #487)
+- Coverity fix - TOCTOU (PR #465)
+- automake 1.13 configure fix (PR #486)
+- Update RPM spec file (rpmbuild -ta, and --rebuild fixes) (PR #523)
+- Support singletons in PMI-1/PMI-2 (PR #537)
 
 
 1.2.3 -- 24 Aug. 2017

--- a/opal/mca/pmix/pmix112/pmix/VERSION
+++ b/opal/mca/pmix/pmix112/pmix/VERSION
@@ -31,7 +31,7 @@ greek=
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=gita3f126f
+repo_rev=gitc9b633d
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -45,7 +45,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Sep 06, 2017"
+date="Oct 30, 2017"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library
@@ -77,3 +77,5 @@ date="Sep 06, 2017"
 # format.
 
 libpmix_so_version=2:3:0
+libpmi_so_version=1:0:0
+libpmi2_so_version=1:0:0

--- a/opal/mca/pmix/pmix112/pmix/config/distscript.sh
+++ b/opal/mca/pmix/pmix112/pmix/config/distscript.sh
@@ -15,6 +15,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -53,4 +54,14 @@ perl -pi -e 's/^repo_rev=.*/repo_rev='$repo_rev'/' -- "${distdir}/VERSION"
 touch -r "${srcdir}/VERSION" "${distdir}/VERSION"
 
 echo "*** Updated VERSION file with repo rev: $repo_rev"
+echo "*** (via dist-hook / config/distscript.sh)"
+
+#
+# Update pmix.spec:%{version} with the main version
+#
+PMIX_SPEC=contrib/pmix.spec
+perl -pi -e 's/^Version:.*/Version: '$PMIX_REPO_REV'/' -- "${distdir}/$PMIX_SPEC"
+touch -r "${srcdir}/$PMIX_VERSION" "${distdir}/$PMIX_VERSION"
+
+echo "*** Updated $PMIX_SPEC file with repo rev: $PMIX_REPO_REV"
 echo "*** (via dist-hook / config/distscript.sh)"

--- a/opal/mca/pmix/pmix112/pmix/configure.ac
+++ b/opal/mca/pmix/pmix112/pmix/configure.ac
@@ -206,6 +206,8 @@ AC_SUBST([CONFIGURE_DEPENDENCIES], ['$(top_srcdir)/VERSION'])
 
 . $srcdir/VERSION
 AC_SUBST([libpmix_so_version])
+AC_SUBST([libpmi_so_version])
+AC_SUBST([libpmi2_so_version])
 
 AC_CONFIG_FILES(pmix_config_prefix[examples/Makefile]
                 pmix_config_prefix[test/Makefile]

--- a/opal/mca/pmix/pmix112/pmix/src/buffer_ops/unpack.c
+++ b/opal/mca/pmix/pmix112/pmix/src/buffer_ops/unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -118,8 +118,9 @@ pmix_status_t pmix_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32_t
     pmix_data_type_t local_type;
     pmix_bfrop_type_info_t *info;
 
-    pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrop_unpack_buffer( %p, %p, %lu, %d )\n",
-                   (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
+    pmix_output_verbose(20, pmix_globals.debug_output,
+                        "pmix_bfrop_unpack_buffer( %p, %p, %lu, %d )\n",
+                        (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
 
     /** Unpack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
@@ -221,8 +222,7 @@ pmix_status_t pmix_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
     if (remote_type == BFROP_TYPE_SIZE_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_SIZE_T))) {
-        }
+        ret = pmix_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_SIZE_T);
     } else {
         /* slow path - types are different sizes */
         UNPACK_SIZE_MISMATCH(size_t, remote_type, ret);
@@ -614,7 +614,7 @@ static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
         }
         break;
     default:
-        pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE");
+        pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", val->type);
         return PMIX_ERROR;
     }
 
@@ -953,7 +953,7 @@ pmix_status_t pmix_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
         if (0 < ptr[i].size) {
             ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_info(buffer, ptr[i].array, &m, PMIX_INFO))) {
                 return ret;
             }
         }

--- a/opal/mca/pmix/pmix112/pmix/src/client/pmi1.c
+++ b/opal/mca/pmix/pmix112/pmix/src/client/pmi1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -45,11 +45,11 @@
 #define PMI_MAX_VAL_LEN      4096            /* Maximum size of a PMI value */
 
 
-#define PMI_CHECK() \
-	do {                     \
-        if (!pmi_init) {     \
-            return PMI_FAIL; \
-        }                    \
+#define PMI_CHECK()             \
+    do {                        \
+        if (!pmi_init) {        \
+            return PMI_FAIL;    \
+        }                       \
     } while (0)
 
 /* local functions */
@@ -57,6 +57,7 @@ static pmix_status_t convert_int(int *value, pmix_value_t *kv);
 static int convert_err(pmix_status_t rc);
 static pmix_proc_t myproc;
 static int pmi_init = 0;
+static bool pmi_singleton = false;
 
 PMIX_EXPORT int PMI_Init(int *spawned)
 {
@@ -66,7 +67,19 @@ PMIX_EXPORT int PMI_Init(int *spawned)
     pmix_info_t info[1];
     bool  val_optinal = 1;
 
-    if (PMIX_SUCCESS != PMIx_Init(&myproc)) {
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
+        /* if we didn't see a PMIx server (e.g., missing envar),
+         * then allow us to run as a singleton */
+        if (PMIX_ERR_INVALID_NAMESPACE == rc) {
+            if (NULL != spawned) {
+                *spawned = 0;
+            }
+            pmi_singleton = true;
+            (void)strncpy(myproc.nspace, "1234", PMIX_MAX_NSLEN);
+            myproc.rank = 0;
+            pmi_init = 1;
+            return PMI_SUCCESS;
+        }
         return PMI_ERR_INIT;
     }
 
@@ -109,7 +122,11 @@ PMIX_EXPORT int PMI_Initialized(PMI_BOOL *initialized)
         return PMI_ERR_INVALID_ARG;
     }
 
-    *initialized = (PMIx_Initialized() ? PMI_TRUE : PMI_FALSE);
+    if (pmi_singleton) {
+        *initialized = PMI_TRUE;
+    } else {
+        *initialized = (PMIx_Initialized() ? PMI_TRUE : PMI_FALSE);
+    }
 
     return PMI_SUCCESS;
 }
@@ -121,6 +138,10 @@ PMIX_EXPORT int PMI_Finalize(void)
     PMI_CHECK();
 
     pmi_init = 0;
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
+
     rc = PMIx_Finalize();
     return convert_err(rc);
 }
@@ -130,6 +151,10 @@ PMIX_EXPORT int PMI_Abort(int flag, const char msg[])
     pmix_status_t rc = PMIX_SUCCESS;
 
     PMI_CHECK();
+
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
 
     rc = PMIx_Abort(flag, msg, NULL, 0);
     return convert_err(rc);
@@ -153,6 +178,9 @@ PMIX_EXPORT int PMI_KVS_Put(const char kvsname[], const char key[], const char v
     if ((value == NULL) || (strlen(value) > PMI_MAX_VAL_LEN)) {
         return PMI_ERR_INVALID_VAL;
     }
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
 
     pmix_output_verbose(2, pmix_globals.debug_output,
             "PMI_KVS_Put: KVS=%s, key=%s value=%s", kvsname, key, value);
@@ -172,6 +200,9 @@ PMIX_EXPORT int PMI_KVS_Commit(const char kvsname[])
 
     if ((kvsname == NULL) || (strlen(kvsname) > PMI_MAX_KVSNAME_LEN)) {
         return PMI_ERR_INVALID_KVS;
+    }
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
     }
 
     pmix_output_verbose(2, pmix_globals.debug_output, "PMI_KVS_Commit: KVS=%s",
@@ -256,6 +287,10 @@ PMIX_EXPORT int PMI_Barrier(void)
 
     PMI_CHECK();
 
+    if (pmi_singleton) {
+        return PMI_SUCCESS;
+    }
+
     info = &buf;
     PMIX_INFO_CONSTRUCT(info);
     PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &val, PMIX_BOOL);
@@ -280,6 +315,11 @@ PMIX_EXPORT int PMI_Get_size(int *size)
 
     if (NULL == size) {
         return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        *size = 1;
+        return PMI_SUCCESS;
     }
 
     /* set controlling parameters
@@ -326,6 +366,11 @@ PMIX_EXPORT int PMI_Get_universe_size(int *size)
         return PMI_ERR_INVALID_ARG;
     }
 
+    if (pmi_singleton) {
+        *size = 1;
+        return PMI_SUCCESS;
+    }
+
     /* set controlling parameters
      * PMIX_OPTIONAL - expect that these keys should be available on startup
      */
@@ -356,6 +401,11 @@ PMIX_EXPORT int PMI_Get_appnum(int *appnum)
 
     if (NULL == appnum) {
         return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        *appnum = 0;
+        return PMI_SUCCESS;
     }
 
     /* set controlling parameters
@@ -390,6 +440,10 @@ PMIX_EXPORT int PMI_Publish_name(const char service_name[], const char port[])
         return PMI_ERR_INVALID_ARG;
     }
 
+    if (pmi_singleton) {
+        return PMI_FAIL;
+    }
+
     /* pass the service/port */
     (void) strncpy(info.key, service_name, PMIX_MAX_KEYLEN);
     info.value.type = PMIX_STRING;
@@ -413,6 +467,10 @@ PMIX_EXPORT int PMI_Unpublish_name(const char service_name[])
         return PMI_ERR_INVALID_ARG;
     }
 
+    if (pmi_singleton) {
+        return PMI_FAIL;
+    }
+
     /* pass the service */
     keys[0] = (char*) service_name;
     keys[1] = NULL;
@@ -430,6 +488,10 @@ PMIX_EXPORT int PMI_Lookup_name(const char service_name[], char port[])
 
     if (NULL == service_name || NULL == port) {
         return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        return PMI_FAIL;
     }
 
     PMIX_PDATA_CONSTRUCT(&pdata);
@@ -512,6 +574,11 @@ PMIX_EXPORT int PMI_Get_clique_size(int *size)
         return PMI_ERR_INVALID_ARG;
     }
 
+    if (pmi_singleton) {
+        *size = 1;
+        return PMI_SUCCESS;
+    }
+
     /* set controlling parameters
      * PMIX_OPTIONAL - expect that these keys should be available on startup
      */
@@ -542,6 +609,11 @@ PMIX_EXPORT int PMI_Get_clique_ranks(int ranks[], int length)
 
     if (NULL == ranks) {
         return PMI_ERR_INVALID_ARGS;
+    }
+
+    if (pmi_singleton) {
+        ranks[0] = 0;
+        return PMI_SUCCESS;
     }
 
     rc = PMIx_Get(&proc, PMIX_LOCAL_PEERS, NULL, 0, &val);
@@ -653,6 +725,10 @@ PMIX_EXPORT int PMI_Spawn_multiple(int count,
 
     if (NULL == cmds) {
         return PMI_ERR_INVALID_ARG;
+    }
+
+    if (pmi_singleton) {
+        return PMI_FAIL;
     }
 
     /* setup the apps */

--- a/opal/mca/pmix/pmix112/pmix/src/client/pmi2.c
+++ b/opal/mca/pmix/pmix112/pmix/src/client/pmi2.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -38,11 +38,11 @@
 
 #define ANL_MAPPING "PMI_process_mapping"
 
-#define PMI2_CHECK() \
-    do {                     \
-        if (!pmi2_init) {     \
-            return PMI2_FAIL; \
-        }                    \
+#define PMI2_CHECK()                \
+    do {                            \
+        if (!pmi2_init) {           \
+            return PMI2_FAIL;       \
+        }                           \
     } while (0)
 
 /* local functions */
@@ -51,6 +51,7 @@ static int convert_err(pmix_status_t rc);
 static pmix_proc_t myproc;
 static int pmi2_init = 0;
 static bool commit_reqd = false;
+static bool pmi2_singleton = false;
 
 PMIX_EXPORT int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
 {
@@ -61,7 +62,28 @@ PMIX_EXPORT int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
     pmix_proc_t proc = myproc;
     proc.rank = PMIX_RANK_WILDCARD;
 
-    if (PMIX_SUCCESS != PMIx_Init(&myproc)) {
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
+        /* if we didn't see a PMIx server (e.g., missing envar),
+         * then allow us to run as a singleton */
+        if (PMIX_ERR_INVALID_NAMESPACE == rc) {
+            if (NULL != spawned) {
+                *spawned = 0;
+            }
+            if (NULL != size) {
+                *size = 1;
+            }
+            if (NULL != rank) {
+                *rank = 0;
+            }
+            if (NULL != appnum) {
+                *appnum = 0;
+            }
+            pmi2_singleton = true;
+            (void)strncpy(myproc.nspace, "1234", PMIX_MAX_NSLEN);
+            myproc.rank = 0;
+            pmi2_init = 1;
+            return PMI2_SUCCESS;
+        }
         return PMI2_ERR_INIT;
     }
 
@@ -132,6 +154,10 @@ error:
 PMIX_EXPORT int PMI2_Initialized(void)
 {
     int initialized;
+    if (pmi2_singleton) {
+        return 1;
+    }
+
     initialized = (int)PMIx_Initialized();
     return initialized;
 }
@@ -143,6 +169,10 @@ PMIX_EXPORT int PMI2_Finalize(void)
     PMI2_CHECK();
 
     pmi2_init = 0;
+    if (pmi2_singleton) {
+        return PMI2_SUCCESS;
+    }
+
     rc = PMIx_Finalize();
     return convert_err(rc);
 }
@@ -152,6 +182,10 @@ PMIX_EXPORT int PMI2_Abort(int flag, const char msg[])
     pmix_status_t rc = PMIX_SUCCESS;
 
     PMI2_CHECK();
+
+    if (pmi2_singleton) {
+        return PMI2_SUCCESS;
+    }
 
     rc = PMIx_Abort(flag, msg, NULL, 0);
     return convert_err(rc);
@@ -177,6 +211,10 @@ PMIX_EXPORT int PMI2_Job_Spawn(int count, const char * cmds[],
 
     if (NULL == cmds) {
         return PMI2_ERR_INVALID_ARGS;
+    }
+
+    if (pmi2_singleton) {
+        return PMI2_FAIL;
     }
 
     /* setup the apps */
@@ -261,6 +299,11 @@ PMIX_EXPORT int PMI2_Info_GetSize(int *size)
         return PMI2_ERR_INVALID_ARGS;
     }
 
+    if (pmi2_singleton) {
+        *size = 1;
+        return PMI2_SUCCESS;
+    }
+
     /* set controlling parameters
      * PMIX_OPTIONAL - expect that these keys should be available on startup
      */
@@ -288,6 +331,10 @@ PMIX_EXPORT int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn)
         return PMI2_ERR_INVALID_ARGS;
     }
 
+    if (pmi2_singleton) {
+        return PMI2_FAIL;
+    }
+
     (void)strncpy(proc.nspace, (jobid ? jobid : myproc.nspace), sizeof(myproc.nspace));
     proc.rank = PMIX_RANK_WILDCARD;
     rc = PMIx_Connect(&proc, 1, NULL, 0);
@@ -300,6 +347,10 @@ PMIX_EXPORT int PMI2_Job_Disconnect(const char jobid[])
     pmix_proc_t proc;
 
     PMI2_CHECK();
+
+    if (pmi2_singleton) {
+        return PMI2_SUCCESS;
+    }
 
     (void)strncpy(proc.nspace, (jobid ? jobid : myproc.nspace), sizeof(myproc.nspace));
     proc.rank = PMIX_RANK_WILDCARD;
@@ -317,6 +368,10 @@ PMIX_EXPORT int PMI2_KVS_Put(const char key[], const char value[])
 
     if ((NULL == key) || (NULL == value)) {
         return PMI2_ERR_INVALID_ARG;
+    }
+
+    if (pmi2_singleton) {
+        return PMI2_SUCCESS;
     }
 
     pmix_output_verbose(3, pmix_globals.debug_output,
@@ -338,6 +393,10 @@ PMIX_EXPORT int PMI2_KVS_Fence(void)
     PMI2_CHECK();
 
     pmix_output_verbose(3, pmix_globals.debug_output, "PMI2_KVS_Fence");
+
+    if (pmi2_singleton) {
+        return PMI2_SUCCESS;
+    }
 
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
         return convert_err(rc);
@@ -430,6 +489,10 @@ PMIX_EXPORT int PMI2_Info_GetNodeAttr(const char name[],
         return PMI2_ERR_INVALID_ARG;
     }
 
+    if (pmi2_singleton) {
+        return PMI2_FAIL;
+    }
+
     /* set controlling parameters
      * PMIX_OPTIONAL - expect that these keys should be available on startup
      */
@@ -474,6 +537,10 @@ PMIX_EXPORT int PMI2_Info_PutNodeAttr(const char name[], const char value[])
         return PMI2_ERR_INVALID_ARG;
     }
 
+    if (pmi2_singleton) {
+        return PMI2_SUCCESS;
+    }
+
     val.type = PMIX_STRING;
     val.data.string = (char*)value;
     rc = PMIx_Put(PMIX_LOCAL, name, &val);
@@ -493,6 +560,10 @@ PMIX_EXPORT int PMI2_Info_GetJobAttr(const char name[], char value[], int valuel
 
     if ((NULL == name) || (NULL == value) || (NULL == found)) {
         return PMI2_ERR_INVALID_ARG;
+    }
+
+    if (pmi2_singleton) {
+        return PMI2_FAIL;
     }
 
     /* set controlling parameters
@@ -567,6 +638,10 @@ PMIX_EXPORT int PMI2_Nameserv_publish(const char service_name[],
         return PMI2_ERR_INVALID_ARG;
     }
 
+    if (pmi2_singleton) {
+        return PMI2_FAIL;
+    }
+
     /* pass the service/port */
     (void)strncpy(info[0].key, service_name, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_STRING;
@@ -599,6 +674,10 @@ PMIX_EXPORT int PMI2_Nameserv_lookup(const char service_name[],
 
     if (NULL == service_name || NULL == info_ptr || NULL == port) {
         return PMI2_ERR_INVALID_ARG;
+    }
+
+    if (pmi2_singleton) {
+        return PMI2_FAIL;
     }
 
     PMIX_PDATA_CONSTRUCT(&pdata[0]);
@@ -652,6 +731,10 @@ PMIX_EXPORT int PMI2_Nameserv_unpublish(const char service_name[],
 
     if (NULL == service_name || NULL == info_ptr) {
         return PMI2_ERR_INVALID_ARG;
+    }
+
+    if (pmi2_singleton) {
+        return PMI2_FAIL;
     }
 
     /* pass the service */

--- a/opal/mca/pmix/pmix112/pmix/src/sec/pmix_sec.c
+++ b/opal/mca/pmix/pmix112/pmix/src/sec/pmix_sec.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -114,12 +114,6 @@ int pmix_sec_init(void)
                         ++navail;
                         break;
                     }
-                }
-                if (NULL == all[i]) {
-                    /* we didn't find one they specified */
-                    pmix_output(0, "Security mode %s is not available", options[j]);
-                    pmix_argv_free(options);
-                    return PMIX_ERR_NOT_FOUND;
                 }
             }
         }


### PR DESCRIPTION
Includes following fixes:

* enable support for singletons when using PMI-1 or PMI-2 backward compatibility interfaces

* fix incorrect data type when unpacking array of pmix_info_t structures

Signed-off-by: Ralph Castain <rhc@open-mpi.org>