### PR TITLE
opal_config_asm.m4: fix typo in new C11 atomic code

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -165,7 +165,6 @@ static void test2(void)
     }
 }
 
-vvvvvvvvvvvvvvvvvvvv
 int main(int argc, char** argv)
 {
     test1();


### PR DESCRIPTION
Delete an obvious typo.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>