### PR TITLE
btl/usnic: missed a preprocessor check in d36648b

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_compat.c
+++ b/opal/mca/btl/usnic/btl_usnic_compat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -659,7 +659,7 @@ int opal_btl_usnic_put(
 
 /*----------------------------------------------------------------------*/
 
-#elif BTL_VERSION == 30
+#elif BTL_VERSION >= 30
 
 /*
  * BTL 3.0 prepare_src function.


### PR DESCRIPTION
Missed updating one instance of `==` to `>=` in d36648b.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>