### PR TITLE
v3.1.x: remove power7be configure block

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,17 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
+3.1.1 -- TBD
+------------
+
+Bug fixes/minor improvements:
+- Disable the POWER 7/BE block in configure.  Note that POWER 7/BE is
+  still not a supported platform, but it is no longer automatically
+  disabled.  See
+  https://github.com/open-mpi/ompi/issues/4349#issuecomment-374970982
+  for more information.
+
+
 3.1.0 -- March, 2018
 ----------------------
 

--- a/README
+++ b/README
@@ -140,6 +140,15 @@ General notes
     using the clang-4.0 system compiler. A workaround is to build
     Open MPI using the GNU compiler.
 
+Platform Notes
+--------------
+
+- ARM and POWER users may experience intermittent hangs when Open MPI
+  is compiled with low optimization settings, due to an issue with our
+  atomic list implementation.  We recommend compiling with -O3
+  optimization, both for performance reasons and to avoid this hang.
+
+
 Compiler Notes
 --------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -84,17 +84,6 @@ AS_IF([test "$host" != "$target"],
       [AC_MSG_WARN([Cross-compile detected])
        AC_MSG_WARN([Cross-compiling is only partially supported])
        AC_MSG_WARN([Proceed at your own risk!])])
-# Check for architectures that we explicitly no longer support
-case "${host}" in
-    powerpc-*|powerpc64-*|ppc-*)
-        AC_MSG_ERROR([Big endian PPC is no longer supported.])
-        ;;
-esac
-case "${target}" in
-    powerpc-*|powerpc64-*|ppc-*)
-        AC_MSG_ERROR([Big endian PPC is no longer supported.])
-        ;;
-esac
 
 # AC_USE_SYSTEM_EXTENSIONS alters CFLAGS (e.g., adds -g -O2)
 OPAL_VAR_SCOPE_PUSH([CFLAGS_save])


### PR DESCRIPTION
Per #5034 and larger discussion on #4349.

Still waiting for #4563 to be fixed (to resolve hangs on some ARM/POWER platforms), but that's a different issue.

RM: Note that the NEWS commit here is specifically for 3.1.1.  If you want to pull this back to v3.1.0, I can adjust the NEWS commit.