### PR TITLE
plm/base: fix typo in variable name

### DIFF
--- a/orte/mca/plm/base/plm_base_frame.c
+++ b/orte/mca/plm/base/plm_base_frame.c
@@ -55,7 +55,7 @@ orte_plm_base_module_t orte_plm = {0};
 static int mca_plm_base_register(mca_base_register_flag_t flags)
 {
     orte_plm_globals.node_regex_threshold = 1024;
-    (void) mca_base_var_register("orte", "pml", "base", "node_regex_threshold",
+    (void) mca_base_framework_var_register (&orte_plm_base_framework, "node_regex_threshold",
                                  "Only pass the node regex on the orted command line if smaller than this threshold",
                                  MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0,
                                  MCA_BASE_VAR_FLAG_INTERNAL,


### PR DESCRIPTION
An incorrectly named variable caused all pml variables to disappear
from ompi_info. This commit fixes the typo. We may add some logic into
the MCA base to catch these sorts of things in the future.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>