### PR TITLE
Use malloc instead of posix_memalign for small (<= sizeof(void *)) alignments

### DIFF
--- a/opal/mca/mpool/base/mpool_base_alloc.c
+++ b/opal/mca/mpool/base/mpool_base_alloc.c
@@ -74,7 +74,7 @@ void *mca_mpool_base_alloc(size_t size, opal_info_t *info, const char *hints)
 
     mpool = mca_mpool_base_module_lookup (hints);
     if (NULL != mpool) {
-        mem = mpool->mpool_alloc (mpool, size, 0, 0);
+        mem = mpool->mpool_alloc (mpool, size, sizeof(void *), 0);
     }
 
     if (NULL == mem) {

--- a/opal/mca/mpool/base/mpool_base_default.c
+++ b/opal/mca/mpool/base/mpool_base_default.c
@@ -31,7 +31,11 @@ static void *mca_mpool_default_alloc (mca_mpool_base_module_t *mpool, size_t siz
 #if HAVE_POSIX_MEMALIGN
     void *addr = NULL;
 
-    (void) posix_memalign (&addr, align, size);
+    if (align <= sizeof(void *)) {
+        addr = malloc (size);
+    } else {
+        (void) posix_memalign (&addr, align, size);
+    }
     return addr;
 #else
     void *addr, *ret;


### PR DESCRIPTION
This works around issue #4564.

Signed-off-by: Ben Menadue <ben.menadue@nci.org.au>