### PR TITLE
io/ompio: fix a bug in handling large write/read operations

### DIFF
--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -405,7 +405,7 @@ OMPI_DECLSPEC void mca_io_ompio_get_bytes_per_agg ( int *bytes_per_agg);
 OMPI_DECLSPEC int mca_io_ompio_build_io_array ( mca_io_ompio_file_t *fh, int index, int cycles,
 						size_t bpc, int max_data, uint32_t iov_count,
 						struct iovec *decoded_iov, int *ii, int *jj,
-						size_t *tbw );
+						size_t *tbw, size_t *spc );
 
 OMPI_DECLSPEC int ompi_io_ompio_set_file_defaults (mca_io_ompio_file_t *fh);
 

--- a/ompi/mca/io/ompio/io_ompio_file_read.c
+++ b/ompi/mca/io/ompio/io_ompio_file_read.c
@@ -81,6 +81,7 @@ int ompio_io_ompio_file_read (mca_io_ompio_file_t *fh,
     struct iovec *decoded_iov = NULL;
 
     size_t max_data=0, real_bytes_read=0;
+    size_t spc=0;
     ssize_t ret_code=0;
     int i = 0; /* index into the decoded iovec of the buffer */
     int j = 0; /* index into the file vie iovec */
@@ -131,7 +132,8 @@ int ompio_io_ompio_file_read (mca_io_ompio_file_t *fh,
 				      decoded_iov,
 				      &i,
 				      &j,
-				      &total_bytes_read);
+				      &total_bytes_read,
+                                      &spc);
 
         if (fh->f_num_of_io_entries) {
             ret_code = fh->f_fbtl->fbtl_preadv (fh);
@@ -227,6 +229,7 @@ int ompio_io_ompio_file_iread (mca_io_ompio_file_t *fh,
 {
     int ret = OMPI_SUCCESS;
     mca_ompio_request_t *ompio_req=NULL;
+    size_t spc=0;
 
     ompio_req = OBJ_NEW(mca_ompio_request_t);
     ompio_req->req_type = MCA_OMPIO_REQUEST_READ;
@@ -272,7 +275,8 @@ int ompio_io_ompio_file_iread (mca_io_ompio_file_t *fh,
 				      decoded_iov,
 				      &i,
 				      &j,
-				      &total_bytes_read);
+				      &total_bytes_read,
+                                      &spc);
 
 	if (fh->f_num_of_io_entries) {
 	  fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);


### PR DESCRIPTION
This is a bug fix based on a problem reported on the mailing list.
For very large read/write operations, ompio breaks the operation
down into multiple cycles. The problem was that
one of the variables required to maintain its values
across the different cycles did not do that, and because
of that the calculations of the memory offsets was wrong.

Fixes issue #4453

This commit is the equivalent of commit c9bb049d00536f3fd51b7c345b0025947be4192d
on master. Directly cherry-picking does not work, since the
structure of ompio has changed significantly between the 2.x and master
branches (specifically: ompio does not use common/ompio in the 2.x series yet).

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>