### PR TITLE
Control inheritance of launch directives by child jobs

### DIFF
--- a/orte/mca/rmaps/base/base.h
+++ b/orte/mca/rmaps/base/base.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,6 +71,8 @@ typedef struct {
     orte_ranking_policy_t ranking;
     /* device specification for min distance mapping */
     char *device;
+    /* whether or not child jobs should inherit launch directives */
+    bool inherit;
 } orte_rmaps_base_t;
 
 /**

--- a/orte/mca/rmaps/base/rmaps_base_frame.c
+++ b/orte/mca/rmaps/base/rmaps_base_frame.c
@@ -69,6 +69,7 @@ static bool rmaps_base_display_devel_map = false;
 static bool rmaps_base_display_diffable_map = false;
 static char *rmaps_base_topo_file = NULL;
 static char *rmaps_dist_device = NULL;
+static bool rmaps_base_inherit = false;
 
 static int orte_rmaps_base_register(mca_base_register_flag_t flags)
 {
@@ -223,6 +224,12 @@ static int orte_rmaps_base_register(mca_base_register_flag_t flags)
                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY, &rmaps_base_topo_file);
 
+    rmaps_base_inherit = false;
+    (void) mca_base_var_register("orte", "rmaps", "base", "inherit",
+                                 "Whether child jobs shall inherit launch directives",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY, &rmaps_base_inherit);
 
     return ORTE_SUCCESS;
 }
@@ -254,6 +261,7 @@ static int orte_rmaps_base_open(mca_base_open_flag_t flags)
     orte_rmaps_base.mapping = 0;
     orte_rmaps_base.ranking = 0;
     orte_rmaps_base.device = NULL;
+    orte_rmaps_base.inherit = rmaps_base_inherit;
 
     /* if a topology file was given, then set our topology
      * from it. Even though our actual topology may differ,


### PR DESCRIPTION
Do not have child jobs inherit launch directives unless requested to do so. This affects the map-by, rank-by, bind-to, npernode, pernode, npersocket, persocket, and cpus-per-rank directives. Values provided in the spawn call always take precedence - if a particular value isn't specified, then the ORTE defaults will be used if inheritance is not requested, and the values specified by MCA param will be used if inheritance is set.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>