### PR TITLE
v4.0.x: UCX: added missing UCX libs to UCX detection

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -46,7 +46,7 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                                    [ucp/api/ucp.h],
                                    [ucp],
                                    [ucp_cleanup],
-                                   [],
+                                   [-luct -lucm -lucs],
                                    [],
                                    [],
                                    [ompi_check_ucx_happy="yes"],

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -78,7 +78,7 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                                             [ucp/api/ucp.h],
                                             [ucp],
                                             [ucp_cleanup],
-                                            [],
+                                            [-luct -lucm -lucs],
                                             [$ompi_check_ucx_dir],
                                             [$ompi_check_ucx_libdir],
                                             [ompi_check_ucx_happy="yes"],


### PR DESCRIPTION
backport from https://github.com/open-mpi/ompi/pull/5666

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit c982645a464147ab9a0824979530cb74e8d8d4b4)