### PR TITLE
coll/libnbc: do not take lock in progress if there are no requests

### DIFF
--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -262,6 +262,11 @@ ompi_coll_libnbc_progress(void)
     ompi_coll_libnbc_request_t* request, *next;
     int res;
 
+    if (0 == opal_list_get_size (&mca_coll_libnbc_component.active_requests)) {
+        /* no requests -- nothing to do. do not grab a lock */
+        return 0;
+    }
+
     /* process active requests, and use mca_coll_libnbc_component.lock to access the
      * mca_coll_libnbc_component.active_requests list */
     OPAL_THREAD_LOCK(&mca_coll_libnbc_component.lock);


### PR DESCRIPTION
This commit fixes a flaw in the progress function for libnbc. The
function was unconditionally taking a lock even if there are no
requests to process. This lock was showing up in vtune traces of
multi-threaded benchmarks.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>