### PR TITLE
hwloc/external: Suppress missing-include-dirs warning

### DIFF
--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -45,13 +45,9 @@ AC_DEFUN([MCA_opal_hwloc_external_POST_CONFIG],[
 
            # Add some stuff to CPPFLAGS so that the rest of the source
            # tree can be built
-           file=$opal_hwloc_external_basedir/hwloc
            CPPFLAGS="$CPPFLAGS $opal_hwloc_external_CPPFLAGS"
            LDFLAGS="$LDFLAGS $opal_hwloc_external_LDFLAGS"
            LIBS="$LIBS $opal_hwloc_external_LIBS"
-           AS_IF([test "$OPAL_TOP_BUILDDIR" != "$OPAL_TOP_SRCDIR"],
-                 [CPPFLAGS="$CPPFLAGS -I$OPAL_TOP_BUILDDIR/$file/include"])
-           unset file
 
            # We have to do some extra indirection to get the
            # OPAL_HWLOC_WANT_VERBS_HELPER to work.  First, the


### PR DESCRIPTION
If OMPI is configured with `--with-hwloc=external` or `--with-hwloc=DIR` and gfortran is used, I see a lot of warnings when compiling files under the `ompi/mpi/fortran` directory.

```
f951: Warning: Nonexistent include directory
'BUILD_DIR/opal/mca/hwloc/external/hwloc/include' [-Wmissing-include-dirs]
```

There is no such `include` directory in the source tree and `configure`-created tree. I think these lines in the `configure.m4` file are wrongly copied from that for the embedded `hwlocXXX` component in the past.

The `-Wmissing-include-dirs` option is enabled in gfortran by default but it is not enabled by default (or even with `-Wall`) in gcc and g++.