### PR TITLE
fortran: Fix PMPI bugs in mpi_f08 module

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2015-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -751,9 +752,13 @@ pmpi_api_files += \
         profile/pfile_get_view_f08.F90 \
         profile/pfile_iread_at_f08.F90 \
         profile/pfile_iread_f08.F90 \
+        profile/pfile_iread_at_all_f08.F90 \
+        profile/pfile_iread_all_f08.F90 \
         profile/pfile_iread_shared_f08.F90 \
         profile/pfile_iwrite_at_f08.F90 \
         profile/pfile_iwrite_f08.F90 \
+        profile/pfile_iwrite_at_all_f08.F90 \
+        profile/pfile_iwrite_all_f08.F90 \
         profile/pfile_iwrite_shared_f08.F90 \
         profile/pfile_open_f08.F90 \
         profile/pfile_preallocate_f08.F90 \

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
@@ -9,6 +9,7 @@
 ! Copyright (c) 2012      Inria.  All rights reserved.
 ! Copyright (c) 2015      Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
+! Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 !
 ! This file provides the interface specifications for the MPI Fortran
@@ -2101,7 +2102,7 @@ subroutine MPI_Type_set_name_f08(datatype,type_name,ierror)
 end subroutine MPI_Type_set_name_f08
 end interface  MPI_Type_set_name
 
-interface MPI_Win_allocate
+interface  MPI_Win_allocate
 subroutine MPI_Win_allocate_f08(size, disp_unit, info, comm, &
       baseptr, win, ierror)
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
@@ -2114,9 +2115,9 @@ subroutine MPI_Win_allocate_f08(size, disp_unit, info, comm, &
   TYPE(MPI_Win), INTENT(OUT) ::  win
   INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
 end subroutine MPI_Win_allocate_f08
-end interface MPI_Win_allocate
+end interface  MPI_Win_allocate
 
-interface MPI_Win_allocate_shared
+interface  MPI_Win_allocate_shared
 subroutine MPI_Win_allocate_shared_f08(size, disp_unit, info, comm, &
       baseptr, win, ierror)
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
@@ -2129,7 +2130,7 @@ subroutine MPI_Win_allocate_shared_f08(size, disp_unit, info, comm, &
   TYPE(MPI_Win), INTENT(OUT) ::  win
   INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
 end subroutine MPI_Win_allocate_shared_f08
-end interface MPI_Win_allocate_shared
+end interface  MPI_Win_allocate_shared
 
 interface  MPI_Win_create_keyval
 subroutine MPI_Win_create_keyval_f08(win_copy_attr_fn,win_delete_attr_fn,win_keyval, &
@@ -2465,7 +2466,7 @@ function  MPI_Wtick_f08( ) BIND(C,name="MPI_Wtick")
    use, intrinsic :: ISO_C_BINDING
    implicit none
    DOUBLE PRECISION :: MPI_Wtick_f08
-end function MPI_Wtick_f08
+end function  MPI_Wtick_f08
 end interface MPI_Wtick
 
 ! MPI_Wtime is not a wrapper function
@@ -2475,7 +2476,7 @@ function  MPI_Wtime_f08( ) BIND(C,name="MPI_Wtime")
    use, intrinsic :: ISO_C_BINDING
    implicit none
    DOUBLE PRECISION :: MPI_Wtime_f08
-end function MPI_Wtime_f08
+end function  MPI_Wtime_f08
 end interface MPI_Wtime
 
 interface MPI_Aint_add
@@ -2485,7 +2486,7 @@ function  MPI_Aint_add_f08(base,diff)
    INTEGER(MPI_ADDRESS_KIND) :: base
    INTEGER(MPI_ADDRESS_KIND) :: diff
    INTEGER(MPI_ADDRESS_KIND) :: MPI_Aint_add_f08
-end function MPI_Aint_add_f08
+end function  MPI_Aint_add_f08
 end interface MPI_Aint_add
 
 interface MPI_Aint_diff
@@ -2495,7 +2496,7 @@ function  MPI_Aint_diff_f08(addr1,addr2)
    INTEGER(MPI_ADDRESS_KIND) :: addr1
    INTEGER(MPI_ADDRESS_KIND) :: addr2
    INTEGER(MPI_ADDRESS_KIND) :: MPI_Aint_diff_f08
-end function MPI_Aint_diff_f08
+end function  MPI_Aint_diff_f08
 end interface MPI_Aint_diff
 
 interface  MPI_Abort
@@ -3341,7 +3342,7 @@ subroutine MPI_Win_post_f08(group,assert,win,ierror)
 end subroutine MPI_Win_post_f08
 end interface  MPI_Win_post
 
-interface MPI_Win_shared_query
+interface  MPI_Win_shared_query
 subroutine MPI_Win_shared_query_f08(win, rank, size, disp_unit, baseptr,&
       ierror)
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
@@ -3353,7 +3354,7 @@ subroutine MPI_Win_shared_query_f08(win, rank, size, disp_unit, baseptr,&
   TYPE(C_PTR), INTENT(OUT) ::  baseptr
   INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
 end subroutine MPI_Win_shared_query_f08
-end interface
+end interface  MPI_Win_shared_query
 
 interface  MPI_Win_start
 subroutine MPI_Win_start_f08(group,assert,win,ierror)

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -1759,7 +1759,7 @@ subroutine PMPI_Comm_get_info_f08(comm,info_used,ierror)
    use :: mpi_f08_types, only : MPI_Comm, MPI_Info
    implicit none
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Comm), INTENT(OUT) :: info_used
+   TYPE(MPI_Info), INTENT(OUT) :: info_used
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Comm_get_info_f08
 end interface  PMPI_Comm_get_info

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -72,13 +72,9 @@ end interface  PMPI_Buffer_attach
 
 interface  PMPI_Buffer_detach
 subroutine PMPI_Buffer_detach_f08(buffer_addr,size,ierror)
+   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
    implicit none
-   !DEC$ ATTRIBUTES NO_ARG_CHECK :: buffer_addr
-   !GCC$ ATTRIBUTES NO_ARG_CHECK :: buffer_addr
-   !$PRAGMA IGNORE_TKR buffer_addr
-   !DIR$ IGNORE_TKR buffer_addr
-   !IBM* IGNORE_TKR buffer_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buffer_addr
+   TYPE(C_PTR), INTENT(OUT) ::  buffer_addr
    INTEGER, INTENT(OUT) :: size
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Buffer_detach_f08

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -2484,21 +2484,23 @@ end function  PMPI_Wtime_f08
 end interface PMPI_Wtime
 
 interface PMPI_Aint_add
-subroutine PMPI_Aint_add_f08(base,diff)
+function  PMPI_Aint_add_f08(base,diff)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND) :: base
    INTEGER(MPI_ADDRESS_KIND) :: diff
-end subroutine PMPI_Aint_add_f08
+   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_add_f08
+end function PMPI_Aint_add_f08
 end interface PMPI_Aint_add
 
 interface PMPI_Aint_diff
-subroutine PMPI_Aint_diff_f08(addr1,addr2)
+function  PMPI_Aint_diff_f08(addr1,addr2)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    implicit none
    INTEGER(MPI_ADDRESS_KIND) :: addr1
    INTEGER(MPI_ADDRESS_KIND) :: addr2
-end subroutine PMPI_Aint_diff_f08
+   INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_diff_f08
+end function PMPI_Aint_diff_f08
 end interface PMPI_Aint_diff
 
 interface  PMPI_Abort

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -2102,7 +2102,7 @@ subroutine PMPI_Type_set_name_f08(datatype,type_name,ierror)
 end subroutine PMPI_Type_set_name_f08
 end interface  PMPI_Type_set_name
 
-interface PMPI_Win_allocate
+interface  PMPI_Win_allocate
 subroutine PMPI_Win_allocate_f08(size, disp_unit, info, comm, &
       baseptr, win, ierror)
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
@@ -2115,9 +2115,9 @@ subroutine PMPI_Win_allocate_f08(size, disp_unit, info, comm, &
   TYPE(MPI_Win), INTENT(OUT) ::  win
   INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
 end subroutine PMPI_Win_allocate_f08
-end interface PMPI_Win_allocate
+end interface  PMPI_Win_allocate
 
-interface PMPI_Win_allocate_shared
+interface  PMPI_Win_allocate_shared
 subroutine PMPI_Win_allocate_shared_f08(size, disp_unit, info, comm, &
       baseptr, win, ierror)
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
@@ -2130,7 +2130,7 @@ subroutine PMPI_Win_allocate_shared_f08(size, disp_unit, info, comm, &
   TYPE(MPI_Win), INTENT(OUT) ::  win
   INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
 end subroutine PMPI_Win_allocate_shared_f08
-end interface PMPI_Win_allocate_shared
+end interface  PMPI_Win_allocate_shared
 
 interface  PMPI_Win_create_keyval
 subroutine PMPI_Win_create_keyval_f08(win_copy_attr_fn,win_delete_attr_fn,win_keyval, &
@@ -2486,7 +2486,7 @@ function  PMPI_Aint_add_f08(base,diff)
    INTEGER(MPI_ADDRESS_KIND) :: base
    INTEGER(MPI_ADDRESS_KIND) :: diff
    INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_add_f08
-end function PMPI_Aint_add_f08
+end function  PMPI_Aint_add_f08
 end interface PMPI_Aint_add
 
 interface PMPI_Aint_diff
@@ -2496,7 +2496,7 @@ function  PMPI_Aint_diff_f08(addr1,addr2)
    INTEGER(MPI_ADDRESS_KIND) :: addr1
    INTEGER(MPI_ADDRESS_KIND) :: addr2
    INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_diff_f08
-end function PMPI_Aint_diff_f08
+end function  PMPI_Aint_diff_f08
 end interface PMPI_Aint_diff
 
 interface  PMPI_Abort
@@ -2681,7 +2681,6 @@ end interface  PMPI_Finalized
 ! ASYNCHRONOUS had to removed from the base argument because
 ! the dummy argument is not an assumed-shape array.  This will
 ! be okay once the Interop TR is implemented.
-!
 interface  PMPI_Free_mem
 subroutine PMPI_Free_mem_f08(base,ierror)
    implicit none
@@ -3343,7 +3342,7 @@ subroutine PMPI_Win_post_f08(group,assert,win,ierror)
 end subroutine PMPI_Win_post_f08
 end interface  PMPI_Win_post
 
-interface PMPI_Win_shared_query
+interface  PMPI_Win_shared_query
 subroutine PMPI_Win_shared_query_f08(win, rank, size, disp_unit, baseptr,&
       ierror)
   USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
@@ -3355,7 +3354,7 @@ subroutine PMPI_Win_shared_query_f08(win, rank, size, disp_unit, baseptr,&
   TYPE(C_PTR), INTENT(OUT) ::  baseptr
   INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
 end subroutine PMPI_Win_shared_query_f08
-end interface PMPI_Win_shared_query
+end interface  PMPI_Win_shared_query
 
 interface  PMPI_Win_start
 subroutine PMPI_Win_start_f08(group,assert,win,ierror)

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -47,7 +47,7 @@ subroutine PMPI_Bsend_init_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -64,7 +64,7 @@ subroutine PMPI_Buffer_attach_f08(buffer,size,ierror)
    !$PRAGMA IGNORE_TKR buffer
    !DIR$ IGNORE_TKR buffer
    !IBM* IGNORE_TKR buffer
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buffer
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buffer
    INTEGER, INTENT(IN) :: size
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Buffer_attach_f08
@@ -113,7 +113,7 @@ subroutine PMPI_Ibsend_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -143,7 +143,7 @@ subroutine PMPI_Irecv_f08(buf,count,datatype,source,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, source, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -161,7 +161,7 @@ subroutine PMPI_Irsend_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -179,7 +179,7 @@ subroutine PMPI_Isend_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -197,7 +197,7 @@ subroutine PMPI_Issend_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -244,7 +244,7 @@ subroutine PMPI_Recv_init_f08(buf,count,datatype,source,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, source, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -299,7 +299,7 @@ subroutine PMPI_Rsend_init_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -373,7 +373,7 @@ subroutine PMPI_Send_init_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -408,7 +408,7 @@ subroutine PMPI_Ssend_init_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, dest, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -550,7 +550,7 @@ subroutine PMPI_Get_address_f08(location,address,ierror)
    !$PRAGMA IGNORE_TKR location
    !DIR$ IGNORE_TKR location
    !IBM* IGNORE_TKR location
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: location
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: location
    INTEGER(MPI_ADDRESS_KIND), INTENT(OUT) :: address
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Get_address_f08
@@ -3009,7 +3009,7 @@ subroutine PMPI_Accumulate_f08(origin_addr,origin_count,origin_datatype,target_r
    !$PRAGMA IGNORE_TKR origin_addr
    !DIR$ IGNORE_TKR origin_addr
    !IBM* IGNORE_TKR origin_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp
@@ -3053,7 +3053,7 @@ subroutine PMPI_Get_f08(origin_addr,origin_count,origin_datatype,target_rank, &
    !$PRAGMA IGNORE_TKR origin_addr
    !DIR$ IGNORE_TKR origin_addr
    !IBM* IGNORE_TKR origin_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp
@@ -3143,7 +3143,7 @@ subroutine PMPI_Put_f08(origin_addr,origin_count,origin_datatype,target_rank, &
    !$PRAGMA IGNORE_TKR origin_addr
    !DIR$ IGNORE_TKR origin_addr
    !IBM* IGNORE_TKR origin_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp
@@ -3233,7 +3233,7 @@ subroutine PMPI_Win_create_f08(base,size,disp_unit,info,comm,win,ierror)
    !$PRAGMA IGNORE_TKR base
    !DIR$ IGNORE_TKR base
    !IBM* IGNORE_TKR base
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: size
    INTEGER, INTENT(IN) :: disp_unit
    TYPE(MPI_Info), INTENT(IN) :: info
@@ -3674,7 +3674,7 @@ subroutine PMPI_File_iread_f08(fh,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3693,7 +3693,7 @@ subroutine PMPI_File_iread_at_f08(fh,offset,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3711,7 +3711,7 @@ subroutine PMPI_File_iread_all_f08(fh,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3730,7 +3730,7 @@ subroutine PMPI_File_iread_at_all_f08(fh,offset,buf,count,datatype,request,ierro
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3748,7 +3748,7 @@ subroutine PMPI_File_iread_shared_f08(fh,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3766,7 +3766,7 @@ subroutine PMPI_File_iwrite_f08(fh,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3785,7 +3785,7 @@ subroutine PMPI_File_iwrite_at_f08(fh,offset,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3803,7 +3803,7 @@ subroutine PMPI_File_iwrite_all_f08(fh,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3822,7 +3822,7 @@ subroutine PMPI_File_iwrite_at_all_f08(fh,offset,buf,count,datatype,request,ierr
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -3839,7 +3839,7 @@ subroutine PMPI_File_iwrite_shared_f08(fh,buf,count,datatype,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    TYPE(MPI_File), INTENT(IN) :: fh
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
@@ -3917,7 +3917,7 @@ subroutine PMPI_File_read_all_begin_f08(fh,buf,count,datatype,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
@@ -3934,7 +3934,7 @@ subroutine PMPI_File_read_all_end_f08(fh,buf,status,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    TYPE(MPI_Status) :: status
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_File_read_all_end_f08
@@ -3989,7 +3989,7 @@ subroutine PMPI_File_read_at_all_begin_f08(fh,offset,buf,count,datatype,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
@@ -4006,7 +4006,7 @@ subroutine PMPI_File_read_at_all_end_f08(fh,buf,status,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    TYPE(MPI_Status) :: status
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_File_read_at_all_end_f08
@@ -4040,7 +4040,7 @@ subroutine PMPI_File_read_ordered_begin_f08(fh,buf,count,datatype,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
@@ -4057,7 +4057,7 @@ subroutine PMPI_File_read_ordered_end_f08(fh,buf,status,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    TYPE(MPI_Status) :: status
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_File_read_ordered_end_f08
@@ -4202,7 +4202,7 @@ subroutine PMPI_File_write_all_begin_f08(fh,buf,count,datatype,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
@@ -4219,7 +4219,7 @@ subroutine PMPI_File_write_all_end_f08(fh,buf,status,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    TYPE(MPI_Status) :: status
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_File_write_all_end_f08
@@ -4274,7 +4274,7 @@ subroutine PMPI_File_write_at_all_begin_f08(fh,offset,buf,count,datatype,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
@@ -4291,7 +4291,7 @@ subroutine PMPI_File_write_at_all_end_f08(fh,buf,status,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    TYPE(MPI_Status) :: status
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_File_write_at_all_end_f08
@@ -4325,7 +4325,7 @@ subroutine PMPI_File_write_ordered_begin_f08(fh,buf,count,datatype,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
@@ -4342,7 +4342,7 @@ subroutine PMPI_File_write_ordered_end_f08(fh,buf,status,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
    TYPE(MPI_Status) :: status
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_File_write_ordered_end_f08
@@ -4475,7 +4475,7 @@ subroutine PMPI_F_sync_reg_f08(buf)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
 end subroutine PMPI_F_sync_reg_f08
 end interface  PMPI_F_sync_reg
 
@@ -4523,7 +4523,7 @@ subroutine PMPI_Imrecv_f08(buf,count,datatype,message,request,ierror)
    !$PRAGMA IGNORE_TKR buf
    !DIR$ IGNORE_TKR buf
    !IBM* IGNORE_TKR buf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE OMPI_ASYNCHRONOUS :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Message), INTENT(INOUT) :: message

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -9,6 +9,7 @@
 ! Copyright (c) 2012      Inria.  All rights reserved.
 ! Copyright (c) 2015      Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
+! Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 !
 ! This file provides the interface specifications for the MPI Fortran
@@ -2105,6 +2106,36 @@ subroutine PMPI_Type_set_name_f08(datatype,type_name,ierror)
 end subroutine PMPI_Type_set_name_f08
 end interface  PMPI_Type_set_name
 
+interface PMPI_Win_allocate
+subroutine PMPI_Win_allocate_f08(size, disp_unit, info, comm, &
+      baseptr, win, ierror)
+  USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
+  use :: mpi_f08_types, only : MPI_Info, MPI_Comm, MPI_Win, MPI_ADDRESS_KIND
+  INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(IN) ::  size
+  INTEGER, INTENT(IN) ::  disp_unit
+  TYPE(MPI_Info), INTENT(IN) ::  info
+  TYPE(MPI_Comm), INTENT(IN) ::  comm
+  TYPE(C_PTR), INTENT(OUT) ::  baseptr
+  TYPE(MPI_Win), INTENT(OUT) ::  win
+  INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
+end subroutine PMPI_Win_allocate_f08
+end interface PMPI_Win_allocate
+
+interface PMPI_Win_allocate_shared
+subroutine PMPI_Win_allocate_shared_f08(size, disp_unit, info, comm, &
+      baseptr, win, ierror)
+  USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
+  use :: mpi_f08_types, only : MPI_Info, MPI_Comm, MPI_Win, MPI_ADDRESS_KIND
+  INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(IN) ::  size
+  INTEGER, INTENT(IN) ::  disp_unit
+  TYPE(MPI_Info), INTENT(IN) ::  info
+  TYPE(MPI_Comm), INTENT(IN) ::  comm
+  TYPE(C_PTR), INTENT(OUT) ::  baseptr
+  TYPE(MPI_Win), INTENT(OUT) ::  win
+  INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
+end subroutine PMPI_Win_allocate_shared_f08
+end interface PMPI_Win_allocate_shared
+
 interface  PMPI_Win_create_keyval
 subroutine PMPI_Win_create_keyval_f08(win_copy_attr_fn,win_delete_attr_fn,win_keyval, &
                                      extra_state,ierror)
@@ -2150,6 +2181,16 @@ subroutine PMPI_Win_get_attr_f08(win,win_keyval,attribute_val,flag,ierror)
 end subroutine PMPI_Win_get_attr_f08
 end interface  PMPI_Win_get_attr
 
+interface  PMPI_Win_get_info
+subroutine PMPI_Win_get_info_f08(win,info,ierror)
+   use :: mpi_f08_types, only : MPI_Win, MPI_Info
+   implicit none
+   TYPE(MPI_Win), INTENT(IN) :: win
+   TYPE(MPI_Info), INTENT(OUT) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Win_get_info_f08
+end interface  PMPI_Win_get_info
+
 interface  PMPI_Win_get_name
 subroutine PMPI_Win_get_name_f08(win,win_name,resultlen,ierror)
    use :: mpi_f08_types, only : MPI_Win, MPI_MAX_OBJECT_NAME
@@ -2171,6 +2212,16 @@ subroutine PMPI_Win_set_attr_f08(win,win_keyval,attribute_val,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Win_set_attr_f08
 end interface  PMPI_Win_set_attr
+
+interface  PMPI_Win_set_info
+subroutine PMPI_Win_set_info_f08(win,info,ierror)
+   use :: mpi_f08_types, only : MPI_Win, MPI_Info
+   implicit none
+   TYPE(MPI_Win), INTENT(IN) :: win
+   TYPE(MPI_Info), INTENT(IN) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Win_set_info_f08
+end interface  PMPI_Win_set_info
 
 interface  PMPI_Win_set_name
 subroutine PMPI_Win_set_name_f08(win,win_name,ierror)
@@ -3192,6 +3243,48 @@ subroutine PMPI_Win_create_f08(base,size,disp_unit,info,comm,win,ierror)
 end subroutine PMPI_Win_create_f08
 end interface  PMPI_Win_create
 
+interface  PMPI_Win_create_dynamic
+subroutine PMPI_Win_create_dynamic_f08(info,comm,win,ierror)
+   use :: mpi_f08_types, only : MPI_Info, MPI_Comm, MPI_Win
+   implicit none
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Win), INTENT(OUT) :: win
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Win_create_dynamic_f08
+end interface  PMPI_Win_create_dynamic
+
+interface  PMPI_Win_attach
+subroutine PMPI_Win_attach_f08(win,base,size,ierror)
+   use :: mpi_f08_types, only : MPI_Win, MPI_ADDRESS_KIND
+   implicit none
+   !DEC$ ATTRIBUTES NO_ARG_CHECK :: base
+   !GCC$ ATTRIBUTES NO_ARG_CHECK :: base
+   !$PRAGMA IGNORE_TKR base
+   !DIR$ IGNORE_TKR base
+   !IBM* IGNORE_TKR base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: size
+   TYPE(MPI_Win), INTENT(IN) :: win
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Win_attach_f08
+end interface  PMPI_Win_attach
+
+interface  PMPI_Win_detach
+subroutine PMPI_Win_detach_f08(win,base,ierror)
+   use :: mpi_f08_types, only : MPI_Win, MPI_ADDRESS_KIND
+   implicit none
+   !DEC$ ATTRIBUTES NO_ARG_CHECK :: base
+   !GCC$ ATTRIBUTES NO_ARG_CHECK :: base
+   !$PRAGMA IGNORE_TKR base
+   !DIR$ IGNORE_TKR base
+   !IBM* IGNORE_TKR base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
+   TYPE(MPI_Win), INTENT(IN) :: win
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Win_detach_f08
+end interface  PMPI_Win_detach
+
 interface  PMPI_Win_fence
 subroutine PMPI_Win_fence_f08(assert,win,ierror)
    use :: mpi_f08_types, only : MPI_Win
@@ -3251,6 +3344,20 @@ subroutine PMPI_Win_post_f08(group,assert,win,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Win_post_f08
 end interface  PMPI_Win_post
+
+interface PMPI_Win_shared_query
+subroutine PMPI_Win_shared_query_f08(win, rank, size, disp_unit, baseptr,&
+      ierror)
+  USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
+  use :: mpi_f08_types, only : MPI_Win, MPI_ADDRESS_KIND
+  TYPE(MPI_Win), INTENT(IN) ::  win
+  INTEGER, INTENT(IN) ::  rank
+  INTEGER(KIND=MPI_ADDRESS_KIND), INTENT(OUT) ::  size
+  INTEGER, INTENT(OUT) ::  disp_unit
+  TYPE(C_PTR), INTENT(OUT) ::  baseptr
+  INTEGER, OPTIONAL, INTENT(OUT) ::  ierror
+end subroutine PMPI_Win_shared_query_f08
+end interface PMPI_Win_shared_query
 
 interface  PMPI_Win_start
 subroutine PMPI_Win_start_f08(group,assert,win,ierror)

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iread_all_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iread_all_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_File_iread_all_f08(fh,buf,count,datatype,request,ierror)
+   use :: mpi_f08_types, only : MPI_File, MPI_Datatype, MPI_Request
+   use :: mpi_f08, only : ompi_file_iread_all_f
+   implicit none
+   TYPE(MPI_File), INTENT(IN) :: fh
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: count
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_file_iread_all_f(fh%MPI_VAL,buf,count,datatype%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_File_iread_all_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iread_at_all_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iread_at_all_f08.F90
@@ -1,0 +1,28 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_File_iread_at_all_f08(fh,offset,buf,count,datatype,request,ierror)
+   use :: mpi_f08_types, only : MPI_File, MPI_Datatype, MPI_Request, MPI_OFFSET_KIND
+   use :: mpi_f08, only : ompi_file_iread_at_all_f
+   implicit none
+   TYPE(MPI_File), INTENT(IN) :: fh
+   INTEGER(MPI_OFFSET_KIND), INTENT(IN) :: offset
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: count
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_file_iread_at_all_f(fh%MPI_VAL,offset,buf,count,&
+                             datatype%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_File_iread_at_all_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iwrite_all_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iwrite_all_f08.F90
@@ -1,0 +1,27 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_File_iwrite_all_f08(fh,buf,count,datatype,request,ierror)
+   use :: mpi_f08_types, only : MPI_File, MPI_Datatype, MPI_Request
+   use :: mpi_f08, only : ompi_file_iwrite_all_f
+   implicit none
+   TYPE(MPI_File), INTENT(IN) :: fh
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: count
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_file_iwrite_all_f(fh%MPI_VAL,buf,count,&
+                           datatype%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_File_iwrite_all_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iwrite_at_all_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pfile_iwrite_at_all_f08.F90
@@ -1,0 +1,28 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+!               All Rights reserved.
+! Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+! $COPYRIGHT$
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPI_File_iwrite_at_all_f08(fh,offset,buf,count,datatype,request,ierror)
+   use :: mpi_f08_types, only : MPI_File, MPI_Datatype, MPI_Request, MPI_OFFSET_KIND
+   use :: mpi_f08, only : ompi_file_iwrite_at_all_f
+   implicit none
+   TYPE(MPI_File), INTENT(IN) :: fh
+   INTEGER(MPI_OFFSET_KIND), INTENT(IN) :: offset
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   INTEGER, INTENT(IN) :: count
+   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_file_iwrite_at_all_f(fh%MPI_VAL,offset,buf,count,&
+                              datatype%MPI_VAL,request%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_File_iwrite_at_all_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pstatus_set_cancelled_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pstatus_set_cancelled_f08.F90
@@ -16,12 +16,12 @@ subroutine PMPI_Status_set_cancelled_f08(status,flag,ierror)
    ! See note in mpi-f-interfaces-bind.h for why we include an
    ! interface here and call a PMPI_* subroutine below.
    interface
-      subroutine MPI_Status_set_cancelled(status, flag, ierror)
+      subroutine PMPI_Status_set_cancelled(status, flag, ierror)
         use :: mpi_f08_types, only : MPI_Status
         type(MPI_Status), intent(inout) :: status
         logical, intent(in) :: flag
         integer, intent(out) :: ierror
-      end subroutine MPI_Status_set_cancelled
+      end subroutine PMPI_Status_set_cancelled
    end interface
 
    call PMPI_Status_set_cancelled(status,flag,c_ierror)


### PR DESCRIPTION
Bring PR #4659, #4667, #4668 to v3.0.x branch.

This PR includes an ABI change but no one will be affected (discussed in #4667).

NEWS: Correct PMPI_Aint_{add|diff} to be functions (not subroutines) in the Fortran mpi_f08 module.
