### PR TITLE
vader fix for 4937 (PPC wmb location)

### DIFF
--- a/opal/mca/btl/vader/btl_vader_fbox.h
+++ b/opal/mca/btl/vader/btl_vader_fbox.h
@@ -51,8 +51,8 @@ static inline void mca_btl_vader_fbox_set_header (mca_btl_vader_fbox_hdr_t *hdr,
                                                   uint16_t seq, uint32_t size)
 {
     mca_btl_vader_fbox_hdr_t tmp = {.data = {.tag = tag, .seq = seq, .size = size}};
-    hdr->ival = tmp.ival;
     opal_atomic_wmb ();
+    hdr->ival = tmp.ival;
 }
 
 /* attempt to reserve a contiguous segment from the remote ep */


### PR DESCRIPTION
I have some tests that failed on PPC with the recent vader changes.
I'm suspicious of the set_header() function where there's a wmb()
call that looks like it boils down to
    set some data
    set the header to indicate the data is available
    wmb
and I think the wmb needs to go up a line.

More details here:
    https://github.com/open-mpi/ompi/issues/4937
with a copy of the "maxsoak.c" testcase at
    https://gist.github.com/markalle/a1c203297cb6af22a3fb5c24e62b2ba3

Fixes #4937