### PR TITLE
java: Fix javadoc build failure with OpenJDK 11

### DIFF
--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -653,7 +653,7 @@ public class Comm implements Freeable, Cloneable
 
 	/**
 	 * Start a buffered mode, nonblocking send.
-	 * <p>Java binding of the MPI operation <tt>MPI_IBSEND</tt>.
+	 * <p>Java binding of the MPI operation {@code MPI_IBSEND}.
 	 * @param buf   send buffer
 	 * @param count number of items to send
 	 * @param type  datatype of each item in send buffer


### PR DESCRIPTION
OpenJDK 11 changed the default javadoc output HTML version to HTML 5 from HTML 4.01. It causes an error on building Open MPI configured with `--enable-mpi-java` (default: disable). This fix is compatible with older OpenJDK.

I don't know whether this problem exists with other vender's JDKs. But this fix should be compatible with other JDKs because the new syntax is used in other places in the same file.

Thanks to Siegmar Gross for the bug report.
