### PR TITLE
Ensure the epilog gets executed in PMIx server

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix/src/include/pmix_globals.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/include/pmix_globals.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -408,6 +408,8 @@ typedef struct {
     pmix_gds_base_module_t *mygds;
 } pmix_globals_t;
 
+/* provide access to a function to cleanup epilogs */
+PMIX_EXPORT void pmix_execute_epilog(pmix_epilog_t *ep);
 
 PMIX_EXPORT extern pmix_globals_t pmix_globals;
 PMIX_EXPORT extern pmix_lock_t pmix_global_lock;


### PR DESCRIPTION
If we abnormally terminate, then we still want any cleanups to be
executed.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>