### PR TITLE
osc/rdma: performance improvments and bug fixes

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -8,7 +8,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
@@ -55,6 +55,7 @@ static void ompi_osc_rdma_pending_op_construct (ompi_osc_rdma_pending_op_t *pend
     pending_op->op_buffer = NULL;
     pending_op->op_result = NULL;
     pending_op->op_complete = false;
+    pending_op->cbfunc = NULL;
 }
 
 static void ompi_osc_rdma_pending_op_destruct (ompi_osc_rdma_pending_op_t *pending_op)
@@ -79,8 +80,14 @@ void ompi_osc_rdma_atomic_complete (mca_btl_base_module_t *btl, struct mca_btl_b
 {
     ompi_osc_rdma_pending_op_t *pending_op = (ompi_osc_rdma_pending_op_t *) context;
 
+    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "pending atomic %p complete with status %d", pending_op, status);
+
     if (pending_op->op_result) {
         memmove (pending_op->op_result, pending_op->op_buffer, pending_op->op_size);
+    }
+
+    if (NULL != pending_op->cbfunc) {
+        pending_op->cbfunc (pending_op->cbdata, pending_op->cbcontext, status);
     }
 
     if (NULL != pending_op->op_frag) {
@@ -194,7 +201,8 @@ static void ompi_osc_rdma_handle_post (ompi_osc_rdma_module_t *module, int rank,
         if (rank == peers[j]->rank) {
             OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_INFO, "got expected post from %d. still expecting posts from %d processes",
                              rank, (int) (npeers - state->num_post_msgs - 1));
-            ++state->num_post_msgs;
+            /* an atomic is not really necessary as this function is currently used but it doesn't hurt */
+            ompi_osc_rdma_counter_add (&state->num_post_msgs, 1);
             return;
         }
     }
@@ -206,13 +214,91 @@ static void ompi_osc_rdma_handle_post (ompi_osc_rdma_module_t *module, int rank,
     OPAL_THREAD_SCOPED_LOCK(&module->lock, opal_list_append (&module->pending_posts, &pending_post->super));
 }
 
+static void ompi_osc_rdma_check_posts (ompi_osc_rdma_module_t *module)
+{
+    ompi_osc_rdma_state_t *state = module->state;
+    ompi_osc_rdma_sync_t *sync = &module->all_sync;
+    int count = 0;
+
+    if (OMPI_OSC_RDMA_SYNC_TYPE_PSCW == sync->type) {
+        count = sync->num_peers;
+    }
+
+    for (int i = 0 ; i < OMPI_OSC_RDMA_POST_PEER_MAX ; ++i) {
+        /* no post at this index (yet) */
+        if (0 == state->post_peers[i]) {
+            continue;
+        }
+
+        ompi_osc_rdma_handle_post (module, state->post_peers[i] - 1, sync->peer_list.peers, count);
+        state->post_peers[i] = 0;
+    }
+}
+
+static int ompi_osc_rdma_post_peer (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer)
+{
+    uint64_t target = (uint64_t) (intptr_t) peer->state + offsetof (ompi_osc_rdma_state_t, post_index);
+    ompi_osc_rdma_lock_t post_index, result, _tmp_value;
+    int my_rank = ompi_comm_rank (module->comm);
+    int ret;
+
+    if (peer->rank == my_rank) {
+        ompi_osc_rdma_handle_post (module, my_rank, NULL, 0);
+        return OMPI_SUCCESS;
+    }
+
+    /* get a post index */
+    if (!ompi_osc_rdma_peer_local_state (peer)) {
+        ret = ompi_osc_rdma_lock_btl_fop (module, peer, target, MCA_BTL_ATOMIC_ADD, 1, &post_index, true);
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+            return ret;
+        }
+    } else {
+        post_index = ompi_osc_rdma_counter_add ((osc_rdma_counter_t *) (intptr_t) target, 1) - 1;
+    }
+
+    post_index &= OMPI_OSC_RDMA_POST_PEER_MAX - 1;
+
+    target = (uint64_t) (intptr_t) peer->state + offsetof (ompi_osc_rdma_state_t, post_peers) +
+        sizeof (osc_rdma_counter_t) * post_index;
+
+    do {
+        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "attempting to post to index %d @ rank %d", (int)post_index, peer->rank);
+
+        _tmp_value = 0;
+
+        /* try to post. if the value isn't 0 then another rank is occupying this index */
+        if (!ompi_osc_rdma_peer_local_state (peer)) {
+            ret = ompi_osc_rdma_lock_btl_cswap (module, peer, target, 0, 1 + (int64_t) my_rank, &result);
+            if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+                return ret;
+            }
+        } else {
+            result = !ompi_osc_rdma_lock_compare_exchange ((osc_rdma_counter_t *) target, &_tmp_value,
+                                                           1 + (osc_rdma_counter_t) my_rank);
+        }
+
+        if (OPAL_LIKELY(0 == result)) {
+            break;
+        }
+
+        /* prevent circular wait by checking for post messages received */
+        ompi_osc_rdma_check_posts (module);
+
+        /* zzzzzzzzzzzzz */
+        nanosleep (&(struct timespec) {.tv_sec = 0, .tv_nsec = 100}, NULL);
+    } while (1);
+
+    return OMPI_SUCCESS;
+}
+
 int ompi_osc_rdma_post_atomic (ompi_group_t *group, int assert, ompi_win_t *win)
 {
     ompi_osc_rdma_module_t *module = GET_MODULE(win);
     ompi_osc_rdma_peer_t **peers;
     int my_rank = ompi_comm_rank (module->comm);
     ompi_osc_rdma_state_t *state = module->state;
-    int ret;
+    int ret = OMPI_SUCCESS;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "post: %p, %d, %s", (void*) group, assert, win->w_name);
 
@@ -253,67 +339,17 @@ int ompi_osc_rdma_post_atomic (ompi_group_t *group, int assert, ompi_win_t *win)
 
     /* send a hello counter to everyone in group */
     for (int i = 0 ; i < ompi_group_size(module->pw_group) ; ++i) {
-        ompi_osc_rdma_peer_t *peer = peers[i];
-        uint64_t target = (uint64_t) (intptr_t) peer->state + offsetof (ompi_osc_rdma_state_t, post_index);
-        ompi_osc_rdma_lock_t post_index;
-
-        if (peer->rank == my_rank) {
-            ompi_osc_rdma_handle_post (module, my_rank, NULL, 0);
-            continue;
+        ret = ompi_osc_rdma_post_peer (module, peers[i]);
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+            break;
         }
-
-        /* get a post index */
-        if (!ompi_osc_rdma_peer_local_state (peer)) {
-            ret = ompi_osc_rdma_lock_btl_fop (module, peer, target, MCA_BTL_ATOMIC_ADD, 1, &post_index, true);
-            assert (OMPI_SUCCESS == ret);
-        } else {
-            post_index = ompi_osc_rdma_counter_add ((osc_rdma_counter_t *) (intptr_t) target, 1) - 1;
-        }
-
-        post_index &= OMPI_OSC_RDMA_POST_PEER_MAX - 1;
-
-        target = (uint64_t) (intptr_t) peer->state + offsetof (ompi_osc_rdma_state_t, post_peers) +
-            sizeof (osc_rdma_counter_t) * post_index;
-
-        do {
-            ompi_osc_rdma_lock_t result;
-
-            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "attempting to post to index %d @ rank %d", (int)post_index, peer->rank);
-
-            /* try to post. if the value isn't 0 then another rank is occupying this index */
-            if (!ompi_osc_rdma_peer_local_state (peer)) {
-                ret = ompi_osc_rdma_lock_btl_cswap (module, peer, target, 0, 1 + (int64_t) my_rank, &result);
-                assert (OMPI_SUCCESS == ret);
-            } else {
-                ompi_osc_rdma_lock_t _tmp_value = 0;
-
-                result = !ompi_osc_rdma_lock_compare_exchange ((osc_rdma_counter_t *) target, &_tmp_value, 1 + (osc_rdma_counter_t) my_rank);
-            }
-
-            if (OPAL_LIKELY(0 == result)) {
-                break;
-            }
-
-            /* prevent circular wait by checking for post messages received */
-            for (int j = 0 ; j < OMPI_OSC_RDMA_POST_PEER_MAX ; ++j) {
-                /* no post at this index (yet) */
-                if (0 == state->post_peers[j]) {
-                    continue;
-                }
-
-                ompi_osc_rdma_handle_post (module, state->post_peers[j] - 1, NULL, 0);
-                state->post_peers[j] = 0;
-            }
-
-            usleep (100);
-        } while (1);
     }
 
     ompi_osc_rdma_release_peers (peers, ompi_group_size(module->pw_group));
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "post complete");
 
-    return OMPI_SUCCESS;
+    return ret;
 }
 
 int ompi_osc_rdma_start_atomic (ompi_group_t *group, int assert, ompi_win_t *win)
@@ -379,8 +415,7 @@ int ompi_osc_rdma_start_atomic (ompi_group_t *group, int assert, ompi_win_t *win
                                      "from %d processes", peer->rank, (int) (group_size - state->num_post_msgs - 1));
                     opal_list_remove_item (&module->pending_posts, &pending_post->super);
                     OBJ_RELEASE(pending_post);
-                    /* only one thread can process post messages so there is no need of atomics here */
-                    ++state->num_post_msgs;
+                    ompi_osc_rdma_counter_add (&state->num_post_msgs, 1);
                     break;
                 }
             }
@@ -390,16 +425,7 @@ int ompi_osc_rdma_start_atomic (ompi_group_t *group, int assert, ompi_win_t *win
         while (state->num_post_msgs != group_size) {
             OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "waiting for post messages. have %d of %d",
                              (int) state->num_post_msgs, group_size);
-            for (int i = 0 ; i < OMPI_OSC_RDMA_POST_PEER_MAX ; ++i) {
-                /* no post at this index (yet) */
-                if (0 == state->post_peers[i]) {
-                    continue;
-                }
-
-                ompi_osc_rdma_handle_post (module, state->post_peers[i] - 1, sync->peer_list.peers, group_size);
-                state->post_peers[i] = 0;
-            }
-
+            ompi_osc_rdma_check_posts (module);
             ompi_osc_rdma_progress (module);
         }
     } else {
@@ -500,7 +526,6 @@ int ompi_osc_rdma_wait_atomic (ompi_win_t *win)
     }
 
     OPAL_THREAD_LOCK(&module->lock);
-    state->num_complete_msgs = 0;
     group = module->pw_group;
     module->pw_group = NULL;
     OPAL_THREAD_UNLOCK(&module->lock);
@@ -551,6 +576,8 @@ int ompi_osc_rdma_test_atomic (ompi_win_t *win, int *flag)
 
     OBJ_RELEASE(group);
 
+    OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "test complete. returning flag: true");
+
     return OMPI_SUCCESS;
 }
 
@@ -567,6 +594,8 @@ int ompi_osc_rdma_fence_atomic (int assert, ompi_win_t *win)
         return OMPI_ERR_RMA_SYNC;
     }
 
+    /* NTH: locking here isn't really needed per-se but it may make user synchronization errors more
+     * predicable. if the user is using RMA correctly then there will be no contention on this lock. */
     OPAL_THREAD_LOCK(&module->lock);
 
     /* active sends are now active (we will close the epoch if NOSUCCEED is specified) */
@@ -578,22 +607,17 @@ int ompi_osc_rdma_fence_atomic (int assert, ompi_win_t *win)
     }
 
     /* technically it is possible to enter a lock epoch (which will close the fence epoch) if
-     * no communication has occurred. this flag will be set on the next put, get, accumulate, etc. */
+     * no communication has occurred. this flag will be set to true on the next put, get,
+     * accumulate, etc if no other synchronization call is made. <sarcasm> yay fence </sarcasm> */
     module->all_sync.epoch_active = false;
 
-    /* short-circuit the noprecede case */
-    if (0 != (assert & MPI_MODE_NOPRECEDE)) {
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "fence complete (short circuit)");
-        /* no communication can occur until a peer has entered the same fence epoch. for now
-         * a barrier is used to ensure this is the case. */
-        ret = module->comm->c_coll->coll_barrier(module->comm, module->comm->c_coll->coll_barrier_module);
-        OPAL_THREAD_UNLOCK(&module->lock);
-        return ret;
-    }
+    /* there really is no practical difference between NOPRECEDE and the normal case. in both cases there
+     * may be local stores that will not be visible as they should if we do not barrier. since that is the
+     * case there is no optimization for NOPRECEDE */
 
     ompi_osc_rdma_sync_rdma_complete (&module->all_sync);
 
-    /* ensure all writes to my memory are complete */
+    /* ensure all writes to my memory are complete (both local stores, and RMA operations) */
     ret = module->comm->c_coll->coll_barrier(module->comm, module->comm->c_coll->coll_barrier_module);
 
     if (assert & MPI_MODE_NOSUCCEED) {

--- a/ompi/mca/osc/rdma/osc_rdma_comm.h
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.h
@@ -24,23 +24,6 @@
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #define ALIGNMENT_MASK(x) ((x) ? (x) - 1 : 0)
 
-/* helper functions */
-static inline void ompi_osc_rdma_cleanup_rdma (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_frag_t *frag,
-                                               mca_btl_base_registration_handle_t *handle, ompi_osc_rdma_request_t *request)
-{
-    if (frag) {
-        ompi_osc_rdma_frag_complete (frag);
-    } else {
-        ompi_osc_rdma_deregister (sync->module, handle);
-    }
-
-    if (request) {
-        (void) OPAL_THREAD_ADD_FETCH32 (&request->outstanding_requests, -1);
-    }
-
-    ompi_osc_rdma_sync_rdma_dec (sync);
-}
-
 /**
  * @brief find a remote segment associate with the memory region
  *
@@ -133,5 +116,9 @@ int ompi_osc_rdma_rget (void *origin_addr, int origin_count, ompi_datatype_t *or
 int ompi_osc_get_data_blocking (ompi_osc_rdma_module_t *module, struct mca_btl_base_endpoint_t *endpoint,
                                 uint64_t source_address, mca_btl_base_registration_handle_t *source_handle,
                                 void *data, size_t len);
+
+int ompi_osc_rdma_put_contig (ompi_osc_rdma_sync_t *sync, ompi_osc_rdma_peer_t *peer, uint64_t target_address,
+                              mca_btl_base_registration_handle_t *target_handle, void *source_buffer, size_t size,
+                              ompi_osc_rdma_request_t *request);
 
 #endif /* OMPI_OSC_RDMA_COMM_H */

--- a/ompi/mca/osc/rdma/osc_rdma_passive_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_passive_target.c
@@ -8,7 +8,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Sandia National Laboratories.  All rights reserved.
@@ -113,23 +113,29 @@ int ompi_osc_rdma_flush_local_all (struct ompi_win_t *win)
 static inline int ompi_osc_rdma_lock_atomic_internal (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer,
                                                       ompi_osc_rdma_sync_t *lock)
 {
+    const int locking_mode = module->locking_mode;
     int ret;
 
     if (MPI_LOCK_EXCLUSIVE == lock->sync.lock.type) {
         do {
             OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "incrementing global exclusive lock");
-            /* lock the master lock. this requires no rank has a global shared lock */
-            ret = ompi_osc_rdma_lock_acquire_shared (module, module->leader, 1, offsetof (ompi_osc_rdma_state_t, global_lock), 0xffffffff00000000L);
-            if (OMPI_SUCCESS != ret) {
-                ompi_osc_rdma_progress (module);
-                continue;
+            if (OMPI_OSC_RDMA_LOCKING_TWO_LEVEL == locking_mode) {
+                /* lock the master lock. this requires no rank has a global shared lock */
+                ret = ompi_osc_rdma_lock_acquire_shared (module, module->leader, 1, offsetof (ompi_osc_rdma_state_t, global_lock),
+                                                         0xffffffff00000000L);
+                if (OMPI_SUCCESS != ret) {
+                    ompi_osc_rdma_progress (module);
+                    continue;
+                }
             }
 
             OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "acquiring exclusive lock on peer");
             ret = ompi_osc_rdma_lock_try_acquire_exclusive (module, peer,  offsetof (ompi_osc_rdma_state_t, local_lock));
             if (ret) {
                 /* release the global lock */
-                ompi_osc_rdma_lock_release_shared (module, module->leader, -1, offsetof (ompi_osc_rdma_state_t, global_lock));
+                if (OMPI_OSC_RDMA_LOCKING_TWO_LEVEL == locking_mode) {
+                    ompi_osc_rdma_lock_release_shared (module, module->leader, -1, offsetof (ompi_osc_rdma_state_t, global_lock));
+                }
                 ompi_osc_rdma_progress (module);
                 continue;
             }
@@ -157,16 +163,44 @@ static inline int ompi_osc_rdma_lock_atomic_internal (ompi_osc_rdma_module_t *mo
 static inline int ompi_osc_rdma_unlock_atomic_internal (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer,
                                                         ompi_osc_rdma_sync_t *lock)
 {
+    const int locking_mode = module->locking_mode;
+
     if (MPI_LOCK_EXCLUSIVE == lock->sync.lock.type) {
         OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "releasing exclusive lock on peer");
         ompi_osc_rdma_lock_release_exclusive (module, peer, offsetof (ompi_osc_rdma_state_t, local_lock));
-        OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "decrementing global exclusive lock");
-        ompi_osc_rdma_lock_release_shared (module, module->leader, -1, offsetof (ompi_osc_rdma_state_t, global_lock));
+
+        if (OMPI_OSC_RDMA_LOCKING_TWO_LEVEL == locking_mode) {
+            OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "decrementing global exclusive lock");
+            ompi_osc_rdma_lock_release_shared (module, module->leader, -1, offsetof (ompi_osc_rdma_state_t, global_lock));
+        }
+
         peer->flags &= ~OMPI_OSC_RDMA_PEER_EXCLUSIVE;
     } else {
         OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_DEBUG, "decrementing global shared lock");
         ompi_osc_rdma_lock_release_shared (module, peer, -1, offsetof (ompi_osc_rdma_state_t, local_lock));
+        peer->flags &= ~OMPI_OSC_RDMA_PEER_DEMAND_LOCKED;
     }
+
+    return OMPI_SUCCESS;
+}
+
+int ompi_osc_rdma_demand_lock_peer (ompi_osc_rdma_module_t *module, ompi_osc_rdma_peer_t *peer)
+{
+    ompi_osc_rdma_sync_t *lock = &module->all_sync;
+    int ret = OMPI_SUCCESS;
+
+    /* check for bad usage */
+    assert (OMPI_OSC_RDMA_SYNC_TYPE_LOCK == lock->type);
+
+    OPAL_THREAD_SCOPED_LOCK(&peer->lock,
+    do {
+        if (!ompi_osc_rdma_peer_is_demand_locked (peer)) {
+            ret = ompi_osc_rdma_lock_atomic_internal (module, peer, lock);
+            OPAL_THREAD_SCOPED_LOCK(&lock->lock, opal_list_append (&lock->demand_locked_peers, &peer->super));
+            peer->flags |= OMPI_OSC_RDMA_PEER_DEMAND_LOCKED;
+        }
+    } while (0);
+    );
 
     return OMPI_SUCCESS;
 }
@@ -315,9 +349,14 @@ int ompi_osc_rdma_lock_all_atomic (int assert, struct ompi_win_t *win)
 
     if (0 == (assert & MPI_MODE_NOCHECK)) {
         /* increment the global shared lock */
-        ret = ompi_osc_rdma_lock_acquire_shared (module, module->leader, 0x0000000100000000UL,
-                                                 offsetof(ompi_osc_rdma_state_t, global_lock),
-                                                 0x00000000ffffffffUL);
+        if (OMPI_OSC_RDMA_LOCKING_TWO_LEVEL == module->locking_mode) {
+            ret = ompi_osc_rdma_lock_acquire_shared (module, module->leader, 0x0000000100000000UL,
+                                                     offsetof(ompi_osc_rdma_state_t, global_lock),
+                                                     0x00000000ffffffffUL);
+        } else {
+            /* always lock myself */
+            ret = ompi_osc_rdma_demand_lock_peer (module, module->my_peer);
+        }
     }
 
     if (OPAL_LIKELY(OMPI_SUCCESS != ret)) {
@@ -357,8 +396,19 @@ int ompi_osc_rdma_unlock_all_atomic (struct ompi_win_t *win)
     ompi_osc_rdma_sync_rdma_complete (lock);
 
     if (0 == (lock->sync.lock.assert & MPI_MODE_NOCHECK)) {
-        /* decrement the master lock shared count */
-        (void) ompi_osc_rdma_lock_release_shared (module, module->leader, -0x0000000100000000UL, offsetof (ompi_osc_rdma_state_t, global_lock));
+        if (OMPI_OSC_RDMA_LOCKING_ON_DEMAND == module->locking_mode) {
+            ompi_osc_rdma_peer_t *peer, *next;
+
+            /* drop all on-demand locks */
+            OPAL_LIST_FOREACH_SAFE(peer, next, &lock->demand_locked_peers, ompi_osc_rdma_peer_t) {
+                (void) ompi_osc_rdma_unlock_atomic_internal (module, peer, lock);
+                opal_list_remove_item (&lock->demand_locked_peers, &peer->super);
+            }
+        } else {
+            /* decrement the master lock shared count */
+            (void) ompi_osc_rdma_lock_release_shared (module, module->leader, -0x0000000100000000UL,
+                                                      offsetof (ompi_osc_rdma_state_t, global_lock));
+        }
     }
 
     lock->type = OMPI_OSC_RDMA_SYNC_TYPE_NONE;

--- a/ompi/mca/osc/rdma/osc_rdma_peer.c
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.c
@@ -303,7 +303,7 @@ static void ompi_osc_rdma_peer_destruct (ompi_osc_rdma_peer_t *peer)
     }
 }
 
-OBJ_CLASS_INSTANCE(ompi_osc_rdma_peer_t, opal_object_t,
+OBJ_CLASS_INSTANCE(ompi_osc_rdma_peer_t, opal_list_item_t,
                    ompi_osc_rdma_peer_construct,
                    ompi_osc_rdma_peer_destruct);
 

--- a/ompi/mca/osc/rdma/osc_rdma_peer.h
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.h
@@ -22,7 +22,7 @@ struct ompi_osc_rdma_module_t;
  * This object is used as a cache for information associated with a peer.
  */
 struct ompi_osc_rdma_peer_t {
-    opal_object_t super;
+    opal_list_item_t super;
 
     /** rdma data endpoint for this peer */
     struct mca_btl_base_endpoint_t *data_endpoint;
@@ -35,6 +35,9 @@ struct ompi_osc_rdma_peer_t {
 
     /** registration handle associated with the state */
     mca_btl_base_registration_handle_t *state_handle;
+
+    /** lock to protrct peer structure */
+    opal_mutex_t lock;
 
     /** rank of this peer in the window */
     int rank;
@@ -134,6 +137,8 @@ enum {
     OMPI_OSC_RDMA_PEER_STATE_FREE           = 0x20,
     /** peer base handle should be freed */
     OMPI_OSC_RDMA_PEER_BASE_FREE            = 0x40,
+    /** peer was demand locked as part of lock-all (when in demand locking mode) */
+    OMPI_OSC_RDMA_PEER_DEMAND_LOCKED        = 0x80,
 };
 
 /**
@@ -248,5 +253,15 @@ static inline bool ompi_osc_rdma_peer_local_state (ompi_osc_rdma_peer_t *peer)
     return !!(peer->flags & OMPI_OSC_RDMA_PEER_LOCAL_STATE);
 }
 
+/**
+ * @brief check if the peer has been demand locked as part of the current epoch
+ *
+ * @param[in] peer            peer object to check
+ *
+ */
+static inline bool ompi_osc_rdma_peer_is_demand_locked (ompi_osc_rdma_peer_t *peer)
+{
+    return !!(peer->flags & OMPI_OSC_RDMA_PEER_DEMAND_LOCKED);
+}
 
 #endif /* OMPI_OSC_RDMA_PEER_H */

--- a/ompi/mca/osc/rdma/osc_rdma_request.c
+++ b/ompi/mca/osc/rdma/osc_rdma_request.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2011-2012 Sandia National Laboratories.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
@@ -44,27 +44,17 @@ static int request_free(struct ompi_request_t **ompi_req)
     return OMPI_SUCCESS;
 }
 
-static int request_complete (struct ompi_request_t *request)
-{
-    ompi_osc_rdma_request_t *parent_request = ((ompi_osc_rdma_request_t *) request)->parent_request;
-
-    if (parent_request && 0 == OPAL_THREAD_ADD_FETCH32 (&parent_request->outstanding_requests, -1)) {
-        ompi_osc_rdma_request_complete (parent_request, OMPI_SUCCESS);
-    }
-
-    return OMPI_SUCCESS;
-}
-
 static void request_construct(ompi_osc_rdma_request_t *request)
 {
     request->super.req_type = OMPI_REQUEST_WIN;
     request->super.req_status._cancelled = 0;
     request->super.req_free = request_free;
     request->super.req_cancel = request_cancel;
-    request->super.req_complete_cb = request_complete;
     request->parent_request = NULL;
+    request->to_free = NULL;
     request->buffer = NULL;
     request->internal = false;
+    request->cleanup = NULL;
     request->outstanding_requests = 0;
     OBJ_CONSTRUCT(&request->convertor, opal_convertor_t);
 }

--- a/ompi/mca/osc/rdma/osc_rdma_sync.c
+++ b/ompi/mca/osc/rdma/osc_rdma_sync.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -16,15 +16,17 @@ static void ompi_osc_rdma_sync_constructor (ompi_osc_rdma_sync_t *rdma_sync)
 {
     rdma_sync->type = OMPI_OSC_RDMA_SYNC_TYPE_NONE;
     rdma_sync->epoch_active = false;
-    rdma_sync->outstanding_rdma = 0;
+    rdma_sync->outstanding_rdma.counter = 0;
     OBJ_CONSTRUCT(&rdma_sync->aggregations, opal_list_t);
     OBJ_CONSTRUCT(&rdma_sync->lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&rdma_sync->demand_locked_peers, opal_list_t);
 }
 
 static void ompi_osc_rdma_sync_destructor (ompi_osc_rdma_sync_t *rdma_sync)
 {
     OBJ_DESTRUCT(&rdma_sync->aggregations);
     OBJ_DESTRUCT(&rdma_sync->lock);
+    OBJ_DESTRUCT(&rdma_sync->demand_locked_peers);
 }
 
 OBJ_CLASS_INSTANCE(ompi_osc_rdma_sync_t, opal_object_t, ompi_osc_rdma_sync_constructor,

--- a/ompi/mca/osc/rdma/osc_rdma_types.h
+++ b/ompi/mca/osc/rdma/osc_rdma_types.h
@@ -205,6 +205,8 @@ typedef struct ompi_osc_rdma_aggregation_t ompi_osc_rdma_aggregation_t;
 
 OBJ_CLASS_DECLARATION(ompi_osc_rdma_aggregation_t);
 
+typedef void (*ompi_osc_rdma_pending_op_cb_fn_t) (void *, void *, int);
+
 struct ompi_osc_rdma_pending_op_t {
     opal_list_item_t super;
     struct ompi_osc_rdma_frag_t *op_frag;
@@ -212,11 +214,28 @@ struct ompi_osc_rdma_pending_op_t {
     void *op_result;
     size_t op_size;
     volatile bool op_complete;
+    ompi_osc_rdma_pending_op_cb_fn_t cbfunc;
+    void *cbdata;
+    void *cbcontext;
 };
 
 typedef struct ompi_osc_rdma_pending_op_t ompi_osc_rdma_pending_op_t;
 
 OBJ_CLASS_DECLARATION(ompi_osc_rdma_pending_op_t);
+
+/** Communication buffer for packing messages */
+struct ompi_osc_rdma_frag_t {
+    opal_free_list_item_t super;
+
+    /* Number of operations which have started writing into the frag, but not yet completed doing so */
+    volatile int32_t pending;
+    volatile int64_t curr_index;
+
+    struct ompi_osc_rdma_module_t *module;
+    mca_btl_base_registration_handle_t *handle;
+};
+typedef struct ompi_osc_rdma_frag_t ompi_osc_rdma_frag_t;
+OBJ_CLASS_DECLARATION(ompi_osc_rdma_frag_t);
 
 #define OSC_RDMA_VERBOSE(x, ...) OPAL_OUTPUT_VERBOSE((x, ompi_osc_base_framework.framework_output, __VA_ARGS__))
 


### PR DESCRIPTION
This commit is a large update to the osc/rdma component. Included in
this commit:

 - Add support for using hardware atomics for fetch-and-op and single
   count accumulate  when using the accumulate lock. This will improve
   the performance of these operations even when not setting the
   single intrinsic info key.

 - Rework how large accumulates are done. They now block on the get
   operation to fix some bugs discovered by an IBM one-sided test. I
   may roll back some of the changes if the underlying bug in the
   original design is discovered. There appear to be no real
   difference (on the hardware this was tested with) in performance so
   its probably a non-issue. References #2530.

 - Add support for an additional lock-all algorithm: on-demand. The
   on-demand algorithm will attempt to acquire the peer lock when
   starting an RMA operation. The lock algorithm default has not
   changed. The algorithm can be selected by setting the
   osc_rdma_locking_mode MCA variable. The valid values are two_level
   and on_demand.

 - Make use of the btl_flush function if available. This can improve
   performance with some btls.

 - When using btl_flush do not keep track of the number of put
   operations. This reduces the number of atomic operations in the
   critical path.

 - Make the window buffers more friendly to multi-threaded
   applications. This was done by dropping support for multiple
   buffers per MPI window. I intend to re-add that support once the
   underlying performance bug under the old buffering scheme is
   fixed.

 - Fix a bug in request completion in the accumulate, get, and put
   paths. This also helps with #2530.

 - General code cleanup and fixes.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>