### PR TITLE
mpool/base: plug a memory leak

### DIFF
--- a/opal/mca/mpool/base/mpool_base_alloc.c
+++ b/opal/mca/mpool/base/mpool_base_alloc.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2010-2017 IBM Corporation. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -84,6 +86,7 @@ void *mca_mpool_base_alloc(size_t size, opal_info_t *info, const char *hints)
         mca_mpool_base_tree_item_put (mpool_tree_item);
     } else {
         mpool_tree_item->mpool = mpool;
+        mpool_tree_item->key = mem;
         mca_mpool_base_tree_insert (mpool_tree_item);
     }
 


### PR DESCRIPTION
set the key of all mpool_tree_item objects, so they can be retrieved
in mpool_base_free and then returned back to the
mca_mpool_base_tree_item_free_list free list.

Refs. open-mpi/ompi#4567

Thanks Philip Blakely for the bug report.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@11e5f86bf89d17f50e00ee8c07d9a336d99b67d2)