### PR TITLE
dist: Update version to 3.0.1rc4

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=1
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc3
+greek=rc4
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
3.0.1rc3 is tagged.  Hopefully, we won't need rc4, but bump
the version just in case.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>