### PR TITLE
fortran: build MPI_Sizeof() interface in use-mpi-tkr bindings

### DIFF
--- a/ompi/mpi/fortran/configure-fortran-output.h.in
+++ b/ompi/mpi/fortran/configure-fortran-output.h.in
@@ -3,7 +3,7 @@
 ! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
-! Copyright (c) 2017      Research Organization for Information Science
+! Copyright (c) 2017-2018 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 !
 ! $COPYRIGHT$
@@ -46,6 +46,8 @@
 ! Line 2 of the ignore TKR syntax
 #define OMPI_FORTRAN_IGNORE_TKR_TYPE @OMPI_FORTRAN_IGNORE_TKR_TYPE@
 
+
+#define OMPI_FORTRAN_BUILD_SIZEOF @OMPI_FORTRAN_BUILD_SIZEOF@
 ! Integers
 
 #define OMPI_HAVE_FORTRAN_INTEGER1 @OMPI_HAVE_FORTRAN_INTEGER1@

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -89,6 +89,8 @@ if BUILD_FORTRAN_SIZEOF
 nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES += \
      mpi-tkr-sizeof.h \
      mpi-tkr-sizeof.f90
+
+mpi.lo: mpi-tkr-sizeof.h
 endif
 
 # Note that we invoke some OPAL functions directly in

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2014-2016 Research Organization for Information Science
@@ -89,9 +89,8 @@ if BUILD_FORTRAN_SIZEOF
 nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES += \
      mpi-tkr-sizeof.h \
      mpi-tkr-sizeof.f90
-
-mpi.lo: mpi-tkr-sizeof.h
 endif
+mpi.lo: $(nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES)
 
 # Note that we invoke some OPAL functions directly in
 # libmpi_usempi.la, so we need to link in the OPAL library directly


### PR DESCRIPTION
whenever possible.

Add the missing OMPI_FORTRAN_BUILD_SIZEOF macro to Fortran
and add a missing dependency.

Thanks Themos Tsikas for reporting this issue.

Refs open-mpi/ompi#5085

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@2abeada0606dd7c7b03c2205149170853d8afbea)