### PR TITLE
Make more robust in finding NAG Fortran Compiler

### DIFF
--- a/config/ltmain_nag_pthread.diff
+++ b/config/ltmain_nag_pthread.diff
@@ -8,7 +8,7 @@
  	if test -n "$inherited_linker_flags"; then
 -	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
 +          case "$CC" in
-+            nagfor*)
++            *nagfor*)
 +	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g' | $SED 's/-pthread/-Wl,-pthread/g'`;;
 +            *)
 +	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`;;


### PR DESCRIPTION
the NAG Fortran check only matched nagfor exactly, and failed if a path to nagfor was provided.

Signed-off-by: themos.tsikas@nag.co.uk
