### PR TITLE
pmix/ext3x: generate component source when only static libraries are …

### DIFF
--- a/opal/mca/pmix/ext3x/Makefile.am
+++ b/opal/mca/pmix/ext3x/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
@@ -63,6 +63,7 @@ mca_pmix_ext3x_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la 
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_ext3x_la_SOURCES =$(sources)
+nodist_libmca_pmix_ext3x_la_SOURCES = $(nodist_sources)
 libmca_pmix_ext3x_la_CFLAGS = $(opal_pmix_ext3x_CFLAGS)
 libmca_pmix_ext3x_la_CPPFLAGS = $(opal_pmix_ext3x_CPPFLAGS)
 libmca_pmix_ext3x_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext3x_LDFLAGS)


### PR DESCRIPTION
…built

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>