### PR TITLE
v3.0.x: Move past the '.' when getting jobstepid

### DIFF
--- a/opal/mca/pmix/s1/pmix_s1.c
+++ b/opal/mca/pmix/s1/pmix_s1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
@@ -220,7 +220,7 @@ static int s1_init(opal_list_t *ilist)
     s1_pname.jobid = strtoul(pmix_id, &str, 10);
     s1_pname.jobid = (s1_pname.jobid << 16) & 0xffff0000;
     if (NULL != str) {
-        ui32 = strtoul(str, NULL, 10);
+        ui32 = strtoul(str+1, NULL, 10);
         s1_pname.jobid |= (ui32 & 0x0000ffff);
     }
     ldr.jobid = s1_pname.jobid;

--- a/opal/mca/pmix/s2/pmix_s2.c
+++ b/opal/mca/pmix/s2/pmix_s2.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC. All
  *                         rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -227,7 +227,7 @@ static int s2_init(opal_list_t *ilist)
     s2_pname.jobid = strtoul(pmix_kvs_name, &str, 10);
     s2_pname.jobid = (s2_pname.jobid << 16) & 0xffff0000;
     if (NULL != str) {
-        stepid = strtoul(str, NULL, 10);
+        stepid = strtoul(str+1, NULL, 10);
         s2_pname.jobid |= (stepid & 0x0000ffff);
     }
     s2_pname.vpid = s2_rank;


### PR DESCRIPTION
The strtoul function returns the pointer to the first non-digit character, which is a '.' in this case. Calling strtoul at that point will always yield a zero - you have to move past it to get the remaining number

Thanks to Greg Lee for the detailed analysis of the problem.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit cd52ccdb6833ac5e7300d9d96d0ddd4bf9d4dce2)

Master PR: #5010