### PR TITLE
Correctly propagate the oversubscribe flag to the spawnees

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -184,6 +184,7 @@ void orte_rmaps_base_map_job(int fd, short args, void *cbdata)
             ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_NO_OVERSUBSCRIBE);
         } else {
             /* pass along the directive */
+            ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_SUBSCRIBE_GIVEN);
             if (ORTE_MAPPING_NO_OVERSUBSCRIBE & ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping)) {
                 ORTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, ORTE_MAPPING_NO_OVERSUBSCRIBE);
             } else {

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -172,7 +172,14 @@ int orte_rmaps_rr_byslot(orte_job_t *jdata,
                 --nxtra_nodes;
             }
         }
-        num_procs_to_assign = node->slots - node->slots_inuse + extra_procs_to_assign;
+        if(node->slots <= node->slots_inuse) {
+            /* nodes are already oversubscribed */
+            num_procs_to_assign = extra_procs_to_assign;
+        }
+        else {
+            /* nodes have some room */
+            num_procs_to_assign = node->slots - node->slots_inuse + extra_procs_to_assign;
+        }
         opal_output_verbose(2, orte_rmaps_base_framework.framework_output,
                             "mca:rmaps:rr:slot adding up to %d procs to node %s",
                             num_procs_to_assign, node->name);


### PR DESCRIPTION
In order for the 'oversubscribe' flag to be propagated to spawnees in an MPI_COMM_SPAWN and friends, the 'SUBSCRIBE_GIVEN' flag must also be set. 

The discussion in #5376 states that by default  OVERSUBSCRIBE would not be propagated to spawns. It however appears that the existing code is not conditional on the inherit mca parameter, hence, by making the feature work, this patch will also make it inherited 'by default'. This is unlike what was discussed in the issue. I believe that, unlike the slot assignments etc, it is useful to inherit `-oversubscribe` by default (same goes for `-nolocal` IMO), but can be debated. 

Signed-off-by: Aurélien Bouteiller <bouteill@icl.utk.edu>