### PR TITLE
Fix external PMIx v1.2.5 support

### DIFF
--- a/opal/mca/pmix/ext1x/pmix1x.h
+++ b/opal/mca/pmix/ext1x/pmix1x.h
@@ -36,6 +36,7 @@ BEGIN_C_DECLS
 typedef struct {
   opal_pmix_base_component_t super;
   opal_list_t jobids;
+  opal_list_t values;
   bool native_launch;
 } mca_pmix_ext1x_component_t;
 

--- a/opal/mca/pmix/ext1x/pmix1x_client.c
+++ b/opal/mca/pmix/ext1x/pmix1x_client.c
@@ -220,6 +220,7 @@ int pmix1_store_local(const opal_process_name_t *proc, opal_value_t *val)
     pmix_status_t rc;
     pmix_proc_t p;
     opal_pmix1_jobid_trkr_t *job, *jptr;
+    opal_value_t *hack;
 
     if (NULL != proc) {
         /* look thru our list of jobids and find the
@@ -232,8 +233,15 @@ int pmix1_store_local(const opal_process_name_t *proc, opal_value_t *val)
             }
         }
         if (NULL == job) {
-            OPAL_ERROR_LOG(OPAL_ERR_NOT_FOUND);
-            return OPAL_ERR_NOT_FOUND;
+            /* if we don't know about the job, then neither will the internal
+             * storage routine in PMIx. In this older version of PMIx, there
+             * is no way to insert an nspace into the client, and so we cannot
+             * get around the problem there. Instead, we need to hold such
+             * values locally in the component. Sadly, we cannot just use
+             * the input val param as it might not be dynamic, so copy it here */
+            opal_dss.copy((void**)&hack, val, OPAL_VALUE);
+            opal_list_append(&mca_pmix_ext1x_component.values, &hack->super);
+            return OPAL_SUCCESS;
         }
         (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
         p.rank = proc->vpid;
@@ -445,6 +453,15 @@ int pmix1_get(const opal_process_name_t *proc, const char *key,
             }
         }
         if (NULL == job) {
+            /* see if we have this key on our local value list */
+            OPAL_LIST_FOREACH(ival, &mca_pmix_ext1x_component.values, opal_value_t) {
+                if (0 == strcmp(key, ival->key)) {
+                    /* got it */
+                    opal_dss.copy((void**)val, ival, OPAL_VALUE);
+                    return OPAL_SUCCESS;
+                }
+            }
+            /* otherwise, we can't find it */
             return OPAL_ERR_NOT_FOUND;
         }
         (void)strncpy(p.nspace, job->nspace, PMIX_MAX_NSLEN);
@@ -495,6 +512,9 @@ int pmix1_get(const opal_process_name_t *proc, const char *key,
             ret = OPAL_SUCCESS;
         } else {
             *val = OBJ_NEW(opal_value_t);
+            if (NULL != key) {
+                (*val)->key = strdup(key);
+            }
             ret = pmix1_value_unload(*val, kv);
             PMIX_VALUE_FREE(kv, 1);
         }

--- a/opal/mca/pmix/ext1x/pmix1x_component.c
+++ b/opal/mca/pmix/ext1x/pmix1x_component.c
@@ -104,6 +104,7 @@ static int external_open(void)
     const char *version;
 
     OBJ_CONSTRUCT(&mca_pmix_ext1x_component.jobids, opal_list_t);
+    OBJ_CONSTRUCT(&mca_pmix_ext1x_component.values, opal_list_t);
 
     version = PMIx_Get_version();
     if (0 != strncmp(version, "1.2", 3)) {
@@ -117,6 +118,7 @@ static int external_open(void)
 static int external_close(void)
 {
     OPAL_LIST_DESTRUCT(&mca_pmix_ext1x_component.jobids);
+    OPAL_LIST_DESTRUCT(&mca_pmix_ext1x_component.values);
     return OPAL_SUCCESS;
 }
 


### PR DESCRIPTION
As @hjelmn and I discussed, this is a little hacky. However, it is the only solution that can be done solely from the OMPI side.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>