### PR TITLE
MTL OFI: Added support for reading multiple CQ events in ofi progress

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -61,8 +61,7 @@ __opal_attribute_always_inline__ static inline int
 ompi_mtl_ofi_progress(void)
 {
     ssize_t ret;
-    int count = 0;
-    struct fi_cq_tagged_entry wc = { 0 };
+    int count = 0, i, events_read;
     struct fi_cq_err_entry error = { 0 };
     ompi_mtl_ofi_request_t *ofi_req = NULL;
 
@@ -72,19 +71,23 @@ ompi_mtl_ofi_progress(void)
      * Call the request's callback.
      */
     while (true) {
-        ret = fi_cq_read(ompi_mtl_ofi.cq, (void *)&wc, 1);
+        ret = fi_cq_read(ompi_mtl_ofi.cq, ompi_mtl_ofi.progress_entries,
+                ompi_mtl_ofi.ofi_progress_event_count);
         if (ret > 0) {
-            count++;
-            if (NULL != wc.op_context) {
-                ofi_req = TO_OFI_REQ(wc.op_context);
-                assert(ofi_req);
-                ret = ofi_req->event_callback(&wc, ofi_req);
-                if (OMPI_SUCCESS != ret) {
-                    opal_output(0, "%s:%d: Error returned by request event callback: %zd.\n"
-                                   "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
-                                   __FILE__, __LINE__, ret);
-                    fflush(stderr);
-                    exit(1);
+            count+= ret;
+            events_read = ret;
+            for (i = 0; i < events_read; i++) {
+                if (NULL != ompi_mtl_ofi.progress_entries[i].op_context) {
+                    ofi_req = TO_OFI_REQ(ompi_mtl_ofi.progress_entries[i].op_context);
+                    assert(ofi_req);
+                    ret = ofi_req->event_callback(&ompi_mtl_ofi.progress_entries[i], ofi_req);
+                    if (OMPI_SUCCESS != ret) {
+                        opal_output(0, "%s:%d: Error returned by request event callback: %zd.\n"
+                                       "*** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                                       __FILE__, __LINE__, ret);
+                        fflush(stderr);
+                        exit(1);
+                    }
                 }
             }
         } else if (OPAL_UNLIKELY(ret == -FI_EAVAIL)) {

--- a/ompi/mca/mtl/ofi/mtl_ofi_types.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_types.h
@@ -49,6 +49,12 @@ typedef struct mca_mtl_ofi_module_t {
     /** Maximum inject size */
     size_t max_inject_size;
 
+    /** Maximum number of CQ events to read in OFI Progress */
+    int ofi_progress_event_count;
+
+    /** CQ event storage */
+    struct fi_cq_tagged_entry *progress_entries;
+
 } mca_mtl_ofi_module_t;
 
 extern mca_mtl_ofi_module_t ompi_mtl_ofi;


### PR DESCRIPTION
-Updated ompi_mtl_ofi_progress to use an array to read CQ events up to a
threshold that can be set by the Open MPI User.

-Users can adjust the number of events that can be handled in the
ompi_mtl_ofi_progress by setting "--mca mtl_ofi_progress_event_cnt #".

-The default value for the the number of CQ events that can be read in a
single call to ofi progress is 100 which is an average
based off workload usecase anaylsis showing 70-128 as the range of
multiple events returned during ofi progress.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>
(cherry picked from commit e7bff501cd0f8bb85c8e90ef2c97c67273f0ad11)