### PR TITLE
PML/SPML/UCX: init global objects using C99 style - v4.0

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -49,33 +49,33 @@
 #define MODEX_KEY "pml-ucx"
 
 mca_pml_ucx_module_t ompi_pml_ucx = {
-    {
-        mca_pml_ucx_add_procs,
-        mca_pml_ucx_del_procs,
-        mca_pml_ucx_enable,
-        NULL,
-        mca_pml_ucx_add_comm,
-        mca_pml_ucx_del_comm,
-        mca_pml_ucx_irecv_init,
-        mca_pml_ucx_irecv,
-        mca_pml_ucx_recv,
-        mca_pml_ucx_isend_init,
-        mca_pml_ucx_isend,
-        mca_pml_ucx_send,
-        mca_pml_ucx_iprobe,
-        mca_pml_ucx_probe,
-        mca_pml_ucx_start,
-        mca_pml_ucx_improbe,
-        mca_pml_ucx_mprobe,
-        mca_pml_ucx_imrecv,
-        mca_pml_ucx_mrecv,
-        mca_pml_ucx_dump,
-        NULL, /* FT */
-        1ul << (PML_UCX_CONTEXT_BITS),
-        1ul << (PML_UCX_TAG_BITS - 1),
+    .super = {
+        .pml_add_procs     = mca_pml_ucx_add_procs,
+        .pml_del_procs     = mca_pml_ucx_del_procs,
+        .pml_enable        = mca_pml_ucx_enable,
+        .pml_progress      = NULL,
+        .pml_add_comm      = mca_pml_ucx_add_comm,
+        .pml_del_comm      = mca_pml_ucx_del_comm,
+        .pml_irecv_init    = mca_pml_ucx_irecv_init,
+        .pml_irecv         = mca_pml_ucx_irecv,
+        .pml_recv          = mca_pml_ucx_recv,
+        .pml_isend_init    = mca_pml_ucx_isend_init,
+        .pml_isend         = mca_pml_ucx_isend,
+        .pml_send          = mca_pml_ucx_send,
+        .pml_iprobe        = mca_pml_ucx_iprobe,
+        .pml_probe         = mca_pml_ucx_probe,
+        .pml_start         = mca_pml_ucx_start,
+        .pml_improbe       = mca_pml_ucx_improbe,
+        .pml_mprobe        = mca_pml_ucx_mprobe,
+        .pml_imrecv        = mca_pml_ucx_imrecv,
+        .pml_mrecv         = mca_pml_ucx_mrecv,
+        .pml_dump          = mca_pml_ucx_dump,
+        .pml_ft_event      = NULL,
+        .pml_max_contextid = 1ul << (PML_UCX_CONTEXT_BITS),
+        .pml_max_tag       = 1ul << (PML_UCX_TAG_BITS - 1)
     },
-    NULL,   /* ucp_context */
-    NULL    /* ucp_worker */
+    .ucp_context           = NULL,
+    .ucp_worker            = NULL
 };
 
 #define PML_UCX_REQ_ALLOCA() \

--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -26,25 +26,25 @@ mca_pml_base_component_2_0_0_t mca_pml_ucx_component = {
 
     /* First, the mca_base_component_t struct containing meta
      * information about the component itself */
-    {
+    .pmlm_version = {
          MCA_PML_BASE_VERSION_2_0_0,
 
-         "ucx", /* MCA component name */
-         OMPI_MAJOR_VERSION,  /* MCA component major version */
-         OMPI_MINOR_VERSION,  /* MCA component minor version */
-         OMPI_RELEASE_VERSION,  /* MCA component release version */
-         mca_pml_ucx_component_open,  /* component open */
-         mca_pml_ucx_component_close,  /* component close */
-         NULL,
-         mca_pml_ucx_component_register,
+         .mca_component_name            = "ucx",
+         .mca_component_major_version   = OMPI_MAJOR_VERSION,
+         .mca_component_minor_version   = OMPI_MINOR_VERSION,
+         .mca_component_release_version = OMPI_RELEASE_VERSION,
+         .mca_open_component            = mca_pml_ucx_component_open,
+         .mca_close_component           = mca_pml_ucx_component_close,
+         .mca_query_component           = NULL,
+         .mca_register_component_params = mca_pml_ucx_component_register,
      },
-     {
+     .pmlm_data = {
          /* This component is not checkpoint ready */
-         MCA_BASE_METADATA_PARAM_NONE
+         .param_field                   = MCA_BASE_METADATA_PARAM_NONE
      },
 
-     mca_pml_ucx_component_init,  /* component init */
-     mca_pml_ucx_component_fini   /* component finalize */
+     .pmlm_init                         = mca_pml_ucx_component_init,
+     .pmlm_finalize                     = mca_pml_ucx_component_fini
 };
 
 static int mca_pml_ucx_component_register(void)

--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -48,47 +48,47 @@ static
 spml_ucx_mkey_t * mca_spml_ucx_get_mkey_slow(int pe, void *va, void **rva);
 
 mca_spml_ucx_t mca_spml_ucx = {
-    {
+    .super = {
         /* Init mca_spml_base_module_t */
-        mca_spml_ucx_add_procs,
-        mca_spml_ucx_del_procs,
-        mca_spml_ucx_enable,
-        mca_spml_ucx_register,
-        mca_spml_ucx_deregister,
-        mca_spml_base_oob_get_mkeys,
-        mca_spml_ucx_ctx_create,
-        mca_spml_ucx_ctx_destroy,
-        mca_spml_ucx_put,
-        mca_spml_ucx_put_nb,
-        mca_spml_ucx_get,
-        mca_spml_ucx_get_nb,
-        mca_spml_ucx_recv,
-        mca_spml_ucx_send,
-        mca_spml_base_wait,
-        mca_spml_base_wait_nb,
-        mca_spml_base_test,
-        mca_spml_ucx_fence,
-        mca_spml_ucx_quiet,
-        mca_spml_ucx_rmkey_unpack,
-        mca_spml_ucx_rmkey_free,
-        mca_spml_ucx_rmkey_ptr,
-        mca_spml_ucx_memuse_hook,
-        (void*)&mca_spml_ucx
+        .spml_add_procs     = mca_spml_ucx_add_procs,
+        .spml_del_procs     = mca_spml_ucx_del_procs,
+        .spml_enable        = mca_spml_ucx_enable,
+        .spml_register      = mca_spml_ucx_register,
+        .spml_deregister    = mca_spml_ucx_deregister,
+        .spml_oob_get_mkeys = mca_spml_base_oob_get_mkeys,
+        .spml_ctx_create    = mca_spml_ucx_ctx_create,
+        .spml_ctx_destroy   = mca_spml_ucx_ctx_destroy,
+        .spml_put           = mca_spml_ucx_put,
+        .spml_put_nb        = mca_spml_ucx_put_nb,
+        .spml_get           = mca_spml_ucx_get,
+        .spml_get_nb        = mca_spml_ucx_get_nb,
+        .spml_recv          = mca_spml_ucx_recv,
+        .spml_send          = mca_spml_ucx_send,
+        .spml_wait          = mca_spml_base_wait,
+        .spml_wait_nb       = mca_spml_base_wait_nb,
+        .spml_test          = mca_spml_base_test,
+        .spml_fence         = mca_spml_ucx_fence,
+        .spml_quiet         = mca_spml_ucx_quiet,
+        .spml_rmkey_unpack  = mca_spml_ucx_rmkey_unpack,
+        .spml_rmkey_free    = mca_spml_ucx_rmkey_free,
+        .spml_rmkey_ptr     = mca_spml_ucx_rmkey_ptr,
+        .spml_memuse_hook   = mca_spml_ucx_memuse_hook,
+        .self               = (void*)&mca_spml_ucx
     },
 
-    NULL,   /* ucp_context */
-    1,      /* num_disconnect */
-    0,      /* heap_reg_nb */
-    0,      /* enabled */
-    mca_spml_ucx_get_mkey_slow
+    .ucp_context            = NULL,
+    .num_disconnect         = 1,
+    .heap_reg_nb            = 0,
+    .enabled                = 0,
+    .get_mkey_slow          = mca_spml_ucx_get_mkey_slow
 };
 
 OBJ_CLASS_INSTANCE(mca_spml_ucx_ctx_list_item_t, opal_list_item_t, NULL, NULL);
 
 mca_spml_ucx_ctx_t mca_spml_ucx_ctx_default = {
-    NULL,   /* ucp_worker */
-    NULL,   /* ucp_peers */
-    0       /* options */
+    .ucp_worker = NULL,
+    .ucp_peers  = NULL,
+    .options    = 0
 };
 
 int mca_spml_ucx_enable(bool enable)

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -38,26 +38,25 @@ mca_spml_base_component_2_0_0_t mca_spml_ucx_component = {
     /* First, the mca_base_component_t struct containing meta
        information about the component itself */
 
-    {
-      MCA_SPML_BASE_VERSION_2_0_0,
-    
-      "ucx",                        /* MCA component name */
-      OSHMEM_MAJOR_VERSION,           /* MCA component major version */
-      OSHMEM_MINOR_VERSION,           /* MCA component minor version */
-      OSHMEM_RELEASE_VERSION,         /* MCA component release version */
-      mca_spml_ucx_component_open,  /* component open */
-      mca_spml_ucx_component_close, /* component close */
-      NULL,
-      mca_spml_ucx_component_register
+    .spmlm_version = {
+        MCA_SPML_BASE_VERSION_2_0_0,
+
+        .mca_component_name            = "ucx",
+        .mca_component_major_version   = OSHMEM_MAJOR_VERSION,
+        .mca_component_minor_version   = OSHMEM_MINOR_VERSION,
+        .mca_component_release_version = OSHMEM_RELEASE_VERSION,
+        .mca_open_component            = mca_spml_ucx_component_open,
+        .mca_close_component           = mca_spml_ucx_component_close,
+        .mca_query_component           = NULL,
+        .mca_register_component_params = mca_spml_ucx_component_register
     },
-    {
+    .spmlm_data = {
         /* The component is checkpoint ready */
-        MCA_BASE_METADATA_PARAM_CHECKPOINT
+        .param_field                   = MCA_BASE_METADATA_PARAM_CHECKPOINT
     },
 
-    mca_spml_ucx_component_init,    /* component init */
-    mca_spml_ucx_component_fini     /* component finalize */
-    
+    .spmlm_init                        = mca_spml_ucx_component_init,
+    .spmlm_finalize                    = mca_spml_ucx_component_fini
 };
 
 


### PR DESCRIPTION
- to avoid value mix used C99 style of object initializations

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit 2806504290ff2fdd10f254f878e92cae6e90c854)