### PR TITLE
pmix: dstore returned for direct modex

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix3x_client.c
+++ b/opal/mca/pmix/pmix3x/pmix3x_client.c
@@ -98,11 +98,6 @@ int pmix3x_client_init(opal_list_t *ilist)
         ninfo = 0;
     }
 
-    /* check for direct modex use-case */
-    if (opal_pmix_base_async_modex && !opal_pmix_collect_all_data) {
-        opal_setenv("PMIX_MCA_gds", "hash", true, &environ);
-    }
-
     OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);
     rc = PMIx_Init(&mca_pmix_pmix3x_component.myproc, pinfo, ninfo);
     if (NULL != pinfo) {

--- a/opal/mca/pmix/pmix3x/pmix3x_server_south.c
+++ b/opal/mca/pmix/pmix3x/pmix3x_server_south.c
@@ -129,11 +129,6 @@ int pmix3x_server_init(opal_pmix_server_module_t *module,
         }
     }
 
-    /* check for direct modex use-case */
-    if (opal_pmix_base_async_modex && !opal_pmix_collect_all_data) {
-        opal_setenv("PMIX_MCA_gds", "hash", true, &environ);
-    }
-
     /* insert ourselves into our list of jobids - it will be the
      * first, and so we'll check it first */
     job = OBJ_NEW(opal_pmix3x_jobid_trkr_t);


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>

Following conversation here https://github.com/open-mpi/ompi/pull/4469, dstore returned for direct modex.