### PR TITLE
btl/uct: fix deadlock in connection code

### DIFF
--- a/opal/mca/btl/uct/btl_uct.h
+++ b/opal/mca/btl/uct/btl_uct.h
@@ -68,7 +68,7 @@ struct mca_btl_uct_module_t {
     opal_hash_table_t id_to_endpoint;
 
     /** mutex to protect the module */
-    opal_mutex_t lock;
+    opal_recursive_mutex_t lock;
 
     /** async context */
     ucs_async_context_t *ucs_async;
@@ -108,6 +108,9 @@ struct mca_btl_uct_module_t {
 
     /** frags that were waiting on connections that are now ready to send */
     opal_list_t pending_frags;
+
+    /** pending connection requests */
+    opal_fifo_t pending_connection_reqs;
 };
 typedef struct mca_btl_uct_module_t mca_btl_uct_module_t;
 
@@ -278,6 +281,7 @@ ucs_status_t mca_btl_uct_am_handler (void *arg, void *data, size_t length, unsig
 struct mca_btl_base_endpoint_t *mca_btl_uct_get_ep (struct mca_btl_base_module_t *module, opal_proc_t *proc);
 
 int mca_btl_uct_query_tls (mca_btl_uct_module_t *module, mca_btl_uct_md_t *md, uct_tl_resource_desc_t *tl_descs, unsigned tl_count);
+int mca_btl_uct_process_connection_request (mca_btl_uct_module_t *module, mca_btl_uct_conn_req_t *req);
 
 /**
  * @brief Checks if a tl is suitable for using for RDMA

--- a/opal/mca/btl/uct/btl_uct_am.h
+++ b/opal/mca/btl/uct/btl_uct_am.h
@@ -27,8 +27,7 @@ int mca_btl_uct_sendi (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endp
 int mca_btl_uct_send (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint, mca_btl_base_descriptor_t *descriptor,
                       mca_btl_base_tag_t tag);
 
-int mca_btl_uct_send_frag (mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint, mca_btl_uct_base_frag_t *frag,
-                           int32_t flags, mca_btl_uct_device_context_t *context, uct_ep_h ep_handle);
+int mca_btl_uct_send_frag (mca_btl_uct_module_t *uct_btl, mca_btl_uct_base_frag_t *frag, bool append);
 
 mca_btl_base_descriptor_t *mca_btl_uct_alloc (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint,
                                               uint8_t order, size_t size, uint32_t flags);

--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -272,7 +272,8 @@ static mca_btl_uct_module_t *mca_btl_uct_alloc_module (const char *md_name, mca_
     OBJ_CONSTRUCT(&module->eager_frags, opal_free_list_t);
     OBJ_CONSTRUCT(&module->max_frags, opal_free_list_t);
     OBJ_CONSTRUCT(&module->pending_frags, opal_list_t);
-    OBJ_CONSTRUCT(&module->lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&module->lock, opal_recursive_mutex_t);
+    OBJ_CONSTRUCT(&module->pending_connection_reqs, opal_fifo_t);
 
     module->md = md;
     module->md_name = strdup (md_name);
@@ -298,10 +299,13 @@ ucs_status_t mca_btl_uct_am_handler (void *arg, void *data, size_t length, unsig
                                   .seg_len = length - sizeof (*header)};
     mca_btl_uct_base_frag_t frag = {.base = {.des_segments = &seg, .des_segment_count = 1}};
 
+    /* prevent recursion */
+    tl_context->in_am_callback = true;
+
     reg = mca_btl_base_active_message_trigger + header->data.tag;
-    mca_btl_uct_context_unlock (tl_context);
     reg->cbfunc (&uct_btl->super, header->data.tag, &frag.base, reg->cbdata);
-    mca_btl_uct_context_lock (tl_context);
+
+    tl_context->in_am_callback = false;
 
     return UCS_OK;
 }
@@ -491,8 +495,7 @@ static int mca_btl_uct_component_progress_pending (mca_btl_uct_module_t *uct_btl
 
         opal_list_remove_item (&uct_btl->pending_frags, (opal_list_item_t *) frag);
 
-        if (OPAL_SUCCESS > mca_btl_uct_send (&uct_btl->super, frag->endpoint, &frag->base,
-                                              frag->header.data.tag)) {
+        if (OPAL_SUCCESS > mca_btl_uct_send_frag (uct_btl, frag, false)) {
             opal_list_prepend (&uct_btl->pending_frags, (opal_list_item_t *) frag);
         }
     }
@@ -523,8 +526,15 @@ static int mca_btl_uct_component_progress (void)
         }
 
         if (module->conn_tl) {
+            mca_btl_uct_pending_connection_request_t *request;
+
             if (module->conn_tl != module->am_tl && module->conn_tl != module->rdma_tl) {
                 ret += mca_btl_uct_tl_progress (module->conn_tl, 0);
+            }
+
+            while (NULL != (request = (mca_btl_uct_pending_connection_request_t *) opal_fifo_pop_atomic (&module->pending_connection_reqs))) {
+                mca_btl_uct_process_connection_request (module, (mca_btl_uct_conn_req_t *) request->request_data);
+                OBJ_RELEASE(request);
             }
         }
 

--- a/opal/mca/btl/uct/btl_uct_endpoint.c
+++ b/opal/mca/btl/uct/btl_uct_endpoint.c
@@ -56,7 +56,7 @@ mca_btl_base_endpoint_t *mca_btl_uct_endpoint_create (opal_proc_t *proc)
 
 static unsigned char *mca_btl_uct_process_modex_tl (unsigned char *modex_data)
 {
-    BTL_VERBOSE(("processing modex for tl %s. size: %u", modex_data, *((uint32_t *) modex_data)));
+    BTL_VERBOSE(("processing modex for tl %s. size: %u", modex_data + 4, *((uint32_t *) modex_data)));
 
     /* skip size and name */
     return modex_data + 4 + strlen ((char *) modex_data + 4) + 1;
@@ -139,13 +139,13 @@ OBJ_CLASS_INSTANCE(mca_btl_uct_connection_ep_t, opal_object_t, mca_btl_uct_conne
 
 static int mca_btl_uct_endpoint_send_conn_req (mca_btl_uct_module_t *uct_btl, mca_btl_base_endpoint_t *endpoint,
                                                mca_btl_uct_device_context_t *conn_tl_context,
-                                               int64_t type, void *request, size_t request_length)
+                                               mca_btl_uct_conn_req_t *request, size_t request_length)
 {
     mca_btl_uct_connection_ep_t *conn_ep = endpoint->conn_ep;
     ucs_status_t ucs_status;
 
-    BTL_VERBOSE(("sending connection request to peer. type: %" PRId64 ", length: %" PRIsize_t,
-                 type, request_length));
+    BTL_VERBOSE(("sending connection request to peer. context id: %d, type: %d, length: %" PRIsize_t,
+                 request->context_id, request->type, request_length));
 
     OBJ_RETAIN(endpoint->conn_ep);
 
@@ -154,7 +154,8 @@ static int mca_btl_uct_endpoint_send_conn_req (mca_btl_uct_module_t *uct_btl, mc
 
     do {
         MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
-                ucs_status = uct_ep_am_short (conn_ep->uct_ep, MCA_BTL_UCT_CONNECT_RDMA, type, request, request_length);
+                ucs_status = uct_ep_am_short (conn_ep->uct_ep, MCA_BTL_UCT_CONNECT_RDMA, request->type, request,
+                                              request_length);
             });
         if (OPAL_LIKELY(UCS_OK == ucs_status)) {
             break;
@@ -169,12 +170,10 @@ static int mca_btl_uct_endpoint_send_conn_req (mca_btl_uct_module_t *uct_btl, mc
     } while (1);
 
     /* for now we just wait for the connection request to complete before continuing */
-    MCA_BTL_UCT_CONTEXT_SERIALIZE(conn_tl_context, {
-            do {
-                uct_worker_progress (conn_tl_context->uct_worker);
-                ucs_status = uct_ep_flush (conn_ep->uct_ep, 0, NULL);
-            } while (UCS_INPROGRESS == ucs_status);
-        });
+    do {
+        ucs_status = uct_ep_flush (conn_ep->uct_ep, 0, NULL);
+        mca_btl_uct_context_progress (conn_tl_context);
+    } while (UCS_INPROGRESS == ucs_status);
 
     opal_mutex_lock (&endpoint->ep_lock);
 
@@ -232,6 +231,7 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
     request->proc_name = OPAL_PROC_MY_NAME;
     request->context_id = tl_context->context_id;
     request->tl_index = tl->tl_index;
+    request->type = !!(ep_addr);
 
     if (NULL == tl_endpoint->uct_ep) {
         BTL_VERBOSE(("allocating endpoint for peer %s and sending connection data",
@@ -244,48 +244,37 @@ static int mca_btl_uct_endpoint_connect_endpoint (mca_btl_uct_module_t *uct_btl,
             OBJ_RELEASE(endpoint->conn_ep);
             return OPAL_ERROR;
         }
+    }
 
-        /* fill in connection request */
-        ucs_status = uct_ep_get_address (tl_endpoint->uct_ep, (uct_ep_addr_t *) request->ep_addr);
+    if (ep_addr) {
+        BTL_VERBOSE(("using remote endpoint address to connect endpoint for tl %s, index %d. ep_addr = %p",
+                     tl->uct_tl_name, tl_context->context_id, ep_addr));
+
+        /* NTH: there is no need to lock the device context in this case */
+        ucs_status = uct_ep_connect_to_ep (tl_endpoint->uct_ep, (uct_device_addr_t *) tl_data, ep_addr);
         if (UCS_OK != ucs_status) {
-            /* this is a fatal a fatal error */
-            OBJ_RELEASE(endpoint->conn_ep);
-            uct_ep_destroy (tl_endpoint->uct_ep);
-            tl_endpoint->uct_ep = NULL;
-            return OPAL_ERROR;
-        }
-
-        rc = mca_btl_uct_endpoint_send_conn_req (uct_btl, endpoint, conn_tl_context, 0, request,
-                                                 request_length);
-        if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
-            OBJ_RELEASE(endpoint->conn_ep);
-            uct_ep_destroy (tl_endpoint->uct_ep);
-            tl_endpoint->uct_ep = NULL;
             return OPAL_ERROR;
         }
     }
 
-    if (ep_addr) {
-        BTL_VERBOSE(("using remote endpoint address to connect endpoint. ep_addr = %p", ep_addr));
+    /* fill in connection request */
+    ucs_status = uct_ep_get_address (tl_endpoint->uct_ep, (uct_ep_addr_t *) request->ep_addr);
+    if (UCS_OK != ucs_status) {
+        /* this is a fatal a fatal error */
+        OBJ_RELEASE(endpoint->conn_ep);
+        uct_ep_destroy (tl_endpoint->uct_ep);
+        tl_endpoint->uct_ep = NULL;
+        return OPAL_ERROR;
+    }
 
-        device_addr = (uct_device_addr_t *) tl_data;
-
-        /* NTH: there is no need to lock the device context in this case */
-        ucs_status = uct_ep_connect_to_ep (tl_endpoint->uct_ep, device_addr, ep_addr);
-        if (UCS_OK != ucs_status) {
-            return OPAL_ERROR;
-        }
-
-        /* let the remote side know that the connection has been established and
-         * wait for the message to be sent */
-        rc = mca_btl_uct_endpoint_send_conn_req (uct_btl, endpoint, conn_tl_context, 1, request,
-                                                 sizeof (mca_btl_uct_conn_req_t));
-        if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
-            OBJ_RELEASE(endpoint->conn_ep);
-            uct_ep_destroy (tl_endpoint->uct_ep);
-            tl_endpoint->uct_ep = NULL;
-            return OPAL_ERROR;
-        }
+    /* let the remote side know that the connection has been established and
+     * wait for the message to be sent */
+    rc = mca_btl_uct_endpoint_send_conn_req (uct_btl, endpoint, conn_tl_context, request, request_length);
+    if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
+        OBJ_RELEASE(endpoint->conn_ep);
+        uct_ep_destroy (tl_endpoint->uct_ep);
+        tl_endpoint->uct_ep = NULL;
+        return OPAL_ERROR;
     }
 
     return (tl_endpoint->flags & MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY) ? OPAL_SUCCESS : OPAL_ERR_OUT_OF_RESOURCE;

--- a/opal/mca/btl/uct/btl_uct_endpoint.h
+++ b/opal/mca/btl/uct/btl_uct_endpoint.h
@@ -72,7 +72,8 @@ static inline int mca_btl_uct_endpoint_check (mca_btl_uct_module_t *module, mca_
 
     rc = mca_btl_uct_endpoint_connect (module, endpoint, ep_index, NULL, tl_index);
     *ep_handle = endpoint->uct_eps[ep_index][tl_index].uct_ep;
-    BTL_VERBOSE(("mca_btl_uct_endpoint_connect returned %d", rc));
+    BTL_VERBOSE(("mca_btl_uct_endpoint_connect returned %d. context id = %d, flags = 0x%x", rc, ep_index,
+                 MCA_BTL_UCT_ENDPOINT_FLAG_CONN_READY & endpoint->uct_eps[ep_index][tl_index].flags));
     return rc;
 }
 

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -74,7 +74,6 @@ static int mca_btl_uct_add_procs (mca_btl_base_module_t *btl,
 
     if (false == uct_module->initialized) {
         mca_btl_uct_tl_t *am_tl = uct_module->am_tl;
-        mca_btl_uct_tl_t *rdma_tl = uct_module->rdma_tl;
 
         /* NTH: might want to vary this size based off the universe size (if
          * one exists). the table is only used for connection lookup and
@@ -277,6 +276,7 @@ int mca_btl_uct_finalize (mca_btl_base_module_t* btl)
     OBJ_DESTRUCT(&uct_module->max_frags);
     OBJ_DESTRUCT(&uct_module->pending_frags);
     OBJ_DESTRUCT(&uct_module->lock);
+    OBJ_DESTRUCT(&uct_module->pending_connection_reqs);
 
     if (uct_module->rcache) {
         mca_rcache_base_module_destroy (uct_module->rcache);

--- a/opal/mca/btl/uct/btl_uct_types.h
+++ b/opal/mca/btl/uct/btl_uct_types.h
@@ -77,6 +77,9 @@ struct mca_btl_uct_conn_req_t {
     /** name of the requesting process */
     opal_process_name_t proc_name;
 
+    /** request type: 0 == endpoint data, 1 == endpoint data + remote ready */
+    int type;
+
     /** context id that should be connected */
     int context_id;
 
@@ -153,6 +156,9 @@ struct mca_btl_uct_device_context_t {
 
     /** progress is enabled on this context */
     bool progress_enabled;
+
+    /** context is in AM callback */
+    volatile bool in_am_callback;
 };
 
 typedef struct mca_btl_uct_device_context_t mca_btl_uct_device_context_t;
@@ -238,8 +244,8 @@ struct mca_btl_uct_base_frag_t {
     /** module this fragment is associated with */
     struct mca_btl_uct_module_t *btl;
 
-    /** context this fragment is waiting on */
-    int context_id;
+    /* tl context */
+    mca_btl_uct_device_context_t *context;
 
     /** is this frag ready to send (only used when pending) */
     bool ready;
@@ -325,5 +331,13 @@ typedef struct mca_btl_uct_tl_t mca_btl_uct_tl_t;
 OBJ_CLASS_DECLARATION(mca_btl_uct_tl_t);
 
 #define MCA_BTL_UCT_TL_ATTR(tl, context_id) (tl)->uct_dev_contexts[(context_id)]->uct_iface_attr
+
+struct mca_btl_uct_pending_connection_request_t {
+    opal_list_item_t super;
+    uint8_t request_data[];
+};
+
+typedef struct mca_btl_uct_pending_connection_request_t mca_btl_uct_pending_connection_request_t;
+OBJ_CLASS_DECLARATION(mca_btl_uct_pending_connection_request_t);
 
 #endif /* !defined(BTL_UCT_TYPES_H) */


### PR DESCRIPTION
This commit fixes a deadlock that can occur when using a TL that
supports the connect to endpoint model. The deadlock was occurring
while processing an incoming connection requests. This was done from
an active-message callback. For some unknown reason (at this time)
this callback was sometimes hanging. To avoid the issue the connection
active-message is saved for later processing.

At the same time I cleaned up the connection code to eliminate
duplicate messages when possible.

Closes #5820
Closes #5821

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>