### PR TITLE
ompi/oshmem: fix shmem_free to perform no-op on null ptr

### DIFF
--- a/oshmem/shmem/c/shmem_free.c
+++ b/oshmem/shmem/c/shmem_free.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +42,12 @@ static inline void _shfree(void* ptr)
 {
     int rc;
 
-    RUNTIME_CHECK_INIT(); RUNTIME_CHECK_ADDR(ptr);
+    RUNTIME_CHECK_INIT();
+    if (NULL == ptr) {
+        return;
+    }
+
+    RUNTIME_CHECK_ADDR(ptr);
 
 #if OSHMEM_SPEC_COMPAT == 1
     shmem_barrier_all();


### PR DESCRIPTION
According to the shmem specification, performing a free on a NULL pointer should have no action. However, because we are checking to see if the pointer value is within a shmem region, we hit an assertion when freeing a NULL. I've added an explicit check to see if the pointer is NULL, so that shmem_free is a no-op on a NULL pointer.