### PR TITLE
OSHMEM/PROFILE: fixed profile build - v4.0

### DIFF
--- a/oshmem/include/oshmem/constants.h
+++ b/oshmem/include/oshmem/constants.h
@@ -105,11 +105,6 @@ enum {
 #define SHMEM_UNDEFINED          -32766                  /* undefined stuff */
 
 
-#define SHMEM_CTX_PRIVATE       (1<<0)
-#define SHMEM_CTX_SERIALIZED    (1<<1)
-#define SHMEM_CTX_NOSTORE       (1<<2)
-
-
 #ifndef UNREFERENCED_PARAMETER
 #define UNREFERENCED_PARAMETER(P) ((void)P)
 #endif

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -99,6 +99,10 @@ enum {
 #define SHMEM_VENDOR_STRING             "http://www.open-mpi.org/"
 #define SHMEM_MAX_NAME_LEN              256
 
+#define SHMEM_CTX_PRIVATE               (1<<0)
+#define SHMEM_CTX_SERIALIZED            (1<<1)
+#define SHMEM_CTX_NOSTORE               (1<<2)
+
 /*
  * Deprecated (but still valid) names
  */
@@ -195,7 +199,9 @@ OSHMEM_DECLSPEC  void *shmem_ptr(const void *ptr, int pe);
 
 typedef struct { int dummy; } * shmem_ctx_t;
 
-#define SHMEM_CTX_DEFAULT oshmem_ctx_default;
+#define SHMEM_CTX_DEFAULT oshmem_ctx_default
+
+extern shmem_ctx_t oshmem_ctx_default;
 
 OSHMEM_DECLSPEC int shmem_ctx_create(long options, shmem_ctx_t *ctx);
 OSHMEM_DECLSPEC void shmem_ctx_destroy(shmem_ctx_t ctx);

--- a/oshmem/shmem/c/profile/Makefile.am
+++ b/oshmem/shmem/c/profile/Makefile.am
@@ -38,6 +38,7 @@ OSHMEM_API_SOURCES = \
 	pshmem_align.c \
 	pshmem_query.c \
 	pshmem_p.c \
+	pshmem_context.c \
 	pshmem_put.c \
 	pshmem_g.c \
 	pshmem_get.c \


### PR DESCRIPTION
- added missing file to profile makefile
- constants SHMEM_CTX_* are shifted into public header

backport from https://github.com/open-mpi/ompi/pull/5985

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit 4a3e83780c0303e7e4d0ff92d7ba85d3a2239737)