### PR TITLE
btl/ugni: update BTL_VERBOSE argument list

### DIFF
--- a/opal/mca/btl/ugni/btl_ugni_component.c
+++ b/opal/mca/btl/ugni/btl_ugni_component.c
@@ -625,7 +625,7 @@ void mca_btl_ugni_handle_rdma_completions (mca_btl_ugni_module_t *ugni_module, m
     int bte_complete = 0;
 
     for (int i = 0 ; i < count ; ++i) {
-        BTL_VERBOSE(("post descriptor complete. status: %d", post_dest[i].rc));
+        BTL_VERBOSE(("post descriptor complete. status: %d", post_desc[i].rc));
 
         if (OPAL_UNLIKELY(OPAL_SUCCESS != post_desc[i].rc)) {
             /* dump the post descriptor if in a debug build */

--- a/opal/mca/btl/ugni/btl_ugni_device.h
+++ b/opal/mca/btl/ugni/btl_ugni_device.h
@@ -278,8 +278,8 @@ static inline intptr_t mca_btl_ugni_post_fma_device (mca_btl_ugni_device_t *devi
     }
 
     BTL_VERBOSE(("Posting FMA descriptor %p with op_type %d, amo %d, remote_addr 0x%lx, "
-                 "length %lu", (void*)desc, desc->gni_desc.type, desc->gni_desc.amo_cmd,
-                 desc->gni_desc.remote_addr, desc->gni_desc.length));
+                 "length %lu", (void*)rdma_desc, rdma_desc->btl_ugni_desc.gni_desc.type, rdma_desc->btl_ugni_desc.gni_desc.amo_cmd,
+                 rdma_desc->btl_ugni_desc.gni_desc.remote_addr, rdma_desc->btl_ugni_desc.gni_desc.length));
 
     rc = GNI_PostFma (rdma_desc->gni_handle, &rdma_desc->btl_ugni_desc.gni_desc);
     if (OPAL_UNLIKELY(GNI_RC_SUCCESS != rc)) {
@@ -323,8 +323,8 @@ static inline intptr_t mca_btl_ugni_post_rdma_device (mca_btl_ugni_device_t *dev
         &device->dev_rdma_local_cq;
 
     BTL_VERBOSE(("Posting RDMA descriptor %p with op_type %d, amo %d, remote_addr 0x%lx, "
-                 "length %lu", (void*)desc, desc->gni_desc.type, desc->gni_desc.amo_cmd,
-                 desc->gni_desc.remote_addr, desc->gni_desc.length));
+                 "length %lu", (void*)rdma_desc, rdma_desc->btl_ugni_desc.gni_desc.type, rdma_desc->btl_ugni_desc.gni_desc.amo_cmd,
+                 rdma_desc->btl_ugni_desc.gni_desc.remote_addr, rdma_desc->btl_ugni_desc.gni_desc.length));
 
     rc = GNI_PostRdma (rdma_desc->gni_handle, &rdma_desc->btl_ugni_desc.gni_desc);
     if (OPAL_UNLIKELY(GNI_RC_SUCCESS != rc)) {


### PR DESCRIPTION
c1ac0c00c52cc59cf531e26579293dcb2702a55c fails to compile on NERSC Cori when configured with --enable-debug:

```
  CC       btl_ugni_component.lo
In file included from btl_ugni_rdma.h(18),
                 from btl_ugni_component.c(16):
btl_ugni_device.h(280): error: identifier "desc" is undefined
      BTL_VERBOSE(("Posting FMA descriptor %p with op_type %d, amo %d, remote_addr 0x%lx, "
      ^   

In file included from btl_ugni_rdma.h(18),
                 from btl_ugni_component.c(16):
btl_ugni_device.h(325): error: identifier "desc" is undefined
      BTL_VERBOSE(("Posting RDMA descriptor %p with op_type %d, amo %d, remote_addr 0x%lx, "
      ^   

btl_ugni_component.c(628): error: identifier "post_dest" is undefined
          BTL_VERBOSE(("post descriptor complete. status: %d", post_dest[i].rc));
          ^   

compilation aborted for btl_ugni_component.c (code 2)
...
btl_ugni_component.c(628): error: identifier "post_dest" is undefined
          BTL_VERBOSE(("post descriptor complete. status: %d", post_dest[i].rc));
          ^   
```

It looks like a couple BTL_VERBOSE argument updates in btl_ugni_component.c were missed in b0ac6276a617cbd70d3ebc2aedf8e03775e2ee9c , and there is a typo in one added to btl_ugni_component.c.