### PR TITLE
- Build warning: stringop-overflow in get_dynamic_win_info() at osc_ucx_comm.c

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -332,7 +332,8 @@ static inline int get_dynamic_win_info(uint64_t remote_addr, ompi_osc_ucx_module
     size_t len = sizeof(uint64_t) + sizeof(ompi_osc_dynamic_win_info_t) * OMPI_OSC_UCX_ATTACH_MAX;
     char *temp_buf = malloc(len);
     ompi_osc_dynamic_win_info_t *temp_dynamic_wins;
-    int win_count, contain, insert = -1;
+    uint64_t win_count;
+    int contain, insert = -1;
     ucs_status_t status;
 
     if ((module->win_info_array[target]).rkey_init == true) {


### PR DESCRIPTION
```
In file included from /usr/include/string.h:494:0,
                 from ../../../../ompi/info/info.h:29,
                 from ../../../../ompi/mca/osc/base/base.h:24,
                 from osc_ucx_comm.c:13:
In function 'memcpy',
    inlined from 'get_dynamic_win_info' at osc_ucx_comm.c:359:5,
    inlined from 'ompi_osc_ucx_put' at osc_ucx_comm.c:401:18:
/usr/include/bits/string_fortified.h:34:10: warning: '__builtin___memcpy_chk' writing 8 bytes into a region of size 4 overflows the destination [-Wstringop-overflow=]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This is caused by a type size mismatch in a call to memcpy

This fix corrects the type definition of the win_count variable.

Signed-off-by: John Jolly <jjolly@suse.com>

Fixes #5183 