### PR TITLE
OSHMEM/API/C11: fixed API macro - v4.0

### DIFF
--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -106,18 +106,6 @@ OSHMEM_DECLSPEC  void pshmem_ctx_float_p(shmem_ctx_t ctx, float* addr, float val
 OSHMEM_DECLSPEC  void pshmem_ctx_double_p(shmem_ctx_t ctx, double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longlong_p(shmem_ctx_t ctx, long long* addr, long long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_p(shmem_ctx_t ctx, long double* addr, long double value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_p(ctx, dst, val, pe)                           \
-    _Generic(&*(dst),                                         \
-            char*:        pshmem_ctx_char_p,                  \
-            short*:       pshmem_ctx_short_p,                 \
-            int*:         pshmem_ctx_int_p,                   \
-            long*:        pshmem_ctx_long_p,                  \
-            long long*:   pshmem_ctx_longlong_p,              \
-            float*:       pshmem_ctx_float_p,                 \
-            double*:      pshmem_ctx_double_p,                \
-            long double*: pshmem_ctx_longdouble_p)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC  void pshmem_char_p(char* addr, char value, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_p(short* addr, short value, int pe);
@@ -128,16 +116,26 @@ OSHMEM_DECLSPEC  void pshmem_double_p(double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void pshmem_longlong_p(long long* addr, long long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_p(long double* addr, long double value, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_p(dst, val, pe)                                \
-    _Generic(&*(dst),                                         \
-            char*:        pshmem_char_p,                      \
-            short*:       pshmem_short_p,                     \
-            int*:         pshmem_int_p,                       \
-            long*:        pshmem_long_p,                      \
-            long long*:   pshmem_longlong_p,                  \
-            float*:       pshmem_float_p,                     \
-            double*:      pshmem_double_p,                    \
-            long double*: pshmem_longdouble_p)(dst, val, pe)
+#define pshmem_p(...)                                                \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_p,                     \
+                short*:       pshmem_ctx_short_p,                    \
+                int*:         pshmem_ctx_int_p,                      \
+                long*:        pshmem_ctx_long_p,                     \
+                long long*:   pshmem_ctx_longlong_p,                 \
+                float*:       pshmem_ctx_float_p,                    \
+                double*:      pshmem_ctx_double_p,                   \
+                long double*: pshmem_ctx_longdouble_p,               \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_p,                             \
+            short*:       pshmem_short_p,                            \
+            int*:         pshmem_int_p,                              \
+            long*:        pshmem_long_p,                             \
+            long long*:   pshmem_longlong_p,                         \
+            float*:       pshmem_float_p,                            \
+            double*:      pshmem_double_p,                           \
+            long double*: pshmem_longdouble_p)(__VA_ARGS__)
 #endif
 
 /*
@@ -151,18 +149,6 @@ OSHMEM_DECLSPEC  void pshmem_ctx_float_put(shmem_ctx_t ctx, float *target, const
 OSHMEM_DECLSPEC  void pshmem_ctx_double_put(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longlong_put(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_put(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_put(ctx, dst, src, len, pe)         \
-    _Generic(&*(dst),                              \
-            char*:        pshmem_ctx_char_put,     \
-            short*:       pshmem_ctx_short_put,    \
-            int*:         pshmem_ctx_int_put,      \
-            long*:        pshmem_ctx_long_put,     \
-            long long*:   pshmem_ctx_longlong_put, \
-            float*:       pshmem_ctx_float_put,    \
-            double*:      pshmem_ctx_double_put,   \
-            long double*: pshmem_ctx_longdouble_put)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void pshmem_char_put(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_put(short *target, const short *source, size_t len, int pe);
@@ -173,16 +159,26 @@ OSHMEM_DECLSPEC  void pshmem_double_put(double *target, const double *source, si
 OSHMEM_DECLSPEC  void pshmem_longlong_put(long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_put(dst, src, len, pe)               \
-    _Generic(&*(dst),                               \
-            char*:        pshmem_char_put,          \
-            short*:       pshmem_short_put,         \
-            int*:         pshmem_int_put,           \
-            long*:        pshmem_long_put,          \
-            long long*:   pshmem_longlong_put,      \
-            float*:       pshmem_float_put,         \
-            double*:      pshmem_double_put,        \
-            long double*: pshmem_longdouble_put)(dst, src, len, pe)
+#define pshmem_put(...)                                              \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_put,                   \
+                short*:       pshmem_ctx_short_put,                  \
+                int*:         pshmem_ctx_int_put,                    \
+                long*:        pshmem_ctx_long_put,                   \
+                long long*:   pshmem_ctx_longlong_put,               \
+                float*:       pshmem_ctx_float_put,                  \
+                double*:      pshmem_ctx_double_put,                 \
+                long double*: pshmem_ctx_longdouble_put,             \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_put,                           \
+            short*:       pshmem_short_put,                          \
+            int*:         pshmem_int_put,                            \
+            long*:        pshmem_long_put,                           \
+            long long*:   pshmem_longlong_put,                       \
+            float*:       pshmem_float_put,                          \
+            double*:      pshmem_double_put,                         \
+            long double*: pshmem_longdouble_put)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void pshmem_ctx_put8(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -210,18 +206,6 @@ OSHMEM_DECLSPEC void pshmem_ctx_float_iput(shmem_ctx_t ctx, float* target, const
 OSHMEM_DECLSPEC void pshmem_ctx_double_iput(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_iput(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longdouble_iput(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_iput(ctx, dst, src, tst, sst, len, pe) \
-    _Generic(&*(dst),                                \
-            char*:        pshmem_ctx_char_iput,      \
-            short*:       pshmem_ctx_short_iput,     \
-            int*:         pshmem_ctx_int_iput,       \
-            long*:        pshmem_ctx_long_iput,      \
-            long long*:   pshmem_ctx_longlong_iput,  \
-            float*:       pshmem_ctx_float_iput,     \
-            double*:      pshmem_ctx_double_iput,    \
-            long double*: pshmem_ctx_longdouble_iput)(ctx, dst, src, tst, sst, len, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_char_iput(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_short_iput(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -232,16 +216,26 @@ OSHMEM_DECLSPEC void pshmem_double_iput(double* target, const double* source, pt
 OSHMEM_DECLSPEC void pshmem_longlong_iput(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_longdouble_iput(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_iput(dst, src, tst, sst, len, pe)     \
-    _Generic(&*(dst),                                \
-            char*:        pshmem_char_iput,          \
-            short*:       pshmem_short_iput,         \
-            int*:         pshmem_int_iput,           \
-            long*:        pshmem_long_iput,          \
-            long long*:   pshmem_longlong_iput,      \
-            float*:       pshmem_float_iput,         \
-            double*:      pshmem_double_iput,        \
-            long double*: pshmem_longdouble_iput)(dst, src, tst, sst, len, pe)
+#define pshmem_iput(...)                                             \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_iput,                  \
+                short*:       pshmem_ctx_short_iput,                 \
+                int*:         pshmem_ctx_int_iput,                   \
+                long*:        pshmem_ctx_long_iput,                  \
+                long long*:   pshmem_ctx_longlong_iput,              \
+                float*:       pshmem_ctx_float_iput,                 \
+                double*:      pshmem_ctx_double_iput,                \
+                long double*: pshmem_ctx_longdouble_iput,            \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_iput,                          \
+            short*:       pshmem_short_iput,                         \
+            int*:         pshmem_int_iput,                           \
+            long*:        pshmem_long_iput,                          \
+            long long*:   pshmem_longlong_iput,                      \
+            float*:       pshmem_float_iput,                         \
+            double*:      pshmem_double_iput,                        \
+            long double*: pshmem_longdouble_iput)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_ctx_iput8(shmem_ctx_t ctx, void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -267,18 +261,6 @@ OSHMEM_DECLSPEC  void pshmem_ctx_longlong_put_nbi(shmem_ctx_t ctx, long long *ta
 OSHMEM_DECLSPEC  void pshmem_ctx_float_put_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_put_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_put_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_put_nbi(ctx, dst, src, len, pe)          \
-    _Generic(&*(dst),                                   \
-            char*:        pshmem_ctx_char_put_nbi,      \
-            short*:       pshmem_ctx_short_put_nbi,     \
-            int*:         pshmem_ctx_int_put_nbi,       \
-            long*:        pshmem_ctx_long_put_nbi,      \
-            long long*:   pshmem_ctx_longlong_put_nbi,  \
-            float*:       pshmem_ctx_float_put_nbi,     \
-            double*:      pshmem_ctx_double_put_nbi,    \
-            long double*: pshmem_ctx_longdouble_put_nbi)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void pshmem_putmem_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
@@ -290,16 +272,26 @@ OSHMEM_DECLSPEC  void pshmem_float_put_nbi(float *target, const float *source, s
 OSHMEM_DECLSPEC  void pshmem_double_put_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_put_nbi(dst, src, len, pe)               \
-    _Generic(&*(dst),                                   \
-            char*:        pshmem_char_put_nbi,          \
-            short*:       pshmem_short_put_nbi,         \
-            int*:         pshmem_int_put_nbi,           \
-            long*:        pshmem_long_put_nbi,          \
-            long long*:   pshmem_longlong_put_nbi,      \
-            float*:       pshmem_float_put_nbi,         \
-            double*:      pshmem_double_put_nbi,        \
-            long double*: pshmem_longdouble_put_nbi)(dst, src, len, pe)
+#define pshmem_put_nbi(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_put_nbi,               \
+                short*:       pshmem_ctx_short_put_nbi,              \
+                int*:         pshmem_ctx_int_put_nbi,                \
+                long*:        pshmem_ctx_long_put_nbi,               \
+                long long*:   pshmem_ctx_longlong_put_nbi,           \
+                float*:       pshmem_ctx_float_put_nbi,              \
+                double*:      pshmem_ctx_double_put_nbi,             \
+                long double*: pshmem_ctx_longdouble_put_nbi,         \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_put_nbi,                       \
+            short*:       pshmem_short_put_nbi,                      \
+            int*:         pshmem_int_put_nbi,                        \
+            long*:        pshmem_long_put_nbi,                       \
+            long long*:   pshmem_longlong_put_nbi,                   \
+            float*:       pshmem_float_put_nbi,                      \
+            double*:      pshmem_double_put_nbi,                     \
+            long double*: pshmem_longdouble_put_nbi)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void pshmem_ctx_put8_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -326,18 +318,6 @@ OSHMEM_DECLSPEC  float pshmem_ctx_float_g(shmem_ctx_t ctx, const float* addr, in
 OSHMEM_DECLSPEC  double pshmem_ctx_double_g(shmem_ctx_t ctx, const double* addr, int pe);
 OSHMEM_DECLSPEC  long long pshmem_ctx_longlong_g(shmem_ctx_t ctx, const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double pshmem_ctx_longdouble_g(shmem_ctx_t ctx, const long double* addr, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_g(ctx, addr, pe)                               \
-    _Generic(&*(addr),                                        \
-            char*:        pshmem_ctx_char_g,                  \
-            short*:       pshmem_ctx_short_g,                 \
-            int*:         pshmem_ctx_int_g,                   \
-            long*:        pshmem_ctx_long_g,                  \
-            long long*:   pshmem_ctx_longlong_g,              \
-            float*:       pshmem_ctx_float_g,                 \
-            double*:      pshmem_ctx_double_g,                \
-            long double*: pshmem_ctx_longdouble_g)(ctx, addr, pe)
-#endif
 
 OSHMEM_DECLSPEC  char pshmem_char_g(const char* addr, int pe);
 OSHMEM_DECLSPEC  short pshmem_short_g(const short* addr, int pe);
@@ -348,16 +328,26 @@ OSHMEM_DECLSPEC  double pshmem_double_g(const double* addr, int pe);
 OSHMEM_DECLSPEC  long long pshmem_longlong_g(const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double pshmem_longdouble_g(const long double* addr, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_g(addr, pe)                                    \
-    _Generic(&*(dst),                                         \
-            char*:        pshmem_char_g,                      \
-            short*:       pshmem_short_g,                     \
-            int*:         pshmem_int_g,                       \
-            long*:        pshmem_long_g,                      \
-            long long*:   pshmem_longlong_g,                  \
-            float*:       pshmem_float_g,                     \
-            double*:      pshmem_double_g,                    \
-            long double*: pshmem_longdouble_g)(addr, pe)
+#define pshmem_g(...)                                                \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_g,                     \
+                short*:       pshmem_ctx_short_g,                    \
+                int*:         pshmem_ctx_int_g,                      \
+                long*:        pshmem_ctx_long_g,                     \
+                long long*:   pshmem_ctx_longlong_g,                 \
+                float*:       pshmem_ctx_float_g,                    \
+                double*:      pshmem_ctx_double_g,                   \
+                long double*: pshmem_ctx_longdouble_g,               \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_g,                             \
+            short*:       pshmem_short_g,                            \
+            int*:         pshmem_int_g,                              \
+            long*:        pshmem_long_g,                             \
+            long long*:   pshmem_longlong_g,                         \
+            float*:       pshmem_float_g,                            \
+            double*:      pshmem_double_g,                           \
+            long double*: pshmem_longdouble_g)(__VA_ARGS__)
 #endif
 
 /*
@@ -371,18 +361,6 @@ OSHMEM_DECLSPEC  void pshmem_ctx_float_get(shmem_ctx_t ctx, float *target, const
 OSHMEM_DECLSPEC  void pshmem_ctx_double_get(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longlong_get(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_get(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_get(ctx, dst, src, len, pe)          \
-    _Generic(&*(dst),                               \
-            char*:        pshmem_ctx_char_get,      \
-            short*:       pshmem_ctx_short_get,     \
-            int*:         pshmem_ctx_int_get,       \
-            long*:        pshmem_ctx_long_get,      \
-            long long*:   pshmem_ctx_longlong_get,  \
-            float*:       pshmem_ctx_float_get,     \
-            double*:      pshmem_ctx_double_get,    \
-            long double*: pshmem_ctx_longdouble_get)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void pshmem_char_get(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_get(short *target, const short *source, size_t len, int pe);
@@ -393,16 +371,26 @@ OSHMEM_DECLSPEC  void pshmem_double_get(double *target, const double *source, si
 OSHMEM_DECLSPEC  void pshmem_longlong_get(long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_get(dst, src, len, pe)               \
-    _Generic(&*(dst),                              \
-            char*:        pshmem_char_get,          \
-            short*:       pshmem_short_get,         \
-            int*:         pshmem_int_get,           \
-            long*:        pshmem_long_get,          \
-            long long*:   pshmem_longlong_get,      \
-            float*:       pshmem_float_get,         \
-            double*:      pshmem_double_get,        \
-            long double*: pshmem_longdouble_get)(dst, src, len, pe)
+#define pshmem_get(...)                                              \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_get,                   \
+                short*:       pshmem_ctx_short_get,                  \
+                int*:         pshmem_ctx_int_get,                    \
+                long*:        pshmem_ctx_long_get,                   \
+                long long*:   pshmem_ctx_longlong_get,               \
+                float*:       pshmem_ctx_float_get,                  \
+                double*:      pshmem_ctx_double_get,                 \
+                long double*: pshmem_ctx_longdouble_get,             \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_get,                           \
+            short*:       pshmem_short_get,                          \
+            int*:         pshmem_int_get,                            \
+            long*:        pshmem_long_get,                           \
+            long long*:   pshmem_longlong_get,                       \
+            float*:       pshmem_float_get,                          \
+            double*:      pshmem_double_get,                         \
+            long double*: pshmem_longdouble_get)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void pshmem_ctx_get8(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -430,18 +418,6 @@ OSHMEM_DECLSPEC void pshmem_ctx_double_iget(shmem_ctx_t ctx, double* target, con
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_iget(ctx, dst, src, tst, sst, len, pe) \
-    _Generic(&*(dst),                                \
-            char*:        pshmem_ctx_char_iget,      \
-            short*:       pshmem_ctx_short_iget,     \
-            int*:         pshmem_ctx_int_iget,       \
-            long*:        pshmem_ctx_long_iget,      \
-            long long*:   pshmem_ctx_longlong_iget,  \
-            float*:       pshmem_ctx_float_iget,     \
-            double*:      pshmem_ctx_double_iget,    \
-            long double*: pshmem_ctx_longdouble_iget)(ctx, dst, src, tst, sst, len, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -452,16 +428,26 @@ OSHMEM_DECLSPEC void pshmem_longlong_iget(long long* target, const long long* so
 OSHMEM_DECLSPEC void pshmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_iget(dst, src, tst, sst, len, pe)     \
-    _Generic(&*(dst),                               \
-            char*:        pshmem_char_iget,          \
-            short*:       pshmem_short_iget,         \
-            int*:         pshmem_int_iget,           \
-            long*:        pshmem_long_iget,          \
-            long long*:   pshmem_longlong_iget,      \
-            float*:       pshmem_float_iget,         \
-            double*:      pshmem_double_iget,        \
-            long double*: pshmem_longdouble_iget)(dst, src, tst, sst, len, pe)
+#define pshmem_iget(...)                                             \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_iget,                  \
+                short*:       pshmem_ctx_short_iget,                 \
+                int*:         pshmem_ctx_int_iget,                   \
+                long*:        pshmem_ctx_long_iget,                  \
+                long long*:   pshmem_ctx_longlong_iget,              \
+                float*:       pshmem_ctx_float_iget,                 \
+                double*:      pshmem_ctx_double_iget,                \
+                long double*: pshmem_ctx_longdouble_iget,            \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_iget,                          \
+            short*:       pshmem_short_iget,                         \
+            int*:         pshmem_int_iget,                           \
+            long*:        pshmem_long_iget,                          \
+            long long*:   pshmem_longlong_iget,                      \
+            float*:       pshmem_float_iget,                         \
+            double*:      pshmem_double_iget,                        \
+            long double*: pshmem_longdouble_iget)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_ctx_iget8(shmem_ctx_t ctx, void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -487,18 +473,6 @@ OSHMEM_DECLSPEC  void pshmem_ctx_longlong_get_nbi(shmem_ctx_t ctx, long long *ta
 OSHMEM_DECLSPEC  void pshmem_ctx_float_get_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_get_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_get_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_get_nbi(ctx, dst, src, len, pe)          \
-    _Generic(&*(dst),                                   \
-            char*:        pshmem_ctx_char_get_nbi,      \
-            short*:       pshmem_ctx_short_get_nbi,     \
-            int*:         pshmem_ctx_int_get_nbi,       \
-            long*:        pshmem_ctx_long_get_nbi,      \
-            long long*:   pshmem_ctx_longlong_get_nbi,  \
-            float*:       pshmem_ctx_float_get_nbi,     \
-            double*:      pshmem_ctx_double_get_nbi,    \
-            long double*: pshmem_ctx_longdouble_get_nbi)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void pshmem_getmem_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_char_get_nbi(char *target, const char *source, size_t len, int pe);
@@ -510,16 +484,26 @@ OSHMEM_DECLSPEC  void pshmem_float_get_nbi(float *target, const float *source, s
 OSHMEM_DECLSPEC  void pshmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_get_nbi(dst, src, len, pe)               \
-    _Generic(&*(dst),                                  \
-            char*:        pshmem_char_get_nbi,          \
-            short*:       pshmem_short_get_nbi,         \
-            int*:         pshmem_int_get_nbi,           \
-            long*:        pshmem_long_get_nbi,          \
-            long long*:   pshmem_longlong_get_nbi,      \
-            float*:       pshmem_float_get_nbi,         \
-            double*:      pshmem_double_get_nbi,        \
-            long double*: pshmem_longdouble_get_nbi)(dst, src, len, pe)
+#define pshmem_get_nbi(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        pshmem_ctx_char_get_nbi,               \
+                short*:       pshmem_ctx_short_get_nbi,              \
+                int*:         pshmem_ctx_int_get_nbi,                \
+                long*:        pshmem_ctx_long_get_nbi,               \
+                long long*:   pshmem_ctx_longlong_get_nbi,           \
+                float*:       pshmem_ctx_float_get_nbi,              \
+                double*:      pshmem_ctx_double_get_nbi,             \
+                long double*: pshmem_ctx_longdouble_get_nbi,         \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        pshmem_char_get_nbi,                       \
+            short*:       pshmem_short_get_nbi,                      \
+            int*:         pshmem_int_get_nbi,                        \
+            long*:        pshmem_long_get_nbi,                       \
+            long long*:   pshmem_longlong_get_nbi,                   \
+            float*:       pshmem_float_get_nbi,                      \
+            double*:      pshmem_double_get_nbi,                     \
+            long double*: pshmem_longdouble_get_nbi)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void pshmem_ctx_get8_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -544,15 +528,6 @@ OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_swap(shmem_ctx_t ctx, long *target, 
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_swap(shmem_ctx_t ctx, long long*target, long long value, int pe);
 OSHMEM_DECLSPEC float pshmem_ctx_float_atomic_swap(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC double pshmem_ctx_double_atomic_swap(shmem_ctx_t ctx, double *target, double value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_swap(ctx, dst, val, pe)                 \
-    _Generic(&*(dst),                                         \
-            int*:         pshmem_ctx_int_atomic_swap,         \
-            long*:        pshmem_ctx_long_atomic_swap,        \
-            long long*:   pshmem_ctx_longlong_atomic_swap,    \
-            float*:       pshmem_ctx_float_atomic_swap,       \
-            double*:      pshmem_ctx_double_atomic_swap)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_swap(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_swap(long *target, long value, int pe);
@@ -560,13 +535,20 @@ OSHMEM_DECLSPEC long long pshmem_longlong_atomic_swap(long long*target, long lon
 OSHMEM_DECLSPEC float pshmem_float_atomic_swap(float *target, float value, int pe);
 OSHMEM_DECLSPEC double pshmem_double_atomic_swap(double *target, double value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_swap(dst, val, pe)                      \
-    _Generic(&*(dst),                                         \
-            int*:         pshmem_int_atomic_swap,             \
-            long*:        pshmem_long_atomic_swap,            \
-            long long*:   pshmem_longlong_atomic_swap,        \
-            float*:       pshmem_float_atomic_swap,           \
-            double*:      pshmem_double_atomic_swap)(dst, val, pe)
+#define pshmem_atomic_swap(...)                                      \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         pshmem_ctx_int_atomic_swap,            \
+                long*:        pshmem_ctx_long_atomic_swap,           \
+                long long*:   pshmem_ctx_longlong_atomic_swap,       \
+                float*:       pshmem_ctx_float_atomic_swap,          \
+                double*:      pshmem_ctx_double_atomic_swap,         \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_swap,                    \
+            long*:        pshmem_long_atomic_swap,                   \
+            long long*:   pshmem_longlong_atomic_swap,               \
+            float*:       pshmem_float_atomic_swap,                  \
+            double*:      pshmem_double_atomic_swap)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_swap(int *target, int value, int pe);
@@ -575,12 +557,12 @@ OSHMEM_DECLSPEC long long pshmem_longlong_swap(long long*target, long long value
 OSHMEM_DECLSPEC float pshmem_float_swap(float *target, float value, int pe);
 OSHMEM_DECLSPEC double pshmem_double_swap(double *target, double value, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_swap(dst, val, pe)                             \
-    _Generic(&*(dst),                                        \
-            int*:         pshmem_int_swap,                    \
-            long*:        pshmem_long_swap,                   \
-            long long*:   pshmem_longlong_swap,               \
-            float*:       pshmem_float_swap,               \
+#define pshmem_swap(dst, val, pe)               \
+    _Generic(&*(dst),                           \
+            int*:         pshmem_int_swap,      \
+            long*:        pshmem_long_swap,     \
+            long long*:   pshmem_longlong_swap, \
+            float*:       pshmem_float_swap,    \
             double*:      pshmem_double_swap)(dst, val, pe)
 #endif
 
@@ -590,15 +572,6 @@ OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_set(shmem_ctx_t ctx, long *target, l
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_set(shmem_ctx_t ctx, long long*target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_float_atomic_set(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_double_atomic_set(shmem_ctx_t ctx, double *target, double value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_set(ctx, dst, val, pe)                 \
-    _Generic(&*(dst),                                        \
-            int*:         pshmem_ctx_int_atomic_set,         \
-            long*:        pshmem_ctx_long_atomic_set,        \
-            long long*:   pshmem_ctx_longlong_atomic_set,    \
-            float*:       pshmem_ctx_float_atomic_set,       \
-            double*:      pshmem_ctx_double_atomic_set)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_set(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_set(long *target, long value, int pe);
@@ -606,13 +579,20 @@ OSHMEM_DECLSPEC void pshmem_longlong_atomic_set(long long*target, long long valu
 OSHMEM_DECLSPEC void pshmem_float_atomic_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void pshmem_double_atomic_set(double *target, double value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_set(dst, val, pe)                      \
-    _Generic(&*(dst),                                        \
-            int*:         pshmem_int_atomic_set,             \
-            long*:        pshmem_long_atomic_set,            \
-            long long*:   pshmem_longlong_atomic_set,        \
-            float*:       pshmem_float_atomic_set,           \
-            double*:      pshmem_double_atomic_set)(dst, val, pe)
+#define pshmem_atomic_set(...)                                       \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         pshmem_ctx_int_atomic_set,             \
+                long*:        pshmem_ctx_long_atomic_set,            \
+                long long*:   pshmem_ctx_longlong_atomic_set,        \
+                float*:       pshmem_ctx_float_atomic_set,           \
+                double*:      pshmem_ctx_double_atomic_set,          \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_set,                     \
+            long*:        pshmem_long_atomic_set,                    \
+            long long*:   pshmem_longlong_atomic_set,                \
+            float*:       pshmem_float_atomic_set,                   \
+            double*:      pshmem_double_atomic_set)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_int_set(int *target, int value, int pe);
@@ -635,24 +615,21 @@ OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_compare_swap(shmem_ctx_t ctx, int *tar
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_compare_swap(shmem_ctx_t ctx, long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_compare_swap(shmem_ctx_t ctx, long long *target, long long cond, long long value, int pe);
 
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_compare_swap(ctx, dst, cond, val, pe)           \
-    _Generic(&*(dst),                                                 \
-            int*:         pshmem_ctx_int_atomic_compare_swap,         \
-            long*:        pshmem_ctx_long_atomic_compare_swap,        \
-            long long*:   pshmem_ctx_longlong_atomic_compare_swap)(ctx, dst, cond, val, pe)
-#endif
-
 OSHMEM_DECLSPEC int pshmem_int_atomic_compare_swap(int *target, int cond, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_compare_swap(long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_compare_swap(long long *target, long long cond, long long value, int pe);
 
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_compare_swap(dst, cond, val, pe)                \
-    _Generic(&*(dst),                                                 \
+#define pshmem_atomic_compare_swap(...)                               \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
+                int*:         pshmem_ctx_int_atomic_compare_swap,     \
+                long*:        pshmem_ctx_long_atomic_compare_swap,    \
+                long long*:   pshmem_ctx_longlong_atomic_compare_swap,\
+                default:      __oshmem_datatype_ignore),              \
             int*:         pshmem_int_atomic_compare_swap,             \
             long*:        pshmem_long_atomic_compare_swap,            \
-            long long*:   pshmem_longlong_atomic_compare_swap)(dst, cond, val, pe)
+            long long*:   pshmem_longlong_atomic_compare_swap)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_cswap(int *target, int cond, int value, int pe);
@@ -670,23 +647,21 @@ OSHMEM_DECLSPEC long long pshmem_longlong_cswap(long long *target, long long con
 OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_add(ctx, dst, val, pe)                 \
-    _Generic(&*(dst),                                              \
-            int*:         pshmem_ctx_int_atomic_fetch_add,         \
-            long*:        pshmem_ctx_long_atomic_fetch_add,        \
-            long long*:   pshmem_ctx_longlong_atomic_fetch_add)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_add(long long *target, long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_add(dst, val, pe)                      \
-    _Generic(&*(dst),                                              \
-            int*:         pshmem_int_atomic_fetch_add,             \
-            long*:        pshmem_long_atomic_fetch_add,            \
-            long long*:   pshmem_longlong_atomic_fetch_add)(dst, val, pe)
+#define pshmem_atomic_fetch_add(...)                                 \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         pshmem_ctx_int_atomic_fetch_add,       \
+                long*:        pshmem_ctx_long_atomic_fetch_add,      \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_add,  \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_fetch_add,               \
+            long*:        pshmem_long_atomic_fetch_add,              \
+            long long*:   pshmem_longlong_atomic_fetch_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_fadd(int *target, int value, int pe);
@@ -704,69 +679,63 @@ OSHMEM_DECLSPEC long long pshmem_longlong_fadd(long long *target, long long valu
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEMP_HAVE_C11
-#define pshmem_atomic_fetch_and(ctx, dst, val, pe)                            \
-    _Generic(&*(dst),                                                         \
-            unsigned int*:         pshmem_ctx_uint_atomic_fetch_and,          \
-            unsigned long*:        pshmem_ctx_ulong_atomic_fetch_and,         \
-            unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_and)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_and(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_and(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                              \
-            unsigned int*:         pshmem_uint_atomic_fetch_and,                   \
-            unsigned long*:        pshmem_ulong_atomic_fetch_and,                  \
-            unsigned long long*:   pshmem_ulonglong_atomic_fetch_and)(dst, val, pe)
+#define pshmem_atomic_fetch_and(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_and,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_and,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_and, \
+                default:               __oshmem_datatype_ignore),             \
+            unsigned int*:         pshmem_uint_atomic_fetch_and,              \
+            unsigned long*:        pshmem_ulong_atomic_fetch_and,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_fetch_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Or */
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_or(ctx, dst, val, pe)                                     \
-    _Generic(&*(dst),                                                                 \
-            unsigned int*:         pshmem_ctx_uint_atomic_fetch_or,                   \
-            unsigned long*:        pshmem_ctx_ulong_atomic_fetch_or,                  \
-            unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_or)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_or(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_or(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                             \
-            unsigned int*:         pshmem_uint_atomic_fetch_or,                   \
-            unsigned long*:        pshmem_ulong_atomic_fetch_or,                  \
-            unsigned long long*:   pshmem_ulonglong_atomic_fetch_or)(dst, val, pe)
+#define pshmem_atomic_fetch_or(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                             \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),         \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_or,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_or,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_or, \
+                default:               __oshmem_datatype_ignore),            \
+            unsigned int*:         pshmem_uint_atomic_fetch_or,              \
+            unsigned long*:        pshmem_ulong_atomic_fetch_or,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_fetch_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Xor */
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_xor(ctx, dst, val, pe)                                     \
-    _Generic(&*(dst),                                                                  \
-            unsigned int*:         pshmem_ctx_uint_atomic_fetch_xor,                   \
-            unsigned long*:        pshmem_ctx_ulong_atomic_fetch_xor,                  \
-            unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_xor)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_xor(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_xor(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                              \
-            unsigned int*:         pshmem_uint_atomic_fetch_xor,                   \
-            unsigned long*:        pshmem_ulong_atomic_fetch_xor,                  \
-            unsigned long long*:   pshmem_ulonglong_atomic_fetch_xor)(dst, val, pe)
+#define pshmem_atomic_fetch_xor(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_xor,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_xor,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_xor, \
+                default:               __oshmem_datatype_ignore),             \
+            unsigned int*:         pshmem_uint_atomic_fetch_xor,              \
+            unsigned long*:        pshmem_ulong_atomic_fetch_xor,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_fetch_xor)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch */
@@ -775,15 +744,6 @@ OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch(shmem_ctx_t ctx, const long *t
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch(shmem_ctx_t ctx, const long long *target, int pe);
 OSHMEM_DECLSPEC float pshmem_ctx_float_atomic_fetch(shmem_ctx_t ctx, const float *target, int pe);
 OSHMEM_DECLSPEC double pshmem_ctx_double_atomic_fetch(shmem_ctx_t ctx, const double *target, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch(ctx, dst, pe)                 \
-    _Generic(&*(dst),                                     \
-            int*:         pshmem_ctx_int_atomic_fetch,    \
-            long*:        pshmem_ctx_long_atomic_fetch,   \
-            long long*:   pshmem_ctx_longlong_atomic_fetch,\
-            float*:       pshmem_ctx_float_atomic_fetch,  \
-            double*:      pshmem_ctx_double_atomic_fetch)(ctx, dst, pe)
-#endif
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch(const int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch(const long *target, int pe);
@@ -791,13 +751,20 @@ OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch(const long long *target, 
 OSHMEM_DECLSPEC float pshmem_float_atomic_fetch(const float *target, int pe);
 OSHMEM_DECLSPEC double pshmem_double_atomic_fetch(const double *target, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch(dst, pe)                      \
-    _Generic(&*(dst),                                     \
-            int*:         pshmem_int_atomic_fetch,        \
-            long*:        pshmem_long_atomic_fetch,       \
-            long long*:   pshmem_longlong_atomic_fetch,   \
-            float*:       pshmem_float_atomic_fetch,      \
-            double*:      pshmem_double_atomic_fetch)(dst, pe)
+#define pshmem_atomic_fetch(...)                                     \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         pshmem_ctx_int_atomic_fetch,           \
+                long*:        pshmem_ctx_long_atomic_fetch,          \
+                long long*:   pshmem_ctx_longlong_atomic_fetch,      \
+                float*:       pshmem_ctx_float_atomic_fetch,         \
+                double*:      pshmem_ctx_double_atomic_fetch,        \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_fetch,                   \
+            long*:        pshmem_long_atomic_fetch,                  \
+            long long*:   pshmem_longlong_atomic_fetch,              \
+            float*:       pshmem_float_atomic_fetch,                 \
+            double*:      pshmem_double_atomic_fetch)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_fetch(const int *target, int pe);
@@ -819,23 +786,21 @@ OSHMEM_DECLSPEC double pshmem_double_fetch(const double *target, int pe);
 OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_inc(shmem_ctx_t ctx, long long *target, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_inc(ctx, dst, pe)                \
-    _Generic(&*(dst),                                        \
-            int*:         pshmem_ctx_int_atomic_fetch_inc,   \
-            long*:        pshmem_ctx_long_atomic_fetch_inc,  \
-            long long*:   pshmem_ctx_longlong_atomic_fetch_inc)(ctx, dst, pe)
-#endif
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_inc(int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_inc(long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_inc(long long *target, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_inc(dst, pe)                     \
-    _Generic(&*(dst),                                        \
-            int*:         pshmem_int_atomic_fetch_inc,       \
-            long*:        pshmem_long_atomic_fetch_inc,      \
-            long long*:   pshmem_longlong_atomic_fetch_inc)(dst, pe)
+#define pshmem_atomic_fetch_inc(...)                                 \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         pshmem_ctx_int_atomic_fetch_inc,       \
+                long*:        pshmem_ctx_long_atomic_fetch_inc,      \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_inc,  \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_fetch_inc,               \
+            long*:        pshmem_long_atomic_fetch_inc,              \
+            long long*:   pshmem_longlong_atomic_fetch_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_finc(int *target, int pe);
@@ -853,23 +818,21 @@ OSHMEM_DECLSPEC long long pshmem_longlong_finc(long long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_add(ctx, dst, val, pe)                 \
-    _Generic(&*(dst),                                        \
-            int*:         pshmem_ctx_int_atomic_add,         \
-            long*:        pshmem_ctx_long_atomic_add,        \
-            long long*:   pshmem_ctx_longlong_atomic_add)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_atomic_add(long long *target, long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_add(dst, val, pe)                      \
-    _Generic(&*(dst),                                        \
-            int*:         pshmem_int_atomic_add,             \
-            long*:        pshmem_long_atomic_add,            \
-            long long*:   pshmem_longlong_atomic_add)(dst, val, pe)
+#define pshmem_atomic_add(...)                                       \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         pshmem_ctx_int_atomic_add,             \
+                long*:        pshmem_ctx_long_atomic_add,            \
+                long long*:   pshmem_ctx_longlong_atomic_add,        \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_add,                     \
+            long*:        pshmem_long_atomic_add,                    \
+            long long*:   pshmem_longlong_atomic_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_int_add(int *target, int value, int pe);
@@ -887,92 +850,84 @@ OSHMEM_DECLSPEC void pshmem_longlong_add(long long *target, long long value, int
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_and(ctx, dst, val, pe)                                    \
-    _Generic(&*(dst),                                                           \
-            unsigned int*:         pshmem_ctx_uint_atomic_and,                  \
-            unsigned long*:        pshmem_ctx_ulong_atomic_and,                 \
-            unsigned long long*:   pshmem_ctx_ulonglong_atomic_and)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_uint_atomic_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_and(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_and(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                        \
-            unsigned int*:         pshmem_uint_atomic_and,                   \
-            unsigned long*:        pshmem_ulong_atomic_and,                  \
-            unsigned long long*:   pshmem_ulonglong_atomic_and)(dst, val, pe)
+#define pshmem_atomic_and(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
+                unsigned int*:         pshmem_ctx_uint_atomic_and,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_and,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_and, \
+                default:               __oshmem_datatype_ignore),       \
+            unsigned int*:         pshmem_uint_atomic_and,              \
+            unsigned long*:        pshmem_ulong_atomic_and,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Or */
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_or(ctx, dst, val, pe)                                    \
-    _Generic(&*(dst),                                                          \
-            unsigned int*:         pshmem_ctx_uint_atomic_or,                  \
-            unsigned long*:        pshmem_ctx_ulong_atomic_or,                 \
-            unsigned long long*:   pshmem_ctx_ulonglong_atomic_or)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_uint_atomic_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_or(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_or(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                       \
-            unsigned int*:         pshmem_uint_atomic_or,                   \
-            unsigned long*:        pshmem_ulong_atomic_or,                  \
-            unsigned long long*:   pshmem_ulonglong_atomic_or)(dst, val, pe)
+#define pshmem_atomic_or(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                unsigned int*:         pshmem_ctx_uint_atomic_or,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_or,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_or, \
+                default:               __oshmem_datatype_ignore),      \
+            unsigned int*:         pshmem_uint_atomic_or,              \
+            unsigned long*:        pshmem_ulong_atomic_or,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Xor */
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_xor(ctx, dst, val, pe)                                    \
-    _Generic(&*(dst),                                                           \
-            unsigned int*:         pshmem_ctx_uint_atomic_xor,                  \
-            unsigned long*:        pshmem_ctx_ulong_atomic_xor,                 \
-            unsigned long long*:   pshmem_ctx_ulonglong_atomic_xor)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_uint_atomic_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_xor(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_xor(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                        \
-            unsigned int*:         pshmem_uint_atomic_xor,                   \
-            unsigned long*:        pshmem_ulong_atomic_xor,                  \
-            unsigned long long*:   pshmem_ulonglong_atomic_xor)(dst, val, pe)
+#define pshmem_atomic_xor(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
+                unsigned int*:         pshmem_ctx_uint_atomic_xor,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_xor,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_xor, \
+                default:               __oshmem_datatype_ignore),       \
+            unsigned int*:         pshmem_uint_atomic_xor,              \
+            unsigned long*:        pshmem_ulong_atomic_xor,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_xor)(__VA_ARGS__)
 #endif
 
 /* Atomic Inc */
 OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_inc(shmem_ctx_t ctx, long long *target, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_inc(ctx, dst, pe)                \
-    _Generic(&*(dst),                                  \
-            int*:         pshmem_ctx_int_atomic_inc,   \
-            long*:        pshmem_ctx_long_atomic_inc,  \
-            long long*:   pshmem_ctx_longlong_atomic_inc)(ctx, dst, pe)
-#endif
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_inc(int *target, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_inc(long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_atomic_inc(long long *target, int pe);
 #if OSHMEM_HAVE_C11
-#define pshmem_atomic_inc(dst, pe)                     \
-    _Generic(&*(dst),                                  \
-            int*:         pshmem_int_atomic_inc,       \
-            long*:        pshmem_long_atomic_inc,      \
-            long long*:   pshmem_longlong_atomic_inc)(dst, pe)
+#define pshmem_atomic_inc(...)                                       \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         pshmem_ctx_int_atomic_inc,             \
+                long*:        pshmem_ctx_long_atomic_inc,            \
+                long long*:   pshmem_ctx_longlong_atomic_inc,        \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_inc,                     \
+            long*:        pshmem_long_atomic_inc,                    \
+            long long*:   pshmem_longlong_atomic_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_int_inc(int *target, int pe);
@@ -1012,7 +967,7 @@ OSHMEM_DECLSPEC  void pshmem_longlong_wait_until(volatile long long *addr, int c
         short*:       pshmem_short_wait_until,               \
         int*:         pshmem_int_wait_until,                 \
         long*:        pshmem_long_wait_until,                \
-        long long*:   pshmem_longlong_wait_until(addr, cmp, value)
+        long long*:   pshmem_longlong_wait_until)(addr, cmp, value)
 #endif
 
 OSHMEM_DECLSPEC  int pshmem_short_test(volatile short *addr, int cmp, short value);
@@ -1025,7 +980,7 @@ OSHMEM_DECLSPEC  int pshmem_longlong_test(volatile long long *addr, int cmp, lon
         short*:       pshmem_short_test,                     \
         int*:         pshmem_int_test,                       \
         long*:        pshmem_long_test,                      \
-        long long*:   pshmem_longlong_test(addr, cmp, value)
+        long long*:   pshmem_longlong_test)(addr, cmp, value)
 #endif
 
 /*

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -54,6 +54,22 @@
 extern "C" {
 #endif
 
+#if OSHMEM_HAVE_C11
+#define __OSHMEM_VAR_ARG1_EXPAND(_arg1, ...) _arg1
+#define __OSHMEM_VAR_ARG1(...) __OSHMEM_VAR_ARG1_EXPAND(__VA_ARGS__, _extra)
+#define __OSHMEM_VAR_ARG2(_arg1, ...) __OSHMEM_VAR_ARG1_EXPAND(__VA_ARGS__, _extra)
+static inline void __oshmem_datatype_ignore(void) {}
+#endif
+
+/*
+ * SHMEM_Init_thread constants
+ */
+enum {
+    SHMEM_THREAD_SINGLE,
+    SHMEM_THREAD_FUNNELED,
+    SHMEM_THREAD_SERIALIZED,
+    SHMEM_THREAD_MULTIPLE
+};
 
 /*
  * OpenSHMEM API (www.openshmem.org)
@@ -195,18 +211,6 @@ OSHMEM_DECLSPEC  void shmem_ctx_float_p(shmem_ctx_t ctx, float* addr, float valu
 OSHMEM_DECLSPEC  void shmem_ctx_double_p(shmem_ctx_t ctx, double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longlong_p(shmem_ctx_t ctx, long long* addr, long long value, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_p(shmem_ctx_t ctx, long double* addr, long double value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_p(ctx, dst, val, pe)                           \
-    _Generic(&*(dst),                                        \
-            char*:        shmem_ctx_char_p,                  \
-            short*:       shmem_ctx_short_p,                 \
-            int*:         shmem_ctx_int_p,                   \
-            long*:        shmem_ctx_long_p,                  \
-            long long*:   shmem_ctx_longlong_p,              \
-            float*:       shmem_ctx_float_p,                 \
-            double*:      shmem_ctx_double_p,                \
-            long double*: shmem_ctx_longdouble_p)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC  void shmem_char_p(char* addr, char value, int pe);
 OSHMEM_DECLSPEC  void shmem_short_p(short* addr, short value, int pe);
@@ -217,16 +221,26 @@ OSHMEM_DECLSPEC  void shmem_double_p(double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void shmem_longlong_p(long long* addr, long long value, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_p(long double* addr, long double value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_p(dst, val, pe)                                \
-    _Generic(&*(dst),                                        \
-            char*:        shmem_char_p,                      \
-            short*:       shmem_short_p,                     \
-            int*:         shmem_int_p,                       \
-            long*:        shmem_long_p,                      \
-            long long*:   shmem_longlong_p,                  \
-            float*:       shmem_float_p,                     \
-            double*:      shmem_double_p,                    \
-            long double*: shmem_longdouble_p)(dst, val, pe)
+#define shmem_p(...)                                                 \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_p,                      \
+                short*:       shmem_ctx_short_p,                     \
+                int*:         shmem_ctx_int_p,                       \
+                long*:        shmem_ctx_long_p,                      \
+                long long*:   shmem_ctx_longlong_p,                  \
+                float*:       shmem_ctx_float_p,                     \
+                double*:      shmem_ctx_double_p,                    \
+                long double*: shmem_ctx_longdouble_p,                \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_p,                              \
+            short*:       shmem_short_p,                             \
+            int*:         shmem_int_p,                               \
+            long*:        shmem_long_p,                              \
+            long long*:   shmem_longlong_p,                          \
+            float*:       shmem_float_p,                             \
+            double*:      shmem_double_p,                            \
+            long double*: shmem_longdouble_p)(__VA_ARGS__)
 #endif
 
 /*
@@ -240,18 +254,6 @@ OSHMEM_DECLSPEC  void shmem_ctx_float_put(shmem_ctx_t ctx, float *target, const 
 OSHMEM_DECLSPEC  void shmem_ctx_double_put(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longlong_put(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_put(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_put(ctx, dst, src, len, pe)          \
-    _Generic(&*(dst),                              \
-            char*:        shmem_ctx_char_put,      \
-            short*:       shmem_ctx_short_put,     \
-            int*:         shmem_ctx_int_put,       \
-            long*:        shmem_ctx_long_put,      \
-            long long*:   shmem_ctx_longlong_put,  \
-            float*:       shmem_ctx_float_put,     \
-            double*:      shmem_ctx_double_put,    \
-            long double*: shmem_ctx_longdouble_put)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void shmem_char_put(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_put(short *target, const short *source, size_t len, int pe);
@@ -262,16 +264,26 @@ OSHMEM_DECLSPEC  void shmem_double_put(double *target, const double *source, siz
 OSHMEM_DECLSPEC  void shmem_longlong_put(long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_put(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_put(dst, src, len, pe)               \
-    _Generic(&*(dst),                              \
-            char*:        shmem_char_put,          \
-            short*:       shmem_short_put,         \
-            int*:         shmem_int_put,           \
-            long*:        shmem_long_put,          \
-            long long*:   shmem_longlong_put,      \
-            float*:       shmem_float_put,         \
-            double*:      shmem_double_put,        \
-            long double*: shmem_longdouble_put)(dst, src, len, pe)
+#define shmem_put(...)                                               \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_put,                    \
+                short*:       shmem_ctx_short_put,                   \
+                int*:         shmem_ctx_int_put,                     \
+                long*:        shmem_ctx_long_put,                    \
+                long long*:   shmem_ctx_longlong_put,                \
+                float*:       shmem_ctx_float_put,                   \
+                double*:      shmem_ctx_double_put,                  \
+                long double*: shmem_ctx_longdouble_put,              \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_put,                            \
+            short*:       shmem_short_put,                           \
+            int*:         shmem_int_put,                             \
+            long*:        shmem_long_put,                            \
+            long long*:   shmem_longlong_put,                        \
+            float*:       shmem_float_put,                           \
+            double*:      shmem_double_put,                          \
+            long double*: shmem_longdouble_put)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void shmem_ctx_put8(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -300,18 +312,6 @@ OSHMEM_DECLSPEC void shmem_ctx_float_iput(shmem_ctx_t ctx, float* target, const 
 OSHMEM_DECLSPEC void shmem_ctx_double_iput(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longlong_iput(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longdouble_iput(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_iput(ctx, dst, src, tst, sst, len, pe) \
-    _Generic(&*(dst),                               \
-            char*:        shmem_ctx_char_iput,      \
-            short*:       shmem_ctx_short_iput,     \
-            int*:         shmem_ctx_int_iput,       \
-            long*:        shmem_ctx_long_iput,      \
-            long long*:   shmem_ctx_longlong_iput,  \
-            float*:       shmem_ctx_float_iput,     \
-            double*:      shmem_ctx_double_iput,    \
-            long double*: shmem_ctx_longdouble_iput)(ctx, dst, src, tst, sst, len, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_char_iput(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_short_iput(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -322,16 +322,26 @@ OSHMEM_DECLSPEC void shmem_double_iput(double* target, const double* source, ptr
 OSHMEM_DECLSPEC void shmem_longlong_iput(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_longdouble_iput(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_iput(dst, src, tst, sst, len, pe)     \
-    _Generic(&*(dst),                               \
-            char*:        shmem_char_iput,          \
-            short*:       shmem_short_iput,         \
-            int*:         shmem_int_iput,           \
-            long*:        shmem_long_iput,          \
-            long long*:   shmem_longlong_iput,      \
-            float*:       shmem_float_iput,         \
-            double*:      shmem_double_iput,        \
-            long double*: shmem_longdouble_iput)(dst, src, tst, sst, len, pe)
+#define shmem_iput(...)                                              \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_iput,                   \
+                short*:       shmem_ctx_short_iput,                  \
+                int*:         shmem_ctx_int_iput,                    \
+                long*:        shmem_ctx_long_iput,                   \
+                long long*:   shmem_ctx_longlong_iput,               \
+                float*:       shmem_ctx_float_iput,                  \
+                double*:      shmem_ctx_double_iput,                 \
+                long double*: shmem_ctx_longdouble_iput,             \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_iput,                           \
+            short*:       shmem_short_iput,                          \
+            int*:         shmem_int_iput,                            \
+            long*:        shmem_long_iput,                           \
+            long long*:   shmem_longlong_iput,                       \
+            float*:       shmem_float_iput,                          \
+            double*:      shmem_double_iput,                         \
+            long double*: shmem_longdouble_iput)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_ctx_iput8(shmem_ctx_t ctx, void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -357,18 +367,6 @@ OSHMEM_DECLSPEC  void shmem_ctx_longlong_put_nbi(shmem_ctx_t ctx, long long *tar
 OSHMEM_DECLSPEC  void shmem_ctx_float_put_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_put_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_put_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_put_nbi(ctx, dst, src, len, pe)          \
-    _Generic(&*(dst),                                  \
-            char*:        shmem_ctx_char_put_nbi,      \
-            short*:       shmem_ctx_short_put_nbi,     \
-            int*:         shmem_ctx_int_put_nbi,       \
-            long*:        shmem_ctx_long_put_nbi,      \
-            long long*:   shmem_ctx_longlong_put_nbi,  \
-            float*:       shmem_ctx_float_put_nbi,     \
-            double*:      shmem_ctx_double_put_nbi,    \
-            long double*: shmem_ctx_longdouble_put_nbi)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void shmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_put_nbi(short *target, const short *source, size_t len, int pe);
@@ -379,16 +377,26 @@ OSHMEM_DECLSPEC  void shmem_float_put_nbi(float *target, const float *source, si
 OSHMEM_DECLSPEC  void shmem_double_put_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_put_nbi(dst, src, len, pe)               \
-    _Generic(&*(dst),                                  \
-            char*:        shmem_char_put_nbi,          \
-            short*:       shmem_short_put_nbi,         \
-            int*:         shmem_int_put_nbi,           \
-            long*:        shmem_long_put_nbi,          \
-            long long*:   shmem_longlong_put_nbi,      \
-            float*:       shmem_float_put_nbi,         \
-            double*:      shmem_double_put_nbi,        \
-            long double*: shmem_longdouble_put_nbi)(dst, src, len, pe)
+#define shmem_put_nbi(...)                                           \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_put_nbi,                \
+                short*:       shmem_ctx_short_put_nbi,               \
+                int*:         shmem_ctx_int_put_nbi,                 \
+                long*:        shmem_ctx_long_put_nbi,                \
+                long long*:   shmem_ctx_longlong_put_nbi,            \
+                float*:       shmem_ctx_float_put_nbi,               \
+                double*:      shmem_ctx_double_put_nbi,              \
+                long double*: shmem_ctx_longdouble_put_nbi,          \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_put_nbi,                        \
+            short*:       shmem_short_put_nbi,                       \
+            int*:         shmem_int_put_nbi,                         \
+            long*:        shmem_long_put_nbi,                        \
+            long long*:   shmem_longlong_put_nbi,                    \
+            float*:       shmem_float_put_nbi,                       \
+            double*:      shmem_double_put_nbi,                      \
+            long double*: shmem_longdouble_put_nbi)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void shmem_ctx_put8_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -416,18 +424,6 @@ OSHMEM_DECLSPEC  float shmem_ctx_float_g(shmem_ctx_t ctx, const float* addr, int
 OSHMEM_DECLSPEC  double shmem_ctx_double_g(shmem_ctx_t ctx, const double* addr, int pe);
 OSHMEM_DECLSPEC  long long shmem_ctx_longlong_g(shmem_ctx_t ctx, const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double shmem_ctx_longdouble_g(shmem_ctx_t ctx, const long double* addr, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_g(ctx, addr, pe)                               \
-    _Generic(&*(addr),                                       \
-            char*:        shmem_ctx_char_g,                  \
-            short*:       shmem_ctx_short_g,                 \
-            int*:         shmem_ctx_int_g,                   \
-            long*:        shmem_ctx_long_g,                  \
-            long long*:   shmem_ctx_longlong_g,              \
-            float*:       shmem_ctx_float_g,                 \
-            double*:      shmem_ctx_double_g,                \
-            long double*: shmem_ctx_longdouble_g)(ctx, addr, pe)
-#endif
 
 OSHMEM_DECLSPEC  char shmem_char_g(const char* addr, int pe);
 OSHMEM_DECLSPEC  short shmem_short_g(const short* addr, int pe);
@@ -438,16 +434,26 @@ OSHMEM_DECLSPEC  double shmem_double_g(const double* addr, int pe);
 OSHMEM_DECLSPEC  long long shmem_longlong_g(const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double shmem_longdouble_g(const long double* addr, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_g(addr, pe)                                    \
-    _Generic(&*(addr),                                        \
-            char*:        shmem_char_g,                      \
-            short*:       shmem_short_g,                     \
-            int*:         shmem_int_g,                       \
-            long*:        shmem_long_g,                      \
-            long long*:   shmem_longlong_g,                  \
-            float*:       shmem_float_g,                     \
-            double*:      shmem_double_g,                    \
-            long double*: shmem_longdouble_g)(addr, pe)
+#define shmem_g(...)                                                 \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_g,                      \
+                short*:       shmem_ctx_short_g,                     \
+                int*:         shmem_ctx_int_g,                       \
+                long*:        shmem_ctx_long_g,                      \
+                long long*:   shmem_ctx_longlong_g,                  \
+                float*:       shmem_ctx_float_g,                     \
+                double*:      shmem_ctx_double_g,                    \
+                long double*: shmem_ctx_longdouble_g,                \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_g,                              \
+            short*:       shmem_short_g,                             \
+            int*:         shmem_int_g,                               \
+            long*:        shmem_long_g,                              \
+            long long*:   shmem_longlong_g,                          \
+            float*:       shmem_float_g,                             \
+            double*:      shmem_double_g,                            \
+            long double*: shmem_longdouble_g)(__VA_ARGS__)
 #endif
 
 /*
@@ -461,18 +467,6 @@ OSHMEM_DECLSPEC  void shmem_ctx_float_get(shmem_ctx_t ctx, float *target, const 
 OSHMEM_DECLSPEC  void shmem_ctx_double_get(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longlong_get(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_get(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_get(ctx, dst, src, len, pe)          \
-    _Generic(&*(dst),                              \
-            char*:        shmem_ctx_char_get,      \
-            short*:       shmem_ctx_short_get,     \
-            int*:         shmem_ctx_int_get,       \
-            long*:        shmem_ctx_long_get,      \
-            long long*:   shmem_ctx_longlong_get,  \
-            float*:       shmem_ctx_float_get,     \
-            double*:      shmem_ctx_double_get,    \
-            long double*: shmem_ctx_longdouble_get)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void shmem_char_get(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_get(short *target, const short *source, size_t len, int pe);
@@ -483,16 +477,26 @@ OSHMEM_DECLSPEC  void shmem_double_get(double *target, const double *source, siz
 OSHMEM_DECLSPEC  void shmem_longlong_get(long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_get(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_get(dst, src, len, pe)               \
-    _Generic(&*(dst),                              \
-            char*:        shmem_char_get,          \
-            short*:       shmem_short_get,         \
-            int*:         shmem_int_get,           \
-            long*:        shmem_long_get,          \
-            long long*:   shmem_longlong_get,      \
-            float*:       shmem_float_get,         \
-            double*:      shmem_double_get,        \
-            long double*: shmem_longdouble_get)(dst, src, len, pe)
+#define shmem_get(...)                                               \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_get,                    \
+                short*:       shmem_ctx_short_get,                   \
+                int*:         shmem_ctx_int_get,                     \
+                long*:        shmem_ctx_long_get,                    \
+                long long*:   shmem_ctx_longlong_get,                \
+                float*:       shmem_ctx_float_get,                   \
+                double*:      shmem_ctx_double_get,                  \
+                long double*: shmem_ctx_longdouble_get,              \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_get,                            \
+            short*:       shmem_short_get,                           \
+            int*:         shmem_int_get,                             \
+            long*:        shmem_long_get,                            \
+            long long*:   shmem_longlong_get,                        \
+            float*:       shmem_float_get,                           \
+            double*:      shmem_double_get,                          \
+            long double*: shmem_longdouble_get)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void shmem_ctx_get8(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -520,18 +524,6 @@ OSHMEM_DECLSPEC void shmem_ctx_double_iget(shmem_ctx_t ctx, double* target, cons
 OSHMEM_DECLSPEC void shmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_iget(ctx, dst, src, tst, sst, len, pe)\
-    _Generic(&*(dst),                               \
-            char*:        shmem_ctx_char_iget,      \
-            short*:       shmem_ctx_short_iget,     \
-            int*:         shmem_ctx_int_iget,       \
-            long*:        shmem_ctx_long_iget,      \
-            long long*:   shmem_ctx_longlong_iget,  \
-            float*:       shmem_ctx_float_iget,     \
-            double*:      shmem_ctx_double_iget,    \
-            long double*: shmem_ctx_longdouble_iget)(ctx, dst, src, tst, sst, len, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -542,16 +534,26 @@ OSHMEM_DECLSPEC void shmem_longlong_iget(long long* target, const long long* sou
 OSHMEM_DECLSPEC void shmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_iget(dst, src, tst, sst, len, pe)     \
-    _Generic(&*(dst),                               \
-            char*:        shmem_char_iget,          \
-            short*:       shmem_short_iget,         \
-            int*:         shmem_int_iget,           \
-            long*:        shmem_long_iget,          \
-            long long*:   shmem_longlong_iget,      \
-            float*:       shmem_float_iget,         \
-            double*:      shmem_double_iget,        \
-            long double*: shmem_longdouble_iget)(dst, src, tst, sst, len, pe)
+#define shmem_iget(...)                                              \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_iget,                   \
+                short*:       shmem_ctx_short_iget,                  \
+                int*:         shmem_ctx_int_iget,                    \
+                long*:        shmem_ctx_long_iget,                   \
+                long long*:   shmem_ctx_longlong_iget,               \
+                float*:       shmem_ctx_float_iget,                  \
+                double*:      shmem_ctx_double_iget,                 \
+                long double*: shmem_ctx_longdouble_iget,             \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_iget,                           \
+            short*:       shmem_short_iget,                          \
+            int*:         shmem_int_iget,                            \
+            long*:        shmem_long_iget,                           \
+            long long*:   shmem_longlong_iget,                       \
+            float*:       shmem_float_iget,                          \
+            double*:      shmem_double_iget,                         \
+            long double*: shmem_longdouble_iget)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_ctx_iget8(shmem_ctx_t ctx, void* target, const void* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -577,18 +579,6 @@ OSHMEM_DECLSPEC  void shmem_ctx_longlong_get_nbi(shmem_ctx_t ctx, long long *tar
 OSHMEM_DECLSPEC  void shmem_ctx_float_get_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_get_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_get_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_get_nbi(ctx, dst, src, len, pe)          \
-    _Generic(&*(dst),                                  \
-            char*:        shmem_ctx_char_get_nbi,      \
-            short*:       shmem_ctx_short_get_nbi,     \
-            int*:         shmem_ctx_int_get_nbi,       \
-            long*:        shmem_ctx_long_get_nbi,      \
-            long long*:   shmem_ctx_longlong_get_nbi,  \
-            float*:       shmem_ctx_float_get_nbi,     \
-            double*:      shmem_ctx_double_get_nbi,    \
-            long double*: shmem_ctx_longdouble_get_nbi)(ctx, dst, src, len, pe)
-#endif
 
 OSHMEM_DECLSPEC  void shmem_getmem_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_char_get_nbi(char *target, const char *source, size_t len, int pe);
@@ -600,16 +590,26 @@ OSHMEM_DECLSPEC  void shmem_float_get_nbi(float *target, const float *source, si
 OSHMEM_DECLSPEC  void shmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_get_nbi(dst, src, len, pe)               \
-    _Generic(&*(dst),                                  \
-            char*:        shmem_char_get_nbi,          \
-            short*:       shmem_short_get_nbi,         \
-            int*:         shmem_int_get_nbi,           \
-            long*:        shmem_long_get_nbi,          \
-            long long*:   shmem_longlong_get_nbi,      \
-            float*:       shmem_float_get_nbi,         \
-            double*:      shmem_double_get_nbi,        \
-            long double*: shmem_longdouble_get_nbi)(dst, src, len, pe)
+#define shmem_get_nbi(...)                                           \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                char*:        shmem_ctx_char_get_nbi,                \
+                short*:       shmem_ctx_short_get_nbi,               \
+                int*:         shmem_ctx_int_get_nbi,                 \
+                long*:        shmem_ctx_long_get_nbi,                \
+                long long*:   shmem_ctx_longlong_get_nbi,            \
+                float*:       shmem_ctx_float_get_nbi,               \
+                double*:      shmem_ctx_double_get_nbi,              \
+                long double*: shmem_ctx_longdouble_get_nbi,          \
+                default:      __oshmem_datatype_ignore),             \
+            char*:        shmem_char_get_nbi,                        \
+            short*:       shmem_short_get_nbi,                       \
+            int*:         shmem_int_get_nbi,                         \
+            long*:        shmem_long_get_nbi,                        \
+            long long*:   shmem_longlong_get_nbi,                    \
+            float*:       shmem_float_get_nbi,                       \
+            double*:      shmem_double_get_nbi,                      \
+            long double*: shmem_longdouble_get_nbi)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC  void shmem_ctx_get8_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe);
@@ -634,15 +634,6 @@ OSHMEM_DECLSPEC long shmem_ctx_long_atomic_swap(shmem_ctx_t ctx, long *target, l
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_swap(shmem_ctx_t ctx, long long*target, long long value, int pe);
 OSHMEM_DECLSPEC float shmem_ctx_float_atomic_swap(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC double shmem_ctx_double_atomic_swap(shmem_ctx_t ctx, double *target, double value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_swap(ctx, dst, val, pe)                 \
-    _Generic(&*(dst),                                        \
-            int*:         shmem_ctx_int_atomic_swap,         \
-            long*:        shmem_ctx_long_atomic_swap,        \
-            long long*:   shmem_ctx_longlong_atomic_swap,    \
-            float*:       shmem_ctx_float_atomic_swap,       \
-            double*:      shmem_ctx_double_atomic_swap)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC int shmem_int_atomic_swap(int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_swap(long *target, long value, int pe);
@@ -650,13 +641,20 @@ OSHMEM_DECLSPEC long long shmem_longlong_atomic_swap(long long*target, long long
 OSHMEM_DECLSPEC float shmem_float_atomic_swap(float *target, float value, int pe);
 OSHMEM_DECLSPEC double shmem_double_atomic_swap(double *target, double value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_swap(dst, val, pe)                      \
-    _Generic(&*(dst),                                        \
-            int*:         shmem_int_atomic_swap,             \
-            long*:        shmem_long_atomic_swap,            \
-            long long*:   shmem_longlong_atomic_swap,        \
-            float*:       shmem_float_atomic_swap,           \
-            double*:      shmem_double_atomic_swap)(dst, val, pe)
+#define shmem_atomic_swap(...)                                       \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         shmem_ctx_int_atomic_swap,             \
+                long*:        shmem_ctx_long_atomic_swap,            \
+                long long*:   shmem_ctx_longlong_atomic_swap,        \
+                float*:       shmem_ctx_float_atomic_swap,           \
+                double*:      shmem_ctx_double_atomic_swap,          \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_swap,                     \
+            long*:        shmem_long_atomic_swap,                    \
+            long long*:   shmem_longlong_atomic_swap,                \
+            float*:       shmem_float_atomic_swap,                   \
+            double*:      shmem_double_atomic_swap)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_swap(int *target, int value, int pe);
@@ -680,15 +678,6 @@ OSHMEM_DECLSPEC void shmem_ctx_long_atomic_set(shmem_ctx_t ctx, long *target, lo
 OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_set(shmem_ctx_t ctx, long long*target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_float_atomic_set(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_double_atomic_set(shmem_ctx_t ctx, double *target, double value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_set(ctx, dst, val, pe)                 \
-    _Generic(&*(dst),                                       \
-            int*:         shmem_ctx_int_atomic_set,         \
-            long*:        shmem_ctx_long_atomic_set,        \
-            long long*:   shmem_ctx_longlong_atomic_set,    \
-            float*:       shmem_ctx_float_atomic_set,       \
-            double*:      shmem_ctx_double_atomic_set)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_int_atomic_set(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_set(long *target, long value, int pe);
@@ -696,13 +685,20 @@ OSHMEM_DECLSPEC void shmem_longlong_atomic_set(long long*target, long long value
 OSHMEM_DECLSPEC void shmem_float_atomic_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void shmem_double_atomic_set(double *target, double value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_set(dst, val, pe)                      \
-    _Generic(&*(dst),                                       \
-            int*:         shmem_int_atomic_set,             \
-            long*:        shmem_long_atomic_set,            \
-            long long*:   shmem_longlong_atomic_set,        \
-            float*:       shmem_float_atomic_set,           \
-            double*:      shmem_double_atomic_set)(dst, val, pe)
+#define shmem_atomic_set(...)                                        \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         shmem_ctx_int_atomic_set,              \
+                long*:        shmem_ctx_long_atomic_set,             \
+                long long*:   shmem_ctx_longlong_atomic_set,         \
+                float*:       shmem_ctx_float_atomic_set,            \
+                double*:      shmem_ctx_double_atomic_set,           \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_set,                      \
+            long*:        shmem_long_atomic_set,                     \
+            long long*:   shmem_longlong_atomic_set,                 \
+            float*:       shmem_float_atomic_set,                    \
+            double*:      shmem_double_atomic_set)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_int_set(int *target, int value, int pe);
@@ -725,24 +721,21 @@ OSHMEM_DECLSPEC int shmem_ctx_int_atomic_compare_swap(shmem_ctx_t ctx, int *targ
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_compare_swap(shmem_ctx_t ctx, long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_compare_swap(shmem_ctx_t ctx, long long *target, long long cond, long long value, int pe);
 
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_compare_swap(ctx, dst, cond, val, pe)    \
-    _Generic(&*(dst),                                         \
-            int*:         shmem_ctx_int_atomic_compare_swap,  \
-            long*:        shmem_ctx_long_atomic_compare_swap, \
-            long long*:   shmem_ctx_longlong_atomic_compare_swap)(ctx, dst, cond, val, pe)
-#endif
-
 OSHMEM_DECLSPEC int shmem_int_atomic_compare_swap(int *target, int cond, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_compare_swap(long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_compare_swap(long long *target, long long cond, long long value, int pe);
 
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_compare_swap(dst, cond, val, pe)         \
-    _Generic(&*(dst),                                         \
-            int*:         shmem_int_atomic_compare_swap,      \
-            long*:        shmem_long_atomic_compare_swap,     \
-            long long*:   shmem_longlong_atomic_compare_swap)(dst, cond, val, pe)
+#define shmem_atomic_compare_swap(...)                                \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
+                int*:         shmem_ctx_int_atomic_compare_swap,      \
+                long*:        shmem_ctx_long_atomic_compare_swap,     \
+                long long*:   shmem_ctx_longlong_atomic_compare_swap, \
+                default:      __oshmem_datatype_ignore),              \
+            int*:         shmem_int_atomic_compare_swap,              \
+            long*:        shmem_long_atomic_compare_swap,             \
+            long long*:   shmem_longlong_atomic_compare_swap)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_cswap(int *target, int cond, int value, int pe);
@@ -761,23 +754,21 @@ OSHMEM_DECLSPEC long long shmem_longlong_cswap(long long *target, long long cond
 OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_add(ctx, dst, val, pe)            \
-    _Generic(&*(dst),                                        \
-            int*:         shmem_ctx_int_atomic_fetch_add,    \
-            long*:        shmem_ctx_long_atomic_fetch_add,   \
-            long long*:   shmem_ctx_longlong_atomic_fetch_add)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_add(long long *target, long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_add(dst, val, pe)                 \
-    _Generic(&*(dst),                                        \
-            int*:         shmem_int_atomic_fetch_add,        \
-            long*:        shmem_long_atomic_fetch_add,       \
-            long long*:   shmem_longlong_atomic_fetch_add)(dst, val, pe)
+#define shmem_atomic_fetch_add(...)                                  \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         shmem_ctx_int_atomic_fetch_add,        \
+                long*:        shmem_ctx_long_atomic_fetch_add,       \
+                long long*:   shmem_ctx_longlong_atomic_fetch_add,   \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_fetch_add,                \
+            long*:        shmem_long_atomic_fetch_add,               \
+            long long*:   shmem_longlong_atomic_fetch_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_fadd(int *target, int value, int pe);
@@ -795,69 +786,63 @@ OSHMEM_DECLSPEC long long shmem_longlong_fadd(long long *target, long long value
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_and(ctx, dst, val, pe)                            \
-    _Generic(&*(dst),                                                        \
-            unsigned int*:         shmem_ctx_uint_atomic_fetch_and,          \
-            unsigned long*:        shmem_ctx_ulong_atomic_fetch_and,         \
-            unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_and)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_and(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_and(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                             \
-            unsigned int*:         shmem_uint_atomic_fetch_and,                   \
-            unsigned long*:        shmem_ulong_atomic_fetch_and,                  \
-            unsigned long long*:   shmem_ulonglong_atomic_fetch_and)(dst, val, pe)
+#define shmem_atomic_fetch_and(...)                                           \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+                unsigned int*:         shmem_ctx_uint_atomic_fetch_and,       \
+                unsigned long*:        shmem_ctx_ulong_atomic_fetch_and,      \
+                unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_and,  \
+                default:               __oshmem_datatype_ignore),             \
+            unsigned int*:         shmem_uint_atomic_fetch_and,               \
+            unsigned long*:        shmem_ulong_atomic_fetch_and,              \
+            unsigned long long*:   shmem_ulonglong_atomic_fetch_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Or */
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_or(ctx, dst, val, pe)                                     \
-    _Generic(&*(dst),                                                                \
-            unsigned int*:         shmem_ctx_uint_atomic_fetch_or,                   \
-            unsigned long*:        shmem_ctx_ulong_atomic_fetch_or,                  \
-            unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_or)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_or(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_or(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                            \
-            unsigned int*:         shmem_uint_atomic_fetch_or,                   \
-            unsigned long*:        shmem_ulong_atomic_fetch_or,                  \
-            unsigned long long*:   shmem_ulonglong_atomic_fetch_or)(dst, val, pe)
+#define shmem_atomic_fetch_or(...)                                           \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+                unsigned int*:         shmem_ctx_uint_atomic_fetch_or,       \
+                unsigned long*:        shmem_ctx_ulong_atomic_fetch_or,      \
+                unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_or,  \
+                default:               __oshmem_datatype_ignore),             \
+            unsigned int*:         shmem_uint_atomic_fetch_or,               \
+            unsigned long*:        shmem_ulong_atomic_fetch_or,              \
+            unsigned long long*:   shmem_ulonglong_atomic_fetch_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Xor */
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_xor(ctx, dst, val, pe)                                     \
-    _Generic(&*(dst),                                                                 \
-            unsigned int*:         shmem_ctx_uint_atomic_fetch_xor,                   \
-            unsigned long*:        shmem_ctx_ulong_atomic_fetch_xor,                  \
-            unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_xor)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_xor(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_xor(dst, val, pe)                                      \
-    _Generic(&*(dst),                                                             \
-            unsigned int*:         shmem_uint_atomic_fetch_xor,                   \
-            unsigned long*:        shmem_ulong_atomic_fetch_xor,                  \
-            unsigned long long*:   shmem_ulonglong_atomic_fetch_xor)(dst, val, pe)
+#define shmem_atomic_fetch_xor(...)                                           \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+                unsigned int*:         shmem_ctx_uint_atomic_fetch_xor,       \
+                unsigned long*:        shmem_ctx_ulong_atomic_fetch_xor,      \
+                unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_xor,  \
+                default:               __oshmem_datatype_ignore),             \
+            unsigned int*:         shmem_uint_atomic_fetch_xor,               \
+            unsigned long*:        shmem_ulong_atomic_fetch_xor,              \
+            unsigned long long*:   shmem_ulonglong_atomic_fetch_xor)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch */
@@ -866,15 +851,6 @@ OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch(shmem_ctx_t ctx, const long *ta
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch(shmem_ctx_t ctx, const long long *target, int pe);
 OSHMEM_DECLSPEC float shmem_ctx_float_atomic_fetch(shmem_ctx_t ctx, const float *target, int pe);
 OSHMEM_DECLSPEC double shmem_ctx_double_atomic_fetch(shmem_ctx_t ctx, const double *target, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch(ctx, dst, pe)                 \
-    _Generic(&*(dst),                                    \
-            int*:         shmem_ctx_int_atomic_fetch,    \
-            long*:        shmem_ctx_long_atomic_fetch,   \
-            long long*:   shmem_ctx_longlong_atomic_fetch,\
-            float*:       shmem_ctx_float_atomic_fetch,  \
-            double*:      shmem_ctx_double_atomic_fetch)(ctx, dst, pe)
-#endif
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch(const int *target, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch(const long *target, int pe);
@@ -882,13 +858,20 @@ OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch(const long long *target, i
 OSHMEM_DECLSPEC float shmem_float_atomic_fetch(const float *target, int pe);
 OSHMEM_DECLSPEC double shmem_double_atomic_fetch(const double *target, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch(dst, pe)                      \
-    _Generic(&*(dst),                                    \
-            int*:         shmem_int_atomic_fetch,        \
-            long*:        shmem_long_atomic_fetch,       \
-            long long*:   shmem_longlong_atomic_fetch,   \
-            float*:       shmem_float_atomic_fetch,      \
-            double*:      shmem_double_atomic_fetch)(dst, pe)
+#define shmem_atomic_fetch(...)                                      \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         shmem_ctx_int_atomic_fetch,            \
+                long*:        shmem_ctx_long_atomic_fetch,           \
+                long long*:   shmem_ctx_longlong_atomic_fetch,       \
+                float*:       shmem_ctx_float_atomic_fetch,          \
+                double*:      shmem_ctx_double_atomic_fetch,         \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_fetch,                    \
+            long*:        shmem_long_atomic_fetch,                   \
+            long long*:   shmem_longlong_atomic_fetch,               \
+            float*:       shmem_float_atomic_fetch,                  \
+            double*:      shmem_double_atomic_fetch)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_fetch(const int *target, int pe);
@@ -910,23 +893,21 @@ OSHMEM_DECLSPEC double shmem_double_fetch(const double *target, int pe);
 OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_inc(shmem_ctx_t ctx, long long *target, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_inc(ctx, dst, pe)           \
-    _Generic(&*(dst),                                  \
-            int*:         shmem_ctx_int_atomic_fetch_inc,\
-            long*:        shmem_ctx_long_atomic_fetch_inc,\
-            long long*:   shmem_ctx_longlong_atomic_fetch_inc)(ctx, dst, pe)
-#endif
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch_inc(int *target, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch_inc(long *target, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_inc(long long *target, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_inc(dst, pe)                \
-    _Generic(&*(dst),                                  \
-            int*:         shmem_int_atomic_fetch_inc,  \
-            long*:        shmem_long_atomic_fetch_inc, \
-            long long*:   shmem_longlong_atomic_fetch_inc)(dst, pe)
+#define shmem_atomic_fetch_inc(...)                                  \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         shmem_ctx_int_atomic_fetch_inc,        \
+                long*:        shmem_ctx_long_atomic_fetch_inc,       \
+                long long*:   shmem_ctx_longlong_atomic_fetch_inc,   \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_fetch_inc,                \
+            long*:        shmem_long_atomic_fetch_inc,               \
+            long long*:   shmem_longlong_atomic_fetch_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_finc(int *target, int pe);
@@ -944,23 +925,21 @@ OSHMEM_DECLSPEC long long shmem_longlong_finc(long long *target, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_int_atomic_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_long_atomic_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_add(ctx, dst, val, pe)                 \
-    _Generic(&*(dst),                                       \
-            int*:         shmem_ctx_int_atomic_add,         \
-            long*:        shmem_ctx_long_atomic_add,        \
-            long long*:   shmem_ctx_longlong_atomic_add)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_int_atomic_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC void shmem_longlong_atomic_add(long long *target, long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_add(dst, val, pe)                      \
-    _Generic(&*(dst),                                       \
-            int*:         shmem_int_atomic_add,             \
-            long*:        shmem_long_atomic_add,            \
-            long long*:   shmem_longlong_atomic_add)(dst, val, pe)
+#define shmem_atomic_add(...)                                        \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         shmem_ctx_int_atomic_add,              \
+                long*:        shmem_ctx_long_atomic_add,             \
+                long long*:   shmem_ctx_longlong_atomic_add,         \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_add,                      \
+            long*:        shmem_long_atomic_add,                     \
+            long long*:   shmem_longlong_atomic_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_int_add(int *target, int value, int pe);
@@ -978,92 +957,84 @@ OSHMEM_DECLSPEC void shmem_longlong_add(long long *target, long long value, int 
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_and(ctx, dst, val, pe)                                    \
-    _Generic(&*(dst),                                                          \
-            unsigned int*:         shmem_ctx_uint_atomic_and,                  \
-            unsigned long*:        shmem_ctx_ulong_atomic_and,                 \
-            unsigned long long*:   shmem_ctx_ulonglong_atomic_and)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_uint_atomic_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_and(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_and(dst, val, pe)                             \
-    _Generic(&*(dst),                                              \
-            unsigned int*:         shmem_uint_atomic_and,                   \
-            unsigned long*:        shmem_ulong_atomic_and,                  \
-            unsigned long long*:   shmem_ulonglong_atomic_and)(dst, val, pe)
+#define shmem_atomic_and(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                unsigned int*:         shmem_ctx_uint_atomic_and,      \
+                unsigned long*:        shmem_ctx_ulong_atomic_and,     \
+                unsigned long long*:   shmem_ctx_ulonglong_atomic_and, \
+                default:               __oshmem_datatype_ignore),      \
+            unsigned int*:         shmem_uint_atomic_and,              \
+            unsigned long*:        shmem_ulong_atomic_and,             \
+            unsigned long long*:   shmem_ulonglong_atomic_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Or */
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_or(ctx, dst, val, pe)                                    \
-    _Generic(&*(dst),                                                         \
-            unsigned int*:         shmem_ctx_uint_atomic_or,                  \
-            unsigned long*:        shmem_ctx_ulong_atomic_or,                 \
-            unsigned long long*:   shmem_ctx_ulonglong_atomic_or)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_uint_atomic_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_or(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_or(dst, val, pe)                             \
-    _Generic(&*(dst),                                             \
-            unsigned int*:         shmem_uint_atomic_or,                   \
-            unsigned long*:        shmem_ulong_atomic_or,                  \
-            unsigned long long*:   shmem_ulonglong_atomic_or)(dst, val, pe)
+#define shmem_atomic_or(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
+                unsigned int*:         shmem_ctx_uint_atomic_or,      \
+                unsigned long*:        shmem_ctx_ulong_atomic_or,     \
+                unsigned long long*:   shmem_ctx_ulonglong_atomic_or, \
+                default:               __oshmem_datatype_ignore),     \
+            unsigned int*:         shmem_uint_atomic_or,              \
+            unsigned long*:        shmem_ulong_atomic_or,             \
+            unsigned long long*:   shmem_ulonglong_atomic_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Xor */
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_xor(ctx, dst, val, pe)                                    \
-    _Generic(&*(dst),                                                          \
-            unsigned int*:         shmem_ctx_uint_atomic_xor,                  \
-            unsigned long*:        shmem_ctx_ulong_atomic_xor,                 \
-            unsigned long long*:   shmem_ctx_ulonglong_atomic_xor)(ctx, dst, val, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_uint_atomic_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_xor(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_xor(dst, val, pe)                             \
-    _Generic(&*(dst),                                              \
-            unsigned int*:         shmem_uint_atomic_xor,                   \
-            unsigned long*:        shmem_ulong_atomic_xor,                  \
-            unsigned long long*:   shmem_ulonglong_atomic_xor)(dst, val, pe)
+#define shmem_atomic_xor(...)                                          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                unsigned int*:         shmem_ctx_uint_atomic_xor,      \
+                unsigned long*:        shmem_ctx_ulong_atomic_xor,     \
+                unsigned long long*:   shmem_ctx_ulonglong_atomic_xor, \
+                default:               __oshmem_datatype_ignore),      \
+            unsigned int*:         shmem_uint_atomic_xor,              \
+            unsigned long*:        shmem_ulong_atomic_xor,             \
+            unsigned long long*:   shmem_ulonglong_atomic_xor)(__VA_ARGS__)
 #endif
 
 /* Atomic Inc */
 OSHMEM_DECLSPEC void shmem_ctx_int_atomic_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_long_atomic_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_inc(shmem_ctx_t ctx, long long *target, int pe);
-#if OSHMEM_HAVE_C11
-#define shmem_atomic_inc(ctx, dst, pe)                \
-    _Generic(&*(dst),                                 \
-            int*:         shmem_ctx_int_atomic_inc,   \
-            long*:        shmem_ctx_long_atomic_inc,  \
-            long long*:   shmem_ctx_longlong_atomic_inc)(ctx, dst, pe)
-#endif
 
 OSHMEM_DECLSPEC void shmem_int_atomic_inc(int *target, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_inc(long *target, int pe);
 OSHMEM_DECLSPEC void shmem_longlong_atomic_inc(long long *target, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_inc(dst, pe)                     \
-    _Generic(&*(dst),                                 \
-            int*:         shmem_int_atomic_inc,       \
-            long*:        shmem_long_atomic_inc,      \
-            long long*:   shmem_longlong_atomic_inc)(dst, pe)
+#define shmem_atomic_inc(...)                                        \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+                int*:         shmem_ctx_int_atomic_inc,              \
+                long*:        shmem_ctx_long_atomic_inc,             \
+                long long*:   shmem_ctx_longlong_atomic_inc,         \
+                default:      __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_inc,                      \
+            long*:        shmem_long_atomic_inc,                     \
+            long long*:   shmem_longlong_atomic_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_int_inc(int *target, int pe);
@@ -1103,7 +1074,7 @@ OSHMEM_DECLSPEC  void shmem_longlong_wait_until(volatile long long *addr, int cm
         short*:       shmem_short_wait_until,                \
         int*:         shmem_int_wait_until,                  \
         long*:        shmem_long_wait_until,                 \
-        long long*:   shmem_longlong_wait_until(addr, cmp, value)
+        long long*:   shmem_longlong_wait_until)(addr, cmp, value)
 #endif
 
 OSHMEM_DECLSPEC  int shmem_short_test(volatile short *addr, int cmp, short value);
@@ -1116,7 +1087,7 @@ OSHMEM_DECLSPEC  int shmem_longlong_test(volatile long long *addr, int cmp, long
         short*:       shmem_short_test,                      \
         int*:         shmem_int_test,                        \
         long*:        shmem_long_test,                       \
-        long long*:   shmem_longlong_test(addr, cmp, value)
+        long long*:   shmem_longlong_test)(addr, cmp, value)
 #endif
 
 /*

--- a/oshmem/runtime/runtime.h
+++ b/oshmem/runtime/runtime.h
@@ -74,16 +74,6 @@ OSHMEM_DECLSPEC extern shmem_ctx_t oshmem_ctx_default;
     } while (0)
 
 
-/*
- * SHMEM_Init_thread constants
- */
-enum {
-    SHMEM_THREAD_SINGLE,
-    SHMEM_THREAD_FUNNELED,
-    SHMEM_THREAD_SERIALIZED,
-    SHMEM_THREAD_MULTIPLE
-};
-
 /** Bitflags to be used for the modex exchange for the various thread
  *  levels. Required to support heterogeneous environments */
 #define OSHMEM_THREADLEVEL_SINGLE_BF     0x00000001


### PR DESCRIPTION
- updated compilation of C11 compiler for API macro
- cherry-picked from https://github.com/open-mpi/ompi/pull/5576

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit be0ea1d7647e8c16cb8f30f4dd916454c2bdd746)