### PR TITLE
opal_free_list: use lifo atomic functions in opal_free_list_wait_mt

### DIFF
--- a/opal/class/opal_free_list.h
+++ b/opal/class/opal_free_list.h
@@ -248,7 +248,7 @@ static inline opal_free_list_item_t *opal_free_list_get (opal_free_list_t *flist
 static inline opal_free_list_item_t *opal_free_list_wait_mt (opal_free_list_t *fl)
 {
     opal_free_list_item_t *item =
-        (opal_free_list_item_t *) opal_lifo_pop (&fl->super);
+        (opal_free_list_item_t *) opal_lifo_pop_atomic (&fl->super);
 
     while (NULL == item) {
         if (!opal_mutex_trylock (&fl->fl_lock)) {
@@ -274,7 +274,7 @@ static inline opal_free_list_item_t *opal_free_list_wait_mt (opal_free_list_t *f
             opal_mutex_lock (&fl->fl_lock);
         }
         opal_mutex_unlock (&fl->fl_lock);
-        item = (opal_free_list_item_t *) opal_lifo_pop (&fl->super);
+        item = (opal_free_list_item_t *) opal_lifo_pop_atomic (&fl->super);
     }
 
     return item;


### PR DESCRIPTION
This commit fixes a multi-threading bug when using the thread-safe
free list functions. opal_free_list_wait_mt() was using the
conditional version of opal_lifo_pop() and not the thread-safe call.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>