### PR TITLE
Fix MPIR Attach Mode for mpirun

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -772,7 +772,7 @@ void orte_plm_base_registered(int fd, short args, void *cbdata)
     jdata->state = caddy->job_state;
 
    /* if this wasn't a debugger job, then need to init_after_spawn for debuggers */
-    if (!ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+    if (orte_debugger_always_create_proctable || !ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
         ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_READY_FOR_DEBUGGERS);
     }
 

--- a/orte/mca/state/base/state_base_fns.c
+++ b/orte/mca/state/base/state_base_fns.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -680,7 +681,7 @@ void orte_state_base_track_procs(int fd, short argc, void *cbdata)
         }
         jdata->num_launched++;
         if (jdata->num_launched == jdata->num_procs) {
-            if (ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+            if (orte_debugger_always_create_proctable || ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_DEBUGGER_DAEMON)) {
                 ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_READY_FOR_DEBUGGERS);
             } else {
                 ORTE_ACTIVATE_JOB_STATE(jdata, ORTE_JOB_STATE_RUNNING);

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2018 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,6 +118,7 @@ char **orted_cmd_line=NULL;
 char **orte_fork_agent=NULL;
 
 /* debugger job */
+bool orte_debugger_always_create_proctable = false;
 bool orte_debugger_dump_proctable = false;
 char *orte_debugger_test_daemon = NULL;
 bool orte_debugger_test_attach = false;

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -505,6 +505,7 @@ ORTE_DECLSPEC extern char **orted_cmd_line;
 ORTE_DECLSPEC extern char **orte_fork_agent;
 
 /* debugger job */
+ORTE_DECLSPEC extern bool orte_debugger_always_create_proctable;
 ORTE_DECLSPEC extern bool orte_debugger_dump_proctable;
 ORTE_DECLSPEC extern char *orte_debugger_test_daemon;
 ORTE_DECLSPEC extern bool orte_debugger_test_attach;

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2018 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -294,6 +294,22 @@ int orte_register_params(void)
                                   MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                   OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL,
                                   &orte_debugger_dump_proctable);
+
+    /*
+     * MPIR Attach Mode requires that the MPIR_proctable be available in the
+     * starter process so that a tool can later attach to the running processes.
+     * This can be limiting to scalability since the MPIR_PROCDESC data structure
+     * requires knowledge of the process pid, which has to be reported back to
+     * the starter. For this scalability reason we do _not_ create the proctable
+     * unless the user asks to do so (or the sysadmin sets this MCA parameter
+     * globally.
+     */
+    orte_debugger_always_create_proctable = false;
+    (void) mca_base_var_register ("orte", "orte", NULL, "always_create_proctable",
+                                  "Whether or not to always create MPIR proctable, even when not debugging (default: false)",
+                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_ALL,
+                                  &orte_debugger_always_create_proctable);
 
     orte_debugger_test_daemon = NULL;
     (void) mca_base_var_register ("orte", "orte", NULL, "debugger_test_daemon",


### PR DESCRIPTION
MPIR Attach Mode requires that the MPIR_proctable be available in the
starter process so that a tool can later attach to the running processes.

This can be limiting to scalability since the MPIR_PROCDESC data structure
requires knowledge of the process pid, which has to be reported back to
the starter. For this scalability reason we do not create the proctable
unless the user asks to do so (or the sysadmin sets this MCA parameter
globally.