### PR TITLE
Fix type of mpi_f08 MPI_ERRCODES_IGNORE

### DIFF
--- a/ompi/mpi/fortran/base/gen-mpi-mangling.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-mangling.pl
@@ -90,7 +90,7 @@ $fortran->{argvs_null} = {
 $fortran->{errcodes_ignore} = {
     c_type => "int *",
     c_name => "mpi_fortran_errcodes_ignore",
-    f_type => "integer",
+    f_type => "integer, dimension(1)",
     f_name => "MPI_ERRCODES_IGNORE",
 };
 $fortran->{status_ignore} = {


### PR DESCRIPTION
Given following program:

```
program test_spawn
   use mpi_f08
   implicit none

   character(len=:), allocatable  :: command
   integer :: command_length, rank
   type(MPI_Comm) :: intercomm, parent

   call get_command_argument(number=0, length=command_length)
   allocate(character(len=command_length) :: command)
   call get_command_argument(number=0, value=command)

   call MPI_Init
   call MPI_Comm_get_parent(parent=parent)
   if (parent == MPI_COMM_NULL) then
      call MPI_Comm_spawn(command=command, argv=MPI_ARGV_NULL, maxprocs=2, info=MPI_INFO_NULL, root=0, &
                         comm=MPI_COMM_WORLD, intercomm=intercomm, array_of_errcodes=MPI_ERRCODES_IGNORE)
      write(unit=*, fmt='(*(g0))') 'parent'
   else
      call MPI_Comm_rank(comm=MPI_COMM_WORLD, rank=rank)
      write(unit=*, fmt='(*(g0))') 'child ', rank
   end if
   call MPI_Finalize
end program test_spawn
```

gfortran 7.1.0 emits the following error:

```
$ mpifort test_spawn.f90

                           comm=MPI_COMM_WORLD, intercomm=intercomm, array_of_errcodes=MPI_ERRCODES_IGNORE)
                                                                                                          1
Error: There is no specific subroutine for the generic 'mpi_comm_spawn' at (1)
``` 

Per MPI 3.1, the data type of the array_of_errcodes argument is:

```
INTEGER :: array_of_errcodes(*)
```

Changing the data type of the mpi_f08 version of MPI_ERRCODES_IGNORE from "integer" to "integer, dimension(1)" seems to resolve the issue:

```
$ mpifort -o test_spawn.x test_spawn.f90 
$ mpiexec -n 1 -mca btl self,tcp ./test_spawn.x
child 0
child 1
parent
```