### PR TITLE
MCA/UCX: fixed error messages for incorrect msg size

### DIFF
--- a/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
@@ -63,7 +63,7 @@ int mca_atomic_ucx_cswap(void *target,
     return ucx_status_to_oshmem(status);
 
 err_size:
-    ATOMIC_ERROR("[#%d] Type size must be 1/2/4 or 8 bytes.", my_pe);
+    ATOMIC_ERROR("[#%d] Type size must be 4 or 8 bytes.", my_pe);
     return OSHMEM_ERROR;
 }
 

--- a/oshmem/mca/atomic/ucx/atomic_ucx_fadd.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_fadd.c
@@ -63,6 +63,6 @@ int mca_atomic_ucx_fadd(void *target,
     return ucx_status_to_oshmem(status);
 
 err_size:
-    ATOMIC_ERROR("[#%d] Type size must be 1/2/4 or 8 bytes.", my_pe);
+    ATOMIC_ERROR("[#%d] Type size must be 4 or 8 bytes.", my_pe);
     return OSHMEM_ERROR;
 }


### PR DESCRIPTION
- supported 4 or 8 bytes only

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>