### PR TITLE
mpiext: fix path to Fortran 2008 modules

### DIFF
--- a/ompi/mpi/fortran/mpiext/Makefile.am
+++ b/ompi/mpi/fortran/mpiext/Makefile.am
@@ -20,7 +20,7 @@ if OMPI_BUILD_FORTRAN_USEMPI_OR_USEMPIF08_EXT
 
 AM_FCFLAGS = -I$(top_builddir)/ompi/include -I$(top_srcdir)/ompi/include \
              $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/base \
-             $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/$(OMPI_FORTRAN_USEMPIF08_MOD) \
+             $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/use-mpi-f08/mod \
              -I$(top_srcdir) $(FCFLAGS_f90)
 
 flibs =

--- a/ompi/mpiext/example/use-mpi-f08/Makefile.am
+++ b/ompi/mpiext/example/use-mpi-f08/Makefile.am
@@ -14,7 +14,7 @@
 
 # We must set these #defines and include paths so that the inner OMPI
 # MPI prototype header files do the Right Thing.
-AM_FCFLAGS = $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/$(OMPI_FORTRAN_USEMPIF08_MOD) \
+AM_FCFLAGS = $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/use-mpi-f08/mod \
              -I$(top_srcdir) $(FCFLAGS_f90)
 
 # Note that the mpi_f08-based bindings are optional -- they can only


### PR DESCRIPTION
OMPI_FORTRAN_USEMPIF08_MOD macro was removed in open-mpi/ompi@791bcee6c065b47869525553265e36deb6fd0390
so this macro is now manually expanded to mpi/fortran/use-mpi-f08/mod

Thanks to Nathan T. Weeks for reporting

Refs open-mpi/ompi#3605

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>