### PR TITLE
OSC/UCX: fixed zero-size window processing - v4.0.x

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -17,6 +17,13 @@
 #include "osc_ucx.h"
 #include "osc_ucx_request.h"
 
+
+#define CHECK_VALID_RKEY(_module, _target, _count)                               \
+    if (!((_module)->win_info_array[_target]).rkey_init && ((_count) > 0)) {     \
+        OSC_UCX_VERBOSE(1, "window with non-zero length does not have an rkey"); \
+        return OMPI_ERROR;                                                       \
+    }
+
 typedef struct ucx_iovec {
     void *addr;
     size_t len;
@@ -380,6 +387,12 @@ int ompi_osc_ucx_put(const void *origin_addr, int origin_count, struct ompi_data
         }
     }
 
+    CHECK_VALID_RKEY(module, target, target_count);
+
+    if (!target_count) {
+        return OMPI_SUCCESS;
+    }
+
     rkey = (module->win_info_array[target]).rkey;
 
     ompi_datatype_get_true_extent(origin_dt, &origin_lb, &origin_extent);
@@ -432,6 +445,12 @@ int ompi_osc_ucx_get(void *origin_addr, int origin_count,
         if (status != UCS_OK) {
             return OMPI_ERROR;
         }
+    }
+
+    CHECK_VALID_RKEY(module, target, target_count);
+
+    if (!target_count) {
+        return OMPI_SUCCESS;
     }
 
     rkey = (module->win_info_array[target]).rkey;
@@ -860,6 +879,8 @@ int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
         }
     }
 
+    CHECK_VALID_RKEY(module, target, target_count);
+
     rkey = (module->win_info_array[target]).rkey;
 
     OMPI_OSC_UCX_REQUEST_ALLOC(win, ucx_req);
@@ -918,6 +939,8 @@ int ompi_osc_ucx_rget(void *origin_addr, int origin_count,
             return OMPI_ERROR;
         }
     }
+
+    CHECK_VALID_RKEY(module, target, target_count);
 
     rkey = (module->win_info_array[target]).rkey;
 


### PR DESCRIPTION
- added processing of zero-size MPI window

backport from https://github.com/open-mpi/ompi/pull/5879

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit ae6f81983fe354de812ebe2532120fb20ae24d3b)