### PR TITLE
Fix DIR, DIR/include search for --with-pmix

### DIFF
--- a/config/opal_check_package.m4
+++ b/config/opal_check_package.m4
@@ -52,6 +52,15 @@ AC_DEFUN([_OPAL_CHECK_PACKAGE_HEADER], [
 
     AS_IF([test "$opal_check_package_header_happy" = "no"],
           [AS_IF([test "$dir_prefix" != ""],
+                 [$1_CPPFLAGS="$$1_CPPFLAGS -I$dir_prefix"
+                  CPPFLAGS="$CPPFLAGS -I$dir_prefix"])
+          AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])
+          AS_IF([test "$opal_check_package_header_happy" = "no"],
+                [# no go on the as is - reset the cache and try again
+                 unset opal_Header])])
+
+    AS_IF([test "$opal_check_package_header_happy" = "no"],
+          [AS_IF([test "$dir_prefix" != ""],
                  [$1_CPPFLAGS="$$1_CPPFLAGS -I$dir_prefix/include"
                   CPPFLAGS="$CPPFLAGS -I$dir_prefix/include"])
           AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -257,36 +257,18 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
                  [pmix_ext_install_dir=/usr],
                  [pmix_ext_install_dir=$with_pmix])
 
-           # Make sure we have the headers and libs in the correct location
-           OPAL_CHECK_WITHDIR([external-pmix], [$pmix_ext_install_dir/include], [pmix.h])
+           AS_IF([test ! -z "$with_pmix_libdir" && test "$with_pmix_libdir" != "yes"],
+                 [pmix_ext_install_libdir="$with_pmix_libdir"])
 
-           AS_IF([test -n "$with_pmix_libdir"],
-                 [AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir])
-                  files=`ls $with_pmix_libdir/libpmix.* 2> /dev/null | wc -l`
-                  AS_IF([test "$files" -gt 0],
-                        [pmix_ext_install_libdir=$with_pmix_libdir],
-                        [AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir/lib64])
-                         files=`ls $with_pmix_libdir/lib64/libpmix.* 2> /dev/null | wc -l`
-                         AS_IF([test "$files" -gt 0],
-                               [pmix_ext_install_libdir=$with_pmix_libdir/lib64],
-                               [AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir/lib])
-                                files=`ls $with_pmix_libdir/lib/libpmix.* 2> /dev/null | wc -l`
-                                AS_IF([test "$files" -gt 0],
-                                      [pmix_ext_install_libdir=$with_pmix_libdir/lib],
-                                      [AC_MSG_RESULT([not found])
-                                       AC_MSG_ERROR([Cannot continue])])])])],
-                 [# check for presence of lib64 directory - if found, see if the
-                  # desired library is present and matches our build requirements
-                  AC_MSG_CHECKING([libpmix.* in $pmix_ext_install_dir/lib64])
-                  files=`ls $pmix_ext_install_dir/lib64/libpmix.* 2> /dev/null | wc -l`
-                  AS_IF([test "$files" -gt 0],
-                        [pmix_ext_install_libdir=$pmix_ext_install_dir/lib64],
-                        [AC_MSG_CHECKING([libpmix.* in $pmix_ext_install_dir/lib])
-                         files=`ls $pmix_ext_install_dir/lib/libpmix.* 2> /dev/null | wc -l`
-                         AS_IF([test "$files" -gt 0],
-                               [pmix_ext_install_libdir=$pmix_ext_install_dir/lib],
-                               [AC_MSG_RESULT([not found])
-                                AC_MSG_ERROR([Cannot continue])])])])
+           OPAL_CHECK_PACKAGE([opal_external_pmix],
+                              [pmix.h],
+                              [pmix],
+                              [PMIx_Init],
+                              [],
+                              [$pmix_ext_install_dir],
+                              [$pmix_ext_install_libdir],
+                              [],
+                              [AC_MSG_ERROR([external pmix not found])])
 
            # check the version
            opal_external_pmix_save_CPPFLAGS=$CPPFLAGS
@@ -296,14 +278,14 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
            # if the pmix_version.h file does not exist, then
            # this must be from a pre-1.1.5 version
            AC_MSG_CHECKING([PMIx version])
-           CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
-           AS_IF([test "x`ls $pmix_ext_install_dir/include/pmix_version.h 2> /dev/null`" = "x"],
-                 [AC_MSG_RESULT([version file not found - assuming v1.1.4])
-                  opal_external_pmix_version_found=1
-                  opal_external_pmix_version=114
-                  opal_external_have_pmix1=1],
-                 [AC_MSG_RESULT([version file found])
-                  opal_external_pmix_version_found=0])
+           CPPFLAGS=$opal_external_pmix_CPPFLAGS
+           AC_CHECK_HEADER([pmix_version.h],
+                           [AC_MSG_RESULT([version file found])
+                            opal_external_pmix_version_found=0],
+                           [AC_MSG_RESULT([version file not found - assuming v1.1.4])
+                            opal_external_pmix_version_found=1
+                            opal_external_pmix_version=114
+                            opal_external_have_pmix1=1])
 
            # if it does exist, then we need to parse it to find
            # the actual release series
@@ -358,10 +340,6 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
            LDFLAGS=$opal_external_pmix_save_LDFLAGS
            LIBS=$opal_external_pmix_save_LIBS
 
-           AS_IF([test "$pmix_ext_install_dir" != "/usr"],
-                 [opal_external_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
-                  opal_external_pmix_LDFLAGS=-L$pmix_ext_install_libdir])
-           opal_external_pmix_LIBS=-lpmix
            opal_external_pmix_happy=yes])
 
     AC_DEFINE_UNQUOTED([OPAL_PMIX_V1],[$opal_external_have_pmix1],


### PR DESCRIPTION
This PR allows ompi to find external pmix headers that were installed to a `DIR/include/pmix` subdirectory. 

When packages contain multiple header files, it is common and desirable to be able to place the headers in a project-named subdirectory.   Doing so with external pmix, e.g. installing headers to `/usr/include/pmix`, renders the headers unusable to ompi. 

To address the issue, an optional new argument (action-if-failed) was added to `OPAL_CHECK_WITHDIR` so that, instead of halting the configure immediately, the caller can, if desired, capture the failure and try a different directory.  New code was added to `opal_check_pmi.m4` to do just that: first try DIR/include and then try DIR/include/pmix.

**./configure --with-pmix=/usr --with-libevent=/usr ...**
```
checking --with-external-pmix value... not found (/usr/include)
checking --with-external-pmix value... sanity check ok (/usr/include/pmix)
```