### PR TITLE
Fix OFI MTL to recognize correct CQ empty scenario

### DIFF
--- a/ompi/mca/mtl/ofi/help-mtl-ofi.txt
+++ b/ompi/mca/mtl/ofi/help-mtl-ofi.txt
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-# Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved
 #
 # $COPYRIGHT$
 #
@@ -8,3 +8,9 @@
 #
 # $HEADER$
 #
+[OFI call fail]
+Open MPI failed an OFI Libfabric library call (%s).This is highly unusual;
+your job may behave unpredictably (and/or abort) after this.
+  Local host: %s
+  Location: %s:%d
+  Error: %s (%zd)

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved
  *
  * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
@@ -14,6 +14,7 @@
 
 #include "mtl_ofi.h"
 #include "opal/util/argv.h"
+#include "opal/util/show_help.h"
 
 static int ompi_mtl_ofi_component_open(void);
 static int ompi_mtl_ofi_component_query(mca_base_module_t **module, int *priority);
@@ -331,9 +332,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                      hints,        /* In: Hints to filter providers            */
                      &providers);   /* Out: List of matching providers          */
     if (0 != ret) {
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
-                            "%s:%d: fi_getinfo failed: %s\n",
-                            __FILE__, __LINE__, fi_strerror(-ret));
+        opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
+                       "fi_getinfo",
+                       ompi_process_info.nodename, __FILE__, __LINE__,
+                       fi_strerror(-ret), ret);
         goto error;
     }
 
@@ -359,9 +361,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                     &ompi_mtl_ofi.fabric, /* Out: Fabric handle                 */
                     NULL);                /* Optional context for fabric events */
     if (0 != ret) {
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
-                            "%s:%d: fi_fabric failed: %s\n",
-                            __FILE__, __LINE__, fi_strerror(-ret));
+        opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
+                       "fi_fabric",
+                       ompi_process_info.nodename, __FILE__, __LINE__,
+                       fi_strerror(-ret), ret);
         goto error;
     }
 
@@ -375,9 +378,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                     &ompi_mtl_ofi.domain, /* Out: Domain oject                  */
                     NULL);                /* Optional context for domain events */
     if (0 != ret) {
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
-                            "%s:%d: fi_domain failed: %s\n",
-                            __FILE__, __LINE__, fi_strerror(-ret));
+        opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
+                       "fi_domain",
+                       ompi_process_info.nodename, __FILE__, __LINE__,
+                       fi_strerror(-ret), ret);
         goto error;
     }
 
@@ -393,9 +397,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                       &ompi_mtl_ofi.ep,    /* Out: Endpoint object */
                       NULL);               /* Optional context     */
     if (0 != ret) {
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
-                            "%s:%d: fi_endpoint failed: %s\n",
-                            __FILE__, __LINE__, fi_strerror(-ret));
+        opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
+                       "fi_endpoint",
+                       ompi_process_info.nodename, __FILE__, __LINE__,
+                       fi_strerror(-ret), ret);
         goto error;
     }
 
@@ -548,38 +553,40 @@ error:
 int
 ompi_mtl_ofi_finalize(struct mca_mtl_base_module_t *mtl)
 {
+    ssize_t ret;
+
     opal_progress_unregister(ompi_mtl_ofi_progress_no_inline);
 
-    /**
- *      * Close all the OFI objects
- *           */
-    if (fi_close((fid_t)ompi_mtl_ofi.ep)) {
-        opal_output(ompi_mtl_base_framework.framework_output,
-                "fi_close failed: %s", strerror(errno));
-        abort();
+    /* Close all the OFI objects */
+    if (ret = fi_close((fid_t)ompi_mtl_ofi.ep)) {
+        goto finalize_err;
     }
-    if (fi_close((fid_t)ompi_mtl_ofi.cq)) {
-        opal_output(ompi_mtl_base_framework.framework_output,
-                "fi_close failed: %s", strerror(errno));
-        abort();
+
+    if (ret = fi_close((fid_t)ompi_mtl_ofi.cq)) {
+        goto finalize_err;
     }
-    if (fi_close((fid_t)ompi_mtl_ofi.av)) {
-        opal_output(ompi_mtl_base_framework.framework_output,
-                "fi_close failed: %s", strerror(errno));
-        abort();
+
+    if (ret = fi_close((fid_t)ompi_mtl_ofi.av)) {
+        goto finalize_err;
     }
-    if (fi_close((fid_t)ompi_mtl_ofi.domain)) {
-        opal_output(ompi_mtl_base_framework.framework_output,
-                "fi_close failed: %s", strerror(errno));
-        abort();
+
+    if (ret = fi_close((fid_t)ompi_mtl_ofi.domain)) {
+        goto finalize_err;
     }
-    if (fi_close((fid_t)ompi_mtl_ofi.fabric)) {
-        opal_output(ompi_mtl_base_framework.framework_output,
-                "fi_close failed: %s", strerror(errno));
-        abort();
+
+    if (ret = fi_close((fid_t)ompi_mtl_ofi.fabric)) {
+        goto finalize_err;
     }
 
     return OMPI_SUCCESS;
+
+finalize_err:
+    opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
+                   "fi_close",
+                   ompi_process_info.nodename, __FILE__, __LINE__,
+                   fi_strerror(-ret), ret);
+
+    return OMPI_ERROR;
 }
 
 


### PR DESCRIPTION
Currently, the progress function is incorrectly interpreting any error
value other than a positive value or -FI_EAVAIL to mean CQ is empty.
CQ is empty only if fi_cq_read() call returned -EAGAIN error
code. Fix that here.

While at it, fix help text output for calls made to OFI API.

Signed-off-by: Aravind Gopalakrishnan <Aravind.Gopalakrishnan@intel.com>
(cherry picked from commit 285fc42b4ea9c16c8e7b9caa1c5def453f80e557)