### PR TITLE
fcoll/two_phase: data sieving has to occur at offset 0 as well

### DIFF
--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
@@ -1068,7 +1068,7 @@ static int two_phase_exchage_data(mca_io_ompio_file_t *fh,
 
     if (nprocs_recv){
 	if (*hole){
-	    if (off > 0){
+	    if (off >= 0){
 		fh->f_io_array = (mca_io_ompio_io_array_t *)malloc
 		    (sizeof(mca_io_ompio_io_array_t));
 		if (NULL == fh->f_io_array) {


### PR DESCRIPTION
data sieving has to occur for any offset provided that is larger
or equal zero for this implementation to work correctly.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>