### PR TITLE
dist: bump version to 3.0.1rc3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=1
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=rc3
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
3.0.1rc2 is tagged; on to rc3.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>