### PR TITLE
configure: use AC_LINK_IFELSE instead of AC_COMPILE_IFELSE for C11 tests

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -29,9 +29,9 @@ AC_DEFUN([OPAL_CC_HELPER],[
 
     opal_prog_cc_c11_helper_tmp=0
 
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([$3],[$4])],[
-                          $2=yes
-                          opal_prog_cc_c11_helper_tmp=1], [$2=no])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([$3],[$4])],[
+                       $2=yes
+                       opal_prog_cc_c11_helper_tmp=1], [$2=no])
 
     AC_DEFINE_UNQUOTED([$5], [$opal_prog_cc_c11_helper_tmp], [$6])
 


### PR DESCRIPTION
This addresses #5189. It's also a workaround for #5190 in my particular case, but doesn't address the underlying problem there of the macros being defined multiple times.

Signed-off-by: Ben Menadue <ben.menadue@nci.org.au>