### PR TITLE
config: remove OPAL_ENABLE_MULTI_THREADS config macro

### DIFF
--- a/config/opal_config_threads.m4
+++ b/config/opal_config_threads.m4
@@ -65,8 +65,5 @@ THREAD_LIBS="$PTHREAD_LIBS"
 
 OPAL_CHECK_PTHREAD_PIDS
 
-AC_DEFINE_UNQUOTED([OPAL_ENABLE_MULTI_THREADS], [1],
-                   [Whether we should enable thread support within the OPAL code base])
-
 ])dnl
 

--- a/ompi/mca/pml/ob1/pml_ob1_comm.h
+++ b/ompi/mca/pml/ob1/pml_ob1_comm.h
@@ -44,11 +44,7 @@ struct mca_pml_ob1_comm_proc_t {
     opal_object_t super;
     struct ompi_proc_t* ompi_proc;
     uint16_t expected_sequence;    /**< send message sequence number - receiver side */
-#if OPAL_ENABLE_MULTI_THREADS
     volatile int32_t send_sequence; /**< send side sequence number */
-#else
-    int32_t send_sequence; /**< send side sequence number */
-#endif
     struct mca_pml_ob1_recv_frag_t* frags_cant_match;  /**< out-of-order fragment queues */
 #if !MCA_PML_OB1_CUSTOM_MATCH
     opal_list_t specific_receives; /**< queues of unmatched specific receives */

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008      UT-Battelle, LLC. All rights reserved.
- * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -205,9 +205,8 @@ recv_request_pml_complete(mca_pml_ob1_recv_request_t *recvreq)
 static inline bool
 recv_request_pml_complete_check(mca_pml_ob1_recv_request_t *recvreq)
 {
-#if OPAL_ENABLE_MULTI_THREADS
     opal_atomic_rmb();
-#endif
+
     if(recvreq->req_match_received &&
             recvreq->req_bytes_received >= recvreq->req_recv.req_bytes_packed &&
             lock_recv_request(recvreq)) {
@@ -245,9 +244,9 @@ static inline void recv_req_matched(mca_pml_ob1_recv_request_t *req,
     req->req_recv.req_base.req_ompi.req_status.MPI_SOURCE = hdr->hdr_src;
     req->req_recv.req_base.req_ompi.req_status.MPI_TAG = hdr->hdr_tag;
     req->req_match_received = true;
-#if OPAL_ENABLE_MULTI_THREADS
+
     opal_atomic_wmb();
-#endif
+
     if(req->req_recv.req_bytes_packed > 0) {
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT
         if(MPI_ANY_SOURCE == req->req_recv.req_base.req_peer) {

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2011-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
@@ -281,9 +281,8 @@ send_request_pml_complete(mca_pml_ob1_send_request_t *sendreq)
 static inline bool
 send_request_pml_complete_check(mca_pml_ob1_send_request_t *sendreq)
 {
-#if OPAL_ENABLE_MULTI_THREADS
     opal_atomic_rmb();
-#endif
+
     /* if no more events are expected for the request and the whole message is
      * already sent and send fragment scheduling isn't running in another
      * thread then complete the request on PML level. From now on, if user

--- a/ompi/mca/pml/ob1/pml_ob1_start.c
+++ b/ompi/mca/pml/ob1/pml_ob1_start.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2016-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -45,9 +45,7 @@ int mca_pml_ob1_start(size_t count, ompi_request_t** requests)
          * completes - and create a new request.
          */
 
-#if OPAL_ENABLE_MULTI_THREADS
         opal_atomic_rmb();
-#endif
 
         /* start the request */
         switch(pml_request->req_type) {

--- a/orte/tools/orte-info/param.c
+++ b/orte/tools/orte-info/param.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -357,9 +360,8 @@ void orte_info_do_config(bool want_all)
     symbol_visibility = OPAL_C_HAVE_VISIBILITY ? "yes" : "no";
 
     /* setup strings that require allocation */
-    asprintf(&threads, "%s (OPAL: %s, ORTE progress: yes, Event lib: yes)",
-             "posix",
-             OPAL_ENABLE_MULTI_THREADS ? "yes" : "no");
+    asprintf(&threads, "%s (OPAL: yes, ORTE progress: yes, Event lib: yes)",
+             "posix");
 
     asprintf(&ft_support, "%s (checkpoint thread: %s)",
              OPAL_ENABLE_FT ? "yes" : "no", OPAL_ENABLE_FT_THREAD ? "yes" : "no");;

--- a/test/threads/opal_thread.c
+++ b/test/threads/opal_thread.c
@@ -1,7 +1,10 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  */
@@ -15,19 +18,6 @@
 #include "opal/threads/threads.h"
 #include "opal/sys/atomic.h"
 
-
-#if !OPAL_ENABLE_MULTI_THREADS
-
-/* If we don't have thread support, there's no point in running this
-   test */
-
-int main(int argc, char *argv[])
-{
-    printf("OMPI was compiled without thread support -- skipping this test\n");
-    return 77;
-}
-
-#else
 
 /* Only have the body of this test if we have thread support */
 
@@ -75,5 +65,3 @@ int main(int argc, char** argv)
     test_verify_int(3, count);
     return test_finalize();
 }
-
-#endif /* OPAL_ENABLE_MULTI_THREADS */


### PR DESCRIPTION
We long ago hard-coded this value to 1. This commit cleans it out
entirely.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>