### PR TITLE
v3.1.x: pml_ucx: add option to use opal memhooks instead of ucx internal hooks

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.h
+++ b/ompi/mca/pml/ucx/pml_ucx.h
@@ -42,6 +42,7 @@ struct mca_pml_ucx_module {
     ompi_request_t            completed_send_req;
     size_t                    request_size;
     int                       num_disconnect;
+    bool                      opal_mem_hooks;
 
     /* Converters pool */
     mca_pml_ucx_freelist_t    convs;


### PR DESCRIPTION
Signed-off-by: Yossi Itigin <yosefe@mellanox.com>

(cherry picked from commit 564f80d)