### PR TITLE
mpi/c/dims_create.c: avoid using log, sqrt, ceil in getfactors

### DIFF
--- a/ompi/mpi/c/dims_create.c
+++ b/ompi/mpi/c/dims_create.c
@@ -233,7 +233,7 @@ upper_ilog2(const int i) {
  *  Returns:	- integer result
  */ 
 static int
-upper_isqrt(const int i; const int ilog2) {
+upper_isqrt(const int i, const int ilog2) {
 	if (i < 2) return i;
 	int a, b, c;
 	a = 1 << (((ilog2+1) >> 1) - 1);
@@ -281,7 +281,7 @@ getfactors(int num, int *nfactors, int **factors) {
         (*factors)[i++] = 2;
     }
 
-    sqrt_num = upper_isqrt(num, size - i);
+    sqrtnum = upper_isqrt(num, size - i);
     /* determine all occurences of uneven prime numbers up to sqrt(num) */
     d = 3;
     for(d = 3; (num > 1) && (d < sqrtnum); d += 2) {

--- a/ompi/mpi/c/dims_create.c
+++ b/ompi/mpi/c/dims_create.c
@@ -207,6 +207,46 @@ assignnodes(int ndim, int nfactor, int *pfacts, int **pdims)
 }
 
 /*
+ *  upper_ilog2
+ *
+ *  Function:   - compute ceiling of log2(i)
+ *  Accepts:	- integer number
+ *  Returns:	- integer result
+ */ 
+static int
+upper_ilog2(const int i) {
+	int ilog2 = 0;
+	int ii = i;
+	while (ii > 1) {
+		ii = (ii + 1) >> 1;
+		ilog2++;
+	}
+	return ilog2;
+}
+
+/*
+ *  upper_isqrt
+ *
+ *  Function:	- compute ceiling of sqrt(i)
+ *  Accepts:	- integer number
+ *  		- integer number (result of upper_ilog2(i))
+ *  Returns:	- integer result
+ */ 
+static int
+upper_isqrt(const int i; const int ilog2) {
+	if (i < 2) return i;
+	int a, b, c;
+	a = 1 << (((ilog2+1) >> 1) - 1);
+	b = 1 <<  ((ilog2+1) >> 1);
+	do {
+		c = (a + b) >> 1;
+		if (c * c >= i) b = c - 1;
+		else            a = c + 1;
+	} while (b > a);
+	return (a * a >= i) ? a : a + 1;
+}
+
+/*
  *  getfactors
  *
  *  Function:   - factorize a number
@@ -221,6 +261,7 @@ getfactors(int num, int *nfactors, int **factors) {
     int d;
     int i;
     int sqrtnum;
+    int factors2;
 
     if(num  < 2) {
         (*nfactors) = 0;
@@ -228,8 +269,9 @@ getfactors(int num, int *nfactors, int **factors) {
         return MPI_SUCCESS;
     }
     /* Allocate the array of prime factors which cannot exceed log_2(num) entries */
-    sqrtnum = ceil(sqrt(num));
-    size = ceil(log(num) / log(2));
+    size = upper_ilog2(num);
+//  sqrtnum = ceil(sqrt(num));
+//  size = ceil(log(num) / log(2));
     *factors = (int *) malloc((unsigned) size * sizeof(int));
 
     i = 0;
@@ -238,6 +280,8 @@ getfactors(int num, int *nfactors, int **factors) {
         num /= 2;
         (*factors)[i++] = 2;
     }
+
+    sqrt_num = upper_isqrt(num, size - i);
     /* determine all occurences of uneven prime numbers up to sqrt(num) */
     d = 3;
     for(d = 3; (num > 1) && (d < sqrtnum); d += 2) {


### PR DESCRIPTION
Hi!

We observed that applications linked against OpenMPI (2.x and onward) yield deviating numerical results than OpenMPI 1.x (or any other MPI-implementation tested).
Investigation revealed that the relatively large deviations (10% and more) originate from small deviations in results of calls to 'log', which then grow due to the error propagation behavior of the numerical algorithms utilized.

It appears that building/compiling ompi and the application with different Versions of ifort/icc made the issue visible: libmpi.so exports an implementation of 'log' from the comliler's preferred math-library.
The responsible call to 'log' was found in ompi/mpi/c/dims_create.c - in the function 'getfactors(...)'.

libmpi.so exports the symbol 'log', this leads to strange deviations, if
ompi was linked against another math-library than applications lateron
(in particular when using Intel's ifort/icc, which bring their own
math-library)
This is fixed by avoiding usage of math-library functions, i.e. log and
sqrt in the getfactors fnction in ompi/mpi/c/dims_create.c

Signed-off-by: Harald Braun harald.braun@atos.net