### PR TITLE
OMPI/OSC/UCX: set priority to 0. （v3.1.x)

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -29,6 +29,7 @@ typedef struct ompi_osc_ucx_component {
     bool enable_mpi_threads;
     opal_free_list_t requests; /* request free list for the r* communication variants */
     int num_incomplete_req_ops;
+    unsigned int priority;
 } ompi_osc_ucx_component_t;
 
 OMPI_DECLSPEC extern ompi_osc_ucx_component_t mca_osc_ucx_component;

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -91,6 +91,15 @@ static int component_open(void) {
 }
 
 static int component_register(void) {
+    char *description_str;
+    mca_osc_ucx_component.priority = 0;
+    asprintf(&description_str, "Priority of the osc/ucx component (default: %d)",
+             mca_osc_ucx_component.priority);
+    (void) mca_base_component_var_register(&mca_osc_ucx_component.super.osc_version, "priority", description_str,
+                                           MCA_BASE_VAR_TYPE_UNSIGNED_INT, NULL, 0, 0, OPAL_INFO_LVL_3,
+                                           MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_ucx_component.priority);
+    free(description_str);
+
     return OMPI_SUCCESS;
 }
 
@@ -201,7 +210,7 @@ static int component_finalize(void) {
 static int component_query(struct ompi_win_t *win, void **base, size_t size, int disp_unit,
                            struct ompi_communicator_t *comm, struct opal_info_t *info, int flavor) {
     if (MPI_WIN_FLAVOR_SHARED == flavor) return -1;
-    return 100;
+    return mca_osc_ucx_component.priority;
 }
 
 static inline int allgather_len_and_info(void *my_info, int my_info_len, char **recv_info,


### PR DESCRIPTION
cherry-picked from #5134 