### PR TITLE
v2.x: configury: Make more robust in finding NAG Fortran Compiler

### DIFF
--- a/config/ltmain_nag_pthread.diff
+++ b/config/ltmain_nag_pthread.diff
@@ -8,7 +8,7 @@
  	if test -n "$inherited_linker_flags"; then
 -	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
 +          case "$CC" in
-+            nagfor*)
++            *nagfor*)
 +	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g' | $SED 's/-pthread/-Wl,-pthread/g'`;;
 +            *)
 +	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`;;


### PR DESCRIPTION
The NAG Fortran check only matched "nagfor" exactly, and failed if a
path to nagfor was provided.  Also change "-pthread" into
"-Wl,-pthread".

Signed-off-by: Themos Tsikas <themos.tsikas@nag.co.uk>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit a8fc30f95a7ef705670f8603361bff34f09a1060)

@hppritcha This can slot in whatever v2.1.x release we want -- it is not absolutely needed for v2.1.3.  OTOH, it's a pretty trivial update (it's not obvious from the github rendering, but it's a 1-character change).

FTI @ThemosTsikas