### PR TITLE
v2.1.x: Fix type of mpi_f08 MPI_ERRCODES_IGNORE

### DIFF
--- a/ompi/mpi/fortran/base/gen-mpi-mangling.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-mangling.pl
@@ -90,7 +90,7 @@ $fortran->{argvs_null} = {
 $fortran->{errcodes_ignore} = {
     c_type => "int *",
     c_name => "mpi_fortran_errcodes_ignore",
-    f_type => "integer",
+    f_type => "integer, dimension(1)",
     f_name => "MPI_ERRCODES_IGNORE",
 };
 $fortran->{status_ignore} = {


### PR DESCRIPTION
Signed-off-by: Nathan T. Weeks <weeks@iastate.edu>
(cherry picked from commit 3158d2c5edd46422976140a3765d9488b54115c5)

Submitted by @nathanweeks, reviewed by @jsquyres.  

@hppritcha This is good to go.

Refs #4693.