### PR TITLE
v3.1.0: monitoring .so versioning

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -103,7 +103,7 @@ libompitrace_so_version=50:0:10
 
 # OMPI layer
 libmca_ompi_common_ompio_so_version=50:0:9
-libmca_ompi_common_monitoring_so_version=0:0:0
+libmca_ompi_common_monitoring_so_version=50:0:0
 
 # ORTE layer
 libmca_orte_common_alps_so_version=50:0:10

--- a/VERSION
+++ b/VERSION
@@ -103,6 +103,7 @@ libompitrace_so_version=50:0:10
 
 # OMPI layer
 libmca_ompi_common_ompio_so_version=50:0:9
+libmca_ompi_common_monitoring_so_version=0:0:0
 
 # ORTE layer
 libmca_orte_common_alps_so_version=50:0:10

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
 #                         reserved.
@@ -170,6 +170,7 @@ AC_SUBST(libmca_opal_common_ugni_so_version)
 AC_SUBST(libmca_opal_common_verbs_so_version)
 AC_SUBST(libmca_orte_common_alps_so_version)
 AC_SUBST(libmca_ompi_common_ompio_so_version)
+AC_SUBST(libmca_ompi_common_monitoring_so_version)
 
 #
 # Get the versions of the autotools that were used to bootstrap us

--- a/ompi/mca/common/monitoring/Makefile.am
+++ b/ompi/mca/common/monitoring/Makefile.am
@@ -5,6 +5,7 @@
 # Copyright (c) 2016      Inria.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,13 +38,14 @@ if OPAL_INSTALL_BINARIES
 bin_SCRIPTS = profile2mat.pl aggregate_profile.pl
 endif # OPAL_INSTALL_BINARIES
 
-else
+else # MCA_BUILD_ompi_common_monitoring_DSO
 noinst_LTLIBRARIES += $(component_noinst)
-endif
+endif # MCA_BUILD_ompi_common_monitoring_DSO
 
 libmca_common_monitoring_la_SOURCES = $(headers) $(sources)
 libmca_common_monitoring_la_CPPFLAGS = $(common_monitoring_CPPFLAGS)
 libmca_common_monitoring_la_LDFLAGS =  \
+        -version-info $(libmca_ompi_common_monitoring_so_version) \
         $(common_monitoring_LDFLAGS)
 libmca_common_monitoring_la_LIBADD = $(common_monitoring_LIBS)
 libmca_common_monitoring_noinst_la_SOURCES = $(headers) $(sources)


### PR DESCRIPTION
Fixes #4843.

I made this two commits:

1. Cherry pick from master (which has `0:0:0` for the C:R:A)
    * I also fixed the typo in the commit message (`.sh` -> `.so`) -- doh!
1. Set the C:R:A for this release.

It seemed cleaner to keep the cherry pick (essentially) a pure cherry pick, not a cherry-pick-and-edit.

@bwbarrett Do you have an opinion about the `A` value for the monitoring library?  I set it to 0, since this is the initial public release of this library.