### PR TITLE
v3.1.x: btl/vader: move backing files into /dev/shm on Linux

### DIFF
--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2010-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  *
@@ -135,6 +135,8 @@ struct mca_btl_vader_component_t {
 
     opal_list_t pending_endpoints;          /**< list of endpoints with pending fragments */
     opal_list_t pending_fragments;          /**< fragments pending remote completion */
+
+    char *backing_directory;                /**< directory to place shared memory backing files */
 
     /* knem stuff */
 #if OPAL_BTL_VADER_HAVE_KNEM

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -15,8 +15,8 @@
  * Copyright (c) 2010-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
- * Copyright (c) 2014-2016 Research Organization for Information Science
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -214,7 +214,7 @@ static int mca_btl_vader_component_register (void)
     if (0 == access ("/dev/shm", W_OK)) {
         mca_btl_vader_component.backing_directory = "/dev/shm";
     } else {
-        mca_btl_vader_component.backing_directory = opal_process_info.proc_session_dir;
+        mca_btl_vader_component.backing_directory = opal_process_info.job_session_dir;
     }
     (void) mca_base_component_var_register (&mca_btl_vader_component.super.btl_version, "backing_directory",
                                             "Directory to place backing files for shared memory communication. "
@@ -504,8 +504,8 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
     if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
         char *sm_file;
 
-        rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%d", mca_btl_vader_component.backing_directory,
-                      opal_process_info.nodename, MCA_BTL_VADER_LOCAL_RANK);
+        rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%x.%d", mca_btl_vader_component.backing_directory,
+                      opal_process_info.nodename, OPAL_PROC_MY_NAME.jobid, MCA_BTL_VADER_LOCAL_RANK);
         if (0 > rc) {
             free (btls);
             return NULL;


### PR DESCRIPTION
This commit moves the backing files to /dev/shm to avoid limitations
that may be set on /tmp. The files are registered with pmix to ensure
they are cleaned up after an erroneous exit.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 48101278160672317ade352365592f56ef3b8977)
(cherry picked from commit 47fd2313abc1cd78f42488ac04384c16ad5703bc)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>