### PR TITLE
roll to 2.0.5a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -15,7 +15,7 @@
 
 major=2
 minor=0
-release=4
+release=5
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -24,7 +24,7 @@ release=4
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc3
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
which we don't plan to release

[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>