### PR TITLE
OPAL/COMMON/UCX: used __func__ macro instead of __FUNCTION__

### DIFF
--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -70,7 +70,7 @@ BEGIN_C_DECLS
                     return OPAL_SUCCESS;                                                 \
                 } else {                                                                 \
                     MCA_COMMON_UCX_VERBOSE(1, "%s failed: %d, %s",                       \
-                                           (_msg) ? (_msg) : __FUNCTION__,               \
+                                           (_msg) ? (_msg) : __func__,                   \
                                            UCS_PTR_STATUS(_request),                     \
                                            ucs_status_string(UCS_PTR_STATUS(_request))); \
                     return OPAL_ERROR;                                                   \


### PR DESCRIPTION
- used __func__ macro instead of __FUNCTION__ to unify
  macro usage with other components

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>