### PR TITLE
fix communicator's c_lock usage

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1315,16 +1315,12 @@ int ompi_comm_compare(ompi_communicator_t *comm1, ompi_communicator_t *comm2, in
 int ompi_comm_set_name (ompi_communicator_t *comm, const char *name )
 {
 
-#ifdef USE_MUTEX_FOR_COMMS
     OPAL_THREAD_LOCK(&(comm->c_lock));
-#endif
     memset(comm->c_name, 0, MPI_MAX_OBJECT_NAME);
     strncpy(comm->c_name, name, MPI_MAX_OBJECT_NAME);
     comm->c_name[MPI_MAX_OBJECT_NAME - 1] = 0;
     comm->c_flags |= OMPI_COMM_NAMEISSET;
-#ifdef USE_MUTEX_FOR_COMMS
     OPAL_THREAD_UNLOCK(&(comm->c_lock));
-#endif
 
     return OMPI_SUCCESS;
 }

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -387,6 +387,9 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
 #ifdef OMPI_WANT_PERUSE
     comm->c_peruse_handles = NULL;
 #endif
+#ifdef USE_MUTEX_FOR_COMMS
+    OBJ_CONSTRUCT(&comm->c_lock, opal_mutex_t);
+#endif
 }
 
 static void ompi_comm_destruct(ompi_communicator_t* comm)

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -387,9 +387,7 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
 #ifdef OMPI_WANT_PERUSE
     comm->c_peruse_handles = NULL;
 #endif
-#ifdef USE_MUTEX_FOR_COMMS
     OBJ_CONSTRUCT(&comm->c_lock, opal_mutex_t);
-#endif
 }
 
 static void ompi_comm_destruct(ompi_communicator_t* comm)

--- a/ompi/mpi/c/comm_get_errhandler.c
+++ b/ompi/mpi/c/comm_get_errhandler.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -63,12 +63,16 @@ int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler)
     }
   }
 
-  opal_mutex_lock (&comm->c_lock);
+#ifdef USE_MUTEX_FOR_COMMS
+    OPAL_THREAD_LOCK(&(comm->c_lock));
+#endif
   /* Retain the errhandler, corresponding to object refcount decrease
      in errhandler_free.c. */
   OBJ_RETAIN(comm->error_handler);
   *errhandler = comm->error_handler;
-  opal_mutex_unlock (&comm->c_lock);
+#ifdef USE_MUTEX_FOR_COMMS
+    OPAL_THREAD_UNLOCK(&(comm->c_lock));
+#endif
 
   /* All done */
 

--- a/ompi/mpi/c/comm_get_errhandler.c
+++ b/ompi/mpi/c/comm_get_errhandler.c
@@ -50,31 +50,27 @@ int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler)
 
     OPAL_CR_NOOP_PROGRESS();
 
-  /* Error checking */
+    /* Error checking */
 
-  if (MPI_PARAM_CHECK) {
-    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-    if (ompi_comm_invalid(comm)) {
-      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
-                                    FUNC_NAME);
-    } else if (NULL == errhandler) {
-      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
-                                    FUNC_NAME);
+    if (MPI_PARAM_CHECK) {
+      OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+      if (ompi_comm_invalid(comm)) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
+                                      FUNC_NAME);
+      } else if (NULL == errhandler) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
+                                      FUNC_NAME);
+      }
     }
-  }
 
-#ifdef USE_MUTEX_FOR_COMMS
     OPAL_THREAD_LOCK(&(comm->c_lock));
-#endif
-  /* Retain the errhandler, corresponding to object refcount decrease
-     in errhandler_free.c. */
-  OBJ_RETAIN(comm->error_handler);
-  *errhandler = comm->error_handler;
-#ifdef USE_MUTEX_FOR_COMMS
+    /* Retain the errhandler, corresponding to object refcount decrease
+       in errhandler_free.c. */
+    OBJ_RETAIN(comm->error_handler);
+    *errhandler = comm->error_handler;
     OPAL_THREAD_UNLOCK(&(comm->c_lock));
-#endif
 
-  /* All done */
+    /* All done */
 
-  return MPI_SUCCESS;
+    return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/comm_get_name.c
+++ b/ompi/mpi/c/comm_get_name.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -60,9 +60,7 @@ int MPI_Comm_get_name(MPI_Comm comm, char *name, int *length)
             return OMPI_ERRHANDLER_INVOKE ( comm, MPI_ERR_ARG,
                                             FUNC_NAME);
     }
-#ifdef USE_MUTEX_FOR_COMMS
     OPAL_THREAD_LOCK(&(comm->c_lock));
-#endif
     /* Note that MPI-2.1 requires:
        - terminating the string with a \0
        - name[*resultlen] == '\0'
@@ -80,9 +78,7 @@ int MPI_Comm_get_name(MPI_Comm comm, char *name, int *length)
         name[0] = '\0';
         *length = 0;
     }
-#ifdef USE_MUTEX_FOR_COMMS
     OPAL_THREAD_UNLOCK(&(comm->c_lock));
-#endif
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/comm_set_errhandler.c
+++ b/ompi/mpi/c/comm_set_errhandler.c
@@ -69,16 +69,12 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
     /* Prepare the new error handler */
     OBJ_RETAIN(errhandler);
 
-#ifdef USE_MUTEX_FOR_COMMS
     OPAL_THREAD_LOCK(&(comm->c_lock));
-#endif
     /* Ditch the old errhandler, and decrement its refcount. */
     tmp = comm->error_handler;
     comm->error_handler = errhandler;
     OBJ_RELEASE(tmp);
-#ifdef USE_MUTEX_FOR_COMMS
     OPAL_THREAD_UNLOCK(&(comm->c_lock));
-#endif
 
     /* All done */
     return MPI_SUCCESS;

--- a/ompi/mpi/c/comm_set_errhandler.c
+++ b/ompi/mpi/c/comm_set_errhandler.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -69,12 +69,16 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
     /* Prepare the new error handler */
     OBJ_RETAIN(errhandler);
 
-    opal_mutex_lock (&comm->c_lock);
+#ifdef USE_MUTEX_FOR_COMMS
+    OPAL_THREAD_LOCK(&(comm->c_lock));
+#endif
     /* Ditch the old errhandler, and decrement its refcount. */
     tmp = comm->error_handler;
     comm->error_handler = errhandler;
     OBJ_RELEASE(tmp);
-    opal_mutex_unlock (&comm->c_lock);
+#ifdef USE_MUTEX_FOR_COMMS
+    OPAL_THREAD_UNLOCK(&(comm->c_lock));
+#endif
 
     /* All done */
     return MPI_SUCCESS;


### PR DESCRIPTION
 - initialize c_lock in the ompi_communicator_t constructor
 - USE_OPAL_THREAD_[UN]LOCK(c_lock)
 - #ifdef USE_MUTEX_FOR_COMMS protect c_lock access

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>