### PR TITLE
java: do not use MPI1 deprecated subroutines

### DIFF
--- a/ompi/mpi/java/c/mpi_Comm.c
+++ b/ompi/mpi/java/c/mpi_Comm.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -696,7 +696,7 @@ JNIEXPORT void JNICALL Java_mpi_Comm_abort(
 JNIEXPORT void JNICALL Java_mpi_Comm_setErrhandler(
         JNIEnv *env, jobject jthis, jlong comm, jlong errhandler)
 {
-    int rc = MPI_Errhandler_set((MPI_Comm)comm, (MPI_Errhandler)errhandler);
+    int rc = MPI_Comm_set_errhandler((MPI_Comm)comm, (MPI_Errhandler)errhandler);
     ompi_java_exceptionCheck(env, rc);
 }
 
@@ -704,7 +704,7 @@ JNIEXPORT jlong JNICALL Java_mpi_Comm_getErrhandler(
         JNIEnv *env, jobject jthis, jlong comm)
 {
     MPI_Errhandler errhandler;
-    int rc = MPI_Errhandler_get((MPI_Comm)comm, &errhandler);
+    int rc = MPI_Comm_get_errhandler((MPI_Comm)comm, &errhandler);
     ompi_java_exceptionCheck(env, rc);
     return (jlong)errhandler;
 }

--- a/ompi/mpi/java/c/mpi_Datatype.c
+++ b/ompi/mpi/java/c/mpi_Datatype.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -185,8 +187,8 @@ JNIEXPORT jlong JNICALL Java_mpi_Datatype_getHVector(
 {
     MPI_Datatype type;
 
-    int rc = MPI_Type_hvector(count, blockLength, stride,
-                              (MPI_Datatype)oldType, &type);
+    int rc = MPI_Type_create_hvector(count, blockLength, stride,
+                                     (MPI_Datatype)oldType, &type);
 
     ompi_java_exceptionCheck(env, rc);
     return (jlong)type;
@@ -267,7 +269,7 @@ JNIEXPORT jlong JNICALL Java_mpi_Datatype_getStruct(
     }
 
     MPI_Datatype type;
-    int rc = MPI_Type_struct(count, cBlockLengths, cDisps, cTypes, &type);
+    int rc = MPI_Type_create_struct(count, cBlockLengths, cDisps, cTypes, &type);
     ompi_java_exceptionCheck(env, rc);
 
     free(cDisps);

--- a/ompi/mpi/java/c/mpi_Op.c
+++ b/ompi/mpi/java/c/mpi_Op.c
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,8 +101,8 @@ static void opIntercept(void *invec, void *inoutvec, int *count,
     jobject jthis = object;
     jobject jin, jio;
 
-    MPI_Aint extent;
-    int rc = MPI_Type_extent(*datatype, &extent);
+    MPI_Aint lb, extent;
+    int rc = MPI_Type_get_extent(*datatype, &lb, &extent);
 
     if(ompi_java_exceptionCheck(env, rc))
         return;


### PR DESCRIPTION
Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>