### PR TITLE
configury: use javac vs javah whenever possible

### DIFF
--- a/config/opal_setup_java.m4
+++ b/config/opal_setup_java.m4
@@ -15,7 +15,7 @@ dnl                         reserved.
 dnl Copyright (c) 2007-2012 Oracle and/or its affiliates.  All rights reserved.
 dnl Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013      Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2015      Research Organization for Information Science
+dnl Copyright (c) 2015-2018 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -36,7 +36,7 @@ AC_DEFUN([OPAL_SETUP_JAVA_BANNER],[
 AC_DEFUN([OPAL_SETUP_JAVA],[
     AC_REQUIRE([OPAL_SETUP_JAVA_BANNER])
 
-    OPAL_VAR_SCOPE_PUSH([opal_java_bad opal_java_found opal_java_dir opal_java_jnih opal_java_PATH_save opal_java_CPPFLAGS_save])
+    OPAL_VAR_SCOPE_PUSH([opal_java_bad opal_javah_happy opal_java_found opal_java_dir opal_java_jnih opal_java_PATH_save opal_java_CPPFLAGS_save])
     AC_ARG_ENABLE(java,
                   AC_HELP_STRING([--enable-java],
                                  [Enable Java-based support in the system - use this option to disable all Java-based compiler tests (default: enabled)]))
@@ -160,12 +160,13 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
             AS_IF([test -n "$with_jdk_bindir" && test "$with_jdk_bindir" != "yes" && test "$with_jdk_bindir" != "no"],
                   [PATH="$with_jdk_bindir:$PATH"])
             AC_PATH_PROG(JAVAC, javac)
-            AC_PATH_PROG(JAVAH, javah)
             AC_PATH_PROG(JAR, jar)
+            AC_PATH_PROG(JAVADOC, javadoc)
+            AC_PATH_PROG(JAVAH, javah)
             PATH=$opal_java_PATH_save
 
             # Check to see if we have all 3 programs.
-            AS_IF([test -z "$JAVAC" || test -z "$JAVAH" || test -z "$JAR"],
+            AS_IF([test -z "$JAVAC" || test -z "$JAR" || test -z "$JAVADOC"],
                   [opal_java_happy=no
                    HAVE_JAVA_SUPPORT=0],
                   [opal_java_happy=yes
@@ -176,6 +177,21 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
                   [opal_java_CPPFLAGS_save=$CPPFLAGS
                    # silence a stupid Mac warning
                    CPPFLAGS="$CPPFLAGS -DTARGET_RT_MAC_CFM=0"
+                   AC_MSG_CHECKING([javac -h])
+                   cat > Conftest.java << EOF
+public final class Conftest {
+    public native void conftest();
+}
+EOF
+                   AS_IF([$JAVAC -d . -h . Conftest.java > /dev/null 2>&1],
+                         [AC_MSG_RESULT([yes])],
+                         [AC_MSG_RESULT([no])
+                          AS_IF([test -n "$JAVAH"],
+                                [opal_javah_happy=yes],
+                                [opal_java_happy=no])])
+                   rm -f Conftest.java Conftest.class Conftest.h
+
+
                    AS_IF([test -n "$with_jdk_headers" && test "$with_jdk_headers" != "yes" && test "$with_jdk_headers" != "no"],
                          [OPAL_JDK_CPPFLAGS="-I$with_jdk_headers"
                           # Some flavors of JDK also require -I<blah>/linux.
@@ -214,5 +230,6 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
 
     AC_DEFINE_UNQUOTED([OPAL_HAVE_JAVA_SUPPORT], [$HAVE_JAVA_SUPPORT], [do we have Java support])
     AM_CONDITIONAL(OPAL_HAVE_JAVA_SUPPORT, test "$opal_java_happy" = "yes")
+    AM_CONDITIONAL(OPAL_HAVE_JAVAH_SUPPORT, test "$opal_javah_happy" = "yes")
     OPAL_VAR_SCOPE_POP
 ])

--- a/ompi/mpi/java/java/Makefile.am
+++ b/ompi/mpi/java/java/Makefile.am
@@ -139,6 +139,7 @@ ompi__v_JAVADOC_QUIET_0 = -quiet
 # in.  This, along with the fact that the .java files seem to have
 # circular references, prevents us from using a .foo.bar: generic
 # Makefile rule. :-(
+if OPAL_HAVE_JAVAH_SUPPORT
 mpi/MPI.class: $(JAVA_SRC_FILES)
 	$(OMPI_V_JAVAC) CLASSPATH=. ; \
 	export CLASSPATH ; \
@@ -147,11 +148,18 @@ mpi/MPI.class: $(JAVA_SRC_FILES)
 # Similar to above, all the generated .h files are dependent upon the
 # token mpi/MPI.class file.  Hence, all the classes will be generated
 # first, then we'll individually generate each of the .h files.
+
 $(JAVA_H): mpi/MPI.class
 	$(OMPI_V_JAVAH) sourcename=mpi.`echo $@ | sed -e s/^mpi_// -e s/.h$$//`; \
 	CLASSPATH=. ; \
 	export CLASSPATH ; \
 	$(JAVAH) -d . -jni $$sourcename
+else
+mpi/MPI.class: $(JAVA_SRC_FILES)
+	$(OMPI_V_JAVAC) CLASSPATH=. ; \
+	export CLASSPATH ; \
+	$(JAVAC) -h . -d . $(top_srcdir)/ompi/mpi/java/java/*.java
+endif # OPAL_HAVE_JAVAH_SUPPORT
 
 # Generate the .jar file from all the class files.  List mpi/MPI.class
 # as a dependency so that it fires the rule above that will generate
@@ -170,7 +178,11 @@ java_DATA = mpi.jar
 # List all the header files in BUILT_SOURCES so that Automake's "all"
 # target will build them.  This will also force the building of the
 # mpi/*.class files (for the jar file).
+if OPAL_HAVE_JAVAH_SUPPORT
 BUILT_SOURCES = $(JAVA_H) doc
+else
+BUILT_SOURCES = mpi/MPI.class doc
+endif
 
 # Convenience for building Javadoc docs
 jdoc: doc


### PR DESCRIPTION
javah is no more available from Java 10, so try
javac -h first (available since Java 8) and fallback on javah

Refs. open-mpi/ompi#5000

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@5370586d98b880d3e14659252620bebca92022af)