### PR TITLE
mpiext/pcollreq: Correct f08 routine signatures

### DIFF
--- a/ompi/mpiext/pcollreq/use-mpi-f08/allgather_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/allgather_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine MPIX_Allgather_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_allgather_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/allgatherv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/allgatherv_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,9 +15,10 @@ subroutine MPIX_Allgatherv_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_allgatherv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
-   INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/allreduce_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/allreduce_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine MPIX_Allreduce_init_f08(sendbuf,recvbuf,count,datatype,op,comm,info,r
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_allreduce_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/alltoall_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/alltoall_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,7 +15,8 @@ subroutine MPIX_Alltoall_init_f08(sendbuf,sendcount,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_alltoall_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/alltoallv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/alltoallv_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,8 +15,9 @@ subroutine MPIX_Alltoallv_init_f08(sendbuf,sendcounts,sdispls,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_alltoallv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/alltoallw_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/alltoallw_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,10 +15,10 @@ subroutine MPIX_Alltoallw_init_f08(sendbuf,sendcounts,sdispls,sendtypes,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_alltoallw_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: recvtypes(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*), recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Request), INTENT(OUT) :: request

--- a/ompi/mpiext/pcollreq/use-mpi-f08/bcast_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/bcast_init_f08.F90
@@ -14,7 +14,7 @@ subroutine MPIX_Bcast_init_f08(buffer,count,datatype,root,comm,info,request,ierr
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_bcast_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buffer
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: buffer
    INTEGER, INTENT(IN) :: count, root
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/exscan_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/exscan_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine MPIX_Exscan_init_f08(sendbuf,recvbuf,count,datatype,op,comm,info,requ
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_exscan_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/gather_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/gather_init_f08.F90
@@ -5,16 +5,18 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Gather_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,&
-                          recvtype,root,comm,info,request,ierror)
+                                recvtype,root,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_gather_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount, root
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/gatherv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/gatherv_init_f08.F90
@@ -5,18 +5,20 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Gatherv_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcounts,&
-                           displs,recvtype,root,comm,info,request,ierror)
+                                 displs,recvtype,root,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_gatherv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, root
-   INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/mpiext_pcollreq_usempif08.h
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/mpiext_pcollreq_usempif08.h
@@ -32,8 +32,8 @@ interface mpix_allgather_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -54,10 +54,10 @@ interface mpix_allgatherv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount
-        integer, intent(in) :: recvcounts(*), displs(*)
+        integer, intent(in), asynchronous :: recvcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -77,8 +77,8 @@ interface mpix_allreduce_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -100,8 +100,8 @@ interface mpix_alltoall_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -122,9 +122,9 @@ interface mpix_alltoallv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -144,10 +144,10 @@ interface mpix_alltoallw_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
-        type(mpi_datatype), intent(in) :: sendtypes(*), recvtypes(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+        type(mpi_datatype), intent(in), asynchronous :: sendtypes(*), recvtypes(*)
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
         type(mpi_request), intent(out) :: request
@@ -176,7 +176,7 @@ interface mpix_bcast_init
         !$PRAGMA IGNORE_TKR buffer
         !DIR$ IGNORE_TKR buffer
         !IBM* IGNORE_TKR buffer
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: buffer
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: buffer
         integer, intent(in) :: count, root
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_comm), intent(in) :: comm
@@ -197,8 +197,8 @@ interface mpix_exscan_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -220,8 +220,8 @@ interface mpix_gather_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount, root
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -242,10 +242,10 @@ interface mpix_gatherv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, root
-        integer, intent(in) :: recvcounts(*), displs(*)
+        integer, intent(in), asynchronous :: recvcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -265,8 +265,8 @@ interface mpix_reduce_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count, root
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -288,9 +288,9 @@ interface mpix_reduce_scatter_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: recvcounts(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: recvcounts(*)
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
         type(mpi_comm), intent(in) :: comm
@@ -311,8 +311,8 @@ interface mpix_reduce_scatter_block_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: recvcount
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -334,8 +334,8 @@ interface mpix_scan_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -357,8 +357,8 @@ interface mpix_scatter_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount, root
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -379,10 +379,10 @@ interface mpix_scatterv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: recvcount, root
-        integer, intent(in) :: sendcounts(*), displs(*)
+        integer, intent(in), asynchronous :: sendcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -402,8 +402,8 @@ interface mpix_neighbor_allgather_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -424,10 +424,10 @@ interface mpix_neighbor_allgatherv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount
-        integer, intent(in) :: recvcounts(*), displs(*)
+        integer, intent(in), asynchronous :: recvcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -447,8 +447,8 @@ interface mpix_neighbor_alltoall_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -469,9 +469,9 @@ interface mpix_neighbor_alltoallv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -491,11 +491,11 @@ interface mpix_neighbor_alltoallw_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), recvcounts(*)
-        integer(mpi_address_kind), intent(in) :: sdispls(*), rdispls(*)
-        type(mpi_datatype), intent(in) :: sendtypes(*), recvtypes(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), recvcounts(*)
+        integer(mpi_address_kind), intent(in), asynchronous :: sdispls(*), rdispls(*)
+        type(mpi_datatype), intent(in), asynchronous :: sendtypes(*), recvtypes(*)
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
         type(mpi_request), intent(out) :: request
@@ -514,8 +514,8 @@ interface pmpix_allgather_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -536,10 +536,10 @@ interface pmpix_allgatherv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount
-        integer, intent(in) :: recvcounts(*), displs(*)
+        integer, intent(in), asynchronous :: recvcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -559,8 +559,8 @@ interface pmpix_allreduce_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -582,8 +582,8 @@ interface pmpix_alltoall_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -604,9 +604,9 @@ interface pmpix_alltoallv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -626,10 +626,10 @@ interface pmpix_alltoallw_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
-        type(mpi_datatype), intent(in) :: sendtypes(*), recvtypes(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+        type(mpi_datatype), intent(in), asynchronous :: sendtypes(*), recvtypes(*)
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
         type(mpi_request), intent(out) :: request
@@ -658,7 +658,7 @@ interface pmpix_bcast_init
         !$PRAGMA IGNORE_TKR buffer
         !DIR$ IGNORE_TKR buffer
         !IBM* IGNORE_TKR buffer
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: buffer
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: buffer
         integer, intent(in) :: count, root
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_comm), intent(in) :: comm
@@ -679,8 +679,8 @@ interface pmpix_exscan_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -702,8 +702,8 @@ interface pmpix_gather_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount, root
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -724,8 +724,8 @@ interface pmpix_gatherv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, root
         integer, intent(in) :: recvcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
@@ -747,8 +747,8 @@ interface pmpix_reduce_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count, root
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -770,9 +770,9 @@ interface pmpix_reduce_scatter_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: recvcounts(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: recvcounts(*)
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
         type(mpi_comm), intent(in) :: comm
@@ -793,8 +793,8 @@ interface pmpix_reduce_scatter_block_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: recvcount
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -816,8 +816,8 @@ interface pmpix_scan_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: count
         type(mpi_datatype), intent(in) :: datatype
         type(mpi_op), intent(in) :: op
@@ -839,8 +839,8 @@ interface pmpix_scatter_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount, root
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -861,10 +861,10 @@ interface pmpix_scatterv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: recvcount, root
-        integer, intent(in) :: sendcounts(*), displs(*)
+        integer, intent(in), asynchronous :: sendcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -884,8 +884,8 @@ interface pmpix_neighbor_allgather_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -906,10 +906,10 @@ interface pmpix_neighbor_allgatherv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount
-        integer, intent(in) :: recvcounts(*), displs(*)
+        integer, intent(in), asynchronous :: recvcounts(*), displs(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -929,8 +929,8 @@ interface pmpix_neighbor_alltoall_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
         integer, intent(in) :: sendcount, recvcount
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
@@ -951,9 +951,9 @@ interface pmpix_neighbor_alltoallv_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
         type(mpi_datatype), intent(in) :: sendtype, recvtype
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info
@@ -973,10 +973,10 @@ interface pmpix_neighbor_alltoallw_init
         !$PRAGMA IGNORE_TKR sendbuf, recvbuf
         !DIR$ IGNORE_TKR sendbuf, recvbuf
         !IBM* IGNORE_TKR sendbuf, recvbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in) :: sendbuf
-        OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-        integer, intent(in) :: sendcounts(*), recvcounts(*)
-        integer(mpi_address_kind), intent(in) :: sdispls(*), rdispls(*)
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, intent(in), asynchronous :: sendbuf
+        OMPI_FORTRAN_IGNORE_TKR_TYPE, asynchronous :: recvbuf
+        integer, intent(in), asynchronous :: sendcounts(*), recvcounts(*)
+        integer(mpi_address_kind), intent(in), asynchronous :: sdispls(*), rdispls(*)
         type(mpi_datatype), intent(in) :: sendtypes(*), recvtypes(*)
         type(mpi_comm), intent(in) :: comm
         type(mpi_info), intent(in) :: info

--- a/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_allgather_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_allgather_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine MPIX_Neighbor_allgather_init_f08(sendbuf,sendcount,sendtype,recvbuf,r
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_allgather_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_allgatherv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_allgatherv_init_f08.F90
@@ -5,18 +5,20 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Neighbor_allgatherv_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcounts,&
-                                        displs,recvtype,comm,info,request,ierror)
+                                             displs,recvtype,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_allgatherv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
-   INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_alltoall_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_alltoall_init_f08.F90
@@ -5,16 +5,18 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Neighbor_alltoall_init_f08(sendbuf,sendcount,sendtype,recvbuf,&
-                                      recvcount,recvtype,comm,info,request,ierror)
+                                           recvcount,recvtype,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_alltoall_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_alltoallv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_alltoallv_init_f08.F90
@@ -5,17 +5,19 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Neighbor_alltoallv_init_f08(sendbuf,sendcounts,sdispls,sendtype,recvbuf,&
-                                       recvcounts,rdispls,recvtype,comm,info,request,ierror)
+                                            recvcounts,rdispls,recvtype,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_alltoallv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_alltoallw_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/neighbor_alltoallw_init_f08.F90
@@ -10,16 +10,16 @@
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Neighbor_alltoallw_init_f08(sendbuf,sendcounts,sdispls,sendtypes,&
-                                       recvbuf,recvcounts,rdispls,recvtypes,comm,info,request,ierror)
+                                            recvbuf,recvcounts,rdispls,recvtypes,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request, MPI_ADDRESS_KIND
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_alltoallw_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), recvcounts(*)
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: sdispls(*), rdispls(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: recvtypes(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), recvcounts(*)
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN), ASYNCHRONOUS :: sdispls(*), rdispls(*)
+   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*)
+   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Request), INTENT(OUT) :: request

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pallgather_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pallgather_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine PMPIX_Allgather_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_allgather_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pallgatherv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pallgatherv_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,9 +15,10 @@ subroutine PMPIX_Allgatherv_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcoun
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_allgatherv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
-   INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pallreduce_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pallreduce_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine PMPIX_Allreduce_init_f08(sendbuf,recvbuf,count,datatype,op,comm,info,
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_allreduce_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/palltoall_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/palltoall_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,7 +15,8 @@ subroutine PMPIX_Alltoall_init_f08(sendbuf,sendcount,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_alltoall_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/palltoallv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/palltoallv_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,8 +15,9 @@ subroutine PMPIX_Alltoallv_init_f08(sendbuf,sendcounts,sdispls,sendtype,recvbuf,
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_alltoallv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/palltoallw_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/palltoallw_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,10 +15,10 @@ subroutine PMPIX_Alltoallw_init_f08(sendbuf,sendcounts,sdispls,sendtypes,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_alltoallw_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: recvtypes(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*), recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Request), INTENT(OUT) :: request

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pbcast_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pbcast_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,7 @@ subroutine PMPIX_Bcast_init_f08(buffer,count,datatype,root,comm,info,request,ier
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_bcast_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buffer
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: buffer
    INTEGER, INTENT(IN) :: count, root
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -25,4 +26,4 @@ subroutine PMPIX_Bcast_init_f08(buffer,count,datatype,root,comm,info,request,ier
    call ompix_bcast_init_f(buffer,count,datatype%MPI_VAL,root,comm%MPI_VAL,info%MPI_VAL,request%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
- end subroutine PMPIX_Bcast_init_f08
+end subroutine PMPIX_Bcast_init_f08

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pexscan_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pexscan_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine PMPIX_Exscan_init_f08(sendbuf,recvbuf,count,datatype,op,comm,info,req
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_exscan_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pgather_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pgather_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,7 +15,8 @@ subroutine PMPIX_Gather_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_gather_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount, root
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pgatherv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pgatherv_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,9 +15,10 @@ subroutine PMPIX_Gatherv_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcounts,
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_gatherv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, root
-   INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_allgather_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_allgather_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine PMPIX_Neighbor_allgather_init_f08(sendbuf,sendcount,sendtype,recvbuf,
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_allgather_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_allgatherv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_allgatherv_init_f08.F90
@@ -5,18 +5,20 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine PMPIX_Neighbor_allgatherv_init_f08(sendbuf,sendcount,sendtype,recvbuf,recvcounts,&
-                                        displs,recvtype,comm,info,request,ierror)
+                                              displs,recvtype,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_allgatherv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
-   INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_alltoall_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_alltoall_init_f08.F90
@@ -5,16 +5,18 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine PMPIX_Neighbor_alltoall_init_f08(sendbuf,sendcount,sendtype,recvbuf,&
-                                      recvcount,recvtype,comm,info,request,ierror)
+                                            recvcount,recvtype,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_alltoall_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_alltoallv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_alltoallv_init_f08.F90
@@ -5,17 +5,19 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine PMPIX_Neighbor_alltoallv_init_f08(sendbuf,sendcounts,sdispls,sendtype,recvbuf,&
-                                       recvcounts,rdispls,recvtype,comm,info,request,ierror)
+                                             recvcounts,rdispls,recvtype,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_alltoallv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_alltoallw_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pneighbor_alltoallw_init_f08.F90
@@ -10,16 +10,16 @@
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine PMPIX_Neighbor_alltoallw_init_f08(sendbuf,sendcounts,sdispls,sendtypes,&
-                                       recvbuf,recvcounts,rdispls,recvtypes,comm,info,request,ierror)
+                                             recvbuf,recvcounts,rdispls,recvtypes,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request, MPI_ADDRESS_KIND
    use :: mpiext_pcollreq_f08, only : ompix_neighbor_alltoallw_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-   INTEGER, INTENT(IN) :: sendcounts(*), recvcounts(*)
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: sdispls(*), rdispls(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*)
-   TYPE(MPI_Datatype), INTENT(IN) :: recvtypes(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), recvcounts(*)
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN), ASYNCHRONOUS :: sdispls(*), rdispls(*)
+   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*)
+   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Request), INTENT(OUT) :: request

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/preduce_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/preduce_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine PMPIX_Reduce_init_f08(sendbuf,recvbuf,count,datatype,op,root,comm,inf
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_reduce_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count, root
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/preduce_scatter_block_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/preduce_scatter_block_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine PMPIX_Reduce_scatter_block_init_f08(sendbuf,recvbuf,recvcount,datatyp
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_reduce_scatter_block_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/preduce_scatter_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/preduce_scatter_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,8 +14,9 @@ subroutine PMPIX_Reduce_scatter_init_f08(sendbuf,recvbuf,recvcounts,datatype,op,
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_reduce_scatter_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: recvcounts(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*)
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pscan_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pscan_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine PMPIX_Scan_init_f08(sendbuf,recvbuf,count,datatype,op,comm,info,reque
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_scan_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pscatter_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pscatter_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,7 +15,8 @@ subroutine PMPIX_Scatter_init_f08(sendbuf,sendcount,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_scatter_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount, root
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/profile/pscatterv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/profile/pscatterv_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -14,9 +15,10 @@ subroutine PMPIX_Scatterv_init_f08(sendbuf,sendcounts,displs,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_scatterv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: recvcount, root
-   INTEGER, INTENT(IN) :: sendcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/reduce_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/reduce_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine MPIX_Reduce_init_f08(sendbuf,recvbuf,count,datatype,op,root,comm,info
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_reduce_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count, root
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/reduce_scatter_block_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/reduce_scatter_block_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine MPIX_Reduce_scatter_block_init_f08(sendbuf,recvbuf,recvcount,datatype
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_reduce_scatter_block_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/reduce_scatter_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/reduce_scatter_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,8 +14,9 @@ subroutine MPIX_Reduce_scatter_init_f08(sendbuf,recvbuf,recvcounts,datatype,op,c
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_reduce_scatter_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
-   INTEGER, INTENT(IN) :: recvcounts(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*)
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpiext/pcollreq/use-mpi-f08/scan_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/scan_init_f08.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
@@ -13,7 +14,8 @@ subroutine MPIX_Scan_init_f08(sendbuf,recvbuf,count,datatype,op,comm,info,reques
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_scan_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op

--- a/ompi/mpiext/pcollreq/use-mpi-f08/scatter_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/scatter_init_f08.F90
@@ -5,16 +5,18 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Scatter_init_f08(sendbuf,sendcount,sendtype,recvbuf,&
-                           recvcount,recvtype,root,comm,info,request,ierror)
+                                 recvcount,recvtype,root,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_scatter_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount, root
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpiext/pcollreq/use-mpi-f08/scatterv_init_f08.F90
+++ b/ompi/mpiext/pcollreq/use-mpi-f08/scatterv_init_f08.F90
@@ -5,18 +5,20 @@
 !                         All rights reserved.
 ! Copyright (c) 2018      Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPIX_Scatterv_init_f08(sendbuf,sendcounts,displs,sendtype,recvbuf,&
-                            recvcount,recvtype,root,comm,info,request,ierror)
+                                  recvcount,recvtype,root,comm,info,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Info, MPI_Request
    use :: mpiext_pcollreq_f08, only : ompix_scatterv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: recvcount, root
-   INTEGER, INTENT(IN) :: sendcounts(*), displs(*)
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm


### PR DESCRIPTION
Changes of nonblocking collectives in e98d794e8b and f750c6932c are applied to persistent collectives. And the module file is updated.

Need PR to v4.0.x branch.

@ggouaillardet FYI
