### PR TITLE
pmix: add implementation of timings framework

### DIFF
--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -660,6 +660,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
 
     OMPI_TIMING_IMPORT_OPAL("orte_init");
     OMPI_TIMING_IMPORT_OPAL("opal_init_util");
+    OMPI_TIMING_IMPORT_PMIX("PMIx_Init");
     OMPI_TIMING_NEXT("rte_init-commit");
 
 
@@ -1023,10 +1024,14 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided)
     /* Finish last measurement, output results
      * and clear timing structure */
     OMPI_TIMING_NEXT("barrier-finish");
-    OMPI_TIMING_OUT;
-    OMPI_TIMING_FINALIZE;
 
     opal_mutex_unlock(&ompi_mpi_bootstrap_mutex);
+
+    /* Import PMIx fence timings at the end to avoid the race of get/setenv 
+     * PMIx timings when used the not blocking fence */
+    OMPI_TIMING_IMPORT_PMIX("PMIx_Fence_nb");
+    OMPI_TIMING_OUT;
+    OMPI_TIMING_FINALIZE;
 
     ompi_hook_base_mpi_init_bottom(argc, argv, requested, provided);
 

--- a/opal/mca/pmix/pmix3x/configure.m4
+++ b/opal/mca/pmix/pmix3x/configure.m4
@@ -31,6 +31,7 @@ AC_DEFUN([MCA_opal_pmix_pmix3x_CONFIG],[
     OPAL_VAR_SCOPE_PUSH([PMIX_VERSION opal_pmix_pmix3x_save_CPPFLAGS opal_pmix_pmix2_save_CFLAGS opal_pmix_pmix3x_save_LDFLAGS opal_pmix_pmix3x_save_LIBS opal_pmix_pmix3x_basedir opal_pmix_pmix3x_args opal_pmix_pmix3x_happy  pmix_pmix3x_status_filename])
 
     opal_pmix_pmix3x_basedir=opal/mca/pmix/pmix3x
+    opal_pmix_pmix3x_rename=OPAL_MCA_PMIX3X_
 
     opal_pmix_pmix3x_save_CFLAGS=$CFLAGS
     opal_pmix_pmix3x_save_CPPFLAGS=$CPPFLAGS
@@ -63,7 +64,10 @@ AC_DEFUN([MCA_opal_pmix_pmix3x_CONFIG],[
     AS_IF([test "$enable_install_libpmix" == "yes"],
           [AC_MSG_RESULT([yes])],
           [AC_MSG_RESULT([no])
-           opal_pmix_pmix3x_args="--with-pmix-symbol-rename=OPAL_MCA_PMIX3X_ --enable-embedded-mode $opal_pmix_pmix3x_args"])
+           opal_pmix_pmix3x_args="--with-pmix-symbol-rename=$opal_pmix_pmix3x_rename --enable-embedded-mode $opal_pmix_pmix3x_args"])
+    AC_DEFINE_UNQUOTED([OPAL_PMIX_RENAME_PREFIX],
+                       ["$opal_pmix_pmix3x_rename"],
+                       [MCA prefix string for PMIx rename])
     AS_IF([test "$with_devel_headers" = "yes"],
           [opal_pmix_pmix3x_args="--with-devel-headers  $opal_pmix_pmix3x_args"])
     CPPFLAGS="-I$OPAL_TOP_SRCDIR -I$OPAL_TOP_BUILDDIR -I$OPAL_TOP_SRCDIR/opal/include -I$OPAL_TOP_BUILDDIR/opal/include $CPPFLAGS"

--- a/opal/mca/pmix/pmix3x/pmix/src/client/pmix_client_fence.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/client/pmix_client_fence.c
@@ -52,9 +52,12 @@
 #include "src/util/error.h"
 #include "src/util/hash.h"
 #include "src/util/output.h"
+#include "src/util/timings.h"
 #include "src/mca/ptl/ptl.h"
 
 #include "pmix_client_ops.h"
+
+PMIX_TIMING_ENV_DEF(pmix_fence_tmng);
 
 static pmix_status_t unpack_return(pmix_buffer_t *data);
 static pmix_status_t pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd,
@@ -122,6 +125,8 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
     pmix_cb_t *cb;
     pmix_proc_t rg, *rgs;
     size_t nrg;
+
+    PMIX_TIMING_ENV_START(pmix_fence_tmng);
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -274,6 +279,9 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     if (NULL != cb->cbfunc.opfn) {
         cb->cbfunc.opfn(rc, cb->cbdata);
     }
+
+    PMIX_TIMING_ENV_NEXT(pmix_fence_tmng, "fence");
+
     PMIX_RELEASE(cb);
 }
 

--- a/opal/mca/pmix/pmix3x/pmix/src/util/timings.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/timings.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014      Artem Polyakov <artpol84@gmail.com>
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2018 Mellanox Technologies Ltd. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -8,18 +9,16 @@
  * $HEADER$
  */
 
-#include <src/include/pmix_config.h>
 
-#include <pmix_common.h>
+#include <src/include/pmix_config.h>
+#include <pmix_rename.h>
 
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
 
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 
 #include <errno.h>
 #ifdef HAVE_SYS_TYPES_H
@@ -32,41 +31,14 @@
 #include <sys/resource.h>
 #endif
 
-
-#if PMIX_ENABLE_TIMING
-
 #include "src/class/pmix_pointer_array.h"
 #include "src/class/pmix_list.h"
+
 #include "src/util/output.h"
 #include "src/util/basename.h"
-
 #include "src/util/timings.h"
 
-#define DELTAS_SANE_LIMIT (10*1024*1024)
-
-struct interval_descr{
-    pmix_timing_event_t *descr_ev, *begin_ev;
-    double interval, overhead;
-};
-
-pmix_timing_event_t *pmix_timing_event_alloc(pmix_timing_t *t);
-void pmix_timing_init(pmix_timing_t *t);
-pmix_timing_prep_t pmix_timing_prep_ev(pmix_timing_t *t, const char *fmt, ...);
-
-static PMIX_CLASS_INSTANCE(pmix_timing_event_t, pmix_list_item_t, NULL, NULL);
-
-
-static char *nodename = NULL;
-static char *jobid = "";
-static double hnp_offs = 0;
-static bool pmix_timing_overhead = false;
-
-void pmix_init_id(char* nspace, int rank)
-{
-    asprintf(&jobid, "%s:%d", nspace, rank);
-}
-
-/* Get current timestamp. Derived from MPI_Wtime */
+extern int pmix_initialized;
 
 static double get_ts_gettimeofday(void)
 {
@@ -79,567 +51,48 @@ static double get_ts_gettimeofday(void)
     return ret;
 }
 
-static get_ts_t _init_timestamping(void)
+#if PMIX_TIMER_CYCLE_NATIVE
+static double get_ts_cycle(void)
 {
-    return get_ts_gettimeofday;
-}
-
-
-pmix_timing_event_t *pmix_timing_event_alloc(pmix_timing_t *t)
-{
-    if( t->buffer_offset >= t->buffer_size ){
-        // notch timings overhead
-        double alloc_begin = t->get_ts();
-
-        t->buffer = malloc(sizeof(pmix_timing_event_t)*t->buffer_size);
-        if( t->buffer == NULL ){
-            return NULL;
-        }
-        memset(t->buffer, 0, sizeof(pmix_timing_event_t)*t->buffer_size);
-
-        double alloc_end = t->get_ts();
-
-        t->buffer_offset = 0;
-        t->buffer[0].fib = 1;
-        t->buffer[0].ts_ovh = alloc_end - alloc_begin;
-    }
-    int tmp = t->buffer_offset;
-    (t->buffer_offset)++;
-    return t->buffer + tmp;
-}
-
-void pmix_timing_init(pmix_timing_t *t)
-{
-    memset(t,0,sizeof(*t));
-
-    t->next_id_cntr = 0;
-    t->current_id = -1;
-    /* initialize events list */
-    t->events = PMIX_NEW(pmix_list_t);
-    /* Set buffer size */
-    t->buffer_size = PMIX_TIMING_BUFSIZE;
-    /* Set buffer_offset = buffer_size so new buffer
-     * will be allocated at first event report */
-    t->buffer_offset = t->buffer_size;
-    /* initialize gettime function */
-    t->get_ts = _init_timestamping();
-
-}
-
-pmix_timing_prep_t pmix_timing_prep_ev(pmix_timing_t *t, const char *fmt, ...)
-{
-    pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-    if( ev == NULL ){
-        pmix_timing_prep_t p = { t, NULL, PMIX_ERR_OUT_OF_RESOURCE };
-        return p;
-    }
-    PMIX_CONSTRUCT(ev, pmix_timing_event_t);
-    ev->ts = t->get_ts();
-    va_list args;
-    va_start( args, fmt );
-    vsnprintf(ev->descr, PMIX_TIMING_DESCR_MAX - 1, fmt, args);
-    ev->descr[PMIX_TIMING_DESCR_MAX-1] = '\0';
-    va_end( args );
-    pmix_timing_prep_t p = { t, ev, 0 };
-    return p;
-}
-
-pmix_timing_prep_t pmix_timing_prep_ev_end(pmix_timing_t *t, const char *fmt, ...)
-{
-    pmix_timing_prep_t p = { t, NULL, 0 };
-
-    if( t->current_id >= 0 ){
-        pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-        if( ev == NULL ){
-            pmix_timing_prep_t p = { t, NULL, PMIX_ERR_OUT_OF_RESOURCE };
-            return p;
-        }
-        PMIX_CONSTRUCT(ev, pmix_timing_event_t);
-        ev->ts = t->get_ts();
-        p.ev = ev;
-    }
-    return p;
-}
-
-void pmix_timing_add_step(pmix_timing_prep_t p,
-                          const char *func, const char *file, int line)
-{
-    if( !p.errcode ) {
-        p.ev->func = func;
-        p.ev->file = file;
-        p.ev->line = line;
-        p.ev->type = PMIX_TIMING_TRACE;
-        pmix_list_append(p.t->events, (pmix_list_item_t*)p.ev);
-    }
-}
-
-/* Add description of the interval */
-int pmix_timing_descr(pmix_timing_prep_t p,
-                           const char *func, const char *file, int line)
-{
-    if( !p.errcode ){
-        p.ev->func = func;
-        p.ev->file = file;
-        p.ev->line = line;
-        p.ev->type = PMIX_TIMING_INTDESCR;
-        p.ev->id = p.t->next_id_cntr;
-        (p.t->next_id_cntr)++;
-        pmix_list_append(p.t->events, (pmix_list_item_t*)p.ev);
-        return p.ev->id;
-    }
-    return -1;
-}
-
-void pmix_timing_start_id(pmix_timing_t *t, int id, const char *func, const char *file, int line)
-{
-    /* No description is needed. If everything is OK
-     * it'll be included in pmix_timing_start_init */
-    pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-    if( ev == NULL ){
-        return;
-    }
-    PMIX_CONSTRUCT(ev, pmix_timing_event_t);
-
-    t->current_id = id;
-    ev->ts = t->get_ts();
-    ev->func = func;
-    ev->file = file;
-    ev->line = line;
-    ev->type = PMIX_TIMING_INTBEGIN;
-    ev->id = id;
-    pmix_list_append(t->events, (pmix_list_item_t*)ev);
-}
-
-void pmix_timing_end(pmix_timing_t *t, int id, const char *func, const char *file, int line )
-{
-    /* No description is needed. If everything is OK
-     * it'll be included in pmix_timing_start_init */
-    pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-    if( ev == NULL ){
-        return;
-    }
-    PMIX_CONSTRUCT(ev, pmix_timing_event_t);
-
-    if( id < 0 ){
-        ev->id = t->current_id;
-        t->current_id = -1;
-    } else {
-        if( t->current_id == id ){
-            t->current_id = -1;
-        }
-        ev->id = id;
-    }
-    ev->ts = t->get_ts();
-    ev->func = func;
-    ev->file = file;
-    ev->line = line;
-    ev->type = PMIX_TIMING_INTEND;
-    pmix_list_append(t->events, (pmix_list_item_t*)ev);
-}
-
-void pmix_timing_end_prep(pmix_timing_prep_t p,
-                                        const char *func, const char *file, int line)
-{
-    pmix_timing_event_t *ev = p.ev;
-
-    if( !p.errcode && ( NULL != ev ) ){
-        assert(  p.t->current_id >=0 );
-        ev->id = p.t->current_id;
-        p.t->current_id = -1;
-        ev->func = func;
-        ev->file = file;
-        ev->line = line;
-        ev->type = PMIX_TIMING_INTEND;
-        pmix_list_append(p.t->events, (pmix_list_item_t*)ev);
-    }
-}
-
-static int _prepare_descriptions(pmix_timing_t *t, struct interval_descr **__descr)
-{
-    struct interval_descr *descr;
-    pmix_timing_event_t *ev, *next;
-
-    if( t->next_id_cntr == 0 ){
-        return 0;
-    }
-
-    *__descr = malloc(sizeof(struct interval_descr) * t->next_id_cntr);
-    descr = *__descr;
-    memset(descr, 0, sizeof(struct interval_descr) * t->next_id_cntr);
-
-    PMIX_LIST_FOREACH_SAFE(ev, next, t->events, pmix_timing_event_t){
-
-        /* pmix_output(0,"EVENT: type = %d, id=%d, ts = %.12le, ovh = %.12le %s",
-                    ev->type, ev->id, ev->ts, ev->ts_ovh,
-                    ev->descr );
-        */
-        switch(ev->type){
-        case PMIX_TIMING_INTDESCR:{
-            if( ev->id >= t->next_id_cntr){
-                char *file = pmix_basename(ev->file);
-                pmix_output(0,"pmix_timing: bad event id at %s:%d:%s, ignore and remove",
-                            file, ev->line, ev->func);
-                free(file);
-                pmix_list_remove_item(t->events, (pmix_list_item_t *)ev);
-                continue;
-            }
-            if( NULL != descr[ev->id].descr_ev ){
-                pmix_timing_event_t *prev = descr[ev->id].descr_ev;
-                char *file = pmix_basename(ev->file);
-                char *file_prev = pmix_basename(prev->file);
-                pmix_output(0,"pmix_timing: duplicated description at %s:%d:%s, "
-                            "previous: %s:%d:%s, ignore and remove", file, ev->line, ev->func,
-                            file_prev, prev->line, prev->func);
-                free(file);
-                free(file_prev);
-                pmix_list_remove_item(t->events, (pmix_list_item_t *)ev);
-                continue;
-            }
-
-            descr[ev->id].descr_ev = ev;
-            descr[ev->id].begin_ev = NULL;
-            descr[ev->id].interval = 0;
-            descr[ev->id].overhead = 0;
-            break;
-        }
-        case PMIX_TIMING_INTBEGIN:
-        case PMIX_TIMING_INTEND:{
-            if( ev->id >= t->next_id_cntr || (NULL == descr[ev->id].descr_ev ) ){
-                char *file = pmix_basename(ev->file);
-                pmix_output(0,"pmix_timing: bad event id at %s:%d:%s, ignore and remove",
-                            file, ev->line, ev->func);
-                free(file);
-                pmix_list_remove_item(t->events, (pmix_list_item_t *)ev);
-                continue;
-            }
-            break;
-        }
-        case PMIX_TIMING_TRACE:
-            break;
-        }
-    }
-    return t->next_id_cntr;
-}
-
-/* Output lines in portions that doesn't
- * exceed PMIX_TIMING_OUTBUF_SIZE for later automatic processing */
-int pmix_timing_report(pmix_timing_t *t, char *fname)
-{
-    pmix_timing_event_t *ev;
-    FILE *fp = NULL;
-    char *buf = NULL;
-    int buf_size = 0;
-    struct interval_descr *descr = NULL;
-    int rc = PMIX_SUCCESS;
-
-    if( fname != NULL ){
-        fp = fopen(fname,"a");
-        if( fp == NULL ){
-            pmix_output(0, "pmix_timing_report: Cannot open %s file"
-                        " for writing timing information!",fname);
-            rc = PMIX_ERROR;
-            goto err_exit;
-        }
-    }
-
-    _prepare_descriptions(t, &descr);
-
-    buf = malloc(PMIX_TIMING_OUTBUF_SIZE+1);
-    if( buf == NULL ){
-        rc = PMIX_ERR_OUT_OF_RESOURCE;
-        goto err_exit;
-    }
-    buf[0] = '\0';
-
-    double overhead = 0;
-    PMIX_LIST_FOREACH(ev, t->events, pmix_timing_event_t){
-        char *line, *file;
-        if( ev->fib && pmix_timing_overhead ){
-            overhead += ev->ts_ovh;
-        }
-        file = pmix_basename(ev->file);
-        switch( ev->type ){
-        case PMIX_TIMING_INTDESCR:
-            // Service event, skip it.
-            continue;
-        case PMIX_TIMING_TRACE:
-            rc = asprintf(&line,"[%s:%d] %s \"%s\" [PMIX_TRACE] %s:%d %.10lf\n",
-                          nodename, getpid(), jobid, ev->descr, file, ev->line,
-                          ev->ts + hnp_offs + overhead);
-            break;
-        case PMIX_TIMING_INTBEGIN:
-            rc = asprintf(&line,"[%s:%d] %s \"%s [start]\" [PMIX_TRACE] %s:%d %.10lf\n",
-                          nodename, getpid(), jobid, descr[ev->id].descr_ev->descr,
-                          file, ev->line, ev->ts + hnp_offs + overhead);
-            break;
-        case PMIX_TIMING_INTEND:
-            rc = asprintf(&line,"[%s:%d] %s \"%s [stop]\" [PMIX_TRACE] %s:%d %.10lf\n",
-                          nodename, getpid(), jobid, descr[ev->id].descr_ev->descr,
-                          file, ev->line, ev->ts + hnp_offs + overhead);
-            break;
-        }
-        free(file);
-
-        if( rc < 0 ){
-            rc = PMIX_ERR_OUT_OF_RESOURCE;
-            goto err_exit;
-        }
-        rc = 0;
-
-        /* Sanity check: this shouldn't happen since description
-             * is event only 1KB long and other fields should never
-             * exceed 9KB */
-        assert( strlen(line) <= PMIX_TIMING_OUTBUF_SIZE );
-
-
-        if( buf_size + strlen(line) > PMIX_TIMING_OUTBUF_SIZE ){
-            // flush buffer to the file
-            if( fp != NULL ){
-                fprintf(fp,"%s", buf);
-                fprintf(fp,"\n");
-            } else {
-                pmix_output(0,"\n%s", buf);
-            }
-            buf[0] = '\0';
-            buf_size = 0;
-        }
-        sprintf(buf,"%s%s", buf, line);
-        buf_size += strlen(line);
-        free(line);
-    }
-
-    if( buf_size > 0 ){
-        // flush buffer to the file
-        if( fp != NULL ){
-            fprintf(fp,"%s", buf);
-            fprintf(fp,"\n");
-        } else {
-            pmix_output(0,"\n%s", buf);
-        }
-        buf[0] = '\0';
-        buf_size = 0;
-    }
-
-err_exit:
-    if( NULL != descr ){
-        free(descr);
-    }
-    if( buf != NULL ){
-        free(buf);
-    }
-    if( fp != NULL ){
-        fflush(fp);
-        fclose(fp);
-    }
-    return rc;
-}
-
-/* Output events as one buffer so the data won't be mixed
- * with other output. This function is supposed to be human readable.
- * The output goes only to stdout. */
-int pmix_timing_deltas(pmix_timing_t *t, char *fname)
-{
-    pmix_timing_event_t *ev;
-    FILE *fp = NULL;
-    char *buf = NULL;
-    struct interval_descr *descr = NULL;
-    int i, rc = PMIX_SUCCESS;
-    size_t buf_size = 0, buf_used = 0;
-
-    if( fname != NULL ){
-        fp = fopen(fname,"a");
-        if( fp == NULL ){
-            pmix_output(0, "pmix_timing_report: Cannot open %s file"
-                        " for writing timing information!",fname);
-            rc = PMIX_ERROR;
-            goto err_exit;
-        }
-    }
-
-    _prepare_descriptions(t, &descr);
-
-    PMIX_LIST_FOREACH(ev, t->events, pmix_timing_event_t){
-        int id;
-        if( ev->fib ){
-            /* this event caused buffered memory allocation
-             * for events. Account the overhead for all active
-             * intervals. */
-            int i;
-            for( i = 0; i < t->next_id_cntr; i++){
-                if( (NULL != descr[i].descr_ev) && (NULL != descr[i].begin_ev) ){
-                    if( pmix_timing_overhead ){
-                        descr[i].overhead += ev->ts_ovh;
-                    }
-                }
-            }
-        }
-
-        /* we already process all PMIX_TIMING_DESCR events
-         * and we ignore PMIX_TIMING_EVENT */
-        if( ev->type == PMIX_TIMING_INTDESCR ||
-                ev->type == PMIX_TIMING_TRACE){
-            /* skip */
-            continue;
-        }
-
-        id = ev->id;
-        if( id < 0 || id >= t->next_id_cntr ){
-            char *file = pmix_basename(ev->file);
-            pmix_output(0,"pmix_timing_deltas: bad interval event id: %d at %s:%d:%s (maxid=%d)",
-                        id, file, ev->line, ev->func, t->next_id_cntr - 1 );
-            free(file);
-            /* skip */
-            continue;
-        }
-
-        /* id's assigned auomatically. Ther shouldn't be any gaps in descr[] */
-        assert( NULL != descr[id].descr_ev);
-
-        if( ev->type == PMIX_TIMING_INTBEGIN ){
-            if( NULL != descr[id].begin_ev ){
-                /* the measurement on this interval was already
-                 * started! */
-                pmix_timing_event_t *prev = descr[ev->id].begin_ev;
-                char *file = pmix_basename(ev->file);
-                char *file_prev = pmix_basename(prev->file);
-                pmix_output(0,"pmix_timing_deltas: duplicated start statement at %s:%d:%s, "
-                            "previous: %s:%d:%s", file, ev->line, ev->func,
-                            file_prev, prev->line, prev->func);
-                free(file);
-                free(file_prev);
-            } else {
-                /* save pointer to the start of measurement event */
-                descr[id].begin_ev = ev;
-            }
-            /* done, go to the next event */
-            continue;
-        }
-
-        if( ev->type == PMIX_TIMING_INTEND ){
-            if( NULL == descr[id].begin_ev ){
-                /* the measurement on this interval wasn't started! */
-                char *file = pmix_basename(ev->file);
-                pmix_output(0,"pmix_timing_deltas: inteval end without start at %s:%d:%s",
-                            file, ev->line, ev->func );
-                free(file);
-            } else {
-                descr[id].interval += ev->ts - descr[id].begin_ev->ts;
-                descr[id].begin_ev = NULL;
-                if( ev->fib ){
-                    descr[id].overhead += ev->ts_ovh;
-                }
-            }
-            continue;
-        }
-
-        /* shouldn't ever get here: bad ev->type */
-        pmix_output(0, "pmix_timing_deltas: bad event type %d", ev->type);
-        assert(0);
-    }
-
-    buf = malloc(PMIX_TIMING_OUTBUF_SIZE + 1);
-    if( buf == NULL ){
-        rc = PMIX_ERR_OUT_OF_RESOURCE;
-        goto err_exit;
-    }
-    buf[0] = '\0';
-    buf_size = PMIX_TIMING_OUTBUF_SIZE + 1;
-    buf_used = 0;
-    for(i = 0; i < t->next_id_cntr; i++){
-        char *line = NULL;
-        size_t line_size;
-        rc = asprintf(&line,"[%s:%d] %s \"%s\" [PMIX_OVHD] %le\n",
-                      nodename, getpid(), jobid, descr[i].descr_ev->descr,
-                      descr[i].interval - descr[i].overhead);
-        if( rc < 0 ){
-            rc = PMIX_ERR_OUT_OF_RESOURCE;
-            goto err_exit;
-        }
-        rc = 0;
-        line_size = strlen(line);
-
-        /* Sanity check: this shouldn't happen since description
-         * is event only 1KB long and other fields should never
-         * exceed 9KB */
-        assert( line_size <= PMIX_TIMING_OUTBUF_SIZE );
-
-        if( buf_used + strlen(line) > buf_size ){
-            // Increase output buffer
-            while( buf_used + line_size > buf_size && buf_size < DELTAS_SANE_LIMIT){
-                buf_size += PMIX_TIMING_OUTBUF_SIZE + 1;
-            }
-            if( buf_size > DELTAS_SANE_LIMIT ){
-                pmix_output(0, "pmix_timing_report: delta sane limit overflow (%u > %u)!\n",
-                            (unsigned int)buf_size, DELTAS_SANE_LIMIT);
-                free(line);
-                rc = PMIX_ERR_OUT_OF_RESOURCE;
-                goto err_exit;
-            }
-            buf = realloc(buf, buf_size);
-            if( buf == NULL ){
-                pmix_output(0, "pmix_timing_deltas: Out of memory!\n");
-                rc = PMIX_ERR_OUT_OF_RESOURCE;
-                goto err_exit;
-            }
-        }
-        sprintf(buf,"%s%s", buf, line);
-        buf_used += line_size;
-        free(line);
-    }
-
-
-    if( buf_used > 0 ){
-        // flush buffer to the file
-        if( fp != NULL ){
-            fprintf(fp,"%s", buf);
-            fprintf(fp,"\n");
-        } else {
-            pmix_output(0,"\n%s", buf);
-        }
-        buf[0] = '\0';
-        buf_size = 0;
-    }
-
-err_exit:
-    if( NULL != descr ){
-        free(descr);
-    }
-    if( NULL != buf ){
-        free(buf);
-    }
-    if( fp != NULL ){
-        fflush(fp);
-        fclose(fp);
-    }
-    return rc;
-}
-
-void pmix_timing_release(pmix_timing_t *t)
-{
-    int cnt = pmix_list_get_size(t->events);
-
-    if( cnt > 0 ){
-        pmix_list_t *tmp = PMIX_NEW(pmix_list_t);
-        int i;
-        for(i=0; i<cnt; i++){
-            pmix_timing_event_t *ev = (pmix_timing_event_t *)pmix_list_remove_first(t->events);
-            if( ev->fib ){
-                pmix_list_append(tmp,(pmix_list_item_t*)ev);
-            }
-        }
-
-        cnt = pmix_list_get_size(tmp);
-        for(i=0; i<cnt; i++){
-            pmix_timing_event_t *ev = (pmix_timing_event_t *)pmix_list_remove_first(tmp);
-            free(ev);
-        }
-        PMIX_RELEASE(tmp);
-    } else {
-        // Error case. At list one event was inserted at initialization.
-
-    }
-
-    PMIX_RELEASE(t->events);
-    t->events = NULL;
+        return ((double) pmix_timer_base_get_cycles()) / pmix_timer_base_get_freq();
 }
 #endif
+
+#if PMIX_TIMER_USEC_NATIVE
+static double get_ts_usec(void)
+{
+        return ((double) pmix_timer_base_get_usec()) / 1000000.0;
+}
+#endif
+
+pmix_timing_ts_func_t pmix_timing_ts_func(pmix_timer_type_t type)
+{
+    switch (type) {
+        case PMIX_TIMING_GET_TIME_OF_DAY:
+            return get_ts_gettimeofday;
+
+        case PMIX_TIMING_CYCLE_NATIVE:
+#if PMIX_TIMER_CYCLE_NATIVE
+           return get_ts_cycle;
+#else
+           return NULL;
+#endif // PMIX_TIMER_CYCLE_NATIVE
+        case PMIX_TIMING_USEC_NATIVE:
+#if PMIX_TIMER_USEC_NATIVE
+            return get_ts_usec;
+#else
+            return NULL;
+#endif // PMIX_TIMER_USEC_NATIVE
+        default:
+            if( !pmix_initialized ){
+                return get_ts_gettimeofday;
+            }
+#if PMIX_TIMER_CYCLE_NATIVE
+            return get_ts_cycle;
+#elif PMIX_TIMER_USEC_NATIVE
+            return get_ts_usec;
+#endif
+            return get_ts_gettimeofday;
+    }
+}
+

--- a/opal/mca/pmix/pmix3x/pmix/src/util/timings.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/timings.h
@@ -1,8 +1,7 @@
 /*
  * Copyright (C) 2014      Artem Polyakov <artpol84@gmail.com>
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Mellanox Technologies Ltd. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,407 +13,233 @@
 #define PMIX_UTIL_TIMING_H
 
 #include <src/include/pmix_config.h>
+#include <pmix_rename.h>
 
+typedef enum {
+    PMIX_TIMING_AUTOMATIC_TIMER,
+    PMIX_TIMING_GET_TIME_OF_DAY,
+    PMIX_TIMING_CYCLE_NATIVE,
+    PMIX_TIMING_USEC_NATIVE
+} pmix_timer_type_t;
 
-#include "src/class/pmix_list.h"
+typedef double (*pmix_timing_ts_func_t)(void);
 
 #if PMIX_ENABLE_TIMING
 
-#define PMIX_TIMING_DESCR_MAX 1024
-#define PMIX_TIMING_BUFSIZE 32
-#define PMIX_TIMING_OUTBUF_SIZE (10*1024)
-
-typedef enum {
-    PMIX_TIMING_TRACE,
-    PMIX_TIMING_INTDESCR,
-    PMIX_TIMING_INTBEGIN,
-    PMIX_TIMING_INTEND
-} pmix_event_type_t;
+#define PMIX_TIMING_STR_LEN 256
 
 typedef struct {
-    pmix_list_item_t super;
-    int fib;
-    pmix_event_type_t type;
-    const char *func;
-    const char *file;
-    int line;
-    double ts, ts_ovh;
-    char descr[PMIX_TIMING_DESCR_MAX];
-    int id;
-} pmix_timing_event_t;
+    char id[PMIX_TIMING_STR_LEN], cntr_env[PMIX_TIMING_STR_LEN];
+    int enabled, error;
+    int cntr;
+    double ts;
+    pmix_timing_ts_func_t get_ts;
+} pmix_timing_env_t;
 
-typedef double (*get_ts_t)(void);
+pmix_timing_ts_func_t pmix_timing_ts_func(pmix_timer_type_t type);
 
-typedef struct pmix_timing_t
-{
-    int next_id_cntr;
-    // not thread safe!
-    // The whole implementation is not thread safe now
-    // since it is supposed to be used in service
-    // thread only. Fix in the future or now?
-    int current_id;
-    pmix_list_t *events;
-    pmix_timing_event_t *buffer;
-    size_t buffer_offset, buffer_size;
-    get_ts_t get_ts;
-} pmix_timing_t;
+#define PMIX_TIMING_ENV_START_TYPE(func, _nm, type, prefix)                       \
+    do {                                                                          \
+        char *ptr = NULL;                                                         \
+        char *_prefix = prefix;                                                   \
+        int n;                                                                    \
+        if( NULL == prefix ){                                                     \
+            _prefix = "";                                                         \
+        }                                                                         \
+        (_nm)->error = 0;                                                         \
+        n = snprintf((_nm)->id, PMIX_TIMING_STR_LEN, "%s%s", _prefix, func);      \
+        if( n > PMIX_TIMING_STR_LEN ){                                            \
+             (_nm)->error = 1;                                                    \
+        }                                                                         \
+        n = sprintf((_nm)->cntr_env,"PMIX_TIMING_%s%s_CNT", prefix, (_nm)->id);   \
+        if( n > PMIX_TIMING_STR_LEN ){                                            \
+            (_nm)->error = 1;                                                     \
+        }                                                                         \
+        ptr = getenv((_nm)->id);                                                  \
+        if( NULL == ptr || strcmp(ptr, "1")){                                     \
+            (_nm)->enabled = 0;                                                   \
+        }                                                                         \
+        (_nm)->get_ts = pmix_timing_ts_func(type);                                \
+        ptr = getenv("PMIX_TIMING_ENABLE");                                       \
+        if (NULL != ptr) {                                                        \
+            (_nm)->enabled = atoi(ptr);                                           \
+        }                                                                         \
+        (_nm)->cntr = 0;                                                          \
+        ptr = getenv((_nm)->cntr_env);                                            \
+        if( NULL != ptr ){                                                        \
+            (_nm)->cntr = atoi(ptr);                                              \
+        }                                                                         \
+        (_nm)->ts = (_nm)->get_ts();                                              \
+        if ( 0 != (_nm)->error ){                                                 \
+            (_nm)->enabled = 0;                                                   \
+        }                                                                         \
+    } while(0)
 
-typedef struct {
-    pmix_timing_t *t;
-    pmix_timing_event_t *ev;
-    int errcode;
-} pmix_timing_prep_t;
+#define PMIX_TIMING_ENV_DEF(name)                                                 \
+    pmix_timing_env_t name ## _val, *name = &(name ## _val);
 
-/* Pass down our namespace and rank for pretty-print purposes */
-PMIX_EXPORT void pmix_init_id(char* nspace, int rank);
+#define PMIX_TIMING_ENV_IMPORT(name)                                              \
+    extern pmix_timing_env_t *name;
 
-/**
- * Initialize timing structure.
- *
- * @param t pointer to the timing handler structure
+#define PMIX_TIMING_ENV_START(name)                                               \
+    PMIX_TIMING_ENV_START_TYPE(__func__, name, PMIX_TIMING_AUTOMATIC_TIMER, "");
+
+#define PMIX_TIMING_ENV_INIT(name)                                                \
+    PMIX_TIMING_ENV_DEF(name);                                                    \
+    PMIX_TIMING_ENV_START(name);
+
+/* We use function names for identification
+ * however this might be a problem for the private
+ * functions declared as static as their names may
+ * conflict.
+ * Use prefix to do a finer-grained identification if needed
  */
-PMIX_EXPORT void pmix_timing_init(pmix_timing_t *t);
+#define PMIX_TIMING_ENV_INIT_PREFIX(prefix, name)                                 \
+    do {                                                                          \
+        pmix_timing_env_t name ## _val, *name = &(name ## _val);                  \
+        *name = PMIX_TIMING_ENV_START_TYPE(__func__, PMIX_TIMING_AUTOMATIC_TIMER, prefix); \
+    } while(0)
 
-/**
- * Prepare timing event, do all printf-like processing.
- * Should not be directly used - for service purposes only.
- *
- * @param t pointer to the timing handler structure
- * @param fmt printf-like format
- * @param ... other parameters that should be converted to string representation
- *
- * @retval partly filled pmix_timing_prep_t structure
-  */
-PMIX_EXPORT pmix_timing_prep_t pmix_timing_prep_ev(pmix_timing_t *t, const char *fmt, ...);
+#define PMIX_TIMING_ENV_NEXT(h, ...)                                              \
+    do {                                                                          \
+        int n;                                                                    \
+        char buf1[PMIX_TIMING_STR_LEN], buf2[PMIX_TIMING_STR_LEN];                \
+        double time;                                                              \
+        char *filename, *func;                                                    \
+        if( h->enabled ){                                                         \
+            /* enabled codepath */                                                \
+            time = h->get_ts() - h->ts;                                           \
+            n = snprintf(buf1, PMIX_TIMING_STR_LEN, "PMIX_TIMING_%s_DESC_%d", h->id, h->cntr); \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            n = snprintf(buf2, PMIX_TIMING_STR_LEN, __VA_ARGS__ );                \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            setenv(buf1, buf2, 1);                                                \
+            n = snprintf(buf1, PMIX_TIMING_STR_LEN, "PMIX_TIMING_%s_VAL_%d", h->id, h->cntr);  \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            n = snprintf(buf2, PMIX_TIMING_STR_LEN, "%lf", time);                 \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            setenv(buf1, buf2, 1);                                                \
+            filename = strrchr(__FILE__, '/') + 1;                                \
+            n = snprintf(buf1, PMIX_TIMING_STR_LEN, "PMIX_TIMING_%s_FILE_%d", h->id, h->cntr); \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            n = snprintf(buf2, PMIX_TIMING_STR_LEN, "%s", filename);              \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            setenv(buf1, buf2, 1);                                                \
+            n = snprintf(buf1, PMIX_TIMING_STR_LEN, "PMIX_TIMING_%s_FUNC_%d", h->id, h->cntr); \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            n = snprintf(buf2, PMIX_TIMING_STR_LEN, "%s", __func__);              \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            setenv(buf1, buf2, 1);                                                \
+            h->cntr++;                                                            \
+            sprintf(buf1, "%d", h->cntr);                                         \
+            setenv(h->cntr_env, buf1, 1);                                         \
+            /* We don't include env operations into the consideration.
+             * Hopefully this will help to make measurements more accurate.
+             */                                                                   \
+            h->ts = h->get_ts();                                                  \
+        }                                                                         \
+        if (h->error) {                                                           \
+            n = snprintf(buf1, PMIX_TIMING_STR_LEN, "PMIX_TIMING_%s_ERROR", h->id);\
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            n = snprintf(buf2, PMIX_TIMING_STR_LEN, "%d", h->error);              \
+            if ( n > PMIX_TIMING_STR_LEN ){                                       \
+                h->error = 1;                                                     \
+            }                                                                     \
+            setenv(buf1, buf2, 1);                                                \
+        }                                                                         \
+    } while(0)
 
-/**
- * Prepare timing event, ignore printf-like processing.
- * Should not be directly used - for service purposes only.
- *
- * @param t pointer to the timing handler structure
- * @param fmt printf-like format
- * @param ... other parameters that should be converted to string representation
- *
- * @retval partly filled pmix_timing_prep_t structure
-  */
-PMIX_EXPORT pmix_timing_prep_t pmix_timing_prep_ev_end(pmix_timing_t *t, const char *fmt, ...);
-
-/**
- * Enqueue timing event into the list of events in handler 't'.
- *
- * @param p result of pmix_timing_prep_ev
- * @param func function name where event occurs
- * @param file file name where event occurs
- * @param line line number in the file
- *
- * @retval
+/* This function supposed to be called from the code that will
+ * do the postprocessing, i.e. OMPI timing portion that will
+ * do the reduction of accumulated values
  */
-PMIX_EXPORT void pmix_timing_add_step(pmix_timing_prep_t p, const char *func,
-                                      const char *file, int line);
+#define PMIX_TIMING_ENV_CNT_PREFIX(prefix, func, _cnt)                            \
+    do {                                                                          \
+        char ename[PMIX_TIMING_STR_LEN];                                          \
+        char *ptr = NULL;                                                         \
+        int n = snprintf(ename, PMIX_TIMING_STR_LEN, "PMIX_TIMING_%s%s_CNT", prefix, func);    \
+        (_cnt) = 0;                                                               \
+        if ( n <= PMIX_TIMING_STR_LEN ){                                          \
+            ptr = getenv(ename);                                                  \
+            if( NULL != ptr ){ (_cnt) = atoi(ptr); };                             \
+        }                                                                         \
+    } while(0)
 
-/**
- * Enqueue the description of the interval into a list of events
- * in handler 't'.
- *
- * @param p result of pmix_timing_prep_ev
- * @param func function name where event occurs
- * @param file file name where event occurs
- * @param line line number in the file
- *
- * @retval id of event interval
- */
-PMIX_EXPORT int pmix_timing_descr(pmix_timing_prep_t p, const char *func,
-                                  const char *file, int line);
+#define PMIX_TIMING_ENV_ERROR_PREFIX(prefix, func, _err)                          \
+    do {                                                                          \
+        char ename[PMIX_TIMING_STR_LEN];                                          \
+        (_err) = 0;                                                               \
+        char *ptr = NULL;                                                         \
+        int n = snprintf(ename, PMIX_TIMING_STR_LEN, "PMIX_TIMING_%s%s_ERROR", prefix, func);    \
+        if ( n <= PMIX_TIMING_STR_LEN ){                                          \
+            ptr = getenv(ename);                                                  \
+            if( NULL != ptr ){ (_err) = atoi(ptr); };                             \
+        }                                                                         \
+    } while(0)
 
-/**
- * Enqueue the beginning of timing interval that already has the
- * description and assigned id into the list of events
- * in handler 't'.
- *
- * @param p result of pmix_timing_prep_ev
- * @param func function name where event occurs
- * @param file file name where event occurs
- * @param line line number in the file
- *
- * @retval
- */
-PMIX_EXPORT void pmix_timing_start_id(pmix_timing_t *t, int id, const char *func,
-                                      const char *file, int line);
+#define PMIX_TIMING_ENV_CNT(func, _cnt)                                           \
+    PMIX_TIMING_ENV_CNT_PREFIX("", func, _cnt)
 
-/**
- * Enqueue the end of timing interval that already has
- * description and assigned id into the list of events
- * in handler 't'.
- *
- * @param p result of pmix_timing_prep_ev
- * @param func function name where event occurs
- * @param file file name where event occurs
- * @param line line number in the file
- *
- * @retval
- */
-PMIX_EXPORT void pmix_timing_end(pmix_timing_t *t, int id, const char *func,
-                                 const char *file, int line );
+#define PMIX_TIMING_ENV_GETDESC_PREFIX(prefix, filename, func, i, desc, _t)       \
+    do {                                                                          \
+        char vname[PMIX_TIMING_STR_LEN];                                          \
+        (_t) = 0.0;                                                               \
+        sprintf(vname, "PMIX_TIMING_%s%s_FILE_%d", prefix, func, i);              \
+        *filename = getenv(vname);                                                \
+        sprintf(vname, "PMIX_TIMING_%s%s_DESC_%d", prefix, func, i);              \
+        *desc = getenv(vname);                                                    \
+        sprintf(vname, "PMIX_TIMING_%s%s_VAL_%d", prefix, func, i);               \
+        char *ptr = getenv(vname);                                                \
+        if ( NULL != ptr ) {                                                      \
+            sscanf(ptr,"%lf", &(_t));                                             \
+        }                                                                         \
+    } while(0)
 
-/**
- * Enqueue both description and start of timing interval
- * into the list of events and assign its id.
- *
- * @param p result of pmix_timing_prep_ev
- * @param func function name where event occurs
- * @param file file name where event occurs
- * @param line line number in the file
- *
- * @retval interval id
- */
-static inline int pmix_timing_start_init(pmix_timing_prep_t p,
-                                         const char *func,
-                                         const char *file, int line)
-{
-    int id = pmix_timing_descr(p, func, file, line);
-    if( id < 0 )
-        return id;
-    pmix_timing_start_id(p.t, id, func, file, line);
-    return id;
-}
+#define PMIX_TIMING_ENV_GETDESC(file, func, index, desc)                          \
+    PMIX_TIMING_ENV_GETDESC_PREFIX("", file, func, index, desc)
 
-/**
- * The wrapper that is used to stop last measurement in PMIX_TIMING_MNEXT.
- *
- * @param p result of pmix_timing_prep_ev
- * @param func function name where event occurs
- * @param file file name where event occurs
- * @param line line number in the file
- *
- * @retval interval id
- */
-PMIX_EXPORT void pmix_timing_end_prep(pmix_timing_prep_t p,
-                                      const char *func, const char *file, int line);
-
-/**
- * Report all events that were enqueued in the timing handler 't'.
- * - if fname == NULL the output will be done using pmix_output and
- * each line will be prefixed with "prefix" to ease grep'ing.
- * - otherwise the corresponding file will be used for output in "append" mode
- * WARRNING: not all filesystems provide enough support for that feature, some records may
- * disappear.
- *
- * @param t timing handler
- * @param account_overhead consider malloc overhead introduced by timing code
- * @param prefix prefix to use when no fname was specifyed to ease grep'ing
- * @param fname name of the output file (may be NULL)
- *
- * @retval PMIX_SUCCESS On success
- * @retval PMIX_ERROR or PMIX_ERR_OUT_OF_RESOURCE On failure
- */
-PMIX_EXPORT pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname);
-
-/**
- * Report all intervals that were enqueued in the timing handler 't'.
- * - if fname == NULL the output will be done using pmix_output and
- * each line will be prefixed with "prefix" to ease grep'ing.
- * - otherwise the corresponding file will be used for output in "append" mode
- * WARRNING: not all filesystems provide enough support for that feature, some records may
- * disappear.
- *
- * @param t timing handler
- * @param account_overhead consider malloc overhead introduced by timing code
-  * @param fname name of the output file (may be NULL)
- *
- * @retval PMIX_SUCCESS On success
- * @retval PMIX_ERROR or PMIX_ERR_OUT_OF_RESOURCE On failure
- */
-PMIX_EXPORT pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname);
-
-/**
- * Release all memory allocated for the timing handler 't'.
- *
- * @param t timing handler
- *
- * @retval
- */
-PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
-
-/**
- * Macro for passing down process id - compiled out
- * when configured without --enable-timing
- */
-#define PMIX_TIMING_ID(n, r) pmix_timing_id((n), (r));
-
-/**
- * Main macro for use in declaring pmix timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- */
-#define PMIX_TIMING_DECLARE(t) pmix_timing_t t;   /* need semicolon here to avoid warnings when not enabled */
-
-/**
- * Main macro for use in declaring external pmix timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- */
-#define PMIX_TIMING_DECLARE_EXT(x, t) x extern pmix_timing_t t;  /* need semicolon here to avoid warnings when not enabled */
-
-/**
- * Main macro for use in initializing pmix timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_init()
- */
-#define PMIX_TIMING_INIT(t) pmix_timing_init(t)
-
-/**
- * Macro that enqueues event with its description to the specified
- * timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_add_step()
- */
-#define PMIX_TIMING_EVENT(x) pmix_timing_add_step( pmix_timing_prep_ev x, __FUNCTION__, __FILE__, __LINE__)
-
-/**
- * MDESCR: Measurement DESCRiption
- * Introduce new timing measurement with string description for the specified
- * timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_descr()
- */
-#define PMIX_TIMING_MDESCR(x) pmix_timing_descr( pmix_timing_prep_ev x, __FUNCTION__, __FILE__, __LINE__)
-
-/**
- * MSTART_ID: Measurement START by ID.
- * Marks the beginning of the measurement with ID=id on the
- * specified timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_start_id()
- */
-#define PMIX_TIMING_MSTART_ID(t, id) pmix_timing_start_id(t, id, __FUNCTION__, __FILE__, __LINE__)
-
-/**
- * MSTART: Measurement START
- * Introduce new timing measurement conjuncted with its start
- * on the specifyed timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_start_init()
- */
-#define PMIX_TIMING_MSTART(x) pmix_timing_start_init( pmix_timing_prep_ev x, __FUNCTION__, __FILE__, __LINE__)
-
-/**
- * MSTOP: STOP Measurement
- * Finishes the most recent measurement on the specifyed timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_end()
- */
-#define PMIX_TIMING_MSTOP(t) pmix_timing_end(t, -1, __FUNCTION__, __FILE__, __LINE__)
-
-/**
- * MSTOP_ID: STOP Measurement with ID=id.
- * Finishes the measurement with give ID on the specifyed timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_end()
- */
-#define PMIX_TIMING_MSTOP_ID(t, id) pmix_timing_end(t, id, __FUNCTION__, __FILE__, __LINE__)
-
-/**
- * MNEXT: start NEXT Measurement
- * Convinient macro, may be implemented with the sequence of three previously
- * defined macroses:
- * - finish current measurement (PMIX_TIMING_MSTOP);
- * - introduce new timing measurement (PMIX_TIMING_MDESCR);
- * - starts next measurement (PMIX_TIMING_MSTART_ID)
- * on the specifyed timing handler;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_start_init()
- */
-#define PMIX_TIMING_MNEXT(x) ( \
-    pmix_timing_end_prep(pmix_timing_prep_ev_end x,             \
-                            __FUNCTION__, __FILE__, __LINE__ ), \
-    pmix_timing_start_init( pmix_timing_prep_ev x,              \
-                            __FUNCTION__, __FILE__, __LINE__)   \
-)
-
-/**
- * The macro for use in reporting collected events with absolute values;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @param enable flag that enables/disables reporting. Used for fine-grained timing.
- * @see pmix_timing_report()
- */
-#define PMIX_TIMING_REPORT(enable, t) { \
-    if( enable ) { \
-        pmix_timing_report(t, pmix_timing_output); \
-    } \
-}
-
-/**
- * The macro for use in reporting collected events with relative times;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @param enable flag that enables/disables reporting. Used for fine-grained timing.
- * @see pmix_timing_deltas()
- */
-#define PMIX_TIMING_DELTAS(enable, t) { \
-    if( enable ) { \
-        pmix_timing_deltas(t, pmix_timing_output); \
-    } \
-}
-
-/**
- * Main macro for use in releasing allocated resources;
- * will be "compiled out" when PMIX is configured without
- * --enable-timing.
- *
- * @see pmix_timing_release()
- */
-#define PMIX_TIMING_RELEASE(t) pmix_timing_release(t)
 
 #else
 
-#define PMIX_TIMING_ID(n, r)
+#define PMIX_TIMING_ENV_START_TYPE(func, type, prefix)
 
-#define PMIX_TIMING_DECLARE(t)
+#define PMIX_TIMING_ENV_INIT(name)
 
-#define PMIX_TIMING_DECLARE_EXT(x, t)
+#define PMIX_TIMING_ENV_INIT_PREFIX(prefix)
 
-#define PMIX_TIMING_INIT(t)
+#define PMIX_TIMING_ENV_NEXT(h, ... )
 
-#define PMIX_TIMING_EVENT(x)
+#define PMIX_TIMING_ENV_CNT_PREFIX(prefix, func)
 
-#define PMIX_TIMING_MDESCR(x)
+#define PMIX_TIMING_ENV_CNT(func)
 
-#define PMIX_TIMING_MSTART_ID(t, id)
+#define PMIX_TIMING_ENV_GETDESC_PREFIX(prefix, func, i, desc)
 
-#define PMIX_TIMING_MSTART(x)
+#define PMIX_TIMING_ENV_GETDESC(func, index, desc)
 
-#define PMIX_TIMING_MSTOP(t)
+#define PMIX_TIMING_ENV_ERROR_PREFIX(prefix, func)
 
-#define PMIX_TIMING_MSTOP_ID(t, id)
+#define PMIX_TIMING_ENV_DEF(name)
 
-#define PMIX_TIMING_MNEXT(x)
-
-#define PMIX_TIMING_REPORT(enable, t)
-
-#define PMIX_TIMING_DELTAS(enable, t)
-
-#define PMIX_TIMING_RELEASE(t)
+#define PMIX_TIMING_ENV_START(name)
 
 #endif
 


### PR DESCRIPTION
To enable need build with `--enable-timing --enable-pmix-timing`, also set the env:
```
 export OMPI_TIMING_ENABLE=1
 export PMIX_TIMING_ENABLE=1
```
Signed-off-by: Boris Karasev <karasev.b@gmail.com>