### PR TITLE
Allow MPI_PROC_NULL as neighbor.

### DIFF
--- a/ompi/mpi/c/dist_graph_create.c
+++ b/ompi/mpi/c/dist_graph_create.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2012-2013 The University of Tennessee and The University
+ * Copyright (c) 2012-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
@@ -62,7 +62,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
         /* Ensure the arrays are full of valid-valued integers */
         comm_size = ompi_comm_size(comm_old);
         for( i = index = 0; i < n; ++i ) {
-            if (sources[i] < 0 || sources[i] >= comm_size) {
+            if (((sources[i] < 0) && (sources[i] != MPI_PROC_NULL)) || sources[i] >= comm_size) {
                 return OMPI_ERRHANDLER_INVOKE(comm_old, MPI_ERR_ARG,
                                               FUNC_NAME);
             } else if (degrees[i] < 0) {
@@ -70,7 +70,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
                                               FUNC_NAME);
             }
             for( j = 0; j < degrees[i]; ++j ) {
-                if (destinations[index] < 0 || destinations[index] >= comm_size) {
+                if (((destinations[index] < 0) && (destinations[index] != MPI_PROC_NULL)) || destinations[index] >= comm_size) {
                     return OMPI_ERRHANDLER_INVOKE(comm_old, MPI_ERR_ARG,
                                                   FUNC_NAME);
                 } else if (MPI_UNWEIGHTED != weights && weights[index] < 0) {

--- a/ompi/mpi/c/dist_graph_create_adjacent.c
+++ b/ompi/mpi/c/dist_graph_create_adjacent.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2008      The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2011-2013 The University of Tennessee and The University
+ * Copyright (c) 2011-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
@@ -74,7 +74,7 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
         }
         comm_size = ompi_comm_size(comm_old);
         for (i = 0; i < indegree; ++i) {
-            if (sources[i] < 0 || sources[i] >= comm_size) {
+            if (((sources[i] < 0) && (sources[i] != MPI_PROC_NULL)) || sources[i] >= comm_size) {
                 return OMPI_ERRHANDLER_INVOKE(comm_old, MPI_ERR_ARG,
                                               "MPI_Dist_graph_create_adjacent invalid sources");
             } else if (MPI_UNWEIGHTED != sourceweights && sourceweights[i] < 0) {
@@ -83,7 +83,7 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
             }
         }
         for (i = 0; i < outdegree; ++i) {
-            if (destinations[i] < 0 || destinations[i] >= comm_size) {
+            if (((destinations[i] < 0) && (destinations[i] != MPI_PROC_NULL)) || destinations[i] >= comm_size) {
                 return OMPI_ERRHANDLER_INVOKE(comm_old, MPI_ERR_ARG,
                                               "MPI_Dist_graph_create_adjacent invalid destinations");
             } else if (MPI_UNWEIGHTED != destweights && destweights[i] < 0) {


### PR DESCRIPTION
Allowing MPI_PROC_NULL as a neighbor in any topology allows us to add
gaps on the send and recv buffers. This does make the traditional
neighbor collective have a similar behavior as the V version, but in
same time it allows the users to skip the step where they prepare the
counts and the displacement array.

For more info please take a look at issue #4675.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>