### PR TITLE
MTL OFI: Redesign sync send with reduced tag bits and quick ack

### DIFF
--- a/ompi/mca/mtl/ofi/README
+++ b/ompi/mca/mtl/ofi/README
@@ -24,8 +24,8 @@ CQ.
 OFI TAG:
 MPI needs to send 96 bits of information per message (32 bits communicator id,
 32 bits source rank, 32 bits MPI tag) but OFI only offers 64 bits tags. In
-addition, the OFI MTL uses 4 bits of the OFI tag for the synchronous send protocol.
-Therefore, there are only 60 bits available in the OFI tag for message usage. The
+addition, the OFI MTL uses 2 bits of the OFI tag for the synchronous send protocol.
+Therefore, there are only 62 bits available in the OFI tag for message usage. The
 OFI MTL offers the mtl_ofi_tag_mode mca parameter with 4 modes to address this:
 
 "auto" (Default):
@@ -36,19 +36,19 @@ fall back to "ofi_tag_1".
 
 "ofi_tag_1":
 For providers that do not support FI_REMOTE_CQ_DATA, the OFI MTL will
-trim the fields (Communicator ID, Source Rank, MPI tag) to make them fit the 60
+trim the fields (Communicator ID, Source Rank, MPI tag) to make them fit the 62
 bits available bit in the OFI tag. There are two options available with different
 number of bits for the Communicator ID and MPI tag fields. This tag distribution
 offers: 12 bits for Communicator ID (max Communicator ID 4,095) subject to
-provider reserved bits (see mem_tag_format below), 16 bits for Source Rank (max
-Source Rank 65,535), 32 bits for MPI tag (max MPI tag is INT_MAX).
+provider reserved bits (see mem_tag_format below), 18 bits for Source Rank (max
+Source Rank 262,143), 32 bits for MPI tag (max MPI tag is INT_MAX).
 
 "ofi_tag_2":
 Same as 2 "ofi_tag_1" but offering a different OFI tag distribution for
 applications that may require a greater number of supported Communicators at the
 expense of fewer MPI tag bits. This tag distribution offers: 24 bits for
-Communicator ID (max Communicator ED 16,777,215. See mem_tag_format below), 16
-bits for Source Rank (max Source Rank 65,535), 20 bits for MPI tag (max MPI tag
+Communicator ID (max Communicator ED 16,777,215. See mem_tag_format below), 18
+bits for Source Rank (max Source Rank 262,143), 20 bits for MPI tag (max MPI tag
 524,287).
 
 "ofi_tag_full":

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -467,6 +467,8 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
     hints->caps               = FI_TAGGED;      /* Tag matching interface    */
     hints->tx_attr->msg_order = FI_ORDER_SAS;
     hints->rx_attr->msg_order = FI_ORDER_SAS;
+    hints->rx_attr->op_flags = FI_COMPLETION;
+    hints->tx_attr->op_flags = FI_COMPLETION;
 
     hints->domain_attr->threading        = FI_THREAD_UNSPEC;
 
@@ -691,7 +693,7 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
      */
     ret = fi_ep_bind(ompi_mtl_ofi.ep,
                      (fid_t)ompi_mtl_ofi.cq,
-                     FI_SEND | FI_RECV);
+                     FI_TRANSMIT | FI_RECV | FI_SELECTIVE_COMPLETION);
     if (0 != ret) {
         opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
                             "%s:%d: fi_bind CQ-EP failed: %s\n",

--- a/ompi/mca/mtl/ofi/mtl_ofi_types.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_types.h
@@ -89,18 +89,19 @@ typedef struct mca_mtl_ofi_component_t {
 */
 
 /* Support FI_REMOTE_CQ_DATA, send the source rank in the CQ data (4 Bytes is the minimum)
- *  01234567 01234567 01234567 0123 4567 01234567 01234567 01234567 01234567
- *                                 |    |
- *           context_id            |prot|          message tag
+ *  01234567 01234567 01234567 012345  67  01234567 01234567 01234567 01234567
+ *                                   |    |
+ *           context_id              |prot|          message tag
  */
-#define MTL_OFI_PROTO_BIT_COUNT         (4)
+#define MTL_OFI_PROTO_BIT_COUNT         (2)
 
-#define MTL_OFI_CID_BIT_COUNT_DATA      (28)
+#define MTL_OFI_CID_MASK_DATA           (0xFFFFFFFC00000000ULL)
+#define MTL_OFI_CID_BIT_COUNT_DATA      (30)
 #define MTL_OFI_TAG_MASK_DATA           (0x00000000FFFFFFFFULL)
 #define MTL_OFI_TAG_BIT_COUNT_DATA      (32)
-#define MTL_OFI_PROTO_MASK_DATA         (0x0000000F00000000ULL)
+#define MTL_OFI_PROTO_MASK_DATA         (0x0000000300000000ULL)
 #define MTL_OFI_SYNC_SEND_DATA          (0x0000000100000000ULL)
-#define MTL_OFI_SYNC_SEND_ACK_DATA      (0x0000000900000000ULL)
+#define MTL_OFI_SYNC_SEND_ACK_DATA      (0x0000000200000000ULL)
 
 /* Send tag with CQ_DATA */
 __opal_attribute_always_inline__ static inline uint64_t
@@ -136,38 +137,38 @@ mtl_ofi_create_recv_tag_CQD(uint64_t *match_bits, uint64_t *mask_bits,
 /*
 * ofi_tag_1: fallback when no FI_REMOTE_CQ_DATA is supported
 *
-*  01234567 0123 4567 01234567 0123 4567 01234567 01234567 01234567 01234567
-*               |                  |    |
-*    Comm id    |     source       |prot|           message tag
+*  01234567 0123 4567 01234567 012345   67   01234567 01234567 01234567 01234567
+*               |                     |    |
+*    Comm id    |     source          |prot|           message tag
 */
 
 #define MTL_OFI_CID_BIT_COUNT_1         (12)
-#define MTL_OFI_SOURCE_TAG_MASK_1       (0x000FFFF000000000ULL)
-#define MTL_OFI_SOURCE_BIT_COUNT_1      (16)
-#define MTL_OFI_SOURCE_MASK_1           (0x000000000000FFFFULL)
+#define MTL_OFI_SOURCE_TAG_MASK_1       (0x000FFFFC00000000ULL)
+#define MTL_OFI_SOURCE_BIT_COUNT_1      (18)
+#define MTL_OFI_SOURCE_MASK_1           (0x000000000003FFFFULL)
 #define MTL_OFI_TAG_MASK_1              (0x00000000FFFFFFFFULL)
 #define MTL_OFI_TAG_BIT_COUNT_1         (32)
-#define MTL_OFI_PROTO_MASK_1            (0x0000000F00000000ULL)
+#define MTL_OFI_PROTO_MASK_1            (0x0000000300000000ULL)
 #define MTL_OFI_SYNC_SEND_1             (0x0000000100000000ULL)
-#define MTL_OFI_SYNC_SEND_ACK_1         (0x0000000900000000ULL)
+#define MTL_OFI_SYNC_SEND_ACK_1         (0x0000000200000000ULL)
 
 /*
 * ofi_tag_2: Alternative tag when no FI_REMOTE_CQ_DATA is supported
 *
-*  01234567 01234567 01234567 01234567 01234567 0123 4567 01234567 01234567
-*                            |                 |    |
-*                Comm id     |     source      |prot|     message tag
+*  01234567 01234567 01234567 01234567 01234567 01  23   4567 01234567 01234567
+*                            |                    |    |
+*                Comm id     |     source         |prot|     message tag
 */
 
 #define MTL_OFI_CID_BIT_COUNT_2         (24)
-#define MTL_OFI_SOURCE_TAG_MASK_2       (0x000000FFFF000000ULL)
-#define MTL_OFI_SOURCE_BIT_COUNT_2      (16)
-#define MTL_OFI_SOURCE_MASK_2           (0x000000000000FFFFULL)
+#define MTL_OFI_SOURCE_TAG_MASK_2       (0x000000FFFFC00000ULL)
+#define MTL_OFI_SOURCE_BIT_COUNT_2      (18)
+#define MTL_OFI_SOURCE_MASK_2           (0x000000000003FFFFULL)
 #define MTL_OFI_TAG_MASK_2              (0x00000000000FFFFFULL)
 #define MTL_OFI_TAG_BIT_COUNT_2         (20)
-#define MTL_OFI_PROTO_MASK_2            (0x0000000000F00000ULL)
+#define MTL_OFI_PROTO_MASK_2            (0x0000000000300000ULL)
 #define MTL_OFI_SYNC_SEND_2             (0x0000000000100000ULL)
-#define MTL_OFI_SYNC_SEND_ACK_2         (0x0000000000900000ULL)
+#define MTL_OFI_SYNC_SEND_ACK_2         (0x0000000000200000ULL)
 
 /* Send tag */
 __opal_attribute_always_inline__ static inline uint64_t


### PR DESCRIPTION
-Updated the design for sync send MPI calls to use 2 protocol bits for
denoting "sync_send" or "sync_send_ack".

-"Sync_send" is added to the send tag only and is masked out in receives
such that it can be read by the original Recv posted in the send/recv
operation.

-"Sync_send_ack" is sent from the recv callback to the send side. This 0
byte send does not generate a completion entry and instead sends the
message and immediately completes the opal completion in the recv.

-Tag formats ofi_tag_1 and ofi_tag_2 have been updated to include 2
more tag bits per format type due to the reduced protocal bits required
by OMPI.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>