### PR TITLE
btl/ofi: Added FI_CONTEXT as requirement.

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -250,6 +250,9 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
     /* ask for capabilities */
     hints.caps = MCA_BTL_OFI_REQUIRED_CAPS;
 
+    /* Ask for completion context */
+    hints.mode = FI_CONTEXT;
+
     hints.fabric_attr = &fabric_attr;
     hints.domain_attr = &domain_attr;
     hints.ep_attr = &ep_attr;


### PR DESCRIPTION
OFI BTL uses context for completion but never ask for it in
fi_getinfo(3). This commit makes sure that we always ask for FI_CONTEXT
to eliminate any potential error.

Signed-off-by: Thananon Patinyasakdikul <thananon.patinyasakdikul@intel.com>