### PR TITLE
v3.1: config/opal_setup_java.m4:  Improve JDK tool path resolution on OS X/…

### DIFF
--- a/config/opal_setup_java.m4
+++ b/config/opal_setup_java.m4
@@ -113,8 +113,8 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
                           with_jdk_headers=$opal_java_dir/include
                           with_jdk_bindir=$opal_java_dir/bin
                       else
-                          AC_MSG_WARN([No recognized directory structure found under $opal_java_dir])
-                          AC_MSG_ERROR([Cannot continue])
+                          AC_MSG_WARN([No recognized OS X/macOS JDK directory structure found under $opal_java_dir])
+                          opal_java_found=0
                       fi],
                      [AC_MSG_RESULT([not found])])
 


### PR DESCRIPTION
…macOS.

Also avoid picking up Apple's Java shims via the sym. links to them in
`/usr/bin` on systems where any one of them could possibly exhibit behavior
that is erratic and, to some extent, likely to be incorrect nowadays (cf.:

- https://www.mail-archive.com/devel@lists.open-mpi.org/msg20551.html
- https://github.com/open-mpi/ompi/pull/5015#issuecomment-379324639
- the last part  of
  https://github.com/open-mpi/ompi/pull/5015#discussion_r184187064
- https://github.com/open-mpi/ompi/pull/5015#issuecomment-384136871

for more detailed context.)

Works alongside #5001 to close #5000.

Signed-off-by: Bryce Glover <RandomDSdevel@gmail.com>

(cherry picked from commit open-mpi/ompi@8c32cd8970991df3497e6db9d8eab2b6dcbacbee)