### PR TITLE
dist: Update library versions for 3.0.1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -82,16 +82,16 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=40:0:0
+libmpi_so_version=40:1:0
 libmpi_cxx_so_version=40:0:0
 libmpi_mpifh_so_version=40:0:0
 libmpi_usempi_tkr_so_version=40:0:0
 libmpi_usempi_ignore_tkr_so_version=40:0:0
 libmpi_usempif08_so_version=40:0:0
-libopen_rte_so_version=40:0:0
-libopen_pal_so_version=40:0:0
+libopen_rte_so_version=40:1:0
+libopen_pal_so_version=41:0:1
 libmpi_java_so_version=40:0:0
-liboshmem_so_version=40:0:0
+liboshmem_so_version=41:0:1
 libompitrace_so_version=40:0:0
 
 # "Common" components install standalone libraries that are run-time
@@ -100,7 +100,7 @@ libompitrace_so_version=40:0:0
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=40:0:0
+libmca_ompi_common_ompio_so_version=41:0:0
 
 # ORTE layer
 libmca_orte_common_alps_so_version=40:0:0


### PR DESCRIPTION
Bump release versions based on 'git diff --name-only v3.0.0 HEAD'.
A convertor initialization option change effectively adds an
interface in libopal (although linking against an old version
of libopal will work with the new library) and an interface change
in ompio_common means that it's not backwards compatible.