### PR TITLE
v2.x: errhandler_predefined: remove erroneous assert()

### DIFF
--- a/ompi/errhandler/errhandler_predefined.c
+++ b/ompi/errhandler/errhandler_predefined.c
@@ -190,10 +190,6 @@ static void backend_fatal_aggregate(char *type,
     const char* usable_prefix = unknown_prefix;
     const char* usable_err_msg = unknown_error;
 
-    int32_t state = ompi_mpi_state;
-    assert(state < OMPI_MPI_STATE_INIT_COMPLETED ||
-           state >= OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT);
-
     arg = va_arg(arglist, char*);
     va_end(arglist);
 


### PR DESCRIPTION
This assert() was added in 13ddcbfbaa2 (which was a back-ported cherry
pick from master: 35438ae9b521), but it is actually exactly the
opposite assert that should be there.  The assert() is actually
superflouous, because the "if" statement resulting in invoking this
function is exactly what the assert() should be.  Hence, the simplest
solution here is just to remove that assert().

This assert() is not present on master: it's only on the v2.x branch.
Hence, this is not a cherry-pick from master -- it's a direct PR to
the v2.x branch.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

This issue found in Cisco MTT runs -- see https://mtt.open-mpi.org/index.php?do_redir=2657