### PR TITLE
v3.0.x: Mention --oversubscribe

### DIFF
--- a/orte/mca/rmaps/seq/help-orte-rmaps-seq.txt
+++ b/orte/mca/rmaps/seq/help-orte-rmaps-seq.txt
@@ -21,10 +21,12 @@
 [orte-rmaps-seq:alloc-error]
 There are not enough slots available in the system to satisfy the %d slots
 that were requested by the application:
+
   %s
 
-Either request fewer slots for your application, or make more slots available
-for use.
+Either request fewer slots for your application or make more slots
+available for use.  If oversubscription is intended, add
+--oversubscribe to the command line.
 #
 [orte-rmaps-seq:resource-not-found]
 The specified hostfile contained a node (%s) that is not in your


### PR DESCRIPTION
The current error message when the number of slots is insufficient
(e.g. running mpirun -n 4 on a dual core machine) does not mention the
use of `--oversubscribe`.

In earlier version of Open MPI, the over-subscription was automatic
(albeit buggy?); but the important point was no error message was
printed and the application runs.  Mentioning the oversubscibe flag in
the message will ease up the transition to the current behaviour where
explicit request is required.

Also make a few other minor tweaks / cleanups to the
orte-rmaps-seq:alloc-error help message.

Signed-off-by: Yu Feng <rainwoodman@gmail.com>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 6aaf62584b7da005bf22023fb3269c4f6d69fec7)

Thanks to @rainwoodman 