### PR TITLE
master: mtl-portals4: don't call progress() in finalize() if Portals4 was not initialized

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4.c
@@ -548,8 +548,10 @@ ompi_mtl_portals4_del_procs(struct mca_mtl_base_module_t *mtl,
 int
 ompi_mtl_portals4_finalize(struct mca_mtl_base_module_t *mtl)
 {
-    opal_progress_unregister(ompi_mtl_portals4_progress);
-    while (0 != ompi_mtl_portals4_progress()) { }
+    if (0 == ompi_mtl_portals4.need_init) {
+        opal_progress_unregister(ompi_mtl_portals4_progress);
+        while (0 != ompi_mtl_portals4_progress()) { }
+    }
 
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
     ompi_mtl_portals4_flowctl_fini();


### PR DESCRIPTION
This PR fixes a segfault in mtl-portals4 finalize().  The segfault
occurs if finalize() is called without any calls to add_procs().  This
commit resolves the segfault by skipping the progress() loop in
finalize() if the Portals was not initialized.

Signed-off-by: Todd Kordenbrock (thkgcode@gmail.com)
