### PR TITLE
v3.0.x: osc/pt2pt: disable when THREAD_MULTIPLE.

### DIFF
--- a/ompi/mca/osc/pt2pt/Makefile.am
+++ b/ompi/mca/osc/pt2pt/Makefile.am
@@ -19,6 +19,8 @@
 # $HEADER$
 #
 
+dist_ompidata_DATA = help-osc-pt2pt.txt
+
 pt2pt_sources = \
 	osc_pt2pt.h \
 	osc_pt2pt_module.c \

--- a/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
+++ b/ompi/mca/osc/pt2pt/help-osc-pt2pt.txt
@@ -1,0 +1,15 @@
+# -*- text -*-
+#
+# Copyright (c) 2016 Los Alamos National Security, LLC. All rights
+#                    reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+[mpi-thread-multiple-not-supported]
+The OSC pt2pt component does not support MPI_THREAD_MULTIPLE in this release.
+Workarounds are to run on a single node, or to use a system with an RDMA
+capable network such as Infiniband.


### PR DESCRIPTION
Per discussion at
https://github.com/open-mpi/ompi/issues/2614#issuecomment-392815654,
do not allow for selection of the OSC PT2PT when creating an MPI RMA
window when THREAD_MULTIPLE is active.  Print a helpful message and
return a not-supported error.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

(cherry picked from commit d0ffd660841623c02d1dfa3151e7f7afd3327698)
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 5b7c866f59d9d148166f6a7157772790fab7dbec)

Per https://github.com/open-mpi/ompi/issues/2614#issuecomment-392815654, we decided to disable osc/pt2pt on v3.0.x when THREAD_MULTIPLE.  Problem will be solved a different way (see that comment for more details).