### PR TITLE
Fix/monitoring

### DIFF
--- a/ompi/mca/pml/base/pml_base_select.c
+++ b/ompi/mca/pml/base/pml_base_select.c
@@ -193,6 +193,14 @@ int mca_pml_base_select(bool enable_progress_threads,
         modex_reqd = true;
     }
 
+    /* Save the winner */
+
+    mca_pml_base_selected_component = *best_component;
+    mca_pml = *best_module;
+    opal_output_verbose( 10, ompi_pml_base_framework.framework_output,
+                         "select: component %s selected",
+                         mca_pml_base_selected_component.pmlm_version.mca_component_name );
+
     /* Finalize all non-selected components */
 
     for (item = opal_list_remove_first(&opened);
@@ -238,14 +246,6 @@ int mca_pml_base_select(bool enable_progress_threads,
         }
     }
 #endif
-
-    /* Save the winner */
-
-    mca_pml_base_selected_component = *best_component;
-    mca_pml = *best_module;
-    opal_output_verbose( 10, ompi_pml_base_framework.framework_output,
-                         "select: component %s selected",
-                         mca_pml_base_selected_component.pmlm_version.mca_component_name );
 
     /* This base function closes, unloads, and removes from the
        available list all unselected components.  The available list will

--- a/opal/mca/base/mca_base_components_close.c
+++ b/opal/mca/base/mca_base_components_close.c
@@ -50,10 +50,16 @@ void mca_base_component_close (const mca_base_component_t *component, int output
 {
     /* Close */
     if (NULL != component->mca_close_component) {
-        component->mca_close_component();
-        opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
-                             "mca: base: close: component %s closed",
-                             component->mca_component_name);
+        if( OPAL_SUCCESS == component->mca_close_component() ) {
+            opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                 "mca: base: close: component %s closed",
+                                 component->mca_component_name);
+        } else {
+            opal_output_verbose (MCA_BASE_VERBOSE_COMPONENT, output_id,
+                                 "mca: base: close: component %s refused to close [drop it]",
+                                 component->mca_component_name);
+            return;
+        }
     }
 
     mca_base_component_unload (component, output_id);


### PR DESCRIPTION
The monitoring PML was unloaded too early, and all its PVARs were marked as invalid, totally defeating the purpose of the PML. Reshape the highjacking order to make it simpler and more robust. There is however a caveat, the monitoring module cannot be unloaded from memory (or we will have to return on a memory region that was just dlclosed).