### PR TITLE
Fix typo in MPI_Cart_shift doc

### DIFF
--- a/ompi/mpi/man/man3/MPI_Cart_shift.3in
+++ b/ompi/mpi/man/man3/MPI_Cart_shift.3in
@@ -83,7 +83,7 @@ Depending on the periodicity of the Cartesian group in the specified coordinate 
 .nf
   \&....
   C find process rank
-        CALL MPI_COMM_RANK(comm, rank, ierr))
+        CALL MPI_COMM_RANK(comm, rank, ierr)
   C find Cartesian coordinates
         CALL MPI_CART_COORDS(comm, rank, maxdims, coords,
                              ierr)


### PR DESCRIPTION
Signed-off-by: Benoît Legat <benoit.legat@gmail.com>
(cherry picked from commit 00600c7cbb1ba72370cc5b4bce3669161360b4d2)

Thanks to @blegat

v3.0.x RMs: this is a trivial man page fix.  But in the spirit of not piling on the v3.0.1 release, I'm marking this as v3.0.2.