### PR TITLE
coll: reduce_scatter_block: rename and MCA parameter description fix

### DIFF
--- a/ompi/mca/coll/base/coll_base_functions.h
+++ b/ompi/mca/coll/base/coll_base_functions.h
@@ -250,7 +250,7 @@ int ompi_coll_base_reduce_scatter_intra_basic_recursivehalving(REDUCESCATTER_ARG
 int ompi_coll_base_reduce_scatter_intra_ring(REDUCESCATTER_ARGS);
 
 /* Reduce_scatter_block */
-int ompi_coll_base_reduce_scatter_block_basic(REDUCESCATTERBLOCK_ARGS);
+int ompi_coll_base_reduce_scatter_block_basic_linear(REDUCESCATTERBLOCK_ARGS);
 int ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(REDUCESCATTERBLOCK_ARGS);
 
 /* Scan */

--- a/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
+++ b/ompi/mca/coll/base/coll_base_reduce_scatter_block.c
@@ -41,7 +41,7 @@
 #include "coll_base_util.h"
 
 /*
- *	ompi_reduce_scatter_block_basic
+ *	ompi_reduce_scatter_block_basic_linear
  *
  *	Function:	- reduce then scatter
  *	Accepts:	- same as MPI_Reduce_scatter_block()
@@ -52,11 +52,11 @@
  *     up at some point)
  */
 int
-ompi_coll_base_reduce_scatter_block_basic(const void *sbuf, void *rbuf, int rcount,
-                                          struct ompi_datatype_t *dtype,
-                                          struct ompi_op_t *op,
-                                          struct ompi_communicator_t *comm,
-                                          mca_coll_base_module_t *module)
+ompi_coll_base_reduce_scatter_block_basic_linear(const void *sbuf, void *rbuf, int rcount,
+                                                 struct ompi_datatype_t *dtype,
+                                                 struct ompi_op_t *op,
+                                                 struct ompi_communicator_t *comm,
+                                                 mca_coll_base_module_t *module)
 {
     int rank, size, count, err = OMPI_SUCCESS;
     ptrdiff_t gap, span;

--- a/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
+++ b/ompi/mca/coll/basic/coll_basic_reduce_scatter_block.c
@@ -57,7 +57,7 @@ mca_coll_basic_reduce_scatter_block_intra(const void *sbuf, void *rbuf, int rcou
                                           struct ompi_communicator_t *comm,
                                           mca_coll_base_module_t *module)
 {
-    return ompi_coll_base_reduce_scatter_block_basic(sbuf, rbuf, rcount, dtype, op, comm, module);
+    return ompi_coll_base_reduce_scatter_block_basic_linear(sbuf, rbuf, rcount, dtype, op, comm, module);
 }
 
 /*

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -516,8 +516,8 @@ int ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed(const void *sbuf, void 
                                                          mca_coll_base_module_t *module)
 {
     OPAL_OUTPUT((ompi_coll_tuned_stream, "ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed"));
-    return ompi_coll_base_reduce_scatter_block_basic(sbuf, rbuf, rcount,
-                                                     dtype, op, comm, module);
+    return ompi_coll_base_reduce_scatter_block_basic_linear(sbuf, rbuf, rcount,
+                                                            dtype, op, comm, module);
 }
 
 /*

--- a/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
+++ b/ompi/mca/coll/tuned/coll_tuned_reduce_scatter_block_decision.c
@@ -33,7 +33,7 @@ static int coll_tuned_reduce_scatter_block_tree_fanout;
 /* valid values for coll_tuned_reduce_scatter_blokc_forced_algorithm */
 static mca_base_var_enum_value_t reduce_scatter_block_algorithms[] = {
     {0, "ignore"},
-    {1, "basic"},
+    {1, "basic_linear"},
     {2, "recursive_doubling"},
     {0, NULL}
 };
@@ -74,7 +74,7 @@ int ompi_coll_tuned_reduce_scatter_block_intra_check_forced_init (coll_tuned_for
         mca_base_component_var_register(&mca_coll_tuned_component.super.collm_version,
                                         "reduce_scatter_block_algorithm",
                                         "Which reduce reduce_scatter_block algorithm is used. "
-                                        "Can be locked down to choice of: 0 ignore, 1 recursive doubling",
+                                        "Can be locked down to choice of: 0 ignore, 1 basic_linear, 2 recursive_doubling",
                                         MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                         OPAL_INFO_LVL_5,
                                         MCA_BASE_VAR_SCOPE_ALL,
@@ -121,8 +121,8 @@ int ompi_coll_tuned_reduce_scatter_block_intra_do_this(const void *sbuf, void *r
     switch (algorithm) {
     case (0): return ompi_coll_tuned_reduce_scatter_block_intra_dec_fixed(sbuf, rbuf, rcount,
                                                                           dtype, op, comm, module);
-    case (1): return ompi_coll_base_reduce_scatter_block_basic(sbuf, rbuf, rcount,
-                                                               dtype, op, comm, module);
+    case (1): return ompi_coll_base_reduce_scatter_block_basic_linear(sbuf, rbuf, rcount,
+                                                                      dtype, op, comm, module);
     case (2): return ompi_coll_base_reduce_scatter_block_intra_recursivedoubling(sbuf, rbuf, rcount,
                                                                                  dtype, op, comm, module);
     } /* switch */


### PR DESCRIPTION
 - rename ompi_coll_base_reduce_scatter_block_basic to
   more self descriptive ompi_coll_base_reduce_scatter_block_basic_linear
 - fix the description of the coll_tuned_reduce_scatter_block_algorithm
   MCA param

this fixes and documents previous open-mpi/ompi@0e8b35b6157c90a53dcffec1927f3f282b2d1777

MPI_Reduce_scatter_block used to be implemented by the coll/basic module only.
A new algo (recursive doubling) was recently introduced and can be used via the coll/tuned module,
but we never intended to make it the default algo.
In order to "restore" the previous default, the initial algo was moved from coll/basic to coll/base,
and is now used by default by coll/tuned.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>