### PR TITLE
platform/mellanox: disable btl-uct by default — v4

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -1,4 +1,4 @@
-enable_mca_no_build=coll-ml
+enable_mca_no_build=coll-ml,btl-uct
 enable_debug_symbols=yes
 enable_orterun_prefix_by_default=yes
 with_verbs=no


### PR DESCRIPTION
(cherry picked from commit 074e9cc92c79e6b9f8c492b2613eac3f27e1c522)
