### PR TITLE
sharedfp/sm and lockedfile: fix naming bug

### DIFF
--- a/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
+++ b/ompi/mca/sharedfp/lockedfile/sharedfp_lockedfile_file_open.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #endif
 #include <fcntl.h>
+#include <unistd.h>
 
 int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
 				       const char* filename,
@@ -49,6 +50,9 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
     struct mca_sharedfp_base_data_t* sh;
     mca_io_ompio_file_t * shfileHandle, *ompio_fh;
     mca_io_ompio_data_t *data;
+
+    pid_t my_pid;
+    int int_pid;
 
     /*------------------------------------------------------------*/
     /*Open the same file again without shared file pointer support*/
@@ -110,7 +114,19 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
     comm->c_coll->coll_bcast ( &masterjobid, 1, MPI_UNSIGNED, 0, comm, 
                                comm->c_coll->coll_bcast_module );
  
-    size_t filenamelen = strlen(filename) + 16;
+    if ( 0 == fh->f_rank ) {
+        my_pid = getpid();
+        int_pid = (int) my_pid;
+    }
+    err = comm->c_coll->coll_bcast (&int_pid, 1, MPI_INT, 0, comm, comm->c_coll->coll_bcast_module );
+    if ( OMPI_SUCCESS != err ) {
+        opal_output(0, "[%d]mca_sharedfp_lockedfile_file_open: Error in bcast operation\n", fh->f_rank);
+        free (sh);
+        free(module_data);
+        return err;
+    }
+
+    size_t filenamelen = strlen(filename) + 24;
     lockedfilename = (char*)malloc(sizeof(char) * filenamelen);
     if ( NULL == lockedfilename ) {
 	free (shfileHandle);
@@ -118,7 +134,7 @@ int mca_sharedfp_lockedfile_file_open (struct ompi_communicator_t *comm,
         free (module_data);
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
-    snprintf(lockedfilename, filenamelen, "%s-%u%s",filename,masterjobid,".lock");
+    snprintf(lockedfilename, filenamelen, "%s-%u-%d%s",filename,masterjobid,int_pid,".lock");
     module_data->filename = lockedfilename;
 
     /*-------------------------------------------------*/


### PR DESCRIPTION
If an application opens a file from multiple processes
using MPI_COMM_SELF (or another set of communicators that have
the same CID on distinct process groups, as can happen as the result
of comm_split), the naming chosen for the managing the shared file pointer position
in a file (in sharedfp/lockedfile) or the mmapped shared memory region
(in sharedfp/sm) component would lead to a collision between the distinct process groups.
This patch ensures that the filename is different by integrating the process id
of rank 0 for each sub-communicator.

This fixes one aspect of the problem reported in github issue #5593

This commit is the equivalent to commit 9b65ec94450a1567f7e42839ac00d6a3493c84ac on master.
It can not be cherry-picked directly due to significant changes in the overal
organization of the file.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>