### PR TITLE
Decrease the size of the TCP BTL proc structure.

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_proc.h
+++ b/opal/mca/btl/tcp/btl_tcp_proc.h
@@ -60,7 +60,7 @@ typedef struct mca_btl_tcp_proc_t mca_btl_tcp_proc_t;
 OBJ_CLASS_DECLARATION(mca_btl_tcp_proc_t);
 
 /*	the highest possible interface kernel index we can handle */
-#define MAX_KERNEL_INTERFACE_INDEX 65536
+#define MAX_KERNEL_INTERFACE_INDEX 64
 
 /*	the maximum number of kernel interfaces we can handle */
 #define MAX_KERNEL_INTERFACES 8


### PR DESCRIPTION
As this structure is allocated on the stack, it should be small enopugh
to never overcome the size of the stack (even for threads). Fixes #5292.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>