### PR TITLE
Pmpi fortran

### DIFF
--- a/ompi/mpi/fortran/base/Makefile.am
+++ b/ompi/mpi/fortran/base/Makefile.am
@@ -50,5 +50,17 @@ libmpi_fortran_base_la_SOURCES = \
         conversion_fn_null_f.c \
         f90_accessors.c \
         strings.c \
-        test_constants_f.c
+        test_constants_f.c \
+        constructed_code_done.h
+
+BUILT_SOURCES = constructed_code_done.h
+
+here_src = $(top_srcdir)/ompi/mpi/fortran/mpif-h
+constructed_code_done.h: $(here_src)/normalize_mpih.pl $(here_src)/mkcode.pl $(top_srcdir)/ompi/include/mpi.h.in
+	rm -f flist && \
+	perl $(here_src)/normalize_mpih.pl $(top_srcdir)/ompi/include/mpi.h.in > flist && \
+	perl $(here_src)/mkcode.pl
+
+clean-local:
+	rm -f constructed_code_*.h
 endif

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -501,3 +501,23 @@ if WANT_INSTALL_HEADERS
 ompidir = $(ompiincludedir)/$(subdir)
 ompi_HEADERS = $(headers)
 endif
+
+here_src = $(top_srcdir)/ompi/mpi/fortran/mpif-h
+
+if OMPI_BUILD_FORTRAN_MPIFH_BINDINGS
+lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += use_fptrs.c constructed_code_done.h
+# This causes constructed_code_done.h to be created before the regular
+# makefile rules happen for the rest of the source.
+BUILT_SOURCES = constructed_code_done.h
+
+use_fptrs.lo: use_fptrs.c constructed_code_done.h
+
+constructed_code_done.h: normalize_mpih.pl mkcode.pl $(top_srcdir)/ompi/include/mpi.h.in
+	rm -f flist && \
+	perl $(here_src)/normalize_mpih.pl $(top_srcdir)/ompi/include/mpi.h.in > flist && \
+	perl $(here_src)/mkcode.pl
+
+clean-local:
+	rm -f constructed_code_*.h
+
+endif

--- a/ompi/mpi/fortran/mpif-h/abort_f.c
+++ b/ompi/mpi/fortran/mpif-h/abort_f.c
@@ -72,6 +72,6 @@ void ompi_abort_f(MPI_Fint *comm, MPI_Fint *errorcode, MPI_Fint *ierr)
     int ierr_c;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
 
-    ierr_c = PMPI_Abort(c_comm, OMPI_FINT_2_INT(*errorcode));
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Abort)(c_comm, OMPI_FINT_2_INT(*errorcode));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 }

--- a/ompi/mpi/fortran/mpif-h/accumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/accumulate_f.c
@@ -81,7 +81,7 @@ void ompi_accumulate_f(char *origin_addr, MPI_Fint *origin_count,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     MPI_Op c_op = PMPI_Op_f2c(*op);
 
-    ierr_c = PMPI_Accumulate(OMPI_F2C_BOTTOM(origin_addr),
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Accumulate)(OMPI_F2C_BOTTOM(origin_addr),
                              OMPI_FINT_2_INT(*origin_count),
                              c_origin_datatype,
                              OMPI_FINT_2_INT(*target_rank),

--- a/ompi/mpi/fortran/mpif-h/add_error_class_f.c
+++ b/ompi/mpi/fortran/mpif-h/add_error_class_f.c
@@ -71,7 +71,7 @@ void ompi_add_error_class_f(MPI_Fint *errorclass, MPI_Fint *ierr)
     int ierr_c;
     OMPI_SINGLE_NAME_DECL(errorclass);
 
-    ierr_c = PMPI_Add_error_class(OMPI_SINGLE_NAME_CONVERT(errorclass));
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Add_error_class)(OMPI_SINGLE_NAME_CONVERT(errorclass));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 
     if (MPI_SUCCESS == ierr_c) {

--- a/ompi/mpi/fortran/mpif-h/add_error_code_f.c
+++ b/ompi/mpi/fortran/mpif-h/add_error_code_f.c
@@ -71,7 +71,7 @@ void ompi_add_error_code_f(MPI_Fint *errorclass, MPI_Fint *errorcode, MPI_Fint *
     int ierr_c;
     OMPI_SINGLE_NAME_DECL(errorcode);
 
-    ierr_c = PMPI_Add_error_code(OMPI_FINT_2_INT(*errorclass),
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Add_error_code)(OMPI_FINT_2_INT(*errorclass),
                                  OMPI_SINGLE_NAME_CONVERT(errorcode)
                                  );
 

--- a/ompi/mpi/fortran/mpif-h/add_error_string_f.c
+++ b/ompi/mpi/fortran/mpif-h/add_error_string_f.c
@@ -83,7 +83,7 @@ void ompi_add_error_string_f(MPI_Fint *errorcode, char *string,
     }
 
     ompi_fortran_string_f2c(string, len, &c_string);
-    ierr_c = PMPI_Add_error_string(OMPI_FINT_2_INT(*errorcode), c_string);
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Add_error_string)(OMPI_FINT_2_INT(*errorcode), c_string);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
     free(c_string);
 }

--- a/ompi/mpi/fortran/mpif-h/address_f.c
+++ b/ompi/mpi/fortran/mpif-h/address_f.c
@@ -71,7 +71,7 @@ void ompi_address_f(char *location, MPI_Fint *address, MPI_Fint *ierr)
     int ierr_c;
     MPI_Aint addr;
 
-    ierr_c = PMPI_Address(location, &addr);
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Address)(location, &addr);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 
     if (MPI_SUCCESS == ierr_c) {

--- a/ompi/mpi/fortran/mpif-h/allgather_f.c
+++ b/ompi/mpi/fortran/mpif-h/allgather_f.c
@@ -83,7 +83,7 @@ void ompi_allgather_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Allgather(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Allgather)(sendbuf,
                             OMPI_FINT_2_INT(*sendcount),
                             c_sendtype,
                             recvbuf,

--- a/ompi/mpi/fortran/mpif-h/allgatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/allgatherv_f.c
@@ -89,7 +89,7 @@ void ompi_allgatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Allgatherv(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Allgatherv)(sendbuf,
                              OMPI_FINT_2_INT(*sendcount),
                              c_sendtype,
                              recvbuf,

--- a/ompi/mpi/fortran/mpif-h/alloc_mem_f.c
+++ b/ompi/mpi/fortran/mpif-h/alloc_mem_f.c
@@ -104,7 +104,7 @@ void ompi_alloc_mem_f(MPI_Aint *size, MPI_Fint *info, char *baseptr, MPI_Fint *i
     int ierr_c;
     MPI_Info c_info = PMPI_Info_f2c(*info);
 
-    ierr_c = PMPI_Alloc_mem(*size, c_info, baseptr);
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Alloc_mem)(*size, c_info, baseptr);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 }
 

--- a/ompi/mpi/fortran/mpif-h/allreduce_f.c
+++ b/ompi/mpi/fortran/mpif-h/allreduce_f.c
@@ -84,7 +84,7 @@ void ompi_allreduce_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Allreduce(sendbuf, recvbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Allreduce)(sendbuf, recvbuf,
                             OMPI_FINT_2_INT(*count),
                             c_type, c_op, c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);

--- a/ompi/mpi/fortran/mpif-h/alltoall_f.c
+++ b/ompi/mpi/fortran/mpif-h/alltoall_f.c
@@ -83,7 +83,7 @@ void ompi_alltoall_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Alltoall(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Alltoall)(sendbuf,
                           OMPI_FINT_2_INT(*sendcount),
                           c_sendtype,
                           recvbuf,

--- a/ompi/mpi/fortran/mpif-h/alltoallv_f.c
+++ b/ompi/mpi/fortran/mpif-h/alltoallv_f.c
@@ -94,7 +94,7 @@ void ompi_alltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sdispls,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Alltoallv(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Alltoallv)(sendbuf,
                            OMPI_ARRAY_NAME_CONVERT(sendcounts),
                            OMPI_ARRAY_NAME_CONVERT(sdispls),
                            c_sendtype,

--- a/ompi/mpi/fortran/mpif-h/alltoallw_f.c
+++ b/ompi/mpi/fortran/mpif-h/alltoallw_f.c
@@ -102,7 +102,7 @@ void ompi_alltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Alltoallw(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Alltoallw)(sendbuf,
                            OMPI_ARRAY_NAME_CONVERT(sendcounts),
                            OMPI_ARRAY_NAME_CONVERT(sdispls),
                            c_sendtypes,

--- a/ompi/mpi/fortran/mpif-h/attr_delete_f.c
+++ b/ompi/mpi/fortran/mpif-h/attr_delete_f.c
@@ -72,6 +72,6 @@ void ompi_attr_delete_f(MPI_Fint *comm, MPI_Fint *keyval, MPI_Fint *ierr)
     MPI_Comm c_comm;
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Attr_delete(c_comm, OMPI_FINT_2_INT(*keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Attr_delete)(c_comm, OMPI_FINT_2_INT(*keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/barrier_f.c
+++ b/ompi/mpi/fortran/mpif-h/barrier_f.c
@@ -73,6 +73,6 @@ void ompi_barrier_f(MPI_Fint *comm, MPI_Fint *ierr)
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    ierr_c = PMPI_Barrier(c_comm);
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Barrier)(c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 }

--- a/ompi/mpi/fortran/mpif-h/bcast_f.c
+++ b/ompi/mpi/fortran/mpif-h/bcast_f.c
@@ -77,7 +77,7 @@ void ompi_bcast_f(char *buffer, MPI_Fint *count, MPI_Fint *datatype,
     c_comm = PMPI_Comm_f2c(*comm);
     c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = PMPI_Bcast(OMPI_F2C_BOTTOM(buffer),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Bcast)(OMPI_F2C_BOTTOM(buffer),
                        OMPI_FINT_2_INT(*count),
                        c_type,
                        OMPI_FINT_2_INT(*root),

--- a/ompi/mpi/fortran/mpif-h/bindings.h
+++ b/ompi/mpi/fortran/mpif-h/bindings.h
@@ -82,4 +82,6 @@
 
 #include "ompi/mpi/fortran/base/fint_2_int.h"
 
+#include "ompi/mpi/fortran/mpif-h/use_fptrs.h"
+
 #endif /* OMPI_F77_BINDINGS_H */

--- a/ompi/mpi/fortran/mpif-h/bsend_f.c
+++ b/ompi/mpi/fortran/mpif-h/bsend_f.c
@@ -75,7 +75,7 @@ void ompi_bsend_f(char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest
 
     c_comm = PMPI_Comm_f2c (*comm);
 
-    c_ierr = PMPI_Bsend(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Bsend)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                        c_type, OMPI_FINT_2_INT(*dest),
                        OMPI_FINT_2_INT(*tag), c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/bsend_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/bsend_init_f.c
@@ -76,7 +76,7 @@ void ompi_bsend_init_f(char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint 
 
     c_comm = PMPI_Comm_f2c (*comm);
 
-    c_ierr = PMPI_Bsend_init(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Bsend_init)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                             c_type,
                             OMPI_FINT_2_INT(*dest),
                             OMPI_FINT_2_INT(*tag),

--- a/ompi/mpi/fortran/mpif-h/buffer_attach_f.c
+++ b/ompi/mpi/fortran/mpif-h/buffer_attach_f.c
@@ -68,6 +68,6 @@ OMPI_GENERATE_F77_BINDINGS (MPI_BUFFER_ATTACH,
 
 void ompi_buffer_attach_f(char *buffer, MPI_Fint *size, MPI_Fint *ierr)
 {
-   int c_ierr = PMPI_Buffer_attach(buffer, OMPI_FINT_2_INT(*size));
+   int c_ierr = OMPI_FORTRAN_FPTR(MPI_Buffer_attach)(buffer, OMPI_FINT_2_INT(*size));
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/buffer_detach_f.c
+++ b/ompi/mpi/fortran/mpif-h/buffer_detach_f.c
@@ -84,7 +84,7 @@ void ompi_buffer_detach_f(char *buffer, MPI_Fint *size, MPI_Fint *ierr)
     void *dummy;
     OMPI_SINGLE_NAME_DECL(size);
 
-    c_ierr = PMPI_Buffer_detach(&dummy, OMPI_SINGLE_NAME_CONVERT(size));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Buffer_detach)(&dummy, OMPI_SINGLE_NAME_CONVERT(size));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/cancel_f.c
+++ b/ompi/mpi/fortran/mpif-h/cancel_f.c
@@ -73,6 +73,6 @@ void ompi_cancel_f(MPI_Fint *request, MPI_Fint *ierr)
     int c_ierr;
     MPI_Request c_req = PMPI_Request_f2c(*request);
 
-    c_ierr = PMPI_Cancel(&c_req);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cancel)(&c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/cart_coords_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_coords_f.c
@@ -76,7 +76,7 @@ void ompi_cart_coords_f(MPI_Fint *comm, MPI_Fint *rank, MPI_Fint *maxdims,
     c_comm = PMPI_Comm_f2c(*comm);
 
     OMPI_ARRAY_FINT_2_INT_ALLOC(coords, OMPI_FINT_2_INT(*maxdims));
-    c_ierr = PMPI_Cart_coords(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cart_coords)(c_comm,
                              OMPI_FINT_2_INT(*rank),
                              OMPI_FINT_2_INT(*maxdims),
                              OMPI_ARRAY_NAME_CONVERT(coords));

--- a/ompi/mpi/fortran/mpif-h/cart_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_create_f.c
@@ -81,7 +81,7 @@ void ompi_cart_create_f(MPI_Fint *old_comm, MPI_Fint *ndims, MPI_Fint *dims,
     OMPI_ARRAY_FINT_2_INT(dims, size);
     OMPI_ARRAY_LOGICAL_2_INT(periods, size);
 
-    c_ierr = PMPI_Cart_create(c_comm1, size,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cart_create)(c_comm1, size,
                              OMPI_ARRAY_NAME_CONVERT(dims),
                              OMPI_LOGICAL_ARRAY_NAME_CONVERT(periods),
                              OMPI_LOGICAL_2_INT(*reorder),

--- a/ompi/mpi/fortran/mpif-h/cart_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_get_f.c
@@ -82,7 +82,7 @@ void ompi_cart_get_f(MPI_Fint *comm, MPI_Fint *maxdims, MPI_Fint *dims,
     OMPI_ARRAY_FINT_2_INT_ALLOC(coords, size);
     OMPI_ARRAY_LOGICAL_2_INT_ALLOC(periods, size);
 
-    c_ierr = PMPI_Cart_get(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cart_get)(c_comm,
                           size,
                           OMPI_ARRAY_NAME_CONVERT(dims),
                           OMPI_LOGICAL_ARRAY_NAME_CONVERT(periods),

--- a/ompi/mpi/fortran/mpif-h/cart_map_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_map_f.c
@@ -81,7 +81,7 @@ void ompi_cart_map_f(MPI_Fint *comm, MPI_Fint *ndims, MPI_Fint *dims,
     OMPI_ARRAY_FINT_2_INT(dims, size);
     OMPI_ARRAY_LOGICAL_2_INT(periods, size);
 
-    c_ierr = PMPI_Cart_map(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cart_map)(c_comm,
                           size,
                           OMPI_ARRAY_NAME_CONVERT(dims),
                           OMPI_LOGICAL_ARRAY_NAME_CONVERT(periods),

--- a/ompi/mpi/fortran/mpif-h/cart_rank_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_rank_f.c
@@ -83,7 +83,7 @@ void ompi_cart_rank_f(MPI_Fint *comm, MPI_Fint *coords, MPI_Fint *rank,
     }
     OMPI_ARRAY_FINT_2_INT(coords, ndims);
 
-    c_ierr = PMPI_Cart_rank(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cart_rank)(c_comm,
                            OMPI_ARRAY_NAME_CONVERT(coords),
                            OMPI_SINGLE_NAME_CONVERT(rank));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/cart_shift_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_shift_f.c
@@ -77,7 +77,7 @@ void ompi_cart_shift_f(MPI_Fint *comm, MPI_Fint *direction, MPI_Fint *disp,
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Cart_shift(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cart_shift)(c_comm,
                             OMPI_FINT_2_INT(*direction),
                             OMPI_FINT_2_INT(*disp),
                             OMPI_SINGLE_NAME_CONVERT(rank_source),

--- a/ompi/mpi/fortran/mpif-h/cart_sub_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_sub_f.c
@@ -92,7 +92,7 @@ void ompi_cart_sub_f(MPI_Fint *comm, ompi_fortran_logical_t *remain_dims,
 #endif
     OMPI_ARRAY_LOGICAL_2_INT(remain_dims, ndims);
 
-    c_ierr = PMPI_Cart_sub(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cart_sub)(c_comm,
                           OMPI_LOGICAL_ARRAY_NAME_CONVERT(remain_dims),
                           &c_new_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/cartdim_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/cartdim_get_f.c
@@ -74,7 +74,7 @@ void ompi_cartdim_get_f(MPI_Fint *comm, MPI_Fint *ndims, MPI_Fint *ierr)
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Cartdim_get(c_comm, OMPI_SINGLE_NAME_CONVERT(ndims));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Cartdim_get)(c_comm, OMPI_SINGLE_NAME_CONVERT(ndims));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/close_port_f.c
+++ b/ompi/mpi/fortran/mpif-h/close_port_f.c
@@ -73,7 +73,7 @@ void ompi_close_port_f(char *port_name, MPI_Fint *ierr, int port_name_len)
     char *c_port_name;
 
     ompi_fortran_string_f2c(port_name, port_name_len, &c_port_name);
-    c_ierr = PMPI_Close_port(c_port_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Close_port)(c_port_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     free ( c_port_name);

--- a/ompi/mpi/fortran/mpif-h/comm_accept_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_accept_f.c
@@ -81,7 +81,7 @@ void ompi_comm_accept_f(char *port_name, MPI_Fint *info, MPI_Fint *root,
     ompi_fortran_string_f2c(port_name, port_name_len, &c_port_name);
 
 
-    c_ierr = PMPI_Comm_accept(c_port_name, c_info,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_accept)(c_port_name, c_info,
                              OMPI_FINT_2_INT(*root),
                              c_comm, &c_new_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/comm_call_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_call_errhandler_f.c
@@ -74,6 +74,6 @@ void ompi_comm_call_errhandler_f(MPI_Fint *comm, MPI_Fint *errorcode,
 
    c_comm = PMPI_Comm_f2c(*comm);
 
-   c_ierr = PMPI_Comm_call_errhandler(c_comm, OMPI_FINT_2_INT(*errorcode));
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_call_errhandler)(c_comm, OMPI_FINT_2_INT(*errorcode));
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/comm_compare_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_compare_f.c
@@ -73,7 +73,7 @@ void ompi_comm_compare_f(MPI_Fint *comm1, MPI_Fint *comm2, MPI_Fint *result, MPI
     MPI_Comm c_comm2 = PMPI_Comm_f2c(*comm2);
     OMPI_SINGLE_NAME_DECL(result);
 
-    c_ierr = PMPI_Comm_compare(c_comm1, c_comm2,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_compare)(c_comm1, c_comm2,
                               OMPI_SINGLE_NAME_CONVERT(result));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/comm_connect_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_connect_f.c
@@ -81,7 +81,7 @@ void ompi_comm_connect_f(char *port_name, MPI_Fint *info,
     c_info = PMPI_Info_f2c(*info);
     ompi_fortran_string_f2c(port_name, port_name_len, &c_port_name);
 
-    c_ierr = PMPI_Comm_connect(c_port_name, c_info,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_connect)(c_port_name, c_info,
                               OMPI_FINT_2_INT(*root),
                               c_comm, &c_new_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/comm_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_create_f.c
@@ -72,7 +72,7 @@ void ompi_comm_create_f(MPI_Fint *comm, MPI_Fint *group, MPI_Fint *newcomm, MPI_
     MPI_Comm c_comm = PMPI_Comm_f2c (*comm);
     MPI_Group c_group = PMPI_Group_f2c(*group);
 
-    c_ierr = PMPI_Comm_create(c_comm, c_group, &c_newcomm);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_create)(c_comm, c_group, &c_newcomm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_create_group_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_create_group_f.c
@@ -75,7 +75,7 @@ void ompi_comm_create_group_f(MPI_Fint *comm, MPI_Fint *group, MPI_Fint *tag, MP
     MPI_Comm c_comm = PMPI_Comm_f2c (*comm);
     MPI_Group c_group = PMPI_Group_f2c(*group);
 
-    c_ierr = PMPI_Comm_create_group (c_comm, c_group, OMPI_FINT_2_INT(*tag), &c_newcomm);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_create_group) (c_comm, c_group, OMPI_FINT_2_INT(*tag), &c_newcomm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_delete_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_delete_attr_f.c
@@ -74,6 +74,6 @@ void ompi_comm_delete_attr_f(MPI_Fint *comm, MPI_Fint *comm_keyval,
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Comm_delete_attr(c_comm, OMPI_FINT_2_INT(*comm_keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_delete_attr)(c_comm, OMPI_FINT_2_INT(*comm_keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/comm_disconnect_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_disconnect_f.c
@@ -73,7 +73,7 @@ void ompi_comm_disconnect_f(MPI_Fint *comm, MPI_Fint *ierr)
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Comm_disconnect(&c_comm);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_disconnect)(&c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_dup_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_dup_f.c
@@ -72,7 +72,7 @@ void ompi_comm_dup_f(MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr)
     MPI_Comm c_newcomm;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Comm_dup(c_comm, &c_newcomm);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_dup)(c_comm, &c_newcomm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_dup_with_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_dup_with_info_f.c
@@ -78,7 +78,7 @@ void ompi_comm_dup_with_info_f(MPI_Fint *comm, MPI_Fint *info, MPI_Fint *newcomm
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Comm_dup_with_info(c_comm, c_info, &c_newcomm);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_dup_with_info)(c_comm, c_info, &c_newcomm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_free_f.c
@@ -71,7 +71,7 @@ void ompi_comm_free_f(MPI_Fint *comm, MPI_Fint *ierr)
     int c_ierr;
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Comm_free(&c_comm);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_free)(&c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_free_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_free_keyval_f.c
@@ -73,7 +73,7 @@ void ompi_comm_free_keyval_f(MPI_Fint *comm_keyval, MPI_Fint *ierr)
 
     OMPI_SINGLE_FINT_2_INT(comm_keyval);
 
-    c_ierr = PMPI_Comm_free_keyval(OMPI_SINGLE_NAME_CONVERT(comm_keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_free_keyval)(OMPI_SINGLE_NAME_CONVERT(comm_keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_get_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_get_errhandler_f.c
@@ -75,7 +75,7 @@ void ompi_comm_get_errhandler_f(MPI_Fint *comm, MPI_Fint *errhandler,
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Comm_get_errhandler(c_comm, &c_errhandler);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_get_errhandler)(c_comm, &c_errhandler);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_get_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_get_info_f.c
@@ -64,7 +64,7 @@ void ompi_comm_get_info_f(MPI_Fint *comm, MPI_Fint *info_used, MPI_Fint *ierr)
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Info c_info;
 
-    c_ierr = PMPI_Comm_get_info(c_comm, &c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_get_info)(c_comm, &c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_get_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_get_name_f.c
@@ -77,7 +77,7 @@ void ompi_comm_get_name_f(MPI_Fint *comm, char *comm_name,
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     char c_name[MPI_MAX_OBJECT_NAME];
 
-    c_ierr = PMPI_Comm_get_name(c_comm, c_name, &c_len);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_get_name)(c_comm, c_name, &c_len);
     if (MPI_SUCCESS == c_ierr) {
         ompi_fortran_string_c2f(c_name, comm_name, name_len);
         *resultlen = OMPI_INT_2_FINT(c_len);

--- a/ompi/mpi/fortran/mpif-h/comm_get_parent_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_get_parent_f.c
@@ -71,7 +71,7 @@ void ompi_comm_get_parent_f(MPI_Fint *parent, MPI_Fint *ierr)
     int c_ierr;
     MPI_Comm c_parent;
 
-    c_ierr = PMPI_Comm_get_parent(&c_parent);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_get_parent)(&c_parent);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_group_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_group_f.c
@@ -72,7 +72,7 @@ void ompi_comm_group_f(MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr)
     MPI_Group c_group;
     MPI_Comm c_comm = PMPI_Comm_f2c( *comm );
 
-    c_ierr = PMPI_Comm_group( c_comm, &c_group);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_group)( c_comm, &c_group);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_idup_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_idup_f.c
@@ -76,7 +76,7 @@ void ompi_comm_idup_f(MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *request, MPI_
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Request c_req;
 
-    c_ierr = PMPI_Comm_idup(c_comm, &c_newcomm, &c_req);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_idup)(c_comm, &c_newcomm, &c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_join_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_join_f.c
@@ -71,7 +71,7 @@ void ompi_comm_join_f(MPI_Fint *fd, MPI_Fint *intercomm, MPI_Fint *ierr)
     int c_ierr;
     MPI_Comm c_intercomm;
 
-    c_ierr = PMPI_Comm_join(OMPI_FINT_2_INT(*fd), &c_intercomm);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_join)(OMPI_FINT_2_INT(*fd), &c_intercomm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_rank_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_rank_f.c
@@ -72,7 +72,7 @@ void ompi_comm_rank_f(MPI_Fint *comm, MPI_Fint *rank, MPI_Fint *ierr)
     MPI_Comm c_comm = PMPI_Comm_f2c( *comm );
     OMPI_SINGLE_NAME_DECL(rank);
 
-    c_ierr = PMPI_Comm_rank( c_comm, OMPI_SINGLE_NAME_CONVERT(rank));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_rank)( c_comm, OMPI_SINGLE_NAME_CONVERT(rank));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_remote_group_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_remote_group_f.c
@@ -71,7 +71,7 @@ void ompi_comm_remote_group_f(MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr)
     MPI_Group c_group;
     MPI_Comm c_comm = PMPI_Comm_f2c ( *comm );
 
-    c_ierr = PMPI_Comm_remote_group(c_comm, &c_group);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_remote_group)(c_comm, &c_group);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_remote_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_remote_size_f.c
@@ -71,7 +71,7 @@ void ompi_comm_remote_size_f(MPI_Fint *comm, MPI_Fint *size, MPI_Fint *ierr)
     MPI_Comm c_comm = PMPI_Comm_f2c ( *comm );
     OMPI_SINGLE_NAME_DECL(size);
 
-    c_ierr = PMPI_Comm_remote_size(c_comm, OMPI_SINGLE_NAME_CONVERT(size ));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_remote_size)(c_comm, OMPI_SINGLE_NAME_CONVERT(size ));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_set_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_set_errhandler_f.c
@@ -77,6 +77,6 @@ void ompi_comm_set_errhandler_f(MPI_Fint *comm, MPI_Fint *errhandler,
     c_comm = PMPI_Comm_f2c(*comm);
     c_errhandler = PMPI_Errhandler_f2c(*errhandler);
 
-    c_ierr = PMPI_Comm_set_errhandler(c_comm, c_errhandler);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_set_errhandler)(c_comm, c_errhandler);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/comm_set_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_set_info_f.c
@@ -64,6 +64,6 @@ void ompi_comm_set_info_f(MPI_Fint *comm, MPI_Fint *info, MPI_Fint *ierr)
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Info c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Comm_set_info(c_comm, c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_set_info)(c_comm, c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/comm_set_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_set_name_f.c
@@ -88,7 +88,7 @@ void ompi_comm_set_name_f(MPI_Fint *comm, char *comm_name, MPI_Fint *ierr,
 
     /* Call the C function */
 
-    c_ierr = PMPI_Comm_set_name(c_comm, c_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_set_name)(c_comm, c_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     /* Free the C name */

--- a/ompi/mpi/fortran/mpif-h/comm_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_size_f.c
@@ -74,7 +74,7 @@ void ompi_comm_size_f(MPI_Fint *comm, MPI_Fint *size, MPI_Fint *ierr)
     MPI_Comm c_comm = PMPI_Comm_f2c( *comm );
     OMPI_SINGLE_NAME_DECL(size);
 
-    c_ierr = PMPI_Comm_size( c_comm, OMPI_SINGLE_NAME_CONVERT(size) );
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_size)( c_comm, OMPI_SINGLE_NAME_CONVERT(size) );
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/comm_spawn_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_spawn_f.c
@@ -104,7 +104,7 @@ void ompi_comm_spawn_f(char *command, char *argv, MPI_Fint *maxprocs,
         ompi_fortran_argv_f2c(argv, string_len, string_len, &c_argv);
     }
 
-    c_ierr = PMPI_Comm_spawn(c_command, c_argv,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_spawn)(c_command, c_argv,
                             OMPI_FINT_2_INT(*maxprocs),
                             c_info,
                             OMPI_FINT_2_INT(*root),

--- a/ompi/mpi/fortran/mpif-h/comm_spawn_multiple_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_spawn_multiple_f.c
@@ -123,7 +123,7 @@ void ompi_comm_spawn_multiple_f(MPI_Fint *count, char *array_commands,
 	c_info[i] = PMPI_Info_f2c(array_info[i]);
     }
 
-    c_ierr = PMPI_Comm_spawn_multiple(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_spawn_multiple)(OMPI_FINT_2_INT(*count),
                                      c_array_commands,
                                      c_array_argv,
                                      OMPI_ARRAY_NAME_CONVERT(array_maxprocs),

--- a/ompi/mpi/fortran/mpif-h/comm_split_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_split_f.c
@@ -73,7 +73,7 @@ void ompi_comm_split_f(MPI_Fint *comm, MPI_Fint *color, MPI_Fint *key,
     MPI_Comm c_newcomm;
     MPI_Comm c_comm = PMPI_Comm_f2c ( *comm );
 
-    c_ierr = PMPI_Comm_split(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_split)(c_comm,
                             OMPI_FINT_2_INT(*color),
                             OMPI_FINT_2_INT(*key),
                             &c_newcomm );

--- a/ompi/mpi/fortran/mpif-h/comm_split_type_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_split_type_f.c
@@ -77,7 +77,7 @@ void ompi_comm_split_type_f(MPI_Fint *comm, MPI_Fint *split_type, MPI_Fint *key,
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = OMPI_INT_2_FINT(PMPI_Comm_split_type(c_comm,
+    c_ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Comm_split_type)(c_comm,
                                                   OMPI_FINT_2_INT(*split_type),
                                                   OMPI_FINT_2_INT(*key),
                                                   c_info,

--- a/ompi/mpi/fortran/mpif-h/comm_test_inter_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_test_inter_f.c
@@ -72,7 +72,7 @@ void ompi_comm_test_inter_f(MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fi
     MPI_Comm c_comm = PMPI_Comm_f2c (*comm);
     OMPI_LOGICAL_NAME_DECL(flag);
 
-    c_ierr = PMPI_Comm_test_inter(c_comm, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Comm_test_inter)(c_comm, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/compare_and_swap_f.c
+++ b/ompi/mpi/fortran/mpif-h/compare_and_swap_f.c
@@ -79,7 +79,7 @@ void ompi_compare_and_swap_f(char *origin_addr, char *compare_addr, char *result
     MPI_Datatype c_datatype = PMPI_Type_f2c(*datatype);
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Compare_and_swap(OMPI_F2C_BOTTOM(origin_addr),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Compare_and_swap)(OMPI_F2C_BOTTOM(origin_addr),
                                   OMPI_F2C_BOTTOM(compare_addr),
                                   OMPI_F2C_BOTTOM(result_addr),
                                   c_datatype,

--- a/ompi/mpi/fortran/mpif-h/dims_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/dims_create_f.c
@@ -74,7 +74,7 @@ void ompi_dims_create_f(MPI_Fint *nnodes, MPI_Fint *ndims,
 
     OMPI_ARRAY_FINT_2_INT(dims, *ndims);
 
-    c_ierr = PMPI_Dims_create(OMPI_FINT_2_INT(*nnodes),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Dims_create)(OMPI_FINT_2_INT(*nnodes),
                              OMPI_FINT_2_INT(*ndims),
                              OMPI_ARRAY_NAME_CONVERT(dims));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/dist_graph_create_adjacent_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_create_adjacent_f.c
@@ -105,7 +105,7 @@ void ompi_dist_graph_create_adjacent_f(MPI_Fint *comm_old, MPI_Fint *indegree,
         c_destweights = OMPI_ARRAY_NAME_CONVERT(destweights);
     }
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_create_adjacent(c_comm_old, OMPI_FINT_2_INT(*indegree),
+    *ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Dist_graph_create_adjacent)(c_comm_old, OMPI_FINT_2_INT(*indegree),
                                                             OMPI_ARRAY_NAME_CONVERT(sources),
                                                             c_sourceweights,
                                                             OMPI_FINT_2_INT(*outdegree),

--- a/ompi/mpi/fortran/mpif-h/dist_graph_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_create_f.c
@@ -98,7 +98,7 @@ void ompi_dist_graph_create_f(MPI_Fint *comm_old, MPI_Fint *n, MPI_Fint *sources
     }
 
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_create(c_comm_old, OMPI_FINT_2_INT(*n), OMPI_ARRAY_NAME_CONVERT(sources),
+    *ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Dist_graph_create)(c_comm_old, OMPI_FINT_2_INT(*n), OMPI_ARRAY_NAME_CONVERT(sources),
                                                    OMPI_ARRAY_NAME_CONVERT(degrees), OMPI_ARRAY_NAME_CONVERT(destinations),
                                                    c_weights, c_info, OMPI_LOGICAL_2_INT(*reorder), &c_comm_graph));
     if (OMPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {

--- a/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_count_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_count_f.c
@@ -72,7 +72,7 @@ void ompi_dist_graph_neighbors_count_f(MPI_Fint *comm, MPI_Fint *inneighbors,
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_neighbors_count(c_comm,
+    *ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Dist_graph_neighbors_count)(c_comm,
                                                             OMPI_SINGLE_NAME_CONVERT(inneighbors),
                                                             OMPI_SINGLE_NAME_CONVERT(outneighbors),
                                                             OMPI_LOGICAL_SINGLE_NAME_CONVERT(weighted)));

--- a/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_f.c
@@ -86,7 +86,7 @@ void ompi_dist_graph_neighbors_f(MPI_Fint* comm, MPI_Fint* maxindegree,
         OMPI_ARRAY_FINT_2_INT_ALLOC(destweights, *maxoutdegree);
     }
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_neighbors(c_comm, OMPI_FINT_2_INT(*maxindegree),
+    *ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Dist_graph_neighbors)(c_comm, OMPI_FINT_2_INT(*maxindegree),
                                                       OMPI_ARRAY_NAME_CONVERT(sources),
                                                       OMPI_IS_FORTRAN_UNWEIGHTED(sourceweights) ? MPI_UNWEIGHTED : OMPI_ARRAY_NAME_CONVERT(sourceweights),
                                                       OMPI_FINT_2_INT(*maxoutdegree), OMPI_ARRAY_NAME_CONVERT(destinations),

--- a/ompi/mpi/fortran/mpif-h/errhandler_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_free_f.c
@@ -73,7 +73,7 @@ void ompi_errhandler_free_f(MPI_Fint *errhandler, MPI_Fint *ierr)
 
     c_errhandler = PMPI_Errhandler_f2c(*errhandler);
 
-    c_ierr = PMPI_Errhandler_free(&c_errhandler);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Errhandler_free)(&c_errhandler);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/errhandler_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_get_f.c
@@ -74,7 +74,7 @@ void ompi_errhandler_get_f(MPI_Fint *comm, MPI_Fint *errhandler, MPI_Fint *ierr)
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Errhandler_get(c_comm, &c_errhandler);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Errhandler_get)(c_comm, &c_errhandler);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/errhandler_set_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_set_f.c
@@ -76,6 +76,6 @@ void ompi_errhandler_set_f(MPI_Fint *comm, MPI_Fint *errhandler, MPI_Fint *ierr)
     c_comm = PMPI_Comm_f2c(*comm);
     c_errhandler = PMPI_Errhandler_f2c(*errhandler);
 
-    c_ierr = PMPI_Errhandler_set(c_comm, c_errhandler);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Errhandler_set)(c_comm, c_errhandler);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/error_class_f.c
+++ b/ompi/mpi/fortran/mpif-h/error_class_f.c
@@ -72,7 +72,7 @@ void ompi_error_class_f(MPI_Fint *errorcode, MPI_Fint *errorclass,
     int c_ierr;
     OMPI_SINGLE_NAME_DECL(errorclass);
 
-    c_ierr = PMPI_Error_class(OMPI_FINT_2_INT(*errorcode),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Error_class)(OMPI_FINT_2_INT(*errorcode),
                              OMPI_SINGLE_NAME_CONVERT(errorclass));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/error_string_f.c
+++ b/ompi/mpi/fortran/mpif-h/error_string_f.c
@@ -83,7 +83,7 @@ void ompi_error_string_f(MPI_Fint *errorcode, char *string,
     char c_string[MPI_MAX_ERROR_STRING + 1];
     OMPI_SINGLE_NAME_DECL(resultlen);
 
-    c_ierr = PMPI_Error_string(OMPI_FINT_2_INT(*errorcode),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Error_string)(OMPI_FINT_2_INT(*errorcode),
                               c_string,
                               OMPI_SINGLE_NAME_CONVERT(resultlen)
                               );

--- a/ompi/mpi/fortran/mpif-h/exscan_f.c
+++ b/ompi/mpi/fortran/mpif-h/exscan_f.c
@@ -84,7 +84,7 @@ void ompi_exscan_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM (sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM (recvbuf);
 
-    c_ierr = PMPI_Exscan(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Exscan)(sendbuf, recvbuf,
                         OMPI_FINT_2_INT(*count),
                         c_type, c_op, c_comm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/fetch_and_op_f.c
+++ b/ompi/mpi/fortran/mpif-h/fetch_and_op_f.c
@@ -80,7 +80,7 @@ void ompi_fetch_and_op_f(char *origin_addr, char *result_addr, MPI_Fint *datatyp
     MPI_Win c_win = PMPI_Win_f2c(*win);
     MPI_Op c_op = PMPI_Op_f2c(*op);
 
-    c_ierr = PMPI_Fetch_and_op(OMPI_F2C_BOTTOM(origin_addr),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Fetch_and_op)(OMPI_F2C_BOTTOM(origin_addr),
                               OMPI_F2C_BOTTOM(result_addr),
                               c_datatype,
                               OMPI_FINT_2_INT(*target_rank),

--- a/ompi/mpi/fortran/mpif-h/file_call_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_call_errhandler_f.c
@@ -74,6 +74,6 @@ void ompi_file_call_errhandler_f(MPI_Fint *fh, MPI_Fint *errorcode,
 
     c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_call_errhandler(c_fh, OMPI_FINT_2_INT(*errorcode));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_call_errhandler)(c_fh, OMPI_FINT_2_INT(*errorcode));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_close_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_close_f.c
@@ -73,7 +73,7 @@ void ompi_file_close_f(MPI_Fint *fh, MPI_Fint *ierr)
 
     c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_close(&c_fh);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_close)(&c_fh);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_delete_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_delete_f.c
@@ -84,7 +84,7 @@ void ompi_file_delete_f(char *filename, MPI_Fint *info, MPI_Fint *ierr, int file
         return;
     }
 
-    c_ierr = PMPI_File_delete(c_filename, c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_delete)(c_filename, c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     free(c_filename);

--- a/ompi/mpi/fortran/mpif-h/file_get_amode_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_amode_f.c
@@ -73,7 +73,7 @@ void ompi_file_get_amode_f(MPI_Fint *fh, MPI_Fint *amode, MPI_Fint *ierr)
     OMPI_SINGLE_NAME_DECL(amode);
 
     c_fh = PMPI_File_f2c(*fh);
-    c_ierr = PMPI_File_get_amode(c_fh, OMPI_SINGLE_NAME_CONVERT(amode));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_amode)(c_fh, OMPI_SINGLE_NAME_CONVERT(amode));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_get_atomicity_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_atomicity_f.c
@@ -73,7 +73,7 @@ void ompi_file_get_atomicity_f(MPI_Fint *fh, ompi_fortran_logical_t *flag, MPI_F
     OMPI_LOGICAL_NAME_DECL(flag);
 
     c_fh = PMPI_File_f2c(*fh);
-    c_ierr = PMPI_File_get_atomicity(c_fh,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_atomicity)(c_fh,
                                     OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/file_get_byte_offset_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_byte_offset_f.c
@@ -74,7 +74,7 @@ void ompi_file_get_byte_offset_f(MPI_Fint *fh, MPI_Offset *offset,
 
     c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_get_byte_offset(c_fh,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_byte_offset)(c_fh,
                                       (MPI_Offset) *offset,
                                       disp);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_get_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_errhandler_f.c
@@ -74,7 +74,7 @@ void ompi_file_get_errhandler_f(MPI_Fint *fh, MPI_Fint *errhandler, MPI_Fint *ie
 
     c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_get_errhandler(c_fh, &c_errhandler);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_errhandler)(c_fh, &c_errhandler);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_get_group_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_group_f.c
@@ -72,7 +72,7 @@ void ompi_file_get_group_f(MPI_Fint *fh, MPI_Fint *group, MPI_Fint *ierr)
     MPI_File c_fh = PMPI_File_f2c(*fh);
     MPI_Group c_grp;
 
-    c_ierr = PMPI_File_get_group(c_fh, &c_grp);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_group)(c_fh, &c_grp);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_get_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_info_f.c
@@ -72,7 +72,7 @@ void ompi_file_get_info_f(MPI_Fint *fh, MPI_Fint *info_used, MPI_Fint *ierr)
     MPI_File c_fh = PMPI_File_f2c(*fh);
     MPI_Info c_info;
 
-    c_ierr = PMPI_File_get_info(c_fh, &c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_info)(c_fh, &c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_get_position_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_position_f.c
@@ -72,7 +72,7 @@ void ompi_file_get_position_f(MPI_Fint *fh, MPI_Offset *offset, MPI_Fint *ierr)
     MPI_File c_fh = PMPI_File_f2c(*fh);
     MPI_Offset c_offset;
 
-    c_ierr = PMPI_File_get_position(c_fh, &c_offset);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_position)(c_fh, &c_offset);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_get_position_shared_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_position_shared_f.c
@@ -73,7 +73,7 @@ void ompi_file_get_position_shared_f(MPI_Fint *fh, MPI_Offset *offset,
     MPI_File c_fh = PMPI_File_f2c(*fh);
     MPI_Offset c_offset;
 
-    c_ierr = PMPI_File_get_position_shared(c_fh, &c_offset);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_position_shared)(c_fh, &c_offset);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_get_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_size_f.c
@@ -72,7 +72,7 @@ void ompi_file_get_size_f(MPI_Fint *fh, MPI_Offset *size, MPI_Fint *ierr)
     MPI_File c_fh = PMPI_File_f2c(*fh);
     MPI_Offset c_size;
 
-    c_ierr = PMPI_File_get_size(c_fh, &c_size);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_size)(c_fh, &c_size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/file_get_type_extent_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_type_extent_f.c
@@ -75,6 +75,6 @@ void ompi_file_get_type_extent_f(MPI_Fint *fh, MPI_Fint *datatype,
 
     c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = PMPI_File_get_type_extent(c_fh, c_type, extent);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_type_extent)(c_fh, c_type, extent);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_get_view_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_get_view_f.c
@@ -78,7 +78,7 @@ void ompi_file_get_view_f(MPI_Fint *fh, MPI_Offset *disp,
     MPI_Offset c_disp;
     char c_datarep[MPI_MAX_DATAREP_STRING];
 
-    c_ierr = PMPI_File_get_view(c_fh, &c_disp, &c_etype,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_get_view)(c_fh, &c_disp, &c_etype,
                                &c_filetype, c_datarep);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/file_iread_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iread_all_f.c
@@ -75,7 +75,7 @@ void ompi_file_iread_all_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iread_all(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iread_all)(c_fh, OMPI_F2C_BOTTOM(buf),
                                OMPI_FINT_2_INT(*count),
                                c_type, &c_request);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_iread_at_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iread_at_all_f.c
@@ -76,7 +76,7 @@ void ompi_file_iread_at_all_f(MPI_Fint *fh, MPI_Offset *offset,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iread_at_all(c_fh, (MPI_Offset) *offset,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iread_at_all)(c_fh, (MPI_Offset) *offset,
                                   OMPI_F2C_BOTTOM(buf),
                                   OMPI_FINT_2_INT(*count),
                                   c_type,

--- a/ompi/mpi/fortran/mpif-h/file_iread_at_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iread_at_f.c
@@ -76,7 +76,7 @@ void ompi_file_iread_at_f(MPI_Fint *fh, MPI_Offset *offset,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iread_at(c_fh, (MPI_Offset) *offset,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iread_at)(c_fh, (MPI_Offset) *offset,
                               OMPI_F2C_BOTTOM(buf),
                               OMPI_FINT_2_INT(*count),
                               c_type,

--- a/ompi/mpi/fortran/mpif-h/file_iread_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iread_f.c
@@ -75,7 +75,7 @@ void ompi_file_iread_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iread(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iread)(c_fh, OMPI_F2C_BOTTOM(buf),
                            OMPI_FINT_2_INT(*count),
                            c_type, &c_request);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_iread_shared_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iread_shared_f.c
@@ -76,7 +76,7 @@ void ompi_file_iread_shared_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iread_shared(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iread_shared)(c_fh,
                                   OMPI_F2C_BOTTOM(buf),
                                   OMPI_FINT_2_INT(*count),
                                   c_type,

--- a/ompi/mpi/fortran/mpif-h/file_iwrite_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iwrite_all_f.c
@@ -74,7 +74,7 @@ void ompi_file_iwrite_all_f(MPI_Fint *fh, char *buf, MPI_Fint *count, MPI_Fint *
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iwrite_all(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iwrite_all)(c_fh, OMPI_F2C_BOTTOM(buf),
                                 OMPI_FINT_2_INT(*count),
                                 c_type, &c_request);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_iwrite_at_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iwrite_at_all_f.c
@@ -76,7 +76,7 @@ void ompi_file_iwrite_at_all_f(MPI_Fint *fh, MPI_Offset *offset, char *buf,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iwrite_at_all(c_fh, (MPI_Offset) *offset,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iwrite_at_all)(c_fh, (MPI_Offset) *offset,
                                    OMPI_F2C_BOTTOM(buf),
                                    OMPI_FINT_2_INT(*count),
                                    c_type, &c_request);

--- a/ompi/mpi/fortran/mpif-h/file_iwrite_at_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iwrite_at_f.c
@@ -76,7 +76,7 @@ void ompi_file_iwrite_at_f(MPI_Fint *fh, MPI_Offset *offset, char *buf,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iwrite_at(c_fh, (MPI_Offset) *offset,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iwrite_at)(c_fh, (MPI_Offset) *offset,
                                OMPI_F2C_BOTTOM(buf),
                                OMPI_FINT_2_INT(*count),
                                c_type, &c_request);

--- a/ompi/mpi/fortran/mpif-h/file_iwrite_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iwrite_f.c
@@ -74,7 +74,7 @@ void ompi_file_iwrite_f(MPI_Fint *fh, char *buf, MPI_Fint *count, MPI_Fint *data
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iwrite(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iwrite)(c_fh, OMPI_F2C_BOTTOM(buf),
                             OMPI_FINT_2_INT(*count),
                             c_type, &c_request);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_iwrite_shared_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_iwrite_shared_f.c
@@ -76,7 +76,7 @@ void ompi_file_iwrite_shared_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
    MPI_Request c_request;
 
-   c_ierr = PMPI_File_iwrite_shared(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_iwrite_shared)(c_fh,
                                    OMPI_F2C_BOTTOM(buf),
                                    OMPI_FINT_2_INT(*count),
                                    c_type,

--- a/ompi/mpi/fortran/mpif-h/file_open_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_open_f.c
@@ -85,7 +85,7 @@ void ompi_file_open_f(MPI_Fint *comm, char *filename, MPI_Fint *amode,
         return;
     }
 
-    c_ierr = PMPI_File_open(c_comm, c_filename,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_open)(c_comm, c_filename,
                            OMPI_FINT_2_INT(*amode),
                            c_info, &c_fh);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_preallocate_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_preallocate_f.c
@@ -71,6 +71,6 @@ void ompi_file_preallocate_f(MPI_Fint *fh, MPI_Offset *size, MPI_Fint *ierr)
     int c_ierr;
     MPI_File c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_preallocate(c_fh, (MPI_Offset) *size);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_preallocate)(c_fh, (MPI_Offset) *size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_read_all_begin_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_all_begin_f.c
@@ -75,7 +75,7 @@ void ompi_file_read_all_begin_f(MPI_Fint *fh, char *buf,
    MPI_File c_fh = PMPI_File_f2c(*fh);
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-   c_ierr = PMPI_File_read_all_begin(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_all_begin)(c_fh, OMPI_F2C_BOTTOM(buf),
                                     OMPI_FINT_2_INT(*count),
                                     c_type);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_read_all_end_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_all_end_f.c
@@ -78,7 +78,7 @@ void ompi_file_read_all_end_f(MPI_Fint *fh, char *buf, MPI_Fint *status,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_read_all_end(c_fh, buf, c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_all_end)(c_fh, buf, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)

--- a/ompi/mpi/fortran/mpif-h/file_read_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_all_f.c
@@ -79,7 +79,7 @@ void ompi_file_read_all_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_read_all(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_all)(c_fh, OMPI_F2C_BOTTOM(buf),
                               OMPI_FINT_2_INT(*count),
                               c_type, c_status);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_read_at_all_begin_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_at_all_begin_f.c
@@ -75,7 +75,7 @@ void ompi_file_read_at_all_begin_f(MPI_Fint *fh, MPI_Offset *offset,
    MPI_File c_fh = PMPI_File_f2c(*fh);
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-   c_ierr = PMPI_File_read_at_all_begin(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_at_all_begin)(c_fh,
                                        (MPI_Offset) *offset,
                                        OMPI_F2C_BOTTOM(buf),
                                        OMPI_FINT_2_INT(*count),

--- a/ompi/mpi/fortran/mpif-h/file_read_at_all_end_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_at_all_end_f.c
@@ -78,7 +78,7 @@ void ompi_file_read_at_all_end_f(MPI_Fint *fh, char *buf,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_read_at_all_end(c_fh, buf, c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_at_all_end)(c_fh, buf, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)

--- a/ompi/mpi/fortran/mpif-h/file_read_at_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_at_all_f.c
@@ -81,7 +81,7 @@ void ompi_file_read_at_all_f(MPI_Fint *fh, MPI_Offset *offset,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_read_at_all(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_at_all)(c_fh,
                                  (MPI_Offset) *offset,
                                  OMPI_F2C_BOTTOM(buf),
                                  OMPI_FINT_2_INT(*count),

--- a/ompi/mpi/fortran/mpif-h/file_read_at_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_at_f.c
@@ -80,7 +80,7 @@ void ompi_file_read_at_f(MPI_Fint *fh, MPI_Offset *offset, char *buf,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_read_at(c_fh,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_at)(c_fh,
                               (MPI_Offset) *offset,
                               buf,
                               OMPI_FINT_2_INT(*count),

--- a/ompi/mpi/fortran/mpif-h/file_read_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_f.c
@@ -79,7 +79,7 @@ void ompi_file_read_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_read(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read)(c_fh, OMPI_F2C_BOTTOM(buf),
                           OMPI_FINT_2_INT(*count),
                           c_type, c_status);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_read_ordered_begin_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_ordered_begin_f.c
@@ -74,7 +74,7 @@ void ompi_file_read_ordered_begin_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
    MPI_File c_fh = PMPI_File_f2c(*fh);
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-   c_ierr = PMPI_File_read_ordered_begin(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_ordered_begin)(c_fh, OMPI_F2C_BOTTOM(buf),
                                         OMPI_FINT_2_INT(*count),
                                         c_type);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_read_ordered_end_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_ordered_end_f.c
@@ -78,7 +78,7 @@ void ompi_file_read_ordered_end_f(MPI_Fint *fh, char *buf,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_read_ordered_end(c_fh, buf, c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_ordered_end)(c_fh, buf, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)

--- a/ompi/mpi/fortran/mpif-h/file_read_ordered_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_ordered_f.c
@@ -80,7 +80,7 @@ void ompi_file_read_ordered_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_read_ordered(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_ordered)(c_fh,
                                   OMPI_F2C_BOTTOM(buf),
                                   OMPI_FINT_2_INT(*count),
                                   c_type,

--- a/ompi/mpi/fortran/mpif-h/file_read_shared_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_read_shared_f.c
@@ -80,7 +80,7 @@ void ompi_file_read_shared_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_read_shared(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_read_shared)(c_fh,
                                  OMPI_F2C_BOTTOM(buf),
                                  OMPI_FINT_2_INT(*count),
                                  c_type,

--- a/ompi/mpi/fortran/mpif-h/file_seek_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_seek_f.c
@@ -72,7 +72,7 @@ void ompi_file_seek_f(MPI_Fint *fh, MPI_Offset *offset,
     int c_ierr;
     MPI_File c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_seek(c_fh, (MPI_Offset) *offset,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_seek)(c_fh, (MPI_Offset) *offset,
                            OMPI_FINT_2_INT(*whence));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_seek_shared_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_seek_shared_f.c
@@ -72,7 +72,7 @@ void ompi_file_seek_shared_f(MPI_Fint *fh, MPI_Offset *offset,
     int c_ierr;
     MPI_File c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_seek_shared(c_fh, (MPI_Offset) *offset,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_seek_shared)(c_fh, (MPI_Offset) *offset,
                                   OMPI_FINT_2_INT(*whence));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_set_atomicity_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_set_atomicity_f.c
@@ -71,7 +71,7 @@ void ompi_file_set_atomicity_f(MPI_Fint *fh, ompi_fortran_logical_t *flag, MPI_F
     int c_ierr;
     MPI_File c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_set_atomicity(c_fh,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_set_atomicity)(c_fh,
                                     OMPI_LOGICAL_2_INT(*flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_set_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_set_errhandler_f.c
@@ -74,6 +74,6 @@ void ompi_file_set_errhandler_f(MPI_Fint *fh, MPI_Fint *errhandler,
     MPI_File c_fh = PMPI_File_f2c(*fh);
     MPI_Errhandler c_err = PMPI_Errhandler_f2c(*errhandler);
 
-    c_ierr = PMPI_File_set_errhandler(c_fh, c_err);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_set_errhandler)(c_fh, c_err);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_set_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_set_info_f.c
@@ -72,6 +72,6 @@ void ompi_file_set_info_f(MPI_Fint *fh, MPI_Fint *info, MPI_Fint *ierr)
     MPI_File c_fh = PMPI_File_f2c(*fh);
     MPI_Info c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_File_set_info(c_fh, c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_set_info)(c_fh, c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_set_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_set_size_f.c
@@ -71,6 +71,6 @@ void ompi_file_set_size_f(MPI_Fint *fh, MPI_Offset *size, MPI_Fint *ierr)
     int c_ierr;
     MPI_File c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_set_size(c_fh, (MPI_Offset) *size);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_set_size)(c_fh, (MPI_Offset) *size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_set_view_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_set_view_f.c
@@ -88,7 +88,7 @@ void ompi_file_set_view_f(MPI_Fint *fh, MPI_Offset *disp,
         return;
    }
 
-   c_ierr = PMPI_File_set_view(c_fh, (MPI_Offset) *disp,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_set_view)(c_fh, (MPI_Offset) *disp,
                               c_etype, c_filetype,
                               c_datarep, c_info);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_sync_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_sync_f.c
@@ -71,6 +71,6 @@ void ompi_file_sync_f(MPI_Fint *fh, MPI_Fint *ierr)
     int c_ierr;
     MPI_File c_fh = PMPI_File_f2c(*fh);
 
-    c_ierr = PMPI_File_sync(c_fh);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_sync)(c_fh);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/file_write_all_begin_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_all_begin_f.c
@@ -75,7 +75,7 @@ void ompi_file_write_all_begin_f(MPI_Fint *fh, char *buf,
    MPI_File c_fh = PMPI_File_f2c(*fh);
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-   c_ierr = PMPI_File_write_all_begin(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_all_begin)(c_fh, OMPI_F2C_BOTTOM(buf),
                                      OMPI_FINT_2_INT(*count),
                                      c_type);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_write_all_end_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_all_end_f.c
@@ -78,7 +78,7 @@ void ompi_file_write_all_end_f(MPI_Fint *fh, char *buf, MPI_Fint *status,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_write_all_end(c_fh, buf, c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_all_end)(c_fh, buf, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)

--- a/ompi/mpi/fortran/mpif-h/file_write_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_all_f.c
@@ -79,7 +79,7 @@ void ompi_file_write_all_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_write_all(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_all)(c_fh, OMPI_F2C_BOTTOM(buf),
                                OMPI_FINT_2_INT(*count),
                                c_type, c_status);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_write_at_all_begin_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_at_all_begin_f.c
@@ -75,7 +75,7 @@ void ompi_file_write_at_all_begin_f(MPI_Fint *fh, MPI_Offset *offset,
    MPI_File c_fh = PMPI_File_f2c(*fh);
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-   c_ierr = PMPI_File_write_at_all_begin(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_at_all_begin)(c_fh,
                                         (MPI_Offset) *offset,
                                         OMPI_F2C_BOTTOM(buf),
                                         OMPI_FINT_2_INT(*count),

--- a/ompi/mpi/fortran/mpif-h/file_write_at_all_end_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_at_all_end_f.c
@@ -78,7 +78,7 @@ void ompi_file_write_at_all_end_f(MPI_Fint *fh, char *buf,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_write_at_all_end(c_fh, buf, c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_at_all_end)(c_fh, buf, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)

--- a/ompi/mpi/fortran/mpif-h/file_write_at_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_at_all_f.c
@@ -81,7 +81,7 @@ void ompi_file_write_at_all_f(MPI_Fint *fh, MPI_Offset *offset,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_write_at_all(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_at_all)(c_fh,
                                   (MPI_Offset) *offset,
                                   OMPI_F2C_BOTTOM(buf),
                                   OMPI_FINT_2_INT(*count),

--- a/ompi/mpi/fortran/mpif-h/file_write_at_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_at_f.c
@@ -82,7 +82,7 @@ void ompi_file_write_at_f(MPI_Fint *fh, MPI_Offset *offset,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_write_at(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_at)(c_fh,
                               (MPI_Offset) *offset,
                               OMPI_F2C_BOTTOM(buf),
                               OMPI_FINT_2_INT(*count),

--- a/ompi/mpi/fortran/mpif-h/file_write_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_f.c
@@ -79,7 +79,7 @@ void ompi_file_write_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_write(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write)(c_fh, OMPI_F2C_BOTTOM(buf),
                            OMPI_FINT_2_INT(*count),
                            c_type, c_status);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_write_ordered_begin_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_ordered_begin_f.c
@@ -75,7 +75,7 @@ void ompi_file_write_ordered_begin_f(MPI_Fint *fh, char *buf,
    MPI_File c_fh = PMPI_File_f2c(*fh);
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-   c_ierr = PMPI_File_write_ordered_begin(c_fh, OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_ordered_begin)(c_fh, OMPI_F2C_BOTTOM(buf),
                                          OMPI_FINT_2_INT(*count),
                                          c_type);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/file_write_ordered_end_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_ordered_end_f.c
@@ -78,7 +78,7 @@ void ompi_file_write_ordered_end_f(MPI_Fint *fh, char *buf,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_File_write_ordered_end(c_fh, buf, c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_ordered_end)(c_fh, buf, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_FORTRAN_STATUS_RETURN(c_status,c_status2,status,c_ierr)

--- a/ompi/mpi/fortran/mpif-h/file_write_ordered_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_ordered_f.c
@@ -80,7 +80,7 @@ void ompi_file_write_ordered_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_write_ordered(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_ordered)(c_fh,
                                    OMPI_F2C_BOTTOM(buf),
                                    OMPI_FINT_2_INT(*count),
                                    c_type,

--- a/ompi/mpi/fortran/mpif-h/file_write_shared_f.c
+++ b/ompi/mpi/fortran/mpif-h/file_write_shared_f.c
@@ -80,7 +80,7 @@ void ompi_file_write_shared_f(MPI_Fint *fh, char *buf, MPI_Fint *count,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-   c_ierr = PMPI_File_write_shared(c_fh,
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_File_write_shared)(c_fh,
                                   OMPI_F2C_BOTTOM(buf),
                                   OMPI_FINT_2_INT(*count),
                                   c_type,

--- a/ompi/mpi/fortran/mpif-h/finalize_f.c
+++ b/ompi/mpi/fortran/mpif-h/finalize_f.c
@@ -68,6 +68,6 @@ OMPI_GENERATE_F77_BINDINGS (MPI_FINALIZE,
 
 void ompi_finalize_f(MPI_Fint *ierr)
 {
-    int c_ierr = PMPI_Finalize();
+    int c_ierr = OMPI_FORTRAN_FPTR(MPI_Finalize)();
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/finalized_f.c
+++ b/ompi/mpi/fortran/mpif-h/finalized_f.c
@@ -72,7 +72,7 @@ void ompi_finalized_f(ompi_fortran_logical_t *flag, MPI_Fint *ierr)
     OMPI_LOGICAL_NAME_DECL(flag);
 
     ompi_fptr_init(0);
-    c_ierr = PMPI_Finalized(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Finalized)(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/finalized_f.c
+++ b/ompi/mpi/fortran/mpif-h/finalized_f.c
@@ -71,6 +71,7 @@ void ompi_finalized_f(ompi_fortran_logical_t *flag, MPI_Fint *ierr)
     int c_ierr;
     OMPI_LOGICAL_NAME_DECL(flag);
 
+    ompi_fptr_init(0);
     c_ierr = PMPI_Finalized(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/free_mem_f.c
+++ b/ompi/mpi/fortran/mpif-h/free_mem_f.c
@@ -68,6 +68,6 @@ OMPI_GENERATE_F77_BINDINGS (MPI_FREE_MEM,
 
 void ompi_free_mem_f(char *base, MPI_Fint *ierr)
 {
-    int c_ierr = PMPI_Free_mem(base);
+    int c_ierr = OMPI_FORTRAN_FPTR(MPI_Free_mem)(base);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/gather_f.c
+++ b/ompi/mpi/fortran/mpif-h/gather_f.c
@@ -83,7 +83,7 @@ void ompi_gather_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Gather(sendbuf, OMPI_FINT_2_INT(*sendcount),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Gather)(sendbuf, OMPI_FINT_2_INT(*sendcount),
                         c_sendtype, recvbuf,
                         OMPI_FINT_2_INT(*recvcount),
                         c_recvtype,

--- a/ompi/mpi/fortran/mpif-h/gatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/gatherv_f.c
@@ -90,7 +90,7 @@ void ompi_gatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Gatherv(sendbuf, OMPI_FINT_2_INT(*sendcount),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Gatherv)(sendbuf, OMPI_FINT_2_INT(*sendcount),
                          c_sendtype, recvbuf,
                          OMPI_ARRAY_NAME_CONVERT(recvcounts),
                          OMPI_ARRAY_NAME_CONVERT(displs),

--- a/ompi/mpi/fortran/mpif-h/get_accumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_accumulate_f.c
@@ -85,7 +85,7 @@ void ompi_get_accumulate_f(char *origin_addr, MPI_Fint *origin_count,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     MPI_Op c_op = PMPI_Op_f2c(*op);
 
-    c_ierr = PMPI_Get_accumulate(OMPI_F2C_BOTTOM(origin_addr),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Get_accumulate)(OMPI_F2C_BOTTOM(origin_addr),
                                 OMPI_FINT_2_INT(*origin_count),
                                 c_origin_datatype,
                                 OMPI_F2C_BOTTOM(result_addr),

--- a/ompi/mpi/fortran/mpif-h/get_address_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_address_f.c
@@ -72,7 +72,7 @@ void ompi_get_address_f(char *location, MPI_Aint *address, MPI_Fint *ierr)
     int c_ierr;
     MPI_Aint c_address;
 
-    c_ierr = PMPI_Get_address(OMPI_F2C_BOTTOM(location), &c_address);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Get_address)(OMPI_F2C_BOTTOM(location), &c_address);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/get_count_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_count_f.c
@@ -81,7 +81,7 @@ void ompi_get_count_f(MPI_Fint *status, MPI_Fint *datatype, MPI_Fint *count, MPI
         c_ierr = PMPI_Status_f2c(status, &c_status);
 
         if (MPI_SUCCESS == c_ierr) {
-            c_ierr = PMPI_Get_count(&c_status, c_type,
+            c_ierr = OMPI_FORTRAN_FPTR(MPI_Get_count)(&c_status, c_type,
                                    OMPI_SINGLE_NAME_CONVERT(count));
             OMPI_SINGLE_INT_2_FINT(count);
         }

--- a/ompi/mpi/fortran/mpif-h/get_elements_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_elements_f.c
@@ -81,7 +81,7 @@ void ompi_get_elements_f(MPI_Fint *status, MPI_Fint *datatype, MPI_Fint *count, 
         c_ierr = PMPI_Status_f2c(status, &c_status);
 
         if (MPI_SUCCESS == c_ierr) {
-            c_ierr = PMPI_Get_elements(&c_status, c_type,
+            c_ierr = OMPI_FORTRAN_FPTR(MPI_Get_elements)(&c_status, c_type,
                                       OMPI_SINGLE_NAME_CONVERT(count));
             OMPI_SINGLE_INT_2_FINT(count);
         }

--- a/ompi/mpi/fortran/mpif-h/get_elements_x_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_elements_x_f.c
@@ -83,7 +83,7 @@ void ompi_get_elements_x_f(MPI_Fint *status, MPI_Fint *datatype, MPI_Count *coun
         c_ierr = PMPI_Status_f2c(status, &c_status);
 
         if (MPI_SUCCESS == c_ierr) {
-            c_ierr = PMPI_Get_elements_x(&c_status, c_type, count);
+            c_ierr = OMPI_FORTRAN_FPTR(MPI_Get_elements_x)(&c_status, c_type, count);
         }
     }
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/get_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_f.c
@@ -78,7 +78,7 @@ void ompi_get_f(char *origin_addr, MPI_Fint *origin_count,
     MPI_Datatype c_target_datatype = PMPI_Type_f2c(*target_datatype);
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Get(OMPI_F2C_BOTTOM(origin_addr),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Get)(OMPI_F2C_BOTTOM(origin_addr),
                      OMPI_FINT_2_INT(*origin_count),
                      c_origin_datatype,
                      OMPI_FINT_2_INT(*target_rank),

--- a/ompi/mpi/fortran/mpif-h/get_library_version_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_library_version_f.c
@@ -73,6 +73,7 @@ void ompi_get_library_version_f(char *version, MPI_Fint *resultlen,
     int c_ierr, c_resultlen;
     char c_version[MPI_MAX_LIBRARY_VERSION_STRING];
 
+    ompi_fptr_init(0);
     c_ierr = PMPI_Get_library_version(c_version, &c_resultlen);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/get_library_version_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_library_version_f.c
@@ -74,7 +74,7 @@ void ompi_get_library_version_f(char *version, MPI_Fint *resultlen,
     char c_version[MPI_MAX_LIBRARY_VERSION_STRING];
 
     ompi_fptr_init(0);
-    c_ierr = PMPI_Get_library_version(c_version, &c_resultlen);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Get_library_version)(c_version, &c_resultlen);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/get_processor_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_processor_name_f.c
@@ -83,7 +83,7 @@ void ompi_get_processor_name_f(char *name, MPI_Fint *resultlen, MPI_Fint *ierr,
     char c_name[MPI_MAX_PROCESSOR_NAME];
     OMPI_SINGLE_NAME_DECL(resultlen);
 
-    ierr_c = PMPI_Get_processor_name(c_name,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Get_processor_name)(c_name,
                                      OMPI_SINGLE_NAME_CONVERT(resultlen));
 
     if (MPI_SUCCESS == ierr_c) {

--- a/ompi/mpi/fortran/mpif-h/get_version_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_version_f.c
@@ -73,7 +73,7 @@ void ompi_get_version_f(MPI_Fint *version, MPI_Fint *subversion, MPI_Fint *ierr)
     OMPI_SINGLE_NAME_DECL(subversion);
 
     ompi_fptr_init(0);
-    c_ierr = PMPI_Get_version(OMPI_SINGLE_NAME_CONVERT(version),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Get_version)(OMPI_SINGLE_NAME_CONVERT(version),
                              OMPI_SINGLE_NAME_CONVERT(subversion));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/get_version_f.c
+++ b/ompi/mpi/fortran/mpif-h/get_version_f.c
@@ -72,6 +72,7 @@ void ompi_get_version_f(MPI_Fint *version, MPI_Fint *subversion, MPI_Fint *ierr)
     OMPI_SINGLE_NAME_DECL(version);
     OMPI_SINGLE_NAME_DECL(subversion);
 
+    ompi_fptr_init(0);
     c_ierr = PMPI_Get_version(OMPI_SINGLE_NAME_CONVERT(version),
                              OMPI_SINGLE_NAME_CONVERT(subversion));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/graph_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/graph_create_f.c
@@ -83,7 +83,7 @@ void ompi_graph_create_f(MPI_Fint *comm_old, MPI_Fint *nnodes,
     /* Number of edges is equal to the last entry in the index array */
     OMPI_ARRAY_FINT_2_INT(edges, indx[*nnodes - 1]);
 
-    c_ierr = PMPI_Graph_create(c_comm_old,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Graph_create)(c_comm_old,
                               OMPI_FINT_2_INT(*nnodes),
                               OMPI_ARRAY_NAME_CONVERT(indx),
                               OMPI_ARRAY_NAME_CONVERT(edges),

--- a/ompi/mpi/fortran/mpif-h/graph_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/graph_get_f.c
@@ -79,7 +79,7 @@ void ompi_graph_get_f(MPI_Fint *comm, MPI_Fint *maxindex,
     OMPI_ARRAY_FINT_2_INT_ALLOC(indx, *maxindex);
     OMPI_ARRAY_FINT_2_INT_ALLOC(edges, *maxedges);
 
-    c_ierr = PMPI_Graph_get(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Graph_get)(c_comm,
                            OMPI_FINT_2_INT(*maxindex),
                            OMPI_FINT_2_INT(*maxedges),
                            OMPI_ARRAY_NAME_CONVERT(indx),

--- a/ompi/mpi/fortran/mpif-h/graph_map_f.c
+++ b/ompi/mpi/fortran/mpif-h/graph_map_f.c
@@ -81,7 +81,7 @@ void ompi_graph_map_f(MPI_Fint *comm, MPI_Fint *nnodes, MPI_Fint *indx,
     OMPI_ARRAY_FINT_2_INT(edges, indx[*nnodes - 1]);
     OMPI_ARRAY_FINT_2_INT(indx, *nnodes);
 
-    c_ierr = PMPI_Graph_map(c_comm, OMPI_FINT_2_INT(*nnodes),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Graph_map)(c_comm, OMPI_FINT_2_INT(*nnodes),
                            OMPI_ARRAY_NAME_CONVERT(indx),
                            OMPI_ARRAY_NAME_CONVERT(edges),
                            OMPI_SINGLE_NAME_CONVERT(nrank));

--- a/ompi/mpi/fortran/mpif-h/graph_neighbors_count_f.c
+++ b/ompi/mpi/fortran/mpif-h/graph_neighbors_count_f.c
@@ -75,7 +75,7 @@ void ompi_graph_neighbors_count_f(MPI_Fint *comm, MPI_Fint *rank,
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Graph_neighbors_count(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Graph_neighbors_count)(c_comm,
                                        OMPI_FINT_2_INT(*rank),
                                        OMPI_SINGLE_NAME_CONVERT(nneighbors));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/graph_neighbors_f.c
+++ b/ompi/mpi/fortran/mpif-h/graph_neighbors_f.c
@@ -80,7 +80,7 @@ void ompi_graph_neighbors_f(MPI_Fint *comm, MPI_Fint *rank,
 
     OMPI_ARRAY_FINT_2_INT_ALLOC(neighbors, *maxneighbors);
 
-    c_ierr = PMPI_Graph_neighbors(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Graph_neighbors)(c_comm,
                                  OMPI_FINT_2_INT(*rank),
                                  OMPI_FINT_2_INT(*maxneighbors),
                                  OMPI_ARRAY_NAME_CONVERT(neighbors)

--- a/ompi/mpi/fortran/mpif-h/graphdims_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/graphdims_get_f.c
@@ -76,7 +76,7 @@ void ompi_graphdims_get_f(MPI_Fint *comm, MPI_Fint *nnodes,
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Graphdims_get(c_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Graphdims_get)(c_comm,
                                OMPI_SINGLE_NAME_CONVERT(nnodes),
                                OMPI_SINGLE_NAME_CONVERT(nedges)
                                );

--- a/ompi/mpi/fortran/mpif-h/grequest_complete_f.c
+++ b/ompi/mpi/fortran/mpif-h/grequest_complete_f.c
@@ -71,6 +71,6 @@ void ompi_grequest_complete_f(MPI_Fint *request, MPI_Fint *ierr)
     int c_ierr;
     MPI_Request c_req = PMPI_Request_f2c(*request);
 
-    c_ierr = PMPI_Grequest_complete(c_req);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Grequest_complete)(c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/grequest_start_f.c
+++ b/ompi/mpi/fortran/mpif-h/grequest_start_f.c
@@ -74,7 +74,7 @@ void ompi_grequest_start_f(MPI_F_Grequest_query_function* query_fn,
 {
     int c_ierr;
     MPI_Request c_req;
-    c_ierr = PMPI_Grequest_start(
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Grequest_start)(
                                 (MPI_Grequest_query_function *) query_fn,
                                 (MPI_Grequest_free_function *) free_fn,
                                 (MPI_Grequest_cancel_function *) cancel_fn,

--- a/ompi/mpi/fortran/mpif-h/group_compare_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_compare_f.c
@@ -85,7 +85,7 @@ void ompi_group_compare_f(MPI_Fint *group1, MPI_Fint *group2,
     c_group1 = PMPI_Group_f2c(*group1);
     c_group2 = PMPI_Group_f2c(*group2);
 
-    c_ierr = PMPI_Group_compare(c_group1, c_group2,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_compare)(c_group1, c_group2,
                                OMPI_SINGLE_NAME_CONVERT(result)
                                );
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/group_difference_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_difference_f.c
@@ -76,7 +76,7 @@ void ompi_group_difference_f(MPI_Fint *group1, MPI_Fint *group2, MPI_Fint *newgr
   c_group1 = PMPI_Group_f2c(*group1);
   c_group2 = PMPI_Group_f2c(*group2);
 
-  c_ierr = PMPI_Group_difference(c_group1, c_group2, &c_newgroup);
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_difference)(c_group1, c_group2, &c_newgroup);
   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
   /* translate the results from c to fortran */

--- a/ompi/mpi/fortran/mpif-h/group_excl_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_excl_f.c
@@ -79,7 +79,7 @@ void ompi_group_excl_f(MPI_Fint *group, MPI_Fint *n,
   c_group = PMPI_Group_f2c(*group);
 
   OMPI_ARRAY_FINT_2_INT(ranks, *n);
-  c_ierr = PMPI_Group_excl(c_group,
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_excl)(c_group,
                           OMPI_FINT_2_INT(*n),
                           OMPI_ARRAY_NAME_CONVERT(ranks),
                           &c_newgroup);

--- a/ompi/mpi/fortran/mpif-h/group_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_free_f.c
@@ -75,7 +75,7 @@ void ompi_group_free_f(MPI_Fint *group, MPI_Fint *ierr)
   /* Make the fortran to c representation conversion */
 
   c_group = PMPI_Group_f2c(*group);
-  c_ierr = PMPI_Group_free( &c_group );
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_free)( &c_group );
   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
   /* This value comes from the MPI_GROUP_NULL value in mpif.h.  Do not

--- a/ompi/mpi/fortran/mpif-h/group_incl_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_incl_f.c
@@ -78,7 +78,7 @@ void ompi_group_incl_f(MPI_Fint *group, MPI_Fint *n, MPI_Fint *ranks, MPI_Fint *
     c_group = PMPI_Group_f2c(*group);
 
     OMPI_ARRAY_FINT_2_INT(ranks, *n);
-    c_ierr = PMPI_Group_incl(c_group,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_incl)(c_group,
                             OMPI_FINT_2_INT(*n),
                             OMPI_ARRAY_NAME_CONVERT(ranks),
                             &c_newgroup);

--- a/ompi/mpi/fortran/mpif-h/group_intersection_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_intersection_f.c
@@ -76,7 +76,7 @@ void ompi_group_intersection_f(MPI_Fint *group1, MPI_Fint *group2, MPI_Fint *new
   c_group1 = PMPI_Group_f2c(*group1);
   c_group2 = PMPI_Group_f2c(*group2);
 
-  c_ierr = PMPI_Group_intersection(c_group1, c_group2, &c_newgroup);
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_intersection)(c_group1, c_group2, &c_newgroup);
   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
   /* translate the results from c to fortran */

--- a/ompi/mpi/fortran/mpif-h/group_range_excl_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_range_excl_f.c
@@ -77,7 +77,7 @@ void ompi_group_range_excl_f(MPI_Fint *group, MPI_Fint *n, MPI_Fint ranges[][3],
   c_group = PMPI_Group_f2c(*group);
 
   OMPI_2_DIM_ARRAY_FINT_2_INT(ranges, *n, 3);
-  c_ierr = PMPI_Group_range_excl(c_group,
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_range_excl)(c_group,
                                 OMPI_FINT_2_INT(*n),
                                 OMPI_ARRAY_NAME_CONVERT(ranges),
                                 &c_newgroup);

--- a/ompi/mpi/fortran/mpif-h/group_range_incl_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_range_incl_f.c
@@ -77,7 +77,7 @@ void ompi_group_range_incl_f(MPI_Fint *group, MPI_Fint *n, MPI_Fint ranges[][3],
   c_group = PMPI_Group_f2c(*group);
 
   OMPI_2_DIM_ARRAY_FINT_2_INT(ranges, *n, 3);
-  c_ierr = PMPI_Group_range_incl(c_group,
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_range_incl)(c_group,
                                 OMPI_FINT_2_INT(*n),
                                 OMPI_ARRAY_NAME_CONVERT(ranges),
                                 &c_newgroup);

--- a/ompi/mpi/fortran/mpif-h/group_rank_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_rank_f.c
@@ -76,7 +76,7 @@ void ompi_group_rank_f(MPI_Fint *group, MPI_Fint *rank, MPI_Fint *ierr)
   /* Make the fortran to c representation conversion */
   c_group = PMPI_Group_f2c(*group);
 
-  c_ierr = PMPI_Group_rank(c_group, OMPI_SINGLE_NAME_CONVERT(rank));
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_rank)(c_group, OMPI_SINGLE_NAME_CONVERT(rank));
   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
   if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/group_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_size_f.c
@@ -76,7 +76,7 @@ void ompi_group_size_f(MPI_Fint *group, MPI_Fint *size, MPI_Fint *ierr)
   /* Make the fortran to c representation conversion */
   c_group = PMPI_Group_f2c(*group);
 
-  c_ierr = PMPI_Group_size(c_group, OMPI_SINGLE_NAME_CONVERT(size));
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_size)(c_group, OMPI_SINGLE_NAME_CONVERT(size));
   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
   if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/group_translate_ranks_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_translate_ranks_f.c
@@ -83,7 +83,7 @@ void ompi_group_translate_ranks_f(MPI_Fint *group1, MPI_Fint *n,
   OMPI_ARRAY_FINT_2_INT(ranks1, *n);
   OMPI_ARRAY_FINT_2_INT_ALLOC(ranks2, *n);
 
-  c_ierr = PMPI_Group_translate_ranks(c_group1,
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_translate_ranks)(c_group1,
                                      OMPI_FINT_2_INT(*n),
                                      OMPI_ARRAY_NAME_CONVERT(ranks1),
                                      c_group2,

--- a/ompi/mpi/fortran/mpif-h/group_union_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_union_f.c
@@ -76,7 +76,7 @@ void ompi_group_union_f(MPI_Fint *group1, MPI_Fint *group2, MPI_Fint *newgroup, 
   c_group1 = PMPI_Group_f2c(*group1);
   c_group2 = PMPI_Group_f2c(*group2);
 
-  c_ierr = PMPI_Group_union(c_group1, c_group2, &c_newgroup);
+  c_ierr = OMPI_FORTRAN_FPTR(MPI_Group_union)(c_group1, c_group2, &c_newgroup);
   if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
   /* translate the results from c to fortran */

--- a/ompi/mpi/fortran/mpif-h/iallgather_f.c
+++ b/ompi/mpi/fortran/mpif-h/iallgather_f.c
@@ -84,7 +84,7 @@ void ompi_iallgather_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Iallgather(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Iallgather)(sendbuf,
                              OMPI_FINT_2_INT(*sendcount),
                              c_sendtype,
                              recvbuf,

--- a/ompi/mpi/fortran/mpif-h/iallgatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/iallgatherv_f.c
@@ -91,7 +91,7 @@ void ompi_iallgatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Iallgatherv(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Iallgatherv)(sendbuf,
                               OMPI_FINT_2_INT(*sendcount),
                               c_sendtype,
                               recvbuf,

--- a/ompi/mpi/fortran/mpif-h/iallreduce_f.c
+++ b/ompi/mpi/fortran/mpif-h/iallreduce_f.c
@@ -85,7 +85,7 @@ void ompi_iallreduce_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Iallreduce(sendbuf, recvbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Iallreduce)(sendbuf, recvbuf,
                              OMPI_FINT_2_INT(*count),
                              c_type, c_op, c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);

--- a/ompi/mpi/fortran/mpif-h/ialltoall_f.c
+++ b/ompi/mpi/fortran/mpif-h/ialltoall_f.c
@@ -84,7 +84,7 @@ void ompi_ialltoall_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ialltoall(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ialltoall)(sendbuf,
                            OMPI_FINT_2_INT(*sendcount),
                            c_sendtype,
                            recvbuf,

--- a/ompi/mpi/fortran/mpif-h/ialltoallv_f.c
+++ b/ompi/mpi/fortran/mpif-h/ialltoallv_f.c
@@ -95,7 +95,7 @@ void ompi_ialltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sdispls,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ialltoallv(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ialltoallv)(sendbuf,
                             OMPI_ARRAY_NAME_CONVERT(sendcounts),
                             OMPI_ARRAY_NAME_CONVERT(sdispls),
                             c_sendtype,

--- a/ompi/mpi/fortran/mpif-h/ialltoallw_f.c
+++ b/ompi/mpi/fortran/mpif-h/ialltoallw_f.c
@@ -103,7 +103,7 @@ void ompi_ialltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ialltoallw(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ialltoallw)(sendbuf,
                             OMPI_ARRAY_NAME_CONVERT(sendcounts),
                             OMPI_ARRAY_NAME_CONVERT(sdispls),
                             c_sendtypes,

--- a/ompi/mpi/fortran/mpif-h/ibarrier_f.c
+++ b/ompi/mpi/fortran/mpif-h/ibarrier_f.c
@@ -74,7 +74,7 @@ void ompi_ibarrier_f(MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr)
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    ierr_c = PMPI_Ibarrier(c_comm, &c_req);
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Ibarrier)(c_comm, &c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(ierr_c);
 
     if (MPI_SUCCESS == ierr_c) *request = PMPI_Request_c2f(c_req);

--- a/ompi/mpi/fortran/mpif-h/ibcast_f.c
+++ b/ompi/mpi/fortran/mpif-h/ibcast_f.c
@@ -79,7 +79,7 @@ void ompi_ibcast_f(char *buffer, MPI_Fint *count, MPI_Fint *datatype,
     c_comm = PMPI_Comm_f2c(*comm);
     c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = PMPI_Ibcast(OMPI_F2C_BOTTOM(buffer),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ibcast)(OMPI_F2C_BOTTOM(buffer),
                         OMPI_FINT_2_INT(*count),
                         c_type,
                         OMPI_FINT_2_INT(*root),

--- a/ompi/mpi/fortran/mpif-h/ibsend_f.c
+++ b/ompi/mpi/fortran/mpif-h/ibsend_f.c
@@ -78,7 +78,7 @@ void ompi_ibsend_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Ibsend(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Ibsend)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                        c_type, OMPI_FINT_2_INT(*dest),
                        OMPI_FINT_2_INT(*tag),
                        c_comm, &c_req);

--- a/ompi/mpi/fortran/mpif-h/iexscan_f.c
+++ b/ompi/mpi/fortran/mpif-h/iexscan_f.c
@@ -85,7 +85,7 @@ void ompi_iexscan_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM (sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM (recvbuf);
 
-    c_ierr = PMPI_Iexscan(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Iexscan)(sendbuf, recvbuf,
                          OMPI_FINT_2_INT(*count),
                          c_type, c_op, c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/igather_f.c
+++ b/ompi/mpi/fortran/mpif-h/igather_f.c
@@ -85,7 +85,7 @@ void ompi_igather_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Igather(sendbuf, OMPI_FINT_2_INT(*sendcount),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Igather)(sendbuf, OMPI_FINT_2_INT(*sendcount),
                          c_sendtype, recvbuf,
                          OMPI_FINT_2_INT(*recvcount),
                          c_recvtype,

--- a/ompi/mpi/fortran/mpif-h/igatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/igatherv_f.c
@@ -91,7 +91,7 @@ void ompi_igatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Igatherv(sendbuf, OMPI_FINT_2_INT(*sendcount),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Igatherv)(sendbuf, OMPI_FINT_2_INT(*sendcount),
                          c_sendtype, recvbuf,
                          OMPI_ARRAY_NAME_CONVERT(recvcounts),
                          OMPI_ARRAY_NAME_CONVERT(displs),

--- a/ompi/mpi/fortran/mpif-h/improbe_f.c
+++ b/ompi/mpi/fortran/mpif-h/improbe_f.c
@@ -87,7 +87,7 @@ void ompi_improbe_f(MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = OMPI_INT_2_FINT(PMPI_Improbe(OMPI_FINT_2_INT(*source),
+    c_ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Improbe)(OMPI_FINT_2_INT(*source),
                                           OMPI_FINT_2_INT(*tag),
                                           c_comm, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                                           &c_message, c_status));

--- a/ompi/mpi/fortran/mpif-h/imrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/imrecv_f.c
@@ -80,7 +80,7 @@ void ompi_imrecv_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_message = PMPI_Message_f2c(*message);
 
-   c_ierr = OMPI_INT_2_FINT(PMPI_Imrecv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Imrecv)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                                         c_type, &c_message, &c_req));
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/ineighbor_allgather_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_allgather_f.c
@@ -87,7 +87,7 @@ void ompi_ineighbor_allgather_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *se
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Ineighbor_allgather(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Ineighbor_allgather)(sendbuf,
                                       OMPI_FINT_2_INT(*sendcount),
                                       c_sendtype,
                                       recvbuf,

--- a/ompi/mpi/fortran/mpif-h/ineighbor_allgatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_allgatherv_f.c
@@ -94,7 +94,7 @@ void ompi_ineighbor_allgatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *s
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Ineighbor_allgatherv(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Ineighbor_allgatherv)(sendbuf,
                                        OMPI_FINT_2_INT(*sendcount),
                                        c_sendtype,
                                        recvbuf,

--- a/ompi/mpi/fortran/mpif-h/ineighbor_alltoall_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_alltoall_f.c
@@ -87,7 +87,7 @@ void ompi_ineighbor_alltoall_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sen
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ineighbor_alltoall(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ineighbor_alltoall)(sendbuf,
                                     OMPI_FINT_2_INT(*sendcount),
                                     c_sendtype,
                                     recvbuf,

--- a/ompi/mpi/fortran/mpif-h/ineighbor_alltoallv_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_alltoallv_f.c
@@ -98,7 +98,7 @@ void ompi_ineighbor_alltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *s
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ineighbor_alltoallv(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ineighbor_alltoallv)(sendbuf,
                                      OMPI_ARRAY_NAME_CONVERT(sendcounts),
                                      OMPI_ARRAY_NAME_CONVERT(sdispls),
                                      c_sendtype,

--- a/ompi/mpi/fortran/mpif-h/ineighbor_alltoallw_f.c
+++ b/ompi/mpi/fortran/mpif-h/ineighbor_alltoallw_f.c
@@ -102,7 +102,7 @@ void ompi_ineighbor_alltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ineighbor_alltoallw(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ineighbor_alltoallw)(sendbuf,
                                      OMPI_ARRAY_NAME_CONVERT(sendcounts),
                                      sdispls,
                                      c_sendtypes,

--- a/ompi/mpi/fortran/mpif-h/info_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_create_f.c
@@ -71,7 +71,7 @@ void ompi_info_create_f(MPI_Fint *info, MPI_Fint *ierr)
     int c_ierr;
     MPI_Info c_info;
 
-    c_ierr = PMPI_Info_create(&c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_create)(&c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/info_delete_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_delete_f.c
@@ -89,7 +89,7 @@ void ompi_info_delete_f(MPI_Fint *info, char *key, MPI_Fint *ierr, int key_len)
     }
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_delete(c_info, c_key);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_delete)(c_info, c_key);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     free(c_key);

--- a/ompi/mpi/fortran/mpif-h/info_dup_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_dup_f.c
@@ -73,7 +73,7 @@ void ompi_info_dup_f(MPI_Fint *info, MPI_Fint *newinfo, MPI_Fint *ierr)
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_dup(c_info, &c_new_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_dup)(c_info, &c_new_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/info_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_free_f.c
@@ -73,7 +73,7 @@ void ompi_info_free_f(MPI_Fint *info, MPI_Fint *ierr)
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_free(&c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_free)(&c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/info_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_f.c
@@ -92,7 +92,7 @@ void ompi_info_get_f(MPI_Fint *info, char *key, MPI_Fint *valuelen,
     }
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_get(c_info, c_key,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_get)(c_info, c_key,
                           OMPI_FINT_2_INT(*valuelen),
                           c_value,
                           OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));

--- a/ompi/mpi/fortran/mpif-h/info_get_nkeys_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_nkeys_f.c
@@ -74,7 +74,7 @@ void ompi_info_get_nkeys_f(MPI_Fint *info, MPI_Fint *nkeys, MPI_Fint *ierr)
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_get_nkeys(c_info, OMPI_SINGLE_NAME_CONVERT(nkeys));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_get_nkeys)(c_info, OMPI_SINGLE_NAME_CONVERT(nkeys));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/info_get_nthkey_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_nthkey_f.c
@@ -85,7 +85,7 @@ void ompi_info_get_nthkey_f(MPI_Fint *info, MPI_Fint *n, char *key,
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_get_nthkey(c_info,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_get_nthkey)(c_info,
                                  OMPI_FINT_2_INT(*n),
                                  c_key);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/info_get_valuelen_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_get_valuelen_f.c
@@ -92,7 +92,7 @@ void ompi_info_get_valuelen_f(MPI_Fint *info, char *key,
         return;
     }
     c_info = PMPI_Info_f2c(*info);
-    c_ierr = PMPI_Info_get_valuelen(c_info, c_key,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_get_valuelen)(c_info, c_key,
                                    OMPI_SINGLE_NAME_CONVERT(valuelen),
                                    OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/info_set_f.c
+++ b/ompi/mpi/fortran/mpif-h/info_set_f.c
@@ -95,7 +95,7 @@ void ompi_info_set_f(MPI_Fint *info, char *key, char *value, MPI_Fint *ierr,
     }
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Info_set(c_info, c_key, c_value);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Info_set)(c_info, c_key, c_value);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     free(c_key);

--- a/ompi/mpi/fortran/mpif-h/init_f.c
+++ b/ompi/mpi/fortran/mpif-h/init_f.c
@@ -82,6 +82,6 @@ void ompi_init_f( MPI_Fint *ierr )
     char **argv = NULL;
 
     ompi_fptr_init(0);
-    c_ierr = PMPI_Init( &argc, &argv );
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Init)( &argc, &argv );
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/init_f.c
+++ b/ompi/mpi/fortran/mpif-h/init_f.c
@@ -81,6 +81,7 @@ void ompi_init_f( MPI_Fint *ierr )
     int argc = 0;
     char **argv = NULL;
 
+    ompi_fptr_init(0);
     c_ierr = PMPI_Init( &argc, &argv );
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/init_thread_f.c
+++ b/ompi/mpi/fortran/mpif-h/init_thread_f.c
@@ -74,7 +74,7 @@ void ompi_init_thread_f( MPI_Fint *required, MPI_Fint *provided, MPI_Fint *ierr 
     OMPI_SINGLE_NAME_DECL(provided);
 
     ompi_fptr_init(0);
-    c_ierr = PMPI_Init_thread(&argc, &argv,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Init_thread)(&argc, &argv,
                              OMPI_FINT_2_INT(*required),
                              OMPI_SINGLE_NAME_CONVERT(provided));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/init_thread_f.c
+++ b/ompi/mpi/fortran/mpif-h/init_thread_f.c
@@ -73,6 +73,7 @@ void ompi_init_thread_f( MPI_Fint *required, MPI_Fint *provided, MPI_Fint *ierr 
     char** argv = NULL;
     OMPI_SINGLE_NAME_DECL(provided);
 
+    ompi_fptr_init(0);
     c_ierr = PMPI_Init_thread(&argc, &argv,
                              OMPI_FINT_2_INT(*required),
                              OMPI_SINGLE_NAME_CONVERT(provided));

--- a/ompi/mpi/fortran/mpif-h/initialized_f.c
+++ b/ompi/mpi/fortran/mpif-h/initialized_f.c
@@ -71,7 +71,7 @@ void ompi_initialized_f(ompi_fortran_logical_t *flag, MPI_Fint *ierr)
     int c_ierr;
     OMPI_LOGICAL_NAME_DECL(flag);
     ompi_fptr_init(0);
-    c_ierr = PMPI_Initialized(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Initialized)(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/initialized_f.c
+++ b/ompi/mpi/fortran/mpif-h/initialized_f.c
@@ -70,6 +70,7 @@ void ompi_initialized_f(ompi_fortran_logical_t *flag, MPI_Fint *ierr)
 {
     int c_ierr;
     OMPI_LOGICAL_NAME_DECL(flag);
+    ompi_fptr_init(0);
     c_ierr = PMPI_Initialized(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/intercomm_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/intercomm_create_f.c
@@ -77,7 +77,7 @@ void ompi_intercomm_create_f(MPI_Fint *local_comm, MPI_Fint *local_leader,
     MPI_Comm c_local_comm = PMPI_Comm_f2c (*local_comm );
     MPI_Comm c_bridge_comm = PMPI_Comm_f2c (*bridge_comm);
 
-    c_ierr = PMPI_Intercomm_create(c_local_comm,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Intercomm_create)(c_local_comm,
                                   OMPI_FINT_2_INT(*local_leader),
                                   c_bridge_comm,
                                   OMPI_FINT_2_INT(*remote_leader),

--- a/ompi/mpi/fortran/mpif-h/intercomm_merge_f.c
+++ b/ompi/mpi/fortran/mpif-h/intercomm_merge_f.c
@@ -73,7 +73,7 @@ void ompi_intercomm_merge_f(MPI_Fint *intercomm, ompi_fortran_logical_t *high,
     MPI_Comm c_newcomm;
     MPI_Comm c_intercomm = PMPI_Comm_f2c(*intercomm);
 
-    c_ierr = PMPI_Intercomm_merge(c_intercomm, OMPI_LOGICAL_2_INT(*high),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Intercomm_merge)(c_intercomm, OMPI_LOGICAL_2_INT(*high),
                                   &c_newcomm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/iprobe_f.c
+++ b/ompi/mpi/fortran/mpif-h/iprobe_f.c
@@ -82,7 +82,7 @@ void ompi_iprobe_f(MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_Iprobe(OMPI_FINT_2_INT(*source),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Iprobe)(OMPI_FINT_2_INT(*source),
                         OMPI_FINT_2_INT(*tag),
                         c_comm, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                         c_status);

--- a/ompi/mpi/fortran/mpif-h/irecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/irecv_f.c
@@ -78,7 +78,7 @@ void ompi_irecv_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Irecv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Irecv)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                       c_type, OMPI_FINT_2_INT(*source),
                       OMPI_FINT_2_INT(*tag), c_comm, &c_req);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/ireduce_f.c
+++ b/ompi/mpi/fortran/mpif-h/ireduce_f.c
@@ -86,7 +86,7 @@ void ompi_ireduce_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ireduce(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ireduce)(sendbuf, recvbuf,
                          OMPI_FINT_2_INT(*count),
                          c_type, c_op,
                          OMPI_FINT_2_INT(*root),

--- a/ompi/mpi/fortran/mpif-h/ireduce_scatter_block_f.c
+++ b/ompi/mpi/fortran/mpif-h/ireduce_scatter_block_f.c
@@ -89,7 +89,7 @@ void ompi_ireduce_scatter_block_f(char *sendbuf, char *recvbuf,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ireduce_scatter_block(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ireduce_scatter_block)(sendbuf, recvbuf,
                                        OMPI_FINT_2_INT(*recvcount),
                                        c_type, c_op, c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/ireduce_scatter_f.c
+++ b/ompi/mpi/fortran/mpif-h/ireduce_scatter_f.c
@@ -91,7 +91,7 @@ void ompi_ireduce_scatter_f(char *sendbuf, char *recvbuf,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Ireduce_scatter(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Ireduce_scatter)(sendbuf, recvbuf,
                                  OMPI_ARRAY_NAME_CONVERT(recvcounts),
                                  c_type, c_op, c_comm, &c_request);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/irsend_f.c
+++ b/ompi/mpi/fortran/mpif-h/irsend_f.c
@@ -76,7 +76,7 @@ void ompi_irsend_f(char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *des
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Irsend(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Irsend)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                        c_type, OMPI_FINT_2_INT(*dest),
                        OMPI_FINT_2_INT(*tag), c_comm,
                        &c_req);

--- a/ompi/mpi/fortran/mpif-h/is_thread_main_f.c
+++ b/ompi/mpi/fortran/mpif-h/is_thread_main_f.c
@@ -71,7 +71,7 @@ void ompi_is_thread_main_f(ompi_fortran_logical_t *flag, MPI_Fint *ierr)
     int c_ierr;
     OMPI_LOGICAL_NAME_DECL(flag);
 
-    c_ierr = PMPI_Is_thread_main(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Is_thread_main)(OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/iscan_f.c
+++ b/ompi/mpi/fortran/mpif-h/iscan_f.c
@@ -85,7 +85,7 @@ void ompi_iscan_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Iscan(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Iscan)(sendbuf, recvbuf,
                        OMPI_FINT_2_INT(*count),
                        c_type, c_op,
                        c_comm, &c_request);

--- a/ompi/mpi/fortran/mpif-h/iscatter_f.c
+++ b/ompi/mpi/fortran/mpif-h/iscatter_f.c
@@ -85,7 +85,7 @@ void ompi_iscatter_f(char *sendbuf, MPI_Fint *sendcount,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Iscatter(sendbuf,OMPI_FINT_2_INT(*sendcount),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Iscatter)(sendbuf,OMPI_FINT_2_INT(*sendcount),
                           c_sendtype, recvbuf,
                           OMPI_FINT_2_INT(*recvcount),
                           c_recvtype,

--- a/ompi/mpi/fortran/mpif-h/iscatterv_f.c
+++ b/ompi/mpi/fortran/mpif-h/iscatterv_f.c
@@ -92,7 +92,7 @@ void ompi_iscatterv_f(char *sendbuf, MPI_Fint *sendcounts,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Iscatterv(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Iscatterv)(sendbuf,
                            OMPI_ARRAY_NAME_CONVERT(sendcounts),
                            OMPI_ARRAY_NAME_CONVERT(displs),
                            c_sendtype, recvbuf,

--- a/ompi/mpi/fortran/mpif-h/isend_f.c
+++ b/ompi/mpi/fortran/mpif-h/isend_f.c
@@ -76,7 +76,7 @@ void ompi_isend_f(char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Isend(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Isend)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag),
                       c_comm, &c_req);

--- a/ompi/mpi/fortran/mpif-h/issend_f.c
+++ b/ompi/mpi/fortran/mpif-h/issend_f.c
@@ -76,7 +76,7 @@ void ompi_issend_f(char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *des
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Issend(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Issend)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                        c_type, OMPI_FINT_2_INT(*dest),
                        OMPI_FINT_2_INT(*tag),
                        c_comm, &c_req);

--- a/ompi/mpi/fortran/mpif-h/keyval_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/keyval_free_f.c
@@ -73,7 +73,7 @@ void ompi_keyval_free_f(MPI_Fint *keyval, MPI_Fint *ierr)
 
     OMPI_SINGLE_FINT_2_INT(keyval);
 
-    c_ierr = PMPI_Keyval_free(OMPI_SINGLE_NAME_CONVERT(keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Keyval_free)(OMPI_SINGLE_NAME_CONVERT(keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/lookup_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/lookup_name_f.c
@@ -85,7 +85,7 @@ void ompi_lookup_name_f(char *service_name, MPI_Fint *info,
 	return;
     }
 
-    c_ierr = PMPI_Lookup_name(c_service_name, c_info, c_port_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Lookup_name)(c_service_name, c_info, c_port_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if ( MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/mkcode.pl
+++ b/ompi/mpi/fortran/mpif-h/mkcode.pl
@@ -1,0 +1,135 @@
+#!/usr/bin/perl
+
+# Expects input in flist to be a bunch of C functions like
+# int MPI_Send(void*, int, MPI_Datatype, int, int, MPI_Comm);
+
+# Print to files, declaring, defining and seting function
+# pointers for ompi_fptr_MPI_Send etc:
+#   - constructed_fptr_declarations.h
+#   - constructed_fptr_definitions.h
+#   - constructed_fptr_assignments_MPI.h
+#   - constructed_fptr_assignments_PMPI.h
+
+sub main {
+    $file = "flist";
+    open $fh, "< $file";
+
+    $file = "constructed_fptr_declarations.h";
+    open $fh1, "> $file";
+    $file = "constructed_fptr_definitions.h";
+    open $fh2, "> $file";
+    $file = "constructed_fptr_assignments_MPI.h";
+    open $fh3, "> $file";
+    $file = "constructed_fptr_assignments_PMPI.h";
+    open $fh4, "> $file";
+
+# Start constructed_fptr_declarations.h with a
+# #define OMPI_FORTRAN_FPTR(fn) ompi_fptr_ ## fn
+# that the various send_f.c files will use
+# This way a configure-time option could be made to disable this feature completely.
+
+    print $fh1 <<"EODATA";
+// At some point the below might become something configurable
+#define OMPI_FORTRAN_USE_FPTR 1
+
+#if OMPI_FORTRAN_USE_FPTR
+#define OMPI_FORTRAN_FPTR(fn) ompi_fptr_ ## fn
+#else
+#define OMPI_FORTRAN_FPTR(fn) P ## fn
+#endif
+
+EODATA
+
+    while ($line = <$fh>) {
+        chomp $line;
+        $oline = $line;
+
+        $ret_type = $line;
+        $ret_type =~ s/ .*$//;
+        $line =~ s/[^ ]* *//; # line should be sitting at "MPI_Foo..." now
+        $func_name = $line;
+        $func_name =~ s/\(.*//;
+        $line =~ s/[^(]*\(*//; # line should be sitting at "type, type, ..." now
+        @type_list = ();
+        while (!($line =~ /^\)/)) {
+            $type = $line;
+            $type =~ s/^\s*//;
+            $type =~ s/\s*([,)])/$1/;
+            $type =~ s/\s*([A-Za-z_\[\]0-9 ]* *\**)[,)].*/$1/;
+            $type =~ s/  */ /g;
+            $type =~ s/ \*/\*/g;
+            if ($type ne "void") {
+                @type_list = (@type_list, $type);
+            }
+            $line =~ s/^[^,\)]*//;
+            $line =~ s/^,//;
+        }
+  
+# From @type_list, construct @var_list
+        @var_list = ();
+        @fvar_list = ();
+        $fnstring = 0; # count number of char* that need ints on the end
+        @fstring_indexes = ();
+        for $i (0 .. $#type_list) {
+            $arg = $type_list[$i];
+            @var_list = (@var_list, "v$i");
+        }
+
+# definitions of the function pointer arrays
+        $argdefs = defstring(\@type_list, \@var_list);
+        print $fh1 "extern $ret_type (*ompi_fptr_${func_name})($argdefs);\n";
+        print $fh2 "$ret_type (*ompi_fptr_${func_name})($argdefs);\n";
+
+# assignments for the function pointer arrays
+
+        print $fh3 "ompi_fptr_${func_name} = &${func_name};\n";
+        print $fh4 "ompi_fptr_${func_name} = &P${func_name};\n";
+    }
+    close($fh1);
+    close($fh2);
+    close($fh3);
+    close($fh4);
+    close($fh);
+
+    system("touch constructed_code_done.h");
+}
+
+# Given a type "int" and a var name "v1" output "int v1".
+# Also handle uglier cases like type "int []" to output "int v1[]"
+# and "const char*" to output "const char* v1"
+sub vardecl {
+    my $type = $_[0];
+    my $vname = $_[1];
+    my $decl;
+    if ($type =~ /\[/) {
+        $decl = $type;
+        $decl =~ s/\[/$vname\[/;
+    } else {
+        $decl = "$type $vname";
+    }
+    return $decl;
+}
+
+# input @type_list and @var_list
+# output string like "int v1, int v2, char* v3"
+sub defstring {
+    my @type_list = @{$_[0]};
+    my @var_list = @{$_[1]};
+    my $argdefs;
+    my $i;
+    my $def;
+    my @outlist;
+
+    @outlist = ();
+    for ($i=0; $i<=$#type_list; ++$i) {
+        $def = vardecl($type_list[$i], $var_list[$i]);
+        push(@outlist, $def);
+    }
+    $argdefs = join(", ", @outlist);
+    if ($argdefs eq "") {
+        $argdefs = "void";
+    }
+    return $argdefs;
+}
+
+main();

--- a/ompi/mpi/fortran/mpif-h/mprobe_f.c
+++ b/ompi/mpi/fortran/mpif-h/mprobe_f.c
@@ -86,7 +86,7 @@ void ompi_mprobe_f(MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = OMPI_INT_2_FINT(PMPI_Mprobe(OMPI_FINT_2_INT(*source),
+    c_ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Mprobe)(OMPI_FINT_2_INT(*source),
                                          OMPI_FINT_2_INT(*tag),
                                          c_comm, &c_message,
                                          c_status));

--- a/ompi/mpi/fortran/mpif-h/mrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/mrecv_f.c
@@ -84,7 +84,7 @@ void ompi_mrecv_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
    /* Call the C function */
-   c_ierr = OMPI_INT_2_FINT(PMPI_Mrecv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_INT_2_FINT(OMPI_FORTRAN_FPTR(MPI_Mrecv)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                                        c_type, &c_message,
                                        c_status));
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/neighbor_allgather_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_allgather_f.c
@@ -86,7 +86,7 @@ void ompi_neighbor_allgather_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sen
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Neighbor_allgather(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Neighbor_allgather)(sendbuf,
                                      OMPI_FINT_2_INT(*sendcount),
                                      c_sendtype,
                                      recvbuf,

--- a/ompi/mpi/fortran/mpif-h/neighbor_allgatherv_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_allgatherv_f.c
@@ -92,7 +92,7 @@ void ompi_neighbor_allgatherv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *se
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    ierr_c = PMPI_Neighbor_allgatherv(sendbuf,
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Neighbor_allgatherv)(sendbuf,
                                       OMPI_FINT_2_INT(*sendcount),
                                       c_sendtype,
                                       recvbuf,

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoall_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoall_f.c
@@ -86,7 +86,7 @@ void ompi_neighbor_alltoall_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *send
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Neighbor_alltoall(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Neighbor_alltoall)(sendbuf,
                                    OMPI_FINT_2_INT(*sendcount),
                                    c_sendtype,
                                    recvbuf,

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoallv_f.c
@@ -97,7 +97,7 @@ void ompi_neighbor_alltoallv_f(char *sendbuf, MPI_Fint *sendcounts, MPI_Fint *sd
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Neighbor_alltoallv(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Neighbor_alltoallv)(sendbuf,
                                     OMPI_ARRAY_NAME_CONVERT(sendcounts),
                                     OMPI_ARRAY_NAME_CONVERT(sdispls),
                                     c_sendtype,

--- a/ompi/mpi/fortran/mpif-h/neighbor_alltoallw_f.c
+++ b/ompi/mpi/fortran/mpif-h/neighbor_alltoallw_f.c
@@ -101,7 +101,7 @@ void ompi_neighbor_alltoallw_f(char *sendbuf, MPI_Fint *sendcounts,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Neighbor_alltoallw(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Neighbor_alltoallw)(sendbuf,
                                     OMPI_ARRAY_NAME_CONVERT(sendcounts),
                                     sdispls,
                                     c_sendtypes,

--- a/ompi/mpi/fortran/mpif-h/normalize_mpih.pl
+++ b/ompi/mpi/fortran/mpif-h/normalize_mpih.pl
@@ -1,0 +1,142 @@
+#!/usr/bin/perl
+
+# This script parses mpi.h to stdout of the form
+# int MPI_Send(void *, int, MPI_Datatype, int, int, MPI_Comm);
+# Only parsing out the MPI_* symbols (skip over PMPI).
+
+# args:
+#   /path/to/mpi.h.in
+# which is expected to contain lines of the form
+# OMPI_DECLSPEC  int MPI_Send(const void *buf, int count,
+#                           MPI_Datatype datatype, int dest,
+#                           int tag, MPI_Comm comm);
+
+$mpih = $ARGV[0];
+if ( ! -e $mpih ) {
+    print "Error, input file [$mpih] not found\n";
+    exit(-1);
+}
+
+# Remove all variable names, leaving only recognized types behind,
+# possibly with const in front of them
+sub fixline {
+    my $string = $_[0];
+    my $rvtype;
+    my $mpifunc;
+    my @args;
+    my $arg;
+    my @modargs;
+    my $type;
+    my $stars;
+
+    if ($string !~ /^\s*([A-Za-z0-9_]+)\s+(MPI_[A-Za-z0-9_]+)\s*\(\s*(.*)\s*\).*/) {
+        print "ERROR, unrecognized syntax:\n";
+        print "$string\n";
+        exit(-1);
+    }
+    $rvtype = $1;
+    $mpifunc = $2;
+    @args = split(/\s*,\s*/, $3);
+
+    @modargs = ();
+    for $arg (@args) {
+        $const = 0;
+        if ($arg =~ s/^const\s+//) {
+            $const = 1;
+        }
+        # check for things like
+        #   int *name[]
+        # then
+        #   int *
+        if ($arg =~ /^([A-Za-z0-9_]+)\s+([ *]*)[A-Za-z0-9_]+\s*([ \[\]0-9]*)/) {
+            $type = $1;
+            $stars = "$2$3";
+            $stars =~ s/\s//g;
+        }
+        elsif ($arg =~ /^([A-Za-z0-9_]+)\s*([ *]*)/) {
+            $type = $1;
+            $stars = $2;
+            $stars =~ s/\s//g;
+        }
+        else {
+            print "ERROR, unrecognized arg [$arg]\n";
+            exit(-1);
+        }
+        if ("$stars" ne "") {
+            $stars = " $stars";
+        }
+        if (!$const) {
+            push(@modargs, "$type$stars");
+        } else {
+            push(@modargs, "const $type$stars");
+        }
+
+# This is a long list of acceptable values for $type, but it helps
+# ensure the parsing isn't broken.
+        if (   $type ne "int"
+            && $type ne "void"
+            && $type ne "char"
+            && $type ne "MPI_Comm"
+            && $type ne "MPI_Datatype"
+            && $type ne "MPI_Aint"
+            && $type ne "MPI_Op"
+            && $type ne "MPI_Win"
+            && $type ne "MPI_Request"
+            && $type ne "MPI_Info"
+            && $type ne "MPI_Errhandler"
+            && $type ne "MPI_Handler_function"
+            && $type !~ /MPI_[A-Za-z]*_errhandler_function/
+            && $type !~ /MPI_[A-Za-z]*_copy_attr_function/
+            && $type !~ /MPI_[A-Za-z]*_delete_attr_function/
+            && $type ne "MPI_Group"
+            && $type ne "MPI_Fint"
+            && $type ne "MPI_File"
+            && $type ne "MPI_Offset"
+            && $type ne "MPI_Status"
+            && $type ne "MPI_Count"
+            && $type !~ /MPI_Grequest_[a-z]*_function/
+            && $type ne "MPI_Message"
+            && $type ne "MPI_Copy_function"
+            && $type ne "MPI_Delete_function"
+            && $type ne "MPI_User_function"
+            && $type !~ /MPI_Datarep_[a-z]*_function/
+            && $type ne "MPI_T_enum"
+            && $type ne "MPI_T_cvar_handle"
+            && $type ne "MPI_T_pvar_session"
+            && $type ne "MPI_T_pvar_handle"
+            )
+        {
+            print "ERROR, unrecognized type $type\n";
+            exit(-1);
+        }
+    }
+
+    # ("MPI_Aint", "int", "void", "char", "MPI_Status", "MPI_Datatype", "MPI_Request", "MPI_Comm")
+
+    $string = "$rvtype $mpifunc(" .
+        join(", ", @modargs) . ");";
+
+    return $string;
+}
+
+open $fh, "< $mpih";
+while ($line = <$fh>) {
+    chomp $line;
+    if ($line =~ /^OMPI_DECLSPEC\s+[A-Za-z0-9_]*\s+MPI_[A-Za-z0-9_]* *\(/) {
+        $line =~ s/^OMPI_DECLSPEC\s+//;
+        while (!($line =~ /\)/)) {
+            $more = <$fh>;
+            chomp $more;
+            $line = "$line $more";
+        }
+
+        if ($line =~ /MPI_Pcontrol/) {
+# I don't think a va_list can be passed through to the next level in
+# general.. that's why things like vprintf exist.
+            $line =~ s/, \.\.\.//;
+        }
+        $line = fixline($line);
+        print "$line\n";
+    }
+}
+close($fh);

--- a/ompi/mpi/fortran/mpif-h/op_commutative_f.c
+++ b/ompi/mpi/fortran/mpif-h/op_commutative_f.c
@@ -74,7 +74,7 @@ void ompi_op_commutative_f(MPI_Fint *op, MPI_Fint *commute, MPI_Fint *ierr)
 
     c_op = PMPI_Op_f2c(*op);
 
-    c_ierr = PMPI_Op_commutative(c_op, OMPI_SINGLE_NAME_CONVERT(commute));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Op_commutative)(c_op, OMPI_SINGLE_NAME_CONVERT(commute));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/op_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/op_create_f.c
@@ -75,7 +75,7 @@ void ompi_op_create_f(ompi_op_fortran_handler_fn_t* function, ompi_fortran_logic
     /* See the note in src/mpi/fortran/mpif-h/prototypes_mpi.h about
        the use of (void*) for function pointers in this function */
 
-    c_ierr = PMPI_Op_create((MPI_User_function *) function,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Op_create)((MPI_User_function *) function,
                            OMPI_LOGICAL_2_INT(*commute),
                            &c_op);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/op_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/op_free_f.c
@@ -73,7 +73,7 @@ void ompi_op_free_f(MPI_Fint *op, MPI_Fint *ierr)
 
     c_op = PMPI_Op_f2c(*op);
 
-    c_ierr = PMPI_Op_free(&c_op);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Op_free)(&c_op);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/open_port_f.c
+++ b/ompi/mpi/fortran/mpif-h/open_port_f.c
@@ -75,7 +75,7 @@ void ompi_open_port_f(MPI_Fint *info, char *port_name, MPI_Fint *ierr, int port_
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Open_port(c_info, c_port_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Open_port)(c_info, c_port_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if ( MPI_SUCCESS == c_ierr ) {

--- a/ompi/mpi/fortran/mpif-h/pack_external_f.c
+++ b/ompi/mpi/fortran/mpif-h/pack_external_f.c
@@ -89,7 +89,7 @@ void ompi_pack_external_f(char *datarep, char *inbuf, MPI_Fint *incount,
         return;
     }
 
-    c_ierr = PMPI_Pack_external(c_datarep, OMPI_F2C_BOTTOM(inbuf),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Pack_external)(c_datarep, OMPI_F2C_BOTTOM(inbuf),
                                OMPI_FINT_2_INT(*incount),
                                type, outbuf,
                                *outsize,

--- a/ompi/mpi/fortran/mpif-h/pack_external_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/pack_external_size_f.c
@@ -88,7 +88,7 @@ void ompi_pack_external_size_f(char *datarep, MPI_Fint *incount,
         return;
     }
 
-    c_ierr = PMPI_Pack_external_size(c_datarep,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Pack_external_size)(c_datarep,
                                     OMPI_FINT_2_INT(*incount),
                                     type, size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/pack_f.c
+++ b/ompi/mpi/fortran/mpif-h/pack_f.c
@@ -80,7 +80,7 @@ void ompi_pack_f(char *inbuf, MPI_Fint *incount, MPI_Fint *datatype,
    c_type = PMPI_Type_f2c(*datatype);
    OMPI_SINGLE_FINT_2_INT(position);
 
-   c_ierr = PMPI_Pack(OMPI_F2C_BOTTOM(inbuf), OMPI_FINT_2_INT(*incount),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Pack)(OMPI_F2C_BOTTOM(inbuf), OMPI_FINT_2_INT(*incount),
                      c_type, outbuf,
                      OMPI_FINT_2_INT(*outsize),
                      OMPI_SINGLE_NAME_CONVERT(position),

--- a/ompi/mpi/fortran/mpif-h/pack_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/pack_size_f.c
@@ -77,7 +77,7 @@ void ompi_pack_size_f(MPI_Fint *incount, MPI_Fint *datatype,
     c_comm = PMPI_Comm_f2c(*comm);
     c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = PMPI_Pack_size(OMPI_FINT_2_INT(*incount),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Pack_size)(OMPI_FINT_2_INT(*incount),
                            c_type, c_comm,
                            OMPI_SINGLE_NAME_CONVERT(size));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/pcontrol_f.c
+++ b/ompi/mpi/fortran/mpif-h/pcontrol_f.c
@@ -68,5 +68,5 @@ OMPI_GENERATE_F77_BINDINGS (MPI_PCONTROL,
 
 void ompi_pcontrol_f(MPI_Fint *level)
 {
-    PMPI_Pcontrol(OMPI_FINT_2_INT(*level));
+    OMPI_FORTRAN_FPTR(MPI_Pcontrol)(OMPI_FINT_2_INT(*level));
 }

--- a/ompi/mpi/fortran/mpif-h/probe_f.c
+++ b/ompi/mpi/fortran/mpif-h/probe_f.c
@@ -80,7 +80,7 @@ void ompi_probe_f(MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *sta
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = PMPI_Probe(OMPI_FINT_2_INT(*source),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Probe)(OMPI_FINT_2_INT(*source),
                        OMPI_FINT_2_INT(*tag),
                        c_comm, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -464,3 +464,16 @@ tags:
 TAGS:
 GTAGS:
 ID:
+
+# This causes constructed_code_done.h to be created before the regular
+# makefile rules happen for the rest of the source.
+BUILT_SOURCES = constructed_code_done.h
+
+here_src = $(top_srcdir)/ompi/mpi/fortran/mpif-h
+constructed_code_done.h: $(here_src)/normalize_mpih.pl $(here_src)/mkcode.pl $(top_srcdir)/ompi/include/mpi.h.in
+	rm -f flist && \
+	perl $(here_src)/normalize_mpih.pl $(top_srcdir)/ompi/include/mpi.h.in > flist && \
+	perl $(here_src)/mkcode.pl
+
+clean-local:
+	rm -f constructed_code_*.h

--- a/ompi/mpi/fortran/mpif-h/publish_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/publish_name_f.c
@@ -79,7 +79,7 @@ void ompi_publish_name_f(char *service_name, MPI_Fint *info,
     ompi_fortran_string_f2c(service_name, service_name_len, &c_service_name);
     ompi_fortran_string_f2c(port_name, port_name_len, &c_port_name);
 
-    c_ierr = PMPI_Publish_name(c_service_name, c_info, c_port_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Publish_name)(c_service_name, c_info, c_port_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     free ( c_service_name);

--- a/ompi/mpi/fortran/mpif-h/put_f.c
+++ b/ompi/mpi/fortran/mpif-h/put_f.c
@@ -78,7 +78,7 @@ void ompi_put_f(char *origin_addr, MPI_Fint *origin_count,
    MPI_Datatype c_target_datatype = PMPI_Type_f2c(*target_datatype);
    MPI_Win c_win = PMPI_Win_f2c(*win);
 
-   c_ierr = PMPI_Put(OMPI_F2C_BOTTOM(origin_addr),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Put)(OMPI_F2C_BOTTOM(origin_addr),
                     OMPI_FINT_2_INT(*origin_count),
                     c_origin_datatype,
                     OMPI_FINT_2_INT(*target_rank),

--- a/ompi/mpi/fortran/mpif-h/query_thread_f.c
+++ b/ompi/mpi/fortran/mpif-h/query_thread_f.c
@@ -71,7 +71,7 @@ void ompi_query_thread_f(MPI_Fint *provided, MPI_Fint *ierr)
     int c_ierr;
     OMPI_SINGLE_NAME_DECL(provided);
 
-    c_ierr = PMPI_Query_thread(OMPI_SINGLE_NAME_CONVERT(provided));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Query_thread)(OMPI_SINGLE_NAME_CONVERT(provided));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/raccumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/raccumulate_f.c
@@ -85,7 +85,7 @@ void ompi_raccumulate_f(char *origin_addr, MPI_Fint *origin_count,
     MPI_Op c_op = PMPI_Op_f2c(*op);
     MPI_Request c_req;
 
-    ierr_c = PMPI_Raccumulate(OMPI_F2C_BOTTOM(origin_addr),
+    ierr_c = OMPI_FORTRAN_FPTR(MPI_Raccumulate)(OMPI_F2C_BOTTOM(origin_addr),
                               OMPI_FINT_2_INT(*origin_count),
                               c_origin_datatype,
                               OMPI_FINT_2_INT(*target_rank),

--- a/ompi/mpi/fortran/mpif-h/recv_f.c
+++ b/ompi/mpi/fortran/mpif-h/recv_f.c
@@ -82,7 +82,7 @@ void ompi_recv_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
    /* Call the C function */
-   c_ierr = PMPI_Recv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Recv)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                      c_type, OMPI_FINT_2_INT(*source),
                      OMPI_FINT_2_INT(*tag), c_comm,
                      c_status);

--- a/ompi/mpi/fortran/mpif-h/recv_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/recv_init_f.c
@@ -78,7 +78,7 @@ void ompi_recv_init_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Recv_init(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Recv_init)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                           c_type, OMPI_FINT_2_INT(*source),
                           OMPI_INT_2_FINT(*tag), c_comm,
                           &c_req);

--- a/ompi/mpi/fortran/mpif-h/reduce_f.c
+++ b/ompi/mpi/fortran/mpif-h/reduce_f.c
@@ -84,7 +84,7 @@ void ompi_reduce_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Reduce(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Reduce)(sendbuf, recvbuf,
                         OMPI_FINT_2_INT(*count),
                         c_type, c_op,
                         OMPI_FINT_2_INT(*root),

--- a/ompi/mpi/fortran/mpif-h/reduce_local_f.c
+++ b/ompi/mpi/fortran/mpif-h/reduce_local_f.c
@@ -80,7 +80,7 @@ void ompi_reduce_local_f(char *inbuf, char *inoutbuf, MPI_Fint *count,
     inbuf = (char *) OMPI_F2C_BOTTOM(inbuf);
     inoutbuf = (char *) OMPI_F2C_BOTTOM(inoutbuf);
 
-    c_ierr = PMPI_Reduce_local(inbuf, inoutbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Reduce_local)(inbuf, inoutbuf,
                               OMPI_FINT_2_INT(*count),
                               c_type, c_op);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/reduce_scatter_block_f.c
+++ b/ompi/mpi/fortran/mpif-h/reduce_scatter_block_f.c
@@ -87,7 +87,7 @@ void ompi_reduce_scatter_block_f(char *sendbuf, char *recvbuf,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Reduce_scatter_block(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Reduce_scatter_block)(sendbuf, recvbuf,
                                       OMPI_FINT_2_INT(*recvcount),
                                       c_type, c_op, c_comm);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/reduce_scatter_f.c
+++ b/ompi/mpi/fortran/mpif-h/reduce_scatter_f.c
@@ -89,7 +89,7 @@ void ompi_reduce_scatter_f(char *sendbuf, char *recvbuf,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Reduce_scatter(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Reduce_scatter)(sendbuf, recvbuf,
                                 OMPI_ARRAY_NAME_CONVERT(recvcounts),
                                 c_type, c_op, c_comm);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/register_datarep_f.c
+++ b/ompi/mpi/fortran/mpif-h/register_datarep_f.c
@@ -194,7 +194,7 @@ void ompi_register_datarep_f(char *datarep,
     /* Now that the intercept data has been setup, call the C function
        with the setup intercept routines and the intercept-specific
        data/extra state. */
-    c_ierr = PMPI_Register_datarep(c_datarep,
+    c_ierr = ompi_fptr_MPI_Register_datarep(c_datarep,
                                   read_fn_c, write_fn_c,
                                   extent_intercept_fn,
                                   intercept);

--- a/ompi/mpi/fortran/mpif-h/request_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/request_free_f.c
@@ -71,7 +71,7 @@ void ompi_request_free_f(MPI_Fint *request, MPI_Fint *ierr)
     int c_ierr;
 
     MPI_Request c_req = PMPI_Request_f2c( *request );
-    c_ierr = PMPI_Request_free(&c_req);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Request_free)(&c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/request_get_status_f.c
+++ b/ompi/mpi/fortran/mpif-h/request_get_status_f.c
@@ -81,7 +81,7 @@ void ompi_request_get_status_f(MPI_Fint *request, ompi_fortran_logical_t *flag,
         *flag = OMPI_INT_2_LOGICAL(0);
         c_ierr = MPI_SUCCESS;
     } else {
-        c_ierr = PMPI_Request_get_status(c_req,
+        c_ierr = OMPI_FORTRAN_FPTR(MPI_Request_get_status)(c_req,
                                         OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                                         &c_status);
         OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
+++ b/ompi/mpi/fortran/mpif-h/rget_accumulate_f.c
@@ -88,7 +88,7 @@ void ompi_rget_accumulate_f(char *origin_addr, MPI_Fint *origin_count,
     MPI_Op c_op = PMPI_Op_f2c(*op);
     MPI_Request c_req;
 
-    c_ierr = PMPI_Rget_accumulate(OMPI_F2C_BOTTOM(origin_addr),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Rget_accumulate)(OMPI_F2C_BOTTOM(origin_addr),
                                  OMPI_FINT_2_INT(*origin_count),
                                  c_origin_datatype,
                                  OMPI_F2C_BOTTOM(result_addr),

--- a/ompi/mpi/fortran/mpif-h/rget_f.c
+++ b/ompi/mpi/fortran/mpif-h/rget_f.c
@@ -83,7 +83,7 @@ void ompi_rget_f(char *origin_addr, MPI_Fint *origin_count,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     MPI_Request c_req;
 
-    c_ierr = PMPI_Rget(OMPI_F2C_BOTTOM(origin_addr),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Rget)(OMPI_F2C_BOTTOM(origin_addr),
                       OMPI_FINT_2_INT(*origin_count),
                       c_origin_datatype,
                       OMPI_FINT_2_INT(*target_rank),

--- a/ompi/mpi/fortran/mpif-h/rput_f.c
+++ b/ompi/mpi/fortran/mpif-h/rput_f.c
@@ -83,7 +83,7 @@ void ompi_rput_f(char *origin_addr, MPI_Fint *origin_count,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     MPI_Request c_req;
 
-    c_ierr = PMPI_Rput(OMPI_F2C_BOTTOM(origin_addr),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Rput)(OMPI_F2C_BOTTOM(origin_addr),
                       OMPI_FINT_2_INT(*origin_count),
                       c_origin_datatype,
                       OMPI_FINT_2_INT(*target_rank),

--- a/ompi/mpi/fortran/mpif-h/rsend_f.c
+++ b/ompi/mpi/fortran/mpif-h/rsend_f.c
@@ -76,7 +76,7 @@ void ompi_rsend_f(char *ibuf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Rsend(OMPI_F2C_BOTTOM(ibuf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Rsend)(OMPI_F2C_BOTTOM(ibuf), OMPI_FINT_2_INT(*count),
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag), c_comm);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/rsend_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/rsend_init_f.c
@@ -79,7 +79,7 @@ void ompi_rsend_init_f(char *buf, MPI_Fint *count,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Rsend_init(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Rsend_init)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                            c_type, OMPI_FINT_2_INT(*dest),
                            OMPI_FINT_2_INT(*tag),
                            c_comm, &c_req);

--- a/ompi/mpi/fortran/mpif-h/scan_f.c
+++ b/ompi/mpi/fortran/mpif-h/scan_f.c
@@ -84,7 +84,7 @@ void ompi_scan_f(char *sendbuf, char *recvbuf, MPI_Fint *count,
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Scan(sendbuf, recvbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Scan)(sendbuf, recvbuf,
                       OMPI_FINT_2_INT(*count),
                       c_type, c_op,
                       c_comm);

--- a/ompi/mpi/fortran/mpif-h/scatter_f.c
+++ b/ompi/mpi/fortran/mpif-h/scatter_f.c
@@ -83,7 +83,7 @@ void ompi_scatter_f(char *sendbuf, MPI_Fint *sendcount,
     recvbuf = (char *) OMPI_F2C_IN_PLACE(recvbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Scatter(sendbuf,OMPI_FINT_2_INT(*sendcount),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Scatter)(sendbuf,OMPI_FINT_2_INT(*sendcount),
                          c_sendtype, recvbuf,
                          OMPI_FINT_2_INT(*recvcount),
                          c_recvtype,

--- a/ompi/mpi/fortran/mpif-h/scatterv_f.c
+++ b/ompi/mpi/fortran/mpif-h/scatterv_f.c
@@ -91,7 +91,7 @@ void ompi_scatterv_f(char *sendbuf, MPI_Fint *sendcounts,
     recvbuf = (char *) OMPI_F2C_IN_PLACE(recvbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
-    c_ierr = PMPI_Scatterv(sendbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Scatterv)(sendbuf,
                           OMPI_ARRAY_NAME_CONVERT(sendcounts),
                           OMPI_ARRAY_NAME_CONVERT(displs),
                           c_sendtype, recvbuf,

--- a/ompi/mpi/fortran/mpif-h/send_f.c
+++ b/ompi/mpi/fortran/mpif-h/send_f.c
@@ -75,7 +75,7 @@ void ompi_send_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
     MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = PMPI_Send(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Send)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag), c_comm);
 

--- a/ompi/mpi/fortran/mpif-h/send_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/send_init_f.c
@@ -78,7 +78,7 @@ void ompi_send_init_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Send_init(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Send_init)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                           c_type, OMPI_FINT_2_INT(*dest),
                           OMPI_FINT_2_INT(*tag),
                           c_comm, &c_req);

--- a/ompi/mpi/fortran/mpif-h/sendrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/sendrecv_f.c
@@ -81,7 +81,7 @@ void ompi_sendrecv_f(char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Sendrecv(OMPI_F2C_BOTTOM(sendbuf), OMPI_FINT_2_INT(*sendcount),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Sendrecv)(OMPI_F2C_BOTTOM(sendbuf), OMPI_FINT_2_INT(*sendcount),
                          c_sendtype,
                          OMPI_FINT_2_INT(*dest),
                          OMPI_FINT_2_INT(*sendtag),

--- a/ompi/mpi/fortran/mpif-h/sendrecv_replace_f.c
+++ b/ompi/mpi/fortran/mpif-h/sendrecv_replace_f.c
@@ -79,7 +79,7 @@ void ompi_sendrecv_replace_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Sendrecv_replace(OMPI_F2C_BOTTOM(buf),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Sendrecv_replace)(OMPI_F2C_BOTTOM(buf),
                                  OMPI_FINT_2_INT(*count),
                                  c_type,
                                  OMPI_FINT_2_INT(*dest),

--- a/ompi/mpi/fortran/mpif-h/ssend_f.c
+++ b/ompi/mpi/fortran/mpif-h/ssend_f.c
@@ -77,7 +77,7 @@ void ompi_ssend_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Ssend(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Ssend)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                       c_type, OMPI_FINT_2_INT(*dest),
                       OMPI_FINT_2_INT(*tag), c_comm);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/ssend_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/ssend_init_f.c
@@ -78,7 +78,7 @@ void ompi_ssend_init_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_comm = PMPI_Comm_f2c (*comm);
 
-   c_ierr = PMPI_Ssend_init(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Ssend_init)(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
                            c_type, OMPI_FINT_2_INT(*dest),
                            OMPI_FINT_2_INT(*tag),
                            c_comm, &c_req);

--- a/ompi/mpi/fortran/mpif-h/start_f.c
+++ b/ompi/mpi/fortran/mpif-h/start_f.c
@@ -72,7 +72,7 @@ void ompi_start_f(MPI_Fint *request, MPI_Fint *ierr)
     MPI_Request c_req = PMPI_Request_f2c(*request);
     MPI_Request tmp_req = c_req;
 
-    c_ierr = PMPI_Start(&c_req);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Start)(&c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/startall_f.c
+++ b/ompi/mpi/fortran/mpif-h/startall_f.c
@@ -90,7 +90,7 @@ void ompi_startall_f(MPI_Fint *count, MPI_Fint *array_of_requests,
         c_req[i] = PMPI_Request_f2c(array_of_requests[i]);
     }
 
-    c_ierr = PMPI_Startall(OMPI_FINT_2_INT(*count), c_req);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Startall)(OMPI_FINT_2_INT(*count), c_req);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     for( i = 0; i < *count; i++ ) {

--- a/ompi/mpi/fortran/mpif-h/status_set_cancelled_f.c
+++ b/ompi/mpi/fortran/mpif-h/status_set_cancelled_f.c
@@ -79,7 +79,7 @@ void ompi_status_set_cancelled_f(MPI_Fint *status, ompi_fortran_logical_t *flag,
     } else {
         PMPI_Status_f2c( status, &c_status );
 
-        c_ierr = PMPI_Status_set_cancelled(&c_status,
+        c_ierr = OMPI_FORTRAN_FPTR(MPI_Status_set_cancelled)(&c_status,
                                           OMPI_LOGICAL_2_INT(*flag));
         if (MPI_SUCCESS == c_ierr) {
             PMPI_Status_c2f(&c_status, status);

--- a/ompi/mpi/fortran/mpif-h/status_set_elements_f.c
+++ b/ompi/mpi/fortran/mpif-h/status_set_elements_f.c
@@ -81,7 +81,7 @@ void ompi_status_set_elements_f(MPI_Fint *status, MPI_Fint *datatype,
     } else {
         PMPI_Status_f2c( status, &c_status );
 
-        c_ierr = PMPI_Status_set_elements(&c_status, c_type,
+        c_ierr = OMPI_FORTRAN_FPTR(MPI_Status_set_elements)(&c_status, c_type,
                                          OMPI_FINT_2_INT(*count));
 
         /* If datatype is really being set, then that needs to be

--- a/ompi/mpi/fortran/mpif-h/status_set_elements_x_f.c
+++ b/ompi/mpi/fortran/mpif-h/status_set_elements_x_f.c
@@ -83,7 +83,7 @@ void ompi_status_set_elements_x_f(MPI_Fint *status, MPI_Fint *datatype,
     } else {
         PMPI_Status_f2c( status, &c_status );
 
-        c_ierr = PMPI_Status_set_elements_x(&c_status, c_type, *count);
+        c_ierr = OMPI_FORTRAN_FPTR(MPI_Status_set_elements_x)(&c_status, c_type, *count);
 
         /* If datatype is really being set, then that needs to be
            converted.... */

--- a/ompi/mpi/fortran/mpif-h/test_cancelled_f.c
+++ b/ompi/mpi/fortran/mpif-h/test_cancelled_f.c
@@ -82,7 +82,7 @@ void ompi_test_cancelled_f(MPI_Fint *status, ompi_fortran_logical_t *flag, MPI_F
         c_ierr = PMPI_Status_f2c( status, &c_status );
 
         if (MPI_SUCCESS == c_ierr) {
-            c_ierr = PMPI_Test_cancelled(&c_status,
+            c_ierr = OMPI_FORTRAN_FPTR(MPI_Test_cancelled)(&c_status,
                                         OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
 
             OMPI_SINGLE_INT_2_LOGICAL(flag);

--- a/ompi/mpi/fortran/mpif-h/test_f.c
+++ b/ompi/mpi/fortran/mpif-h/test_f.c
@@ -75,7 +75,7 @@ void ompi_test_f(MPI_Fint *request, ompi_fortran_logical_t *flag,
     MPI_Status c_status;
     OMPI_LOGICAL_NAME_DECL(flag);
 
-    c_ierr = PMPI_Test(&c_req,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Test)(&c_req,
                       OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                       &c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/testall_f.c
+++ b/ompi/mpi/fortran/mpif-h/testall_f.c
@@ -100,7 +100,7 @@ void ompi_testall_f(MPI_Fint *count, MPI_Fint *array_of_requests, ompi_fortran_l
         c_req[i] = PMPI_Request_f2c(array_of_requests[i]);
     }
 
-    c_ierr = PMPI_Testall(OMPI_FINT_2_INT(*count), c_req,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Testall)(OMPI_FINT_2_INT(*count), c_req,
                          OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                          c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/testany_f.c
+++ b/ompi/mpi/fortran/mpif-h/testany_f.c
@@ -103,7 +103,7 @@ void ompi_testany_f(MPI_Fint *count, MPI_Fint *array_of_requests, MPI_Fint *indx
         c_req[i] = PMPI_Request_f2c(array_of_requests[i]);
     }
 
-    c_ierr = PMPI_Testany(OMPI_FINT_2_INT(*count), c_req,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Testany)(OMPI_FINT_2_INT(*count), c_req,
                          OMPI_SINGLE_NAME_CONVERT(indx),
                          OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
                          &c_status);

--- a/ompi/mpi/fortran/mpif-h/testsome_f.c
+++ b/ompi/mpi/fortran/mpif-h/testsome_f.c
@@ -106,7 +106,7 @@ void ompi_testsome_f(MPI_Fint *incount, MPI_Fint *array_of_requests,
     }
 
     OMPI_ARRAY_FINT_2_INT_ALLOC(array_of_indices, OMPI_FINT_2_INT(*incount));
-    c_ierr = PMPI_Testsome(OMPI_FINT_2_INT(*incount), c_req,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Testsome)(OMPI_FINT_2_INT(*incount), c_req,
                           OMPI_SINGLE_NAME_CONVERT(outcount),
                           OMPI_ARRAY_NAME_CONVERT(array_of_indices),
                           c_status);

--- a/ompi/mpi/fortran/mpif-h/topo_test_f.c
+++ b/ompi/mpi/fortran/mpif-h/topo_test_f.c
@@ -75,7 +75,7 @@ void ompi_topo_test_f(MPI_Fint *comm, MPI_Fint *topo_type, MPI_Fint *ierr)
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Topo_test(c_comm, OMPI_SINGLE_NAME_CONVERT(topo_type));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Topo_test)(c_comm, OMPI_SINGLE_NAME_CONVERT(topo_type));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_commit_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_commit_f.c
@@ -71,7 +71,7 @@ void ompi_type_commit_f(MPI_Fint *type, MPI_Fint *ierr)
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
 
-    c_ierr = PMPI_Type_commit(&c_type);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_commit)(&c_type);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_contiguous_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_contiguous_f.c
@@ -73,7 +73,7 @@ void ompi_type_contiguous_f(MPI_Fint *count, MPI_Fint *oldtype,
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
 
-    c_ierr = PMPI_Type_contiguous(OMPI_FINT_2_INT(*count), c_old, &c_new);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_contiguous)(OMPI_FINT_2_INT(*count), c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_create_darray_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_darray_f.c
@@ -86,7 +86,7 @@ void ompi_type_create_darray_f(MPI_Fint *size, MPI_Fint *rank,
     OMPI_ARRAY_FINT_2_INT(darg_array, *ndims);
     OMPI_ARRAY_FINT_2_INT(psize_array, *ndims);
 
-    c_ierr = PMPI_Type_create_darray(OMPI_FINT_2_INT(*size),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_darray)(OMPI_FINT_2_INT(*size),
                                     OMPI_FINT_2_INT(*rank),
                                     OMPI_FINT_2_INT(*ndims),
                                     OMPI_ARRAY_NAME_CONVERT(gsize_array),

--- a/ompi/mpi/fortran/mpif-h/type_create_f90_complex_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_f90_complex_f.c
@@ -72,7 +72,7 @@ void ompi_type_create_f90_complex_f(MPI_Fint *p, MPI_Fint *r,
     int c_ierr;
     MPI_Datatype c_newtype = PMPI_Type_f2c(*newtype);
 
-    c_ierr = PMPI_Type_create_f90_complex(OMPI_FINT_2_INT(*p),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_f90_complex)(OMPI_FINT_2_INT(*p),
                                          OMPI_FINT_2_INT(*r),
                                          &c_newtype);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/type_create_f90_integer_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_f90_integer_f.c
@@ -72,7 +72,7 @@ void ompi_type_create_f90_integer_f(MPI_Fint *r, MPI_Fint *newtype,
     int c_ierr;
     MPI_Datatype c_new = PMPI_Type_f2c(*newtype);
 
-    c_ierr = PMPI_Type_create_f90_integer(OMPI_FINT_2_INT(*r), &c_new);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_f90_integer)(OMPI_FINT_2_INT(*r), &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_create_f90_real_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_f90_real_f.c
@@ -72,7 +72,7 @@ void ompi_type_create_f90_real_f(MPI_Fint *p, MPI_Fint *r,
     int c_ierr;
     MPI_Datatype c_new = PMPI_Type_f2c(*newtype);
 
-    c_ierr = PMPI_Type_create_f90_real(OMPI_FINT_2_INT(*p),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_f90_real)(OMPI_FINT_2_INT(*p),
                                       OMPI_FINT_2_INT(*r),
                                       &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/type_create_hindexed_block_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_hindexed_block_f.c
@@ -68,7 +68,7 @@ void ompi_type_create_hindexed_block_f(MPI_Fint *count, MPI_Fint *blocklength,
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
 
-    c_ierr = PMPI_Type_create_hindexed_block(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_hindexed_block)(OMPI_FINT_2_INT(*count),
 			OMPI_FINT_2_INT(*blocklength),
 			array_of_displacements,
                         c_old, &c_new);

--- a/ompi/mpi/fortran/mpif-h/type_create_hindexed_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_hindexed_f.c
@@ -80,7 +80,7 @@ void ompi_type_create_hindexed_f(MPI_Fint *count,
 
     OMPI_ARRAY_FINT_2_INT(array_of_blocklengths, *count);
 
-    c_ierr = PMPI_Type_create_hindexed(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_hindexed)(OMPI_FINT_2_INT(*count),
                                 OMPI_ARRAY_NAME_CONVERT(array_of_blocklengths),
                                 array_of_displacements, c_old,
                                 &c_new);

--- a/ompi/mpi/fortran/mpif-h/type_create_indexed_block_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_indexed_block_f.c
@@ -78,7 +78,7 @@ void ompi_type_create_indexed_block_f(MPI_Fint *count, MPI_Fint *blocklength,
 
     OMPI_ARRAY_FINT_2_INT(array_of_displacements, *count);
 
-    c_ierr = PMPI_Type_create_indexed_block(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_indexed_block)(OMPI_FINT_2_INT(*count),
 			OMPI_FINT_2_INT(*blocklength),
 			OMPI_ARRAY_NAME_CONVERT(array_of_displacements),
                         c_old, &c_new);

--- a/ompi/mpi/fortran/mpif-h/type_create_resized_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_resized_f.c
@@ -74,7 +74,7 @@ void ompi_type_create_resized_f(MPI_Fint *oldtype, MPI_Aint *lb,
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
     MPI_Datatype c_new;
 
-    c_ierr = PMPI_Type_create_resized(c_old, *lb, *extent, &c_new);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_resized)(c_old, *lb, *extent, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_create_struct_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_struct_f.c
@@ -96,7 +96,7 @@ void ompi_type_create_struct_f(MPI_Fint *count,
 
     OMPI_ARRAY_FINT_2_INT(array_of_block_lengths, *count);
 
-    c_ierr = PMPI_Type_create_struct(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_struct)(OMPI_FINT_2_INT(*count),
 			   OMPI_ARRAY_NAME_CONVERT(array_of_block_lengths),
                            array_of_displacements, c_type_old_array, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/type_create_subarray_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_subarray_f.c
@@ -85,7 +85,7 @@ void ompi_type_create_subarray_f(MPI_Fint *ndims, MPI_Fint *size_array,
     OMPI_ARRAY_FINT_2_INT(subsize_array, *ndims);
     OMPI_ARRAY_FINT_2_INT(start_array, *ndims);
 
-    c_ierr = PMPI_Type_create_subarray(OMPI_FINT_2_INT(*ndims),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_create_subarray)(OMPI_FINT_2_INT(*ndims),
                                       OMPI_ARRAY_NAME_CONVERT(size_array),
                                       OMPI_ARRAY_NAME_CONVERT(subsize_array),
                                       OMPI_ARRAY_NAME_CONVERT(start_array),

--- a/ompi/mpi/fortran/mpif-h/type_delete_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_delete_attr_f.c
@@ -72,6 +72,6 @@ void ompi_type_delete_attr_f(MPI_Fint *type, MPI_Fint *type_keyval,
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
 
-    c_ierr = PMPI_Type_delete_attr(c_type, OMPI_FINT_2_INT(*type_keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_delete_attr)(c_type, OMPI_FINT_2_INT(*type_keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/type_dup_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_dup_f.c
@@ -72,7 +72,7 @@ void ompi_type_dup_f(MPI_Fint *type, MPI_Fint *newtype, MPI_Fint *ierr)
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
     MPI_Datatype c_new;
 
-    c_ierr = PMPI_Type_dup(c_type, &c_new);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_dup)(c_type, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_extent_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_extent_f.c
@@ -72,7 +72,7 @@ void ompi_type_extent_f(MPI_Fint *type, MPI_Fint *extent, MPI_Fint *ierr)
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
     MPI_Aint c_extent;
 
-    c_ierr = PMPI_Type_extent(c_type, &c_extent);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_extent)(c_type, &c_extent);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_free_f.c
@@ -73,7 +73,7 @@ void ompi_type_free_f(MPI_Fint *type, MPI_Fint *ierr)
 
     c_type = PMPI_Type_f2c(*type);
 
-    c_ierr = PMPI_Type_free(&c_type);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_free)(&c_type);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_free_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_free_keyval_f.c
@@ -73,7 +73,7 @@ void ompi_type_free_keyval_f(MPI_Fint *type_keyval, MPI_Fint *ierr)
 
     OMPI_SINGLE_FINT_2_INT(type_keyval);
 
-    c_ierr = PMPI_Type_free_keyval(OMPI_SINGLE_NAME_CONVERT(type_keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_free_keyval)(OMPI_SINGLE_NAME_CONVERT(type_keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_get_contents_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_contents_f.c
@@ -109,7 +109,7 @@ void ompi_type_get_contents_f(MPI_Fint *mtype, MPI_Fint *max_integers,
 
     OMPI_ARRAY_FINT_2_INT(array_of_integers, *max_integers);
 
-    c_ierr = PMPI_Type_get_contents(c_mtype,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_get_contents)(c_mtype,
                                    OMPI_FINT_2_INT(*max_integers),
                                    OMPI_FINT_2_INT(*max_addresses),
                                    OMPI_FINT_2_INT(*max_datatypes),

--- a/ompi/mpi/fortran/mpif-h/type_get_envelope_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_envelope_f.c
@@ -78,7 +78,7 @@ void ompi_type_get_envelope_f(MPI_Fint *type, MPI_Fint *num_integers,
     OMPI_SINGLE_NAME_DECL(num_datatypes);
     OMPI_SINGLE_NAME_DECL(combiner);
 
-    c_ierr = PMPI_Type_get_envelope(c_type,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_get_envelope)(c_type,
                                    OMPI_SINGLE_NAME_CONVERT(num_integers),
                                    OMPI_SINGLE_NAME_CONVERT(num_addresses),
                                    OMPI_SINGLE_NAME_CONVERT(num_datatypes),

--- a/ompi/mpi/fortran/mpif-h/type_get_extent_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_extent_f.c
@@ -72,6 +72,6 @@ void ompi_type_get_extent_f(MPI_Fint *type, MPI_Aint *lb,
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
 
-    c_ierr = PMPI_Type_get_extent(c_type, lb, extent);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_get_extent)(c_type, lb, extent);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/type_get_extent_x_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_extent_x_f.c
@@ -74,6 +74,6 @@ void ompi_type_get_extent_x_f(MPI_Fint *type, MPI_Count *lb,
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
 
-    c_ierr = PMPI_Type_get_extent_x(c_type, lb, extent);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_get_extent_x)(c_type, lb, extent);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/type_get_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_name_f.c
@@ -74,7 +74,7 @@ void ompi_type_get_name_f(MPI_Fint *type, char *type_name, MPI_Fint *resultlen, 
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
     char c_name[MPI_MAX_OBJECT_NAME];
 
-    c_ierr = PMPI_Type_get_name(c_type, c_name, &c_len);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_get_name)(c_type, c_name, &c_len);
     if (MPI_SUCCESS == c_ierr) {
         ompi_fortran_string_c2f(c_name, type_name, name_len);
         *resultlen = OMPI_INT_2_FINT(c_len);

--- a/ompi/mpi/fortran/mpif-h/type_get_true_extent_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_true_extent_f.c
@@ -71,6 +71,6 @@ void ompi_type_get_true_extent_f(MPI_Fint *datatype, MPI_Aint *true_lb, MPI_Aint
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = PMPI_Type_get_true_extent(c_type, true_lb, true_extent);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_get_true_extent)(c_type, true_lb, true_extent);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/type_get_true_extent_x_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_get_true_extent_x_f.c
@@ -73,6 +73,6 @@ void ompi_type_get_true_extent_x_f(MPI_Fint *datatype, MPI_Count *true_lb, MPI_C
     int c_ierr;
     MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
-    c_ierr = PMPI_Type_get_true_extent_x(c_type, true_lb, true_extent);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_get_true_extent_x)(c_type, true_lb, true_extent);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/type_hindexed_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_hindexed_f.c
@@ -94,7 +94,7 @@ void ompi_type_hindexed_f(MPI_Fint *count, MPI_Fint *array_of_blocklengths,
 
     OMPI_ARRAY_FINT_2_INT(array_of_blocklengths, *count);
 
-    c_ierr = PMPI_Type_hindexed(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_hindexed)(OMPI_FINT_2_INT(*count),
                                OMPI_ARRAY_NAME_CONVERT(array_of_blocklengths),
                                c_disp_array, c_old, &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/type_hvector_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_hvector_f.c
@@ -75,7 +75,7 @@ void ompi_type_hvector_f(MPI_Fint *count, MPI_Fint *blocklength,
 
     c_oldtype = PMPI_Type_f2c(*oldtype);
 
-    c_ierr = PMPI_Type_hvector(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_hvector)(OMPI_FINT_2_INT(*count),
                               OMPI_FINT_2_INT(*blocklength),
                               (MPI_Aint)*stride,
                               c_oldtype, &c_newtype);

--- a/ompi/mpi/fortran/mpif-h/type_indexed_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_indexed_f.c
@@ -79,7 +79,7 @@ void ompi_type_indexed_f(MPI_Fint *count, MPI_Fint *array_of_blocklengths,
     OMPI_ARRAY_FINT_2_INT(array_of_blocklengths, *count);
     OMPI_ARRAY_FINT_2_INT(array_of_displacements, *count);
 
-    c_ierr = PMPI_Type_indexed(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_indexed)(OMPI_FINT_2_INT(*count),
                               OMPI_ARRAY_NAME_CONVERT(array_of_blocklengths),
                               OMPI_ARRAY_NAME_CONVERT(array_of_displacements),
                               c_old, &c_new);

--- a/ompi/mpi/fortran/mpif-h/type_lb_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_lb_f.c
@@ -72,7 +72,7 @@ void ompi_type_lb_f(MPI_Fint *type, MPI_Fint *lb, MPI_Fint *ierr)
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
     MPI_Aint c_lb;
 
-    c_ierr = PMPI_Type_lb(c_type, &c_lb);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_lb)(c_type, &c_lb);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_set_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_set_name_f.c
@@ -91,7 +91,7 @@ void ompi_type_set_name_f(MPI_Fint *type, char *type_name, MPI_Fint *ierr,
 
     /* Call the C function */
 
-    c_ierr = PMPI_Type_set_name(c_type, c_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_set_name)(c_type, c_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     /* Free the C name */

--- a/ompi/mpi/fortran/mpif-h/type_size_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_size_f.c
@@ -72,7 +72,7 @@ void ompi_type_size_f(MPI_Fint *type, MPI_Fint *size, MPI_Fint *ierr)
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
     OMPI_SINGLE_NAME_DECL(size);
 
-    c_ierr = PMPI_Type_size(c_type, OMPI_SINGLE_NAME_CONVERT(size));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_size)(c_type, OMPI_SINGLE_NAME_CONVERT(size));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_size_x_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_size_x_f.c
@@ -74,6 +74,6 @@ void ompi_type_size_x_f(MPI_Fint *type, MPI_Count *size, MPI_Fint *ierr)
     MPI_Datatype c_type = PMPI_Type_f2c(*type);
     OMPI_SINGLE_NAME_DECL(size);
 
-    c_ierr = PMPI_Type_size_x(c_type, size);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_size_x)(c_type, size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/type_struct_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_struct_f.c
@@ -99,7 +99,7 @@ void ompi_type_struct_f(MPI_Fint *count, MPI_Fint *array_of_blocklengths,
 
     OMPI_ARRAY_FINT_2_INT(array_of_blocklengths, *count);
 
-    c_ierr = PMPI_Type_struct(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_struct)(OMPI_FINT_2_INT(*count),
                              OMPI_ARRAY_NAME_CONVERT(array_of_blocklengths),
                              c_disp_array,
                              c_type_old_array, &c_new);

--- a/ompi/mpi/fortran/mpif-h/type_ub_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_ub_f.c
@@ -72,7 +72,7 @@ void ompi_type_ub_f(MPI_Fint *mtype, MPI_Fint *ub, MPI_Fint *ierr)
     MPI_Datatype c_mtype = PMPI_Type_f2c(*mtype);
     MPI_Aint c_ub;
 
-    c_ierr = PMPI_Type_ub(c_mtype, &c_ub);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_ub)(c_mtype, &c_ub);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/type_vector_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_vector_f.c
@@ -76,7 +76,7 @@ void ompi_type_vector_f(MPI_Fint *count, MPI_Fint *blocklength,
 
     c_old = PMPI_Type_f2c(*oldtype);
 
-    c_ierr = PMPI_Type_vector(OMPI_FINT_2_INT(*count),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Type_vector)(OMPI_FINT_2_INT(*count),
                              OMPI_FINT_2_INT(*blocklength),
                              OMPI_FINT_2_INT(*stride),
                              c_old, &c_new);

--- a/ompi/mpi/fortran/mpif-h/unpack_external_f.c
+++ b/ompi/mpi/fortran/mpif-h/unpack_external_f.c
@@ -91,7 +91,7 @@ void ompi_unpack_external_f (char *datarep, char *inbuf, MPI_Aint *insize,
         return;
     }
 
-    c_ierr = PMPI_Unpack_external(c_datarep, inbuf,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Unpack_external)(c_datarep, inbuf,
                                  *insize,
                                  position,
                                  OMPI_F2C_BOTTOM(outbuf),

--- a/ompi/mpi/fortran/mpif-h/unpack_f.c
+++ b/ompi/mpi/fortran/mpif-h/unpack_f.c
@@ -80,7 +80,7 @@ void ompi_unpack_f(char *inbuf, MPI_Fint *insize, MPI_Fint *position,
    c_type = PMPI_Type_f2c(*datatype);
    OMPI_SINGLE_FINT_2_INT(position);
 
-   c_ierr = PMPI_Unpack(inbuf, OMPI_FINT_2_INT(*insize),
+   c_ierr = OMPI_FORTRAN_FPTR(MPI_Unpack)(inbuf, OMPI_FINT_2_INT(*insize),
                        OMPI_SINGLE_NAME_CONVERT(position),
                        OMPI_F2C_BOTTOM(outbuf), OMPI_FINT_2_INT(*outcount),
                        c_type, c_comm);

--- a/ompi/mpi/fortran/mpif-h/unpublish_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/unpublish_name_f.c
@@ -80,7 +80,7 @@ void ompi_unpublish_name_f(char *service_name, MPI_Fint *info,
     ompi_fortran_string_f2c(service_name, service_name_len, &c_service_name);
     ompi_fortran_string_f2c(port_name, port_name_len, &c_port_name);
 
-    c_ierr = PMPI_Unpublish_name(c_service_name, c_info, c_port_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Unpublish_name)(c_service_name, c_info, c_port_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     free ( c_service_name);

--- a/ompi/mpi/fortran/mpif-h/use_fptrs.c
+++ b/ompi/mpi/fortran/mpif-h/use_fptrs.c
@@ -1,0 +1,78 @@
+#include <mpi.h>
+#include <strings.h>
+#include <stdbool.h>
+
+#include "ompi/include/ompi/constants.h"
+#include "opal/mca/base/mca_base_var.h"
+
+#include "constructed_fptr_definitions.h"
+
+// Most fortran entrypoints mpi_foo() boil down to a C call through
+// a function pointer ompi_fptr_MPI_Foo() which is set to either
+// &MPI_Foo or &PMPI_Foo.
+//
+// We decide which setting to use based on an MCA parameter
+//   --mca mpi_fortcall PMPI   (the default)
+//   --mca mpi_fortcall MPI
+// but it's legal for a few functions (MPI_GET_VERSION,
+// MPI_GET_LIBRARY_VERSION, MPI_INITIALIZED, MPI_FINALIZED)
+// to be called before MPI_Init and thus before the MCA system
+// is setup, so in that case we'll just make a best guess as to
+// what the function pointers should point to.
+//
+// That gray area before MPI_Init where we still need some initial value
+// is what the STATE_PARTIALLY_INTIALIZED below is for.
+
+#define STATE_NOT_INITIALIZED       0
+#define STATE_PARTIALLY_INTIALIZED  1
+#define STATE_INTIALIZED            2
+
+static int ompi_fptr_initialization_state = STATE_NOT_INITIALIZED;
+
+void
+ompi_fptr_init(int mca_system_is_ready) {
+    int use_mpi = 0; // the default is to use PMPI
+
+    if (ompi_fptr_initialization_state == STATE_INTIALIZED) {
+        return;
+    }
+    else if (ompi_fptr_initialization_state == STATE_PARTIALLY_INTIALIZED
+        && !mca_system_is_ready)
+    {
+        return;
+    }
+    else if (ompi_fptr_initialization_state < STATE_INTIALIZED
+        && mca_system_is_ready)
+    {
+        int var_id;
+        const char **value;
+        var_id = mca_base_var_find("ompi", "mpi", NULL, "fortcall");
+        if (0 <= var_id) {
+            int ret = mca_base_var_get_value(var_id, &value, NULL, NULL);
+            if (OMPI_SUCCESS == ret &&
+                value && *value && 0 == strcasecmp(*value, "MPI"))
+            {
+                use_mpi = 1;
+            }
+        }
+
+        ompi_fptr_initialization_state = STATE_INTIALIZED;
+    }
+    else if (ompi_fptr_initialization_state < STATE_PARTIALLY_INTIALIZED
+        && !mca_system_is_ready)
+    {
+        char *p;
+        p = getenv("OMPI_MCA_mpi_fortcall");
+        if (p && *p && 0==strcasecmp(p, "MPI")) {
+            use_mpi = 1;
+        }
+
+        ompi_fptr_initialization_state = STATE_PARTIALLY_INTIALIZED;
+    }
+
+    if (use_mpi) {
+#include "constructed_fptr_assignments_MPI.h"
+    } else {
+#include "constructed_fptr_assignments_PMPI.h"
+    }
+}

--- a/ompi/mpi/fortran/mpif-h/use_fptrs.h
+++ b/ompi/mpi/fortran/mpif-h/use_fptrs.h
@@ -1,0 +1,19 @@
+// The way this is used in the Fortran wrapper C files is
+// code that used to say
+//     int mpi_send(....) {
+//         ...
+//         MPI_Send(....);
+//         ...
+//     }
+// will become
+//     int mpi_send(....) {
+//         ...
+//         ompi_fptr_MPI_Send(....);
+//         ...
+//     }
+// and in the small number of functions that can happen before MPI_Init
+// those functions also get an ompi_fptr_init(0) call added.
+
+#include "constructed_fptr_declarations.h"
+
+void ompi_fptr_init(int mca_system_is_ready);

--- a/ompi/mpi/fortran/mpif-h/wait_f.c
+++ b/ompi/mpi/fortran/mpif-h/wait_f.c
@@ -73,7 +73,7 @@ void ompi_wait_f(MPI_Fint *request, MPI_Fint *status, MPI_Fint *ierr)
     MPI_Request c_req = PMPI_Request_f2c(*request);
     MPI_Status  c_status;
 
-    c_ierr = PMPI_Wait(&c_req, &c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Wait)(&c_req, &c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/waitall_f.c
+++ b/ompi/mpi/fortran/mpif-h/waitall_f.c
@@ -101,7 +101,7 @@ void ompi_waitall_f(MPI_Fint *count, MPI_Fint *array_of_requests,
         c_req[i] = PMPI_Request_f2c(array_of_requests[i]);
     }
 
-    c_ierr = PMPI_Waitall(OMPI_FINT_2_INT(*count), c_req, c_status);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Waitall)(OMPI_FINT_2_INT(*count), c_req, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/waitany_f.c
+++ b/ompi/mpi/fortran/mpif-h/waitany_f.c
@@ -101,7 +101,7 @@ void ompi_waitany_f(MPI_Fint *count, MPI_Fint *array_of_requests,
         c_req[i] = PMPI_Request_f2c(array_of_requests[i]);
     }
 
-    c_ierr = PMPI_Waitany(OMPI_FINT_2_INT(*count), c_req,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Waitany)(OMPI_FINT_2_INT(*count), c_req,
                          OMPI_SINGLE_NAME_CONVERT(indx),
                          &c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/waitsome_f.c
+++ b/ompi/mpi/fortran/mpif-h/waitsome_f.c
@@ -107,7 +107,7 @@ void ompi_waitsome_f(MPI_Fint *incount, MPI_Fint *array_of_requests,
     }
 
     OMPI_ARRAY_FINT_2_INT_ALLOC(array_of_indices, *incount);
-    c_ierr = PMPI_Waitsome(OMPI_FINT_2_INT(*incount), c_req,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Waitsome)(OMPI_FINT_2_INT(*incount), c_req,
                           OMPI_SINGLE_NAME_CONVERT(outcount),
                           OMPI_ARRAY_NAME_CONVERT(array_of_indices),
                           c_status);

--- a/ompi/mpi/fortran/mpif-h/win_allocate_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_allocate_f.c
@@ -119,7 +119,7 @@ void ompi_win_allocate_f(MPI_Aint *size, MPI_Fint *disp_unit,
     c_info = PMPI_Info_f2c(*info);
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Win_allocate(*size, OMPI_FINT_2_INT(*disp_unit),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_allocate)(*size, OMPI_FINT_2_INT(*disp_unit),
                                      c_info, c_comm,
                                      baseptr, &c_win);
     *win = PMPI_Win_c2f(c_win);

--- a/ompi/mpi/fortran/mpif-h/win_allocate_shared_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_allocate_shared_f.c
@@ -119,7 +119,7 @@ void ompi_win_allocate_shared_f(MPI_Aint *size, MPI_Fint *disp_unit,
     c_info = PMPI_Info_f2c(*info);
     c_comm = PMPI_Comm_f2c(*comm);
 
-    c_ierr = PMPI_Win_allocate_shared(*size, OMPI_FINT_2_INT(*disp_unit),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_allocate_shared)(*size, OMPI_FINT_2_INT(*disp_unit),
                                      c_info, c_comm,
                                      baseptr, &c_win);
     *win = PMPI_Win_c2f(c_win);

--- a/ompi/mpi/fortran/mpif-h/win_attach_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_attach_f.c
@@ -62,6 +62,6 @@ void ompi_win_attach_f(MPI_Fint *win, char *base, MPI_Aint *size,
     MPI_Win c_win;
 
     c_win = PMPI_Win_f2c(*win);
-    c_ierr = PMPI_Win_attach(c_win, base, *size);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_attach)(c_win, base, *size);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_call_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_call_errhandler_f.c
@@ -74,6 +74,6 @@ void ompi_win_call_errhandler_f(MPI_Fint *win, MPI_Fint *errorcode,
 
     c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_call_errhandler(c_win, OMPI_FINT_2_INT(*errorcode));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_call_errhandler)(c_win, OMPI_FINT_2_INT(*errorcode));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_complete_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_complete_f.c
@@ -73,6 +73,6 @@ void ompi_win_complete_f(MPI_Fint *win, MPI_Fint *ierr)
 
     c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_complete(c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_complete)(c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_create_dynamic_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_create_dynamic_f.c
@@ -66,7 +66,7 @@ void ompi_win_create_dynamic_f(MPI_Fint *info, MPI_Fint *comm, MPI_Fint *win,
     c_comm = PMPI_Comm_f2c(*comm);
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Win_create_dynamic(c_info, c_comm, &c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_create_dynamic)(c_info, c_comm, &c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/win_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_create_f.c
@@ -78,7 +78,7 @@ void ompi_win_create_f(char *base, MPI_Aint *size, MPI_Fint *disp_unit,
     c_comm = PMPI_Comm_f2c(*comm);
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = PMPI_Win_create(base, *size,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_create)(base, *size,
                             OMPI_FINT_2_INT(*disp_unit),
                             c_info, c_comm, &c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/win_delete_attr_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_delete_attr_f.c
@@ -72,6 +72,6 @@ void ompi_win_delete_attr_f(MPI_Fint *win, MPI_Fint *win_keyval, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_delete_attr(c_win, OMPI_FINT_2_INT(*win_keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_delete_attr)(c_win, OMPI_FINT_2_INT(*win_keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_detach_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_detach_f.c
@@ -62,6 +62,6 @@ void ompi_win_detach_f(MPI_Fint *win, char *base,
     MPI_Win c_win;
 
     c_win = PMPI_Win_f2c(*win);
-    c_ierr = PMPI_Win_detach(c_win, base);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_detach)(c_win, base);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_fence_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_fence_f.c
@@ -71,6 +71,6 @@ void ompi_win_fence_f(MPI_Fint *assert, MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_fence(OMPI_FINT_2_INT(*assert), c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_fence)(OMPI_FINT_2_INT(*assert), c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_flush_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_flush_all_f.c
@@ -74,6 +74,6 @@ void ompi_win_flush_all_f(MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_flush_all(c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_flush_all)(c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_flush_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_flush_f.c
@@ -74,6 +74,6 @@ void ompi_win_flush_f(MPI_Fint *rank, MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_flush(OMPI_FINT_2_INT(*rank), c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_flush)(OMPI_FINT_2_INT(*rank), c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_flush_local_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_flush_local_all_f.c
@@ -74,6 +74,6 @@ void ompi_win_flush_local_all_f(MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_flush_local_all(c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_flush_local_all)(c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_flush_local_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_flush_local_f.c
@@ -74,6 +74,6 @@ void ompi_win_flush_local_f(MPI_Fint *rank, MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_flush_local(OMPI_FINT_2_INT(*rank), c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_flush_local)(OMPI_FINT_2_INT(*rank), c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_free_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_free_f.c
@@ -71,7 +71,7 @@ void ompi_win_free_f(MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_free(&c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_free)(&c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/win_free_keyval_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_free_keyval_f.c
@@ -73,7 +73,7 @@ void ompi_win_free_keyval_f(MPI_Fint *win_keyval, MPI_Fint *ierr)
 
     OMPI_SINGLE_FINT_2_INT(win_keyval);
 
-    c_ierr = PMPI_Win_free_keyval(OMPI_SINGLE_NAME_CONVERT(win_keyval));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_free_keyval)(OMPI_SINGLE_NAME_CONVERT(win_keyval));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/win_get_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_get_errhandler_f.c
@@ -73,7 +73,7 @@ void ompi_win_get_errhandler_f(MPI_Fint *win, MPI_Fint *errhandler,
     MPI_Errhandler c_err;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_get_errhandler(c_win, &c_err);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_get_errhandler)(c_win, &c_err);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/win_get_group_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_get_group_f.c
@@ -72,7 +72,7 @@ void ompi_win_get_group_f(MPI_Fint *win, MPI_Fint *group, MPI_Fint *ierr)
     MPI_Group c_grp;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_get_group(c_win, &c_grp);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_get_group)(c_win, &c_grp);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/win_get_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_get_info_f.c
@@ -62,7 +62,7 @@ void ompi_win_get_info_f(MPI_Fint *win, MPI_Fint *info, MPI_Fint *ierr)
     MPI_Info c_info;
 
     c_win = PMPI_Win_f2c(*win);
-    c_ierr = PMPI_Win_get_info(c_win, &c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_get_info)(c_win, &c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     *info = PMPI_Info_c2f(c_info);
 }

--- a/ompi/mpi/fortran/mpif-h/win_get_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_get_name_f.c
@@ -76,7 +76,7 @@ void ompi_win_get_name_f(MPI_Fint *win, char *win_name,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     char c_name[MPI_MAX_OBJECT_NAME];
 
-    c_ierr = PMPI_Win_get_name(c_win, c_name, &c_len);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_get_name)(c_win, c_name, &c_len);
     if (MPI_SUCCESS == c_ierr) {
         ompi_fortran_string_c2f(c_name, win_name, name_len);
         *resultlen = OMPI_INT_2_FINT(c_len);

--- a/ompi/mpi/fortran/mpif-h/win_lock_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_lock_all_f.c
@@ -71,7 +71,7 @@ void ompi_win_lock_all_f(MPI_Fint *assert, MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_lock_all(OMPI_FINT_2_INT(*assert),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_lock_all)(OMPI_FINT_2_INT(*assert),
                               c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_lock_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_lock_f.c
@@ -72,7 +72,7 @@ void ompi_win_lock_f(MPI_Fint *lock_type, MPI_Fint *rank,
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_lock(OMPI_FINT_2_INT(*lock_type),
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_lock)(OMPI_FINT_2_INT(*lock_type),
                           OMPI_FINT_2_INT(*rank),
                           OMPI_FINT_2_INT(*assert),
                           c_win);

--- a/ompi/mpi/fortran/mpif-h/win_post_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_post_f.c
@@ -73,7 +73,7 @@ void ompi_win_post_f(MPI_Fint *group, MPI_Fint *assert,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     MPI_Group c_grp = PMPI_Group_f2c(*group);
 
-    c_ierr = PMPI_Win_post(c_grp,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_post)(c_grp,
                           OMPI_FINT_2_INT(*assert),
                           c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/win_set_errhandler_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_set_errhandler_f.c
@@ -74,6 +74,6 @@ void ompi_win_set_errhandler_f(MPI_Fint *win, MPI_Fint *errhandler,
     MPI_Win c_win = PMPI_Win_f2c(*win);
     MPI_Errhandler c_err = PMPI_Errhandler_f2c(*errhandler);
 
-    c_ierr = PMPI_Win_set_errhandler(c_win, c_err);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_set_errhandler)(c_win, c_err);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_set_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_set_info_f.c
@@ -63,6 +63,6 @@ void ompi_win_set_info_f(MPI_Fint *win, MPI_Fint *info, MPI_Fint *ierr)
 
     c_win = PMPI_Win_f2c(*win);
     c_info = PMPI_Info_f2c(*info);
-    c_ierr = PMPI_Win_set_info(c_win, c_info);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_set_info)(c_win, c_info);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_set_name_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_set_name_f.c
@@ -90,7 +90,7 @@ void ompi_win_set_name_f(MPI_Fint *win, char *win_name, MPI_Fint *ierr,
 
     /* Call the C function */
 
-    c_ierr = PMPI_Win_set_name(c_win, c_name);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_set_name)(c_win, c_name);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     /* Free the C name */

--- a/ompi/mpi/fortran/mpif-h/win_shared_query_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_shared_query_f.c
@@ -117,7 +117,7 @@ void ompi_win_shared_query_f(MPI_Fint *win, MPI_Fint *rank, MPI_Aint *size,
 
     c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_shared_query(c_win, OMPI_FINT_2_INT(*rank), size,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_shared_query)(c_win, OMPI_FINT_2_INT(*rank), size,
                                    OMPI_SINGLE_NAME_CONVERT(disp_unit), baseptr);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 

--- a/ompi/mpi/fortran/mpif-h/win_start_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_start_f.c
@@ -73,7 +73,7 @@ void ompi_win_start_f(MPI_Fint *group, MPI_Fint *assert,
     MPI_Group c_grp = PMPI_Group_f2c(*group);
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_start(c_grp,
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_start)(c_grp,
                            OMPI_FINT_2_INT(*assert),
                            c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/win_sync_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_sync_f.c
@@ -71,6 +71,6 @@ void ompi_win_sync_f(MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_sync(c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_sync)(c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_test_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_test_f.c
@@ -72,7 +72,7 @@ void ompi_win_test_f(MPI_Fint *win, ompi_fortran_logical_t *flag, MPI_Fint *ierr
     MPI_Win c_win = PMPI_Win_f2c(*win);
     OMPI_LOGICAL_NAME_DECL(flag);
 
-    c_ierr = PMPI_Win_test(c_win, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_test)(c_win, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag));
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/win_unlock_all_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_unlock_all_f.c
@@ -71,6 +71,6 @@ void ompi_win_unlock_all_f(MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_unlock_all(c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_unlock_all)(c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_unlock_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_unlock_f.c
@@ -71,6 +71,6 @@ void ompi_win_unlock_f(MPI_Fint *rank, MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_unlock(OMPI_FINT_2_INT(*rank), c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_unlock)(OMPI_FINT_2_INT(*rank), c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/win_wait_f.c
+++ b/ompi/mpi/fortran/mpif-h/win_wait_f.c
@@ -71,6 +71,6 @@ void ompi_win_wait_f(MPI_Fint *win, MPI_Fint *ierr)
     int c_ierr;
     MPI_Win c_win = PMPI_Win_f2c(*win);
 
-    c_ierr = PMPI_Win_wait(c_win);
+    c_ierr = OMPI_FORTRAN_FPTR(MPI_Win_wait)(c_win);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 }

--- a/ompi/mpi/fortran/mpif-h/wtick_f.c
+++ b/ompi/mpi/fortran/mpif-h/wtick_f.c
@@ -70,5 +70,5 @@ double mpi_wtick__(void) { return ompi_wtick_f(); }
 
 double ompi_wtick_f(void)
 {
-    return PMPI_Wtick();
+    return OMPI_FORTRAN_FPTR(MPI_Wtick)();
 }

--- a/ompi/mpi/fortran/mpif-h/wtime_f.c
+++ b/ompi/mpi/fortran/mpif-h/wtime_f.c
@@ -70,5 +70,5 @@ double mpi_wtime__(void) { return ompi_wtime_f(); }
 
 double ompi_wtime_f(void)
 {
-    return PMPI_Wtime();
+    return OMPI_FORTRAN_FPTR(MPI_Wtime)();
 }

--- a/ompi/runtime/ompi_mpi_params.c
+++ b/ompi/runtime/ompi_mpi_params.c
@@ -75,6 +75,8 @@ bool ompi_async_mpi_finalize = false;
 uint32_t ompi_add_procs_cutoff = OMPI_ADD_PROCS_CUTOFF_DEFAULT;
 bool ompi_mpi_dynamics_enabled = true;
 
+char *ompi_fortcall = "PMPI";
+
 static bool show_default_mca_params = false;
 static bool show_file_mca_params = false;
 static bool show_enviro_mca_params = false;
@@ -314,6 +316,13 @@ int ompi_mpi_register_params(void)
         (void) mca_base_var_register_synonym(value, "ompi", "mpi", NULL, "abort_print_stack",
                                       MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     }
+
+    (void) mca_base_var_register("ompi", "mpi", NULL, "fortcall",
+                                 "Whether Fortran wrappers should call MPI or PMPI (default). The former allows language wrapping for the profiling interface. Possible values are the strings MPI or PMPI.",
+                                 MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &ompi_fortcall);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
This is a convenience feature for PMPI wrapper library writers, that allows them to have F77 language wrapping for free (something allowed but not required by the standard).

Eg if a wrapper library redefines
    int MPI_Send(...args...) { ... record stuff... ; rv = PMPI_Send; return(rv); }
and a Fortran app calls mpi_send() it's possible to have the mpi_send() definition in fortran/mpif-h/send_f.c call MPI_Send which would resolve back out into the wrapper library.

A longer discussion about this feature is here:
    https://github.com/open-mpi/ompi/issues/3954

The main argument against this is it's not required by the standard, and hence there's no good way for wrapper library writers to use this functionality: If they want to support all MPI vendors they can't rely on having access to the above. If they want to be complete, they have to write their own mpi_send() as well, and call either pmpi_send or PMPI_Send from it.

The argument for this feature is that pragmatically these C-only wrapper tools already exist, and customers try to use them with their Fortran apps, so it's a nice convenience feature to offer (and it's not random, it's an optional part of the standard).

This PR changes the fortran/mpif-h/send_f.c (etc) code from a direct PMPI_Send() call to a function pointer where the function pointer defaults to PMPI_Send(), and gives runtime control:
    -mca mpi_fortcall PMPI    :    the default behavior (mpi_send calls PMPI_Send)
    -mca mpi_fortcall MPI     :    make mpi_send call MPI_Send

The code's got an extra
#if OMPI_FORTRAN_USE_FPTR
that isn't being used right now, but is a stub for the idea of making this configurable. Eg if someone wanted no trace of the above changes and just wanted the original direct PMPI_Send() calls.