### PR TITLE
v3.0.x: osc/sm: avoid filename collision when multiple windows share same CID

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -275,9 +275,9 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
         posts_size += OPAL_ALIGN_PAD_AMOUNT(posts_size, 64);
         if (0 == ompi_comm_rank (module->comm)) {
             char *data_file;
-            ret = asprintf (&data_file, "%s" OPAL_PATH_SEP "osc_sm.%s.%x.%d",
-                           mca_osc_sm_component.backing_directory, ompi_process_info.nodename,
-                           OMPI_PROC_MY_NAME->jobid, ompi_comm_get_cid(module->comm));
+            ret = asprintf (&data_file, "%s" OPAL_PATH_SEP "osc_sm.%s.%x.%d.%d",
+                            mca_osc_sm_component.backing_directory, ompi_process_info.nodename,
+                            OMPI_PROC_MY_NAME->jobid, (int) OMPI_PROC_MY_NAME->vpid, ompi_comm_get_cid(module->comm));
             if (ret < 0) {
                 return OMPI_ERR_OUT_OF_RESOURCE;
             }


### PR DESCRIPTION
This commit fixes an issue identified by MTT where we can have two
different sets of processes on the same node creating a shared memory
window with communicators sharing the same CID. To avoid this issue
the temporary filename now includes the creating processes vpid.

References #5363

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 35a75a6bf5356b47939b5a336ed0dabac443e086)
Signed-off-by: Peter Gottesman <pgottesm@cisco.com>