### PR TITLE
v3.0.x: make common/verbs-usnic actually check if it can compile

### DIFF
--- a/README
+++ b/README
@@ -996,15 +996,33 @@ NETWORKING SUPPORT / OPTIONS
   configurations.
 
 --with-verbs-usnic
+  Note that this option is no longer necessary in recent Linux distro
+  versions.  If your Linux distro uses the "rdma-core" package (instead
+  of a standalone "libibverbs" package), not only do you not need this
+  option, you shouldn't use it, either.  More below.
+
   This option will activate support in Open MPI for disabling a
   dire-sounding warning message from libibverbs that Cisco usNIC
   devices are not supported (because Cisco usNIC devices are supported
   through libfabric, not libibverbs).  This libibverbs warning can
   also be suppressed by installing the "no op" libusnic_verbs plugin
   for libibverbs (see https://github.com/cisco/libusnic_verbs, or
-  download binaries from cisco.com).  This option is disabled by
-  default because it causes libopen-pal.so to depend on libibverbs.so,
-  which is undesirable to many downstream packagers.
+  download binaries from cisco.com).
+
+  This option is disabled by default for two reasons:
+
+  1. It causes libopen-pal.so to depend on libibverbs.so, which is
+     undesirable to many downstream packagers.
+  2. As mentioned above, recent versions of the libibverbs library
+     (included in the "rdma-core" package) do not have the bug that
+     will emit dire-sounding warnings about usnic devices.  Indeed,
+     the --with-verbs-usnic option will enable code in Open MPI that
+     is actually incompatible with rdma-core (i.e., cause Open MPI to
+     fail to compile).
+
+   If you enable --with-verbs-usnic and your system uses the rdma-core
+   package, configure will safely abort with a helpful message telling
+   you that you should not use --with-verbs-usnic.
 
 --with-usnic
   Abort configure if Cisco usNIC support cannot be built.

--- a/opal/mca/common/verbs_usnic/configure.m4
+++ b/opal/mca/common/verbs_usnic/configure.m4
@@ -69,6 +69,21 @@ AC_DEFUN([MCA_opal_common_verbs_usnic_CONFIG],[
                                   [common_verbs_usnic_happy=0])
           ])
 
+    AS_IF([test $common_verbs_usnic_happy -eq 1],
+          [AC_CHECK_MEMBER([struct ibv_device.ops],
+                           [],
+                           [AC_MSG_WARN([--with-verbs-usnic specified, but the verbs.h does not])
+                            AC_MSG_WARN([have the required member fields.  It is highly likely])
+                            AC_MSG_WARN([that you do not need --with-verbs-usnic.  Try configuring])
+                            AC_MSG_WARN([and building Open MPI without it; if you get warnings])
+                            AC_MSG_WARN([about usnic IB devices anyway, please let us know.])
+                            AC_MSG_WARN([Since you asked for --with-verbs-usnic and we cannot])
+                            AC_MSG_WARN([deliver it, configure will now abort.])
+                            AC_MSG_ERROR([Cannot continue])
+                           ],
+                          [#include <infiniband/verbs.h>])
+           ])
+
     AC_DEFINE_UNQUOTED([OPAL_COMMON_VERBS_USNIC_HAPPY],
                        [$common_verbs_usnic_happy],
                        [Whether the common/usnic_verbs component is being built or not])


### PR DESCRIPTION
Previously, we only checked to see if the user specified `--with-verbs-usnic`.  Now do the Right Thing and actually verify that it can compile, too.