### PR TITLE
v3.0.x: Fix config/opal_setup_java.m4 from commit merged in #5119

### DIFF
--- a/config/opal_setup_java.m4
+++ b/config/opal_setup_java.m4
@@ -112,8 +112,8 @@ AC_DEFUN([OPAL_SETUP_JAVA],[
                           with_jdk_headers=$opal_java_dir/include
                           with_jdk_bindir=$opal_java_dir/bin
                       else
-                          AC_MSG_WARN([No recognized directory structure found under $opal_java_dir])
-                          AC_MSG_ERROR([Cannot continue])
+                          AC_MSG_WARN([No recognized OS X/macOS JDK directory structure found under $opal_java_dir])
+                          opal_java_found=0
                       fi],
                      [AC_MSG_RESULT([not found])])
 


### PR DESCRIPTION
That PR accidentally changed Open MPI's build configuration infrastructure's Java toolchain detection logic so that it would, as reported by @bosilca in https://github.com/open-mpi/ompi/pull/5001#issuecomment-387803012 and tracked down by me in https://github.com/open-mpi/ompi/pull/5001#issuecomment-387851005, abort your entire in-progress Open MPI build when it failed to find an OS X/macOS JDK instead of simply falling back to checking for a JDK in locations where it would be found on other platforms.  _Oops…!_

Signed-off-by: Bryce Glover <RandomDSdevel@gmail.com>
(cherry picked from commit 4a05c7e29fbe5e20b2b6eb52db529cf19979f8f7)

This is the v3.0.x version of the last java configury fix from #5160 (#5119 was already merged into v3.0.x branch, so I had to make a new PR for this one additional commit -- #5118 will include this PR when @ggouaillardet pulls it in).