### PR TITLE
osc/pt2pt: disable when THREAD_MULITPLE

### DIFF
--- a/ompi/mca/osc/pt2pt/Makefile.am
+++ b/ompi/mca/osc/pt2pt/Makefile.am
@@ -19,6 +19,8 @@
 # $HEADER$
 #
 
+dist_ompidata_DATA = help-osc-pt2pt.txt
+
 pt2pt_sources = \
 	osc_pt2pt.h \
 	osc_pt2pt_module.c \

--- a/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
+++ b/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
@@ -1,0 +1,15 @@
+# -*- text -*-
+#
+# Copyright (c) 2016 Los Alamos National Security, LLC. All rights
+#                    reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+[mpi-thread-multiple-not-supported]
+The OSC pt2pt component does not support MPI_THREAD_MULTIPLE in this release.
+Workarounds are to run on a single node, or to use a system with an RDMA
+capable network such as Infiniband.

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -25,6 +25,7 @@
  */
 
 #include "ompi_config.h"
+#include "opal/util/show_help.h"
 
 #include <string.h>
 
@@ -108,6 +109,7 @@ ompi_osc_pt2pt_module_t ompi_osc_pt2pt_module_template = {
 };
 
 bool ompi_osc_pt2pt_no_locks = false;
+static bool using_thread_multiple = false;
 
 /* look up parameters for configuring this window.  The code first
    looks in the info structure passed by the user, then through mca
@@ -206,6 +208,10 @@ component_init(bool enable_progress_threads,
 {
     int ret;
 
+    if (enable_mpi_threads) {
+        using_thread_multiple = true;
+    }
+
     OBJ_CONSTRUCT(&mca_osc_pt2pt_component.lock, opal_mutex_t);
     OBJ_CONSTRUCT(&mca_osc_pt2pt_component.pending_operations, opal_list_t);
     OBJ_CONSTRUCT(&mca_osc_pt2pt_component.pending_operations_lock, opal_mutex_t);
@@ -301,6 +307,15 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     /* We don't support shared windows; that's for the sm onesided
        component */
     if (MPI_WIN_FLAVOR_SHARED == flavor) return OMPI_ERR_NOT_SUPPORTED;
+
+    /*
+     * workaround for issue https://github.com/open-mpi/ompi/issues/2614
+     * The following check needs to be removed once 2614 is addressed.
+     */
+    if (using_thread_multiple) {
+        opal_show_help("help-osc-pt2pt.txt", "mpi-thread-multiple-not-supported", true);
+        return OMPI_ERR_NOT_SUPPORTED;
+    }
 
     /* create module structure with all fields initialized to zero */
     module = (ompi_osc_pt2pt_module_t*)


### PR DESCRIPTION
osc/pt2pt: disable osc/pt2pt with THREAD_MULTIPLE.

Per discussion at https://github.com/open-mpi/ompi/issues/2614#issuecomment-392815654, do not allow for selection of the OSC PT2PT when creating an MPI RMA window when THREAD_MULTIPLE is active.  Print a helpful message and return a not-supported error.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

(cherry picked from commit d0ffd660841623c02d1dfa3151e7f7afd3327698)

This will be PR'ed to v3.0.x and v3.1.x when merged to master (and will naturally be included in v4.0.x because we haven't branched for it yet).

Fixes #2614.