### PR TITLE
ompi/oshmem: fix bug in shmem_finalize.

### DIFF
--- a/oshmem/shmem/c/shmem_finalize.c
+++ b/oshmem/shmem/c/shmem_finalize.c
@@ -22,15 +22,9 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
-extern int oshmem_shmem_globalexit_status;
-
 void shmem_finalize(void)
 {
     OPAL_CR_FINALIZE_LIBRARY();
-    if (oshmem_shmem_globalexit_status != 0)
-    {
-        return;
-    }
     oshmem_shmem_finalize();
 }
 

--- a/oshmem/shmem/c/shmem_init.c
+++ b/oshmem/shmem/c/shmem_init.c
@@ -32,8 +32,6 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
-extern int oshmem_shmem_globalexit_status;
-
 static inline void _shmem_init(void);
 
 void shmem_init(void)
@@ -50,7 +48,6 @@ void start_pes(int npes)
 
 static void shmem_onexit(int exitcode, void *arg)
 {
-    oshmem_shmem_globalexit_status = exitcode;
     shmem_finalize();
 }
 


### PR DESCRIPTION
Originally there is a "oshmem_shmem_globalexit_status" variable to track if current shmem_finalize is the implicit one at end of main, and shmem_finalize does real work when it is, otherwise it does nothing.
This is not correct, if shmem_finalize is the explicit one in the program, it should still guarantee the completion of pending communications, according to specification 1.3 page 10.

This PR deleted "oshmem_shmem_globalexit_status" variable and let shmem_finalize always does real work.

Signed-off-by: xinz@mellanox.com