### PR TITLE
Disable OSHMEM layer when no SPMLs available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2015 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2014      Intel, Inc. All rights reserved.
-# Copyright (c) 2017      Amazon.com, Inc. or its affiliates.
+# Copyright (c) 2017-2018 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
 #
@@ -22,6 +22,7 @@
 #
 
 SUBDIRS = config contrib $(MCA_PROJECT_SUBDIRS) test
+DIST_SUBDIRS = config contrib $(MCA_PROJECT_DIST_SUBDIRS) test
 EXTRA_DIST = README INSTALL VERSION Doxyfile LICENSE autogen.pl README.JAVA.txt AUTHORS
 
 include examples/Makefile.include

--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,9 @@ Master (not on release branches yet)
 ------------------------------------
 
 - Fix rank-by algorithms to properly rank by object and span
+- Do not build Open SHMEM layer when there are no SPMLs available.
+  Currently, this means the Open SHMEM layer will only build if
+  a MXM or UCX library is found.
 
 3.1.0 -- May, 2018
 ------------------

--- a/config/opal_mca.m4
+++ b/config/opal_mca.m4
@@ -12,6 +12,8 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+dnl Copyright (c) 2018      Amazon.com, Inc. or its affiliates.
+dnl                         All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -225,16 +227,19 @@ AC_DEFUN([OPAL_MCA],[
     # now configure all the projects, frameworks, and components.  Most
     # of the hard stuff is in here
     MCA_PROJECT_SUBDIRS=
+    MCA_PROJECT_DIST_SUBDIRS=
     m4_foreach(mca_project, [mca_project_list],
                [# BWB: Until projects have separate configure scripts
                 # and can skip running all of ORTE, just avoid recursing
                 # into orte sub directory if orte disabled
                 if (test "mca_project" = "ompi" && test "$enable_mpi" != "no") || test "mca_project" = "opal" || test "mca_project" = "orte" || test "mca_project" = "oshmem"; then
                    MCA_PROJECT_SUBDIRS="$MCA_PROJECT_SUBDIRS mca_project"
+                   MCA_PROJECT_DIST_SUBDIRS="$MCA_PROJECT_DIST_SUBDIRS mca_project"
                 fi
                 MCA_CONFIGURE_PROJECT(mca_project)])
 
     AC_SUBST(MCA_PROJECT_SUBDIRS)
+    AC_SUBST(MCA_PROJECT_DIST_SUBDIRS)
 
     m4_undefine([mca_component_configure_active])
 ])

--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -76,8 +76,10 @@ EOF
 
     if test "$project_oshmem_amc" = "true" ; then
         echo "Build Open SHMEM support: yes"
-    else
+    elif test -z "$project_oshmem_amc" ; then
         echo "Build Open SHMEM support: no"
+    else
+	echo "Build Open SHMEM support: $project_oshmem_amc"
     fi
 
     if test $WANT_DEBUG = 0 ; then

--- a/config/oshmem_configure_options.m4
+++ b/config/oshmem_configure_options.m4
@@ -6,6 +6,8 @@ dnl Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2014      Intel, Inc. All rights reserved
 dnl Copyright (c) 2014-2015 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2018      Amazon.com, Inc. or its affiliates.
+dnl                         All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -25,27 +27,22 @@ AC_SUBST(OSHMEM_LIBSHMEM_EXTRA_LDFLAGS)
 AC_MSG_CHECKING([if want oshmem])
 AC_ARG_ENABLE([oshmem],
               [AC_HELP_STRING([--enable-oshmem],
-                              [Enable building the OpenSHMEM interface (available on Linux only, where it is enabled by default)])],
-              [oshmem_arg_given=yes],
-              [oshmem_arg_given=no])
-if test "$oshmem_arg_given" = "yes"; then
-    if test "$enable_oshmem" = "yes"; then
-        AC_MSG_RESULT([yes])
-        if test "$opal_found_linux" != "yes"; then
-            AC_MSG_WARN([OpenSHMEM support was requested, but currently])
-            AC_MSG_WARN([only supports Linux.])
-            AC_MSG_ERROR([Cannot continue])
-        fi
-    else
-        AC_MSG_RESULT([no])
-    fi
-else
+                              [Enable building the OpenSHMEM interface (available on Linux only, where it is enabled by default)])])
+if test "$enable_oshmem" = "no"; then
+    AC_MSG_RESULT([no])
+elif test "$enable_oshmem" = ""; then
     if test "$opal_found_linux" = "yes"; then
-        enable_oshmem=yes
         AC_MSG_RESULT([yes])
     else
         enable_oshmem=no
         AC_MSG_RESULT([not supported on this platform])
+    fi
+else
+    AC_MSG_RESULT([yes])
+    if test "$opal_found_linux" != "yes"; then
+        AC_MSG_WARN([OpenSHMEM support was requested, but currently])
+        AC_MSG_WARN([only supports Linux.])
+        AC_MSG_ERROR([Cannot continue])
     fi
 fi
 
@@ -56,7 +53,7 @@ AC_MSG_CHECKING([if want SGI/Quadrics compatibility mode])
 AC_ARG_ENABLE(oshmem-compat,
         AC_HELP_STRING([--enable-oshmem-compat],
             [enable compatibility mode (default: enabled)]))
-if test "$enable_oshmem" != "no" && test "$enable_oshmem_compat" != "no"; then
+if test "$enable_oshmem_compat" != "no"; then
     AC_MSG_RESULT([yes])
     OSHMEM_SPEC_COMPAT=1
 else
@@ -75,26 +72,21 @@ AC_MSG_CHECKING([if want OSHMEM API parameter checking])
 AC_ARG_WITH(oshmem-param-check,
     AC_HELP_STRING([--with-oshmem-param-check(=VALUE)],
                    [behavior of OSHMEM API function parameter checking.  Valid values are: always, never.  If --with-oshmem-param-check is specified with no VALUE argument, it is equivalent to a VALUE of "always"; --without-oshmem-param-check is equivalent to "never" (default: always).]))
-if test "$enable_oshmem" != "no"; then
-    if test "$with_oshmem_param_check" = "no" || \
-       test "$with_oshmem_param_check" = "never"; then
-        shmem_param_check=0
-        AC_MSG_RESULT([never])
-    elif test "$with_oshmem_param_check" = "yes" || \
-         test "$with_oshmem_param_check" = "always" || \
-         test -z "$with_oshmem_param_check"; then
-        shmem_param_check=1
-        AC_MSG_RESULT([always])
-    else
-        shmem_param_check=1
-        AC_MSG_RESULT([unknown])
-        AC_MSG_WARN([*** Unrecognized --with-oshmem-param-check value])
-        AC_MSG_WARN([*** See "configure --help" output])
-        AC_MSG_WARN([*** Defaulting to "always"])
-    fi
-else
+if test "$with_oshmem_param_check" = "no" || \
+	test "$with_oshmem_param_check" = "never"; then
     shmem_param_check=0
-    AC_MSG_RESULT([no])
+    AC_MSG_RESULT([never])
+elif test "$with_oshmem_param_check" = "yes" || \
+        test "$with_oshmem_param_check" = "always" || \
+        test -z "$with_oshmem_param_check"; then
+    shmem_param_check=1
+    AC_MSG_RESULT([always])
+else
+    shmem_param_check=1
+    AC_MSG_RESULT([unknown])
+    AC_MSG_WARN([*** Unrecognized --with-oshmem-param-check value])
+    AC_MSG_WARN([*** See "configure --help" output])
+    AC_MSG_WARN([*** Defaulting to "always"])
 fi
 AC_DEFINE_UNQUOTED(OSHMEM_PARAM_CHECK, $shmem_param_check,
     [Whether we want to check OSHMEM parameters always or never])
@@ -132,7 +124,7 @@ AC_MSG_CHECKING([if want to build OSHMEM fortran bindings])
 AC_ARG_ENABLE(oshmem-fortran,
 AC_HELP_STRING([--enable-oshmem-fortran],
                [enable OSHMEM Fortran bindings (default: enabled if Fortran compiler found)]))
-if test "$enable_oshmem" != "no" && test "$enable_oshmem_fortran" != "no"; then
+if test "$enable_oshmem_fortran" != "no"; then
 # If no OMPI FORTRAN, bail
    AS_IF([test $OMPI_TRY_FORTRAN_BINDINGS -eq $OMPI_FORTRAN_NO_BINDINGS && \
           test "$enable_oshmem_fortran" = "yes"],

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,8 @@
 # Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
+# Copyright (c) 2018      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -266,15 +268,12 @@ m4_ifdef([project_oshmem], [OSHMEM_CONFIGURE_OPTIONS])
 # Set up project specific AM_CONDITIONALs
 AS_IF([test "$enable_ompi" != "no"], [project_ompi_amc=true], [project_ompi_amc=false])
 m4_ifndef([project_ompi], [project_ompi_amc=false])
-AM_CONDITIONAL([PROJECT_OMPI], [test "$project_ompi_amc" = "true"])
 
 AS_IF([test "$enable_orte" != "no"], [project_orte_amc=true], [project_orte_amc=false])
 m4_ifndef([project_orte], [project_orte_amc=false])
-AM_CONDITIONAL([PROJECT_ORTE], [test "$project_orte_amc" = "true"])
 
 AS_IF([test "$enable_oshmem" != "no"], [project_oshmem_amc=true], [project_oshmem_amc=false])
 m4_ifndef([project_oshmem], [project_oshmem_amc=false])
-AM_CONDITIONAL([PROJECT_OSHMEM], [test "$project_oshmem_amc" = "true"])
 
 if test "$enable_binaries" = "no" && test "$enable_dist" = "yes"; then
     AC_MSG_WARN([--disable-binaries is incompatible with --enable dist])
@@ -1343,6 +1342,14 @@ m4_ifdef([project_ompi],
 ############################################################################
 # Party on
 ############################################################################
+
+# set projects good/no good AM_CONDITIONALS.  This is at the end so
+# that the OSHMEM/OMPI projects can be disabled, if needed, based on
+# MCA tests.  If a project is to be disabled, also remove it from
+# MCA_PROJECT_SUBDIRS to actually disable building.
+AM_CONDITIONAL([PROJECT_OMPI], [test "$project_ompi_amc" = "true"])
+AM_CONDITIONAL([PROJECT_ORTE], [test "$project_orte_amc" = "true"])
+AM_CONDITIONAL([PROJECT_OSHMEM], [test "$project_oshmem_amc" = "true"])
 
 AC_MSG_CHECKING([if libtool needs -no-undefined flag to build shared libraries])
 case "`uname`" in

--- a/configure.ac
+++ b/configure.ac
@@ -272,8 +272,8 @@ m4_ifndef([project_ompi], [project_ompi_amc=false])
 AS_IF([test "$enable_orte" != "no"], [project_orte_amc=true], [project_orte_amc=false])
 m4_ifndef([project_orte], [project_orte_amc=false])
 
-AS_IF([test "$enable_oshmem" != "no"], [project_oshmem_amc=true], [project_oshmem_amc=false])
-m4_ifndef([project_oshmem], [project_oshmem_amc=false])
+AS_IF([test "$enable_oshmem" != "no"], [project_oshmem_amc=true], [project_oshmem_amc="no (disabled)"])
+m4_ifndef([project_oshmem], [project_oshmem_amc="no (not available)"])
 
 if test "$enable_binaries" = "no" && test "$enable_dist" = "yes"; then
     AC_MSG_WARN([--disable-binaries is incompatible with --enable dist])
@@ -1105,6 +1105,23 @@ AC_MSG_RESULT([$opal_subdir_args])
 OPAL_MCA
 
 m4_ifdef([project_ompi], [OMPI_REQUIRE_ENDPOINT_TAG_FINI])
+
+# Last minute disable of OpenSHMEM if we didn't find any oshmem SPMLs
+if test "$project_oshmem_amc" = "true" && test $OSHMEM_FOUND_WORKING_SPML -eq 0 ; then
+    # We don't have an spml that will work, so oshmem wouldn't be able
+    # to run an application.  Therefore, don't build the oshmem layer.
+    if test "$enable_oshmem" != "no" && test -n "$enable_oshmem"; then
+	AC_MSG_WARN([No spml found, so OpenSHMEM layer will be non functional.])
+	AC_MSG_ERROR([Aborting because OpenSHMEM requested, but can not build.])
+    else
+	AC_MSG_WARN([No spml found.  Will not build OpenSHMEM layer.])
+	project_oshmem_amc="false (no spml)"
+	# now for the hard part, remove project from list that will
+	# run.  This is a hack, but it works as long as the project
+	# remains named "oshmem".
+	MCA_PROJECT_SUBDIRS=`echo "$MCA_PROJECT_SUBDIRS" | sed -e 's/oshmem//'`
+    fi
+fi
 
 # checkpoint results
 AC_CACHE_SAVE

--- a/oshmem/mca/spml/configure.m4
+++ b/oshmem/mca/spml/configure.m4
@@ -16,4 +16,10 @@ AC_DEFUN([MCA_oshmem_spml_CONFIG],[
 
     # this is a direct callable component, so set that up.
     MCA_SETUP_DIRECT_CALL($1, $2)
+
+    if test -z "$MCA_$1_$2_DSO_COMPONENTS" && test -z "$MCA_$1_$2_STATIC_COMPONENTS"; then
+	OSHMEM_FOUND_WORKING_SPML=0
+    else
+	OSHMEM_FOUND_WORKING_SPML=1
+    fi
 ])


### PR DESCRIPTION
Implement the action item from last devel meeting to not build the OSHMEM layer when there are no SPMLs available (ie, the shmem layer can't possibly work).