### PR TITLE
README: add a blurb about sun compiler and PMIx

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -53,8 +53,8 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
-2.0.4 -- October, 2017
-----------------------
+2.0.4 -- November, 2017
+-----------------------
 
 Bug fixes/minor improvements:
 - Fix an issue with visibility of functions defined in the built-in PMIx.

--- a/README
+++ b/README
@@ -250,6 +250,10 @@ Compiler Notes
   command.  Officially, Solaris Studio is not supported on Ubuntu Linux
   distributions, so additional problems might be incurred.
 
+- There are known problems building the internal PMIx package using
+  Oracle (Sun) Studio C compiler, at least version 5.15.  A possible
+  workaround is to build against the latest external PMIx 1.2 release.
+
 - Open MPI does not support the gccfss compiler (GCC For SPARC
   Systems; a now-defunct compiler project from Sun).
 


### PR DESCRIPTION
Seems like at least for some versions of the sun
compiler, the embedded PMIx in the 2.0.4 rlease
can't be build.  So add a blurb to the README.

Also adjust NEWS to reflect the new date.

Not going to roll new release tarball just for this,
so keep at rc2 in VERSION

[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>