### PR TITLE
opal/asm: add support for and, or, and xor atomics

### DIFF
--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2010      ARM ltd.  All rights reserved.
- * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -36,8 +36,14 @@
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
 #define OPAL_HAVE_ATOMIC_LLSC_64 1
 #define OPAL_HAVE_ATOMIC_ADD_32 1
+#define OPAL_HAVE_ATOMIC_AND_32 1
+#define OPAL_HAVE_ATOMIC_OR_32 1
+#define OPAL_HAVE_ATOMIC_XOR_32 1
 #define OPAL_HAVE_ATOMIC_SUB_32 1
 #define OPAL_HAVE_ATOMIC_ADD_64 1
+#define OPAL_HAVE_ATOMIC_AND_64 1
+#define OPAL_HAVE_ATOMIC_OR_64 1
+#define OPAL_HAVE_ATOMIC_XOR_64 1
 #define OPAL_HAVE_ATOMIC_SUB_64 1
 
 #define MB()  __asm__ __volatile__ ("dmb sy" : : : "memory")
@@ -292,8 +298,14 @@ static inline int opal_atomic_sc_64 (volatile int64_t *addr, int64_t newval)
     }
 
 OPAL_ASM_MAKE_ATOMIC(int32_t, 32, add, "add", "w")
+OPAL_ASM_MAKE_ATOMIC(int32_t, 32, and, "and", "w")
+OPAL_ASM_MAKE_ATOMIC(int32_t, 32, or, "orr", "w")
+OPAL_ASM_MAKE_ATOMIC(int32_t, 32, xor, "eor", "w")
 OPAL_ASM_MAKE_ATOMIC(int32_t, 32, sub, "sub", "w")
 OPAL_ASM_MAKE_ATOMIC(int64_t, 64, add, "add", "")
+OPAL_ASM_MAKE_ATOMIC(int64_t, 64, and, "and", "")
+OPAL_ASM_MAKE_ATOMIC(int64_t, 64, or, "orr", "")
+OPAL_ASM_MAKE_ATOMIC(int64_t, 64, xor, "eor", "")
 OPAL_ASM_MAKE_ATOMIC(int64_t, 64, sub, "sub", "")
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -108,8 +108,14 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
 #define OPAL_HAVE_INLINE_ATOMIC_CMPSET_32 0
 #define OPAL_HAVE_INLINE_ATOMIC_CMPSET_64 0
 #define OPAL_HAVE_INLINE_ATOMIC_ADD_32 0
+#define OPAL_HAVE_INLINE_ATOMIC_AND_32 0
+#define OPAL_HAVE_INLINE_ATOMIC_OR_32 0
+#define OPAL_HAVE_INLINE_ATOMIC_XOR_32 0
 #define OPAL_HAVE_INLINE_ATOMIC_SUB_32 0
 #define OPAL_HAVE_INLINE_ATOMIC_ADD_64 0
+#define OPAL_HAVE_INLINE_ATOMIC_AND_64 0
+#define OPAL_HAVE_INLINE_ATOMIC_OR_64 0
+#define OPAL_HAVE_INLINE_ATOMIC_XOR_64 0
 #define OPAL_HAVE_INLINE_ATOMIC_SUB_64 0
 #define OPAL_HAVE_INLINE_ATOMIC_SWAP_32 0
 #define OPAL_HAVE_INLINE_ATOMIC_SWAP_64 0
@@ -118,8 +124,14 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
 #define OPAL_HAVE_INLINE_ATOMIC_CMPSET_32 1
 #define OPAL_HAVE_INLINE_ATOMIC_CMPSET_64 1
 #define OPAL_HAVE_INLINE_ATOMIC_ADD_32 1
+#define OPAL_HAVE_INLINE_ATOMIC_AND_32 1
+#define OPAL_HAVE_INLINE_ATOMIC_OR_32 1
+#define OPAL_HAVE_INLINE_ATOMIC_XOR_32 1
 #define OPAL_HAVE_INLINE_ATOMIC_SUB_32 1
 #define OPAL_HAVE_INLINE_ATOMIC_ADD_64 1
+#define OPAL_HAVE_INLINE_ATOMIC_AND_64 1
+#define OPAL_HAVE_INLINE_ATOMIC_OR_64 1
+#define OPAL_HAVE_INLINE_ATOMIC_XOR_64 1
 #define OPAL_HAVE_INLINE_ATOMIC_SUB_64 1
 #define OPAL_HAVE_INLINE_ATOMIC_SWAP_32 1
 #define OPAL_HAVE_INLINE_ATOMIC_SWAP_64 1
@@ -393,6 +405,21 @@ static inline
 #endif
 int32_t opal_atomic_add_32(volatile int32_t *addr, int delta);
 
+#if OPAL_HAVE_INLINE_ATOMIC_AND_32 || (!defined(OPAL_HAVE_ATOMIC_AND_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+static inline
+#endif
+int32_t opal_atomic_and_32(volatile int32_t *addr, int32_t value);
+
+#if OPAL_HAVE_INLINE_ATOMIC_OR_32 || (!defined(OPAL_HAVE_ATOMIC_OR_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+static inline
+#endif
+int32_t opal_atomic_or_32(volatile int32_t *addr, int32_t value);
+
+#if OPAL_HAVE_INLINE_ATOMIC_XOR_32 || (!defined(OPAL_HAVE_ATOMIC_XOR_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+static inline
+#endif
+int32_t opal_atomic_xor_32(volatile int32_t *addr, int32_t value);
+
 /* OPAL_HAVE_INLINE_ATOMIC_*_32 will be 1 if <arch>/atomic.h provides
    a static inline version of it (in assembly).  If we have to fall
    back to cmpset 32, that too will be inline. */
@@ -423,6 +450,21 @@ int32_t opal_atomic_sub_32(volatile int32_t *addr, int delta);
 static inline
 #endif
 int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta);
+
+#if OPAL_HAVE_INLINE_ATOMIC_AND_64 || (!defined(OPAL_HAVE_ATOMIC_AND_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+static inline
+#endif
+int64_t opal_atomic_and_64(volatile int64_t *addr, int64_t value);
+
+#if OPAL_HAVE_INLINE_ATOMIC_OR_64 || (!defined(OPAL_HAVE_ATOMIC_OR_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+static inline
+#endif
+int64_t opal_atomic_or_64(volatile int64_t *addr, int64_t value);
+
+#if OPAL_HAVE_INLINE_ATOMIC_XOR_64 || (!defined(OPAL_HAVE_ATOMIC_XOR_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+static inline
+#endif
+int64_t opal_atomic_xor_64(volatile int64_t *addr, int64_t value);
 
 /* OPAL_HAVE_INLINE_ATOMIC_*_64 will be 1 if <arch>/atomic.h provides
    a static inline version of it (in assembly).  If we have to fall

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -67,6 +67,48 @@ opal_atomic_add_32(volatile int32_t *addr, int delta)
 }
 #endif  /* OPAL_HAVE_ATOMIC_ADD_32 */
 
+#if !defined(OPAL_HAVE_ATOMIC_AND_32)
+#define OPAL_HAVE_ATOMIC_AND_32 1
+static inline int32_t
+opal_atomic_and_32(volatile int32_t *addr, int32_t value)
+{
+   int32_t oldval;
+
+   do {
+      oldval = *addr;
+   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval & value));
+   return (oldval & value);
+}
+#endif  /* OPAL_HAVE_ATOMIC_AND_32 */
+
+#if !defined(OPAL_HAVE_ATOMIC_OR_32)
+#define OPAL_HAVE_ATOMIC_OR_32 1
+static inline int32_t
+opal_atomic_or_32(volatile int32_t *addr, int32_t value)
+{
+   int32_t oldval;
+
+   do {
+      oldval = *addr;
+   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval | value));
+   return (oldval | value);
+}
+#endif  /* OPAL_HAVE_ATOMIC_OR_32 */
+
+#if !defined(OPAL_HAVE_ATOMIC_XOR_32)
+#define OPAL_HAVE_ATOMIC_XOR_32 1
+static inline int32_t
+opal_atomic_xor_32(volatile int32_t *addr, int32_t value)
+{
+   int32_t oldval;
+
+   do {
+      oldval = *addr;
+   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval ^ value));
+   return (oldval ^ value);
+}
+#endif  /* OPAL_HAVE_ATOMIC_XOR_32 */
+
 
 #if !defined(OPAL_HAVE_ATOMIC_SUB_32)
 #define OPAL_HAVE_ATOMIC_SUB_32 1
@@ -114,6 +156,47 @@ opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
 }
 #endif  /* OPAL_HAVE_ATOMIC_ADD_64 */
 
+#if !defined(OPAL_HAVE_ATOMIC_AND_64)
+#define OPAL_HAVE_ATOMIC_AND_64 1
+static inline int64_t
+opal_atomic_and_64(volatile int64_t *addr, int64_t value)
+{
+   int64_t oldval;
+
+   do {
+      oldval = *addr;
+   } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval & value));
+   return (oldval & value);
+}
+#endif  /* OPAL_HAVE_ATOMIC_AND_64 */
+
+#if !defined(OPAL_HAVE_ATOMIC_OR_64)
+#define OPAL_HAVE_ATOMIC_OR_64 1
+static inline int64_t
+opal_atomic_or_64(volatile int64_t *addr, int64_t value)
+{
+   int64_t oldval;
+
+   do {
+      oldval = *addr;
+   } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval | value));
+   return (oldval | value);
+}
+#endif  /* OPAL_HAVE_ATOMIC_OR_64 */
+
+#if !defined(OPAL_HAVE_ATOMIC_XOR_64)
+#define OPAL_HAVE_ATOMIC_XOR_64 1
+static inline int64_t
+opal_atomic_xor_64(volatile int64_t *addr, int64_t value)
+{
+   int64_t oldval;
+
+   do {
+      oldval = *addr;
+   } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval ^ value));
+   return (oldval ^ value);
+}
+#endif  /* OPAL_HAVE_ATOMIC_XOR_64 */
 
 #if !defined(OPAL_HAVE_ATOMIC_SUB_64)
 #define OPAL_HAVE_ATOMIC_SUB_64 1

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -37,11 +37,17 @@
 #define OPAL_HAVE_ATOMIC_MATH_32 1
 #define OPAL_HAVE_ATOMIC_CMPSET_32 1
 #define OPAL_HAVE_ATOMIC_ADD_32 1
+#define OPAL_HAVE_ATOMIC_AND_32 1
+#define OPAL_HAVE_ATOMIC_OR_32 1
+#define OPAL_HAVE_ATOMIC_XOR_32 1
 #define OPAL_HAVE_ATOMIC_SUB_32 1
 #define OPAL_HAVE_ATOMIC_SWAP_32 1
 #define OPAL_HAVE_ATOMIC_MATH_64 1
 #define OPAL_HAVE_ATOMIC_CMPSET_64 1
 #define OPAL_HAVE_ATOMIC_ADD_64 1
+#define OPAL_HAVE_ATOMIC_AND_64 1
+#define OPAL_HAVE_ATOMIC_OR_64 1
+#define OPAL_HAVE_ATOMIC_XOR_64 1
 #define OPAL_HAVE_ATOMIC_SUB_64 1
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
 
@@ -111,6 +117,21 @@ static inline int32_t opal_atomic_add_32(volatile int32_t *addr, int32_t delta)
     return __atomic_add_fetch (addr, delta, __ATOMIC_RELAXED);
 }
 
+static inline int32_t opal_atomic_and_32(volatile int32_t *addr, int32_t value)
+{
+    return __atomic_and_fetch (addr, value, __ATOMIC_RELAXED);
+}
+
+static inline int32_t opal_atomic_or_32(volatile int32_t *addr, int32_t value)
+{
+    return __atomic_or_fetch (addr, value, __ATOMIC_RELAXED);
+}
+
+static inline int32_t opal_atomic_xor_32(volatile int32_t *addr, int32_t value)
+{
+    return __atomic_xor_fetch (addr, value, __ATOMIC_RELAXED);
+}
+
 static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
 {
     return __atomic_sub_fetch (addr, delta, __ATOMIC_RELAXED);
@@ -148,6 +169,21 @@ static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newva
 static inline int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
 {
     return __atomic_add_fetch (addr, delta, __ATOMIC_RELAXED);
+}
+
+static inline int64_t opal_atomic_and_64(volatile int64_t *addr, int64_t value)
+{
+    return __atomic_and_fetch (addr, value, __ATOMIC_RELAXED);
+}
+
+static inline int64_t opal_atomic_or_64(volatile int64_t *addr, int64_t value)
+{
+    return __atomic_or_fetch (addr, value, __ATOMIC_RELAXED);
+}
+
+static inline int64_t opal_atomic_xor_64(volatile int64_t *addr, int64_t value)
+{
+    return __atomic_xor_fetch (addr, value, __ATOMIC_RELAXED);
 }
 
 static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)

--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -80,6 +80,24 @@ static inline int32_t opal_atomic_add_32(volatile int32_t *addr, int32_t delta)
     return __sync_add_and_fetch(addr, delta);
 }
 
+#define OPAL_HAVE_ATOMIC_AND_32 1
+static inline int32_t opal_atomic_and_32(volatile int32_t *addr, int32_t value)
+{
+    return __sync_and_and_fetch(addr, value);
+}
+
+#define OPAL_HAVE_ATOMIC_OR_32 1
+static inline int32_t opal_atomic_or_32(volatile int32_t *addr, int32_t value)
+{
+    return __sync_or_and_fetch(addr, value);
+}
+
+#define OPAL_HAVE_ATOMIC_XOR_32 1
+static inline int32_t opal_atomic_xor_32(volatile int32_t *addr, int32_t value)
+{
+    return __sync_xor_and_fetch(addr, value);
+}
+
 #define OPAL_HAVE_ATOMIC_SUB_32 1
 static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
 {
@@ -112,6 +130,24 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
 static inline int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
 {
     return __sync_add_and_fetch(addr, delta);
+}
+
+#define OPAL_HAVE_ATOMIC_AND_64 1
+static inline int64_t opal_atomic_and_64(volatile int64_t *addr, int64_t value)
+{
+    return __sync_and_and_fetch(addr, value);
+}
+
+#define OPAL_HAVE_ATOMIC_OR_64 1
+static inline int64_t opal_atomic_or_64(volatile int64_t *addr, int64_t value)
+{
+    return __sync_or_and_fetch(addr, value);
+}
+
+#define OPAL_HAVE_ATOMIC_XOR_64 1
+static inline int64_t opal_atomic_xor_64(volatile int64_t *addr, int64_t value)
+{
+    return __sync_xor_and_fetch(addr, value);
 }
 
 #define OPAL_HAVE_ATOMIC_SUB_64 1

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -103,6 +103,36 @@ static inline type opal_thread_add_ ## suffix (volatile type *addr, type delta) 
     return (*addr += delta);                                            \
 }
 
+#define OPAL_THREAD_DEFINE_ATOMIC_AND(type, suffix)     \
+static inline type opal_thread_and_ ## suffix (volatile type *addr, type delta) \
+{                                                                       \
+    if (OPAL_UNLIKELY(opal_using_threads())) {                          \
+        return opal_atomic_and_ ## suffix (addr, delta);                \
+    }                                                                   \
+                                                                        \
+    return (*addr &= delta);                                            \
+}
+
+#define OPAL_THREAD_DEFINE_ATOMIC_OR(type, suffix)     \
+static inline type opal_thread_or_ ## suffix (volatile type *addr, type delta) \
+{                                                                       \
+    if (OPAL_UNLIKELY(opal_using_threads())) {                          \
+        return opal_atomic_or_ ## suffix (addr, delta);                 \
+    }                                                                   \
+                                                                        \
+    return (*addr |= delta);                                            \
+}
+
+#define OPAL_THREAD_DEFINE_ATOMIC_XOR(type, suffix)     \
+static inline type opal_thread_xor_ ## suffix (volatile type *addr, type delta) \
+{                                                                       \
+    if (OPAL_UNLIKELY(opal_using_threads())) {                          \
+        return opal_atomic_xor_ ## suffix (addr, delta);                \
+    }                                                                   \
+                                                                        \
+    return (*addr ^= delta);                                            \
+}
+
 #define OPAL_THREAD_DEFINE_ATOMIC_SUB(type, suffix)     \
 static inline type opal_thread_sub_ ## suffix (volatile type *addr, type delta) \
 {                                                                       \
@@ -143,6 +173,10 @@ static inline type opal_thread_swap_ ## suffix (volatile addr_type *ptr, type ne
 
 OPAL_THREAD_DEFINE_ATOMIC_ADD(int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_ADD(size_t, size_t)
+OPAL_THREAD_DEFINE_ATOMIC_AND(int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_OR(int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_XOR(int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_SUB(int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_SUB(size_t, size_t)
 OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int32_t, int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_CMPSET(void *, intptr_t, ptr)
@@ -151,6 +185,15 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
 
 #define OPAL_THREAD_ADD32 opal_thread_add_32
 #define OPAL_ATOMIC_ADD32 opal_thread_add_32
+
+#define OPAL_THREAD_AND32 opal_thread_and_32
+#define OPAL_ATOMIC_AND32 opal_thread_and_32
+
+#define OPAL_THREAD_OR32 opal_thread_or_32
+#define OPAL_ATOMIC_OR32 opal_thread_or_32
+
+#define OPAL_THREAD_XOR32 opal_thread_xor_32
+#define OPAL_ATOMIC_XOR32 opal_thread_xor_32
 
 #define OPAL_THREAD_ADD_SIZE_T opal_thread_add_size_t
 #define OPAL_ATOMIC_ADD_SIZE_T opal_thread_add_size_t
@@ -174,11 +217,23 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
 #if OPAL_HAVE_ATOMIC_MATH_64
 
 OPAL_THREAD_DEFINE_ATOMIC_ADD(int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_AND(int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_OR(int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_XOR(int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int64_t, int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 
 #define OPAL_THREAD_ADD64 opal_thread_add_64
 #define OPAL_ATOMIC_ADD64 opal_thread_add_64
+
+#define OPAL_THREAD_AND64 opal_thread_and_64
+#define OPAL_ATOMIC_AND64 opal_thread_and_64
+
+#define OPAL_THREAD_OR64 opal_thread_or_64
+#define OPAL_ATOMIC_OR64 opal_thread_or_64
+
+#define OPAL_THREAD_XOR64 opal_thread_xor_64
+#define OPAL_ATOMIC_XOR64 opal_thread_xor_64
 
 #define OPAL_THREAD_CMPSET_64 opal_thread_cmpset_bool_64
 #define OPAL_ATOMIC_CMPSET_64 opal_thread_cmpset_bool_64


### PR DESCRIPTION
This commit adds additional atomics math operations that are needed
throughout the codebase. The semantics of the new operations are
consistent with the existing atomics (op then fetch).

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>