### PR TITLE
OMPI/OSC/UCX: move memory hooks init in osc to win creation.

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -36,6 +36,7 @@ typedef struct ompi_osc_ucx_component {
     ucp_worker_h ucp_worker;
     bool enable_mpi_threads;
     opal_free_list_t requests; /* request free list for the r* communication variants */
+    bool env_initialized; /* UCX environment is initialized or not */
     int num_incomplete_req_ops;
     unsigned int priority;
 } ompi_osc_ucx_component_t;


### PR DESCRIPTION
Move memory hooks init (for request based operation) in osc ucx to window
creation time, to avoid performance issue in MPI initialization.

Signed-off-by: Xin Zhao <xinz@mellanox.com>