### PR TITLE
mpool/memkind: be careful with the memkind API

### DIFF
--- a/opal/mca/mpool/memkind/configure.m4
+++ b/opal/mca/mpool/memkind/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
+# Copyright (c) 2013-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -24,7 +24,11 @@ AC_DEFUN([MCA_opal_mpool_memkind_CONFIG],[
 	        opal_check_memkind_dir=$with_memkind
 	    fi
 
-	    OPAL_CHECK_PACKAGE([mpool_memkind], [memkind.h], [memkind], [memkind_malloc], [ -lnuma],
+            #
+            # look specifically for memkind_get_kind_by_partition since
+            # this branch of Open MPI uses this now deprecated API.
+            #
+	    OPAL_CHECK_PACKAGE([mpool_memkind], [memkind.h], [memkind], [memkind_get_kind_by_partition], [ -lnuma],
 	        [$opal_check_memkind_dir], [], [opal_mpool_memkind_happy="yes"], [])
 
 	    if test "$opal_mpool_memkind_happy" != "yes" -a -n "$with_memkind" ; then


### PR DESCRIPTION
The memkind crew deprecated the API this branch of
Open MPI is using.  For certain releases,
these deprecated functions were dropped, causing
the Open MPI mpool/memkind to fail to compile.

Make a configury change to not build this component/abort
the config if a user is trying to use a newer version
of memkind which does not support this deprecated function.

Related to #4971

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 504b6e9d5be3960e430c7dec29f88979394d9abe)