### PR TITLE
MTL OFI: Allow retries in MTL progress for interrupted syscalls

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -115,7 +115,7 @@ ompi_mtl_ofi_progress(void)
                 exit(1);
             }
         } else {
-            if (ret == -FI_EAGAIN) {
+            if (ret == -FI_EAGAIN || ret == -EINTR) {
                 break;
             } else {
                 opal_output(0, "%s:%d: Error returned from fi_cq_read: %s(%zd).\n"


### PR DESCRIPTION
This fixes a regression in sockets provider which could return -EINTR value
from fi_cq_read() due to a syscall being interrupted. The error value is
currently interpreted as fatal condition. Relax the rule so that we can retry
fi_cq_read() operation.

Signed-off-by: Aravind Gopalakrishnan <Aravind.Gopalakrishnan@intel.com>
(cherry picked from commit fb68726baf0aa482e53ffb1f4e4490949c7e0e05)