### PR TITLE
Fix/local bind

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -361,9 +361,9 @@ static int mca_btl_tcp_component_open(void)
 #if OPAL_ENABLE_IPV6
     mca_btl_tcp_component.tcp6_listen_sd = -1;
 #endif
-    mca_btl_tcp_component.tcp_num_btls=0;
+    mca_btl_tcp_component.tcp_num_btls = 0;
     mca_btl_tcp_component.tcp_addr_count = 0;
-    mca_btl_tcp_component.tcp_btls=NULL;
+    mca_btl_tcp_component.tcp_btls = NULL;
 
     /* initialize objects */
     OBJ_CONSTRUCT(&mca_btl_tcp_component.tcp_lock, opal_mutex_t);

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -732,12 +732,12 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
         }
         free(proc_data->local_interfaces[i]);
     }
-    free(proc_data->local_interfaces);
+    free(proc_data->local_interfaces); proc_data->local_interfaces = NULL;
     proc_data->max_local_interfaces = 0;
 
-    free(proc_data->weights);
-    free(proc_data->best_addr);
-    free(proc_data->best_assignment);
+    free(proc_data->weights); proc_data->weights = NULL;
+    free(proc_data->best_addr); proc_data->best_addr = NULL;
+    free(proc_data->best_assignment); proc_data->best_assignment = NULL;
 
     OBJ_DESTRUCT(&_proc_data.local_kindex_to_index);
     OBJ_DESTRUCT(&_proc_data.peer_kindex_to_index);


### PR DESCRIPTION
This should fix Ralph issue on OSX. In particular, I was not able to figure out why OSX refuses to bind on a local IP with port 0, but for some reasons it does. Ignoring the failed bind and issuing the connect to the expected peer makes things right.

Fixes #5815 