### PR TITLE
v2.1.x: MPI_Attr_get: doc fix: MPI_Comm_create_attr -> MPI_Comm_get_attr

### DIFF
--- a/ompi/mpi/man/man3/MPI_Attr_get.3in
+++ b/ompi/mpi/man/man3/MPI_Attr_get.3in
@@ -50,7 +50,7 @@ Fortran only: Error status (integer).
 .SH DESCRIPTION
 .ft R
 Note that use of this routine is \fIdeprecated\fP as of MPI-2, and
-was \fIdeleted\fP in MPI-3. Please use MPI_Comm_create_attr.  This
+was \fIdeleted\fP in MPI-3. Please use MPI_Comm_get_attr.  This
 function does not have a C++ or mpi_f08 binding.
 .sp
 Retrieves attribute value by key. The call is erroneous if there is no key


### PR DESCRIPTION
MPI_Comm_create_attr does not exist.

Signed-off-by: Jed Brown <jed@jedbrown.org>

(cherry picked from commit 533800070e0d1cfbc7ad06bdfe386a142f26f86b)