### PR TITLE
ompi/oshmem: fix cswap bug in mca/atomic/mxm.

### DIFF
--- a/oshmem/mca/atomic/mxm/atomic_mxm_cswap.c
+++ b/oshmem/mca/atomic/mxm/atomic_mxm_cswap.c
@@ -34,8 +34,9 @@ int mca_atomic_mxm_cswap(void *target,
     mxm_send_req_t sreq;
 
     mca_atomic_mxm_req_init(&sreq, pe, target, nlong);
+    memcpy(prev, value, nlong);
 
-    sreq.base.data.buffer.ptr = (void *) value;
+    sreq.base.data.buffer.ptr = prev;
     if (NULL == cond) {
         sreq.opcode = MXM_REQ_OP_ATOMIC_SWAP;
     } else {
@@ -44,8 +45,6 @@ int mca_atomic_mxm_cswap(void *target,
     }
 
     mca_atomic_mxm_post(&sreq);
-
-    memcpy(prev, value, nlong);
 
     return OSHMEM_SUCCESS;
 }


### PR DESCRIPTION
In a CSWAP(prev, cond, value) operation, 'prev' returns the previous value on target side, 'cond' is condition value, and 'value' contains value to be swapped to the target. CSWAP operation should not change 'value'. Originally mca/atomic/mxm changes content of 'value' buffer with 'prev' value, which is not correct. This PR fixes this issue.

Signed-off-by: Xin Zhao <xinz@mellanox.com>