### PR TITLE
v3.0.x: Allow OPAL DDT to receive size_t count argument.

### DIFF
--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -166,7 +166,7 @@ OMPI_DECLSPEC int32_t ompi_datatype_destroy( ompi_datatype_t** type);
  * Datatype creation functions
  */
 static inline int32_t
-ompi_datatype_add( ompi_datatype_t* pdtBase, const ompi_datatype_t* pdtAdd, uint32_t count,
+ompi_datatype_add( ompi_datatype_t* pdtBase, const ompi_datatype_t* pdtAdd, size_t count,
                    ptrdiff_t disp, ptrdiff_t extent )
 {
     return opal_datatype_add( &pdtBase->super, &pdtAdd->super, count, disp, extent );

--- a/ompi/datatype/ompi_datatype_create_vector.c
+++ b/ompi/datatype/ompi_datatype_create_vector.c
@@ -49,7 +49,7 @@ int32_t ompi_datatype_create_vector( int count, int bLength, int stride,
 
     pData = ompi_datatype_create( oldType->super.desc.used + 2 );
     if( (bLength == stride) || (1 >= count) ) {  /* the elements are contiguous */
-        ompi_datatype_add( pData, oldType, count * bLength, 0, extent );
+        ompi_datatype_add( pData, oldType, (size_t)count * bLength, 0, extent );
     } else {
         if( 1 == bLength ) {
             ompi_datatype_add( pData, oldType, count, 0, extent * stride );

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -230,7 +230,7 @@ OPAL_DECLSPEC void opal_datatype_dump( const opal_datatype_t* pData );
 OPAL_DECLSPEC int32_t opal_datatype_clone( const opal_datatype_t * src_type, opal_datatype_t * dest_type );
 OPAL_DECLSPEC int32_t opal_datatype_create_contiguous( int count, const opal_datatype_t* oldType, opal_datatype_t** newType );
 OPAL_DECLSPEC int32_t opal_datatype_resize( opal_datatype_t* type, ptrdiff_t lb, ptrdiff_t extent );
-OPAL_DECLSPEC int32_t opal_datatype_add( opal_datatype_t* pdtBase, const opal_datatype_t* pdtAdd, uint32_t count,
+OPAL_DECLSPEC int32_t opal_datatype_add( opal_datatype_t* pdtBase, const opal_datatype_t* pdtAdd, size_t count,
                                          ptrdiff_t disp, ptrdiff_t extent );
 
 static inline int32_t

--- a/opal/datatype/opal_datatype_add.c
+++ b/opal/datatype/opal_datatype_add.c
@@ -103,7 +103,7 @@ static inline int  IMAX( int a, int b ) { return ( a < b ? b : a ); }
  * set to ZERO if it's a empty datatype.
  */
 int32_t opal_datatype_add( opal_datatype_t* pdtBase, const opal_datatype_t* pdtAdd,
-                           uint32_t count, ptrdiff_t disp, ptrdiff_t extent )
+                           size_t count, ptrdiff_t disp, ptrdiff_t extent )
 {
     uint32_t newLength, place_needed = 0, i;
     short localFlags = 0;  /* no specific options yet */


### PR DESCRIPTION
Fixes issue #5069, which relates a BigMPI bug with the use of
MPI_Type_vectpor to construct very large datatypes (>2GB).

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>
(cherry picked from commit cd683e3eeccc8a9b80f07634a84b9343a5958e27)

Refs #5069