### PR TITLE
README: Remove MXM from MTL list

### DIFF
--- a/README
+++ b/README
@@ -507,7 +507,6 @@ MPI Functionality and Features
   - yalla
 
   (1) The cm PML and the following MTLs support MPI_THREAD_MULTIPLE:
-      - MXM
       - ofi (Libfabric)
       - portals4
 


### PR DESCRIPTION
The MXM MTL has been deleted from Open MPI; no need to include it in the readme anymore.

Signed-off-by: Dennis Field <fury@xibase.com>