### PR TITLE
Add the __optnone__ attribute

### DIFF
--- a/config/opal_check_attributes.m4
+++ b/config/opal_check_attributes.m4
@@ -16,6 +16,7 @@ dnl Copyright (c) 2013      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2017      Intel, Inc. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -221,6 +222,7 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
     opal_cv___attribute__warn_unused_result=0
     opal_cv___attribute__weak_alias=0
     opal_cv___attribute__destructor=0
+    opal_cv___attribute__optnone=0
   else
     AC_MSG_RESULT([yes])
 
@@ -556,6 +558,15 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
         ],
         [],
         [])
+
+    _OPAL_CHECK_SPECIFIC_ATTRIBUTE([optnone],
+        [
+        void foo(void) __attribute__ ((__optnone__));
+        void foo(void) { return ; }
+        ],
+        [],
+        [])
+
   fi
 
   # Now that all the values are set, define them
@@ -608,4 +619,6 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
                      [Whether your compiler has __attribute__ weak alias or not])
   AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_DESTRUCTOR, [$opal_cv___attribute__destructor],
                      [Whether your compiler has __attribute__ destructor or not])
+  AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_OPTNONE, [$opal_cv___attribute__optnone],
+                     [Whether your compiler has __attribute__ optnone or not])
 ])

--- a/opal/include/opal_config_bottom.h
+++ b/opal/include/opal_config_bottom.h
@@ -15,7 +15,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -234,6 +234,12 @@
 #    define __opal_attribute_destructor__
 #endif
 
+#if OPAL_HAVE_ATTRIBUTE_OPTNONE
+#    define __opal_attribute_optnone__    __attribute__((__optnone__))
+#else
+#    define __opal_attribute_optnone__
+#endif
+
 #  if OPAL_C_HAVE_VISIBILITY
 #    define OPAL_DECLSPEC           __opal_attribute_visibility__("default")
 #    define OPAL_MODULE_DECLSPEC    __opal_attribute_visibility__("default")
@@ -268,11 +274,11 @@
 #include <sys/param.h>
 #endif
 #if defined(PATH_MAX)
-#define OPAL_PATH_MAX	(PATH_MAX + 1)
+#define OPAL_PATH_MAX   (PATH_MAX + 1)
 #elif defined(_POSIX_PATH_MAX)
-#define OPAL_PATH_MAX	(_POSIX_PATH_MAX + 1)
+#define OPAL_PATH_MAX   (_POSIX_PATH_MAX + 1)
 #else
-#define OPAL_PATH_MAX	256
+#define OPAL_PATH_MAX   256
 #endif
 
 /*

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -173,7 +173,7 @@ char MPIR_attach_fifo[MPIR_MAX_PATH_LENGTH] = {0};
 int MPIR_force_to_main = 0;
 static void orte_debugger_init_before_spawn(orte_job_t *jdata);
 
-ORTE_DECLSPEC void* MPIR_Breakpoint(void);
+ORTE_DECLSPEC void* MPIR_Breakpoint(void)  __opal_attribute_optnone__;
 
 /*
  * Breakpoint function for parallel debuggers


### PR DESCRIPTION
Add the __optnone__ attribute to help avoid optimizing out MPIR_Breakpoint

Thanks to @kiranchandramohan for the suggestion

Signed-off-by: Ralph Castain <rhc@open-mpi.org>