### PR TITLE
Mention --oversubscribe when application fails due to insufficient slots.

### DIFF
--- a/orte/mca/rmaps/seq/help-orte-rmaps-seq.txt
+++ b/orte/mca/rmaps/seq/help-orte-rmaps-seq.txt
@@ -21,10 +21,12 @@
 [orte-rmaps-seq:alloc-error]
 There are not enough slots available in the system to satisfy the %d slots
 that were requested by the application:
+
   %s
 
-Either request fewer slots for your application, or make more slots available
-for use.
+Either request fewer slots for your application or make more slots
+available for use.  If oversubscription is intended, add
+--oversubscribe to the command line.
 #
 [orte-rmaps-seq:resource-not-found]
 The specified hostfile contained a node (%s) that is not in your


### PR DESCRIPTION
The current error message when the number of slots is insufficient (e.g. running mpirun -n 4 on a dual core machine) does not mention the use of `--oversubscribe`. 

In earlier version of openmpi, the over-subscription was automatic (albeit buggy?); but the important point was
no error message was printed and the application runs. 
Mentioning the oversubscibe flag in the message will ease up the transition to the current behaviour where explicit
request is required.

Please be aware that I don't really know if this is the right file hosting the message or if other places shall also be changed.