### PR TITLE
v3.1.x: Sync to PMIx v2.1 (PR pmix/pmix#698)

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server_get.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/server/pmix_server_get.c
@@ -610,7 +610,14 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
 
     /* retrieve the data for the specific rank they are asking about */
     if (PMIX_RANK_WILDCARD != rank) {
-        if (!peer->commit_cnt) {
+        if (!PMIX_PROC_IS_SERVER(peer) && !peer->commit_cnt) {
+            /* this condition works only for local requests, server does 
+             * count commits for local ranks, and check this count when 
+             * local request.
+             * if that request performs for remote rank on the remote 
+             * node (by direct modex) so `peer->commit_cnt` should be ignored,
+             * it is can not be counted for the remote side and this condition 
+             * does not matter for remote case */
             return PMIX_ERR_NOT_FOUND;
         }
         proc.rank = rank;


### PR DESCRIPTION
This commit fixes the case when local client asks for the key from the
process on the remote node. The local server don't have commit count for
remote ranks, it is maintained by another PMIx server, so commit count
should be ignored for remote requests.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>