### PR TITLE
configury: add portals4 include path to osc-monitoring component build

### DIFF
--- a/ompi/mca/osc/monitoring/Makefile.am
+++ b/ompi/mca/osc/monitoring/Makefile.am
@@ -19,6 +19,8 @@ monitoring_sources  = \
 	osc_monitoring_module.h \
 	osc_monitoring_template.h
 
+AM_CPPFLAGS = $(osc_monitoring_portals4_CPPFLAGS)
+
 if MCA_BUILD_ompi_osc_monitoring_DSO
 component_noinst =
 component_install = mca_osc_monitoring.la

--- a/ompi/mca/osc/monitoring/configure.m4
+++ b/ompi/mca/osc/monitoring/configure.m4
@@ -16,7 +16,11 @@ AC_DEFUN([MCA_ompi_osc_monitoring_CONFIG],[
     AS_IF([test "$MCA_BUILD_ompi_common_monitoring_DSO_TRUE" = ''],
           [$1],
           [$2])
-    OPAL_CHECK_PORTALS4([osc_monitoring],
+    OPAL_CHECK_PORTALS4([osc_monitoring_portals4],
                         [AC_DEFINE([OMPI_WITH_OSC_PORTALS4], [1], [Whether or not to generate template for osc_portals4])],
                         [])
+    # substitute in the things needed to build portals4
+    AC_SUBST([osc_monitoring_portals4_CPPFLAGS])
+    AC_SUBST([osc_monitoring_portals4_LDFLAGS])
+    AC_SUBST([osc_monitoring_portals4_LIBS])
 ])dnl

--- a/ompi/mca/osc/monitoring/configure.m4
+++ b/ompi/mca/osc/monitoring/configure.m4
@@ -21,6 +21,4 @@ AC_DEFUN([MCA_ompi_osc_monitoring_CONFIG],[
                         [])
     # substitute in the things needed to build portals4
     AC_SUBST([osc_monitoring_portals4_CPPFLAGS])
-    AC_SUBST([osc_monitoring_portals4_LDFLAGS])
-    AC_SUBST([osc_monitoring_portals4_LIBS])
 ])dnl


### PR DESCRIPTION
The osc-monitoring component didn't add the Portals4 include directory to AM_CPPFLAGS which causes a build failure if Portals4 is installed in a location that isn't in the compiler's default search path.

The PR clarifies the OPAL_CHECK_PORTALS4() prefix name, exports the Portals4 variables and adds the Portals4 CPPFLAGS to AM_CPPFLAGS.

Signed-off-by: Todd Kordenbrock <thkgcode@gmail.com>

@bosilca @jsquyres Please review.
