### PR TITLE
dist: Don't build case-conflicting html man pages

### DIFF
--- a/contrib/dist/make-html-man-pages.pl
+++ b/contrib/dist/make-html-man-pages.pl
@@ -76,7 +76,7 @@ sub doit {
 # Autogen if we don't have a configure script
 doit("./autogen.pl")
     if (! -x "configure");
-doit("./configure --prefix=$prefix --enable-mpi-ext=all");
+doit("./configure --prefix=$prefix --enable-mpi-ext=all --without-cs-fs");
 
 # Find this OMPI's version
 my $version = `fgrep PACKAGE_VERSION opal/include/opal_config.h | cut -d\\\" -f2`;


### PR DESCRIPTION
The html man page builder creates a web page for every
man page generated by our releases.  We then check all
those pages into the ompi-www repo.  Force the build
to skip case-conflicting pages (ie, mpiCC because it
conflicts with mpicc), even if building on Linux, so that
ompi-www continues to be sane when cloned onto MacOS.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit fe2b6cf1d63d352aca247c9d026bb7038cb412c6)