### PR TITLE
v3.0.x: btl/vader: change the way fast boxes are used

### DIFF
--- a/opal/mca/btl/vader/btl_vader_frag.c
+++ b/opal/mca/btl/vader/btl_vader_frag.c
@@ -36,7 +36,6 @@ static inline void mca_btl_vader_frag_constructor (mca_btl_vader_frag_t *frag)
 
     frag->base.des_segments      = frag->segments;
     frag->base.des_segment_count = 1;
-    frag->fbox = NULL;
 }
 
 int mca_btl_vader_frag_init (opal_free_list_item_t *item, void *ctx)

--- a/opal/mca/btl/vader/btl_vader_frag.h
+++ b/opal/mca/btl/vader/btl_vader_frag.h
@@ -67,8 +67,6 @@ struct mca_btl_vader_frag_t {
     mca_btl_base_segment_t segments[2];
     /** endpoint this fragment is active on */
     struct mca_btl_base_endpoint_t *endpoint;
-    /** fast box in use (or NULL) */
-    unsigned char * restrict fbox;
     /** fragment header (in the shared memory region) */
     mca_btl_vader_hdr_t *hdr;
     /** free list this fragment was allocated within */
@@ -95,7 +93,6 @@ static inline void mca_btl_vader_frag_return (mca_btl_vader_frag_t *frag)
 
     frag->segments[0].seg_addr.pval = (char *)(frag->hdr + 1);
     frag->base.des_segment_count = 1;
-    frag->fbox = NULL;
 
     opal_free_list_return (frag->my_list, (opal_free_list_item_t *)frag);
 }

--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -440,7 +440,6 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
 {
     const size_t total_size = reserve + *size;
     mca_btl_vader_frag_t *frag;
-    unsigned char *fbox;
     void *data_ptr;
     int rc;
 
@@ -506,19 +505,6 @@ static struct mca_btl_base_descriptor_t *vader_prepare_src (struct mca_btl_base_
             frag->base.des_segment_count = 2;
         } else {
 #endif
-
-            /* inline send */
-            if (OPAL_LIKELY(MCA_BTL_DES_FLAGS_BTL_OWNERSHIP & flags)) {
-                /* try to reserve a fast box for this transfer only if the
-                 * fragment does not belong to the caller */
-                fbox = mca_btl_vader_reserve_fbox (endpoint, total_size);
-                if (OPAL_LIKELY(fbox)) {
-                    frag->segments[0].seg_addr.pval = fbox;
-                }
-
-                frag->fbox = fbox;
-            }
-
             /* NTH: the covertor adds some latency so we bypass it here */
             memcpy ((void *)((uintptr_t)frag->segments[0].seg_addr.pval + reserve), data_ptr, *size);
             frag->segments[0].seg_len = total_size;

--- a/opal/mca/btl/vader/btl_vader_send.c
+++ b/opal/mca/btl/vader/btl_vader_send.c
@@ -42,13 +42,6 @@ int mca_btl_vader_send (struct mca_btl_base_module_t *btl,
     mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) descriptor;
     const size_t total_size = frag->segments[0].seg_len;
 
-    if (OPAL_LIKELY(frag->fbox)) {
-        mca_btl_vader_fbox_send (frag->fbox, tag);
-        mca_btl_vader_frag_complete (frag);
-
-        return 1;
-    }
-
     /* in order to work around a long standing ob1 bug (see #3845) we have to always
      * make the callback. once this is fixed in ob1 we can restore the code below. */
     frag->base.des_flags |= MCA_BTL_DES_SEND_ALWAYS_CALLBACK;


### PR DESCRIPTION
There were multiple paths that could lead to a fast box
allocation. One of them made little sense (in-place send) so it has
been removed to allow a rework of the fast-box send function. This
should fix a number of issues with hanging/crashing when using the
vader btl.

References #4260

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit a82f761a4a6670ff83d3c47601eeb26120d83be5)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>