### PR TITLE
Fix PATH and LD_LIBRARY_PATH prefixing to use first app context value…

### DIFF
--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -866,6 +867,12 @@ static int setup_fork(orte_job_t *jdata,
        variables. */
     param = NULL;
     orte_get_attribute(&app->attributes, ORTE_APP_PREFIX_DIR, (void**)&param, OPAL_STRING);
+    /* grab the parameter from the first app context because the current context does not have a prefix assigned */
+    if (NULL == param) {
+        tmp_app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, 0);
+        assert (NULL != tmp_app);
+        orte_get_attribute(&tmp_app->attributes, ORTE_APP_PREFIX_DIR, (void**)&param, OPAL_STRING);
+    } 
     for (i = 0; NULL != param && NULL != app->env && NULL != app->env[i]; ++i) {
         char *newenv;
 


### PR DESCRIPTION
… for ORTE_APP_PREFIX_DIR

When reconstructing PATH and LD_LIBRARY_PATH, with the value from the ORTE_APP_PREFIX_DIR parameter, we are not correctly picking out the prefix dir on multiple app contexts (should only use the first app context to retrieve the prefix dir). This can be seen in an MPMD style launch. The second application will receive NULL == param and skip over the loop to appropriately set PATH and LD_LIBRARY_PATH. We can see something similar to the fix I have made: https://github.ibm.com/smpi/ibm-ompi/blob/ibm_smpi_viper_master/orte/orted/orted_submit.c#L1022-L1033

Using the app prefix from **multiple app contexts**:

mpirun --prefix garbage_prefix -mca btl_openib_warn_default_gid_prefix 0 -np 1 env : -np 1 env | grep "^PATH"
PATH=garbage_prefix/bin:/garbage_prefix/bin:/smpi_dev/smiller/ompi-master//bin:..........
PATH=/garbage_prefix/bin:/smpi_dev/smiller/ompi-master//bin:.........

Using only the app prefix from the **first app context**:

PATH=garbage_prefix/bin:/garbage_prefix/bin:/smpi_dev/smiller/ompi-master//bin:..........
PATH=garbage_prefix/bin:/garbage_prefix/bin:/smpi_dev/smiller/ompi-master//bin:..........