### PR TITLE
OSHMEM: fixed compilation warning

### DIFF
--- a/oshmem/shmem/c/shmem_add.c
+++ b/oshmem/shmem/c/shmem_add.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 #include "oshmem/op/op.h"

--- a/oshmem/shmem/c/shmem_cswap.c
+++ b/oshmem/shmem/c/shmem_cswap.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_fadd.c
+++ b/oshmem/shmem/c/shmem_fadd.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_fetch.c
+++ b/oshmem/shmem/c/shmem_fetch.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_finc.c
+++ b/oshmem/shmem/c/shmem_finc.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_g.c
+++ b/oshmem/shmem/c/shmem_g.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_inc.c
+++ b/oshmem/shmem/c/shmem_inc.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_p.c
+++ b/oshmem/shmem/c/shmem_p.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_reduce.c
+++ b/oshmem/shmem/c/shmem_reduce.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_set.c
+++ b/oshmem/shmem/c/shmem_set.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_swap.c
+++ b/oshmem/shmem/c/shmem_swap.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 

--- a/oshmem/shmem/c/shmem_wait.c
+++ b/oshmem/shmem/c/shmem_wait.c
@@ -11,6 +11,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/include/shmemx.h"
 
 #include "oshmem/runtime/runtime.h"
 


### PR DESCRIPTION
- suppressed warning like: warning: no previous prototype for
  'shmemx_XXXXX_OP' [-Wmissing-prototypes]

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>