### PR TITLE
java: Improve descriptions of `javadoc`

### DIFF
--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -13,7 +13,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1137,8 +1137,8 @@ public class Comm implements Freeable, Cloneable
 	/**
 	 * Returns the type of topology associated with the communicator.
 	 * <p>Java binding of the MPI operation {@code MPI_TOPO_TEST}.
-	 * <p>The return value will be one of {@code MPI.GRAPH}, {@code MPI.CART}
-	 * or {@code MPI.UNDEFINED}.
+	 * <p>The return value will be one of {@code MPI.GRAPH}, {@code MPI.CART},
+	 * {@code MPI.DIST_GRAPH} or {@code MPI.UNDEFINED}.
 	 * @return topology type of communicator
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
 	 */
@@ -1170,7 +1170,7 @@ public class Comm implements Freeable, Cloneable
 
 	/**
 	 * Associates a new error handler with communicator at the calling process.
-	 * <p>Java binding of the MPI operation {@code MPI_ERRHANDLER_SET}.
+	 * <p>Java binding of the MPI operation {@code MPI_COMM_SET_ERRHANDLER}.
 	 * @param errhandler new MPI error handler for communicator
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
 	 */
@@ -1185,7 +1185,7 @@ public class Comm implements Freeable, Cloneable
 
 	/**
 	 * Returns the error handler currently associated with the communicator.
-	 * <p>Java binding of the MPI operation {@code MPI_ERRHANDLER_GET}.
+	 * <p>Java binding of the MPI operation {@code MPI_COMM_GET_ERRHANDLER}.
 	 * @return MPI error handler currently associated with communicator
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
 	 */
@@ -2385,9 +2385,9 @@ public class Comm implements Freeable, Cloneable
 					throws MPIException;
 
 	/**
-	 * Adds flexibility to {@code allToAll}: location of data for send is  //here
-	 * specified by {@code sDispls} and location to place data on receive
-	 * side is specified by {@code rDispls}.
+	 * Adds more flexibility to {@code allToAllv}: datatypes for send are
+	 * specified by {@code sendTypes} and datatypes for receive are specified
+	 * by {@code recvTypes} per process.
 	 * <p>Java binding of the MPI operation {@code MPI_ALLTOALLW}.
 	 * @param sendBuf   send buffer
 	 * @param sendCount number of items sent to each buffer
@@ -2421,9 +2421,9 @@ public class Comm implements Freeable, Cloneable
 					throws MPIException;
 
 	/**
-	 * Adds flexibility to {@code iAllToAll}: location of data for send is
-	 * specified by {@code sDispls} and location to place data on receive
-	 * side is specified by {@code rDispls}.
+	 * Adds more flexibility to {@code iAllToAllv}: datatypes for send are
+	 * specified by {@code sendTypes} and datatypes for receive are specified
+	 * by {@code recvTypes} per process.
 	 * <p>Java binding of the MPI operation {@code MPI_IALLTOALLW}.
 	 * @param sendBuf   send buffer
 	 * @param sendCount number of items sent to each buffer

--- a/ompi/mpi/java/java/Datatype.java
+++ b/ompi/mpi/java/java/Datatype.java
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -419,7 +420,7 @@ public final class Datatype implements Freeable, Cloneable
 
 	/**
 	 * The most general type constructor.
-	 * <p>Java binding of the MPI operation {@code MPI_TYPE_STRUCT}.
+	 * <p>Java binding of the MPI operation {@code MPI_TYPE_CREATE_STRUCT}.
 	 * <p>The number of blocks is taken to be size of the {@code blockLengths}
 	 * argument. The second and third arguments, {@code displacements},
 	 * and {@code types}, should be the same size.

--- a/ompi/mpi/java/java/File.java
+++ b/ompi/mpi/java/java/File.java
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -153,7 +153,7 @@ public final class File
 
 	/**
 	 * Java binding of {@code MPI_FILE_GET_GROUP}.
-	 * @return group wich opened the file
+	 * @return group which opened the file
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
 	 */
 	public Group getGroup() throws MPIException

--- a/ompi/mpi/java/java/Info.java
+++ b/ompi/mpi/java/java/Info.java
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,7 +70,7 @@ public final class Info implements Freeable, Cloneable
 			throws MPIException;
 
 	/**
-	 * Java binding of the MPI operation {@code MPI_INFO_SET}.
+	 * Java binding of the MPI operation {@code MPI_INFO_GET}.
 	 * @param key key
 	 * @return value or {@code null} if key is not defined
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
@@ -83,7 +84,7 @@ public final class Info implements Freeable, Cloneable
 	private native String get(long handle, String key) throws MPIException;
 
 	/**
-	 * Java binding of the MPI operation {@code MPI_INFO_SET}.
+	 * Java binding of the MPI operation {@code MPI_INFO_DELETE}.
 	 * @param key key
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
 	 */

--- a/ompi/mpi/java/java/MPI.java
+++ b/ompi/mpi/java/java/MPI.java
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -528,7 +529,7 @@ public final class MPI
 
 	/**
 	 * Returns resolution of timer.
-	 * <p>Java binding of the MPI operation {MPI_WTICK}.
+	 * <p>Java binding of the MPI operation {@code MPI_WTICK}.
 	 * @return resolution of {@code wtime} in seconds.
 	 * @throws MPIException Signals that an MPI exception of some sort has occurred.
 	 */

--- a/ompi/mpi/java/java/Op.java
+++ b/ompi/mpi/java/java/Op.java
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,7 +110,7 @@ public final class Op implements Freeable
 	}
 
 	/**
-	 * Test if the operation is conmutative.
+	 * Test if the operation is commutative.
 	 * <p>Java binding of the MPI operation {@code MPI_OP_COMMUTATIVE}.
 	 * @return {@code true} if commutative, {@code false} otherwise
 	 */


### PR DESCRIPTION
- Improve descriptions
- Fix some typos
- Remove MPI-1 functions and replace them with MPI-2 functions

Signed-off-by: Kurita, Takehiro <fj6370fp@aa.jp.fujitsu.com>