### PR TITLE
Fix the hang in connect/accept operations

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -588,13 +588,8 @@ int ompi_dpm_disconnect(ompi_communicator_t *comm)
     }
 
     /* ensure we tell the host RM to disconnect us - this
-     * is a blocking operation that must include a fence */
-    if (NULL == opal_pmix.disconnect) {
-        /* use the fence */
-        ret = opal_pmix.fence(&coll, false);
-    } else {
-        ret = opal_pmix.disconnect(&coll);
-    }
+     * is a blocking operation so just use a fence */
+    ret = opal_pmix.fence(&coll, false);
     OPAL_LIST_DESTRUCT(&coll);
 
     return ret;


### PR DESCRIPTION
Take the smallest change approach to fixing the hang on disconnect of connect/accept operations by replacing the call to pmix.disconnect with a simple pmix.fence as this is all OMPI currently requires

Fixes #4542 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>