### PR TITLE
Cleanup some string operations

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2011 University of Houston. All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
  * Copyright (c) 2011-2013 Universite Bordeaux 1
@@ -38,6 +38,7 @@
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/dss/dss.h"
 #include "opal/mca/pmix/pmix.h"
+#include "opal/util/string_copy.h"
 
 #include "ompi/proc/proc.h"
 #include "opal/threads/mutex.h"
@@ -1317,9 +1318,7 @@ int ompi_comm_set_name (ompi_communicator_t *comm, const char *name )
 {
 
     OPAL_THREAD_LOCK(&(comm->c_lock));
-    memset(comm->c_name, 0, MPI_MAX_OBJECT_NAME);
-    strncpy(comm->c_name, name, MPI_MAX_OBJECT_NAME);
-    comm->c_name[MPI_MAX_OBJECT_NAME - 1] = 0;
+    opal_string_copy(comm->c_name, name, MPI_MAX_OBJECT_NAME);
     comm->c_flags |= OMPI_COMM_NAMEISSET;
     OPAL_THREAD_UNLOCK(&(comm->c_lock));
 

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2017 University of Houston. All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
@@ -35,6 +35,7 @@
 
 #include "opal/util/bit_ops.h"
 #include "opal/util/info_subscriber.h"
+#include "opal/util/string_copy.h"
 #include "opal/mca/pmix/pmix.h"
 #include "ompi/constants.h"
 #include "ompi/mca/pml/pml.h"
@@ -139,9 +140,8 @@ int ompi_comm_init(void)
     OMPI_COMM_SET_PML_ADDED(&ompi_mpi_comm_world.comm);
     opal_pointer_array_set_item (&ompi_mpi_communicators, 0, &ompi_mpi_comm_world);
 
-    MEMCHECKER (memset (ompi_mpi_comm_world.comm.c_name, 0, MPI_MAX_OBJECT_NAME));
-    strncpy (ompi_mpi_comm_world.comm.c_name, "MPI_COMM_WORLD",
-             strlen("MPI_COMM_WORLD")+1 );
+    opal_string_copy(ompi_mpi_comm_world.comm.c_name, "MPI_COMM_WORLD",
+                     sizeof(ompi_mpi_comm_world.comm.c_name));
     ompi_mpi_comm_world.comm.c_flags |= OMPI_COMM_NAMEISSET;
     ompi_mpi_comm_world.comm.c_flags |= OMPI_COMM_INTRINSIC;
 
@@ -193,8 +193,8 @@ int ompi_comm_init(void)
     OMPI_COMM_SET_PML_ADDED(&ompi_mpi_comm_self.comm);
     opal_pointer_array_set_item (&ompi_mpi_communicators, 1, &ompi_mpi_comm_self);
 
-    MEMCHECKER (memset (ompi_mpi_comm_self.comm.c_name, 0, MPI_MAX_OBJECT_NAME));
-    strncpy(ompi_mpi_comm_self.comm.c_name,"MPI_COMM_SELF",strlen("MPI_COMM_SELF")+1);
+    opal_string_copy(ompi_mpi_comm_self.comm.c_name, "MPI_COMM_SELF",
+                     sizeof(ompi_mpi_comm_self.comm.c_name));
     ompi_mpi_comm_self.comm.c_flags |= OMPI_COMM_NAMEISSET;
     ompi_mpi_comm_self.comm.c_flags |= OMPI_COMM_INTRINSIC;
 
@@ -218,8 +218,8 @@ int ompi_comm_init(void)
     OBJ_RETAIN( &ompi_mpi_errors_are_fatal.eh );
     opal_pointer_array_set_item (&ompi_mpi_communicators, 2, &ompi_mpi_comm_null);
 
-    MEMCHECKER (memset (ompi_mpi_comm_null.comm.c_name, 0, MPI_MAX_OBJECT_NAME));
-    strncpy(ompi_mpi_comm_null.comm.c_name,"MPI_COMM_NULL",strlen("MPI_COMM_NULL")+1);
+    opal_string_copy(ompi_mpi_comm_null.comm.c_name, "MPI_COMM_NULL",
+                     sizeof(ompi_mpi_comm_null.comm.c_name));
     ompi_mpi_comm_null.comm.c_flags |= OMPI_COMM_NAMEISSET;
     ompi_mpi_comm_null.comm.c_flags |= OMPI_COMM_INTRINSIC;
 

--- a/ompi/datatype/ompi_datatype_create.c
+++ b/ompi/datatype/ompi_datatype_create.c
@@ -25,6 +25,7 @@
 
 #include "opal/class/opal_pointer_array.h"
 #include "opal/util/printf.h"
+#include "opal/util/string_copy.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/attribute/attribute.h"
 
@@ -113,7 +114,7 @@ ompi_datatype_duplicate( const ompi_datatype_t* oldType, ompi_datatype_t** newTy
 
     char *new_name;
     opal_asprintf(&new_name, "Dup %s", oldType->name);
-    strncpy(new_ompi_datatype->name, new_name, MPI_MAX_OBJECT_NAME - 1);
+    opal_string_copy(new_ompi_datatype->name, new_name, MPI_MAX_OBJECT_NAME);
     new_ompi_datatype->name[MPI_MAX_OBJECT_NAME - 1] = '\0';
     free(new_name);
 

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
@@ -32,6 +32,7 @@
 
 #include "opal/datatype/opal_convertor_internal.h"
 #include "opal/util/output.h"
+#include "opal/util/string_copy.h"
 #include "opal/class/opal_pointer_array.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
@@ -420,7 +421,7 @@ opal_pointer_array_t ompi_datatype_f_to_c_table = {{0}};
         ptype->super.desc.desc = NULL;                                               \
         ptype->super.opt_desc.desc = NULL;                                           \
         OBJ_RELEASE( ptype );                                                        \
-        strncpy( (PDATA)->name, MPIDDTNAME, MPI_MAX_OBJECT_NAME );                   \
+        opal_string_copy( (PDATA)->name, MPIDDTNAME, MPI_MAX_OBJECT_NAME );          \
     } while(0)
 
 #define DECLARE_MPI2_COMPOSED_BLOCK_DDT( PDATA, MPIDDT, MPIDDTNAME, MPIType, FLAGS ) \
@@ -438,14 +439,14 @@ opal_pointer_array_t ompi_datatype_f_to_c_table = {{0}};
         ptype->super.desc.desc = NULL;                                               \
         ptype->super.opt_desc.desc = NULL;                                           \
         OBJ_RELEASE( ptype );                                                        \
-        strncpy( (PDATA)->name, (MPIDDTNAME), MPI_MAX_OBJECT_NAME );                 \
+        opal_string_copy( (PDATA)->name, (MPIDDTNAME), MPI_MAX_OBJECT_NAME );        \
     } while(0)
 
 #define DECLARE_MPI_SYNONYM_DDT( PDATA, MPIDDTNAME, PORIGDDT)                        \
     do {                                                                             \
         /* just memcpy as it's easier this way */                                    \
         memcpy( (PDATA), (PORIGDDT), sizeof(ompi_datatype_t) );                      \
-        strncpy( (PDATA)->name, MPIDDTNAME, MPI_MAX_OBJECT_NAME );                   \
+        opal_string_copy( (PDATA)->name, MPIDDTNAME, MPI_MAX_OBJECT_NAME );          \
         /* forget the language flag */                                               \
         (PDATA)->super.flags &= ~OMPI_DATATYPE_FLAG_DATA_LANGUAGE;                   \
         (PDATA)->super.flags &= ~OPAL_DATATYPE_FLAG_PREDEFINED;                      \

--- a/ompi/errhandler/errcode-internal.c
+++ b/ompi/errhandler/errcode-internal.c
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reseved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +27,8 @@
 #include <stdio.h>
 #include <string.h>
 #include "mpi.h"
+
+#include "opal/util/string_copy.h"
 
 #include "ompi/errhandler/errcode-internal.h"
 
@@ -79,7 +82,8 @@ int ompi_errcode_intern_init (void)
     ompi_success_intern.code = OMPI_SUCCESS;
     ompi_success_intern.mpi_code = MPI_SUCCESS;
     ompi_success_intern.index = pos++;
-    strncpy(ompi_success_intern.errstring, "OMPI_SUCCESS", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_success_intern.errstring, "OMPI_SUCCESS",
+                     OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_success_intern.index,
                                 &ompi_success_intern);
 
@@ -87,7 +91,8 @@ int ompi_errcode_intern_init (void)
     ompi_error_intern.code = OMPI_ERROR;
     ompi_error_intern.mpi_code = MPI_ERR_OTHER;
     ompi_error_intern.index = pos++;
-    strncpy(ompi_error_intern.errstring, "OMPI_ERROR", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_error_intern.errstring, "OMPI_ERROR",
+                     OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_error_intern.index,
                                 &ompi_error_intern);
 
@@ -95,7 +100,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_out_of_resource_intern.code = OMPI_ERR_OUT_OF_RESOURCE;
     ompi_err_out_of_resource_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_out_of_resource_intern.index = pos++;
-    strncpy(ompi_err_out_of_resource_intern.errstring, "OMPI_ERR_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_out_of_resource_intern.errstring,
+                     "OMPI_ERR_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_out_of_resource_intern.index,
                                 &ompi_err_out_of_resource_intern);
 
@@ -103,7 +109,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_temp_out_of_resource_intern.code = OMPI_ERR_TEMP_OUT_OF_RESOURCE;
     ompi_err_temp_out_of_resource_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_temp_out_of_resource_intern.index = pos++;
-    strncpy(ompi_err_temp_out_of_resource_intern.errstring, "OMPI_ERR_TEMP_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_temp_out_of_resource_intern.errstring,
+                     "OMPI_ERR_TEMP_OUT_OF_RESOURCE", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_temp_out_of_resource_intern.index,
                                 &ompi_err_temp_out_of_resource_intern);
 
@@ -111,7 +118,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_resource_busy_intern.code = OMPI_ERR_RESOURCE_BUSY;
     ompi_err_resource_busy_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_resource_busy_intern.index = pos++;
-    strncpy(ompi_err_resource_busy_intern.errstring, "OMPI_ERR_RESOURCE_BUSY", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_resource_busy_intern.errstring,
+                     "OMPI_ERR_RESOURCE_BUSY", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_resource_busy_intern.index,
                                 &ompi_err_resource_busy_intern);
 
@@ -119,7 +127,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_bad_param_intern.code = OMPI_ERR_BAD_PARAM;
     ompi_err_bad_param_intern.mpi_code = MPI_ERR_ARG;
     ompi_err_bad_param_intern.index = pos++;
-    strncpy(ompi_err_bad_param_intern.errstring, "OMPI_ERR_BAD_PARAM", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_bad_param_intern.errstring,
+                     "OMPI_ERR_BAD_PARAM", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_bad_param_intern.index,
                                 &ompi_err_bad_param_intern);
 
@@ -127,7 +136,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_fatal_intern.code = OMPI_ERR_FATAL;
     ompi_err_fatal_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_fatal_intern.index = pos++;
-    strncpy(ompi_err_fatal_intern.errstring, "OMPI_ERR_FATAL", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_fatal_intern.errstring, "OMPI_ERR_FATAL",
+                     OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_fatal_intern.index,
                                 &ompi_err_fatal_intern);
 
@@ -135,7 +145,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_not_implemented_intern.code = OMPI_ERR_NOT_IMPLEMENTED;
     ompi_err_not_implemented_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_not_implemented_intern.index = pos++;
-    strncpy(ompi_err_not_implemented_intern.errstring, "OMPI_ERR_NOT_IMPLEMENTED", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_not_implemented_intern.errstring,
+                     "OMPI_ERR_NOT_IMPLEMENTED", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_implemented_intern.index,
                                 &ompi_err_not_implemented_intern);
 
@@ -143,7 +154,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_not_supported_intern.code = OMPI_ERR_NOT_SUPPORTED;
     ompi_err_not_supported_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_not_supported_intern.index = pos++;
-    strncpy(ompi_err_not_supported_intern.errstring, "OMPI_ERR_NOT_SUPPORTED", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_not_supported_intern.errstring,
+                     "OMPI_ERR_NOT_SUPPORTED", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_supported_intern.index,
                                 &ompi_err_not_supported_intern);
 
@@ -151,7 +163,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_interupted_intern.code = OMPI_ERR_INTERUPTED;
     ompi_err_interupted_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_interupted_intern.index = pos++;
-    strncpy(ompi_err_interupted_intern.errstring, "OMPI_ERR_INTERUPTED", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_interupted_intern.errstring,
+                     "OMPI_ERR_INTERUPTED", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_interupted_intern.index,
                                 &ompi_err_interupted_intern);
 
@@ -159,7 +172,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_would_block_intern.code = OMPI_ERR_WOULD_BLOCK;
     ompi_err_would_block_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_would_block_intern.index = pos++;
-    strncpy(ompi_err_would_block_intern.errstring, "OMPI_ERR_WOULD_BLOCK", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_would_block_intern.errstring,
+                     "OMPI_ERR_WOULD_BLOCK", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_would_block_intern.index,
                                 &ompi_err_would_block_intern);
 
@@ -167,7 +181,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_in_errno_intern.code = OMPI_ERR_IN_ERRNO;
     ompi_err_in_errno_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_in_errno_intern.index = pos++;
-    strncpy(ompi_err_in_errno_intern.errstring, "OMPI_ERR_IN_ERRNO", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_in_errno_intern.errstring,
+                     "OMPI_ERR_IN_ERRNO", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_in_errno_intern.index,
                                 &ompi_err_in_errno_intern);
 
@@ -175,7 +190,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_unreach_intern.code = OMPI_ERR_UNREACH;
     ompi_err_unreach_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_unreach_intern.index = pos++;
-    strncpy(ompi_err_unreach_intern.errstring, "OMPI_ERR_UNREACH", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_unreach_intern.errstring,
+                     "OMPI_ERR_UNREACH", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_unreach_intern.index,
                                 &ompi_err_unreach_intern);
 
@@ -183,7 +199,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_not_found_intern.code = OMPI_ERR_NOT_FOUND;
     ompi_err_not_found_intern.mpi_code = MPI_ERR_INTERN;
     ompi_err_not_found_intern.index = pos++;
-    strncpy(ompi_err_not_found_intern.errstring, "OMPI_ERR_NOT_FOUND", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_not_found_intern.errstring,
+                     "OMPI_ERR_NOT_FOUND", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_not_found_intern.index,
                                 &ompi_err_not_found_intern);
 
@@ -191,7 +208,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_buffer_intern.code = OMPI_ERR_BUFFER;
     ompi_err_buffer_intern.mpi_code = MPI_ERR_BUFFER;
     ompi_err_buffer_intern.index = pos++;
-    strncpy(ompi_err_buffer_intern.errstring, "OMPI_ERR_BUFFER", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_buffer_intern.errstring,
+                     "OMPI_ERR_BUFFER", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_buffer_intern.index,
                                 &ompi_err_buffer_intern);
 
@@ -199,7 +217,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_request_intern.code = OMPI_ERR_REQUEST;
     ompi_err_request_intern.mpi_code = MPI_ERR_REQUEST;
     ompi_err_request_intern.index = pos++;
-    strncpy(ompi_err_request_intern.errstring, "OMPI_ERR_REQUEST", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_request_intern.errstring,
+                     "OMPI_ERR_REQUEST", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_request_intern.index,
                                 &ompi_err_request_intern);
 
@@ -207,7 +226,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_rma_sync_intern.code = OMPI_ERR_RMA_SYNC;
     ompi_err_rma_sync_intern.mpi_code = MPI_ERR_RMA_SYNC;
     ompi_err_rma_sync_intern.index = pos++;
-    strncpy(ompi_err_rma_sync_intern.errstring, "OMPI_ERR_RMA_SYNC", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_rma_sync_intern.errstring,
+                     "OMPI_ERR_RMA_SYNC", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_sync_intern.index,
                                 &ompi_err_rma_sync_intern);
 
@@ -215,7 +235,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_rma_shared_intern.code = OMPI_ERR_RMA_SHARED;
     ompi_err_rma_shared_intern.mpi_code = MPI_ERR_RMA_SHARED;
     ompi_err_rma_shared_intern.index = pos++;
-    strncpy(ompi_err_rma_shared_intern.errstring, "OMPI_ERR_RMA_SHARED", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_rma_shared_intern.errstring,
+                     "OMPI_ERR_RMA_SHARED", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_shared_intern.index,
                                 &ompi_err_rma_shared_intern);
 
@@ -223,7 +244,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_rma_attach_intern.code = OMPI_ERR_RMA_ATTACH;
     ompi_err_rma_attach_intern.mpi_code = MPI_ERR_RMA_ATTACH;
     ompi_err_rma_attach_intern.index = pos++;
-    strncpy(ompi_err_rma_attach_intern.errstring, "OMPI_ERR_RMA_ATTACH", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_rma_attach_intern.errstring,
+                     "OMPI_ERR_RMA_ATTACH", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_attach_intern.index,
                                 &ompi_err_rma_attach_intern);
 
@@ -231,7 +253,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_rma_range_intern.code = OMPI_ERR_RMA_RANGE;
     ompi_err_rma_range_intern.mpi_code = MPI_ERR_RMA_RANGE;
     ompi_err_rma_range_intern.index = pos++;
-    strncpy(ompi_err_rma_range_intern.errstring, "OMPI_ERR_RMA_RANGE", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_rma_range_intern.errstring,
+                     "OMPI_ERR_RMA_RANGE", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_range_intern.index,
                                 &ompi_err_rma_range_intern);
 
@@ -239,7 +262,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_rma_conflict_intern.code = OMPI_ERR_RMA_CONFLICT;
     ompi_err_rma_conflict_intern.mpi_code = MPI_ERR_RMA_CONFLICT;
     ompi_err_rma_conflict_intern.index = pos++;
-    strncpy(ompi_err_rma_conflict_intern.errstring, "OMPI_ERR_RMA_CONFLICT", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_rma_conflict_intern.errstring,
+                     "OMPI_ERR_RMA_CONFLICT", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_conflict_intern.index,
                                 &ompi_err_rma_conflict_intern);
 
@@ -247,7 +271,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_win_intern.code = OMPI_ERR_WIN;
     ompi_err_win_intern.mpi_code = MPI_ERR_WIN;
     ompi_err_win_intern.index = pos++;
-    strncpy(ompi_err_win_intern.errstring, "OMPI_ERR_WIN", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_win_intern.errstring,
+                     "OMPI_ERR_WIN", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_win_intern.index,
                                 &ompi_err_win_intern);
 
@@ -255,7 +280,8 @@ int ompi_errcode_intern_init (void)
     ompi_err_rma_flavor_intern.code = OMPI_ERR_RMA_FLAVOR;
     ompi_err_rma_flavor_intern.mpi_code = MPI_ERR_RMA_FLAVOR;
     ompi_err_rma_flavor_intern.index = pos++;
-    strncpy(ompi_err_rma_flavor_intern.errstring, "OMPI_ERR_RMA_FLAVOR", OMPI_MAX_ERROR_STRING);
+    opal_string_copy(ompi_err_rma_flavor_intern.errstring,
+                     "OMPI_ERR_RMA_FLAVOR", OMPI_MAX_ERROR_STRING);
     opal_pointer_array_set_item(&ompi_errcodes_intern, ompi_err_rma_flavor_intern.index,
                                 &ompi_err_rma_flavor_intern);
 

--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
- * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -29,6 +29,8 @@
 #include <string.h>
 
 #include "mpi.h"
+
+#include "opal/util/string_copy.h"
 
 #include "ompi/errhandler/errcode.h"
 #include "ompi/constants.h"
@@ -124,7 +126,7 @@ do {                                                                      \
     OBJ_CONSTRUCT(&(VAR), ompi_mpi_errcode_t);                            \
     (VAR).code = (ERRCODE);                                               \
     (VAR).cls = (ERRCODE);                                                \
-    strncpy((VAR).errstring, (TXT), MPI_MAX_ERROR_STRING);                \
+    opal_string_copy((VAR).errstring, (TXT), MPI_MAX_ERROR_STRING);       \
     opal_pointer_array_set_item(&ompi_mpi_errcodes, (ERRCODE), &(VAR));   \
 } while (0)
 
@@ -353,7 +355,7 @@ int ompi_mpi_errnum_add_string(int errnum, const char *errstring, int len)
         len = MPI_MAX_ERROR_STRING;
     }
 
-    strncpy ( errcodep->errstring, errstring, len );
+    opal_string_copy( errcodep->errstring, errstring, len );
     return OMPI_SUCCESS;
 }
 

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -32,6 +32,7 @@
 #include "ompi/errhandler/errhandler_predefined.h"
 #include "opal/class/opal_pointer_array.h"
 #include "opal/mca/pmix/pmix.h"
+#include "opal/util/string_copy.h"
 
 
 /*
@@ -98,9 +99,8 @@ int ompi_errhandler_init(void)
   ompi_mpi_errhandler_null.eh.eh_file_fn = NULL;
   ompi_mpi_errhandler_null.eh.eh_win_fn  = NULL ;
   ompi_mpi_errhandler_null.eh.eh_fort_fn = NULL;
-  strncpy (ompi_mpi_errhandler_null.eh.eh_name, "MPI_ERRHANDLER_NULL",
-	   strlen("MPI_ERRHANDLER_NULL")+1 );
-
+  opal_string_copy(ompi_mpi_errhandler_null.eh.eh_name, "MPI_ERRHANDLER_NULL",
+                   sizeof(ompi_mpi_errhandler_null.eh.eh_name));
 
   OBJ_CONSTRUCT( &ompi_mpi_errors_are_fatal.eh, ompi_errhandler_t );
   if( ompi_mpi_errors_are_fatal.eh.eh_f_to_c_index != OMPI_ERRORS_ARE_FATAL_FORTRAN )
@@ -111,8 +111,9 @@ int ompi_errhandler_init(void)
   ompi_mpi_errors_are_fatal.eh.eh_file_fn = ompi_mpi_errors_are_fatal_file_handler;
   ompi_mpi_errors_are_fatal.eh.eh_win_fn  = ompi_mpi_errors_are_fatal_win_handler ;
   ompi_mpi_errors_are_fatal.eh.eh_fort_fn = NULL;
-  strncpy (ompi_mpi_errors_are_fatal.eh.eh_name, "MPI_ERRORS_ARE_FATAL",
-	   strlen("MPI_ERRORS_ARE_FATAL")+1 );
+  opal_string_copy(ompi_mpi_errors_are_fatal.eh.eh_name,
+                   "MPI_ERRORS_ARE_FATAL",
+                   sizeof(ompi_mpi_errors_are_fatal.eh.eh_name));
 
   OBJ_CONSTRUCT( &ompi_mpi_errors_return.eh, ompi_errhandler_t );
   if( ompi_mpi_errors_return.eh.eh_f_to_c_index != OMPI_ERRORS_RETURN_FORTRAN )
@@ -123,8 +124,8 @@ int ompi_errhandler_init(void)
   ompi_mpi_errors_return.eh.eh_file_fn = ompi_mpi_errors_return_file_handler;
   ompi_mpi_errors_return.eh.eh_win_fn  = ompi_mpi_errors_return_win_handler;
   ompi_mpi_errors_return.eh.eh_fort_fn = NULL;
-  strncpy (ompi_mpi_errors_return.eh.eh_name, "MPI_ERRORS_RETURN",
-	   strlen("MPI_ERRORS_RETURN")+1 );
+  opal_string_copy(ompi_mpi_errors_return.eh.eh_name, "MPI_ERRORS_RETURN",
+                   sizeof(ompi_mpi_errors_return.eh.eh_name));
 
   /* If we're going to use C++, functions will be fixed up during
      MPI::Init.  Note that it is proper to use ERRHANDLER_LANG_C here;
@@ -142,8 +143,9 @@ int ompi_errhandler_init(void)
   ompi_mpi_errors_throw_exceptions.eh.eh_win_fn  =
       ompi_mpi_errors_are_fatal_win_handler ;
   ompi_mpi_errors_throw_exceptions.eh.eh_fort_fn = NULL;
-  strncpy (ompi_mpi_errors_throw_exceptions.eh.eh_name, "MPI_ERRORS_THROW_EXCEPTIONS",
-	   strlen("MPI_ERRORS_THROW_EXCEPTIONS")+1 );
+  opal_string_copy(ompi_mpi_errors_throw_exceptions.eh.eh_name,
+                   "MPI_ERRORS_THROW_EXCEPTIONS",
+                   sizeof(ompi_mpi_errors_throw_exceptions.eh.eh_name));
 
   /* All done */
 

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -43,7 +43,6 @@
 #include "opal/util/argv.h"
 #include "opal/util/opal_getcwd.h"
 #include "opal/util/output.h"
-#include "opal/util/strncpy.h"
 #include "opal/util/info.h"
 
 #include "ompi/info/info.h"

--- a/ompi/mca/fs/base/fs_base_get_parent_dir.c
+++ b/ompi/mca/fs/base/fs_base_get_parent_dir.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2008-2016 University of Houston. All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,12 +22,15 @@
 
 
 #include "ompi_config.h"
+
 #include <stdio.h>
 
-#include "ompi/mca/mca.h"
 #include "opal/mca/base/base.h"
 #include "opal/util/path.h"
+#include "opal/util/printf.h"
+#include "opal/util/string_copy.h"
 
+#include "ompi/mca/mca.h"
 #include "ompi/mca/fs/fs.h"
 #include "ompi/mca/fs/base/base.h"
 #include "ompi/mca/common/ompio/common_ompio.h"
@@ -52,6 +56,11 @@ void mca_fs_base_get_parent_dir ( char *filename, char **dirnamep)
     int err;
     char *dir = NULL, *slash;
     struct stat statbuf;
+
+    if (strlen(filename) < 1) {
+        opal_asprintf(dirnamep, ".%s", OPAL_PATH_SEP);
+        return;
+    }
 
     err = lstat(filename, &statbuf);
 
@@ -86,10 +95,16 @@ void mca_fs_base_get_parent_dir ( char *filename, char **dirnamep)
     }
 
     slash = strrchr(dir, '/');
-    if (!slash) strncpy(dir, ".", 2);
-    else {
-	if (slash == dir) *(dir + 1) = '\0';
-	else *slash = '\0';
+    if (!slash) {
+        // It is guaranteed in this case that "dir" will be at least 2
+        // characters long.
+        opal_string_copy(dir, ".", 2);
+    } else {
+	if (slash == dir) {
+            *(dir + 1) = '\0';
+        } else {
+            *slash = '\0';
+        }
     }
 
     *dirnamep = dir;

--- a/ompi/mca/pml/v/pml_v_component.c
+++ b/ompi/mca/pml/v/pml_v_component.c
@@ -21,6 +21,7 @@
 #include "opal/mca/base/base.h"
 #include "opal/mca/base/mca_base_component_repository.h"
 #include "opal/util/printf.h"
+#include "opal/util/string_copy.h"
 #include "ompi/constants.h"
 #include "ompi/mca/pml/base/base.h"
 #include "ompi/mca/vprotocol/vprotocol.h"
@@ -146,10 +147,9 @@ static int mca_pml_v_component_close(void)
     opal_asprintf(&new_name, "%s]v%s",
              mca_pml_v.host_pml_component.pmlm_version.mca_component_name,
              mca_vprotocol_component.pmlm_version.mca_component_name);
-    size_t len = sizeof(mca_pml_base_selected_component.pmlm_version.mca_component_name);
-    strncpy(mca_pml_base_selected_component.pmlm_version.mca_component_name,
-            new_name, len - 1);
-    mca_pml_base_selected_component.pmlm_version.mca_component_name[len - 1] = '\0';
+    opal_string_copy(mca_pml_base_selected_component.pmlm_version.mca_component_name,
+                     new_name,
+                     sizeof(mca_pml_base_selected_component.pmlm_version.mca_component_name));
     free(new_name);
 
     /* Replace finalize */

--- a/ompi/mca/rte/pmix/rte_pmix_module.c
+++ b/ompi/mca/rte/pmix/rte_pmix_module.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2012-2014 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * $COPYRIGHT$
  */
@@ -38,6 +38,7 @@
 #include "opal/util/printf.h"
 #include "opal/util/proc.h"
 #include "opal/util/show_help.h"
+#include "opal/util/string_copy.h"
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/mca/pmix/base/base.h"
 #include "opal/threads/threads.h"
@@ -430,7 +431,8 @@ static int ompi_pmix_snprintf_jobid(char *jobid_string, size_t size, const opal_
 
     /* check for wildcard value - handle appropriately */
     if (OPAL_JOBID_WILDCARD == jobid) {
-        (void)strncpy(jobid_string, OPAL_SCHEMA_WILDCARD_STRING, size);
+        (void)opal_string_copy(jobid_string,
+                               OPAL_SCHEMA_WILDCARD_STRING, size);
     } else {
         rc = snprintf(jobid_string, size, "%ld", (long) jobid);
         if (0 > rc) {

--- a/ompi/mpi/c/comm_get_name.c
+++ b/ompi/mpi/c/comm_get_name.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -23,12 +23,14 @@
 
 #include <string.h>
 
+#include "opal/threads/mutex.h"
+#include "opal/util/string_copy.h"
+
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/totalview.h"
-#include "opal/threads/mutex.h"
 #include "ompi/memchecker.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -72,7 +74,7 @@ int MPI_Comm_get_name(MPI_Comm comm, char *name, int *length)
        able to completely fit into MPI_MAX_OBJECT_NAME bytes (i.e.,
        name+\0). */
     if ( comm->c_flags & OMPI_COMM_NAMEISSET ) {
-        strncpy(name, comm->c_name, MPI_MAX_OBJECT_NAME);
+        opal_string_copy(name, comm->c_name, MPI_MAX_OBJECT_NAME);
         *length = (int) strlen(comm->c_name);
     } else {
         name[0] = '\0';

--- a/ompi/mpi/c/error_string.c
+++ b/ompi/mpi/c/error_string.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2006      University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,6 +21,8 @@
  */
 #include "ompi_config.h"
 #include <string.h>
+
+#include "opal/util/string_copy.h"
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
@@ -53,7 +56,7 @@ int MPI_Error_string(int errorcode, char *string, int *resultlen)
     }
 
     tmpstring = ompi_mpi_errnum_get_string (errorcode);
-    strncpy(string, tmpstring, MPI_MAX_ERROR_STRING);
+    opal_string_copy(string, tmpstring, MPI_MAX_ERROR_STRING);
     *resultlen = (int)strlen(string);
 
     return MPI_SUCCESS;

--- a/ompi/mpi/c/lookup_name.c
+++ b/ompi/mpi/c/lookup_name.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,6 +28,7 @@
 #include "opal/class/opal_list.h"
 #include "opal/mca/pmix/pmix.h"
 #include "opal/util/show_help.h"
+#include "opal/util/string_copy.h"
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
@@ -138,7 +139,8 @@ int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
         return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, ret, FUNC_NAME);
     }
 
-    strncpy ( port_name, pdat->value.data.string, MPI_MAX_PORT_NAME );
+    opal_string_copy( port_name, pdat->value.data.string,
+                      MPI_MAX_PORT_NAME );
     OPAL_LIST_DESTRUCT(&results);
 
     OPAL_CR_EXIT_LIBRARY();

--- a/ompi/mpi/c/type_create_f90_complex.c
+++ b/ompi/mpi/c/type_create_f90_complex.c
@@ -27,14 +27,14 @@
 
 #include "ompi_config.h"
 
+#include <float.h>
+
 #include "opal/util/printf.h"
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
-
-#include <float.h>
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -110,12 +110,12 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
          */
         datatype->super.flags |= OMPI_DATATYPE_FLAG_PREDEFINED;
         /* Mark the datatype as a special F90 convenience type */
-        char *new_name;
-        opal_asprintf(&new_name, "COMBINER %s", (*newtype)->name);
-        size_t max_len = MPI_MAX_OBJECT_NAME;
-        strncpy(datatype->name, new_name, max_len - 1);
-        datatype->name[max_len - 1] = '\0';
-        free(new_name);
+        // Specifically using opal_snprintf() here (instead of
+        // snprintf()) so that over-eager compilers do not warn us
+        // that we may be truncating the output.  We *know* that the
+        // output may be truncated, and that's ok.
+        opal_snprintf(datatype->name, sizeof(datatype->name),
+                      "COMBINER %s", (*newtype)->name);
 
         a_i[0] = &p;
         a_i[1] = &r;

--- a/ompi/mpi/c/type_create_f90_integer.c
+++ b/ompi/mpi/c/type_create_f90_integer.c
@@ -106,12 +106,12 @@ int MPI_Type_create_f90_integer(int r, MPI_Datatype *newtype)
          */
         datatype->super.flags |= OMPI_DATATYPE_FLAG_PREDEFINED;
         /* Mark the datatype as a special F90 convenience type */
-        char *new_name;
-        opal_asprintf(&new_name, "COMBINER %s", (*newtype)->name);
-        size_t max_len = MPI_MAX_OBJECT_NAME;
-        strncpy(datatype->name, new_name, max_len - 1);
-        datatype->name[max_len - 1] = '\0';
-        free(new_name);
+        // Specifically using opal_snprintf() here (instead of
+        // snprintf()) so that over-eager compilers do not warn us
+        // that we may be truncating the output.  We *know* that the
+        // output may be truncated, and that's ok.
+        opal_snprintf(datatype->name, sizeof(datatype->name),
+                      "COMBINER %s", (*newtype)->name);
 
         a_i[0] = &r;
         ompi_datatype_set_args( datatype, 1, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_INTEGER );

--- a/ompi/mpi/c/type_create_f90_real.c
+++ b/ompi/mpi/c/type_create_f90_real.c
@@ -27,14 +27,14 @@
 
 #include "ompi_config.h"
 
+#include <float.h>
+
 #include "opal/util/printf.h"
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
-
-#include <float.h>
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -110,12 +110,12 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
          */
         datatype->super.flags |= OMPI_DATATYPE_FLAG_PREDEFINED;
         /* Mark the datatype as a special F90 convenience type */
-        char *new_name;
-        opal_asprintf(&new_name, "COMBINER %s", (*newtype)->name);
-        size_t max_len = MPI_MAX_OBJECT_NAME;
-        strncpy(datatype->name, new_name, max_len - 1);
-        datatype->name[max_len - 1] = '\0';
-        free(new_name);
+        // Specifically using opal_snprintf() here (instead of
+        // snprintf()) so that over-eager compilers do not warn us
+        // that we may be truncating the output.  We *know* that the
+        // output may be truncated, and it's ok.
+        opal_snprintf(datatype->name, sizeof(datatype->name),
+                      "COMBINER %s", (*newtype)->name);
 
         ompi_datatype_set_args( datatype, 2, a_i, 0, NULL, 0, NULL, MPI_COMBINER_F90_REAL );
 

--- a/ompi/mpi/c/type_get_name.c
+++ b/ompi/mpi/c/type_get_name.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -22,6 +22,8 @@
 #include "ompi_config.h"
 
 #include <string.h>
+
+#include "opal/util/string_copy.h"
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
@@ -71,6 +73,6 @@ int MPI_Type_get_name(MPI_Datatype type, char *type_name, int *resultlen)
        able to completely fit into MPI_MAX_OBJECT_NAME bytes (i.e.,
        name+\0). */
    *resultlen = (int)strlen(type->name);
-   strncpy(type_name, type->name, MPI_MAX_OBJECT_NAME);
+   opal_string_copy(type_name, type->name, MPI_MAX_OBJECT_NAME);
    return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/type_set_name.c
+++ b/ompi/mpi/c/type_set_name.c
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +25,8 @@
 #include "ompi_config.h"
 
 #include <string.h>
+
+#include "opal/util/string_copy.h"
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
@@ -66,6 +69,6 @@ int MPI_Type_set_name (MPI_Datatype type, const char *type_name)
     if( length >= MPI_MAX_OBJECT_NAME ) {
         length = MPI_MAX_OBJECT_NAME - 1;
     }
-    strncpy( type->name, type_name, length );
+    opal_string_copy( type->name, type_name, length );
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/fortran/base/strings.c
+++ b/ompi/mpi/fortran/base/strings.c
@@ -25,8 +25,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "ompi/constants.h"
 #include "opal/util/argv.h"
+#include "opal/util/string_copy.h"
+
+#include "ompi/constants.h"
 #include "ompi/mpi/fortran/base/fortran_base_strings.h"
 
 
@@ -65,9 +67,10 @@ int ompi_fortran_string_f2c(char *fstr, int len, char **cstr)
     /* Copy F77 string into C string and NULL terminate it. */
 
     if (len > 0) {
-        strncpy(*cstr, fstr, len);
+        opal_string_copy(*cstr, fstr, len + 1);
+    } else {
+        (*cstr)[0] = '\0';
     }
-    (*cstr)[len] = '\0';
 
     return OMPI_SUCCESS;
 }
@@ -91,7 +94,7 @@ int ompi_fortran_string_c2f(char *cstr, char *fstr, int len)
 {
     int i;
 
-    strncpy(fstr, cstr, len);
+    opal_string_copy(fstr, cstr, len);
     for (i = strlen(cstr); i < len; ++i) {
         fstr[i] = ' ';
     }

--- a/ompi/mpi/tool/mpit-internal.h
+++ b/ompi/mpi/tool/mpit-internal.h
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2011      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,9 +15,11 @@
 #if !defined(MPIT_INTERNAL_H)
 #define MPIT_INTERNAL_H
 
-#include "ompi/include/ompi_config.h"
+#include "opal/util/string_copy.h"
 #include "opal/mca/base/mca_base_var.h"
 #include "opal/mca/base/mca_base_pvar.h"
+
+#include "ompi/include/ompi_config.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/constants.h"
@@ -64,8 +67,7 @@ static inline void mpit_copy_string (char *dest, int *len, const char *source)
             *len = strlen (source) + 1;
         }
 
-        strncpy (dest, source, *len);
-        dest[*len - 1] = '\0';
+        opal_string_copy (dest, source, *len);
     } else {
         *len = strlen (source) + 1;
     }

--- a/ompi/mpiext/affinity/c/mpiext_affinity_str.c
+++ b/ompi/mpiext/affinity/c/mpiext_affinity_str.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -31,6 +31,7 @@
 
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/runtime/opal.h"
+#include "opal/util/string_copy.h"
 
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
@@ -101,7 +102,7 @@ static int get_rsrc_ompi_bound(char str[OMPI_AFFINITY_STRING_MAX])
 
     /* If OMPI did not bind, indicate that */
     if (!ompi_rte_proc_is_bound) {
-        strncpy(str, ompi_nobind_str, OMPI_AFFINITY_STRING_MAX - 1);
+        opal_string_copy(str, ompi_nobind_str, OMPI_AFFINITY_STRING_MAX);
         return OMPI_SUCCESS;
     }
 
@@ -113,7 +114,7 @@ static int get_rsrc_ompi_bound(char str[OMPI_AFFINITY_STRING_MAX])
                                        ompi_proc_applied_binding);
     }
     if (OPAL_ERR_NOT_BOUND == ret) {
-        strncpy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX - 1);
+        opal_string_copy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX);
         ret = OMPI_SUCCESS;
     }
     return ret;
@@ -163,7 +164,7 @@ static int get_rsrc_current_binding(char str[OMPI_AFFINITY_STRING_MAX])
                                        opal_hwloc_topology,
                                        boundset);
         if (OPAL_ERR_NOT_BOUND == ret) {
-            strncpy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX - 1);
+            opal_string_copy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX);
             ret = OMPI_SUCCESS;
         }
     }
@@ -293,7 +294,7 @@ static int get_layout_ompi_bound(char str[OMPI_AFFINITY_STRING_MAX])
 
     /* If OMPI did not bind, indicate that */
     if (!ompi_rte_proc_is_bound) {
-        strncpy(str, ompi_nobind_str, OMPI_AFFINITY_STRING_MAX - 1);
+        opal_string_copy(str, ompi_nobind_str, OMPI_AFFINITY_STRING_MAX);
         return OMPI_SUCCESS;
     }
 
@@ -306,7 +307,7 @@ static int get_layout_ompi_bound(char str[OMPI_AFFINITY_STRING_MAX])
                                           ompi_proc_applied_binding);
     }
     if (OPAL_ERR_NOT_BOUND == ret) {
-        strncpy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX - 1);
+        opal_string_copy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX);
         ret = OMPI_SUCCESS;
     }
 
@@ -356,7 +357,7 @@ static int get_layout_current_binding(char str[OMPI_AFFINITY_STRING_MAX])
                                           opal_hwloc_topology,
                                           boundset);
         if (OPAL_ERR_NOT_BOUND == ret) {
-            strncpy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX - 1);
+            opal_string_copy(str, not_bound_str, OMPI_AFFINITY_STRING_MAX);
             ret = OMPI_SUCCESS;
         }
     }

--- a/ompi/mpiext/cr/c/migrate.c
+++ b/ompi/mpiext/cr/c/migrate.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,6 +11,8 @@
  */
 #include "ompi_config.h"
 #include <stdio.h>
+
+#include "opal/util/string_copy.h"
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/info/info.h"
@@ -59,8 +61,7 @@ int OMPI_CR_Migrate(MPI_Comm comm, char *hostname, int rank, MPI_Info *info)
     if( NULL == hostname ) {
         loc_hostname[0] = '\0';
     } else {
-        strncpy(loc_hostname, hostname, strlen(hostname));
-        loc_hostname[strlen(hostname)] = '\0';
+        opal_string_copy(loc_hostname, hostname, sizeof(loc_hostname));
     }
     my_vpid = (int) OMPI_PROC_MY_NAME->vpid;
 

--- a/ompi/op/op.c
+++ b/ompi/op/op.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -26,6 +26,7 @@
 #include "ompi_config.h"
 
 #include "opal/class/opal_pointer_array.h"
+#include "opal/util/string_copy.h"
 
 #include "ompi/constants.h"
 #include "ompi/op/op.h"
@@ -356,7 +357,7 @@ ompi_op_t *ompi_op_create_user(bool commute,
         new_op->o_flags |= OMPI_OP_FLAGS_COMMUTE;
     }
 
-    strncpy(new_op->o_name, "USER OP", sizeof(new_op->o_name) - 1);
+    opal_string_copy(new_op->o_name, "USER OP", sizeof(new_op->o_name));
     new_op->o_name[sizeof(new_op->o_name) - 1] = '\0';
 
     /* Set the user-defined callback function.  The "fort_fn" member
@@ -423,7 +424,7 @@ static int add_intrinsic(ompi_op_t *op, int fort_handle, int flags,
 
     /* Set the members */
     op->o_flags = flags;
-    strncpy(op->o_name, name, sizeof(op->o_name) - 1);
+    opal_string_copy(op->o_name, name, sizeof(op->o_name));
     op->o_name[sizeof(op->o_name) - 1] = '\0';
 
     /* Perform the selection on this op to fill in the function

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
- * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -27,6 +27,7 @@
 #include "ompi_config.h"
 
 #include "opal/util/info_subscriber.h"
+#include "opal/util/string_copy.h"
 
 #include "mpi.h"
 #include "ompi/win/win.h"
@@ -383,9 +384,7 @@ int
 ompi_win_set_name(ompi_win_t *win, const char *win_name)
 {
     OPAL_THREAD_LOCK(&(win->w_lock));
-    memset(win->w_name, 0, MPI_MAX_OBJECT_NAME);
-    strncpy(win->w_name, win_name, MPI_MAX_OBJECT_NAME);
-    win->w_name[MPI_MAX_OBJECT_NAME - 1] = 0;
+    opal_string_copy(win->w_name, win_name, MPI_MAX_OBJECT_NAME);
     OPAL_THREAD_UNLOCK(&(win->w_lock));
 
     return OMPI_SUCCESS;
@@ -396,7 +395,7 @@ int
 ompi_win_get_name(ompi_win_t *win, char *win_name, int *length)
 {
     OPAL_THREAD_LOCK(&(win->w_lock));
-    strncpy(win_name, win->w_name, MPI_MAX_OBJECT_NAME);
+    opal_string_copy(win_name, win->w_name, MPI_MAX_OBJECT_NAME);
     *length = (int)strlen(win->w_name);
     OPAL_THREAD_UNLOCK(&(win->w_lock));
 

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2014      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -56,6 +56,7 @@
 #include "opal/util/show_help.h"
 #include "opal/util/proc.h"
 #include "opal/util/printf.h"
+#include "opal/util/string_copy.h"
 #include "opal/mca/btl/base/btl_base_error.h"
 
 #include "btl_tcp.h"
@@ -404,7 +405,8 @@ mca_btl_tcp_endpoint_send_connect_ack(mca_btl_base_endpoint_t* btl_endpoint)
     OPAL_PROCESS_NAME_HTON(guid);
     
     mca_btl_tcp_endpoint_hs_msg_t hs_msg;
-    strcpy(hs_msg.magic_id, mca_btl_tcp_magic_id_string);
+    opal_string_copy(hs_msg.magic_id, mca_btl_tcp_magic_id_string,
+                     sizeof(hs_msg.magic_id));
     hs_msg.guid = guid;
     
     if(sizeof(hs_msg) != 

--- a/opal/test/reachable/reachable_netlink.c
+++ b/opal/test/reachable/reachable_netlink.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Amazon.com, Inc. or its affiliates.  All Rights
  *                    reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -137,7 +138,7 @@ int main(int argc, char **argv)
                 break;
             default:
                 family = "Unknown";
-                strcpy(addr, "Unknown");
+                opal_string_copy(addr, "Unknown", sizeof(addr));
                 break;
         }
 
@@ -165,7 +166,7 @@ int main(int argc, char **argv)
                 break;
             default:
                 family = "Unknown";
-                strcpy(addr, "Unknown");
+                opal_string_copy(addr, "Unknown", sizeof(addr));
                 break;
         }
 

--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -96,7 +96,6 @@ static void opal_info_get_nolock (opal_info_t *info, const char *key, int valuel
                                  char *value, int *flag)
 {
     opal_info_entry_t *search;
-    int value_length;
 
     search = info_find_key (info, key);
     if (NULL == search){
@@ -104,7 +103,7 @@ static void opal_info_get_nolock (opal_info_t *info, const char *key, int valuel
     } else if (value && valuelen) {
         /*
          * We have found the element, so we can return the value
-         * Set the flag, value_length and value
+         * Set the flag and value
          */
         *flag = 1;
         opal_string_copy(value, search->ie_value, valuelen);

--- a/opal/util/opal_pty.c
+++ b/opal/util/opal_pty.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,7 +136,9 @@ int opal_openpty(int *amaster, int *aslave, char *name,
         return -1;
     }
     if (name) {
-        strcpy(name, line);
+        // We don't know the max length of name, but we do know the
+        // max length of the source, so at least use that.
+        opal_string_copy(name, line, sizeof(line));
     }
 #ifndef TCSAFLUSH
 #define TCSAFLUSH TCSETAF

--- a/opal/util/os_path.c
+++ b/opal/util/os_path.c
@@ -54,14 +54,12 @@ char *opal_os_path(int relative, ...)
     va_end(ap);
 
     if (0 == num_elements) { /* must be looking for a simple answer */
-    	path = (char *)malloc(3);
-        path[0] = '\0';
+        size_t len = 3;
+        path = (char *)calloc(len, sizeof(char));
     	if (relative) {
-    	    strcpy(path, ".");
-            strcat(path, path_sep);
-    	} else {
-    	    strcpy(path, path_sep);
-    	}
+            path[0] = '.';
+        }
+        strncat(path, path_sep, len);
     	return(path);
     }
 
@@ -76,28 +74,27 @@ char *opal_os_path(int relative, ...)
     	return(NULL);
     }
 
-    path = (char *)malloc(total_length);
+    path = (char *)calloc(total_length, sizeof(char));
     if (NULL == path) {
         return(NULL);
     }
-    path[0] = 0;
 
     if (relative) {
-        strcpy(path, ".");
+        path[0] = '.';
     }
 
     va_start(ap, relative);
     if( NULL != (element = va_arg(ap, char*)) ) {
     	if (path_sep[0] != element[0]) {
-            strcat(path, path_sep);
+            strncat(path, path_sep, total_length);
         }
         strcat(path, element);
     }
     while (NULL != (element=va_arg(ap, char*))) {
     	if (path_sep[0] != element[0]) {
-            strcat(path, path_sep);
+            strncat(path, path_sep, total_length);
         }
-        strcat(path, element);
+        strncat(path, element, total_length);
     }
 
     va_end(ap);

--- a/opal/util/path.c
+++ b/opal/util/path.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2010      IBM Corporation.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
@@ -77,6 +77,7 @@
 #include "opal/util/path.h"
 #include "opal/util/os_path.h"
 #include "opal/util/argv.h"
+#include "opal/util/printf.h"
 
 /*
  * Sanity check to ensure we have either statfs or statvfs
@@ -146,12 +147,7 @@ char *opal_path_find(char *fname, char **pathv, int mode, char **envv)
                 if (!delimit) {
                     fullpath = opal_path_access(fname, env, mode);
                 } else {
-                    pfix = (char*) malloc(strlen(env) + strlen(delimit) + 1);
-                    if (NULL == pfix) {
-                        return NULL;
-                    }
-                    strcpy(pfix, env);
-                    strcat(pfix, delimit);
+                    opal_asprintf(&pfix, "%s%s", env, delimit);
                     fullpath = opal_path_access(fname, pfix, mode);
                     free(pfix);
                 }

--- a/orte/mca/oob/tcp/oob_tcp_sendrecv.h
+++ b/orte/mca/oob/tcp/oob_tcp_sendrecv.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2010-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -26,6 +26,7 @@
 #include "orte_config.h"
 
 #include "opal/class/opal_list.h"
+#include "opal/util/string_copy.h"
 
 #include "orte/mca/rml/base/base.h"
 #include "orte/util/threads.h"
@@ -109,7 +110,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
         _s->hdr.tag = (m)->tag;                                        \
         _s->hdr.seq_num = (m)->seq_num;                                \
         if (NULL != (m)->routed) {                                      \
-            (void)strncpy(_s->hdr.routed, (m)->routed,                 \
+            (void)opal_string_copy(_s->hdr.routed, (m)->routed,         \
                           ORTE_MAX_RTD_SIZE);                           \
         }                                                               \
         /* point to the actual message */                               \
@@ -157,7 +158,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
         _s->hdr.tag = (m)->tag;                                        \
         _s->hdr.seq_num = (m)->seq_num;                                \
         if (NULL != (m)->routed) {                                      \
-            (void)strncpy(_s->hdr.routed, (m)->routed,                 \
+            (void)opal_string_copy(_s->hdr.routed, (m)->routed,         \
                           ORTE_MAX_RTD_SIZE);                           \
         }                                                               \
         /* point to the actual message */                               \
@@ -202,7 +203,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
         _s->hdr.dst = (m)->hdr.dst;                                    \
         _s->hdr.type = MCA_OOB_TCP_USER;                               \
         _s->hdr.tag = (m)->hdr.tag;                                    \
-        (void)strncpy(_s->hdr.routed, (m)->hdr.routed,                 \
+        (void)opal_string_copy(_s->hdr.routed, (m)->hdr.routed,         \
                       ORTE_MAX_RTD_SIZE);                               \
         /* point to the actual message */                               \
         _s->data = (m)->data;                                          \

--- a/orte/mca/plm/rsh/plm_rsh_component.c
+++ b/orte/mca/plm/rsh/plm_rsh_component.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights
  *                         reserved.
- * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011      IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -45,6 +45,7 @@
 #include "opal/util/argv.h"
 #include "opal/util/basename.h"
 #include "opal/util/path.h"
+#include "opal/util/string_copy.h"
 
 #include "orte/mca/state/state.h"
 #include "orte/util/name_fns.h"
@@ -365,8 +366,7 @@ char **orte_plm_rsh_search(const char* agent_list, const char *path)
     if (NULL == path) {
         getcwd(cwd, OPAL_PATH_MAX);
     } else {
-        strncpy(cwd, path, OPAL_PATH_MAX - 1);
-        cwd[OPAL_PATH_MAX - 1] = '\0';
+        opal_string_copy(cwd, path, OPAL_PATH_MAX);
     }
     if (NULL == agent_list) {
         lines = opal_argv_split(mca_plm_rsh_component.agent, ':');

--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
@@ -29,6 +29,7 @@
 
 #include "orte/mca/mca.h"
 #include "opal/util/output.h"
+#include "opal/util/string_copy.h"
 #include "opal/mca/base/base.h"
 #include "opal/mca/hwloc/base/base.h"
 #include "opal/dss/dss.h"
@@ -530,14 +531,14 @@ void orte_rmaps_base_display_map(orte_job_t *jdata)
                 memset(tmp1, 0, sizeof(tmp1));
                 if (orte_get_attribute(&proc->attributes, ORTE_PROC_HWLOC_BOUND, (void**)&bd, OPAL_PTR)) {
                     if (NULL == bd) {
-                        (void)strncpy(tmp1, "UNBOUND", sizeof(tmp1));
+                        (void)opal_string_copy(tmp1, "UNBOUND", sizeof(tmp1));
                     } else {
                         if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2mapstr(tmp1, sizeof(tmp1), node->topology->topo, bd->cpuset)) {
-                            (void)strncpy(tmp1, "UNBOUND", sizeof(tmp1));
+                            (void)opal_string_copy(tmp1, "UNBOUND", sizeof(tmp1));
                         }
                     }
                 } else {
-                    (void)strncpy(tmp1, "UNBOUND", sizeof(tmp1));
+                    (void)opal_string_copy(tmp1, "UNBOUND", sizeof(tmp1));
                 }
                 opal_output(orte_clean_output, "\t\t<process rank=%s app_idx=%ld local_rank=%lu node_rank=%lu binding=%s>",
                             ORTE_VPID_PRINT(proc->name.vpid),  (long)proc->app_idx,

--- a/orte/mca/snapc/full/snapc_full_global.c
+++ b/orte/mca/snapc/full/snapc_full_global.c
@@ -9,6 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Evergrid, Inc. All rights reserved.
  *
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,6 +29,7 @@
 #include "opal/util/opal_environ.h"
 #include "opal/util/basename.h"
 #include "opal/util/show_help.h"
+#include "opal/util/string_copy.h"
 #include "orte/mca/mca.h"
 #include "opal/mca/base/base.h"
 #include "opal/mca/crs/crs.h"
@@ -1381,7 +1383,7 @@ static void snapc_full_process_request_op_cmd(orte_process_name_t* sender,
                 ORTE_ERROR_LOG(ret);
                 goto cleanup;
             }
-            strncpy( ((datum->mig_host_pref)[i]), tmp_str, OPAL_MAX_PROCESSOR_NAME);
+            opal_string_copy( ((datum->mig_host_pref)[i]), tmp_str, OPAL_MAX_PROCESSOR_NAME);
 
             count = 1;
             if (ORTE_SUCCESS != (ret = opal_dss.unpack(sbuffer, &((datum->mig_vpid_pref)[i]), &count, OPAL_INT))) {

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -72,6 +72,7 @@
 #include "opal/util/opal_getcwd.h"
 #include "opal/util/show_help.h"
 #include "opal/util/fd.h"
+#include "opal/util/string_copy.h"
 #include "opal/sys/atomic.h"
 #if OPAL_ENABLE_FT_CR == 1
 #include "opal/runtime/opal_cr.h"
@@ -2295,7 +2296,8 @@ static void orte_debugger_init_before_spawn(orte_job_t *jdata)
                 free(attach_fifo);
                 return;
             }
-            strncpy(MPIR_attach_fifo, attach_fifo, MPIR_MAX_PATH_LENGTH - 1);
+            opal_string_copy(MPIR_attach_fifo, attach_fifo,
+                             MPIR_MAX_PATH_LENGTH);
             free(attach_fifo);
             open_fifo();
         }

--- a/orte/test/system/pmixtool.c
+++ b/orte/test/system/pmixtool.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
@@ -27,6 +27,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+
+#include "opal/util/string_copy.h"
 
 #include <pmix_tool.h>
 
@@ -47,7 +49,7 @@ int main(int argc, char **argv)
     /* query something */
     ninfo = 1;
     PMIX_INFO_CREATE(info, ninfo);
-    (void)strncpy(info[0].key, PMIX_QUERY_NAMESPACES, PMIX_MAX_KEYLEN);
+    (void)opal_string_copy(info[0].key, PMIX_QUERY_NAMESPACES, PMIX_MAX_KEYLEN);
     if (PMIX_SUCCESS != (rc = PMIx_Query_info(info, ninfo))) {
         fprintf(stderr, "Tool ns %s rank %d: PMIx_Query_info failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;

--- a/orte/util/attr.c
+++ b/orte/util/attr.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +16,7 @@
 
 #include "opal/dss/dss.h"
 #include "opal/util/output.h"
+#include "opal/util/string_copy.h"
 
 #include "orte/mca/errmgr/errmgr.h"
 
@@ -187,7 +189,8 @@ int orte_attr_register(const char *project,
     for (i = 0 ; i < MAX_CONVERTERS ; ++i) {
         if (0 == converters[i].init) {
             converters[i].init = 1;
-            strncpy(converters[i].project, project, MAX_CONVERTER_PROJECT_LEN);
+            opal_string_copy(converters[i].project, project,
+                             MAX_CONVERTER_PROJECT_LEN);
             converters[i].project[MAX_CONVERTER_PROJECT_LEN-1] = '\0';
             converters[i].key_base = key_base;
             converters[i].key_max = key_max;

--- a/orte/util/name_fns.c
+++ b/orte/util/name_fns.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +28,7 @@
 #include <string.h>
 
 #include "opal/util/printf.h"
+#include "opal/util/string_copy.h"
 #include "opal/threads/tsd.h"
 
 #include "orte/mca/errmgr/errmgr.h"
@@ -292,7 +294,7 @@ int orte_util_snprintf_jobid(char *jobid_string, size_t size, const orte_jobid_t
 
     /* check for wildcard value - handle appropriately */
     if (ORTE_JOBID_WILDCARD == jobid) {
-        (void)strncpy(jobid_string, ORTE_SCHEMA_WILDCARD_STRING, size);
+        (void)opal_string_copy(jobid_string, ORTE_SCHEMA_WILDCARD_STRING, size);
     } else {
         rc = snprintf(jobid_string, size, "%ld", (long) jobid);
         if (0 > rc) {


### PR DESCRIPTION
This is a follow-on to #5786: change `strncpy()` to `opal_string_copy()` in ORTE and OMPI.  Also do a few more string cleanups.

I also added a commit in here to fix a minor warning in `opal/util/info.c` -- just because it was a target of opportunity.

More could be done, but this is a good start, and fixes some obscure-put-possible string handling bugs.