### PR TITLE
hwloc: bring back the configure error when external hwloc is >= 2.0

### DIFF
--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -184,7 +184,21 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                [AC_MSG_RESULT([yes])],
                [AC_MSG_RESULT([no])
                 AC_MSG_ERROR([Cannot continue])])
-
+           AC_MSG_CHECKING([if external hwloc version is lower than 2.0])
+           AS_IF([test "$opal_hwloc_dir" != ""],
+                 [opal_hwloc_external_CFLAGS_save=$CFLAGS
+                  CFLAGS="-I$opal_hwloc_dir/include $opal_hwloc_external_CFLAGS_save"])
+           AC_COMPILE_IFELSE(
+               [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+                   [[
+#if HWLOC_API_VERSION >= 0x00020000
+#error "hwloc API version is greater or equal than 0x00020000"
+#endif
+                   ]])],
+               [AC_MSG_RESULT([yes])],
+               [AC_MSG_RESULT([no])
+                AC_MSG_ERROR([OMPI does not currently support hwloc v2 API
+Cannot continue])])
            AS_IF([test "$opal_hwloc_dir" != ""],
                  [CFLAGS=$opal_hwloc_external_CFLAGS_save])
 


### PR DESCRIPTION
@jsquyres Here's the patch to abort configure in 3.1 if hwloc external is 2.0.

@ggouaillardet added that code a while ago (it's still in 3.0.x, no need to backport there). Then he removed it from master/3.1.x when porting OMPI to the non-final hwloc 2.0 API (which isn't done yet). I am putting it back in 3.1.x but not in master.
