### PR TITLE
dist: Update shared library versions for v3.0.2

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -82,16 +82,16 @@ date="Unreleased developer copy"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=40:1:0
+libmpi_so_version=40:2:0
 libmpi_cxx_so_version=40:0:0
-libmpi_mpifh_so_version=40:0:0
-libmpi_usempi_tkr_so_version=40:0:0
-libmpi_usempi_ignore_tkr_so_version=40:0:0
-libmpi_usempif08_so_version=40:0:0
-libopen_rte_so_version=40:1:0
-libopen_pal_so_version=41:0:1
+libmpi_mpifh_so_version=40:1:0
+libmpi_usempi_tkr_so_version=40:1:0
+libmpi_usempi_ignore_tkr_so_version=40:1:0
+libmpi_usempif08_so_version=40:1:0
+libopen_rte_so_version=40:2:0
+libopen_pal_so_version=41:1:1
 libmpi_java_so_version=40:0:0
-liboshmem_so_version=41:0:1
+liboshmem_so_version=41:1:1
 libompitrace_so_version=40:0:0
 
 # "Common" components install standalone libraries that are run-time
@@ -100,7 +100,7 @@ libompitrace_so_version=40:0:0
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=41:0:0
+libmca_ompi_common_ompio_so_version=41:1:0
 
 # ORTE layer
 libmca_orte_common_alps_so_version=40:0:0
@@ -110,4 +110,4 @@ libmca_opal_common_cuda_so_version=40:0:0
 libmca_opal_common_libfabric_so_version=40:0:0
 libmca_opal_common_sm_so_version=40:0:0
 libmca_opal_common_ugni_so_version=40:0:0
-libmca_opal_common_verbs_so_version=40:0:0
+libmca_opal_common_verbs_so_version=41:0:1


### PR DESCRIPTION
All the FORTRAN interfaces saw changes for COMM_SPAWN_MULTIPLE
handling.  We're calling the named parameter fixes an interface
addition (and not removal) under the assumption that no one was
using the old (wrong, hard to discover) names, but could use the
new names.

The verbose interface add was the define for the HDR link speeds.

All other changes were code changes identified through git log.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>