### PR TITLE
Fixing 'make check' test opal_fifo.

### DIFF
--- a/test/class/opal_fifo.c
+++ b/test/class/opal_fifo.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -103,7 +104,7 @@ static void *thread_test_exhaust (void *arg) {
 
 static bool check_fifo_consistency (opal_fifo_t *fifo, int expected_count)
 {
-    opal_list_item_t *item;
+    volatile opal_list_item_t *volatile item;
     int count;
 
     for (count = 0, item = fifo->opal_fifo_head.data.item ; item != &fifo->opal_fifo_ghost ;


### PR DESCRIPTION
xlc on ppc64le complains about incompatible pointer types discards qualifiers.
This fix allows 'make check' to pass on ppc64le Power9 for master and v3.1.x.

> opal_fifo.c:110:26: warning: assigning to 'opal_list_item_t *' (aka 'struct opal_list_item_t *') from
>       'volatile opal_list_item_t *volatile' (aka 'volatile struct opal_list_item_t *volatile') discards qualifiers
>       [-Wincompatible-pointer-types-discards-qualifiers]
>     for (count = 0, item = fifo->opal_fifo_head.data.item ; item != &fifo->opal_fifo_ghost ;
>                          ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> 1 warning generated.

v3.1.x version of PR #5144
Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>
(cherry picked from commit cc9f713d09381699e6052d1fea1c0232eb9852e2)