### PR TITLE
btl/vader: add support for atomics and emulated rdma

### DIFF
--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -189,6 +189,7 @@ typedef uint8_t mca_btl_base_tag_t;
 #define MCA_BTL_TAG_IB                (MCA_BTL_TAG_BTL + 0)
 #define MCA_BTL_TAG_UDAPL             (MCA_BTL_TAG_BTL + 1)
 #define MCA_BTL_TAG_SMCUDA            (MCA_BTL_TAG_BTL + 2)
+#define MCA_BTL_TAG_VADER             (MCA_BTL_TAG_BTL + 3)
 
 /* prefered protocol */
 #define MCA_BTL_FLAGS_SEND            0x0001

--- a/opal/mca/btl/vader/Makefile.am
+++ b/opal/mca/btl/vader/Makefile.am
@@ -40,7 +40,9 @@ libmca_btl_vader_la_sources = \
     btl_vader_xpmem.c \
     btl_vader_xpmem.h \
     btl_vader_knem.c \
-    btl_vader_knem.h
+    btl_vader_knem.h \
+    btl_vader_sc_emu.c \
+    btl_vader_atomic.c
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2017 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2010-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  *
@@ -92,6 +92,7 @@ enum {
     MCA_BTL_VADER_CMA   = 1,
     MCA_BTL_VADER_KNEM  = 2,
     MCA_BTL_VADER_NONE  = 3,
+    MCA_BTL_VADER_EMUL  = 4,
 };
 
 /**
@@ -233,6 +234,11 @@ int mca_btl_vader_put_knem (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t 
                             int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
 #endif
 
+int mca_btl_vader_put_sc_emu (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint, void *local_address,
+                               uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
+                               mca_btl_base_registration_handle_t *remote_handle, size_t size, int flags,
+                               int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
+
 /**
  * Initiate an synchronous get.
  *
@@ -260,6 +266,29 @@ int mca_btl_vader_get_knem (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t 
                             mca_btl_base_registration_handle_t *remote_handle, size_t size, int flags,
                             int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
 #endif
+
+int mca_btl_vader_get_sc_emu (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint, void *local_address,
+                               uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
+                               mca_btl_base_registration_handle_t *remote_handle, size_t size, int flags,
+                               int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
+
+int mca_btl_vader_emu_aop (struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                           uint64_t remote_address, mca_btl_base_registration_handle_t *remote_handle,
+                           mca_btl_base_atomic_op_t op, uint64_t operand, int flags, int order,
+                           mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
+
+int mca_btl_vader_emu_afop (struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                            void *local_address, uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
+                            mca_btl_base_registration_handle_t *remote_handle, mca_btl_base_atomic_op_t op,
+                            uint64_t operand, int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc,
+                            void *cbcontext, void *cbdata);
+
+int mca_btl_vader_emu_acswap (struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                              void *local_address, uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
+                              mca_btl_base_registration_handle_t *remote_handle, uint64_t compare, uint64_t value, int flags,
+                              int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
+
+void mca_btl_vader_sc_emu_init (void);
 
 /**
  * Allocate a segment.

--- a/opal/mca/btl/vader/btl_vader_atomic.c
+++ b/opal/mca/btl/vader/btl_vader_atomic.c
@@ -1,0 +1,100 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2010-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "btl_vader.h"
+#include "btl_vader_frag.h"
+#include "btl_vader_endpoint.h"
+#include "btl_vader_xpmem.h"
+
+static void mca_btl_vader_sc_emu_aop_complete (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint,
+                                                mca_btl_base_descriptor_t *desc, int status)
+{
+    mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) desc;
+    void *local_address = frag->rdma.local_address;
+
+    frag->rdma.cbfunc (btl, endpoint, local_address, NULL, frag->rdma.context, frag->rdma.cbdata, status);
+}
+
+int mca_btl_vader_emu_aop (struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                           uint64_t remote_address, mca_btl_base_registration_handle_t *remote_handle,
+                           mca_btl_base_atomic_op_t op, uint64_t operand, int flags, int order,
+                           mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
+{
+    mca_btl_vader_frag_t *frag;
+
+    frag = mca_btl_vader_rdma_frag_alloc (btl, endpoint, MCA_BTL_VADER_OP_ATOMIC, operand, 0, op, 0, order, flags, NULL,
+                                          remote_address, cbfunc, cbcontext, cbdata, mca_btl_vader_sc_emu_aop_complete);
+    if (OPAL_UNLIKELY(NULL == frag)) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* send is always successful */
+    (void) mca_btl_vader_send (btl, endpoint, &frag->base, MCA_BTL_TAG_VADER);
+
+    return OPAL_SUCCESS;
+}
+
+static void mca_btl_vader_sc_emu_afop_complete (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint,
+                                                mca_btl_base_descriptor_t *desc, int status)
+{
+    mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) desc;
+    mca_btl_vader_sc_emu_hdr_t *hdr;
+    void *local_address = frag->rdma.local_address;
+
+    hdr = (mca_btl_vader_sc_emu_hdr_t *) frag->segments[0].seg_addr.pval;
+
+    *((int64_t *) frag->rdma.local_address) = hdr->operand[0];
+
+    frag->rdma.cbfunc (btl, endpoint, local_address, NULL, frag->rdma.context, frag->rdma.cbdata, status);
+}
+
+int mca_btl_vader_emu_afop (struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                            void *local_address, uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
+                            mca_btl_base_registration_handle_t *remote_handle, mca_btl_base_atomic_op_t op,
+                            uint64_t operand, int flags, int order, mca_btl_base_rdma_completion_fn_t cbfunc,
+                            void *cbcontext, void *cbdata)
+{
+    mca_btl_vader_frag_t *frag;
+
+    frag = mca_btl_vader_rdma_frag_alloc (btl, endpoint, MCA_BTL_VADER_OP_ATOMIC, operand, 0, op, 0, order, flags,
+                                          local_address, remote_address, cbfunc, cbcontext, cbdata,
+                                          mca_btl_vader_sc_emu_afop_complete);
+    if (OPAL_UNLIKELY(NULL == frag)) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* send is always successful */
+    (void) mca_btl_vader_send (btl, endpoint, &frag->base, MCA_BTL_TAG_VADER);
+
+    return OPAL_SUCCESS;
+}
+
+int mca_btl_vader_emu_acswap (struct mca_btl_base_module_t *btl, struct mca_btl_base_endpoint_t *endpoint,
+                              void *local_address, uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
+                              mca_btl_base_registration_handle_t *remote_handle, uint64_t compare, uint64_t value, int flags,
+                              int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
+{
+    mca_btl_vader_frag_t *frag;
+
+    frag = mca_btl_vader_rdma_frag_alloc (btl, endpoint, MCA_BTL_VADER_OP_CSWAP, compare, value, 0, 0, order,
+                                          flags, local_address, remote_address, cbfunc, cbcontext, cbdata,
+                                          mca_btl_vader_sc_emu_afop_complete);
+    if (OPAL_UNLIKELY(NULL == frag)) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* send is always successful */
+    (void) mca_btl_vader_send (btl, endpoint, &frag->base, MCA_BTL_TAG_VADER);
+
+    return OPAL_SUCCESS;
+}

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2010-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
@@ -68,6 +68,7 @@ static mca_base_var_enum_value_t single_copy_mechanisms[] = {
 #if OPAL_BTL_VADER_HAVE_KNEM
     {.value = MCA_BTL_VADER_KNEM, .string = "knem"},
 #endif
+    {.value = MCA_BTL_VADER_EMUL, .string = "emulated"},
     {.value = MCA_BTL_VADER_NONE, .string = "none"},
     {.value = 0, .string = NULL}
 };
@@ -95,14 +96,6 @@ mca_btl_vader_component_t mca_btl_vader_component = {
     }  /* end super */
 };
 
-static void mca_btl_vader_dummy_rdma (void)
-{
-    /* If a backtrace ends at this function something has gone wrong with
-     * the btl bootstrapping. Check that the btl_get function was set to
-     * something reasonable. */
-    abort ();
-}
-
 static int mca_btl_vader_component_register (void)
 {
     mca_base_var_enum_t *new_enum;
@@ -119,7 +112,7 @@ static int mca_btl_vader_component_register (void)
                                            MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_9,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &mca_btl_vader_component.vader_free_list_num);
-    mca_btl_vader_component.vader_free_list_max = 4096;
+    mca_btl_vader_component.vader_free_list_max = 512;
     (void) mca_base_component_var_register(&mca_btl_vader_component.super.btl_version,
                                            "free_list_max", "Maximum number of fragments "
                                            "to allocate for shared memory communication.",
@@ -252,19 +245,41 @@ static int mca_btl_vader_component_register (void)
     mca_btl_vader.super.btl_rdma_pipeline_send_length = mca_btl_vader.super.btl_eager_limit;
     mca_btl_vader.super.btl_rdma_pipeline_frag_size   = mca_btl_vader.super.btl_eager_limit;
 
-    mca_btl_vader.super.btl_flags = MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_SEND;
+#if OPAL_HAVE_ATOMIC_MATH_64
+    mca_btl_vader.super.btl_flags = MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_SEND | MCA_BTL_FLAGS_RDMA |
+        MCA_BTL_FLAGS_ATOMIC_OPS | MCA_BTL_FLAGS_ATOMIC_FOPS;
+
+    mca_btl_vader.super.btl_atomic_flags = MCA_BTL_ATOMIC_SUPPORTS_ADD | MCA_BTL_ATOMIC_SUPPORTS_AND |
+        MCA_BTL_ATOMIC_SUPPORTS_OR | MCA_BTL_ATOMIC_SUPPORTS_XOR | MCA_BTL_ATOMIC_SUPPORTS_CSWAP |
+        MCA_BTL_ATOMIC_SUPPORTS_GLOB | MCA_BTL_ATOMIC_SUPPORTS_SWAP;
+#if OPAL_HAVE_ATOMIC_MATH_32
+    mca_btl_vader.super.btl_atomic_flags |= MCA_BTL_ATOMIC_SUPPORTS_32BIT;
+#endif /* OPAL_HAVE_ATOMIC_MATH_32 */
+
+#if OPAL_HAVE_ATOMIC_MIN_64
+    mca_btl_vader.super.btl_atomic_flags |= MCA_BTL_ATOMIC_SUPPORTS_MIN;
+#endif /* OPAL_HAVE_ATOMIC_MIN_64 */
+
+#if OPAL_HAVE_ATOMIC_MAX_64
+    mca_btl_vader.super.btl_atomic_flags |= MCA_BTL_ATOMIC_SUPPORTS_MAX;
+#endif /* OPAL_HAVE_ATOMIC_MAX_64 */
+
+#else
+    mca_btl_vader.super.btl_flags = MCA_BTL_FLAGS_SEND_INPLACE | MCA_BTL_FLAGS_SEND | MCA_BTL_FLAGS_RDMA;
+#endif /* OPAL_HAVE_ATOMIC_MATH_64 */
 
     if (MCA_BTL_VADER_NONE != mca_btl_vader_component.single_copy_mechanism) {
-        mca_btl_vader.super.btl_flags    |= MCA_BTL_FLAGS_RDMA;
-        /* Single copy mechanisms should provide better bandwidth */
+        /* True single copy mechanisms should provide better bandwidth */
         mca_btl_vader.super.btl_bandwidth = 40000; /* Mbs */
-
-        /* Set dummy values so the RDMA flag doesn't get unset by mca_btl_base_param_verify() */
-        mca_btl_vader.super.btl_get = (mca_btl_base_module_get_fn_t) mca_btl_vader_dummy_rdma;
-        mca_btl_vader.super.btl_put = (mca_btl_base_module_get_fn_t) mca_btl_vader_dummy_rdma;
     } else {
         mca_btl_vader.super.btl_bandwidth = 10000; /* Mbs */
     }
+
+    mca_btl_vader.super.btl_get = mca_btl_vader_get_sc_emu;
+    mca_btl_vader.super.btl_put = mca_btl_vader_put_sc_emu;
+    mca_btl_vader.super.btl_atomic_op = mca_btl_vader_emu_aop;
+    mca_btl_vader.super.btl_atomic_fop = mca_btl_vader_emu_afop;
+    mca_btl_vader.super.btl_atomic_cswap = mca_btl_vader_emu_acswap;
 
     mca_btl_vader.super.btl_latency   = 1;     /* Microsecs */
 
@@ -350,7 +365,6 @@ static int mca_btl_base_vader_modex_send (void)
     return rc;
 }
 
-#if OPAL_BTL_VADER_HAVE_XPMEM || OPAL_BTL_VADER_HAVE_CMA || OPAL_BTL_VADER_HAVE_KNEM
 static void mca_btl_vader_select_next_single_copy_mechanism (void)
 {
     for (int i = 0 ; single_copy_mechanisms[i].value != MCA_BTL_VADER_NONE ; ++i) {
@@ -446,8 +460,14 @@ static void mca_btl_vader_check_single_copy (void)
         mca_btl_vader.super.btl_get = NULL;
         mca_btl_vader.super.btl_put = NULL;
     }
+
+    if (MCA_BTL_VADER_EMUL == mca_btl_vader_component.single_copy_mechanism) {
+        mca_btl_vader_sc_emu_init ();
+        /* limit to the maximum fragment size */
+        mca_btl_vader.super.btl_put_limit = mca_btl_vader.super.btl_max_send_size - sizeof (mca_btl_vader_sc_emu_hdr_t);
+        mca_btl_vader.super.btl_get_limit = mca_btl_vader.super.btl_max_send_size - sizeof (mca_btl_vader_sc_emu_hdr_t);
+    }
 }
-#endif
 
 /*
  *  VADER component initialization
@@ -497,11 +517,10 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
     component->num_fbox_in_endpoints = 0;
     component->fbox_count = 0;
 
-#if OPAL_BTL_VADER_HAVE_XPMEM || OPAL_BTL_VADER_HAVE_CMA || OPAL_BTL_VADER_HAVE_KNEM
     mca_btl_vader_check_single_copy ();
-#endif
 
     if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
+        const char *base_dir = opal_process_info.proc_session_dir;
         char *sm_file;
 
         rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%x.%d", mca_btl_vader_component.backing_directory,

--- a/opal/mca/btl/vader/btl_vader_frag.h
+++ b/opal/mca/btl/vader/btl_vader_frag.h
@@ -36,6 +36,23 @@ enum {
 struct mca_btl_vader_frag_t;
 struct mca_btl_vader_fbox_t;
 
+enum mca_btl_vader_sc_emu_type_t {
+    MCA_BTL_VADER_OP_PUT,
+    MCA_BTL_VADER_OP_GET,
+    MCA_BTL_VADER_OP_ATOMIC,
+    MCA_BTL_VADER_OP_CSWAP,
+};
+typedef enum mca_btl_vader_sc_emu_type_t mca_btl_vader_sc_emu_type_t;
+
+struct mca_btl_vader_sc_emu_hdr_t {
+    mca_btl_vader_sc_emu_type_t type;
+    uint64_t addr;
+    mca_btl_base_atomic_op_t op;
+    int flags;
+    int64_t operand[2];
+};
+typedef struct mca_btl_vader_sc_emu_hdr_t mca_btl_vader_sc_emu_hdr_t;
+
 /**
  * FIFO fragment header
  */
@@ -71,6 +88,13 @@ struct mca_btl_vader_frag_t {
     mca_btl_vader_hdr_t *hdr;
     /** free list this fragment was allocated within */
     opal_free_list_t *my_list;
+    /** rdma callback data */
+    struct mca_btl_vader_rdma_cbdata_t {
+        void *local_address;
+        mca_btl_base_rdma_completion_fn_t cbfunc;
+        void *context;
+        void *cbdata;
+    } rdma;
 };
 
 typedef struct mca_btl_vader_frag_t mca_btl_vader_frag_t;
@@ -112,16 +136,54 @@ OBJ_CLASS_DECLARATION(mca_btl_vader_frag_t);
 
 
 static inline void mca_btl_vader_frag_complete (mca_btl_vader_frag_t *frag) {
-    if (OPAL_UNLIKELY(MCA_BTL_DES_SEND_ALWAYS_CALLBACK & frag->base.des_flags)) {
+    /* save the descriptor flags since the callback is allowed to free the frag */
+    int des_flags = frag->base.des_flags;
+
+    if (OPAL_UNLIKELY(MCA_BTL_DES_SEND_ALWAYS_CALLBACK & des_flags)) {
         /* completion callback */
         frag->base.des_cbfunc (&mca_btl_vader.super, frag->endpoint, &frag->base, OPAL_SUCCESS);
     }
 
-    if (OPAL_LIKELY(frag->base.des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP)) {
+    if (OPAL_LIKELY(des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP)) {
         MCA_BTL_VADER_FRAG_RETURN(frag);
     }
 }
 
 int mca_btl_vader_frag_init (opal_free_list_item_t *item, void *ctx);
+
+static inline mca_btl_vader_frag_t *
+mca_btl_vader_rdma_frag_alloc (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint, int type,
+                               uint64_t operand1, uint64_t operand2, mca_btl_base_atomic_op_t op, int order,
+                               int flags, size_t size, void *local_address, int64_t remote_address,
+                               mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext,
+                               void *cbdata, mca_btl_base_completion_fn_t des_cbfunc)
+{
+    mca_btl_vader_sc_emu_hdr_t *hdr;
+    size_t total_size = size + sizeof (*hdr);
+    mca_btl_vader_frag_t *frag;
+
+    frag = (mca_btl_vader_frag_t *) mca_btl_vader_alloc (btl, endpoint, order, total_size,
+                                                         MCA_BTL_DES_SEND_ALWAYS_CALLBACK);
+    if (OPAL_UNLIKELY(NULL == frag)) {
+        return NULL;
+    }
+
+    frag->base.des_cbfunc = des_cbfunc;
+    frag->rdma.local_address = local_address;
+    frag->rdma.cbfunc = cbfunc;
+    frag->rdma.context = cbcontext;
+    frag->rdma.cbdata = cbdata;
+
+    hdr = (mca_btl_vader_sc_emu_hdr_t *) frag->segments[0].seg_addr.pval;
+
+    hdr->type = type;
+    hdr->addr = remote_address;
+    hdr->op = op;
+    hdr->flags = flags;
+    hdr->operand[0] = operand1;
+    hdr->operand[1] = operand2;
+
+    return frag;
+}
 
 #endif /* MCA_BTL_VADER_SEND_FRAG_H */

--- a/opal/mca/btl/vader/btl_vader_put.c
+++ b/opal/mca/btl/vader/btl_vader_put.c
@@ -134,3 +134,50 @@ int mca_btl_vader_put_knem (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t 
     return OPAL_SUCCESS;
 }
 #endif
+
+static void mca_btl_vader_sc_emu_put_complete (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint,
+                                               mca_btl_base_descriptor_t *desc, int status)
+{
+    mca_btl_vader_frag_t *frag = (mca_btl_vader_frag_t *) desc;
+    void *local_address = frag->rdma.local_address;
+    void *context = frag->rdma.context;
+    void *cbdata = frag->rdma.cbdata;
+    mca_btl_base_rdma_completion_fn_t cbfunc = frag->rdma.cbfunc;
+
+    /* return the fragment first since the callback may call put/get/amo and could use this fragment */
+    MCA_BTL_VADER_FRAG_RETURN(frag);
+
+    cbfunc (btl, endpoint, local_address, NULL, context, cbdata, status);
+}
+
+/**
+ * @brief Provides an emulated put path which uses copy-in copy-out with shared memory buffers
+ */
+int mca_btl_vader_put_sc_emu (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint, void *local_address,
+                              uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,
+                              mca_btl_base_registration_handle_t *remote_handle, size_t size, int flags,
+                              int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata)
+{
+    mca_btl_vader_sc_emu_hdr_t *hdr;
+    mca_btl_vader_frag_t *frag;
+
+    if (size > mca_btl_vader.super.btl_put_limit) {
+        return OPAL_ERR_NOT_AVAILABLE;
+    }
+
+    frag = mca_btl_vader_rdma_frag_alloc (btl, endpoint, MCA_BTL_VADER_OP_PUT, 0, 0, 0, order, flags, size,
+                                          local_address, remote_address, cbfunc, cbcontext, cbdata,
+                                          mca_btl_vader_sc_emu_put_complete);
+    if (OPAL_UNLIKELY(NULL == frag)) {
+        return OPAL_ERR_OUT_OF_RESOURCE;
+    }
+
+    hdr = (mca_btl_vader_sc_emu_hdr_t *) frag->segments[0].seg_addr.pval;
+
+    memcpy ((void *) (hdr + 1), local_address, size);
+
+    /* send is always successful */
+    (void) mca_btl_vader_send (btl, endpoint, &frag->base, MCA_BTL_TAG_VADER);
+
+    return OPAL_SUCCESS;
+}

--- a/opal/mca/btl/vader/btl_vader_sc_emu.c
+++ b/opal/mca/btl/vader/btl_vader_sc_emu.c
@@ -1,0 +1,150 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "btl_vader.h"
+#include "btl_vader_frag.h"
+
+#if OPAL_HAVE_ATOMIC_MATH_64
+static void mca_btl_vader_sc_emu_atomic_64 (int64_t *operand, volatile int64_t *addr, mca_btl_base_atomic_op_t op)
+{
+    int64_t result;
+
+    fprintf (stderr, "Performing atomic operation %d on address %p\n", op, (void *) addr);
+
+    switch (op) {
+    case MCA_BTL_ATOMIC_ADD:
+        result = opal_atomic_fetch_add_64 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_AND:
+        result = opal_atomic_fetch_and_64 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_OR:
+        result = opal_atomic_fetch_or_64 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_XOR:
+        result = opal_atomic_fetch_xor_64 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_SWAP:
+        result = opal_atomic_swap_64 (addr, *operand);
+        break;
+#if OPAL_HAVE_ATOMIC_MIN_64
+    case MCA_BTL_ATOMIC_MIN:
+        result = opal_atomic_fetch_min_64 (addr, *operand);
+        break;
+#endif
+#if OPAL_HAVE_ATOMIC_MAX_64
+    case MCA_BTL_ATOMIC_MAX:
+        result = opal_atomic_fetch_max_64 (addr, *operand);
+        break;
+#endif
+    default:
+        assert (0);
+    }
+
+    *operand = result;
+}
+#endif
+
+#if OPAL_HAVE_ATOMIC_MATH_32
+static void mca_btl_vader_sc_emu_atomic_32 (int32_t *operand, volatile int32_t *addr, mca_btl_base_atomic_op_t op)
+{
+    int32_t result;
+
+    fprintf (stderr, "Performing atomic operation %d on address %p\n", op, (void *) addr);
+
+    switch (op) {
+    case MCA_BTL_ATOMIC_ADD:
+        result = opal_atomic_fetch_add_32 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_AND:
+        result = opal_atomic_fetch_and_32 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_OR:
+        result = opal_atomic_fetch_or_32 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_XOR:
+        result = opal_atomic_fetch_xor_32 (addr, *operand);
+        break;
+    case MCA_BTL_ATOMIC_SWAP:
+        result = opal_atomic_swap_32 (addr, *operand);
+        break;
+#if OPAL_HAVE_ATOMIC_MIN_32
+    case MCA_BTL_ATOMIC_MIN:
+        result = opal_atomic_fetch_min_32 (addr, *operand);
+        break;
+#endif
+#if OPAL_HAVE_ATOMIC_MAX_32
+    case MCA_BTL_ATOMIC_MAX:
+        result = opal_atomic_fetch_max_32 (addr, *operand);
+        break;
+#endif
+    default:
+        assert (0);
+    }
+
+    *operand = result;
+}
+#endif
+
+static void mca_btl_vader_sc_emu_rdma (mca_btl_base_module_t *btl, mca_btl_base_tag_t tag, mca_btl_base_descriptor_t *desc, void *ctx)
+{
+    mca_btl_vader_sc_emu_hdr_t *hdr = (mca_btl_vader_sc_emu_hdr_t *) desc->des_segments[0].seg_addr.pval;
+    size_t size = desc->des_segments[0].seg_len - sizeof (*hdr);
+    void *data = (void *)(hdr + 1);
+
+    switch (hdr->type) {
+    case MCA_BTL_VADER_OP_PUT:
+        memcpy ((void *) hdr->addr, data, size);
+        break;
+    case MCA_BTL_VADER_OP_GET:
+        memcpy (data, (void *) hdr->addr, size);
+        break;
+#if OPAL_HAVE_ATOMIC_MATH_64
+    case MCA_BTL_VADER_OP_ATOMIC:
+        if (!(hdr->flags & MCA_BTL_ATOMIC_FLAG_32BIT)) {
+            mca_btl_vader_sc_emu_atomic_64 (hdr->operand, (void *) hdr->addr, hdr->op);
+#if OPAL_HAVE_ATOMIC_MATH_32
+        } else {
+            int32_t tmp = (int32_t) hdr->operand[0];
+            mca_btl_vader_sc_emu_atomic_32 (&tmp, (void *) hdr->addr, hdr->op);
+            hdr->operand[0] = tmp;
+#else
+        } else {
+            /* developer error. should not happen */
+            assert (0);
+#endif /* OPAL_HAVE_ATOMIC_MATH_32 */
+        }
+        break;
+#endif /* OPAL_HAVE_ATOMIC_MATH_64 */
+#if OPAL_HAVE_ATOMIC_MATH_64
+    case MCA_BTL_VADER_OP_CSWAP:
+        if (!(hdr->flags & MCA_BTL_ATOMIC_FLAG_32BIT)) {
+            opal_atomic_compare_exchange_strong_64 ((volatile int64_t *) hdr->addr, &hdr->operand[0], hdr->operand[1]);
+#if OPAL_HAVE_ATOMIC_MATH_32
+        } else {
+            opal_atomic_compare_exchange_strong_32 ((volatile int32_t *) hdr->addr, (int32_t *) &hdr->operand[0],
+                                                    (int32_t) hdr->operand[1]);
+#else
+        } else {
+            /* developer error. should not happen */
+            assert (0);
+#endif /* OPAL_HAVE_ATOMIC_MATH_32 */
+        }
+        break;
+#endif /* OPAL_HAVE_ATOMIC_MATH_64 */
+    }
+}
+
+void mca_btl_vader_sc_emu_init (void)
+{
+    mca_btl_base_active_message_trigger[MCA_BTL_TAG_VADER].cbfunc = mca_btl_vader_sc_emu_rdma;
+    mca_btl_base_active_message_trigger[MCA_BTL_TAG_VADER].cbdata = NULL;
+}


### PR DESCRIPTION
This commit adds support for atomic operations as well as rdma for
systems without rdma support. This support is implemented using an
internal send tag.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>