### PR TITLE
ess/base: be sure to update the routing tree

### DIFF
--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -533,6 +533,9 @@ int orte_ess_base_orted_setup(void)
             error = "construct nidmap";
             goto error;
         }
+        /* be sure to update the routing tree so any tree spawn operation
+         * properly gets the number of children underneath us */
+        orte_routed.update_routing_plan(NULL);
     }
 
     if (orte_static_ports) {


### PR DESCRIPTION
so any tree spawn operation properly gets the number of children underneath us.

This commit is a tiny subset of open-mpi/ompi@347ca412b0fd3063d67f254d9470f66fb7e6d955
that should have been back-ported into the v3.0.x branch

Fixes open-mpi/ompi#4578

Thanks to Carlos Eduardo de Andrade for reporting.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>