### PR TITLE
rpmbuild: fix rpmtopdir redefinition — v4.0.x

### DIFF
--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -267,7 +267,6 @@ fi
 # Find where the top RPM-building directory is
 #
 
-rpmtopdir=
 file=~/.rpmmacros
 if test -r $file; then
     rpmtopdir=${rpmtopdir:-"`grep %_topdir $file | awk '{ print $2 }'`"}


### PR DESCRIPTION
Erasing this variable by default makes outside definition useless.

(cherry picked from commit c7d51a3a837206cb4dc2ca8aa15d5b8f59598db4)