### PR TITLE
io/ompio: Call component-specific file_delete function instead of POSIX unlink

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      DataDirect Networks. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -291,8 +292,10 @@ OMPI_DECLSPEC int mca_common_ompio_file_open (ompi_communicator_t *comm, const c
                                               int amode, opal_info_t *info,
                                               ompio_file_t *ompio_fh, bool use_sharedfp);
 
-int mca_common_ompio_file_delete (const char *filename,
-                                  struct opal_info_t *info);
+OMPI_DECLSPEC int mca_common_ompio_file_delete (const char *filename,
+                                                struct opal_info_t *info);
+OMPI_DECLSPEC int mca_common_ompio_create_incomplete_file_handle (const char *filename,
+                                                                  ompio_file_t **fh);
 
 OMPI_DECLSPEC int mca_common_ompio_file_close (ompio_file_t *ompio_fh);
 OMPI_DECLSPEC int mca_common_ompio_file_get_size (ompio_file_t *ompio_fh, OMPI_MPI_OFFSET_TYPE *size);

--- a/ompi/mca/fs/base/fs_base_file_delete.c
+++ b/ompi/mca/fs/base/fs_base_file_delete.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008-2018 University of Houston. All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      DataDirect Networks. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,8 +42,16 @@ int mca_fs_base_file_delete (char* file_name,
     int ret;
 
     ret = unlink(file_name);
-    if (0 > ret) {
-        return OMPI_ERROR;
+
+    if (0 > ret ) {
+        if ( ENOENT == errno ) {
+            return MPI_ERR_NO_SUCH_FILE;
+        } else {
+            opal_output (0, "mca_fs_base_file_delete: Could not remove file "
+                            "%s errno = %d %s\n",
+                            file_name, errno, strerror(errno));
+            return MPI_ERR_ACCESS;
+        }
     }
 
     return OMPI_SUCCESS;

--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2018 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      DataDirect Networks. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,15 +90,18 @@ mca_fs_lustre_component_file_query (ompio_file_t *fh, int *priority)
 
     tmp = strchr (fh->f_filename, ':');
     if (!tmp) {
-        if (OMPIO_ROOT == fh->f_rank) {
+        /* The communicator might be NULL if we only want to delete the file */
+        if (OMPIO_ROOT == fh->f_rank || MPI_COMM_NULL == fh->f_comm) {
             fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
         }
-	fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
-				       1,
-				       MPI_INT,
-				       OMPIO_ROOT,
-				       fh->f_comm,
-				       fh->f_comm->c_coll->coll_bcast_module);
+        if (fh->f_comm != MPI_COMM_NULL) {
+            fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
+                        1,
+                        MPI_INT,
+                        OMPIO_ROOT,
+                        fh->f_comm,
+                        fh->f_comm->c_coll->coll_bcast_module);
+        }
     }
     else {
 	if (!strncmp(fh->f_filename, "lustre:", 7) ||

--- a/ompi/mca/fs/pvfs2/fs_pvfs2.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      DataDirect Networks. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,15 +95,18 @@ mca_fs_pvfs2_component_file_query (ompio_file_t *fh, int *priority)
 
     tmp = strchr (fh->f_filename, ':');
     if (!tmp) {
-        if (OMPIO_ROOT == fh->f_rank) {
+        /* The communicator might be NULL if we only want to delete the file */
+        if (OMPIO_ROOT == fh->f_rank || MPI_COMM_NULL == fh->f_comm) {
             fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
-	}
-	fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
-				       1,
-				       MPI_INT,
-				       OMPIO_ROOT,
-				       fh->f_comm,
-				       fh->f_comm->c_coll->coll_bcast_module);
+	    }
+        if (fh->f_comm != MPI_COMM_NULL) {
+            fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
+                        1,
+                        MPI_INT,
+                        OMPIO_ROOT,
+                        fh->f_comm,
+                        fh->f_comm->c_coll->coll_bcast_module);
+        }
     }
     else {
         if (!strncmp(fh->f_filename, "pvfs2:", 6) ||


### PR DESCRIPTION
This PR is a quick fix for the bug referenced in this issue: #5443
Again, this is a work in progress, and it shouldn’t be considered a definitive solution. This is more of a workaround, and any help is appreciated to improve my work.

This is what I have done:
I “moved” the code of mca_common_ompio_file_delete to fs_base_file_delete, which is where it should go because this code is common to both UFS and Lustre.

Then, in the mca_common_ompio_file_delete function, instead of calling POSIX unlink, I do the following:
* Create an “incomplete” ompio file handle: It will basically only contain the file name, and an MPI_COMM_NULL communicator.
* Run the fs selection algorithm (mca_fs_base_delete) with this file handle
* Use the delete function of the selected component

However, because the query functions of the fs components used to always work with a complete file handle, no checks were performed on the file handle attributes. For this reason, I had to add checks on the communicator validity for each component’s query function.
