### PR TITLE
Fixed the NUMA obj detection for hwloc ver >= 2.0.0

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -16,6 +16,8 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (C) 2018      Mellanox Technologies, Ltd. 
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -1857,9 +1857,18 @@ static void sort_by_dist(hwloc_topology_t topo, char* device_name, opal_list_t *
             if (!strcmp(device_obj->name, device_name)) {
                 /* find numa node containing this device */
                 obj = device_obj->parent;
+#if HWLOC_API_VERSION < 0x20000
                 while ((obj != NULL) && (obj->type != HWLOC_OBJ_NODE)) {
                     obj = obj->parent;
                 }
+#else
+                while (obj && !obj->memory_arity) {
+                    obj = obj->parent; /* no memory child, walk up */
+                }
+                if (obj != NULL) {
+                    obj = obj->memory_first_child;
+                }
+#endif
                 if (obj == NULL) {
                     opal_output_verbose(5, opal_hwloc_base_framework.framework_output,
                             "hwloc:base:get_sorted_numa_list: NUMA node closest to %s wasn't found.",

--- a/orte/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/orte/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -331,6 +331,9 @@ static int mindist_map(orte_job_t *jdata)
                         }
                     }
                 }
+                /* first we need to fill summary object for root with information about nodes
+                 * so we call opal_hwloc_base_get_nbobjs_by_type */
+                opal_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NODE, 0, OPAL_HWLOC_AVAILABLE);
                 OBJ_CONSTRUCT(&numa_list, opal_list_t);
                 ret = opal_hwloc_get_sorted_numa_list(node->topology->topo, orte_rmaps_base.device, &numa_list);
                 if (ret > 1) {

--- a/orte/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/orte/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      Mellanox Technologies, Inc.
+ * Copyright (c) 2017-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *


### PR DESCRIPTION
Since version hwloc 2.0.0 has a new organization of NUMA nodes on the
topology tree. This commit adds the detection of local NUMA object for
hwloc => 2.0.0, which fixes the procs bindings policy for rmaps mindist
component.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>