### PR TITLE
fortran: build MPI_Sizeof() interface in use-mpi-tkr bindings

### DIFF
--- a/ompi/mpi/fortran/configure-fortran-output.h.in
+++ b/ompi/mpi/fortran/configure-fortran-output.h.in
@@ -3,6 +3,8 @@
 ! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST). All rights reserved.
 !
 ! $COPYRIGHT$
 !
@@ -47,6 +49,8 @@
 ! Line 2 of the ignore TKR syntax
 #define OMPI_FORTRAN_IGNORE_TKR_TYPE @OMPI_FORTRAN_IGNORE_TKR_TYPE@
 
+
+#define OMPI_FORTRAN_BUILD_SIZEOF @OMPI_FORTRAN_BUILD_SIZEOF@
 ! Integers
 
 #define OMPI_HAVE_FORTRAN_INTEGER1 @OMPI_HAVE_FORTRAN_INTEGER1@

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -85,6 +85,8 @@ if BUILD_FORTRAN_SIZEOF
 nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES += \
      mpi-tkr-sizeof.h \
      mpi-tkr-sizeof.f90
+
+mpi.lo: mpi-tkr-sizeof.h
 endif
 
 # Note that we invoke some OPAL functions directly in


### PR DESCRIPTION
whenever possible.

Add the missing OMPI_FORTRAN_BUILD_SIZEOF macro to Fortran
and add a missing dependency.

Thanks Themos Tsikas for reporting this issue.

Refs open-mpi/ompi#5085

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@2abeada0606dd7c7b03c2205149170853d8afbea)