### PR TITLE
Try to debug the MTT failures

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -949,9 +949,9 @@ int pmix2x_value_unload(opal_value_t *kv,
         kv->type = OPAL_STATUS;
         kv->data.status = pmix2x_convert_rc(v->data.status);
         break;
-    case PMIX_PROC_RANK:
-        kv->type = OPAL_VPID;
-        kv->data.name.vpid = pmix2x_convert_rank(v->data.rank);
+    case PMIX_VALUE:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
         break;
     case PMIX_PROC:
         kv->type = OPAL_NAME;
@@ -971,6 +971,18 @@ int pmix2x_value_unload(opal_value_t *kv,
         }
         kv->data.name.vpid = pmix2x_convert_rank(v->data.proc->rank);
         break;
+    case PMIX_INFO:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_PDATA:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_BUFFER:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
     case PMIX_BYTE_OBJECT:
         kv->type = OPAL_BYTE_OBJECT;
         if (NULL != v->data.bo.bytes && 0 < v->data.bo.size) {
@@ -982,9 +994,21 @@ int pmix2x_value_unload(opal_value_t *kv,
             kv->data.bo.size = 0;
         }
         break;
+    case PMIX_KVAL:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_MODEX:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
     case PMIX_PERSIST:
         kv->type = OPAL_PERSIST;
         kv->data.uint8 = pmix2x_convert_persist(v->data.persist);
+        break;
+    case PMIX_POINTER:
+        kv->type = OPAL_PTR;
+        kv->data.ptr = v->data.ptr;
         break;
     case PMIX_SCOPE:
         kv->type = OPAL_SCOPE;
@@ -994,15 +1018,54 @@ int pmix2x_value_unload(opal_value_t *kv,
         kv->type = OPAL_DATA_RANGE;
         kv->data.uint8 = pmix2x_convert_range(v->data.range);
         break;
+    case PMIX_COMMAND:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_INFO_DIRECTIVES:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_DATA_TYPE:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
     case PMIX_PROC_STATE:
         kv->type = OPAL_PROC_STATE;
         /* the OPAL layer doesn't have any concept of proc state,
          * so the ORTE layer is responsible for converting it */
         memcpy(&kv->data.uint8, &v->data.state, sizeof(uint8_t));
         break;
-    case PMIX_POINTER:
-        kv->type = OPAL_PTR;
-        kv->data.ptr = v->data.ptr;
+    case PMIX_PROC_INFO:
+        kv->type = OPAL_PROC_INFO;
+        if (NULL == v->data.pinfo) {
+            rc = OPAL_ERR_BAD_PARAM;
+            break;
+        }
+        /* see if this job is in our list of known nspaces */
+        found = false;
+        OPAL_LIST_FOREACH(job, &mca_pmix_pmix2x_component.jobids, opal_pmix2x_jobid_trkr_t) {
+            if (0 == strncmp(job->nspace, v->data.pinfo->proc.nspace, PMIX_MAX_NSLEN)) {
+                kv->data.pinfo.name.jobid = job->jobid;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            if (OPAL_SUCCESS != (rc = opal_convert_string_to_jobid(&kv->data.pinfo.name.jobid, v->data.pinfo->proc.nspace))) {
+                return pmix2x_convert_opalrc(rc);
+            }
+        }
+        kv->data.pinfo.name.vpid = pmix2x_convert_rank(v->data.pinfo->proc.rank);
+        if (NULL != v->data.pinfo->hostname) {
+            kv->data.pinfo.hostname = strdup(v->data.pinfo->hostname);
+        }
+        if (NULL != v->data.pinfo->executable_name) {
+            kv->data.pinfo.executable_name = strdup(v->data.pinfo->executable_name);
+        }
+        kv->data.pinfo.pid = v->data.pinfo->pid;
+        kv->data.pinfo.exit_code = v->data.pinfo->exit_code;
+        kv->data.pinfo.state = pmix2x_convert_state(v->data.pinfo->state);
         break;
     case PMIX_DATA_ARRAY:
         if (NULL == v->data.darray || NULL == v->data.darray->array) {
@@ -1029,6 +1092,27 @@ int pmix2x_value_unload(opal_value_t *kv,
             }
         }
         break;
+    case PMIX_PROC_RANK:
+        kv->type = OPAL_VPID;
+        kv->data.name.vpid = pmix2x_convert_rank(v->data.rank);
+        break;
+    case PMIX_QUERY:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_COMPRESSED_STRING:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_ALLOC_DIRECTIVE:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+    case PMIX_INFO_ARRAY:
+        OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
+        rc = OPAL_ERR_NOT_SUPPORTED;
+        break;
+
     default:
         /* silence warnings */
         rc = OPAL_ERROR;
@@ -1415,6 +1499,95 @@ opal_pmix_alloc_directive_t pmix2x_convert_allocdir(pmix_alloc_directive_t dir)
             return OPAL_PMIX_ALLOC_REAQCUIRE;
         default:
             return OPAL_PMIX_ALLOC_UNDEF;
+    }
+}
+
+int pmix2x_convert_state(pmix_proc_state_t state)
+{
+    switch(state) {
+        case PMIX_PROC_STATE_UNDEF:
+            return 0;
+        case PMIX_PROC_STATE_PREPPED:
+        case PMIX_PROC_STATE_LAUNCH_UNDERWAY:
+            return 1;
+        case PMIX_PROC_STATE_RESTART:
+            return 2;
+        case PMIX_PROC_STATE_TERMINATE:
+            return 3;
+        case PMIX_PROC_STATE_RUNNING:
+            return 4;
+        case PMIX_PROC_STATE_CONNECTED:
+            return 5;
+        case PMIX_PROC_STATE_UNTERMINATED:
+            return 15;
+        case PMIX_PROC_STATE_TERMINATED:
+            return 20;
+        case PMIX_PROC_STATE_KILLED_BY_CMD:
+            return 51;
+        case PMIX_PROC_STATE_ABORTED:
+            return 52;
+        case PMIX_PROC_STATE_FAILED_TO_START:
+            return 53;
+        case PMIX_PROC_STATE_ABORTED_BY_SIG:
+            return 54;
+        case PMIX_PROC_STATE_TERM_WO_SYNC:
+            return 55;
+        case PMIX_PROC_STATE_COMM_FAILED:
+            return 56;
+        case PMIX_PROC_STATE_CALLED_ABORT:
+            return 58;
+        case PMIX_PROC_STATE_MIGRATING:
+            return 60;
+        case PMIX_PROC_STATE_CANNOT_RESTART:
+            return 61;
+        case PMIX_PROC_STATE_TERM_NON_ZERO:
+            return 62;
+        case PMIX_PROC_STATE_FAILED_TO_LAUNCH:
+            return 63;
+        default:
+            return 0;  // undef
+    }
+}
+
+pmix_proc_state_t pmix2x_convert_opalstate(int state)
+{
+    switch(state) {
+        case 0:
+            return PMIX_PROC_STATE_UNDEF;
+        case 1:
+            return PMIX_PROC_STATE_LAUNCH_UNDERWAY;
+        case 2:
+            return PMIX_PROC_STATE_RESTART;
+        case 3:
+            return PMIX_PROC_STATE_TERMINATE;
+        case 4:
+            return PMIX_PROC_STATE_RUNNING;
+        case 5:
+            return PMIX_PROC_STATE_CONNECTED;
+        case 51:
+            return PMIX_PROC_STATE_KILLED_BY_CMD;
+        case 52:
+            return PMIX_PROC_STATE_ABORTED;
+        case 53:
+            return PMIX_PROC_STATE_FAILED_TO_START;
+        case 54:
+            return PMIX_PROC_STATE_ABORTED_BY_SIG;
+        case 55:
+            return PMIX_PROC_STATE_TERM_WO_SYNC;
+        case 56:
+            return PMIX_PROC_STATE_COMM_FAILED;
+        case 58:
+            return PMIX_PROC_STATE_CALLED_ABORT;
+        case 59:
+            return PMIX_PROC_STATE_MIGRATING;
+        case 61:
+            return PMIX_PROC_STATE_CANNOT_RESTART;
+        case 62:
+            return PMIX_PROC_STATE_TERM_NON_ZERO;
+        case 63:
+            return PMIX_PROC_STATE_FAILED_TO_LAUNCH;
+        default:
+            return PMIX_PROC_STATE_UNDEF;
     }
 }
 

--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -1115,6 +1115,7 @@ int pmix2x_value_unload(opal_value_t *kv,
 
     default:
         /* silence warnings */
+        opal_output(0, "VALUE UNLOAD NOT SUPPORTED FOR TYPE %d", v->type);
         rc = OPAL_ERROR;
         break;
     }

--- a/opal/mca/pmix/pmix2x/pmix2x.h
+++ b/opal/mca/pmix/pmix2x/pmix2x.h
@@ -339,6 +339,10 @@ OPAL_MODULE_DECLSPEC opal_pmix_alloc_directive_t pmix2x_convert_allocdir(pmix_al
 
 OPAL_MODULE_DECLSPEC char* pmix2x_convert_jobid(opal_jobid_t jobid);
 
+OPAL_MODULE_DECLSPEC int pmix2x_convert_state(pmix_proc_state_t state);
+
+OPAL_MODULE_DECLSPEC pmix_proc_state_t pmix2x_convert_opalstate(int state);
+
 END_C_DECLS
 
 #endif /* MCA_PMIX_EXTERNAL_H */


### PR DESCRIPTION
Provide complete coverage of PMIx data types in the opal transition layer, printing an OPAL_ERROR_LOG where we don't support one so we can see what is missing in the MTT tests. I've been unable to reproduce them locally.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>