### PR TITLE
iof: optimize handling of stdin

### DIFF
--- a/orte/mca/odls/alps/odls_alps_module.c
+++ b/orte/mca/odls/alps/odls_alps_module.c
@@ -468,7 +468,9 @@ static int do_parent(orte_odls_spawn_caddy_t *cd, int read_fd)
     orte_odls_pipe_err_msg_t msg;
     char file[ORTE_ODLS_MAX_FILE_LEN + 1], topic[ORTE_ODLS_MAX_TOPIC_LEN + 1], *str = NULL;
 
-    close(cd->opts.p_stdin[0]);
+    if (cd->opts.connect_stdin) {
+        close(cd->opts.p_stdin[0]);
+    }
     close(cd->opts.p_stdout[1]);
     close(cd->opts.p_stderr[1]);
     close(cd->opts.p_internal[1]);

--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -449,7 +449,9 @@ static int do_parent(orte_odls_spawn_caddy_t *cd, int read_fd)
     orte_odls_pipe_err_msg_t msg;
     char file[ORTE_ODLS_MAX_FILE_LEN + 1], topic[ORTE_ODLS_MAX_TOPIC_LEN + 1], *str = NULL;
 
-    close(cd->opts.p_stdin[0]);
+    if (cd->opts.connect_stdin) {
+        close(cd->opts.p_stdin[0]);
+    }
     close(cd->opts.p_stdout[1]);
     close(cd->opts.p_stderr[1]);
     close(cd->opts.p_internal[1]);


### PR DESCRIPTION
since some tasks migth end up having /dev/null as their stdin,
simply avoid pipe creation and destruction for these tasks.

From a pragmatic and MPI point of view, and unless explicitly required
otherwise, all MPI tasks but (the first) one end up with /dev/null
as their stdin.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>