### PR TITLE
doc: Add README note about ARM/POWER hangs

### DIFF
--- a/README
+++ b/README
@@ -140,6 +140,14 @@ General notes
     using the clang-4.0 system compiler. A workaround is to build
     Open MPI using the GNU compiler.
 
+Platform Notes
+--------------
+
+- ARM and POWER users may experience intermittent hangs when Open MPI
+  is compiled with low optimization settings, due to an issue with our
+  atomic list implementation.  We recommend compiling with -O3
+  optimization, both for performance reasons and to avoid this hang.
+
 Compiler Notes
 --------------
 


### PR DESCRIPTION
As documented in #4563 and #3697, there is an issue on ARM and
POWER platforms when the atomic fifo assembly isn't inlined,
which manifests as a hang.  Document the issue and the
work-around until a proper fix is committed.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>