### PR TITLE
ompi/oshmem: ucx is selected over yalla/ikrit by default

### DIFF
--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -213,6 +213,7 @@ static int mca_pml_base_open(mca_base_open_flag_t flags)
              0 == strlen(default_pml[0])) || (default_pml[0][0] == '^') ) {
             opal_pointer_array_add(&mca_pml_base_pml, strdup("ob1"));
             opal_pointer_array_add(&mca_pml_base_pml, strdup("yalla"));
+            opal_pointer_array_add(&mca_pml_base_pml, strdup("ucx"));
             opal_pointer_array_add(&mca_pml_base_pml, strdup("cm"));
         } else {
             opal_pointer_array_add(&mca_pml_base_pml, strdup(default_pml[0]));

--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -55,7 +55,7 @@ static int mca_pml_ucx_component_register(void)
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &ompi_pml_ucx.verbose);
 
-    ompi_pml_ucx.priority = 5;
+    ompi_pml_ucx.priority = 51;
     (void) mca_base_component_var_register(&mca_pml_ucx_component.pmlm_version, "priority",
                                            "Priority of the UCX component",
                                            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -93,7 +93,7 @@ static inline void  mca_spml_ucx_param_register_string(const char* param_name,
 
 static int mca_spml_ucx_component_register(void)
 {
-    mca_spml_ucx_param_register_int("priority", 5,
+    mca_spml_ucx_param_register_int("priority", 21,
                                       "[integer] ucx priority",
                                       &mca_spml_ucx.priority);
 


### PR DESCRIPTION
Signed-off-by: Alex Mikheev <alexm@mellanox.com>

@yosefe please take a look