### PR TITLE
Fix add-host support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -435,6 +435,7 @@ orte/test/mpi/badcoll
 orte/test/mpi/iof
 orte/test/mpi/no-disconnect
 orte/test/mpi/nonzero
+orte/test/mpi/add_host
 
 orte/test/system/radix
 orte/test/system/sigusr_trap

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -173,6 +173,8 @@ void orte_plm_base_daemons_reported(int fd, short args, void *cbdata)
     if (orte_display_allocation) {
         orte_ras_base_display_alloc();
     }
+    /* ensure we update the routing plan */
+    orte_routed.update_routing_plan(NULL);
 
     /* progress the job */
     caddy->jdata->state = ORTE_JOB_STATE_DAEMONS_REPORTED;
@@ -1346,8 +1348,9 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
         } else {
             jdatorted->num_reported++;
             OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
-                                 "%s plm:base:orted_report_launch recvd %d of %d reported daemons",
+                                 "%s plm:base:orted_report_launch job %s recvd %d of %d reported daemons",
                                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                                 ORTE_JOBID_PRINT(jdatorted->jobid),
                                  jdatorted->num_reported, jdatorted->num_procs));
             if (jdatorted->num_procs == jdatorted->num_reported) {
                 bool dvm = true;

--- a/orte/test/mpi/Makefile
+++ b/orte/test/mpi/Makefile
@@ -5,7 +5,7 @@ PROGS = mpi_no_op mpi_barrier hello hello_nodename abort multi_abort simple_spaw
 		parallel_w8 parallel_w64 parallel_r8 parallel_r64 sio sendrecv_blaster early_abort \
 		debugger singleton_client_server intercomm_create spawn_tree init-exit77 mpi_info \
 		info_spawn server client paccept pconnect ring hello.sapp binding badcoll attach xlib \
-		no-disconnect nonzero
+		no-disconnect nonzero interlib pinterlib add_host
 
 all: $(PROGS)
 

--- a/orte/test/mpi/add_host.c
+++ b/orte/test/mpi/add_host.c
@@ -1,0 +1,68 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/param.h>
+
+#include <mpi.h>
+
+int main(int argc, char* argv[])
+{
+    int msg, rc;
+    MPI_Comm parent, child;
+    int rank, size;
+    char hostname[MAXHOSTNAMELEN];
+    pid_t pid;
+    char *env_rank,*env_nspace;
+    MPI_Info info;
+
+    env_rank = getenv("PMIX_RANK");
+    env_nspace = getenv("PMIX_NAMESPACE");
+    pid = getpid();
+    gethostname(hostname, sizeof(hostname));
+
+    printf("[%s:%s pid %ld] starting up on node %s!\n", env_nspace, env_rank, (long)pid, hostname);
+
+    MPI_Init(NULL, NULL);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    printf("%d completed MPI_Init\n", rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_get_parent(&parent);
+    /* If we get COMM_NULL back, then we're the parent */
+    if (MPI_COMM_NULL == parent) {
+        pid = getpid();
+        printf("Parent [pid %ld] about to spawn!\n", (long)pid);
+        MPI_Info_create(&info);
+        MPI_Info_set(info, "add-host", "rhc002:24");
+        if (MPI_SUCCESS != (rc = MPI_Comm_spawn(argv[0], MPI_ARGV_NULL, 3, info,
+                                                0, MPI_COMM_WORLD, &child, MPI_ERRCODES_IGNORE))) {
+            printf("Child failed to spawn\n");
+            return rc;
+        }
+        printf("Parent done with spawn\n");
+        if (0 == rank) {
+            msg = 38;
+            printf("Parent sending message to child\n");
+            MPI_Send(&msg, 1, MPI_INT, 0, 1, child);
+        }
+        MPI_Comm_disconnect(&child);
+        printf("Parent disconnected\n");
+    }
+    /* Otherwise, we're the child */
+    else {
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+        pid = getpid();
+        printf("Hello from the child %d of %d on host %s pid %ld\n", rank, 3, hostname, (long)pid);
+        if (0 == rank) {
+            MPI_Recv(&msg, 1, MPI_INT, 0, 1, parent, MPI_STATUS_IGNORE);
+            printf("Child %d received msg: %d\n", rank, msg);
+        }
+        MPI_Comm_disconnect(&parent);
+        printf("Child %d disconnected\n", rank);
+    }
+
+    MPI_Finalize();
+    fprintf(stderr, "%d: exiting\n", pid);
+    return 0;
+}


### PR DESCRIPTION
Fix add-host support by including the location for procs of prior jobs when spawning new daemons.

Thanks to CalugaruVaxile for the report

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 4316213805362a0bb100ff2de7ff1397938caaee)