### PR TITLE
Add MCA param for multithread opal_progress().

### DIFF
--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -76,6 +76,8 @@ bool opal_leave_pinned_pipeline = false;
 bool opal_abort_print_stack = false;
 int opal_abort_delay = 0;
 
+int opal_max_thread_in_progress = 1;
+
 static bool opal_register_done = false;
 
 int opal_register_params(void)
@@ -359,6 +361,12 @@ int opal_register_params(void)
             "Store SHELL env variables from amca conf file",
             MCA_BASE_VAR_TYPE_STRING, NULL, 0, MCA_BASE_VAR_FLAG_INTERNAL, OPAL_INFO_LVL_3,
             MCA_BASE_VAR_SCOPE_READONLY, &mca_base_env_list_internal);
+
+    /* Number of threads allowed in opal_progress. This might increase multithreaded performance. */
+    (void)mca_base_var_register ("opal", "opal", NULL, "max_thread_in_progress",
+            "Number of thread allowed in opal_progress. Default: 1",
+            MCA_BASE_VAR_TYPE_INT, NULL, 0, 0, OPAL_INFO_LVL_8,
+            MCA_BASE_VAR_SCOPE_READONLY, &opal_max_thread_in_progress);
 
     /* The ddt engine has a few parameters */
     ret = opal_datatype_register_params();

--- a/opal/threads/wait_sync.c
+++ b/opal/threads/wait_sync.c
@@ -17,6 +17,8 @@
 static opal_mutex_t wait_sync_lock = OPAL_MUTEX_STATIC_INIT;
 static ompi_wait_sync_t* wait_sync_list = NULL;
 
+static opal_atomic_int32_t num_thread_in_progress = 0;
+
 #define WAIT_SYNC_PASS_OWNERSHIP(who)                  \
     do {                                               \
         pthread_mutex_lock( &(who)->lock);             \
@@ -63,7 +65,7 @@ int ompi_sync_wait_mt(ompi_wait_sync_t *sync)
      *  - our sync has been triggered.
      */
  check_status:
-    if( sync != wait_sync_list ) {
+    if( sync != wait_sync_list && num_thread_in_progress >= opal_max_thread_in_progress) {
         pthread_cond_wait(&sync->condition, &sync->lock);
 
         /**
@@ -79,11 +81,14 @@ int ompi_sync_wait_mt(ompi_wait_sync_t *sync)
         /* either promoted, or spurious wakeup ! */
         goto check_status;
     }
-
     pthread_mutex_unlock(&sync->lock);
+
+    OPAL_THREAD_ADD_FETCH32(&num_thread_in_progress, 1);
     while(sync->count > 0) {  /* progress till completion */
         opal_progress();  /* don't progress with the sync lock locked or you'll deadlock */
     }
+    OPAL_THREAD_ADD_FETCH32(&num_thread_in_progress, -1);
+
     assert(sync == wait_sync_list);
 
  i_am_done:

--- a/opal/threads/wait_sync.h
+++ b/opal/threads/wait_sync.h
@@ -25,6 +25,8 @@
 
 BEGIN_C_DECLS
 
+extern int opal_max_thread_in_progress;
+
 typedef struct ompi_wait_sync_t {
     opal_atomic_int32_t count;
     int32_t status;


### PR DESCRIPTION
This is more of a discussion than a PR. After some work into multi-thread support, all of us found the bottleneck at `opal_progress()` since we serialize the threads here. (The request refactoring a few years back was to handle the serialization better for oversubscribed case.)

Now let's discuss here. @hjelmn , @bosilca and I agreed that we should allow threads in opal_progress to maximize the use of multiple resources and most of the components are now thread-safe. We should push this forward. However, this will be a problem with oversubscribed case. So I think the first good step should be an MCA param. 

So I drafted a PR. This is just a simple way to do it and I'm open to discussion. This does not have to be in 4.0. release.