### PR TITLE
btl/openib: only look for iwarp/roce by default

### DIFF
--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2006-2009 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2006-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2006-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006-2007 Voltaire All rights reserved.
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
@@ -245,6 +245,7 @@ struct mca_btl_openib_component_t {
        guarantee about the size of an enum. this value will be registered as an
        integer with the MCA variable system */
     int device_type;
+    bool allow_ib;
     char *if_include;
     char **if_include_list;
     char *if_exclude;

--- a/opal/mca/btl/openib/btl_openib_mca.c
+++ b/opal/mca/btl/openib/btl_openib_mca.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2006-2009 Mellanox Technologies. All rights reserved.
- * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2006-2018 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006-2007 Voltaire All rights reserved.
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
@@ -290,6 +290,19 @@ int btl_openib_register_mca_params(void)
                                           &mca_btl_openib_component.device_type);
     if (0 > tmp) ret = tmp;
     OBJ_RELEASE(new_enum);
+
+    /*
+     * Provide way for using to override policy of ignoring IB HCAs
+     */
+
+    mca_btl_openib_component.allow_ib = false;
+    tmp = mca_base_component_var_register(&mca_btl_openib_component.super.btl_version,
+                                          "allow_ib",
+                                          "Override policy since Open MPI 4.0 of ignoring IB HCAs for openib BTL",
+                                          MCA_BASE_VAR_TYPE_BOOL, NULL,
+                                          0, 0, OPAL_INFO_LVL_5,
+                                          MCA_BASE_VAR_SCOPE_READONLY,
+                                          &mca_btl_openib_component.allow_ib);
 
     CHECK(reg_int("max_btls", NULL,
                   "Maximum number of device ports to use "

--- a/opal/mca/btl/openib/help-mpi-btl-openib.txt
+++ b/opal/mca/btl/openib/help-mpi-btl-openib.txt
@@ -14,6 +14,8 @@
 # Copyright (c) 2007-2009 Mellanox Technologies. All rights reserved.
 # Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2013-2014 NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2018      Los Alamos National Security, LLC.  All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -250,6 +252,10 @@ this run.
 
 If the "requested type" is "<any>", this usually means that *no*
 OpenFabrics devices were found within the requested bus distance.
+
+Note starting with Open MPI 4.0, only iWarp and RoCE devices are considered
+for selection by default.  Set the btl_openib_allow_ib MCA
+parameter to "true" to allow use of Infiniband devices.
 #
 [default subnet prefix]
 WARNING: There are more than one active ports on host '%s', but the
@@ -706,3 +712,14 @@ Open MPI has detected that you have attempted to set the btl_openib_cuda_max_sen
 value. This is not supported. Setting back to default value of 0.
 
   Local host:              %s
+[ib port not selected]
+By default, for Open MPI 4.0 and later, infiniband ports on a device
+are not used by default.  The intent is to use UCX for these devices.
+You can override this policy by setting the btl_openib_allow_ib MCA parameter
+to true.
+
+  Local host:              %s
+  Local adapter:           %s
+  Local port:              %d
+#
+


### PR DESCRIPTION
Due to decreasing support by vendors/other orgs for the OpenIB BTL,
only look for iWarp/RoCE devices by default.  Other IB device types
can supposedly use UCX or OFI libfabric.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>