### PR TITLE
orted: fix tree-spawn when the node regex is too long

### DIFF
--- a/orte/mca/odls/odls_types.h
+++ b/orte/mca/odls/odls_types.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,7 +46,6 @@ typedef uint8_t orte_daemon_cmd_flag_t;
 #define ORTE_DAEMON_KILL_LOCAL_PROCS        (orte_daemon_cmd_flag_t) 2
 #define ORTE_DAEMON_SIGNAL_LOCAL_PROCS      (orte_daemon_cmd_flag_t) 3
 #define ORTE_DAEMON_ADD_LOCAL_PROCS         (orte_daemon_cmd_flag_t) 4
-#define ORTE_DAEMON_TREE_SPAWN              (orte_daemon_cmd_flag_t) 5
 #define ORTE_DAEMON_HEARTBEAT_CMD           (orte_daemon_cmd_flag_t) 6
 #define ORTE_DAEMON_EXIT_CMD                (orte_daemon_cmd_flag_t) 7
 #define ORTE_DAEMON_PROCESS_AND_RELAY_CMD   (orte_daemon_cmd_flag_t) 9

--- a/orte/mca/plm/base/plm_base_frame.c
+++ b/orte/mca/plm/base/plm_base_frame.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -52,6 +52,19 @@ orte_plm_globals_t orte_plm_globals = {0};
 orte_plm_base_module_t orte_plm = {0};
 
 
+static int mca_plm_base_register(mca_base_register_flag_t flags)
+{
+    orte_plm_globals.node_regex_threshold = 1024;
+    (void) mca_base_var_register("orte", "pml", "base", "node_regex_threshold",
+                                 "Only pass the node regex on the orted command line if smaller than this threshold",
+                                 MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0,
+                                 MCA_BASE_VAR_FLAG_INTERNAL,
+                                 OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &orte_plm_globals.node_regex_threshold);
+    return ORTE_SUCCESS;
+}
+
 static int orte_plm_base_close(void)
 {
     int rc;
@@ -88,5 +101,5 @@ static int orte_plm_base_open(mca_base_open_flag_t flags)
     return mca_base_framework_components_open(&orte_plm_base_framework, flags);
 }
 
-MCA_BASE_FRAMEWORK_DECLARE(orte, plm, NULL, NULL, orte_plm_base_open, orte_plm_base_close,
+MCA_BASE_FRAMEWORK_DECLARE(orte, plm, NULL, mca_plm_base_register, orte_plm_base_open, orte_plm_base_close,
                            mca_plm_base_static_components, 0);

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1565,16 +1565,19 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
         ORTE_ERROR_LOG(rc);
         return rc;
     }
+    if (NULL != orte_node_regex) {
+        free(orte_node_regex);
+    }
+    orte_node_regex = param;
     /* if this is too long, then we'll have to do it with
      * a phone home operation instead */
     if (strlen(param) < orte_plm_globals.node_regex_threshold) {
         opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
         opal_argv_append(argc, argv, "orte_node_regex");
-        opal_argv_append(argc, argv, param);
+        opal_argv_append(argc, argv, orte_node_regex);
         /* mark that the nidmap has been communicated */
         orte_nidmap_communicated = true;
     }
-    free(param);
 
     if (!orte_static_ports && !orte_fwd_mpirun_port) {
         /* if we are using static ports, or we are forwarding

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1567,7 +1567,7 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
     }
     /* if this is too long, then we'll have to do it with
      * a phone home operation instead */
-    if (strlen(param) < ORTE_MAX_REGEX_CMD_LENGTH) {
+    if (strlen(param) < orte_plm_globals.node_regex_threshold) {
         opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
         opal_argv_append(argc, argv, "orte_node_regex");
         opal_argv_append(argc, argv, param);

--- a/orte/mca/plm/base/plm_private.h
+++ b/orte/mca/plm/base/plm_private.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,6 +61,7 @@ typedef struct {
     opal_buffer_t tree_spawn_cmd;
     /* daemon nodes assigned at launch */
     bool daemon_nodes_assigned_at_launch;
+    size_t node_regex_threshold;
 } orte_plm_globals_t;
 /**
  * Global instance of PLM framework data

--- a/orte/mca/plm/isolated/plm_isolated.c
+++ b/orte/mca/plm/isolated/plm_isolated.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011      IBM Corporation.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,7 +52,7 @@
 
 static int isolated_init(void);
 static int isolated_launch(orte_job_t *jdata);
-static int remote_spawn(opal_buffer_t *launch);
+static int remote_spawn();
 static int isolated_terminate_orteds(void);
 static int isolated_finalize(void);
 
@@ -93,7 +95,7 @@ static int isolated_init(void)
 /*
  * launch a set of daemons from a remote daemon
  */
-static int remote_spawn(opal_buffer_t *launch)
+static int remote_spawn()
 {
     /* unused function in this mode */
     return ORTE_SUCCESS;

--- a/orte/mca/plm/plm.h
+++ b/orte/mca/plm/plm.h
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,7 +65,7 @@ typedef int (*orte_plm_base_module_spawn_fn_t)(orte_job_t *jdata);
 /*
  * Remote spawn - spawn called by a daemon to launch a process on its own
  */
-typedef int (*orte_plm_base_module_remote_spawn_fn_t)(opal_buffer_t *launch);
+typedef int (*orte_plm_base_module_remote_spawn_fn_t)(void);
 
 /*
  * Entry point to set the HNP name

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -825,7 +825,6 @@ static int remote_spawn(opal_buffer_t *launch)
             prefix = NULL;
         }
     }
-
     /* get the updated routing list */
     rtmod = orte_rml.get_routed(orte_coll_conduit);
     OBJ_CONSTRUCT(&coll, opal_list_t);

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -263,7 +263,8 @@ static int rsh_init(void)
 static void rsh_wait_daemon(int sd, short flags, void *cbdata)
 {
     orte_job_t *jdata;
-    orte_plm_rsh_caddy_t *caddy=(orte_plm_rsh_caddy_t*)cbdata;
+    orte_wait_tracker_t *t2 = (orte_wait_tracker_t*)cbdata;
+    orte_plm_rsh_caddy_t *caddy=(orte_plm_rsh_caddy_t*)t2->cbdata;
     orte_proc_t *daemon = caddy->daemon;
     char *rtmod;
 
@@ -272,6 +273,7 @@ static void rsh_wait_daemon(int sd, short flags, void *cbdata)
          * session attached, e.g., while debugging
          */
         OBJ_RELEASE(caddy);
+        OBJ_RELEASE(t2);
         return;
     }
 
@@ -325,7 +327,7 @@ static void rsh_wait_daemon(int sd, short flags, void *cbdata)
         opal_event_active(&launch_event, EV_WRITE, 1);
     }
     /* cleanup */
-    OBJ_RELEASE(caddy);
+    OBJ_RELEASE(t2);
 }
 
 static int setup_launch(int *argcptr, char ***argvptr,

--- a/orte/mca/rml/rml_types.h
+++ b/orte/mca/rml/rml_types.h
@@ -13,6 +13,8 @@
  *                         reserved.
  * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -174,6 +176,9 @@ BEGIN_C_DECLS
 
 /* warmup connection - simply establishes the connection */
 #define ORTE_RML_TAG_WARMUP_CONNECTION      63
+
+/* node regex report */
+#define ORTE_RML_TAG_NODE_REGEX_REPORT      64
 
 #define ORTE_RML_TAG_MAX                   100
 

--- a/orte/mca/sstore/stage/sstore_stage_local.c
+++ b/orte/mca/sstore/stage/sstore_stage_local.c
@@ -1,9 +1,11 @@
 /*
- * Copyright (c)      2010 The Trustees of Indiana University.
+ * Copyright (c) 2010      The Trustees of Indiana University.
  *                         All rights reserved.
  * Copyright (c) 2004-2011 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1550,8 +1552,9 @@ static int start_compression(orte_sstore_stage_local_snapshot_info_t *handle_inf
 static void sstore_stage_local_compress_waitpid_cb(orte_proc_t *proc, void* cbdata)
 {
     orte_sstore_stage_local_app_snapshot_info_t *app_info = NULL;
+    orte_wait_tracker_t *t2 = (orte_wait_tracker_t *)cbdata;
 
-    app_info = (orte_sstore_stage_local_app_snapshot_info_t*)cbdata;
+    app_info = (orte_sstore_stage_local_app_snapshot_info_t*)t2->cbdata;
 
     OPAL_OUTPUT_VERBOSE((10, mca_sstore_stage_component.super.output_handle,
                          "sstore:stage:(local): waitpid(%6d) Compression finished for Process %s",
@@ -1560,6 +1563,7 @@ static void sstore_stage_local_compress_waitpid_cb(orte_proc_t *proc, void* cbda
 
     app_info->compress_pid = 0;
     OBJ_RELEASE(proc);
+    OBJ_RELEASE(t2);
 }
 
 static int wait_all_compressed(orte_sstore_stage_local_snapshot_info_t *handle_info)

--- a/orte/orted/orted_comm.c
+++ b/orte/orted/orted_comm.c
@@ -341,22 +341,6 @@ void orte_daemon_recv(int status, orte_process_name_t* sender,
 
         break;
 
-        /****    TREE_SPAWN   ****/
-    case ORTE_DAEMON_TREE_SPAWN:
-        if (orte_debug_daemons_flag) {
-            opal_output(0, "%s orted_cmd: received tree_spawn",
-                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
-        }
-        /* if the PLM supports remote spawn, pass it all along */
-        if (NULL != orte_plm.remote_spawn) {
-            if (ORTE_SUCCESS != (ret = orte_plm.remote_spawn(buffer))) {
-                ORTE_ERROR_LOG(ret);
-            }
-        } else {
-            opal_output(0, "%s remote spawn is NULL!", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
-        }
-        break;
-
         /****    EXIT COMMAND    ****/
     case ORTE_DAEMON_EXIT_CMD:
         if (orte_debug_daemons_flag) {
@@ -1400,8 +1384,6 @@ static char *get_orted_comm_cmd_str(int command)
         return strdup("ORTE_DAEMON_SIGNAL_LOCAL_PROCS");
     case ORTE_DAEMON_ADD_LOCAL_PROCS:
         return strdup("ORTE_DAEMON_ADD_LOCAL_PROCS");
-    case ORTE_DAEMON_TREE_SPAWN:
-        return strdup("ORTE_DAEMON_TREE_SPAWN");
 
     case ORTE_DAEMON_HEARTBEAT_CMD:
         return strdup("ORTE_DAEMON_HEARTBEAT_CMD");

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -117,8 +117,14 @@ static void pipe_closed(int fd, short flags, void *arg);
 static void rollup(int status, orte_process_name_t* sender,
                    opal_buffer_t *buffer,
                    orte_rml_tag_t tag, void *cbdata);
+static void node_regex_report(int status, orte_process_name_t* sender,
+                              opal_buffer_t *buffer,
+                              orte_rml_tag_t tag, void *cbdata);
+static void report_orted(void);
+
 static opal_buffer_t *bucket, *mybucket = NULL;
 static int ncollected = 0;
+static bool node_regex_waiting = false;
 
 static char *orte_parent_uri = NULL;
 
@@ -734,6 +740,11 @@ int orte_daemon(int argc, char *argv[])
              * a little time in the launch phase by "warming up" the
              * connection to our parent while we wait for our children */
             buffer = OBJ_NEW(opal_buffer_t);  // zero-byte message
+            if (NULL == orte_node_regex) {
+                orte_rml.recv_buffer_nb(ORTE_PROC_MY_PARENT, ORTE_RML_TAG_NODE_REGEX_REPORT,
+                                        ORTE_RML_PERSISTENT, node_regex_report, &node_regex_waiting);
+                node_regex_waiting = true;
+            }
             if (0 > (ret = orte_rml.send_buffer_nb(orte_mgmt_conduit,
                                                    ORTE_PROC_MY_PARENT, buffer,
                                                    ORTE_RML_TAG_WARMUP_CONNECTION,
@@ -969,8 +980,10 @@ int orte_daemon(int argc, char *argv[])
                 i += 2;
             }
         }
-        /* now launch any child daemons of ours */
-        orte_plm.remote_spawn(orte_tree_launch_cmd);
+        if (NULL != orte_node_regex) {
+            /* now launch any child daemons of ours */
+            orte_plm.remote_spawn(orte_tree_launch_cmd);
+        }
     }
 
     if (orte_debug_daemons_flag) {
@@ -1052,8 +1065,6 @@ static void rollup(int status, orte_process_name_t* sender,
                    opal_buffer_t *buffer,
                    orte_rml_tag_t tag, void *cbdata)
 {
-    int nreqd;
-    char *rtmod;
     int ret;
     orte_process_name_t child;
     int32_t i, flag, cnt;
@@ -1095,10 +1106,17 @@ static void rollup(int status, orte_process_name_t* sender,
     }
 
   report:
+    report_orted();
+}
+
+static void report_orted() {
+    char *rtmod;
+    int nreqd, ret;
+
     /* get the number of children */
     rtmod = orte_rml.get_routed(orte_mgmt_conduit);
     nreqd = orte_routed.num_routes(rtmod) + 1;
-    if (nreqd == ncollected && NULL != mybucket) {
+    if (nreqd == ncollected && NULL != mybucket && !node_regex_waiting) {
         /* add the collection of our children's buckets to ours */
         opal_dss.copy_payload(mybucket, bucket);
         OBJ_RELEASE(bucket);
@@ -1111,4 +1129,37 @@ static void rollup(int status, orte_process_name_t* sender,
             OBJ_RELEASE(mybucket);
         }
     }
+}
+
+static void node_regex_report(int status, orte_process_name_t* sender,
+                              opal_buffer_t *buffer,
+                              orte_rml_tag_t tag, void *cbdata) {
+    int rc, n=1;
+    char * regex;
+    assert(NULL == orte_node_regex);
+    bool * active = (bool *)cbdata;
+
+    /* extract the node regex if needed, and update the routing tree */
+    n = 1;
+    if (ORTE_SUCCESS != (rc = opal_dss.unpack(buffer, &regex, &n, OPAL_STRING))) {
+        ORTE_ERROR_LOG(rc);
+        return;
+    }
+    orte_node_regex = regex;
+
+    if (ORTE_SUCCESS != (rc = orte_util_nidmap_parse(orte_node_regex))) {
+        ORTE_ERROR_LOG(rc);
+        return;
+    }
+
+    /* update the routing tree so any tree spawn operation
+     * properly gets the number of children underneath us */
+    orte_routed.update_routing_plan(NULL);
+
+    *active = false;
+
+    /* now launch any child daemons of ours */
+    orte_plm.remote_spawn(orte_tree_launch_cmd);
+
+    report_orted();
 }

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -982,7 +982,7 @@ int orte_daemon(int argc, char *argv[])
         }
         if (NULL != orte_node_regex) {
             /* now launch any child daemons of ours */
-            orte_plm.remote_spawn(orte_tree_launch_cmd);
+            orte_plm.remote_spawn();
         }
     }
 
@@ -1159,7 +1159,7 @@ static void node_regex_report(int status, orte_process_name_t* sender,
     *active = false;
 
     /* now launch any child daemons of ours */
-    orte_plm.remote_spawn(orte_tree_launch_cmd);
+    orte_plm.remote_spawn();
 
     report_orted();
 }

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -135,8 +135,6 @@ int orte_startup_timeout = -1;
 int orte_timeout_usec_per_proc = -1;
 float orte_max_timeout = -1.0;
 orte_timer_t *orte_mpiexec_timeout = NULL;
-
-opal_buffer_t *orte_tree_launch_cmd = NULL;
 
 int orte_stack_trace_wait_timeout = 30;
 

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -15,6 +15,8 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -517,7 +519,6 @@ ORTE_DECLSPEC extern int orte_startup_timeout;
 ORTE_DECLSPEC extern int orte_timeout_usec_per_proc;
 ORTE_DECLSPEC extern float orte_max_timeout;
 ORTE_DECLSPEC extern orte_timer_t *orte_mpiexec_timeout;
-ORTE_DECLSPEC extern opal_buffer_t *orte_tree_launch_cmd;
 
 /* global arrays for data storage */
 ORTE_DECLSPEC extern opal_hash_table_t *orte_job_data;

--- a/orte/util/nidmap.h
+++ b/orte/util/nidmap.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,8 +38,6 @@
 #include "orte/runtime/orte_globals.h"
 
 BEGIN_C_DECLS
-
-#define ORTE_MAX_REGEX_CMD_LENGTH   1024
 
 #define ORTE_MAX_NODE_PREFIX        50
 #define ORTE_CONTIG_NODE_CMD        0x01


### PR DESCRIPTION
When the node regex is too long to be sent on the command line,
retrieve  it first from the parent, and then spawn the remote orted

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>