### PR TITLE
v3.0.x: orterun.1in: fix typo

### DIFF
--- a/orte/tools/orterun/orterun.1in
+++ b/orte/tools/orterun/orterun.1in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
 .\" Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
 .\" Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
@@ -1495,7 +1495,7 @@ If the following command line is used:
     \fB%\fP mpirun --prefix /remote/node/directory
 
 Open MPI will add "/remote/node/directory/bin" to the \fIPATH\fR
-and "/remote/node/directory/lib64" to the \fLD_LIBRARY_PATH\fR on the
+and "/remote/node/directory/lib64" to the \fILD_LIBRARY_PATH\fR on the
 remote node before attempting to execute anything.
 .PP
 The \fI--prefix\fR option is not sufficient if the installation paths


### PR DESCRIPTION
Trivial man page typo fix.

Found via https://github.com/open-mpi/ompi-www/pull/61.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 7a6e8cac58ae4f4ef7da7c2aba9da179a9fcfca6)