### PR TITLE
sharedfp/sm and lockedfile: fix naming bug

### DIFF
--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #endif
 #include <fcntl.h>
+#include <unistd.h>
 
 int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
 				       const char* filename,
@@ -47,7 +48,9 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
     int handle;
     struct mca_sharedfp_lockedfile_data * module_data = NULL;
     struct mca_sharedfp_base_data_t* sh;
-
+    pid_t my_pid;
+    int int_pid;
+    
     /*Memory is allocated here for the sh structure*/
     sh = (struct mca_sharedfp_base_data_t*)malloc(sizeof(struct mca_sharedfp_base_data_t));
     if ( NULL == sh){
@@ -87,16 +90,28 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
         return err;
     }
 
-    size_t filenamelen = strlen(filename) + 16;
+    if ( 0 == fh->f_rank ) {
+        my_pid = getpid();
+        int_pid = (int) my_pid;
+    }
+    err = comm->c_coll->coll_bcast (&int_pid, 1, MPI_INT, 0, comm, comm->c_coll->coll_bcast_module );
+    if ( OMPI_SUCCESS != err ) {
+        opal_output(0, "[%d]mca_sharedfp_lockedfile_file_open: Error in bcast operation\n", fh->f_rank);
+	free (sh);
+	free(module_data);
+        return err;
+    }
+
+    size_t filenamelen = strlen(filename) + 24;
     lockedfilename = (char*)malloc(sizeof(char) * filenamelen);
     if ( NULL == lockedfilename ) {
 	free (sh);
         free (module_data);
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
-    snprintf(lockedfilename, filenamelen, "%s-%u%s",filename,masterjobid,".lock");
+    snprintf(lockedfilename, filenamelen, "%s-%u-%d%s",filename,masterjobid,int_pid,".lock");
     module_data->filename = lockedfilename;
-
+    
     /*-------------------------------------------------*/
     /*Open the lockedfile without shared file pointer  */
     /*-------------------------------------------------*/

--- a/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
+++ b/ompi/mca/sharedfp/sm/sharedfp_sm_file_open.c
@@ -44,7 +44,7 @@
 #include <semaphore.h>
 #include <sys/mman.h>
 #include <libgen.h>
-
+#include <unistd.h>
 
 int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
                                const char* filename,
@@ -62,6 +62,8 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     struct mca_sharedfp_sm_offset sm_offset;
     int sm_fd;
     uint32_t comm_cid;
+    int int_pid;
+    pid_t my_pid;
 
     /*Memory is allocated here for the sh structure*/
     if ( mca_sharedfp_sm_verbose ) {
@@ -100,7 +102,7 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     ** For sharedfp we also want to put the file backed shared memory into the tmp directory
     */
     filename_basename = basename((char*)filename);
-    /* format is "%s/%s_cid-%d.sm", see below */
+    /* format is "%s/%s_cid-%d-%d.sm", see below */
     sm_filename_length = strlen(ompi_process_info.job_session_dir) + 1 + strlen(filename_basename) + 5 + (3*sizeof(uint32_t)+1) + 4;
     sm_filename = (char*) malloc( sizeof(char) * sm_filename_length);
     if (NULL == sm_filename) {
@@ -111,7 +113,21 @@ int mca_sharedfp_sm_file_open (struct ompi_communicator_t *comm,
     }
 
     comm_cid = ompi_comm_get_cid(comm);
-    sprintf(sm_filename, "%s/%s_cid-%d.sm", ompi_process_info.job_session_dir, filename_basename, comm_cid);
+    if ( 0 == fh->f_rank ) {
+        my_pid = getpid();
+        int_pid = (int) my_pid;
+    }
+    err = comm->c_coll->coll_bcast (&int_pid, 1, MPI_INT, 0, comm, comm->c_coll->coll_bcast_module );
+    if ( OMPI_SUCCESS != err ) {
+        opal_output(0,"mca_sharedfp_sm_file_open: Error in bcast operation \n");
+        free(sm_filename);
+        free(sm_data);
+        free(sh);
+        return err;
+    }
+
+    snprintf(sm_filename, sm_filename_length, "%s/%s_cid-%d-%d.sm", ompi_process_info.job_session_dir,
+             filename_basename, comm_cid, int_pid);
     /* open shared memory file, initialize to 0, map into memory */
     sm_fd = open(sm_filename, O_RDWR | O_CREAT,
                  S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);


### PR DESCRIPTION
If an application opens a file for reading from multiple processes
using MPI_COMM_SELF (or another communicator that has distinct
process groups but the same comm-id, as can happen as the result
of comm_split), the naming chosen for the lockedfile or the mmapped
file used by the sharedfp/sm component would collide. This patch
ensures that the filename is different by integrating the process id
of rank 0 for each sub-communicator.

This fixes one aspect of the problem reported in github issue #5593

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>