### PR TITLE
opal/asm/arm64: Fix `opal_atomic_compare_exchange_*` bug

### DIFF
--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -201,7 +201,7 @@ static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *add
                           : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    ret = (prev == oldval);
+    ret = (prev == *oldval);
     *oldval = prev;
     return ret;
 }
@@ -242,7 +242,7 @@ static inline bool opal_atomic_compare_exchange_strong_acq_64 (volatile int64_t 
                           : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    ret = (prev == oldval);
+    ret = (prev == *oldval);
     *oldval = prev;
     return ret;
 }
@@ -264,7 +264,7 @@ static inline bool opal_atomic_compare_exchange_strong_rel_64 (volatile int64_t 
                           : "r" (addr), "r" (*oldval), "r" (newval)
                           : "cc", "memory");
 
-    ret = (prev == oldval);
+    ret = (prev == *oldval);
     *oldval = prev;
     return ret;
 }


### PR DESCRIPTION
Only master and aarch64 is affected.
@hjelmn FYI: This is a bug introduced in recent atomic asm change (#4552).
