### PR TITLE
topo/treematch - quash compiler warning

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -1642,7 +1642,7 @@ int ompi_osc_pt2pt_process_receive (ompi_osc_pt2pt_receive_t *recv)
     ompi_osc_pt2pt_header_t *base_header = (ompi_osc_pt2pt_header_t *) recv->buffer;
     size_t incoming_length = recv->pml_request->req_status._ucount;
     int source = recv->pml_request->req_status.MPI_SOURCE;
-    int rc;
+    int rc __opal_attribute_unused__;
 
     assert(incoming_length >= sizeof(ompi_osc_pt2pt_header_base_t));
     (void)incoming_length;  // silence compiler warning

--- a/ompi/mca/osc/rdma/osc_rdma_active_target.c
+++ b/ompi/mca/osc/rdma/osc_rdma_active_target.c
@@ -443,7 +443,8 @@ int ompi_osc_rdma_complete_atomic (ompi_win_t *win)
     ompi_osc_rdma_sync_t *sync = &module->all_sync;
     ompi_osc_rdma_peer_t **peers;
     ompi_group_t *group;
-    int group_size, ret;
+    int group_size;
+    int ret __opal_attribute_unused__;
 
     OSC_RDMA_VERBOSE(MCA_BASE_VERBOSE_TRACE, "complete: %s", win->w_name);
 

--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -135,7 +135,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
     int *lindex_to_grank = NULL;
     int *nodes_roots = NULL, *k = NULL;
     int *localrank_to_objnum  = NULL;
-    int depth, effective_depth, obj_rank = -1;
+    int depth, effective_depth = 0, obj_rank = -1;
     int num_objs_in_node = 0, num_pus_in_node = 0;
     int numlevels = 0, num_nodes = 0, num_procs_in_node = 0;
     int rank, size, newrank = -1, hwloc_err, i, j, idx;

--- a/opal/mca/btl/ugni/btl_ugni_component.c
+++ b/opal/mca/btl/ugni/btl_ugni_component.c
@@ -503,7 +503,7 @@ mca_btl_ugni_component_init (int *num_btl_modules,
 int mca_btl_ugni_progress_datagram (mca_btl_ugni_device_t *device)
 {
     mca_btl_ugni_module_t *ugni_module = mca_btl_ugni_component.modules;
-    mca_btl_base_endpoint_t *ep;
+    mca_btl_base_endpoint_t *ep = NULL;
     gni_ep_handle_t handle;
     int count = 0, rc;
 

--- a/opal/mca/btl/vader/btl_vader_xpmem.c
+++ b/opal/mca/btl/vader/btl_vader_xpmem.c
@@ -153,7 +153,6 @@ mca_rcache_base_registration_t *vader_get_registation (struct mca_btl_base_endpo
 
 static int mca_btl_vader_endpoint_xpmem_rcache_cleanup (mca_rcache_base_registration_t *reg, void *ctx)
 {
-    mca_rcache_base_vma_module_t *vma_module = mca_btl_vader_component.vma_module;
     mca_btl_vader_endpoint_t *ep = (mca_btl_vader_endpoint_t *) ctx;
     if ((intptr_t) reg->alloc_base == ep->peer_smp_rank) {
         /* otherwise dereg will fail on assert */


### PR DESCRIPTION
quash compiler warnings showing up with gcc 7.3

Signed-off-by: Howard Pritchard <howardp@lanl.gov>