### PR TITLE
v3.0.x: use-mpi-f08: fix a typo in [P]MPI_Dist_graph_create_adjacent bindings

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/dist_graph_create_adjacent_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/dist_graph_create_adjacent_f08.F90
@@ -3,6 +3,8 @@
 ! Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
 ! $COPYRIGHT$
 
 subroutine MPI_Dist_graph_create_adjacent_f08(comm_old,indegree,sources,sourceweights,&
@@ -25,6 +27,6 @@ subroutine MPI_Dist_graph_create_adjacent_f08(comm_old,indegree,sources,sourcewe
    call PMPI_Dist_graph_create_adjacent(comm_old%MPI_VAL,indegree,sources,&
                                           sourceweights,outdegree,destinations,&
                                           destweights,info%MPI_VAL,&
-                                          reorder,comm_dist_graph%MPI_VAL,ierror)
+                                          reorder,comm_dist_graph%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 end subroutine MPI_Dist_graph_create_adjacent_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pdist_graph_create_adjacent_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pdist_graph_create_adjacent_f08.F90
@@ -3,6 +3,8 @@
 ! Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
 ! $COPYRIGHT$
 
 subroutine PMPI_Dist_graph_create_adjacent_f08(comm_old,indegree,sources,sourceweights,&
@@ -25,6 +27,6 @@ subroutine PMPI_Dist_graph_create_adjacent_f08(comm_old,indegree,sources,sourcew
    call PMPI_Dist_graph_create_adjacent(comm_old%MPI_VAL,indegree,sources,&
                                           sourceweights,outdegree,destinations,&
                                           destweights,info%MPI_VAL,&
-                                          reorder,comm_dist_graph%MPI_VAL,ierror)
+                                          reorder,comm_dist_graph%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 end subroutine PMPI_Dist_graph_create_adjacent_f08


### PR DESCRIPTION
Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@d2393251f7259a72ad0409d2bff8016646cc6bcb)