### PR TITLE
mpi.h.in: remove C99-style comments

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -417,10 +417,12 @@ typedef ompi_file_errhandler_function MPI_File_errhandler_fn
 typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn
         __mpi_interface_removed__("MPI_Win_errhandler_fn was removed in MPI-3.0; use MPI_Win_errhandler_function instead");
 
-// NOTE: We intentionally do *not* mark the following as
-// deprecated/removed because they are used below in function
-// prototypes (and would therefore emit warnings, just for #including
-// <mpi.h>).
+/*
+ * NOTE: We intentionally do *not* mark the following as
+ * deprecated/removed because they are used below in function
+ * prototypes (and would therefore emit warnings, just for #including
+ * <mpi.h>).
+ */
 typedef void (MPI_Handler_function)(MPI_Comm *, int *, ...);
 typedef int (MPI_Copy_function)(MPI_Comm, int, void *,
                                 void *, void *, int *);


### PR DESCRIPTION
While we require C99 to build Open MPI, we do not require C99 to build
user MPI applications.  As such, we shouldn't have C99-style comments
(i.e., "//"-style) in mpi.h.in.

Thanks to @AdamSimpson for reporting the issue.

This commit simply converts a //-style comment to a /**/-style
comment.  No code or logic changes.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #5893.