### PR TITLE
fortran: fix MPI_Comm_spawn_multiple() parameter handling.

### DIFF
--- a/ompi/mpi/fortran/base/fortran_base_strings.h
+++ b/ompi/mpi/fortran/base/fortran_base_strings.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,6 +58,27 @@ BEGIN_C_DECLS
      * fortran string is already allocated and has a length of len.
      */
     OMPI_DECLSPEC int ompi_fortran_string_c2f(char *cstr, char *fstr, int len);
+
+    /**
+     * Convert an array of count Fortran strings to an argv-style array of C
+     * strings.
+     *
+     * @param farray Array of fortran strings
+     * @param count Size of the Fortran strings array
+     * @param string_len Length of each fortran string in the array
+     * @param cargv Returned argv-style array of C strings
+     *
+     * @retval OMPI_SUCCESS upon success
+     * @retval OMPI_ERROR upon error
+     *
+     * This function is intented to be used in the MPI F77 bindings to
+     * convert arrays of fortran strings to argv-style arrays of C
+     * strings.  The argv array will be allocated and returned; it is
+     * the caller's responsibility to invoke opal_argv_free() to free
+     * it later (or equivalent).
+     */
+    OMPI_DECLSPEC int ompi_fortran_args_f2c(char *farray, int count,
+                                            int string_len, char ***cargv);
 
     /**
      * Convert an array of Fortran strings to an argv-style array of C

--- a/ompi/mpi/fortran/base/strings.c
+++ b/ompi/mpi/fortran/base/strings.c
@@ -10,8 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,6 +136,40 @@ int ompi_fortran_argv_f2c(char *array, int string_len, int advance,
     }
 
     free(cstr);
+    return OMPI_SUCCESS;
+}
+
+
+/*
+ * creates a C argument vector from an F77 array of strings
+ */
+int ompi_fortran_args_f2c(char *array, int count,
+                          int string_len, char ***argv)
+{
+    int err, argc = 0;
+    char *cstr;
+
+    /* Fortran lines up strings in memory, each delimited by \0.  So
+       just convert them until we hit an extra \0. */
+
+    *argv = NULL;
+    for (int i=0; i < count ; i++) {
+	if (OMPI_SUCCESS != (err = ompi_fortran_string_f2c(array, string_len,
+                                                           &cstr))) {
+	    opal_argv_free(*argv);
+	    return err;
+	}
+
+	if (OMPI_SUCCESS != (err = opal_argv_append(&argc, argv, cstr))) {
+	    opal_argv_free(*argv);
+            free(cstr);
+	    return err;
+	}
+
+	free(cstr);
+	array += string_len;
+    }
+
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mpi/fortran/mpif-h/comm_spawn_multiple_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_spawn_multiple_f.c
@@ -10,8 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -115,7 +115,7 @@ void ompi_comm_spawn_multiple_f(MPI_Fint *count, char *array_commands,
 
     OMPI_ARRAY_FINT_2_INT(array_maxprocs, array_size);
 
-    ompi_fortran_argv_f2c(array_commands, cmd_string_len,
+    ompi_fortran_args_f2c(array_commands, array_size,
                           cmd_string_len, &c_array_commands);
 
     c_info = (MPI_Info *) malloc (array_size * sizeof(MPI_Info));


### PR DESCRIPTION
internally handle 'array_of_commands' as an array with size 'count'

Refs open-mpi/ompi#4788

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>