### PR TITLE
dist: Update .so version numbers for v3.1.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -84,17 +84,17 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=0:0:0
-libmpi_cxx_so_version=0:0:0
-libmpi_mpifh_so_version=0:0:0
-libmpi_usempi_tkr_so_version=0:0:0
-libmpi_usempi_ignore_tkr_so_version=0:0:0
-libmpi_usempif08_so_version=0:0:0
-libopen_rte_so_version=0:0:0
-libopen_pal_so_version=0:0:0
-libmpi_java_so_version=0:0:0
-liboshmem_so_version=0:0:0
-libompitrace_so_version=0:0:0
+libmpi_so_version=50:0:10
+libmpi_cxx_so_version=50:0:10
+libmpi_mpifh_so_version=50:0:10
+libmpi_usempi_tkr_so_version=50:0:10
+libmpi_usempi_ignore_tkr_so_version=50:0:10
+libmpi_usempif08_so_version=50:0:10
+libopen_rte_so_version=50:0:10
+libopen_pal_so_version=50:0:10
+libmpi_java_so_version=50:0:10
+liboshmem_so_version=50:0:10
+libompitrace_so_version=50:0:10
 
 # "Common" components install standalone libraries that are run-time
 # linked by one or more components.  So they need to be versioned as
@@ -102,14 +102,14 @@ libompitrace_so_version=0:0:0
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=0:0:0
+libmca_ompi_common_ompio_so_version=50:0:9
 
 # ORTE layer
-libmca_orte_common_alps_so_version=0:0:0
+libmca_orte_common_alps_so_version=50:0:10
 
 # OPAL layer
-libmca_opal_common_cuda_so_version=0:0:0
-libmca_opal_common_ofi_so_version=0:0:0
-libmca_opal_common_sm_so_version=0:0:0
-libmca_opal_common_ugni_so_version=0:0:0
-libmca_opal_common_verbs_so_version=0:0:0
+libmca_opal_common_cuda_so_version=50:0:10
+libmca_opal_common_ofi_so_version=50:0:10
+libmca_opal_common_sm_so_version=50:0:10
+libmca_opal_common_ugni_so_version=50:0:10
+libmca_opal_common_verbs_so_version=50:0:10


### PR DESCRIPTION
Update the shared library version numbers for v3.1.0.  As a
ABI compatible version with the v3.0.x series, follow our
convention of bumping the current number by 10 and setting the
age to v3.0.0 age + 10.  There is one exception to that rule,
as libmca_ompi_common_ompio was changed in an incompatible
way in v3.0.1 (v3.1.x includes that change), so we are only
backwards compatible to that version, not all the way to
v3.0.0.  Since ompi_common isn't part of the stable ABI and
users would have to do something really weird to even hit
that case, this isn't too big of a deal.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>