### PR TITLE
romio/romio321: silence some compiler warnings

### DIFF
--- a/ompi/mca/io/romio321/romio/adio/common/ad_read_coll.c
+++ b/ompi/mca/io/romio321/romio/adio/common/ad_read_coll.c
@@ -735,7 +735,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
 	if (for_next_iter) {
 	    tmp_buf = (char *) ADIOI_Malloc(for_next_iter);
       ADIOI_Assert((((ADIO_Offset)(MPIU_Upint)read_buf)+real_size-for_next_iter) == (ADIO_Offset)(MPIU_Upint)(read_buf+real_size-for_next_iter));
-      ADIOI_Assert((for_next_iter+coll_bufsize) == (size_t)(for_next_iter+coll_bufsize));
+      ADIOI_Assert((ADIO_Size) (for_next_iter+coll_bufsize) == (size_t)(for_next_iter+coll_bufsize));
 	    memcpy(tmp_buf, read_buf+real_size-for_next_iter, for_next_iter);
 	    ADIOI_Free(fd->io_buf);
 	    fd->io_buf = (char *) ADIOI_Malloc(for_next_iter+coll_bufsize);
@@ -929,7 +929,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
     while (size) { \
 	size_in_buf = ADIOI_MIN(size, flat_buf_sz); \
   ADIOI_Assert((((ADIO_Offset)(MPIU_Upint)buf) + user_buf_idx) == (ADIO_Offset)(MPIU_Upint)((MPIU_Upint)buf + user_buf_idx)); \
-  ADIOI_Assert(size_in_buf == (size_t)size_in_buf); \
+  ADIOI_Assert((ADIO_Size) size_in_buf == (size_t)size_in_buf);          \
 	memcpy(((char *) buf) + user_buf_idx, \
 	       &(recv_buf[p][recv_buf_idx[p]]), size_in_buf); \
 	recv_buf_idx[p] += size_in_buf; /* already tested (size_t)size_in_buf*/ \

--- a/ompi/mca/io/romio321/romio/adio/common/ad_read_str.c
+++ b/ompi/mca/io/romio321/romio/adio/common/ad_read_str.c
@@ -34,7 +34,7 @@
              &status1, error_code); \
         if (*error_code != MPI_SUCCESS) return; \
     } \
-    ADIOI_Assert(req_len == (size_t)req_len); \
+    ADIOI_Assert((ADIO_Size) req_len == (size_t)req_len);                \
     memcpy((char *)buf + userbuf_off, readbuf+req_off-readbuf_off, req_len); \
 }
 

--- a/ompi/mca/io/romio321/romio/adio/common/ad_write_coll.c
+++ b/ompi/mca/io/romio321/romio/adio/common/ad_write_coll.c
@@ -832,7 +832,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
     while (size) { \
         size_in_buf = ADIOI_MIN(size, flat_buf_sz); \
   ADIOI_Assert((((ADIO_Offset)(MPIU_Upint)buf) + user_buf_idx) == (ADIO_Offset)(MPIU_Upint)((MPIU_Upint)buf + user_buf_idx)); \
-  ADIOI_Assert(size_in_buf == (size_t)size_in_buf); \
+  ADIOI_Assert((ADIO_Size) size_in_buf == (size_t)size_in_buf);          \
         memcpy(&(send_buf[p][send_buf_idx[p]]), \
                ((char *) buf) + user_buf_idx, size_in_buf); \
         send_buf_idx[p] += size_in_buf; \

--- a/ompi/mca/io/romio321/romio/adio/common/ad_write_nolock.c
+++ b/ompi/mca/io/romio321/romio/adio/common/ad_write_nolock.c
@@ -335,7 +335,7 @@ void ADIOI_NOLOCK_WriteStrided(ADIO_File fd, const void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING 
 		    MPE_Log_event( ADIOI_MPE_write_a, 0, NULL );
 #endif
-                    ADIOI_Assert(size == (size_t) size);
+                    ADIOI_Assert((ADIO_Size) size == (size_t) size);
                     ADIOI_Assert(off == (off_t) off);
 		    err = write(fd->fd_sys, ((char *) buf) + indx, size);
 #ifdef ADIOI_MPE_LOGGING

--- a/ompi/mca/io/romio321/romio/adio/include/adio.h
+++ b/ompi/mca/io/romio321/romio/adio/include/adio.h
@@ -96,9 +96,11 @@
 
 #ifdef MPI_OFFSET_IS_INT
    typedef int ADIO_Offset;
+   typedef unsigned ADIO_Size;
 #  define ADIO_OFFSET MPI_INT
 #elif defined(HAVE_LONG_LONG_64)
    typedef long long ADIO_Offset;
+   typedef unsigned long long ADIO_Size;
 #  ifdef HAVE_MPI_LONG_LONG_INT
 #     define ADIO_OFFSET MPI_LONG_LONG_INT
 #  else
@@ -106,9 +108,11 @@
 #  endif
 #elif defined(HAVE_INT64)
    typedef __int64 ADIO_Offset;
+   typedef unsigned __int64 ADIO_Size;
 #  define ADIO_OFFSET MPI_DOUBLE
 #else
    typedef long ADIO_Offset;
+   typedef unsigned long ADIO_Size;
 #  define ADIO_OFFSET MPI_LONG
 #endif
 


### PR DESCRIPTION
Some compilers complain when comparing signed and unsigned. romio321
was doing just this. The check is meant to check whether a size (which
is an ADIO_Offset-- a signed number) will work with memcpy which takes
a size_t. To silence the warning I added a new type (ADIO_Size) which
is an unsigned type and cast the ADIO_Offset to this new type.

Fixes #5951

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>