### PR TITLE
fortran/tkr: Fix Makefile.am warnings

### DIFF
--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2014-2016 Research Organization for Information Science
@@ -89,9 +89,8 @@ if BUILD_FORTRAN_SIZEOF
 nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES += \
      mpi-tkr-sizeof.h \
      mpi-tkr-sizeof.f90
-
-mpi.lo: mpi-tkr-sizeof.h
 endif
+mpi.lo: $(nodist_lib@OMPI_LIBMPI_NAME@_usempi_la_SOURCES)
 
 # Note that we invoke some OPAL functions directly in
 # libmpi_usempi.la, so we need to link in the OPAL library directly


### PR DESCRIPTION
Set mpi.lo dependencies outside of AM conditionals.  Per
https://github.com/open-mpi/ompi/issues/5085, make mpi.lo depend on
whatever we decide the sizeof source files are (which may be empty, if
this compiler does not support the Right Stuff for MPI_SIZEOF, or it
may be mpi-tkr-sizeof.[h|f90]).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

This is a follow-on to #5085.  It fixes the autogen warnings that @rhc54 cited in https://github.com/open-mpi/ompi/issues/5085#issuecomment-384333070.  If this is this correct solution, it should be added to the existing PRs for the #5085 function on the v2.x, v3.0.x, and v3.1.x PRs.