### PR TITLE
io/ompio: fix an erroneous condition when selecting aggregator selection algorithm

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -172,7 +172,7 @@ int mca_common_ompio_set_view (mca_io_ompio_file_t *fh,
        }
     }
 
-    if ( SIMPLE != mca_io_ompio_grouping_option || SIMPLE_PLUS != mca_io_ompio_grouping_option ) {
+    if ( SIMPLE != mca_io_ompio_grouping_option && SIMPLE_PLUS != mca_io_ompio_grouping_option ) {
 
         ret = mca_io_ompio_fview_based_grouping(fh,
                                                 &num_groups,


### PR DESCRIPTION
fix the logic in the decision which aggregator selection algorithm
to use.. Note, that this lead to a suboptimal decision, but was not necessarily a problem.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>