### PR TITLE
v3.1.x: configure: Fix typo in `configure --help`

### DIFF
--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -133,7 +133,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
 
     AC_MSG_CHECKING([if want wrapper compiler runpath support])
     AC_ARG_ENABLE([wrapper-runpath],
-                  [AS_HELP_STRING([--enable--wrapper-runpath],
+                  [AS_HELP_STRING([--enable-wrapper-runpath],
                   [enable runpath in the wrapper compilers if linker supports it (default: enabled,  unless wrapper-rpath is disabled).])])
     AS_IF([test "$enable_wrapper_runpath" != "no"], [enable_wrapper_runpath=yes])
     AC_MSG_RESULT([$enable_wrapper_runpath])


### PR DESCRIPTION
This affects only output of `configure --help`.

This change is trivial and low risk. If RM prefers fix in v3.1.0, please change the milestone.

cherry picked from commit a01d4654c800a09d4adcec1d183f533028b9cf29
