### PR TITLE
OPAL: Rewrite of registration caches

### DIFF
--- a/opal/class/Makefile.am
+++ b/opal/class/Makefile.am
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+# Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -38,7 +38,8 @@ headers += \
         class/opal_pointer_array.h \
         class/opal_value_array.h \
         class/opal_ring_buffer.h \
-        class/opal_rb_tree.h
+        class/opal_rb_tree.h \
+        class/opal_interval_tree.h
 
 lib@OPAL_LIB_PREFIX@open_pal_la_SOURCES += \
         class/opal_bitmap.c \
@@ -54,4 +55,5 @@ lib@OPAL_LIB_PREFIX@open_pal_la_SOURCES += \
         class/opal_pointer_array.c \
         class/opal_value_array.c \
         class/opal_ring_buffer.c \
-        class/opal_rb_tree.c
+        class/opal_rb_tree.c \
+        class/opal_interval_tree.c

--- a/opal/class/opal_interval_tree.c
+++ b/opal/class/opal_interval_tree.c
@@ -1,0 +1,909 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/*
+ * @file
+ */
+
+#include "opal_config.h"
+
+#include "opal/class/opal_interval_tree.h"
+#include <limits.h>
+
+/* Private functions */
+static void opal_interval_tree_insert_node (opal_interval_tree_t *tree, opal_interval_tree_node_t *node);
+
+/* tree rebalancing functions */
+static void opal_interval_tree_delete_fixup (opal_interval_tree_t *tree, opal_interval_tree_node_t *node,
+                                             opal_interval_tree_node_t *parent);
+static void opal_interval_tree_insert_fixup (opal_interval_tree_t *tree, opal_interval_tree_node_t *x);
+
+static opal_interval_tree_node_t *opal_interval_tree_next (opal_interval_tree_t *tree,
+                                                           opal_interval_tree_node_t *node);
+static opal_interval_tree_node_t * opal_interval_tree_find_node(opal_interval_tree_t *tree,
+                                                                uint64_t low, uint64_t high,
+                                                                bool exact, void *data);
+
+static opal_interval_tree_node_t *left_rotate (opal_interval_tree_t *tree, opal_interval_tree_node_t *x);
+static opal_interval_tree_node_t *right_rotate (opal_interval_tree_t *tree, opal_interval_tree_node_t *x);
+
+static void inorder_destroy(opal_interval_tree_t *tree, opal_interval_tree_node_t * node);
+
+#define max(x,y) (((x) > (y)) ? (x) : (y))
+
+/**
+ * the constructor function. creates the free list to get the nodes from
+ *
+ * @param object the tree that is to be used
+ *
+ * @retval NONE
+ */
+static void opal_interval_tree_construct (opal_interval_tree_t *tree)
+{
+    OBJ_CONSTRUCT(&tree->root, opal_interval_tree_node_t);
+    OBJ_CONSTRUCT(&tree->nill, opal_interval_tree_node_t);
+    OBJ_CONSTRUCT(&tree->free_list, opal_free_list_t);
+    OBJ_CONSTRUCT(&tree->gc_list, opal_list_t);
+
+    /* initialize sentinel */
+    tree->nill.color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+    tree->nill.left = tree->nill.right = tree->nill.parent = &tree->nill;
+    tree->nill.max = 0;
+    tree->nill.data = NULL;
+
+    /* initialize root sentinel */
+    tree->root.color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+    tree->root.left = tree->root.right = tree->root.parent = &tree->nill;
+    /* this simplifies inserting at the root as we only have to check the
+     * low value. */
+    tree->root.low = (uint64_t) -1;
+    tree->root.data = NULL;
+
+    /* set the tree size to zero */
+    tree->tree_size = 0;
+    tree->lock = 0;
+    tree->reader_count = 0;
+    tree->epoch = 0;
+
+    /* set all reader epochs to UINT_MAX. this value is used to simplfy
+     * checks against the current epoch. */
+    for (int i = 0 ; i < OPAL_INTERVAL_TREE_MAX_READERS ; ++i) {
+        tree->reader_epochs[i] = UINT_MAX;
+    }
+}
+
+/**
+ * the destructor function. Free the tree and destroys the free list.
+ *
+ * @param object the tree object
+ */
+static void opal_interval_tree_destruct (opal_interval_tree_t *tree)
+{
+    opal_interval_tree_destroy (tree);
+
+    OBJ_DESTRUCT(&tree->free_list);
+    OBJ_DESTRUCT(&tree->root);
+    OBJ_DESTRUCT(&tree->nill);
+}
+
+/* declare the instance of the classes  */
+OBJ_CLASS_INSTANCE(opal_interval_tree_node_t, opal_free_list_item_t, NULL, NULL);
+OBJ_CLASS_INSTANCE(opal_interval_tree_t, opal_object_t, opal_interval_tree_construct,
+                   opal_interval_tree_destruct);
+
+typedef int32_t opal_interval_tree_token_t;
+
+/**
+ * @brief pick and return a reader slot
+ */
+static opal_interval_tree_token_t opal_interval_tree_reader_get_token (opal_interval_tree_t *tree)
+{
+    opal_interval_tree_token_t token = -1;
+
+    if (token < 0) {
+        int32_t reader_count = tree->reader_count;
+        /* NTH: could have used an atomic here but all we are after is some distribution of threads
+         * across the reader slots. with high thread counts i see no real performance difference
+         * using atomics. */
+        token = tree->reader_id++ % OPAL_INTERVAL_TREE_MAX_READERS;
+        while (OPAL_UNLIKELY(reader_count <= token)) {
+            if (opal_atomic_compare_exchange_strong_32 (&tree->reader_count, &reader_count, token + 1)) {
+                break;
+            }
+        }
+    }
+
+    while (!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32((volatile int32_t *) &tree->reader_epochs[token],
+                                                   &(int32_t) {UINT_MAX}, tree->epoch));
+
+    return token;
+}
+
+static void opal_interval_tree_reader_return_token (opal_interval_tree_t *tree, opal_interval_tree_token_t token)
+{
+    tree->reader_epochs[token] = UINT_MAX;
+}
+
+/* Create the tree */
+int opal_interval_tree_init (opal_interval_tree_t *tree)
+{
+    return opal_free_list_init (&tree->free_list, sizeof(opal_interval_tree_node_t),
+                                opal_cache_line_size, OBJ_CLASS(opal_interval_tree_node_t),
+                                0, opal_cache_line_size, 0, -1 , 128, NULL, 0, NULL, NULL, NULL);
+}
+
+static bool opal_interval_tree_write_trylock (opal_interval_tree_t *tree)
+{
+    opal_atomic_rmb ();
+    return !(tree->lock || opal_atomic_swap_32 (&tree->lock, 1));
+}
+
+static void opal_interval_tree_write_lock (opal_interval_tree_t *tree)
+{
+    while (!opal_interval_tree_write_trylock (tree));
+}
+
+static void opal_interval_tree_write_unlock (opal_interval_tree_t *tree)
+{
+    opal_atomic_wmb ();
+    tree->lock = 0;
+}
+
+static void opal_interval_tree_insert_fixup_helper (opal_interval_tree_t *tree, opal_interval_tree_node_t *node) {
+    opal_interval_tree_node_t *y, *parent = node->parent;
+    bool rotate_right = false;
+
+    if (parent->color == OPAL_INTERVAL_TREE_COLOR_BLACK) {
+        return;
+    }
+
+    if (parent == parent->parent->left) {
+        y = parent->parent->right;
+        rotate_right = true;
+    } else {
+        y = parent->parent->left;
+    }
+
+    if (y->color == OPAL_INTERVAL_TREE_COLOR_RED) {
+        parent->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        y->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        parent->parent->color = OPAL_INTERVAL_TREE_COLOR_RED;
+        opal_interval_tree_insert_fixup_helper (tree, parent->parent);
+        return;
+    }
+
+    if (rotate_right) {
+        if (node == parent->right) {
+            node = left_rotate (tree, parent);
+            parent = node->parent;
+        }
+
+        parent->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        parent->parent->color = OPAL_INTERVAL_TREE_COLOR_RED;
+        (void) right_rotate(tree, parent->parent);
+    } else {
+        if (node == parent->left) {
+            node = right_rotate(tree, parent);
+            parent = node->parent;
+        }
+        parent->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        parent->parent->color = OPAL_INTERVAL_TREE_COLOR_RED;
+        (void) left_rotate(tree, parent->parent);
+    }
+
+    opal_interval_tree_insert_fixup_helper (tree, node);
+}
+
+static void opal_interval_tree_insert_fixup (opal_interval_tree_t *tree, opal_interval_tree_node_t *node) {
+    /* do the rotations */
+    /* usually one would have to check for NULL, but because of the sentinal,
+     * we don't have to   */
+    opal_interval_tree_insert_fixup_helper (tree, node);
+
+    /* after the rotations the root is black */
+    tree->root.left->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+}
+
+/**
+ * @brief Guts of the delete fixup
+ *
+ * @param[in] tree    opal interval tree
+ * @param[in] node    node to fixup
+ * @param[in] left    true if the node is a left child of its parent
+ *
+ * @returns the next node to fixup or root if done
+ */
+static inline opal_interval_tree_node_t *
+opal_interval_tree_delete_fixup_helper (opal_interval_tree_t *tree, opal_interval_tree_node_t *node,
+                                        opal_interval_tree_node_t *parent, const bool left)
+{
+    opal_interval_tree_node_t *w;
+
+    /* get sibling */
+    w = left ? parent->right : parent->left;
+    if (w->color == OPAL_INTERVAL_TREE_COLOR_RED) {
+        w->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        parent->color = OPAL_INTERVAL_TREE_COLOR_RED;
+        if (left) {
+            (void) left_rotate(tree, parent);
+            w = parent->right;
+        } else {
+            (void) right_rotate(tree, parent);
+            w = parent->left;
+        }
+    }
+
+    if ((w->left->color == OPAL_INTERVAL_TREE_COLOR_BLACK) && (w->right->color == OPAL_INTERVAL_TREE_COLOR_BLACK)) {
+        w->color = OPAL_INTERVAL_TREE_COLOR_RED;
+        return parent;
+    }
+
+    if (left) {
+        if (w->right->color == OPAL_INTERVAL_TREE_COLOR_BLACK) {
+            w->left->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+            w->color = OPAL_INTERVAL_TREE_COLOR_RED;
+            (void) right_rotate(tree, w);
+            w = parent->right;
+        }
+        w->color = parent->color;
+        parent->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        w->right->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        (void) left_rotate(tree, parent);
+    } else {
+        if (w->left->color == OPAL_INTERVAL_TREE_COLOR_BLACK) {
+            w->right->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+            w->color = OPAL_INTERVAL_TREE_COLOR_RED;
+            (void) left_rotate(tree, w);
+            w = parent->left;
+        }
+        w->color = parent->color;
+        parent->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        w->left->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        (void) right_rotate(tree, parent);
+    }
+
+    /* return the root */
+    return tree->root.left;
+ }
+
+/* Fixup the balance of the btree after deletion    */
+static void opal_interval_tree_delete_fixup (opal_interval_tree_t *tree, opal_interval_tree_node_t *node,
+                                             opal_interval_tree_node_t *parent)
+{
+    while ((node != tree->root.left) && (node->color == OPAL_INTERVAL_TREE_COLOR_BLACK)) {
+        node = opal_interval_tree_delete_fixup_helper (tree, node, parent, node == parent->left);
+        parent = node->parent;
+    }
+
+    node->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+    tree->nill.color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+}
+
+/* traverse the garbage-collection list and return any nodes that can not have any
+ * references. this function MUST be called with the writer lock held. */
+static void opal_interval_tree_gc_clean (opal_interval_tree_t *tree)
+{
+    opal_interval_tree_node_t *node, *next;
+    uint32_t oldest_epoch = UINT_MAX;
+
+    if (0 == opal_list_get_size (&tree->gc_list)) {
+        return;
+    }
+
+    for (int i = 0 ; i < tree->reader_count ; ++i) {
+        oldest_epoch = (oldest_epoch < tree->reader_epochs[i]) ? oldest_epoch : tree->reader_epochs[i];
+    }
+
+    OPAL_LIST_FOREACH_SAFE(node, next, &tree->gc_list, opal_interval_tree_node_t) {
+        if (node->epoch < oldest_epoch) {
+            opal_list_remove_item (&tree->gc_list, &node->super.super);
+            opal_free_list_return_st (&tree->free_list, &node->super);
+        }
+    }
+}
+
+/* This inserts a node into the tree based on the passed values. */
+int opal_interval_tree_insert (opal_interval_tree_t *tree, void *value, uint64_t low, uint64_t high)
+{
+    opal_interval_tree_node_t * node;
+
+    if (low > high) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    opal_interval_tree_write_lock (tree);
+
+    opal_interval_tree_gc_clean (tree);
+
+    /* get the memory for a node */
+    node = (opal_interval_tree_node_t *) opal_free_list_get (&tree->free_list);
+    if (OPAL_UNLIKELY(NULL == node)) {
+        opal_interval_tree_write_unlock (tree);
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* insert the data into the node */
+    node->data = value;
+    node->low = low;
+    node->high = high;
+    node->max = high;
+    node->epoch = tree->epoch;
+
+    /* insert the node into the tree */
+    opal_interval_tree_insert_node (tree, node);
+
+    opal_interval_tree_insert_fixup (tree, node);
+    opal_interval_tree_write_unlock (tree);
+
+    return OPAL_SUCCESS;
+}
+
+static opal_interval_tree_node_t *opal_interval_tree_find_interval(opal_interval_tree_t *tree, opal_interval_tree_node_t *node, uint64_t low,
+                                                                   uint64_t high, bool exact, void *data)
+{
+    if (node == &tree->nill) {
+        return NULL;
+    }
+
+    if (((exact && node->low == low && node->high == high) || (!exact && node->low <= low && node->high >= high)) &&
+        (!data || node->data == data)) {
+        return node;
+    }
+
+    if (low <= node->low) {
+        return opal_interval_tree_find_interval (tree, node->left, low, high, exact, data);
+    }
+
+    return opal_interval_tree_find_interval (tree, node->right, low, high, exact, data);
+}
+
+/* Finds the node in the tree based on the key and returns a pointer
+ * to the node. This is a bit a code duplication, but this has to be fast
+ * so we go ahead with the duplication */
+static opal_interval_tree_node_t *opal_interval_tree_find_node(opal_interval_tree_t *tree, uint64_t low, uint64_t high, bool exact, void *data)
+{
+    return opal_interval_tree_find_interval (tree, tree->root.left, low, high, exact, data);
+}
+
+void *opal_interval_tree_find_overlapping (opal_interval_tree_t *tree, uint64_t low, uint64_t high)
+{
+    opal_interval_tree_token_t token;
+    opal_interval_tree_node_t *node;
+
+    token = opal_interval_tree_reader_get_token (tree);
+    node = opal_interval_tree_find_node (tree, low, high, true, NULL);
+    opal_interval_tree_reader_return_token (tree, token);
+
+    return node ? node->data : NULL;
+}
+
+static size_t opal_interval_tree_depth_node (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    if (&tree->nill == node) {
+        return 0;
+    }
+
+    return 1 + max (opal_interval_tree_depth_node (tree, node->right), opal_interval_tree_depth_node (tree, node->left));
+}
+
+size_t opal_interval_tree_depth (opal_interval_tree_t *tree)
+{
+    opal_interval_tree_token_t token;
+    size_t depth;
+
+    token = opal_interval_tree_reader_get_token (tree);
+    depth = opal_interval_tree_depth_node (tree, &tree->root);
+    opal_interval_tree_reader_return_token (tree, token);
+
+    return depth;
+}
+
+/* update the value of a tree pointer */
+static inline void rp_publish (opal_interval_tree_node_t **ptr, opal_interval_tree_node_t *node)
+{
+    /* ensure all writes complete before continuing */
+    opal_atomic_wmb ();
+    /* just set the value */
+    *ptr = node;
+}
+
+
+static inline void rp_wait_for_readers (opal_interval_tree_t *tree)
+{
+    uint32_t epoch_id = ++tree->epoch;
+
+    /* wait for all readers to see the new tree version */
+    for (int i = 0 ; i < tree->reader_count ; ++i) {
+        while (tree->reader_epochs[i] < epoch_id);
+    }
+}
+
+/* waits for all writers to finish with the node then releases the last reference */
+static inline void rp_free_wait (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    rp_wait_for_readers (tree);
+    /* no other threads are working on this node so go ahead and return it */
+    opal_free_list_return_st (&tree->free_list, &node->super);
+}
+
+/* schedules the node for releasing */
+static inline void rp_free (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    opal_list_append (&tree->gc_list, &node->super.super);
+}
+
+static opal_interval_tree_node_t *opal_interval_tree_node_copy (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    opal_interval_tree_node_t *copy = (opal_interval_tree_node_t *) opal_free_list_wait_st (&tree->free_list);
+    size_t color_offset = offsetof(opal_interval_tree_node_t, color);
+    assert (NULL != copy);
+    memcpy ((unsigned char *) copy + color_offset, (unsigned char *) node + color_offset,
+            sizeof (*node) - color_offset);
+    return copy;
+}
+
+/* this function deletes a node that is either a left or right leaf (or both) */
+static void opal_interval_tree_delete_leaf (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    const opal_interval_tree_node_t *nill = &tree->nill;
+    opal_interval_tree_node_t **parent_ptr, *next, *parent = node->parent;
+    opal_interval_tree_nodecolor_t color = node->color;
+
+    assert (node->left == nill || node->right == nill);
+
+    parent_ptr = (parent->right == node) ? &parent->right : &parent->left;
+
+    next = (node->right == nill) ? node->left : node->right;
+
+    next->parent = node->parent;
+    rp_publish (parent_ptr, next);
+
+    rp_free (tree, node);
+
+    if (OPAL_INTERVAL_TREE_COLOR_BLACK == color) {
+        if (OPAL_INTERVAL_TREE_COLOR_RED == next->color) {
+            next->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+        } else {
+            opal_interval_tree_delete_fixup (tree, next, parent);
+        }
+    }
+}
+
+static void opal_interval_tree_delete_interior (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    opal_interval_tree_node_t **parent_ptr, *next, *next_copy, *parent = node->parent;
+    opal_interval_tree_nodecolor_t color = node->color, next_color;
+
+    parent_ptr = (parent->right == node) ? &parent->right : &parent->left;
+    next = opal_interval_tree_next (tree, node);
+    next_color = next->color;
+
+    if (next != node->right) {
+        /* case 3 */
+        next_copy = opal_interval_tree_node_copy (tree, next);
+        next_copy->color = node->color;
+        next_copy->left = node->left;
+        next_copy->left->parent = next_copy;
+        next_copy->right = node->right;
+        next_copy->right->parent = next_copy;
+        next_copy->parent = node->parent;
+
+        rp_publish (parent_ptr, next_copy);
+        rp_free_wait (tree, node);
+
+        opal_interval_tree_delete_leaf (tree, next);
+    } else {
+        /* case 2. no copies are needed */
+        next->color = color;
+        next->left = node->left;
+        next->left->parent = next;
+        next->parent = node->parent;
+        rp_publish (parent_ptr, next);
+        rp_free (tree, node);
+
+	/* since we are actually "deleting" the next node the fixup needs to happen on the
+	 * right child of next (by definition next was a left child) */
+        if (OPAL_INTERVAL_TREE_COLOR_BLACK == next_color) {
+	    if (OPAL_INTERVAL_TREE_COLOR_RED == next->right->color) {
+		next->right->color = OPAL_INTERVAL_TREE_COLOR_BLACK;
+            } else {
+		opal_interval_tree_delete_fixup (tree, next->right, next);
+	    }
+	}
+    }
+}
+
+/* Delete a node from the tree based on the key */
+int opal_interval_tree_delete (opal_interval_tree_t *tree, uint64_t low, uint64_t high, void *data)
+{
+    opal_interval_tree_node_t *node;
+
+    opal_interval_tree_write_lock (tree);
+    node = opal_interval_tree_find_node (tree, low, high, true, data);
+    if (NULL == node) {
+        opal_interval_tree_write_unlock (tree);
+        return OPAL_ERR_NOT_FOUND;
+    }
+
+    /* there are three cases that have to be handled:
+     * 1) the node p is a left leaf or a right left (one of p's children is nill)
+     *    in this case we can delete p and we can replace it with one of it's children
+     *    or nill (if both children are nill).
+     * 2) the right child of p is a left leaf (node->right->left == nill)
+     *    in this case we can set node->right->left = node->left and replace node with node->right
+     * 3) p is a interior node
+     *    we replace node with next(node)
+     */
+    
+    if ((node->left == &tree->nill) || (node->right == &tree->nill)) {
+        /* handle case 1 */
+        opal_interval_tree_delete_leaf (tree, node);
+    } else {
+        /* handle case 2 and 3 */
+        opal_interval_tree_delete_interior (tree, node);
+    }
+
+    --tree->tree_size;
+
+    opal_interval_tree_write_unlock (tree);
+
+    return OPAL_SUCCESS;
+}
+
+int opal_interval_tree_destroy (opal_interval_tree_t *tree)
+{
+    /* Recursive inorder traversal for delete */
+    inorder_destroy(tree, &tree->root);
+    tree->tree_size = 0;
+    return OPAL_SUCCESS;
+}
+
+
+/* Find the next inorder successor of a node    */
+static opal_interval_tree_node_t *opal_interval_tree_next (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    opal_interval_tree_node_t *p = node->right;
+
+    if (p == &tree->nill) {
+        p = node->parent;
+        while (node == p->right) {
+            node = p;
+            p = p->parent;
+        }
+
+        if (p == &tree->root) {
+            return &tree->nill;
+        }
+
+        return p;
+    }
+
+    while (p->left != &tree->nill) {
+        p = p->left;
+    }
+
+    return p;
+}
+
+/* Insert an element in the normal binary search tree fashion    */
+/* this function goes through the tree and finds the leaf where
+ * the node will be inserted   */
+static void opal_interval_tree_insert_node (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    opal_interval_tree_node_t *parent = &tree->root;
+    opal_interval_tree_node_t *n = parent->left; /* the real root of the tree */
+    opal_interval_tree_node_t *nill = &tree->nill;
+
+    /* set up initial values for the node */
+    node->color = OPAL_INTERVAL_TREE_COLOR_RED;
+    node->parent = NULL;
+    node->left = nill;
+    node->right = nill;
+
+    /* find the leaf where we will insert the node */
+    while (n != nill) {
+        if (n->max < node->high) {
+            n->max = node->high;
+        }
+
+        parent = n;
+        n = ((node->low < n->low) ? n->left : n->right);
+        assert (nill == n || n->parent == parent);
+    }
+
+    /* place it on either the left or the right */
+    if ((node->low < parent->low)) {
+        parent->left = node;
+    } else {
+        parent->right = node;
+    }
+
+    /* set its parent and children */
+    node->parent = parent;
+
+    ++tree->tree_size;
+}
+
+static int inorder_traversal (opal_interval_tree_t *tree, uint64_t low, uint64_t high,
+			      bool partial_ok, opal_interval_tree_action_fn_t action,
+			      opal_interval_tree_node_t * node, void *ctx)
+{
+    int rc;
+
+    if (node == &tree->nill) {
+        return OPAL_SUCCESS;
+    }
+
+    rc = inorder_traversal(tree, low, high, partial_ok, action, node->left, ctx);
+    if (OPAL_SUCCESS != rc) {
+        return rc;
+    }
+
+    if ((!partial_ok && (node->low <= low && node->high >= high)) ||
+        (partial_ok && ((low >= node->low && low <= node->high) ||
+                        (high >= node->low && high <= node->high) ||
+                        (node->low >= low && node->low <= high) ||
+                        (node->high >= high && node->high <= high)))) {
+        rc = action (node->low, node->high, node->data, ctx);
+        if (OPAL_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    return inorder_traversal(tree, low, high, partial_ok, action, node->right, ctx);
+}
+
+/* Free the nodes in inorder fashion    */
+
+static void inorder_destroy (opal_interval_tree_t *tree, opal_interval_tree_node_t *node)
+{
+    if (node == &tree->nill) {
+        return;
+    }
+
+    inorder_destroy(tree, node->left);
+    inorder_destroy(tree, node->right);
+
+    if (node->left != &tree->nill) {
+        opal_free_list_return_st (&tree->free_list, &node->left->super);
+    }
+
+    if (node->right != &tree->nill) {
+        opal_free_list_return_st (&tree->free_list, &node->right->super);
+    }
+}
+
+/* Try to access all the elements of the hashmap conditionally */
+
+int opal_interval_tree_traverse (opal_interval_tree_t *tree, uint64_t low, uint64_t high,
+                                 bool partial_ok, opal_interval_tree_action_fn_t action, void *ctx)
+{
+    opal_interval_tree_token_t token;
+    int rc;
+
+    if (action == NULL) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    token = opal_interval_tree_reader_get_token (tree);
+    rc = inorder_traversal (tree, low, high, partial_ok, action, tree->root.left, ctx);
+    opal_interval_tree_reader_return_token (tree, token);
+    return rc;
+}
+
+/* Left rotate the tree    */
+/* basically what we want to do is to make x be the left child
+ * of its right child    */
+static opal_interval_tree_node_t *left_rotate (opal_interval_tree_t *tree, opal_interval_tree_node_t *x)
+{
+    opal_interval_tree_node_t *x_copy = x;
+    opal_interval_tree_node_t *y = x->right;
+    opal_interval_tree_node_t *parent = x->parent;
+
+    /* make the left child of y's parent be x if it is not the sentinal node*/
+    if (y->left != &tree->nill) {
+        y->left->parent = x_copy;
+    }
+
+    /* x's parent is now y */
+    x_copy->parent = y;
+    x_copy->right = y->left;
+    x_copy->max = max (x_copy->high, max (x_copy->left->max, x_copy->left->max));
+
+    rp_publish (&y->left, x_copy);
+
+    /* normlly we would have to check to see if we are at the root.
+     * however, the root sentinal takes care of it for us */
+    if (x == parent->left) {
+        rp_publish (&parent->left, y);
+    } else {
+        rp_publish (&parent->right, y);
+    }
+
+    /* the old parent of x is now y's parent */
+    y->parent = parent;
+
+    return x_copy;
+}
+
+
+/* Right rotate the tree    */
+/* basically what we want to do is to make x be the right child
+ * of its left child */
+static opal_interval_tree_node_t *right_rotate (opal_interval_tree_t *tree, opal_interval_tree_node_t *x)
+{
+    opal_interval_tree_node_t *x_copy = x;
+    opal_interval_tree_node_t *y = x->left;
+    opal_interval_tree_node_t *parent = x->parent;
+
+    /* make the left child of y's parent be x if it is not the sentinal node*/
+    if (y->right != &tree->nill) {
+        y->right->parent = x_copy;
+    }
+
+    x_copy->left = y->right;
+    x_copy->parent = y;
+
+    rp_publish (&y->right, x_copy);
+
+    /* the maximum value in the subtree rooted at y is now the value it
+     * was at x */
+    y->max = x->max;
+    y->parent = parent;
+
+    if (parent->left == x) {
+        rp_publish (&parent->left, y);
+    } else {
+        rp_publish (&parent->right, y);
+    }
+
+    return x_copy;
+}
+
+/* returns the size of the tree */
+size_t opal_interval_tree_size(opal_interval_tree_t *tree)
+{
+    return tree->tree_size;
+}
+
+static bool opal_interval_tree_verify_node (opal_interval_tree_t *tree, opal_interval_tree_node_t *node, int black_depth,
+                                            int current_black_depth)
+{
+    if (node == &tree->nill) {
+        return true;
+    }
+
+    if (OPAL_INTERVAL_TREE_COLOR_RED == node->color &&
+        (OPAL_INTERVAL_TREE_COLOR_BLACK != node->left->color ||
+         OPAL_INTERVAL_TREE_COLOR_BLACK != node->right->color)) {
+        fprintf (stderr, "Red node has a red child!\n");
+        return false;
+    }
+
+    if (OPAL_INTERVAL_TREE_COLOR_BLACK == node->color) {
+        current_black_depth++;
+    }
+
+    if (node->left == &tree->nill && node->right == &tree->nill) {
+        if (black_depth != current_black_depth) {
+            fprintf (stderr, "Found leaf with unexpected black depth: %d, expected: %d\n", current_black_depth, black_depth);
+            return false;
+        }
+
+        return true;
+    }
+
+    return opal_interval_tree_verify_node (tree, node->left, black_depth, current_black_depth) ||
+        opal_interval_tree_verify_node (tree, node->right, black_depth, current_black_depth);
+}
+
+static int opal_interval_tree_black_depth (opal_interval_tree_t *tree, opal_interval_tree_node_t *node, int depth)
+{
+    if (node == &tree->nill) {
+        return depth;
+    }
+
+    /* suffices to always go left */
+    if (OPAL_INTERVAL_TREE_COLOR_BLACK == node->color) {
+        depth++;
+    }
+
+    return opal_interval_tree_black_depth (tree, node->left, depth);
+}
+
+bool opal_interval_tree_verify (opal_interval_tree_t *tree)
+{
+    int black_depth;
+
+    if (OPAL_INTERVAL_TREE_COLOR_BLACK != tree->root.left->color) {
+        fprintf (stderr, "Root node of tree is NOT black!\n");
+        return false;
+    }
+
+    if (OPAL_INTERVAL_TREE_COLOR_BLACK != tree->nill.color) {
+        fprintf (stderr, "Leaf node color is NOT black!\n");
+        return false;
+    }
+
+    black_depth = opal_interval_tree_black_depth (tree, tree->root.left, 0);
+
+    return opal_interval_tree_verify_node (tree, tree->root.left, black_depth, 0);
+}
+
+static void opal_interval_tree_dump_node (opal_interval_tree_t *tree, opal_interval_tree_node_t *node, int black_rank, FILE *fh)
+{
+    const char *color = (node->color == OPAL_INTERVAL_TREE_COLOR_BLACK) ? "black" : "red";
+    uintptr_t left = (uintptr_t) node->left, right = (uintptr_t) node->right;
+    opal_interval_tree_node_t *nill = &tree->nill;
+
+    if (node->color == OPAL_INTERVAL_TREE_COLOR_BLACK) {
+	++black_rank;
+    }
+
+    if (nill == node) {
+        return;
+    }
+
+    /* print out nill nodes if any */
+    if ((uintptr_t) nill == left) {
+        left = (uintptr_t) node | 0x1;
+        fprintf (fh, "  Node%lx [color=black,label=nill];\n\n", left);
+    } else {
+        left = (uintptr_t) node->left;
+    }
+
+    if ((uintptr_t) nill == right) {
+        right = (uintptr_t) node | 0x2;
+        fprintf (fh, "  Node%lx [color=black,label=nill];\n\n", right);
+    } else {
+        right = (uintptr_t) node->right;
+    }
+
+    /* print out this node and its edges */
+    fprintf (fh, "  Node%lx [color=%s,shape=box,label=\"[0x%" PRIx64 ",0x%" PRIx64 "]\\nmax=0x%" PRIx64
+             "\\ndata=0x%lx\\nblack rank=%d\"];\n", (uintptr_t) node, color, node->low, node->high, node->max,
+             (uintptr_t) node->data, black_rank);
+    fprintf (fh, "  Node%lx -> Node%lx;\n", (uintptr_t) node, left);
+    fprintf (fh, "  Node%lx -> Node%lx;\n\n", (uintptr_t) node, right);
+    if (node != tree->root.left) {
+        fprintf (fh, "  Node%lx -> Node%lx;\n\n", (uintptr_t) node, (uintptr_t) node->parent);
+    }
+    opal_interval_tree_dump_node (tree, node->left, black_rank, fh);
+    opal_interval_tree_dump_node (tree, node->right, black_rank, fh);
+}
+
+int opal_interval_tree_dump (opal_interval_tree_t *tree, const char *path)
+{
+    FILE *fh;
+
+    fh = fopen (path, "w");
+    if (NULL == fh) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    fprintf (fh, "digraph {\n");
+    fprintf (fh, "  graph [ordering=\"out\"];");
+    opal_interval_tree_dump_node (tree, tree->root.left, 0, fh);
+    fprintf (fh, "}\n");
+
+    fclose (fh);
+
+    return OPAL_SUCCESS;
+}

--- a/opal/class/opal_interval_tree.h
+++ b/opal/class/opal_interval_tree.h
@@ -1,0 +1,241 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/** @file
+ *
+ *     A thread-safe interval tree derived from opal_rb_tree_t
+ */
+
+#ifndef OPAL_INTERVAL_TREE_H
+#define OPAL_INTERVAL_TREE_H
+
+#include "opal_config.h"
+#include <stdlib.h>
+#include "opal/constants.h"
+#include "opal/class/opal_object.h"
+#include "opal/class/opal_free_list.h"
+
+BEGIN_C_DECLS
+/*
+ * Data structures and datatypes
+ */
+
+/**
+  * red and black enum
+  */
+typedef enum {OPAL_INTERVAL_TREE_COLOR_RED, OPAL_INTERVAL_TREE_COLOR_BLACK} opal_interval_tree_nodecolor_t;
+
+/**
+  * node data structure
+  */
+struct opal_interval_tree_node_t
+{
+    opal_free_list_item_t super;        /**< the parent class */
+    opal_interval_tree_nodecolor_t color;     /**< the node color */
+    struct opal_interval_tree_node_t *parent;/**< the parent node, can be NULL */
+    struct opal_interval_tree_node_t *left;  /**< the left child - can be nill */
+    struct opal_interval_tree_node_t *right; /**< the right child - can be nill */
+    /** edit epoch associated with this node */
+    uint32_t epoch;
+    /** data for this interval */
+    void *data;
+    /** low value of this interval */
+    uint64_t low;
+    /** high value of this interval */
+    uint64_t high;
+    /** maximum value of all intervals in tree rooted at this node */
+    uint64_t max;
+};
+typedef struct opal_interval_tree_node_t opal_interval_tree_node_t;
+
+/** maximum number of simultaneous readers */
+#define OPAL_INTERVAL_TREE_MAX_READERS 128
+
+/**
+  * the data structure that holds all the needed information about the tree.
+  */
+struct opal_interval_tree_t {
+    opal_object_t super;           /**< the parent class */
+    /* this root pointer doesn't actually point to the root of the tree.
+     * rather, it points to a sentinal node who's left branch is the real
+     * root of the tree. This is done to eliminate special cases */
+    opal_interval_tree_node_t root; /**< a pointer to the root of the tree */
+    opal_interval_tree_node_t nill;     /**< the nill sentinal node */
+    opal_free_list_t free_list;   /**< the free list to get the memory from */
+    opal_list_t gc_list;          /**< list of nodes that need to be released */
+    uint32_t epoch;               /**< current update epoch */
+    volatile size_t tree_size;    /**< the current size of the tree */
+    volatile int32_t lock;        /**< update lock */
+    volatile int32_t reader_count;    /**< current highest reader slot to check */
+    volatile uint32_t reader_id;  /**< next reader slot to check */
+    volatile uint32_t reader_epochs[OPAL_INTERVAL_TREE_MAX_READERS];
+};
+typedef struct opal_interval_tree_t opal_interval_tree_t;
+
+/** declare the tree node as a class */
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_interval_tree_node_t);
+/** declare the tree as a class */
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_interval_tree_t);
+
+/* Function pointers for map traversal function */
+/**
+  * this function is used for the opal_interval_tree_traverse function.
+  * it is passed a pointer to the value for each node and, if it returns
+  * a one, the action function is called on that node. Otherwise, the node is ignored.
+  */
+typedef int (*opal_interval_tree_condition_fn_t)(void *);
+/**
+ * this function is used for the user to perform any action on the passed
+ * values. The first argument is the key and the second is the value.
+ * note that this function SHOULD NOT modify the keys, as that would
+ * mess up the tree.
+ */
+typedef int (*opal_interval_tree_action_fn_t)(uint64_t low, uint64_t high, void *data, void *ctx);
+
+/*
+ * Public function protoypes
+ */
+
+/**
+  * the function creates a new tree
+  *
+  * @param tree a pointer to an allocated area of memory for the main
+  *  tree data structure.
+  * @param comp a pointer to the function to use for comaparing 2 nodes
+  *
+  * @retval OPAL_SUCCESS if it is successful
+  * @retval OPAL_ERR_TEMP_OUT_OF_RESOURCE if unsuccessful
+  */
+OPAL_DECLSPEC int opal_interval_tree_init(opal_interval_tree_t * tree);
+
+
+/**
+  * inserts a node into the tree
+  *
+  * @param tree a pointer to the tree data structure
+  * @param key the key for the node
+  * @param value the value for the node
+  *
+  * @retval OPAL_SUCCESS
+  * @retval OPAL_ERR_TEMP_OUT_OF_RESOURCE if unsuccessful
+  */
+OPAL_DECLSPEC int opal_interval_tree_insert(opal_interval_tree_t *tree, void *value, uint64_t low, uint64_t high);
+
+/**
+  * finds a value in the tree based on the passed key using passed
+  * compare function
+  *
+  * @param tree a pointer to the tree data structure
+  * @param key a pointer to the key
+  * @param compare function
+  *
+  * @retval pointer to the value if found
+  * @retval NULL if not found
+  */
+OPAL_DECLSPEC void *opal_interval_tree_find_overlapping (opal_interval_tree_t *tree, uint64_t low, uint64_t high);
+
+/**
+  * deletes a node based on its interval
+  *
+  * @param tree a pointer to the tree data structure
+  * @param low low value of interval
+  * @param high high value of interval
+  * @param data data to match (NULL for any)
+  *
+  * @retval OPAL_SUCCESS if the node is found and deleted
+  * @retval OPAL_ERR_NOT_FOUND if the node is not found
+  *
+  * This function finds and deletes an interval from the tree that exactly matches
+  * the given range.
+  */
+OPAL_DECLSPEC int opal_interval_tree_delete(opal_interval_tree_t *tree, uint64_t low, uint64_t high, void *data);
+
+/**
+  * frees all the nodes on the tree
+  *
+  * @param tree a pointer to the tree data structure
+  *
+  * @retval OPAL_SUCCESS
+  */
+OPAL_DECLSPEC int opal_interval_tree_destroy(opal_interval_tree_t *tree);
+
+/**
+  * traverses the entire tree, performing the cond function on each of the
+  * values and if it returns one it performs the action function on the values
+  *
+  * @param tree a pointer to the tree
+  * @param low low value of interval
+  * @param high high value of interval
+  * @param partial_ok traverse nodes that parially overlap the given range
+  * @param action a pointer to the action function
+  * @param ctx context to pass to action function
+  *
+  * @retval OPAL_SUCCESS
+  * @retval OPAL_ERROR if there is an error
+  */
+OPAL_DECLSPEC int opal_interval_tree_traverse (opal_interval_tree_t *tree, uint64_t low, uint64_t high,
+                                               bool complete, opal_interval_tree_action_fn_t action, void *ctx);
+
+/**
+  * returns the size of the tree
+  *
+  * @param tree a pointer to the tree data structure
+  *
+  * @retval int the nuber of items on the tree
+  */
+OPAL_DECLSPEC size_t opal_interval_tree_size (opal_interval_tree_t *tree);
+
+/**
+ * Diagnostic function to get the max depth of an interval tree.
+ *
+ * @param[in] tree    opal interval tree pointer
+ *
+ * This is an expensive function that walks the entire tree to find the
+ * maximum depth. For a valid interval tree this depth will always be
+ * O(log(n)) where n is the number of intervals in the tree.
+ */
+OPAL_DECLSPEC size_t opal_interval_tree_depth (opal_interval_tree_t *tree);
+
+/**
+ * Diagnostic function that can be used to verify that an interval tree
+ * is valid.
+ *
+ * @param[in] tree    opal interval tree pointer
+ *
+ * @returns true if the tree is a valid interval tree
+ * @returns false otherwise
+ */
+OPAL_DECLSPEC bool opal_interval_tree_verify (opal_interval_tree_t *tree);
+
+/**
+ * Dump a DOT representation of the interval tree
+ *
+ * @param[in] tree    opal interval tree pointer
+ * @param[in] path    output file path
+ *
+ * This function dumps the tree and includes: color, data value, interval, and sub-tree
+ * min and max.
+ */
+OPAL_DECLSPEC int opal_interval_tree_dump (opal_interval_tree_t *tree, const char *path);
+
+END_C_DECLS
+#endif /* OPAL_INTERVAL_TREE_H */

--- a/opal/mca/mpool/hugepage/mpool_hugepage.h
+++ b/opal/mca/mpool/hugepage/mpool_hugepage.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Voltaire. All rights reserved.
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -29,6 +29,7 @@
 #include "opal_config.h"
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_free_list.h"
+#include "opal/class/opal_rb_tree.h"
 #include "opal/mca/event/event.h"
 #include "opal/mca/mpool/mpool.h"
 #include "opal/util/proc.h"

--- a/opal/mca/rcache/base/rcache_base_frame.c
+++ b/opal/mca/rcache/base/rcache_base_frame.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2012-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2012-2018 Los Alamos National Security, LLC.
  *                         All rights reserved
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -73,11 +73,6 @@ OBJ_CLASS_INSTANCE(mca_rcache_base_registration_t, opal_free_list_item_t,
  * Global variables
  */
 opal_list_t mca_rcache_base_modules = {{0}};
-opal_free_list_t mca_rcache_base_vma_tree_items = {{{0}}};
-bool mca_rcache_base_vma_tree_items_inited = false;
-unsigned int mca_rcache_base_vma_tree_items_min = TREE_ITEMS_MIN;
-int mca_rcache_base_vma_tree_items_max = TREE_ITEMS_MAX;
-unsigned int mca_rcache_base_vma_tree_items_inc = TREE_ITEMS_INC;
 
 OBJ_CLASS_INSTANCE(mca_rcache_base_selected_module_t, opal_list_item_t, NULL, NULL);
 
@@ -114,9 +109,6 @@ static int mca_rcache_base_close(void)
         (void) mca_base_framework_close (&opal_memory_base_framework);
     }
 
-    OBJ_DESTRUCT(&mca_rcache_base_vma_tree_items);
-    mca_rcache_base_vma_tree_items_inited = false;
-
     /* All done */
     /* Close all remaining available components */
     return mca_base_framework_components_close(&opal_rcache_base_framework, NULL);
@@ -133,37 +125,12 @@ static int mca_rcache_base_open(mca_base_open_flag_t flags)
 
     OBJ_CONSTRUCT(&mca_rcache_base_modules, opal_list_t);
 
-    /* the free list is only initialized when a VMA tree is created */
-    OBJ_CONSTRUCT(&mca_rcache_base_vma_tree_items, opal_free_list_t);
-
      /* Open up all available components */
     return mca_base_framework_components_open(&opal_rcache_base_framework, flags);
 }
 
 static int mca_rcache_base_register_mca_variables (mca_base_register_flag_t flags)
 {
-
-    mca_rcache_base_vma_tree_items_min = TREE_ITEMS_MIN;
-    (void) mca_base_framework_var_register (&opal_rcache_base_framework, "vma_tree_items_min",
-                                            "Minimum number of VMA tree items to allocate (default: "
-                                            STRINGIFY(TREE_ITEMS_MIN) ")", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
-                                            NULL, MCA_BASE_VAR_BIND_NO_OBJECT, 0, OPAL_INFO_LVL_6,
-                                            MCA_BASE_VAR_SCOPE_READONLY, &mca_rcache_base_vma_tree_items_min);
-
-    mca_rcache_base_vma_tree_items_max = TREE_ITEMS_MAX;
-    (void) mca_base_framework_var_register (&opal_rcache_base_framework, "vma_tree_items_max",
-                                            "Maximum number of VMA tree items to allocate (default: "
-                                            STRINGIFY(TREE_ITEMS_MAX) ", -1: unlimited)", MCA_BASE_VAR_TYPE_INT,
-                                            NULL, MCA_BASE_VAR_BIND_NO_OBJECT, 0, OPAL_INFO_LVL_6,
-                                            MCA_BASE_VAR_SCOPE_READONLY, &mca_rcache_base_vma_tree_items_max);
-
-    mca_rcache_base_vma_tree_items_inc = TREE_ITEMS_INC;
-    (void) mca_base_framework_var_register (&opal_rcache_base_framework, "vma_tree_items_inc",
-                                            "Number of VMA tree items to allocate at a time (default: "
-                                            STRINGIFY(TREE_ITEMS_INC) ")", MCA_BASE_VAR_TYPE_UNSIGNED_INT,
-                                            NULL, MCA_BASE_VAR_BIND_NO_OBJECT, 0, OPAL_INFO_LVL_6,
-                                            MCA_BASE_VAR_SCOPE_READONLY, &mca_rcache_base_vma_tree_items_inc);
-
     return OPAL_SUCCESS;
 }
 

--- a/opal/mca/rcache/base/rcache_base_vma.c
+++ b/opal/mca/rcache/base/rcache_base_vma.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -53,14 +53,6 @@ OBJ_CLASS_INSTANCE(mca_rcache_base_vma_module_t, opal_object_t,
 
 mca_rcache_base_vma_module_t *mca_rcache_base_vma_module_alloc (void)
 {
-    if (!mca_rcache_base_vma_tree_items_inited) {
-        opal_free_list_init (&mca_rcache_base_vma_tree_items, sizeof (mca_rcache_base_vma_item_t),
-                             8, OBJ_CLASS(mca_rcache_base_vma_item_t), 0, 8,
-                             mca_rcache_base_vma_tree_items_min, mca_rcache_base_vma_tree_items_max,
-                             mca_rcache_base_vma_tree_items_inc, NULL, 0, NULL, NULL, NULL);
-        mca_rcache_base_vma_tree_items_inited = true;
-    }
-
     return OBJ_NEW(mca_rcache_base_vma_module_t);
 }
 
@@ -154,15 +146,20 @@ int mca_rcache_base_vma_delete (mca_rcache_base_vma_module_t *vma_module,
 }
 
 int mca_rcache_base_vma_iterate (mca_rcache_base_vma_module_t *vma_module,
-                                 unsigned char *base, size_t size,
+                                 unsigned char *base, size_t size, bool partial_ok,
                                  int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
                                  void *ctx)
 {
-    return mca_rcache_base_vma_tree_iterate (vma_module, base, size, callback_fn, ctx);
+    return mca_rcache_base_vma_tree_iterate (vma_module, base, size, partial_ok, callback_fn, ctx);
 }
 
 void mca_rcache_base_vma_dump_range (mca_rcache_base_vma_module_t *vma_module,
                                      unsigned char *base, size_t size, char *msg)
 {
     mca_rcache_base_vma_tree_dump_range (vma_module, base, size, msg);
+}
+
+size_t mca_rcache_base_vma_size (mca_rcache_base_vma_module_t *vma_module)
+{
+    return mca_rcache_base_vma_tree_size (vma_module);
 }

--- a/opal/mca/rcache/base/rcache_base_vma.h
+++ b/opal/mca/rcache/base/rcache_base_vma.h
@@ -13,7 +13,7 @@
  *
  * Copyright (c) 2006      Voltaire. All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -33,7 +33,7 @@
 
 #include "opal_config.h"
 #include "opal/class/opal_list.h"
-#include "opal/class/opal_rb_tree.h"
+#include "opal/class/opal_interval_tree.h"
 #include "opal/class/opal_lifo.h"
 
 BEGIN_C_DECLS
@@ -42,7 +42,7 @@ struct mca_rcache_base_registration_t;
 
 struct mca_rcache_base_vma_module_t {
     opal_object_t super;
-    opal_rb_tree_t rb_tree;
+    opal_interval_tree_t tree;
     opal_list_t vma_list;
     opal_lifo_t vma_gc_lifo;
     size_t reg_cur_cache_size;
@@ -77,6 +77,7 @@ void mca_rcache_base_vma_dump_range (mca_rcache_base_vma_module_t *vma_module,
  * @param[in] vma_module  vma tree
  * @param[in] base        base address of region
  * @param[in] size        size of region
+ * @param[in] partial_ok  partial overlap of range is ok
  * @param[in] callback_fn function to call for each matching registration handle
  * @param[in] ctx         callback context
  *
@@ -87,9 +88,11 @@ void mca_rcache_base_vma_dump_range (mca_rcache_base_vma_module_t *vma_module,
  * other than OPAL_SUCCESS.
  */
 int mca_rcache_base_vma_iterate (mca_rcache_base_vma_module_t *vma_module,
-                                 unsigned char *base, size_t size,
+                                 unsigned char *base, size_t size, bool partial_ok,
                                  int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
                                  void *ctx);
+
+size_t mca_rcache_base_vma_size (mca_rcache_base_vma_module_t *vma_module);
 
 END_C_DECLS
 

--- a/opal/mca/rcache/base/rcache_base_vma_tree.c
+++ b/opal/mca/rcache/base/rcache_base_vma_tree.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -31,332 +31,56 @@
 #include "rcache_base_vma_tree.h"
 #include "opal/mca/rcache/base/base.h"
 
-OBJ_CLASS_INSTANCE(mca_rcache_base_vma_reg_list_item_t, opal_list_item_t, NULL, NULL);
-
-static void mca_rcache_base_vma_item_construct (mca_rcache_base_vma_item_t *vma_item)
-{
-    OBJ_CONSTRUCT(&vma_item->reg_list, opal_list_t);
-    vma_item->in_use = false;
-}
-
-static void mca_rcache_base_vma_item_destruct (mca_rcache_base_vma_item_t *vma_item)
-{
-    OPAL_LIST_DESTRUCT(&vma_item->reg_list);
-}
-
-OBJ_CLASS_INSTANCE(mca_rcache_base_vma_item_t, opal_free_list_item_t,
-                   mca_rcache_base_vma_item_construct,
-                   mca_rcache_base_vma_item_destruct);
-
-
-/**
- * Function for the red black tree to compare 2 keys
- *
- * @param key1 a pointer to the 1st key
- * @param key2 a pointer to the second key
- *
- * @retval -1 if key1 is below key2
- * @retval 1 if key 1 is above key2
- * @retval 0 if the keys are the same
- */
-
-static int mca_rcache_base_vma_tree_node_compare(void *key1, void *key2)
-{
-    mca_rcache_base_vma_item_t *vma1 = (mca_rcache_base_vma_item_t *) key1,
-        *vma2 = (mca_rcache_base_vma_item_t *) key2;
-
-    if (vma1->start < vma2->start) {
-        return -1;
-    }
-
-    if (vma1->start > vma2->start) {
-        return 1;
-    }
-
-    return 0;
-}
-
-static int mca_rcache_base_vma_tree_node_compare_search(void *key1, void *key2)
-{
-    mca_rcache_base_vma_item_t *vma = (mca_rcache_base_vma_item_t *) key2;
-    uintptr_t addr = (uintptr_t) key1;
-
-    if (vma->end < addr) {
-        return 1;
-    }
-
-    if (vma->start <= addr) {
-        return 0;
-    }
-
-    return -1;
-}
-
-static int mca_rcache_base_vma_tree_node_compare_closest(void *key1, void *key2)
-{
-    mca_rcache_base_vma_item_t *vma = (mca_rcache_base_vma_item_t *) key2, *prev_vma;
-    uintptr_t addr = (uintptr_t) key1;
-
-    if (vma->end < addr) {
-        return 1;
-    }
-
-    if (vma->start <= addr) {
-        return 0;
-    }
-
-    prev_vma = (mca_rcache_base_vma_item_t *) opal_list_get_prev (&vma->super);
-    if (prev_vma == (mca_rcache_base_vma_item_t *) opal_list_get_end (&vma->vma_module->vma_list)
-        || prev_vma->end < addr) {
-        return 0;
-    }
-
-    return -1;
-}
-
-static inline
-mca_rcache_base_vma_item_t *mca_rcache_base_vma_new (mca_rcache_base_vma_module_t *vma_module,
-                                                     uintptr_t start, uintptr_t end)
-{
-    mca_rcache_base_vma_item_t *vma_item = (mca_rcache_base_vma_item_t *) opal_free_list_get (&mca_rcache_base_vma_tree_items);
-    if (NULL == vma_item) {
-        return NULL;
-    }
-
-    vma_item->start = start;
-    vma_item->end = end;
-    vma_item->vma_module = vma_module;
-
-    (void) opal_rb_tree_insert (&vma_module->rb_tree, vma_item, vma_item);
-
-    return vma_item;
-}
-
-static void mca_rcache_base_vma_return (mca_rcache_base_vma_module_t *vma_module, mca_rcache_base_vma_item_t *vma_item)
-{
-    opal_list_item_t *item;
-    while (NULL != (item = opal_list_remove_first (&vma_item->reg_list))) {
-        OBJ_RELEASE(item);
-    }
-
-    opal_free_list_return (&mca_rcache_base_vma_tree_items, &vma_item->super);
-}
-
-static inline int mca_rcache_base_vma_compare_regs (mca_rcache_base_registration_t *reg1,
-                                                    mca_rcache_base_registration_t *reg2)
-{
-    /* persisten registration are on top */
-    if ((reg1->flags & MCA_RCACHE_FLAGS_PERSIST) &&
-        !(reg2->flags & MCA_RCACHE_FLAGS_PERSIST)) {
-        return 1;
-    }
-
-    if (!(reg1->flags & MCA_RCACHE_FLAGS_PERSIST) &&
-        (reg2->flags & MCA_RCACHE_FLAGS_PERSIST)) {
-        return -1;
-    }
-
-    if (reg1->bound != reg2->bound) {
-        return (int)(reg1->bound - reg2->bound);
-    }
-
-    /* tie breaker */
-    return (int)((intptr_t)reg1 - (intptr_t)reg2);
-}
-
-static inline int mca_rcache_base_vma_add_reg (mca_rcache_base_vma_item_t *vma_item,
-                                               struct mca_rcache_base_registration_t *reg)
-{
-    mca_rcache_base_vma_reg_list_item_t *item, *entry;
-
-    entry = OBJ_NEW(mca_rcache_base_vma_reg_list_item_t);
-
-    if (!entry) {
-        return -1;
-    }
-
-    entry->reg = reg;
-
-    OPAL_LIST_FOREACH(item, &vma_item->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-        if (mca_rcache_base_vma_compare_regs(item->reg, reg) > 0) {
-            continue;
-        }
-
-        opal_list_insert_pos (&vma_item->reg_list, &item->super, &entry->super);
-        return 0;
-    }
-
-    opal_list_append (&vma_item->reg_list, &entry->super);
-
-    return 0;
-}
-
-static inline void mca_rcache_base_vma_remove_reg (mca_rcache_base_vma_item_t *vma_item,
-                                                   struct mca_rcache_base_registration_t *reg)
-{
-    mca_rcache_base_vma_reg_list_item_t *item;
-
-    OPAL_LIST_FOREACH(item, &vma_item->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-        if (item->reg == reg) {
-            opal_list_remove_item(&vma_item->reg_list, &item->super);
-            OBJ_RELEASE(item);
-            break;
-        }
-    }
-}
-
-static inline int mca_rcache_base_vma_copy_reg_list (mca_rcache_base_vma_item_t *to,
-                                                     mca_rcache_base_vma_item_t *from)
-{
-
-    mca_rcache_base_vma_reg_list_item_t *item_f, *item_t;
-    OPAL_LIST_FOREACH(item_f, &from->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-        item_t = OBJ_NEW(mca_rcache_base_vma_reg_list_item_t);
-
-        if (NULL == item_t) {
-            return OPAL_ERR_OUT_OF_RESOURCE;
-        }
-
-        item_t->reg = item_f->reg;
-
-        opal_list_append (&to->reg_list, &item_t->super);
-    }
-
-    return OPAL_SUCCESS;
-}
-
-/* returns 1 iff two lists contain the same entries */
-static inline int mca_rcache_base_vma_compare_reg_lists (mca_rcache_base_vma_item_t *vma1,
-                                                         mca_rcache_base_vma_item_t *vma2)
-{
-    mca_rcache_base_vma_reg_list_item_t *i1, *i2;
-
-    if (!vma1 || !vma2 || opal_list_get_size (&vma1->reg_list) != opal_list_get_size (&vma2->reg_list)) {
-        return 0;
-    }
-
-    i2 = (mca_rcache_base_vma_reg_list_item_t *) opal_list_get_first(&vma2->reg_list);
-
-    OPAL_LIST_FOREACH(i1, &vma1->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-        if ((void *) i2 == (void *) opal_list_get_end (&vma2->reg_list) || i1->reg != i2->reg) {
-            return 0;
-        }
-
-        i2 = (mca_rcache_base_vma_reg_list_item_t *) opal_list_get_next (&i2->super);
-    }
-
-    return 1;
-}
-
 int mca_rcache_base_vma_tree_init (mca_rcache_base_vma_module_t *vma_module)
 {
-    OBJ_CONSTRUCT(&vma_module->rb_tree, opal_rb_tree_t);
-    OBJ_CONSTRUCT(&vma_module->vma_list, opal_list_t);
-    OBJ_CONSTRUCT(&vma_module->vma_gc_lifo, opal_lifo_t);
+    OBJ_CONSTRUCT(&vma_module->tree, opal_interval_tree_t);
     vma_module->reg_cur_cache_size = 0;
-    return opal_rb_tree_init (&vma_module->rb_tree, mca_rcache_base_vma_tree_node_compare);
+    return opal_interval_tree_init (&vma_module->tree);
 }
 
 void mca_rcache_base_vma_tree_finalize (mca_rcache_base_vma_module_t *vma_module)
 {
-    opal_rb_tree_init(&vma_module->rb_tree,  mca_rcache_base_vma_tree_node_compare);
-    OBJ_DESTRUCT(&vma_module->vma_list);
-    OBJ_DESTRUCT(&vma_module->vma_gc_lifo);
-    OBJ_DESTRUCT(&vma_module->rb_tree);
+    OBJ_DESTRUCT(&vma_module->tree);
 }
 
 mca_rcache_base_registration_t *mca_rcache_base_vma_tree_find (mca_rcache_base_vma_module_t *vma_module,
-                                                              unsigned char *base, unsigned char *bound)
+                                                               unsigned char *base, unsigned char *bound)
 {
-    mca_rcache_base_vma_item_t *vma;
-    mca_rcache_base_vma_reg_list_item_t *item;
-
-    opal_mutex_lock (&vma_module->vma_lock);
-
-    vma = (mca_rcache_base_vma_item_t *) opal_rb_tree_find_with (&vma_module->rb_tree, base,
-                                                                 mca_rcache_base_vma_tree_node_compare_search);
-    if (!vma) {
-        opal_mutex_unlock (&vma_module->vma_lock);
-        return NULL;
-    }
-
-    OPAL_LIST_FOREACH(item, &vma->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-        if(item->reg->flags & MCA_RCACHE_FLAGS_INVALID) {
-            continue;
-        }
-
-        if(item->reg->bound >= bound) {
-            opal_mutex_unlock (&vma_module->vma_lock);
-            return item->reg;
-        }
-
-        if(!(item->reg->flags & MCA_RCACHE_FLAGS_PERSIST)) {
-            break;
-        }
-    }
-
-    opal_mutex_unlock (&vma_module->vma_lock);
-
-    return NULL;
+    return (mca_rcache_base_registration_t *) opal_interval_tree_find_overlapping (&vma_module->tree, (uintptr_t) base,
+                                                                                   ((uintptr_t) bound) + 1);
 }
 
-static inline bool is_reg_in_array (mca_rcache_base_registration_t **regs,
-                                    int cnt, mca_rcache_base_registration_t *p)
+struct mca_rcache_base_vma_tree_find_all_helper_args_t {
+    mca_rcache_base_registration_t **regs;
+    int reg_cnt;
+    int reg_max;
+};
+
+typedef struct mca_rcache_base_vma_tree_find_all_helper_args_t mca_rcache_base_vma_tree_find_all_helper_args_t;
+
+static int mca_rcache_base_vma_tree_find_all_helper (uint64_t low, uint64_t high, void *data, void *ctx)
 {
-    for (int i = 0 ; i < cnt ; ++i) {
-        if (regs[i] == p) {
-            return true;
-        }
+    mca_rcache_base_vma_tree_find_all_helper_args_t *args = (mca_rcache_base_vma_tree_find_all_helper_args_t *) ctx;
+    mca_rcache_base_registration_t *reg = (mca_rcache_base_registration_t *) data;
+
+    if (args->reg_cnt == args->reg_max) {
+        return args->reg_max;
     }
 
-    return false;
+    args->regs[args->reg_cnt++] = reg;
+
+    return OPAL_SUCCESS;
 }
 
 int mca_rcache_base_vma_tree_find_all (mca_rcache_base_vma_module_t *vma_module, unsigned char *base,
                                        unsigned char *bound, mca_rcache_base_registration_t **regs,
                                        int reg_cnt)
 {
-    int cnt = 0;
+    mca_rcache_base_vma_tree_find_all_helper_args_t args = {.regs = regs, .reg_max = reg_cnt, .reg_cnt = 0};
 
-    if(opal_list_get_size(&vma_module->vma_list) == 0)
-        return cnt;
-
-    opal_mutex_lock (&vma_module->vma_lock);
-
-    do {
-        mca_rcache_base_vma_item_t *vma;
-        mca_rcache_base_vma_reg_list_item_t *vma_item;
-        vma = (mca_rcache_base_vma_item_t *) opal_rb_tree_find_with (&vma_module->rb_tree, base,
-                                                                     mca_rcache_base_vma_tree_node_compare_closest);
-
-        if (NULL == vma) {
-            /* base is bigger than any registered memory */
-            break;
-        }
-
-        if (base < (unsigned char *) vma->start) {
-            base = (unsigned char *) vma->start;
-            continue;
-        }
-
-        OPAL_LIST_FOREACH(vma_item, &vma->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-            if (vma_item->reg->flags & MCA_RCACHE_FLAGS_INVALID ||
-                is_reg_in_array (regs, cnt, vma_item->reg)) {
-                continue;
-            }
-            regs[cnt++] = vma_item->reg;
-            if (cnt == reg_cnt) {
-                opal_mutex_unlock (&vma_module->vma_lock);
-                return cnt; /* no space left in the provided array */
-            }
-        }
-
-        base = (unsigned char *)vma->end + 1;
-    } while (bound >= base);
-
-    opal_mutex_unlock (&vma_module->vma_lock);
-
-    return cnt;
+    (void) opal_interval_tree_traverse (&vma_module->tree, (uint64_t) (uintptr_t) base, ((uint64_t) (uintptr_t) bound) + 1,
+                                        true, mca_rcache_base_vma_tree_find_all_helper, &args);
+    return args.reg_cnt;
 }
 
 static inline void mca_rcache_base_vma_update_byte_count (mca_rcache_base_vma_module_t *vma_module,
@@ -365,59 +89,28 @@ static inline void mca_rcache_base_vma_update_byte_count (mca_rcache_base_vma_mo
     vma_module->reg_cur_cache_size += nbytes;
 }
 
-int mca_rcache_base_vma_tree_iterate (mca_rcache_base_vma_module_t *vma_module, unsigned char *base,
-                                      size_t size, int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
+struct mca_rcache_base_vma_tree_iterate_helper_args_t {
+    int (*callback_fn) (struct mca_rcache_base_registration_t *, void *);
+    void *ctx;
+};
+typedef struct mca_rcache_base_vma_tree_iterate_helper_args_t mca_rcache_base_vma_tree_iterate_helper_args_t;
+
+static int mca_rcache_base_vma_tree_iterate_helper (uint64_t low, uint64_t high, void *data, void *ctx)
+{
+    mca_rcache_base_vma_tree_iterate_helper_args_t *args = (mca_rcache_base_vma_tree_iterate_helper_args_t *) ctx;
+    return args->callback_fn ((mca_rcache_base_registration_t *) data, args->ctx);
+}
+
+int mca_rcache_base_vma_tree_iterate (mca_rcache_base_vma_module_t *vma_module, unsigned char *base, size_t size,
+                                      bool partial_ok, int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
                                       void *ctx)
 {
-    unsigned char *bound = base + size - 1;
-    mca_rcache_base_vma_item_t *vma;
-    int rc = OPAL_SUCCESS;
+    mca_rcache_base_vma_tree_iterate_helper_args_t args = {.callback_fn = callback_fn, .ctx = ctx};
+    uintptr_t bound = (uintptr_t) base + size;
+    int rc;
 
-    if (opal_list_get_size(&vma_module->vma_list) == 0) {
-        /* nothin to do */
-        return OPAL_SUCCESS;
-    }
-
-    opal_mutex_lock (&vma_module->vma_lock);
-
-    do {
-        mca_rcache_base_vma_reg_list_item_t *vma_item, *next;
-        vma = (mca_rcache_base_vma_item_t *) opal_rb_tree_find_with (&vma_module->rb_tree, base,
-                                                                     mca_rcache_base_vma_tree_node_compare_closest);
-
-        if (NULL == vma) {
-            /* base is bigger than any registered memory */
-            break;
-        }
-
-        if (base < (unsigned char *) vma->start) {
-            base = (unsigned char *) vma->start;
-            continue;
-        }
-
-        base = (unsigned char *)vma->end + 1;
-
-        /* all the registrations in the vma may be deleted by the callback so keep a
-         * reference until we are done with it. */
-        vma->in_use = true;
-
-        OPAL_LIST_FOREACH_SAFE(vma_item, next, &vma->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-            rc = callback_fn (vma_item->reg, ctx);
-            if (OPAL_SUCCESS != rc) {
-                break;
-            }
-        }
-
-        vma->in_use = false;
-
-        if (OPAL_SUCCESS != rc) {
-            break;
-        }
-    } while (bound >= base);
-
-    opal_mutex_unlock (&vma_module->vma_lock);
-
-    return rc;
+    return opal_interval_tree_traverse (&vma_module->tree, (uint64_t) (intptr_t) base, bound, partial_ok,
+                                        mca_rcache_base_vma_tree_iterate_helper, &args);
 }
 
 static inline int mca_rcache_base_vma_can_insert (mca_rcache_base_vma_module_t *vma_module, size_t nbytes, size_t limit)
@@ -425,139 +118,10 @@ static inline int mca_rcache_base_vma_can_insert (mca_rcache_base_vma_module_t *
     return (0 == limit || vma_module->reg_cur_cache_size + nbytes <= limit);
 }
 
-/**
- * Free deleted vmas. This can not be done when they are deleted without running
- * into deadlock problems with some libc versions. The caller MUST hold the vma_lock
- * when calling this function.
- */
-static void mca_rcache_base_vma_cleanup (mca_rcache_base_vma_module_t *vma_module, int depth)
-{
-    mca_rcache_base_vma_item_t *item;
-
-    while (NULL != (item = (mca_rcache_base_vma_item_t *) opal_lifo_pop_atomic (&vma_module->vma_gc_lifo))) {
-        if (OPAL_UNLIKELY(item->in_use)) {
-            /* another thread is currently iterating on this vma and its registrations */
-            if (depth < 8) {
-                /* try to clean up additional vmas before returning */
-                mca_rcache_base_vma_cleanup (vma_module, depth + 1);
-            }
-
-            if (item->in_use) {
-                /* will clean it up later */
-                opal_lifo_push_atomic (&vma_module->vma_gc_lifo, &item->super.super);
-                return;
-            }
-        }
-
-        mca_rcache_base_vma_return (vma_module, (mca_rcache_base_vma_item_t *) item);
-    }
-}
-
 int mca_rcache_base_vma_tree_insert (mca_rcache_base_vma_module_t *vma_module,
                                      mca_rcache_base_registration_t *reg, size_t limit)
 {
-    mca_rcache_base_vma_item_t *i;
-    uintptr_t begin = (uintptr_t)reg->base, end = (uintptr_t)reg->bound;
-
-    mca_rcache_base_vma_cleanup (vma_module, 0);
-
-    opal_mutex_lock (&vma_module->vma_lock);
-
-    i = (mca_rcache_base_vma_item_t *) opal_rb_tree_find_with (&vma_module->rb_tree,
-            (void *) begin, mca_rcache_base_vma_tree_node_compare_closest);
-
-    if (!i) {
-        i = (mca_rcache_base_vma_item_t *) opal_list_get_end (&vma_module->vma_list);
-    }
-
-    while (begin <= end) {
-        mca_rcache_base_vma_item_t *vma = NULL;
-
-        if (opal_list_get_end (&vma_module->vma_list) == &i->super.super) {
-            if (mca_rcache_base_vma_can_insert (vma_module, end - begin + 1, limit)) {
-                vma = mca_rcache_base_vma_new(vma_module, begin, end);
-            }
-
-            if (!vma) {
-                goto remove;
-            }
-
-            mca_rcache_base_vma_update_byte_count (vma_module, end - begin + 1);
-
-            opal_list_append(&vma_module->vma_list, &vma->super.super);
-            begin = vma->end + 1;
-            mca_rcache_base_vma_add_reg (vma, reg);
-            opal_mutex_unlock (&vma_module->vma_lock);
-            return OPAL_SUCCESS;
-        }
-
-        if (i->start > begin) {
-            uintptr_t tend = (i->start <= end) ? (i->start - 1) : end;
-            if (mca_rcache_base_vma_can_insert(vma_module, tend - begin + 1, limit)) {
-                vma = mca_rcache_base_vma_new(vma_module, begin, tend);
-            }
-
-            if (!vma) {
-                goto remove;
-            }
-
-            mca_rcache_base_vma_update_byte_count (vma_module, tend - begin + 1);
-
-            /* insert before */
-            opal_list_insert_pos(&vma_module->vma_list, &i->super.super, &vma->super.super);
-            i = vma;
-            begin = vma->end + 1;
-            mca_rcache_base_vma_add_reg (vma, reg);
-        } else if(i->start == begin) {
-            if (i->end > end) {
-                vma = mca_rcache_base_vma_new (vma_module, end + 1, i->end);
-                if (!vma) {
-                    goto remove;
-                }
-
-                i->end = end;
-
-                mca_rcache_base_vma_copy_reg_list (vma, i);
-
-                /* add after */
-                opal_list_insert_pos (&vma_module->vma_list,
-                                      opal_list_get_next (&i->super),
-                                      &vma->super.super);
-                mca_rcache_base_vma_add_reg (i, reg);
-                begin = end + 1;
-            } else {
-                mca_rcache_base_vma_add_reg(i, reg);
-                begin = i->end + 1;
-            }
-        } else {
-                vma = mca_rcache_base_vma_new (vma_module, begin, i->end);
-
-                if (!vma) {
-                    goto remove;
-                }
-
-                i->end = begin - 1;
-
-                mca_rcache_base_vma_copy_reg_list (vma, i);
-
-                /* add after */
-                opal_list_insert_pos (&vma_module->vma_list,
-                                      opal_list_get_next (&i->super.super),
-                                      &vma->super.super);
-        }
-
-        i = (mca_rcache_base_vma_item_t *) opal_list_get_next (&i->super);
-    }
-
-    opal_mutex_unlock (&vma_module->vma_lock);
-
-    return OPAL_SUCCESS;
-
-remove:
-    mca_rcache_base_vma_tree_delete (vma_module, reg);
-    opal_mutex_unlock (&vma_module->vma_lock);
-
-    return OPAL_ERR_TEMP_OUT_OF_RESOURCE;
+    return opal_interval_tree_insert (&vma_module->tree, reg, (uintptr_t) reg->base, (uintptr_t) reg->bound + 1);
 }
 
 /**
@@ -571,119 +135,36 @@ remove:
 int mca_rcache_base_vma_tree_delete (mca_rcache_base_vma_module_t *vma_module,
                                      mca_rcache_base_registration_t *reg)
 {
-    mca_rcache_base_vma_item_t *vma;
+    return opal_interval_tree_delete (&vma_module->tree, (uintptr_t) reg->base, (uintptr_t) reg->bound + 1, reg);
+}
 
-    opal_mutex_lock (&vma_module->vma_lock);
+static int mca_rcache_base_tree_dump_range_helper (uint64_t low, uint64_t high, void *data, void *ctx)
+{
+    mca_rcache_base_registration_t *reg = ( mca_rcache_base_registration_t *) data;
 
-    vma = (mca_rcache_base_vma_item_t *)
-        opal_rb_tree_find_with (&vma_module->rb_tree, reg->base,
-                                mca_rcache_base_vma_tree_node_compare_search);
+    opal_output(0, "    reg: base=%p, bound=%p, ref_count=%d, flags=0x%x",
+                (void *) reg->base, (void *) reg->bound, reg->ref_count, reg->flags);
 
-    if (!vma) {
-        opal_mutex_unlock (&vma_module->vma_lock);
-        return OPAL_ERROR;
-    }
-
-    while (vma != (mca_rcache_base_vma_item_t *) opal_list_get_end (&vma_module->vma_list)
-           && vma->start <= (uintptr_t) reg->bound) {
-        mca_rcache_base_vma_remove_reg(vma, reg);
-
-        if(opal_list_is_empty(&vma->reg_list)) {
-            mca_rcache_base_vma_item_t *next =
-                (mca_rcache_base_vma_item_t *) opal_list_get_next (&vma->super);
-            opal_rb_tree_delete (&vma_module->rb_tree, vma);
-            mca_rcache_base_vma_update_byte_count (vma_module,
-                                                   vma->start - vma->end - 1);
-            opal_list_remove_item (&vma_module->vma_list, &vma->super.super);
-            opal_lifo_push_atomic (&vma_module->vma_gc_lifo, &vma->super.super);
-            vma = next;
-        } else {
-            int merged;
-
-            do {
-                mca_rcache_base_vma_item_t *prev = NULL, *next = NULL;
-                if (opal_list_get_first (&vma_module->vma_list) != &vma->super.super) {
-                    prev = (mca_rcache_base_vma_item_t *) opal_list_get_prev(vma);
-                }
-
-                merged = 0;
-
-                if (prev && vma->start == prev->end + 1 &&
-                    mca_rcache_base_vma_compare_reg_lists(vma, prev)) {
-                    prev->end = vma->end;
-                    opal_list_remove_item(&vma_module->vma_list, &vma->super.super);
-                    opal_rb_tree_delete(&vma_module->rb_tree, vma);
-                    opal_lifo_push_atomic (&vma_module->vma_gc_lifo, &vma->super.super);
-                    vma = prev;
-                    merged = 1;
-                }
-
-                if (opal_list_get_last (&vma_module->vma_list) != &vma->super.super) {
-                    next = (mca_rcache_base_vma_item_t *) opal_list_get_next (vma);
-                }
-
-                if (next && vma->end + 1 == next->start &&
-                    mca_rcache_base_vma_compare_reg_lists (vma, next)) {
-                    vma->end = next->end;
-                    opal_list_remove_item(&vma_module->vma_list, &next->super.super);
-                    opal_rb_tree_delete(&vma_module->rb_tree, next);
-                    opal_lifo_push_atomic (&vma_module->vma_gc_lifo, &next->super.super);
-                    merged = 1;
-                }
-            } while (merged);
-
-            vma = (mca_rcache_base_vma_item_t *) opal_list_get_next (vma);
-        }
-    }
-
-    opal_mutex_unlock (&vma_module->vma_lock);
-
-    return 0;
+    return OPAL_SUCCESS;
 }
 
 /* Dump out rcache entries within a range of memory.  Useful for debugging. */
 void mca_rcache_base_vma_tree_dump_range (mca_rcache_base_vma_module_t *vma_module,
                                           unsigned char *base, size_t size, char *msg)
 {
-    unsigned char * bound = base + size -1;
-    mca_rcache_base_registration_t *reg;
+    uintptr_t bound = (uintptr_t) base + size;
 
-    if (NULL == msg) {
-        msg = "";
-    }
+    opal_output(0, "Dumping rcache entries: %s", msg ? msg : "");
 
-    opal_output(0, "Dumping rcache entries: %s", msg);
-
-    if(opal_list_is_empty(&vma_module->vma_list)) {
+    if (opal_interval_tree_size (&vma_module->tree)) {
+        (void) opal_interval_tree_traverse (&vma_module->tree, (uintptr_t) base, bound, false,
+                                            mca_rcache_base_tree_dump_range_helper, NULL);
+    } else {
         opal_output(0, "  rcache is empty");
-        return;
     }
+}
 
-    do {
-        mca_rcache_base_vma_item_t *vma;
-        mca_rcache_base_vma_reg_list_item_t *vma_item;
-        vma = (mca_rcache_base_vma_item_t *)
-            opal_rb_tree_find_with (&vma_module->rb_tree, base,
-                                    mca_rcache_base_vma_tree_node_compare_closest);
-
-        if (NULL == vma) {
-            /* base is bigger than any registered memory */
-            break;
-        }
-
-        if (base < (unsigned char *) vma->start) {
-            base = (unsigned char *) vma->start;
-            continue;
-        }
-
-        opal_output(0, "  vma: base=%p, bound=%p, size=%lu, number of registrations=%d",
-                    (void *)vma->start, (void *)vma->end, vma->end - vma->start + 1,
-                    (int) opal_list_get_size(&vma->reg_list));
-        OPAL_LIST_FOREACH(vma_item, &vma->reg_list, mca_rcache_base_vma_reg_list_item_t) {
-            reg = vma_item->reg;
-            opal_output(0, "    reg: base=%p, bound=%p, ref_count=%d, flags=0x%x",
-                        (void *) reg->base, (void *) reg->bound, reg->ref_count, reg->flags);
-        }
-        base = (unsigned char *)vma->end + 1;
-    } while (bound >= base);
+size_t mca_rcache_base_vma_tree_size (mca_rcache_base_vma_module_t *vma_module)
+{
+    return opal_interval_tree_size (&vma_module->tree);
 }

--- a/opal/mca/rcache/base/rcache_base_vma_tree.h
+++ b/opal/mca/rcache/base/rcache_base_vma_tree.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  *
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -34,35 +34,6 @@
 
 #include "opal/mca/rcache/rcache.h"
 #include "rcache_base_vma.h"
-
-/*
- * Data structures for the tree of allocated memory
- */
-
-struct mca_rcache_base_vma_reg_list_item_t
-{
-    opal_list_item_t super;
-    mca_rcache_base_registration_t *reg;
-};
-typedef struct mca_rcache_base_vma_reg_list_item_t mca_rcache_base_vma_reg_list_item_t;
-OBJ_CLASS_DECLARATION(mca_rcache_base_vma_reg_list_item_t);
-
-/**
- * The item in the vma_tree itself
- */
-struct mca_rcache_base_vma_item_t
-{
-    opal_free_list_item_t super;     /**< the parent class */
-    uintptr_t start;                 /**< the base of the memory range */
-    uintptr_t end;                   /**< the bound of the memory range */
-    opal_list_t reg_list;            /**< list of regs on this vma */
-    bool in_use;                     /**< vma is in use in iterate */
-    mca_rcache_base_vma_module_t *vma_module; /**< pointer to rcache vma belongs to */
-};
-typedef struct mca_rcache_base_vma_item_t mca_rcache_base_vma_item_t;
-
-OBJ_CLASS_DECLARATION(mca_rcache_base_vma_item_t);
-
 
 /*
  * initialize the vma tree
@@ -111,8 +82,17 @@ void mca_rcache_base_vma_tree_dump_range (mca_rcache_base_vma_module_t *vma_modu
  * Iterate over matching registration handles in the tree.
  */
 int mca_rcache_base_vma_tree_iterate (mca_rcache_base_vma_module_t *vma_module,
-                                      unsigned char *base, size_t size,
+                                      unsigned char *base, size_t size, bool partial_ok,
                                       int (*callback_fn) (struct mca_rcache_base_registration_t *, void *),
                                       void *ctx);
+
+/**
+ * @brief Get the current size of the vma tree
+ *
+ * @param[in] vma_module   rcache vma tree module
+ *
+ * @returns the current number of vma regions in the tree
+ */
+size_t mca_rcache_base_vma_tree_size (mca_rcache_base_vma_module_t *vma_module);
 
 #endif /* MCA_RCACHE_BASE_VMA_TREE_H */

--- a/opal/mca/rcache/grdma/rcache_grdma.h
+++ b/opal/mca/rcache/grdma/rcache_grdma.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Voltaire. All rights reserved.
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  *
  * $COPYRIGHT$
@@ -33,6 +33,8 @@
 #if HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
+
+#define MCA_RCACHE_GRDMA_REG_FLAG_IN_LRU MCA_RCACHE_FLAGS_MOD_RESV0
 
 BEGIN_C_DECLS
 

--- a/opal/mca/rcache/rcache.h
+++ b/opal/mca/rcache/rcache.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
- * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -47,6 +47,14 @@ enum {
     MCA_RCACHE_FLAGS_CUDA_REGISTER_MEM = 0x0010,
     /** invalid registration (no valid for passing to rcache register) */
     MCA_RCACHE_FLAGS_INVALID           = 0x0080,
+    /** reserved for rcache module */
+    MCA_RCACHE_FLAGS_MOD_RESV0         = 0x0100,
+    /** reserved for rcache module */
+    MCA_RCACHE_FLAGS_MOD_RESV1         = 0x0200,
+    /** reserved for rcache module */
+    MCA_RCACHE_FLAGS_MOD_RESV2         = 0x0400,
+    /** reserved for rcache module */
+    MCA_RCACHE_FLAGS_MOD_RESV3         = 0x0800,
     /** reserved for register function */
     MCA_RCACHE_FLAGS_RESV0             = 0x1000,
     /** reserved for register function */
@@ -84,9 +92,9 @@ struct mca_rcache_base_registration_t {
     /** artifact of old mpool/rcache architecture. used by cuda code */
     unsigned char *alloc_base;
     /** number of outstanding references */
-    int32_t ref_count;
+    volatile int32_t ref_count;
     /** registration flags */
-    uint32_t flags;
+    volatile uint32_t flags;
     /** internal rcache context */
     void *rcache_context;
 #if OPAL_CUDA_GDR_SUPPORT


### PR DESCRIPTION
This PR rewrites the code underlying the primary registration cache (rcache/grdma). The updated code is multi-reader, single-writer thread safe. This greatly reduces the bottlenecks when using the registration cache from multi-threaded programs.

The thread-safety is provided by a 1-dimensional interval tree (see CLRS textbook "Introduction to Algorithms") implemented using a relativistic red-black tree. More information about the red-black tree can be found in the following paper: http://onlinelibrary.wiley.com/store/10.1002/cpe.3157/asset/cpe3157.pdf?v=1&t=jddfnb4n&s=63a9b1a0be52676242f7b422e6a9224c3838f892

