### PR TITLE
dist: bump version to 3.1.0rc2

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -26,7 +26,7 @@ release=0
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
3.1.0rc1 is tagged; on to rc2.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>