### PR TITLE
configure: check for __thread support.

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -46,7 +46,7 @@ AC_DEFUN([OPAL_PROG_CC_C11_HELPER],[
     opal_prog_cc_c11_helper_CFLAGS_save=$CFLAGS
     CFLAGS="$CFLAGS $1"
 
-    OPAL_CC_HELPER([if $CC $1 supports C11 thread local storage], [opal_prog_cc_c11_helper__Thread_local_available],
+    OPAL_CC_HELPER([if $CC $1 supports C11 _Thread_local], [opal_prog_cc_c11_helper__Thread_local_available],
                    [],[[static _Thread_local int  foo = 1;++foo;]], [OPAL_C_HAVE__THREAD_LOCAL],
                    [Whether C compiler supports __Thread_local])
 
@@ -159,6 +159,13 @@ AC_DEFUN([OPAL_SETUP_CC],[
         # changed
         OPAL_PROG_CC_C11_HELPER([],[],[])
     fi
+
+    # Check if compiler support __thread
+    OPAL_VAR_SCOPE_PUSH([opal_prog_cc__thread_available])
+    OPAL_CC_HELPER([if $CC $1 supports __thread], [opal_prog_cc__thread_available],
+               [],[[static __thread int  foo = 1;++foo;]], [OPAL_C_HAVE___THREAD],
+               [Whether C compiler supports __thread])
+    OPAL_VAR_SCOPE_POP
 
     OPAL_C_COMPILER_VENDOR([opal_c_vendor])
 

--- a/opal/threads/thread_usage.h
+++ b/opal/threads/thread_usage.h
@@ -249,4 +249,18 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
 
 #endif
 
+/* thread local storage */
+#if OPAL_C_HAVE__THREAD_LOCAL
+#define opal_thread_local _Thread_local
+#define OPAL_HAVE_THREAD_LOCAL 1
+
+#elif OPAL_C_HAVE___THREAD /* OPAL_C_HAVE__THREAD_LOCAL */
+#define opal_thread_local __thread
+#define OPAL_HAVE_THREAD_LOCAL 1
+#endif /* OPAL_C_HAVE___THREAD */
+
+#if !defined(OPAL_HAVE_THREAD_LOCAL)
+#define OPAL_HAVE_THREAD_LOCAL 0
+#endif /* !defined(OPAL_HAVE_THREAD_LOCAL) */
+
 #endif /* !defined(OPAL_THREAD_USAGE_H) */


### PR DESCRIPTION
Add configure to check if compiler support `__thread` (older gcc).  This will make it easier for components to use TLS and implement fallback. We already have `OPAL_C_HAVE__THREAD_LOCAL` but that only detect `_Thread_local` (gcc 4.9+).

I'm still not sure where to put the check but here seems to work? (I don't think its c11. please suggest)
