### PR TITLE
status_set_cancelled: fix F08 binding

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
 ! Copyright (c) 2009-2015 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! Copyright (c) 2012      The University of Tennessee and The University
@@ -3503,7 +3503,7 @@ subroutine MPI_Status_set_cancelled_f08(status,flag,ierror)
    use :: mpi_f08_types, only : MPI_Status
    implicit none
    TYPE(MPI_Status), INTENT(INOUT) :: status
-   LOGICAL, INTENT(OUT) :: flag
+   LOGICAL, INTENT(IN) :: flag
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Status_set_cancelled_f08
 end interface  MPI_Status_set_cancelled

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
 ! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! Copyright (c) 2012      The University of Tennessee and The University
@@ -3503,7 +3503,7 @@ subroutine PMPI_Status_set_cancelled_f08(status,flag,ierror)
    use :: mpi_f08_types, only : MPI_Status
    implicit none
    TYPE(MPI_Status), INTENT(INOUT) :: status
-   LOGICAL, INTENT(OUT) :: flag
+   LOGICAL, INTENT(IN) :: flag
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Status_set_cancelled_f08
 end interface  PMPI_Status_set_cancelled

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pstatus_set_cancelled_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pstatus_set_cancelled_f08.F90
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !               All Rights reserved.
 ! $COPYRIGHT$
@@ -9,7 +9,7 @@ subroutine PMPI_Status_set_cancelled_f08(status,flag,ierror)
    use :: mpi_f08_types, only : MPI_Status
    implicit none
    TYPE(MPI_Status), INTENT(INOUT) :: status
-   LOGICAL, INTENT(OUT) :: flag
+   LOGICAL, INTENT(IN) :: flag
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 

--- a/ompi/mpi/fortran/use-mpi-f08/status_set_cancelled_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/status_set_cancelled_f08.F90
@@ -1,6 +1,6 @@
 ! -*- f90 -*-
 !
-! Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !               All Rights reserved.
 ! $COPYRIGHT$
@@ -9,7 +9,7 @@ subroutine MPI_Status_set_cancelled_f08(status,flag,ierror)
    use :: mpi_f08_types, only : MPI_Status
    implicit none
    TYPE(MPI_Status), INTENT(INOUT) :: status
-   LOGICAL, INTENT(OUT) :: flag
+   LOGICAL, INTENT(IN) :: flag
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 


### PR DESCRIPTION
The F08 bindings for MPI_STATUS_SET_CANCELLED incorrectly had the
"flag" dummy parameter set as INTENT(OUT) when it really should be
INTENT(IN).

On the one hand, this is technically an ABI change.  On the other
hand, this is an incorrect MPI binding.  On the other hand (that's 3
hands for you fans counting at home), this is such a rarely-used API
-- even in the C bindings -- that I'm guessing no one is using this
API, and therefore no one has noticed this error and it isn't worth
porting back to the release branches.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

I found this while reviewing #5077, so @hjelmn gets to review this one.  😄 