### PR TITLE
v2.x: external libevent: fix for Cygwin

### DIFF
--- a/opal/mca/event/external/external.h
+++ b/opal/mca/event/external/external.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -21,6 +21,10 @@
 #define MCA_OPAL_EVENT_EXTERNAL_H
 
 #include "opal_config.h"
+
+#if defined(__CYGWIN__) && defined(WIN32)
+#undef WIN32
+#endif
 
 #include "event.h"
 #include "event2/event.h"


### PR DESCRIPTION
Port #5277 to v2.x branch.

Fix from Marco Atzeri for building on Cygwin.

Signed-off-by: Marco Atzeri <marco.atzeri@gmail.com>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 07c8ec6)
Signed-off-by: Peter Gottesman <pgottesm@cisco.com>