### PR TITLE
fcoll/two_phase: do not use removed function (MPI_Address)

### DIFF
--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_read_all.c
@@ -689,7 +689,7 @@ static int two_phase_read_and_exch(mca_io_ompio_file_t *fh,
 		    }
 		    if (req_off < real_off + real_size) {
 			count[i]++;
-			PMPI_Address(read_buf+req_off-real_off,
+			PMPI_Get_address(read_buf+req_off-real_off,
 				     &(others_req[i].mem_ptrs[j]));
 
 			send_size[i] += (int)(OMPIO_MIN(real_off + real_size - req_off,

--- a/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
+++ b/ompi/mca/fcoll/two_phase/fcoll_two_phase_file_write_all.c
@@ -781,7 +781,7 @@ static int two_phase_exch_and_write(mca_io_ompio_file_t *fh,
 			       size,i,
 			       count[i]);
 #endif
-			PMPI_Address(write_buf+req_off-off,
+			PMPI_Get_address(write_buf+req_off-off,
 				     &(others_req[i].mem_ptrs[j]));
 #if DEBUG_ON
 			printf("%d : mem_ptrs : %ld\n", fh->f_rank,


### PR DESCRIPTION
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>