### PR TITLE
VERSION: roll to 2.0.4rc2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,6 +57,8 @@ included in the vX.Y.Z section and be denoted as:
 ----------------------
 
 Bug fixes/minor improvements:
+- Fix an issue with visibility of functions defined in the built-in PMIx.
+  Thanks to Siegmar Gross for reporting this issue.
 - Add configure check to prevent trying to build this release of
   Open MPI with an external hwloc 2.0 or newer release.
 - Add ability to specify layered providers for OFI MTL.

--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=4
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
update NEWS for fixes since rc1

[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>