### PR TITLE
fortran: Call PMPI from PMPI_Status_set_cancelled_f08

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/profile/pstatus_set_cancelled_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pstatus_set_cancelled_f08.F90
@@ -16,12 +16,12 @@ subroutine PMPI_Status_set_cancelled_f08(status,flag,ierror)
    ! See note in mpi-f-interfaces-bind.h for why we include an
    ! interface here and call a PMPI_* subroutine below.
    interface
-      subroutine MPI_Status_set_cancelled(status, flag, ierror)
+      subroutine PMPI_Status_set_cancelled(status, flag, ierror)
         use :: mpi_f08_types, only : MPI_Status
         type(MPI_Status), intent(inout) :: status
         logical, intent(in) :: flag
         integer, intent(out) :: ierror
-      end subroutine MPI_Status_set_cancelled
+      end subroutine PMPI_Status_set_cancelled
    end interface
 
    call PMPI_Status_set_cancelled(status,flag,c_ierror)


### PR DESCRIPTION
One more fix for Fortran PMPI with `mpi_f08`.

This is a bug which was forgotten to change in c08f97b0304.
