### PR TITLE
opal/atomic.h: prevent preprocessor macro redefinition

### DIFF
--- a/opal/include/opal/sys/sync_builtin/atomic.h
+++ b/opal/include/opal/sys/sync_builtin/atomic.h
@@ -45,7 +45,16 @@ static inline void opal_atomic_wmb(void)
     __sync_synchronize();
 }
 
+// This avoids a duplicate definition in PMIx <v1.2.5 (Open MPI v2.1.x
+// has PMIx 1.2.4).  This was fixed in PMIx v1.2.5, but it is not
+// worth updating the embedded PMIx in Open MPI v2.1.x because a) the
+// OMPI v2.1.x series is nearing its end of life, and b) it's
+// convenient/simple to say that the PMIx forward compatibility story
+// starts with Open MPI v3.0.x (vs. a specific release in the Open MPI
+// v2.1.x series).
+#ifndef MB
 #define MB() opal_atomic_mb()
+#endif
 
 /**********************************************************************
  *


### PR DESCRIPTION
This is not a cherry-pick from master because it is an Open MPI
v2.1.x-specific issue.

The embedded PMIx (v1.2.4) and Open MPI have duplicate definitions of
the "MB" preprocessor macro.  This was fixed in PMIx v1.2.5, but it's
not worth updating the embedded PMIx here in Open MPI because the
v2.1.x series is reaching its end of life.

Instead, just surround the OPAL "MB" definition with an #ifdef and
call it "good enough".

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>