### PR TITLE
MCA/COMMON/UCX: minor unification of del_proces calls

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -108,7 +108,7 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                                  [AC_DEFINE([HAVE_UCP_TAG_SEND_NBR],[1],
                                             [have ucp_tag_send_nbr()])], [],
                                  [#include <ucp/api/ucp.h>])
-                  AC_CHECK_DECLS([ucp_ep_flush_nb, ucp_worker_flush_nb, ucp_request_check_status],
+                  AC_CHECK_DECLS([ucp_ep_flush_nb, ucp_worker_flush_nb, ucp_request_check_status, ucp_put_nb, ucp_get_nb],
                                  [], [],
                                  [#include <ucp/api/ucp.h>])
                   CPPFLAGS=$old_CPPFLAGS

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -108,7 +108,8 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                                  [AC_DEFINE([HAVE_UCP_TAG_SEND_NBR],[1],
                                             [have ucp_tag_send_nbr()])], [],
                                  [#include <ucp/api/ucp.h>])
-                  AC_CHECK_DECLS([ucp_ep_flush_nb, ucp_worker_flush_nb, ucp_request_check_status, ucp_put_nb, ucp_get_nb],
+                  AC_CHECK_DECLS([ucp_ep_flush_nb, ucp_worker_flush_nb,
+                                  ucp_request_check_status, ucp_put_nb, ucp_get_nb],
                                  [], [],
                                  [#include <ucp/api/ucp.h>])
                   CPPFLAGS=$old_CPPFLAGS

--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -27,6 +27,7 @@ extern int opal_common_ucx_progress_iterations;
 
 OPAL_DECLSPEC void opal_common_ucx_mca_register(void);
 OPAL_DECLSPEC void opal_common_ucx_empty_complete_cb(void *request, ucs_status_t status);
+OPAL_DECLSPEC void opal_common_ucx_mca_pmix_fence(ucp_worker_h worker);
 
 static inline
 ucs_status_t opal_common_ucx_wait_request(ucs_status_ptr_t request, ucp_worker_h worker)

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -103,15 +103,11 @@ static void mca_spml_ucx_waitall(void **reqs, int *count_p)
 
     SPML_VERBOSE(10, "waiting for %d disconnect requests", *count_p);
     for (i = 0; i < *count_p; ++i) {
-        do {
-            opal_progress();
-            status = ucp_request_test(reqs[i], NULL);
-        } while (status == UCS_INPROGRESS);
+        status = opal_common_ucx_wait_request(reqs[i], mca_spml_ucx.ucp_worker);
         if (status != UCS_OK) {
             SPML_ERROR("disconnect request failed: %s",
                        ucs_status_string(status));
         }
-        ucp_request_release(reqs[i]);
         reqs[i] = NULL;
     }
 
@@ -175,8 +171,9 @@ int mca_spml_ucx_del_procs(ompi_proc_t** procs, size_t nprocs)
     mca_spml_ucx_waitall(dreqs, &num_reqs);
     free(dreqs);
 
-    opal_pmix.fence(NULL, 0);
+    opal_common_ucx_mca_pmix_fence(mca_spml_ucx.ucp_worker);
     free(mca_spml_ucx.ucp_peers);
+    mca_spml_ucx.ucp_peers = NULL;
     return OSHMEM_SUCCESS;
 }
 
@@ -585,12 +582,14 @@ int mca_spml_ucx_put(void* dst_addr, size_t size, void* src_addr, int dst)
 {
     void *rva;
     ucs_status_t status;
+    ucs_status_ptr_t request;
     spml_ucx_mkey_t *ucx_mkey;
 
     ucx_mkey = mca_spml_ucx_get_mkey(dst, dst_addr, &rva, &mca_spml_ucx);
-    status = ucp_put(mca_spml_ucx.ucp_peers[dst].ucp_conn, src_addr, size,
-                     (uint64_t)rva, ucx_mkey->rkey);
-
+    request = ucp_put_nb(mca_spml_ucx.ucp_peers[dst].ucp_conn, src_addr, size,
+                         (uint64_t)rva, ucx_mkey->rkey, opal_common_ucx_empty_complete_cb);
+    /* TODO: replace wait_request by opal_common_ucx_wait_request_opal_status */
+    status = opal_common_ucx_wait_request(request, mca_spml_ucx.ucp_worker);
     return ucx_status_to_oshmem(status);
 }
 

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -604,7 +604,7 @@ int mca_spml_ucx_put(void* dst_addr, size_t size, void* src_addr, int dst)
     /* TODO: replace wait_request by opal_common_ucx_wait_request_opal_status */
     status = opal_common_ucx_wait_request(request, mca_spml_ucx.ucp_worker);
 #else
-    request = ucp_put(mca_spml_ucx.ucp_peers[dst].ucp_conn, src_addr, size,
+    status = ucp_put(mca_spml_ucx.ucp_peers[dst].ucp_conn, src_addr, size,
                      (uint64_t)rva, ucx_mkey->rkey);
 #endif
     return ucx_status_to_oshmem(status);


### PR DESCRIPTION
- some common functionality of del_procs calls is moved into
  mca_common module
- blocking ucp_put call is replaced by non-blocking routine

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>