### PR TITLE
orted_submit: fix the --oversubscribe option

### DIFF
--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
+ * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -917,6 +917,7 @@ int orte_submit_job(char *argv[], int *index,
     }
     if (orte_cmd_options.oversubscribe) {
         ORTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_NO_OVERSUBSCRIBE);
+        ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_SUBSCRIBE_GIVEN);
     }
     if (orte_cmd_options.report_bindings) {
         orte_set_attribute(&jdata->attributes, ORTE_JOB_REPORT_BINDINGS, ORTE_ATTR_GLOBAL, NULL, OPAL_BOOL);


### PR DESCRIPTION
do set the ORTE_MAPPING_SUBSCRIBE_GIVEN directive when --oversubscribe is used

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>