### PR TITLE
Bringback some MPI.h items removed by 89da9651b

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -791,14 +791,6 @@ enum {
    protection for this case. */
 
 #if !defined(OMPI_COMPILING_FORTRAN_WRAPPERS)
-/*
- * Deprecated Defines:
- */
-#define MPI_NULL_DELETE_FN OMPI_C_MPI_NULL_DELETE_FN
-#define MPI_NULL_COPY_FN OMPI_C_MPI_NULL_COPY_FN
-#define MPI_DUP_FN OMPI_C_MPI_DUP_FN
-
-/***/:w
 
 #define MPI_TYPE_NULL_DELETE_FN OMPI_C_MPI_TYPE_NULL_DELETE_FN
 #define MPI_TYPE_NULL_COPY_FN OMPI_C_MPI_TYPE_NULL_COPY_FN
@@ -2610,7 +2602,6 @@ OMPI_DECLSPEC  int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
             __mpi_interface_deprecated__("MPI_Attr_put is deprecated in MPI-2.0; use MPI_Comm_set_attr instead");
 OMPI_DECLSPEC  int PMPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
             __mpi_interface_deprecated__("PMPI_Attr_put is deprecated in MPI-2.0; use PMPI_Comm_set_attr instead");
-/***/
 
 /*
  * Even though MPI_Copy_function and MPI_Delete_function are
@@ -2635,18 +2626,21 @@ OMPI_DECLSPEC  int MPI_Keyval_free(int *keyval)
             __mpi_interface_deprecated__("MPI_Keyval_free is deprecated in MPI-2.0; MPI_Comm_free_keyval instead.");
 OMPI_DECLSPEC  int PMPI_Keyval_free(int *keyval)
             __mpi_interface_deprecated__("PMPI_Keyval_free is deprecated in MPI-2.0; PMPI_Comm_free_keyval instead.");
+#define MPI_DUP_FN OMPI_C_MPI_DUP_FN
 OMPI_DECLSPEC int OMPI_C_MPI_DUP_FN( MPI_Comm comm, int comm_keyval,
                                      void* extra_state,
                                      void* attribute_val_in,
                                      void* attribute_val_out,
                                      int* flag )
             __mpi_interface_deprecated__("MPI_DUP_FN is deprecated in MPI-2.0; use MPI_COMM_DUP_FN instead.");
+#define MPI_NULL_COPY_FN OMPI_C_MPI_NULL_COPY_FN
 OMPI_DECLSPEC int OMPI_C_MPI_NULL_COPY_FN( MPI_Comm comm, int comm_keyval,
                                            void* extra_state,
                                            void* attribute_val_in,
                                            void* attribute_val_out,
                                            int* flag )
             __mpi_interface_deprecated__("MPI_NULL_COPY_FN is deprecated in MPI-2.0; use MPI_COMM_NULL_COPY_FN instead.");
+#define MPI_NULL_DELETE_FN OMPI_C_MPI_NULL_DELETE_FN
 OMPI_DECLSPEC int OMPI_C_MPI_NULL_DELETE_FN( MPI_Comm comm, int comm_keyval,
                                              void* attribute_val_out,
                                              void* extra_state )
@@ -2695,7 +2689,7 @@ OMPI_DECLSPEC  int PMPI_Type_struct(int count, int array_of_blocklengths[],
                                     MPI_Datatype array_of_types[],
                                     MPI_Datatype *newtype)
             __mpi_interface_removed__("PMPI_Type_struct is removed in MPI-3.0; use PMPI_Type_create_struct instead.");
-/***/
+
 OMPI_DECLSPEC  int MPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
             __mpi_interface_removed__("MPI_Type_extent is removed in MPI-3.0; use MPI_Type_get_extent instead.");
 OMPI_DECLSPEC  int PMPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
@@ -2708,7 +2702,7 @@ OMPI_DECLSPEC  int MPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
             __mpi_interface_removed__("MPI_Type_lb has been removed in MPI-3.0; use MPI_Type_get_extent instead.");
 OMPI_DECLSPEC  int PMPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
             __mpi_interface_removed__("PMPI_Type_lb has been removed in MPI-3.0; use PMPI_Type_get_extent instead.");
-/***/
+
 OMPI_DECLSPEC  int MPI_Errhandler_create(MPI_Handler_function *function,
                                          MPI_Errhandler *errhandler)
             __mpi_interface_removed__("MPI_Errhandler_create is removed in MPI-3.0; use MPI_Comm_create_errhandler instead.");

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -19,7 +19,7 @@
  * Copyright (c) 2015      University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2018 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -377,7 +377,6 @@ typedef struct ompi_status_public_t ompi_status_public_t;
 
 /*
  * User typedefs
- *
  */
 typedef int (MPI_Datarep_extent_function)(MPI_Datatype, MPI_Aint *, void *);
 typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype,
@@ -389,7 +388,6 @@ typedef void (MPI_Comm_errhandler_function)(MPI_Comm *, int *, ...);
        allows us to maintain a stable ABI within OMPI, at least for
        apps that don't use MPI I/O. */
 typedef void (ompi_file_errhandler_function)(MPI_File *, int *, ...);
-typedef ompi_file_errhandler_function MPI_File_errhandler_function;
 typedef void (MPI_Win_errhandler_function)(MPI_Win *, int *, ...);
 typedef void (MPI_User_function)(void *, void *, int *, MPI_Datatype *);
 typedef int (MPI_Comm_copy_attr_function)(MPI_Comm, int, void *,
@@ -406,28 +404,15 @@ typedef int (MPI_Grequest_query_function)(void *, MPI_Status *);
 typedef int (MPI_Grequest_free_function)(void *);
 typedef int (MPI_Grequest_cancel_function)(void *, int);
 
-#if !OMPI_OMIT_MPI1_COMPAT_DECLS
 /*
- * Removed typedefs. These will be deleted in a future Open MPI release.
+ * Deprecated typedefs. These will be deleted in a future MPI standard.
  */
 typedef MPI_Comm_errhandler_function MPI_Comm_errhandler_fn
-        __mpi_interface_removed__("MPI_Comm_errhandler_fn was removed in MPI-3.0; use MPI_Comm_errhandler_function instead");
+        __mpi_interface_deprecated__("MPI_Comm_errhandler_fn was deprecated in MPI-2.2; use MPI_Comm_errhandler_function instead");
 typedef ompi_file_errhandler_function MPI_File_errhandler_fn
-        __mpi_interface_removed__("MPI_File_errhandler_fn was removed in MPI-3.0; use MPI_File_errhandler_function instead");
+        __mpi_interface_deprecated__("MPI_File_errhandler_fn was deprecated in MPI-2.2; use MPI_File_errhandler_function instead");
 typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn
-        __mpi_interface_removed__("MPI_Win_errhandler_fn was removed in MPI-3.0; use MPI_Win_errhandler_function instead");
-
-/*
- * NOTE: We intentionally do *not* mark the following as
- * deprecated/removed because they are used below in function
- * prototypes (and would therefore emit warnings, just for #including
- * <mpi.h>).
- */
-typedef void (MPI_Handler_function)(MPI_Comm *, int *, ...);
-typedef int (MPI_Copy_function)(MPI_Comm, int, void *,
-                                void *, void *, int *);
-typedef int (MPI_Delete_function)(MPI_Comm, int, void *, void *);
-#endif /* !OMPI_OMIT_MPI1_COMPAT_DECLS */
+        __mpi_interface_deprecated__("MPI_Win_errhandler_fn was deprecated in MPI-2.2; use MPI_Win_errhandler_function instead");
 
 
 /*
@@ -806,9 +791,14 @@ enum {
    protection for this case. */
 
 #if !defined(OMPI_COMPILING_FORTRAN_WRAPPERS)
+/*
+ * Deprecated Defines:
+ */
 #define MPI_NULL_DELETE_FN OMPI_C_MPI_NULL_DELETE_FN
 #define MPI_NULL_COPY_FN OMPI_C_MPI_NULL_COPY_FN
 #define MPI_DUP_FN OMPI_C_MPI_DUP_FN
+
+/***/:w
 
 #define MPI_TYPE_NULL_DELETE_FN OMPI_C_MPI_TYPE_NULL_DELETE_FN
 #define MPI_TYPE_NULL_COPY_FN OMPI_C_MPI_TYPE_NULL_COPY_FN
@@ -877,24 +867,6 @@ OMPI_DECLSPEC int OMPI_C_MPI_WIN_DUP_FN( MPI_Win window, int win_keyval,
                                          void* attribute_val_in,
                                          void* attribute_val_out,
                                          int* flag );
-#if !OMPI_OMIT_MPI1_COMPAT_DECLS
-/*
- * Removed in MPI-3.0. Will be deleted in a future Open MPI release.
- */
-OMPI_DECLSPEC int OMPI_C_MPI_NULL_DELETE_FN( MPI_Comm comm, int comm_keyval,
-                                             void* attribute_val_out,
-                                             void* extra_state );
-OMPI_DECLSPEC int OMPI_C_MPI_NULL_COPY_FN( MPI_Comm comm, int comm_keyval,
-                                           void* extra_state,
-                                           void* attribute_val_in,
-                                           void* attribute_val_out,
-                                           int* flag );
-OMPI_DECLSPEC int OMPI_C_MPI_DUP_FN( MPI_Comm comm, int comm_keyval,
-                                     void* extra_state,
-                                     void* attribute_val_in,
-                                     void* attribute_val_out,
-                                     int* flag );
-#endif /* !OMPI_OMIT_MPI1_COMPAT_DECLS */
 
 /*
  * External variables
@@ -1039,8 +1011,13 @@ OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUSES_IGNORE;
 /*
  * Removed datatypes
  */
-OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_lb __mpi_interface_removed__("MPI_LB was removed in MPI-3.0");
-OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_ub __mpi_interface_removed__("MPI_UB was removed in MPI-3.0");
+#define MPI_UB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_ub)
+#define MPI_LB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_lb)
+
+OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_lb
+            __mpi_interface_removed__("MPI_LB was removed in MPI-3.0; use MPI_Type_create_resized instead.");
+OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_ub
+            __mpi_interface_removed__("MPI_UB was removed in MPI-3.0; use MPI_Type_create_resized instead.");
 #endif /* !OMPI_OMIT_MPI1_COMPAT_DECLS */
 
 /*
@@ -1090,13 +1067,7 @@ OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_ub __mpi_interfa
 #define MPI_LONG_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_long_int)
 #define MPI_SHORT_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_short_int)
 #define MPI_2INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_2int)
-#if !OMPI_OMIT_MPI1_COMPAT_DECLS
-/*
- * Removed datatypes
- */
-#define MPI_UB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_ub)
-#define MPI_LB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_lb)
-#endif
+
 #define MPI_WCHAR OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_wchar)
 #if OPAL_HAVE_LONG_LONG
 #define MPI_LONG_LONG_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_long_long_int)
@@ -2624,89 +2595,135 @@ OMPI_DECLSPEC  int MPI_T_pvar_readreset(MPI_T_pvar_session session, MPI_T_pvar_h
 OMPI_DECLSPEC  int MPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *name, int *name_len);
 OMPI_DECLSPEC  int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name,
                                        int *name_len);
-
-#if !OMPI_OMIT_MPI1_COMPAT_DECLS
 /*
- * Removed APIs
+ * Deprecated Prototypes:
  */
-OMPI_DECLSPEC  int MPI_Address(void *location, MPI_Aint *address)
-                               __mpi_interface_removed__("MPI_Address is superseded by MPI_Get_address in MPI-2.0");
 OMPI_DECLSPEC  int MPI_Attr_delete(MPI_Comm comm, int keyval)
-                                   __mpi_interface_deprecated__("MPI_Attr_delete is superseded by MPI_Comm_delete_attr in MPI-2.0");
+            __mpi_interface_deprecated__("MPI_Attr_delete is deprecated in MPI-2.0; use MPI_Comm_delete_attr instead");
+OMPI_DECLSPEC  int PMPI_Attr_delete(MPI_Comm comm, int keyval)
+            __mpi_interface_deprecated__("PMPI_Attr_delete is deprecated in MPI-2.0; use PMPI_Comm_delete_attr instead");
 OMPI_DECLSPEC  int MPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag)
-                                __mpi_interface_deprecated__("MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0");
+            __mpi_interface_deprecated__("MPI_Attr_get is deprecated in MPI-2.0; use MPI_Comm_get_attr instead");
+OMPI_DECLSPEC  int PMPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag)
+            __mpi_interface_deprecated__("PMPI_Attr_get is deprecated in MPI-2.0; use PMPI_Comm_get_attr instead");
 OMPI_DECLSPEC  int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
-                                __mpi_interface_deprecated__("MPI_Attr_put is superseded by MPI_Comm_set_attr in MPI-2.0");
-OMPI_DECLSPEC  int MPI_Errhandler_create(MPI_Handler_function *function,
-                                         MPI_Errhandler *errhandler)
-                                         __mpi_interface_removed__("MPI_Errhandler_create is superseded by MPI_Comm_create_errhandler in MPI-2.0");
-OMPI_DECLSPEC  int MPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
-                                      __mpi_interface_removed__("MPI_Errhandler_get is superseded by MPI_Comm_get_errhandler in MPI-2.0");
-OMPI_DECLSPEC  int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
-                                      __mpi_interface_removed__("MPI_Errhandler_set is superseded by MPI_Comm_set_errhandler in MPI-2.0");
+            __mpi_interface_deprecated__("MPI_Attr_put is deprecated in MPI-2.0; use MPI_Comm_set_attr instead");
+OMPI_DECLSPEC  int PMPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
+            __mpi_interface_deprecated__("PMPI_Attr_put is deprecated in MPI-2.0; use PMPI_Comm_set_attr instead");
+/***/
+
+/*
+ * Even though MPI_Copy_function and MPI_Delete_function are
+ * deprecated, we do not use the attributes marking them as such,
+ * because otherwise the compiler will warn for all the functions that
+ * are declared using them (e.g., MPI_Keyval_create).
+ */
+typedef int (MPI_Copy_function)(MPI_Comm, int, void *,
+                                void *, void *, int *);
+/* MPI_Copy_function is deprecated in MPI-2.0; use MPI_Comm_copy_attr_function instead. */
+typedef int (MPI_Delete_function)(MPI_Comm, int, void *, void *);
+/* MPI_Delete_function is deprecated in MPI-2.0; use MPI_Comm_delete_attr_function instead. */
 OMPI_DECLSPEC  int MPI_Keyval_create(MPI_Copy_function *copy_fn,
                                      MPI_Delete_function *delete_fn,
                                      int *keyval, void *extra_state)
-                                     __mpi_interface_deprecated__("MPI_Keyval_create is superseded by MPI_Comm_create_keyval in MPI-2.0");
+            __mpi_interface_deprecated__("MPI_Keyval_create is deprecated in MPI-2.0; use MPI_Comm_create_keyval instead.");
+OMPI_DECLSPEC  int PMPI_Keyval_create(MPI_Copy_function *copy_fn,
+                                      MPI_Delete_function *delete_fn,
+                                      int *keyval, void *extra_state)
+            __mpi_interface_deprecated__("PMPI_Keyval_create is deprecated in MPI-2.0; use PMPI_Comm_create_keyval instead.");
 OMPI_DECLSPEC  int MPI_Keyval_free(int *keyval)
-                                   __mpi_interface_deprecated__("MPI_Keyval_free is superseded by MPI_Comm_free_keyval in MPI-2.0");
-OMPI_DECLSPEC  int MPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
-                                   __mpi_interface_removed__("MPI_Type_extent is superseded by MPI_Type_get_extent in MPI-2.0");
+            __mpi_interface_deprecated__("MPI_Keyval_free is deprecated in MPI-2.0; MPI_Comm_free_keyval instead.");
+OMPI_DECLSPEC  int PMPI_Keyval_free(int *keyval)
+            __mpi_interface_deprecated__("PMPI_Keyval_free is deprecated in MPI-2.0; PMPI_Comm_free_keyval instead.");
+OMPI_DECLSPEC int OMPI_C_MPI_DUP_FN( MPI_Comm comm, int comm_keyval,
+                                     void* extra_state,
+                                     void* attribute_val_in,
+                                     void* attribute_val_out,
+                                     int* flag )
+            __mpi_interface_deprecated__("MPI_DUP_FN is deprecated in MPI-2.0; use MPI_COMM_DUP_FN instead.");
+OMPI_DECLSPEC int OMPI_C_MPI_NULL_COPY_FN( MPI_Comm comm, int comm_keyval,
+                                           void* extra_state,
+                                           void* attribute_val_in,
+                                           void* attribute_val_out,
+                                           int* flag )
+            __mpi_interface_deprecated__("MPI_NULL_COPY_FN is deprecated in MPI-2.0; use MPI_COMM_NULL_COPY_FN instead.");
+OMPI_DECLSPEC int OMPI_C_MPI_NULL_DELETE_FN( MPI_Comm comm, int comm_keyval,
+                                             void* attribute_val_out,
+                                             void* extra_state )
+            __mpi_interface_deprecated__("MPI_NULL_DELETE_FN is deprecated in MPI-2.0; use MPI_COMM_NULL_DELETE_FN instead.");
+
+#if !OMPI_OMIT_MPI1_COMPAT_DECLS
+/*
+ * Removed Typedefs - only available via OMPI_OMIT_MPI1_COMPAT_DECLS
+ *
+ * Even though MPI_Handler_function is removed, we do not use the
+ * attributes marking them as such, because otherwise the compiler
+ * will warn for all the functions that are declared using them
+ * (e.g., MPI_Errhandler_create).
+ */
+typedef void (MPI_Handler_function)(MPI_Comm *, int *, ...);
+/* MPI_Handler_function is removed in MPI-3.0; use MPI_Comm_use_errhandler_function instead. */
+
+/*
+ * Removed APIs - only available via OMPI_OMIT_MPI1_COMPAT_DECLS
+ */
+OMPI_DECLSPEC  int MPI_Address(void *location, MPI_Aint *address)
+            __mpi_interface_removed__("MPI_Address is removed in MPI-3.0; use MPI_Get_address instead.");
+OMPI_DECLSPEC  int PMPI_Address(void *location, MPI_Aint *address)
+            __mpi_interface_removed__("PMPI_Address is removed in MPI-3.0; use MPI_Get_address instead.");
 OMPI_DECLSPEC  int MPI_Type_hindexed(int count, int array_of_blocklengths[],
                                      MPI_Aint array_of_displacements[],
                                      MPI_Datatype oldtype, MPI_Datatype *newtype)
-                                     __mpi_interface_removed__("MPI_Type_hindexed is superseded by MPI_Type_create_hindexed in MPI-2.0");
+            __mpi_interface_removed__("MPI_Type_hindexed is removed in MPI-3.0; use MPI_Type_create_hindexed instead.");
+OMPI_DECLSPEC  int PMPI_Type_hindexed(int count, int array_of_blocklengths[],
+                                      MPI_Aint array_of_displacements[],
+                                      MPI_Datatype oldtype, MPI_Datatype *newtype)
+            __mpi_interface_removed__("PMPI_Type_hindexed is removed in MPI-3.0; use PMPI_Type_create_hindexed instead.");
 OMPI_DECLSPEC  int MPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
                                     MPI_Datatype oldtype, MPI_Datatype *newtype)
-                                    __mpi_interface_removed__("MPI_Type_hvector is superseded by MPI_Type_create_hvector in MPI-2.0");
-OMPI_DECLSPEC  int MPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
-                               __mpi_interface_removed__("MPI_Type_lb has been removed, use MPI_Type_get_extent in MPI-2.0");
+            __mpi_interface_removed__("MPI_Type_hvector is removed in MPI-3.0; use MPI_Type_create_hvector instead.");
+OMPI_DECLSPEC  int PMPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
+                                     MPI_Datatype oldtype, MPI_Datatype *newtype)
+            __mpi_interface_removed__("PMPI_Type_hvector is removed in MPI-3.0; use PMPI_Type_create_hvector instead.");
 OMPI_DECLSPEC  int MPI_Type_struct(int count, int array_of_blocklengths[],
                                    MPI_Aint array_of_displacements[],
                                    MPI_Datatype array_of_types[],
                                    MPI_Datatype *newtype)
-                                   __mpi_interface_removed__("MPI_Type_struct is superseded by MPI_Type_create_struct in MPI-2.0");
-OMPI_DECLSPEC  int MPI_Type_ub(MPI_Datatype mtype, MPI_Aint *ub)
-                               __mpi_interface_removed__("MPI_Type_ub has been removed, use MPI_Type_get_extent in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Address(void *location, MPI_Aint *address)
-                                __mpi_interface_removed__("MPI_Address is superseded by MPI_Get_address in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Attr_delete(MPI_Comm comm, int keyval)
-                                    __mpi_interface_deprecated__("MPI_Attr_delete is superseded by MPI_Comm_delete_attr in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag)
-                                 __mpi_interface_deprecated__("MPI_Attr_get is superseded by MPI_Comm_get_attr in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val)
-                                 __mpi_interface_deprecated__("MPI_Attr_put is superseded by MPI_Comm_set_attr in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Errhandler_create(MPI_Handler_function *function,
-                                          MPI_Errhandler *errhandler)
-                                          __mpi_interface_removed__("MPI_Errhandler_create is superseded by MPI_Comm_create_errhandler in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
-                                       __mpi_interface_removed__("MPI_Errhandler_get is superseded by MPI_Comm_get_errhandler in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
-                                       __mpi_interface_removed__("MPI_Errhandler_set is superseded by MPI_Comm_set_errhandler in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Keyval_create(MPI_Copy_function *copy_fn,
-                                      MPI_Delete_function *delete_fn,
-                                      int *keyval, void *extra_state)
-                                      __mpi_interface_deprecated__("MPI_Keyval_create is superseded by MPI_Comm_create_keyval in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Keyval_free(int *keyval)
-                                    __mpi_interface_deprecated__("MPI_Keyval_free is superseded by MPI_Comm_free_keyval in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
-                                    __mpi_interface_removed__("MPI_Type_extent is superseded by MPI_Type_get_extent in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Type_hindexed(int count, int array_of_blocklengths[],
-                                      MPI_Aint array_of_displacements[],
-                                      MPI_Datatype oldtype, MPI_Datatype *newtype)
-                                      __mpi_interface_removed__("MPI_Type_hindexed is superseded by MPI_Type_create_hindexed in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
-                                     MPI_Datatype oldtype, MPI_Datatype *newtype)
-                                     __mpi_interface_removed__("MPI_Type_hvector is superseded by MPI_Type_create_hvector in MPI-2.0");
-OMPI_DECLSPEC  int PMPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
-                                __mpi_interface_removed__("MPI_Type_lb has been removed, use MPI_Type_get_extent in MPI-2.0");
+            __mpi_interface_removed__("MPI_Type_struct is removed in MPI-3.0; use MPI_Type_create_struct instead.");
 OMPI_DECLSPEC  int PMPI_Type_struct(int count, int array_of_blocklengths[],
                                     MPI_Aint array_of_displacements[],
                                     MPI_Datatype array_of_types[],
                                     MPI_Datatype *newtype)
-                                    __mpi_interface_removed__("MPI_Type_struct is superseded by MPI_Type_create_struct in MPI-2.0");
+            __mpi_interface_removed__("PMPI_Type_struct is removed in MPI-3.0; use PMPI_Type_create_struct instead.");
+/***/
+OMPI_DECLSPEC  int MPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
+            __mpi_interface_removed__("MPI_Type_extent is removed in MPI-3.0; use MPI_Type_get_extent instead.");
+OMPI_DECLSPEC  int PMPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
+            __mpi_interface_removed__("PMPI_Type_extent is removed in MPI-3.0; use PMPI_Type_get_extent instead.");
+OMPI_DECLSPEC  int MPI_Type_ub(MPI_Datatype mtype, MPI_Aint *ub)
+            __mpi_interface_removed__("MPI_Type_ub has been removed in MPI-3.0; use MPI_Type_get_extent instead.");
 OMPI_DECLSPEC  int PMPI_Type_ub(MPI_Datatype mtype, MPI_Aint *ub)
-                                __mpi_interface_removed__("MPI_Type_ub has been removed, use MPI_Type_get_extent in MPI-2.0");
+            __mpi_interface_removed__("PMPI_Type_ub has been removed in MPI-3.0; use PMPI_Type_get_extent instead.");
+OMPI_DECLSPEC  int MPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
+            __mpi_interface_removed__("MPI_Type_lb has been removed in MPI-3.0; use MPI_Type_get_extent instead.");
+OMPI_DECLSPEC  int PMPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
+            __mpi_interface_removed__("PMPI_Type_lb has been removed in MPI-3.0; use PMPI_Type_get_extent instead.");
+/***/
+OMPI_DECLSPEC  int MPI_Errhandler_create(MPI_Handler_function *function,
+                                         MPI_Errhandler *errhandler)
+            __mpi_interface_removed__("MPI_Errhandler_create is removed in MPI-3.0; use MPI_Comm_create_errhandler instead.");
+OMPI_DECLSPEC  int PMPI_Errhandler_create(MPI_Handler_function *function,
+                                          MPI_Errhandler *errhandler)
+            __mpi_interface_removed__("PMPI_Errhandler_create is removed in MPI-3.0; use PMPI_Comm_create_errhandler instead.");
+OMPI_DECLSPEC  int MPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
+            __mpi_interface_removed__("MPI_Errhandler_get is removed in MPI-3.0; use MPI_Comm_get_errhandler instead.");
+
+OMPI_DECLSPEC  int PMPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
+            __mpi_interface_removed__("PMPI_Errhandler_get is removed in MPI-3.0; use PMPI_Comm_get_errhandler instead.");
+OMPI_DECLSPEC  int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
+            __mpi_interface_removed__("MPI_Errhandler_set is removed in MPI-3.0; use MPI_Comm_set_errhandler instead.");
+OMPI_DECLSPEC  int PMPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
+            __mpi_interface_removed__("PMPI_Errhandler_set is removed in MPI-3.0; use PMPI_Comm_set_errhandler instead.");
 #endif /* !OMPI_OMIT_MPI1_COMPAT_DECLS */
 
 #if defined(c_plusplus) || defined(__cplusplus)


### PR DESCRIPTION
In commit 89da9651b, we finally removed some MPI items that were
removed in MPI 3.0 / 3.1 (Unless the user configures with an
mpi1-compat flag).  Unfortunately some of the items removed in
that commit, were NOT removed in the standard, and were left as
deprecated.

This commit brings those items back, as deprecated with/without
the --mpi1-compat flag.

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>