### PR TITLE
v4.0.x: Allow run-as-root if 2 envars are set

### DIFF
--- a/orte/tools/orterun/orterun.1in
+++ b/orte/tools/orterun/orterun.1in
@@ -645,7 +645,10 @@ Allow
 .I mpirun
 to run when executed by the root user
 .RI ( mpirun
-defaults to aborting when launched as the root user).
+defaults to aborting when launched as the root user).  Be sure to see
+the
+.I Running as root
+section, below, for more detail.
 .
 .
 .TP
@@ -1628,7 +1631,26 @@ To override this default, you can add the
 .I --allow-run-as-root
 option to the
 .I mpirun
-command line.
+command line, or you can set the environmental parameters
+.I OMPI_ALLOW_RUN_AS_ROOT=1
+and
+.IR OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 .
+Note that it takes setting
+.I two
+environment variables to effect the same behavior as
+.I --allow-run-as-root
+in order to stress the Open MPI team's strong advice against running
+as the root user.  After extended discussions with communities who use
+containers (where running as the root user is the default), there was
+a persistent desire to be able to enable root execution of
+.I mpirun
+via an environmental control (vs. the existing
+.I --allow-run-as-root
+command line parameter).  The compromise of using
+.I two
+environment variables was reached: it allows root execution via an
+environmental control, but it conveys the Open MPI team's strong
+recomendation against this behavior.
 .
 .SS Exit status
 .


### PR DESCRIPTION
Per suggestion by @bangerth, allow mpirun to execute as root if two
envars are set to specific values

Per conversation with @jsquyres, name the envars OMPI_ALLOW_RUN_AS_ROOT
and OMPI_ALLOW_RUN_AS_ROOT_CONFIRM

Fixes #4451

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 7f1444d5f9e504ff50392a0f73e81787c01b7a0e)