### PR TITLE
Test PR to verify IPv6 checks

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -742,7 +742,7 @@ static int mca_btl_tcp_endpoint_start_connect(mca_btl_base_endpoint_t* btl_endpo
     }
 #if OPAL_ENABLE_IPV6
     if (endpoint_addr.ss_family == AF_INET6) {
-        assert(NULL != &btl_endpoint->endpoint_btl->tcp_ifaddr);
+        assert(NULL != &btl_endpoint->endpoint_btl->tcp_ifaddr_6);
         if (bind(btl_endpoint->endpoint_sd, (struct sockaddr*) &btl_endpoint->endpoint_btl->tcp_ifaddr,
                  sizeof(struct sockaddr_in6)) < 0) {
             BTL_ERROR(("bind on local address (%s:%d) failed: %s (%d)",


### PR DESCRIPTION
Don't merge this.  It's just to make sure the PR builder now fails on IPv6 breakage.