### PR TITLE
configury: use javac vs javah whenever possible

### DIFF
--- a/ompi/mpi/java/java/Makefile.am
+++ b/ompi/mpi/java/java/Makefile.am
@@ -140,6 +140,7 @@ ompi__v_JAVADOC_QUIET_0 = -quiet
 # in.  This, along with the fact that the .java files seem to have
 # circular references, prevents us from using a .foo.bar: generic
 # Makefile rule. :-(
+if OPAL_HAVE_JAVAH_SUPPORT
 mpi/MPI.class: $(JAVA_SRC_FILES)
 	$(OMPI_V_JAVAC) CLASSPATH=. ; \
 	export CLASSPATH ; \
@@ -148,11 +149,18 @@ mpi/MPI.class: $(JAVA_SRC_FILES)
 # Similar to above, all the generated .h files are dependent upon the
 # token mpi/MPI.class file.  Hence, all the classes will be generated
 # first, then we'll individually generate each of the .h files.
+
 $(JAVA_H): mpi/MPI.class
 	$(OMPI_V_JAVAH) sourcename=mpi.`echo $@ | sed -e s/^mpi_// -e s/.h$$//`; \
 	CLASSPATH=. ; \
 	export CLASSPATH ; \
 	$(JAVAH) -d . -jni $$sourcename
+else
+mpi/MPI.class: $(JAVA_SRC_FILES)
+	$(OMPI_V_JAVAC) CLASSPATH=. ; \
+	export CLASSPATH ; \
+	$(JAVAC) -h . -d . $(top_srcdir)/ompi/mpi/java/java/*.java
+endif # OPAL_HAVE_JAVAH_SUPPORT
 
 # Generate the .jar file from all the class files.  List mpi/MPI.class
 # as a dependency so that it fires the rule above that will generate
@@ -171,7 +179,11 @@ java_DATA = mpi.jar
 # List all the header files in BUILT_SOURCES so that Automake's "all"
 # target will build them.  This will also force the building of the
 # mpi/*.class files (for the jar file).
+if OPAL_HAVE_JAVAH_SUPPORT
 BUILT_SOURCES = $(JAVA_H) doc
+else
+BUILT_SOURCES = mpi/MPI.class doc
+endif
 
 # Convenience for building Javadoc docs
 jdoc: doc


### PR DESCRIPTION
javah is no more available from Java 10, so try
javac -h first (available since Java 8) and fallback on javah

Refs. open-mpi/ompi#5000

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@5370586d98b880d3e14659252620bebca92022af)