### PR TITLE
iof: optimize handling of stderr when iof_base_redirect_app_stderr_to…

### DIFF
--- a/orte/mca/iof/hnp/iof_hnp.c
+++ b/orte/mca/iof/hnp/iof_hnp.c
@@ -201,7 +201,8 @@ static int hnp_push(const orte_process_name_t* dst_name, orte_iof_tag_t src_tag,
          * because one of the readevents fires -prior- to all of them having
          * been defined!
          */
-        if (NULL != proct->revstdout && NULL != proct->revstderr && NULL != proct->revstddiag) {
+        if (NULL != proct->revstdout && NULL != proct->revstddiag &&
+            (orte_iof_base.redirect_app_stderr_to_stdout || NULL != proct->revstderr)) {
             if (proct->copy) {
                 /* see if there are any wildcard subscribers out there that
                  * apply to us */
@@ -216,7 +217,9 @@ static int hnp_push(const orte_process_name_t* dst_name, orte_iof_tag_t src_tag,
                 }
             }
             ORTE_IOF_READ_ACTIVATE(proct->revstdout);
-            ORTE_IOF_READ_ACTIVATE(proct->revstderr);
+            if (!orte_iof_base.redirect_app_stderr_to_stdout) {
+                ORTE_IOF_READ_ACTIVATE(proct->revstderr);
+            }
             ORTE_IOF_READ_ACTIVATE(proct->revstddiag);
        }
         return ORTE_SUCCESS;

--- a/orte/mca/iof/orted/iof_orted.c
+++ b/orte/mca/iof/orted/iof_orted.c
@@ -14,6 +14,8 @@
  *                         reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -190,9 +192,12 @@ SETUP:
      * because one of the readevents fires -prior- to all of them having
      * been defined!
      */
-    if (NULL != proct->revstdout && NULL != proct->revstderr && NULL != proct->revstddiag) {
+    if (NULL != proct->revstdout && NULL != proct->revstddiag &&
+        (orte_iof_base.redirect_app_stderr_to_stdout || NULL != proct->revstderr)) {
         ORTE_IOF_READ_ACTIVATE(proct->revstdout);
-        ORTE_IOF_READ_ACTIVATE(proct->revstderr);
+        if (!orte_iof_base.redirect_app_stderr_to_stdout) {
+            ORTE_IOF_READ_ACTIVATE(proct->revstderr);
+        }
         ORTE_IOF_READ_ACTIVATE(proct->revstddiag);
     }
     return ORTE_SUCCESS;

--- a/orte/mca/odls/alps/odls_alps_module.c
+++ b/orte/mca/odls/alps/odls_alps_module.c
@@ -472,7 +472,9 @@ static int do_parent(orte_odls_spawn_caddy_t *cd, int read_fd)
         close(cd->opts.p_stdin[0]);
     }
     close(cd->opts.p_stdout[1]);
-    close(cd->opts.p_stderr[1]);
+    if( !orte_iof_base.redirect_app_stderr_to_stdout ) {
+        close(cd->opts.p_stderr[1]);
+    }
     close(cd->opts.p_internal[1]);
 
     /* Block reading a message from the pipe */

--- a/orte/mca/odls/default/odls_default_module.c
+++ b/orte/mca/odls/default/odls_default_module.c
@@ -453,7 +453,9 @@ static int do_parent(orte_odls_spawn_caddy_t *cd, int read_fd)
         close(cd->opts.p_stdin[0]);
     }
     close(cd->opts.p_stdout[1]);
-    close(cd->opts.p_stderr[1]);
+    if( !orte_iof_base.redirect_app_stderr_to_stdout ) {
+        close(cd->opts.p_stderr[1]);
+    }
     close(cd->opts.p_internal[1]);
 
     /* Block reading a message from the pipe */


### PR DESCRIPTION
…_stdout is set

avoid creating a pipe for a task stderr when we know it will be redirected to stdout

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>