### PR TITLE
opal/asm: fix compilation of 128-bit compare-exchange with gcc7

### DIFF
--- a/opal/include/opal/sys/x86_64/atomic.h
+++ b/opal/include/opal/sys/x86_64/atomic.h
@@ -134,7 +134,7 @@ static inline bool opal_atomic_compare_exchange_strong_128 (volatile opal_int128
                                   "sete     %0      \n\t"
                           : "=qm" (ret), "+a" (((int64_t *)oldval)[0]), "+d" (((int64_t *)oldval)[1])
                           : "S" (addr), "b" (((int64_t *)&newval)[0]), "c" (((int64_t *)&newval)[1])
-                          : "memory", "cc", "eax", "edx");
+                          : "memory", "cc");
 
     return (bool) ret;
 }


### PR DESCRIPTION
This commit removes eax and edx from the clobber list. Older versions
of gcc handled these ok but gcc 7 does not. They are not required as
eax and edx are specified in output constraints.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>