### PR TITLE
MTL OFI updates

### DIFF
--- a/ompi/mca/mtl/ofi/help-mtl-ofi.txt
+++ b/ompi/mca/mtl/ofi/help-mtl-ofi.txt
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved
 #
+# Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -9,8 +10,9 @@
 # $HEADER$
 #
 [OFI call fail]
-Open MPI failed an OFI Libfabric library call (%s).This is highly unusual;
-your job may behave unpredictably (and/or abort) after this.
+Open MPI failed an OFI Libfabric library call (%s).  This is highly
+unusual; your job may behave unpredictably (and/or abort) after this.
+
   Local host: %s
   Location: %s:%d
   Error: %s (%zd)

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -594,23 +594,23 @@ ompi_mtl_ofi_finalize(struct mca_mtl_base_module_t *mtl)
     opal_progress_unregister(ompi_mtl_ofi_progress_no_inline);
 
     /* Close all the OFI objects */
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.ep)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.ep))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.cq)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.cq))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.av)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.av))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.domain)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.domain))) {
         goto finalize_err;
     }
 
-    if (ret = fi_close((fid_t)ompi_mtl_ofi.fabric)) {
+    if ((ret = fi_close((fid_t)ompi_mtl_ofi.fabric))) {
         goto finalize_err;
     }
 

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2013-2017 Intel, Inc. All rights reserved
  *
- * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -362,7 +362,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                      NULL,          /* Optional name or fabric to resolve       */
                      NULL,          /* Optional service name or port to request */
                      0ULL,          /* Optional flag                            */
-                     hints,        /* In: Hints to filter providers            */
+                     hints,         /* In: Hints to filter providers            */
                      &providers);   /* Out: List of matching providers          */
     if (0 != ret) {
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -364,7 +364,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
                      0ULL,          /* Optional flag                            */
                      hints,         /* In: Hints to filter providers            */
                      &providers);   /* Out: List of matching providers          */
-    if (0 != ret) {
+    if (FI_ENODATA == -ret) {
+        // It is not an error if no information is returned.
+        goto error;
+    } else if (0 != ret) {
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_getinfo",
                        ompi_process_info.nodename, __FILE__, __LINE__,

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -368,7 +368,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_getinfo",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -397,7 +397,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_fabric",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -414,7 +414,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_domain",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -433,7 +433,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
         opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                        "fi_endpoint",
                        ompi_process_info.nodename, __FILE__, __LINE__,
-                       fi_strerror(-ret), ret);
+                       fi_strerror(-ret), -ret);
         goto error;
     }
 
@@ -617,7 +617,7 @@ finalize_err:
     opal_show_help("help-mtl-ofi.txt", "OFI call fail", true,
                    "fi_close",
                    ompi_process_info.nodename, __FILE__, __LINE__,
-                   fi_strerror(-ret), ret);
+                   fi_strerror(-ret), -ret);
 
     return OMPI_ERROR;
 }


### PR DESCRIPTION
The most important of these is to not show an error if `fi_getinfo()` returns no data.

Need to get these fixes in to release branches before they go out, or usNIC customers will be asking my why they are getting these warnings.  😦   This affects:

* v2.x
* v3.0.x (PR #4458)
* v3.1.x (PR #4459)

These commits should be added to #4458 and #4459 before those PRs are merged.