### PR TITLE
Ensure required hwloc directories are in dist tarballs

### DIFF
--- a/opal/mca/hwloc/hwloc201/Makefile.am
+++ b/opal/mca/hwloc/hwloc201/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2018 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
@@ -25,7 +25,9 @@ EXTRA_DIST = \
         hwloc/doc/README.txt \
         hwloc/contrib/systemd/README.txt \
         hwloc/tests/README.txt \
-        hwloc/utils/README.txt
+        hwloc/utils/README.txt \
+        hwloc/netloc/README.txt \
+        hwloc/contrib/misc/README.txt
 
 SUBDIRS = hwloc
 


### PR DESCRIPTION
Fixes MTT failure when running autogen.pl on a tarball, as seen at https://mtt.open-mpi.org/index.php?do_redir=2632
```
ompi/Makefile.am: installing 'config/depcomp'
opal/mca/hwloc/hwloc201/hwloc/Makefile.am:23: error: required directory
opal/mca/hwloc/hwloc201/hwloc/netloc does not exist
opal/mca/hwloc/hwloc201/hwloc/Makefile.am:25: error: required directory
opal/mca/hwloc/hwloc201/hwloc/contrib/misc does not exist
opal/mca/hwloc/hwloc201/hwloc/Makefile.am:36: error: required directory
opal/mca/hwloc/hwloc201/hwloc/netloc does not existautoreconf: automake failed with exit status: 1
Command failed: autoreconf -ivf --warnings=all,no-obsolete,no-override -I config
```

Signed-off-by: Peter Gottesman <peter@petergottesman.com>