### PR TITLE
man: fix indentation of MPI_Comm_spawn[_multiple]

### DIFF
--- a/ompi/mpi/man/man3/MPI_Comm_spawn.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_spawn.3in
@@ -173,7 +173,7 @@ ompi_preload_files     char *   A comma-separated list of files that
                                 \fIompi_preload_binary\fP - files can
                                 be moved to the target even if an
                                 executable is not moved.
-ompi_stdin_target   char* Comma-delimited list of ranks to
+ompi_stdin_target      char *   Comma-delimited list of ranks to
                                 receive stdin when forwarded.
 ompi_non_mpi           bool     If set to true, launching a non-MPI
                                 application; the returned communicator
@@ -186,25 +186,25 @@ ompi_param             char *   Pass an OMPI MCA parameter to the
                                 exists in the environment, the value
                                 will be overwritten by the provided
                                 value.
-mapper                    char*  Mapper to be used for this job
-map_by                    char*  Mapping directive indicating how
+mapper                 char *   Mapper to be used for this job
+map_by                 char *   Mapping directive indicating how
                                 processes are to be mapped (slot,
                                 node, socket, etc.).
-rank_by                   char *  Ranking directive indicating how
+rank_by                char *   Ranking directive indicating how
                                 processes are to be ranked (slot,
                                 node, socket, etc.).
-bind_to                    char *  Binding directive indicating how
+bind_to                char *   Binding directive indicating how
                                 processes are to be bound (core, slot,
                                 node, socket, etc.).
-path                         char*  List of directories to search for
+path                   char *   List of directories to search for
                                 the executable
-npernode                 char* Number of processes to spawn on
+npernode               char *   Number of processes to spawn on
                                 each node of the allocation
-pernode                   bool  Equivalent to npernode of 1
-ppr                          char* Spawn specified number of processes
-                               on each of the identified object type
-env                         char*  Newline-delimited list of envars to
-                               be passed to the spawned procs
+pernode                bool     Equivalent to npernode of 1
+ppr                    char *   Spawn specified number of processes
+                                on each of the identified object type
+env                    char *   Newline-delimited list of envars to
+                                be passed to the spawned procs
 .fi
 
 \fIbool\fP info keys are actually strings but are evaluated as

--- a/ompi/mpi/man/man3/MPI_Comm_spawn_multiple.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_spawn_multiple.3in
@@ -179,7 +179,7 @@ ompi_preload_files     char *   A comma-separated list of files that
                                 \fIompi_preload_binary\fP - files can
                                 be moved to the target even if an
                                 executable is not moved.
-ompi_stdin_target   char* Comma-delimited list of ranks to
+ompi_stdin_target      char *   Comma-delimited list of ranks to
                                 receive stdin when forwarded.
 ompi_non_mpi           bool     If set to true, launching a non-MPI
                                 application; the returned communicator
@@ -192,25 +192,25 @@ ompi_param             char *   Pass an OMPI MCA parameter to the
                                 exists in the environment, the value
                                 will be overwritten by the provided
                                 value.
-mapper                    char*  Mapper to be used for this job
-map_by                    char*  Mapping directive indicating how
+mapper                 char *   Mapper to be used for this job
+map_by                 char *   Mapping directive indicating how
                                 processes are to be mapped (slot,
                                 node, socket, etc.).
-rank_by                   char *  Ranking directive indicating how
+rank_by                char *   Ranking directive indicating how
                                 processes are to be ranked (slot,
                                 node, socket, etc.).
-bind_to                    char *  Binding directive indicating how
+bind_to                char *   Binding directive indicating how
                                 processes are to be bound (core, slot,
                                 node, socket, etc.).
-path                         char*  List of directories to search for
+path                   char *   List of directories to search for
                                 the executable
-npernode                 char* Number of processes to spawn on
+npernode               char *   Number of processes to spawn on
                                 each node of the allocation
-pernode                   bool  Equivalent to npernode of 1
-ppr                          char* Spawn specified number of processes
-                               on each of the identified object type
-env                         char*  Newline-delimited list of envars to
-                               be passed to the spawned procs
+pernode                bool     Equivalent to npernode of 1
+ppr                    char *   Spawn specified number of processes
+                                on each of the identified object type
+env                    char *   Newline-delimited list of envars to
+                                be passed to the spawned procs
 .fi
 
 .sp


### PR DESCRIPTION
no code change.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@cb5dfbe5b172c1f197674410019b03de2ceb9db8)