### PR TITLE
v3.1.x: fortran/use-mpi-f08: Correct f08 routine signatures

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/aint_add_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/aint_add_f08.F90
@@ -7,12 +7,12 @@
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-function MPI_Aint_add_f08(addr1, addr2)
+function MPI_Aint_add_f08(base, disp)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_aint_add_f
    implicit none
    INTEGER(MPI_ADDRESS_KIND) :: MPI_Aint_add_f08
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr1
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: addr2
-   MPI_Aint_add_f08 = ompi_aint_add_f(addr1, addr2)
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: disp
+   MPI_Aint_add_f08 = ompi_aint_add_f(base, disp)
 end function MPI_Aint_add_f08

--- a/ompi/mpi/fortran/use-mpi-f08/bcast_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/bcast_f08.F90
@@ -21,4 +21,4 @@ subroutine MPI_Bcast_f08(buffer,count,datatype,root,comm,ierror)
    call ompi_bcast_f(buffer,count,datatype%MPI_VAL,root,comm%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
- end subroutine MPI_Bcast_f08
+end subroutine MPI_Bcast_f08

--- a/ompi/mpi/fortran/use-mpi-f08/buffer_attach_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_attach_f08.F90
@@ -10,7 +10,7 @@
 subroutine MPI_Buffer_attach_f08(buffer,size,ierror)
    use :: mpi_f08, only : ompi_buffer_attach_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buffer
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buffer
    INTEGER, INTENT(IN) :: size
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror

--- a/ompi/mpi/fortran/use-mpi-f08/buffer_detach_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/buffer_detach_f08.F90
@@ -8,8 +8,8 @@
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 subroutine MPI_Buffer_detach_f08(buffer_addr,size,ierror)
-   use :: mpi_f08, only : ompi_buffer_detach_f
    USE, INTRINSIC ::  ISO_C_BINDING, ONLY : C_PTR
+   use :: mpi_f08, only : ompi_buffer_detach_f
    implicit none
    TYPE(C_PTR), INTENT(OUT) ::  buffer_addr
    INTEGER, INTENT(OUT) :: size

--- a/ompi/mpi/fortran/use-mpi-f08/comm_spawn_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_spawn_f08.F90
@@ -10,7 +10,7 @@ subroutine MPI_Comm_spawn_f08(command,argv,maxprocs,info,root,comm,intercomm, &
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm
    use :: mpi_f08, only : ompi_comm_spawn_f
    implicit none
-   CHARACTER(LEN=*), INTENT(IN) :: command, argv
+   CHARACTER(LEN=*), INTENT(IN) :: command, argv(*)
    INTEGER, INTENT(IN) :: maxprocs, root
    TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpi/fortran/use-mpi-f08/comm_spawn_multiple_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_spawn_multiple_f08.F90
@@ -15,7 +15,7 @@ subroutine MPI_Comm_spawn_multiple_f08(count,array_of_commands,array_of_argv, &
    implicit none
    INTEGER, INTENT(IN) :: count, root
    INTEGER, INTENT(IN) :: array_of_maxprocs(count)
-   CHARACTER(LEN=*), INTENT(IN) :: array_of_commands(count), array_of_argv(count)
+   CHARACTER(LEN=*), INTENT(IN) :: array_of_commands(count), array_of_argv(count, *)
    TYPE(MPI_Info), INTENT(IN) :: array_of_info(count)
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Comm), INTENT(OUT) :: intercomm

--- a/ompi/mpi/fortran/use-mpi-f08/ialltoallw_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/ialltoallw_f08.F90
@@ -15,8 +15,7 @@ subroutine MPI_Ialltoallw_f08(sendbuf,sendcounts,sdispls,sendtypes,&
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
    OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
-   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*)
-   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: recvtypes(*)
+   TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*), recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror

--- a/ompi/mpi/fortran/use-mpi-f08/ibcast_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/ibcast_f08.F90
@@ -11,7 +11,7 @@ subroutine MPI_Ibcast_f08(buffer,count,datatype,root,comm,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ibcast_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: buffer
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: buffer
    INTEGER, INTENT(IN) :: count, root
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -22,4 +22,4 @@ subroutine MPI_Ibcast_f08(buffer,count,datatype,root,comm,request,ierror)
    call ompi_ibcast_f(buffer,count,datatype%MPI_VAL,root,comm%MPI_VAL,request%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
- end subroutine MPI_Ibcast_f08
+end subroutine MPI_Ibcast_f08

--- a/ompi/mpi/fortran/use-mpi-f08/improbe_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/improbe_f08.F90
@@ -33,4 +33,5 @@ subroutine MPI_Improbe_f08(source,tag,comm,flag,message,status,ierror)
 
    call PMPI_Improbe(source,tag,comm%MPI_VAL,flag,message%MPI_VAL,status,c_ierror)
    if (present(ierror)) ierror = c_ierror
+
 end subroutine MPI_Improbe_f08

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_allgather_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_allgather_f08.F90
@@ -11,7 +11,8 @@ subroutine MPI_Ineighbor_allgather_f08(sendbuf,sendcount,sendtype,recvbuf,recvco
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_allgather_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_allgatherv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_allgatherv_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Ineighbor_allgatherv_f08(sendbuf,sendcount,sendtype,recvbuf,recvc
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_allgatherv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
    INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoall_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoall_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Ineighbor_alltoall_f08(sendbuf,sendcount,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_alltoall_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoallv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/ineighbor_alltoallv_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Ineighbor_alltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recvb
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_alltoallv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
@@ -1086,7 +1086,7 @@ subroutine MPI_Ialltoall_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,recvty
    !IBM* IGNORE_TKR sendbuf, recvbuf
    OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
    OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
-   INTEGER, INTENT(IN) :: sendcount, recvcount
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype, recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -1128,7 +1128,7 @@ subroutine MPI_Ialltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recvbuf,recvco
    INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype, recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Ialltoallv_f08
 end interface  MPI_Ialltoallv
@@ -1167,7 +1167,7 @@ subroutine MPI_Ialltoallw_f08(sendbuf,sendcounts,sdispls,sendtypes,recvbuf,recvc
    INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*), recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Ialltoallw_f08
 end interface  MPI_Ialltoallw
@@ -4690,7 +4690,7 @@ subroutine MPI_Ineighbor_alltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recvb
    INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype, recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Ineighbor_alltoallv_f08
 end interface  MPI_Ineighbor_alltoallv
@@ -4731,7 +4731,7 @@ subroutine MPI_Ineighbor_alltoallw_f08(sendbuf,sendcounts,sdispls,sendtypes,recv
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: sdispls(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*), recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Ineighbor_alltoallw_f08
 end interface  MPI_Ineighbor_alltoallw

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -1084,10 +1084,9 @@ subroutine PMPI_Ialltoall_f08(sendbuf,sendcount,sendtype,recvbuf,recvcount,recvt
    !$PRAGMA IGNORE_TKR sendbuf, recvbuf
    !DIR$ IGNORE_TKR sendbuf, recvbuf
    !IBM* IGNORE_TKR sendbuf, recvbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcount
-   INTEGER, ASYNCHRONOUS :: recvcount
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype, recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Request), INTENT(OUT) :: request
@@ -1129,7 +1128,7 @@ subroutine PMPI_Ialltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recvbuf,recvc
    INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype, recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Ialltoallv_f08
 end interface  PMPI_Ialltoallv
@@ -1168,7 +1167,7 @@ subroutine PMPI_Ialltoallw_f08(sendbuf,sendcounts,sdispls,sendtypes,recvbuf,recv
    INTEGER, INTENT(IN), ASYNCHRONOUS :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN), ASYNCHRONOUS :: sendtypes(*), recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Ialltoallw_f08
 end interface  PMPI_Ialltoallw
@@ -1444,9 +1443,9 @@ subroutine PMPI_Reduce_scatter_f08(sendbuf,recvbuf,recvcounts,datatype,op,comm, 
    !$PRAGMA IGNORE_TKR sendbuf, recvbuf
    !DIR$ IGNORE_TKR sendbuf, recvbuf
    !IBM* IGNORE_TKR sendbuf, recvbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
-   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+   INTEGER, INTENT(IN) :: recvcounts(*)
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -1464,9 +1463,9 @@ subroutine PMPI_Ireduce_scatter_f08(sendbuf,recvbuf,recvcounts,datatype,op,comm,
    !$PRAGMA IGNORE_TKR sendbuf, recvbuf
    !DIR$ IGNORE_TKR sendbuf, recvbuf
    !IBM* IGNORE_TKR sendbuf, recvbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
-   INTEGER, INTENT(IN) :: recvcounts(*)
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
+   INTEGER, INTENT(IN), ASYNCHRONOUS :: recvcounts(*)
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op
    TYPE(MPI_Comm), INTENT(IN) :: comm
@@ -1544,8 +1543,8 @@ subroutine PMPI_Iscan_f08(sendbuf,recvbuf,count,datatype,op,comm,request,ierror)
    !$PRAGMA IGNORE_TKR sendbuf, recvbuf
    !DIR$ IGNORE_TKR sendbuf, recvbuf
    !IBM* IGNORE_TKR sendbuf, recvbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: recvbuf
    INTEGER, INTENT(IN) :: count
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Op), INTENT(IN) :: op
@@ -4691,7 +4690,7 @@ subroutine PMPI_Ineighbor_alltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recv
    INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype, recvtype
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Ineighbor_alltoallv_f08
 end interface  PMPI_Ineighbor_alltoallv
@@ -4732,7 +4731,7 @@ subroutine PMPI_Ineighbor_alltoallw_f08(sendbuf,sendcounts,sdispls,sendtypes,rec
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: sdispls(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*), recvtypes(*)
    TYPE(MPI_Comm), INTENT(IN) :: comm
-   TYPE(MPI_Request), INTENT(IN) :: request
+   TYPE(MPI_Request), INTENT(OUT) :: request
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Ineighbor_alltoallw_f08
 end interface  PMPI_Ineighbor_alltoallw

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_allgather_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_allgather_f08.F90
@@ -11,7 +11,8 @@ subroutine MPI_Neighbor_allgather_f08(sendbuf,sendcount,sendtype,recvbuf,recvcou
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_allgather_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_allgatherv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_allgatherv_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Neighbor_allgatherv_f08(sendbuf,sendcount,sendtype,recvbuf,recvco
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_allgatherv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
    INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoall_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoall_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Neighbor_alltoall_f08(sendbuf,sendcount,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_alltoall_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/neighbor_alltoallv_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Neighbor_alltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recvbu
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_alltoallv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/pack_external_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pack_external_f08.F90
@@ -13,7 +13,8 @@ subroutine MPI_Pack_external_f08(datarep,inbuf,incount,datatype,outbuf,outsize, 
    use :: mpi_f08, only : ompi_pack_external_f
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: datarep
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER, INTENT(IN) :: incount
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: outsize

--- a/ompi/mpi/fortran/use-mpi-f08/pack_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/pack_f08.F90
@@ -11,7 +11,8 @@ subroutine MPI_Pack_f08(inbuf,incount,datatype,outbuf,outsize,position,comm,ierr
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_pack_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER, INTENT(IN) :: incount, outsize
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, INTENT(INOUT) :: position

--- a/ompi/mpi/fortran/use-mpi-f08/profile/paccumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/paccumulate_f08.F90
@@ -13,7 +13,7 @@ subroutine PMPI_Accumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_accumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/paint_add_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/paint_add_f08.F90
@@ -7,12 +7,12 @@
 
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
-function PMPI_Aint_add_f08(base, diff)
+function PMPI_Aint_add_f08(base, disp)
    use :: mpi_f08_types, only : MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_aint_add_f
    implicit none
    INTEGER(MPI_ADDRESS_KIND) :: PMPI_Aint_add_f08
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: base
-   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: diff
-   PMPI_Aint_add_f08 = ompi_aint_add_f(base, diff)
+   INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: disp
+   PMPI_Aint_add_f08 = ompi_aint_add_f(base, disp)
 end function PMPI_Aint_add_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pbcast_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pbcast_f08.F90
@@ -21,4 +21,4 @@ subroutine PMPI_Bcast_f08(buffer,count,datatype,root,comm,ierror)
    call ompi_bcast_f(buffer,count,datatype%MPI_VAL,root,comm%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
- end subroutine PMPI_Bcast_f08
+end subroutine PMPI_Bcast_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pbuffer_attach_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pbuffer_attach_f08.F90
@@ -10,7 +10,7 @@
 subroutine PMPI_Buffer_attach_f08(buffer,size,ierror)
    use :: mpi_f08, only : ompi_buffer_attach_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buffer
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buffer
    INTEGER, INTENT(IN) :: size
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_create_keyval_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_create_keyval_f08.F90
@@ -25,7 +25,7 @@ subroutine PMPI_Comm_create_keyval_f08(comm_copy_attr_fn,comm_delete_attr_fn,&
 
    fcopy_fn = c_funloc(comm_copy_attr_fn)
    fdelete_fn = c_funloc(comm_delete_attr_fn)
-   call ompi_comm_create_keyval_f(fcopy_fn, fdelete_fn,&
+   call ompi_comm_create_keyval_f(fcopy_fn,fdelete_fn,&
                                   comm_keyval,extra_state,c_ierror)
    if (present(ierror)) ierror = c_ierror
 

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_spawn_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_spawn_f08.F90
@@ -10,7 +10,7 @@ subroutine PMPI_Comm_spawn_f08(command,argv,maxprocs,info,root,comm,intercomm, &
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm
    use :: mpi_f08, only : ompi_comm_spawn_f
    implicit none
-   CHARACTER(LEN=*), INTENT(IN) :: command, argv
+   CHARACTER(LEN=*), INTENT(IN) :: command, argv(*)
    INTEGER, INTENT(IN) :: maxprocs, root
    TYPE(MPI_Info), INTENT(IN) :: info
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_spawn_multiple_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_spawn_multiple_f08.F90
@@ -16,7 +16,7 @@ subroutine PMPI_Comm_spawn_multiple_f08(count,array_of_commands,array_of_argv, &
    implicit none
    INTEGER, INTENT(IN) :: count, root
    INTEGER, INTENT(IN) :: array_of_maxprocs(count)
-   CHARACTER(LEN=*), INTENT(IN) :: array_of_commands(count), array_of_argv(count)
+   CHARACTER(LEN=*), INTENT(IN) :: array_of_commands(count), array_of_argv(count, *)
    TYPE(MPI_Info), INTENT(IN) :: array_of_info(count)
    TYPE(MPI_Comm), INTENT(IN) :: comm
    TYPE(MPI_Comm), INTENT(OUT) :: intercomm

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pcompare_and_swap_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pcompare_and_swap_f08.F90
@@ -13,8 +13,8 @@ subroutine PMPI_Compare_and_swap_f08(origin_addr,compare_addr,result_addr,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_compare_and_swap_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr, compare_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr, compare_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: target_rank
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pfetch_and_op_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pfetch_and_op_f08.F90
@@ -12,8 +12,8 @@ subroutine PMPI_Fetch_and_op_f08(origin_addr,result_addr,datatype,target_rank, &
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_fetch_and_op_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, INTENT(IN) :: target_rank
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pfree_mem_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pfree_mem_f08.F90
@@ -12,7 +12,7 @@
 subroutine PMPI_Free_mem_f08(base,ierror)
    use :: mpi_f08, only : ompi_free_mem_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE,INTENT(IN) :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: base
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pget_accumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pget_accumulate_f08.F90
@@ -14,10 +14,10 @@ subroutine PMPI_Get_accumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_get_accumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, result_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: result_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp
    TYPE(MPI_Datatype), INTENT(IN) :: target_datatype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pget_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pget_f08.F90
@@ -12,7 +12,7 @@ subroutine PMPI_Get_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_get_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pget_processor_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pget_processor_name_f08.F90
@@ -16,5 +16,4 @@ subroutine PMPI_Get_processor_name_f08(name,resultlen,ierror)
    call ompi_get_processor_name_f(name,resultlen,c_ierror,len(name))
    if (present(ierror)) ierror = c_ierror
 
-
 end subroutine PMPI_Get_processor_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pibcast_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pibcast_f08.F90
@@ -22,4 +22,4 @@ subroutine PMPI_Ibcast_f08(buffer,count,datatype,root,comm,request,ierror)
    call ompi_ibcast_f(buffer,count,datatype%MPI_VAL,root,comm%MPI_VAL,request%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
- end subroutine PMPI_Ibcast_f08
+end subroutine PMPI_Ibcast_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pimprobe_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pimprobe_f08.F90
@@ -16,6 +16,8 @@ subroutine PMPI_Improbe_f08(source,tag,comm,flag,message,status,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
+   ! See note in mpi-f-interfaces-bind.h for why we include an
+   ! interface here and call a PMPI_* subroutine below.
    interface
       subroutine PMPI_Improbe(source, tag, comm, flag, message, status, ierror)
         use :: mpi_f08_types, only : MPI_Status
@@ -29,8 +31,6 @@ subroutine PMPI_Improbe_f08(source,tag,comm,flag,message,status,ierror)
       end subroutine PMPI_Improbe
    end interface
 
-   ! See note in ompi/mpi/fortran/use-mpi-f08/iprobe_f09.F90 about why
-   ! we call an PMPI_* subroutine here
    call PMPI_Improbe(source,tag,comm%MPI_VAL,flag,message%MPI_VAL,status,c_ierror)
    if (present(ierror)) ierror = c_ierror
 

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_allgather_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_allgather_f08.F90
@@ -11,7 +11,8 @@ subroutine PMPI_Ineighbor_allgather_f08(sendbuf,sendcount,sendtype,recvbuf,recvc
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_allgather_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_allgatherv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_allgatherv_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Ineighbor_allgatherv_f08(sendbuf,sendcount,sendtype,recvbuf,recv
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_allgatherv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
    INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_alltoall_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_alltoall_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Ineighbor_alltoall_f08(sendbuf,sendcount,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_alltoall_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_alltoallv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_alltoallv_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Ineighbor_alltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recv
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_ineighbor_alltoallv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_alltoallw_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pineighbor_alltoallw_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Ineighbor_alltoallw_f08(sendbuf,sendcounts,sdispls,sendtypes,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_ineighbor_alltoallw_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcounts(*), recvcounts(*)
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: sdispls(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*)

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pinfo_get_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pinfo_get_f08.F90
@@ -19,6 +19,6 @@ subroutine PMPI_Info_get_f08(info,key,valuelen,value,flag,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call PMPI_Info_get(info%MPI_VAL,key,valuelen,value,flag,c_ierror);
+   call PMPI_Info_get(info%MPI_VAL,key,valuelen,value,flag,c_ierror)
    if (present(ierror)) ierror = c_ierror
 end subroutine PMPI_Info_get_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/piprobe_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/piprobe_f08.F90
@@ -31,4 +31,5 @@ subroutine PMPI_Iprobe_f08(source,tag,comm,flag,status,ierror)
 
    call PMPI_Iprobe(source,tag,comm%MPI_VAL,flag,status,c_ierror)
    if (present(ierror)) ierror = c_ierror
+
 end subroutine PMPI_Iprobe_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_allgather_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_allgather_f08.F90
@@ -11,7 +11,8 @@ subroutine PMPI_Neighbor_allgather_f08(sendbuf,sendcount,sendtype,recvbuf,recvco
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_allgather_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_allgatherv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_allgatherv_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Neighbor_allgatherv_f08(sendbuf,sendcount,sendtype,recvbuf,recvc
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_allgatherv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount
    INTEGER, INTENT(IN) :: recvcounts(*), displs(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_alltoall_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_alltoall_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Neighbor_alltoall_f08(sendbuf,sendcount,sendtype,recvbuf,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_alltoall_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, recvcount
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_alltoallv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_alltoallv_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Neighbor_alltoallv_f08(sendbuf,sendcounts,sdispls,sendtype,recvb
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_neighbor_alltoallv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_alltoallw_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pneighbor_alltoallw_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Neighbor_alltoallw_f08(sendbuf,sendcounts,sdispls,sendtypes,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_neighbor_alltoallw_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcounts(*), recvcounts(*)
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: sdispls(*), rdispls(*)
    TYPE(MPI_Datatype), INTENT(IN) :: sendtypes(*)

--- a/ompi/mpi/fortran/use-mpi-f08/profile/ppack_external_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/ppack_external_f08.F90
@@ -13,7 +13,8 @@ subroutine PMPI_Pack_external_f08(datarep,inbuf,incount,datatype,outbuf,outsize,
    use :: mpi_f08, only : ompi_pack_external_f
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: datarep
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER, INTENT(IN) :: incount
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: outsize

--- a/ompi/mpi/fortran/use-mpi-f08/profile/ppack_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/ppack_f08.F90
@@ -11,7 +11,8 @@ subroutine PMPI_Pack_f08(inbuf,incount,datatype,outbuf,outsize,position,comm,ier
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_pack_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER, INTENT(IN) :: incount, outsize
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    INTEGER, INTENT(INOUT) :: position

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pput_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pput_f08.F90
@@ -12,7 +12,7 @@ subroutine PMPI_Put_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_put_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/praccumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/praccumulate_f08.F90
@@ -13,7 +13,7 @@ subroutine PMPI_Raccumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_raccumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/precv_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/precv_init_f08.F90
@@ -11,7 +11,7 @@ subroutine PMPI_Recv_init_f08(buf,count,datatype,source,tag,comm,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_recv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, source, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpi/fortran/use-mpi-f08/profile/prget_accumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/prget_accumulate_f08.F90
@@ -14,10 +14,10 @@ subroutine PMPI_Rget_accumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_rget_accumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, result_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
-   OMPI_FORTRAN_IGNORE_TKR_TYPE :: result_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: result_addr
    TYPE(MPI_Datatype), INTENT(IN) :: result_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp
    TYPE(MPI_Datatype), INTENT(IN) :: target_datatype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/prget_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/prget_f08.F90
@@ -12,7 +12,7 @@ subroutine PMPI_Rget_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_rget_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/prput_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/prput_f08.F90
@@ -12,7 +12,7 @@ subroutine PMPI_Rput_f08(origin_addr,origin_count,origin_datatype,target_rank,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_rput_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psendrecv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psendrecv_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Sendrecv_f08(sendbuf,sendcount,sendtype,dest,sendtag,recvbuf, &
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Status
    use :: mpi_f08, only : ompi_sendrecv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, dest, sendtag, recvcount, source, recvtag
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psendrecv_replace_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psendrecv_replace_f08.F90
@@ -12,7 +12,7 @@ subroutine PMPI_Sendrecv_replace_f08(buf,count,datatype,dest,sendtag,source, &
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Status
    use :: mpi_f08, only : ompi_sendrecv_replace_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, dest, sendtag, source, recvtag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpi/fortran/use-mpi-f08/profile/ptype_vector_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/ptype_vector_f08.F90
@@ -6,7 +6,7 @@
 ! $COPYRIGHT$
 
 subroutine PMPI_Type_vector_f08(count,blocklength,stride,oldtype,newtype,ierror)
-   use :: mpi_f08_types, only : MPI_Datatype, MPI_ADDRESS_KIND
+   use :: mpi_f08_types, only : MPI_Datatype
    use :: mpi_f08, only : ompi_type_vector_f
    implicit none
    INTEGER, INTENT(IN) :: count, blocklength, stride

--- a/ompi/mpi/fortran/use-mpi-f08/profile/punpack_external_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/punpack_external_f08.F90
@@ -12,7 +12,8 @@ subroutine PMPI_Unpack_external_f08(datarep,inbuf,insize,position,outbuf,outcoun
    use :: mpi_f08, only : ompi_unpack_external_f
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: datarep
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: insize
    INTEGER(MPI_ADDRESS_KIND), INTENT(INOUT) :: position
    INTEGER, INTENT(IN) :: outcount

--- a/ompi/mpi/fortran/use-mpi-f08/profile/punpack_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/punpack_f08.F90
@@ -11,7 +11,8 @@ subroutine PMPI_Unpack_f08(inbuf,insize,position,outbuf,outcount,datatype,comm,i
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_unpack_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER, INTENT(IN) :: insize, outcount
    INTEGER, INTENT(INOUT) :: position
    TYPE(MPI_Datatype), INTENT(IN) :: datatype

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pwin_attach_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pwin_attach_f08.F90
@@ -10,7 +10,7 @@ subroutine PMPI_Win_attach_f08(win,base,size,ierror)
    use :: mpi_f08_types, only : MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_win_attach_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: size
    TYPE(MPI_Win), INTENT(IN) :: win
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pwin_create_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pwin_create_f08.F90
@@ -11,7 +11,7 @@ subroutine PMPI_Win_create_f08(base,size,disp_unit,info,comm,win,ierror)
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_win_create_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: size
    INTEGER, INTENT(IN) :: disp_unit
    TYPE(MPI_Info), INTENT(IN) :: info

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pwin_detach_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pwin_detach_f08.F90
@@ -10,7 +10,7 @@ subroutine PMPI_Win_detach_f08(win,base,ierror)
    use :: mpi_f08_types, only : MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_win_detach_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
    TYPE(MPI_Win), INTENT(IN) :: win
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pwin_sync_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pwin_sync_f08.F90
@@ -16,4 +16,4 @@ subroutine PMPI_Win_sync_f08(win,ierror)
    call ompi_win_sync_f(win%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
- end subroutine PMPI_Win_sync_f08
+end subroutine PMPI_Win_sync_f08

--- a/ompi/mpi/fortran/use-mpi-f08/raccumulate_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/raccumulate_f08.F90
@@ -13,7 +13,7 @@ subroutine MPI_Raccumulate_f08(origin_addr,origin_count,origin_datatype,&
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Op, MPI_Win, MPI_Request, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_raccumulate_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN),ASYNCHRONOUS :: origin_addr
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN), ASYNCHRONOUS :: origin_addr
    INTEGER, INTENT(IN) :: origin_count, target_rank, target_count
    TYPE(MPI_Datatype), INTENT(IN) :: origin_datatype
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: target_disp

--- a/ompi/mpi/fortran/use-mpi-f08/recv_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/recv_init_f08.F90
@@ -11,7 +11,7 @@ subroutine MPI_Recv_init_f08(buf,count,datatype,source,tag,comm,request,ierror)
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Request
    use :: mpi_f08, only : ompi_recv_init_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, source, tag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpi/fortran/use-mpi-f08/sendrecv_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/sendrecv_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Sendrecv_f08(sendbuf,sendcount,sendtype,dest,sendtag,recvbuf, &
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Status
    use :: mpi_f08, only : ompi_sendrecv_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf, recvbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: sendbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: recvbuf
    INTEGER, INTENT(IN) :: sendcount, dest, sendtag, recvcount, source, recvtag
    TYPE(MPI_Datatype), INTENT(IN) :: sendtype
    TYPE(MPI_Datatype), INTENT(IN) :: recvtype

--- a/ompi/mpi/fortran/use-mpi-f08/sendrecv_replace_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/sendrecv_replace_f08.F90
@@ -12,7 +12,7 @@ subroutine MPI_Sendrecv_replace_f08(buf,count,datatype,dest,sendtag,source, &
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm, MPI_Status
    use :: mpi_f08, only : ompi_sendrecv_replace_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: buf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: buf
    INTEGER, INTENT(IN) :: count, dest, sendtag, source, recvtag
    TYPE(MPI_Datatype), INTENT(IN) :: datatype
    TYPE(MPI_Comm), INTENT(IN) :: comm

--- a/ompi/mpi/fortran/use-mpi-f08/status_set_cancelled_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/status_set_cancelled_f08.F90
@@ -13,13 +13,15 @@ subroutine MPI_Status_set_cancelled_f08(status,flag,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
+   ! See note in mpi-f-interfaces-bind.h for why we include an
+   ! interface here and call a PMPI_* subroutine below.
    interface
-      subroutine MPI_Status_set_cancelled(status, flag, ierror)
+      subroutine PMPI_Status_set_cancelled(status, flag, ierror)
         use :: mpi_f08_types, only : MPI_Status
         type(MPI_Status), intent(inout) :: status
         logical, intent(in) :: flag
         integer, intent(out) :: ierror
-      end subroutine MPI_Status_set_cancelled
+      end subroutine PMPI_Status_set_cancelled
    end interface
 
    call PMPI_Status_set_cancelled(status,flag,c_ierror)

--- a/ompi/mpi/fortran/use-mpi-f08/type_dup_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/type_dup_f08.F90
@@ -5,16 +5,16 @@
 !                         All rights reserved.
 ! $COPYRIGHT$
 
-subroutine MPI_Type_dup_f08(datatype,newtype,ierror)
+subroutine MPI_Type_dup_f08(oldtype,newtype,ierror)
    use :: mpi_f08_types, only : MPI_Datatype
    use :: mpi_f08, only : ompi_type_dup_f
    implicit none
-   TYPE(MPI_Datatype), INTENT(IN) :: datatype
+   TYPE(MPI_Datatype), INTENT(IN) :: oldtype
    TYPE(MPI_Datatype), INTENT(OUT) :: newtype
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_type_dup_f(datatype%MPI_VAL,newtype%MPI_VAL,c_ierror)
+   call ompi_type_dup_f(oldtype%MPI_VAL,newtype%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Type_dup_f08

--- a/ompi/mpi/fortran/use-mpi-f08/unpack_external_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/unpack_external_f08.F90
@@ -12,7 +12,8 @@ subroutine MPI_Unpack_external_f08(datarep,inbuf,insize,position,outbuf,outcount
    use :: mpi_f08, only : ompi_unpack_external_f
    implicit none
    CHARACTER(LEN=*), INTENT(IN) :: datarep
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: insize
    INTEGER(MPI_ADDRESS_KIND), INTENT(INOUT) :: position
    INTEGER, INTENT(IN) :: outcount

--- a/ompi/mpi/fortran/use-mpi-f08/unpack_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/unpack_f08.F90
@@ -11,7 +11,8 @@ subroutine MPI_Unpack_f08(inbuf,insize,position,outbuf,outcount,datatype,comm,ie
    use :: mpi_f08_types, only : MPI_Datatype, MPI_Comm
    use :: mpi_f08, only : ompi_unpack_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf, outbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: inbuf
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: outbuf
    INTEGER, INTENT(IN) :: insize, outcount
    INTEGER, INTENT(INOUT) :: position
    TYPE(MPI_Datatype), INTENT(IN) :: datatype

--- a/ompi/mpi/fortran/use-mpi-f08/win_attach_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/win_attach_f08.F90
@@ -10,7 +10,7 @@ subroutine MPI_Win_attach_f08(win,base,size,ierror)
    use :: mpi_f08_types, only : MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_win_attach_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: size
    TYPE(MPI_Win), INTENT(IN) :: win
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror

--- a/ompi/mpi/fortran/use-mpi-f08/win_create_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/win_create_f08.F90
@@ -11,7 +11,7 @@ subroutine MPI_Win_create_f08(base,size,disp_unit,info,comm,win,ierror)
    use :: mpi_f08_types, only : MPI_Info, MPI_Comm, MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_win_create_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
    INTEGER(MPI_ADDRESS_KIND), INTENT(IN) :: size
    INTEGER, INTENT(IN) :: disp_unit
    TYPE(MPI_Info), INTENT(IN) :: info

--- a/ompi/mpi/fortran/use-mpi-f08/win_detach_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/win_detach_f08.F90
@@ -10,7 +10,7 @@ subroutine MPI_Win_detach_f08(win,base,ierror)
    use :: mpi_f08_types, only : MPI_Win, MPI_ADDRESS_KIND
    use :: mpi_f08, only : ompi_win_detach_f
    implicit none
-   OMPI_FORTRAN_IGNORE_TKR_TYPE, INTENT(IN) :: base
+   OMPI_FORTRAN_IGNORE_TKR_TYPE :: base
    TYPE(MPI_Win), INTENT(IN) :: win
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror

--- a/ompi/mpi/fortran/use-mpi-f08/win_sync_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/win_sync_f08.F90
@@ -16,4 +16,4 @@ subroutine MPI_Win_sync_f08(win,ierror)
    call ompi_win_sync_f(win%MPI_VAL,c_ierror)
    if (present(ierror)) ierror = c_ierror
 
- end subroutine MPI_Win_sync_f08
+end subroutine MPI_Win_sync_f08


### PR DESCRIPTION
This is v3.1.x version of #5799.

@jsquyres Please review.
Please review #5843 too (for v4.0.x).

Following the commit f750c6932c, I compared
`ompi/mpi/fortran/use-mpi-f08/*.F90` and
`ompi/mpi/fortran/use-mpi-f08/profile/p*.F90`, and
`ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90` and
`ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90`.

There are many differences. Some are bugs of `MPI_*`, some are bugs of `PMPI_*`. I'm not sure how these bugs affect applications.

To make it easy to compare these files future, I also removed editorial differences.

(back-ported from commit cf6d28cb66981cf315f84e5efb8f8256b6c6a3a4)