### PR TITLE
v2.1: osc/rdma: fix bug introduced in b90c838

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_request.c
+++ b/ompi/mca/osc/rdma/osc_rdma_request.c
@@ -33,7 +33,7 @@ static int request_free(struct ompi_request_t **ompi_req)
     ompi_osc_rdma_request_t *request =
         (ompi_osc_rdma_request_t*) *ompi_req;
 
-    if( REQUEST_COMPLETE(&request->super) ) {
+    if (!REQUEST_COMPLETE(&request->super)) {
         return MPI_ERR_REQUEST;
     }
 


### PR DESCRIPTION
This commit fixes an bug that was introduced back in 2016 which
impacts request-based RMA in some cases.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 037656bc1d974be7c4e9e3eecbb72a8e31f8ff5c)
Signed-off-by: Nathan Hjelm <hjelmn@me.com>