### PR TITLE
MCA/COMMON/UCX: added synonym to opal_mem_hook variable

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -107,6 +107,8 @@ static int component_register(void) {
                                            MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_ucx_component.priority);
     free(description_str);
 
+    opal_common_ucx_mca_var_register(&mca_osc_ucx_component.super.osc_version);
+
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -64,6 +64,7 @@ static int mca_pml_ucx_component_register(void)
                                            OPAL_INFO_LVL_3,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &ompi_pml_ucx.num_disconnect);
+    opal_common_ucx_mca_var_register(&mca_pml_ucx_component.pmlm_version);
     return 0;
 }
 

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -38,26 +38,39 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
 {
     static int registered = 0;
     static int hook_index;
+    static int verbose_index;
+    static int progress_index;
     if (!registered) {
-        mca_base_var_register("opal", "opal_common", "ucx", "verbose",
-                              "Verbose level of the UCX components",
-                              MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
-                              OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
-                              &opal_common_ucx.verbose);
-        mca_base_var_register("opal", "opal_common", "ucx", "progress_iterations",
-                              "Set number of calls of internal UCX progress calls per opal_progress call",
-                              MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
-                              OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
-                              &opal_common_ucx.progress_iterations);
+        verbose_index = mca_base_var_register("opal", "opal_common", "ucx", "verbose",
+                                              "Verbose level of the UCX components",
+                                              MCA_BASE_VAR_TYPE_INT, NULL, 0,
+                                              MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_3,
+                                              MCA_BASE_VAR_SCOPE_LOCAL,
+                                              &opal_common_ucx.verbose);
+        progress_index = mca_base_var_register("opal", "opal_common", "ucx", "progress_iterations",
+                                               "Set number of calls of internal UCX progress "
+                                               "calls per opal_progress call",
+                                               MCA_BASE_VAR_TYPE_INT, NULL, 0,
+                                               MCA_BASE_VAR_FLAG_SETTABLE, OPAL_INFO_LVL_3,
+                                               MCA_BASE_VAR_SCOPE_LOCAL,
+                                               &opal_common_ucx.progress_iterations);
         hook_index = mca_base_var_register("opal", "opal_common", "ucx", "opal_mem_hooks",
-                                           "Use OPAL memory hooks, instead of UCX internal memory hooks",
-                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           "Use OPAL memory hooks, instead of UCX internal "
+                                           "memory hooks", MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                            OPAL_INFO_LVL_3,
                                            MCA_BASE_VAR_SCOPE_LOCAL,
                                            &opal_common_ucx.opal_mem_hooks);
         registered = 1;
     }
     if (component) {
+        mca_base_var_register_synonym(verbose_index, component->mca_project_name,
+                                      component->mca_type_name,
+                                      component->mca_component_name,
+                                      "verbose", 0);
+        mca_base_var_register_synonym(progress_index, component->mca_project_name,
+                                      component->mca_type_name,
+                                      component->mca_component_name,
+                                      "progress_iterations", 0);
         mca_base_var_register_synonym(hook_index, component->mca_project_name,
                                       component->mca_type_name,
                                       component->mca_component_name,

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -34,6 +34,37 @@ static void opal_common_ucx_mem_release_cb(void *buf, size_t length,
     ucm_vm_munmap(buf, length);
 }
 
+OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *component)
+{
+    static int registered = 0;
+    static int hook_index;
+    if (!registered) {
+        mca_base_var_register("opal", "ucx", "*", "verbose",
+                              "Verbose level of the UCX components",
+                              MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                              OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
+                              &opal_common_ucx.verbose);
+        mca_base_var_register("opal", "opal_common", "ucx", "progress_iterations",
+                              "Set number of calls of internal UCX progress calls per opal_progress call",
+                              MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
+                              OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,
+                              &opal_common_ucx.progress_iterations);
+        hook_index = mca_base_var_register("opal", "opal_common", "ucx", "opal_mem_hooks",
+                                           "Use OPAL memory hooks, instead of UCX internal memory hooks",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                           OPAL_INFO_LVL_3,
+                                           MCA_BASE_VAR_SCOPE_LOCAL,
+                                           &opal_common_ucx.opal_mem_hooks);
+        registered = 1;
+    }
+    if (component) {
+        mca_base_var_register_synonym(hook_index, component->mca_project_name,
+                                      component->mca_type_name,
+                                      component->mca_component_name,
+                                      "opal_mem_hooks", 0);
+    }
+}
+
 OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
 {
     opal_common_ucx.registered++;
@@ -41,23 +72,6 @@ OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
         /* process once */
         return;
     }
-
-    mca_base_var_register("opal", "opal_common", "ucx", "verbose",
-                          "Verbose level of the UCX components",
-                          MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
-                          OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_LOCAL,
-                          &opal_common_ucx.verbose);
-    mca_base_var_register("opal", "opal_common", "ucx", "progress_iterations",
-                          "Set number of calls of internal UCX progress calls per opal_progress call",
-                          MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
-                          OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_LOCAL,
-                          &opal_common_ucx.progress_iterations);
-    mca_base_var_register("opal", "opal_common", "ucx", "opal_mem_hooks",
-                          "Use OPAL memory hooks, instead of UCX internal memory hooks",
-                          MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                          OPAL_INFO_LVL_3,
-                          MCA_BASE_VAR_SCOPE_LOCAL,
-                          &opal_common_ucx.opal_mem_hooks);
 
     opal_common_ucx.output = opal_output_open(NULL);
     opal_output_set_verbosity(opal_common_ucx.output, opal_common_ucx.verbose);

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -39,7 +39,7 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
     static int registered = 0;
     static int hook_index;
     if (!registered) {
-        mca_base_var_register("opal", "ucx", "*", "verbose",
+        mca_base_var_register("opal", "opal_common", "ucx", "verbose",
                               "Verbose level of the UCX components",
                               MCA_BASE_VAR_TYPE_INT, NULL, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                               OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_LOCAL,

--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -73,6 +73,7 @@ OPAL_DECLSPEC void opal_common_ucx_empty_complete_cb(void *request, ucs_status_t
 OPAL_DECLSPEC int opal_common_ucx_mca_pmix_fence(ucp_worker_h worker);
 OPAL_DECLSPEC int opal_common_ucx_del_procs(opal_common_ucx_del_proc_t *procs, size_t count,
                                             size_t my_rank, size_t max_disconnect, ucp_worker_h worker);
+OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *component);
 
 static inline
 int opal_common_ucx_wait_request(ucs_status_ptr_t request, ucp_worker_h worker,

--- a/oshmem/mca/atomic/ucx/atomic_ucx_component.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_component.c
@@ -86,6 +86,8 @@ static int ucx_register(void)
                                      MCA_BASE_VAR_SCOPE_ALL_EQ,
                                      &mca_atomic_ucx_component.priority);
 
+    opal_common_ucx_mca_var_register(&mca_atomic_ucx_component.atomic_version);
+
     return OSHMEM_SUCCESS;
 }
 

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -104,6 +104,8 @@ static int mca_spml_ucx_component_register(void)
                                     "Use non-blocking memory registration for shared heap",
                                     &mca_spml_ucx.heap_reg_nb);
 
+    opal_common_ucx_mca_var_register(&mca_spml_ucx_component.spmlm_version);
+
     return OSHMEM_SUCCESS;
 }
 


### PR DESCRIPTION
- added synonim to opal_mem_hook variable to allow
  to print it in opal_info -a

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>