### PR TITLE
test: protect <sys/mount.h> with the HAVE_SYS_MOUNT_H macro

### DIFF
--- a/test/util/opal_path_nfs.c
+++ b/test/util/opal_path_nfs.c
@@ -16,6 +16,8 @@
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +33,9 @@
 #include <dirent.h>
 
 #include <sys/param.h>
+#ifdef HAVE_SYS_MOUNT_H
 #include <sys/mount.h>
+#endif
 #ifdef HAVE_SYS_STATFS_H
 #include <sys/statfs.h>
 #endif


### PR DESCRIPTION
Thanks Zoltan Mizsei for bringing this to our attention.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>