### PR TITLE
Fail configure if pmix won't build

### DIFF
--- a/opal/mca/pmix/pmix4x/configure.m4
+++ b/opal/mca/pmix/pmix4x/configure.m4
@@ -87,6 +87,9 @@ AC_DEFUN([MCA_opal_pmix_pmix4x_CONFIG],[
           [AC_MSG_RESULT([no - disqualifying this component])
            opal_pmix_pmix4x_happy=0],
           [AC_MSG_RESULT([yes - using the internal v4.x library])
+           AS_IF([test "$opal_pmix_pmix4x_happy" = "0"],
+                 [AC_MSG_WARN([INTERNAL PMIX FAILED TO CONFIGURE])
+                  AC_MSG_ERROR([CANNOT CONTINUE])])
            # Build flags for our Makefile.am
            opal_pmix_pmix4x_LDFLAGS=
            opal_pmix_pmix4x_LIBS="$OPAL_TOP_BUILDDIR/$opal_pmix_pmix4x_basedir/pmix/src/libpmix.la"

--- a/opal/mca/pmix/pmix4x/pmix/config/pmix_setup_hwloc.m4
+++ b/opal/mca/pmix/pmix4x/pmix/config/pmix_setup_hwloc.m4
@@ -24,6 +24,8 @@ AC_DEFUN([PMIX_HWLOC_CONFIG],[
                                 [Search for hwloc libraries in DIR ])])
 
     pmix_hwloc_support=0
+    AS_IF([test "$with_hwloc" = "internal" || test "$with_hwloc" = "external"],
+          [with_hwloc=])
 
     if test "$with_hwloc" != "no"; then
         AC_MSG_CHECKING([for hwloc in])


### PR DESCRIPTION
If we are using the internal PMIx component and the embedded library fails to configure, then fail - don't silently fail to build and then fail in execution

Signed-off-by: Ralph Castain <rhc@open-mpi.org>