### PR TITLE
v2.0.x: osc/rdma: fix a segfault in MPI_Win_unlock due to an access to a NULL…

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_lock.h
+++ b/ompi/mca/osc/rdma/osc_rdma_lock.h
@@ -68,7 +68,7 @@ static inline int ompi_osc_rdma_lock_btl_fop (ompi_osc_rdma_module_t *module, om
     }
 
     if (NULL != frag) {
-        if (*result) {
+        if (NULL != result) {
             *result = *temp;
         }
         ompi_osc_rdma_frag_complete (frag);


### PR DESCRIPTION
fixes #5581.


Signed-off-by: Nadia Derbey <Nadia.Derbey@atos.net>