### PR TITLE
iof/base: remove the unused iof_base_input_files MCA parameter

### DIFF
--- a/orte/mca/iof/base/base.h
+++ b/orte/mca/iof/base/base.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -144,7 +146,6 @@ ORTE_DECLSPEC OBJ_CLASS_DECLARATION(orte_iof_write_output_t);
 /* the iof globals struct */
 struct orte_iof_base_t {
     size_t                  output_limit;
-    char                    *input_files;
     orte_iof_sink_t         *iof_write_stdout;
     orte_iof_sink_t         *iof_write_stderr;
     bool                    redirect_app_stderr_to_stdout;

--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
+ * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
@@ -71,15 +71,6 @@ static int orte_iof_base_register(mca_base_register_flag_t flags)
                                  OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &orte_iof_base.output_limit);
-
-    /* check for files to be sent to stdin of procs */
-    orte_iof_base.input_files = NULL;
-    (void) mca_base_var_register("orte", "iof","base", "input_files",
-                                 "Comma-separated list of input files to be read and sent to stdin of procs (default: NULL)",
-                                 MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                 OPAL_INFO_LVL_9,
-                                 MCA_BASE_VAR_SCOPE_READONLY,
-                                 &orte_iof_base.input_files);
 
     /* Redirect application stderr to stdout (at source) */
     orte_iof_base.redirect_app_stderr_to_stdout = false;


### PR DESCRIPTION
this option was only used by the iof/mr_hnp (aka Map/Reduce)
component that is no more part of master nor v3 branches.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@ebffaded5d6b947007ac26384f32323744e8806d)