### PR TITLE
dist: prep for 3.1.2 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,10 @@ included in the vX.Y.Z section and be denoted as:
 
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
+
+3.1.2 -- September, 2018
+------------------------
+
 3.1.1 -- June, 2018
 -------------------
 

--- a/VERSION
+++ b/VERSION
@@ -17,7 +17,7 @@
 
 major=3
 minor=1
-release=1
+release=2
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -26,7 +26,7 @@ release=1
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
3.1.1 is tagged and shipping, so prep for next release version by updating the VERSION to 3.1.2a1 and adding a NEWS header.