### PR TITLE
Preferentially use /dev/shm on Linux

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -106,6 +106,9 @@ struct ompi_osc_rdma_component_t {
 
     /** aggregation free list */
     opal_free_list_t aggregate;
+
+    /** directory where to place backing files */
+    char *backing_directory;
 };
 typedef struct ompi_osc_rdma_component_t ompi_osc_rdma_component_t;
 

--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -61,6 +61,8 @@ typedef struct ompi_osc_sm_node_state_t ompi_osc_sm_node_state_t;
 
 struct ompi_osc_sm_component_t {
     ompi_osc_base_component_t super;
+
+    char *backing_directory;
 };
 typedef struct ompi_osc_sm_component_t ompi_osc_sm_component_t;
 OMPI_DECLSPEC extern ompi_osc_sm_component_t mca_osc_sm_component;


### PR DESCRIPTION
These commits add MCA variables to control where the osc/rdma and osc/sm components store shared memory segments. This variable is set to /dev/shm if it exists. This works around possible performance issues if the session directory is not a tmpfs.

Master will move this support into opal/shmem.