### PR TITLE
shmem/lock: progress communications while waiting for shmem_lock

### DIFF
--- a/oshmem/shmem/c/shmem_lock.c
+++ b/oshmem/shmem/c/shmem_lock.c
@@ -708,6 +708,7 @@ static int shmem_lock_wait_for_ticket(void *lock,
 
     do {
         shmem_int_get(&remote_turn, lock_turn, 1, server_pe);
+        opal_progress();
     } while (remote_turn != ticket);
 
     shmem_get_wrapper(&temp, lock, lock_size, 1, server_pe);


### PR DESCRIPTION
When the underlying SPML requires active progress on target side (e.g RMA emulation over active messages), need to call opal_progress() to avoid a deadlock.
For example, when UCX is using TCP transport.