### PR TITLE
Remove the orte_enable_instant_on MCA param

### DIFF
--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -431,7 +431,7 @@ int orte_odls_base_default_get_add_procs_data(opal_buffer_t *buffer,
     }
 
     /* get any application prep info */
-    if (orte_enable_instant_on_support && NULL != opal_pmix.server_setup_application) {
+    if (NULL != opal_pmix.server_setup_application) {
         /* we don't want to block here because it could
          * take some indeterminate time to get the info */
         if (OPAL_SUCCESS != (rc = opal_pmix.server_setup_application(jdata->jobid, NULL, setup_cbfunc, jdata))) {
@@ -798,8 +798,7 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
     /* if we have local support setup info, then execute it here - we
      * have to do so AFTER we register the nspace so the PMIx server
      * has the nspace info it needs */
-    if (orte_enable_instant_on_support &&
-        0 < opal_list_get_size(&local_support) &&
+    if (0 < opal_list_get_size(&local_support) &&
         NULL != opal_pmix.server_setup_local_support) {
         if (OPAL_SUCCESS != (rc = opal_pmix.server_setup_local_support(jdata->jobid, &local_support,
                                                                        ls_cbunc, &lock))) {

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -509,12 +509,6 @@ static opal_cmd_line_init_t cmd_line_init[] = {
       "Forward mpirun port to compute node daemons so all will use it",
       OPAL_CMD_LINE_OTYPE_LAUNCH },
 
-    /* enable instant-on support */
-    { "orte_enable_instant_on_support", '\0', "enable-instant-on-support", "enable-instant-on-support", 0,
-      NULL, OPAL_CMD_LINE_TYPE_BOOL,
-      "Enable PMIx-based instant on launch support (experimental)",
-      OPAL_CMD_LINE_OTYPE_LAUNCH },
-
     /* End of list */
     { NULL, '\0', NULL, NULL, 0,
       NULL, OPAL_CMD_LINE_TYPE_NULL, NULL }

--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -205,9 +205,6 @@ char *orte_job_ident = NULL;
 bool orte_execute_quiet = false;
 bool orte_report_silent_errors = false;
 
-/* enable PMIx-based "instant on" support */
-bool orte_enable_instant_on_support = false;
-
 /* See comment in orte/tools/orterun/debuggers.c about this MCA
    param */
 bool orte_in_parallel_debugger = false;

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -588,9 +588,6 @@ ORTE_DECLSPEC extern char *orte_daemon_cores;
 /* Max time to wait for stack straces to return */
 ORTE_DECLSPEC extern int orte_stack_trace_wait_timeout;
 
-/* enable PMIx-based "instant on" support */
-ORTE_DECLSPEC extern bool orte_enable_instant_on_support;
-
 END_C_DECLS
 
 #endif /* ORTE_RUNTIME_ORTE_GLOBALS_H */

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -790,12 +790,5 @@ int orte_register_params(void)
                                   OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_ALL,
                                   &orte_data_server_uri);
 
-    orte_enable_instant_on_support = false;
-    (void) mca_base_var_register ("orte", "orte", NULL, "enable_instant_on_support",
-                                  "Enable PMIx-based instant on launch support (experimental)",
-                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
-                                  &orte_enable_instant_on_support);
-
     return ORTE_SUCCESS;
 }


### PR DESCRIPTION
We have adequate protection to ensure that we only utilize the PMIx
features related to "instant on" when they are available, so this param
is no longer required and causes confusion.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>