### PR TITLE
btl/ofi: change required mr mode bits.

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -35,7 +35,7 @@
 
 
 #define MCA_BTL_OFI_REQUIRED_CAPS       (FI_RMA | FI_ATOMIC)
-#define MCA_BTL_OFI_REQUESTED_MR_MODE   (FI_MR_UNSPEC)
+#define MCA_BTL_OFI_REQUESTED_MR_MODE   (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR)
 
 static char *prov_include;
 static char *prov_exclude;


### PR DESCRIPTION
It turns out FI_MR_UNSPEC is not supposed to be used beyond ofi version 1.5. This
commit replaces FI_MR_UNSPEC with the new FI_MR_BASIC mode bits
(FI_MR_PROV_KEY | FI_MR_ALLOCATED | FI_MR_VIRT_ADDR).

The btl functionality remains the same.

Signed-off-by: Thananon Patinyasakdikul <thananon.patinyasakdikul@intel.com>

Clarification: The btl will work with or without these 3 flags returned from the provider but will fail if any other flag is returned.