### PR TITLE
PML/UCX: fixed ucp request free on persistent request completion - v3.1

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx_request.c
+++ b/ompi/mca/pml/ucx/pml_ucx_request.c
@@ -85,10 +85,10 @@ mca_pml_ucx_persistent_request_complete(mca_pml_ucx_persistent_request_t *preq,
                                         ompi_request_t *tmp_req)
 {
     preq->ompi.req_status = tmp_req->req_status;
-    ompi_request_complete(&preq->ompi, true);
-    mca_pml_ucx_persistent_request_detach(preq, tmp_req);
     mca_pml_ucx_request_reset(tmp_req);
+    mca_pml_ucx_persistent_request_detach(preq, tmp_req);
     ucp_request_free(tmp_req);
+    ompi_request_complete(&preq->ompi, true);
 }
 
 static inline void mca_pml_ucx_preq_completion(ompi_request_t *tmp_req)


### PR DESCRIPTION
- in sine cases persistent request was deleted during completion
  callback, this cause double free of linked UCX request (assert
  in debug build or hang in release build)
- UCX request is freed prior completion callback

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit 6fe0a73861b53efac12e740c831802057391525d)