### PR TITLE
opal/btl: add support for flushing RDMA/atomic operations

### DIFF
--- a/opal/mca/btl/base/btl_base_frame.c
+++ b/opal/mca/btl/base/btl_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2016-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -53,6 +53,7 @@ mca_base_var_enum_value_flag_t mca_btl_base_flag_enum_flags[] = {
     {MCA_BTL_FLAGS_NEED_ACK, "need-ack", 0},
     {MCA_BTL_FLAGS_NEED_CSUM, "need-csum", 0},
     {MCA_BTL_FLAGS_HETEROGENEOUS_RDMA, "hetero-rdma", 0},
+    {MCA_BTL_FLAGS_RDMA_FLUSH, "rdma-flush", 0},
     {0, NULL, 0}
 };
 

--- a/opal/mca/btl/base/btl_base_mca.c
+++ b/opal/mca/btl/base/btl_base_mca.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2016-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -180,6 +180,10 @@ int mca_btl_base_param_verify(mca_btl_base_module_t *module)
 
     if (NULL == module->btl_get) {
         module->btl_flags &= ~MCA_BTL_FLAGS_GET;
+    }
+
+    if (NULL == module->btl_flush) {
+        module->btl_flags &= ~MCA_BTL_FLAGS_RDMA_FLUSH;
     }
 
     if (0 == module->btl_atomic_flags) {


### PR DESCRIPTION
This commit adds a new optional function to the BTL module:
btl_flush. This function takes an optional BTL endpoint. When called
this function completes all outstanding RDMA and atomic operations
started prior to the call to btl_flush.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>