### PR TITLE
v2.x: osc/pt2pt: disable osc/pt2pt for THREAD_MULTIPLE scenarios

### DIFF
--- a/ompi/mca/osc/pt2pt/Makefile.am
+++ b/ompi/mca/osc/pt2pt/Makefile.am
@@ -18,6 +18,8 @@
 # $HEADER$
 #
 
+dist_ompidata_DATA = help-osc-pt2pt.txt
+
 pt2pt_sources = \
 	osc_pt2pt.h \
 	osc_pt2pt_module.c \

--- a/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
+++ b/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
@@ -1,0 +1,15 @@
+# -*- text -*-
+#
+# Copyright (c) 2016 Los Alamos National Security, LLC. All rights
+#                    reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+[mpi-thread-multiple-not-supported]
+The OSC pt2pt component does not support MPI_THREAD_MULTIPLE in this release.
+Workarounds are to run on a single node, or to use a system with an RDMA
+capable network such as Infiniband.


### PR DESCRIPTION
As a workaround for issue #2614 for the v2.0.2 release,
do not allow for selection of the OSC PT2PT when
creating an MPI RMA window.  Print a hopefully helpful
message and return an not-supported error.

This PR should be reverted once a fix for #2614
is in place.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit d0ffd660841623c02d1dfa3151e7f7afd3327698)

The original commit message is shown above.  Followup: as of this
writing (26 Mar 2018), we do not plan to fix this issue for the v2.0.x
or v2.x.  Hence, the osc/pt2pt component will continue to disable
itself in THREAD_MULTIPLE scenarios for the life of all v2.x series.
It is possible (likely?) that this will be fixed in a v3.0.x release
(where x>1).

See #2614.