### PR TITLE
btl/ofi: the component now compiles with libfabric < 1.5.

### DIFF
--- a/opal/mca/btl/ofi/Makefile.am
+++ b/opal/mca/btl/ofi/Makefile.am
@@ -53,10 +53,10 @@ mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_btl_ofi_la_SOURCES = $(component_sources)
 mca_btl_ofi_la_LDFLAGS = -module -avoid-version \
-						 $(opal_btl_ofi_LDFLAGS)
+						 $(opal_common_ofi_LDFLAGS)
 mca_btl_ofi_la_LIBADD = $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
 	$(OPAL_TOP_BUILDDIR)/opal/mca/common/ofi/lib@OPAL_LIB_PREFIX@mca_common_ofi.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_btl_ofi_la_SOURCES = $(lib_sources)
-libmca_btl_ofi_la_LDFLAGS = -module -avoid-version $(opal_btl_ofi_LDFLAGS)
+libmca_btl_ofi_la_LDFLAGS = -module -avoid-version $(opal_common_ofi_LDFLAGS)

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -184,7 +184,13 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
 
     /* Set up libfabric hints. */
     uint32_t libfabric_api;
-    libfabric_api = FI_VERSION(1, 5);       /* 1.5 because of the newer API */
+    libfabric_api = fi_version();
+
+    /* bail if OFI version is less than 1.5. */
+    if (libfabric_api < FI_VERSION(1, 5)) {
+        BTL_VERBOSE(("ofi btl disqualified because OFI version < 1.5."));
+        return NULL;
+    }
 
     struct fi_info *info, *info_list;
     struct fi_info hints = {0};
@@ -230,7 +236,7 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
     mca_btl_ofi_component.module_count = 0;
 
     /* do the query. */
-    rc = fi_getinfo(libfabric_api, NULL, NULL, 0, &hints, &info_list);
+    rc = fi_getinfo(FI_VERSION(1, 5), NULL, NULL, 0, &hints, &info_list);
     if (0 != rc) {
         BTL_VERBOSE(("fi_getinfo failed with code %d: %s",rc, fi_strerror(-rc)));
         return NULL;

--- a/opal/mca/btl/ofi/configure.m4
+++ b/opal/mca/btl/ofi/configure.m4
@@ -30,16 +30,22 @@
 # support, otherwise executes action-if-not-found
 
 AC_DEFUN([MCA_opal_btl_ofi_CONFIG],[
+    OPAL_VAR_SCOPE_PUSH([opal_btl_ofi_happy CPPFLAGS_save])
+
     AC_CONFIG_FILES([opal/mca/btl/ofi/Makefile])
 
     AC_REQUIRE([MCA_opal_common_ofi_CONFIG])
 
+    opal_btl_ofi_happy=0
     AS_IF([test "$opal_common_ofi_happy" = "yes"],
+          [CPPFLAGS_save=$CPPFLAGS
+           CPPFLAGS="$opal_common_ofi_CPPFLAGS $CPPFLAGS"
+           AC_CHECK_DECL([FI_MR_VIRT_ADDR], [opal_btl_ofi_happy=1], [],
+                         [#include <rdma/fabric.h>])
+           CPPFLAGS=$CPPFLAGS_save])
+    AS_IF([test $opal_btl_ofi_happy -eq 1],
           [$1],
           [$2])
 
-    # substitute in the things needed to build ofi
-    AC_SUBST([btl_ofi_CPPFLAGS])
-    AC_SUBST([btl_ofi_LDFLAGS])
-    AC_SUBST([btl_ofi_LIBS])
+    OPAL_VAR_SCOPE_POP
 ])dnl


### PR DESCRIPTION
Hotfix for #5214 

Now btl/ofi will compile with libfabric version < 1.5 but will disqualify itself. I'm sure there is a better way to do this and I'm open to discuss.

Tested with libfabric version 1.4.
