### PR TITLE
btl/ofi: progress now happens after a threshold.

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi.h
+++ b/opal/mca/btl/ofi/btl_ofi.h
@@ -48,6 +48,8 @@
 BEGIN_C_DECLS
 #define MCA_BTL_OFI_MAX_MODULES         16
 #define MCA_BTL_OFI_MAX_CQ_READ_ENTRIES 128
+#define MCA_BTL_OFI_NUM_CQE_READ        64
+#define MCA_BTL_OFI_PROGRESS_THRESHOLD  64
 
 #define MCA_BTL_OFI_ABORT(args)     mca_btl_ofi_exit(args)
 
@@ -129,6 +131,7 @@ struct mca_btl_ofi_component_t {
     int module_count;
     int num_contexts_per_module;
     int num_cqe_read;
+    int progress_threshold;
 
     size_t namelen;
 

--- a/opal/mca/btl/ofi/btl_ofi_atomics.c
+++ b/opal/mca/btl/ofi/btl_ofi_atomics.c
@@ -81,9 +81,6 @@ int mca_btl_ofi_afop (struct mca_btl_base_module_t *btl, struct mca_btl_base_end
 
     MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
-    /* force a bit of progress. */
-    mca_btl_ofi_component.super.btl_progress();
-
     return OPAL_SUCCESS;
 }
 
@@ -135,7 +132,6 @@ int mca_btl_ofi_aop (struct mca_btl_base_module_t *btl, mca_btl_base_endpoint_t 
     }
 
     MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
-    mca_btl_ofi_component.super.btl_progress();
 
     return OPAL_SUCCESS;
 }
@@ -191,9 +187,6 @@ int mca_btl_ofi_acswap (struct mca_btl_base_module_t *btl, struct mca_btl_base_e
     }
 
     MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
-
-    /* force a bit of progress. */
-    mca_btl_ofi_component.super.btl_progress();
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/ofi/btl_ofi_endpoint.c
+++ b/opal/mca/btl/ofi/btl_ofi_endpoint.c
@@ -176,6 +176,7 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
     struct fi_rx_attr rx_attr = {0};
 
     mca_btl_ofi_context_t *contexts;
+    tx_attr.op_flags = FI_DELIVERY_COMPLETE;
 
     contexts = (mca_btl_ofi_context_t*) calloc(num_contexts, sizeof(*contexts));
     if (NULL == contexts) {

--- a/opal/mca/btl/ofi/btl_ofi_rdma.c
+++ b/opal/mca/btl/ofi/btl_ofi_rdma.c
@@ -95,9 +95,6 @@ int mca_btl_ofi_get (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
 
     MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
 
-    /* force a bit of progress */
-    mca_btl_ofi_component.super.btl_progress();
-
     return OPAL_SUCCESS;
 }
 
@@ -142,9 +139,6 @@ int mca_btl_ofi_put (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
     }
 
     MCA_BTL_OFI_NUM_RDMA_INC(ofi_btl);
-
-    /* force a bit of progress */
-    mca_btl_ofi_component.super.btl_progress();
 
     return OPAL_SUCCESS;
 

--- a/opal/mca/btl/ofi/btl_ofi_rdma.h
+++ b/opal/mca/btl/ofi/btl_ofi_rdma.h
@@ -29,8 +29,11 @@ mca_btl_ofi_completion_t *mca_btl_ofi_completion_alloc (
                                          void *cbcontext, void *cbdata,
                                          int type);
 
-#define MCA_BTL_OFI_NUM_RDMA_INC(module)                            \
-            OPAL_THREAD_ADD_FETCH64(&(module)->outstanding_rdma, 1);
+#define MCA_BTL_OFI_NUM_RDMA_INC(module)                                                \
+            OPAL_THREAD_ADD_FETCH64(&(module)->outstanding_rdma, 1);                    \
+            if (module->outstanding_rdma > mca_btl_ofi_component.progress_threshold){   \
+                mca_btl_ofi_component.super.btl_progress();                             \
+            }
 
 #define MCA_BTL_OFI_NUM_RDMA_DEC(module)                            \
             OPAL_THREAD_ADD_FETCH64(&(module)->outstanding_rdma, -1);


### PR DESCRIPTION
This commit changed the way btl/ofi call progress. Before, we force
progression with every rdma/atomic call. This gives performance boost in
some case and slow down on others. Now we only force progression after
some number of rdma calls which result in better performance overall.

Also added new MCA parameter 'mca_btl_ofi_progress_threshold' to set
the threshold number. The new default is 64.

Also:
Added FI_DELIVERY_COMPLETE to tx_rtx flags to ensure that the completion
is generated after the message has been received on the remote side.

Signed-off-by: Thananon Patinyasakdikul <thananon.patinyasakdikul@intel.com>