### PR TITLE
use-mpi-f08: fix rma function signatures

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/accumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/accumulate_f08.F90
@@ -13,7 +13,7 @@ subroutine MPI_Accumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_accumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/compare_and_swap_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/compare_and_swap_f08.F90
@@ -13,8 +13,8 @@ subroutine MPI_Compare_and_swap_f08(origin_addr,compare_addr,result_addr,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_compare_and_swap_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr, compare_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr, compare_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: target_rank
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/fetch_and_op_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/fetch_and_op_f08.F90
@@ -12,8 +12,8 @@ subroutine MPI_Fetch_and_op_f08(origin_addr,result_addr,datatype,target_rank, &
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_fetch_and_op_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: target_rank
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/get_accumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/get_accumulate_f08.F90
@@ -14,10 +14,10 @@ subroutine MPI_Get_accumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_get_accumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, result_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: result_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp
    TYPE(MPI_Datatype), INTENT(IN) :: target_datatype

--- a/ompi/mpi/fortran/use-mpi-f08/get_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/get_f08.F90
@@ -1,7 +1,7 @@
 ! -*- f90 -*-
 !
 ! Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
-! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
+! Copyright (c) 2009-2018 Los Alamos National Security, LLC.
 !               All Rights reserved.
 ! $COPYRIGHT$
 
@@ -12,7 +12,7 @@ subroutine MPI_Get_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_get_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/put_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/put_f08.F90
@@ -12,7 +12,7 @@ subroutine MPI_Put_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_put_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/raccumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/raccumulate_f08.F90
@@ -13,7 +13,7 @@ subroutine MPI_Raccumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_raccumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN),ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/rget_accumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/rget_accumulate_f08.F90
@@ -14,10 +14,10 @@ subroutine MPI_Rget_accumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_rget_accumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, result_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: result_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp
    TYPE(MPI_Datatype), INTENT(IN) :: target_datatype

--- a/ompi/mpi/fortran/use-mpi-f08/rget_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/rget_f08.F90
@@ -12,7 +12,7 @@ subroutine MPI_Rget_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_rget_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/rput_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/rput_f08.F90
@@ -12,7 +12,7 @@ subroutine MPI_Rput_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_rput_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp


### PR DESCRIPTION
The various RMA functions need to have the asynchronous property on
all buffers. This property was missing and some buffers were
incorrectly marked as intent(in). This commit fixes the function
signatures.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 1c75aa82fc44782f1a034173312114386fd0b333)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>