### PR TITLE
sharedfp/individual: only complain about fseek if sharedfp operations…

### DIFF
--- a/ompi/mca/sharedfp/individual/sharedfp_individual.h
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.h
@@ -42,6 +42,7 @@ int mca_sharedfp_individual_module_finalize (ompio_file_t *file);
 
 extern int mca_sharedfp_individual_priority;
 extern int mca_sharedfp_individual_verbose;
+extern int mca_sharedfp_individual_usage_counter;
 
 OMPI_MODULE_DECLSPEC extern mca_sharedfp_base_component_2_0_0_t mca_sharedfp_individual_component;
 /*

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_iwrite.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_iwrite.c
@@ -45,6 +45,7 @@ int mca_sharedfp_individual_iwrite(ompio_file_t *fh,
                     "mca_sharedfp_individual_iwrite: module not initialized \n");
         return OMPI_ERROR;
     }
+    mca_sharedfp_individual_usage_counter++;
 
     /* Calculate the number of bytes of data that needs to be written*/
     opal_datatype_type_size ( &datatype->super, &numofbytes);
@@ -103,6 +104,7 @@ int mca_sharedfp_individual_write_ordered_begin(ompio_file_t *fh,
                     "at any given point in time!\n");
         return MPI_ERR_REQUEST;
     }
+    mca_sharedfp_individual_usage_counter++;
 
     /*Retrieve the sharedfp data structures*/
     sh = fh->f_sharedfp_data;

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_seek.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_seek.c
@@ -27,19 +27,18 @@
 #include "ompi/constants.h"
 #include "ompi/mca/sharedfp/sharedfp.h"
 
-static int seek_counter=0;
+int mca_sharedfp_individual_usage_counter=0;
 
 int mca_sharedfp_individual_seek (ompio_file_t *fh,
                          OMPI_MPI_OFFSET_TYPE offset, int whence)
 {
-    if ( 0 == seek_counter && 
-         0 == offset       && 
-         MPI_SEEK_SET == whence ) {
-        /* This is occuring when setting the default file view. THat is ok.
-        ** The component doesn't support however further seek operations. 
+    if ( 0 == mca_sharedfp_individual_usage_counter  ) {
+        /* As long as nobody using this module 'inapproprialy', its is ok.
+        ** to call this function, since it might come out of File_set_view.
+        ** however, we have to return an error as soon as people are calling
+        ** this function on this component and expect it to work. 
         */
         
-        seek_counter++;
         return OMPI_SUCCESS;
     }
 

--- a/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
@@ -45,6 +45,7 @@ int mca_sharedfp_individual_write (ompio_file_t *fh,
                     "sharedfp_individual_write: module not initialized \n");
         return OMPI_ERROR;
     }
+    mca_sharedfp_individual_usage_counter++;
 
     /* Calculate the number of bytes of data that need to be written*/
     opal_datatype_type_size ( &datatype->super, &numofbytes);
@@ -97,6 +98,8 @@ int mca_sharedfp_individual_write_ordered (ompio_file_t *fh,
                     "sharedfp_individual_write_ordered: module not initialized \n");
         return OMPI_ERROR;
     }
+
+    mca_sharedfp_individual_usage_counter++;
 
     /*Retrieve the sharedfp data structures*/
     sh = fh->f_sharedfp_data;


### PR DESCRIPTION
… are really in use

this component can only be used in very specific scenarios. However, since some file systems do not support file locking and processes might be distributed over multiple nodes (hence the sm sharedfp component is also inelligible), the component might be selected in some scenarios, even if an application does not intend to use shared file pointers.

Since the fseek_shared function is involved as part of the File_set_view operation, only complain about the inability to perform the seek_shared operation if actual shared file pointer operations are being used. This avoid spurious error values being returned.

This is an addendum to the previous commit.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>