### PR TITLE
v2.x: ompi/opal: add support for HDR link speeds

### DIFF
--- a/opal/mca/common/verbs/common_verbs_port.c
+++ b/opal/mca/common/verbs/common_verbs_port.c
@@ -68,6 +68,10 @@ int opal_common_verbs_port_bw(struct ibv_port_attr *port_attr,
         /* EDR: 25.78125 Gbps * 64/66, in megabits */
         *bandwidth = 25000;
         break;
+    case 64:
+        /* HDR: 50Gbps * 64/66, in megabits */
+        *bandwidth = 50000;
+        break;
     default:
         /* Who knows? */
         return OPAL_ERR_NOT_FOUND;


### PR DESCRIPTION
This patch enables to use adapters with HDR speeds.
issue id 3431

Signed-off-by: Devesh Sharma <devesh.sharma@broadcom.com>
(cherry picked from commit 90e9b2219630877f7fb43ca1ec56ccf6c3c32cf6)