### PR TITLE
v2.1.x: MPI_Comm_spawn_multiple.3in: update Fortran string array notes

### DIFF
--- a/ompi/mpi/man/man3/MPI_Comm_spawn_multiple.3in
+++ b/ompi/mpi/man/man3/MPI_Comm_spawn_multiple.3in
@@ -1,6 +1,6 @@
 .\" -*- nroff -*-
 .\" Copyright 2013 Los Alamos National Security, LLC. All rights reserved.
-.\" Copyright (c) 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
 .\" Copyright 2006-2008 Sun Microsystems, Inc.
 .\" Copyright (c) 1996 Thinking Machines Corporation
 .\" $COPYRIGHT$
@@ -231,6 +231,15 @@ Other restrictions apply to the
 parameter; see MPI_Comm_spawn(3)'s description of the
 .I argv
 parameter for more details.
+.sp
+MPI-3.1 implies (but does not directly state) that the argument
+\fIarray_of_commands\fP must be an array of strings of length
+\fIcount\fP.  Unlike the \fIarray_of_argv\fP parameter,
+\fIarray_of_commands\fP does not need to be terminated with a NULL
+pointer in C or a blank string in Fortran.  Older versions of Open MPI
+required that \fIarray_of_commands\fP be terminated with a blank
+string in Fortran; that is no longer required in this version of Open
+MPI.
 .sp
 Calling MPI_Comm_spawn(3) many times would create many sets of
 children with different MPI_COMM_WORLDs, whereas


### PR DESCRIPTION
Per 0ab6b201fed, note in the MPI_Comm_spawn_multiple.3in man page that
the array_of_commands does not need to be terminated -- it just need
to have exactly "count" entries.  In the Fortran binding, at least,
this is different than in prior released versions of Open MPI (it's
not a backwards incompatibility, since prior versions of Open MPI
required array_of_commands to be blank-string-terminated in Fortran --
this change makes Open MPI be *less* restrictive, and therefore still
backwards compatible).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit fc8ebbb0e09b83bfa19ad68dff4f07cb21c619cf)