### PR TITLE
output-filename: cleanup obsolete code.

### DIFF
--- a/orte/mca/iof/base/iof_base_frame.c
+++ b/orte/mca/iof/base/iof_base_frame.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * $COPYRIGHT$
@@ -110,29 +110,6 @@ static int orte_iof_base_close(void)
 static int orte_iof_base_open(mca_base_open_flag_t flags)
 {
     int rc, xmlfd;
-
-    /* did the user request we print output to files? */
-    if (NULL != orte_output_filename) {
-        /* we will setup the files themselves as needed in the iof
-         * module. For now, let's see if the filename contains a
-         * path, or just a name
-         */
-        char *path;
-        path = opal_dirname(orte_output_filename);
-        if (NULL == path) {
-            return ORTE_ERR_OUT_OF_RESOURCE;
-        }
-        if (0 != strcmp(path, orte_output_filename)) {
-            /* there is a path in this name - ensure that the directory
-             * exists, and create it if not
-             */
-            if (ORTE_SUCCESS != (rc = opal_os_dirpath_create(path, S_IRWXU))) {
-                free(path);
-                return rc;
-            }
-        }
-        free(path);
-    }
 
     /* daemons do not need to do this as they do not write out stdout/err */
     if (!ORTE_PROC_IS_DAEMON) {

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -14,8 +14,8 @@
  *                         et Automatique. All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -1530,13 +1530,6 @@ int orte_plm_base_orted_append_basic_args(int *argc, char ***argv,
         opal_argv_append(argc, argv, "oob_tcp_static_ipv4_ports");
         opal_argv_append(argc, argv, param);
         free(param);
-    }
-
-    /* if output-filename was specified, pass that along */
-    if (NULL != orte_output_filename) {
-        opal_argv_append(argc, argv, "-"OPAL_MCA_CMD_LINE_ID);
-        opal_argv_append(argc, argv, "orte_output_filename");
-        opal_argv_append(argc, argv, orte_output_filename);
     }
 
     /* if --xterm was specified, pass that along */

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -818,7 +818,7 @@ int orte_submit_job(char *argv[], int *index,
          * the directory where prun was given as that is what
          * the user will have seen */
         if (!opal_path_is_absolute(orte_cmd_options.output_filename)) {
-            char cwd[OPAL_PATH_MAX], path;
+            char cwd[OPAL_PATH_MAX], *path;
             getcwd(cwd, sizeof(cwd));
             path = opal_os_path(false, cwd, orte_cmd_options.output_filename, NULL);
             orte_set_attribute(&jdata->attributes, ORTE_JOB_OUTPUT_TO_FILE, ORTE_ATTR_GLOBAL, path, OPAL_STRING);

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -14,8 +14,8 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -148,7 +148,6 @@ orte_vpid_t orte_total_procs = 0;
 /* IOF controls */
 bool orte_tag_output = false;
 bool orte_timestamp_output = false;
-char *orte_output_filename = NULL;
 /* generate new xterm windows to display output from specified ranks */
 char *orte_xterm = NULL;
 

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -15,8 +15,8 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -530,7 +530,6 @@ ORTE_DECLSPEC extern orte_vpid_t orte_total_procs;
 /* IOF controls */
 ORTE_DECLSPEC extern bool orte_tag_output;
 ORTE_DECLSPEC extern bool orte_timestamp_output;
-ORTE_DECLSPEC extern char *orte_output_filename;
 /* generate new xterm windows to display output from specified ranks */
 ORTE_DECLSPEC extern char *orte_xterm;
 

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -14,8 +14,8 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -495,14 +495,6 @@ int orte_register_params(void)
                                   MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                   OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
                                   &orte_timestamp_output);
-
-    /* redirect output into files */
-    orte_output_filename = NULL;
-    (void) mca_base_var_register ("orte", "orte", NULL, "output_filename",
-                                  "Redirect output from application processes into filename.rank [default: NULL]",
-                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-                                  &orte_output_filename);
 
     orte_show_resolved_nodenames = false;
     (void) mca_base_var_register ("orte", "orte", NULL, "show_resolved_nodenames",


### PR DESCRIPTION
Since output-filename has been moved to a per-job attribute,
remove the orte_output_filename global variable, and stop passing
this option to orted.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>