### PR TITLE
doc: Add README note about ARM/POWER hangs

### DIFF
--- a/README
+++ b/README
@@ -148,6 +148,10 @@ Platform Notes
   can build hwloc 1.11.6 externally and tell Open MPI's configure to
   use the external hwloc with the --with-hwloc=external (if in default
   search path) or --with-hwloc=<path>.
+- ARM and POWER users may experience intermittent hangs when Open MPI
+  is compiled with low optimization settings, due to an issue with our
+  atomic list implementation.  We recommend compiling with -O3
+  optimization, both for performance reasons and to avoid this hang.
 
 Compiler Notes
 --------------


### PR DESCRIPTION
As documented in #4563 and #3697, there is an issue on ARM and
POWER platforms when the atomic fifo assembly isn't inlined,
which manifests as a hang.  Document the issue and the
work-around until a proper fix is committed.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 465842294f8eb839b8816b5e0d7a13446f04735d)