### PR TITLE
Fix -H operations for multi-app case

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/orte/mca/rmaps/base/rmaps_base_support_fns.c
@@ -469,12 +469,19 @@ int orte_rmaps_base_get_target_nodes(opal_list_t *allocated_nodes, orte_std_cntr
                 continue;
             }
             if (node->slots > node->slots_inuse) {
+                orte_std_cntr_t s;
+                /* check for any -host allocations */
+                if (orte_get_attribute(&app->attributes, ORTE_APP_DASH_HOST, (void**)&hosts, OPAL_STRING)) {
+                    s = orte_util_dash_host_compute_slots(node, hosts);
+                } else {
+                    s = node->slots - node->slots_inuse;
+                }
                 /* add the available slots */
                 OPAL_OUTPUT_VERBOSE((5, orte_rmaps_base_framework.framework_output,
                                      "%s node %s has %d slots available",
                                      ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                                     node->name, node->slots - node->slots_inuse));
-                num_slots += node->slots - node->slots_inuse;
+                                     node->name, s));
+                num_slots += s;
                 continue;
             }
             if (!(ORTE_MAPPING_NO_OVERSUBSCRIBE & ORTE_GET_MAPPING_DIRECTIVE(policy))) {

--- a/orte/util/dash_host/dash_host.h
+++ b/orte/util/dash_host/dash_host.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +27,7 @@
 
 #include "opal/class/opal_list.h"
 
+#include "orte/runtime/orte_globals.h"
 
 BEGIN_C_DECLS
 
@@ -40,6 +41,8 @@ ORTE_DECLSPEC int orte_util_filter_dash_host_nodes(opal_list_t *nodes,
 
 ORTE_DECLSPEC int orte_util_get_ordered_dash_host_list(opal_list_t *nodes,
                                                        char *hosts);
+
+ORTE_DECLSPEC int orte_util_dash_host_compute_slots(orte_node_t *node, char *hosts);
 
 END_C_DECLS
 


### PR DESCRIPTION
Correctly aggregate slots across -H entries from each app. Take into
account any -H entry when computing nprocs when no value was given.

Fixes #5894 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>