### PR TITLE
opal/os_path: fix minor string overrun

### DIFF
--- a/opal/util/os_path.c
+++ b/opal/util/os_path.c
@@ -59,7 +59,7 @@ char *opal_os_path(int relative, ...)
     	if (relative) {
             path[0] = '.';
         }
-        strncat(path, path_sep, len);
+        strncat(path, path_sep, len - 1);
     	return(path);
     }
 


### PR DESCRIPTION
This is a follow on to 54ca3310ea35b7dc857afc59e00ffbb8f57e15ec to fix
a minor bug identified by Coverity.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>