### PR TITLE
rpmbuild: fix rpmtopdir redefinition

### DIFF
--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -267,7 +267,6 @@ fi
 # Find where the top RPM-building directory is
 #
 
-rpmtopdir=
 file=~/.rpmmacros
 if test -r $file; then
     rpmtopdir=${rpmtopdir:-"`grep %_topdir $file | awk '{ print $2 }'`"}


### PR DESCRIPTION
Erasing this variable by default makes outside definition useless.

Signed-off-by: Andrey Maslennikov <andreyma@mellanox.com>