### PR TITLE
v3.1.x: plm/base: fixed the hosts filtering

### DIFF
--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -2183,6 +2183,11 @@ int orte_plm_base_setup_virtual_machine(orte_job_t *jdata)
             if (!ORTE_FLAG_TEST(node, ORTE_NODE_FLAG_MAPPED)) {
                 opal_list_remove_item(&nodes, item);
                 OBJ_RELEASE(item);
+            } else {
+                /* The filtering logic sets this flag only for nodes which 
+                 * are kept after filtering. This flag will be subsequently
+                 * used in rmaps components and must be reset here */
+                ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
             }
             item = next;
         }


### PR DESCRIPTION
Reseting the `ORTE_NODE_FLAG_MAPPED` flag after hosts filtering, this
flag is used subsequently and can be affect to the node mapping logic

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit 6afc7099a01fe15d1227fafc019df187afbe4424)

Corresponds to https://github.com/open-mpi/ompi/pull/4957