### PR TITLE
opal/util/net.c: fix compiler warning

### DIFF
--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.


### PR DESCRIPTION
This variable is only used when IPv6 support is enabled; ensure to
protect it in an #if OPAL_ENABLE_IPv6 check.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

This commit pulled out from #4199.