### PR TITLE
opal/asm: change ll/sc atomics to macros

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Copyright (c) 2010      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2011      University of Houston. All rights reserved.
 Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 Copyright (c) 2015      NVIDIA Corporation.  All rights reserved.
-Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
+Copyright (c) 2017-2018 Los Alamos National Security, LLC.  All rights
                         reserved.
 Copyright (c) 2017      Research Organization for Information Science
                         and Technology (RIST). All rights reserved.
@@ -143,10 +143,7 @@ General notes
 Platform Notes
 --------------
 
-- ARM and POWER users may experience intermittent hangs when Open MPI
-  is compiled with low optimization settings, due to an issue with our
-  atomic list implementation.  We recommend compiling with -O3
-  optimization, both for performance reasons and to avoid this hang.
+- N/A
 
 Compiler Notes
 --------------

--- a/opal/class/opal_fifo.h
+++ b/opal/class/opal_fifo.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
- * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
  *                         reseved.
  * $COPYRIGHT$
  *
@@ -183,9 +183,10 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
 static inline opal_list_item_t *opal_fifo_push_atomic (opal_fifo_t *fifo,
                                                        opal_list_item_t *item)
 {
+    const opal_list_item_t * const ghost = &fifo->opal_fifo_ghost;
     opal_list_item_t *tail_item;
 
-    item->opal_list_next = &fifo->opal_fifo_ghost;
+    item->opal_list_next = (opal_list_item_t *) ghost;
 
     opal_atomic_wmb ();
 
@@ -194,7 +195,7 @@ static inline opal_list_item_t *opal_fifo_push_atomic (opal_fifo_t *fifo,
 
     opal_atomic_wmb ();
 
-    if (&fifo->opal_fifo_ghost == tail_item) {
+    if (ghost == tail_item) {
         /* update the head */
         fifo->opal_fifo_head.data.item = item;
     } else {
@@ -212,12 +213,22 @@ static inline opal_list_item_t *opal_fifo_push_atomic (opal_fifo_t *fifo,
  */
 static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
 {
-    opal_list_item_t *item, *next, *ghost = &fifo->opal_fifo_ghost;
+    const opal_list_item_t * const ghost = &fifo->opal_fifo_ghost;
 
 #if OPAL_HAVE_ATOMIC_LLSC_PTR
+    register opal_list_item_t *item, *next;
+    int attempt = 0, ret = 0;
+
     /* use load-linked store-conditional to avoid ABA issues */
     do {
-        item = opal_atomic_ll_ptr (&fifo->opal_fifo_head.data.item);
+        if (++attempt == 5) {
+            /* deliberatly suspend this thread to allow other threads to run. this should
+             * only occur during periods of contention on the lifo. */
+            _opal_lifo_release_cpu ();
+            attempt = 0;
+        }
+
+        opal_atomic_ll_ptr(&fifo->opal_fifo_head.data.item, item);
         if (ghost == item) {
             if (ghost == fifo->opal_fifo_tail.data.item) {
                 return NULL;
@@ -229,11 +240,12 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
         }
 
         next = (opal_list_item_t *) item->opal_list_next;
-        if (opal_atomic_sc_ptr (&fifo->opal_fifo_head.data.item, next)) {
-            break;
-        }
-    } while (1);
+        opal_atomic_sc_ptr(&fifo->opal_fifo_head.data.item, next, ret);
+    } while (!ret);
+
 #else
+    opal_list_item_t *item, *next;
+
     /* protect against ABA issues by "locking" the head */
     do {
         if (!opal_atomic_swap_32 ((volatile int32_t *) &fifo->opal_fifo_head.data.counter, 1)) {
@@ -258,10 +270,10 @@ static inline opal_list_item_t *opal_fifo_pop_atomic (opal_fifo_t *fifo)
     if (ghost == next) {
         void *tmp = item;
 
-        if (!opal_atomic_compare_exchange_strong_ptr (&fifo->opal_fifo_tail.data.item, &tmp, ghost)) {
-            while (ghost == item->opal_list_next) {
+        if (!opal_atomic_compare_exchange_strong_ptr (&fifo->opal_fifo_tail.data.item, &tmp, (void *) ghost)) {
+            do {
                 opal_atomic_rmb ();
-            }
+            } while (ghost == item->opal_list_next);
 
             fifo->opal_fifo_head.data.item = (opal_list_item_t *) item->opal_list_next;
         }

--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -162,28 +162,31 @@ static inline bool opal_atomic_compare_exchange_strong_rel_32 (volatile int32_t 
     return ret;
 }
 
-static inline int32_t opal_atomic_ll_32 (volatile int32_t *addr)
-{
-    int32_t ret;
+#define opal_atomic_ll_32(addr, ret)                                    \
+    do {                                                                \
+        volatile int32_t *_addr = (addr);                               \
+        int32_t _ret;                                                   \
+                                                                        \
+        __asm__ __volatile__ ("ldaxr    %w0, [%1]          \n"          \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr));                           \
+                                                                        \
+        ret = (typeof(ret)) _ret;                                       \
+    } while (0)
 
-    __asm__ __volatile__ ("ldaxr    %w0, [%1]          \n"
-                          : "=&r" (ret)
-                          : "r" (addr));
-
-    return ret;
-}
-
-static inline int opal_atomic_sc_32 (volatile int32_t *addr, int32_t newval)
-{
-    int ret;
-
-    __asm__ __volatile__ ("stlxr    %w0, %w2, [%1]     \n"
-                          : "=&r" (ret)
-                          : "r" (addr), "r" (newval)
-                          : "cc", "memory");
-
-    return ret == 0;
-}
+#define opal_atomic_sc_32(addr, newval, ret)                            \
+    do {                                                                \
+        volatile int32_t *_addr = (addr);                               \
+        int32_t _newval = (int32_t) newval;                             \
+        int _ret;                                                       \
+                                                                        \
+        __asm__ __volatile__ ("stlxr    %w0, %w2, [%1]     \n"          \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr), "r" (_newval)              \
+                              : "cc", "memory");                        \
+                                                                        \
+        ret = (_ret == 0);                                              \
+    } while (0)
 
 static inline bool opal_atomic_compare_exchange_strong_64 (volatile int64_t *addr, int64_t *oldval, int64_t newval)
 {
@@ -269,28 +272,31 @@ static inline bool opal_atomic_compare_exchange_strong_rel_64 (volatile int64_t 
     return ret;
 }
 
-static inline int64_t opal_atomic_ll_64 (volatile int64_t *addr)
-{
-    int64_t ret;
+#define opal_atomic_ll_64(addr, ret)                            \
+    do {                                                        \
+        volatile int64_t *_addr = (addr);                       \
+        int64_t _ret;                                           \
+                                                                \
+        __asm__ __volatile__ ("ldaxr    %0, [%1]          \n"   \
+                              : "=&r" (_ret)                    \
+                              : "r" (_addr));                   \
+                                                                \
+        ret = (typeof(ret)) _ret;                               \
+    } while (0)
 
-    __asm__ __volatile__ ("ldaxr    %0, [%1]        \n"
-                          : "=&r" (ret)
-                          : "r" (addr));
-
-    return ret;
-}
-
-static inline int opal_atomic_sc_64 (volatile int64_t *addr, int64_t newval)
-{
-    int ret;
-
-    __asm__ __volatile__ ("stlxr    %w0, %2, [%1]    \n"
-                          : "=&r" (ret)
-                          : "r" (addr), "r" (newval)
-                          : "cc", "memory");
-
-    return ret == 0;
-}
+#define opal_atomic_sc_64(addr, newval, ret)                            \
+    do {                                                                \
+        volatile int64_t *_addr = (addr);                               \
+        int64_t _newval = (int64_t) newval;                             \
+        int _ret;                                                       \
+                                                                        \
+        __asm__ __volatile__ ("stlxr    %w0, %2, [%1]     \n"           \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr), "r" (_newval)              \
+                              : "cc", "memory");                        \
+                                                                        \
+        ret = (_ret == 0);                                              \
+    } while (0)
 
 #define OPAL_ASM_MAKE_ATOMIC(type, bits, name, inst, reg)                   \
     static inline type opal_atomic_fetch_ ## name ## _ ## bits (volatile type *addr, type value) \

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -308,15 +308,15 @@ OPAL_ATOMIC_DEFINE_CMPXCG_PTR_XX(_rel_)
 
 #if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_LLSC_32
 
-#define opal_atomic_ll_ptr(addr) (void *) opal_atomic_ll_32((int32_t *) addr)
-#define opal_atomic_sc_ptr(addr, newval) opal_atomic_sc_32((int32_t *) addr, (int32_t) newval)
+#define opal_atomic_ll_ptr(addr, ret) opal_atomic_ll_32((volatile int32_t *) (addr), ret)
+#define opal_atomic_sc_ptr(addr, value, ret) opal_atomic_sc_32((volatile int32_t *) (addr), (intptr_t) (value), ret)
 
 #define OPAL_HAVE_ATOMIC_LLSC_PTR 1
 
 #elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_LLSC_64
 
-#define opal_atomic_ll_ptr(addr) (void *) opal_atomic_ll_64((int64_t *) addr)
-#define opal_atomic_sc_ptr(addr, newval) opal_atomic_sc_64((int64_t *) addr, (int64_t) newval)
+#define opal_atomic_ll_ptr(addr, ret) opal_atomic_ll_64((volatile int64_t *) (addr), ret)
+#define opal_atomic_sc_ptr(addr, value, ret) opal_atomic_sc_64((volatile int64_t *) (addr), (intptr_t) (value), ret)
 
 #define OPAL_HAVE_ATOMIC_LLSC_PTR 1
 


### PR DESCRIPTION
This commit fixes a hang that occurs with debug builds of Open MPI on
aarch64 and power/powerpc systems. When the ll/sc atomics are inline
functions the compiler emits load/store instructions for the function
arguments with -O0. These extra load/store arguments can cause the ll
reservation to be cancelled causing live-lock.

Note that we did attempt to fix this with always_inline but the extra
instructions are stil emitted by the compiler (gcc). There may be
another fix but this has been tested and is working well.

References #3697. Close when applied to v3.0.x and v3.1.x.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>