### PR TITLE
fortran/mpif-h: fix MPI1 compatibility Makefile

### DIFF
--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -15,7 +15,7 @@
 # Copyright (c) 2011-2013 Universite Bordeaux 1
 # Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2015-2017 Research Organization for Information Science
+# Copyright (c) 2015-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
@@ -393,7 +393,7 @@ linked_files = \
         pwin_flush_local_all_f.c
 
 if OMPI_ENABLE_MPI1_COMPAT
-linked_files = \
+linked_files += \
         paddress_f.c \
         pattr_delete_f.c \
         pattr_get_f.c \


### PR DESCRIPTION
appends MPI1 compatible source files instead of redefining all the source files
fix a typo from open-mpi/ompi@89da9651bb2fe26900ac16aa074d0efb11073251

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>