### PR TITLE
Expose PMIx tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -390,6 +390,10 @@ opal/mca/pmix/pmix*/pmix/examples/jctrl
 opal/mca/pmix/pmix*/pmix/examples/pub
 opal/mca/pmix/pmix*/pmix/examples/server
 opal/mca/pmix/pmix*/pmix/examples/tool
+opal/mca/pmix/pmix4x/pmix/src/tools/pevent/pevent
+opal/mca/pmix/pmix4x/pmix/src/tools/pmix_info/pmix_info
+opal/mca/pmix/pmix4x/pmix/src/tools/plookup/plookup
+opal/mca/pmix/pmix4x/pmix/src/tools/pps/pps
 
 opal/mca/pmix/ext4x/ext4x.c
 opal/mca/pmix/ext4x/ext4x.h

--- a/opal/mca/pmix/pmix4x/configure.m4
+++ b/opal/mca/pmix/pmix4x/configure.m4
@@ -53,7 +53,7 @@ AC_DEFUN([MCA_opal_pmix_pmix4x_CONFIG],[
         opal_pmix_pmix4x_timing_flag=--disable-pmix-timing
     fi
 
-    opal_pmix_pmix4x_args="$opal_pmix_pmix4x_timing_flag --without-tests-examples --disable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
+    opal_pmix_pmix4x_args="$opal_pmix_pmix4x_timing_flag --without-tests-examples --enable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --with-pmix-extra-ltlib=$OPAL_TOP_BUILDDIR/opal/libopen-pal.la"
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix4x_args="--enable-debug $opal_pmix_pmix4x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],

--- a/opal/mca/pmix/pmix4x/configure.m4
+++ b/opal/mca/pmix/pmix4x/configure.m4
@@ -53,12 +53,16 @@ AC_DEFUN([MCA_opal_pmix_pmix4x_CONFIG],[
         opal_pmix_pmix4x_timing_flag=--disable-pmix-timing
     fi
 
-    opal_pmix_pmix4x_args="$opal_pmix_pmix4x_timing_flag --without-tests-examples --enable-pmix-binaries --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\" --with-pmix-extra-ltlib=$OPAL_TOP_BUILDDIR/opal/libopen-pal.la"
+    opal_pmix_pmix4x_args="$opal_pmix_pmix4x_timing_flag --without-tests-examples --disable-pmix-backward-compatibility --disable-visibility --enable-embedded-libevent --with-libevent-header=\\\"opal/mca/event/$opal_event_base_include\\\""
     AS_IF([test "$enable_debug" = "yes"],
           [opal_pmix_pmix4x_args="--enable-debug $opal_pmix_pmix4x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],
           [opal_pmix_pmix4x_args="--disable-debug $opal_pmix_pmix4x_args"
            CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS"])
+    AS_IF([test $OPAL_ENABLE_DLOPEN_SUPPORT -eq 1],
+          [opal_pmix_pmix4x_args="--with-pmix-extra-ltlib=$OPAL_TOP_BUILDDIR/opal/libopen-pal.la --enable-pmix-binaries $opal_pmix_pmix4x_args"],
+          [opal_pmix_pmix4x_args="--disable-pmix-binaries $opal_pmix_pmix4x_args"])
+
     AC_MSG_CHECKING([if want to install standalone libpmix])
     AS_IF([test "$enable_install_libpmix" == "yes"],
           [AC_MSG_RESULT([yes])],

--- a/opal/mca/pmix/pmix4x/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix4x/pmix/config/pmix.m4
@@ -189,11 +189,31 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                                [Link the output PMIx library to this extra lib (used in embedded mode)]))
     AC_MSG_CHECKING([for extra lib])
     AS_IF([test ! -z "$with_pmix_extra_lib"],
-          [AC_MSG_RESULT([$with_pmix_extra_lib])
-           PMIX_EXTRA_LIB=$with_pmix_extra_lib],
+          [AS_IF([test "$with_pmix_extra_lib" == "yes" || test "$with_pmix_extra_lib" == "no"],
+                 [AC_MSG_RESULT([$with_pmix_extra_lib])
+                  AC_MSG_WARN([Invalid value - must be the path name of the library to add])
+                  AC_MSG_ERROR([Cannot continue])],
+                 [AC_MSG_RESULT([$with_pmix_extra_lib])
+                  PMIX_EXTRA_LIB=$with_pmix_extra_lib])],
           [AC_MSG_RESULT([no])
            PMIX_EXTRA_LIB=])
     AC_SUBST(PMIX_EXTRA_LIB)
+
+    # Add any extra libtool lib?
+    AC_ARG_WITH([pmix-extra-ltlib],
+                AC_HELP_STRING([--with-pmix-extra-ltlib=LIB],
+                               [Link any embedded components/tools that require it to the provided libtool lib (used in embedded mode)]))
+    AC_MSG_CHECKING([for extra ltlib])
+    AS_IF([test ! -z "$with_pmix_extra_ltlib"],
+          [AS_IF([test "$with_pmix_extra_ltlib" == "yes" || test "$with_pmix_extra_ltlib" == "no"],
+                 [AC_MSG_RESULT([$with_pmix_extra_ltlib])
+                  AC_MSG_WARN([Invalid value - must be path name of the library to add])
+                  AC_MSG_ERROR([Cannot continue])],
+                 [AC_MSG_RESULT([$with_pmix_extra_ltlib])
+                  PMIX_EXTRA_LTLIB=$with_pmix_extra_ltlib])],
+          [AC_MSG_RESULT([no])
+           PMIX_EXTRA_LTLIB=])
+    AC_SUBST(PMIX_EXTRA_LTLIB)
 
     #
     # Package/brand string

--- a/opal/mca/pmix/pmix4x/pmix/config/pmix_setup_cli.m4
+++ b/opal/mca/pmix/pmix4x/pmix/config/pmix_setup_cli.m4
@@ -3,6 +3,7 @@ dnl
 dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2018      Cisco Systems, Inc. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -33,6 +34,7 @@ AC_DEFUN([PMIX_CAPTURE_CONFIGURE_CLI],[
 
         eval "$1=\$$1\\ \$quoted_arg"
     done
+    AC_DEFINE_UNQUOTED([$1], ["$$1"], [Capture the configure cmd line])
     PMIX_VAR_SCOPE_POP
     AC_SUBST($1)
 ])

--- a/opal/mca/pmix/pmix4x/pmix/src/tools/pevent/Makefile.am
+++ b/opal/mca/pmix/pmix4x/pmix/src/tools/pevent/Makefile.am
@@ -29,4 +29,5 @@ endif # PMIX_INSTALL_BINARIES
 
 pevent_SOURCES = pevent.c
 pevent_LDADD = \
-	$(top_builddir)/src/libpmix.la
+	$(top_builddir)/src/libpmix.la \
+    $(PMIX_EXTRA_LTLIB)

--- a/opal/mca/pmix/pmix4x/pmix/src/tools/plookup/Makefile.am
+++ b/opal/mca/pmix/pmix4x/pmix/src/tools/plookup/Makefile.am
@@ -29,4 +29,5 @@ endif # PMIX_INSTALL_BINARIES
 
 plookup_SOURCES = plookup.c
 plookup_LDADD = \
-	$(top_builddir)/src/libpmix.la
+	$(top_builddir)/src/libpmix.la \
+    $(PMIX_EXTRA_LTLIB)

--- a/opal/mca/pmix/pmix4x/pmix/src/tools/pmix_info/Makefile.am
+++ b/opal/mca/pmix/pmix4x/pmix/src/tools/pmix_info/Makefile.am
@@ -31,7 +31,6 @@ AM_CFLAGS = \
             -DPMIX_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
             -DPMIX_BUILD_LIBS="\"@LIBS@\"" \
             -DPMIX_CC_ABSOLUTE="\"@PMIX_CC_ABSOLUTE@\"" \
-            -DPMIX_CONFIGURE_CLI="\"@PMIX_CONFIGURE_CLI@\"" \
             -DPMIX_GREEK_VERSION="\"@PMIX_GREEK_VERSION@\"" \
             -DPMIX_REPO_REV="\"@PMIX_REPO_REV@\"" \
             -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
@@ -51,4 +50,5 @@ pmix_info_SOURCES =  \
     support.c
 
 pmix_info_LDADD = \
-	$(top_builddir)/src/libpmix.la
+	$(top_builddir)/src/libpmix.la \
+    $(PMIX_EXTRA_LTLIB)

--- a/opal/mca/pmix/pmix4x/pmix/src/tools/pps/Makefile.am
+++ b/opal/mca/pmix/pmix4x/pmix/src/tools/pps/Makefile.am
@@ -29,4 +29,5 @@ endif # PMIX_INSTALL_BINARIES
 
 pps_SOURCES = pps.c
 pps_LDADD = \
-	$(top_builddir)/src/libpmix.la
+	$(top_builddir)/src/libpmix.la \
+    $(PMIX_EXTRA_LTLIB)


### PR DESCRIPTION
Provide users with a mechanism for seeing how the embedded PMIx was
built and what PMIx MCA params are supported. Fix a strange issue with
how the PMIX_CONFIGURE_CLI value gets passed to pmix_info.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>