### PR TITLE
coll/base/allgather: fix MPI_IN_PLACE processing

### DIFF
--- a/ompi/mca/coll/base/coll_base_allgather.c
+++ b/ompi/mca/coll/base/coll_base_allgather.c
@@ -90,7 +90,7 @@ int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
                                           mca_coll_base_module_t *module)
 {
     int line = -1, rank, size, sendto, recvfrom, distance, blockcount, err = 0;
-    ptrdiff_t slb, rlb, sext, rext;
+    ptrdiff_t rlb, rext;
     char *tmpsend = NULL, *tmprecv = NULL;
 
     size = ompi_comm_size(comm);
@@ -98,9 +98,6 @@ int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
 
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                  "coll:base:allgather_intra_bruck rank %d", rank));
-
-    err = ompi_datatype_get_extent (sdtype, &slb, &sext);
-    if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
     err = ompi_datatype_get_extent (rdtype, &rlb, &rext);
     if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
@@ -262,7 +259,7 @@ ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, int scount,
 {
     int line = -1, rank, size, pow2size, err;
     int remote, distance, sendblocklocation;
-    ptrdiff_t slb, rlb, sext, rext;
+    ptrdiff_t rlb, rext;
     char *tmpsend = NULL, *tmprecv = NULL;
 
     size = ompi_comm_size(comm);
@@ -288,9 +285,6 @@ ompi_coll_base_allgather_intra_recursivedoubling(const void *sbuf, int scount,
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                  "coll:base:allgather_intra_recursivedoubling rank %d, size %d",
                  rank, size));
-
-    err = ompi_datatype_get_extent (sdtype, &slb, &sext);
-    if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
     err = ompi_datatype_get_extent (rdtype, &rlb, &rext);
     if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
@@ -369,7 +363,7 @@ int ompi_coll_base_allgather_intra_ring(const void *sbuf, int scount,
                                          mca_coll_base_module_t *module)
 {
     int line = -1, rank, size, err, sendto, recvfrom, i, recvdatafrom, senddatafrom;
-    ptrdiff_t slb, rlb, sext, rext;
+    ptrdiff_t rlb, rext;
     char *tmpsend = NULL, *tmprecv = NULL;
 
     size = ompi_comm_size(comm);
@@ -377,9 +371,6 @@ int ompi_coll_base_allgather_intra_ring(const void *sbuf, int scount,
 
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                  "coll:base:allgather_intra_ring rank %d", rank));
-
-    err = ompi_datatype_get_extent (sdtype, &slb, &sext);
-    if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
     err = ompi_datatype_get_extent (rdtype, &rlb, &rext);
     if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
@@ -499,7 +490,7 @@ ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, int scount,
 {
     int line = -1, rank, size, i, even_rank, err;
     int neighbor[2], offset_at_step[2], recv_data_from[2], send_data_from;
-    ptrdiff_t slb, rlb, sext, rext;
+    ptrdiff_t rlb, rext;
     char *tmpsend = NULL, *tmprecv = NULL;
 
     size = ompi_comm_size(comm);
@@ -516,9 +507,6 @@ ompi_coll_base_allgather_intra_neighborexchange(const void *sbuf, int scount,
 
     OPAL_OUTPUT((ompi_coll_base_framework.framework_output,
                  "coll:base:allgather_intra_neighborexchange rank %d", rank));
-
-    err = ompi_datatype_get_extent (sdtype, &slb, &sext);
-    if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
     err = ompi_datatype_get_extent (rdtype, &rlb, &rext);
     if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
@@ -616,7 +604,7 @@ int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, int scount,
 {
     int line = -1, err, rank, remote;
     char *tmpsend = NULL, *tmprecv = NULL;
-    ptrdiff_t sext, rext, lb;
+    ptrdiff_t rext, lb;
 
     rank = ompi_comm_rank(comm);
 
@@ -626,9 +614,6 @@ int ompi_coll_base_allgather_intra_two_procs(const void *sbuf, int scount,
     if (2 != ompi_comm_size(comm)) {
         return MPI_ERR_UNSUPPORTED_OPERATION;
     }
-
-    err = ompi_datatype_get_extent (sdtype, &lb, &sext);
-    if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }
 
     err = ompi_datatype_get_extent (rdtype, &lb, &rext);
     if (MPI_SUCCESS != err) { line = __LINE__; goto err_hndl; }


### PR DESCRIPTION
The call of MPI_Allgather with sendbuf and sendtype parameters equal to MPI_IN_PLACE and NULL correspondingly, produces the segmentation fault.

The problem is that sendtype is used even when sendbuf value is MPI_IN_PLACE. But according to the standard, sendtype and sendcount parameters should be ignored in this case.

Signed-off-by: Mikhail Kurnosov mkurnosov@gmail.com
(cherry picked from commit 540c2d1)