### PR TITLE
Fix MPIR_proctable structure visibility

### DIFF
--- a/orte/orted/Makefile.am
+++ b/orte/orted/Makefile.am
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2018      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,7 +30,17 @@ headers += \
 
 lib@ORTE_LIB_PREFIX@open_rte_la_SOURCES += \
         orted/orted_main.c \
-        orted/orted_comm.c \
-        orted/orted_submit.c
+        orted/orted_comm.c
+
+# The MPIR portion of the library must be built with -g, even if
+# the rest of the library has other optimization flags.
+# Use an intermediate library to isolate the debug object.
+noinst_LTLIBRARIES += liborted_mpir.la
+liborted_mpir_la_SOURCES = \
+	orted/orted_submit.c
+liborted_mpir_la_CFLAGS = $(CFLAGS_WITHOUT_OPTFLAGS) $(DEBUGGER_CFLAGS)
+
+lib@ORTE_LIB_PREFIX@open_rte_la_LIBADD += liborted_mpir.la
+
 
 include orted/pmix/Makefile.am

--- a/orte/tools/orterun/Makefile.am
+++ b/orte/tools/orterun/Makefile.am
@@ -12,21 +12,13 @@
 # Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2015      Intel, Inc.  All rights reserved.
+# Copyright (c) 2018      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
-
-# This is not quite in the Automake spirit, but we have to do it.
-# Since the totalview portion of the library must be built with -g, we
-# must eliminate the CFLAGS that are passed in here by default (which
-# may already have debugging and/or optimization flags).  We use
-# post-processed forms of the CFLAGS in the library targets down
-# below.
-
-CFLAGS = $(CFLAGS_WITHOUT_OPTFLAGS) $(DEBUGGER_CFLAGS)
 
 include $(top_srcdir)/Makefile.ompi-rules
 


### PR DESCRIPTION
 * The `MPIR_PROCDESC` structure needs to be visible even in optimized
   builds so that debuggers can attach to `mpirun` and properly read the
   `MPIR_proctable`.
 * In the v2.0.x and v2.x series this structure resided in the `orterun`
   directory and included the `CFLAGS` fix included here. This code
   moved in the v3.x series and the `CFLAGS` did not move causing this
   issue.
   - Instead of applying the debug `CFLAGS` globally to libopen-rte,
     only apply them to the `orted_submit.c` compile which contains the
     MPIR symbols.
