### PR TITLE
OSHMEM: removed incorrect pshmem_wait_until macro redefinition - v4.0

### DIFF
--- a/oshmem/shmem/c/profile/defines.h
+++ b/oshmem/shmem/c/profile/defines.h
@@ -529,7 +529,6 @@
 #define shmem_int_wait_until         pshmem_int_wait_until
 #define shmem_long_wait_until        pshmem_long_wait_until
 #define shmem_longlong_wait_until    pshmem_longlong_wait_until
-#define shmem_wait_until             pshmem_wait_until
 #define shmemx_int32_wait_until      pshmemx_int32_wait_until
 #define shmemx_int64_wait_until      pshmemx_int64_wait_until
 


### PR DESCRIPTION
- fixes https://github.com/open-mpi/ompi/issues/5585

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit 7a5ff6a076e40938789b03d41970564e31a11976)