### PR TITLE
coll/libnbc: remove debug output

### DIFF
--- a/ompi/mca/coll/libnbc/nbc_iallgather.c
+++ b/ompi/mca/coll/libnbc/nbc_iallgather.c
@@ -132,12 +132,10 @@ static int nbc_allgather_init(const void* sendbuf, int sendcount, MPI_Datatype s
 
     switch (alg) {
       case NBC_ALLGATHER_LINEAR:
-        if (rank == 0) printf("MK: LINEAR\n");
         res = allgather_sched_linear(rank, p, schedule, sendbuf, sendcount, sendtype,
                                      recvbuf, recvcount, recvtype);
         break;
       case NBC_ALLGATHER_RDBL:
-        if (rank == 0) printf("MK: RDBL\n");
         res = allgather_sched_recursivedoubling(rank, p, schedule, sendbuf, sendcount,
                                                 sendtype, recvbuf, recvcount, recvtype);
         break;

--- a/ompi/mca/coll/libnbc/nbc_ibcast.c
+++ b/ompi/mca/coll/libnbc/nbc_ibcast.c
@@ -368,7 +368,6 @@ static inline int bcast_sched_chain(int rank, int p, int root, NBC_Schedule *sch
  * Description: an implementation of Ibcast using k-nomial tree algorithm
  *
  * Time: (radix - 1)O(log_{radix}(comm_size))
- * Memory: O(reqs_max)
  * Schedule length (rounds): O(log(comm_size))
  */
 static inline int bcast_sched_knomial(


### PR DESCRIPTION
1. Remove debug output in iallgather. Sorry, I have forgotten to remove it in the PR #5896.
2. Remove an incorrect comment in description of ibcast

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>