### PR TITLE
platform/mellanox: disable openib/verbs — v4.0.x

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -1,7 +1,7 @@
 enable_mca_no_build=coll-ml
 enable_debug_symbols=yes
 enable_orterun_prefix_by_default=yes
-with_verbs=yes
+with_verbs=no
 with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes


### PR DESCRIPTION
(cherry picked from commit 7180ab144a52136f8c0ec0c63a61b1a31dfed023)