### PR TITLE
Provide deprecation warning of MPIR debugger

### DIFF
--- a/orte/orted/help-orted.txt
+++ b/orte/orted/help-orted.txt
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -89,3 +89,21 @@ to it - please check the connection info and ensure the server
 is alive:
 
   Connection:  %s
+#
+[mpir-debugger-detected]
+Open MPI has detected that you have attached a debugger to this MPI
+job, and that debugger is using the legacy "MPIR" method of
+attachment.
+
+Please note that Open MPI has deprecated the "MPIR" debugger
+attachment method in favor of the new "PMIx" debugger attchment
+mechanisms.
+
+*** This means that future versions of Open MPI may not support the
+*** "MPIR" debugger attachment method at all.  Specifically: the
+*** debugger you just attached may not work with future versions of
+*** Open MPI.
+
+You may wish to contact your debugger vendor to inquire about support
+for PMIx-based debugger attachment mechanisms. Meantime, you can
+disable this warning by setting the OMPI_MPIR_DO_NOT_WARN envar to 1.

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -2258,6 +2258,8 @@ struct MPIR_PROCDESC {
  * spawn we need to check if we are being run under a TotalView-like
  * debugger; if so then inform applications via an MCA parameter.
  */
+static bool mpir_warning_printed = false;
+
 static void orte_debugger_init_before_spawn(orte_job_t *jdata)
 {
     char *env_name;
@@ -2306,6 +2308,15 @@ static void orte_debugger_init_before_spawn(orte_job_t *jdata)
 
  launchit:
     opal_output_verbose(1, orte_debug_output, "Info: Spawned by a debugger");
+
+    /* if we haven't previously warned about it */
+    if (!mpir_warning_printed) {
+        mpir_warning_printed = true;
+        /* check for silencing envar */
+        if (NULL == getenv("OMPI_MPIR_DO_NOT_WARN")) {
+            orte_show_help("help-orted.txt", "mpir-debugger-detected", true);
+        }
+    }
 
     /* tell the procs they are being debugged */
     (void) mca_base_var_env_name ("orte_in_parallel_debugger", &env_name);
@@ -2520,6 +2531,14 @@ void orte_debugger_init_after_spawn(int fd, short event, void *cbdata)
         if (MPIR_being_debugged || NULL != orte_debugger_test_daemon ||
             NULL != getenv("ORTE_TEST_DEBUGGER_ATTACH")) {
             OBJ_RELEASE(caddy);
+            /* if we haven't previously warned about it */
+            if (!mpir_warning_printed) {
+                mpir_warning_printed = true;
+                /* check for silencing envar */
+                if (NULL == getenv("OMPI_MPIR_DO_NOT_WARN")) {
+                    orte_show_help("help-orted.txt", "mpir-debugger-detected", true);
+                }
+            }
             if (!mpir_breakpoint_fired) {
                 /* record that we have triggered the debugger */
                 mpir_breakpoint_fired = true;
@@ -2615,6 +2634,15 @@ void orte_debugger_init_after_spawn(int fd, short event, void *cbdata)
      */
     if (MPIR_being_debugged || NULL != orte_debugger_test_daemon ||
         NULL != getenv("ORTE_TEST_DEBUGGER_ATTACH")) {
+        /* if we haven't previously warned about it */
+        if (!mpir_warning_printed) {
+            mpir_warning_printed = true;
+            /* check for silencing envar */
+            if (NULL == getenv("OMPI_MPIR_DO_NOT_WARN")) {
+                orte_show_help("help-orted.txt", "mpir-debugger-detected", true);
+            }
+        }
+
         /* if we are not launching debugger daemons, then trigger
          * the debugger - otherwise, we need to wait for the debugger
          * daemons to be started
@@ -2923,6 +2951,15 @@ static void attach_debugger(int fd, short event, void *arg)
                         "%s Attaching debugger %s", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
                         (NULL == orte_debugger_test_daemon) ? MPIR_executable_path : orte_debugger_test_daemon);
 
+    /* if we haven't previously warned about it */
+    if (!mpir_warning_printed) {
+        mpir_warning_printed = true;
+        /* check for silencing envar */
+        if (NULL == getenv("OMPI_MPIR_DO_NOT_WARN")) {
+            orte_show_help("help-orted.txt", "mpir-debugger-detected", true);
+        }
+    }
+
     /* a debugger has attached! All the MPIR_Proctable
      * data is already available, so we only need to
      * check to see if we should spawn any daemons
@@ -3036,6 +3073,15 @@ static void run_debugger(char *basename, opal_cmd_line_t *cmd_line,
     if (OPAL_SUCCESS == ret && NULL != env_name) {
         opal_setenv(env_name, "1", true, &environ);
         free(env_name);
+    }
+
+    /* if we haven't previously warned about it */
+    if (!mpir_warning_printed) {
+        mpir_warning_printed = true;
+        /* check for silencing envar */
+        if (NULL == getenv("OMPI_MPIR_DO_NOT_WARN")) {
+            orte_show_help("help-orted.txt", "mpir-debugger-detected", true);
+        }
     }
 
     /* Launch the debugger */


### PR DESCRIPTION
If we detect that we are being debugged by an MPIR-based debugger, then
print a warning that OMPI's MPIR support has been deprecated and will be
removed in a subsequent release.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>