### PR TITLE
Allow the user to tell PMIx to support legacy usock connections so cross-version operations can be supported

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,12 @@ it is possible for items to appear more than once in the list.
   file systems, locks the entire file per operation on NFS file systems, and selective byte-range
   locking on other distributed file systems.
 
+- Add an mca parameter pmix_server_usock_connections to allow mpirun to
+  support applications statically built against the Open MPI v2.x release,
+  or installed in a container along with the Open MPI v2.x libraries. It is
+  set to false by default.
+
+
 3.0.0 -- July, 2017
 -------------------
 

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -263,6 +263,7 @@ typedef struct {
     orte_process_name_t server;
     opal_list_t notifications;
     bool pubsub_init;
+    bool legacy;
 } pmix_server_globals_t;
 
 extern pmix_server_globals_t orte_pmix_server_globals;


### PR DESCRIPTION
Extracted from master a63904d47f6dab340a1011fdfaec7f938e3eb864

Signed-off-by: Ralph Castain <rhc@open-mpi.org>