### PR TITLE
Try adding local spawn threads by default to parallelize the fork/exec process.

### DIFF
--- a/orte/mca/odls/base/base.h
+++ b/orte/mca/odls/base/base.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2017      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,6 +44,10 @@ ORTE_DECLSPEC extern mca_base_framework_t orte_odls_base_framework;
  * Select an available component.
  */
 ORTE_DECLSPEC int orte_odls_base_select(void);
+
+ORTE_DECLSPEC void orte_odls_base_start_threads(orte_job_t *jdata);
+
+ORTE_DECLSPEC void orte_odls_base_harvest_threads(void);
 
 END_C_DECLS
 #endif

--- a/orte/mca/odls/base/odls_base_frame.c
+++ b/orte/mca/odls/base/odls_base_frame.c
@@ -188,7 +188,6 @@ static int orte_odls_base_close(void)
     orte_proc_t *proc;
     opal_list_item_t *item;
 
-opal_output(0, "CLOSE");
     /* cleanup ODLS globals */
     while (NULL != (item = opal_list_remove_first(&orte_odls_globals.xterm_ranks))) {
         OBJ_RELEASE(item);

--- a/orte/mca/odls/base/odls_private.h
+++ b/orte/mca/odls/base/odls_private.h
@@ -14,6 +14,8 @@
  *                         reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,7 +42,7 @@
 #include "orte/mca/iof/base/iof_base_setup.h"
 #include "orte/mca/rml/rml_types.h"
 #include "orte/runtime/orte_globals.h"
-
+#include "orte/util/threads.h"
 #include "orte/mca/odls/odls_types.h"
 
 BEGIN_C_DECLS
@@ -59,11 +61,14 @@ typedef struct {
     /* the xterm cmd to be used */
     char **xtermcmd;
     /* thread pool */
+    int max_threads;
     int num_threads;
+    int cutoff;
     opal_event_base_t **ev_bases;   // event base array for progress threads
     char** ev_threads;              // event progress thread names
     int next_base;                  // counter to load-level thread use
     bool signal_direct_children_only;
+    orte_lock_t lock;
 } orte_odls_globals_t;
 
 ORTE_DECLSPEC extern orte_odls_globals_t orte_odls_globals;
@@ -127,7 +132,7 @@ OBJ_CLASS_DECLARATION(orte_odls_launch_local_t);
 
 ORTE_DECLSPEC void orte_odls_base_default_launch_local(int fd, short sd, void *cbdata);
 
-ORTE_DECLSPEC void ompi_odls_base_default_wait_local_proc(orte_proc_t *proc, void* cbdata);
+ORTE_DECLSPEC void orte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata);
 
 /* define a function type to signal a local proc */
 typedef int (*orte_odls_base_signal_local_fn_t)(pid_t pid, int signum);

--- a/orte/mca/plm/alps/plm_alps_module.c
+++ b/orte/mca/plm/alps/plm_alps_module.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -578,7 +580,7 @@ static int plm_alps_start_proc(int argc, char **argv, char **env,
     /* be sure to mark it as alive so we don't instantly fire */
     ORTE_FLAG_SET(alpsrun, ORTE_PROC_FLAG_ALIVE);
     /* setup the waitpid so we can find out if alps succeeds! */
-    orte_wait_cb(alpsrun, alps_wait_cb, NULL);
+    orte_wait_cb(alpsrun, alps_wait_cb, orte_event_base, NULL);
 
     if (0 == alps_pid) {  /* child */
         char *bin_base = NULL, *lib_base = NULL;

--- a/orte/mca/plm/alps/plm_alps_module.c
+++ b/orte/mca/plm/alps/plm_alps_module.c
@@ -517,7 +517,9 @@ static int plm_alps_finalize(void)
 }
 
 
-static void alps_wait_cb(orte_proc_t *proc, void* cbdata){
+static void alps_wait_cb(int sd, short args, void *cbdata) {
+    orte_wait_tracker_t *t2 = (orte_wait_tracker_t*)cbdata;
+    orte_proc_t *proc = t2->child;
     orte_job_t *jdata;
 
     /* According to the ALPS folks, alps always returns the highest exit
@@ -550,6 +552,7 @@ static void alps_wait_cb(orte_proc_t *proc, void* cbdata){
             ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_ABORTED);
         }
     }
+    OBJ_RELEASE(t2);
 }
 
 

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -49,6 +49,7 @@
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/mca/ess/ess.h"
 #include "orte/mca/iof/base/base.h"
+#include "orte/mca/odls/base/base.h"
 #include "orte/mca/ras/base/base.h"
 #include "orte/mca/rmaps/rmaps.h"
 #include "orte/mca/rmaps/base/base.h"
@@ -56,7 +57,6 @@
 #include "orte/mca/rml/rml_types.h"
 #include "orte/mca/routed/routed.h"
 #include "orte/mca/grpcomm/base/base.h"
-#include "orte/mca/odls/odls.h"
 #if OPAL_ENABLE_FT_CR == 1
 #include "orte/mca/snapc/base/base.h"
 #endif

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -259,10 +259,11 @@ static int rsh_init(void)
 /**
  * Callback on daemon exit.
  */
-static void rsh_wait_daemon(orte_proc_t *daemon, void* cbdata)
+static void rsh_wait_daemon(int sd, short flags, void *cbdata)
 {
     orte_job_t *jdata;
     orte_plm_rsh_caddy_t *caddy=(orte_plm_rsh_caddy_t*)cbdata;
+    orte_proc_t *daemon = caddy->daemon;
     char *rtmod;
 
     if (orte_orteds_term_ordered || orte_abnormal_term_ordered) {
@@ -938,7 +939,7 @@ static void process_launch_list(int fd, short args, void *cbdata)
         caddy = (orte_plm_rsh_caddy_t*)item;
         /* register the sigchild callback */
         ORTE_FLAG_SET(caddy->daemon, ORTE_PROC_FLAG_ALIVE);
-        orte_wait_cb(caddy->daemon, rsh_wait_daemon, (void*)caddy);
+        orte_wait_cb(caddy->daemon, rsh_wait_daemon, orte_event_base, (void*)caddy);
 
         /* fork a child to exec the rsh/ssh session */
         pid = fork();

--- a/orte/mca/state/orted/state_orted.c
+++ b/orte/mca/state/orted/state_orted.c
@@ -23,6 +23,7 @@
 
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/mca/iof/base/base.h"
+#include "orte/mca/odls/base/base.h"
 #include "orte/mca/rmaps/rmaps_types.h"
 #include "orte/mca/rml/rml.h"
 #include "orte/mca/routed/routed.h"
@@ -288,6 +289,13 @@ static void track_procs(int fd, short argc, void *cbdata)
         /* update the proc state */
         pdata->state = state;
         jdata->num_launched++;
+        if (jdata->num_launched == jdata->num_local_procs) {
+            /* tell the state machine that all local procs for this job
+             * were launched so that it can do whatever it needs to do,
+             * like send a state update message for all procs to the HNP
+             */
+            ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE);
+        }
         /* don't update until we are told that all are done */
     } else if (ORTE_PROC_STATE_REGISTERED == state) {
         /* update the proc state */

--- a/orte/runtime/orte_wait.h
+++ b/orte/runtime/orte_wait.h
@@ -53,7 +53,18 @@
 BEGIN_C_DECLS
 
 /** typedef for callback function used in \c orte_wait_cb */
-typedef void (*orte_wait_fn_t)(orte_proc_t *proc, void *data);
+typedef void (*orte_wait_cbfunc_t)(int fd, short args, void* cb);
+
+/* define a tracker */
+typedef struct {
+    opal_list_item_t super;
+    opal_event_t ev;
+    opal_event_base_t *evb;
+    orte_proc_t *child;
+    orte_wait_cbfunc_t cbfunc;
+    void *cbdata;
+} orte_wait_tracker_t;
+OBJ_CLASS_DECLARATION(orte_wait_tracker_t);
 
 /**
  * Disable / re-Enable SIGCHLD handler
@@ -71,7 +82,8 @@ ORTE_DECLSPEC void orte_wait_disable(void);
  * \c waitpid() will have already been called on the process at this
  * time.
  */
-ORTE_DECLSPEC void orte_wait_cb(orte_proc_t *proc, orte_wait_fn_t callback, void *data);
+ORTE_DECLSPEC void orte_wait_cb(orte_proc_t *proc, orte_wait_cbfunc_t callback,
+                                opal_event_base_t *evb, void *data);
 
 ORTE_DECLSPEC void orte_wait_cb_cancel(orte_proc_t *proc);
 


### PR DESCRIPTION
Clean up the threads once initial launch is complete - let comm_spawn launches proceed at a slower pace.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>