### PR TITLE
v4.0.x: MTL PSM2: Remove shadow variables from v4.0.x

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2_types.h
+++ b/ompi/mca/mtl/psm2/mtl_psm2_types.h
@@ -50,17 +50,6 @@ struct mca_mtl_psm2_module_t {
     psm2_mq_t	 mq;
     psm2_epid_t  epid;
     psm2_epaddr_t epaddr;
-    char *psm2_devices;
-    char *psm2_memory;
-    unsigned long psm2_mq_sendreqs_max;
-    unsigned long psm2_mq_recvreqs_max;
-    unsigned long psm2_mq_rndv_hfi_threshold;
-    unsigned long psm2_mq_rndv_shm_threshold;
-    unsigned long psm2_max_contexts_per_job;
-    unsigned long psm2_tracemask;
-    bool psm2_recvthread;
-    bool psm2_shared_contexts;
-    unsigned long psm2_opa_sl;
 };
 
 typedef struct mca_mtl_psm2_module_t mca_mtl_psm2_module_t;


### PR DESCRIPTION
As agreed on #4574, where removed in past release branches
to avoid perfomance impacts in the default values for
some paramters.

Signed-off-by: Matias Cabral <matias.a.cabral@intel.com>