### PR TITLE
btl tcp: Work around shutdown race bug

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -542,19 +542,44 @@ void mca_btl_tcp_endpoint_close(mca_btl_base_endpoint_t* btl_endpoint)
      * re-route or re-schedule the fragments.
      */
     if( MCA_BTL_TCP_FAILED == btl_endpoint->endpoint_state ) {
+        bool frag_cleaned = false;
         mca_btl_tcp_frag_t* frag = btl_endpoint->endpoint_send_frag;
         if( NULL == frag )
             frag = (mca_btl_tcp_frag_t*)opal_list_remove_first(&btl_endpoint->endpoint_frags);
         while(NULL != frag) {
             frag->base.des_cbfunc(&frag->btl->super, frag->endpoint, &frag->base, OPAL_ERR_UNREACH);
             if( frag->base.des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP ) {
+                frag_cleaned = true;
                 MCA_BTL_TCP_FRAG_RETURN(frag);
             }
             frag = (mca_btl_tcp_frag_t*)opal_list_remove_first(&btl_endpoint->endpoint_frags);
         }
         btl_endpoint->endpoint_send_frag = NULL;
-        /* Let's report the error upstream */
-        if(NULL != btl_endpoint->endpoint_btl->tcp_error_cb) {
+        /*
+         * Let's report the error upstream.  The frag_cleaned check is
+         * a hack to work around a shutdown race (and probably a
+         * bigger problem in the TCP BTL design).  writev() or readv()
+         * in btl_tcp_frag.c returning 0 means the socket was closed
+         * cleanly on the other side, but we move the endpoint into a
+         * FAILED state.  However, the most common reason for getting
+         * into that case is the natural shutdown race when multiple
+         * peers are clealy closing sockets.  Suddenly, the error
+         * handler changes a harmless shutdown race into an error that
+         * aborts the job from MPI_FINALIZE.
+         *
+         * The quick fix is to just skip error reporting if there wree
+         * no outstanding frags.  If the PML tries to reuse this
+         * endpoint and there really is a persistent error, the
+         * connect will fail and return an error.  If it was just the
+         * shutdown race, the PML will never try to connect.
+         *
+         * The right fix is probably to drive a graceful BTL-level
+         * reconnect on a dropped TCP connection and keep going
+         * without dropping any frags or returning errors upwards and
+         * use the retries counter to notify the PML that there's a
+         * more permanent problem.
+         */
+        if(frag_cleaned && NULL != btl_endpoint->endpoint_btl->tcp_error_cb) {
             btl_endpoint->endpoint_btl->tcp_error_cb((mca_btl_base_module_t*)btl_endpoint->endpoint_btl, 0,
                                                       btl_endpoint->endpoint_proc->proc_opal, "Socket closed");
         }


### PR DESCRIPTION
Work around a shutdown race in the TCP BTL when one process closes
the endpoint socket and the FIN arrives at the other process before
the second process shuts down.  In this case, the socket will
close, readv() will return 0, and the TCP BTL will push the error
to the PML, which will abort the job (from MPI_FINALIZE, which is
just rude).

There are two commits that appear to cause this issue.  First, in
ed8141e7c0 (Dec 2014), we started setting the endpoint state to
FAILED on a readv() returning 0.  Second, in 6acebc40a1 we started
pushing the error to the PML for any FAILED state endpoints that
enter endpoint_close().

The best workaround I could think of without rewriting lots of
code is to only error to the PML if there were frags in flight.
There is a long comment in the commit as to why I think this is
a reasonable approach for now, as well as future approaches.  The
future approach, I think, is to add some auto-retry to the endpoint
so that a single TCP disconnect doesn't abort a job.