### PR TITLE
v3.0.x: Make interface's kernel index an int instead of int16_t

### DIFF
--- a/opal/util/if.c
+++ b/opal/util/if.c
@@ -137,7 +137,7 @@ int opal_ifnametoindex(const char* if_name)
  *  corresponding kernel index.
  */
 
-int16_t opal_ifnametokindex(const char* if_name)
+int opal_ifnametokindex(const char* if_name)
 {
     opal_if_t* intf;
 
@@ -246,7 +246,7 @@ int opal_ifaddrtoname(const char* if_addr, char* if_name, int length)
  *  or hostname) and return the kernel index of the interface
  *  on the same network as the specified address
  */
-int16_t opal_ifaddrtokindex(const char* if_addr)
+int opal_ifaddrtokindex(const char* if_addr)
 {
     opal_if_t* intf;
     int error;
@@ -762,7 +762,7 @@ opal_ifnametoindex(const char* if_name)
     return OPAL_ERR_NOT_SUPPORTED;
 }
 
-int16_t
+int
 opal_ifnametokindex(const char* if_name)
 {
     return OPAL_ERR_NOT_SUPPORTED;

--- a/opal/util/if.h
+++ b/opal/util/if.h
@@ -88,14 +88,14 @@ OPAL_DECLSPEC int opal_ifnametoindex(const char* if_name);
  *  @param if_name (IN)  Interface name
  *  @return              Interface kernel index
  */
-OPAL_DECLSPEC int16_t opal_ifnametokindex(const char* if_name);
+OPAL_DECLSPEC int opal_ifnametokindex(const char* if_name);
 
 /*
  *  Attempt to resolve an address (given as either IPv4/IPv6 string
  *  or hostname) and return the kernel index of the interface
  *  that is on the same network as the specified address
  */
-OPAL_DECLSPEC int16_t opal_ifaddrtokindex(const char* if_addr);
+OPAL_DECLSPEC int opal_ifaddrtokindex(const char* if_addr);
 
 /**
  *  Lookup an interface by opal_list index and return its kernel index.


### PR DESCRIPTION
Sometimes, the ethernet interfaces can get quite high kernel indices. struct
ifreq (see netdevice(7)) defines ifr_ifindex to be int's. The OOB component
used int16_t internally for matching (in case of -mca oob_tcp_if_[in|ex]clude)
which meant that any interface index > 32767 would never be matched because the
integer would be truncated to int16_t upon return from the function. OOB would
then refuse to work because it didn't find any usable interfaces and MPI job
would abort.

Signed-off-by: Wojtek Wasko <wwasko@nvidia.com>
(cherry picked from commit 276de13a1e729c104fc564ddcce775608888c666)

Master PR: #4506