### PR TITLE
fortran/use TKR: remove excess declaration for PMPI_Type_extent

### DIFF
--- a/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
@@ -1595,17 +1595,6 @@ end subroutine PMPI_Type_dup
 end interface
 
 
-interface PMPI_Type_extent
-
-subroutine PMPI_Type_extent(datatype, extent, ierror)
-  integer, intent(in) :: datatype
-  integer, intent(out) :: extent
-  integer, intent(out) :: ierror
-end subroutine PMPI_Type_extent
-
-end interface
-
-
 interface PMPI_Type_free
 
 subroutine PMPI_Type_free(datatype, ierror)


### PR DESCRIPTION
This delcaration was accidentally left behind in 89da9651bb2fe.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fixes #5551.