### PR TITLE
io/ompio: don't reset amode if MODE_SEQUENTIAL is set

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -111,7 +111,7 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
 
     /* This fix is needed for data seiving to work with
        two-phase collective I/O */
-    if ( mca_io_ompio_overwrite_amode ) {
+    if ( mca_io_ompio_overwrite_amode && !(amode & MPI_MODE_SEQUENTIAL) ) {
         if ((amode & MPI_MODE_WRONLY)){
             amode -= MPI_MODE_WRONLY;
             amode += MPI_MODE_RDWR;


### PR DESCRIPTION
the ompio module resets the amode from WRONLY to RDWR in order
to accoomodate data sieving in the two-phase fcoll componet. This
leads however to an error if MPI_MODE_SEQUENTIAL has been requested
by the user, since MODE_SEQUENTIAL is incompatible with MODE_RDWR.
SInce the change to the amode was done after opening the file for
individual file pointers but before opening the file for shared filepointers,
this lead to an error message in the sharedfp component.

Note, that data sieving is never necessary if MODE_SEQUENTIAL is set,
so this should not be a problem for any scenario.

Fixes #4991

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>