### PR TITLE
coll/spacc: fix module initialization in v3.1.x

### DIFF
--- a/ompi/mca/coll/spacc/coll_spacc_module.c
+++ b/ompi/mca/coll/spacc/coll_spacc_module.c
@@ -11,6 +11,7 @@
 #include "mpi.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/base/coll_base_functions.h"
 #include "ompi/mca/coll/coll.h"
 #include "coll_spacc.h"
 
@@ -87,6 +88,11 @@ static int spacc_module_enable(mca_coll_base_module_t *module,
                                struct ompi_communicator_t *comm)
 {
     opal_output_verbose(30, mca_coll_spacc_stream, "coll:spacc:module_enable called");
+    /* prepare the placeholder for the array of request* */
+    module->base_data = OBJ_NEW(mca_coll_base_comm_t);
+    if (NULL == module->base_data) {
+        return OMPI_ERROR;
+    }
     return OMPI_SUCCESS;
 }
 


### PR DESCRIPTION
Prepare the placeholder for the array of requests at module initialization time.

The call of coll/spacc/MPI_Allreduce with `count < comm_size` or with non-commutative binary operation produces the segmentation fault (only in v3.1.x).

The problem is that spacc/MPI_Allreduce in this case switched to the `ompi_coll_base_allreduce_intra_basic_linear`. But a lot of base collective operations require prepared placeholder for the array of requests.

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>