### PR TITLE
btl/ofi: handles FI_EINTR properly.

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -560,7 +560,15 @@ static int mca_btl_ofi_component_progress (void)
 
             MCA_BTL_OFI_ABORT();
 
-        } else if (OPAL_UNLIKELY(ret != -FI_EAGAIN && ret != -FI_EINTR)) {
+        }
+#ifdef FI_EINTR
+        /* sometimes, sockets provider complain about interupt. */
+        else if (OPAL_UNLIKELY(ret == -FI_EINTR)) {
+            continue;
+        }
+#endif
+        /* If the error is not FI_EAGAIN, report the error and abort. */
+        else if (OPAL_UNLIKELY(ret != -FI_EAGAIN)) {
             BTL_ERROR(("fi_cq_read returned error %d:%s", ret, fi_strerror(-ret)));
             MCA_BTL_OFI_ABORT();
         }


### PR DESCRIPTION
OFI sockets provider will sometime return FI_EINTR. Apparently this flag
does not exist in OFI version 1.5. This commit added an ifdef check.

Signed-off-by: Thananon Patinyasakdikul <thananon.patinyasakdikul@intel.com>

This commit fixes #5233 
Tested with libfabric version 1.4, 1.5, 1.6