### PR TITLE
orte: only set the ORTE_NODE_ALIAS attribute when required

### DIFF
--- a/orte/mca/ess/hnp/ess_hnp_module.c
+++ b/orte/mca/ess/hnp/ess_hnp_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
+ * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -493,12 +493,14 @@ static int rte_init(void)
     if (orte_retain_aliases) {
         aliases = NULL;
         opal_ifgetaliases(&aliases);
-        /* add our own local name to it */
-        opal_argv_append_nosize(&aliases, orte_process_info.nodename);
-        aptr = opal_argv_join(aliases, ',');
+        if (0 < opal_argv_count(aliases)) {
+            /* add our own local name to it */
+            opal_argv_append_nosize(&aliases, orte_process_info.nodename);
+            aptr = opal_argv_join(aliases, ',');
+            orte_set_attribute(&node->attributes, ORTE_NODE_ALIAS, ORTE_ATTR_LOCAL, aptr, OPAL_STRING);
+            free(aptr);
+        }
         opal_argv_free(aliases);
-        orte_set_attribute(&node->attributes, ORTE_NODE_ALIAS, ORTE_ATTR_LOCAL, aptr, OPAL_STRING);
-        free(aptr);
     }
     /* record that the daemon job is running */
     jdata->num_procs = 1;

--- a/orte/mca/plm/base/plm_base_launch_support.c
+++ b/orte/mca/plm/base/plm_base_launch_support.c
@@ -1170,10 +1170,12 @@ void orte_plm_base_daemon_callback(int status, orte_process_name_t* sender,
                 opal_argv_append_nosize(&atmp, alias);
                 free(alias);
             }
-            alias = opal_argv_join(atmp, ',');
+            if (0 < naliases) {
+                alias = opal_argv_join(atmp, ',');
+                orte_set_attribute(&daemon->node->attributes, ORTE_NODE_ALIAS, ORTE_ATTR_LOCAL, alias, OPAL_STRING);
+                free(alias);
+            }
             opal_argv_free(atmp);
-            orte_set_attribute(&daemon->node->attributes, ORTE_NODE_ALIAS, ORTE_ATTR_LOCAL, alias, OPAL_STRING);
-            free(alias);
         }
 
         /* unpack the topology signature for that node */

--- a/orte/mca/ras/base/ras_base_node.c
+++ b/orte/mca/ras/base/ras_base_node.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -157,10 +157,12 @@ int orte_ras_base_node_insert(opal_list_t* nodes, orte_job_t *jdata)
                     opal_argv_free(nalias);
                 }
                 /* and store the result */
-                ptr = opal_argv_join(alias, ',');
+                if (0 < opal_argv_count(alias)) {
+                    ptr = opal_argv_join(alias, ',');
+                    orte_set_attribute(&hnp_node->attributes, ORTE_NODE_ALIAS, ORTE_ATTR_LOCAL, ptr, OPAL_STRING);
+                    free(ptr);
+                }
                 opal_argv_free(alias);
-                orte_set_attribute(&hnp_node->attributes, ORTE_NODE_ALIAS, ORTE_ATTR_LOCAL, ptr, OPAL_STRING);
-                free(ptr);
             }
             /* don't keep duplicate copy */
             OBJ_RELEASE(node);


### PR DESCRIPTION
When there is no alias for a given node, do not set the
ORTE_NODE_ALIAS attribute to an empty string any more.

Thanks Erico for reporting this issue.
Thanks Ralph for the guidance.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@a05456ab5ed4f415798b202abf251e28afa5c397)