### PR TITLE
PML/UCX: fixed hand on MPI_Finalize

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -435,6 +435,10 @@ int mca_pml_ucx_del_procs(struct ompi_proc_t **procs, size_t nprocs)
 
     mca_pml_ucx_waitall(dreqs, &num_reqs);
     free(dreqs);
+    /* flush worker to allow all pending operations to complete.
+     * ignore error (we can do nothing here), just try to
+     * finalize gracefully */
+    ucp_worker_flush(ompi_pml_ucx.ucp_worker);
 
     opal_pmix.fence(NULL, 0);
 


### PR DESCRIPTION
fixes issue https://github.com/openucx/ucx/issues/2656

added flush for worker object to complete all pending operations

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>