### PR TITLE
btl/vader: work around Oracle compiler bug

### DIFF
--- a/opal/mca/btl/vader/btl_vader_fifo.h
+++ b/opal/mca/btl/vader/btl_vader_fifo.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2010-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -154,7 +154,11 @@ static inline mca_btl_vader_hdr_t *vader_fifo_read (vader_fifo_t *fifo, struct m
 
 static inline void vader_fifo_init (vader_fifo_t *fifo)
 {
-    fifo->fifo_head = fifo->fifo_tail = VADER_FIFO_FREE;
+    /* due to a compiler bug in Oracle C 5.15 the following line was broken into two. Not
+     * ideal but oh well. See #5814 */
+    /* fifo->fifo_head = fifo->fifo_tail = VADER_FIFO_FREE; */
+    fifo->fifo_head = VADER_FIFO_FREE;
+    fifo->fifo_tail = VADER_FIFO_FREE;
     fifo->fbox_available = mca_btl_vader_component.fbox_max;
     mca_btl_vader_component.my_fifo = fifo;
 }


### PR DESCRIPTION
This commit works around an Oracle C compiler bug in 5.15 (not sure
when it was introduced). The bug is triggered when we chain
assignments of atomic variables. Ex:

_Atomic intptr x, y;
intptr_t z = 0;

x = y = z;

Will produce a compiler error of the form:

operand cannot have void type: op "="
assignment type mismatch:
	long "=" void

To work around the issue we are removing the chain assignment and
setting the head and tail on different lines.

Fixes #5814

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>