### PR TITLE
dist: Update version to 3.1.0rc3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -26,7 +26,7 @@ release=0
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=rc3
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
3.1.0rc2 is tagged.  Hopefully, we won't need rc3, but bump
the version just in case.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>