### PR TITLE
pmix: Fix filename typo

### DIFF
--- a/opal/mca/pmix/pmix4x/pmix/src/mca/pinstalldirs/config/Makefile.am
+++ b/opal/mca/pmix/pmix4x/pmix/src/mca/pinstalldirs/config/Makefile.am
@@ -19,4 +19,4 @@ libmca_pinstalldirs_config_la_SOURCES = \
 
 # This file is generated; we do not want to include it in the tarball
 nodist_libmca_pinstalldirs_config_la_SOURCES = \
-        install_dirs.h
+        pinstall_dirs.h


### PR DESCRIPTION
Looks like a filename was missed when pmix sucked in the installdirs
framework.  Fixing the typo fixes "make ctags" and "make cscope".

Signed-off-by: Brian Barrett <bbarrett@amazon.com>