### PR TITLE
opal: Remove outdated MacOS workaround

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -53,7 +53,7 @@ Copyright (c) 2014-2015 Hewlett-Packard Development Company, LP.  All
                         rights reserved.
 Copyright (c) 2013-2017 Research Organization for Information Science (RIST).
                         All rights reserved.
-Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+Copyright (c) 2017-2018 Amazon.com, Inc. or its affiliates.  All Rights
                         reserved.
 Copyright (c) 2018      DataDirect Networks. All rights reserved.
 

--- a/opal/mca/if/bsdx_ipv6/if_bsdx_ipv6.c
+++ b/opal/mca/if/bsdx_ipv6/if_bsdx_ipv6.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,23 +38,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_NET_IF_H
-#if defined(__APPLE__) && defined(_LP64)
-/* Apple engineering suggested using options align=power as a
-   workaround for a bug in OS X 10.4 (Tiger) that prevented ioctl(...,
-   SIOCGIFCONF, ...) from working properly in 64 bit mode on Power PC.
-   It turns out that the underlying issue is the size of struct
-   ifconf, which the kernel expects to be 12 and natural 64 bit
-   alignment would make 16.  The same bug appears in 64 bit mode on
-   Intel macs, but align=power is a no-op there, so instead, use the
-   pack pragma to instruct the compiler to pack on 4 byte words, which
-   has the same effect as align=power for our needs and works on both
-   Intel and Power PC Macs. */
-#pragma pack(push,4)
-#endif
 #include <net/if.h>
-#if defined(__APPLE__) && defined(_LP64)
-#pragma pack(pop)
-#endif
 #endif
 #ifdef HAVE_NETDB_H
 #include <netdb.h>

--- a/opal/mca/if/if.h
+++ b/opal/mca/if/if.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,23 +41,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_NET_IF_H
-#if defined(__APPLE__) && defined(_LP64)
-/* Apple engineering suggested using options align=power as a
-   workaround for a bug in OS X 10.4 (Tiger) that prevented ioctl(...,
-   SIOCGIFCONF, ...) from working properly in 64 bit mode on Power PC.
-   It turns out that the underlying issue is the size of struct
-   ifconf, which the kernel expects to be 12 and natural 64 bit
-   alignment would make 16.  The same bug appears in 64 bit mode on
-   Intel macs, but align=power is a no-op there, so instead, use the
-   pack pragma to instruct the compiler to pack on 4 byte words, which
-   has the same effect as align=power for our needs and works on both
-   Intel and Power PC Macs. */
-#pragma pack(push,4)
-#endif
 #include <net/if.h>
-#if defined(__APPLE__) && defined(_LP64)
-#pragma pack(pop)
-#endif
 #endif
 #ifdef HAVE_NETDB_H
 #include <netdb.h>

--- a/opal/mca/if/linux_ipv6/if_linux_ipv6.c
+++ b/opal/mca/if/linux_ipv6/if_linux_ipv6.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,23 +36,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_NET_IF_H
-#if defined(__APPLE__) && defined(_LP64)
-/* Apple engineering suggested using options align=power as a
-   workaround for a bug in OS X 10.4 (Tiger) that prevented ioctl(...,
-   SIOCGIFCONF, ...) from working properly in 64 bit mode on Power PC.
-   It turns out that the underlying issue is the size of struct
-   ifconf, which the kernel expects to be 12 and natural 64 bit
-   alignment would make 16.  The same bug appears in 64 bit mode on
-   Intel macs, but align=power is a no-op there, so instead, use the
-   pack pragma to instruct the compiler to pack on 4 byte words, which
-   has the same effect as align=power for our needs and works on both
-   Intel and Power PC Macs. */
-#pragma pack(push,4)
-#endif
 #include <net/if.h>
-#if defined(__APPLE__) && defined(_LP64)
-#pragma pack(pop)
-#endif
 #endif
 #ifdef HAVE_NETDB_H
 #include <netdb.h>

--- a/opal/util/if.c
+++ b/opal/util/if.c
@@ -16,6 +16,8 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,23 +51,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_NET_IF_H
-#if defined(__APPLE__) && defined(_LP64)
-/* Apple engineering suggested using options align=power as a
-   workaround for a bug in OS X 10.4 (Tiger) that prevented ioctl(...,
-   SIOCGIFCONF, ...) from working properly in 64 bit mode on Power PC.
-   It turns out that the underlying issue is the size of struct
-   ifconf, which the kernel expects to be 12 and natural 64 bit
-   alignment would make 16.  The same bug appears in 64 bit mode on
-   Intel macs, but align=power is a no-op there, so instead, use the
-   pack pragma to instruct the compiler to pack on 4 byte words, which
-   has the same effect as align=power for our needs and works on both
-   Intel and Power PC Macs. */
-#pragma pack(push,4)
-#endif
 #include <net/if.h>
-#if defined(__APPLE__) && defined(_LP64)
-#pragma pack(pop)
-#endif
 #endif
 #ifdef HAVE_NETDB_H
 #include <netdb.h>

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2013      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,23 +51,7 @@
 #include <arpa/inet.h>
 #endif
 #ifdef HAVE_NET_IF_H
-#if defined(__APPLE__) && defined(_LP64)
-/* Apple engineering suggested using options align=power as a
-   workaround for a bug in OS X 10.4 (Tiger) that prevented ioctl(...,
-   SIOCGIFCONF, ...) from working properly in 64 bit mode on Power PC.
-   It turns out that the underlying issue is the size of struct
-   ifconf, which the kernel expects to be 12 and natural 64 bit
-   alignment would make 16.  The same bug appears in 64 bit mode on
-   Intel macs, but align=power is a no-op there, so instead, use the
-   pack pragma to instruct the compiler to pack on 4 byte words, which
-   has the same effect as align=power for our needs and works on both
-   Intel and Power PC Macs. */
-#pragma pack(push,4)
-#endif
 #include <net/if.h>
-#if defined(__APPLE__) && defined(_LP64)
-#pragma pack(pop)
-#endif
 #endif
 #ifdef HAVE_NETDB_H
 #include <netdb.h>


### PR DESCRIPTION
Remove the pack/unpack pragma around net/if.h on MacOS, which was added to fix a bug in MacOS X 10.4.x on 64-bit platforms. The bug was fixed in Mac OS X 10.5.0 and, sometime in the last 11 years, compilers started emitting warnings about the fact that the Apple header stomped over the pragma pack settings from the workaround.  We already don't support versions of MacOS earlier than 10.5, so there's no point in keeping the workaround.
    
Signed-off-by: Brian Barrett <bbarrett@amazon.com>