### PR TITLE
v3.1.x aarch64 support

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Copyright (c) 2010      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2011      University of Houston. All rights reserved.
 Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 Copyright (c) 2015      NVIDIA Corporation.  All rights reserved.
-Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
+Copyright (c) 2017-2018 Los Alamos National Security, LLC.  All rights
                         reserved.
 Copyright (c) 2017      Research Organization for Information Science
                         and Technology (RIST). All rights reserved.
@@ -143,10 +143,7 @@ General notes
 Platform Notes
 --------------
 
-- ARM and POWER users may experience intermittent hangs when Open MPI
-  is compiled with low optimization settings, due to an issue with our
-  atomic list implementation.  We recommend compiling with -O3
-  optimization, both for performance reasons and to avoid this hang.
+- N/A
 
 
 Compiler Notes

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
  *                         reseved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -204,8 +204,8 @@ static inline void _opal_lifo_release_cpu (void)
  */
 static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
 {
-    opal_list_item_t *item, *next;
-    int attempt = 0;
+    register opal_list_item_t *item, *next;
+    int attempt = 0, ret;
 
     do {
         if (++attempt == 5) {
@@ -215,13 +215,14 @@ static inline opal_list_item_t *opal_lifo_pop_atomic (opal_lifo_t* lifo)
             attempt = 0;
         }
 
-        item = (opal_list_item_t *) opal_atomic_ll_ptr (&lifo->opal_lifo_head.data.item);
+        opal_atomic_ll_ptr(&lifo->opal_lifo_head.data.item, item);
         if (&lifo->opal_lifo_ghost == item) {
             return NULL;
         }
 
         next = (opal_list_item_t *) item->opal_list_next;
-    } while (!opal_atomic_sc_ptr (&lifo->opal_lifo_head.data.item, next));
+        opal_atomic_sc_ptr(&lifo->opal_lifo_head.data.item, next, ret);
+    } while (!ret);
 
     opal_atomic_wmb ();
 

--- a/opal/include/opal/sys/arm64/atomic.h
+++ b/opal/include/opal/sys/arm64/atomic.h
@@ -150,28 +150,31 @@ static inline int opal_atomic_cmpset_rel_32(volatile int32_t *addr,
     return (ret == oldval);
 }
 
-static inline int32_t opal_atomic_ll_32 (volatile int32_t *addr)
-{
-    int32_t ret;
+#define opal_atomic_ll_32(addr, ret)                                    \
+    do {                                                                \
+        volatile int32_t *_addr = (addr);                               \
+        int32_t _ret;                                                   \
+                                                                        \
+        __asm__ __volatile__ ("ldaxr    %w0, [%1]          \n"          \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr));                           \
+                                                                        \
+        ret = (typeof(ret)) _ret;                                       \
+    } while (0)
 
-    __asm__ __volatile__ ("ldaxr    %w0, [%1]          \n"
-                          : "=&r" (ret)
-                          : "r" (addr));
-
-    return ret;
-}
-
-static inline int opal_atomic_sc_32 (volatile int32_t *addr, int32_t newval)
-{
-    int ret;
-
-    __asm__ __volatile__ ("stlxr    %w0, %w2, [%1]     \n"
-                          : "=&r" (ret)
-                          : "r" (addr), "r" (newval)
-                          : "cc", "memory");
-
-    return ret == 0;
-}
+#define opal_atomic_sc_32(addr, newval, ret)                            \
+    do {                                                                \
+        volatile int32_t *_addr = (addr);                               \
+        int32_t _newval = (int32_t) newval;                             \
+        int _ret;                                                       \
+                                                                        \
+        __asm__ __volatile__ ("stlxr    %w0, %w2, [%1]     \n"          \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr), "r" (_newval)              \
+                              : "cc", "memory");                        \
+                                                                        \
+        ret = (_ret == 0);                                              \
+    } while (0)
 
 static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
                                         int64_t oldval, int64_t newval)
@@ -251,28 +254,31 @@ static inline int opal_atomic_cmpset_rel_64(volatile int64_t *addr,
     return (ret == oldval);
 }
 
-static inline int64_t opal_atomic_ll_64 (volatile int64_t *addr)
-{
-    int64_t ret;
+#define opal_atomic_ll_64(addr, ret)                            \
+    do {                                                        \
+        volatile int64_t *_addr = (addr);                       \
+        int64_t _ret;                                           \
+                                                                \
+        __asm__ __volatile__ ("ldaxr    %0, [%1]          \n"   \
+                              : "=&r" (_ret)                    \
+                              : "r" (_addr));                   \
+                                                                \
+        ret = (typeof(ret)) _ret;                               \
+    } while (0)
 
-    __asm__ __volatile__ ("ldaxr    %0, [%1]        \n"
-                          : "=&r" (ret)
-                          : "r" (addr));
-
-    return ret;
-}
-
-static inline int opal_atomic_sc_64 (volatile int64_t *addr, int64_t newval)
-{
-    int ret;
-
-    __asm__ __volatile__ ("stlxr    %w0, %2, [%1]    \n"
-                          : "=&r" (ret)
-                          : "r" (addr), "r" (newval)
-                          : "cc", "memory");
-
-    return ret == 0;
-}
+#define opal_atomic_sc_64(addr, newval, ret)                            \
+    do {                                                                \
+        volatile int64_t *_addr = (addr);                               \
+        int64_t _newval = (int64_t) newval;                             \
+        int _ret;                                                       \
+                                                                        \
+        __asm__ __volatile__ ("stlxr    %w0, %2, [%1]     \n"           \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr), "r" (_newval)              \
+                              : "cc", "memory");                        \
+                                                                        \
+        ret = (_ret == 0);                                              \
+    } while (0)
 
 #define OPAL_ASM_MAKE_ATOMIC(type, bits, name, inst, reg)                   \
     static inline type opal_atomic_ ## name ## _ ## bits (volatile type *addr, type value) \

--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -278,15 +278,15 @@ static inline int opal_atomic_cmpset_rel_ptr(volatile void* addr,
 
 #if SIZEOF_VOID_P == 4 && OPAL_HAVE_ATOMIC_LLSC_32
 
-#define opal_atomic_ll_ptr(addr) (void *) opal_atomic_ll_32((int32_t *) addr)
-#define opal_atomic_sc_ptr(addr, newval) opal_atomic_sc_32((int32_t *) addr, (int32_t) newval)
+#define opal_atomic_ll_ptr(addr, ret) opal_atomic_ll_32((volatile int32_t *) (addr), ret)
+#define opal_atomic_sc_ptr(addr, value, ret) opal_atomic_sc_32((volatile int32_t *) (addr), (intptr_t) (value), ret)
 
 #define OPAL_HAVE_ATOMIC_LLSC_PTR 1
 
 #elif SIZEOF_VOID_P == 8 && OPAL_HAVE_ATOMIC_LLSC_64
 
-#define opal_atomic_ll_ptr(addr) (void *) opal_atomic_ll_64((int64_t *) addr)
-#define opal_atomic_sc_ptr(addr, newval) opal_atomic_sc_64((int64_t *) addr, (int64_t) newval)
+#define opal_atomic_ll_ptr(addr, ret) opal_atomic_ll_64((volatile int64_t *) (addr), ret)
+#define opal_atomic_sc_ptr(addr, value, ret) opal_atomic_sc_64((volatile int64_t *) (addr), (intptr_t) (value), ret)
 
 #define OPAL_HAVE_ATOMIC_LLSC_PTR 1
 

--- a/opal/include/opal/sys/powerpc/atomic.h
+++ b/opal/include/opal/sys/powerpc/atomic.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2017 IBM Corporation.  All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -158,31 +158,35 @@ static inline int opal_atomic_cmpset_32(volatile int32_t *addr,
    return (ret == oldval);
 }
 
-static inline int32_t opal_atomic_ll_32 (volatile int32_t *addr)
-{
-   int32_t ret;
+/* NTH: the LL/SC support is done through macros due to issues with non-optimized builds. The reason
+ * is that even with an always_inline attribute the compiler may still emit instructions to store then
+ * load the arguments to/from the stack. This sequence may cause the ll reservation to be cancelled. */
+#define opal_atomic_ll_32(addr, ret)                                    \
+    do {                                                                \
+        volatile int32_t *_addr = (addr);                               \
+        int32_t _ret;                                                   \
+        __asm__ __volatile__ ("lwarx   %0, 0, %1  \n\t"                 \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr)                             \
+                              );                                        \
+        ret = (typeof(ret)) _ret;                                       \
+    } while (0)
 
-   __asm__ __volatile__ ("lwarx   %0, 0, %1  \n\t"
-                         : "=&r" (ret)
-                         : "r" (addr)
-                         );
-   return ret;
-}
-
-static inline int opal_atomic_sc_32 (volatile int32_t *addr, int32_t newval)
-{
-    int32_t ret, foo;
-
-    __asm__ __volatile__ ("   stwcx.  %4, 0, %3  \n\t"
-                          "   li      %0,0       \n\t"
-                          "   bne-    1f         \n\t"
-                          "   ori     %0,%0,1    \n\t"
-                          "1:"
-                          : "=r" (ret), "=m" (*addr), "=r" (foo)
-                          : "r" (addr), "r" (newval)
-                          : "cc", "memory");
-    return ret;
-}
+#define opal_atomic_sc_32(addr, value, ret)                             \
+    do {                                                                \
+        volatile int32_t *_addr = (addr);                               \
+        int32_t _ret, _foo, _newval = (int32_t) value;                  \
+                                                                        \
+        __asm__ __volatile__ ("   stwcx.  %4, 0, %3  \n\t"              \
+                              "   li      %0,0       \n\t"              \
+                              "   bne-    1f         \n\t"              \
+                              "   ori     %0,%0,1    \n\t"              \
+                              "1:"                                      \
+                              : "=r" (_ret), "=m" (*_addr), "=r" (_foo) \
+                              : "r" (_addr), "r" (_newval)              \
+                              : "cc", "memory");                        \
+        ret = _ret;                                                     \
+    } while (0)
 
 /* these two functions aren't inlined in the non-gcc case because then
    there would be two function calls (since neither cmpset_32 nor
@@ -280,31 +284,33 @@ static inline int opal_atomic_cmpset_64(volatile int64_t *addr,
    return (ret == oldval);
 }
 
-static inline int64_t opal_atomic_ll_64(volatile int64_t *addr)
-{
-   int64_t ret;
+#define opal_atomic_ll_64(addr, ret)                                    \
+    do {                                                                \
+        volatile int64_t *_addr = (addr);                               \
+        int64_t _ret;                                                   \
+        __asm__ __volatile__ ("ldarx   %0, 0, %1  \n\t"                 \
+                              : "=&r" (_ret)                            \
+                              : "r" (_addr)                             \
+                              );                                        \
+        ret = (typeof(ret)) _ret;                                       \
+    } while (0)
 
-   __asm__ __volatile__ ("ldarx   %0, 0, %1  \n\t"
-                         : "=&r" (ret)
-                         : "r" (addr)
-                         );
-   return ret;
-}
-
-static inline int opal_atomic_sc_64(volatile int64_t *addr, int64_t newval)
-{
-    int32_t ret;
-
-    __asm__ __volatile__ ("   stdcx.  %2, 0, %1  \n\t"
-                          "   li      %0,0       \n\t"
-                          "   bne-    1f         \n\t"
-                          "   ori     %0,%0,1    \n\t"
-                          "1:"
-                          : "=r" (ret)
-                          : "r" (addr), "r" (OPAL_ASM_VALUE64(newval))
-                          : "cc", "memory");
-    return ret;
-}
+#define opal_atomic_sc_64(addr, value, ret)                             \
+    do {                                                                \
+        volatile int64_t *_addr = (addr);                               \
+        int64_t _foo, _newval = (int64_t) value;                        \
+        int32_t _ret;                                                   \
+                                                                        \
+        __asm__ __volatile__ ("   stdcx.  %2, 0, %1  \n\t"              \
+                              "   li      %0,0       \n\t"              \
+                              "   bne-    1f         \n\t"              \
+                              "   ori     %0,%0,1    \n\t"              \
+                              "1:"                                      \
+                              : "=r" (_ret)                             \
+                              : "r" (_addr), "r" (OPAL_ASM_VALUE64(_newval)) \
+                              : "cc", "memory");                        \
+        ret = _ret;                                                     \
+    } while (0)
 
 /* these two functions aren't inlined in the non-gcc case because then
    there would be two function calls (since neither cmpset_64 nor

--- a/opal/mca/patcher/base/patcher_base_patch.c
+++ b/opal/mca/patcher/base/patcher_base_patch.c
@@ -106,6 +106,8 @@ static void flush_and_invalidate_cache (unsigned long a)
     __asm__ volatile("mfence;clflush %0;mfence" : :"m" (*(char*)a));
 #elif OPAL_ASSEMBLY_ARCH == OPAL_IA64
     __asm__ volatile ("fc %0;; sync.i;; srlz.i;;" : : "r"(a) : "memory");
+#elif OPAL_ASSEMBLY_ARCH == OPAL_ARM64
+    __asm__ volatile ("dsb sy");
 #endif
 }
 

--- a/opal/mca/patcher/overwrite/configure.m4
+++ b/opal/mca/patcher/overwrite/configure.m4
@@ -32,7 +32,7 @@ AC_DEFUN([MCA_opal_patcher_overwrite_CONFIG],[
     if test $OPAL_ENABLE_DLOPEN_SUPPORT = 1; then
 # Disable ia64 for now. We can revive it later if anyone cares
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#if !defined(__i386__) && !defined(__x86_64__) && !defined(__PPC__)
+#if !defined(__i386__) && !defined(__x86_64__) && !defined(__PPC__) && !defined(__aarch64__)
 #error "platform not supported"
 #endif
 ]],[])],[opal_patcher_overwrite_happy=yes],[])


### PR DESCRIPTION
These commits improve the aarch64 support as promised. The three commits:
 1) Fix debug builds (and update the README to reflect this).
 2) Make the patcher code work with aarch64.