### PR TITLE
Fix regression in RDMA shared memory registration

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -653,6 +653,9 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
             }
         }
 
+        /* barrier to make sure memory is registered */
+        shared_comm->c_coll->coll_barrier(shared_comm, shared_comm->c_coll->coll_barrier_module);
+
         if (MPI_WIN_FLAVOR_CREATE == module->flavor) {
             ret = ompi_osc_rdma_initialize_region (module, base, size);
             if (OMPI_SUCCESS != ret) {


### PR DESCRIPTION
Fix regression introduced in #5921 NUMA by re-adding a node-local barrier to wait for memory registration to complete. Addresses #5969 

Tested on a Cray XC40 using the provided reproducer.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>