### PR TITLE
Fix the no-disconnect test

### DIFF
--- a/contrib/platform/intel/bend/linux.conf
+++ b/contrib/platform/intel/bend/linux.conf
@@ -65,3 +65,4 @@ orte_abort_timeout = 10
 hwloc_base_mem_bind_failure_action = silent
 btl_tcp_if_include=10.10.10.0/24
 oob=^ud
+btl=self,vader,tcp


### PR DESCRIPTION
A race condition exists based on whether or not the userdata object attached to a hwloc_obj_t has been initialized. These objects are setup whenever we scan for resources under that location. You therefore must not set a variable to the pointer to the userdata object and then call a function that will initialize the data in it - you need to set the variable after the function call, and protect against a NULL pointer

Signed-off-by: Ralph Castain <rhc@open-mpi.org>