### PR TITLE
config/opal_setup_java.m4:  Improve JDK tool path resolution on OS X/…

### DIFF
--- a/config/opal_setup_java.m4
+++ b/config/opal_setup_java.m4
@@ -92,18 +92,29 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
         # hard-code a few of the common ones so that users don't have to
         # specify --with-java-<foo>=LONG_ANNOYING_DIRECTORY.
         AS_IF([test -z "$with_jdk_bindir"],
-              [ # OS X Snow Leopard and Lion (10.6 and 10.7 -- did not
-                # check prior versions)
+              [ # OS X/macOS
                opal_java_found=0
+               # The following logic was deliberately decided upon in https://github.com/open-mpi/ompi/pull/5015 specifically to prevent this script and the
+               # rest of Open MPI's build system from getting confused by the somewhat unorthodox Java toolchain layout present on OS X/macOS systems, described
+               # in depth by https://github.com/open-mpi/ompi/pull/5015#issuecomment-379324639, and mishandling OS X/macOS Java toolchain path
+               # detection as a result.
                AS_IF([test -x /usr/libexec/java_home],
-                    [opal_java_dir=`/usr/libexec/java_home`/include],
-                    [opal_java_dir=/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers])
-               AC_MSG_CHECKING([OSX locations])
+                     [opal_java_dir=`/usr/libexec/java_home`],
+                     [opal_java_dir=/System/Library/Frameworks/JavaVM.framework/Versions/Current])
+               AC_MSG_CHECKING([OS X/macOS locations])
                AS_IF([test -d $opal_java_dir],
                      [AC_MSG_RESULT([found ($opal_java_dir)])
                       opal_java_found=1
-                      with_jdk_headers=$opal_java_dir
-                      with_jdk_bindir=/usr/bin],
+                      if test -d "$opal_java_dir/Headers" && test -d "$opal_java_dir/Commands"; then
+                          with_jdk_headers=$opal_java_dir/Headers
+                          with_jdk_bindir=$opal_java_dir/Commands
+                      elif test -d "$opal_java_dir/include" && test -d "$opal_java_dir/bin"; then
+                          with_jdk_headers=$opal_java_dir/include
+                          with_jdk_bindir=$opal_java_dir/bin
+                      else
+                          AC_MSG_WARN([No recognized directory structure found under $opal_java_dir])
+                          AC_MSG_ERROR([Cannot continue])
+                      fi],
                      [AC_MSG_RESULT([not found])])
 
                if test "$opal_java_found" = "0"; then


### PR DESCRIPTION
…macOS.

Also avoid picking up Apple's Java shims via the sym. links to them in
`/usr/bin` on systems where any one of them could possibly exhibit behavior
that is erratic and, to some extent, likely to be incorrect nowadays (cf.:

- https://www.mail-archive.com/devel@lists.open-mpi.org/msg20551.html
- https://github.com/open-mpi/ompi/pull/5015#issuecomment-379324639
- the last part  of
  https://github.com/open-mpi/ompi/pull/5015#discussion_r184187064
- https://github.com/open-mpi/ompi/pull/5015#issuecomment-384136871

for more detailed context.)

Works alongside #5001 to close #5000.

Signed-off-by: Bryce Glover <RandomDSdevel@gmail.com>

(cherry picked from commit open-mpi/ompi@8c32cd8970991df3497e6db9d8eab2b6dcbacbee)