### PR TITLE
COMMON/UCX: suppressed coverity warnings - v4.0

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_active_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_active_target.c
@@ -193,8 +193,9 @@ int ompi_osc_ucx_complete(struct ompi_win_t *win) {
             OSC_UCX_VERBOSE(1, "ucp_atomic_post failed: %d", status);
         }
 
-        if (OMPI_SUCCESS != opal_common_ucx_ep_flush(ep, mca_osc_ucx_component.ucp_worker)) {
-            OSC_UCX_VERBOSE(1, "opal_common_ucx_ep_flush failed");
+        ret = opal_common_ucx_ep_flush(ep, mca_osc_ucx_component.ucp_worker);
+        if (OMPI_SUCCESS != ret) {
+            OSC_UCX_VERBOSE(1, "opal_common_ucx_ep_flush failed: %d", ret);
         }
     }
 

--- a/ompi/mca/osc/ucx/osc_ucx_active_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_active_target.c
@@ -193,7 +193,9 @@ int ompi_osc_ucx_complete(struct ompi_win_t *win) {
             OSC_UCX_VERBOSE(1, "ucp_atomic_post failed: %d", status);
         }
 
-        opal_common_ucx_ep_flush(ep, mca_osc_ucx_component.ucp_worker);
+        if (OMPI_SUCCESS != opal_common_ucx_ep_flush(ep, mca_osc_ucx_component.ucp_worker)) {
+            OSC_UCX_VERBOSE(1, "opal_common_ucx_ep_flush failed");
+        }
     }
 
     OBJ_RELEASE(module->start_group);

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -822,7 +822,9 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
         ucp_worker_progress(mca_osc_ucx_component.ucp_worker);
     }
 
-    opal_common_ucx_worker_flush(mca_osc_ucx_component.ucp_worker);
+    if (OMPI_SUCCESS != opal_common_ucx_worker_flush(mca_osc_ucx_component.ucp_worker)) {
+        OSC_UCX_VERBOSE(1, "opal_common_ucx_worker_flush failed");
+    }
 
     ret = module->comm->c_coll->coll_barrier(module->comm,
                                              module->comm->c_coll->coll_barrier_module);

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -822,8 +822,9 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
         ucp_worker_progress(mca_osc_ucx_component.ucp_worker);
     }
 
-    if (OMPI_SUCCESS != opal_common_ucx_worker_flush(mca_osc_ucx_component.ucp_worker)) {
-        OSC_UCX_VERBOSE(1, "opal_common_ucx_worker_flush failed");
+    ret = opal_common_ucx_worker_flush(mca_osc_ucx_component.ucp_worker);
+    if (OMPI_SUCCESS != ret) {
+        OSC_UCX_VERBOSE(1, "opal_common_ucx_worker_flush failed: %d", ret);
     }
 
     ret = module->comm->c_coll->coll_barrier(module->comm,

--- a/ompi/mca/pml/ucx/pml_ucx_datatype.c
+++ b/ompi/mca/pml/ucx/pml_ucx_datatype.c
@@ -133,7 +133,7 @@ int mca_pml_ucx_datatype_attr_del_fn(ompi_datatype_t* datatype, int keyval,
 {
     ucp_datatype_t ucp_datatype = (ucp_datatype_t)attr_val;
 
-    PML_UCX_ASSERT((void*)ucp_datatype == datatype->pml_data);
+    PML_UCX_ASSERT((uint64_t)ucp_datatype == datatype->pml_data);
 
     ucp_dt_destroy(ucp_datatype);
     datatype->pml_data = PML_UCX_DATATYPE_INVALID;

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -89,7 +89,12 @@ OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
     opal_common_ucx.output = opal_output_open(NULL);
     opal_output_set_verbosity(opal_common_ucx.output, opal_common_ucx.verbose);
 
-    mca_base_framework_open(&opal_memory_base_framework, 0);
+    if (OPAL_SUCCESS != mca_base_framework_open(&opal_memory_base_framework, 0)) {
+        /* failed to initialize memory framework - just exit */
+        MCA_COMMON_UCX_VERBOSE(1, "%s", "failed to initialize memory base framework, "
+                                        "memory hooks will not be used");
+        return;
+    }
 
     /* Set memory hooks */
     if (opal_common_ucx.opal_mem_hooks &&

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -80,6 +80,8 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
 
 OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
 {
+    int ret;
+
     opal_common_ucx.registered++;
     if (opal_common_ucx.registered > 1) {
         /* process once */
@@ -89,10 +91,11 @@ OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
     opal_common_ucx.output = opal_output_open(NULL);
     opal_output_set_verbosity(opal_common_ucx.output, opal_common_ucx.verbose);
 
-    if (OPAL_SUCCESS != mca_base_framework_open(&opal_memory_base_framework, 0)) {
+    ret = mca_base_framework_open(&opal_memory_base_framework, 0);
+    if (OPAL_SUCCESS != ret) {
         /* failed to initialize memory framework - just exit */
-        MCA_COMMON_UCX_VERBOSE(1, "%s", "failed to initialize memory base framework, "
-                                        "memory hooks will not be used");
+        MCA_COMMON_UCX_VERBOSE(1, "failed to initialize memory base framework: %d, "
+                                  "memory hooks will not be used", ret);
         return;
     }
 


### PR DESCRIPTION
COMMON/UCX: suppressed coverity warnings  …
- suppressed coverity warnings - added log messages on failed calls

backport from https://github.com/open-mpi/ompi/pull/5934

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>