### PR TITLE
osc/rdma: fix overflow in offset calculation

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -483,11 +483,10 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
     unsigned long offset, total_size;
     unsigned long state_base, data_base;
     int local_rank, local_size, ret;
-    size_t local_rank_array_size, leader_peer_data_size;
+    size_t local_rank_array_size, leader_peer_data_size, my_base_offset = 0;
     int my_rank = ompi_comm_rank (module->comm);
     int global_size = ompi_comm_size (module->comm);
     ompi_osc_rdma_region_t *state_region;
-    int my_base_offset = 0;
     struct _local_data *temp;
     char *data_file;
 


### PR DESCRIPTION
This commit fixes a bug is osc/rdma that can occur if the total size
of the shared memory segment gets larger than 4 GiB. The bug was
caused by a typo. The type of my_base_offset should have been size_t
not int.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit e79debc3208f0c506e6f3b856ecac1ddc703bf1b)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>