### PR TITLE
configury: revamp the OPAL_CHECK_PACKAGE macro

### DIFF
--- a/config/opal_check_package2.m4
+++ b/config/opal_check_package2.m4
@@ -1,0 +1,237 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2012-2017 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2015-2018 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl OPAL_DECLARE_PACKAGE(name,[help],[cppflagshelp],[ldflagshelp])
+AC_DEFUN([OPAL_DECLARE_PACKAGE],[
+    AC_ARG_WITH([$1], [AC_HELP_STRING([--with-$1=DIR], [$2])])
+    AC_ARG_WITH([$1-cppflags], [AC_HELP_STRING([--with-$1-cppflags=FLAGS], [$3])])
+    AC_ARG_WITH([$1-ldflags], [AC_HELP_STRING([--with-$1-ldflags=FLAGS], [$4])])
+    AC_ARG_WITH([$1-libdir], [AC_HELP_STRING([--with-$1-libdir=DIR],
+                                             [Deprecated, use --with-$1-ldflags instead])])
+    AS_IF([test -n "$with_$1_libdir"],
+          [AS_IF([test -n "$with_$1_ldflags"],
+                 [AC_MSG_WARN([It is not possible to use both --with-$1-ldflags and --with-$1-libdir])
+                  AC_MSG_ERROR([Cannot continue])],
+                 [AC_MSG_WARN([--with_$1_libdir=DIR is deprecated, use --with-$1_ldflags=FLAGS instead])
+                  with_$1_ldflags="-L$with_$1_libdir"])])
+])
+
+dnl --------------------------------------------------------------------
+dnl _OPAL_CHECK_PACKAGE2_HEADER(prefix, header, cppflags,
+dnl                             [action-if-found], [action-if-not-found],
+dnl                             includes)
+dnl --------------------------------------------------------------------
+AC_DEFUN([_OPAL_CHECK_PACKAGE2_HEADER], [
+    # This is stolen from autoconf to peek under the covers to get the
+    # cache variable for the library check.  one should not copy this
+    # code into other places unless you want much pain and suffering
+    AS_VAR_PUSHDEF([opal_Header], [ac_cv_header_$2])
+
+    # so this sucks, but there's no way to get through the progression
+    # of header includes without killing off the cache variable and trying
+    # again...
+    unset opal_Header
+
+    # get rid of the trailing slash(es)
+    opal_check_package_header_happy="no"
+    AS_IF([test -z "$3"],
+          [# try as is...
+           AC_VERBOSE([looking for header])
+           AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [])
+           AS_IF([test "$opal_check_package_header_happy" = "no"],
+                 [# no go on the as is - reset the cache and try again
+                  unset opal_Header])],
+          [$1_CPPFLAGS="$$1_CPPFLAGS $3"
+           CPPFLAGS="$CPPFLAGS $3"
+           AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])])
+
+    AS_IF([test "$opal_check_package_header_happy" = "yes"], [$4], [$5])
+    unset opal_check_package_header_happy
+
+    AS_VAR_POPDEF([opal_Header])dnl
+])
+
+
+dnl _OPAL_CHECK_PACKAGE2_LIB(prefix, library, function, extra-libraries,
+dnl                          package,
+dnl                          [action-if-found], [action-if-not-found]])
+dnl --------------------------------------------------------------------
+AC_DEFUN([_OPAL_CHECK_PACKAGE2_LIB], [
+    # This is stolen from autoconf to peek under the covers to get the
+    # cache variable for the library check.  one should not copy this
+    # code into other places unless you want much pain and suffering
+    AS_VAR_PUSHDEF([opal_Lib], [ac_cv_search_$3])
+
+    # see comment above
+    unset opal_Lib
+    opal_check_package_lib_happy="no"
+    AS_IF([test -n "$with_$5_ldflags" || test -z "$with_$5" || test "$with_$5" = "yes"],
+          [# ldflags was specified - use as is
+           $1_LDFLAGS="$$1_LDFLAGS $with_$5_ldflags"
+           LDFLAGS="$LDFLAGS $with_$5_ldflags"
+           AS_IF([test -z "$with_$5_ldflags"],
+                 [AC_VERBOSE([looking for library without search path])])
+           AC_SEARCH_LIBS([$3], [$2],
+                        [opal_check_package_lib_happy="yes"],
+                        [opal_check_package_lib_happy="no"], [$4])
+           AS_IF([test "$opal_check_package_lib_happy" = "no"],
+                 [LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+                  $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+                  unset opal_Lib])],
+          [AS_IF([test -d "$with_$5/lib"],
+                 [$1_LDFLAGS="$$1_LDFLAGS -L$with_$5/lib"
+                  LDFLAGS="$LDFLAGS -L$with_$5/lib"
+                  AC_VERBOSE([looking for library in lib])
+                  AC_SEARCH_LIBS([$3], [$2],
+                                 [opal_check_package_lib_happy="yes"],
+                                 [opal_check_package_lib_happy="no"], [$4])
+                  AS_IF([test "$opal_check_package_lib_happy" = "no"],
+                        [# no go on the as is..  see what happens later...
+                         LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+                         $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+                         unset opal_Lib])])
+
+           AS_IF([test "$opal_check_package_lib_happy" = "no" && test -d "$with_$5/lib64"],
+                 [$1_LDFLAGS="$$1_LDFLAGS -L$with_$5/lib64"
+                  LDFLAGS="$LDFLAGS -L$with_$5/lib64"
+                  AC_VERBOSE([looking for library in lib64])
+                  AC_SEARCH_LIBS([$3], [$2],
+                                 [opal_check_package_lib_happy="yes"],
+                                 [opal_check_package_lib_happy="no"], [$4])
+                  AS_IF([test "$opal_check_package_lib_happy" = "no"],
+                        [# no go on the as is..  see what happens later...
+                         LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+                         $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+                         unset opal_Lib])])])
+
+    AS_IF([test "$opal_check_package_lib_happy" = "yes"],
+          [ # libnl v1 and libnl3 are known to *not* coexist
+            # harmoniously in the same process.  Check to see if this
+            # new package will introduce such a conflict.
+           OPAL_LIBNL_SANITY_CHECK([$2], [$3], [$$1_LIBS],
+                                   [opal_check_package_libnl_check_ok])
+           AS_IF([test $opal_check_package_libnl_check_ok -eq 0],
+                 [opal_check_package_lib_happy=no])
+           ])
+
+    AS_IF([test "$opal_check_package_lib_happy" = "yes"],
+          [ # The result of AC SEARCH_LIBS is cached in $ac_cv_search_[function]
+           AS_IF([test "$ac_cv_search_$3" != "no" &&
+                  test "$ac_cv_search_$3" != "none required"],
+                 [$1_LIBS="$ac_cv_search_$3 $4"],
+                 [$1_LIBS="$4"])
+           $6],
+          [$7])
+
+    AS_VAR_POPDEF([opal_Lib])dnl
+])
+
+
+dnl OPAL_CHECK_PACKAGE(prefix,
+dnl                    header,
+dnl                    library,
+dnl                    function,
+dnl                    extra-libraries,
+dnl                    package,
+dnl                    [action-if-found], [action-if-not-found],
+dnl                    includes)
+dnl -----------------------------------------------------------
+dnl Check for package defined by header and libs, and probably
+dnl located in dir-prefix, possibly with libs in libdir-prefix.
+dnl Both dir-prefix and libdir-prefix can be empty.  Will set
+dnl prefix_{CPPFLAGS, LDFLAGS, LIBS} as needed.
+dnl
+dnl The general intent of this macro is to provide finer-grained scoping
+dnl of C preprocessor flags, linker flags, and libraries (as opposed to
+dnl unconditionally adding to the top-level CPFLAGS, LDFLAGS, and LIBS,
+dnl which get used to compile/link *everything*).
+dnl
+dnl Here is a breakdown of the parameters:
+dnl
+dnl * prefix: the macro sets $prefix_CPPFLAGS, $prefix_LDFLAGS, and
+dnl   $prefix_LIBS (and AC_SUBSTs all of them).  For example, if a
+dnl   provider uses this macro to check for a header/library that it
+dnl   needs, it might well set prefix to be its provider name.
+dnl * header_filename: the foo.h file to check for
+dnl * library_name / function_name: check for function function_name in
+dnl   -llibrary_name.  Specifically, for library_name, use the "foo" form,
+dnl   as opposed to "libfoo".
+dnl * extra_libraries: if the library_name you are checking for requires
+dnl   additonal -l arguments to link successfully, list them here.
+dnl * dir_prefix: if the header/library is located in a non-standard
+dnl   location (e.g., /opt/foo as opposed to /usr), list it here
+dnl * libdir_prefix: if the library is not under $dir_prefix/lib or
+dnl   $dir_prefix/lib64, list it here.
+dnl * action_if_found: if both the header and library are found and
+dnl   usable, execute action_if_found
+dnl * action_if_not_found: otherwise, execute action_if_not_found
+dnl * extra_includes: if including header_filename requires additional
+dnl   headers to be included first, list them here
+dnl
+dnl The output _CPPFLAGS, _LDFLAGS, and _LIBS can be used to limit the
+dnl scope various flags in Makefiles.
+dnl
+AC_DEFUN([OPAL_CHECK_PACKAGE2],[
+    OPAL_VAR_SCOPE_PUSH([opal_check_package2_happy opal_check_package2_cppflags opal_check_package_$1_save_CPPFLAGS opal_check_package_$1_save_LDFLAGS opal_check_package_$1_save_LIBS opal_check_package_$1_orig_CPPFLAGS opal_check_package_$1_orig_LDFLAGS opal_check_package_$1_orig_LIBS])
+    opal_check_package_$1_save_CPPFLAGS="$CPPFLAGS"
+    opal_check_package_$1_save_LDFLAGS="$LDFLAGS"
+    opal_check_package_$1_save_LIBS="$LIBS"
+
+    opal_check_package_$1_orig_CPPFLAGS="$$1_CPPFLAGS"
+    opal_check_package_$1_orig_LDFLAGS="$$1_LDFLAGS"
+    opal_check_package_$1_orig_LIBS="$$1_LIBS"
+
+    AS_IF([test "$with_$6" != "no"],
+          [AS_IF([test -n "$with_$6_cppflags" || test -z "$with_$6" || test "$with_$6" = "yes"],
+                 [opal_check_package2_cppflags=$with_$6_cppflags],
+                 [AS_IF([test -n "$with_$6"],
+                        [AS_IF([test -r "$with_$6/$2"],
+                               [opal_check_package2_cppflags="-I$with_$6"],
+                               [AS_IF([test -r "$with_$6/include/$2"],
+                                      [opal_check_package2_cppflags="-I$with_$6/include"],
+                                      [opal_check_package2_happy=no])])])])
+
+           AS_IF([test "$opal_check_package2_happy" != "no"],
+                 [_OPAL_CHECK_PACKAGE2_HEADER([$1], [$2], [$opal_check_package2_cppflags],
+                                              [_OPAL_CHECK_PACKAGE2_LIB([$1], [$3], [$4], [$5], [$6],
+                                                                        [opal_check_package2_happy="yes"],
+                                                                        [opal_check_package2_happy="no"])],
+                                              [opal_check_package2_happy=no],
+                                              [$9])])])
+
+    AS_IF([test "$opal_check_package2_happy" = "yes"],
+          [$7],
+          [$1_CPPFLAGS="$opal_check_package_$1_orig_CPPFLAGS"
+           $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+           $1_LIBS="$opal_check_package_$1_orig_LIBS"
+           AS_IF([test "$with_$6" != "no"],
+                 [$8])])
+
+
+    CPPFLAGS="$opal_check_package_$1_save_CPPFLAGS"
+    LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+    LIBS="$opal_check_package_$1_save_LIBS"
+
+    OPAL_VAR_SCOPE_POP
+])

--- a/config/opal_check_package2.m4
+++ b/config/opal_check_package2.m4
@@ -83,44 +83,52 @@ AC_DEFUN([_OPAL_CHECK_PACKAGE2_LIB], [
     AS_VAR_PUSHDEF([opal_Ldflags], [with_$1_ldflags])
 
     opal_check_package2_lib_happy="no"
-    AS_IF([test -n "$opal_Ldflags" || test -z "$opal_With" || test "$opal_With" = "yes"],
+    AS_IF([test -n "$opal_Ldflags"],
           [# ldflags was specified - use as is
            $2_LDFLAGS="$$2_LDFLAGS $opal_Ldflags"
            LDFLAGS="$LDFLAGS $opal_Ldflags"
-           AS_IF([test -z "$opal_Ldflags"],
-                 [AC_VERBOSE([looking for library without search path])])
-           AC_SEARCH_LIBS([$3], [$4],
+           AC_CHECK_LIB([$4], [$3],
                         [opal_check_package2_lib_happy="yes"],
                         [opal_check_package2_lib_happy="no"], [$5])
            AS_IF([test "$opal_check_package2_lib_happy" = "no"],
                  [LDFLAGS="$opal_check_package_$2_save_LDFLAGS"
                   $2_LDFLAGS="$opal_check_package_$2_orig_LDFLAGS"
                   unset opal_Lib])],
-          [AS_IF([test -d "$opal_With/lib"],
-                 [$2_LDFLAGS="$$2_LDFLAGS -L$opal_With/lib"
-                  LDFLAGS="$LDFLAGS -L$opal_With/lib"
-                  AC_VERBOSE([looking for library in lib])
+          [AS_IF([test -z "$opal_With" || test "$opal_With" = "yes"],
+                 [# no path specified, try the default AC_SEARCH_LIBS
+                  AC_VERBOSE([looking for library without search path])
                   AC_SEARCH_LIBS([$3], [$4],
-                                 [opal_check_package2_lib_happy="yes"],
-                                 [opal_check_package2_lib_happy="no"], [$5])
+                               [opal_check_package2_lib_happy="yes"],
+                               [opal_check_package2_lib_happy="no"], [$5])
                   AS_IF([test "$opal_check_package2_lib_happy" = "no"],
-                        [# no go on the as is..  see what happens later...
-                         LDFLAGS="$opal_check_package_$2_save_LDFLAGS"
-                         $2_LDFLAGS="$opal_check_package_$2_orig_LDFLAGS"
-                         unset opal_Lib])])
-
-           AS_IF([test "$opal_check_package2_lib_happy" = "no" && test -d "$opal_With/lib64"],
-                 [$2_LDFLAGS="$$2_LDFLAGS -L$opal_With/lib64"
-                  LDFLAGS="$LDFLAGS -L$opal_With/lib64"
-                  AC_VERBOSE([looking for library in lib64])
-                  AC_SEARCH_LIBS([$3], [$4],
-                                 [opal_check_package2_lib_happy="yes"],
-                                 [opal_check_package2_lib_happy="no"], [$5])
-                  AS_IF([test "$opal_check_package2_lib_happy" = "no"],
-                        [# no go on the as is..  see what happens later...
-                         LDFLAGS="$opal_check_package_$2_save_LDFLAGS"
-                         $2_LDFLAGS="$opal_check_package_$2_orig_LDFLAGS"
-                         unset opal_Lib])])])
+                        [unset opal_Lib])],
+                 [# --with-foo=DIR was specified, try DIR/lib and DIR/lib64 if libraries exist
+                  files=`ls $opal_With/lib/lib$4.* 2> /dev/null | wc -l`
+                  AS_IF([test $files -gt 0],
+                        [$2_LDFLAGS="$$2_LDFLAGS -L$opal_With/lib"
+                         LDFLAGS="$LDFLAGS -L$opal_With/lib"
+                         AC_VERBOSE([looking for library in lib])
+                         AC_CHECK_LIB([$4], [$3],
+                                      [opal_check_package2_lib_happy="yes"],
+                                      [opal_check_package2_lib_happy="no"], [$5])
+                         AS_IF([test "$opal_check_package2_lib_happy" = "no"],
+                               [# no go on the as is..  see what happens later...
+                                LDFLAGS="$opal_check_package_$2_save_LDFLAGS"
+                                $2_LDFLAGS="$opal_check_package_$2_orig_LDFLAGS"
+                                unset opal_Lib])])
+                  files=`ls $opal_With/lib64/lib$4.* 2> /dev/null | wc -l`
+                  AS_IF([test "$opal_check_package2_lib_happy" = "no" && test -$files -gt 0],
+                        [$2_LDFLAGS="$$2_LDFLAGS -L$opal_With/lib64"
+                         LDFLAGS="$LDFLAGS -L$opal_With/lib64"
+                         AC_VERBOSE([looking for library in lib64])
+                         AC_CHECK_LIB([$4], [$3],
+                                      [opal_check_package2_lib_happy="yes"],
+                                      [opal_check_package2_lib_happy="no"], [$5])
+                         AS_IF([test "$opal_check_package2_lib_happy" = "no"],
+                               [# no go on the as is..  see what happens later...
+                                LDFLAGS="$opal_check_package_$2_save_LDFLAGS"
+                                $2_LDFLAGS="$opal_check_package_$2_orig_LDFLAGS"
+                                unset opal_Lib])])])])
 
     AS_IF([test "$opal_check_package2_lib_happy" = "yes"],
           [ # libnl v1 and libnl3 are known to *not* coexist

--- a/config/opal_setup_zlib.m4
+++ b/config/opal_setup_zlib.m4
@@ -1,4 +1,4 @@
-# -*- shell-script -*-
+# -*- autocont -*-
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
@@ -15,18 +15,18 @@
 # MCA_zlib_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([OPAL_ZLIB_CONFIG],[
-
     OPAL_DECLARE_PACKAGE([zlib],
                          [Search for zlib headers and libraries in DIR],
                          [Search for zlib headers with these CPPFLAGS],
                          [Search for zlib library with these LDFLAGS])
 
-    OPAL_CHECK_PACKAGE2([opal_zlib],
+    OPAL_CHECK_PACKAGE2([zlib],
+                        [opal_zlib],
                         [zlib.h],
-                        [z],
+                        [],
                         [deflate],
-                        [-lz],
-                        [zlib],
+                        [z],
+                        [],
                         [opal_zlib_support=1],
                         [opal_zlib_support=0])
 
@@ -49,5 +49,4 @@ AC_DEFUN([OPAL_ZLIB_CONFIG],[
 
     AC_DEFINE_UNQUOTED([OPAL_HAVE_ZLIB], [$opal_zlib_support],
                        [Whether or not we have zlib support])
-
 ])dnl

--- a/config/opal_setup_zlib.m4
+++ b/config/opal_setup_zlib.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
-# Copyright (c) 2017      Research Organization for Information Science
+# Copyright (c) 2017-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
@@ -15,62 +15,25 @@
 # MCA_zlib_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([OPAL_ZLIB_CONFIG],[
-    OPAL_VAR_SCOPE_PUSH([opal_zlib_dir opal_zlib_libdir opal_zlib_standard_header_location opal_zlib_standard_lib_location])
 
-    AC_ARG_WITH([zlib],
-                [AC_HELP_STRING([--with-zlib=DIR],
-                                [Search for zlib headers and libraries in DIR ])])
+    OPAL_DECLARE_PACKAGE([zlib],
+                         [Search for zlib headers and libraries in DIR],
+                         [Search for zlib headers with these CPPFLAGS],
+                         [Search for zlib library with these LDFLAGS])
 
-    AC_ARG_WITH([zlib-libdir],
-                [AC_HELP_STRING([--with-zlib-libdir=DIR],
-                                [Search for zlib libraries in DIR ])])
+    OPAL_CHECK_PACKAGE2([opal_zlib],
+                        [zlib.h],
+                        [z],
+                        [deflate],
+                        [-lz],
+                        [zlib],
+                        [opal_zlib_support=1],
+                        [opal_zlib_support=0])
 
-    opal_zlib_support=0
-    if test "$with_zlib" != "no"; then
-        AC_MSG_CHECKING([for zlib in])
-        if test ! -z "$with_zlib" && test "$with_zlib" != "yes"; then
-            opal_zlib_dir=$with_zlib
-            opal_zlib_standard_header_location=no
-            opal_zlib_standard_lib_location=no
-            AS_IF([test -z "$with_zlib_libdir" || test "$with_zlib_libdir" = "yes"],
-                  [if test -d $with_zlib/lib; then
-                       opal_zlib_libdir=$with_zlib/lib
-                   elif test -d $with_zlib/lib64; then
-                       opal_zlib_libdir=$with_zlib/lib64
-                   else
-                       AC_MSG_RESULT([Could not find $with_zlib/lib or $with_zlib/lib64])
-                       AC_MSG_ERROR([Can not continue])
-                   fi
-                   AC_MSG_RESULT([$opal_zlib_dir and $opal_zlib_libdir])],
-                  [AC_MSG_RESULT([$with_zlib_libdir])])
-        else
-            AC_MSG_RESULT([(default search paths)])
-            opal_zlib_standard_header_location=yes
-            opal_zlib_standard_lib_location=yes
-        fi
-        AS_IF([test ! -z "$with_zlib_libdir" && test "$with_zlib_libdir" != "yes"],
-              [opal_zlib_libdir="$with_zlib_libdir"
-               opal_zlib_standard_lib_location=no])
-
-        OPAL_CHECK_PACKAGE([opal_zlib],
-                           [zlib.h],
-                           [z],
-                           [deflate],
-                           [-lz],
-                           [$opal_zlib_dir],
-                           [$opal_zlib_libdir],
-                           [opal_zlib_support=1],
-                           [opal_zlib_support=0])
-        if test $opal_zlib_support = "1"; then
-            LIBS="$LIBS -lz"
-            if test "$opal_zlib_standard_header_location" != "yes"; then
-                CPPFLAGS="$CPPFLAGS $opal_zlib_CPPFLAGS"
-            fi
-            if test "$opal_zlib_standard_lib_location" != "yes"; then
-                LDFLAGS="$LDFLAGS $opal_zlib_LDFLAGS"
-            fi
-        fi
-    fi
+    AS_IF([test $opal_zlib_support -eq 1],
+          [LIBS="$LIBS -lz"
+           CPPFLAGS="$CPPFLAGS $opal_zlib_CPPFLAGS"
+           LDFLAGS="$LDFLAGS $opal_zlib_LDFLAGS"])
 
     if test ! -z "$with_zlib" && test "$with_zlib" != "no" && test "$opal_zlib_support" != "1"; then
         AC_MSG_WARN([ZLIB SUPPORT REQUESTED AND NOT FOUND])
@@ -86,5 +49,5 @@ AC_DEFUN([OPAL_ZLIB_CONFIG],[
 
     AC_DEFINE_UNQUOTED([OPAL_HAVE_ZLIB], [$opal_zlib_support],
                        [Whether or not we have zlib support])
-    OPAL_VAR_SCOPE_POP
+
 ])dnl

--- a/opal/mca/event/external/configure.m4
+++ b/opal/mca/event/external/configure.m4
@@ -1,4 +1,4 @@
-# -*- shell-script -*-
+# -*- autoconf -*-
 #
 # Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
@@ -96,12 +96,13 @@ AC_DEFUN([MCA_opal_event_external_CONFIG],[
            opal_event_external_LDFLAGS_save=$LDFLAGS
            opal_event_external_LIBS_save=$LIBS
 
-           OPAL_CHECK_PACKAGE2([opal_event_external],
+           OPAL_CHECK_PACKAGE2([libevent],
+                               [opal_event_external],
                                [event.h],
-                               [event],
+                               [],
                                [event_config_new],
+                               [event],
                                [-levent_pthreads],
-                               [libevent],
                                [opal_event_external_support=yes],
                                [opal_event_external_support=no])
 


### PR DESCRIPTION
add the OPAL_DEFINE_PACKAGE helper that define
 --with-FOO=DIR
 --with-FOO-cppflags=FLAGS
 --with-FOO-ldflags=FLAGS
 --with-FOO-libdir=DIR (deprecated)

OPAL_CHECK_PACKAGE2(prefix,
                    header,
                    library,
                    function,
                    extra-libraries,
                    package,
                    [action-if-found], [action-if-not-found],
                    includes)

is much easier to use and handle most of the work under the hood.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>