### PR TITLE
ompi/oshmem: fix bug in shmem_finalize.

### DIFF
--- a/oshmem/shmem/c/shmem_finalize.c
+++ b/oshmem/shmem/c/shmem_finalize.c
@@ -22,15 +22,9 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
-extern int oshmem_shmem_globalexit_status;
-
 void shmem_finalize(void)
 {
     OPAL_CR_FINALIZE_LIBRARY();
-    if (oshmem_shmem_globalexit_status != 0)
-    {
-        return;
-    }
     oshmem_shmem_finalize();
 }
 


### PR DESCRIPTION
Originally there is a "oshmem_shmem_globalexit_status" variable to track if current shmem_finalize is the implicit one at end of main, and shmem_finalize does real work when it is, otherwise it does nothing.
This is not correct, if shmem_finalize is the explicit one in the program, it should still guarantee the completion of pending communications, according to specification 1.3 page 10.
This PR modified use of "oshmem_shmem_globalexit_status" variable so that if shmem_finalize is not the one at end of main, it still waits for all oshmem communications and release oshmem resources.

Signed-off-by: Xin Zhao <xinz@mellanox.com>