### PR TITLE
configure: remove POWER 7/BE block

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,9 +69,12 @@ Master (not on release branches yet)
   true when using SLURM, as it improves interoperability with SLURM's signal
   propagation tools.  By default it is set to false, except for Cray XC systems.
 - Remove IB XRC support from the OpenIB BTL due to lack of support.
-- Remove support for big endian PowerPC.
-- Remove support for XL compilers older than v13.1
 - Fix rank-by algorithms to properly rank by object and span
+- Disable the POWER 7/BE block in configure.  Note that POWER 7/BE is
+  still not a supported platform, but it is no longer automatically
+  disabled.  See
+  https://github.com/open-mpi/ompi/issues/4349#issuecomment-374970982
+  for more information.
 
 3.0.1 -- March, 2018
 ----------------------

--- a/configure.ac
+++ b/configure.ac
@@ -84,17 +84,6 @@ AS_IF([test "$host" != "$target"],
       [AC_MSG_WARN([Cross-compile detected])
        AC_MSG_WARN([Cross-compiling is only partially supported])
        AC_MSG_WARN([Proceed at your own risk!])])
-# Check for architectures that we explicitly no longer support
-case "${host}" in
-    powerpc-*|powerpc64-*|ppc-*)
-        AC_MSG_ERROR([Big endian PPC is no longer supported.])
-        ;;
-esac
-case "${target}" in
-    powerpc-*|powerpc64-*|ppc-*)
-        AC_MSG_ERROR([Big endian PPC is no longer supported.])
-        ;;
-esac
 
 # AC_USE_SYSTEM_EXTENSIONS alters CFLAGS (e.g., adds -g -O2)
 OPAL_VAR_SCOPE_PUSH([CFLAGS_save])


### PR DESCRIPTION
Do not merge until #4563 is fixed.

Fixes #5032.

This will need to be cherry-picked to v2.x, v3.0.x, and v3.1.x.  Let's hope this his master before we branch for v4.0.x, but if it doesn't, it will need to be merged there, too.

Note that there's 2 commits on this PR: one that removes the block (and is easily cherry-picked) and another that contains the NEWS update (that almost certainly will not cherry-pick to the release branches properly).