### PR TITLE
orterun: use consistent CLI option name for --bind-to

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2011-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -119,7 +119,7 @@ static int opal_hwloc_base_register(mca_base_register_flag_t flags)
     opal_hwloc_base_binding_policy = NULL;
     (void) mca_base_var_register("opal", "hwloc", "base", "binding_policy",
                                  "Policy for binding processes. Allowed values: none, hwthread, core, l1cache, l2cache, "
-                                 "l3cache, socket, numa, board, cpuset (\"none\" is the default when oversubscribed, \"core\" is "
+                                 "l3cache, socket, numa, board, cpu-list (\"none\" is the default when oversubscribed, \"core\" is "
                                  "the default when np<=2, and \"numa\" is the default when np>2). Allowed qualifiers: "
                                  "overload-allowed, if-supported, ordered",
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,
@@ -536,7 +536,11 @@ int opal_hwloc_base_set_binding_policy(opal_binding_policy_t *policy, char *spec
                 OPAL_SET_BINDING_POLICY(tmp, OPAL_BIND_TO_NUMA);
             } else if (0 == strcasecmp(tmpvals[0], "board")) {
                 OPAL_SET_BINDING_POLICY(tmp, OPAL_BIND_TO_BOARD);
-            } else if (0 == strcasecmp(tmpvals[0], "cpuset")) {
+            } else if (0 == strcasecmp(tmpvals[0], "cpu-list") ||
+                       0 == strcasecmp(tmpvals[0], "cpulist")) {
+                // Accept both "cpu-list" (which matches the
+                // "--cpu-list" CLI option) and "cpulist" (because
+                // people will be lazy)
                 OPAL_SET_BINDING_POLICY(tmp, OPAL_BIND_TO_CPUSET);
             } else {
                 opal_show_help("help-opal-hwloc-base.txt", "invalid binding_policy", true, "binding", spec);

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2017 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2017      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
@@ -337,7 +337,7 @@ static opal_cmd_line_init_t cmd_line_init[] = {
       /* Binding options */
     { "hwloc_base_binding_policy", '\0', NULL, "bind-to", 1,
       &orte_cmd_options.binding_policy, OPAL_CMD_LINE_TYPE_STRING,
-      "Policy for binding processes. Allowed values: none, hwthread, core, l1cache, l2cache, l3cache, socket, numa, board, cpuset (\"none\" is the default when oversubscribed, \"core\" is the default when np<=2, and \"socket\" is the default when np>2). Allowed qualifiers: overload-allowed, if-supported, ordered", OPAL_CMD_LINE_OTYPE_BINDING },
+      "Policy for binding processes. Allowed values: none, hwthread, core, l1cache, l2cache, l3cache, socket, numa, board, cpu-list (\"none\" is the default when oversubscribed, \"core\" is the default when np<=2, and \"socket\" is the default when np>2). Allowed qualifiers: overload-allowed, if-supported, ordered", OPAL_CMD_LINE_OTYPE_BINDING },
 
     /* backward compatiblity */
     { "hwloc_base_bind_to_core", '\0', "bind-to-core", "bind-to-core", 0,

--- a/orte/tools/orterun/orterun.1in
+++ b/orte/tools/orterun/orterun.1in
@@ -341,7 +341,10 @@ MPI_COMM_WORLD ranks in a round-robin, "by node" manner.
 .
 .TP
 .B -cpu-list\fR,\fP --cpu-list \fR<cpus>\fP
-List of processor IDs to bind processes to [default=NULL].
+Comma-delimited list of processor IDs to which to bind processes
+[default=NULL].  Processor IDs are interpreted as hwloc logical core
+IDs.  Run the hwloc \fIlstopo(1)\fR command to see a list of available
+cores and their logical IDs.
 .
 .
 .
@@ -366,7 +369,7 @@ For process binding:
 .TP
 .B --bind-to \fR<foo>\fP
 Bind processes to the specified object, defaults to \fIcore\fP. Supported options
-include slot, hwthread, core, l1cache, l2cache, l3cache, socket, numa, board, cpuset, and none.
+include slot, hwthread, core, l1cache, l2cache, l3cache, socket, numa, board, cpu-list, and none.
 .
 .TP
 .B -cpus-per-proc\fR,\fP --cpus-per-proc \fR<#perproc>\fP
@@ -1149,13 +1152,15 @@ cause the process to be bound to the processors that share a single L3
 cache within that socket.
 .
 .PP
-Alternatively, processes can be assigned to processors based on
-their local rank on a node using the \fI--bind-to cpuset:ordered\fP option
-with an associated \fI--cpu-list "0,2,5"\fP. This directs that the first
-rank on a node be bound to cpu0, the second rank on the node be bound
-to cpu1, and the third rank on the node be bound to cpu5. Note that an
-error will result if more processes are assigned to a node than cpus
-are provided.
+Alternatively, processes can be assigned to processors based on their
+local rank on a node using the \fI--bind-to cpu-list:ordered\fP option
+with an associated \fI--cpu-list "0,2,5"\fP. In this example, the
+first process on a node will be bound to cpu 0, the second process on
+the node will be bound to cpu 2, and the third process on the node
+will be bound to cpu 5. \fI--bind-to\fP will also accept
+\fIcpulist:ortered\fP as a synonym to \fIcpu-list:ordered\fP.  Note
+that an error will result if more processes are assigned to a node
+than cpus are provided.
 .
 .PP
 To help balance loads, the binding directive uses a round-robin method when binding to


### PR DESCRIPTION
Since the new binding option is tied to the --cpu-list orterun CLI
option, make the --bind-to option reflect the same name (vs. the
--cpu-set CLI option, which is entirely different).  For example:

    mpirun --bind-to cpu-list:ordered ...

Note that "--bind-to cpulist:ordered" is accepted as a synonym,
because people will be lazy.

Also add some minor updates to the orterun.1in man page for
clarification.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>