### PR TITLE
ompi/communicator: optimize ompi_comm_split()

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Research Organization for Information Science
+ * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
@@ -592,6 +592,14 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
         }
     }
 
+    /* set the rank to MPI_UNDEFINED. This prevents this process from interfering
+     * in ompi_comm_nextcid() and the collective module selection in ompi_comm_activate()
+     * for a communicator that will be freed anyway.
+     */
+    if ( MPI_UNDEFINED == color || (inter && my_rsize==0)) {
+        newcomp->c_local_group->grp_my_rank = MPI_UNDEFINED;
+    }
+
     /* Determine context id. It is identical to f_2_c_handle */
     rc = ompi_comm_nextcid (newcomp, comm, NULL, NULL, NULL, false, mode);
     if ( OMPI_SUCCESS != rc ) {
@@ -602,13 +610,6 @@ int ompi_comm_split( ompi_communicator_t* comm, int color, int key,
     snprintf(newcomp->c_name, MPI_MAX_OBJECT_NAME, "MPI COMMUNICATOR %d SPLIT FROM %d",
              newcomp->c_contextid, comm->c_contextid );
 
-    /* set the rank to MPI_UNDEFINED. This prevents in comm_activate
-     * the collective module selection for a communicator that will
-     * be freed anyway.
-     */
-    if ( MPI_UNDEFINED == color || (inter && my_rsize==0)) {
-        newcomp->c_local_group->grp_my_rank = MPI_UNDEFINED;
-    }
 
 
     /* Activate the communicator and init coll-component */


### PR DESCRIPTION
set grp_local_rank as MPI_UNDEFINED before invoking
ompi_comm_nexcid() in order to benefit from the optimizations
introduced in open-mpi/ompi@68167ec879fae81c39a0d064ef49baaae6740707

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>