### PR TITLE
pmix: check the old topo key to keep compatibility with old RMs

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -350,6 +350,11 @@ int opal_hwloc_base_get_topology(void)
         OPAL_MODEX_RECV_VALUE_IMMEDIATE(rc, OPAL_PMIX_HWLOC_XML_V1,
                                         &wildcard_rank, &val, OPAL_STRING);
 #endif
+        if (rc != OPAL_SUCCESS) {
+            /* check the old topo key to keep compatibility with older RMs */
+            OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, OPAL_PMIX_LOCAL_TOPO,
+                                           &wildcard_rank, &val, OPAL_STRING);
+        }
     } else {
         opal_output_verbose(1, opal_hwloc_base_framework.framework_output,
                             "hwloc:base PMIx not available");


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>

Closes #5177 