### PR TITLE
mca/registry: fix problem group_component_register

### DIFF
--- a/opal/mca/base/mca_base_var_group.c
+++ b/opal/mca/base/mca_base_var_group.c
@@ -319,8 +319,7 @@ int mca_base_var_group_register (const char *project_name, const char *framework
 int mca_base_var_group_component_register (const mca_base_component_t *component,
                                            const char *description)
 {
-    /* 1.7 components do not store the project */
-    return group_register (NULL, component->mca_type_name,
+    return group_register (component->mca_project_name, component->mca_type_name,
                            component->mca_component_name, description);
 }
 


### PR DESCRIPTION
Turns out that supplying NULL to group_register in the
mca_base_var_group_component_register is not a good
idea if one wants for ompi_info to work as intended.

The ugni and vader btl's both call this before
registering component variables.  This borks up
the ompi_info works since NULL is supplied as the project
name.  So, now supply the project name rather than
just NULL to group register.

Fixes #4020.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 55774d13907ce002185bb97525faa6300e0910b5)