### PR TITLE
opal/asm: add opal_atomic_compare_exchange_strong functions

### DIFF
--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2013-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -487,7 +487,8 @@ int ompi_datatype_get_pack_description( ompi_datatype_t* datatype,
     void* recursive_buffer;
 
     if (NULL == packed_description) {
-        if (opal_atomic_bool_cmpset (&datatype->packed_description, NULL, (void *) 1)) {
+        void *_tmp_ptr = NULL;
+        if (opal_atomic_compare_exchange_strong_ptr (&datatype->packed_description, (void *) &_tmp_ptr, (void *) 1)) {
             if( ompi_datatype_is_predefined(datatype) ) {
                 packed_description = malloc(2 * sizeof(int));
             } else if( NULL == args ) {

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2007-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2013-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -356,7 +356,7 @@ static inline struct ompi_proc_t *ompi_group_dense_lookup (ompi_group_t *group, 
         ompi_proc_t *real_proc =
             (ompi_proc_t *) ompi_proc_for_name (ompi_proc_sentinel_to_name ((uintptr_t) proc));
 
-        if (opal_atomic_bool_cmpset_ptr (group->grp_proc_pointers + peer_id, proc, real_proc)) {
+        if (opal_atomic_compare_exchange_strong_ptr (group->grp_proc_pointers + peer_id, &proc, real_proc)) {
             OBJ_RETAIN(real_proc);
         }
 

--- a/ompi/mca/mtl/portals4/mtl_portals4_flowctl.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4_flowctl.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -296,9 +296,10 @@ ompi_mtl_portals4_flowctl_add_procs(size_t me,
 int
 ompi_mtl_portals4_flowctl_trigger(void)
 {
+    int32_t _tmp_value = 0;
     int ret;
 
-    if (true == OPAL_ATOMIC_BOOL_CMPSET_32(&ompi_mtl_portals4.flowctl.flowctl_active, false, true)) {
+    if (true == OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32(&ompi_mtl_portals4.flowctl.flowctl_active, &_tmp_value, 1)) {
         /* send trigger to root */
         ret = PtlPut(ompi_mtl_portals4.zero_md_h,
                      0,

--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -8,7 +8,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
@@ -145,15 +145,11 @@ static inline bool ompi_osc_pt2pt_peer_eager_active (ompi_osc_pt2pt_peer_t *peer
 
 static inline void ompi_osc_pt2pt_peer_set_flag (ompi_osc_pt2pt_peer_t *peer, int32_t flag, bool value)
 {
-    int32_t peer_flags, new_flags;
-    do {
-        peer_flags = peer->flags;
-        if (value) {
-            new_flags = peer_flags | flag;
-        } else {
-            new_flags = peer_flags & ~flag;
-        }
-    } while (!OPAL_ATOMIC_BOOL_CMPSET_32 (&peer->flags, peer_flags, new_flags));
+    if (value) {
+        OPAL_ATOMIC_OR32 (&peer->flags, flag);
+    } else {
+        OPAL_ATOMIC_AND32 (&peer->flags, ~flag);
+    }
 }
 
 static inline void ompi_osc_pt2pt_peer_set_locked (ompi_osc_pt2pt_peer_t *peer, bool value)

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -105,7 +105,7 @@ static int ompi_osc_pt2pt_flush_active_frag (ompi_osc_pt2pt_module_t *module, om
                          "osc pt2pt: flushing active fragment to target %d. pending: %d",
                          active_frag->target, active_frag->pending));
 
-    if (opal_atomic_bool_cmpset (&peer->active_frag, active_frag, NULL)) {
+    if (opal_atomic_compare_exchange_strong_ptr (&peer->active_frag, &active_frag, NULL)) {
         if (0 != OPAL_THREAD_ADD32(&active_frag->pending, -1)) {
             /* communication going on while synchronizing; this is an rma usage bug */
             return OMPI_ERR_RMA_SYNC;

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.h
@@ -67,7 +67,7 @@ static inline ompi_osc_pt2pt_frag_t *ompi_osc_pt2pt_frag_alloc_non_buffered (omp
 
     /* to ensure ordering flush the buffer on the peer */
     curr = peer->active_frag;
-    if (NULL != curr && opal_atomic_bool_cmpset (&peer->active_frag, curr, NULL)) {
+    if (NULL != curr && opal_atomic_compare_exchange_strong_ptr (&peer->active_frag, &curr, NULL)) {
         /* If there's something pending, the pending finish will
            start the buffer.  Otherwise, we need to start it now. */
         int ret = ompi_osc_pt2pt_frag_finish (module, curr);

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_passive_target.c
@@ -744,14 +744,13 @@ static bool ompi_osc_pt2pt_lock_try_acquire (ompi_osc_pt2pt_module_t* module, in
                 break;
             }
 
-            if (opal_atomic_bool_cmpset_32 (&module->lock_status, lock_status, lock_status + 1)) {
+            if (opal_atomic_compare_exchange_strong_32 (&module->lock_status, &lock_status, lock_status + 1)) {
                 break;
             }
-
-            lock_status = module->lock_status;
         } while (1);
     } else {
-        queue = !opal_atomic_bool_cmpset_32 (&module->lock_status, 0, -1);
+        int32_t _tmp_value = 0;
+        queue = !opal_atomic_compare_exchange_strong_32 (&module->lock_status, &_tmp_value, -1);
     }
 
     if (queue) {

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -8,7 +8,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
@@ -285,7 +285,9 @@ int ompi_osc_rdma_post_atomic (ompi_group_t *group, int assert, ompi_win_t *win)
                 ret = ompi_osc_rdma_lock_btl_cswap (module, peer, target, 0, 1 + (int64_t) my_rank, &result);
                 assert (OMPI_SUCCESS == ret);
             } else {
-                result = !ompi_osc_rdma_lock_cmpset ((osc_rdma_counter_t *) target, 0, 1 + (osc_rdma_counter_t) my_rank);
+                ompi_osc_rdma_lock_t _tmp_value = 0;
+
+                result = !ompi_osc_rdma_lock_compare_exchange ((osc_rdma_counter_t *) target, &_tmp_value, 1 + (osc_rdma_counter_t) my_rank);
             }
 
             if (OPAL_LIKELY(0 == result)) {

--- a/ompi/mca/osc/rdma/osc_rdma_lock.h
+++ b/ompi/mca/osc/rdma/osc_rdma_lock.h
@@ -17,7 +17,8 @@
 
 static inline int ompi_osc_rdma_trylock_local (volatile ompi_osc_rdma_lock_t *lock)
 {
-    return !ompi_osc_rdma_lock_cmpset (lock, 0, OMPI_OSC_RDMA_LOCK_EXCLUSIVE);
+    ompi_osc_rdma_lock_t _tmp_value = 0;
+    return !ompi_osc_rdma_lock_compare_exchange (lock, &_tmp_value, OMPI_OSC_RDMA_LOCK_EXCLUSIVE);
 }
 
 static inline void ompi_osc_rdma_unlock_local (volatile ompi_osc_rdma_lock_t *lock)

--- a/ompi/mca/osc/rdma/osc_rdma_peer.h
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.h
@@ -201,14 +201,13 @@ static inline bool ompi_osc_rdma_peer_test_set_flag (ompi_osc_rdma_peer_t *peer,
     int32_t flags;
 
     opal_atomic_mb ();
+    flags = peer->flags;
 
     do {
-        flags = peer->flags;
         if (flags & flag) {
             return false;
         }
-
-    } while (!OPAL_THREAD_BOOL_CMPSET_32 (&peer->flags, flags, flags | flag));
+    } while (!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32 (&peer->flags, &flags, flags | flag));
 
     return true;
 }

--- a/ompi/mca/osc/rdma/osc_rdma_types.h
+++ b/ompi/mca/osc/rdma/osc_rdma_types.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -54,12 +54,12 @@ static inline int64_t ompi_osc_rdma_lock_add (volatile int64_t *p, int64_t value
     return new;
 }
 
-static inline int ompi_osc_rdma_lock_cmpset (volatile int64_t *p, int64_t comp, int64_t value)
+static inline int ompi_osc_rdma_lock_compare_exchange (volatile int64_t *p, int64_t *comp, int64_t value)
 {
     int ret;
 
     opal_atomic_mb ();
-    ret = opal_atomic_bool_cmpset_64 (p, comp, value);
+    ret = opal_atomic_compare_exchange_strong_64 (p, comp, value);
     opal_atomic_mb ();
 
     return ret;
@@ -83,12 +83,12 @@ static inline int32_t ompi_osc_rdma_lock_add (volatile int32_t *p, int32_t value
     return new;
 }
 
-static inline int ompi_osc_rdma_lock_cmpset (volatile int32_t *p, int32_t comp, int32_t value)
+static inline int ompi_osc_rdma_lock_compare_exchange (volatile int32_t *p, int32_t *comp, int32_t value)
 {
     int ret;
 
     opal_atomic_mb ();
-    ret = opal_atomic_bool_cmpset_32 (p, comp, value);
+    ret = opal_atomic_compare_exchange_strong_32 (p, comp, value);
     opal_atomic_mb ();
 
     return ret;

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -396,10 +396,12 @@ static inline int ompi_request_free(ompi_request_t** request)
 static inline void ompi_request_wait_completion(ompi_request_t *req)
 {
     if (opal_using_threads () && !REQUEST_COMPLETE(req)) {
+        void *_tmp_ptr = REQUEST_PENDING;
         ompi_wait_sync_t sync;
+
         WAIT_SYNC_INIT(&sync, 1);
 
-        if (OPAL_ATOMIC_BOOL_CMPSET_PTR(&req->req_complete, REQUEST_PENDING, &sync)) {
+        if (OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR(&req->req_complete, &_tmp_ptr, &sync)) {
             SYNC_WAIT(&sync);
         } else {
             /* completed before we had a chance to swap in the sync object */
@@ -439,7 +441,9 @@ static inline int ompi_request_complete(ompi_request_t* request, bool with_signa
 
     if (0 == rc) {
         if( OPAL_LIKELY(with_signal) ) {
-            if(!OPAL_ATOMIC_BOOL_CMPSET_PTR(&request->req_complete, REQUEST_PENDING, REQUEST_COMPLETED)) {
+            void *_tmp_ptr = REQUEST_PENDING;
+
+            if(!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR(&request->req_complete, &_tmp_ptr, REQUEST_COMPLETED)) {
                 ompi_wait_sync_t *tmp_sync = (ompi_wait_sync_t *) OPAL_ATOMIC_SWAP_PTR(&request->req_complete,
                                                                                        REQUEST_COMPLETED);
                 /* In the case where another thread concurrently changed the request to REQUEST_PENDING */

--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -76,7 +76,7 @@ static inline bool opal_fifo_is_empty( opal_fifo_t* fifo )
     return opal_fifo_head (fifo) == &fifo->opal_fifo_ghost;
 }
 
-#if OPAL_HAVE_ATOMIC_CMPSET_128
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128
 
 /* Add one element to the FIFO. We will return the last head of the list
  * to allow the upper level to detect if this element is the first one in the

--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
- * Copyright (c) 2014-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
  *                         reseved.
  * $COPYRIGHT$
  *
@@ -85,14 +85,12 @@ static inline bool opal_fifo_is_empty( opal_fifo_t* fifo )
 static inline opal_list_item_t *opal_fifo_push_atomic (opal_fifo_t *fifo,
                                                        opal_list_item_t *item)
 {
-    opal_counted_pointer_t tail;
+    opal_counted_pointer_t tail = {.value = fifo->opal_fifo_tail.value};
 
     item->opal_list_next = &fifo->opal_fifo_ghost;
 
     do {
-        tail.value = fifo->opal_fifo_tail.value;
-
-        if (opal_update_counted_pointer (&fifo->opal_fifo_tail, tail, item)) {
+        if (opal_update_counted_pointer (&fifo->opal_fifo_tail, &tail, item)) {
             break;
         }
     } while (1);
@@ -102,7 +100,7 @@ static inline opal_list_item_t *opal_fifo_push_atomic (opal_fifo_t *fifo,
     if (&fifo->opal_fifo_ghost == tail.data.item) {
         /* update the head */
         opal_counted_pointer_t head = {.value = fifo->opal_fifo_head.value};
-        opal_update_counted_pointer (&fifo->opal_fifo_head, head, item);
+        opal_update_counted_pointer (&fifo->opal_fifo_head, &head, item);
     } else {
         /* update previous item */
         tail.data.item->opal_list_next = item;
@@ -116,29 +114,28 @@ static inline opal_list_item_t *opal_fifo_push_atomic (opal_fifo_t *fifo,
  */
 static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
 {
-    opal_list_item_t *item, *next;
-    opal_counted_pointer_t head, tail;
+    opal_list_item_t *item, *next, *ghost = &fifo->opal_fifo_ghost;
+    opal_counted_pointer_t head = {.value = fifo->opal_fifo_head.value}, tail;
 
     do {
-        head.value = fifo->opal_fifo_head.value;
         tail.value = fifo->opal_fifo_tail.value;
         opal_atomic_rmb ();
 
         item = (opal_list_item_t *) head.data.item;
         next = (opal_list_item_t *) item->opal_list_next;
 
-        if (&fifo->opal_fifo_ghost == tail.data.item && &fifo->opal_fifo_ghost == item) {
+        if (ghost == tail.data.item && ghost == item) {
             return NULL;
         }
 
         /* the head or next pointer are in an inconsistent state. keep looping. */
-        if (tail.data.item != item && &fifo->opal_fifo_ghost != tail.data.item &&
-            &fifo->opal_fifo_ghost == next) {
+        if (tail.data.item != item && ghost != tail.data.item && ghost == next) {
+            head.value =  fifo->opal_fifo_head.value;
             continue;
         }
 
         /* try popping the head */
-        if (opal_update_counted_pointer (&fifo->opal_fifo_head, head, next)) {
+        if (opal_update_counted_pointer (&fifo->opal_fifo_head, &head, next)) {
             break;
         }
     } while (1);
@@ -146,14 +143,14 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
     opal_atomic_wmb ();
 
     /* check for tail and head consistency */
-    if (&fifo->opal_fifo_ghost == next) {
+    if (ghost == next) {
         /* the head was just set to &fifo->opal_fifo_ghost. try to update the tail as well */
-        if (!opal_update_counted_pointer (&fifo->opal_fifo_tail, tail, &fifo->opal_fifo_ghost)) {
+        if (!opal_update_counted_pointer (&fifo->opal_fifo_tail, &tail, ghost)) {
             /* tail was changed by a push operation. wait for the item's next pointer to be se then
              * update the head */
 
             /* wait for next pointer to be updated by push */
-            while (&fifo->opal_fifo_ghost == item->opal_list_next) {
+            while (ghost == item->opal_list_next) {
                 opal_atomic_rmb ();
             }
 
@@ -166,7 +163,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
             head.value = fifo->opal_fifo_head.value;
             next = (opal_list_item_t *) item->opal_list_next;
 
-            assert (&fifo->opal_fifo_ghost == head.data.item);
+            assert (ghost == head.data.item);
 
             fifo->opal_fifo_head.data.item = next;
             opal_atomic_wmb ();
@@ -215,14 +212,14 @@ static inline opal_list_item_t *opal_fifo_push_atomic (opal_fifo_t *fifo,
  */
 static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
 {
-    opal_list_item_t *item, *next;
+    opal_list_item_t *item, *next, *ghost = &fifo->opal_fifo_ghost;
 
 #if OPAL_HAVE_ATOMIC_LLSC_PTR
     /* use load-linked store-conditional to avoid ABA issues */
     do {
         item = opal_atomic_ll_ptr (&fifo->opal_fifo_head.data.item);
-        if (&fifo->opal_fifo_ghost == item) {
-            if (&fifo->opal_fifo_ghost == fifo->opal_fifo_tail.data.item) {
+        if (ghost == item) {
+            if (ghost == fifo->opal_fifo_tail.data.item) {
                 return NULL;
             }
 
@@ -239,7 +236,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
 #else
     /* protect against ABA issues by "locking" the head */
     do {
-        if (opal_atomic_bool_cmpset_32 ((int32_t *) &fifo->opal_fifo_head.data.counter, 0, 1)) {
+        if (!opal_atomic_swap_32 ((volatile int32_t *) &fifo->opal_fifo_head.data.counter, 1)) {
             break;
         }
 
@@ -249,7 +246,7 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
     opal_atomic_wmb();
 
     item = opal_fifo_head (fifo);
-    if (&fifo->opal_fifo_ghost == item) {
+    if (ghost == item) {
         fifo->opal_fifo_head.data.counter = 0;
         return NULL;
     }
@@ -258,9 +255,11 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
     fifo->opal_fifo_head.data.item = next;
 #endif
 
-    if (&fifo->opal_fifo_ghost == next) {
-        if (!opal_atomic_bool_cmpset_ptr (&fifo->opal_fifo_tail.data.item, item, &fifo->opal_fifo_ghost)) {
-            while (&fifo->opal_fifo_ghost == item->opal_list_next) {
+    if (ghost == next) {
+        void *tmp = item;
+
+        if (!opal_atomic_compare_exchange_strong_ptr (&fifo->opal_fifo_tail.data.item, &tmp, ghost)) {
+            while (ghost == item->opal_list_next) {
                 opal_atomic_rmb ();
             }
 

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -36,8 +36,8 @@
 BEGIN_C_DECLS
 
 /* NTH: temporarily suppress warnings about this not being defined */
-#if !defined(OPAL_HAVE_ATOMIC_CMPSET_128)
-#define OPAL_HAVE_ATOMIC_CMPSET_128 0
+#if !defined(OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128)
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 0
 #endif
 
 /**
@@ -50,7 +50,7 @@ union opal_counted_pointer_t {
         /** list item pointer */
         volatile opal_list_item_t * volatile item;
     } data;
-#if OPAL_HAVE_ATOMIC_CMPSET_128 && HAVE_OPAL_INT128_T
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 && HAVE_OPAL_INT128_T
     /** used for atomics when there is a cmpset that can operate on
      * two 64-bit values */
     opal_int128_t value;
@@ -59,7 +59,7 @@ union opal_counted_pointer_t {
 typedef union opal_counted_pointer_t opal_counted_pointer_t;
 
 
-#if OPAL_HAVE_ATOMIC_CMPSET_128
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128
 
 /* Add one element to the FIFO. We will return the last head of the list
  * to allow the upper level to detect if this element is the first one in the
@@ -110,7 +110,7 @@ static inline bool opal_lifo_is_empty( opal_lifo_t* lifo )
 }
 
 
-#if OPAL_HAVE_ATOMIC_CMPSET_128
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128
 
 /* Add one element to the LIFO. We will return the last head of the list
  * to allow the upper level to detect if this element is the first one in the

--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -29,10 +29,10 @@
 
 #define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
 #define OPAL_HAVE_ATOMIC_LLSC_32 1
-#define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 1
 #define OPAL_HAVE_ATOMIC_SWAP_32 1
 #define OPAL_HAVE_ATOMIC_MATH_32 1
-#define OPAL_HAVE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 1
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
 #define OPAL_HAVE_ATOMIC_LLSC_64 1
 #define OPAL_HAVE_ATOMIC_ADD_32 1
@@ -82,10 +82,10 @@ static inline void opal_atomic_isync (void)
  *
  *********************************************************************/
 
-static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
-                                              int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-    int32_t ret, tmp;
+    int32_t prev, tmp;
+    bool ret;
 
     __asm__ __volatile__ ("1:  ldaxr    %w0, [%2]      \n"
                           "    cmp     %w0, %w3        \n"
@@ -93,11 +93,13 @@ static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
                           "    stxr    %w1, %w4, [%2]  \n"
                           "    cbnz    %w1, 1b         \n"
                           "2:                          \n"
-                          : "=&r" (ret), "=&r" (tmp)
-                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "=&r" (prev), "=&r" (tmp)
+                          : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    return (ret == oldval);
+    ret = (prev == *oldval);
+    *oldval = prev;
+    return ret;
 }
 
 static inline int32_t opal_atomic_swap_32(volatile int32_t *addr, int32_t newval)
@@ -119,10 +121,10 @@ static inline int32_t opal_atomic_swap_32(volatile int32_t *addr, int32_t newval
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr,
-                                                  int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_acq_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-    int32_t ret, tmp;
+    int32_t prev, tmp;
+    bool ret;
 
     __asm__ __volatile__ ("1:  ldaxr   %w0, [%2]       \n"
                           "    cmp     %w0, %w3        \n"
@@ -130,18 +132,20 @@ static inline bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr,
                           "    stxr    %w1, %w4, [%2]  \n"
                           "    cbnz    %w1, 1b         \n"
                           "2:                          \n"
-                          : "=&r" (ret), "=&r" (tmp)
-                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "=&r" (prev), "=&r" (tmp)
+                          : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    return (ret == oldval);
+    ret = (prev == *oldval);
+    *oldval = prev;
+    return ret;
 }
 
 
-static inline bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr,
-                                                  int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_rel_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-    int32_t ret, tmp;
+    int32_t prev, tmp;
+    bool ret;
 
     __asm__ __volatile__ ("1:  ldxr    %w0, [%2]       \n"
                           "    cmp     %w0, %w3        \n"
@@ -149,11 +153,13 @@ static inline bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr,
                           "    stlxr   %w1, %w4, [%2]  \n"
                           "    cbnz    %w1, 1b         \n"
                           "2:                          \n"
-                          : "=&r" (ret), "=&r" (tmp)
-                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "=&r" (prev), "=&r" (tmp)
+                          : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    return (ret == oldval);
+    ret = (prev == *oldval);
+    *oldval = prev;
+    return ret;
 }
 
 static inline int32_t opal_atomic_ll_32 (volatile int32_t *addr)
@@ -179,11 +185,11 @@ static inline int opal_atomic_sc_32 (volatile int32_t *addr, int32_t newval)
     return ret == 0;
 }
 
-static inline bool opal_atomic_bool_cmpset_64(volatile int64_t *addr,
-                                              int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-    int64_t ret;
+    int64_t prev;
     int tmp;
+    bool ret;
 
     __asm__ __volatile__ ("1:  ldaxr    %0, [%2]       \n"
                           "    cmp     %0, %3          \n"
@@ -191,11 +197,13 @@ static inline bool opal_atomic_bool_cmpset_64(volatile int64_t *addr,
                           "    stxr    %w1, %4, [%2]   \n"
                           "    cbnz    %w1, 1b         \n"
                           "2:                          \n"
-                          : "=&r" (ret), "=&r" (tmp)
-                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "=&r" (prev), "=&r" (tmp)
+                          : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    return (ret == oldval);
+    ret = (prev == oldval);
+    *oldval = prev;
+    return ret;
 }
 
 static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newval)
@@ -218,11 +226,11 @@ static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newva
    atomic_?mb can be inlined).  Instead, we "inline" them by hand in
    the assembly, meaning there is one function call overhead instead
    of two */
-static inline bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr,
-                                                  int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_acq_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-    int64_t ret;
+    int64_t prev;
     int tmp;
+    bool ret;
 
     __asm__ __volatile__ ("1:  ldaxr   %0, [%2]        \n"
                           "    cmp     %0, %3          \n"
@@ -230,19 +238,21 @@ static inline bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr,
                           "    stxr    %w1, %4, [%2]   \n"
                           "    cbnz    %w1, 1b         \n"
                           "2:                          \n"
-                          : "=&r" (ret), "=&r" (tmp)
-                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "=&r" (prev), "=&r" (tmp)
+                          : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    return (ret == oldval);
+    ret = (prev == oldval);
+    *oldval = prev;
+    return ret;
 }
 
 
-static inline bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr,
-                                                  int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_rel_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-    int64_t ret;
+    int64_t prev;
     int tmp;
+    bool ret;
 
     __asm__ __volatile__ ("1:  ldxr    %0, [%2]        \n"
                           "    cmp     %0, %3          \n"
@@ -250,11 +260,13 @@ static inline bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr,
                           "    stlxr   %w1, %4, [%2]   \n"
                           "    cbnz    %w1, 1b         \n"
                           "2:                          \n"
-                          : "=&r" (ret), "=&r" (tmp)
-                          : "r" (addr), "r" (oldval), "r" (newval)
+                          : "=&r" (prev), "=&r" (tmp)
+                          : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    return (ret == oldval);
+    ret = (prev == oldval);
+    *oldval = prev;
+    return ret;
 }
 
 static inline int64_t opal_atomic_ll_64 (volatile int64_t *addr)

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -347,19 +347,23 @@ void opal_atomic_unlock(opal_atomic_lock_t *lock);
 #endif
 #if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_CMPSET_32
 
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_32
+#if OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_32
 static inline
 #endif
-bool opal_atomic_bool_cmpset_32(volatile int32_t *addr, int32_t oldval,
-                                int32_t newval);
+bool opal_atomic_compare_exchange_strong_32 (volatile int32_t *addr, int32_t *oldval,
+                                             int32_t newval);
 
+#if OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_32
 static inline
-bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr, int32_t oldval,
-                                    int32_t newval);
+#endif
+bool opal_atomic_compare_exchange_strong_acq_32 (volatile int32_t *addr, int32_t *oldval,
+                                                 int32_t newval);
 
+#if OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_32
 static inline
-bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr, int32_t oldval,
-                                    int32_t newval);
+#endif
+bool opal_atomic_compare_exchange_strong_rel_32 (volatile int32_t *addr, int32_t *oldval,
+                                                 int32_t newval);
 #endif
 
 
@@ -368,42 +372,23 @@ bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr, int32_t oldval,
 #endif
 #if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
 
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
+#if OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_64
 static inline
 #endif
 bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval,
                                              int64_t newval);
 
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
+#if OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_64
 static inline
 #endif
 bool opal_atomic_compare_exchange_strong_acq_64 (volatile int64_t *addr, int64_t *oldval,
                                                  int64_t newval);
 
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
+#if OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_64
 static inline
 #endif
 bool opal_atomic_compare_exchange_strong_rel_64 (volatile int64_t *addr, int64_t *oldval,
                                                  int64_t newval);
-
-/* XXX -- DEPRECATED -- XXX -- Legacy cmpset functions */
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
-static inline
-#endif
-bool opal_atomic_bool_cmpset_64(volatile int64_t *addr, int64_t oldval,
-                                int64_t newval);
-
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
-static inline
-#endif
-bool opal_atomic_bool_cmpset_acq_64(volatile int64_t *addr, int64_t oldval,
-                                    int64_t newval);
-
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
-static inline
-#endif
-bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr, int64_t oldval,
-                                    int64_t newval);
 
 #endif
 
@@ -558,26 +543,6 @@ static inline bool opal_atomic_compare_exchange_strong_acq_ptr (volatile void* a
 static inline bool opal_atomic_compare_exchange_strong_rel_ptr (volatile void* addr, void *oldval,
                                                                 void *newval);
 
-/* XXX -- DEPRECATED -- XXX -- Define legacy cmpset functions */
-static inline bool opal_atomic_bool_cmpset_xx(volatile void* addr, int64_t oldval,
-                                              int64_t newval, size_t length);
-static inline bool opal_atomic_bool_cmpset_acq_xx(volatile void* addr,
-                                                  int64_t oldval,  int64_t newval,
-                                                  size_t length);
-static inline bool opal_atomic_bool_cmpset_rel_xx(volatile void* addr,
-                                                  int64_t oldval, int64_t newval,
-                                                  size_t length);
-
-static inline bool opal_atomic_bool_cmpset_ptr(volatile void* addr,
-                                               void* oldval,
-                                               void* newval);
-static inline bool opal_atomic_bool_cmpset_acq_ptr(volatile void* addr,
-                                                   void* oldval,
-                                                   void* newval);
-static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
-                                                   void* oldval,
-                                                   void* newval);
-
 /**
  * Atomic compare and set of generic type with relaxed semantics. This
  * macro detect at compile time the type of the first argument and
@@ -629,61 +594,6 @@ static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
     opal_atomic_compare_exchange_strong_rel_xx( (volatile void*)(ADDR), (void *)(OLDVAL), \
                                                 (intptr_t)(NEWVAL), sizeof(*(ADDR)) )
 
-
-
-/* XXX -- DEPRECATED -- XXX -- Define legacy cmpset functions */
-
-/**
- * Atomic compare and set of pointer with relaxed semantics. This
- * macro detect at compile time the type of the first argument and
- * choose the correct function to be called.
- *
- * \note This macro should only be used for integer types.
- *
- * @param addr          Address of <TYPE>.
- * @param oldval        Comparison value <TYPE>.
- * @param newval        New value to set if comparision is true <TYPE>.
- *
- * See opal_atomic_bool_cmpset_* for pseudo-code.
- */
-#define opal_atomic_bool_cmpset( ADDR, OLDVAL, NEWVAL )                  \
-   opal_atomic_bool_cmpset_xx( (volatile void*)(ADDR), (intptr_t)(OLDVAL), \
-                          (intptr_t)(NEWVAL), sizeof(*(ADDR)) )
-
-/**
- * Atomic compare and set of pointer with acquire semantics. This
- * macro detect at compile time the type of the first argument
- * and choose the correct function to be called.
- *
- * \note This macro should only be used for integer types.
- *
- * @param addr          Address of <TYPE>.
- * @param oldval        Comparison value <TYPE>.
- * @param newval        New value to set if comparision is true <TYPE>.
- *
- * See opal_atomic_bool_cmpset_acq_* for pseudo-code.
- */
-#define opal_atomic_bool_cmpset_acq( ADDR, OLDVAL, NEWVAL )           \
-   opal_atomic_bool_cmpset_acq_xx( (volatile void*)(ADDR), (int64_t)(OLDVAL), \
-                              (int64_t)(NEWVAL), sizeof(*(ADDR)) )
-
-
-/**
- * Atomic compare and set of pointer with release semantics. This
- * macro detect at compile time the type of the first argument
- * and choose the correct function to b
- *
- * \note This macro should only be used for integer types.
- *
- * @param addr          Address of <TYPE>.
- * @param oldval        Comparison value <TYPE>.
- * @param newval        New value to set if comparision is true <TYPE>.
- *
- * See opal_atomic_bool_cmpsetrel_* for pseudo-code.
- */
-#define opal_atomic_bool_cmpset_rel( ADDR, OLDVAL, NEWVAL )           \
-   opal_atomic_bool_cmpset_rel_xx( (volatile void*)(ADDR), (int64_t)(OLDVAL), \
-                              (int64_t)(NEWVAL), sizeof(*(ADDR)) )
 
 #endif /* (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64) */
 

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -40,11 +40,11 @@
  *
  *  - \c OPAL_HAVE_ATOMIC_MEM_BARRIER atomic memory barriers
  *  - \c OPAL_HAVE_ATOMIC_SPINLOCKS atomic spinlocks
- *  - \c OPAL_HAVE_ATOMIC_MATH_32 if 32 bit add/sub/cmpset can be done "atomicly"
- *  - \c OPAL_HAVE_ATOMIC_MATH_64 if 64 bit add/sub/cmpset can be done "atomicly"
+ *  - \c OPAL_HAVE_ATOMIC_MATH_32 if 32 bit add/sub/compare-exchange can be done "atomicly"
+ *  - \c OPAL_HAVE_ATOMIC_MATH_64 if 64 bit add/sub/compare-exchange can be done "atomicly"
  *
  * Note that for the Atomic math, atomic add/sub may be implemented as
- * C code using opal_atomic_bool_cmpset.  The appearance of atomic
+ * C code using opal_atomic_compare_exchange.  The appearance of atomic
  * operation will be upheld in these cases.
  */
 
@@ -107,8 +107,8 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
  *********************************************************************/
 #if !OPAL_GCC_INLINE_ASSEMBLY
 #define OPAL_HAVE_INLINE_ATOMIC_MEM_BARRIER 0
-#define OPAL_HAVE_INLINE_ATOMIC_CMPSET_32 0
-#define OPAL_HAVE_INLINE_ATOMIC_CMPSET_64 0
+#define OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_32 0
+#define OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_64 0
 #define OPAL_HAVE_INLINE_ATOMIC_ADD_32 0
 #define OPAL_HAVE_INLINE_ATOMIC_AND_32 0
 #define OPAL_HAVE_INLINE_ATOMIC_OR_32 0
@@ -123,8 +123,8 @@ typedef struct opal_atomic_lock_t opal_atomic_lock_t;
 #define OPAL_HAVE_INLINE_ATOMIC_SWAP_64 0
 #else
 #define OPAL_HAVE_INLINE_ATOMIC_MEM_BARRIER 1
-#define OPAL_HAVE_INLINE_ATOMIC_CMPSET_32 1
-#define OPAL_HAVE_INLINE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_32 1
+#define OPAL_HAVE_INLINE_ATOMIC_COMPARE_EXCHANGE_64 1
 #define OPAL_HAVE_INLINE_ATOMIC_ADD_32 1
 #define OPAL_HAVE_INLINE_ATOMIC_AND_32 1
 #define OPAL_HAVE_INLINE_ATOMIC_OR_32 1
@@ -187,14 +187,14 @@ enum {
 /* compare and set operations can't really be emulated from software,
    so if these defines aren't already set, they should be set to 0
    now */
-#ifndef OPAL_HAVE_ATOMIC_CMPSET_32
-#define OPAL_HAVE_ATOMIC_CMPSET_32 0
+#ifndef OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 0
 #endif
-#ifndef OPAL_HAVE_ATOMIC_CMPSET_64
-#define OPAL_HAVE_ATOMIC_CMPSET_64 0
+#ifndef OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 0
 #endif
-#ifndef OPAL_HAVE_ATOMIC_CMPSET_128
-#define OPAL_HAVE_ATOMIC_CMPSET_128 0
+#ifndef OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 0
 #endif
 #ifndef OPAL_HAVE_ATOMIC_LLSC_32
 #define OPAL_HAVE_ATOMIC_LLSC_32 0
@@ -270,7 +270,7 @@ void opal_atomic_wmb(void);
 
 /**********************************************************************
  *
- * Atomic spinlocks - always inlined, if have atomic cmpset
+ * Atomic spinlocks - always inlined, if have atomic compare-and-swap
  *
  *********************************************************************/
 
@@ -280,7 +280,7 @@ void opal_atomic_wmb(void);
 #define OPAL_HAVE_ATOMIC_SPINLOCKS 0
 #endif
 
-#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_SPINLOCKS || (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
+#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_SPINLOCKS || (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 
 /**
  * Initialize a lock to value
@@ -330,7 +330,7 @@ void opal_atomic_unlock(opal_atomic_lock_t *lock);
 
 #if OPAL_HAVE_ATOMIC_SPINLOCKS == 0
 #undef OPAL_HAVE_ATOMIC_SPINLOCKS
-#define OPAL_HAVE_ATOMIC_SPINLOCKS (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
+#define OPAL_HAVE_ATOMIC_SPINLOCKS (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 #define OPAL_NEED_INLINE_ATOMIC_SPINLOCKS 1
 #endif
 
@@ -353,25 +353,40 @@ static inline
 bool opal_atomic_bool_cmpset_32(volatile int32_t *addr, int32_t oldval,
                                 int32_t newval);
 
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_32
 static inline
-#endif
 bool opal_atomic_bool_cmpset_acq_32(volatile int32_t *addr, int32_t oldval,
                                     int32_t newval);
 
-#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_32
 static inline
-#endif
 bool opal_atomic_bool_cmpset_rel_32(volatile int32_t *addr, int32_t oldval,
                                     int32_t newval);
 #endif
 
 
-#if !defined(OPAL_HAVE_ATOMIC_CMPSET_64) && !defined(DOXYGEN)
-#define OPAL_HAVE_ATOMIC_CMPSET_64 0
+#if !defined(OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64) && !defined(DOXYGEN)
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 0
 #endif
-#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_CMPSET_64
+#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
 
+#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
+static inline
+#endif
+bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval,
+                                             int64_t newval);
+
+#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
+static inline
+#endif
+bool opal_atomic_compare_exchange_strong_acq_64 (volatile int64_t *addr, int64_t *oldval,
+                                                 int64_t newval);
+
+#if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
+static inline
+#endif
+bool opal_atomic_compare_exchange_strong_rel_64 (volatile int64_t *addr, int64_t *oldval,
+                                                 int64_t newval);
+
+/* XXX -- DEPRECATED -- XXX -- Legacy cmpset functions */
 #if OPAL_HAVE_INLINE_ATOMIC_CMPSET_64
 static inline
 #endif
@@ -397,35 +412,35 @@ bool opal_atomic_bool_cmpset_rel_64(volatile int64_t *addr, int64_t oldval,
   #define OPAL_HAVE_ATOMIC_MATH_32 0
 #endif
 
-#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_MATH_32 || OPAL_HAVE_ATOMIC_CMPSET_32
+#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_MATH_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
 
 /* OPAL_HAVE_INLINE_ATOMIC_*_32 will be 1 if <arch>/atomic.h provides
    a static inline version of it (in assembly).  If we have to fall
-   back on cmpset 32, that too will be inline. */
-#if OPAL_HAVE_INLINE_ATOMIC_ADD_32 || (!defined(OPAL_HAVE_ATOMIC_ADD_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+   back on compare-exchange 32, that too will be inline. */
+#if OPAL_HAVE_INLINE_ATOMIC_ADD_32 || (!defined(OPAL_HAVE_ATOMIC_ADD_32) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32)
 static inline
 #endif
 int32_t opal_atomic_add_32(volatile int32_t *addr, int delta);
 
-#if OPAL_HAVE_INLINE_ATOMIC_AND_32 || (!defined(OPAL_HAVE_ATOMIC_AND_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+#if OPAL_HAVE_INLINE_ATOMIC_AND_32 || (!defined(OPAL_HAVE_ATOMIC_AND_32) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32)
 static inline
 #endif
 int32_t opal_atomic_and_32(volatile int32_t *addr, int32_t value);
 
-#if OPAL_HAVE_INLINE_ATOMIC_OR_32 || (!defined(OPAL_HAVE_ATOMIC_OR_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+#if OPAL_HAVE_INLINE_ATOMIC_OR_32 || (!defined(OPAL_HAVE_ATOMIC_OR_32) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32)
 static inline
 #endif
 int32_t opal_atomic_or_32(volatile int32_t *addr, int32_t value);
 
-#if OPAL_HAVE_INLINE_ATOMIC_XOR_32 || (!defined(OPAL_HAVE_ATOMIC_XOR_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+#if OPAL_HAVE_INLINE_ATOMIC_XOR_32 || (!defined(OPAL_HAVE_ATOMIC_XOR_32) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32)
 static inline
 #endif
 int32_t opal_atomic_xor_32(volatile int32_t *addr, int32_t value);
 
 /* OPAL_HAVE_INLINE_ATOMIC_*_32 will be 1 if <arch>/atomic.h provides
    a static inline version of it (in assembly).  If we have to fall
-   back to cmpset 32, that too will be inline. */
-#if OPAL_HAVE_INLINE_ATOMIC_SUB_32 || (!defined(OPAL_HAVE_ATOMIC_ADD_32) && OPAL_HAVE_ATOMIC_CMPSET_32)
+   back to compare-exchange 32, that too will be inline. */
+#if OPAL_HAVE_INLINE_ATOMIC_SUB_32 || (!defined(OPAL_HAVE_ATOMIC_ADD_32) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32)
 static inline
 #endif
 int32_t opal_atomic_sub_32(volatile int32_t *addr, int delta);
@@ -435,7 +450,7 @@ int32_t opal_atomic_sub_32(volatile int32_t *addr, int delta);
 #if ! OPAL_HAVE_ATOMIC_MATH_32
 /* fix up the value of opal_have_atomic_math_32 to allow for C versions */
 #undef OPAL_HAVE_ATOMIC_MATH_32
-#define OPAL_HAVE_ATOMIC_MATH_32 OPAL_HAVE_ATOMIC_CMPSET_32
+#define OPAL_HAVE_ATOMIC_MATH_32 OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
 #endif
 
 #ifndef OPAL_HAVE_ATOMIC_MATH_64
@@ -443,35 +458,35 @@ int32_t opal_atomic_sub_32(volatile int32_t *addr, int delta);
 #define OPAL_HAVE_ATOMIC_MATH_64 0
 #endif
 
-#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_MATH_64 || OPAL_HAVE_ATOMIC_CMPSET_64
+#if defined(DOXYGEN) || OPAL_HAVE_ATOMIC_MATH_64 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
 
 /* OPAL_HAVE_INLINE_ATOMIC_*_64 will be 1 if <arch>/atomic.h provides
    a static inline version of it (in assembly).  If we have to fall
-   back to cmpset 64, that too will be inline */
-#if OPAL_HAVE_INLINE_ATOMIC_ADD_64 || (!defined(OPAL_HAVE_ATOMIC_ADD_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+   back to compare-exchange 64, that too will be inline */
+#if OPAL_HAVE_INLINE_ATOMIC_ADD_64 || (!defined(OPAL_HAVE_ATOMIC_ADD_64) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 static inline
 #endif
 int64_t opal_atomic_add_64(volatile int64_t *addr, int64_t delta);
 
-#if OPAL_HAVE_INLINE_ATOMIC_AND_64 || (!defined(OPAL_HAVE_ATOMIC_AND_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+#if OPAL_HAVE_INLINE_ATOMIC_AND_64 || (!defined(OPAL_HAVE_ATOMIC_AND_64) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 static inline
 #endif
 int64_t opal_atomic_and_64(volatile int64_t *addr, int64_t value);
 
-#if OPAL_HAVE_INLINE_ATOMIC_OR_64 || (!defined(OPAL_HAVE_ATOMIC_OR_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+#if OPAL_HAVE_INLINE_ATOMIC_OR_64 || (!defined(OPAL_HAVE_ATOMIC_OR_64) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 static inline
 #endif
 int64_t opal_atomic_or_64(volatile int64_t *addr, int64_t value);
 
-#if OPAL_HAVE_INLINE_ATOMIC_XOR_64 || (!defined(OPAL_HAVE_ATOMIC_XOR_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+#if OPAL_HAVE_INLINE_ATOMIC_XOR_64 || (!defined(OPAL_HAVE_ATOMIC_XOR_64) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 static inline
 #endif
 int64_t opal_atomic_xor_64(volatile int64_t *addr, int64_t value);
 
 /* OPAL_HAVE_INLINE_ATOMIC_*_64 will be 1 if <arch>/atomic.h provides
    a static inline version of it (in assembly).  If we have to fall
-   back to cmpset 64, that too will be inline */
-#if OPAL_HAVE_INLINE_ATOMIC_SUB_64 || (!defined(OPAL_HAVE_ATOMIC_ADD_64) && OPAL_HAVE_ATOMIC_CMPSET_64)
+   back to compare-exchange 64, that too will be inline */
+#if OPAL_HAVE_INLINE_ATOMIC_SUB_64 || (!defined(OPAL_HAVE_ATOMIC_ADD_64) && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 static inline
 #endif
 int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta);
@@ -481,7 +496,7 @@ int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta);
 #if ! OPAL_HAVE_ATOMIC_MATH_64
 /* fix up the value of opal_have_atomic_math_64 to allow for C versions */
 #undef OPAL_HAVE_ATOMIC_MATH_64
-#define OPAL_HAVE_ATOMIC_MATH_64 OPAL_HAVE_ATOMIC_CMPSET_64
+#define OPAL_HAVE_ATOMIC_MATH_64 OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
 #endif
 
 /* provide a size_t add/subtract.  When in debug mode, make it an
@@ -524,9 +539,26 @@ opal_atomic_sub_size_t(volatile size_t *addr, size_t delta)
 #endif
 #endif
 
-#if defined(DOXYGEN) || (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
+#if defined(DOXYGEN) || (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 /* these are always done with inline functions, so always mark as
    static inline */
+
+static inline bool opal_atomic_compare_exchange_strong_xx (volatile void *addr, void *oldval,
+                                                           int64_t newval, size_t length);
+static inline bool opal_atomic_compare_exchange_strong_acq_xx (volatile void *addr, void *oldval,
+                                                               int64_t newval, size_t length);
+static inline bool opal_atomic_compare_exchange_strong_rel_xx (volatile void *addr, void *oldval,
+                                                               int64_t newval, size_t length);
+
+
+static inline bool opal_atomic_compare_exchange_strong_ptr (volatile void* addr, void *oldval,
+                                                            void *newval);
+static inline bool opal_atomic_compare_exchange_strong_acq_ptr (volatile void* addr, void *oldval,
+                                                                void *newval);
+static inline bool opal_atomic_compare_exchange_strong_rel_ptr (volatile void* addr, void *oldval,
+                                                                void *newval);
+
+/* XXX -- DEPRECATED -- XXX -- Define legacy cmpset functions */
 static inline bool opal_atomic_bool_cmpset_xx(volatile void* addr, int64_t oldval,
                                               int64_t newval, size_t length);
 static inline bool opal_atomic_bool_cmpset_acq_xx(volatile void* addr,
@@ -545,6 +577,61 @@ static inline bool opal_atomic_bool_cmpset_acq_ptr(volatile void* addr,
 static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
                                                    void* oldval,
                                                    void* newval);
+
+/**
+ * Atomic compare and set of generic type with relaxed semantics. This
+ * macro detect at compile time the type of the first argument and
+ * choose the correct function to be called.
+ *
+ * \note This macro should only be used for integer types.
+ *
+ * @param addr          Address of <TYPE>.
+ * @param oldval        Comparison value address of <TYPE>.
+ * @param newval        New value to set if comparision is true <TYPE>.
+ *
+ * See opal_atomic_compare_exchange_* for pseudo-code.
+ */
+#define opal_atomic_compare_exchange_strong( ADDR, OLDVAL, NEWVAL )                  \
+    opal_atomic_compare_exchange_strong_xx( (volatile void*)(ADDR), (void *)(OLDVAL), \
+                                            (intptr_t)(NEWVAL), sizeof(*(ADDR)) )
+
+/**
+ * Atomic compare and set of generic type with acquire semantics. This
+ * macro detect at compile time the type of the first argument and
+ * choose the correct function to be called.
+ *
+ * \note This macro should only be used for integer types.
+ *
+ * @param addr          Address of <TYPE>.
+ * @param oldval        Comparison value address of <TYPE>.
+ * @param newval        New value to set if comparision is true <TYPE>.
+ *
+ * See opal_atomic_compare_exchange_acq_* for pseudo-code.
+ */
+#define opal_atomic_compare_exchange_strong_acq( ADDR, OLDVAL, NEWVAL )                  \
+    opal_atomic_compare_exchange_strong_acq_xx( (volatile void*)(ADDR), (void *)(OLDVAL), \
+                                                (intptr_t)(NEWVAL), sizeof(*(ADDR)) )
+
+/**
+ * Atomic compare and set of generic type with release semantics. This
+ * macro detect at compile time the type of the first argument and
+ * choose the correct function to be called.
+ *
+ * \note This macro should only be used for integer types.
+ *
+ * @param addr          Address of <TYPE>.
+ * @param oldval        Comparison value address of <TYPE>.
+ * @param newval        New value to set if comparision is true <TYPE>.
+ *
+ * See opal_atomic_compare_exchange_rel_* for pseudo-code.
+ */
+#define opal_atomic_compare_exchange_strong_rel( ADDR, OLDVAL, NEWVAL ) \
+    opal_atomic_compare_exchange_strong_rel_xx( (volatile void*)(ADDR), (void *)(OLDVAL), \
+                                                (intptr_t)(NEWVAL), sizeof(*(ADDR)) )
+
+
+
+/* XXX -- DEPRECATED -- XXX -- Define legacy cmpset functions */
 
 /**
  * Atomic compare and set of pointer with relaxed semantics. This
@@ -598,7 +685,7 @@ static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
    opal_atomic_bool_cmpset_rel_xx( (volatile void*)(ADDR), (int64_t)(OLDVAL), \
                               (int64_t)(NEWVAL), sizeof(*(ADDR)) )
 
-#endif /* (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64) */
+#endif /* (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64) */
 
 #if defined(DOXYGEN) || (OPAL_HAVE_ATOMIC_MATH_32 || OPAL_HAVE_ATOMIC_MATH_64)
 
@@ -606,10 +693,10 @@ static inline void opal_atomic_add_xx(volatile void* addr,
                                       int32_t value, size_t length);
 static inline void opal_atomic_sub_xx(volatile void* addr,
                                       int32_t value, size_t length);
-#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_CMPSET_32
+#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
 static inline int32_t opal_atomic_add_ptr( volatile void* addr, void* delta );
 static inline int32_t opal_atomic_sub_ptr( volatile void* addr, void* delta );
-#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_CMPSET_64
+#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
 static inline int64_t opal_atomic_add_ptr( volatile void* addr, void* delta );
 static inline int64_t opal_atomic_sub_ptr( volatile void* addr, void* delta );
 #else

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -56,10 +56,9 @@
 static inline int32_t opal_atomic_swap_32(volatile int32_t *addr,
                                           int32_t newval)
 {
-    int32_t old;
+    int32_t old = *addr;
     do {
-        old = *addr;
-    } while (!opal_atomic_bool_cmpset_32(addr, old, newval));
+    } while (!opal_atomic_compare_exchange_strong_32 (addr, &old, newval));
 
     return old;
 }
@@ -111,10 +110,10 @@ OPAL_ATOMIC_DEFINE_CMPXCG_OP(int32_t, 32, -, sub)
 static inline int64_t opal_atomic_swap_64(volatile int64_t *addr,
                                           int64_t newval)
 {
-    int64_t old;
+    int64_t old = *addr;
     do {
-        old = *addr;
-    } while (!opal_atomic_bool_cmpset_64(addr, old, newval));
+    } while (!opal_atomic_compare_exchange_strong_64 (addr, &old, newval));
+
     return old;
 }
 #endif /* OPAL_HAVE_ATOMIC_SWAP_32 */
@@ -228,177 +227,6 @@ OPAL_ATOMIC_DEFINE_CMPXCG_PTR_XX(_rel_)
 
 #endif /* (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64) */
 
-
-/* XXX -- DEPRECATED -- XXX -- Define legacy cmpset functions */
-#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32)
-static inline bool opal_atomic_bool_cmpset_32 (volatile int32_t *addr, int32_t oldval,
-                                               int32_t newval)
-{
-    return opal_atomic_compare_exchange_strong_32 (addr, &oldval, newval);
-}
-
-static inline bool opal_atomic_bool_cmpset_acq_32 (volatile int32_t *addr, int32_t oldval,
-                                                   int32_t newval)
-{
-    return opal_atomic_compare_exchange_strong_acq_32 (addr, &oldval, newval);
-}
-
-static inline bool opal_atomic_bool_cmpset_rel_32 (volatile int32_t *addr, int32_t oldval,
-                                                   int32_t newval)
-{
-    return opal_atomic_compare_exchange_strong_rel_32 (addr, &oldval, newval);
-}
-#endif
-
-#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
-static inline bool opal_atomic_bool_cmpset_64 (volatile int64_t *addr, int64_t oldval,
-                                               int64_t newval)
-{
-    return opal_atomic_compare_exchange_strong_64 (addr, &oldval, newval);
-}
-
-static inline bool opal_atomic_bool_cmpset_acq_64 (volatile int64_t *addr, int64_t oldval,
-                                                   int64_t newval)
-{
-    return opal_atomic_compare_exchange_strong_acq_64 (addr, &oldval, newval);
-}
-
-static inline bool opal_atomic_bool_cmpset_rel_64 (volatile int64_t *addr, int64_t oldval,
-                                                   int64_t newval)
-{
-    return opal_atomic_compare_exchange_strong_rel_64 (addr, &oldval, newval);
-}
-#endif
-
-#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128)
-static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr, opal_int128_t oldval,
-                                                opal_int128_t newval)
-{
-    return opal_atomic_compare_exchange_strong_128 (addr, &oldval, newval);
-}
-#endif
-
-#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
-
-static inline bool
-opal_atomic_bool_cmpset_xx(volatile void* addr, int64_t oldval,
-                           int64_t newval, size_t length)
-{
-   switch( length ) {
-#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
-   case 4:
-      return opal_atomic_bool_cmpset_32( (volatile int32_t*)addr,
-                                    (int32_t)oldval, (int32_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
-
-#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
-   case 8:
-      return opal_atomic_bool_cmpset_64( (volatile int64_t*)addr,
-                                    (int64_t)oldval, (int64_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 */
-   }
-   abort();
-   /* This should never happen, so deliberately abort (hopefully
-      leaving a corefile for analysis) */
-}
-
-
-static inline bool
-opal_atomic_bool_cmpset_acq_xx(volatile void* addr, int64_t oldval,
-                               int64_t newval, size_t length)
-{
-   switch( length ) {
-#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
-   case 4:
-      return opal_atomic_bool_cmpset_acq_32( (volatile int32_t*)addr,
-                                        (int32_t)oldval, (int32_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
-
-#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
-   case 8:
-      return opal_atomic_bool_cmpset_acq_64( (volatile int64_t*)addr,
-                                        (int64_t)oldval, (int64_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 */
-   }
-   /* This should never happen, so deliberately abort (hopefully
-      leaving a corefile for analysis) */
-   abort();
-}
-
-
-static inline bool
-opal_atomic_bool_cmpset_rel_xx(volatile void* addr, int64_t oldval,
-                               int64_t newval, size_t length)
-{
-   switch( length ) {
-#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
-   case 4:
-      return opal_atomic_bool_cmpset_rel_32( (volatile int32_t*)addr,
-                                        (int32_t)oldval, (int32_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
-
-#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
-   case 8:
-      return opal_atomic_bool_cmpset_rel_64( (volatile int64_t*)addr,
-                                        (int64_t)oldval, (int64_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 */
-   }
-   /* This should never happen, so deliberately abort (hopefully
-      leaving a corefile for analysis) */
-   abort();
-}
-
-
-static inline bool
-opal_atomic_bool_cmpset_ptr(volatile void* addr,
-                            void* oldval,
-                            void* newval)
-{
-#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
-    return opal_atomic_bool_cmpset_32((int32_t*) addr, (unsigned long) oldval,
-                                 (unsigned long) newval);
-#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
-    return opal_atomic_bool_cmpset_64((int64_t*) addr, (unsigned long) oldval,
-                                 (unsigned long) newval);
-#else
-    abort();
-#endif
-}
-
-
-static inline bool
-opal_atomic_bool_cmpset_acq_ptr(volatile void* addr,
-                                void* oldval,
-                                void* newval)
-{
-#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
-    return opal_atomic_bool_cmpset_acq_32((int32_t*) addr, (unsigned long) oldval,
-                                     (unsigned long) newval);
-#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
-    return opal_atomic_bool_cmpset_acq_64((int64_t*) addr, (unsigned long) oldval,
-                                     (unsigned long) newval);
-#else
-    abort();
-#endif
-}
-
-
-static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
-                                                   void* oldval,
-                                                   void* newval)
-{
-#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
-    return opal_atomic_bool_cmpset_rel_32((int32_t*) addr, (unsigned long) oldval,
-                                     (unsigned long) newval);
-#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
-    return opal_atomic_bool_cmpset_rel_64((int64_t*) addr, (unsigned long) oldval,
-                                     (unsigned long) newval);
-#else
-    abort();
-#endif
-}
-
-#endif /* (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64) */
 
 #if (OPAL_HAVE_ATOMIC_SWAP_32 || OPAL_HAVE_ATOMIC_SWAP_64)
 
@@ -546,21 +374,20 @@ opal_atomic_lock_init( opal_atomic_lock_t* lock, int32_t value )
 static inline int
 opal_atomic_trylock(opal_atomic_lock_t *lock)
 {
-    bool ret = opal_atomic_bool_cmpset_acq_32( &(lock->u.lock),
-                                               OPAL_ATOMIC_LOCK_UNLOCKED, OPAL_ATOMIC_LOCK_LOCKED);
-    return (ret == 0) ? 1 : 0;
+    int32_t unlocked = OPAL_ATOMIC_LOCK_UNLOCKED;
+    bool ret = opal_atomic_compare_exchange_strong_32 (&lock->u.lock, &unlocked, OPAL_ATOMIC_LOCK_LOCKED);
+    return (ret == false) ? 1 : 0;
 }
 
 
 static inline void
 opal_atomic_lock(opal_atomic_lock_t *lock)
 {
-   while( !opal_atomic_bool_cmpset_acq_32( &(lock->u.lock),
-                                      OPAL_ATOMIC_LOCK_UNLOCKED, OPAL_ATOMIC_LOCK_LOCKED) ) {
-      while (lock->u.lock == OPAL_ATOMIC_LOCK_LOCKED) {
-         /* spin */ ;
-      }
-   }
+    while (opal_atomic_trylock (lock)) {
+        while (lock->u.lock == OPAL_ATOMIC_LOCK_LOCKED) {
+            /* spin */ ;
+        }
+    }
 }
 
 

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -34,10 +34,22 @@
  *
  * Some architectures do not provide support for the 64 bits
  * atomic operations. Until we find a better solution let's just
- * undefine all those functions if there is no 64 bit cmpset
+ * undefine all those functions if there is no 64 bit compare-exchange
  *
  *********************************************************************/
-#if OPAL_HAVE_ATOMIC_CMPSET_32
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
+
+#define OPAL_ATOMIC_DEFINE_CMPXCG_OP(type, bits, operand, name)  \
+    static inline type opal_atomic_ ## name ## _ ## bits (volatile type *addr, type value) \
+    {                                                                   \
+        type oldval, newval;                                            \
+        do {                                                            \
+            oldval = *addr;                                             \
+            newval = oldval operand value;                              \
+        } while (!opal_atomic_compare_exchange_strong_ ## bits (addr, &oldval, newval)); \
+                                                                        \
+        return newval;                                                  \
+    }
 
 #if !defined(OPAL_HAVE_ATOMIC_SWAP_32)
 #define OPAL_HAVE_ATOMIC_SWAP_32 1
@@ -55,79 +67,44 @@ static inline int32_t opal_atomic_swap_32(volatile int32_t *addr,
 
 #if !defined(OPAL_HAVE_ATOMIC_ADD_32)
 #define OPAL_HAVE_ATOMIC_ADD_32 1
-static inline int32_t
-opal_atomic_add_32(volatile int32_t *addr, int delta)
-{
-   int32_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval + delta));
-   return (oldval + delta);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int32_t, 32, +, add)
+
 #endif  /* OPAL_HAVE_ATOMIC_ADD_32 */
 
 #if !defined(OPAL_HAVE_ATOMIC_AND_32)
 #define OPAL_HAVE_ATOMIC_AND_32 1
-static inline int32_t
-opal_atomic_and_32(volatile int32_t *addr, int32_t value)
-{
-   int32_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval & value));
-   return (oldval & value);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int32_t, 32, &, and)
+
 #endif  /* OPAL_HAVE_ATOMIC_AND_32 */
 
 #if !defined(OPAL_HAVE_ATOMIC_OR_32)
 #define OPAL_HAVE_ATOMIC_OR_32 1
-static inline int32_t
-opal_atomic_or_32(volatile int32_t *addr, int32_t value)
-{
-   int32_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval | value));
-   return (oldval | value);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int32_t, 32, |, or)
+
 #endif  /* OPAL_HAVE_ATOMIC_OR_32 */
 
 #if !defined(OPAL_HAVE_ATOMIC_XOR_32)
 #define OPAL_HAVE_ATOMIC_XOR_32 1
-static inline int32_t
-opal_atomic_xor_32(volatile int32_t *addr, int32_t value)
-{
-   int32_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval ^ value));
-   return (oldval ^ value);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int32_t, 32, ^, xor)
+
 #endif  /* OPAL_HAVE_ATOMIC_XOR_32 */
 
 
 #if !defined(OPAL_HAVE_ATOMIC_SUB_32)
 #define OPAL_HAVE_ATOMIC_SUB_32 1
-static inline int32_t
-opal_atomic_sub_32(volatile int32_t *addr, int delta)
-{
-   int32_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_32(addr, oldval, oldval - delta));
-   return (oldval - delta);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int32_t, 32, -, sub)
+
 #endif  /* OPAL_HAVE_ATOMIC_SUB_32 */
 
-#endif /* OPAL_HAVE_ATOMIC_CMPSET_32 */
+#endif /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
 
 
-#if OPAL_HAVE_ATOMIC_CMPSET_64
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
 
 #if !defined(OPAL_HAVE_ATOMIC_SWAP_64)
 #define OPAL_HAVE_ATOMIC_SWAP_64 1
@@ -144,72 +121,37 @@ static inline int64_t opal_atomic_swap_64(volatile int64_t *addr,
 
 #if !defined(OPAL_HAVE_ATOMIC_ADD_64)
 #define OPAL_HAVE_ATOMIC_ADD_64 1
-static inline int64_t
-opal_atomic_add_64(volatile int64_t *addr, int64_t delta)
-{
-   int64_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval + delta));
-   return (oldval + delta);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int64_t, 64, +, add)
+
 #endif  /* OPAL_HAVE_ATOMIC_ADD_64 */
 
 #if !defined(OPAL_HAVE_ATOMIC_AND_64)
 #define OPAL_HAVE_ATOMIC_AND_64 1
-static inline int64_t
-opal_atomic_and_64(volatile int64_t *addr, int64_t value)
-{
-   int64_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval & value));
-   return (oldval & value);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int64_t, 64, &, and)
+
 #endif  /* OPAL_HAVE_ATOMIC_AND_64 */
 
 #if !defined(OPAL_HAVE_ATOMIC_OR_64)
 #define OPAL_HAVE_ATOMIC_OR_64 1
-static inline int64_t
-opal_atomic_or_64(volatile int64_t *addr, int64_t value)
-{
-   int64_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval | value));
-   return (oldval | value);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int64_t, 64, |, or)
+
 #endif  /* OPAL_HAVE_ATOMIC_OR_64 */
 
 #if !defined(OPAL_HAVE_ATOMIC_XOR_64)
 #define OPAL_HAVE_ATOMIC_XOR_64 1
-static inline int64_t
-opal_atomic_xor_64(volatile int64_t *addr, int64_t value)
-{
-   int64_t oldval;
 
-   do {
-      oldval = *addr;
-   } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval ^ value));
-   return (oldval ^ value);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int64_t, 64, ^, xor)
+
 #endif  /* OPAL_HAVE_ATOMIC_XOR_64 */
 
 #if !defined(OPAL_HAVE_ATOMIC_SUB_64)
 #define OPAL_HAVE_ATOMIC_SUB_64 1
-static inline int64_t
-opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
-{
-    int64_t oldval;
 
-    do {
-        oldval = *addr;
-    } while (!opal_atomic_bool_cmpset_64(addr, oldval, oldval - delta));
-    return (oldval - delta);
-}
+OPAL_ATOMIC_DEFINE_CMPXCG_OP(int64_t, 64, -, sub)
+
 #endif  /* OPAL_HAVE_ATOMIC_SUB_64 */
 
 #else
@@ -222,27 +164,138 @@ opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 #define OPAL_HAVE_ATOMIC_SUB_64 0
 #endif
 
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_64 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 */
+
+#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
+
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
+#define OPAL_ATOMIC_DEFINE_CMPXCG_XX(semantics)                         \
+    static inline bool                                                  \
+    opal_atomic_compare_exchange_strong ## semantics ## xx (volatile void* addr, void *oldval, \
+                                                            int64_t newval, const size_t length) \
+    {                                                                   \
+        switch (length) {                                               \
+        case 4:                                                         \
+            return opal_atomic_compare_exchange_strong_32 ((volatile int32_t *) addr, \
+                                                           (int32_t *) oldval, (int32_t) newval); \
+        case 8:                                                         \
+            return opal_atomic_compare_exchange_strong_64 ((volatile int64_t *) addr, \
+                                                           (int64_t *) oldval, (int64_t) newval); \
+        }                                                               \
+        abort();                                                        \
+    }
+#elif OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
+#define OPAL_ATOMIC_DEFINE_CMPXCG_XX(semantics)                         \
+    static inline bool                                                  \
+    opal_atomic_compare_exchange_strong ## semantics ## xx (volatile void* addr, void *oldval, \
+                                                            int64_t newval, const size_t length) \
+    {                                                                   \
+        switch (length) {                                               \
+        case 4:                                                         \
+            return opal_atomic_compare_exchange_strong_32 ((volatile int32_t *) addr, \
+                                                           (int32_t *) oldval, (int32_t) newval); \
+        abort();                                                        \
+    }
+#else
+#error "Platform does not have required atomic compare-and-swap functionality"
+#endif
+
+OPAL_ATOMIC_DEFINE_CMPXCG_XX(_)
+OPAL_ATOMIC_DEFINE_CMPXCG_XX(_acq_)
+OPAL_ATOMIC_DEFINE_CMPXCG_XX(_rel_)
+
+#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
+#define OPAL_ATOMIC_DEFINE_CMPXCG_PTR_XX(semantics)                     \
+    static inline bool                                                  \
+        opal_atomic_compare_exchange_strong ## semantics ## ptr (volatile void* addr, void *oldval, void *newval) \
+    {                                                                   \
+        return opal_atomic_compare_exchange_strong_32 ((volatile int32_t *) addr, (int32_t *) oldval, (int32_t) newval); \
+    }
+#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
+#define OPAL_ATOMIC_DEFINE_CMPXCG_PTR_XX(semantics)                     \
+    static inline bool                                                  \
+        opal_atomic_compare_exchange_strong ## semantics ## ptr (volatile void* addr, void *oldval, void *newval) \
+    {                                                                   \
+        return opal_atomic_compare_exchange_strong_64 ((volatile int64_t *) addr, (int64_t *) oldval, (int64_t) newval); \
+    }
+#else
+#error "Can not define opal_atomic_compare_exchange_strong_ptr with existing atomics"
+#endif
+
+OPAL_ATOMIC_DEFINE_CMPXCG_PTR_XX(_)
+OPAL_ATOMIC_DEFINE_CMPXCG_PTR_XX(_acq_)
+OPAL_ATOMIC_DEFINE_CMPXCG_PTR_XX(_rel_)
+
+#endif /* (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64) */
 
 
-#if (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64)
+/* XXX -- DEPRECATED -- XXX -- Define legacy cmpset functions */
+#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32)
+static inline bool opal_atomic_bool_cmpset_32 (volatile int32_t *addr, int32_t oldval,
+                                               int32_t newval)
+{
+    return opal_atomic_compare_exchange_strong_32 (addr, &oldval, newval);
+}
+
+static inline bool opal_atomic_bool_cmpset_acq_32 (volatile int32_t *addr, int32_t oldval,
+                                                   int32_t newval)
+{
+    return opal_atomic_compare_exchange_strong_acq_32 (addr, &oldval, newval);
+}
+
+static inline bool opal_atomic_bool_cmpset_rel_32 (volatile int32_t *addr, int32_t oldval,
+                                                   int32_t newval)
+{
+    return opal_atomic_compare_exchange_strong_rel_32 (addr, &oldval, newval);
+}
+#endif
+
+#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
+static inline bool opal_atomic_bool_cmpset_64 (volatile int64_t *addr, int64_t oldval,
+                                               int64_t newval)
+{
+    return opal_atomic_compare_exchange_strong_64 (addr, &oldval, newval);
+}
+
+static inline bool opal_atomic_bool_cmpset_acq_64 (volatile int64_t *addr, int64_t oldval,
+                                                   int64_t newval)
+{
+    return opal_atomic_compare_exchange_strong_acq_64 (addr, &oldval, newval);
+}
+
+static inline bool opal_atomic_bool_cmpset_rel_64 (volatile int64_t *addr, int64_t oldval,
+                                                   int64_t newval)
+{
+    return opal_atomic_compare_exchange_strong_rel_64 (addr, &oldval, newval);
+}
+#endif
+
+#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128)
+static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr, opal_int128_t oldval,
+                                                opal_int128_t newval)
+{
+    return opal_atomic_compare_exchange_strong_128 (addr, &oldval, newval);
+}
+#endif
+
+#if (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64)
 
 static inline bool
 opal_atomic_bool_cmpset_xx(volatile void* addr, int64_t oldval,
                            int64_t newval, size_t length)
 {
    switch( length ) {
-#if OPAL_HAVE_ATOMIC_CMPSET_32
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
    case 4:
       return opal_atomic_bool_cmpset_32( (volatile int32_t*)addr,
                                     (int32_t)oldval, (int32_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_32 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
 
-#if OPAL_HAVE_ATOMIC_CMPSET_64
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
    case 8:
       return opal_atomic_bool_cmpset_64( (volatile int64_t*)addr,
                                     (int64_t)oldval, (int64_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_64 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 */
    }
    abort();
    /* This should never happen, so deliberately abort (hopefully
@@ -255,17 +308,17 @@ opal_atomic_bool_cmpset_acq_xx(volatile void* addr, int64_t oldval,
                                int64_t newval, size_t length)
 {
    switch( length ) {
-#if OPAL_HAVE_ATOMIC_CMPSET_32
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
    case 4:
       return opal_atomic_bool_cmpset_acq_32( (volatile int32_t*)addr,
                                         (int32_t)oldval, (int32_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_32 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
 
-#if OPAL_HAVE_ATOMIC_CMPSET_64
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
    case 8:
       return opal_atomic_bool_cmpset_acq_64( (volatile int64_t*)addr,
                                         (int64_t)oldval, (int64_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_64 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 */
    }
    /* This should never happen, so deliberately abort (hopefully
       leaving a corefile for analysis) */
@@ -278,17 +331,17 @@ opal_atomic_bool_cmpset_rel_xx(volatile void* addr, int64_t oldval,
                                int64_t newval, size_t length)
 {
    switch( length ) {
-#if OPAL_HAVE_ATOMIC_CMPSET_32
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
    case 4:
       return opal_atomic_bool_cmpset_rel_32( (volatile int32_t*)addr,
                                         (int32_t)oldval, (int32_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_32 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
 
-#if OPAL_HAVE_ATOMIC_CMPSET_64
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
    case 8:
       return opal_atomic_bool_cmpset_rel_64( (volatile int64_t*)addr,
                                         (int64_t)oldval, (int64_t)newval );
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_64 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 */
    }
    /* This should never happen, so deliberately abort (hopefully
       leaving a corefile for analysis) */
@@ -301,10 +354,10 @@ opal_atomic_bool_cmpset_ptr(volatile void* addr,
                             void* oldval,
                             void* newval)
 {
-#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_CMPSET_32
+#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
     return opal_atomic_bool_cmpset_32((int32_t*) addr, (unsigned long) oldval,
                                  (unsigned long) newval);
-#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_CMPSET_64
+#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
     return opal_atomic_bool_cmpset_64((int64_t*) addr, (unsigned long) oldval,
                                  (unsigned long) newval);
 #else
@@ -318,10 +371,10 @@ opal_atomic_bool_cmpset_acq_ptr(volatile void* addr,
                                 void* oldval,
                                 void* newval)
 {
-#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_CMPSET_32
+#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
     return opal_atomic_bool_cmpset_acq_32((int32_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
-#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_CMPSET_64
+#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
     return opal_atomic_bool_cmpset_acq_64((int64_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
 #else
@@ -334,10 +387,10 @@ static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
                                                    void* oldval,
                                                    void* newval)
 {
-#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_CMPSET_32
+#if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32
     return opal_atomic_bool_cmpset_rel_32((int32_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
-#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_CMPSET_64
+#elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64
     return opal_atomic_bool_cmpset_rel_64((int64_t*) addr, (unsigned long) oldval,
                                      (unsigned long) newval);
 #else
@@ -345,7 +398,7 @@ static inline bool opal_atomic_bool_cmpset_rel_ptr(volatile void* addr,
 #endif
 }
 
-#endif /* (OPAL_HAVE_ATOMIC_CMPSET_32 || OPAL_HAVE_ATOMIC_CMPSET_64) */
+#endif /* (OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 || OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64) */
 
 #if (OPAL_HAVE_ATOMIC_SWAP_32 || OPAL_HAVE_ATOMIC_SWAP_64)
 
@@ -392,7 +445,7 @@ opal_atomic_add_xx(volatile void* addr, int32_t value, size_t length)
    case 4:
       opal_atomic_add_32( (volatile int32_t*)addr, (int32_t)value );
       break;
-#endif  /* OPAL_HAVE_ATOMIC_CMPSET_32 */
+#endif  /* OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 */
 
 #if OPAL_HAVE_ATOMIC_ADD_64
    case 8:

--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -33,7 +33,7 @@
 #define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
 
 #define OPAL_HAVE_ATOMIC_MATH_32 1
-#define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 1
 #define OPAL_HAVE_ATOMIC_ADD_32 1
 #define OPAL_HAVE_ATOMIC_AND_32 1
 #define OPAL_HAVE_ATOMIC_OR_32 1
@@ -41,7 +41,7 @@
 #define OPAL_HAVE_ATOMIC_SUB_32 1
 #define OPAL_HAVE_ATOMIC_SWAP_32 1
 #define OPAL_HAVE_ATOMIC_MATH_64 1
-#define OPAL_HAVE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 1
 #define OPAL_HAVE_ATOMIC_ADD_64 1
 #define OPAL_HAVE_ATOMIC_AND_64 1
 #define OPAL_HAVE_ATOMIC_OR_64 1
@@ -81,26 +81,20 @@ static inline void opal_atomic_wmb(void)
 #pragma error_messages(off, E_ARG_INCOMPATIBLE_WITH_ARG_L)
 #endif
 
-static inline bool opal_atomic_bool_cmpset_acq_32( volatile int32_t *addr,
-                                                   int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_acq_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
-                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+    return __atomic_compare_exchange_n (addr, oldval, newval, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
 
-static inline bool opal_atomic_bool_cmpset_rel_32( volatile int32_t *addr,
-                                                   int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_rel_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
-                                        __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+    return __atomic_compare_exchange_n (addr, oldval, newval, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
 
-static inline bool opal_atomic_bool_cmpset_32( volatile int32_t *addr,
-                                               int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
-                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+    return __atomic_compare_exchange_n (addr, oldval, newval, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
 static inline int32_t opal_atomic_swap_32 (volatile int32_t *addr, int32_t newval)
@@ -135,26 +129,20 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
     return __atomic_sub_fetch (addr, delta, __ATOMIC_RELAXED);
 }
 
-static inline bool opal_atomic_bool_cmpset_acq_64( volatile int64_t *addr,
-                                                   int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_acq_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
-                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+    return __atomic_compare_exchange_n (addr, oldval, newval, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
-static inline bool opal_atomic_bool_cmpset_rel_64( volatile int64_t *addr,
-                                                   int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_rel_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
-                                        __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+    return __atomic_compare_exchange_n (addr, oldval, newval, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
 
 
-static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
-                                               int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
-                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+    return __atomic_compare_exchange_n (addr, oldval, newval, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
 static inline int64_t opal_atomic_swap_64 (volatile int64_t *addr, int64_t newval)
@@ -191,25 +179,28 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 
 #if OPAL_HAVE_GCC_BUILTIN_CSWAP_INT128
 
-#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 1
 
-static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr,
-                                                opal_int128_t oldval, opal_int128_t newval)
+static inline bool opal_atomic_compare_exchange_strong_128 (volatile opal_int128_t *addr,
+                                                            opal_int128_t *oldval, opal_int128_t newval)
 {
-    return __atomic_compare_exchange_n (addr, &oldval, newval, false,
+    return __atomic_compare_exchange_n (addr, oldval, newval, false,
                                         __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
 #elif defined(OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128) && OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
 
-#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 1
 
 /* __atomic version is not lock-free so use legacy __sync version */
 
-static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr,
-                                                opal_int128_t oldval, opal_int128_t newval)
+static inline bool opal_atomic_compare_exchange_strong_128 (volatile opal_int128_t *addr,
+                                                            opal_int128_t *oldval, opal_int128_t newval)
 {
-    return __sync_bool_compare_and_swap (addr, oldval, newval);
+    opal_int128_t prev = __sync_val_compare_and_swap (addr, *oldval, newval);
+    bool ret = prev == *oldval;
+    *oldval = prev;
+    return ret;
 }
 
 #endif

--- a/opal/include/opal/sys/ia32/atomic.h
+++ b/opal/include/opal/sys/ia32/atomic.h
@@ -40,7 +40,7 @@
  *********************************************************************/
 #define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
 
-#define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 1
 
 #define OPAL_HAVE_ATOMIC_MATH_32 1
 #define OPAL_HAVE_ATOMIC_ADD_32 1
@@ -84,15 +84,13 @@ static inline void opal_atomic_isync(void)
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
-                                              int32_t oldval,
-                                              int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
    unsigned char ret;
    __asm__ __volatile__ (
                        SMPLOCK "cmpxchgl %3,%2   \n\t"
                                "sete     %0      \n\t"
-                       : "=qm" (ret), "+a" (oldval), "+m" (*addr)
+                       : "=qm" (ret), "+a" (*oldval), "+m" (*addr)
                        : "q"(newval)
                        : "memory", "cc");
 
@@ -101,8 +99,8 @@ static inline bool opal_atomic_bool_cmpset_32(volatile int32_t *addr,
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 
-#define opal_atomic_bool_cmpset_acq_32 opal_atomic_bool_cmpset_32
-#define opal_atomic_bool_cmpset_rel_32 opal_atomic_bool_cmpset_32
+#define opal_atomic_compare_exchange_strong_acq_32 opal_atomic_compare_exchange_strong_32
+#define opal_atomic_compare_exchange_strong_rel_32 opal_atomic_compare_exchange_strong_32
 
 #if OPAL_GCC_INLINE_ASSEMBLY
 

--- a/opal/include/opal/sys/sparcv9/atomic.h
+++ b/opal/include/opal/sys/sparcv9/atomic.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserverd.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,9 +41,9 @@
  *********************************************************************/
 #define OPAL_HAVE_ATOMIC_MEM_BARRIER 1
 
-#define OPAL_HAVE_ATOMIC_CMPSET_32 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 1
 
-#define OPAL_HAVE_ATOMIC_CMPSET_64 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 1
 
 
 /**********************************************************************
@@ -82,50 +85,49 @@ static inline void opal_atomic_isync(void)
  *********************************************************************/
 #if OPAL_GCC_INLINE_ASSEMBLY
 
-static inline bool opal_atomic_bool_cmpset_32( volatile int32_t *addr,
-                                               int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-   /* casa [reg(rs1)] %asi, reg(rs2), reg(rd)
-    *
-    * if (*(reg(rs1)) == reg(rs2) )
-    *    swap reg(rd), *(reg(rs1))
-    * else
-    *    reg(rd) = *(reg(rs1))
-    */
+    /* casa [reg(rs1)] %asi, reg(rs2), reg(rd)
+     *
+     * if (*(reg(rs1)) == reg(rs2) )
+     *    swap reg(rd), *(reg(rs1))
+     * else
+     *    reg(rd) = *(reg(rs1))
+     */
 
-   int32_t ret = newval;
+    int32_t prev = newval;
+    bool ret;
 
-   __asm__ __volatile__("casa [%1] " ASI_P ", %2, %0"
-                      : "+r" (ret)
-                      : "r" (addr), "r" (oldval));
-   return (ret == oldval);
+    __asm__ __volatile__("casa [%1] " ASI_P ", %2, %0"
+                         : "+r" (prev)
+                         : "r" (addr), "r" (*oldval));
+    ret = (prev == *oldval);
+    *oldval = prev;
+    return ret;
 }
 
 
-static inline bool opal_atomic_bool_cmpset_acq_32( volatile int32_t *addr,
-                                                   int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_acq_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-   bool rc;
+    bool rc;
 
-   rc = opal_atomic_bool_cmpset_32(addr, oldval, newval);
-   opal_atomic_rmb();
+    rc = opal_atomic_compare_exchange_strong_32 (addr, oldval, newval);
+    opal_atomic_rmb();
 
-   return rc;
+    return rc;
 }
 
 
-static inline bool opal_atomic_bool_cmpset_rel_32( volatile int32_t *addr,
-                                                   int32_t oldval, int32_t newval)
+static inline bool opal_atomic_compare_exchange_strong_rel_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-   opal_atomic_wmb();
-   return opal_atomic_bool_cmpset_32(addr, oldval, newval);
+    opal_atomic_wmb();
+    return opal_atomic_compare_exchange_strong_32 (addr, oldval, newval);
 }
 
 
 #if OPAL_ASSEMBLY_ARCH == OPAL_SPARCV9_64
 
-static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
-                                               int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
     /* casa [reg(rs1)] %asi, reg(rs2), reg(rd)
      *
@@ -134,18 +136,20 @@ static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
      * else
      *    reg(rd) = *(reg(rs1))
      */
-   int64_t ret = newval;
+    int64_t prev = newval;
+    bool ret;
 
-   __asm__ __volatile__("casxa [%1] " ASI_P ", %2, %0"
-                      : "+r" (ret)
-                      : "r" (addr), "r" (oldval));
-   return (ret == oldval);
+    __asm__ __volatile__("casxa [%1] " ASI_P ", %2, %0"
+                         : "+r" (prev)
+                         : "r" (addr), "r" (*oldval));
+    ret = (prev == *oldval);
+    *oldval = prev;
+    return ret;
 }
 
 #else /* OPAL_ASSEMBLY_ARCH == OPAL_SPARCV9_64 */
 
-static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
-                                               int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
     /* casa [reg(rs1)] %asi, reg(rs2), reg(rd)
      *
@@ -155,40 +159,41 @@ static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
      *    reg(rd) = *(reg(rs1))
      *
      */
-    long long ret = newval;
+    int64_t prev = newval;
+    bool ret;
 
     __asm__ __volatile__(
                        "ldx %0, %%g1               \n\t" /* g1 = ret */
                        "ldx %2, %%g2               \n\t" /* g2 = oldval */
                        "casxa [%1] " ASI_P ", %%g2, %%g1 \n\t"
                        "stx %%g1, %0               \n"
-                       : "+m"(ret)
-                       : "r"(addr), "m"(oldval)
+                       : "+m"(prev)
+                       : "r"(addr), "m"(*oldval)
                        : "%g1", "%g2"
                        );
 
-   return (ret == oldval);
+   ret = (prev == *oldval);
+   *oldval = prev;
+   return ret;
 }
 
 #endif /* OPAL_ASSEMBLY_ARCH == OPAL_SPARCV9_64 */
 
-static inline bool opal_atomic_bool_cmpset_acq_64( volatile int64_t *addr,
-                                                   int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_acq_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-   bool rc;
+    bool rc;
 
-   rc = opal_atomic_bool_cmpset_64(addr, oldval, newval);
-   opal_atomic_rmb();
+    rc = opal_atomic_compare_exchange_strong_64 (addr, oldval, newval);
+    opal_atomic_rmb();
 
-   return rc;
+    return rc;
 }
 
 
-static inline bool opal_atomic_bool_cmpset_rel_64( volatile int64_t *addr,
-                                                   int64_t oldval, int64_t newval)
+static inline bool opal_atomic_compare_exchange_strong_rel_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-   opal_atomic_wmb();
-   return opal_atomic_bool_cmpset_64(addr, oldval, newval);
+    opal_atomic_wmb();
+    return opal_atomic_compare_exchange_strong_64 (addr, oldval, newval);
 }
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */

--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -53,24 +53,18 @@ static inline void opal_atomic_wmb(void)
  *
  *********************************************************************/
 
-#define OPAL_HAVE_ATOMIC_CMPSET_32 1
-static inline bool opal_atomic_bool_cmpset_acq_32( volatile int32_t *addr,
-                                                   int32_t oldval, int32_t newval)
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_32 1
+
+static inline bool opal_atomic_compare_exchange_strong_32 (volatile int32_t *addr, int32_t *oldval, int32_t newval)
 {
-    return __sync_bool_compare_and_swap(addr, oldval, newval);
+    int32_t prev = __sync_val_compare_and_swap (add, *oldval, newval);
+    bool ret = prev == *oldval;
+    *oldval = prev;
+    return ret;
 }
 
-
-static inline bool opal_atomic_bool_cmpset_rel_32( volatile int32_t *addr,
-                                                   int32_t oldval, int32_t newval)
-{
-    return __sync_bool_compare_and_swap(addr, oldval, newval);}
-
-static inline bool opal_atomic_bool_cmpset_32( volatile int32_t *addr,
-                                               int32_t oldval, int32_t newval)
-{
-    return __sync_bool_compare_and_swap(addr, oldval, newval);
-}
+#define opal_atomic_compare_exchange_strong_acq_32 opal_atomic_compare_exchange_strong_32
+#define opal_atomic_compare_exchange_strong_rel_32 opal_atomic_compare_exchange_strong_32
 
 #define OPAL_HAVE_ATOMIC_MATH_32 1
 
@@ -106,24 +100,18 @@ static inline int32_t opal_atomic_sub_32(volatile int32_t *addr, int32_t delta)
 
 #if OPAL_ASM_SYNC_HAVE_64BIT
 
-#define OPAL_HAVE_ATOMIC_CMPSET_64 1
-static inline bool opal_atomic_bool_cmpset_acq_64( volatile int64_t *addr,
-                                                   int64_t oldval, int64_t newval)
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_64 1
+
+static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
-    return __sync_bool_compare_and_swap(addr, oldval, newval);
+    int64_t prev = __sync_val_compare_and_swap (add, *oldval, newval);
+    bool ret = prev == *oldval;
+    *oldval = prev;
+    return ret;
 }
 
-static inline bool opal_atomic_bool_cmpset_rel_64( volatile int64_t *addr,
-                                                   int64_t oldval, int64_t newval)
-{
-    return __sync_bool_compare_and_swap(addr, oldval, newval);}
-
-
-static inline bool opal_atomic_bool_cmpset_64( volatile int64_t *addr,
-                                               int64_t oldval, int64_t newval)
-{
-    return __sync_bool_compare_and_swap(addr, oldval, newval);
-}
+#define opal_atomic_compare_exchange_strong_acq_64 opal_atomic_compare_exchange_strong_64
+#define opal_atomic_compare_exchange_strong_rel_64 opal_atomic_compare_exchange_strong_64
 
 #define OPAL_HAVE_ATOMIC_MATH_64 1
 #define OPAL_HAVE_ATOMIC_ADD_64 1
@@ -159,13 +147,16 @@ static inline int64_t opal_atomic_sub_64(volatile int64_t *addr, int64_t delta)
 #endif
 
 #if OPAL_HAVE_SYNC_BUILTIN_CSWAP_INT128
-static inline bool opal_atomic_bool_cmpset_128 (volatile opal_int128_t *addr,
-                                                opal_int128_t oldval, opal_int128_t newval)
+static inline bool opal_atomic_compare_exchange_strong_128 (volatile opal_int128_t *addr,
+                                                            opal_int128_t *oldval, opal_int128_t newval)
 {
-    return __sync_bool_compare_and_swap(addr, oldval, newval);
+    opal_int128_t prev = __sync_val_compare_and_swap (addr, *oldval, newval);
+    bool ret = prev == *oldval;
+    *oldval = prev;
+    return ret;
 }
 
-#define OPAL_HAVE_ATOMIC_CMPSET_128 1
+#define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 1
 
 #endif
 

--- a/opal/mca/btl/openib/btl_openib_endpoint.h
+++ b/opal/mca/btl/openib/btl_openib_endpoint.h
@@ -446,14 +446,19 @@ static inline int mca_btl_openib_endpoint_post_rr(
     return ret;
 }
 
-#define BTL_OPENIB_CREDITS_SEND_TRYLOCK(E, Q) \
-    OPAL_ATOMIC_BOOL_CMPSET_32(&(E)->qps[(Q)].rd_credit_send_lock, 0, 1)
-#define BTL_OPENIB_CREDITS_SEND_UNLOCK(E, Q) \
-    OPAL_ATOMIC_BOOL_CMPSET_32(&(E)->qps[(Q)].rd_credit_send_lock, 1, 0)
-#define BTL_OPENIB_GET_CREDITS(FROM, TO)                                        \
-    do {                                                     \
-        TO = FROM;                                           \
-    } while(0 == OPAL_ATOMIC_BOOL_CMPSET_32(&FROM, TO, 0))
+static inline __opal_attribute_always_inline__ bool btl_openib_credits_send_trylock (mca_btl_openib_endpoint_t *ep, int qp)
+{
+    int32_t _tmp_value = 0;
+    return OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32(&ep->qps[qp].rd_credit_send_lock, &_tmp_value, 1);
+}
+
+#define BTL_OPENIB_CREDITS_SEND_UNLOCK(E, Q)                            \
+    do {                                                                \
+        int32_t _tmp_value = 1;                                         \
+        OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32(&(E)->qps[(Q)].rd_credit_send_lock, &_tmp_value, 0); \
+    } while (0)
+#define BTL_OPENIB_GET_CREDITS(FROM, TO)        \
+    TO = OPAL_ATOMIC_SWAP_32(&FROM, 0)
 
 
 static inline bool check_eager_rdma_credits(const mca_btl_openib_endpoint_t *ep)
@@ -486,7 +491,7 @@ static inline void send_credits(mca_btl_openib_endpoint_t *ep, int qp)
         return;
 
 try_send:
-    if(BTL_OPENIB_CREDITS_SEND_TRYLOCK(ep, qp))
+    if(btl_openib_credits_send_trylock(ep, qp))
         mca_btl_openib_endpoint_send_credits(ep, qp);
 }
 

--- a/opal/mca/btl/ugni/btl_ugni_smsg.c
+++ b/opal/mca/btl/ugni/btl_ugni_smsg.c
@@ -59,12 +59,13 @@ int mca_btl_ugni_smsg_process (mca_btl_base_endpoint_t *ep)
     mca_btl_ugni_base_frag_t frag;
     mca_btl_base_segment_t seg;
     bool disconnect = false;
+    int32_t _tmp_value = 0;
     uintptr_t data_ptr;
     gni_return_t rc;
     uint32_t len;
     int count = 0;
 
-    if (!opal_atomic_bool_cmpset_32 (&ep->smsg_progressing, 0, 1)) {
+    if (!opal_atomic_compare_exchange_strong_32 (&ep->smsg_progressing, &_tmp_value, 1)) {
         /* already progressing (we can't support reentry here) */
         return 0;
     }

--- a/opal/runtime/opal_cr.c
+++ b/opal/runtime/opal_cr.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Cisco Systems, Inc.  All rights reserved.
@@ -171,15 +171,16 @@ static const uint32_t ProcInc    = 0x2;
       opal_cr_thread_in_library = false;                         \
     }                                                            \
  }
-#define OPAL_CR_THREAD_LOCK()                                                      \
- {                                                                                 \
-    while(!OPAL_ATOMIC_BOOL_CMPSET_32(&opal_cr_thread_num_in_library, 0, ThreadFlag)) { \
-      if( !opal_cr_thread_is_active && opal_cr_thread_is_done) {                   \
-          break;                                                                   \
-      }                                                                            \
-      sched_yield();                                                               \
-      usleep(opal_cr_thread_sleep_check);                                          \
-    }                                                                              \
+#define OPAL_CR_THREAD_LOCK()                                           \
+    {                                                                   \
+      int32_t _tmp_value = 0;                                           \
+      while(!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32 (&opal_cr_thread_num_in_library, &_tmp_value, ThreadFlag)) { \
+          if( !opal_cr_thread_is_active && opal_cr_thread_is_done) {    \
+              break;                                                    \
+          }                                                             \
+          sched_yield();                                                \
+          usleep(opal_cr_thread_sleep_check);                           \
+      }                                                                 \
  }
 #define OPAL_CR_THREAD_UNLOCK()                                     \
  {                                                                  \

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -223,8 +223,8 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
 #define OPAL_THREAD_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
 #define OPAL_ATOMIC_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
 
-#define OPAL_THREAD_BOOL_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
-#define OPAL_ATOMIC_BOOL_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
+#define OPAL_THREAD_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
+#define OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
 
 #define OPAL_THREAD_BOOL_CMPSET_PTR(x, y, z) opal_thread_cmpset_bool_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
 #define OPAL_ATOMIC_BOOL_CMPSET_PTR OPAL_THREAD_BOOL_CMPSET_PTR

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  * 
@@ -158,6 +158,23 @@ static inline bool opal_thread_cmpset_bool_ ## suffix (volatile addr_type *addr,
     return false;                                                       \
 }
 
+#define OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(type, addr_type, suffix)       \
+static inline bool opal_thread_compare_exchange_strong_ ## suffix (volatile addr_type *addr, type *compare, type value) \
+{                                                                       \
+    if (OPAL_UNLIKELY(opal_using_threads())) {                          \
+        return opal_atomic_compare_exchange_strong_ ## suffix ((volatile type *) addr, compare, value); \
+    }                                                                   \
+                                                                        \
+    if ((type) *addr == *compare) {                                     \
+        ((type *) addr)[0] = value;                                     \
+        return true;                                                    \
+    }                                                                   \
+                                                                        \
+    *compare = ((type *) addr)[0];                                      \
+                                                                        \
+    return false;                                                       \
+}
+
 #define OPAL_THREAD_DEFINE_ATOMIC_SWAP(type, addr_type, suffix)         \
 static inline type opal_thread_swap_ ## suffix (volatile addr_type *ptr, type newvalue) \
 {                                                                       \
@@ -180,6 +197,8 @@ OPAL_THREAD_DEFINE_ATOMIC_SUB(int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_SUB(size_t, size_t)
 OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int32_t, int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_CMPSET(void *, intptr_t, ptr)
+OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int32_t, int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(void *, intptr_t, ptr)
 OPAL_THREAD_DEFINE_ATOMIC_SWAP(int32_t, int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
 
@@ -204,8 +223,14 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
 #define OPAL_THREAD_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
 #define OPAL_ATOMIC_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
 
+#define OPAL_THREAD_BOOL_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
+#define OPAL_ATOMIC_BOOL_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
+
 #define OPAL_THREAD_BOOL_CMPSET_PTR(x, y, z) opal_thread_cmpset_bool_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
 #define OPAL_ATOMIC_BOOL_CMPSET_PTR OPAL_THREAD_BOOL_CMPSET_PTR
+
+#define OPAL_THREAD_COMPARE_EXCHANGE_STRONG_PTR(x, y, z) opal_thread_compare_exchange_strong_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
+#define OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR OPAL_THREAD_COMPARE_EXCHANGE_STRONG_PTR
 
 #define OPAL_THREAD_SWAP_32 opal_thread_swap_32
 #define OPAL_ATOMIC_SWAP_32 opal_thread_swap_32
@@ -221,6 +246,7 @@ OPAL_THREAD_DEFINE_ATOMIC_AND(int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_OR(int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_XOR(int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int64_t, int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int64_t, int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 
 #define OPAL_THREAD_ADD64 opal_thread_add_64
@@ -237,6 +263,9 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 
 #define OPAL_THREAD_BOOL_CMPSET_64 opal_thread_cmpset_bool_64
 #define OPAL_ATOMIC_BOOL_CMPSET_64 opal_thread_cmpset_bool_64
+
+#define OPAL_THREAD_COMPARE_EXCHANGE_STRONG_64 opal_thread_compare_exchange_strong_64
+#define OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_64 opal_thread_compare_exchange_strong_64
 
 #define OPAL_THREAD_SWAP_64 opal_thread_swap_64
 #define OPAL_ATOMIC_SWAP_64 opal_thread_swap_64

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -143,21 +143,6 @@ static inline type opal_thread_sub_ ## suffix (volatile type *addr, type delta) 
     return (*addr -= delta);                                            \
 }
 
-#define OPAL_THREAD_DEFINE_ATOMIC_CMPSET(type, addr_type, suffix)       \
-static inline bool opal_thread_cmpset_bool_ ## suffix (volatile addr_type *addr, type compare, type value) \
-{                                                                       \
-    if (OPAL_UNLIKELY(opal_using_threads())) {                          \
-        return opal_atomic_bool_cmpset_ ## suffix ((volatile type *) addr, compare, value); \
-    }                                                                   \
-                                                                        \
-    if ((type) *addr == compare) {                                      \
-        ((type *) addr)[0] = value;                                     \
-        return true;                                                    \
-    }                                                                   \
-                                                                        \
-    return false;                                                       \
-}
-
 #define OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(type, addr_type, suffix)       \
 static inline bool opal_thread_compare_exchange_strong_ ## suffix (volatile addr_type *addr, type *compare, type value) \
 {                                                                       \
@@ -195,8 +180,6 @@ OPAL_THREAD_DEFINE_ATOMIC_OR(int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_XOR(int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_SUB(int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_SUB(size_t, size_t)
-OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int32_t, int32_t, 32)
-OPAL_THREAD_DEFINE_ATOMIC_CMPSET(void *, intptr_t, ptr)
 OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int32_t, int32_t, 32)
 OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(void *, intptr_t, ptr)
 OPAL_THREAD_DEFINE_ATOMIC_SWAP(int32_t, int32_t, 32)
@@ -220,14 +203,8 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(void *, intptr_t, ptr)
 #define OPAL_THREAD_SUB_SIZE_T opal_thread_sub_size_t
 #define OPAL_ATOMIC_SUB_SIZE_T opal_thread_sub_size_t
 
-#define OPAL_THREAD_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
-#define OPAL_ATOMIC_BOOL_CMPSET_32 opal_thread_cmpset_bool_32
-
 #define OPAL_THREAD_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
 #define OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32 opal_thread_compare_exchange_strong_32
-
-#define OPAL_THREAD_BOOL_CMPSET_PTR(x, y, z) opal_thread_cmpset_bool_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
-#define OPAL_ATOMIC_BOOL_CMPSET_PTR OPAL_THREAD_BOOL_CMPSET_PTR
 
 #define OPAL_THREAD_COMPARE_EXCHANGE_STRONG_PTR(x, y, z) opal_thread_compare_exchange_strong_ptr ((volatile intptr_t *) x, (void *) y, (void *) z)
 #define OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR OPAL_THREAD_COMPARE_EXCHANGE_STRONG_PTR
@@ -245,7 +222,6 @@ OPAL_THREAD_DEFINE_ATOMIC_ADD(int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_AND(int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_OR(int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_XOR(int64_t, 64)
-OPAL_THREAD_DEFINE_ATOMIC_CMPSET(int64_t, int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int64_t, int64_t, 64)
 OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 
@@ -260,9 +236,6 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 
 #define OPAL_THREAD_XOR64 opal_thread_xor_64
 #define OPAL_ATOMIC_XOR64 opal_thread_xor_64
-
-#define OPAL_THREAD_BOOL_CMPSET_64 opal_thread_cmpset_bool_64
-#define OPAL_ATOMIC_BOOL_CMPSET_64 opal_thread_cmpset_bool_64
 
 #define OPAL_THREAD_COMPARE_EXCHANGE_STRONG_64 opal_thread_compare_exchange_strong_64
 #define OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_64 opal_thread_compare_exchange_strong_64

--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -64,8 +64,9 @@ int oshmem_shmem_finalize(void)
 {
     int ret = OSHMEM_SUCCESS;
     static int32_t finalize_has_already_started = 0;
+    int32_t _tmp = 0;
 
-    if (opal_atomic_bool_cmpset_32(&finalize_has_already_started, 0, 1)
+    if (opal_atomic_compare_exchange_strong_32 (&finalize_has_already_started, &_tmp, 1)
             && oshmem_shmem_initialized && !oshmem_shmem_aborted) {
         /* Should be called first because ompi_mpi_finalize makes orte and opal finalization */
         ret = _shmem_finalize();

--- a/test/asm/atomic_cmpset.c
+++ b/test/asm/atomic_cmpset.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,6 +55,13 @@ volatile int64_t vol64 = 0;
 int64_t val64 = 0;
 int64_t old64 = 0;
 int64_t new64 = 0;
+#endif
+
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128
+volatile opal_int128_t vol128;
+opal_int128_t val128;
+opal_int128_t old128;
+opal_int128_t new128;
 #endif
 
 volatile int volint = 0;
@@ -99,124 +109,165 @@ int main(int argc, char *argv[])
     /* -- cmpset 32-bit tests -- */
 
     vol32 = 42, old32 = 42, new32 = 50;
-    assert(opal_atomic_bool_cmpset_32(&vol32, old32, new32) == 1);
+    assert(opal_atomic_compare_exchange_strong_32 (&vol32, &old32, new32) == true);
     opal_atomic_rmb();
     assert(vol32 == new32);
+    assert(old32 == 42);
 
     vol32 = 42, old32 = 420, new32 = 50;
-    assert(opal_atomic_bool_cmpset_32(&vol32, old32, new32) ==  0);
+    assert(opal_atomic_compare_exchange_strong_32 (&vol32, &old32, new32) ==  false);
     opal_atomic_rmb();
     assert(vol32 == 42);
+    assert(old32 == 42);
 
     vol32 = 42, old32 = 42, new32 = 50;
-    assert(opal_atomic_bool_cmpset_acq_32(&vol32, old32, new32) == 1);
+    assert(opal_atomic_compare_exchange_strong_32 (&vol32, &old32, new32) == true);
     assert(vol32 == new32);
+    assert(old32 == 42);
 
     vol32 = 42, old32 = 420, new32 = 50;
-    assert(opal_atomic_bool_cmpset_acq_32(&vol32, old32, new32) == 0);
+    assert(opal_atomic_compare_exchange_strong_acq_32 (&vol32, &old32, new32) == false);
     assert(vol32 == 42);
+    assert(old32 == 42);
 
     vol32 = 42, old32 = 42, new32 = 50;
-    assert(opal_atomic_bool_cmpset_rel_32(&vol32, old32, new32) ==  1);
+    assert(opal_atomic_compare_exchange_strong_rel_32 (&vol32, &old32, new32) ==  true);
     opal_atomic_rmb();
     assert(vol32 == new32);
+    assert(old32 == 42);
 
     vol32 = 42, old32 = 420, new32 = 50;
-    assert(opal_atomic_bool_cmpset_rel_32(&vol32, old32, new32) == 0);
+    assert(opal_atomic_compare_exchange_strong_rel_32 (&vol32, &old32, new32) == false);
     opal_atomic_rmb();
     assert(vol32 == 42);
+    assert(old32 == 42);
 
     /* -- cmpset 64-bit tests -- */
 
 #if OPAL_HAVE_ATOMIC_MATH_64
     vol64 = 42, old64 = 42, new64 = 50;
-    assert(1 == opal_atomic_bool_cmpset_64(&vol64, old64, new64));
+    assert(opal_atomic_compare_exchange_strong_64 (&vol64, &old64, new64) == true);
     opal_atomic_rmb();
     assert(new64 == vol64);
+    assert(old64 == 42);
 
     vol64 = 42, old64 = 420, new64 = 50;
-    assert(opal_atomic_bool_cmpset_64(&vol64, old64, new64) == 0);
+    assert(opal_atomic_compare_exchange_strong_64 (&vol64, &old64, new64) == false);
     opal_atomic_rmb();
     assert(vol64 == 42);
+    assert(old64 == 42);
 
     vol64 = 42, old64 = 42, new64 = 50;
-    assert(opal_atomic_bool_cmpset_acq_64(&vol64, old64, new64) == 1);
+    assert(opal_atomic_compare_exchange_strong_acq_64 (&vol64, &old64, new64) == true);
     assert(vol64 == new64);
+    assert(old64 == 42);
 
     vol64 = 42, old64 = 420, new64 = 50;
-    assert(opal_atomic_bool_cmpset_acq_64(&vol64, old64, new64) == 0);
+    assert(opal_atomic_compare_exchange_strong_acq_64 (&vol64, &old64, new64) == false);
     assert(vol64 == 42);
+    assert(old64 == 42);
 
     vol64 = 42, old64 = 42, new64 = 50;
-    assert(opal_atomic_bool_cmpset_rel_64(&vol64, old64, new64) == 1);
+    assert(opal_atomic_compare_exchange_strong_rel_64 (&vol64, &old64, new64) == true);
     opal_atomic_rmb();
     assert(vol64 == new64);
+    assert(old64 == 42);
 
     vol64 = 42, old64 = 420, new64 = 50;
-    assert(opal_atomic_bool_cmpset_rel_64(&vol64, old64, new64) == 0);
+    assert(opal_atomic_compare_exchange_strong_rel_64 (&vol64, &old64, new64) == false);
     opal_atomic_rmb();
     assert(vol64 == 42);
+    assert(old64 == 42);
 #endif
+
+    /* -- cmpset 128-bit tests -- */
+
+#if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128
+    vol128 = 42, old128 = 42, new128 = 50;
+    assert(opal_atomic_compare_exchange_strong_128 (&vol128, &old128, new128) == true);
+    opal_atomic_rmb();
+    assert(new128 == vol128);
+    assert(old128 == 42);
+
+    vol128 = 42, old128 = 420, new128 = 50;
+    assert(opal_atomic_compare_exchange_strong_128 (&vol128, &old128, new128) == false);
+    opal_atomic_rmb();
+    assert(vol128 == 42);
+    assert(old128 == 42);
+#endif
+
     /* -- cmpset int tests -- */
 
     volint = 42, oldint = 42, newint = 50;
-    assert(opal_atomic_bool_cmpset(&volint, oldint, newint) == 1);
-    opal_atomic_rmb();
-    assert(volint ==newint);
-
-    volint = 42, oldint = 420, newint = 50;
-    assert(opal_atomic_bool_cmpset(&volint, oldint, newint) == 0);
-    opal_atomic_rmb();
-    assert(volint == 42);
-
-    volint = 42, oldint = 42, newint = 50;
-    assert(opal_atomic_bool_cmpset_acq(&volint, oldint, newint) == 1);
-    assert(volint == newint);
-
-    volint = 42, oldint = 420, newint = 50;
-    assert(opal_atomic_bool_cmpset_acq(&volint, oldint, newint) == 0);
-    assert(volint == 42);
-
-    volint = 42, oldint = 42, newint = 50;
-    assert(opal_atomic_bool_cmpset_rel(&volint, oldint, newint) == 1);
+    assert(opal_atomic_compare_exchange_strong (&volint, &oldint, newint) == true);
     opal_atomic_rmb();
     assert(volint == newint);
+    assert(oldint == 42);
 
     volint = 42, oldint = 420, newint = 50;
-    assert(opal_atomic_bool_cmpset_rel(&volint, oldint, newint) == 0);
+    assert(opal_atomic_compare_exchange_strong (&volint, &oldint, newint) == false);
     opal_atomic_rmb();
     assert(volint == 42);
+    assert(oldint == 42);
+
+    volint = 42, oldint = 42, newint = 50;
+    assert(opal_atomic_compare_exchange_strong_acq (&volint, &oldint, newint) == true);
+    assert(volint == newint);
+    assert(oldint == 42);
+
+    volint = 42, oldint = 420, newint = 50;
+    assert(opal_atomic_compare_exchange_strong_acq (&volint, &oldint, newint) == false);
+    assert(volint == 42);
+    assert(oldint == 42);
+
+    volint = 42, oldint = 42, newint = 50;
+    assert(opal_atomic_compare_exchange_strong_rel (&volint, &oldint, newint) == true);
+    opal_atomic_rmb();
+    assert(volint == newint);
+    assert(oldint == 42);
+
+    volint = 42, oldint = 420, newint = 50;
+    assert(opal_atomic_compare_exchange_strong_rel (&volint, &oldint, newint) == false);
+    opal_atomic_rmb();
+    assert(volint == 42);
+    assert(oldint == 42);
 
 
     /* -- cmpset ptr tests -- */
 
     volptr = (void *) 42, oldptr = (void *) 42, newptr = (void *) 50;
-    assert(opal_atomic_bool_cmpset_ptr(&volptr, oldptr, newptr) == 1);
+    assert(opal_atomic_compare_exchange_strong_ptr (&volptr, &oldptr, newptr) == true);
     opal_atomic_rmb();
     assert(volptr == newptr);
+    assert(oldptr == (void *) 42);
 
     volptr = (void *) 42, oldptr = (void *) 420, newptr = (void *) 50;
-    assert(opal_atomic_bool_cmpset_ptr(&volptr, oldptr, newptr) == 0);
+    assert(opal_atomic_compare_exchange_strong_ptr (&volptr, &oldptr, newptr) == false);
     opal_atomic_rmb();
     assert(volptr == (void *) 42);
+    assert(oldptr == (void *) 42);
 
     volptr = (void *) 42, oldptr = (void *) 42, newptr = (void *) 50;
-    assert(opal_atomic_bool_cmpset_acq_ptr(&volptr, oldptr, newptr) == 1);
+    assert(opal_atomic_compare_exchange_strong_acq_ptr (&volptr, &oldptr, newptr) == true);
     assert(volptr == newptr);
+    assert(oldptr == (void *) 42);
 
     volptr = (void *) 42, oldptr = (void *) 420, newptr = (void *) 50;
-    assert(opal_atomic_bool_cmpset_acq_ptr(&volptr, oldptr, newptr) == 0);
+    assert(opal_atomic_compare_exchange_strong_acq_ptr (&volptr, &oldptr, newptr) == false);
     assert(volptr == (void *) 42);
+    assert(oldptr == (void *) 42);
 
     volptr = (void *) 42, oldptr = (void *) 42, newptr = (void *) 50;
-    assert(opal_atomic_bool_cmpset_rel_ptr(&volptr, oldptr, newptr) == 1);
+    assert(opal_atomic_compare_exchange_strong_rel_ptr (&volptr, &oldptr, newptr) == true);
     opal_atomic_rmb();
     assert(volptr == newptr);
+    assert(oldptr == (void *) 42);
 
     volptr = (void *) 42, oldptr = (void *) 420, newptr = (void *) 50;
-    assert(opal_atomic_bool_cmpset_rel_ptr(&volptr, oldptr, newptr) == 0);
+    assert(opal_atomic_compare_exchange_strong_rel_ptr (&volptr, &oldptr, newptr) == false);
     opal_atomic_rmb();
     assert(volptr == (void *) 42);
+    assert(oldptr == (void *) 42);
 
     /* -- add_32 tests -- */
 


### PR DESCRIPTION
This commit adds a new set of compare-and-exchange functions. These
functions have a signature similar to the functions found in C11. The
old cmpset functions are now deprecated and defined in terms of the
new compare-and-exchange functions. All asm backends have been
updated.
    
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>