### PR TITLE
ppc/asm: Fix opal_atomic_wmb definition

### DIFF
--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -89,7 +89,7 @@ void opal_atomic_rmb(void)
 static inline
 void opal_atomic_wmb(void)
 {
-    RMB();
+    WMB();
 }
 
 static inline
@@ -115,7 +115,7 @@ void opal_atomic_isync(void)
 #pragma mc_func opal_atomic_rmb { "7c2004ac" }         /* lwsync  */
 #pragma reg_killed_by opal_atomic_rmb                  /* none */
 
-#pragma mc_func opal_atomic_wmb { "7c0006ac" }         /* eieio */
+#pragma mc_func opal_atomic_wmb { "7c2004ac" }         /* lwsync */
 #pragma reg_killed_by opal_atomic_wmb                  /* none */
 
 #endif


### PR DESCRIPTION
 * Fix typo in the `opal_atomic_wmb` declaration.
 * Fix lingering `eieio` reference in the XL assembly to be `lwsync`

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>