### PR TITLE
Fix OFI MTL to recognize correct CQ empty scenario

### DIFF
--- a/ompi/mca/mtl/ofi/help-mtl-ofi.txt
+++ b/ompi/mca/mtl/ofi/help-mtl-ofi.txt
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-# Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved
 #
 # $COPYRIGHT$
 #
@@ -8,3 +8,9 @@
 #
 # $HEADER$
 #
+[OFI call fail]
+Open MPI failed an OFI Libfabric library call (%s).This is highly unusual;
+your job may behave unpredictably (and/or abort) after this.
+  Local host: %s
+  Location: %s:%d
+  Error: %s (%zd)

--- a/ompi/mca/mtl/ofi/help-mtl-ofi.txt
+++ b/ompi/mca/mtl/ofi/help-mtl-ofi.txt
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved
 #
+# Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -9,8 +10,9 @@
 # $HEADER$
 #
 [OFI call fail]
-Open MPI failed an OFI Libfabric library call (%s).This is highly unusual;
-your job may behave unpredictably (and/or abort) after this.
+Open MPI failed an OFI Libfabric library call (%s).  This is highly
+unusual; your job may behave unpredictably (and/or abort) after this.
+
   Local host: %s
   Location: %s:%d
   Error: %s (%zd)

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved
  *
  * $COPYRIGHT$
  *
@@ -14,6 +14,7 @@
 #include "ompi/mca/mtl/mtl.h"
 #include "ompi/mca/mtl/base/base.h"
 #include "opal/datatype/opal_convertor.h"
+#include "opal/util/show_help.h"
 
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
@@ -79,13 +80,14 @@ ompi_mtl_ofi_progress(void)
                 assert(ofi_req);
                 ret = ofi_req->event_callback(&wc, ofi_req);
                 if (OMPI_SUCCESS != ret) {
-                    opal_output(ompi_mtl_base_framework.framework_output,
-                                "Error returned by request event callback: %zd",
-                                ret);
-                    abort();
+                    opal_output(0, "%s:%d: Error returned by request event callback: %zd.\n"
+                                   "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                                   __FILE__, __LINE__, ret);
+                    fflush(stderr);
+                    exit(1);
                 }
             }
-        } else if (ret == -FI_EAVAIL) {
+        } else if (OPAL_UNLIKELY(ret == -FI_EAVAIL)) {
             /**
              * An error occured and is being reported via the CQ.
              * Read the error and forward it to the upper layer.
@@ -94,9 +96,11 @@ ompi_mtl_ofi_progress(void)
                                 &error,
                                 0);
             if (0 > ret) {
-                opal_output(ompi_mtl_base_framework.framework_output,
-                            "Error returned from fi_cq_readerr: %zd", ret);
-                abort();
+                opal_output(0, "%s:%d: Error returned from fi_cq_readerr: %s(%zd).\n"
+                               "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                               __FILE__, __LINE__, fi_strerror(-ret), ret);
+                fflush(stderr);
+                exit(1);
             }
 
             assert(error.op_context);
@@ -104,16 +108,22 @@ ompi_mtl_ofi_progress(void)
             assert(ofi_req);
             ret = ofi_req->error_callback(&error, ofi_req);
             if (OMPI_SUCCESS != ret) {
-                opal_output(ompi_mtl_base_framework.framework_output,
-                        "Error returned by request error callback: %zd",
-                        ret);
-                abort();
+                    opal_output(0, "%s:%d: Error returned by request error callback: %zd.\n"
+                                   "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                                   __FILE__, __LINE__, ret);
+                fflush(stderr);
+                exit(1);
             }
         } else {
-            /**
-             * The CQ is empty. Return.
-             */
-            break;
+            if (ret == -FI_EAGAIN) {
+                break;
+            } else {
+                opal_output(0, "%s:%d: Error returned from fi_cq_read: %s(%zd).\n"
+                               "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                               __FILE__, __LINE__, fi_strerror(-ret), ret);
+                fflush(stderr);
+                exit(1);
+            }
         }
     }
     return count;

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -594,23 +594,23 @@ ompi_mtl_ofi_finalize(struct mca_mtl_base_module_t *mtl)
     opal_progress_unregister(ompi_mtl_ofi_progress_no_inline);
 
     /* Close all the OFI objects */
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.ep)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.ep))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.cq)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.cq))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.av)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.av))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.domain)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.domain))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.fabric)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.fabric))) {
         goto finalize_err;
     }
 

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2013-2017 Intel, Inc. All rights reserved
  *
- * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -362,7 +362,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                      NULL,          /* Optional name or fabric to resolve       */
                      NULL,          /* Optional service name or port to request */
                      0ULL,          /* Optional flag                            */
-                     hints,        /* In: Hints to filter providers            */
+                     hints,         /* In: Hints to filter providers            */
                      &providers);   /* Out: List of matching providers          */
     if (0 != ret) {
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -364,7 +364,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                      0ULL,          /* Optional flag                            */
                      hints,         /* In: Hints to filter providers            */
                      &providers);   /* Out: List of matching providers          */
-    if (0 != ret) {
+    if (FI_ENODATA == -ret) {
+        // It is not an error if no information is returned.
+        goto error;
+    } else if (0 != ret) {
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_getinfo",
                        ompi_process_info.nodename, __FILE__, __LINE__,

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -368,7 +368,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_getinfo",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -397,7 +397,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_fabric",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -414,7 +414,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_domain",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -433,7 +433,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_endpoint",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -617,7 +617,7 @@ finalize_err:
     opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                    "fi_close",
                    ompi_process_info.nodename, __FILE__, __LINE__,
-                   fi_strerror(-ret), ret);
+                   fi_strerror(-ret), -ret);
 
     return OMPI_ERROR;
 }


### PR DESCRIPTION
Currently, the progress function is incorrectly interpreting any error
value other than a positive value or -FI_EAVAIL to mean CQ is empty.
CQ is empty only if fi_cq_read() call returned -EAGAIN error
code. Fix that here.

While at it, fix help text output for calls made to OFI API.

Signed-off-by: Aravind Gopalakrishnan <Aravind.Gopalakrishnan@intel.com>
(cherry picked from commit 285fc42b4ea9c16c8e7b9caa1c5def453f80e557)