### PR TITLE
v3.0.x: Fix output of XPMEM detection in configure summary

### DIFF
--- a/config/opal_check_xpmem.m4
+++ b/config/opal_check_xpmem.m4
@@ -101,7 +101,7 @@ AC_DEFUN([OPAL_CHECK_XPMEM], [
 	    fi
 	fi
 
-	OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/XPMEM]],[$1],[$opal_check_cray_xpmem_happy])
+	OPAL_SUMMARY_ADD([[Transports]],[[Shared memory/XPMEM]],[$1],[$opal_check_xpmem_happy])
     fi
 
     AS_IF([test "$opal_check_xpmem_happy" = "yes"], [


### PR DESCRIPTION
Signed-off-by: Moritz Kreutzer <mokreutzer@gmail.com>

Refs open-mpi/ompi#5377

(cherry picked from commit d0a770c8d0ef422e9da62a9f91772f5b95a94413)

Refs #5377.  This is an old master commit that was intended to be cherry-picked to the release branches, but we forgot about it.  Found during 2018-09-14 bug scrub.