### PR TITLE
btl/uct: bug fixes and general improvements

### DIFF
--- a/opal/mca/btl/uct/btl_uct.h
+++ b/opal/mca/btl/uct/btl_uct.h
@@ -68,7 +68,7 @@ struct mca_btl_uct_module_t {
     opal_hash_table_t id_to_endpoint;
 
     /** mutex to protect the module */
-    opal_mutex_t lock;
+    opal_recursive_mutex_t lock;
 
     /** async context */
     ucs_async_context_t *ucs_async;
@@ -108,6 +108,9 @@ struct mca_btl_uct_module_t {
 
     /** frags that were waiting on connections that are now ready to send */
     opal_list_t pending_frags;
+
+    /** pending connection requests */
+    opal_fifo_t pending_connection_reqs;
 };
 typedef struct mca_btl_uct_module_t mca_btl_uct_module_t;
 
@@ -278,6 +281,7 @@ ucs_status_t mca_btl_uct_am_handler (void *arg, void *data, size_t length, unsig
 struct mca_btl_base_endpoint_t *mca_btl_uct_get_ep (struct mca_btl_base_module_t *module, opal_proc_t *proc);
 
 int mca_btl_uct_query_tls (mca_btl_uct_module_t *module, mca_btl_uct_md_t *md, uct_tl_resource_desc_t *tl_descs, unsigned tl_count);
+int mca_btl_uct_process_connection_request (mca_btl_uct_module_t *module, mca_btl_uct_conn_req_t *req);
 
 /**
  * @brief Checks if a tl is suitable for using for RDMA

--- a/opal/mca/btl/uct/btl_uct.h
+++ b/opal/mca/btl/uct/btl_uct.h
@@ -106,9 +106,6 @@ struct mca_btl_uct_module_t {
     /** large registered frags for packing non-contiguous data */
     opal_free_list_t max_frags;
 
-    /** RDMA completions */
-    opal_free_list_t rdma_completions;
-
     /** frags that were waiting on connections that are now ready to send */
     opal_list_t pending_frags;
 };

--- a/opal/mca/btl/uct/btl_uct.h
+++ b/opal/mca/btl/uct/btl_uct.h
@@ -286,7 +286,7 @@ int mca_btl_uct_query_tls (mca_btl_uct_module_t *module, mca_btl_uct_md_t *md, u
  */
 static inline bool mca_btl_uct_tl_supports_rdma (mca_btl_uct_tl_t *tl)
 {
-    return (tl->uct_iface_attr.cap.flags & (UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_GET_ZCOPY)) ==
+    return (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & (UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_GET_ZCOPY)) ==
         (UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_GET_ZCOPY);
 }
 
@@ -295,7 +295,7 @@ static inline bool mca_btl_uct_tl_supports_rdma (mca_btl_uct_tl_t *tl)
  */
 static inline bool mca_btl_uct_tl_support_am (mca_btl_uct_tl_t *tl)
 {
-    return (tl->uct_iface_attr.cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_AM_ZCOPY));
+    return (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_AM_ZCOPY));
 }
 
 /**
@@ -305,7 +305,7 @@ static inline bool mca_btl_uct_tl_support_am (mca_btl_uct_tl_t *tl)
  */
 static inline bool mca_btl_uct_tl_supports_conn (mca_btl_uct_tl_t *tl)
 {
-    return (tl->uct_iface_attr.cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CONNECT_TO_IFACE)) ==
+    return (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CONNECT_TO_IFACE)) ==
         (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CONNECT_TO_IFACE);
 }
 
@@ -316,7 +316,7 @@ static inline bool mca_btl_uct_tl_supports_conn (mca_btl_uct_tl_t *tl)
  */
 static inline bool mca_btl_uct_tl_requires_connection_tl (mca_btl_uct_tl_t *tl)
 {
-    return !(tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
+    return !(MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
 }
 
 END_C_DECLS

--- a/opal/mca/btl/uct/btl_uct_am.h
+++ b/opal/mca/btl/uct/btl_uct_am.h
@@ -27,8 +27,7 @@ int mca_btl_uct_sendi (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endp
 int mca_btl_uct_send (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint, mca_btl_base_descriptor_t *descriptor,
                       mca_btl_base_tag_t tag);
 
-int mca_btl_uct_send_frag (mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint, mca_btl_uct_base_frag_t *frag,
-                           int32_t flags, mca_btl_uct_device_context_t *context, uct_ep_h ep_handle);
+int mca_btl_uct_send_frag (mca_btl_uct_module_t *uct_btl, mca_btl_uct_base_frag_t *frag, bool append);
 
 mca_btl_base_descriptor_t *mca_btl_uct_alloc (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint,
                                               uint8_t order, size_t size, uint32_t flags);

--- a/opal/mca/btl/uct/btl_uct_amo.c
+++ b/opal/mca/btl/uct/btl_uct_amo.c
@@ -104,8 +104,10 @@ int mca_btl_uct_afop (struct mca_btl_base_module_t *btl, struct mca_btl_base_end
         rc = OPAL_SUCCESS;
     } else if (UCS_OK == ucs_status) {
         rc = 1;
+        mca_btl_uct_uct_completion_release (comp);
     } else {
         rc = OPAL_ERR_OUT_OF_RESOURCE;
+        mca_btl_uct_uct_completion_release (comp);
     }
 
     uct_rkey_release (&rkey);
@@ -176,8 +178,10 @@ int mca_btl_uct_acswap (struct mca_btl_base_module_t *btl, struct mca_btl_base_e
         rc = OPAL_SUCCESS;
     } else if (UCS_OK == ucs_status) {
         rc = 1;
+        mca_btl_uct_uct_completion_release (comp);
     } else {
         rc = OPAL_ERR_OUT_OF_RESOURCE;
+        mca_btl_uct_uct_completion_release (comp);
     }
 
     uct_rkey_release (&rkey);

--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -149,12 +149,12 @@ static size_t mca_btl_uct_tl_modex_size (mca_btl_uct_tl_t *tl)
 {
     const size_t size = strlen (tl->uct_tl_name) + 1;
 
-    if (tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+    if (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
         /* pad out to a multiple of 4 bytes */
-        return (4 + 3 + size + tl->uct_iface_attr.device_addr_len + tl->uct_iface_attr.iface_addr_len) & ~3;
+        return (4 + 3 + size + MCA_BTL_UCT_TL_ATTR(tl, 0).device_addr_len + MCA_BTL_UCT_TL_ATTR(tl, 0).iface_addr_len) & ~3;
     }
 
-    return (4 + 3 + size + tl->uct_iface_attr.device_addr_len) & ~3;
+    return (4 + 3 + size + MCA_BTL_UCT_TL_ATTR(tl, 0).device_addr_len) & ~3;
 }
 
 static size_t mca_btl_uct_module_modex_size (mca_btl_uct_module_t *module)
@@ -193,13 +193,13 @@ static size_t mca_btl_uct_tl_modex_pack (mca_btl_uct_tl_t *tl, uint8_t *modex_da
      * the same endpoint since we are only doing RDMA. if any of these assumptions are
      * wrong then we can't delay creating the other contexts and must include their
      * information in the modex. */
-    if (tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+    if (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
         uct_iface_get_address (dev_context->uct_iface, (uct_iface_addr_t *) modex_data);
-        modex_data += tl->uct_iface_attr.iface_addr_len;
+        modex_data += MCA_BTL_UCT_TL_ATTR(tl, 0).iface_addr_len;
     }
 
     uct_iface_get_device_address (dev_context->uct_iface, (uct_device_addr_t *) modex_data);
-    modex_data += tl->uct_iface_attr.device_addr_len;
+    modex_data += MCA_BTL_UCT_TL_ATTR(tl, 0).device_addr_len;
 
     return modex_size;
 }

--- a/opal/mca/btl/uct/btl_uct_device_context.h
+++ b/opal/mca/btl/uct/btl_uct_device_context.h
@@ -23,7 +23,7 @@
  * @param[in] tl         btl uct tl pointer
  * @param[in] context_id identifier for this context (0..MCA_BTL_UCT_MAX_WORKERS-1)
  */
-mca_btl_uct_device_context_t *mca_btl_uct_context_create (mca_btl_uct_module_t *module, mca_btl_uct_tl_t *tl, int context_id);
+mca_btl_uct_device_context_t *mca_btl_uct_context_create (mca_btl_uct_module_t *module, mca_btl_uct_tl_t *tl, int context_id, bool enable_progress);
 
 /**
  * @brief Destroy a device context and release all resources
@@ -91,7 +91,7 @@ mca_btl_uct_module_get_tl_context_specific (mca_btl_uct_module_t *module, mca_bt
     if (OPAL_UNLIKELY(NULL == context)) {
         mca_btl_uct_device_context_t *new_context;
 
-        new_context = mca_btl_uct_context_create (module, tl, context_id);
+        new_context = mca_btl_uct_context_create (module, tl, context_id, true);
         if (!opal_atomic_compare_exchange_strong_ptr (&tl->uct_dev_contexts[context_id], &context, new_context)) {
             mca_btl_uct_context_destroy (new_context);
         } else {

--- a/opal/mca/btl/uct/btl_uct_device_context.h
+++ b/opal/mca/btl/uct/btl_uct_device_context.h
@@ -89,14 +89,12 @@ mca_btl_uct_module_get_tl_context_specific (mca_btl_uct_module_t *module, mca_bt
     mca_btl_uct_device_context_t *context = tl->uct_dev_contexts[context_id];
 
     if (OPAL_UNLIKELY(NULL == context)) {
-        mca_btl_uct_device_context_t *new_context;
-
-        new_context = mca_btl_uct_context_create (module, tl, context_id, true);
-        if (!opal_atomic_compare_exchange_strong_ptr (&tl->uct_dev_contexts[context_id], &context, new_context)) {
-            mca_btl_uct_context_destroy (new_context);
-        } else {
-            context = new_context;
+        OPAL_THREAD_LOCK(&module->lock);
+        context = tl->uct_dev_contexts[context_id];
+        if (OPAL_UNLIKELY(NULL == context)) {
+            context = tl->uct_dev_contexts[context_id] = mca_btl_uct_context_create (module, tl, context_id, true);
         }
+        OPAL_THREAD_UNLOCK(&module->lock);
     }
 
     return context;

--- a/opal/mca/btl/uct/btl_uct_endpoint.c
+++ b/opal/mca/btl/uct/btl_uct_endpoint.c
@@ -109,15 +109,14 @@ static int mca_btl_uct_endpoint_connect_iface (mca_btl_uct_module_t *uct_btl, mc
 
     /* easy case. just connect to the interface */
     iface_addr = (uct_iface_addr_t *) tl_data;
-    device_addr = (uct_device_addr_t *) ((uintptr_t) iface_addr + tl->uct_iface_attr.iface_addr_len);
+    device_addr = (uct_device_addr_t *) ((uintptr_t) iface_addr + MCA_BTL_UCT_TL_ATTR(tl, tl_context->context_id).iface_addr_len);
 
     BTL_VERBOSE(("connecting endpoint to interface"));
 
     mca_btl_uct_context_lock (tl_context);
     ucs_status = uct_ep_create_connected (tl_context->uct_iface, device_addr, iface_addr, &tl_endpoint->uct_ep);
-    mca_btl_uct_context_unlock (tl_context);
-
     tl_endpoint->flags = MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY;
+    mca_btl_uct_context_unlock (tl_context);
 
     return (UCS_OK == ucs_status) ? OPAL_SUCCESS : OPAL_ERROR;
 }
@@ -189,7 +188,7 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
                                                   mca_btl_uct_tl_endpoint_t *tl_endpoint, uint8_t *tl_data,
                                                   uint8_t *conn_tl_data, void *ep_addr)
 {
-    size_t request_length = sizeof (mca_btl_uct_conn_req_t) + tl->uct_iface_attr.ep_addr_len;
+    size_t request_length = sizeof (mca_btl_uct_conn_req_t) + MCA_BTL_UCT_TL_ATTR(tl, tl_context->context_id).ep_addr_len;
     mca_btl_uct_connection_ep_t *conn_ep = endpoint->conn_ep;
     mca_btl_uct_tl_t *conn_tl = uct_btl->conn_tl;
     mca_btl_uct_device_context_t *conn_tl_context = conn_tl->uct_dev_contexts[0];
@@ -208,7 +207,7 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
                      opal_process_name_print (endpoint->ep_proc->proc_name)));
 
         iface_addr = (uct_iface_addr_t *) conn_tl_data;
-        device_addr = (uct_device_addr_t *) ((uintptr_t) conn_tl_data + conn_tl->uct_iface_attr.iface_addr_len);
+        device_addr = (uct_device_addr_t *) ((uintptr_t) conn_tl_data + MCA_BTL_UCT_TL_ATTR(conn_tl, 0).iface_addr_len);
 
         endpoint->conn_ep = conn_ep = OBJ_NEW(mca_btl_uct_connection_ep_t);
         if (OPAL_UNLIKELY(NULL == conn_ep)) {

--- a/opal/mca/btl/uct/btl_uct_endpoint.c
+++ b/opal/mca/btl/uct/btl_uct_endpoint.c
@@ -56,7 +56,7 @@ mca_btl_base_endpoint_t *mca_btl_uct_endpoint_create (opal_proc_t *proc)
 
 static unsigned char *mca_btl_uct_process_modex_tl (unsigned char *modex_data)
 {
-    BTL_VERBOSE(("processing modex for tl %s. size: %u", modex_data, *((uint32_t *) modex_data)));
+    BTL_VERBOSE(("processing modex for tl %s. size: %u", modex_data + 4, *((uint32_t *) modex_data)));
 
     /* skip size and name */
     return modex_data + 4 + strlen ((char *) modex_data + 4) + 1;
@@ -139,13 +139,13 @@ OBJ_CLASS_INSTANCE(mca_btl_uct_connection_ep_t, opal_object_t, mca_btl_uct_conne
 
 static int mca_btl_uct_endpoint_send_conn_req (mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint,
                                                mca_btl_uct_device_context_t *conn_tl_context,
-                                               int64_t type, void *request, size_t request_length)
+                                               mca_btl_uct_conn_req_t *request, size_t request_length)
 {
     mca_btl_uct_connection_ep_t *conn_ep = endpoint->conn_ep;
     ucs_status_t ucs_status;
 
-    BTL_VERBOSE(("sending connection request to peer. type: %" PRId64 ", length: %" PRIsize_t,
-                 type, request_length));
+    BTL_VERBOSE(("sending connection request to peer. context id: %d, type: %d, length: %" PRIsize_t,
+                 request->context_id, request->type, request_length));
 
     OBJ_RETAIN(endpoint->conn_ep);
 
@@ -154,7 +154,8 @@ static int mca_btl_uct_endpoint_send_conn_req (mca_btl_uct_module_t *uct_btl, mc
 
     do {
         MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
-                ucs_status = uct_ep_am_short (conn_ep->uct_ep, MCA_BTL_UCT_CONNECT_RDMA, type, request, request_length);
+                ucs_status = uct_ep_am_short (conn_ep->uct_ep, MCA_BTL_UCT_CONNECT_RDMA, request->type, request,
+                                              request_length);
             });
         if (OPAL_LIKELY(UCS_OK == ucs_status)) {
             break;
@@ -169,12 +170,10 @@ static int mca_btl_uct_endpoint_send_conn_req (mca_btl_uct_module_t *uct_btl, mc
     } while (1);
 
     /* for now we just wait for the connection request to complete before continuing */
-    MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
-            do {
-                uct_worker_progress (conn_tl_context->uct_worker);
-                ucs_status = uct_ep_flush (conn_ep->uct_ep, 0, NULL);
-            } while (UCS_INPROGRESS == ucs_status);
-        });
+    do {
+        ucs_status = uct_ep_flush (conn_ep->uct_ep, 0, NULL);
+        mca_btl_uct_context_progress (conn_tl_context);
+    } while (UCS_INPROGRESS == ucs_status);
 
     opal_mutex_lock (&endpoint->ep_lock);
 
@@ -232,6 +231,7 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
     request->proc_name = OPAL_PROC_MY_NAME;
     request->context_id = tl_context->context_id;
     request->tl_index = tl->tl_index;
+    request->type = !!(ep_addr);
 
     if (NULL == tl_endpoint->uct_ep) {
         BTL_VERBOSE(("allocating endpoint for peer %s and sending connection data",
@@ -244,48 +244,37 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
             OBJ_RELEASE(endpoint->conn_ep);
             return OPAL_ERROR;
         }
+    }
 
-        /* fill in connection request */
-        ucs_status = uct_ep_get_address (tl_endpoint->uct_ep, (uct_ep_addr_t *) request->ep_addr);
+    if (ep_addr) {
+        BTL_VERBOSE(("using remote endpoint address to connect endpoint for tl %s, index %d. ep_addr = %p",
+                     tl->uct_tl_name, tl_context->context_id, ep_addr));
+
+        /* NTH: there is no need to lock the device context in this case */
+        ucs_status = uct_ep_connect_to_ep (tl_endpoint->uct_ep, (uct_device_addr_t *) tl_data, ep_addr);
         if (UCS_OK != ucs_status) {
-            /* this is a fatal a fatal error */
-            OBJ_RELEASE(endpoint->conn_ep);
-            uct_ep_destroy (tl_endpoint->uct_ep);
-            tl_endpoint->uct_ep = NULL;
-            return OPAL_ERROR;
-        }
-
-        rc = mca_btl_uct_endpoint_send_conn_req (uct_btl, endpoint, conn_tl_context, 0, request,
-                                                 request_length);
-        if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
-            OBJ_RELEASE(endpoint->conn_ep);
-            uct_ep_destroy (tl_endpoint->uct_ep);
-            tl_endpoint->uct_ep = NULL;
             return OPAL_ERROR;
         }
     }
 
-    if (ep_addr) {
-        BTL_VERBOSE(("using remote endpoint address to connect endpoint. ep_addr = %p", ep_addr));
+    /* fill in connection request */
+    ucs_status = uct_ep_get_address (tl_endpoint->uct_ep, (uct_ep_addr_t *) request->ep_addr);
+    if (UCS_OK != ucs_status) {
+        /* this is a fatal a fatal error */
+        OBJ_RELEASE(endpoint->conn_ep);
+        uct_ep_destroy (tl_endpoint->uct_ep);
+        tl_endpoint->uct_ep = NULL;
+        return OPAL_ERROR;
+    }
 
-        device_addr = (uct_device_addr_t *) tl_data;
-
-        /* NTH: there is no need to lock the device context in this case */
-        ucs_status = uct_ep_connect_to_ep (tl_endpoint->uct_ep, device_addr, ep_addr);
-        if (UCS_OK != ucs_status) {
-            return OPAL_ERROR;
-        }
-
-        /* let the remote side know that the connection has been established and
-         * wait for the message to be sent */
-        rc = mca_btl_uct_endpoint_send_conn_req (uct_btl, endpoint, conn_tl_context, 1, request,
-                                                 sizeof (mca_btl_uct_conn_req_t));
-        if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
-            OBJ_RELEASE(endpoint->conn_ep);
-            uct_ep_destroy (tl_endpoint->uct_ep);
-            tl_endpoint->uct_ep = NULL;
-            return OPAL_ERROR;
-        }
+    /* let the remote side know that the connection has been established and
+     * wait for the message to be sent */
+    rc = mca_btl_uct_endpoint_send_conn_req (uct_btl, endpoint, conn_tl_context, request, request_length);
+    if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
+        OBJ_RELEASE(endpoint->conn_ep);
+        uct_ep_destroy (tl_endpoint->uct_ep);
+        tl_endpoint->uct_ep = NULL;
+        return OPAL_ERROR;
     }
 
     return (tl_endpoint->flags & MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY) ? OPAL_SUCCESS : OPAL_ERR_OUT_OF_RESOURCE;

--- a/opal/mca/btl/uct/btl_uct_endpoint.h
+++ b/opal/mca/btl/uct/btl_uct_endpoint.h
@@ -72,7 +72,8 @@ static inline int mca_btl_uct_endpoint_check (mca_btl_uct_module_t *module, mca_
 
     rc = mca_btl_uct_endpoint_connect (module, endpoint, ep_index, NULL, tl_index);
     *ep_handle = endpoint->uct_eps[ep_index][tl_index].uct_ep;
-    BTL_VERBOSE(("mca_btl_uct_endpoint_connect returned %d", rc));
+    BTL_VERBOSE(("mca_btl_uct_endpoint_connect returned %d. context id = %d, flags = 0x%x", rc, ep_index,
+                 MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY & endpoint->uct_eps[ep_index][tl_index].flags));
     return rc;
 }
 

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -74,7 +74,6 @@ static int mca_btl_uct_add_procs (mca_btl_base_module_t *btl,
 
     if (false == uct_module->initialized) {
         mca_btl_uct_tl_t *am_tl = uct_module->am_tl;
-        mca_btl_uct_tl_t *rdma_tl = uct_module->rdma_tl;
 
         /* NTH: might want to vary this size based off the universe size (if
          * one exists). the table is only used for connection lookup and
@@ -277,6 +276,7 @@ int mca_btl_uct_finalize (mca_btl_base_module_t* btl)
     OBJ_DESTRUCT(&uct_module->max_frags);
     OBJ_DESTRUCT(&uct_module->pending_frags);
     OBJ_DESTRUCT(&uct_module->lock);
+    OBJ_DESTRUCT(&uct_module->pending_connection_reqs);
 
     if (uct_module->rcache) {
         mca_rcache_base_module_destroy (uct_module->rcache);

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -31,15 +31,6 @@
 #include "btl_uct_endpoint.h"
 #include "btl_uct_am.h"
 
-#include "opal/memoryhooks/memory.h"
-#include "opal/mca/memory/base/base.h"
-#include <ucm/api/ucm.h>
-
-static void mca_btl_uct_mem_release_cb(void *buf, size_t length, void *cbdata, bool from_alloc)
-{
-    ucm_vm_munmap(buf, length);
-}
-
 struct mca_btl_base_endpoint_t *mca_btl_uct_get_ep (struct mca_btl_base_module_t *module, opal_proc_t *proc)
 {
     mca_btl_uct_module_t *uct_module = (mca_btl_uct_module_t *) module;
@@ -109,18 +100,6 @@ static int mca_btl_uct_add_procs (mca_btl_base_module_t *btl,
                                       opal_cache_line_size, OBJ_CLASS(mca_btl_uct_base_frag_t),
                                       btl->btl_max_send_size, opal_cache_line_size, 0, 128, 8,
                                       NULL, 0, uct_module->rcache, NULL, NULL);
-        }
-
-        if (rdma_tl) {
-            rc = opal_free_list_init (&uct_module->rdma_completions, sizeof (mca_btl_uct_uct_completion_t),
-                                      opal_cache_line_size, OBJ_CLASS(mca_btl_uct_uct_completion_t),
-                                      0, opal_cache_line_size, 0, 4096, 128, NULL, 0, NULL, NULL,
-                                      NULL);
-        }
-
-        if (mca_btl_uct_component.disable_ucx_memory_hooks) {
-            ucm_set_external_event(UCM_EVENT_VM_UNMAPPED);
-            opal_mem_hooks_register_release(mca_btl_uct_mem_release_cb, NULL);
         }
 
         uct_module->initialized = true;
@@ -288,10 +267,6 @@ int mca_btl_uct_finalize (mca_btl_base_module_t* btl)
     mca_btl_uct_endpoint_t *endpoint;
     uint64_t key;
 
-    if (mca_btl_uct_component.disable_ucx_memory_hooks) {
-        opal_mem_hooks_unregister_release (mca_btl_uct_mem_release_cb);
-    }
-
     /* clean up any leftover endpoints */
     OPAL_HASH_TABLE_FOREACH(key, uint64, endpoint, &uct_module->id_to_endpoint) {
         OBJ_RELEASE(endpoint);
@@ -300,7 +275,6 @@ int mca_btl_uct_finalize (mca_btl_base_module_t* btl)
     OBJ_DESTRUCT(&uct_module->short_frags);
     OBJ_DESTRUCT(&uct_module->eager_frags);
     OBJ_DESTRUCT(&uct_module->max_frags);
-    OBJ_DESTRUCT(&uct_module->rdma_completions);
     OBJ_DESTRUCT(&uct_module->pending_frags);
     OBJ_DESTRUCT(&uct_module->lock);
 

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -88,7 +88,7 @@ static int mca_btl_uct_add_procs (mca_btl_base_module_t *btl,
         if (am_tl) {
             rc = opal_free_list_init (&uct_module->short_frags, sizeof (mca_btl_uct_base_frag_t),
                                       opal_cache_line_size, OBJ_CLASS(mca_btl_uct_base_frag_t),
-                                      am_tl->uct_iface_attr.cap.am.max_short, opal_cache_line_size,
+                                      MCA_BTL_UCT_TL_ATTR(am_tl, 0).cap.am.max_short, opal_cache_line_size,
                                       0, 1024, 64, NULL, 0, NULL, NULL, NULL);
 
             rc = opal_free_list_init (&uct_module->eager_frags, sizeof (mca_btl_uct_base_frag_t),

--- a/opal/mca/btl/uct/btl_uct_rdma.c
+++ b/opal/mca/btl/uct/btl_uct_rdma.c
@@ -98,13 +98,12 @@ int mca_btl_uct_get (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
 
     mca_btl_uct_context_lock (context);
 
-    if (size <= uct_btl->rdma_tl->uct_iface_attr.cap.get.max_bcopy) {
+    if (size <= MCA_BTL_UCT_TL_ATTR(uct_btl->rdma_tl, context->context_id).cap.get.max_bcopy) {
         ucs_status = uct_ep_get_bcopy (ep_handle, mca_btl_uct_get_unpack, local_address, size, remote_address,
                                        rkey.rkey, &comp->uct_comp);
     } else {
         uct_iov_t iov = {.buffer = local_address, .length = size, .stride = 0, .count = 1,
                          .memh = MCA_BTL_UCT_REG_REMOTE_TO_LOCAL(local_handle)->uct_memh};
-
         ucs_status = uct_ep_get_zcopy (ep_handle, &iov, 1, remote_address, rkey.rkey, &comp->uct_comp);
     }
 
@@ -183,7 +182,7 @@ int mca_btl_uct_put (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
 
     /* determine what UCT prototol should be used */
     if (size <= uct_btl->super.btl_put_local_registration_threshold) {
-        use_short = size <= uct_btl->rdma_tl->uct_iface_attr.cap.put.max_short;
+        use_short = size <= MCA_BTL_UCT_TL_ATTR(uct_btl->rdma_tl, context->context_id).cap.put.max_short;
         use_bcopy = !use_short;
     }
 

--- a/opal/mca/btl/uct/btl_uct_types.h
+++ b/opal/mca/btl/uct/btl_uct_types.h
@@ -77,6 +77,9 @@ struct mca_btl_uct_conn_req_t {
     /** name of the requesting process */
     opal_process_name_t proc_name;
 
+    /** request type: 0 == endpoint data, 1 == endpoint data + remote ready */
+    int type;
+
     /** context id that should be connected */
     int context_id;
 
@@ -153,6 +156,9 @@ struct mca_btl_uct_device_context_t {
 
     /** progress is enabled on this context */
     bool progress_enabled;
+
+    /** context is in AM callback */
+    volatile bool in_am_callback;
 };
 
 typedef struct mca_btl_uct_device_context_t mca_btl_uct_device_context_t;
@@ -238,8 +244,8 @@ struct mca_btl_uct_base_frag_t {
     /** module this fragment is associated with */
     struct mca_btl_uct_module_t *btl;
 
-    /** context this fragment is waiting on */
-    int context_id;
+    /* tl context */
+    mca_btl_uct_device_context_t *context;
 
     /** is this frag ready to send (only used when pending) */
     bool ready;
@@ -325,5 +331,13 @@ typedef struct mca_btl_uct_tl_t mca_btl_uct_tl_t;
 OBJ_CLASS_DECLARATION(mca_btl_uct_tl_t);
 
 #define MCA_BTL_UCT_TL_ATTR(tl, context_id) (tl)->uct_dev_contexts[(context_id)]->uct_iface_attr
+
+struct mca_btl_uct_pending_connection_request_t {
+    opal_list_item_t super;
+    uint8_t request_data[];
+};
+
+typedef struct mca_btl_uct_pending_connection_request_t mca_btl_uct_pending_connection_request_t;
+OBJ_CLASS_DECLARATION(mca_btl_uct_pending_connection_request_t);
 
 #endif /* !defined(BTL_UCT_TYPES_H) */

--- a/opal/mca/btl/uct/btl_uct_types.h
+++ b/opal/mca/btl/uct/btl_uct_types.h
@@ -141,6 +141,9 @@ struct mca_btl_uct_device_context_t {
     /** UCT interface handle */
     uct_iface_h uct_iface;
 
+    /** interface attributes */
+    uct_iface_attr_t uct_iface_attr;
+
     /** RDMA completions */
     opal_free_list_t rdma_completions;
 
@@ -307,9 +310,6 @@ struct mca_btl_uct_tl_t {
     /** device name for this tl (used for creating device contexts) */
     char *uct_dev_name;
 
-    /** interface attributes */
-    uct_iface_attr_t uct_iface_attr;
-
     /** maxiumum number of device contexts that can be created */
     int max_device_contexts;
 
@@ -323,5 +323,7 @@ struct mca_btl_uct_tl_t {
 
 typedef struct mca_btl_uct_tl_t mca_btl_uct_tl_t;
 OBJ_CLASS_DECLARATION(mca_btl_uct_tl_t);
+
+#define MCA_BTL_UCT_TL_ATTR(tl, context_id) (tl)->uct_dev_contexts[(context_id)]->uct_iface_attr
 
 #endif /* !defined(BTL_UCT_TYPES_H) */

--- a/opal/mca/btl/uct/btl_uct_types.h
+++ b/opal/mca/btl/uct/btl_uct_types.h
@@ -141,9 +141,15 @@ struct mca_btl_uct_device_context_t {
     /** UCT interface handle */
     uct_iface_h uct_iface;
 
+    /** RDMA completions */
+    opal_free_list_t rdma_completions;
+
     /** complete fragments and rdma operations. this fifo is used to avoid making
      * callbacks while holding the device lock. */
     opal_fifo_t completion_fifo;
+
+    /** progress is enabled on this context */
+    bool progress_enabled;
 };
 
 typedef struct mca_btl_uct_device_context_t mca_btl_uct_device_context_t;


### PR DESCRIPTION
This commit updates the uct btl to change the transports parameter
into a priority list. The dc_mlx5, rc_mlx5, and ud transports to the
priority list. This will give better out of the box performance for
multi-threaded codes beacuse the *_mlx5 transports can avoid the mlx5
lock inside libmlx5_rdmav2.

This commit also fixes a number of leaks and a possible deadlock when
using RDMA.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 39be6ec15c202d31423476f09e70199453d25adc)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>