### PR TITLE
separate automatic selection of high-low for intercomm

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1724,8 +1724,6 @@ int ompi_comm_determine_first ( ompi_communicator_t *intercomm, int high )
     int *rdisps;
     int scount=0;
     int rc;
-    ompi_proc_t *ourproc, *theirproc;
-    ompi_rte_cmp_bitmask_t mask;
 
     rank = ompi_comm_rank        (intercomm);
     rsize= ompi_comm_remote_size (intercomm);
@@ -1774,20 +1772,32 @@ int ompi_comm_determine_first ( ompi_communicator_t *intercomm, int high )
         flag = true;
     }
     else {
-        ourproc   = ompi_group_peer_lookup(intercomm->c_local_group,0);
-        theirproc = ompi_group_peer_lookup(intercomm->c_remote_group,0);
-
-        mask = OMPI_RTE_CMP_JOBID | OMPI_RTE_CMP_VPID;
-        rc = ompi_rte_compare_name_fields(mask, (const ompi_process_name_t*)&(ourproc->super.proc_name),
-                                                (const ompi_process_name_t*)&(theirproc->super.proc_name));
-        if ( 0 > rc ) {
-            flag = true;
-        }
-        else {
-            flag = false;
-        }
+        flag = ompi_comm_determine_first_auto(intercomm);
     }
 
+    return flag;
+}
+/********************************************************************************/
+/********************************************************************************/
+/********************************************************************************/
+int ompi_comm_determine_first_auto ( ompi_communicator_t* intercomm )
+{
+    ompi_proc_t *ourproc, *theirproc;
+    ompi_rte_cmp_bitmask_t mask;
+    int rc, flag;
+
+    ourproc   = ompi_group_peer_lookup(intercomm->c_local_group,0);
+    theirproc = ompi_group_peer_lookup(intercomm->c_remote_group,0);
+
+    mask = OMPI_RTE_CMP_JOBID | OMPI_RTE_CMP_VPID;
+    rc = ompi_rte_compare_name_fields(mask, (const ompi_process_name_t*)&(ourproc->super.proc_name),
+                                            (const ompi_process_name_t*)&(theirproc->super.proc_name));
+    if ( 0 > rc ) {
+        flag = true;
+    }
+    else {
+        flag = false;
+    }
     return flag;
 }
 /********************************************************************************/

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -671,6 +671,14 @@ int ompi_comm_overlapping_groups (int size, struct ompi_proc_t ** lprocs,
 int ompi_comm_determine_first ( ompi_communicator_t *intercomm,
                                 int high );
 
+/**
+ * This is a routine determining automatically wether the local or the
+ * remote group will be first in an operation spanning both sides of an
+ * inter-comm.
+ * It does not communicate to exchange the "high" values; used in some
+ * CID allocation algorithms.
+ */
+int ompi_comm_determine_first_auto ( ompi_communicator_t* intercomm );
 
 OMPI_DECLSPEC int ompi_comm_activate (ompi_communicator_t **newcomm, ompi_communicator_t *comm,
                                       ompi_communicator_t *bridgecomm, const void *arg0,


### PR DESCRIPTION
This PR contains a separation of the logic to auto-select high-low sides in an intercomm in an automatic fashion. The new function (determine_first_auto) is called from only one call site here; but it can be called from alternative (i.e. from out-of-trunk) cid algorithms and fault-tolerant algorithms when operating on intercomms.


Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>