### PR TITLE
fcoll/dynamic_gen2: ensure some variables can hold an intermediate value

### DIFF
--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -1379,7 +1379,8 @@ int mca_fcoll_dynamic_gen2_break_file_view ( struct iovec *mem_iov, int mem_coun
     }
     
     /* Step 1: separate the local_iov_array per aggregator */
-    int owner, rest, len, temp_len, blocklen, memlen=0;
+    int owner;
+    size_t rest, len, temp_len, blocklen, memlen=0;
     off_t offset, temp_offset, start_offset, memoffset=0;
 
     i=j=0;


### PR DESCRIPTION
make sure that intermediate variables can hold the displacement

for very large offsets, ome ariables used in the fcoll/dynamic_gen2
code base were under certain circumstances not large enough to hold
intermediate values. This issue was detected in the vulcan component
but could happen in the dynamic_gen2 component as well.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>