### PR TITLE
opal_check_package: filter /usr[/local]/include from CPPFLAGS 

### DIFF
--- a/config/opal_check_package.m4
+++ b/config/opal_check_package.m4
@@ -42,7 +42,9 @@ AC_DEFUN([_OPAL_CHECK_PACKAGE_HEADER], [
     dir_prefix=$(echo $3 | sed -e 'sX/*$XXg')
     opal_check_package_header_happy="no"
     AS_IF([test "$dir_prefix" = "/usr" || \
-           test "$dir_prefix" = "/usr/local"],
+           test "$dir_prefix" = "/usr/local" || \
+           test "$dir_prefix" = "/usr/include" || \
+           test "$dir_prefix" = "/usr/local/include"],
            [ # try as is...
             AC_VERBOSE([looking for header without includes])
             AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [])


### PR DESCRIPTION
When using `./configure --with-package=/usr/include` or `--with-package=/usr/local/include` we do not want those directories to appear in the CPPFLAGS since they are standard system directories.

```
./configure --with-pmix=/usr/include --with-libevent --with-hwloc
grep opal_pmix config.log | grep CPPFLAGS
opal_pmix_ext1x_CPPFLAGS=''
opal_pmix_ext2x_CPPFLAGS=''
opal_pmix_ext3x_CPPFLAGS=''
opal_pmix_pmix3x_CPPFLAGS=''
```

Signed-off-by: Philip Kovacs <pkdevel@yahoo.com>