### PR TITLE
F90 removed interfaces: add missing "end interface"

### DIFF
--- a/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-removed-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-removed-interfaces.h
@@ -10,7 +10,7 @@
 !                         University of Stuttgart.  All rights reserved.
 ! Copyright (c) 2004-2005 The Regents of the University of California.
 !                         All rights reserved.
-! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2016      Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! Copyright (c) 2018      Los Alamos National Security, LLC. All rights
@@ -181,3 +181,5 @@ subroutine MPI_Type_ub(datatype, ub, ierror)
   integer, intent(out) :: ub
   integer, intent(out) :: ierror
 end subroutine MPI_Type_ub
+
+end interface


### PR DESCRIPTION
Thanks to @fsciortino for reporting.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fixes #5346.

This is not needed in any release branches (whew!) -- this fixes a bug from a May 1, 2018 master commit that hasn't gone to any releases yet.