### PR TITLE
v2.1.5: looks like this will be needed after all

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -53,6 +53,23 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
+2.1.5 -- August 2018
+--------------------
+
+- A subtle race condition bug was discovered in the "vader" BTL
+  (shared memory communications) that, in rare instances, can cause
+  MPI processes to crash or incorrectly classify (or effectively drop)
+  an MPI message sent via shared memory.  If you are using the "ob1"
+  PML with "vader" for shared memory communication (note that vader is
+  the default for shared memory communication with ob1), you need to
+  upgrade to v2.1.5 to fix this issue.  You may also upgrade to the
+  following versions to fix this issue:
+  - Open MPI v3.0.1 (released March, 2018) or later in the v3.0.x
+    series
+  - Open MPI v3.1.2 (expected end of August, 2018) or later
+- A link issue was fixed when the UCX library was not located in the
+  linker-default search paths.
+
 2.1.4 -- August, 2018
 ---------------------
 

--- a/VERSION
+++ b/VERSION
@@ -26,7 +26,7 @@ release=5
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=a1
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
Doing a v1.2.5 release to fix a serious vader BTL bug.  Also pick up a
trivial UCX compile/link bug.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Note that no shared library version number changes are needed -- the only 2 changes were in btl/vader and pml/ucx.