### PR TITLE
opal: rename opal_atomic_cmpset* to opal_atomic_bool_cmpset*

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -487,7 +487,7 @@ int ompi_datatype_get_pack_description( ompi_datatype_t* datatype,
     void* recursive_buffer;
 
     if (NULL == packed_description) {
-        if (opal_atomic_cmpset (&datatype->packed_description, NULL, (void *) 1)) {
+        if (opal_atomic_bool_cmpset (&datatype->packed_description, NULL, (void *) 1)) {
             if( ompi_datatype_is_predefined(datatype) ) {
                 packed_description = malloc(2 * sizeof(int));
             } else if( NULL == args ) {

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -356,7 +356,7 @@ static inline struct ompi_proc_t *ompi_group_dense_lookup (ompi_group_t *group, 
         ompi_proc_t *real_proc =
             (ompi_proc_t *) ompi_proc_for_name (ompi_proc_sentinel_to_name ((uintptr_t) proc));
 
-        if (opal_atomic_cmpset_ptr (group->grp_proc_pointers + peer_id, proc, real_proc)) {
+        if (opal_atomic_bool_cmpset_ptr (group->grp_proc_pointers + peer_id, proc, real_proc)) {
             OBJ_RETAIN(real_proc);
         }
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_flowctl.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_flowctl.c
@@ -298,7 +298,7 @@ ompi_mtl_portals4_flowctl_trigger(void)
 {
     int ret;
 
-    if (true == OPAL_ATOMIC_CMPSET_32(&ompi_mtl_portals4.flowctl.flowctl_active, false, true)) {
+    if (true == OPAL_ATOMIC_BOOL_CMPSET_32(&ompi_mtl_portals4.flowctl.flowctl_active, false, true)) {
         /* send trigger to root */
         ret = PtlPut(ompi_mtl_portals4.zero_md_h,
                      0,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -153,7 +153,7 @@ static inline void ompi_osc_pt2pt_peer_set_flag (ompi_osc_pt2pt_peer_t *peer, in
         } else {
             new_flags = peer_flags & ~flag;
         }
-    } while (!OPAL_ATOMIC_CMPSET_32 (&peer->flags, peer_flags, new_flags));
+    } while (!OPAL_ATOMIC_BOOL_CMPSET_32 (&peer->flags, peer_flags, new_flags));
 }
 
 static inline void ompi_osc_pt2pt_peer_set_locked (ompi_osc_pt2pt_peer_t *peer, bool value)

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
@@ -105,7 +105,7 @@ static int ompi_osc_pt2pt_flush_active_frag (ompi_osc_pt2pt_module_t *module, om
                          "osc pt2pt: flushing active fragment to target %d. pending: %d",
                          active_frag->target, active_frag->pending));
 
-    if (opal_atomic_cmpset (&peer->active_frag, active_frag, NULL)) {
+    if (opal_atomic_bool_cmpset (&peer->active_frag, active_frag, NULL)) {
         if (0 != OPAL_THREAD_ADD32(&active_frag->pending, -1)) {
             /* communication going on while synchronizing; this is an rma usage bug */
             return OMPI_ERR_RMA_SYNC;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
@@ -67,7 +67,7 @@ static inline ompi_osc_pt2pt_frag_t *ompi_osc_pt2pt_frag_alloc_non_buffered (omp
 
     /* to ensure ordering flush the buffer on the peer */
     curr = peer->active_frag;
-    if (NULL != curr && opal_atomic_cmpset (&peer->active_frag, curr, NULL)) {
+    if (NULL != curr && opal_atomic_bool_cmpset (&peer->active_frag, curr, NULL)) {
         /* If there's something pending, the pending finish will
            start the buffer.  Otherwise, we need to start it now. */
         int ret = ompi_osc_pt2pt_frag_finish (module, curr);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
@@ -744,14 +744,14 @@ static bool ompi_osc_pt2pt_lock_try_acquire (ompi_osc_pt2pt_module_t* module, in
                 break;
             }
 
-            if (opal_atomic_cmpset_32 (&module->lock_status, lock_status, lock_status + 1)) {
+            if (opal_atomic_bool_cmpset_32 (&module->lock_status, lock_status, lock_status + 1)) {
                 break;
             }
 
             lock_status = module->lock_status;
         } while (1);
     } else {
-        queue = !opal_atomic_cmpset_32 (&module->lock_status, 0, -1);
+        queue = !opal_atomic_bool_cmpset_32 (&module->lock_status, 0, -1);
     }
 
     if (queue) {

--- a/ompi/mca/osc/rdma/osc_rdma_types.h
+++ b/ompi/mca/osc/rdma/osc_rdma_types.h
@@ -59,7 +59,7 @@ static inline int ompi_osc_rdma_lock_cmpset (volatile int64_t *p, int64_t comp, 
     int ret;
 
     opal_atomic_mb ();
-    ret = opal_atomic_cmpset_64 (p, comp, value);
+    ret = opal_atomic_bool_cmpset_64 (p, comp, value);
     opal_atomic_mb ();
 
     return ret;
@@ -88,7 +88,7 @@ static inline int ompi_osc_rdma_lock_cmpset (volatile int32_t *p, int32_t comp, 
     int ret;
 
     opal_atomic_mb ();
-    ret = opal_atomic_cmpset_32 (p, comp, value);
+    ret = opal_atomic_bool_cmpset_32 (p, comp, value);
     opal_atomic_mb ();
 
     return ret;

--- a/ompi/mca/osc/sm/osc_sm_active_target.c
+++ b/ompi/mca/osc/sm/osc_sm_active_target.c
@@ -133,7 +133,7 @@ ompi_osc_sm_start(struct ompi_group_t *group,
 
     OBJ_RETAIN(group);
 
-    if (!OPAL_ATOMIC_CMPSET_PTR(&module->start_group, NULL, group)) {
+    if (!OPAL_ATOMIC_BOOL_CMPSET_PTR(&module->start_group, NULL, group)) {
         OBJ_RELEASE(group);
         return OMPI_ERR_RMA_SYNC;
     }
@@ -162,7 +162,7 @@ ompi_osc_sm_start(struct ompi_group_t *group,
 
             do {
                 old = module->posts[my_rank][rank_byte];
-            } while (!opal_atomic_cmpset ((volatile osc_sm_post_type_t *) module->posts[my_rank] + rank_byte, old, old ^ rank_bit));
+            } while (!opal_atomic_bool_cmpset ((volatile osc_sm_post_type_t *) module->posts[my_rank] + rank_byte, old, old ^ rank_bit));
        }
 
         free (ranks);
@@ -185,7 +185,7 @@ ompi_osc_sm_complete(struct ompi_win_t *win)
     opal_atomic_mb();
 
     group = module->start_group;
-    if (NULL == group || !OPAL_ATOMIC_CMPSET_PTR(&module->start_group, group, NULL)) {
+    if (NULL == group || !OPAL_ATOMIC_BOOL_CMPSET_PTR(&module->start_group, group, NULL)) {
         return OMPI_ERR_RMA_SYNC;
     }
 

--- a/ompi/mpi/c/comm_get_errhandler.c
+++ b/ompi/mpi/c/comm_get_errhandler.c
@@ -69,7 +69,7 @@ int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler)
      error_handler became atomic. */
   do {
       tmp = comm->error_handler;
-  } while (!OPAL_ATOMIC_CMPSET_PTR(&(comm->error_handler), tmp, tmp));
+  } while (!OPAL_ATOMIC_BOOL_CMPSET_PTR(&(comm->error_handler), tmp, tmp));
 
   /* Retain the errhandler, corresponding to object refcount decrease
      in errhandler_free.c. */

--- a/ompi/mpi/c/file_get_errhandler.c
+++ b/ompi/mpi/c/file_get_errhandler.c
@@ -68,7 +68,7 @@ int MPI_File_get_errhandler( MPI_File file, MPI_Errhandler *errhandler)
      error_handler became atomic. */
   do {
       tmp = file->error_handler;
-  } while (!OPAL_ATOMIC_CMPSET_PTR(&(file->error_handler), tmp, tmp));
+  } while (!OPAL_ATOMIC_BOOL_CMPSET_PTR(&(file->error_handler), tmp, tmp));
 
   /* Retain the errhandler, corresponding to object refcount
      decrease in errhandler_free.c. */

--- a/ompi/mpi/c/win_get_errhandler.c
+++ b/ompi/mpi/c/win_get_errhandler.c
@@ -61,7 +61,7 @@ int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler)
        error_handler became atomic. */
     do {
         tmp = win->error_handler;
-    } while (!OPAL_ATOMIC_CMPSET_PTR(&(win->error_handler), tmp, tmp));
+    } while (!OPAL_ATOMIC_BOOL_CMPSET_PTR(&(win->error_handler), tmp, tmp));
 
     /* Retain the errhandler, corresponding to object refcount
        decrease in errhandler_free.c. */

--- a/ompi/request/req_wait.c
+++ b/ompi/request/req_wait.c
@@ -110,7 +110,7 @@ int ompi_request_default_wait_any(size_t count,
             continue;
         }
 
-        if( !OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync) ) {
+        if( !OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync) ) {
             assert(REQUEST_COMPLETE(request));
             completed = i;
             *index = i;
@@ -146,7 +146,7 @@ int ompi_request_default_wait_any(size_t count,
          * Otherwise, the request has been completed meanwhile, and it
          * has been atomically marked as REQUEST_COMPLETE.
          */
-        if( !OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING) ) {
+        if( !OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING) ) {
             *index = i;
         }
     }
@@ -218,7 +218,7 @@ int ompi_request_default_wait_all( size_t count,
             continue;
         }
 
-        if (!OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync)) {
+        if (!OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync)) {
             if( OPAL_UNLIKELY( MPI_SUCCESS != request->req_status.MPI_ERROR ) ) {
                 failed++;
             }
@@ -260,7 +260,7 @@ int ompi_request_default_wait_all( size_t count,
                  * mark the request as pending then it is neither failed nor complete, and
                  * we must stop altering it.
                  */
-                if( OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING ) ) {
+                if( OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING ) ) {
                     /*
                      * Per MPI 2.2 p 60:
                      * Allows requests to be marked as MPI_ERR_PENDING if they are
@@ -320,7 +320,7 @@ int ompi_request_default_wait_all( size_t count,
                 /* If the request is still pending due to a failed request
                  * then skip it in this loop.
                  */
-                 if( OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING ) ) {
+                 if( OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING ) ) {
                     /*
                      * Per MPI 2.2 p 60:
                      * Allows requests to be marked as MPI_ERR_PENDING if they are
@@ -407,7 +407,7 @@ int ompi_request_default_wait_some(size_t count,
             num_requests_null_inactive++;
             continue;
         }
-        indices[i] = OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync);
+        indices[i] = OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, &sync);
         if( !indices[i] ) {
             /* If the request is completed go ahead and mark it as such */
             assert( REQUEST_COMPLETE(request) );
@@ -454,7 +454,7 @@ int ompi_request_default_wait_some(size_t count,
          */
         if( !indices[i] ){
             indices[num_requests_done++] = i;
-        } else if( !OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING) ) {
+        } else if( !OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, &sync, REQUEST_PENDING) ) {
             indices[num_requests_done++] = i;
         }
     }

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -399,7 +399,7 @@ static inline void ompi_request_wait_completion(ompi_request_t *req)
         ompi_wait_sync_t sync;
         WAIT_SYNC_INIT(&sync, 1);
 
-        if (OPAL_ATOMIC_CMPSET_PTR(&req->req_complete, REQUEST_PENDING, &sync)) {
+        if (OPAL_ATOMIC_BOOL_CMPSET_PTR(&req->req_complete, REQUEST_PENDING, &sync)) {
             SYNC_WAIT(&sync);
         } else {
             /* completed before we had a chance to swap in the sync object */
@@ -439,7 +439,7 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
 
     if (0 == rc) {
         if( OPAL_LIKELY(with_signal) ) {
-            if(!OPAL_ATOMIC_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, REQUEST_COMPLETED)) {
+            if(!OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, REQUEST_COMPLETED)) {
                 ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWAP_PTR(&request->req_complete,
                                                                                        REQUEST_COMPLETED);
                 /* In the case where another thread concurrently changed the request to REQUEST_PENDING */

--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -239,7 +239,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
 #else
     /* protect against ABA issues by "locking" the head */
     do {
-        if (opal_atomic_cmpset_32 ((int32_t *) &fifo->opal_fifo_head.data.counter, 0, 1)) {
+        if (opal_atomic_bool_cmpset_32 ((int32_t *) &fifo->opal_fifo_head.data.counter, 0, 1)) {
             break;
         }
 
@@ -259,7 +259,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
 #endif
 
     if (&fifo->opal_fifo_ghost == next) {
-        if (!opal_atomic_cmpset_ptr (&fifo->opal_fifo_tail.data.item, item, &fifo->opal_fifo_ghost)) {
+        if (!opal_atomic_bool_cmpset_ptr (&fifo->opal_fifo_tail.data.item, item, &fifo->opal_fifo_ghost)) {
             while (&fifo->opal_fifo_ghost == item->opal_list_next) {
                 opal_atomic_rmb ();
             }

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -71,7 +71,7 @@ static inline bool opal_update_counted_pointer (volatile opal_counted_pointer_t 
     opal_counted_pointer_t new_p;
     new_p.data.item = item;
     new_p.data.counter = old.data.counter + 1;
-    return opal_atomic_cmpset_128 (&addr->value, old.value, new_p.value);
+    return opal_atomic_bool_cmpset_128 (&addr->value, old.value, new_p.value);
 }
 
 #endif
@@ -126,7 +126,7 @@ static inline opal_list_item_t *opal_lifo_push_atomic (opal_lifo_t *lifo,
         opal_atomic_wmb ();
 
         /* to protect against ABA issues it is sufficient to only update the counter in pop */
-        if (opal_atomic_cmpset_ptr (&lifo->opal_lifo_head.data.item, next, item)) {
+        if (opal_atomic_bool_cmpset_ptr (&lifo->opal_lifo_head.data.item, next, item)) {
             return next;
         }
         /* DO some kind of pause to release the bus */
@@ -175,7 +175,7 @@ static inline opal_list_item_t *opal_lifo_push_atomic (opal_lifo_t *lifo,
         opal_list_item_t *next = (opal_list_item_t *) lifo->opal_lifo_head.data.item;
         item->opal_list_next = next;
         opal_atomic_wmb();
-        if (opal_atomic_cmpset_ptr (&lifo->opal_lifo_head.data.item, next, item)) {
+        if (opal_atomic_bool_cmpset_ptr (&lifo->opal_lifo_head.data.item, next, item)) {
             opal_atomic_wmb ();
             /* now safe to pop this item */
             item->item_free = 0;
@@ -246,7 +246,7 @@ static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
         opal_atomic_wmb ();
 
         /* try to swap out the head pointer */
-        if (opal_atomic_cmpset_ptr (&lifo->opal_lifo_head.data.item, item,
+        if (opal_atomic_bool_cmpset_ptr (&lifo->opal_lifo_head.data.item, item,
                                    (void *) item->opal_list_next)) {
             break;
         }

--- a/opal/include/opal/sys/arm/atomic.h
+++ b/opal/include/opal/sys/arm/atomic.h
@@ -106,8 +106,8 @@ void opal_atomic_isync(void)
 
 #define OPAL_HAVE_ATOMIC_CMPSET_32 1
 #define OPAL_HAVE_ATOMIC_MATH_32 1
-static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
-                                        int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
+                                              int32_t oldval, int32_t newval)
 {
   int32_t ret, tmp;
 
@@ -132,30 +132,30 @@ static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline int opal_atomic_cmpset_acq_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
-    int rc;
+    bool rc;
 
-    rc = opal_atomic_cmpset_32(addr, oldval, newval);
+    rc = opal_atomic_bool_cmpset_32(addr, oldval, newval);
     opal_atomic_rmb();
 
     return rc;
 }
 
 
-static inline int opal_atomic_cmpset_rel_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
     opal_atomic_wmb();
-    return opal_atomic_cmpset_32(addr, oldval, newval);
+    return opal_atomic_bool_cmpset_32(addr, oldval, newval);
 }
 
 #if (OPAL_ASM_SUPPORT_64BIT == 1)
 
 #define OPAL_HAVE_ATOMIC_CMPSET_64 1
-static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
-                                        int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64(volatile int64_t *addr,
+                                              int64_t oldval, int64_t newval)
 {
   int64_t ret;
   int tmp;
@@ -184,23 +184,23 @@ static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline int opal_atomic_cmpset_acq_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
-    int rc;
+    bool rc;
 
-    rc = opal_atomic_cmpset_64(addr, oldval, newval);
+    rc = opal_atomic_bool_cmpset_64(addr, oldval, newval);
     opal_atomic_rmb();
 
     return rc;
 }
 
 
-static inline int opal_atomic_cmpset_rel_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
     opal_atomic_wmb();
-    return opal_atomic_cmpset_64(addr, oldval, newval);
+    return opal_atomic_bool_cmpset_64(addr, oldval, newval);
 }
 
 #endif
@@ -251,24 +251,24 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t* v, int dec)
 
 #define OPAL_HAVE_ATOMIC_CMPSET_32 1
 #define __kuser_cmpxchg (*((int (*)(int, int, volatile int*))(0xffff0fc0)))
-static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
-                                        int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
+                                              int32_t oldval, int32_t newval)
 {
     return !(__kuser_cmpxchg(oldval, newval, addr));
 }
 
-static inline int opal_atomic_cmpset_acq_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
     /* kernel function includes all necessary memory barriers */
-    return opal_atomic_cmpset_32(addr, oldval, newval);
+    return opal_atomic_bool_cmpset_32(addr, oldval, newval);
 }
 
-static inline int opal_atomic_cmpset_rel_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
     /* kernel function includes all necessary memory barriers */
-    return opal_atomic_cmpset_32(addr, oldval, newval);
+    return opal_atomic_bool_cmpset_32(addr, oldval, newval);
 }
 
 #endif

--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -82,8 +82,8 @@ static inline void opal_atomic_isync (void)
  *
  *********************************************************************/
 
-static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
-                                        int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
+                                              int32_t oldval, int32_t newval)
 {
     int32_t ret, tmp;
 
@@ -119,8 +119,8 @@ static inline int32_t opal_atomic_swap_32(volatile int32_t *addr, int32_t newval
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline int opal_atomic_cmpset_acq_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
     int32_t ret, tmp;
 
@@ -138,8 +138,8 @@ static inline int opal_atomic_cmpset_acq_32(volatile int32_t *addr,
 }
 
 
-static inline int opal_atomic_cmpset_rel_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
     int32_t ret, tmp;
 
@@ -179,8 +179,8 @@ static inline int opal_atomic_sc_32 (volatile int32_t *addr, int32_t newval)
     return ret == 0;
 }
 
-static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
-                                        int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64(volatile int64_t *addr,
+                                              int64_t oldval, int64_t newval)
 {
     int64_t ret;
     int tmp;
@@ -218,8 +218,8 @@ static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newva
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline int opal_atomic_cmpset_acq_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
     int64_t ret;
     int tmp;
@@ -238,8 +238,8 @@ static inline int opal_atomic_cmpset_acq_64(volatile int64_t *addr,
 }
 
 
-static inline int opal_atomic_cmpset_rel_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
     int64_t ret;
     int tmp;

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -44,7 +44,7 @@
  *  - \c OPAL_HAVE_ATOMIC_MATH_64 if 64 bit add/sub/cmpset can be done "atomicly"
  *
  * Note that for the Atomic math, atomic add/sub may be implemented as
- * C code using opal_atomic_cmpset.  The appearance of atomic
+ * C code using opal_atomic_bool_cmpset.  The appearance of atomic
  * operation will be upheld in these cases.
  */
 
@@ -348,20 +348,20 @@ void opal_atomic_unlock(opal_atomic_lock_t *lock);
 #if OPAL_HAVE_INLINE_ATOMIC_CMPSET_32
 static inline
 #endif
-int opal_atomic_cmpset_32(volatile int32_t *addr, int32_t oldval,
-                          int32_t newval);
+bool opal_atomic_bool_cmpset_32(volatile int32_t *addr, int32_t oldval,
+                                int32_t newval);
 
 #if OPAL_HAVE_INLINE_ATOMIC_CMPSET_32
 static inline
 #endif
-int opal_atomic_cmpset_acq_32(volatile int32_t *addr, int32_t oldval,
-                              int32_t newval);
+bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr, int32_t oldval,
+                                    int32_t newval);
 
 #if OPAL_HAVE_INLINE_ATOMIC_CMPSET_32
 static inline
 #endif
-int opal_atomic_cmpset_rel_32(volatile int32_t *addr, int32_t oldval,
-                              int32_t newval);
+bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr, int32_t oldval,
+                                    int32_t newval);
 #endif
 
 
@@ -373,20 +373,20 @@ int opal_atomic_cmpset_rel_32(volatile int32_t *addr, int32_t oldval,
 #if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
 static inline
 #endif
-int opal_atomic_cmpset_64(volatile int64_t *addr, int64_t oldval,
-                          int64_t newval);
+bool opal_atomic_bool_cmpset_64(volatile int64_t *addr, int64_t oldval,
+                                int64_t newval);
 
 #if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
 static inline
 #endif
-int opal_atomic_cmpset_acq_64(volatile int64_t *addr, int64_t oldval,
-                              int64_t newval);
+bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr, int64_t oldval,
+                                    int64_t newval);
 
 #if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
 static inline
 #endif
-int opal_atomic_cmpset_rel_64(volatile int64_t *addr, int64_t oldval,
-                              int64_t newval);
+bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr, int64_t oldval,
+                                    int64_t newval);
 
 #endif
 
@@ -525,24 +525,24 @@ opal_atomic_sub_size_t(volatile size_t *addr, size_t delta)
 #if defined(DOXYGEN) || (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
 /* these are always done with inline functions, so always mark as
    static inline */
-static inline int opal_atomic_cmpset_xx(volatile void* addr, int64_t oldval,
-                                        int64_t newval, size_t length);
-static inline int opal_atomic_cmpset_acq_xx(volatile void* addr,
-                                            int64_t oldval,  int64_t newval,
-                                            size_t length);
-static inline int opal_atomic_cmpset_rel_xx(volatile void* addr,
-                                            int64_t oldval, int64_t newval,
-                                            size_t length);
+static inline bool opal_atomic_bool_cmpset_xx(volatile void* addr, int64_t oldval,
+                                              int64_t newval, size_t length);
+static inline bool opal_atomic_bool_cmpset_acq_xx(volatile void* addr,
+                                                  int64_t oldval,  int64_t newval,
+                                                  size_t length);
+static inline bool opal_atomic_bool_cmpset_rel_xx(volatile void* addr,
+                                                  int64_t oldval, int64_t newval,
+                                                  size_t length);
 
-static inline int opal_atomic_cmpset_ptr(volatile void* addr,
-                                         void* oldval,
-                                         void* newval);
-static inline int opal_atomic_cmpset_acq_ptr(volatile void* addr,
-                                             void* oldval,
-                                             void* newval);
-static inline int opal_atomic_cmpset_rel_ptr(volatile void* addr,
-                                             void* oldval,
-                                             void* newval);
+static inline bool opal_atomic_bool_cmpset_ptr(volatile void* addr,
+                                               void* oldval,
+                                               void* newval);
+static inline bool opal_atomic_bool_cmpset_acq_ptr(volatile void* addr,
+                                                   void* oldval,
+                                                   void* newval);
+static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
+                                                   void* oldval,
+                                                   void* newval);
 
 /**
  * Atomic compare and set of pointer with relaxed semantics. This
@@ -555,10 +555,10 @@ static inline int opal_atomic_cmpset_rel_ptr(volatile void* addr,
  * @param oldval        Comparison value <TYPE>.
  * @param newval        New value to set if comparision is true <TYPE>.
  *
- * See opal_atomic_cmpset_* for pseudo-code.
+ * See opal_atomic_bool_cmpset_* for pseudo-code.
  */
-#define opal_atomic_cmpset( ADDR, OLDVAL, NEWVAL )                  \
-   opal_atomic_cmpset_xx( (volatile void*)(ADDR), (intptr_t)(OLDVAL), \
+#define opal_atomic_bool_cmpset( ADDR, OLDVAL, NEWVAL )                  \
+   opal_atomic_bool_cmpset_xx( (volatile void*)(ADDR), (intptr_t)(OLDVAL), \
                           (intptr_t)(NEWVAL), sizeof(*(ADDR)) )
 
 /**
@@ -572,10 +572,10 @@ static inline int opal_atomic_cmpset_rel_ptr(volatile void* addr,
  * @param oldval        Comparison value <TYPE>.
  * @param newval        New value to set if comparision is true <TYPE>.
  *
- * See opal_atomic_cmpset_acq_* for pseudo-code.
+ * See opal_atomic_bool_cmpset_acq_* for pseudo-code.
  */
-#define opal_atomic_cmpset_acq( ADDR, OLDVAL, NEWVAL )           \
-   opal_atomic_cmpset_acq_xx( (volatile void*)(ADDR), (int64_t)(OLDVAL), \
+#define opal_atomic_bool_cmpset_acq( ADDR, OLDVAL, NEWVAL )           \
+   opal_atomic_bool_cmpset_acq_xx( (volatile void*)(ADDR), (int64_t)(OLDVAL), \
                               (int64_t)(NEWVAL), sizeof(*(ADDR)) )
 
 
@@ -590,10 +590,10 @@ static inline int opal_atomic_cmpset_rel_ptr(volatile void* addr,
  * @param oldval        Comparison value <TYPE>.
  * @param newval        New value to set if comparision is true <TYPE>.
  *
- * See opal_atomic_cmpsetrel_* for pseudo-code.
+ * See opal_atomic_bool_cmpsetrel_* for pseudo-code.
  */
-#define opal_atomic_cmpset_rel( ADDR, OLDVAL, NEWVAL )           \
-   opal_atomic_cmpset_rel_xx( (volatile void*)(ADDR), (int64_t)(OLDVAL), \
+#define opal_atomic_bool_cmpset_rel( ADDR, OLDVAL, NEWVAL )           \
+   opal_atomic_bool_cmpset_rel_xx( (volatile void*)(ADDR), (int64_t)(OLDVAL), \
                               (int64_t)(NEWVAL), sizeof(*(ADDR)) )
 
 #endif /* (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64) */

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -47,7 +47,7 @@ static inline int32_t opal_atomic_swap_32(volatile int32_t *addr,
     int32_t old;
     do {
         old = *addr;
-    } while (0 == opal_atomic_cmpset_32(addr, old, newval));
+    } while (!opal_atomic_bool_cmpset_32(addr, old, newval));
 
     return old;
 }
@@ -62,7 +62,7 @@ opal_atomic_add_32(volatile int32_t *addr, int delta)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval + delta));
+   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval + delta));
    return (oldval + delta);
 }
 #endif  /* OPAL_HAVE_ATOMIC_ADD_32 */
@@ -76,7 +76,7 @@ opal_atomic_and_32(volatile int32_t *addr, int32_t value)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval & value));
+   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval & value));
    return (oldval & value);
 }
 #endif  /* OPAL_HAVE_ATOMIC_AND_32 */
@@ -90,7 +90,7 @@ opal_atomic_or_32(volatile int32_t *addr, int32_t value)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval | value));
+   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval | value));
    return (oldval | value);
 }
 #endif  /* OPAL_HAVE_ATOMIC_OR_32 */
@@ -104,7 +104,7 @@ opal_atomic_xor_32(volatile int32_t *addr, int32_t value)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval ^ value));
+   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval ^ value));
    return (oldval ^ value);
 }
 #endif  /* OPAL_HAVE_ATOMIC_XOR_32 */
@@ -119,7 +119,7 @@ opal_atomic_sub_32(volatile int32_t *addr, int delta)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_32(addr, oldval, oldval - delta));
+   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval - delta));
    return (oldval - delta);
 }
 #endif  /* OPAL_HAVE_ATOMIC_SUB_32 */
@@ -137,7 +137,7 @@ static inline int64_t opal_atomic_swap_64(volatile int64_t *addr,
     int64_t old;
     do {
         old = *addr;
-    } while (0 == opal_atomic_cmpset_64(addr, old, newval));
+    } while (!opal_atomic_bool_cmpset_64(addr, old, newval));
     return old;
 }
 #endif /* OPAL_HAVE_ATOMIC_SWAP_32 */
@@ -151,7 +151,7 @@ opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval + delta));
+   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval + delta));
    return (oldval + delta);
 }
 #endif  /* OPAL_HAVE_ATOMIC_ADD_64 */
@@ -165,7 +165,7 @@ opal_atomic_and_64(volatile int64_t *addr, int64_t value)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval & value));
+   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval & value));
    return (oldval & value);
 }
 #endif  /* OPAL_HAVE_ATOMIC_AND_64 */
@@ -179,7 +179,7 @@ opal_atomic_or_64(volatile int64_t *addr, int64_t value)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval | value));
+   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval | value));
    return (oldval | value);
 }
 #endif  /* OPAL_HAVE_ATOMIC_OR_64 */
@@ -193,7 +193,7 @@ opal_atomic_xor_64(volatile int64_t *addr, int64_t value)
 
    do {
       oldval = *addr;
-   } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval ^ value));
+   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval ^ value));
    return (oldval ^ value);
 }
 #endif  /* OPAL_HAVE_ATOMIC_XOR_64 */
@@ -207,7 +207,7 @@ opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 
     do {
         oldval = *addr;
-    } while (0 == opal_atomic_cmpset_64(addr, oldval, oldval - delta));
+    } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval - delta));
     return (oldval - delta);
 }
 #endif  /* OPAL_HAVE_ATOMIC_SUB_64 */
@@ -227,20 +227,20 @@ opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 
 #if (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
 
-static inline int
-opal_atomic_cmpset_xx(volatile void* addr, int64_t oldval,
-                      int64_t newval, size_t length)
+static inline bool
+opal_atomic_bool_cmpset_xx(volatile void* addr, int64_t oldval,
+                           int64_t newval, size_t length)
 {
    switch( length ) {
 #if OPAL_HAVE_ATOMIC_CMPSET_32
    case 4:
-      return opal_atomic_cmpset_32( (volatile int32_t*)addr,
+      return opal_atomic_bool_cmpset_32( (volatile int32_t*)addr,
                                     (int32_t)oldval, (int32_t)newval );
 #endif  /* OPAL_HAVE_ATOMIC_CMPSET_32 */
 
 #if OPAL_HAVE_ATOMIC_CMPSET_64
    case 8:
-      return opal_atomic_cmpset_64( (volatile int64_t*)addr,
+      return opal_atomic_bool_cmpset_64( (volatile int64_t*)addr,
                                     (int64_t)oldval, (int64_t)newval );
 #endif  /* OPAL_HAVE_ATOMIC_CMPSET_64 */
    }
@@ -250,20 +250,20 @@ opal_atomic_cmpset_xx(volatile void* addr, int64_t oldval,
 }
 
 
-static inline int
-opal_atomic_cmpset_acq_xx(volatile void* addr, int64_t oldval,
-                          int64_t newval, size_t length)
+static inline bool
+opal_atomic_bool_cmpset_acq_xx(volatile void* addr, int64_t oldval,
+                               int64_t newval, size_t length)
 {
    switch( length ) {
 #if OPAL_HAVE_ATOMIC_CMPSET_32
    case 4:
-      return opal_atomic_cmpset_acq_32( (volatile int32_t*)addr,
+      return opal_atomic_bool_cmpset_acq_32( (volatile int32_t*)addr,
                                         (int32_t)oldval, (int32_t)newval );
 #endif  /* OPAL_HAVE_ATOMIC_CMPSET_32 */
 
 #if OPAL_HAVE_ATOMIC_CMPSET_64
    case 8:
-      return opal_atomic_cmpset_acq_64( (volatile int64_t*)addr,
+      return opal_atomic_bool_cmpset_acq_64( (volatile int64_t*)addr,
                                         (int64_t)oldval, (int64_t)newval );
 #endif  /* OPAL_HAVE_ATOMIC_CMPSET_64 */
    }
@@ -273,20 +273,20 @@ opal_atomic_cmpset_acq_xx(volatile void* addr, int64_t oldval,
 }
 
 
-static inline int
-opal_atomic_cmpset_rel_xx(volatile void* addr, int64_t oldval,
-                          int64_t newval, size_t length)
+static inline bool
+opal_atomic_bool_cmpset_rel_xx(volatile void* addr, int64_t oldval,
+                               int64_t newval, size_t length)
 {
    switch( length ) {
 #if OPAL_HAVE_ATOMIC_CMPSET_32
    case 4:
-      return opal_atomic_cmpset_rel_32( (volatile int32_t*)addr,
+      return opal_atomic_bool_cmpset_rel_32( (volatile int32_t*)addr,
                                         (int32_t)oldval, (int32_t)newval );
 #endif  /* OPAL_HAVE_ATOMIC_CMPSET_32 */
 
 #if OPAL_HAVE_ATOMIC_CMPSET_64
    case 8:
-      return opal_atomic_cmpset_rel_64( (volatile int64_t*)addr,
+      return opal_atomic_bool_cmpset_rel_64( (volatile int64_t*)addr,
                                         (int64_t)oldval, (int64_t)newval );
 #endif  /* OPAL_HAVE_ATOMIC_CMPSET_64 */
    }
@@ -296,16 +296,16 @@ opal_atomic_cmpset_rel_xx(volatile void* addr, int64_t oldval,
 }
 
 
-static inline int
-opal_atomic_cmpset_ptr(volatile void* addr,
-                       void* oldval,
-                       void* newval)
+static inline bool
+opal_atomic_bool_cmpset_ptr(volatile void* addr,
+                            void* oldval,
+                            void* newval)
 {
 #if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_CMPSET_32
-    return opal_atomic_cmpset_32((int32_t*) addr, (unsigned long) oldval,
+    return opal_atomic_bool_cmpset_32((int32_t*) addr, (unsigned long) oldval,
                                  (unsigned long) newval);
 #elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_CMPSET_64
-    return opal_atomic_cmpset_64((int64_t*) addr, (unsigned long) oldval,
+    return opal_atomic_bool_cmpset_64((int64_t*) addr, (unsigned long) oldval,
                                  (unsigned long) newval);
 #else
     abort();
@@ -313,16 +313,16 @@ opal_atomic_cmpset_ptr(volatile void* addr,
 }
 
 
-static inline int
-opal_atomic_cmpset_acq_ptr(volatile void* addr,
-                           void* oldval,
-                           void* newval)
+static inline bool
+opal_atomic_bool_cmpset_acq_ptr(volatile void* addr,
+                                void* oldval,
+                                void* newval)
 {
 #if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_CMPSET_32
-    return opal_atomic_cmpset_acq_32((int32_t*) addr, (unsigned long) oldval,
+    return opal_atomic_bool_cmpset_acq_32((int32_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
 #elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_CMPSET_64
-    return opal_atomic_cmpset_acq_64((int64_t*) addr, (unsigned long) oldval,
+    return opal_atomic_bool_cmpset_acq_64((int64_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
 #else
     abort();
@@ -330,15 +330,15 @@ opal_atomic_cmpset_acq_ptr(volatile void* addr,
 }
 
 
-static inline int opal_atomic_cmpset_rel_ptr(volatile void* addr,
-                                             void* oldval,
-                                             void* newval)
+static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
+                                                   void* oldval,
+                                                   void* newval)
 {
 #if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_CMPSET_32
-    return opal_atomic_cmpset_rel_32((int32_t*) addr, (unsigned long) oldval,
+    return opal_atomic_bool_cmpset_rel_32((int32_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
 #elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_CMPSET_64
-    return opal_atomic_cmpset_rel_64((int64_t*) addr, (unsigned long) oldval,
+    return opal_atomic_bool_cmpset_rel_64((int64_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
 #else
     abort();
@@ -493,8 +493,8 @@ opal_atomic_lock_init( opal_atomic_lock_t* lock, int32_t value )
 static inline int
 opal_atomic_trylock(opal_atomic_lock_t *lock)
 {
-    int ret = opal_atomic_cmpset_acq_32( &(lock->u.lock),
-                                         OPAL_ATOMIC_LOCK_UNLOCKED, OPAL_ATOMIC_LOCK_LOCKED);
+    bool ret = opal_atomic_bool_cmpset_acq_32( &(lock->u.lock),
+                                               OPAL_ATOMIC_LOCK_UNLOCKED, OPAL_ATOMIC_LOCK_LOCKED);
     return (ret == 0) ? 1 : 0;
 }
 
@@ -502,7 +502,7 @@ opal_atomic_trylock(opal_atomic_lock_t *lock)
 static inline void
 opal_atomic_lock(opal_atomic_lock_t *lock)
 {
-   while( !opal_atomic_cmpset_acq_32( &(lock->u.lock),
+   while( !opal_atomic_bool_cmpset_acq_32( &(lock->u.lock),
                                       OPAL_ATOMIC_LOCK_UNLOCKED, OPAL_ATOMIC_LOCK_LOCKED) ) {
       while (lock->u.lock == OPAL_ATOMIC_LOCK_LOCKED) {
          /* spin */ ;

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -83,23 +83,23 @@ static inline void opal_atomic_wmb(void)
 #pragma error_messages(off, E_ARG_INCOMPATIBLE_WITH_ARG_L)
 #endif
 
-static inline int opal_atomic_cmpset_acq_32( volatile int32_t *addr,
-                                             int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_32( volatile int32_t *addr,
+                                                   int32_t oldval, int32_t newval)
 {
     return __atomic_compare_exchange_n (addr, &oldval, newval, false,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
 
-static inline int opal_atomic_cmpset_rel_32( volatile int32_t *addr,
-                                             int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_32( volatile int32_t *addr,
+                                                   int32_t oldval, int32_t newval)
 {
     return __atomic_compare_exchange_n (addr, &oldval, newval, false,
                                         __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
 
-static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
-                                         int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32( volatile int32_t *addr,
+                                               int32_t oldval, int32_t newval)
 {
     return __atomic_compare_exchange_n (addr, &oldval, newval, false,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
@@ -137,23 +137,23 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
     return __atomic_sub_fetch (addr, delta, __ATOMIC_RELAXED);
 }
 
-static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
-                                             int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_64( volatile int64_t *addr,
+                                                   int64_t oldval, int64_t newval)
 {
     return __atomic_compare_exchange_n (addr, &oldval, newval, false,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
-static inline int opal_atomic_cmpset_rel_64( volatile int64_t *addr,
-                                             int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_64( volatile int64_t *addr,
+                                                   int64_t oldval, int64_t newval)
 {
     return __atomic_compare_exchange_n (addr, &oldval, newval, false,
                                         __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
 
 
-static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
-                                         int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
+                                               int64_t oldval, int64_t newval)
 {
     return __atomic_compare_exchange_n (addr, &oldval, newval, false,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
@@ -195,8 +195,8 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 
 #define OPAL_HAVE_ATOMIC_CMPSET_128 1
 
-static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
-                                          opal_int128_t oldval, opal_int128_t newval)
+static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr,
+                                                opal_int128_t oldval, opal_int128_t newval)
 {
     return __atomic_compare_exchange_n (addr, &oldval, newval, false,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
@@ -208,8 +208,8 @@ static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
 
 /* __atomic version is not lock-free so use legacy __sync version */
 
-static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
-                                          opal_int128_t oldval, opal_int128_t newval)
+static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr,
+                                                opal_int128_t oldval, opal_int128_t newval)
 {
     return __sync_bool_compare_and_swap (addr, oldval, newval);
 }

--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -84,9 +84,9 @@ static inline void opal_atomic_isync(void)
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
-                                        int32_t oldval,
-                                        int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
+                                              int32_t oldval,
+                                              int32_t newval)
 {
    unsigned char ret;
    __asm__ __volatile__ (
@@ -96,13 +96,13 @@ static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
                        : "q"(newval)
                        : "memory", "cc");
 
-   return (int)ret;
+   return (bool) ret;
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
-#define opal_atomic_cmpset_acq_32 opal_atomic_cmpset_32
-#define opal_atomic_cmpset_rel_32 opal_atomic_cmpset_32
+#define opal_atomic_bool_cmpset_acq_32 opal_atomic_bool_cmpset_32
+#define opal_atomic_bool_cmpset_rel_32 opal_atomic_bool_cmpset_32
 
 #if OPAL_GCC_INLINE_ASSEMBLY
 

--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2017 IBM Corporation.  All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -145,8 +145,8 @@ void opal_atomic_isync(void)
 #endif
 
 
-static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
-                                        int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
+                                              int32_t oldval, int32_t newval)
 {
    int32_t ret;
 
@@ -195,23 +195,23 @@ static inline int opal_atomic_sc_32 (volatile int32_t *addr, int32_t newval)
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline int opal_atomic_cmpset_acq_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
-    int rc;
+    bool rc;
 
-    rc = opal_atomic_cmpset_32(addr, oldval, newval);
+    rc = opal_atomic_bool_cmpset_32(addr, oldval, newval);
     opal_atomic_rmb();
 
     return rc;
 }
 
 
-static inline int opal_atomic_cmpset_rel_32(volatile int32_t *addr,
-                                            int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr,
+                                                  int32_t oldval, int32_t newval)
 {
     opal_atomic_wmb();
-    return opal_atomic_cmpset_32(addr, oldval, newval);
+    return opal_atomic_bool_cmpset_32(addr, oldval, newval);
 }
 
 static inline int32_t opal_atomic_swap_32(volatile int32_t *addr, int32_t newval)
@@ -258,8 +258,8 @@ OPAL_ATOMIC_POWERPC_DEFINE_ATOMIC_64(or, or)
 OPAL_ATOMIC_POWERPC_DEFINE_ATOMIC_64(xor, xor)
 OPAL_ATOMIC_POWERPC_DEFINE_ATOMIC_64(sub, subf)
 
-static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
-                                        int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64(volatile int64_t *addr,
+                                              int64_t oldval, int64_t newval)
 {
    int64_t ret;
 
@@ -308,23 +308,23 @@ static inline int opal_atomic_sc_64(volatile int64_t *addr, int64_t newval)
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline int opal_atomic_cmpset_acq_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
-    int rc;
+    bool rc;
 
-    rc = opal_atomic_cmpset_64(addr, oldval, newval);
+    rc = opal_atomic_bool_cmpset_64(addr, oldval, newval);
     opal_atomic_rmb();
 
     return rc;
 }
 
 
-static inline int opal_atomic_cmpset_rel_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
     opal_atomic_wmb();
-    return opal_atomic_cmpset_64(addr, oldval, newval);
+    return opal_atomic_bool_cmpset_64(addr, oldval, newval);
 }
 
 static inline int64_t opal_atomic_swap_64(volatile int64_t *addr, int64_t newval)
@@ -352,7 +352,7 @@ static inline int64_t opal_atomic_swap_64(volatile int64_t *addr, int64_t newval
 
 #if  OPAL_GCC_INLINE_ASSEMBLY
 
-static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
+static inline int opal_atomic_bool_cmpset_64(volatile int64_t *addr,
                                         int64_t oldval, int64_t newval)
 {
     int ret;
@@ -393,23 +393,23 @@ static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline int opal_atomic_cmpset_acq_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
     int rc;
 
-    rc = opal_atomic_cmpset_64(addr, oldval, newval);
+    rc = opal_atomic_bool_cmpset_64(addr, oldval, newval);
     opal_atomic_rmb();
 
     return rc;
 }
 
 
-static inline int opal_atomic_cmpset_rel_64(volatile int64_t *addr,
-                                            int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr,
+                                                  int64_t oldval, int64_t newval)
 {
     opal_atomic_wmb();
-    return opal_atomic_cmpset_64(addr, oldval, newval);
+    return opal_atomic_bool_cmpset_64(addr, oldval, newval);
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */

--- a/opal/include/opal/sys/sparcv9/atomic.h
+++ b/opal/include/opal/sys/sparcv9/atomic.h
@@ -82,8 +82,8 @@ static inline void opal_atomic_isync(void)
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
-                                         int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32( volatile int32_t *addr,
+                                               int32_t oldval, int32_t newval)
 {
    /* casa [reg(rs1)] %asi, reg(rs2), reg(rd)
     *
@@ -102,30 +102,30 @@ static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
 }
 
 
-static inline int opal_atomic_cmpset_acq_32( volatile int32_t *addr,
-                                             int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_32( volatile int32_t *addr,
+                                                   int32_t oldval, int32_t newval)
 {
-   int rc;
+   bool rc;
 
-   rc = opal_atomic_cmpset_32(addr, oldval, newval);
+   rc = opal_atomic_bool_cmpset_32(addr, oldval, newval);
    opal_atomic_rmb();
 
    return rc;
 }
 
 
-static inline int opal_atomic_cmpset_rel_32( volatile int32_t *addr,
-                                             int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_32( volatile int32_t *addr,
+                                                   int32_t oldval, int32_t newval)
 {
    opal_atomic_wmb();
-   return opal_atomic_cmpset_32(addr, oldval, newval);
+   return opal_atomic_bool_cmpset_32(addr, oldval, newval);
 }
 
 
 #if OPAL_ASSEMBLY_ARCH == OPAL_SPARCV9_64
 
-static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
-                                         int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
+                                               int64_t oldval, int64_t newval)
 {
     /* casa [reg(rs1)] %asi, reg(rs2), reg(rd)
      *
@@ -144,8 +144,8 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
 
 #else /* OPAL_ASSEMBLY_ARCH == OPAL_SPARCV9_64 */
 
-static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
-                                         int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
+                                               int64_t oldval, int64_t newval)
 {
     /* casa [reg(rs1)] %asi, reg(rs2), reg(rd)
      *
@@ -172,23 +172,23 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
 
 #endif /* OPAL_ASSEMBLY_ARCH == OPAL_SPARCV9_64 */
 
-static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
-                                             int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_64( volatile int64_t *addr,
+                                                   int64_t oldval, int64_t newval)
 {
-   int rc;
+   bool rc;
 
-   rc = opal_atomic_cmpset_64(addr, oldval, newval);
+   rc = opal_atomic_bool_cmpset_64(addr, oldval, newval);
    opal_atomic_rmb();
 
    return rc;
 }
 
 
-static inline int opal_atomic_cmpset_rel_64( volatile int64_t *addr,
-                                             int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_64( volatile int64_t *addr,
+                                                   int64_t oldval, int64_t newval)
 {
    opal_atomic_wmb();
-   return opal_atomic_cmpset_64(addr, oldval, newval);
+   return opal_atomic_bool_cmpset_64(addr, oldval, newval);
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */

--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -54,20 +54,20 @@ static inline void opal_atomic_wmb(void)
  *********************************************************************/
 
 #define OPAL_HAVE_ATOMIC_CMPSET_32 1
-static inline int opal_atomic_cmpset_acq_32( volatile int32_t *addr,
-                                             int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_32( volatile int32_t *addr,
+                                                   int32_t oldval, int32_t newval)
 {
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }
 
 
-static inline int opal_atomic_cmpset_rel_32( volatile int32_t *addr,
-                                             int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_32( volatile int32_t *addr,
+                                                   int32_t oldval, int32_t newval)
 {
     return __sync_bool_compare_and_swap(addr, oldval, newval);}
 
-static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
-                                         int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32( volatile int32_t *addr,
+                                               int32_t oldval, int32_t newval)
 {
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }
@@ -107,20 +107,20 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
 #if OPAL_ASM_SYNC_HAVE_64BIT
 
 #define OPAL_HAVE_ATOMIC_CMPSET_64 1
-static inline int opal_atomic_cmpset_acq_64( volatile int64_t *addr,
-                                             int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_acq_64( volatile int64_t *addr,
+                                                   int64_t oldval, int64_t newval)
 {
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }
 
-static inline int opal_atomic_cmpset_rel_64( volatile int64_t *addr,
-                                             int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_rel_64( volatile int64_t *addr,
+                                                   int64_t oldval, int64_t newval)
 {
     return __sync_bool_compare_and_swap(addr, oldval, newval);}
 
 
-static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
-                                         int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
+                                               int64_t oldval, int64_t newval)
 {
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }
@@ -159,8 +159,8 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 #endif
 
 #if OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
-static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr,
-                                          opal_int128_t oldval, opal_int128_t newval)
+static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr,
+                                                opal_int128_t oldval, opal_int128_t newval)
 {
     return __sync_bool_compare_and_swap(addr, oldval, newval);
 }

--- a/opal/include/opal/sys/x86_64/atomic.h
+++ b/opal/include/opal/sys/x86_64/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserverd.
- * Copyright (c) 2012-2014 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -82,8 +82,8 @@ static inline void opal_atomic_isync(void)
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
-                                        int32_t oldval, int32_t newval)
+static inline bool opal_atomic_bool_cmpset_32( volatile int32_t *addr,
+                                               int32_t oldval, int32_t newval)
 {
    unsigned char ret;
    __asm__ __volatile__ (
@@ -93,18 +93,18 @@ static inline int opal_atomic_cmpset_32( volatile int32_t *addr,
                        : "q"(newval)
                        : "memory", "cc");
 
-   return (int)ret;
+   return (bool) ret;
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
-#define opal_atomic_cmpset_acq_32 opal_atomic_cmpset_32
-#define opal_atomic_cmpset_rel_32 opal_atomic_cmpset_32
+#define opal_atomic_bool_cmpset_acq_32 opal_atomic_bool_cmpset_32
+#define opal_atomic_bool_cmpset_rel_32 opal_atomic_bool_cmpset_32
 
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
-                                         int64_t oldval, int64_t newval)
+static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
+                                               int64_t oldval, int64_t newval)
 {
    unsigned char ret;
    __asm__ __volatile__ (
@@ -115,18 +115,18 @@ static inline int opal_atomic_cmpset_64( volatile int64_t *addr,
                        : "memory", "cc"
                        );
 
-   return (int)ret;
+   return (bool) ret;
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
-#define opal_atomic_cmpset_acq_64 opal_atomic_cmpset_64
-#define opal_atomic_cmpset_rel_64 opal_atomic_cmpset_64
+#define opal_atomic_bool_cmpset_acq_64 opal_atomic_bool_cmpset_64
+#define opal_atomic_bool_cmpset_rel_64 opal_atomic_bool_cmpset_64
 
 #if OPAL_GCC_INLINE_ASSEMBLY && OPAL_HAVE_CMPXCHG16B && HAVE_OPAL_INT128_T
 
-static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr, opal_int128_t oldval,
-                                          opal_int128_t newval)
+static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr, opal_int128_t oldval,
+                                                opal_int128_t newval)
 {
     unsigned char ret;
 
@@ -140,7 +140,7 @@ static inline int opal_atomic_cmpset_128 (volatile opal_int128_t *addr, opal_int
                             "a" (((int64_t *)&oldval)[0]), "d" (((int64_t *)&oldval)[1])
                           : "memory", "cc");
 
-    return (int) ret;
+    return (bool) ret;
 }
 
 #define OPAL_HAVE_ATOMIC_CMPSET_128 1

--- a/opal/mca/btl/openib/btl_openib_endpoint.c
+++ b/opal/mca/btl/openib/btl_openib_endpoint.c
@@ -377,7 +377,7 @@ static void mca_btl_openib_endpoint_destruct(mca_btl_base_endpoint_t* endpoint)
          * was not in "connect" or "bad" flow (failed to allocate memory)
          * and changed the pointer back to NULL
          */
-        if(!opal_atomic_cmpset_ptr(&endpoint->eager_rdma_local.base.pval, NULL, (void*)1)) {
+        if(!opal_atomic_bool_cmpset_ptr(&endpoint->eager_rdma_local.base.pval, NULL, (void*)1)) {
             if (NULL != endpoint->eager_rdma_local.reg) {
                 endpoint->endpoint_btl->device->rcache->rcache_deregister (endpoint->endpoint_btl->device->rcache,
                                                                            &endpoint->eager_rdma_local.reg->base);
@@ -897,7 +897,7 @@ void mca_btl_openib_endpoint_connect_eager_rdma(
 
     /* Set local rdma pointer to 1 temporarily so other threads will not try
      * to enter the function */
-    if(!opal_atomic_cmpset_ptr(&endpoint->eager_rdma_local.base.pval, NULL,
+    if(!opal_atomic_bool_cmpset_ptr(&endpoint->eager_rdma_local.base.pval, NULL,
                 (void*)1))
         return;
 
@@ -975,7 +975,7 @@ void mca_btl_openib_endpoint_connect_eager_rdma(
         endpoint->eager_rdma_local.rd_win?endpoint->eager_rdma_local.rd_win:1;
 
     /* set local rdma pointer to real value */
-    (void)opal_atomic_cmpset_ptr(&endpoint->eager_rdma_local.base.pval,
+    (void)opal_atomic_bool_cmpset_ptr(&endpoint->eager_rdma_local.base.pval,
                                  (void*)1, buf);
     endpoint->eager_rdma_local.alloc_base = alloc_base;
 
@@ -986,7 +986,7 @@ void mca_btl_openib_endpoint_connect_eager_rdma(
         assert(((opal_object_t*)endpoint)->obj_reference_count == 2);
         do {
             p = &device->eager_rdma_buffers[device->eager_rdma_buffers_count];
-        } while(!opal_atomic_cmpset_ptr(p, NULL, endpoint));
+        } while(!opal_atomic_bool_cmpset_ptr(p, NULL, endpoint));
 
         OPAL_THREAD_ADD32(&openib_btl->eager_rdma_channels, 1);
         /* from this point progress function starts to poll new buffer */
@@ -1001,7 +1001,7 @@ free_headers_buf:
     free(headers_buf);
 unlock_rdma_local:
     /* set local rdma pointer back to zero. Will retry later */
-    (void)opal_atomic_cmpset_ptr(&endpoint->eager_rdma_local.base.pval,
+    (void)opal_atomic_bool_cmpset_ptr(&endpoint->eager_rdma_local.base.pval,
                                  endpoint->eager_rdma_local.base.pval, NULL);
     endpoint->eager_rdma_local.frags = NULL;
 }

--- a/opal/mca/btl/openib/btl_openib_endpoint.h
+++ b/opal/mca/btl/openib/btl_openib_endpoint.h
@@ -447,13 +447,13 @@ static inline int mca_btl_openib_endpoint_post_rr(
 }
 
 #define BTL_OPENIB_CREDITS_SEND_TRYLOCK(E, Q) \
-    OPAL_ATOMIC_CMPSET_32(&(E)->qps[(Q)].rd_credit_send_lock, 0, 1)
+    OPAL_ATOMIC_BOOL_CMPSET_32(&(E)->qps[(Q)].rd_credit_send_lock, 0, 1)
 #define BTL_OPENIB_CREDITS_SEND_UNLOCK(E, Q) \
-    OPAL_ATOMIC_CMPSET_32(&(E)->qps[(Q)].rd_credit_send_lock, 1, 0)
+    OPAL_ATOMIC_BOOL_CMPSET_32(&(E)->qps[(Q)].rd_credit_send_lock, 1, 0)
 #define BTL_OPENIB_GET_CREDITS(FROM, TO)                                        \
     do {                                                     \
         TO = FROM;                                           \
-    } while(0 == OPAL_ATOMIC_CMPSET_32(&FROM, TO, 0))
+    } while(0 == OPAL_ATOMIC_BOOL_CMPSET_32(&FROM, TO, 0))
 
 
 static inline bool check_eager_rdma_credits(const mca_btl_openib_endpoint_t *ep)

--- a/opal/mca/btl/ugni/btl_ugni_smsg.c
+++ b/opal/mca/btl/ugni/btl_ugni_smsg.c
@@ -64,7 +64,7 @@ int mca_btl_ugni_smsg_process (mca_btl_base_endpoint_t *ep)
     uint32_t len;
     int count = 0;
 
-    if (!opal_atomic_cmpset_32 (&ep->smsg_progressing, 0, 1)) {
+    if (!opal_atomic_bool_cmpset_32 (&ep->smsg_progressing, 0, 1)) {
         /* already progressing (we can't support reentry here) */
         return 0;
     }

--- a/opal/mca/btl/vader/btl_vader_fifo.h
+++ b/opal/mca/btl/vader/btl_vader_fifo.h
@@ -31,7 +31,7 @@
 #include "btl_vader_frag.h"
 
 #if SIZEOF_VOID_P == 8
-  #define vader_item_cmpset(x, y, z) opal_atomic_cmpset_64((volatile int64_t *)(x), (int64_t)(y), (int64_t)(z))
+  #define vader_item_cmpset(x, y, z) opal_atomic_bool_cmpset_64((volatile int64_t *)(x), (int64_t)(y), (int64_t)(z))
   #define vader_item_swap(x, y)      opal_atomic_swap_64((volatile int64_t *)(x), (int64_t)(y))
 
   #define MCA_BTL_VADER_OFFSET_MASK 0xffffffffll
@@ -40,7 +40,7 @@
 
   typedef int64_t fifo_value_t;
 #else
-  #define vader_item_cmpset(x, y, z) opal_atomic_cmpset_32((volatile int32_t *)(x), (int32_t)(y), (int32_t)(z))
+  #define vader_item_cmpset(x, y, z) opal_atomic_bool_cmpset_32((volatile int32_t *)(x), (int32_t)(y), (int32_t)(z))
   #define vader_item_swap(x, y)      opal_atomic_swap_32((volatile int32_t *)(x), (int32_t)(y))
 
   #define MCA_BTL_VADER_OFFSET_MASK 0x00ffffffl

--- a/opal/runtime/opal_cr.c
+++ b/opal/runtime/opal_cr.c
@@ -173,7 +173,7 @@ static const uint32_t ProcInc    = 0x2;
  }
 #define OPAL_CR_THREAD_LOCK()                                                      \
  {                                                                                 \
-    while(!OPAL_ATOMIC_CMPSET_32(&opal_cr_thread_num_in_library, 0, ThreadFlag)) { \
+    while(!OPAL_ATOMIC_BOOL_CMPSET_32(&opal_cr_thread_num_in_library, 0, ThreadFlag)) { \
       if( !opal_cr_thread_is_active && opal_cr_thread_is_done) {                   \
           break;                                                                   \
       }                                                                            \

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -147,7 +147,7 @@ static inline type opal_thread_sub_ ## suffix (volatile type *addr, type delta) 
 static inline bool opal_thread_cmpset_bool_ ## suffix (volatile addr_type *addr, type compare, type value) \
 {                                                                       \
     if (OPAL_UNLIKELY(opal_using_threads())) {                          \
-        return opal_atomic_cmpset_ ## suffix ((volatile type *) addr, compare, value); \
+        return opal_atomic_bool_cmpset_ ## suffix ((volatile type *) addr, compare, value); \
     }                                                                   \
                                                                         \
     if ((type) *addr == compare) {                                      \
@@ -201,11 +201,11 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
 #define OPAL_THREAD_SUB_SIZE_T opal_thread_sub_size_t
 #define OPAL_ATOMIC_SUB_SIZE_T opal_thread_sub_size_t
 
-#define OPAL_THREAD_CMPSET_32 opal_thread_cmpset_bool_32
-#define OPAL_ATOMIC_CMPSET_32 opal_thread_cmpset_bool_32
+#define OPAL_THREAD_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
+#define OPAL_ATOMIC_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
 
-#define OPAL_THREAD_CMPSET_PTR(x, y, z) opal_thread_cmpset_bool_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
-#define OPAL_ATOMIC_CMPSET_PTR OPAL_THREAD_CMPSET_PTR
+#define OPAL_THREAD_BOOL_CMPSET_PTR(x, y, z) opal_thread_cmpset_bool_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
+#define OPAL_ATOMIC_BOOL_CMPSET_PTR OPAL_THREAD_BOOL_CMPSET_PTR
 
 #define OPAL_THREAD_SWAP_32 opal_thread_swap_32
 #define OPAL_ATOMIC_SWAP_32 opal_thread_swap_32
@@ -235,8 +235,8 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 #define OPAL_THREAD_XOR64 opal_thread_xor_64
 #define OPAL_ATOMIC_XOR64 opal_thread_xor_64
 
-#define OPAL_THREAD_CMPSET_64 opal_thread_cmpset_bool_64
-#define OPAL_ATOMIC_CMPSET_64 opal_thread_cmpset_bool_64
+#define OPAL_THREAD_BOOL_CMPSET_64 opal_thread_cmpset_bool_64
+#define OPAL_ATOMIC_BOOL_CMPSET_64 opal_thread_cmpset_bool_64
 
 #define OPAL_THREAD_SWAP_64 opal_thread_swap_64
 #define OPAL_ATOMIC_SWAP_64 opal_thread_swap_64

--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -65,7 +65,7 @@ int oshmem_shmem_finalize(void)
     int ret = OSHMEM_SUCCESS;
     static int32_t finalize_has_already_started = 0;
 
-    if (opal_atomic_cmpset_32(&finalize_has_already_started, 0, 1)
+    if (opal_atomic_bool_cmpset_32(&finalize_has_already_started, 0, 1)
             && oshmem_shmem_initialized && !oshmem_shmem_aborted) {
         /* Should be called first because ompi_mpi_finalize makes orte and opal finalization */
         ret = _shmem_finalize();

--- a/test/asm/atomic_cmpset.c
+++ b/test/asm/atomic_cmpset.c
@@ -99,30 +99,30 @@ int main(int argc, char *argv[])
     /* -- cmpset 32-bit tests -- */
 
     vol32 = 42, old32 = 42, new32 = 50;
-    assert(opal_atomic_cmpset_32(&vol32, old32, new32) == 1);
+    assert(opal_atomic_bool_cmpset_32(&vol32, old32, new32) == 1);
     opal_atomic_rmb();
     assert(vol32 == new32);
 
     vol32 = 42, old32 = 420, new32 = 50;
-    assert(opal_atomic_cmpset_32(&vol32, old32, new32) ==  0);
+    assert(opal_atomic_bool_cmpset_32(&vol32, old32, new32) ==  0);
     opal_atomic_rmb();
     assert(vol32 == 42);
 
     vol32 = 42, old32 = 42, new32 = 50;
-    assert(opal_atomic_cmpset_acq_32(&vol32, old32, new32) == 1);
+    assert(opal_atomic_bool_cmpset_acq_32(&vol32, old32, new32) == 1);
     assert(vol32 == new32);
 
     vol32 = 42, old32 = 420, new32 = 50;
-    assert(opal_atomic_cmpset_acq_32(&vol32, old32, new32) == 0);
+    assert(opal_atomic_bool_cmpset_acq_32(&vol32, old32, new32) == 0);
     assert(vol32 == 42);
 
     vol32 = 42, old32 = 42, new32 = 50;
-    assert(opal_atomic_cmpset_rel_32(&vol32, old32, new32) ==  1);
+    assert(opal_atomic_bool_cmpset_rel_32(&vol32, old32, new32) ==  1);
     opal_atomic_rmb();
     assert(vol32 == new32);
 
     vol32 = 42, old32 = 420, new32 = 50;
-    assert(opal_atomic_cmpset_rel_32(&vol32, old32, new32) == 0);
+    assert(opal_atomic_bool_cmpset_rel_32(&vol32, old32, new32) == 0);
     opal_atomic_rmb();
     assert(vol32 == 42);
 
@@ -130,60 +130,60 @@ int main(int argc, char *argv[])
 
 #if OPAL_HAVE_ATOMIC_MATH_64
     vol64 = 42, old64 = 42, new64 = 50;
-    assert(1 == opal_atomic_cmpset_64(&vol64, old64, new64));
+    assert(1 == opal_atomic_bool_cmpset_64(&vol64, old64, new64));
     opal_atomic_rmb();
     assert(new64 == vol64);
 
     vol64 = 42, old64 = 420, new64 = 50;
-    assert(opal_atomic_cmpset_64(&vol64, old64, new64) == 0);
+    assert(opal_atomic_bool_cmpset_64(&vol64, old64, new64) == 0);
     opal_atomic_rmb();
     assert(vol64 == 42);
 
     vol64 = 42, old64 = 42, new64 = 50;
-    assert(opal_atomic_cmpset_acq_64(&vol64, old64, new64) == 1);
+    assert(opal_atomic_bool_cmpset_acq_64(&vol64, old64, new64) == 1);
     assert(vol64 == new64);
 
     vol64 = 42, old64 = 420, new64 = 50;
-    assert(opal_atomic_cmpset_acq_64(&vol64, old64, new64) == 0);
+    assert(opal_atomic_bool_cmpset_acq_64(&vol64, old64, new64) == 0);
     assert(vol64 == 42);
 
     vol64 = 42, old64 = 42, new64 = 50;
-    assert(opal_atomic_cmpset_rel_64(&vol64, old64, new64) == 1);
+    assert(opal_atomic_bool_cmpset_rel_64(&vol64, old64, new64) == 1);
     opal_atomic_rmb();
     assert(vol64 == new64);
 
     vol64 = 42, old64 = 420, new64 = 50;
-    assert(opal_atomic_cmpset_rel_64(&vol64, old64, new64) == 0);
+    assert(opal_atomic_bool_cmpset_rel_64(&vol64, old64, new64) == 0);
     opal_atomic_rmb();
     assert(vol64 == 42);
 #endif
     /* -- cmpset int tests -- */
 
     volint = 42, oldint = 42, newint = 50;
-    assert(opal_atomic_cmpset(&volint, oldint, newint) == 1);
+    assert(opal_atomic_bool_cmpset(&volint, oldint, newint) == 1);
     opal_atomic_rmb();
     assert(volint ==newint);
 
     volint = 42, oldint = 420, newint = 50;
-    assert(opal_atomic_cmpset(&volint, oldint, newint) == 0);
+    assert(opal_atomic_bool_cmpset(&volint, oldint, newint) == 0);
     opal_atomic_rmb();
     assert(volint == 42);
 
     volint = 42, oldint = 42, newint = 50;
-    assert(opal_atomic_cmpset_acq(&volint, oldint, newint) == 1);
+    assert(opal_atomic_bool_cmpset_acq(&volint, oldint, newint) == 1);
     assert(volint == newint);
 
     volint = 42, oldint = 420, newint = 50;
-    assert(opal_atomic_cmpset_acq(&volint, oldint, newint) == 0);
+    assert(opal_atomic_bool_cmpset_acq(&volint, oldint, newint) == 0);
     assert(volint == 42);
 
     volint = 42, oldint = 42, newint = 50;
-    assert(opal_atomic_cmpset_rel(&volint, oldint, newint) == 1);
+    assert(opal_atomic_bool_cmpset_rel(&volint, oldint, newint) == 1);
     opal_atomic_rmb();
     assert(volint == newint);
 
     volint = 42, oldint = 420, newint = 50;
-    assert(opal_atomic_cmpset_rel(&volint, oldint, newint) == 0);
+    assert(opal_atomic_bool_cmpset_rel(&volint, oldint, newint) == 0);
     opal_atomic_rmb();
     assert(volint == 42);
 
@@ -191,30 +191,30 @@ int main(int argc, char *argv[])
     /* -- cmpset ptr tests -- */
 
     volptr = (void *) 42, oldptr = (void *) 42, newptr = (void *) 50;
-    assert(opal_atomic_cmpset_ptr(&volptr, oldptr, newptr) == 1);
+    assert(opal_atomic_bool_cmpset_ptr(&volptr, oldptr, newptr) == 1);
     opal_atomic_rmb();
     assert(volptr == newptr);
 
     volptr = (void *) 42, oldptr = (void *) 420, newptr = (void *) 50;
-    assert(opal_atomic_cmpset_ptr(&volptr, oldptr, newptr) == 0);
+    assert(opal_atomic_bool_cmpset_ptr(&volptr, oldptr, newptr) == 0);
     opal_atomic_rmb();
     assert(volptr == (void *) 42);
 
     volptr = (void *) 42, oldptr = (void *) 42, newptr = (void *) 50;
-    assert(opal_atomic_cmpset_acq_ptr(&volptr, oldptr, newptr) == 1);
+    assert(opal_atomic_bool_cmpset_acq_ptr(&volptr, oldptr, newptr) == 1);
     assert(volptr == newptr);
 
     volptr = (void *) 42, oldptr = (void *) 420, newptr = (void *) 50;
-    assert(opal_atomic_cmpset_acq_ptr(&volptr, oldptr, newptr) == 0);
+    assert(opal_atomic_bool_cmpset_acq_ptr(&volptr, oldptr, newptr) == 0);
     assert(volptr == (void *) 42);
 
     volptr = (void *) 42, oldptr = (void *) 42, newptr = (void *) 50;
-    assert(opal_atomic_cmpset_rel_ptr(&volptr, oldptr, newptr) == 1);
+    assert(opal_atomic_bool_cmpset_rel_ptr(&volptr, oldptr, newptr) == 1);
     opal_atomic_rmb();
     assert(volptr == newptr);
 
     volptr = (void *) 42, oldptr = (void *) 420, newptr = (void *) 50;
-    assert(opal_atomic_cmpset_rel_ptr(&volptr, oldptr, newptr) == 0);
+    assert(opal_atomic_bool_cmpset_rel_ptr(&volptr, oldptr, newptr) == 0);
     opal_atomic_rmb();
     assert(volptr == (void *) 42);
 


### PR DESCRIPTION
This commit renames the atomic compare-and-swap functions to indicate
the return value. This is in preperation for adding support for a
compare-and-swap that returns the old value. At the same time the
return type has been changed to bool.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>