### PR TITLE
v2.x: rcache/grdma: fix crash when part of a registration is unmapped

### DIFF
--- a/opal/mca/rcache/grdma/rcache_grdma_module.c
+++ b/opal/mca/rcache/grdma/rcache_grdma_module.c
@@ -415,7 +415,11 @@ static int mca_rcache_grdma_deregister (mca_rcache_base_module_t *rcache,
         return OPAL_SUCCESS;
     }
 
-    rc = dereg_mem (reg);
+    if (!(reg->flags & MCA_RCACHE_FLAGS_INVALID)) {
+        /* only call dereg mem if this registration is not in the GC lifo */
+        rc = dereg_mem (reg);
+    }
+
     opal_mutex_unlock (&rcache_grdma->cache->vma_module->vma_lock);
 
     return rc;
@@ -450,7 +454,7 @@ static int gc_add (mca_rcache_base_registration_t *grdma_reg, void *ctx)
     /* This may be called from free() so avoid recursively calling into free by just
      * shifting this registration into the garbage collection list. The cleanup will
      * be done on the next registration attempt. */
-    if (registration_is_cacheable (grdma_reg)) {
+    if (registration_is_cacheable (grdma_reg) && !grdma_reg->ref_count) {
         opal_list_remove_item (&rcache_grdma->cache->lru_list, (opal_list_item_t *) grdma_reg);
     }
 


### PR DESCRIPTION
This commit fixes an issue when a registration is created for a large
region and then invalidated while part of it is in use.

References #4509

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 39d598899bcd1dff2bbbe6f6eff9aa09ccb810b4)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>