### PR TITLE
fs/ufs: remove erroneous return statement

### DIFF
--- a/ompi/mca/fs/ufs/fs_ufs_file_open.c
+++ b/ompi/mca/fs/ufs/fs_ufs_file_open.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2017 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2018 University of Houston. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
@@ -157,7 +157,6 @@ mca_fs_ufs_file_open (struct ompi_communicator_t *comm,
                 ret = MPI_ERR_OTHER;
             }
 	}
-        return ret;
     }
 
     fh->f_stripe_size=0;


### PR DESCRIPTION
an erroneous return statement has creeped in commit 1885d99
which leads to some processes not resetting stripe_size
and stripe_count correctly. This can lead in 3.0.x to different
fcoll modules being selected. The impact is not that dramatic on
master and 3.1.x, but could lead to problems as well.

Fixes #4745

This is equivalen to commit 22a2b99181e6ed16b4877ef09ec91501199d82c3
on master. I did not cherry pick, since they are some differences in the
fs/lustre component and I did not want to introduce those
changes in this commit.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>
(cherry picked from commit f31f4b2462da91cb3b0dac658f3e9e37bca9a5c5)