### PR TITLE
btl/uct: use the correct tl interface attributes

### DIFF
--- a/opal/mca/btl/uct/btl_uct.h
+++ b/opal/mca/btl/uct/btl_uct.h
@@ -286,7 +286,7 @@ int mca_btl_uct_query_tls (mca_btl_uct_module_t *module, mca_btl_uct_md_t *md, u
  */
 static inline bool mca_btl_uct_tl_supports_rdma (mca_btl_uct_tl_t *tl)
 {
-    return (tl->uct_iface_attr.cap.flags & (UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_GET_ZCOPY)) ==
+    return (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & (UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_GET_ZCOPY)) ==
         (UCT_IFACE_FLAG_PUT_ZCOPY | UCT_IFACE_FLAG_GET_ZCOPY);
 }
 
@@ -295,7 +295,7 @@ static inline bool mca_btl_uct_tl_supports_rdma (mca_btl_uct_tl_t *tl)
  */
 static inline bool mca_btl_uct_tl_support_am (mca_btl_uct_tl_t *tl)
 {
-    return (tl->uct_iface_attr.cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_AM_ZCOPY));
+    return (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_AM_BCOPY | UCT_IFACE_FLAG_AM_ZCOPY));
 }
 
 /**
@@ -305,7 +305,7 @@ static inline bool mca_btl_uct_tl_support_am (mca_btl_uct_tl_t *tl)
  */
 static inline bool mca_btl_uct_tl_supports_conn (mca_btl_uct_tl_t *tl)
 {
-    return (tl->uct_iface_attr.cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CONNECT_TO_IFACE)) ==
+    return (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CONNECT_TO_IFACE)) ==
         (UCT_IFACE_FLAG_AM_SHORT | UCT_IFACE_FLAG_CONNECT_TO_IFACE);
 }
 
@@ -316,7 +316,7 @@ static inline bool mca_btl_uct_tl_supports_conn (mca_btl_uct_tl_t *tl)
  */
 static inline bool mca_btl_uct_tl_requires_connection_tl (mca_btl_uct_tl_t *tl)
 {
-    return !(tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
+    return !(MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE);
 }
 
 END_C_DECLS

--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -152,12 +152,12 @@ static size_t mca_btl_uct_tl_modex_size (mca_btl_uct_tl_t *tl)
 {
     const size_t size = strlen (tl->uct_tl_name) + 1;
 
-    if (tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+    if (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
         /* pad out to a multiple of 4 bytes */
-        return (4 + 3 + size + tl->uct_iface_attr.device_addr_len + tl->uct_iface_attr.iface_addr_len) & ~3;
+        return (4 + 3 + size + MCA_BTL_UCT_TL_ATTR(tl, 0).device_addr_len + MCA_BTL_UCT_TL_ATTR(tl, 0).iface_addr_len) & ~3;
     }
 
-    return (4 + 3 + size + tl->uct_iface_attr.device_addr_len) & ~3;
+    return (4 + 3 + size + MCA_BTL_UCT_TL_ATTR(tl, 0).device_addr_len) & ~3;
 }
 
 static size_t mca_btl_uct_module_modex_size (mca_btl_uct_module_t *module)
@@ -196,13 +196,13 @@ static size_t mca_btl_uct_tl_modex_pack (mca_btl_uct_tl_t *tl, uint8_t *modex_da
      * the same endpoint since we are only doing RDMA. if any of these assumptions are
      * wrong then we can't delay creating the other contexts and must include their
      * information in the modex. */
-    if (tl->uct_iface_attr.cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
+    if (MCA_BTL_UCT_TL_ATTR(tl, 0).cap.flags & UCT_IFACE_FLAG_CONNECT_TO_IFACE) {
         uct_iface_get_address (dev_context->uct_iface, (uct_iface_addr_t *) modex_data);
-        modex_data += tl->uct_iface_attr.iface_addr_len;
+        modex_data += MCA_BTL_UCT_TL_ATTR(tl, 0).iface_addr_len;
     }
 
     uct_iface_get_device_address (dev_context->uct_iface, (uct_device_addr_t *) modex_data);
-    modex_data += tl->uct_iface_attr.device_addr_len;
+    modex_data += MCA_BTL_UCT_TL_ATTR(tl, 0).device_addr_len;
 
     return modex_size;
 }

--- a/opal/mca/btl/uct/btl_uct_endpoint.c
+++ b/opal/mca/btl/uct/btl_uct_endpoint.c
@@ -109,15 +109,14 @@ static int mca_btl_uct_endpoint_connect_iface (mca_btl_uct_module_t *uct_btl, mc
 
     /* easy case. just connect to the interface */
     iface_addr = (uct_iface_addr_t *) tl_data;
-    device_addr = (uct_device_addr_t *) ((uintptr_t) iface_addr + tl->uct_iface_attr.iface_addr_len);
+    device_addr = (uct_device_addr_t *) ((uintptr_t) iface_addr + MCA_BTL_UCT_TL_ATTR(tl, tl_context->context_id).iface_addr_len);
 
     BTL_VERBOSE(("connecting endpoint to interface"));
 
     mca_btl_uct_context_lock (tl_context);
     ucs_status = uct_ep_create_connected (tl_context->uct_iface, device_addr, iface_addr, &tl_endpoint->uct_ep);
-    mca_btl_uct_context_unlock (tl_context);
-
     tl_endpoint->flags = MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY;
+    mca_btl_uct_context_unlock (tl_context);
 
     return (UCS_OK == ucs_status) ? OPAL_SUCCESS : OPAL_ERROR;
 }
@@ -189,7 +188,7 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
                                                   mca_btl_uct_tl_endpoint_t *tl_endpoint, uint8_t *tl_data,
                                                   uint8_t *conn_tl_data, void *ep_addr)
 {
-    size_t request_length = sizeof (mca_btl_uct_conn_req_t) + tl->uct_iface_attr.ep_addr_len;
+    size_t request_length = sizeof (mca_btl_uct_conn_req_t) + MCA_BTL_UCT_TL_ATTR(tl, tl_context->context_id).ep_addr_len;
     mca_btl_uct_connection_ep_t *conn_ep = endpoint->conn_ep;
     mca_btl_uct_tl_t *conn_tl = uct_btl->conn_tl;
     mca_btl_uct_device_context_t *conn_tl_context = conn_tl->uct_dev_contexts[0];
@@ -208,7 +207,7 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
                      opal_process_name_print (endpoint->ep_proc->proc_name)));
 
         iface_addr = (uct_iface_addr_t *) conn_tl_data;
-        device_addr = (uct_device_addr_t *) ((uintptr_t) conn_tl_data + conn_tl->uct_iface_attr.iface_addr_len);
+        device_addr = (uct_device_addr_t *) ((uintptr_t) conn_tl_data + MCA_BTL_UCT_TL_ATTR(conn_tl, 0).iface_addr_len);
 
         endpoint->conn_ep = conn_ep = OBJ_NEW(mca_btl_uct_connection_ep_t);
         if (OPAL_UNLIKELY(NULL == conn_ep)) {

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -88,7 +88,7 @@ static int mca_btl_uct_add_procs (mca_btl_base_module_t *btl,
         if (am_tl) {
             rc = opal_free_list_init (&uct_module->short_frags, sizeof (mca_btl_uct_base_frag_t),
                                       opal_cache_line_size, OBJ_CLASS(mca_btl_uct_base_frag_t),
-                                      am_tl->uct_iface_attr.cap.am.max_short, opal_cache_line_size,
+                                      MCA_BTL_UCT_TL_ATTR(am_tl, 0).cap.am.max_short, opal_cache_line_size,
                                       0, 1024, 64, NULL, 0, NULL, NULL, NULL);
 
             rc = opal_free_list_init (&uct_module->eager_frags, sizeof (mca_btl_uct_base_frag_t),

--- a/opal/mca/btl/uct/btl_uct_rdma.c
+++ b/opal/mca/btl/uct/btl_uct_rdma.c
@@ -98,13 +98,12 @@ int mca_btl_uct_get (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
 
     mca_btl_uct_context_lock (context);
 
-    if (size <= uct_btl->rdma_tl->uct_iface_attr.cap.get.max_bcopy) {
+    if (size <= MCA_BTL_UCT_TL_ATTR(uct_btl->rdma_tl, context->context_id).cap.get.max_bcopy) {
         ucs_status = uct_ep_get_bcopy (ep_handle, mca_btl_uct_get_unpack, local_address, size, remote_address,
                                        rkey.rkey, &comp->uct_comp);
     } else {
         uct_iov_t iov = {.buffer = local_address, .length = size, .stride = 0, .count = 1,
                          .memh = MCA_BTL_UCT_REG_REMOTE_TO_LOCAL(local_handle)->uct_memh};
-
         ucs_status = uct_ep_get_zcopy (ep_handle, &iov, 1, remote_address, rkey.rkey, &comp->uct_comp);
     }
 
@@ -183,7 +182,7 @@ int mca_btl_uct_put (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
 
     /* determine what UCT prototol should be used */
     if (size <= uct_btl->super.btl_put_local_registration_threshold) {
-        use_short = size <= uct_btl->rdma_tl->uct_iface_attr.cap.put.max_short;
+        use_short = size <= MCA_BTL_UCT_TL_ATTR(uct_btl->rdma_tl, context->context_id).cap.put.max_short;
         use_bcopy = !use_short;
     }
 

--- a/opal/mca/btl/uct/btl_uct_types.h
+++ b/opal/mca/btl/uct/btl_uct_types.h
@@ -141,6 +141,9 @@ struct mca_btl_uct_device_context_t {
     /** UCT interface handle */
     uct_iface_h uct_iface;
 
+    /** interface attributes */
+    uct_iface_attr_t uct_iface_attr;
+
     /** RDMA completions */
     opal_free_list_t rdma_completions;
 
@@ -307,9 +310,6 @@ struct mca_btl_uct_tl_t {
     /** device name for this tl (used for creating device contexts) */
     char *uct_dev_name;
 
-    /** interface attributes */
-    uct_iface_attr_t uct_iface_attr;
-
     /** maxiumum number of device contexts that can be created */
     int max_device_contexts;
 
@@ -323,5 +323,7 @@ struct mca_btl_uct_tl_t {
 
 typedef struct mca_btl_uct_tl_t mca_btl_uct_tl_t;
 OBJ_CLASS_DECLARATION(mca_btl_uct_tl_t);
+
+#define MCA_BTL_UCT_TL_ATTR(tl, context_id) (tl)->uct_dev_contexts[(context_id)]->uct_iface_attr
 
 #endif /* !defined(BTL_UCT_TYPES_H) */


### PR DESCRIPTION
It is apparently possible for different instances of the same UCT
transport to have different limits (max short put for example). To
account for this we need to store the attributes per TL context not
per TL. This commit fixes the issue.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>