### PR TITLE
v4.0.x: java: Fix javadoc build failure with OpenJDK 11

### DIFF
--- a/ompi/mpi/java/java/Comm.java
+++ b/ompi/mpi/java/java/Comm.java
@@ -653,7 +653,7 @@ public class Comm implements Freeable, Cloneable
 
 	/**
 	 * Start a buffered mode, nonblocking send.
-	 * <p>Java binding of the MPI operation <tt>MPI_IBSEND</tt>.
+	 * <p>Java binding of the MPI operation {@code MPI_IBSEND}.
 	 * @param buf   send buffer
 	 * @param count number of items to send
 	 * @param type  datatype of each item in send buffer


### PR DESCRIPTION
@ggouaillardet Please review.

Though this commit changes only a comment part, it is needed for release branches because Open MPI cannot be built with the following conditions (`javadoc` error during `make`).

- OpenJDK 11 (released on 25 September 2018)
- `configure --enable-mpi-java` (not default)

Need NEWS update?

----

OpenJDK 11 changed the default javadoc output HTML version to HTML 5 from HTML 4.01. It causes an error on building Open MPI configured with `--enable-mpi-java` (default: disable). This fix is compatible with older OpenJDK.

I don't know whether this problem exists with other vender's JDKs. But this fix should be compatible with other JDKs because the new syntax is used in other places in the same file.

Thanks to Siegmar Gross for the bug report.

(cherry picked from commit b491b454dc304a72c03970326880fbd01641a3d3)