### PR TITLE
io/ompio: correctly reset the request

### DIFF
--- a/ompi/mca/io/ompio/io_ompio_request.c
+++ b/ompi/mca/io/ompio/io_ompio_request.c
@@ -34,6 +34,7 @@ static int mca_io_ompio_request_free ( struct ompi_request_t **req)
     opal_list_remove_item (&mca_io_ompio_pending_requests, &ompio_req->req_item);
 
     OBJ_RELEASE (*req);
+    *req = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
after performing the final OBJ_RELEASE on the request,
reset the user level variable to MPI_REQUEST_NULL.
Otherwise the c_2_f translation step in the fortran
interface fails.

Fixes issue #4807

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>