### PR TITLE
fortran/use TKR: remove excess declaration for PMPI_Type_extent

### DIFF
--- a/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
@@ -1595,17 +1595,6 @@ end subroutine PMPI_Type_dup
 end interface
 
 
-interface PMPI_Type_extent
-
-subroutine PMPI_Type_extent(datatype, extent, ierror)
-  integer, intent(in) :: datatype
-  integer, intent(out) :: extent
-  integer, intent(out) :: ierror
-end subroutine PMPI_Type_extent
-
-end interface
-
-
 interface PMPI_Type_free
 
 subroutine PMPI_Type_free(datatype, ierror)


### PR DESCRIPTION
This declaration was accidentally left behind in 89da9651bb2fe.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 8a0b5454ae26acc4984129e20ac152ca8e2214e5)

@gpaulsen Please review/confirm.
@bwbarrett You said you wanted to add this to your AWS tests (i.e., `--enable-mpi1-compatibility` with the RHEL7-default gcc compiler).