### PR TITLE
Fix openib support for RoCE HCA

### DIFF
--- a/opal/mca/btl/openib/mca-btl-openib-device-params.ini
+++ b/opal/mca/btl/openib/mca-btl-openib-device-params.ini
@@ -234,6 +234,11 @@ use_eager_rdma = 1
 mtu = 4096
 max_inline_data = 0
 
+[QLogic FastLinQ QL41000]
+vendor_id = 0x1077
+vendor_part_id = 32880
+receive_queues = P,65536,64
+
 ############################################################################
 
 # Chelsio's OUI is 0x0743.  0x1425 is the PCI ID.

--- a/opal/mca/btl/openib/mca-btl-openib-device-params.ini
+++ b/opal/mca/btl/openib/mca-btl-openib-device-params.ini
@@ -329,3 +329,15 @@ use_eager_rdma = 1
 mtu = 2048
 receive_queues = P,65536,64
 max_inline_data = 72
+
+############################################################################
+
+# Broadcom NetXtreme-E RDMA Ethernet Controller
+
+[Broadcom Cumulus]
+vendor_id = 0x14e4
+vendor_part_id = 0x16d7
+use_eager_rdma = 1
+mtu = 1024
+receive_queues = P,65536,256,192,128
+max_inline_data = 96


### PR DESCRIPTION
We encountered at least 2 RoCE HCA that did not work out of the box with the openib BTL as they need specific parameters

These patches add support for them.
They should be added to the v2 and v3 maintenance branches aswell