### PR TITLE
v3.0.x: mpi/fortran: Fix IN_PLACE detection of ISCATTER(V)

### DIFF
--- a/ompi/mpi/fortran/mpif-h/iscatter_f.c
+++ b/ompi/mpi/fortran/mpif-h/iscatter_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,8 +82,8 @@ void ompi_iscatter_f(char *sendbuf, MPI_Fint *sendcount,
     c_sendtype = PMPI_Type_f2c(*sendtype);
     c_recvtype = PMPI_Type_f2c(*recvtype);
 
-    sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
+    recvbuf = (char *) OMPI_F2C_IN_PLACE(recvbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = PMPI_Iscatter(sendbuf,OMPI_FINT_2_INT(*sendcount),

--- a/ompi/mpi/fortran/mpif-h/iscatterv_f.c
+++ b/ompi/mpi/fortran/mpif-h/iscatterv_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,8 +89,8 @@ void ompi_iscatterv_f(char *sendbuf, MPI_Fint *sendcounts,
     OMPI_ARRAY_FINT_2_INT(sendcounts, size);
     OMPI_ARRAY_FINT_2_INT(displs, size);
 
-    sendbuf = (char *) OMPI_F2C_IN_PLACE(sendbuf);
     sendbuf = (char *) OMPI_F2C_BOTTOM(sendbuf);
+    recvbuf = (char *) OMPI_F2C_IN_PLACE(recvbuf);
     recvbuf = (char *) OMPI_F2C_BOTTOM(recvbuf);
 
     c_ierr = PMPI_Iscatterv(sendbuf,


### PR DESCRIPTION
Blocking `MPI_SCATTER` and `MPI_SCATTERV` were fixed in 506d0e96f4 but noblocking `MPI_ISCATTER` and `MPI_ISCATTERV` were not fixed yet.

cherry picked from commit 5ddf0f64182e2073a7a30e3f2efc35783ecd2cc7