### PR TITLE
OSC/PT2PT: fixed request_free call

### DIFF
--- a/ompi/mca/osc/pt2pt/osc_pt2pt.h
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt.h
@@ -72,6 +72,12 @@ struct ompi_osc_pt2pt_component_t {
     /** Free list of requests */
     opal_free_list_t requests;
 
+    /** Free list of completed requests */
+    opal_free_list_t completed_requests;
+
+    /** List of requests scheduled to free */
+    opal_list_t completed_requests_list;
+
     /** PT2PT component buffer size */
     unsigned int buffer_size;
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_comm.c
@@ -46,7 +46,7 @@ static int ompi_osc_pt2pt_comm_complete (ompi_request_t *request)
 
     mark_outgoing_completion(module);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
 
     return 1;
 }
@@ -101,7 +101,7 @@ static int ompi_osc_pt2pt_dt_send_complete (ompi_request_t *request)
     OPAL_THREAD_UNLOCK(&mca_osc_pt2pt_component.lock);
     assert (NULL != module);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
 
     return 1;
 }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_data_move.c
@@ -239,7 +239,7 @@ static int ompi_osc_pt2pt_control_send_unbuffered_cb (ompi_request_t *request)
     /* free the temporary buffer */
     free (ctx);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
     return 1;
 }
 
@@ -436,7 +436,7 @@ static int osc_pt2pt_incoming_req_complete (ompi_request_t *request)
 
     mark_incoming_completion (module, rank);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
     return 1;
 }
 
@@ -457,7 +457,7 @@ static int osc_pt2pt_get_post_send_cb (ompi_request_t *request)
     /* mark this as a completed "incoming" request */
     mark_incoming_completion (module, rank);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
     return 1;
 }
 
@@ -694,7 +694,7 @@ static int accumulate_cb (ompi_request_t *request)
 
     mark_incoming_completion (module, rank);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
     return ret;
 }
 
@@ -772,7 +772,7 @@ static int replace_cb (ompi_request_t *request)
     /* unlock the accumulate lock */
     ompi_osc_pt2pt_accumulate_unlock (module);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
     return 1;
 }
 
@@ -1441,7 +1441,7 @@ static int process_large_datatype_request_cb (ompi_request_t *request)
     /* free the datatype buffer */
     osc_pt2pt_gc_add_buffer (module, &ddt_buffer->super);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
     return 1;
 }
 

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_frag.c
@@ -38,7 +38,7 @@ static int frag_send_cb (ompi_request_t *request)
     mark_outgoing_completion(module);
     opal_free_list_return (&mca_osc_pt2pt_component.frags, &frag->super);
 
-    ompi_request_free (&request);
+    ompi_osc_pt2pt_request_schedule(request);
 
     return 1;
 }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_request.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_request.c
@@ -61,3 +61,23 @@ OBJ_CLASS_INSTANCE(ompi_osc_pt2pt_request_t,
                    ompi_request_t,
                    request_construct,
                    NULL);
+
+static int completed_request_free(ompi_osc_pt2pt_completed_request_t **com_req)
+{
+    if (*com_req && (*com_req)->request) {
+        ompi_request_free(&(*com_req)->request);
+        (*com_req)->request = NULL;
+    }
+    *com_req = NULL;
+    return OMPI_SUCCESS;
+}
+
+static void completed_request_construct(ompi_osc_pt2pt_completed_request_t *com_req)
+{
+    com_req->request = NULL;
+}
+
+OBJ_CLASS_INSTANCE(ompi_osc_pt2pt_completed_request_t,
+                   opal_free_list_item_t,
+                   completed_request_construct,
+                   completed_request_free);


### PR DESCRIPTION
- there was issue in request completion callback in osc/pt2pt
  module: request should not be destroyed during completion
  callback because OMPI updates request status after callback
  completed
- implemented delayed request free (called from opal_progress)
  to free completed request after processing completed

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>