### PR TITLE
MCA/ATOMIC: atomic_init renamed to atomic_startup - v4.0

### DIFF
--- a/oshmem/mca/atomic/atomic.h
+++ b/oshmem/mca/atomic/atomic.h
@@ -135,7 +135,7 @@ struct mca_atomic_base_component_1_0_0_t {
     mca_base_component_data_t atomic_data;
 
     /** Component initialization function */
-    mca_atomic_base_component_init_fn_t atomic_init;
+    mca_atomic_base_component_init_fn_t atomic_startup;
     mca_atomic_base_component_finalize_fn_t atomic_finalize;
     mca_atomic_base_component_query_fn_t atomic_query;
 

--- a/oshmem/mca/atomic/base/atomic_base_available.c
+++ b/oshmem/mca/atomic/base/atomic_base_available.c
@@ -104,7 +104,7 @@ static int init_query(const mca_base_component_t * component,
         mca_atomic_base_component_t *atomic =
                 (mca_atomic_base_component_t *) component;
 
-        ret = atomic->atomic_init(enable_progress_threads, enable_threads);
+        ret = atomic->atomic_startup(enable_progress_threads, enable_threads);
     } else {
         /* Unrecognized coll API version */
 

--- a/oshmem/mca/atomic/basic/atomic_basic.h
+++ b/oshmem/mca/atomic/basic/atomic_basic.h
@@ -31,7 +31,7 @@ OSHMEM_DECLSPEC void atomic_basic_unlock(shmem_ctx_t ctx, int pe);
 
 /* API functions */
 
-int mca_atomic_basic_init(bool enable_progress_threads, bool enable_threads);
+int mca_atomic_basic_startup(bool enable_progress_threads, bool enable_threads);
 int mca_atomic_basic_finalize(void);
 mca_atomic_base_module_t*
 mca_atomic_basic_query(int *priority);

--- a/oshmem/mca/atomic/basic/atomic_basic_component.c
+++ b/oshmem/mca/atomic/basic/atomic_basic_component.c
@@ -62,7 +62,7 @@ mca_atomic_base_component_t mca_atomic_basic_component = {
 
     /* Initialization / querying functions */
 
-    .atomic_init = mca_atomic_basic_init,
+    .atomic_startup = mca_atomic_basic_startup,
     .atomic_finalize = mca_atomic_basic_finalize,
     .atomic_query = mca_atomic_basic_query,
 };

--- a/oshmem/mca/atomic/basic/atomic_basic_module.c
+++ b/oshmem/mca/atomic/basic/atomic_basic_module.c
@@ -34,7 +34,7 @@ enum {
  * Initial query function that is invoked during initialization, allowing
  * this module to indicate what level of thread support it provides.
  */
-int mca_atomic_basic_init(bool enable_progress_threads, bool enable_threads)
+int mca_atomic_basic_startup(bool enable_progress_threads, bool enable_threads)
 {
     int rc = OSHMEM_SUCCESS;
     void* ptr = NULL;

--- a/oshmem/mca/atomic/mxm/atomic_mxm.h
+++ b/oshmem/mca/atomic/mxm/atomic_mxm.h
@@ -37,7 +37,7 @@ OSHMEM_DECLSPEC void atomic_mxm_unlock(int pe);
 
 /* API functions */
 
-int mca_atomic_mxm_init(bool enable_progress_threads, bool enable_threads);
+int mca_atomic_mxm_startup(bool enable_progress_threads, bool enable_threads);
 int mca_atomic_mxm_finalize(void);
 mca_atomic_base_module_t*
 mca_atomic_mxm_query(int *priority);

--- a/oshmem/mca/atomic/mxm/atomic_mxm_component.c
+++ b/oshmem/mca/atomic/mxm/atomic_mxm_component.c
@@ -66,7 +66,7 @@ mca_atomic_base_component_t mca_atomic_mxm_component = {
 
     /* Initialization / querying functions */
 
-    .atomic_init = mca_atomic_mxm_init,
+    .atomic_startup = mca_atomic_mxm_startup,
     .atomic_finalize  = mca_atomic_mxm_finalize,
     .atomic_query = mca_atomic_mxm_query,
 };

--- a/oshmem/mca/atomic/mxm/atomic_mxm_module.c
+++ b/oshmem/mca/atomic/mxm/atomic_mxm_module.c
@@ -22,7 +22,7 @@
  * Initial query function that is invoked during initialization, allowing
  * this module to indicate what level of thread support it provides.
  */
-int mca_atomic_mxm_init(bool enable_progress_threads, bool enable_threads)
+int mca_atomic_mxm_startup(bool enable_progress_threads, bool enable_threads)
 {
     return OSHMEM_SUCCESS;
 }

--- a/oshmem/mca/atomic/ucx/atomic_ucx.h
+++ b/oshmem/mca/atomic/ucx/atomic_ucx.h
@@ -37,7 +37,7 @@ OSHMEM_DECLSPEC void atomic_ucx_unlock(int pe);
 
 /* API functions */
 
-int mca_atomic_ucx_init(bool enable_progress_threads, bool enable_threads);
+int mca_atomic_ucx_startup(bool enable_progress_threads, bool enable_threads);
 int mca_atomic_ucx_finalize(void);
 mca_atomic_base_module_t*
 mca_atomic_ucx_query(int *priority);

--- a/oshmem/mca/atomic/ucx/atomic_ucx_component.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_component.c
@@ -70,7 +70,7 @@ mca_atomic_base_component_t mca_atomic_ucx_component = {
 
     /* Initialization / querying functions */
 
-    mca_atomic_ucx_init,
+    mca_atomic_ucx_startup,
     mca_atomic_ucx_finalize,
     mca_atomic_ucx_query
 };

--- a/oshmem/mca/atomic/ucx/atomic_ucx_module.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_module.c
@@ -22,7 +22,7 @@
  * Initial query function that is invoked during initialization, allowing
  * this module to indicate what level of thread support it provides.
  */
-int mca_atomic_ucx_init(bool enable_progress_threads, bool enable_threads)
+int mca_atomic_ucx_startup(bool enable_progress_threads, bool enable_threads)
 {
     return OSHMEM_SUCCESS;
 }


### PR DESCRIPTION
- there is C11 naming conflict - atomic_init is C macro
  which cause building issue

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit 3295b238008a6b2e27941c60d757e64ad796fea2)