### PR TITLE
Revert "RDMA OSC: initialize segment memory before registering the segment"

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -647,7 +647,6 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
 
         if (size && MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
             *base = (void *)((intptr_t) module->segment_base + my_base_offset);
-            memset (*base, 0, size);
         }
 
         module->rank_array = (ompi_osc_rdma_rank_data_t *) module->segment_base;
@@ -661,12 +660,7 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
         /* initialize my state */
         memset (module->state, 0, module->state_size);
 
-        /* barrier to make sure all ranks have attached and initialized */
-        shared_comm->c_coll->coll_barrier(shared_comm, shared_comm->c_coll->coll_barrier_module);
-
         if (0 == local_rank) {
-            /* unlink the shared memory backing file */
-            opal_shmem_unlink (&module->seg_ds);
             /* just go ahead and register the whole segment */
             ret = ompi_osc_rdma_register (module, MCA_BTL_ENDPOINT_ANY, module->segment_base, total_size, MCA_BTL_REG_FLAG_ACCESS_ANY,
                                           &module->state_handle);
@@ -685,6 +679,14 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
             if (OMPI_SUCCESS != ret) {
                 break;
             }
+        }
+
+        /* barrier to make sure all ranks have attached */
+        shared_comm->c_coll->coll_barrier(shared_comm, shared_comm->c_coll->coll_barrier_module);
+
+        /* unlink the shared memory backing file */
+        if (0 == local_rank) {
+            opal_shmem_unlink (&module->seg_ds);
         }
 
         if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {


### PR DESCRIPTION
This reverts commit 4fbe078359feb8606952cb991091e32dc4787140.

Issue #5969 was caused by this commit and the 4.0.x release
managers decided not to take this patch, so having it in
3.0.x and 3.1.x is a bit awkward.