### PR TITLE
mpi.h.in updates

### DIFF
--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -202,7 +202,7 @@ ompi_errhandler_t *ompi_errhandler_create(ompi_errhandler_type_t object_type,
 	      new_errhandler->eh_comm_fn = (MPI_Comm_errhandler_function *)func;
 	      break;
 	  case (OMPI_ERRHANDLER_TYPE_FILE):
-	      new_errhandler->eh_file_fn = (ompi_file_errhandler_fn *)func;
+	      new_errhandler->eh_file_fn = (ompi_file_errhandler_function *)func;
 	      break;
 	  case (OMPI_ERRHANDLER_TYPE_WIN):
 	      new_errhandler->eh_win_fn = (MPI_Win_errhandler_function *)func;

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -117,7 +117,7 @@ struct ompi_errhandler_t {
        can be invoked on any MPI object type, so we need callbacks for
        all of three. */
     MPI_Comm_errhandler_function *eh_comm_fn;
-    ompi_file_errhandler_fn *eh_file_fn;
+    ompi_file_errhandler_function *eh_file_fn;
     MPI_Win_errhandler_function *eh_win_fn;
     ompi_errhandler_fortran_handler_fn_t *eh_fort_fn;
 

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -385,11 +385,11 @@ typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype,
 typedef void (MPI_Comm_errhandler_function)(MPI_Comm *, int *, ...);
 
     /* This is a little hackish, but errhandler.h needs space for a
-       MPI_File_errhandler_fn.  While it could just be removed, this
+       MPI_File_errhandler_function.  While it could just be removed, this
        allows us to maintain a stable ABI within OMPI, at least for
        apps that don't use MPI I/O. */
-typedef void (ompi_file_errhandler_fn)(MPI_File *, int *, ...);
-typedef ompi_file_errhandler_fn MPI_File_errhandler_function;
+typedef void (ompi_file_errhandler_function)(MPI_File *, int *, ...);
+typedef ompi_file_errhandler_function MPI_File_errhandler_function;
 typedef void (MPI_Win_errhandler_function)(MPI_Win *, int *, ...);
 typedef void (MPI_User_function)(void *, void *, int *, MPI_Datatype *);
 typedef int (MPI_Comm_copy_attr_function)(MPI_Comm, int, void *,
@@ -412,7 +412,7 @@ typedef int (MPI_Grequest_cancel_function)(void *, int);
  */
 typedef MPI_Comm_errhandler_function MPI_Comm_errhandler_fn
         __mpi_interface_removed__("MPI_Comm_errhandler_fn was removed in MPI-3.0; use MPI_Comm_errhandler_function instead");
-typedef ompi_file_errhandler_fn MPI_File_errhandler_fn
+typedef ompi_file_errhandler_function MPI_File_errhandler_fn
         __mpi_interface_removed__("MPI_File_errhandler_fn was removed in MPI-3.0; use MPI_File_errhandler_function instead");
 typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn
         __mpi_interface_removed__("MPI_Win_errhandler_fn was removed in MPI-3.0; use MPI_Win_errhandler_function instead");

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1088,8 +1088,13 @@ OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_ub __mpi_interfa
 #define MPI_LONG_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_long_int)
 #define MPI_SHORT_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_short_int)
 #define MPI_2INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_2int)
+#if !OMPI_OMIT_MPI1_COMPAT_DECLS
+/*
+ * Removed datatypes
+ */
 #define MPI_UB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_ub)
 #define MPI_LB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_lb)
+#endif
 #define MPI_WCHAR OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_wchar)
 #if OPAL_HAVE_LONG_LONG
 #define MPI_LONG_LONG_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_long_long_int)

--- a/ompi/mpi/cxx/cxx_glue.c
+++ b/ompi/mpi/cxx/cxx_glue.c
@@ -144,7 +144,7 @@ ompi_cxx_intercept_file_extra_state_t
 }
 
 void ompi_cxx_errhandler_set_callbacks (struct ompi_errhandler_t *errhandler, MPI_Comm_errhandler_function *eh_comm_fn,
-                                        ompi_file_errhandler_fn *eh_file_fn, MPI_Win_errhandler_function *eh_win_fn)
+                                        ompi_file_errhandler_function *eh_file_fn, MPI_Win_errhandler_function *eh_win_fn)
 {
     errhandler->eh_comm_fn = eh_comm_fn;
     errhandler->eh_file_fn = eh_file_fn;

--- a/ompi/mpi/cxx/cxx_glue.h
+++ b/ompi/mpi/cxx/cxx_glue.h
@@ -79,7 +79,7 @@ ompi_cxx_intercept_file_extra_state_t
                                void *extra_state_cxx);
 
 void ompi_cxx_errhandler_set_callbacks (struct ompi_errhandler_t *errhandler, MPI_Comm_errhandler_function *eh_comm_fn,
-                                        ompi_file_errhandler_fn *eh_file_fn, MPI_Win_errhandler_function *eh_win_fn);
+                                        ompi_file_errhandler_function *eh_file_fn, MPI_Win_errhandler_function *eh_win_fn);
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }


### PR DESCRIPTION
2 minor fixes:

1. Update an internal typedef name (not noticeable to end users).
2. Remove MPI_UB and MPI_LB #defines when `--enable-mpi1-compatibility` is not specified (the back-end OMPI symbols for MPI_UB and MPI_LB were already disabled, but the #defines were not).