### PR TITLE
usnic: only output unknown frames in verbose mode

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_recv.c
+++ b/opal/mca/btl/usnic/btl_usnic_recv.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Sandia National Laboratories. All rights
  *                         reserved.
- * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -351,9 +351,9 @@ void opal_btl_usnic_recv_call(opal_btl_usnic_module_t *module,
     else {
         ++module->stats.num_unk_recvs;
         if (module->stats.num_unk_recvs < 10) {
-            opal_output(0, "unrecognized payload type %d", bseg->us_btl_header->payload_type);
-            opal_output(0, "base = %p, proto = %p, hdr = %p", bseg->us_list.ptr, seg->rs_protocol_header, (void*) bseg->us_btl_header);
-            opal_btl_usnic_dump_hex(bseg->us_list.ptr, 96+sizeof(*bseg->us_btl_header));
+            opal_output_verbose(15, USNIC_OUT, "unrecognized payload type %d", bseg->us_btl_header->payload_type);
+            opal_output_verbose(15, USNIC_OUT, "base = %p, proto = %p, hdr = %p", bseg->us_list.ptr, seg->rs_protocol_header, (void*) bseg->us_btl_header);
+            opal_btl_usnic_dump_hex(15, USNIC_OUT, bseg->us_list.ptr, 96+sizeof(*bseg->us_btl_header));
         }
         goto repost;
     }

--- a/opal/mca/btl/usnic/btl_usnic_recv.h
+++ b/opal/mca/btl/usnic/btl_usnic_recv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -295,7 +295,7 @@ opal_btl_usnic_recv_fast(opal_btl_usnic_module_t *module,
 
 #if 0
 opal_output(0, "fast recv %d bytes:\n", bseg->us_btl_header->payload_len + sizeof(opal_btl_usnic_btl_header_t));
-opal_btl_usnic_dump_hex(bseg->us_btl_header, bseg->us_btl_header->payload_len + sizeof(opal_btl_usnic_btl_header_t));
+opal_btl_usnic_dump_hex(15, USNIC_OUT, bseg->us_btl_header, bseg->us_btl_header->payload_len + sizeof(opal_btl_usnic_btl_header_t));
 #endif
     /* If this is a short incoming message (i.e., the message is
        wholly contained in this one message -- it is not chunked

--- a/opal/mca/btl/usnic/btl_usnic_util.c
+++ b/opal/mca/btl/usnic/btl_usnic_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,7 +75,8 @@ void opal_btl_usnic_util_abort(const char *msg, const char *file, int line)
 
 
 void
-opal_btl_usnic_dump_hex(void *vaddr, int len)
+opal_btl_usnic_dump_hex(int verbose_level, int output_id,
+                        void *vaddr, int len)
 {
     char buf[128];
     size_t bufspace;
@@ -96,7 +97,8 @@ opal_btl_usnic_dump_hex(void *vaddr, int len)
 
         sum += addr[i];
         if ((i&15) == 15) {
-            opal_output(0, "%4x: %s\n", i&~15, buf);
+            opal_output_verbose(verbose_level, output_id,
+                                "%4x: %s\n", i&~15, buf);
 
             p = buf;
             memset(buf, 0, sizeof(buf));
@@ -104,9 +106,10 @@ opal_btl_usnic_dump_hex(void *vaddr, int len)
         }
     }
     if ((i&15) != 0) {
-        opal_output(0, "%4x: %s\n", i&~15, buf);
+        opal_output_verbose(verbose_level, output_id,
+                            "%4x: %s\n", i&~15, buf);
     }
-    /*opal_output(0, "buffer sum = %x\n", sum); */
+    /*opal_output_verbose(verbose_level, output_id, "buffer sum = %x\n", sum); */
 }
 
 

--- a/opal/mca/btl/usnic/btl_usnic_util.h
+++ b/opal/mca/btl/usnic/btl_usnic_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -117,7 +117,8 @@ void opal_btl_usnic_snprintf_ipv4_addr(char *out, size_t maxlen,
 
 void opal_btl_usnic_snprintf_bool_array(char *s, size_t slen, bool a[], size_t alen);
 
-void opal_btl_usnic_dump_hex(void *vaddr, int len);
+void opal_btl_usnic_dump_hex(int verbose_level, int output_id,
+                             void *vaddr, int len);
 
 size_t opal_btl_usnic_convertor_pack_peek(const opal_convertor_t *conv,
                                           size_t max_len);


### PR DESCRIPTION
Per https://www.mail-archive.com/users@lists.open-mpi.org/msg31758.html, only output unknown frames when we're outputting verbose BTL messages.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>