### PR TITLE
MCA base var followup

### DIFF
--- a/opal/mca/mca.h
+++ b/opal/mca/mca.h
@@ -256,6 +256,10 @@ typedef int (*mca_base_register_component_params_2_0_0_fn_t)(void);
  * Maximum length of MCA component string names.
  */
 #define MCA_BASE_MAX_COMPONENT_NAME_LEN 63
+/**
+ * Maximum length of MCA component variable names.
+ */
+#define MCA_BASE_MAX_VARIABLE_NAME_LEN 63
 
 /**
  * Component flags (mca_component_flags field)


### PR DESCRIPTION
Ensure that the project, framework, component, and variable names are lower than max lengths.  This is a follow-on to 992a8e8297f7f044ef3b30bfc235566d43d68cb5, per discussion on https://github.com/open-mpi/ompi/pull/5642.
    
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

NOTE: The current max lengths for project, framework, component, and variable name add up to more than 128 (per discussion on #5642):

https://github.com/open-mpi/ompi/blob/42b0e3bd6161cfaafcb66db008bdc96de84f52d6/opal/mca/mca.h#L247-L258

With MCA_BASE_VAR_MAX_VARIABLE_NAME_LEN set to 63 in this PR, that's (15+31+63+63)=172.

We *could* reduce the length of the TYPE_LEN and COMPONENT_NAME_LEN to, say, 15 and 31, respectively, bringing the total down to (15+15+31+63)=124.  But this:

1. Would be a major ABI break
1. Would require cherry picking to be in 4.0.0 (not 4.0.1 or later!)
1. Would likely require bumping the MCA version number from 2 to 3
1. Would require some extra code to safely handle opening DSOs from earlier versions (even if we just end up closing/discarding those components).

That seems like a bunch of extra work for a pretty minor win.  So I didn't do it in this PR.