### PR TITLE
mpiext/pcollreq: Fix zero-count reduction

### DIFF
--- a/ompi/mpiext/pcollreq/c/allreduce_init.c
+++ b/ompi/mpiext/pcollreq/c/allreduce_init.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,8 +107,8 @@ int MPIX_Allreduce_init(const void *sendbuf, void *recvbuf, int count,
      * So handle that case.
      */
     if (0 == count) {
-        *request = &ompi_request_empty;
-        return MPI_SUCCESS;
+        err = ompi_request_persistent_noop_create(request);
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
     }
 
     OPAL_CR_ENTER_LIBRARY();

--- a/ompi/mpiext/pcollreq/c/reduce_init.c
+++ b/ompi/mpiext/pcollreq/c/reduce_init.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -131,8 +132,8 @@ int MPIX_Reduce_init(const void *sendbuf, void *recvbuf, int count,
      * So handle that case.
      */
     if (0 == count) {
-        *request = &ompi_request_empty;
-        return MPI_SUCCESS;
+        err = ompi_request_persistent_noop_create(request);
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
     }
 
     OPAL_CR_ENTER_LIBRARY();

--- a/ompi/mpiext/pcollreq/c/reduce_scatter_init.c
+++ b/ompi/mpiext/pcollreq/c/reduce_scatter_init.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,8 +127,8 @@ int MPIX_Reduce_scatter_init(const void *sendbuf, void *recvbuf, const int recvc
         }
     }
     if (size == count) {
-        *request = &ompi_request_empty;
-        return MPI_SUCCESS;
+        err = ompi_request_persistent_noop_create(request);
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
     }
 
     OPAL_CR_ENTER_LIBRARY();


### PR DESCRIPTION
We need to return a persistent request.
`ompi_request_empty` is not a persistent request.

Need PR to v4.0 branch.