### PR TITLE
io/romio314: Replace deprecated MPI-1 functions

### DIFF
--- a/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -610,8 +610,8 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
 		    if (req_off < real_off + real_size) {
 			count[i]++;
       ADIOI_Assert((((ADIO_Offset)(MPIR_Upint)read_buf)+req_off-real_off) == (ADIO_Offset)(MPIR_Upint)(read_buf+req_off-real_off));
-			MPI_Address(read_buf+req_off-real_off,
-                               &(others_req[i].mem_ptrs[j]));
+			MPI_Get_address(read_buf+req_off-real_off,
+                                   &(others_req[i].mem_ptrs[j]));
       ADIOI_Assert((real_off + real_size - req_off) == (int)(real_off + real_size - req_off));
 			send_size[i] += (int)(ADIOI_MIN(real_off + real_size - req_off,
                                       (ADIO_Offset)(unsigned)req_len));

--- a/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -440,7 +440,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
     int req_len, flag, rank;
     MPI_Status status;
     ADIOI_Flatlist_node *flat_buf=NULL;
-    MPI_Aint buftype_extent;
+    MPI_Aint buftype_extent, buftype_lb;
     int coll_bufsize;
 #ifdef RDCOLL_DEBUG
     int iii;
@@ -523,7 +523,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
 	flat_buf = ADIOI_Flatlist;
         while (flat_buf->type != datatype) flat_buf = flat_buf->next;
     }
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
 
     done = 0;
     off = st_loc;

--- a/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -706,8 +706,8 @@ static void ADIOI_Exch_and_write(ADIO_File fd, const void *buf, MPI_Datatype
 		    if (req_off < off + size) {
 			count[i]++;
       ADIOI_Assert((((ADIO_Offset)(MPIR_Upint)write_buf)+req_off-off) == (ADIO_Offset)(MPIR_Upint)(write_buf+req_off-off));
-			MPI_Address(write_buf+req_off-off,
-                               &(others_req[i].mem_ptrs[j]));
+			MPI_Get_address(write_buf+req_off-off,
+                                   &(others_req[i].mem_ptrs[j]));
       ADIOI_Assert((off + size - req_off) == (int)(off + size - req_off));
 			recv_size[i] += (int)(ADIOI_MIN(off + size - req_off,
                                       (unsigned)req_len));

--- a/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -517,7 +517,7 @@ static void ADIOI_Exch_and_write(ADIO_File fd, const void *buf, MPI_Datatype
     int *send_buf_idx, *curr_to_proc, *done_to_proc;
     MPI_Status status;
     ADIOI_Flatlist_node *flat_buf=NULL;
-    MPI_Aint buftype_extent;
+    MPI_Aint buftype_extent, buftype_lb;
     int info_flag, coll_bufsize;
     char *value;
     static char myname[] = "ADIOI_EXCH_AND_WRITE";
@@ -634,7 +634,7 @@ static void ADIOI_Exch_and_write(ADIO_File fd, const void *buf, MPI_Datatype
 	flat_buf = ADIOI_Flatlist;
         while (flat_buf->type != datatype) flat_buf = flat_buf->next;
     }
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
 
 
 /* I need to check if there are any outstanding nonblocking writes to

--- a/ompi/mca/io/romio314/romio/adio/ad_gridftp/ad_gridftp_read.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_gridftp/ad_gridftp_read.c
@@ -195,9 +195,9 @@ void ADIOI_GRIDFTP_ReadDiscontig(ADIO_File fd, void *buf, int count,
     char myname[]="ADIOI_GRIDFTP_ReadDiscontig";
     int myrank,nprocs;
     /* size and extent of buffer in memory */
-    MPI_Aint btype_size,btype_extent;
+    MPI_Aint btype_size,btype_extent,btype_lb;
     /* size and extent of file record layout */
-    MPI_Aint ftype_size,ftype_extent;
+    MPI_Aint ftype_size,ftype_extent,ftype_lb;
     /* size of file elemental type; seeks are done in units of this */
     MPI_Aint etype_size;
     MPI_Aint extent;
@@ -221,11 +221,11 @@ void ADIOI_GRIDFTP_ReadDiscontig(ADIO_File fd, void *buf, int count,
 
     etype_size=fd->etype_size;
     MPI_Type_size_x(fd->filetype,&ftype_size);
-    MPI_Type_extent(fd->filetype,&ftype_extent);
+    MPI_Type_get_extent(fd->filetype,&ftype_lb,&ftype_extent);
     /* This is arguably unnecessary, as this routine assumes that the
        buffer in memory is contiguous */
     MPI_Type_size_x(datatype,&btype_size);
-    MPI_Type_extent(datatype,&btype_extent);
+    MPI_Type_get_extent(datatype,&btype_lb,&btype_extent);
     ADIOI_Datatype_iscontig(datatype,&buf_contig);
 
     if ( ( btype_extent!=btype_size ) || ( ! buf_contig ) )

--- a/ompi/mca/io/romio314/romio/adio/ad_gridftp/ad_gridftp_write.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_gridftp/ad_gridftp_write.c
@@ -207,8 +207,8 @@ void ADIOI_GRIDFTP_WriteDiscontig(ADIO_File fd, void *buf, int count,
 {
     char myname[]="ADIOI_GRIDFTP_WriteDiscontig";
     int myrank,nprocs;
-    MPI_Aint btype_size,btype_extent;
-    MPI_Aint ftype_size,ftype_extent;
+    MPI_Aint btype_size,btype_extent,btype_lb;
+    MPI_Aint ftype_size,ftype_extent,ftype_lb;
     MPI_Aint etype_size;
     MPI_Aint extent;
     ADIOI_Flatlist_node *flat_file;
@@ -221,11 +221,11 @@ void ADIOI_GRIDFTP_WriteDiscontig(ADIO_File fd, void *buf, int count,
     MPI_Comm_size(fd->comm,&nprocs);
     etype_size=fd->etype_size;
     MPI_Type_size_x(fd->filetype,&ftype_size);
-    MPI_Type_extent(fd->filetype,&ftype_extent);
+    MPI_Type_get_extent(fd->filetype,&ftype_lb,&ftype_extent);
     /* This is arguably unnecessary, as this routine assumes that the
        buffer in memory is contiguous */
     MPI_Type_size_x(datatype,&btype_size);
-    MPI_Type_extent(datatype,&btype_extent);
+    MPI_Type_get_extent(datatype,&btype_lb,&btype_extent);
     ADIOI_Datatype_iscontig(datatype,&buf_contig);
 
     if ( ( btype_extent!=btype_size ) || ( ! buf_contig ) )

--- a/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -501,8 +501,8 @@ static void ADIOI_LUSTRE_Exch_and_write(ADIO_File fd, const void *buf,
 		    if (req_off < iter_st_off + max_size) {
 			recv_count[i]++;
                         ADIOI_Assert((((ADIO_Offset)(MPIR_Upint)write_buf)+req_off-off) == (ADIO_Offset)(MPIR_Upint)(write_buf+req_off-off));
-			MPI_Address(write_buf + req_off - off,
-				    &(others_req[i].mem_ptrs[j]));
+			MPI_Get_address(write_buf + req_off - off,
+				        &(others_req[i].mem_ptrs[j]));
                         recv_size[i] += req_len;
 		    } else {
 			break;

--- a/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -316,7 +316,7 @@ static void ADIOI_LUSTRE_Exch_and_write(ADIO_File fd, const void *buf,
     char *write_buf = NULL;
     MPI_Status status;
     ADIOI_Flatlist_node *flat_buf = NULL;
-    MPI_Aint buftype_extent;
+    MPI_Aint buftype_extent, buftype_lb;
     int stripe_size = striping_info[0], avail_cb_nodes = striping_info[2];
     int data_sieving = 0;
     ADIO_Offset *srt_off = NULL;
@@ -420,7 +420,7 @@ static void ADIOI_LUSTRE_Exch_and_write(ADIO_File fd, const void *buf,
 	while (flat_buf->type != datatype)
 	    flat_buf = flat_buf->next;
     }
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     /* I need to check if there are any outstanding nonblocking writes to
      * the file, which could potentially interfere with the writes taking
      * place in this collective write call. Since this is not likely to be

--- a/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_wrstr.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_lustre/ad_lustre_wrstr.c
@@ -157,7 +157,7 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
     ADIO_Offset num, size, n_filetypes, etype_in_filetype, st_n_filetypes;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent;
+    MPI_Aint filetype_extent, buftype_extent, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset userbuf_off;
     ADIO_Offset off, req_off, disp, end_offset=0, writebuf_off, start_off;
@@ -195,9 +195,9 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     ADIOI_Assert((buftype_size * count) == ((ADIO_Offset)(unsigned)buftype_size * (ADIO_Offset)count));

--- a/ompi/mca/io/romio314/romio/adio/ad_piofs/ad_piofs_write.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_piofs/ad_piofs_write.c
@@ -76,7 +76,7 @@ void ADIOI_PIOFS_WriteStrided(ADIO_File fd, void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent, indx;
+    MPI_Aint filetype_extent, buftype_extent, indx, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset off, disp;
     int flag, new_bwr_size, new_fwr_size, err_flag=0;
@@ -101,9 +101,9 @@ void ADIOI_PIOFS_WriteStrided(ADIO_File fd, void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;

--- a/ompi/mca/io/romio314/romio/adio/ad_pvfs/ad_pvfs_read.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_pvfs/ad_pvfs_read.c
@@ -115,7 +115,7 @@ void ADIOI_PVFS_ReadStridedListIO(ADIO_File fd, void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent;
+    MPI_Aint filetype_extent, buftype_extent, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset userbuf_off;
     ADIO_Offset off, disp, start_off;
@@ -158,9 +158,9 @@ void ADIOI_PVFS_ReadStridedListIO(ADIO_File fd, void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;

--- a/ompi/mca/io/romio314/romio/adio/ad_pvfs/ad_pvfs_write.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_pvfs/ad_pvfs_write.c
@@ -101,7 +101,7 @@ void ADIOI_PVFS_WriteStrided(ADIO_File fd, void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent, indx;
+    MPI_Aint filetype_extent, buftype_extent, indx, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset off, disp;
     int flag, new_bwr_size, new_fwr_size, err_flag=0;
@@ -138,9 +138,9 @@ void ADIOI_PVFS_WriteStrided(ADIO_File fd, void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;
@@ -475,7 +475,7 @@ void ADIOI_PVFS_WriteStridedListIO(ADIO_File fd, void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent;
+    MPI_Aint filetype_extent, buftype_extent, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset userbuf_off;
     ADIO_Offset off, disp, start_off;
@@ -526,9 +526,9 @@ void ADIOI_PVFS_WriteStridedListIO(ADIO_File fd, void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;

--- a/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_io_dtype.c
@@ -24,7 +24,7 @@ int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, int count,
     PVFS_Request tmp_mem_req, mem_req, tmp_file_req, file_req;
     PVFS_sysresp_io resp_io;
     ADIO_Offset off = -1, bytes_into_filetype = 0;
-    MPI_Aint filetype_extent = -1;
+    MPI_Aint filetype_extent = -1, filetype_lb = -1;
     int i = -1;
     MPI_Count etype_size;
     PVFS_size pvfs_disp = -1;
@@ -54,7 +54,7 @@ int ADIOI_PVFS2_StridedDtypeIO(ADIO_File fd, void *buf, int count,
         *error_code = MPI_SUCCESS;
         return -1;
     }
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(fd->etype, &etype_size);
     if (filetype_size == 0) {
         *error_code = MPI_SUCCESS;

--- a/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_io_list.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_io_list.c
@@ -44,6 +44,7 @@ int ADIOI_PVFS2_StridedListIO(ADIO_File fd, void *buf, int count,
     ADIOI_Flatlist_node *flat_buf_p, *flat_file_p;
     MPI_Count buftype_size = -1, filetype_size = -1;
     MPI_Aint filetype_extent = -1, buftype_extent = -1;;
+    MPI_Aint filetype_lb = -1, buftype_lb = -1;;
     int buftype_is_contig = -1, filetype_is_contig = -1;
 
     /* PVFS2 specific parameters */
@@ -67,9 +68,9 @@ int ADIOI_PVFS2_StridedListIO(ADIO_File fd, void *buf, int count,
         *error_code = MPI_SUCCESS;
         return -1;
     }
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     io_size = buftype_size*count;
 
     pvfs_fs = (ADIOI_PVFS2_fs*)fd->fs_ptr;

--- a/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_open.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_open.c
@@ -208,8 +208,8 @@ void ADIOI_PVFS2_Open(ADIO_File fd, int *error_code)
 #endif
 
     /* broadcast status and (possibly valid) object reference */
-    MPI_Address(&o_status.error, &offsets[0]);
-    MPI_Address(&o_status.object_ref, &offsets[1]);
+    MPI_Get_address(&o_status.error, &offsets[0]);
+    MPI_Get_address(&o_status.object_ref, &offsets[1]);
 
     MPI_Type_struct(2, lens, offsets, types, &open_status_type);
     MPI_Type_commit(&open_status_type);

--- a/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_read_list_classic.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_read_list_classic.c
@@ -24,7 +24,7 @@ void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent;
+    MPI_Aint filetype_extent, buftype_extent, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset off, disp, start_off, initial_off;
     int flag, st_frd_size, st_n_filetypes;
@@ -78,9 +78,9 @@ void ADIOI_PVFS2_OldReadStrided(ADIO_File fd, void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;

--- a/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_write_list_classic.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_pvfs2/ad_pvfs2_write_list_classic.c
@@ -29,7 +29,7 @@ void ADIOI_PVFS2_OldWriteStrided(ADIO_File fd, const void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent;
+    MPI_Aint filetype_extent, buftype_extent, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset off, disp, start_off, initial_off;
     int flag, st_fwr_size, st_n_filetypes;
@@ -94,9 +94,9 @@ void ADIOI_PVFS2_OldWriteStrided(ADIO_File fd, const void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;

--- a/ompi/mca/io/romio314/romio/adio/ad_zoidfs/ad_zoidfs_open.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_zoidfs/ad_zoidfs_open.c
@@ -115,8 +115,8 @@ void ADIOI_ZOIDFS_Open(ADIO_File fd, int *error_code)
 #endif
 
     /* broadcast status and (possibly valid) object reference */
-    MPI_Address(&o_status.error, &offsets[0]);
-    MPI_Address(&o_status.handle, &offsets[1]);
+    MPI_Get_address(&o_status.error, &offsets[0]);
+    MPI_Get_address(&o_status.handle, &offsets[1]);
 
     MPI_Type_struct(2, lens, offsets, types, &open_status_type);
     MPI_Type_commit(&open_status_type);

--- a/ompi/mca/io/romio314/romio/adio/ad_zoidfs/ad_zoidfs_read_list.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_zoidfs/ad_zoidfs_read_list.c
@@ -26,7 +26,7 @@ void ADIOI_ZOIDFS_ReadStrided(ADIO_File fd, void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent;
+    MPI_Aint filetype_extent, buftype_extent, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset off, disp, start_off, initial_off;
     int flag, st_frd_size, st_n_filetypes;
@@ -80,9 +80,9 @@ void ADIOI_ZOIDFS_ReadStrided(ADIO_File fd, void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;

--- a/ompi/mca/io/romio314/romio/adio/ad_zoidfs/ad_zoidfs_write_list.c
+++ b/ompi/mca/io/romio314/romio/adio/ad_zoidfs/ad_zoidfs_write_list.c
@@ -31,7 +31,7 @@ void ADIOI_ZOIDFS_WriteStrided(ADIO_File fd, void *buf, int count,
     int n_filetypes, etype_in_filetype;
     ADIO_Offset abs_off_in_filetype=0;
     MPI_Count filetype_size, etype_size, buftype_size;
-    MPI_Aint filetype_extent, buftype_extent;
+    MPI_Aint filetype_extent, buftype_extent, filetype_lb, buftype_lb;
     int buf_count, buftype_is_contig, filetype_is_contig;
     ADIO_Offset off, disp, start_off, initial_off;
     int flag, st_fwr_size, st_n_filetypes;
@@ -94,9 +94,9 @@ void ADIOI_ZOIDFS_WriteStrided(ADIO_File fd, void *buf, int count,
 	return;
     }
 
-    MPI_Type_extent(fd->filetype, &filetype_extent);
+    MPI_Type_get_extent(fd->filetype, &filetype_lb, &filetype_extent);
     MPI_Type_size_x(datatype, &buftype_size);
-    MPI_Type_extent(datatype, &buftype_extent);
+    MPI_Type_get_extent(datatype, &buftype_lb, &buftype_extent);
     etype_size = fd->etype_size;
 
     bufsize = buftype_size * count;

--- a/ompi/mca/io/romio314/romio/mpi2-other/array/darray.c
+++ b/ompi/mca/io/romio314/romio/mpi2-other/array/darray.c
@@ -50,7 +50,7 @@ int MPI_Type_create_darray(int size, int rank, int ndims,
 {
     int err, error_code;
     int i;
-    MPI_Aint orig_extent, size_with_aint;
+    MPI_Aint orig_extent, orig_lb, size_with_aint;
     MPI_Offset size_with_offset;
     static char myname[] = "MPI_TYPE_CREATE_DARRAY";
 
@@ -159,7 +159,7 @@ int MPI_Type_create_darray(int size, int rank, int ndims,
 	return MPIO_Err_return_comm(MPI_COMM_SELF, error_code);
     }
 
-    MPI_Type_extent(oldtype, &orig_extent);
+    MPI_Type_get_extent(oldtype, &orig_lb, &orig_extent);
 
 /* check if MPI_Aint is large enough for size of global array.
    if not, complain. */

--- a/ompi/mca/io/romio314/romio/mpi2-other/array/subarray.c
+++ b/ompi/mca/io/romio314/romio/mpi2-other/array/subarray.c
@@ -43,7 +43,7 @@ int MPI_Type_create_subarray(int ndims, int *array_of_sizes,
                              int order, MPI_Datatype oldtype,
                              MPI_Datatype *newtype)
 {
-    MPI_Aint extent, size_with_aint;
+    MPI_Aint extent, lb, size_with_aint;
     int i, err, error_code;
     MPI_Offset size_with_offset;
 
@@ -128,7 +128,7 @@ int MPI_Type_create_subarray(int ndims, int *array_of_sizes,
 	return MPIO_Err_return_comm(MPI_COMM_SELF, error_code);
     }
 
-    MPI_Type_extent(oldtype, &extent);
+    MPI_Type_get_extent(oldtype, &lb, &extent);
 
 /* check if MPI_Aint is large enough for size of global array.
    if not, complain. */


### PR DESCRIPTION
Replace `MPI_Address` with `MPI_Get_address` and `MPI_Type_extent` with `MPI_Type_get_extent` in io/romio314. This addresses #5223 and allows ROMIO to build without needing `--enable-mpi1-compat`.

However, I could only test the changes to the Lustre ADIO - I don't have access to the other filesystems to test these.

Signed-off-by: Ben Menadue <ben.menadue@nci.org.au>