### PR TITLE
v3.1.x: Backport threadshift for show_help messages

### DIFF
--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -879,6 +879,16 @@ void pmix_tool_connected_fn(opal_list_t *info,
 
 }
 
+static void lgcbfn(int sd, short args, void *cbdata)
+{
+    orte_pmix_server_op_caddy_t *cd = (orte_pmix_server_op_caddy_t*)cbdata;
+
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(cd->status, cd->cbdata);
+    }
+    OBJ_RELEASE(cd);
+}
+
 void pmix_server_log_fn(opal_process_name_t *requestor,
                         opal_list_t *info,
                         opal_list_t *directives,
@@ -924,9 +934,13 @@ void pmix_server_log_fn(opal_process_name_t *requestor,
         }
     }
 
-    if (NULL != cbfunc) {
-        cbfunc(OPAL_SUCCESS, cbdata);
-    }
+    /* we cannot directly execute the callback here
+     * as it would threadlock - so shift to somewhere
+     * safe */
+    rc = ORTE_SUCCESS;  // unused - silence compiler warning
+    ORTE_PMIX_THREADSHIFT(requestor, NULL, rc,
+                          NULL, NULL, lgcbfn,
+                          cbfunc, cbdata);
 }
 
 int pmix_server_job_ctrl_fn(const opal_process_name_t *requestor,


### PR DESCRIPTION
Avoid threadlock between the ORTE and PMIx layers

Signed-off-by: Ralph Castain <rhc@open-mpi.org>

Refs #5528