### PR TITLE
v3.1: osc/sm: fix a typo

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012      Sandia National Laboratories.  All rights reserved.
- * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
@@ -309,8 +309,8 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 	    goto error;
 	}
 
-	ret = module->comm->c_coll->coll_bcast (&module->seg_ds, sizeof (module->seg_ds), MPI_BYTE, 0,
-					       module->comm, module->comm->c_coll->coll_bcast_module);
+        /* wait for all processes to attach */
+	ret = module->comm->c_coll->coll_barrier (module->comm, module->comm->c_coll->coll_barrier_module);
 	if (OMPI_SUCCESS != ret) {
 	    goto error;
 	}


### PR DESCRIPTION
This commit fixes a typo where a bcast is used instead of the intended
collective (barrier).

References #5262

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 4c230683e77b3a447295c060580c8cccbf36562a)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>