### PR TITLE
Strip --with-foo=internal from opal_subdir_args

### DIFF
--- a/config/opal_config_subdir_args.m4
+++ b/config/opal_config_subdir_args.m4
@@ -10,7 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
-dnl Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+dnl Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -60,6 +60,8 @@ do
 	    ;;
 	-with-platform=* | --with-platform=*)
 	    ;;
+        -with*=internal)
+            ;;
 	*)
 	    case $subdir_arg in
 	    *\'*) subdir_arg=`echo "$subdir_arg" | sed "s/'/'\\\\\\\\''/g"` ;;


### PR DESCRIPTION
Our components that have a --with-foo configure option won't know what
to do with a value of "internal". This scenario only occurs with hwloc
and libevent, both of which are statically contained in libopen-pal

Thanks to @jsquyres for the diff

Signed-off-by: Ralph Castain <rhc@open-mpi.org>