### PR TITLE
opal_config_subdir_args.m4: fix typo

### DIFF
--- a/config/opal_config_subdir_args.m4
+++ b/config/opal_config_subdir_args.m4
@@ -60,7 +60,7 @@ do
 	    ;;
 	-with-platform=* | --with-platform=*)
 	    ;;
-        -with*=internal)
+        --with*=internal)
             ;;
 	*)
 	    case $subdir_arg in


### PR DESCRIPTION
A typo inadvertantly crept in to e836dbd506.  Add the extra '-' to
make it correctly search for --with-*=internal.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>