### PR TITLE
io/romio314: mark datatypes of size 0 as contiguous

### DIFF
--- a/ompi/mca/io/romio314/src/io_romio314_module.c
+++ b/ompi/mca/io/romio314/src/io_romio314_module.c
@@ -137,6 +137,14 @@ void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag)
      * In addition, if the data is contiguous but true_lb differes
      * from zero, ROMIO will ignore the displacement. Thus, lie!
      */
+
+    size_t size;
+    opal_datatype_type_size (&datatype->super, &size);
+    if ( 0 == size ) {
+        *flag = 1;
+        return;
+    }
+
     *flag = ompi_datatype_is_contiguous_memory_layout(datatype, 2);
     if (*flag) {
         MPI_Aint true_extent, true_lb;


### PR DESCRIPTION
this commit fixes an issue observed with romio314 and the hdf5 1.10.x testsuite.
The ADIOI_Datatype_iscontig() routine in romio314/src/io_romio314_module.c
will now return for a datatype of size 0 that it is contiguous, even if the extent
of the datatype is non-zero. This avoids a segmentation fault observed in the
ADIOI_Flatten routine, and fixes this particular with the hdf5 1.10.x testsuite in
OpenMPI with romio314.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>
(cherry picked from commit c83b47c266c4eac23e352f134e660dd8c6d532b1)