### PR TITLE
mpi.h.in: remove some deprecation/removed warnings

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Rigde National Laboratory.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
@@ -419,17 +419,21 @@ typedef int MPIX_Grequest_class;
 /*
  * Removed typedefs. These will be deleted in a future Open MPI release.
  */
-typedef int (MPI_Copy_function)(MPI_Comm, int, void *,
-                                void *, void *, int *);
-typedef int (MPI_Delete_function)(MPI_Comm, int, void *, void *);
 typedef MPI_Comm_errhandler_function MPI_Comm_errhandler_fn
         __mpi_interface_removed__("MPI_Comm_errhandler_fn was removed in MPI-3.0; use MPI_Comm_errhandler_function instead");
 typedef ompi_file_errhandler_fn MPI_File_errhandler_fn
         __mpi_interface_removed__("MPI_File_errhandler_fn was removed in MPI-3.0; use MPI_File_errhandler_function instead");
 typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn
         __mpi_interface_removed__("MPI_Win_errhandler_fn was removed in MPI-3.0; use MPI_Win_errhandler_function instead");
-typedef void (MPI_Handler_function)(MPI_Comm *, int *, ...)
-        __mpi_interface_removed__("MPI_Handler_function was removed in MPI-3.0; use MPI_Win_errhandler_function instead");
+
+// NOTE: We intentionally do *not* mark the following as
+// deprecated/removed because they are used below in function
+// prototypes (and would therefore emit warnings, just for #including
+// <mpi.h>).
+typedef void (MPI_Handler_function)(MPI_Comm *, int *, ...);
+typedef int (MPI_Copy_function)(MPI_Comm, int, void *,
+                                void *, void *, int *);
+typedef int (MPI_Delete_function)(MPI_Comm, int, void *, void *);
 #endif /* !OMPI_OMIT_MPI1_COMPAT_DECLS */
 
 


### PR DESCRIPTION
Intentionally do not mark some MPI-1 function pointer typedefs as
`__mpi_interface_removed__` because we have to use them in prototyping
some MPI-1 functions when `--enable-mpi1-compatibility` is used.

Fixes #5357.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>