### PR TITLE
pmix/ext2x: generate component source when only static libraries are …

### DIFF
--- a/opal/mca/pmix/ext2x/Makefile.am
+++ b/opal/mca/pmix/ext2x/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
+# Copyright (c) 2015-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
@@ -56,13 +56,14 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_ext2x_la_SOURCES = $(sources)
 nodist_mca_pmix_ext2x_la_SOURCES = $(nodist_sources)
 mca_pmix_ext2x_la_CFLAGS = $(opal_pmix_ext2x_CFLAGS)
-mca_pmix_ext2x_la_CPPFLAGS =$(opal_pmix_ext2x_CPPFLAGS)
+mca_pmix_ext2x_la_CPPFLAGS = $(opal_pmix_ext2x_CPPFLAGS)
 mca_pmix_ext2x_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext2x_LDFLAGS)
 mca_pmix_ext2x_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(opal_pmix_ext2x_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
-libmca_pmix_ext2x_la_SOURCES =$(sources)
+libmca_pmix_ext2x_la_SOURCES = $(sources)
+nodist_libmca_pmix_ext2x_la_SOURCES = $(nodist_sources)
 libmca_pmix_ext2x_la_CFLAGS = $(opal_pmix_ext2x_CFLAGS)
 libmca_pmix_ext2x_la_CPPFLAGS = $(opal_pmix_ext2x_CPPFLAGS)
 libmca_pmix_ext2x_la_LDFLAGS = -module -avoid-version $(opal_pmix_ext2x_LDFLAGS)


### PR DESCRIPTION
…built

Fixes open-mpi/ompi#4771

(back-ported from commit open-mpi/ompi@0285c633483c5635dc73fcf3336e6485d98ad255)

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>