### PR TITLE
Update to PMIx v3.0 PR for cleanup registration

### DIFF
--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2010-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  *
@@ -135,6 +135,8 @@ struct mca_btl_vader_component_t {
 
     opal_list_t pending_endpoints;          /**< list of endpoints with pending fragments */
     opal_list_t pending_fragments;          /**< fragments pending remote completion */
+
+    char *backing_directory;                /**< directory to place shared memory backing files */
 
     /* knem stuff */
 #if OPAL_BTL_VADER_HAVE_KNEM

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
+ * Copyright (c) 2010-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
@@ -210,6 +210,19 @@ static int mca_btl_vader_component_register (void)
                                            MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_GROUP, &mca_btl_vader_component.single_copy_mechanism);
     OBJ_RELEASE(new_enum);
+
+    if (0 == access ("/dev/shm", W_OK)) {
+        mca_btl_vader_component.backing_directory = "/dev/shm";
+    } else {
+        mca_btl_vader_component.backing_directory = opal_process_info.proc_session_dir;
+    }
+    (void) mca_base_component_var_register (&mca_btl_vader_component.super.btl_version, "backing_directory",
+                                            "Directory to place backing files for shared memory communication. "
+                                            "This directory should be on a local filesystem such as /tmp or "
+                                            "/dev/shm (default: (linux) /dev/shm, (others) session directory)",
+                                            MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_3,
+                                            MCA_BASE_VAR_SCOPE_READONLY, &mca_btl_vader_component.backing_directory);
+
 
 #if OPAL_BTL_VADER_HAVE_KNEM
     /* Currently disabling DMA mode by default; it's not clear that this is useful in all applications and architectures. */
@@ -491,11 +504,15 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
     if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
         char *sm_file;
 
-        rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%d", opal_process_info.proc_session_dir,
+        rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%d", mca_btl_vader_component.backing_directory,
                       opal_process_info.nodename, MCA_BTL_VADER_LOCAL_RANK);
         if (0 > rc) {
             free (btls);
             return NULL;
+        }
+
+        if (NULL != opal_pmix.register_cleanup) {
+            opal_pmix.register_cleanup (sm_file, false, false);
         }
 
         rc = opal_shmem_segment_create (&component->seg_ds, sm_file, component->segment_size);

--- a/opal/mca/pmix/base/base.h
+++ b/opal/mca/pmix/base/base.h
@@ -65,6 +65,7 @@ typedef struct {
     opal_mutex_t mutex;
     opal_pmix_condition_t cond;
     volatile bool active;
+    int status;
 } opal_pmix_lock_t;
 
 

--- a/opal/mca/pmix/pmix.h
+++ b/opal/mca/pmix/pmix.h
@@ -867,6 +867,9 @@ typedef int (*opal_pmix_base_process_monitor_fn_t)(opal_list_t *monitor,
                                                    opal_list_t *directives,
                                                    opal_pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+/* register cleanup */
+typedef int (*opal_pmix_base_register_cleanup_fn_t)(char *path, bool ignore, bool jobscope);
+
 /*
  * the standard public API data structure
  */
@@ -901,6 +904,7 @@ typedef struct {
     opal_pmix_base_alloc_fn_t                               allocate;
     opal_pmix_base_job_control_fn_t                         job_control;
     opal_pmix_base_process_monitor_fn_t                     monitor;
+    opal_pmix_base_register_cleanup_fn_t                    register_cleanup;
     /* server APIs */
     opal_pmix_base_module_server_init_fn_t                  server_init;
     opal_pmix_base_module_server_finalize_fn_t              server_finalize;

--- a/opal/mca/pmix/pmix3x/pmix/VERSION
+++ b/opal/mca/pmix/pmix3x/pmix/VERSION
@@ -30,7 +30,7 @@ greek=
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=gitf56d30e
+repo_rev=git5c0b64b
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Nov 11, 2017"
+date="Dec 11, 2017"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/opal/mca/pmix/pmix3x/pmix/include/pmix_common.h.in
+++ b/opal/mca/pmix/pmix3x/pmix/include/pmix_common.h.in
@@ -462,6 +462,16 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_JOB_CTRL_PROVISION_IMAGE       "pmix.jctrl.pvnimg"     // (char*) name of the image that is to be provisioned
 #define PMIX_JOB_CTRL_PREEMPTIBLE           "pmix.jctrl.preempt"    // (bool) job can be pre-empted
 #define PMIX_JOB_CTRL_TERMINATE             "pmix.jctrl.term"       // (bool) politely terminate the specified procs
+#define PMIX_REGISTER_CLEANUP               "pmix.reg.cleanup"      // (char*) comma-delimited list of files/directories to
+                                                                    //         be removed upon process termination
+#define PMIX_CLEANUP_RECURSIVE              "pmix.clnup.recurse"    // (bool) recursively cleanup all subdirectories under the
+                                                                    //        specified one(s)
+#define PMIX_CLEANUP_EMPTY                  "pmix.clnup.empty"      // (bool) only remove empty subdirectories
+#define PMIX_CLEANUP_IGNORE                 "pmix.clnup.ignore"     // (char*) comma-delimited list of filenames that are not
+                                                                    //         to be removed
+#define PMIX_CLEANUP_LEAVE_TOPDIR           "pmix.clnup.lvtop"      // (bool) when recursively cleaning subdirs, do not remove
+                                                                    //        the top-level directory (the one given in the
+                                                                    //        cleanup request)
 
 /* monitoring attributes */
 #define PMIX_MONITOR_ID                     "pmix.monitor.id"       // (char*) provide a string identifier for this request
@@ -584,6 +594,7 @@ typedef int pmix_status_t;
 #define PMIX_ERR_NOT_IMPLEMENTED                    -48
 #define PMIX_ERR_COMM_FAILURE                       -49
 #define PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER     -50         // internal-only
+#define PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES     -51
 
 /* define a starting point for v2.x error values */
 #define PMIX_ERR_V2X_BASE                   -100

--- a/opal/mca/pmix/pmix3x/pmix/src/atomics/sys/powerpc/atomic.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/atomics/sys/powerpc/atomic.h
@@ -84,7 +84,7 @@ void pmix_atomic_rmb(void)
 static inline
 void pmix_atomic_wmb(void)
 {
-    PMIXRMB();
+    PMIXWMB();
 }
 
 static inline
@@ -110,7 +110,7 @@ void pmix_atomic_isync(void)
 #pragma mc_func pmix_atomic_rmb { "7c2004ac" }         /* lwsync  */
 #pragma reg_killed_by pmix_atomic_rmb                  /* none */
 
-#pragma mc_func pmix_atomic_wmb { "7c0006ac" }         /* eieio */
+#pragma mc_func pmix_atomic_wmb { "7c2004ac" }         /* lwsync */
 #pragma reg_killed_by pmix_atomic_wmb                  /* none */
 
 #endif

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/gds/hash/gds_hash.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/gds/hash/gds_hash.c
@@ -426,6 +426,7 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
             /* an array of data pertaining to a specific proc */
             if (PMIX_DATA_ARRAY != info[n].value.type) {
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                rc = PMIX_ERR_TYPE_MISMATCH;
                 goto release;
             }
             size = info[n].value.data.darray->size;
@@ -433,6 +434,7 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
             /* first element of the array must be the rank */
             if (0 != strcmp(iptr[0].key, PMIX_RANK) ||
                 PMIX_PROC_RANK != iptr[0].value.type) {
+                rc = PMIX_ERR_TYPE_MISMATCH;
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                 goto release;
             }
@@ -458,7 +460,7 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
                         if (NULL == tmp) {
                             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
                             rc = PMIX_ERR_NOMEM;
-                            return rc;
+                            goto release;
                         }
                         kp2->value->type = PMIX_COMPRESSED_STRING;
                         free(kp2->value->data.string);
@@ -493,10 +495,10 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
             if (PMIX_STRING_SIZE_CHECK(kp2->value)) {
                 if (pmix_util_compress_string(kp2->value->data.string, &tmp, &len)) {
                     if (NULL == tmp) {
-                        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-                        PMIX_RELEASE(kp2);
                         rc = PMIX_ERR_NOMEM;
-                        return rc;
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_RELEASE(kp2);
+                        goto release;
                     }
                     kp2->value->type = PMIX_COMPRESSED_STRING;
                     free(kp2->value->data.string);

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1161,6 +1161,12 @@ static void connection_handler(int sd, short args, void *cbdata)
     peer->nptr = nptr;
     PMIX_RETAIN(info);
     peer->info = info;
+    /* update the epilog fields */
+    peer->epilog.uid = info->uid;
+    peer->epilog.gid = info->gid;
+    /* ensure the nspace epilog is updated too */
+    nptr->epilog.uid = info->uid;
+    nptr->epilog.gid = info->gid;
     info->proc_cnt++; /* increase number of processes on this rank */
     peer->sd = pnd->sd;
     if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
@@ -1399,6 +1405,11 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     peer->nptr = nptr;
     PMIX_RETAIN(info);
     peer->info = info;
+    /* save the uid/gid */
+    peer->epilog.uid = info->uid;
+    peer->epilog.gid = info->gid;
+    nptr->epilog.uid = info->uid;
+    nptr->epilog.gid = info->gid;
     peer->proc_cnt = 1;
     peer->sd = pnd->sd;
 

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/usock/ptl_usock_component.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/usock/ptl_usock_component.c
@@ -601,6 +601,11 @@ static void connection_handler(int sd, short args, void *cbdata)
     psave->nptr = nptr;
     PMIX_RETAIN(info);
     psave->info = info;
+    /* save the epilog info */
+    psave->epilog.uid = info->uid;
+    psave->epilog.gid = info->gid;
+    nptr->epilog.uid = info->uid;
+    nptr->epilog.gid = info->gid;
     info->proc_cnt++; /* increase number of processes on this rank */
     psave->sd = pnd->sd;
     if (0 > (psave->index = pmix_pointer_array_add(&pmix_server_globals.clients, psave))) {

--- a/opal/mca/pmix/pmix3x/pmix/src/server/pmix_server_get.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/server/pmix_server_get.c
@@ -382,6 +382,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     }
     if (PMIX_ERR_NOT_FOUND != rc || NULL == lcd) {
         /* we have a problem - e.g., out of memory */
+        cbfunc(PMIX_ERR_NOT_FOUND, NULL, 0, cbdata, NULL, NULL);
         PMIX_INFO_FREE(info, ninfo);
         return rc;
     }

--- a/opal/mca/pmix/pmix3x/pmix/src/util/error.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/error.c
@@ -171,6 +171,8 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
         return "PMIX MODEL DECLARED";
     case PMIX_ERR_TEMP_UNAVAILABLE:
         return "PMIX TEMPORARILY UNAVAILABLE";
+    case PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES:
+        return "PMIX CONFLICTING CLEANUP DIRECTIVES";
     case PMIX_SUCCESS:
         return "SUCCESS";
     default:

--- a/opal/mca/pmix/pmix3x/pmix3x.c
+++ b/opal/mca/pmix/pmix3x/pmix3x.c
@@ -25,6 +25,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
 
 #include "opal/dss/dss.h"
 #include "opal/mca/event/event.h"
@@ -71,6 +74,8 @@ static void pmix3x_query(opal_list_t *queries,
 static void pmix3x_log(opal_list_t *info,
                        opal_pmix_op_cbfunc_t cbfunc, void *cbdata);
 
+static int pmix3x_register_cleanup(char *path, bool ignore, bool jobscope);
+
 const opal_pmix_base_module_t opal_pmix_pmix3x_module = {
     /* client APIs */
     .init = pmix3x_client_init,
@@ -101,6 +106,7 @@ const opal_pmix_base_module_t opal_pmix_pmix3x_module = {
     .log = pmix3x_log,
     .allocate = pmix3x_allocate,
     .job_control = pmix3x_job_control,
+    .register_cleanup = pmix3x_register_cleanup,
     /* server APIs */
     .server_init = pmix3x_server_init,
     .server_finalize = pmix3x_server_finalize,
@@ -331,6 +337,78 @@ void pmix3x_event_hdlr(size_t evhdlr_registration_id,
     OPAL_LIST_RELEASE(cd->info);
     OBJ_RELEASE(cd);
     return;
+}
+
+static void cleanup_cbfunc(pmix_status_t status,
+                           pmix_info_t *info, size_t ninfo,
+                           void *cbdata,
+                           pmix_release_cbfunc_t release_fn,
+                           void *release_cbdata)
+{
+    opal_pmix_lock_t *lk = (opal_pmix_lock_t*)cbdata;
+
+    OPAL_POST_OBJECT(lk);
+
+    /* let the library release the data and cleanup from
+     * the operation */
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+
+    /* release the block */
+    lk->status = pmix3x_convert_rc(status);
+    OPAL_PMIX_WAKEUP_THREAD(lk);
+}
+
+static int pmix3x_register_cleanup(char *path, bool ignore, bool jobscope)
+{
+    opal_pmix_lock_t lk;
+    pmix_info_t pinfo[3];
+    size_t n, ninfo=0;
+    pmix_status_t rc;
+    int ret;
+    struct stat statbuf;
+
+    OPAL_PMIX_CONSTRUCT_LOCK(&lk);
+
+    if (ignore) {
+        /* they want this path ignored */
+        PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_CLEANUP_IGNORE, path, PMIX_STRING);
+        ++ninfo;
+    } else {
+        /* order cleanup of the provided path */
+        PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_REGISTER_CLEANUP, path, PMIX_STRING);
+        ++ninfo;
+        /* if the path is a directory, then we need to tell the server
+         * to recursively clean up */
+        if (stat(path, &statbuf) != 0) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        if (S_ISDIR(statbuf.st_mode)) {
+            /* recursively cleanup directories */
+            PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_CLEANUP_RECURSIVE, NULL, PMIX_BOOL);
+            ++ninfo;
+        }
+    }
+
+    /* if they want this applied to the job, then indicate so */
+    if (jobscope) {
+        rc = PMIx_Job_control_nb(NULL, 0, pinfo, ninfo, cleanup_cbfunc, (void*)&lk);
+    } else {
+        /* only applies to us */
+        rc = PMIx_Job_control_nb(&mca_pmix_pmix3x_component.myproc, 1, pinfo, ninfo, cleanup_cbfunc, (void*)&lk);
+    }
+    if (PMIX_SUCCESS != rc) {
+        ret = pmix3x_convert_rc(rc);
+    } else {
+        OPAL_PMIX_WAIT_THREAD(&lk);
+        ret = lk.status;
+    }
+    OPAL_PMIX_DESTRUCT_LOCK(&lk);
+    for (n=0; n < ninfo; n++) {
+        PMIX_INFO_DESTRUCT(&pinfo[n]);
+    }
+    return ret;
 }
 
 opal_vpid_t pmix3x_convert_rank(pmix_rank_t rank)

--- a/opal/mca/pmix/pmix3x/pmix3x.h
+++ b/opal/mca/pmix/pmix3x/pmix3x.h
@@ -38,15 +38,16 @@
 BEGIN_C_DECLS
 
 typedef struct {
-  opal_pmix_base_component_t super;
-  opal_list_t jobids;
-  bool native_launch;
-  size_t evindex;
-  opal_list_t events;
-  int cache_size;
-  opal_list_t cache;
-  opal_list_t dmdx;
-  bool silence_warning;
+    opal_pmix_base_component_t super;
+    pmix_proc_t myproc;
+    opal_list_t jobids;
+    bool native_launch;
+    size_t evindex;
+    opal_list_t events;
+    int cache_size;
+    opal_list_t cache;
+    opal_list_t dmdx;
+    bool silence_warning;
 } mca_pmix_pmix3x_component_t;
 
 OPAL_DECLSPEC extern mca_pmix_pmix3x_component_t mca_pmix_pmix3x_component;

--- a/opal/mca/pmix/pmix_types.h
+++ b/opal/mca/pmix/pmix_types.h
@@ -118,6 +118,7 @@ BEGIN_C_DECLS
 
 
 /* information about relative ranks as assigned by the RM */
+#define OPAL_PMIX_CLUSTER_ID                    "pmix.clid"             // (char*) a string name for the cluster this proc is executing on
 #define OPAL_PMIX_PROCID                        "pmix.procid"           // (opal_process_name_t) process identifier
 #define OPAL_PMIX_NSPACE                        "pmix.nspace"           // (char*) nspace of a job
 #define OPAL_PMIX_JOBID                         "pmix.jobid"            // (uint32_t) jobid assigned by scheduler
@@ -189,6 +190,7 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_NOTIFY_COMPLETION             "pmix.notecomp"         // (bool) notify parent process upon termination of child job
 #define OPAL_PMIX_RANGE                         "pmix.range"            // (int) opal_pmix_data_range_t value for calls to publish/lookup/unpublish
 #define OPAL_PMIX_PERSISTENCE                   "pmix.persist"          // (int) opal_pmix_persistence_t value for calls to publish
+#define OPAL_PMIX_DATA_SCOPE                    "pmix.scope"            // (pmix_scope_t) scope of the data to be found in a PMIx_Get call
 #define OPAL_PMIX_OPTIONAL                      "pmix.optional"         // (bool) look only in the immediate data store for the requested value - do
                                                                         //        not request data from the server if not found
 #define OPAL_PMIX_EMBED_BARRIER                 "pmix.embed.barrier"    // (bool) execute a blocking fence operation before executing the
@@ -364,6 +366,16 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_JOB_CTRL_PROVISION_IMAGE      "pmix.jctrl.pvnimg"     // (char*) name of the image that is to be provisioned
 #define OPAL_PMIX_JOB_CTRL_PREEMPTIBLE          "pmix.jctrl.preempt"    // (bool) job can be pre-empted
 #define OPAL_PMIX_JOB_CTRL_TERMINATE            "pmix.jctrl.term"       // (bool) politely terminate the specified procs
+#define OPAL_PMIX_REGISTER_CLEANUP              "pmix.reg.cleanup"      // (char*) comma-delimited list of files/directories to
+                                                                        //         be removed upon process termination
+#define OPAL_PMIX_CLEANUP_RECURSIVE             "pmix.clnup.recurse"    // (bool) recursively cleanup all subdirectories under the
+                                                                        //        specified one(s)
+#define OPAL_PMIX_CLEANUP_EMPTY                 "pmix.clnup.empty"      // (bool) only remove empty subdirectories
+#define OPAL_PMIX_CLEANUP_IGNORE                "pmix.clnup.ignore"     // (char*) comma-delimited list of filenames that are not
+                                                                        //         to be removed
+#define OPAL_PMIX_CLEANUP_LEAVE_TOPDIR          "pmix.clnup.lvtop"      // (bool) when recursively cleaning subdirs, do not remove
+                                                                        //        the top-level directory (the one given in the
+                                                                        //        cleanup request)
 
 
 /* monitoring attributes */


### PR DESCRIPTION
If available, have apps use registration capability to cleanup their session directories. Setup capability for vader to register its shared memory file location - let someone familiar with that code do so.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>