### PR TITLE
Revert the MPI_Init fence operations to use volatile bool instead of thread macros

### DIFF
--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -95,8 +95,10 @@ extern bool ompi_enable_timing;
 
 static void fence_cbfunc(int status, void *cbdata)
 {
-  volatile bool *active = (volatile bool*)cbdata;
-  *active = false;
+    volatile bool *active = (volatile bool*)cbdata;
+    OPAL_ACQUIRE_OBJECT(active);
+    *active = false;
+    OPAL_POST_OBJECT(active);
 }
 
 int ompi_mpi_finalize(void)
@@ -256,6 +258,7 @@ int ompi_mpi_finalize(void)
     if (!ompi_async_mpi_finalize) {
         if (NULL != opal_pmix.fence_nb) {
             active = true;
+            OPAL_POST_OBJECT(&active);
             /* Note that use of the non-blocking PMIx fence will
              * allow us to lazily cycle calling
              * opal_progress(), which will allow any other pending

--- a/opal/mca/pmix/base/base.h
+++ b/opal/mca/pmix/base/base.h
@@ -82,10 +82,12 @@ extern opal_pmix_base_t opal_pmix_base;
         OBJ_CONSTRUCT(&(l)->mutex, opal_mutex_t);       \
         pthread_cond_init(&(l)->cond, NULL);            \
         (l)->active = true;                             \
+        OPAL_POST_OBJECT((l));                          \
     } while(0)
 
 #define OPAL_PMIX_DESTRUCT_LOCK(l)          \
     do {                                    \
+        OPAL_ACQUIRE_OBJECT((l));           \
         OBJ_DESTRUCT(&(l)->mutex);          \
         pthread_cond_destroy(&(l)->cond);   \
     } while(0)

--- a/opal/mca/pmix/pmix3x/pmix/src/threads/threads.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/threads/threads.h
@@ -75,10 +75,12 @@ typedef struct {
         PMIX_CONSTRUCT(&(l)->mutex, pmix_mutex_t);      \
         pthread_cond_init(&(l)->cond, NULL);            \
         (l)->active = true;                             \
+        PMIX_POST_OBJECT((l));                          \
     } while(0)
 
 #define PMIX_DESTRUCT_LOCK(l)               \
     do {                                    \
+        PMIX_ACQUIRE_OBJECT((l));           \
         PMIX_DESTRUCT(&(l)->mutex);         \
         pthread_cond_destroy(&(l)->cond);   \
     } while(0)


### PR DESCRIPTION
Refs https://github.com/pmix/pmix/issues/580

Signed-off-by: Ralph Castain <rhc@open-mpi.org>