### PR TITLE
patch/overwrite: add support for aarch64

### DIFF
--- a/opal/mca/patcher/base/patcher_base_patch.c
+++ b/opal/mca/patcher/base/patcher_base_patch.c
@@ -106,6 +106,8 @@ static void flush_and_invalidate_cache (unsigned long a)
     __asm__ volatile("mfence;clflush %0;mfence" : :"m" (*(char*)a));
 #elif OPAL_ASSEMBLY_ARCH == OPAL_IA64
     __asm__ volatile ("fc %0;; sync.i;; srlz.i;;" : : "r"(a) : "memory");
+#elif OPAL_ASSEMBLY_ARCH == OPAL_ARM64
+    __asm__ volatile ("dsb sy");
 #endif
 }
 

--- a/opal/mca/patcher/overwrite/configure.m4
+++ b/opal/mca/patcher/overwrite/configure.m4
@@ -32,7 +32,7 @@ AC_DEFUN([MCA_opal_patcher_overwrite_CONFIG],[
     if test $OPAL_ENABLE_DLOPEN_SUPPORT = 1; then
 # Disable ia64 for now. We can revive it later if anyone cares
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#if !defined(__i386__) && !defined(__x86_64__) && !defined(__PPC__)
+#if !defined(__i386__) && !defined(__x86_64__) && !defined(__PPC__) && !defined(__aarch64__)
 #error "platform not supported"
 #endif
 ]],[])],[opal_patcher_overwrite_happy=yes],[])


### PR DESCRIPTION
This commit adds patcher support of aarch64. The current
implementation uses mov, movk, and br to perform the jump. This uses 5
instructions.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>