### PR TITLE
Correct the comment in the default MCA param template

### DIFF
--- a/opal/etc/openmpi-mca-params.conf
+++ b/opal/etc/openmpi-mca-params.conf
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2018      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -52,7 +53,7 @@
 # directory.  For example:
 
 # Change component loading path
-#   component_path = /usr/local/lib/openmpi:~/my_openmpi_components
+#   mca_base_component_path = /usr/local/lib/openmpi:~/my_openmpi_components
 
 # See "ompi_info --param all all --level 9" for a full listing of Open
 # MPI MCA parameters available and their default values.


### PR DESCRIPTION
Correct the comment in the default MCA param template - we do not support a param called "component_path". The correct syntax is "mca_base_component_path"

[skip ci]
bot:notest

Signed-off-by: Ralph Castain <rhc@open-mpi.org>