### PR TITLE
OSHMEM/AMO: added missing C11 macro datatypes - v4.0

### DIFF
--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -105,6 +105,12 @@ OSHMEM_DECLSPEC  void pshmem_ctx_long_p(shmem_ctx_t ctx, long* addr, long value,
 OSHMEM_DECLSPEC  void pshmem_ctx_float_p(shmem_ctx_t ctx, float* addr, float value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_p(shmem_ctx_t ctx, double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longlong_p(shmem_ctx_t ctx, long long* addr, long long value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_schar_p(shmem_ctx_t ctx, signed char* addr, signed char value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uchar_p(shmem_ctx_t ctx, unsigned char* addr, unsigned char value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ushort_p(shmem_ctx_t ctx, unsigned short* addr, unsigned short value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint_p(shmem_ctx_t ctx, unsigned int* addr, unsigned int value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulong_p(shmem_ctx_t ctx, unsigned long* addr, unsigned long value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_p(shmem_ctx_t ctx, unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_p(shmem_ctx_t ctx, long double* addr, long double value, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_char_p(char* addr, char value, int pe);
@@ -114,25 +120,43 @@ OSHMEM_DECLSPEC  void pshmem_long_p(long* addr, long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_float_p(float* addr, float value, int pe);
 OSHMEM_DECLSPEC  void pshmem_double_p(double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void pshmem_longlong_p(long long* addr, long long value, int pe);
+OSHMEM_DECLSPEC  void pshmem_schar_p(signed char* addr, signed char value, int pe);
+OSHMEM_DECLSPEC  void pshmem_uchar_p(unsigned char* addr, unsigned char value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ushort_p(unsigned short* addr, unsigned short value, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint_p(unsigned int* addr, unsigned int value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulong_p(unsigned long* addr, unsigned long value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulonglong_p(unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_p(long double* addr, long double value, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_p(...)                                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                char*:        pshmem_ctx_char_p,                     \
-                short*:       pshmem_ctx_short_p,                    \
-                int*:         pshmem_ctx_int_p,                      \
-                long*:        pshmem_ctx_long_p,                     \
-                long long*:   pshmem_ctx_longlong_p,                 \
+                char*:       pshmem_ctx_char_p,                      \
+                short*:      pshmem_ctx_short_p,                     \
+                int*:        pshmem_ctx_int_p,                       \
+                long*:       pshmem_ctx_long_p,                      \
+                long long*:  pshmem_ctx_longlong_p,                  \
+                signed char*:        pshmem_ctx_schar_p,             \
+                unsigned char*:      pshmem_ctx_uchar_p,             \
+                unsigned short*:     pshmem_ctx_ushort_p,            \
+                unsigned int*:       pshmem_ctx_uint_p,              \
+                unsigned long*:      pshmem_ctx_ulong_p,             \
+                unsigned long long*: pshmem_ctx_ulonglong_p,         \
                 float*:       pshmem_ctx_float_p,                    \
                 double*:      pshmem_ctx_double_p,                   \
                 long double*: pshmem_ctx_longdouble_p,               \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        pshmem_char_p,                             \
-            short*:       pshmem_short_p,                            \
-            int*:         pshmem_int_p,                              \
-            long*:        pshmem_long_p,                             \
-            long long*:   pshmem_longlong_p,                         \
+                default:      __opshmem_datatype_ignore),            \
+            char*:       pshmem_char_p,                              \
+            short*:      pshmem_short_p,                             \
+            int*:        pshmem_int_p,                               \
+            long*:       pshmem_long_p,                              \
+            long long*:  pshmem_longlong_p,                          \
+            signed char*:        pshmem_schar_p,                     \
+            unsigned char*:      pshmem_uchar_p,                     \
+            unsigned short*:     pshmem_ushort_p,                    \
+            unsigned int*:       pshmem_uint_p,                      \
+            unsigned long*:      pshmem_ulong_p,                     \
+            unsigned long long*: pshmem_ulonglong_p,                 \
             float*:       pshmem_float_p,                            \
             double*:      pshmem_double_p,                           \
             long double*: pshmem_longdouble_p)(__VA_ARGS__)
@@ -143,39 +167,63 @@ OSHMEM_DECLSPEC  void pshmem_longdouble_p(long double* addr, long double value, 
  */
 OSHMEM_DECLSPEC  void pshmem_ctx_char_put(shmem_ctx_t ctx, char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_short_put(shmem_ctx_t ctx, short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void pshmem_ctx_int_put(shmem_ctx_t ctx, int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int_put(shmem_ctx_t ctx, int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_long_put(shmem_ctx_t ctx, long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_float_put(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_put(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longlong_put(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_schar_put(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uchar_put(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ushort_put(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint_put(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulong_put(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_put(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_put(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_char_put(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_put(short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void pshmem_int_put(int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int_put(int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_long_put(long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_float_put(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_double_put(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longlong_put(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_schar_put(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uchar_put(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ushort_put(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint_put(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulong_put(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulonglong_put(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_put(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+            shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
                 char*:        pshmem_ctx_char_put,                   \
                 short*:       pshmem_ctx_short_put,                  \
                 int*:         pshmem_ctx_int_put,                    \
                 long*:        pshmem_ctx_long_put,                   \
                 long long*:   pshmem_ctx_longlong_put,               \
+                signed char*:        pshmem_ctx_schar_put,           \
+                unsigned char*:      pshmem_ctx_uchar_put,           \
+                unsigned short*:     pshmem_ctx_ushort_put,          \
+                unsigned int*:       pshmem_ctx_uint_put,            \
+                unsigned long*:      pshmem_ctx_ulong_put,           \
+                unsigned long long*: pshmem_ctx_ulonglong_put,       \
                 float*:       pshmem_ctx_float_put,                  \
                 double*:      pshmem_ctx_double_put,                 \
                 long double*: pshmem_ctx_longdouble_put,             \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        pshmem_char_put,                           \
-            short*:       pshmem_short_put,                          \
-            int*:         pshmem_int_put,                            \
-            long*:        pshmem_long_put,                           \
-            long long*:   pshmem_longlong_put,                       \
+                default:      __opshmem_datatype_ignore),            \
+            char*:       pshmem_char_put,                            \
+            short*:      pshmem_short_put,                           \
+            int*:        pshmem_int_put,                             \
+            long*:       pshmem_long_put,                            \
+            long long*:  pshmem_longlong_put,                        \
+            signed char*:        pshmem_schar_put,                   \
+            unsigned char*:      pshmem_uchar_put,                   \
+            unsigned short*:     pshmem_ushort_put,                  \
+            unsigned int*:       pshmem_uint_put,                    \
+            unsigned long*:      pshmem_ulong_put,                   \
+            unsigned long long*: pshmem_ulonglong_put,               \
             float*:       pshmem_float_put,                          \
             double*:      pshmem_double_put,                         \
             long double*: pshmem_longdouble_put)(__VA_ARGS__)
@@ -205,6 +253,12 @@ OSHMEM_DECLSPEC void pshmem_ctx_long_iput(shmem_ctx_t ctx, long* target, const l
 OSHMEM_DECLSPEC void pshmem_ctx_float_iput(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_double_iput(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_iput(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_schar_iput(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uchar_iput(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ushort_iput(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint_iput(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulong_iput(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_iput(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longdouble_iput(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 OSHMEM_DECLSPEC void pshmem_char_iput(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -214,6 +268,12 @@ OSHMEM_DECLSPEC void pshmem_long_iput(long* target, const long* source, ptrdiff_
 OSHMEM_DECLSPEC void pshmem_float_iput(float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_double_iput(double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_iput(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_schar_iput(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uchar_iput(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ushort_iput(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint_iput(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ulong_iput(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ulonglong_iput(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_longdouble_iput(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_iput(...)                                             \
@@ -224,15 +284,27 @@ OSHMEM_DECLSPEC void pshmem_longdouble_iput(long double* target, const long doub
                 int*:         pshmem_ctx_int_iput,                   \
                 long*:        pshmem_ctx_long_iput,                  \
                 long long*:   pshmem_ctx_longlong_iput,              \
+                signed char*:        pshmem_ctx_schar_iput,          \
+                unsigned char*:      pshmem_ctx_uchar_iput,          \
+                unsigned short*:     pshmem_ctx_ushort_iput,         \
+                unsigned int*:       pshmem_ctx_uint_iput,           \
+                unsigned long*:      pshmem_ctx_ulong_iput,          \
+                unsigned long long*: pshmem_ctx_ulonglong_iput,      \
                 float*:       pshmem_ctx_float_iput,                 \
                 double*:      pshmem_ctx_double_iput,                \
                 long double*: pshmem_ctx_longdouble_iput,            \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        pshmem_char_iput,                          \
-            short*:       pshmem_short_iput,                         \
-            int*:         pshmem_int_iput,                           \
-            long*:        pshmem_long_iput,                          \
-            long long*:   pshmem_longlong_iput,                      \
+                default:      __opshmem_datatype_ignore),            \
+            char*:       pshmem_char_iput,                           \
+            short*:      pshmem_short_iput,                          \
+            int*:        pshmem_int_iput,                            \
+            long*:       pshmem_long_iput,                           \
+            long long*:  pshmem_longlong_iput,                       \
+            signed char*:        pshmem_schar_iput,                  \
+            unsigned char*:      pshmem_uchar_iput,                  \
+            unsigned short*:     pshmem_ushort_iput,                 \
+            unsigned int*:       pshmem_uint_iput,                   \
+            unsigned long*:      pshmem_ulong_iput,                  \
+            unsigned long long*: pshmem_ulonglong_iput,              \
             float*:       pshmem_float_iput,                         \
             double*:      pshmem_double_iput,                        \
             long double*: pshmem_longdouble_iput)(__VA_ARGS__)
@@ -255,40 +327,64 @@ OSHMEM_DECLSPEC void pshmem_iput128(void* target, const void* source, ptrdiff_t 
  */
 OSHMEM_DECLSPEC  void pshmem_ctx_char_put_nbi(shmem_ctx_t ctx, char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_short_put_nbi(shmem_ctx_t ctx, short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void pshmem_ctx_int_put_nbi(shmem_ctx_t ctx, int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int_put_nbi(shmem_ctx_t ctx, int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_long_put_nbi(shmem_ctx_t ctx, long *target, const long *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void pshmem_ctx_longlong_put_nbi(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_float_put_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_put_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_longlong_put_nbi(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_schar_put_nbi(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uchar_put_nbi(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ushort_put_nbi(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint_put_nbi(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulong_put_nbi(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_put_nbi(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_put_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_putmem_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_put_nbi(short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void pshmem_int_put_nbi(int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int_put_nbi(int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_long_put_nbi(long *target, const long *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void pshmem_longlong_put_nbi(long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_float_put_nbi(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_double_put_nbi(double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_longlong_put_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_schar_put_nbi(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uchar_put_nbi(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ushort_put_nbi(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint_put_nbi(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulong_put_nbi(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulonglong_put_nbi(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_put_nbi(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+            shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
                 char*:        pshmem_ctx_char_put_nbi,               \
                 short*:       pshmem_ctx_short_put_nbi,              \
                 int*:         pshmem_ctx_int_put_nbi,                \
                 long*:        pshmem_ctx_long_put_nbi,               \
                 long long*:   pshmem_ctx_longlong_put_nbi,           \
+                signed char*:        pshmem_ctx_schar_put_nbi,       \
+                unsigned char*:      pshmem_ctx_uchar_put_nbi,       \
+                unsigned short*:     pshmem_ctx_ushort_put_nbi,      \
+                unsigned int*:       pshmem_ctx_uint_put_nbi,        \
+                unsigned long*:      pshmem_ctx_ulong_put_nbi,       \
+                unsigned long long*: pshmem_ctx_ulonglong_put_nbi,   \
                 float*:       pshmem_ctx_float_put_nbi,              \
                 double*:      pshmem_ctx_double_put_nbi,             \
                 long double*: pshmem_ctx_longdouble_put_nbi,         \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        pshmem_char_put_nbi,                       \
-            short*:       pshmem_short_put_nbi,                      \
-            int*:         pshmem_int_put_nbi,                        \
-            long*:        pshmem_long_put_nbi,                       \
-            long long*:   pshmem_longlong_put_nbi,                   \
+                default:      __opshmem_datatype_ignore),            \
+            char*:       pshmem_char_put_nbi,                        \
+            short*:      pshmem_short_put_nbi,                       \
+            int*:        pshmem_int_put_nbi,                         \
+            long*:       pshmem_long_put_nbi,                        \
+            long long*:  pshmem_longlong_put_nbi,                    \
+            signed char*:        pshmem_schar_put_nbi,               \
+            unsigned char*:      pshmem_uchar_put_nbi,               \
+            unsigned short*:     pshmem_ushort_put_nbi,              \
+            unsigned int*:       pshmem_uint_put_nbi,                \
+            unsigned long*:      pshmem_ulong_put_nbi,               \
+            unsigned long long*: pshmem_ulonglong_put_nbi,           \
             float*:       pshmem_float_put_nbi,                      \
             double*:      pshmem_double_put_nbi,                     \
             long double*: pshmem_longdouble_put_nbi)(__VA_ARGS__)
@@ -318,6 +414,12 @@ OSHMEM_DECLSPEC  float pshmem_ctx_float_g(shmem_ctx_t ctx, const float* addr, in
 OSHMEM_DECLSPEC  double pshmem_ctx_double_g(shmem_ctx_t ctx, const double* addr, int pe);
 OSHMEM_DECLSPEC  long long pshmem_ctx_longlong_g(shmem_ctx_t ctx, const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double pshmem_ctx_longdouble_g(shmem_ctx_t ctx, const long double* addr, int pe);
+OSHMEM_DECLSPEC  signed char pshmem_ctx_schar_g(shmem_ctx_t ctx, const signed char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned char pshmem_ctx_uchar_g(shmem_ctx_t ctx, const unsigned char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned short pshmem_ctx_ushort_g(shmem_ctx_t ctx, const unsigned short* addr, int pe);
+OSHMEM_DECLSPEC  unsigned int pshmem_ctx_uint_g(shmem_ctx_t ctx, const unsigned int* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long pshmem_ctx_ulong_g(shmem_ctx_t ctx, const unsigned long* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long long pshmem_ctx_ulonglong_g(shmem_ctx_t ctx, const unsigned long long* addr, int pe);
 
 OSHMEM_DECLSPEC  char pshmem_char_g(const char* addr, int pe);
 OSHMEM_DECLSPEC  short pshmem_short_g(const short* addr, int pe);
@@ -327,6 +429,12 @@ OSHMEM_DECLSPEC  float pshmem_float_g(const float* addr, int pe);
 OSHMEM_DECLSPEC  double pshmem_double_g(const double* addr, int pe);
 OSHMEM_DECLSPEC  long long pshmem_longlong_g(const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double pshmem_longdouble_g(const long double* addr, int pe);
+OSHMEM_DECLSPEC  signed char pshmem_schar_g(const signed char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned char pshmem_uchar_g(const unsigned char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned short pshmem_ushort_g(const unsigned short* addr, int pe);
+OSHMEM_DECLSPEC  unsigned int pshmem_uint_g(const unsigned int* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long pshmem_ulong_g(const unsigned long* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long long pshmem_ulonglong_g(const unsigned long long* addr, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_g(...)                                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -336,15 +444,27 @@ OSHMEM_DECLSPEC  long double pshmem_longdouble_g(const long double* addr, int pe
                 int*:         pshmem_ctx_int_g,                      \
                 long*:        pshmem_ctx_long_g,                     \
                 long long*:   pshmem_ctx_longlong_g,                 \
+                signed char*:        pshmem_ctx_schar_g,             \
+                unsigned char*:      pshmem_ctx_uchar_g,             \
+                unsigned short*:     pshmem_ctx_ushort_g,            \
+                unsigned int*:       pshmem_ctx_uint_g,              \
+                unsigned long*:      pshmem_ctx_ulong_g,             \
+                unsigned long long*: pshmem_ctx_ulonglong_g,         \
                 float*:       pshmem_ctx_float_g,                    \
                 double*:      pshmem_ctx_double_g,                   \
                 long double*: pshmem_ctx_longdouble_g,               \
-                default:      __oshmem_datatype_ignore),             \
+                default:      __opshmem_datatype_ignore),            \
             char*:        pshmem_char_g,                             \
             short*:       pshmem_short_g,                            \
             int*:         pshmem_int_g,                              \
             long*:        pshmem_long_g,                             \
             long long*:   pshmem_longlong_g,                         \
+            signed char*:        pshmem_schar_g,                     \
+            unsigned char*:      pshmem_char_g,                      \
+            unsigned short*:     pshmem_short_g,                     \
+            unsigned int*:       pshmem_int_g,                       \
+            unsigned long*:      pshmem_long_g,                      \
+            unsigned long long*: pshmem_longlong_g,                  \
             float*:       pshmem_float_g,                            \
             double*:      pshmem_double_g,                           \
             long double*: pshmem_longdouble_g)(__VA_ARGS__)
@@ -360,6 +480,12 @@ OSHMEM_DECLSPEC  void pshmem_ctx_long_get(shmem_ctx_t ctx, long *target, const l
 OSHMEM_DECLSPEC  void pshmem_ctx_float_get(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_get(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longlong_get(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_schar_get(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uchar_get(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ushort_get(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint_get(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulong_get(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_get(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_get(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_char_get(char *target, const char *source, size_t len, int pe);
@@ -369,6 +495,12 @@ OSHMEM_DECLSPEC  void pshmem_long_get(long *target, const long *source, size_t l
 OSHMEM_DECLSPEC  void pshmem_float_get(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_double_get(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longlong_get(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_schar_get(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uchar_get(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ushort_get(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint_get(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulong_get(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulonglong_get(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_get(...)                                              \
@@ -379,15 +511,27 @@ OSHMEM_DECLSPEC  void pshmem_longdouble_get(long double *target, const long doub
                 int*:         pshmem_ctx_int_get,                    \
                 long*:        pshmem_ctx_long_get,                   \
                 long long*:   pshmem_ctx_longlong_get,               \
+                signed char*:        pshmem_ctx_schar_get,           \
+                unsigned char*:      pshmem_ctx_uchar_get,           \
+                unsigned short*:     pshmem_ctx_ushort_get,          \
+                unsigned int*:       pshmem_ctx_uint_get,            \
+                unsigned long*:      pshmem_ctx_ulong_get,           \
+                unsigned long long*: pshmem_ctx_ulonglong_get,       \
                 float*:       pshmem_ctx_float_get,                  \
                 double*:      pshmem_ctx_double_get,                 \
                 long double*: pshmem_ctx_longdouble_get,             \
-                default:      __oshmem_datatype_ignore),             \
+                default:      __opshmem_datatype_ignore),            \
             char*:        pshmem_char_get,                           \
             short*:       pshmem_short_get,                          \
             int*:         pshmem_int_get,                            \
             long*:        pshmem_long_get,                           \
             long long*:   pshmem_longlong_get,                       \
+            signed char*:        pshmem_schar_get,                   \
+            unsigned char*:      pshmem_uchar_get,                   \
+            unsigned short*:     pshmem_ushort_get,                  \
+            unsigned int*:       pshmem_uint_get,                    \
+            unsigned long*:      pshmem_ulong_get,                   \
+            unsigned long long*: pshmem_ulonglong_get,               \
             float*:       pshmem_float_get,                          \
             double*:      pshmem_double_get,                         \
             long double*: pshmem_longdouble_get)(__VA_ARGS__)
@@ -413,11 +557,17 @@ OSHMEM_DECLSPEC  void pshmem_getmem(void *target, const void *source, size_t len
 OSHMEM_DECLSPEC void pshmem_ctx_char_iget(shmem_ctx_t ctx, char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_short_iget(shmem_ctx_t ctx, short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_int_iget(shmem_ctx_t ctx, int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_schar_iget(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uchar_iget(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ushort_iget(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint_iget(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulong_iget(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_iget(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_float_iget(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_double_iget(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 OSHMEM_DECLSPEC void pshmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -427,6 +577,12 @@ OSHMEM_DECLSPEC void pshmem_double_iget(double* target, const double* source, pt
 OSHMEM_DECLSPEC void pshmem_longlong_iget(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_schar_iget(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uchar_iget(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ushort_iget(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint_iget(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ulong_iget(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ulonglong_iget(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_iget(...)                                             \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -436,15 +592,27 @@ OSHMEM_DECLSPEC void pshmem_long_iget(long* target, const long* source, ptrdiff_
                 int*:         pshmem_ctx_int_iget,                   \
                 long*:        pshmem_ctx_long_iget,                  \
                 long long*:   pshmem_ctx_longlong_iget,              \
+                signed char*:        pshmem_ctx_schar_iget,          \
+                unsigned char*:      pshmem_ctx_uchar_iget,          \
+                unsigned short*:     pshmem_ctx_ushort_iget,         \
+                unsigned int*:       pshmem_ctx_uint_iget,           \
+                unsigned long*:      pshmem_ctx_ulong_iget,          \
+                unsigned long long*: pshmem_ctx_ulonglong_iget,      \
                 float*:       pshmem_ctx_float_iget,                 \
                 double*:      pshmem_ctx_double_iget,                \
                 long double*: pshmem_ctx_longdouble_iget,            \
-                default:      __oshmem_datatype_ignore),             \
+                default:      __opshmem_datatype_ignore),            \
             char*:        pshmem_char_iget,                          \
             short*:       pshmem_short_iget,                         \
             int*:         pshmem_int_iget,                           \
             long*:        pshmem_long_iget,                          \
             long long*:   pshmem_longlong_iget,                      \
+            signed char*:        pshmem_schar_iget,                  \
+            unsigned char*:      pshmem_uchar_iget,                  \
+            unsigned short*:     pshmem_ushort_iget,                 \
+            unsigned int*:       pshmem_uint_iget,                   \
+            unsigned long*:      pshmem_ulong_iget,                  \
+            unsigned long long*: pshmem_ulonglong_iget,              \
             float*:       pshmem_float_iget,                         \
             double*:      pshmem_double_iget,                        \
             long double*: pshmem_longdouble_iget)(__VA_ARGS__)
@@ -470,6 +638,12 @@ OSHMEM_DECLSPEC  void pshmem_ctx_short_get_nbi(shmem_ctx_t ctx, short *target, c
 OSHMEM_DECLSPEC  void pshmem_ctx_int_get_nbi(shmem_ctx_t ctx, int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_long_get_nbi(shmem_ctx_t ctx, long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longlong_get_nbi(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_schar_get_nbi(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uchar_get_nbi(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ushort_get_nbi(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint_get_nbi(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulong_get_nbi(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_get_nbi(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_float_get_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_get_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_get_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
@@ -480,6 +654,12 @@ OSHMEM_DECLSPEC  void pshmem_short_get_nbi(short *target, const short *source, s
 OSHMEM_DECLSPEC  void pshmem_int_get_nbi(int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_long_get_nbi(long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longlong_get_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_schar_get_nbi(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uchar_get_nbi(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ushort_get_nbi(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint_get_nbi(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulong_get_nbi(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ulonglong_get_nbi(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_float_get_nbi(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
@@ -492,15 +672,27 @@ OSHMEM_DECLSPEC  void pshmem_longdouble_get_nbi(long double *target, const long 
                 int*:         pshmem_ctx_int_get_nbi,                \
                 long*:        pshmem_ctx_long_get_nbi,               \
                 long long*:   pshmem_ctx_longlong_get_nbi,           \
+                signed char*:        pshmem_ctx_schar_get_nbi,       \
+                unsigned char*:      pshmem_ctx_uchar_get_nbi,       \
+                unsigned short*:     pshmem_ctx_ushort_get_nbi,      \
+                unsigned int*:       pshmem_ctx_uint_get_nbi,        \
+                unsigned long*:      pshmem_ctx_ulong_get_nbi,       \
+                unsigned long long*: pshmem_ctx_ulonglong_get_nbi,   \
                 float*:       pshmem_ctx_float_get_nbi,              \
                 double*:      pshmem_ctx_double_get_nbi,             \
                 long double*: pshmem_ctx_longdouble_get_nbi,         \
-                default:      __oshmem_datatype_ignore),             \
+                default:      __opshmem_datatype_ignore),            \
             char*:        pshmem_char_get_nbi,                       \
             short*:       pshmem_short_get_nbi,                      \
             int*:         pshmem_int_get_nbi,                        \
             long*:        pshmem_long_get_nbi,                       \
             long long*:   pshmem_longlong_get_nbi,                   \
+            signed char*:        pshmem_schar_get_nbi,               \
+            unsigned char*:      pshmem_uchar_get_nbi,               \
+            unsigned short*:     pshmem_ushort_get_nbi,              \
+            unsigned int*:       pshmem_uint_get_nbi,                \
+            unsigned long*:      pshmem_ulong_get_nbi,               \
+            unsigned long long*: pshmem_ulonglong_get_nbi,           \
             float*:       pshmem_float_get_nbi,                      \
             double*:      pshmem_double_get_nbi,                     \
             long double*: pshmem_longdouble_get_nbi)(__VA_ARGS__)
@@ -525,29 +717,41 @@ OSHMEM_DECLSPEC  void pshmem_get128_nbi(void *target, const void *source, size_t
 /* Atomic swap */
 OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_swap(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_swap(shmem_ctx_t ctx, long *target, long value, int pe);
-OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_swap(shmem_ctx_t ctx, long long*target, long long value, int pe);
+OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_swap(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_swap(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_swap(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_swap(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC float pshmem_ctx_float_atomic_swap(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC double pshmem_ctx_double_atomic_swap(shmem_ctx_t ctx, double *target, double value, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_swap(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_swap(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_swap(long long*target, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_swap(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_swap(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_swap(unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC float pshmem_float_atomic_swap(float *target, float value, int pe);
 OSHMEM_DECLSPEC double pshmem_double_atomic_swap(double *target, double value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_swap(...)                                      \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         pshmem_ctx_int_atomic_swap,            \
-                long*:        pshmem_ctx_long_atomic_swap,           \
-                long long*:   pshmem_ctx_longlong_atomic_swap,       \
-                float*:       pshmem_ctx_float_atomic_swap,          \
-                double*:      pshmem_ctx_double_atomic_swap,         \
-                default:      __oshmem_datatype_ignore),             \
-            int*:         pshmem_int_atomic_swap,                    \
-            long*:        pshmem_long_atomic_swap,                   \
-            long long*:   pshmem_longlong_atomic_swap,               \
-            float*:       pshmem_float_atomic_swap,                  \
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_swap(...)                                       \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
+                int*:         pshmem_ctx_int_atomic_swap,             \
+                long*:        pshmem_ctx_long_atomic_swap,            \
+                long long*:   pshmem_ctx_longlong_atomic_swap,        \
+                unsigned int*:       pshmem_ctx_uint_atomic_swap,     \
+                unsigned long*:      pshmem_ctx_ulong_atomic_swap,    \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_swap,\
+                float*:       pshmem_ctx_float_atomic_swap,           \
+                double*:      pshmem_ctx_double_atomic_swap,          \
+                default:      __opshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_swap,                     \
+            long*:        pshmem_long_atomic_swap,                    \
+            long long*:   pshmem_longlong_atomic_swap,                \
+            unsigned int*:       pshmem_uint_atomic_swap,             \
+            unsigned long*:      pshmem_ulong_atomic_swap,            \
+            unsigned long long*: pshmem_ulonglong_atomic_swap,        \
+            float*:       pshmem_float_atomic_swap,                   \
             double*:      pshmem_double_atomic_swap)(__VA_ARGS__)
 #endif
 
@@ -569,35 +773,47 @@ OSHMEM_DECLSPEC double pshmem_double_swap(double *target, double value, int pe);
 /* Atomic set */
 OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_set(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_set(shmem_ctx_t ctx, long *target, long value, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_set(shmem_ctx_t ctx, long long*target, long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_set(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_set(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_set(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_set(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_float_atomic_set(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_double_atomic_set(shmem_ctx_t ctx, double *target, double value, int pe);
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_set(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_set(long *target, long value, int pe);
-OSHMEM_DECLSPEC void pshmem_longlong_atomic_set(long long*target, long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_longlong_atomic_set(long long *target, long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_uint_atomic_set(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void pshmem_ulong_atomic_set(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_set(unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_float_atomic_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void pshmem_double_atomic_set(double *target, double value, int pe);
-#if OSHMEM_HAVE_C11
+#if OSHMEMP_HAVE_C11
 #define pshmem_atomic_set(...)                                       \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
                 int*:         pshmem_ctx_int_atomic_set,             \
                 long*:        pshmem_ctx_long_atomic_set,            \
                 long long*:   pshmem_ctx_longlong_atomic_set,        \
+                unsigned int*:       pshmem_ctx_uint_atomic_set,     \
+                unsigned long*:      pshmem_ctx_ulong_atomic_set,    \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_set,\
                 float*:       pshmem_ctx_float_atomic_set,           \
                 double*:      pshmem_ctx_double_atomic_set,          \
-                default:      __oshmem_datatype_ignore),             \
+                default:      __opshmem_datatype_ignore),            \
             int*:         pshmem_int_atomic_set,                     \
             long*:        pshmem_long_atomic_set,                    \
             long long*:   pshmem_longlong_atomic_set,                \
+            unsigned int*:         pshmem_uint_atomic_set,           \
+            unsigned long*:        pshmem_ulong_atomic_set,          \
+            unsigned long long*:   pshmem_ulonglong_atomic_set,      \
             float*:       pshmem_float_atomic_set,                   \
             double*:      pshmem_double_atomic_set)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_int_set(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_set(long *target, long value, int pe);
-OSHMEM_DECLSPEC void pshmem_longlong_set(long long*target, long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_longlong_set(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_float_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void pshmem_double_set(double *target, double value, int pe);
 #if OSHMEMP_HAVE_C11
@@ -614,22 +830,34 @@ OSHMEM_DECLSPEC void pshmem_double_set(double *target, double value, int pe);
 OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_compare_swap(shmem_ctx_t ctx, int *target, int cond, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_compare_swap(shmem_ctx_t ctx, long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_compare_swap(shmem_ctx_t ctx, long long *target, long long cond, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_compare_swap(shmem_ctx_t ctx, unsigned int *target, unsigned int cond, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_compare_swap(shmem_ctx_t ctx, unsigned long *target, unsigned long cond, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_compare_swap(shmem_ctx_t ctx, unsigned long long *target, unsigned long long cond, unsigned long long value, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_compare_swap(int *target, int cond, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_compare_swap(long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_compare_swap(long long *target, long long cond, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_compare_swap(unsigned int *target, unsigned int cond, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_compare_swap(unsigned long *target, unsigned long cond, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_compare_swap(unsigned long long *target, unsigned long long cond, unsigned long long value, int pe);
 
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_compare_swap(...)                               \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
-                int*:         pshmem_ctx_int_atomic_compare_swap,     \
-                long*:        pshmem_ctx_long_atomic_compare_swap,    \
-                long long*:   pshmem_ctx_longlong_atomic_compare_swap,\
-                default:      __oshmem_datatype_ignore),              \
-            int*:         pshmem_int_atomic_compare_swap,             \
-            long*:        pshmem_long_atomic_compare_swap,            \
-            long long*:   pshmem_longlong_atomic_compare_swap)(__VA_ARGS__)
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_compare_swap(...)                                \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                int*:         pshmem_ctx_int_atomic_compare_swap,      \
+                long*:        pshmem_ctx_long_atomic_compare_swap,     \
+                long long*:   pshmem_ctx_longlong_atomic_compare_swap, \
+                unsigned int*:       pshmem_ctx_uint_atomic_compare_swap,      \
+                unsigned long*:      pshmem_ctx_ulong_atomic_compare_swap,     \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_compare_swap, \
+                default:      __opshmem_datatype_ignore),              \
+            int*:         pshmem_int_atomic_compare_swap,              \
+            long*:        pshmem_long_atomic_compare_swap,             \
+            long long*:   pshmem_longlong_atomic_compare_swap,         \
+            unsigned int*:       pshmem_uint_atomic_compare_swap,      \
+            unsigned long*:      pshmem_ulong_atomic_compare_swap,     \
+            unsigned long long*: pshmem_ulonglong_atomic_compare_swap)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_cswap(int *target, int cond, int value, int pe);
@@ -647,21 +875,33 @@ OSHMEM_DECLSPEC long long pshmem_longlong_cswap(long long *target, long long con
 OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_add(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_add(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_add(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_add(long long *target, long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_add(...)                                 \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         pshmem_ctx_int_atomic_fetch_add,       \
-                long*:        pshmem_ctx_long_atomic_fetch_add,      \
-                long long*:   pshmem_ctx_longlong_atomic_fetch_add,  \
-                default:      __oshmem_datatype_ignore),             \
-            int*:         pshmem_int_atomic_fetch_add,               \
-            long*:        pshmem_long_atomic_fetch_add,              \
-            long long*:   pshmem_longlong_atomic_fetch_add)(__VA_ARGS__)
+OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_add(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_add(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_add(unsigned long long *target, unsigned long long value, int pe);
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_fetch_add(...)                                        \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                            \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),        \
+                int*:         pshmem_ctx_int_atomic_fetch_add,              \
+                long*:        pshmem_ctx_long_atomic_fetch_add,             \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_add,         \
+                unsigned int*:       pshmem_ctx_uint_atomic_fetch_add,      \
+                unsigned long*:      pshmem_ctx_ulong_atomic_fetch_add,     \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_fetch_add, \
+                default:      __opshmem_datatype_ignore),                   \
+            int*:         pshmem_int_atomic_fetch_add,                      \
+            long*:        pshmem_long_atomic_fetch_add,                     \
+            long long*:   pshmem_longlong_atomic_fetch_add,                 \
+            unsigned int*:       pshmem_uint_atomic_fetch_add,              \
+            unsigned long*:      pshmem_ulong_atomic_fetch_add,             \
+            unsigned long long*: pshmem_ulonglong_atomic_fetch_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_fadd(int *target, int value, int pe);
@@ -676,65 +916,101 @@ OSHMEM_DECLSPEC long long pshmem_longlong_fadd(long long *target, long long valu
 #endif
 
 /* Atomic Fetch&And */
+OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch_and(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch_and(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_and(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_and(int *target, int value, int pe);
+OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_and(long *target, long value, int pe);
+OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_and(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_and(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_and(...)                                          \
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_fetch_and(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
-                unsigned int*:         pshmem_ctx_uint_atomic_fetch_and,      \
-                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_and,     \
-                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_and, \
-                default:               __oshmem_datatype_ignore),             \
-            unsigned int*:         pshmem_uint_atomic_fetch_and,              \
-            unsigned long*:        pshmem_ulong_atomic_fetch_and,             \
+                int*:         pshmem_ctx_int_atomic_fetch_and,                 \
+                long*:        pshmem_ctx_long_atomic_fetch_and,                \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_and,            \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_and,       \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_and,      \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_and,  \
+                default:               __opshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_fetch_and,                         \
+            long*:        pshmem_long_atomic_fetch_and,                        \
+            long long*:   pshmem_longlong_atomic_fetch_and,                    \
+            unsigned int*:         pshmem_uint_atomic_fetch_and,               \
+            unsigned long*:        pshmem_ulong_atomic_fetch_and,              \
             unsigned long long*:   pshmem_ulonglong_atomic_fetch_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Or */
+OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch_or(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch_or(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_or(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_or(int *target, int value, int pe);
+OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_or(long *target, long value, int pe);
+OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_or(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_or(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_or(...)                                          \
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_fetch_or(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                             \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),         \
-                unsigned int*:         pshmem_ctx_uint_atomic_fetch_or,      \
-                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_or,     \
-                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_or, \
-                default:               __oshmem_datatype_ignore),            \
-            unsigned int*:         pshmem_uint_atomic_fetch_or,              \
-            unsigned long*:        pshmem_ulong_atomic_fetch_or,             \
+                int*:         pshmem_ctx_int_atomic_fetch_or,                 \
+                long*:        pshmem_ctx_long_atomic_fetch_or,                \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_or,            \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_or,       \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_or,      \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_or,  \
+                default:               __opshmem_datatype_ignore),            \
+            int*:         pshmem_int_atomic_fetch_or,                         \
+            long*:        pshmem_long_atomic_fetch_or,                        \
+            long long*:   pshmem_longlong_atomic_fetch_or,                    \
+            unsigned int*:         pshmem_uint_atomic_fetch_or,               \
+            unsigned long*:        pshmem_ulong_atomic_fetch_or,              \
             unsigned long long*:   pshmem_ulonglong_atomic_fetch_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Xor */
+OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch_xor(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch_xor(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_xor(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_xor(int *target, int value, int pe);
+OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_xor(long *target, long value, int pe);
+OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_xor(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_xor(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch_xor(...)                                          \
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_fetch_xor(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
-                unsigned int*:         pshmem_ctx_uint_atomic_fetch_xor,      \
-                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_xor,     \
-                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_xor, \
-                default:               __oshmem_datatype_ignore),             \
-            unsigned int*:         pshmem_uint_atomic_fetch_xor,              \
-            unsigned long*:        pshmem_ulong_atomic_fetch_xor,             \
+                int*:         pshmem_ctx_int_atomic_fetch_xor,                 \
+                long*:        pshmem_ctx_long_atomic_fetch_xor,                \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_xor,            \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_xor,       \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_xor,      \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_xor,  \
+                default:               __opshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_fetch_xor,                         \
+            long*:        pshmem_long_atomic_fetch_xor,                        \
+            long long*:   pshmem_longlong_atomic_fetch_xor,                    \
+            unsigned int*:         pshmem_uint_atomic_fetch_xor,               \
+            unsigned long*:        pshmem_ulong_atomic_fetch_xor,              \
             unsigned long long*:   pshmem_ulonglong_atomic_fetch_xor)(__VA_ARGS__)
 #endif
 
@@ -742,28 +1018,40 @@ OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_xor(unsigned lo
 OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch(shmem_ctx_t ctx, const int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch(shmem_ctx_t ctx, const long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch(shmem_ctx_t ctx, const long long *target, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch(shmem_ctx_t ctx, const unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch(shmem_ctx_t ctx, const unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch(shmem_ctx_t ctx, const unsigned long long *target, int pe);
 OSHMEM_DECLSPEC float pshmem_ctx_float_atomic_fetch(shmem_ctx_t ctx, const float *target, int pe);
 OSHMEM_DECLSPEC double pshmem_ctx_double_atomic_fetch(shmem_ctx_t ctx, const double *target, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch(const int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch(const long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch(const long long *target, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch(const unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch(const unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch(const unsigned long long *target, int pe);
 OSHMEM_DECLSPEC float pshmem_float_atomic_fetch(const float *target, int pe);
 OSHMEM_DECLSPEC double pshmem_double_atomic_fetch(const double *target, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_fetch(...)                                     \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         pshmem_ctx_int_atomic_fetch,           \
-                long*:        pshmem_ctx_long_atomic_fetch,          \
-                long long*:   pshmem_ctx_longlong_atomic_fetch,      \
-                float*:       pshmem_ctx_float_atomic_fetch,         \
-                double*:      pshmem_ctx_double_atomic_fetch,        \
-                default:      __oshmem_datatype_ignore),             \
-            int*:         pshmem_int_atomic_fetch,                   \
-            long*:        pshmem_long_atomic_fetch,                  \
-            long long*:   pshmem_longlong_atomic_fetch,              \
-            float*:       pshmem_float_atomic_fetch,                 \
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_fetch(...)                                        \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
+                int*:         pshmem_ctx_int_atomic_fetch,              \
+                long*:        pshmem_ctx_long_atomic_fetch,             \
+                long long*:   pshmem_ctx_longlong_atomic_fetch,         \
+                unsigned int*:       pshmem_ctx_uint_atomic_fetch,      \
+                unsigned long*:      pshmem_ctx_ulong_atomic_fetch,     \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_fetch, \
+                float*:       pshmem_ctx_float_atomic_fetch,            \
+                double*:      pshmem_ctx_double_atomic_fetch,           \
+                default:      __opshmem_datatype_ignore),               \
+            int*:        pshmem_int_atomic_fetch,                       \
+            long*:       pshmem_long_atomic_fetch,                      \
+            long long*:  pshmem_longlong_atomic_fetch,                  \
+            unsigned int*:       pshmem_uint_atomic_fetch,              \
+            unsigned long*:      pshmem_ulong_atomic_fetch,             \
+            unsigned long long*: pshmem_ulonglong_atomic_fetch,         \
+            float*:       pshmem_float_atomic_fetch,                    \
             double*:      pshmem_double_atomic_fetch)(__VA_ARGS__)
 #endif
 
@@ -772,35 +1060,47 @@ OSHMEM_DECLSPEC long pshmem_long_fetch(const long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_fetch(const long long *target, int pe);
 OSHMEM_DECLSPEC float pshmem_float_fetch(const float *target, int pe);
 OSHMEM_DECLSPEC double pshmem_double_fetch(const double *target, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_fetch(dst, pe)                             \
-    _Generic(&*(dst),                                     \
-            int*:         pshmem_int_fetch,               \
-            long*:        pshmem_long_fetch,              \
-            long long*:   pshmem_longlong_fetch,          \
-            float*:       pshmem_float_fetch,             \
-            double*:      pshmem_double_fetch)(dst, pe)
+#if OSHMEMP_HAVE_C11
+#define pshmem_fetch(dst, pe)                            \
+    _Generic(&*(dst),                                    \
+            int*:        pshmem_int_fetch,               \
+            long*:       pshmem_long_fetch,              \
+            long long*:  pshmem_longlong_fetch,          \
+            float*:      pshmem_float_fetch,             \
+            double*:     pshmem_double_fetch)(dst, pe)
 #endif
 
 /* Atomic Fetch&Inc */
 OSHMEM_DECLSPEC int pshmem_ctx_int_atomic_fetch_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_ctx_long_atomic_fetch_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_inc(shmem_ctx_t ctx, long long *target, int pe);
+OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_inc(shmem_ctx_t ctx, unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_inc(shmem_ctx_t ctx, unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_inc(shmem_ctx_t ctx, unsigned long long *target, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_inc(int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_inc(long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_inc(long long *target, int pe);
-#if OSHMEM_HAVE_C11
+OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_inc(unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_inc(unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_inc(unsigned long long *target, int pe);
+#if OSHMEMP_HAVE_C11
 #define pshmem_atomic_fetch_inc(...)                                 \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
                 int*:         pshmem_ctx_int_atomic_fetch_inc,       \
                 long*:        pshmem_ctx_long_atomic_fetch_inc,      \
                 long long*:   pshmem_ctx_longlong_atomic_fetch_inc,  \
-                default:      __oshmem_datatype_ignore),             \
+                unsigned int*:       pshmem_ctx_uint_atomic_fetch_inc,      \
+                unsigned long*:      pshmem_ctx_ulong_atomic_fetch_inc,     \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_fetch_inc, \
+                default:      __opshmem_datatype_ignore),            \
             int*:         pshmem_int_atomic_fetch_inc,               \
             long*:        pshmem_long_atomic_fetch_inc,              \
-            long long*:   pshmem_longlong_atomic_fetch_inc)(__VA_ARGS__)
+            long long*:   pshmem_longlong_atomic_fetch_inc,          \
+            unsigned int*:       pshmem_uint_atomic_fetch_inc,       \
+            unsigned long*:      pshmem_ulong_atomic_fetch_inc,      \
+            unsigned long long*: pshmem_ulonglong_atomic_fetch_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int pshmem_int_finc(int *target, int pe);
@@ -818,21 +1118,33 @@ OSHMEM_DECLSPEC long long pshmem_longlong_finc(long long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_add(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_add(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_add(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_atomic_add(long long *target, long long value, int pe);
-#if OSHMEM_HAVE_C11
-#define pshmem_atomic_add(...)                                       \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         pshmem_ctx_int_atomic_add,             \
-                long*:        pshmem_ctx_long_atomic_add,            \
-                long long*:   pshmem_ctx_longlong_atomic_add,        \
-                default:      __oshmem_datatype_ignore),             \
-            int*:         pshmem_int_atomic_add,                     \
-            long*:        pshmem_long_atomic_add,                    \
-            long long*:   pshmem_longlong_atomic_add)(__VA_ARGS__)
+OSHMEM_DECLSPEC void pshmem_uint_atomic_add(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void pshmem_ulong_atomic_add(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_add(unsigned long long *target, unsigned long long value, int pe);
+#if OSHMEMP_HAVE_C11
+#define pshmem_atomic_add(...)                                        \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
+                int*:         pshmem_ctx_int_atomic_add,              \
+                long*:        pshmem_ctx_long_atomic_add,             \
+                long long*:   pshmem_ctx_longlong_atomic_add,         \
+                unsigned int*:       pshmem_ctx_uint_atomic_add,      \
+                unsigned long*:      pshmem_ctx_ulong_atomic_add,     \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_add, \
+                default:      __opshmem_datatype_ignore),             \
+            int*:         pshmem_int_atomic_add,                      \
+            long*:        pshmem_long_atomic_add,                     \
+            long long*:   pshmem_longlong_atomic_add,                 \
+            unsigned int*:       pshmem_uint_atomic_add,              \
+            unsigned long*:      pshmem_ulong_atomic_add,             \
+            unsigned long long*: pshmem_ulonglong_atomic_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_int_add(int *target, int value, int pe);
@@ -847,63 +1159,99 @@ OSHMEM_DECLSPEC void pshmem_longlong_add(long long *target, long long value, int
 #endif
 
 /* Atomic And */
+OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_and(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_and(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_and(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC void pshmem_int_atomic_and(int *target, int value, int pe);
+OSHMEM_DECLSPEC void pshmem_long_atomic_and(long *target, long value, int pe);
+OSHMEM_DECLSPEC void pshmem_longlong_atomic_and(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint_atomic_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_and(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
+#if OSHMEMP_HAVE_C11
 #define pshmem_atomic_and(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
+                int*:         pshmem_ctx_int_atomic_and,                \
+                long*:        pshmem_ctx_long_atomic_and,               \
+                long long*:   pshmem_ctx_longlong_atomic_and,           \
                 unsigned int*:         pshmem_ctx_uint_atomic_and,      \
                 unsigned long*:        pshmem_ctx_ulong_atomic_and,     \
                 unsigned long long*:   pshmem_ctx_ulonglong_atomic_and, \
-                default:               __oshmem_datatype_ignore),       \
+                default:               __opshmem_datatype_ignore),      \
+            int*:         pshmem_int_atomic_and,                        \
+            long*:        pshmem_long_atomic_and,                       \
+            long long*:   pshmem_longlong_atomic_and,                   \
             unsigned int*:         pshmem_uint_atomic_and,              \
             unsigned long*:        pshmem_ulong_atomic_and,             \
             unsigned long long*:   pshmem_ulonglong_atomic_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Or */
+OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_or(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_or(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_or(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC void pshmem_int_atomic_or(int *target, int value, int pe);
+OSHMEM_DECLSPEC void pshmem_long_atomic_or(long *target, long value, int pe);
+OSHMEM_DECLSPEC void pshmem_longlong_atomic_or(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint_atomic_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_or(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
+#if OSHMEMP_HAVE_C11
 #define pshmem_atomic_or(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                int*:         pshmem_ctx_int_atomic_or,                \
+                long*:        pshmem_ctx_long_atomic_or,               \
+                long long*:   pshmem_ctx_longlong_atomic_or,           \
                 unsigned int*:         pshmem_ctx_uint_atomic_or,      \
                 unsigned long*:        pshmem_ctx_ulong_atomic_or,     \
                 unsigned long long*:   pshmem_ctx_ulonglong_atomic_or, \
-                default:               __oshmem_datatype_ignore),      \
+                default:               __opshmem_datatype_ignore),     \
+            int*:         pshmem_int_atomic_or,                        \
+            long*:        pshmem_long_atomic_or,                       \
+            long long*:   pshmem_longlong_atomic_or,                   \
             unsigned int*:         pshmem_uint_atomic_or,              \
             unsigned long*:        pshmem_ulong_atomic_or,             \
             unsigned long long*:   pshmem_ulonglong_atomic_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Xor */
+OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_xor(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_xor(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_xor(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC void pshmem_int_atomic_xor(int *target, int value, int pe);
+OSHMEM_DECLSPEC void pshmem_long_atomic_xor(long *target, long value, int pe);
+OSHMEM_DECLSPEC void pshmem_longlong_atomic_xor(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint_atomic_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_xor(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEM_HAVE_C11
+#if OSHMEMP_HAVE_C11
 #define pshmem_atomic_xor(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
+                int*:         pshmem_ctx_int_atomic_xor,                \
+                long*:        pshmem_ctx_long_atomic_xor,               \
+                long long*:   pshmem_ctx_longlong_atomic_xor,           \
                 unsigned int*:         pshmem_ctx_uint_atomic_xor,      \
                 unsigned long*:        pshmem_ctx_ulong_atomic_xor,     \
                 unsigned long long*:   pshmem_ctx_ulonglong_atomic_xor, \
-                default:               __oshmem_datatype_ignore),       \
+                default:               __opshmem_datatype_ignore),      \
+            int*:         pshmem_int_atomic_xor,                        \
+            long*:        pshmem_long_atomic_xor,                       \
+            long long*:   pshmem_longlong_atomic_xor,                   \
             unsigned int*:         pshmem_uint_atomic_xor,              \
             unsigned long*:        pshmem_ulong_atomic_xor,             \
             unsigned long long*:   pshmem_ulonglong_atomic_xor)(__VA_ARGS__)
@@ -913,21 +1261,33 @@ OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_xor(unsigned long long *target, uns
 OSHMEM_DECLSPEC void pshmem_ctx_int_atomic_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_long_atomic_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_inc(shmem_ctx_t ctx, long long *target, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_inc(shmem_ctx_t ctx, unsigned int *target, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_inc(shmem_ctx_t ctx, unsigned long *target, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_inc(shmem_ctx_t ctx, unsigned long long *target, int pe);
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_inc(int *target, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_inc(long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_atomic_inc(long long *target, int pe);
-#if OSHMEM_HAVE_C11
+OSHMEM_DECLSPEC void pshmem_uint_atomic_inc(unsigned int *target, int pe);
+OSHMEM_DECLSPEC void pshmem_ulong_atomic_inc(unsigned long *target, int pe);
+OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_inc(unsigned long long *target, int pe);
+#if OSHMEMP_HAVE_C11
 #define pshmem_atomic_inc(...)                                       \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
                 int*:         pshmem_ctx_int_atomic_inc,             \
                 long*:        pshmem_ctx_long_atomic_inc,            \
                 long long*:   pshmem_ctx_longlong_atomic_inc,        \
-                default:      __oshmem_datatype_ignore),             \
+                unsigned int*:       pshmem_ctx_uint_atomic_inc,     \
+                unsigned long*:      pshmem_ctx_ulong_atomic_inc,    \
+                unsigned long long*: pshmem_ctx_ulonglong_atomic_inc,\
+                default:      __opshmem_datatype_ignore),            \
             int*:         pshmem_int_atomic_inc,                     \
             long*:        pshmem_long_atomic_inc,                    \
-            long long*:   pshmem_longlong_atomic_inc)(__VA_ARGS__)
+            long long*:   pshmem_longlong_atomic_inc,                \
+            unsigned int*:       pshmem_uint_atomic_inc,             \
+            unsigned long*:      pshmem_ulong_atomic_inc,            \
+            unsigned long long*: pshmem_ulonglong_atomic_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void pshmem_int_inc(int *target, int pe);
@@ -961,7 +1321,7 @@ OSHMEM_DECLSPEC  void pshmem_short_wait_until(volatile short *addr, int cmp, sho
 OSHMEM_DECLSPEC  void pshmem_int_wait_until(volatile int *addr, int cmp, int value);
 OSHMEM_DECLSPEC  void pshmem_long_wait_until(volatile long *addr, int cmp, long value);
 OSHMEM_DECLSPEC  void pshmem_longlong_wait_until(volatile long long *addr, int cmp, long long value);
-#if OSHMEM_HAVE_C11
+#if OSHMEMP_HAVE_C11
 #define pshmem_wait_until(addr, cmp, value)                  \
     _Generic(&*(addr),                                       \
         short*:       pshmem_short_wait_until,               \
@@ -974,7 +1334,7 @@ OSHMEM_DECLSPEC  int pshmem_short_test(volatile short *addr, int cmp, short valu
 OSHMEM_DECLSPEC  int pshmem_int_test(volatile int *addr, int cmp, int value);
 OSHMEM_DECLSPEC  int pshmem_long_test(volatile long *addr, int cmp, long value);
 OSHMEM_DECLSPEC  int pshmem_longlong_test(volatile long long *addr, int cmp, long long value);
-#if OSHMEM_HAVE_C11
+#if OSHMEMP_HAVE_C11
 #define pshmem_test(addr, cmp, value)                        \
     _Generic(&*(addr),                                       \
         short*:       pshmem_short_test,                     \

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -195,7 +195,9 @@ OSHMEM_DECLSPEC  void *shmem_ptr(const void *ptr, int pe);
 
 typedef struct { int dummy; } * shmem_ctx_t;
 
-#define SHMEM_CTX_DEFAULT oshmem_ctx_default;
+#define SHMEM_CTX_DEFAULT oshmem_ctx_default
+
+extern shmem_ctx_t oshmem_ctx_default;
 
 OSHMEM_DECLSPEC int shmem_ctx_create(long options, shmem_ctx_t *ctx);
 OSHMEM_DECLSPEC void shmem_ctx_destroy(shmem_ctx_t ctx);
@@ -210,6 +212,12 @@ OSHMEM_DECLSPEC  void shmem_ctx_long_p(shmem_ctx_t ctx, long* addr, long value, 
 OSHMEM_DECLSPEC  void shmem_ctx_float_p(shmem_ctx_t ctx, float* addr, float value, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_p(shmem_ctx_t ctx, double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longlong_p(shmem_ctx_t ctx, long long* addr, long long value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_schar_p(shmem_ctx_t ctx, signed char* addr, signed char value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uchar_p(shmem_ctx_t ctx, unsigned char* addr, unsigned char value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ushort_p(shmem_ctx_t ctx, unsigned short* addr, unsigned short value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint_p(shmem_ctx_t ctx, unsigned int* addr, unsigned int value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulong_p(shmem_ctx_t ctx, unsigned long* addr, unsigned long value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_p(shmem_ctx_t ctx, unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_p(shmem_ctx_t ctx, long double* addr, long double value, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_p(char* addr, char value, int pe);
@@ -219,6 +227,12 @@ OSHMEM_DECLSPEC  void shmem_long_p(long* addr, long value, int pe);
 OSHMEM_DECLSPEC  void shmem_float_p(float* addr, float value, int pe);
 OSHMEM_DECLSPEC  void shmem_double_p(double* addr, double value, int pe);
 OSHMEM_DECLSPEC  void shmem_longlong_p(long long* addr, long long value, int pe);
+OSHMEM_DECLSPEC  void shmem_schar_p(signed char* addr, signed char value, int pe);
+OSHMEM_DECLSPEC  void shmem_uchar_p(unsigned char* addr, unsigned char value, int pe);
+OSHMEM_DECLSPEC  void shmem_ushort_p(unsigned short* addr, unsigned short value, int pe);
+OSHMEM_DECLSPEC  void shmem_uint_p(unsigned int* addr, unsigned int value, int pe);
+OSHMEM_DECLSPEC  void shmem_ulong_p(unsigned long* addr, unsigned long value, int pe);
+OSHMEM_DECLSPEC  void shmem_ulonglong_p(unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_p(long double* addr, long double value, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_p(...)                                                 \
@@ -229,6 +243,12 @@ OSHMEM_DECLSPEC  void shmem_longdouble_p(long double* addr, long double value, i
                 int*:         shmem_ctx_int_p,                       \
                 long*:        shmem_ctx_long_p,                      \
                 long long*:   shmem_ctx_longlong_p,                  \
+                signed char*:        shmem_ctx_schar_p,              \
+                unsigned char*:      shmem_ctx_uchar_p,              \
+                unsigned short*:     shmem_ctx_ushort_p,             \
+                unsigned int*:       shmem_ctx_uint_p,               \
+                unsigned long*:      shmem_ctx_ulong_p,              \
+                unsigned long long*: shmem_ctx_ulonglong_p,          \
                 float*:       shmem_ctx_float_p,                     \
                 double*:      shmem_ctx_double_p,                    \
                 long double*: shmem_ctx_longdouble_p,                \
@@ -238,6 +258,12 @@ OSHMEM_DECLSPEC  void shmem_longdouble_p(long double* addr, long double value, i
             int*:         shmem_int_p,                               \
             long*:        shmem_long_p,                              \
             long long*:   shmem_longlong_p,                          \
+            signed char*:        shmem_schar_p,                      \
+            unsigned char*:      shmem_uchar_p,                      \
+            unsigned short*:     shmem_ushort_p,                     \
+            unsigned int*:       shmem_uint_p,                       \
+            unsigned long*:      shmem_ulong_p,                      \
+            unsigned long long*: shmem_ulonglong_p,                  \
             float*:       shmem_float_p,                             \
             double*:      shmem_double_p,                            \
             long double*: shmem_longdouble_p)(__VA_ARGS__)
@@ -248,41 +274,65 @@ OSHMEM_DECLSPEC  void shmem_longdouble_p(long double* addr, long double value, i
  */
 OSHMEM_DECLSPEC  void shmem_ctx_char_put(shmem_ctx_t ctx, char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_short_put(shmem_ctx_t ctx, short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void shmem_ctx_int_put(shmem_ctx_t ctx, int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int_put(shmem_ctx_t ctx, int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_long_put(shmem_ctx_t ctx, long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_float_put(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_put(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longlong_put(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_schar_put(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uchar_put(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ushort_put(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint_put(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulong_put(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_put(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_put(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_put(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_put(short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void shmem_int_put(int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int_put(int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_long_put(long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_float_put(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_double_put(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longlong_put(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_schar_put(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uchar_put(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ushort_put(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint_put(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulong_put(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulonglong_put(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_put(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_put(...)                                               \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                char*:        shmem_ctx_char_put,                    \
-                short*:       shmem_ctx_short_put,                   \
-                int*:         shmem_ctx_int_put,                     \
-                long*:        shmem_ctx_long_put,                    \
-                long long*:   shmem_ctx_longlong_put,                \
-                float*:       shmem_ctx_float_put,                   \
-                double*:      shmem_ctx_double_put,                  \
-                long double*: shmem_ctx_longdouble_put,              \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        shmem_char_put,                            \
-            short*:       shmem_short_put,                           \
-            int*:         shmem_int_put,                             \
-            long*:        shmem_long_put,                            \
-            long long*:   shmem_longlong_put,                        \
-            float*:       shmem_float_put,                           \
-            double*:      shmem_double_put,                          \
+#define shmem_put(...)                                              \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
+            shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
+                char*:        shmem_ctx_char_put,                   \
+                short*:       shmem_ctx_short_put,                  \
+                int*:         shmem_ctx_int_put,                    \
+                long*:        shmem_ctx_long_put,                   \
+                long long*:   shmem_ctx_longlong_put,               \
+                signed char*:        shmem_ctx_schar_put,           \
+                unsigned char*:      shmem_ctx_uchar_put,           \
+                unsigned short*:     shmem_ctx_ushort_put,          \
+                unsigned int*:       shmem_ctx_uint_put,            \
+                unsigned long*:      shmem_ctx_ulong_put,           \
+                unsigned long long*: shmem_ctx_ulonglong_put,       \
+                float*:       shmem_ctx_float_put,                  \
+                double*:      shmem_ctx_double_put,                 \
+                long double*: shmem_ctx_longdouble_put,             \
+                default:      __oshmem_datatype_ignore),            \
+            char*:        shmem_char_put,                           \
+            short*:       shmem_short_put,                          \
+            int*:         shmem_int_put,                            \
+            long*:        shmem_long_put,                           \
+            long long*:   shmem_longlong_put,                       \
+            signed char*:        shmem_schar_put,                   \
+            unsigned char*:      shmem_uchar_put,                   \
+            unsigned short*:     shmem_ushort_put,                  \
+            unsigned int*:       shmem_uint_put,                    \
+            unsigned long*:      shmem_ulong_put,                   \
+            unsigned long long*: shmem_ulonglong_put,               \
+            float*:       shmem_float_put,                          \
+            double*:      shmem_double_put,                         \
             long double*: shmem_longdouble_put)(__VA_ARGS__)
 #endif
 
@@ -311,6 +361,12 @@ OSHMEM_DECLSPEC void shmem_ctx_long_iput(shmem_ctx_t ctx, long* target, const lo
 OSHMEM_DECLSPEC void shmem_ctx_float_iput(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_double_iput(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longlong_iput(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_schar_iput(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uchar_iput(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ushort_iput(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint_iput(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulong_iput(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulonglong_iput(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longdouble_iput(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 OSHMEM_DECLSPEC void shmem_char_iput(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -320,16 +376,28 @@ OSHMEM_DECLSPEC void shmem_long_iput(long* target, const long* source, ptrdiff_t
 OSHMEM_DECLSPEC void shmem_float_iput(float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_double_iput(double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_longlong_iput(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_schar_iput(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uchar_iput(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ushort_iput(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint_iput(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ulong_iput(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ulonglong_iput(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_longdouble_iput(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_iput(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+            shmem_ctx_t:  _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
                 char*:        shmem_ctx_char_iput,                   \
                 short*:       shmem_ctx_short_iput,                  \
                 int*:         shmem_ctx_int_iput,                    \
                 long*:        shmem_ctx_long_iput,                   \
                 long long*:   shmem_ctx_longlong_iput,               \
+                signed char*:        shmem_ctx_schar_iput,           \
+                unsigned char*:      shmem_ctx_uchar_iput,           \
+                unsigned short*:     shmem_ctx_ushort_iput,          \
+                unsigned int*:       shmem_ctx_uint_iput,            \
+                unsigned long*:      shmem_ctx_ulong_iput,           \
+                unsigned long long*: shmem_ctx_ulonglong_iput,       \
                 float*:       shmem_ctx_float_iput,                  \
                 double*:      shmem_ctx_double_iput,                 \
                 long double*: shmem_ctx_longdouble_iput,             \
@@ -339,6 +407,12 @@ OSHMEM_DECLSPEC void shmem_longdouble_iput(long double* target, const long doubl
             int*:         shmem_int_iput,                            \
             long*:        shmem_long_iput,                           \
             long long*:   shmem_longlong_iput,                       \
+            signed char*:        shmem_schar_iput,                   \
+            unsigned char*:      shmem_uchar_iput,                   \
+            unsigned short*:     shmem_ushort_iput,                  \
+            unsigned int*:       shmem_uint_iput,                    \
+            unsigned long*:      shmem_ulong_iput,                   \
+            unsigned long long*: shmem_ulonglong_iput,               \
             float*:       shmem_float_iput,                          \
             double*:      shmem_double_iput,                         \
             long double*: shmem_longdouble_iput)(__VA_ARGS__)
@@ -361,41 +435,65 @@ OSHMEM_DECLSPEC void shmem_iput128(void* target, const void* source, ptrdiff_t t
  */
 OSHMEM_DECLSPEC  void shmem_ctx_char_put_nbi(shmem_ctx_t ctx, char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_short_put_nbi(shmem_ctx_t ctx, short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void shmem_ctx_int_put_nbi(shmem_ctx_t ctx, int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int_put_nbi(shmem_ctx_t ctx, int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_long_put_nbi(shmem_ctx_t ctx, long *target, const long *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void shmem_ctx_longlong_put_nbi(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_float_put_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_put_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_longlong_put_nbi(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_schar_put_nbi(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uchar_put_nbi(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ushort_put_nbi(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint_put_nbi(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulong_put_nbi(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_put_nbi(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_put_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_put_nbi(short *target, const short *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void shmem_int_put_nbi(int* target, const int* source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int_put_nbi(int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_long_put_nbi(long *target, const long *source, size_t len, int pe);
-OSHMEM_DECLSPEC  void shmem_longlong_put_nbi(long long *target, const long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_float_put_nbi(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_double_put_nbi(double *target, const double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_longlong_put_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_schar_put_nbi(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uchar_put_nbi(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ushort_put_nbi(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint_put_nbi(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulong_put_nbi(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulonglong_put_nbi(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_put_nbi(...)                                           \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                char*:        shmem_ctx_char_put_nbi,                \
-                short*:       shmem_ctx_short_put_nbi,               \
-                int*:         shmem_ctx_int_put_nbi,                 \
-                long*:        shmem_ctx_long_put_nbi,                \
-                long long*:   shmem_ctx_longlong_put_nbi,            \
-                float*:       shmem_ctx_float_put_nbi,               \
-                double*:      shmem_ctx_double_put_nbi,              \
-                long double*: shmem_ctx_longdouble_put_nbi,          \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        shmem_char_put_nbi,                        \
-            short*:       shmem_short_put_nbi,                       \
-            int*:         shmem_int_put_nbi,                         \
-            long*:        shmem_long_put_nbi,                        \
-            long long*:   shmem_longlong_put_nbi,                    \
-            float*:       shmem_float_put_nbi,                       \
-            double*:      shmem_double_put_nbi,                      \
+#define shmem_put_nbi(...)                                              \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
+            shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                char*:        shmem_ctx_char_put_nbi,                   \
+                short*:       shmem_ctx_short_put_nbi,                  \
+                int*:         shmem_ctx_int_put_nbi,                    \
+                long*:        shmem_ctx_long_put_nbi,                   \
+                long long*:   shmem_ctx_longlong_put_nbi,               \
+                signed char*:        shmem_ctx_schar_put_nbi,           \
+                unsigned char*:      shmem_ctx_uchar_put_nbi,           \
+                unsigned short*:     shmem_ctx_ushort_put_nbi,          \
+                unsigned int*:       shmem_ctx_uint_put_nbi,            \
+                unsigned long*:      shmem_ctx_ulong_put_nbi,           \
+                unsigned long long*: shmem_ctx_ulonglong_put_nbi,       \
+                float*:       shmem_ctx_float_put_nbi,                  \
+                double*:      shmem_ctx_double_put_nbi,                 \
+                long double*: shmem_ctx_longdouble_put_nbi,             \
+                default:      __oshmem_datatype_ignore),                \
+            char*:        shmem_char_put_nbi,                           \
+            short*:       shmem_short_put_nbi,                          \
+            int*:         shmem_int_put_nbi,                            \
+            long*:        shmem_long_put_nbi,                           \
+            long long*:   shmem_longlong_put_nbi,                       \
+            signed char*:        shmem_schar_put_nbi,                   \
+            unsigned char*:      shmem_uchar_put_nbi,                   \
+            unsigned short*:     shmem_ushort_put_nbi,                  \
+            unsigned int*:       shmem_uint_put_nbi,                    \
+            unsigned long*:      shmem_ulong_put_nbi,                   \
+            unsigned long long*: shmem_ulonglong_put_nbi,               \
+            float*:       shmem_float_put_nbi,                          \
+            double*:      shmem_double_put_nbi,                         \
             long double*: shmem_longdouble_put_nbi)(__VA_ARGS__)
 #endif
 
@@ -424,6 +522,12 @@ OSHMEM_DECLSPEC  float shmem_ctx_float_g(shmem_ctx_t ctx, const float* addr, int
 OSHMEM_DECLSPEC  double shmem_ctx_double_g(shmem_ctx_t ctx, const double* addr, int pe);
 OSHMEM_DECLSPEC  long long shmem_ctx_longlong_g(shmem_ctx_t ctx, const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double shmem_ctx_longdouble_g(shmem_ctx_t ctx, const long double* addr, int pe);
+OSHMEM_DECLSPEC  signed char shmem_ctx_schar_g(shmem_ctx_t ctx, const signed char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned char shmem_ctx_uchar_g(shmem_ctx_t ctx, const unsigned char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned short shmem_ctx_ushort_g(shmem_ctx_t ctx, const unsigned short* addr, int pe);
+OSHMEM_DECLSPEC  unsigned int shmem_ctx_uint_g(shmem_ctx_t ctx, const unsigned int* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long shmem_ctx_ulong_g(shmem_ctx_t ctx, const unsigned long* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long long shmem_ctx_ulonglong_g(shmem_ctx_t ctx, const unsigned long long* addr, int pe);
 
 OSHMEM_DECLSPEC  char shmem_char_g(const char* addr, int pe);
 OSHMEM_DECLSPEC  short shmem_short_g(const short* addr, int pe);
@@ -433,26 +537,44 @@ OSHMEM_DECLSPEC  float shmem_float_g(const float* addr, int pe);
 OSHMEM_DECLSPEC  double shmem_double_g(const double* addr, int pe);
 OSHMEM_DECLSPEC  long long shmem_longlong_g(const long long* addr, int pe);
 OSHMEM_DECLSPEC  long double shmem_longdouble_g(const long double* addr, int pe);
+OSHMEM_DECLSPEC  signed char shmem_schar_g(const signed char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned char shmem_uchar_g(const unsigned char* addr, int pe);
+OSHMEM_DECLSPEC  unsigned short shmem_ushort_g(const unsigned short* addr, int pe);
+OSHMEM_DECLSPEC  unsigned int shmem_uint_g(const unsigned int* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long shmem_ulong_g(const unsigned long* addr, int pe);
+OSHMEM_DECLSPEC  unsigned long long shmem_ulonglong_g(const unsigned long long* addr, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_g(...)                                                 \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                char*:        shmem_ctx_char_g,                      \
-                short*:       shmem_ctx_short_g,                     \
-                int*:         shmem_ctx_int_g,                       \
-                long*:        shmem_ctx_long_g,                      \
-                long long*:   shmem_ctx_longlong_g,                  \
-                float*:       shmem_ctx_float_g,                     \
-                double*:      shmem_ctx_double_g,                    \
-                long double*: shmem_ctx_longdouble_g,                \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        shmem_char_g,                              \
-            short*:       shmem_short_g,                             \
-            int*:         shmem_int_g,                               \
-            long*:        shmem_long_g,                              \
-            long long*:   shmem_longlong_g,                          \
-            float*:       shmem_float_g,                             \
-            double*:      shmem_double_g,                            \
+#define shmem_g(...)                                                \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
+                char*:        shmem_ctx_char_g,                     \
+                short*:       shmem_ctx_short_g,                    \
+                int*:         shmem_ctx_int_g,                      \
+                long*:        shmem_ctx_long_g,                     \
+                long long*:   shmem_ctx_longlong_g,                 \
+                signed char*:        shmem_ctx_schar_g,             \
+                unsigned char*:      shmem_ctx_uchar_g,             \
+                unsigned short*:     shmem_ctx_ushort_g,            \
+                unsigned int*:       shmem_ctx_uint_g,              \
+                unsigned long*:      shmem_ctx_ulong_g,             \
+                unsigned long long*: shmem_ctx_ulonglong_g,         \
+                float*:       shmem_ctx_float_g,                    \
+                double*:      shmem_ctx_double_g,                   \
+                long double*: shmem_ctx_longdouble_g,               \
+                default:      __oshmem_datatype_ignore),            \
+            char*:        shmem_char_g,                             \
+            short*:       shmem_short_g,                            \
+            int*:         shmem_int_g,                              \
+            long*:        shmem_long_g,                             \
+            long long*:   shmem_longlong_g,                         \
+            signed char*:        shmem_schar_g,                     \
+            unsigned char*:      shmem_uchar_g,                     \
+            unsigned short*:     shmem_ushort_g,                    \
+            unsigned int*:       shmem_uint_g,                      \
+            unsigned long*:      shmem_ulong_g,                     \
+            unsigned long long*: shmem_ulonglong_g,                 \
+            float*:       shmem_float_g,                            \
+            double*:      shmem_double_g,                           \
             long double*: shmem_longdouble_g)(__VA_ARGS__)
 #endif
 
@@ -466,6 +588,12 @@ OSHMEM_DECLSPEC  void shmem_ctx_long_get(shmem_ctx_t ctx, long *target, const lo
 OSHMEM_DECLSPEC  void shmem_ctx_float_get(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_get(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longlong_get(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_schar_get(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uchar_get(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ushort_get(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint_get(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulong_get(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_get(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_get(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_get(char *target, const char *source, size_t len, int pe);
@@ -475,27 +603,45 @@ OSHMEM_DECLSPEC  void shmem_long_get(long *target, const long *source, size_t le
 OSHMEM_DECLSPEC  void shmem_float_get(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_double_get(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longlong_get(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_schar_get(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uchar_get(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ushort_get(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint_get(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulong_get(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulonglong_get(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_get(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_get(...)                                               \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                char*:        shmem_ctx_char_get,                    \
-                short*:       shmem_ctx_short_get,                   \
-                int*:         shmem_ctx_int_get,                     \
-                long*:        shmem_ctx_long_get,                    \
-                long long*:   shmem_ctx_longlong_get,                \
-                float*:       shmem_ctx_float_get,                   \
-                double*:      shmem_ctx_double_get,                  \
-                long double*: shmem_ctx_longdouble_get,              \
-                default:      __oshmem_datatype_ignore),             \
-            char*:        shmem_char_get,                            \
-            short*:       shmem_short_get,                           \
-            int*:         shmem_int_get,                             \
-            long*:        shmem_long_get,                            \
-            long long*:   shmem_longlong_get,                        \
-            float*:       shmem_float_get,                           \
-            double*:      shmem_double_get,                          \
+#define shmem_get(...)                                              \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
+            shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
+                char*:        shmem_ctx_char_get,                   \
+                short*:       shmem_ctx_short_get,                  \
+                int*:         shmem_ctx_int_get,                    \
+                long*:        shmem_ctx_long_get,                   \
+                long long*:   shmem_ctx_longlong_get,               \
+                signed char*:        shmem_ctx_schar_get,           \
+                unsigned char*:      shmem_ctx_uchar_get,           \
+                unsigned short*:     shmem_ctx_ushort_get,          \
+                unsigned int*:       shmem_ctx_uint_get,            \
+                unsigned long*:      shmem_ctx_ulong_get,           \
+                unsigned long long*: shmem_ctx_ulonglong_get,       \
+                float*:       shmem_ctx_float_get,                  \
+                double*:      shmem_ctx_double_get,                 \
+                long double*: shmem_ctx_longdouble_get,             \
+                default:      __oshmem_datatype_ignore),            \
+            char*:        shmem_char_get,                           \
+            short*:       shmem_short_get,                          \
+            int*:         shmem_int_get,                            \
+            long*:        shmem_long_get,                           \
+            long long*:   shmem_longlong_get,                       \
+            signed char*:        shmem_schar_get,                   \
+            unsigned char*:      shmem_uchar_get,                   \
+            unsigned short*:     shmem_ushort_get,                  \
+            unsigned int*:       shmem_uint_get,                    \
+            unsigned long*:      shmem_ulong_get,                   \
+            unsigned long long*: shmem_ulonglong_get,               \
+            float*:       shmem_float_get,                          \
+            double*:      shmem_double_get,                         \
             long double*: shmem_longdouble_get)(__VA_ARGS__)
 #endif
 
@@ -519,11 +665,17 @@ OSHMEM_DECLSPEC  void shmem_getmem(void *target, const void *source, size_t len,
 OSHMEM_DECLSPEC void shmem_ctx_char_iget(shmem_ctx_t ctx, char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_short_iget(shmem_ctx_t ctx, short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_int_iget(shmem_ctx_t ctx, int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_schar_iget(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uchar_iget(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ushort_iget(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint_iget(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulong_iget(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulonglong_iget(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_float_iget(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_double_iget(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 OSHMEM_DECLSPEC void shmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -533,15 +685,27 @@ OSHMEM_DECLSPEC void shmem_double_iget(double* target, const double* source, ptr
 OSHMEM_DECLSPEC void shmem_longlong_iget(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_schar_iget(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uchar_iget(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ushort_iget(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint_iget(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ulong_iget(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ulonglong_iget(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_iget(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+            shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
                 char*:        shmem_ctx_char_iget,                   \
                 short*:       shmem_ctx_short_iget,                  \
                 int*:         shmem_ctx_int_iget,                    \
                 long*:        shmem_ctx_long_iget,                   \
                 long long*:   shmem_ctx_longlong_iget,               \
+                signed char*:        shmem_ctx_schar_iget,           \
+                unsigned char*:      shmem_ctx_uchar_iget,           \
+                unsigned short*:     shmem_ctx_ushort_iget,          \
+                unsigned int*:       shmem_ctx_uint_iget,            \
+                unsigned long*:      shmem_ctx_ulong_iget,           \
+                unsigned long long*: shmem_ctx_ulonglong_iget,       \
                 float*:       shmem_ctx_float_iget,                  \
                 double*:      shmem_ctx_double_iget,                 \
                 long double*: shmem_ctx_longdouble_iget,             \
@@ -551,6 +715,12 @@ OSHMEM_DECLSPEC void shmem_long_iget(long* target, const long* source, ptrdiff_t
             int*:         shmem_int_iget,                            \
             long*:        shmem_long_iget,                           \
             long long*:   shmem_longlong_iget,                       \
+            signed char*:        shmem_schar_iget,                   \
+            unsigned char*:      shmem_uchar_iget,                   \
+            unsigned short*:     shmem_ushort_iget,                  \
+            unsigned int*:       shmem_uint_iget,                    \
+            unsigned long*:      shmem_ulong_iget,                   \
+            unsigned long long*: shmem_ulonglong_iget,               \
             float*:       shmem_float_iget,                          \
             double*:      shmem_double_iget,                         \
             long double*: shmem_longdouble_iget)(__VA_ARGS__)
@@ -576,6 +746,12 @@ OSHMEM_DECLSPEC  void shmem_ctx_short_get_nbi(shmem_ctx_t ctx, short *target, co
 OSHMEM_DECLSPEC  void shmem_ctx_int_get_nbi(shmem_ctx_t ctx, int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_long_get_nbi(shmem_ctx_t ctx, long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longlong_get_nbi(shmem_ctx_t ctx, long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_schar_get_nbi(shmem_ctx_t ctx, signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uchar_get_nbi(shmem_ctx_t ctx, unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ushort_get_nbi(shmem_ctx_t ctx, unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint_get_nbi(shmem_ctx_t ctx, unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulong_get_nbi(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_get_nbi(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_float_get_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_get_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_get_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
@@ -586,18 +762,30 @@ OSHMEM_DECLSPEC  void shmem_short_get_nbi(short *target, const short *source, si
 OSHMEM_DECLSPEC  void shmem_int_get_nbi(int *target, const int *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_long_get_nbi(long *target, const long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longlong_get_nbi(long long *target, const long long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_schar_get_nbi(signed char *target, const signed char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uchar_get_nbi(unsigned char *target, const unsigned char *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ushort_get_nbi(unsigned short *target, const unsigned short *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint_get_nbi(unsigned int *target, const unsigned int *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulong_get_nbi(unsigned long *target, const unsigned long *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ulonglong_get_nbi(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_float_get_nbi(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_get_nbi(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
+            shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
                 char*:        shmem_ctx_char_get_nbi,                \
                 short*:       shmem_ctx_short_get_nbi,               \
                 int*:         shmem_ctx_int_get_nbi,                 \
                 long*:        shmem_ctx_long_get_nbi,                \
                 long long*:   shmem_ctx_longlong_get_nbi,            \
+                signed char*:        shmem_ctx_schar_get_nbi,        \
+                unsigned char*:      shmem_ctx_uchar_get_nbi,        \
+                unsigned short*:     shmem_ctx_ushort_get_nbi,       \
+                unsigned int*:       shmem_ctx_uint_get_nbi,         \
+                unsigned long*:      shmem_ctx_ulong_get_nbi,        \
+                unsigned long long*: shmem_ctx_ulonglong_get_nbi,    \
                 float*:       shmem_ctx_float_get_nbi,               \
                 double*:      shmem_ctx_double_get_nbi,              \
                 long double*: shmem_ctx_longdouble_get_nbi,          \
@@ -607,6 +795,12 @@ OSHMEM_DECLSPEC  void shmem_longdouble_get_nbi(long double *target, const long d
             int*:         shmem_int_get_nbi,                         \
             long*:        shmem_long_get_nbi,                        \
             long long*:   shmem_longlong_get_nbi,                    \
+            signed char*:        shmem_schar_get_nbi,                \
+            unsigned char*:      shmem_uchar_get_nbi,                \
+            unsigned short*:     shmem_ushort_get_nbi,               \
+            unsigned int*:       shmem_uint_get_nbi,                 \
+            unsigned long*:      shmem_ulong_get_nbi,                \
+            unsigned long long*: shmem_ulonglong_get_nbi,            \
             float*:       shmem_float_get_nbi,                       \
             double*:      shmem_double_get_nbi,                      \
             long double*: shmem_longdouble_get_nbi)(__VA_ARGS__)
@@ -631,13 +825,19 @@ OSHMEM_DECLSPEC  void shmem_get128_nbi(void *target, const void *source, size_t 
 /* Atomic swap */
 OSHMEM_DECLSPEC int shmem_ctx_int_atomic_swap(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_swap(shmem_ctx_t ctx, long *target, long value, int pe);
-OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_swap(shmem_ctx_t ctx, long long*target, long long value, int pe);
+OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_swap(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_swap(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_swap(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_swap(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC float shmem_ctx_float_atomic_swap(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC double shmem_ctx_double_atomic_swap(shmem_ctx_t ctx, double *target, double value, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_swap(int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_swap(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_swap(long long*target, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_swap(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_swap(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_swap(unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC float shmem_float_atomic_swap(float *target, float value, int pe);
 OSHMEM_DECLSPEC double shmem_double_atomic_swap(double *target, double value, int pe);
 #if OSHMEM_HAVE_C11
@@ -647,12 +847,18 @@ OSHMEM_DECLSPEC double shmem_double_atomic_swap(double *target, double value, in
                 int*:         shmem_ctx_int_atomic_swap,             \
                 long*:        shmem_ctx_long_atomic_swap,            \
                 long long*:   shmem_ctx_longlong_atomic_swap,        \
+                unsigned int*:       shmem_ctx_uint_atomic_swap,     \
+                unsigned long*:      shmem_ctx_ulong_atomic_swap,    \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_swap,\
                 float*:       shmem_ctx_float_atomic_swap,           \
                 double*:      shmem_ctx_double_atomic_swap,          \
                 default:      __oshmem_datatype_ignore),             \
             int*:         shmem_int_atomic_swap,                     \
             long*:        shmem_long_atomic_swap,                    \
             long long*:   shmem_longlong_atomic_swap,                \
+            unsigned int*:       shmem_uint_atomic_swap,             \
+            unsigned long*:      shmem_ulong_atomic_swap,            \
+            unsigned long long*: shmem_ulonglong_atomic_swap,        \
             float*:       shmem_float_atomic_swap,                   \
             double*:      shmem_double_atomic_swap)(__VA_ARGS__)
 #endif
@@ -675,35 +881,47 @@ OSHMEM_DECLSPEC double shmem_double_swap(double *target, double value, int pe);
 /* Atomic set */
 OSHMEM_DECLSPEC void shmem_ctx_int_atomic_set(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_long_atomic_set(shmem_ctx_t ctx, long *target, long value, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_set(shmem_ctx_t ctx, long long*target, long long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_set(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_set(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_set(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_set(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_float_atomic_set(shmem_ctx_t ctx, float *target, float value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_double_atomic_set(shmem_ctx_t ctx, double *target, double value, int pe);
 
 OSHMEM_DECLSPEC void shmem_int_atomic_set(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_set(long *target, long value, int pe);
-OSHMEM_DECLSPEC void shmem_longlong_atomic_set(long long*target, long long value, int pe);
+OSHMEM_DECLSPEC void shmem_longlong_atomic_set(long long *target, long long value, int pe);
+OSHMEM_DECLSPEC void shmem_uint_atomic_set(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void shmem_ulong_atomic_set(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void shmem_ulonglong_atomic_set(unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC void shmem_float_atomic_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void shmem_double_atomic_set(double *target, double value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_set(...)                                        \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         shmem_ctx_int_atomic_set,              \
-                long*:        shmem_ctx_long_atomic_set,             \
-                long long*:   shmem_ctx_longlong_atomic_set,         \
-                float*:       shmem_ctx_float_atomic_set,            \
-                double*:      shmem_ctx_double_atomic_set,           \
-                default:      __oshmem_datatype_ignore),             \
-            int*:         shmem_int_atomic_set,                      \
-            long*:        shmem_long_atomic_set,                     \
-            long long*:   shmem_longlong_atomic_set,                 \
-            float*:       shmem_float_atomic_set,                    \
+#define shmem_atomic_set(...)                                       \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
+                int*:         shmem_ctx_int_atomic_set,             \
+                long*:        shmem_ctx_long_atomic_set,            \
+                long long*:   shmem_ctx_longlong_atomic_set,        \
+                unsigned int*:       shmem_ctx_uint_atomic_set,     \
+                unsigned long*:      shmem_ctx_ulong_atomic_set,    \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_set,\
+                float*:       shmem_ctx_float_atomic_set,           \
+                double*:      shmem_ctx_double_atomic_set,          \
+                default:      __oshmem_datatype_ignore),            \
+            int*:         shmem_int_atomic_set,                     \
+            long*:        shmem_long_atomic_set,                    \
+            long long*:   shmem_longlong_atomic_set,                \
+            unsigned int*:         shmem_uint_atomic_set,           \
+            unsigned long*:        shmem_ulong_atomic_set,          \
+            unsigned long long*:   shmem_ulonglong_atomic_set,      \
+            float*:       shmem_float_atomic_set,                   \
             double*:      shmem_double_atomic_set)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_int_set(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_set(long *target, long value, int pe);
-OSHMEM_DECLSPEC void shmem_longlong_set(long long*target, long long value, int pe);
+OSHMEM_DECLSPEC void shmem_longlong_set(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_float_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void shmem_double_set(double *target, double value, int pe);
 #if OSHMEM_HAVE_C11
@@ -720,10 +938,16 @@ OSHMEM_DECLSPEC void shmem_double_set(double *target, double value, int pe);
 OSHMEM_DECLSPEC int shmem_ctx_int_atomic_compare_swap(shmem_ctx_t ctx, int *target, int cond, int value, int pe);
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_compare_swap(shmem_ctx_t ctx, long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_compare_swap(shmem_ctx_t ctx, long long *target, long long cond, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_compare_swap(shmem_ctx_t ctx, unsigned int *target, unsigned int cond, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_compare_swap(shmem_ctx_t ctx, unsigned long *target, unsigned long cond, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_compare_swap(shmem_ctx_t ctx, unsigned long long *target, unsigned long long cond, unsigned long long value, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_compare_swap(int *target, int cond, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_compare_swap(long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_compare_swap(long long *target, long long cond, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_compare_swap(unsigned int *target, unsigned int cond, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_compare_swap(unsigned long *target, unsigned long cond, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_compare_swap(unsigned long long *target, unsigned long long cond, unsigned long long value, int pe);
 
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_compare_swap(...)                                \
@@ -732,10 +956,16 @@ OSHMEM_DECLSPEC long long shmem_longlong_atomic_compare_swap(long long *target, 
                 int*:         shmem_ctx_int_atomic_compare_swap,      \
                 long*:        shmem_ctx_long_atomic_compare_swap,     \
                 long long*:   shmem_ctx_longlong_atomic_compare_swap, \
+                unsigned int*:       shmem_ctx_uint_atomic_compare_swap,      \
+                unsigned long*:      shmem_ctx_ulong_atomic_compare_swap,     \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_compare_swap, \
                 default:      __oshmem_datatype_ignore),              \
             int*:         shmem_int_atomic_compare_swap,              \
             long*:        shmem_long_atomic_compare_swap,             \
-            long long*:   shmem_longlong_atomic_compare_swap)(__VA_ARGS__)
+            long long*:   shmem_longlong_atomic_compare_swap,         \
+            unsigned int*:       shmem_uint_atomic_compare_swap,      \
+            unsigned long*:      shmem_ulong_atomic_compare_swap,     \
+            unsigned long long*: shmem_ulonglong_atomic_compare_swap)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_cswap(int *target, int cond, int value, int pe);
@@ -754,21 +984,33 @@ OSHMEM_DECLSPEC long long shmem_longlong_cswap(long long *target, long long cond
 OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_add(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_add(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_add(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_add(long long *target, long long value, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_add(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_add(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_add(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_add(...)                                  \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         shmem_ctx_int_atomic_fetch_add,        \
-                long*:        shmem_ctx_long_atomic_fetch_add,       \
-                long long*:   shmem_ctx_longlong_atomic_fetch_add,   \
-                default:      __oshmem_datatype_ignore),             \
-            int*:         shmem_int_atomic_fetch_add,                \
-            long*:        shmem_long_atomic_fetch_add,               \
-            long long*:   shmem_longlong_atomic_fetch_add)(__VA_ARGS__)
+#define shmem_atomic_fetch_add(...)                                        \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                           \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),       \
+                int*:         shmem_ctx_int_atomic_fetch_add,              \
+                long*:        shmem_ctx_long_atomic_fetch_add,             \
+                long long*:   shmem_ctx_longlong_atomic_fetch_add,         \
+                unsigned int*:       shmem_ctx_uint_atomic_fetch_add,      \
+                unsigned long*:      shmem_ctx_ulong_atomic_fetch_add,     \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_fetch_add, \
+                default:      __oshmem_datatype_ignore),                   \
+            int*:         shmem_int_atomic_fetch_add,                      \
+            long*:        shmem_long_atomic_fetch_add,                     \
+            long long*:   shmem_longlong_atomic_fetch_add,                 \
+            unsigned int*:       shmem_uint_atomic_fetch_add,              \
+            unsigned long*:      shmem_ulong_atomic_fetch_add,             \
+            unsigned long long*: shmem_ulonglong_atomic_fetch_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_fadd(int *target, int value, int pe);
@@ -783,10 +1025,16 @@ OSHMEM_DECLSPEC long long shmem_longlong_fadd(long long *target, long long value
 #endif
 
 /* Atomic Fetch&And */
+OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch_and(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch_and(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_and(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC int shmem_int_atomic_fetch_and(int *target, int value, int pe);
+OSHMEM_DECLSPEC long shmem_long_atomic_fetch_and(long *target, long value, int pe);
+OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_and(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_and(unsigned long long *target, unsigned long long value, int pe);
@@ -794,41 +1042,65 @@ OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_and(unsigned lon
 #define shmem_atomic_fetch_and(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+                int*:         shmem_ctx_int_atomic_fetch_and,                 \
+                long*:        shmem_ctx_long_atomic_fetch_and,                \
+                long long*:   shmem_ctx_longlong_atomic_fetch_and,            \
                 unsigned int*:         shmem_ctx_uint_atomic_fetch_and,       \
                 unsigned long*:        shmem_ctx_ulong_atomic_fetch_and,      \
                 unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_and,  \
                 default:               __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_fetch_and,                         \
+            long*:        shmem_long_atomic_fetch_and,                        \
+            long long*:   shmem_longlong_atomic_fetch_and,                    \
             unsigned int*:         shmem_uint_atomic_fetch_and,               \
             unsigned long*:        shmem_ulong_atomic_fetch_and,              \
             unsigned long long*:   shmem_ulonglong_atomic_fetch_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Or */
+OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch_or(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch_or(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_or(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC int shmem_int_atomic_fetch_or(int *target, int value, int pe);
+OSHMEM_DECLSPEC long shmem_long_atomic_fetch_or(long *target, long value, int pe);
+OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_or(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_or(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_fetch_or(...)                                           \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                             \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),         \
+                int*:         shmem_ctx_int_atomic_fetch_or,                 \
+                long*:        shmem_ctx_long_atomic_fetch_or,                \
+                long long*:   shmem_ctx_longlong_atomic_fetch_or,            \
                 unsigned int*:         shmem_ctx_uint_atomic_fetch_or,       \
                 unsigned long*:        shmem_ctx_ulong_atomic_fetch_or,      \
                 unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_or,  \
-                default:               __oshmem_datatype_ignore),             \
+                default:               __oshmem_datatype_ignore),            \
+            int*:         shmem_int_atomic_fetch_or,                         \
+            long*:        shmem_long_atomic_fetch_or,                        \
+            long long*:   shmem_longlong_atomic_fetch_or,                    \
             unsigned int*:         shmem_uint_atomic_fetch_or,               \
             unsigned long*:        shmem_ulong_atomic_fetch_or,              \
             unsigned long long*:   shmem_ulonglong_atomic_fetch_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Xor */
+OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch_xor(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch_xor(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_xor(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC int shmem_int_atomic_fetch_xor(int *target, int value, int pe);
+OSHMEM_DECLSPEC long shmem_long_atomic_fetch_xor(long *target, long value, int pe);
+OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_xor(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_xor(unsigned long long *target, unsigned long long value, int pe);
@@ -836,10 +1108,16 @@ OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_xor(unsigned lon
 #define shmem_atomic_fetch_xor(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
+                int*:         shmem_ctx_int_atomic_fetch_xor,                 \
+                long*:        shmem_ctx_long_atomic_fetch_xor,                \
+                long long*:   shmem_ctx_longlong_atomic_fetch_xor,            \
                 unsigned int*:         shmem_ctx_uint_atomic_fetch_xor,       \
                 unsigned long*:        shmem_ctx_ulong_atomic_fetch_xor,      \
                 unsigned long long*:   shmem_ctx_ulonglong_atomic_fetch_xor,  \
                 default:               __oshmem_datatype_ignore),             \
+            int*:         shmem_int_atomic_fetch_xor,                         \
+            long*:        shmem_long_atomic_fetch_xor,                        \
+            long long*:   shmem_longlong_atomic_fetch_xor,                    \
             unsigned int*:         shmem_uint_atomic_fetch_xor,               \
             unsigned long*:        shmem_ulong_atomic_fetch_xor,              \
             unsigned long long*:   shmem_ulonglong_atomic_fetch_xor)(__VA_ARGS__)
@@ -849,12 +1127,18 @@ OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_xor(unsigned lon
 OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch(shmem_ctx_t ctx, const int *target, int pe);
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch(shmem_ctx_t ctx, const long *target, int pe);
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch(shmem_ctx_t ctx, const long long *target, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch(shmem_ctx_t ctx, const unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch(shmem_ctx_t ctx, const unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch(shmem_ctx_t ctx, const unsigned long long *target, int pe);
 OSHMEM_DECLSPEC float shmem_ctx_float_atomic_fetch(shmem_ctx_t ctx, const float *target, int pe);
 OSHMEM_DECLSPEC double shmem_ctx_double_atomic_fetch(shmem_ctx_t ctx, const double *target, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch(const int *target, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch(const long *target, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch(const long long *target, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch(const unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch(const unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch(const unsigned long long *target, int pe);
 OSHMEM_DECLSPEC float shmem_float_atomic_fetch(const float *target, int pe);
 OSHMEM_DECLSPEC double shmem_double_atomic_fetch(const double *target, int pe);
 #if OSHMEM_HAVE_C11
@@ -864,12 +1148,18 @@ OSHMEM_DECLSPEC double shmem_double_atomic_fetch(const double *target, int pe);
                 int*:         shmem_ctx_int_atomic_fetch,            \
                 long*:        shmem_ctx_long_atomic_fetch,           \
                 long long*:   shmem_ctx_longlong_atomic_fetch,       \
+                unsigned int*:       shmem_ctx_uint_atomic_fetch,      \
+                unsigned long*:      shmem_ctx_ulong_atomic_fetch,     \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_fetch, \
                 float*:       shmem_ctx_float_atomic_fetch,          \
                 double*:      shmem_ctx_double_atomic_fetch,         \
                 default:      __oshmem_datatype_ignore),             \
             int*:         shmem_int_atomic_fetch,                    \
             long*:        shmem_long_atomic_fetch,                   \
             long long*:   shmem_longlong_atomic_fetch,               \
+            unsigned int*:       shmem_uint_atomic_fetch,            \
+            unsigned long*:      shmem_ulong_atomic_fetch,           \
+            unsigned long long*: shmem_ulonglong_atomic_fetch,       \
             float*:       shmem_float_atomic_fetch,                  \
             double*:      shmem_double_atomic_fetch)(__VA_ARGS__)
 #endif
@@ -893,21 +1183,33 @@ OSHMEM_DECLSPEC double shmem_double_fetch(const double *target, int pe);
 OSHMEM_DECLSPEC int shmem_ctx_int_atomic_fetch_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC long shmem_ctx_long_atomic_fetch_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_inc(shmem_ctx_t ctx, long long *target, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_inc(shmem_ctx_t ctx, unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_inc(shmem_ctx_t ctx, unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_inc(shmem_ctx_t ctx, unsigned long long *target, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch_inc(int *target, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch_inc(long *target, int pe);
 OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_inc(long long *target, int pe);
+OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_inc(unsigned int *target, int pe);
+OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_inc(unsigned long *target, int pe);
+OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_inc(unsigned long long *target, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_fetch_inc(...)                                  \
+#define shmem_atomic_fetch_inc(...)                                 \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         shmem_ctx_int_atomic_fetch_inc,        \
-                long*:        shmem_ctx_long_atomic_fetch_inc,       \
-                long long*:   shmem_ctx_longlong_atomic_fetch_inc,   \
+                int*:         shmem_ctx_int_atomic_fetch_inc,       \
+                long*:        shmem_ctx_long_atomic_fetch_inc,      \
+                long long*:   shmem_ctx_longlong_atomic_fetch_inc,  \
+                unsigned int*:       shmem_ctx_uint_atomic_fetch_inc,      \
+                unsigned long*:      shmem_ctx_ulong_atomic_fetch_inc,     \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_fetch_inc, \
                 default:      __oshmem_datatype_ignore),             \
-            int*:         shmem_int_atomic_fetch_inc,                \
-            long*:        shmem_long_atomic_fetch_inc,               \
-            long long*:   shmem_longlong_atomic_fetch_inc)(__VA_ARGS__)
+            int*:         shmem_int_atomic_fetch_inc,               \
+            long*:        shmem_long_atomic_fetch_inc,              \
+            long long*:   shmem_longlong_atomic_fetch_inc,          \
+            unsigned int*:       shmem_uint_atomic_fetch_inc,       \
+            unsigned long*:      shmem_ulong_atomic_fetch_inc,      \
+            unsigned long long*: shmem_ulonglong_atomic_fetch_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC int shmem_int_finc(int *target, int pe);
@@ -925,10 +1227,16 @@ OSHMEM_DECLSPEC long long shmem_longlong_finc(long long *target, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_int_atomic_add(shmem_ctx_t ctx, int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_long_atomic_add(shmem_ctx_t ctx, long *target, long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_add(shmem_ctx_t ctx, long long *target, long long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_add(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_add(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_add(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
 OSHMEM_DECLSPEC void shmem_int_atomic_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC void shmem_longlong_atomic_add(long long *target, long long value, int pe);
+OSHMEM_DECLSPEC void shmem_uint_atomic_add(unsigned int *target, unsigned int value, int pe);
+OSHMEM_DECLSPEC void shmem_ulong_atomic_add(unsigned long *target, unsigned long value, int pe);
+OSHMEM_DECLSPEC void shmem_ulonglong_atomic_add(unsigned long long *target, unsigned long long value, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_add(...)                                        \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -936,10 +1244,16 @@ OSHMEM_DECLSPEC void shmem_longlong_atomic_add(long long *target, long long valu
                 int*:         shmem_ctx_int_atomic_add,              \
                 long*:        shmem_ctx_long_atomic_add,             \
                 long long*:   shmem_ctx_longlong_atomic_add,         \
+                unsigned int*:       shmem_ctx_uint_atomic_add,      \
+                unsigned long*:      shmem_ctx_ulong_atomic_add,     \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_add, \
                 default:      __oshmem_datatype_ignore),             \
             int*:         shmem_int_atomic_add,                      \
             long*:        shmem_long_atomic_add,                     \
-            long long*:   shmem_longlong_atomic_add)(__VA_ARGS__)
+            long long*:   shmem_longlong_atomic_add,                 \
+            unsigned int*:       shmem_uint_atomic_add,              \
+            unsigned long*:      shmem_ulong_atomic_add,             \
+            unsigned long long*: shmem_ulonglong_atomic_add)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_int_add(int *target, int value, int pe);
@@ -954,10 +1268,16 @@ OSHMEM_DECLSPEC void shmem_longlong_add(long long *target, long long value, int 
 #endif
 
 /* Atomic And */
+OSHMEM_DECLSPEC void shmem_ctx_int_atomic_and(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_long_atomic_and(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_and(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC void shmem_int_atomic_and(int *target, int value, int pe);
+OSHMEM_DECLSPEC void shmem_long_atomic_and(long *target, long value, int pe);
+OSHMEM_DECLSPEC void shmem_longlong_atomic_and(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_uint_atomic_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_and(unsigned long long *target, unsigned long long value, int pe);
@@ -965,20 +1285,32 @@ OSHMEM_DECLSPEC void shmem_ulonglong_atomic_and(unsigned long long *target, unsi
 #define shmem_atomic_and(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                int*:         shmem_ctx_int_atomic_and,                \
+                long*:        shmem_ctx_long_atomic_and,               \
+                long long*:   shmem_ctx_longlong_atomic_and,           \
                 unsigned int*:         shmem_ctx_uint_atomic_and,      \
                 unsigned long*:        shmem_ctx_ulong_atomic_and,     \
                 unsigned long long*:   shmem_ctx_ulonglong_atomic_and, \
                 default:               __oshmem_datatype_ignore),      \
+            int*:         shmem_int_atomic_and,                        \
+            long*:        shmem_long_atomic_and,                       \
+            long long*:   shmem_longlong_atomic_and,                   \
             unsigned int*:         shmem_uint_atomic_and,              \
             unsigned long*:        shmem_ulong_atomic_and,             \
             unsigned long long*:   shmem_ulonglong_atomic_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Or */
+OSHMEM_DECLSPEC void shmem_ctx_int_atomic_or(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_long_atomic_or(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_or(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC void shmem_int_atomic_or(int *target, int value, int pe);
+OSHMEM_DECLSPEC void shmem_long_atomic_or(long *target, long value, int pe);
+OSHMEM_DECLSPEC void shmem_longlong_atomic_or(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_uint_atomic_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_or(unsigned long long *target, unsigned long long value, int pe);
@@ -986,20 +1318,32 @@ OSHMEM_DECLSPEC void shmem_ulonglong_atomic_or(unsigned long long *target, unsig
 #define shmem_atomic_or(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
+                int*:         shmem_ctx_int_atomic_or,                \
+                long*:        shmem_ctx_long_atomic_or,               \
+                long long*:   shmem_ctx_longlong_atomic_or,           \
                 unsigned int*:         shmem_ctx_uint_atomic_or,      \
                 unsigned long*:        shmem_ctx_ulong_atomic_or,     \
                 unsigned long long*:   shmem_ctx_ulonglong_atomic_or, \
                 default:               __oshmem_datatype_ignore),     \
+            int*:         shmem_int_atomic_or,                        \
+            long*:        shmem_long_atomic_or,                       \
+            long long*:   shmem_longlong_atomic_or,                   \
             unsigned int*:         shmem_uint_atomic_or,              \
             unsigned long*:        shmem_ulong_atomic_or,             \
             unsigned long long*:   shmem_ulonglong_atomic_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Xor */
+OSHMEM_DECLSPEC void shmem_ctx_int_atomic_xor(shmem_ctx_t ctx, int *target, int value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_long_atomic_xor(shmem_ctx_t ctx, long *target, long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_xor(shmem_ctx_t ctx, long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
 
+OSHMEM_DECLSPEC void shmem_int_atomic_xor(int *target, int value, int pe);
+OSHMEM_DECLSPEC void shmem_long_atomic_xor(long *target, long value, int pe);
+OSHMEM_DECLSPEC void shmem_longlong_atomic_xor(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void shmem_uint_atomic_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_xor(unsigned long long *target, unsigned long long value, int pe);
@@ -1007,10 +1351,16 @@ OSHMEM_DECLSPEC void shmem_ulonglong_atomic_xor(unsigned long long *target, unsi
 #define shmem_atomic_xor(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
+                int*:         shmem_ctx_int_atomic_xor,                \
+                long*:        shmem_ctx_long_atomic_xor,               \
+                long long*:   shmem_ctx_longlong_atomic_xor,           \
                 unsigned int*:         shmem_ctx_uint_atomic_xor,      \
                 unsigned long*:        shmem_ctx_ulong_atomic_xor,     \
                 unsigned long long*:   shmem_ctx_ulonglong_atomic_xor, \
                 default:               __oshmem_datatype_ignore),      \
+            int*:         shmem_int_atomic_xor,                        \
+            long*:        shmem_long_atomic_xor,                       \
+            long long*:   shmem_longlong_atomic_xor,                   \
             unsigned int*:         shmem_uint_atomic_xor,              \
             unsigned long*:        shmem_ulong_atomic_xor,             \
             unsigned long long*:   shmem_ulonglong_atomic_xor)(__VA_ARGS__)
@@ -1020,21 +1370,33 @@ OSHMEM_DECLSPEC void shmem_ulonglong_atomic_xor(unsigned long long *target, unsi
 OSHMEM_DECLSPEC void shmem_ctx_int_atomic_inc(shmem_ctx_t ctx, int *target, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_long_atomic_inc(shmem_ctx_t ctx, long *target, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_inc(shmem_ctx_t ctx, long long *target, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_inc(shmem_ctx_t ctx, unsigned int *target, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_inc(shmem_ctx_t ctx, unsigned long *target, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_inc(shmem_ctx_t ctx, unsigned long long *target, int pe);
 
 OSHMEM_DECLSPEC void shmem_int_atomic_inc(int *target, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_inc(long *target, int pe);
 OSHMEM_DECLSPEC void shmem_longlong_atomic_inc(long long *target, int pe);
+OSHMEM_DECLSPEC void shmem_uint_atomic_inc(unsigned int *target, int pe);
+OSHMEM_DECLSPEC void shmem_ulong_atomic_inc(unsigned long *target, int pe);
+OSHMEM_DECLSPEC void shmem_ulonglong_atomic_inc(unsigned long long *target, int pe);
 #if OSHMEM_HAVE_C11
-#define shmem_atomic_inc(...)                                        \
-    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
-            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
-                int*:         shmem_ctx_int_atomic_inc,              \
-                long*:        shmem_ctx_long_atomic_inc,             \
-                long long*:   shmem_ctx_longlong_atomic_inc,         \
-                default:      __oshmem_datatype_ignore),             \
-            int*:         shmem_int_atomic_inc,                      \
-            long*:        shmem_long_atomic_inc,                     \
-            long long*:   shmem_longlong_atomic_inc)(__VA_ARGS__)
+#define shmem_atomic_inc(...)                                       \
+    _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
+            shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
+                int*:         shmem_ctx_int_atomic_inc,             \
+                long*:        shmem_ctx_long_atomic_inc,            \
+                long long*:   shmem_ctx_longlong_atomic_inc,        \
+                unsigned int*:       shmem_ctx_uint_atomic_inc,     \
+                unsigned long*:      shmem_ctx_ulong_atomic_inc,    \
+                unsigned long long*: shmem_ctx_ulonglong_atomic_inc,\
+                default:      __oshmem_datatype_ignore),            \
+            int*:         shmem_int_atomic_inc,                     \
+            long*:        shmem_long_atomic_inc,                    \
+            long long*:   shmem_longlong_atomic_inc,                \
+            unsigned int*:       shmem_uint_atomic_inc,             \
+            unsigned long*:      shmem_ulong_atomic_inc,            \
+            unsigned long long*: shmem_ulonglong_atomic_inc)(__VA_ARGS__)
 #endif
 
 OSHMEM_DECLSPEC void shmem_int_inc(int *target, int pe);

--- a/oshmem/shmem/c/profile/defines.h
+++ b/oshmem/shmem/c/profile/defines.h
@@ -80,6 +80,12 @@
 #define shmem_ctx_float_p            pshmem_ctx_float_p
 #define shmem_ctx_double_p           pshmem_ctx_double_p
 #define shmem_ctx_longlong_p         pshmem_ctx_longlong_p
+#define shmem_ctx_schar_p            pshmem_ctx_schar_p
+#define shmem_ctx_uchar_p            pshmem_ctx_uchar_p
+#define shmem_ctx_ushort_p           pshmem_ctx_ushort_p
+#define shmem_ctx_uint_p             pshmem_ctx_uint_p
+#define shmem_ctx_ulong_p            pshmem_ctx_ulong_p
+#define shmem_ctx_ulonglong_p        pshmem_ctx_ulonglong_p
 #define shmem_ctx_longdouble_p       pshmem_ctx_longdouble_p
 #define shmem_char_p                 pshmem_char_p
 #define shmem_short_p                pshmem_short_p
@@ -88,6 +94,12 @@
 #define shmem_float_p                pshmem_float_p
 #define shmem_double_p               pshmem_double_p
 #define shmem_longlong_p             pshmem_longlong_p
+#define shmem_schar_p                pshmem_schar_p
+#define shmem_uchar_p                pshmem_uchar_p
+#define shmem_ushort_p               pshmem_ushort_p
+#define shmem_uint_p                 pshmem_uint_p
+#define shmem_ulong_p                pshmem_ulong_p
+#define shmem_ulonglong_p            pshmem_ulonglong_p
 #define shmem_longdouble_p           pshmem_longdouble_p
 #define shmemx_int16_p               pshmemx_int16_p
 #define shmemx_int32_p               pshmemx_int32_p
@@ -103,6 +115,12 @@
 #define shmem_ctx_float_put          pshmem_ctx_float_put
 #define shmem_ctx_double_put         pshmem_ctx_double_put
 #define shmem_ctx_longlong_put       pshmem_ctx_longlong_put
+#define shmem_ctx_schar_put          pshmem_ctx_schar_put
+#define shmem_ctx_uchar_put          pshmem_ctx_uchar_put
+#define shmem_ctx_ushort_put         pshmem_ctx_ushort_put
+#define shmem_ctx_uint_put           pshmem_ctx_uint_put
+#define shmem_ctx_ulong_put          pshmem_ctx_ulong_put
+#define shmem_ctx_ulonglong_put      pshmem_ctx_ulonglong_put
 #define shmem_ctx_longdouble_put     pshmem_ctx_longdouble_put
 #define shmem_char_put               pshmem_char_put /* shmem-compat.h */
 #define shmem_short_put              pshmem_short_put
@@ -111,6 +129,12 @@
 #define shmem_float_put              pshmem_float_put
 #define shmem_double_put             pshmem_double_put
 #define shmem_longlong_put           pshmem_longlong_put
+#define shmem_schar_put              pshmem_schar_put
+#define shmem_uchar_put              pshmem_uchar_put
+#define shmem_ushort_put             pshmem_ushort_put
+#define shmem_uint_put               pshmem_uint_put
+#define shmem_ulong_put              pshmem_ulong_put
+#define shmem_ulonglong_put          pshmem_ulonglong_put
 #define shmem_longdouble_put         pshmem_longdouble_put
 
 #define shmem_ctx_put8               pshmem_ctx_put8
@@ -129,22 +153,34 @@
 /*
  * Strided put routines
  */
-#define shmem_ctx_char_iput          pshmem_ctx_char_iput
-#define shmem_ctx_short_iput         pshmem_ctx_short_iput
-#define shmem_ctx_int_iput           pshmem_ctx_int_iput
-#define shmem_ctx_float_iput         pshmem_ctx_float_iput
-#define shmem_ctx_double_iput        pshmem_ctx_double_iput
-#define shmem_ctx_longlong_iput      pshmem_ctx_longlong_iput
-#define shmem_ctx_longdouble_iput    pshmem_ctx_longdouble_iput
-#define shmem_ctx_long_iput          pshmem_ctx_long_iput
-#define shmem_char_iput              pshmem_char_iput
-#define shmem_short_iput             pshmem_short_iput
-#define shmem_int_iput               pshmem_int_iput
-#define shmem_float_iput             pshmem_float_iput
-#define shmem_double_iput            pshmem_double_iput
-#define shmem_longlong_iput          pshmem_longlong_iput
-#define shmem_longdouble_iput        pshmem_longdouble_iput
-#define shmem_long_iput              pshmem_long_iput
+#define shmem_ctx_char_iput           pshmem_ctx_char_iput
+#define shmem_ctx_short_iput          pshmem_ctx_short_iput
+#define shmem_ctx_int_iput            pshmem_ctx_int_iput
+#define shmem_ctx_long_iput           pshmem_ctx_long_iput
+#define shmem_ctx_float_iput          pshmem_ctx_float_iput
+#define shmem_ctx_double_iput         pshmem_ctx_double_iput
+#define shmem_ctx_longlong_iput       pshmem_ctx_longlong_iput
+#define shmem_ctx_schar_iput          pshmem_ctx_schar_iput
+#define shmem_ctx_uchar_iput          pshmem_ctx_uchar_iput
+#define shmem_ctx_ushort_iput         pshmem_ctx_ushort_iput
+#define shmem_ctx_uint_iput           pshmem_ctx_uint_iput
+#define shmem_ctx_ulong_iput          pshmem_ctx_ulong_iput
+#define shmem_ctx_ulonglong_iput      pshmem_ctx_ulonglong_iput
+#define shmem_ctx_longdouble_iput     pshmem_ctx_longdouble_iput
+#define shmem_char_iput               pshmem_char_iput
+#define shmem_short_iput              pshmem_short_iput
+#define shmem_int_iput                pshmem_int_iput
+#define shmem_long_iput               pshmem_long_iput
+#define shmem_float_iput              pshmem_float_iput
+#define shmem_double_iput             pshmem_double_iput
+#define shmem_longlong_iput           pshmem_longlong_iput
+#define shmem_schar_iput              pshmem_schar_iput
+#define shmem_uchar_iput              pshmem_uchar_iput
+#define shmem_ushort_iput             pshmem_ushort_iput
+#define shmem_uint_iput               pshmem_uint_iput
+#define shmem_ulong_iput              pshmem_ulong_iput
+#define shmem_ulonglong_iput          pshmem_ulonglong_iput
+#define shmem_longdouble_iput         pshmem_longdouble_iput
 
 #define shmem_ctx_iput8              pshmem_ctx_iput8
 #define shmem_ctx_iput16             pshmem_ctx_iput16
@@ -160,22 +196,34 @@
 /*
  * Non-block data put routines
  */
-#define shmem_ctx_char_put_nbi       pshmem_ctx_char_put_nbi
-#define shmem_ctx_short_put_nbi      pshmem_ctx_short_put_nbi
-#define shmem_ctx_int_put_nbi        pshmem_ctx_int_put_nbi
-#define shmem_ctx_long_put_nbi       pshmem_ctx_long_put_nbi
-#define shmem_ctx_float_put_nbi      pshmem_ctx_float_put_nbi
-#define shmem_ctx_double_put_nbi     pshmem_ctx_double_put_nbi
-#define shmem_ctx_longlong_put_nbi   pshmem_ctx_longlong_put_nbi
-#define shmem_ctx_longdouble_put_nbi pshmem_ctx_longdouble_put_nbi
-#define shmem_char_put_nbi           pshmem_char_put_nbi
-#define shmem_short_put_nbi          pshmem_short_put_nbi
-#define shmem_int_put_nbi            pshmem_int_put_nbi
-#define shmem_long_put_nbi           pshmem_long_put_nbi
-#define shmem_float_put_nbi          pshmem_float_put_nbi
-#define shmem_double_put_nbi         pshmem_double_put_nbi
-#define shmem_longlong_put_nbi       pshmem_longlong_put_nbi
-#define shmem_longdouble_put_nbi     pshmem_longdouble_put_nbi
+#define shmem_ctx_char_put_nbi           pshmem_ctx_char_put_nbi
+#define shmem_ctx_short_put_nbi          pshmem_ctx_short_put_nbi
+#define shmem_ctx_int_put_nbi            pshmem_ctx_int_put_nbi
+#define shmem_ctx_long_put_nbi           pshmem_ctx_long_put_nbi
+#define shmem_ctx_float_put_nbi          pshmem_ctx_float_put_nbi
+#define shmem_ctx_double_put_nbi         pshmem_ctx_double_put_nbi
+#define shmem_ctx_longlong_put_nbi       pshmem_ctx_longlong_put_nbi
+#define shmem_ctx_schar_put_nbi          pshmem_ctx_schar_put_nbi
+#define shmem_ctx_uchar_put_nbi          pshmem_ctx_uchar_put_nbi
+#define shmem_ctx_ushort_put_nbi         pshmem_ctx_ushort_put_nbi
+#define shmem_ctx_uint_put_nbi           pshmem_ctx_uint_put_nbi
+#define shmem_ctx_ulong_put_nbi          pshmem_ctx_ulong_put_nbi
+#define shmem_ctx_ulonglong_put_nbi      pshmem_ctx_ulonglong_put_nbi
+#define shmem_ctx_longdouble_put_nbi     pshmem_ctx_longdouble_put_nbi
+#define shmem_char_put_nbi               pshmem_char_put_nbi
+#define shmem_short_put_nbi              pshmem_short_put_nbi
+#define shmem_int_put_nbi                pshmem_int_put_nbi
+#define shmem_long_put_nbi               pshmem_long_put_nbi
+#define shmem_float_put_nbi              pshmem_float_put_nbi
+#define shmem_double_put_nbi             pshmem_double_put_nbi
+#define shmem_longlong_put_nbi           pshmem_longlong_put_nbi
+#define shmem_schar_put_nbi              pshmem_schar_put_nbi
+#define shmem_uchar_put_nbi              pshmem_uchar_put_nbi
+#define shmem_ushort_put_nbi             pshmem_ushort_put_nbi
+#define shmem_uint_put_nbi               pshmem_uint_put_nbi
+#define shmem_ulong_put_nbi              pshmem_ulong_put_nbi
+#define shmem_ulonglong_put_nbi          pshmem_ulonglong_put_nbi
+#define shmem_longdouble_put_nbi         pshmem_longdouble_put_nbi
 
 #define shmem_ctx_put8_nbi           pshmem_ctx_put8_nbi
 #define shmem_ctx_put16_nbi          pshmem_ctx_put16_nbi
@@ -200,6 +248,12 @@
 #define shmem_ctx_float_g            pshmem_ctx_float_g
 #define shmem_ctx_double_g           pshmem_ctx_double_g
 #define shmem_ctx_longlong_g         pshmem_ctx_longlong_g
+#define shmem_ctx_schar_g            pshmem_ctx_schar_g
+#define shmem_ctx_uchar_g            pshmem_ctx_uchar_g
+#define shmem_ctx_ushort_g           pshmem_ctx_ushort_g
+#define shmem_ctx_uint_g             pshmem_ctx_uint_g
+#define shmem_ctx_ulong_g            pshmem_ctx_ulong_g
+#define shmem_ctx_ulonglong_g        pshmem_ctx_ulonglong_g
 #define shmem_ctx_longdouble_g       pshmem_ctx_longdouble_g
 #define shmem_char_g                 pshmem_char_g
 #define shmem_short_g                pshmem_short_g
@@ -208,6 +262,12 @@
 #define shmem_float_g                pshmem_float_g
 #define shmem_double_g               pshmem_double_g
 #define shmem_longlong_g             pshmem_longlong_g
+#define shmem_schar_g                pshmem_schar_g
+#define shmem_uchar_g                pshmem_uchar_g
+#define shmem_ushort_g               pshmem_ushort_g
+#define shmem_uint_g                 pshmem_uint_g
+#define shmem_ulong_g                pshmem_ulong_g
+#define shmem_ulonglong_g            pshmem_ulonglong_g
 #define shmem_longdouble_g           pshmem_longdouble_g
 #define shmemx_int16_g               pshmemx_int16_g
 #define shmemx_int32_g               pshmemx_int32_g
@@ -223,6 +283,12 @@
 #define shmem_ctx_float_get          pshmem_ctx_float_get
 #define shmem_ctx_double_get         pshmem_ctx_double_get
 #define shmem_ctx_longlong_get       pshmem_ctx_longlong_get
+#define shmem_ctx_schar_get          pshmem_ctx_schar_get
+#define shmem_ctx_uchar_get          pshmem_ctx_uchar_get
+#define shmem_ctx_ushort_get         pshmem_ctx_ushort_get
+#define shmem_ctx_uint_get           pshmem_ctx_uint_get
+#define shmem_ctx_ulong_get          pshmem_ctx_ulong_get
+#define shmem_ctx_ulonglong_get      pshmem_ctx_ulonglong_get
 #define shmem_ctx_longdouble_get     pshmem_ctx_longdouble_get
 #define shmem_char_get               pshmem_char_get /* shmem-compat.h */
 #define shmem_short_get              pshmem_short_get
@@ -231,6 +297,12 @@
 #define shmem_float_get              pshmem_float_get
 #define shmem_double_get             pshmem_double_get
 #define shmem_longlong_get           pshmem_longlong_get
+#define shmem_schar_get              pshmem_schar_get
+#define shmem_uchar_get              pshmem_uchar_get
+#define shmem_ushort_get             pshmem_ushort_get
+#define shmem_uint_get               pshmem_uint_get
+#define shmem_ulong_get              pshmem_ulong_get
+#define shmem_ulonglong_get          pshmem_ulonglong_get
 #define shmem_longdouble_get         pshmem_longdouble_get
 
 #define shmem_ctx_get8               pshmem_ctx_get8
@@ -249,22 +321,34 @@
 /*
  * Strided get routines
  */
-#define shmem_ctx_char_iget          pshmem_ctx_char_iget
-#define shmem_ctx_short_iget         pshmem_ctx_short_iget
-#define shmem_ctx_int_iget           pshmem_ctx_int_iget
-#define shmem_ctx_float_iget         pshmem_ctx_float_iget
-#define shmem_ctx_double_iget        pshmem_ctx_double_iget
-#define shmem_ctx_longlong_iget      pshmem_ctx_longlong_iget
-#define shmem_ctx_longdouble_iget    pshmem_ctx_longdouble_iget
-#define shmem_ctx_long_iget          pshmem_ctx_long_iget
-#define shmem_char_iget              pshmem_char_iget
-#define shmem_short_iget             pshmem_short_iget
-#define shmem_int_iget               pshmem_int_iget
-#define shmem_float_iget             pshmem_float_iget
-#define shmem_double_iget            pshmem_double_iget
-#define shmem_longlong_iget          pshmem_longlong_iget
-#define shmem_longdouble_iget        pshmem_longdouble_iget
-#define shmem_long_iget              pshmem_long_iget
+#define shmem_ctx_char_iget           pshmem_ctx_char_iget
+#define shmem_ctx_short_iget          pshmem_ctx_short_iget
+#define shmem_ctx_int_iget            pshmem_ctx_int_iget
+#define shmem_ctx_long_iget           pshmem_ctx_long_iget
+#define shmem_ctx_float_iget          pshmem_ctx_float_iget
+#define shmem_ctx_double_iget         pshmem_ctx_double_iget
+#define shmem_ctx_longlong_iget       pshmem_ctx_longlong_iget
+#define shmem_ctx_schar_iget          pshmem_ctx_schar_iget
+#define shmem_ctx_uchar_iget          pshmem_ctx_uchar_iget
+#define shmem_ctx_ushort_iget         pshmem_ctx_ushort_iget
+#define shmem_ctx_uint_iget           pshmem_ctx_uint_iget
+#define shmem_ctx_ulong_iget          pshmem_ctx_ulong_iget
+#define shmem_ctx_ulonglong_iget      pshmem_ctx_ulonglong_iget
+#define shmem_ctx_longdouble_iget     pshmem_ctx_longdouble_iget
+#define shmem_char_iget               pshmem_char_iget
+#define shmem_short_iget              pshmem_short_iget
+#define shmem_int_iget                pshmem_int_iget
+#define shmem_long_iget               pshmem_long_iget
+#define shmem_float_iget              pshmem_float_iget
+#define shmem_double_iget             pshmem_double_iget
+#define shmem_longlong_iget           pshmem_longlong_iget
+#define shmem_schar_iget              pshmem_schar_iget
+#define shmem_uchar_iget              pshmem_uchar_iget
+#define shmem_ushort_iget             pshmem_ushort_iget
+#define shmem_uint_iget               pshmem_uint_iget
+#define shmem_ulong_iget              pshmem_ulong_iget
+#define shmem_ulonglong_iget          pshmem_ulonglong_iget
+#define shmem_longdouble_iget         pshmem_longdouble_iget
 
 #define shmem_ctx_iget8              pshmem_ctx_iget8
 #define shmem_ctx_iget16             pshmem_ctx_iget16
@@ -280,22 +364,34 @@
 /*
  * Non-block data get routines
  */
-#define shmem_ctx_char_get_nbi       pshmem_ctx_char_get_nbi
-#define shmem_ctx_short_get_nbi      pshmem_ctx_short_get_nbi
-#define shmem_ctx_int_get_nbi        pshmem_ctx_int_get_nbi
-#define shmem_ctx_long_get_nbi       pshmem_ctx_long_get_nbi
-#define shmem_ctx_float_get_nbi      pshmem_ctx_float_get_nbi
-#define shmem_ctx_double_get_nbi     pshmem_ctx_double_get_nbi
-#define shmem_ctx_longlong_get_nbi   pshmem_ctx_longlong_get_nbi
-#define shmem_ctx_longdouble_get_nbi pshmem_ctx_longdouble_get_nbi
-#define shmem_char_get_nbi           pshmem_char_get_nbi
-#define shmem_short_get_nbi          pshmem_short_get_nbi
-#define shmem_int_get_nbi            pshmem_int_get_nbi
-#define shmem_long_get_nbi           pshmem_long_get_nbi
-#define shmem_float_get_nbi          pshmem_float_get_nbi
-#define shmem_double_get_nbi         pshmem_double_get_nbi
-#define shmem_longlong_get_nbi       pshmem_longlong_get_nbi
-#define shmem_longdouble_get_nbi     pshmem_longdouble_get_nbi
+#define shmem_ctx_char_get_nbi           pshmem_ctx_char_get_nbi
+#define shmem_ctx_short_get_nbi          pshmem_ctx_short_get_nbi
+#define shmem_ctx_int_get_nbi            pshmem_ctx_int_get_nbi
+#define shmem_ctx_long_get_nbi           pshmem_ctx_long_get_nbi
+#define shmem_ctx_float_get_nbi          pshmem_ctx_float_get_nbi
+#define shmem_ctx_double_get_nbi         pshmem_ctx_double_get_nbi
+#define shmem_ctx_longlong_get_nbi       pshmem_ctx_longlong_get_nbi
+#define shmem_ctx_schar_get_nbi          pshmem_ctx_schar_get_nbi
+#define shmem_ctx_uchar_get_nbi          pshmem_ctx_uchar_get_nbi
+#define shmem_ctx_ushort_get_nbi         pshmem_ctx_ushort_get_nbi
+#define shmem_ctx_uint_get_nbi           pshmem_ctx_uint_get_nbi
+#define shmem_ctx_ulong_get_nbi          pshmem_ctx_ulong_get_nbi
+#define shmem_ctx_ulonglong_get_nbi      pshmem_ctx_ulonglong_get_nbi
+#define shmem_ctx_longdouble_get_nbi     pshmem_ctx_longdouble_get_nbi
+#define shmem_char_get_nbi               pshmem_char_get_nbi
+#define shmem_short_get_nbi              pshmem_short_get_nbi
+#define shmem_int_get_nbi                pshmem_int_get_nbi
+#define shmem_long_get_nbi               pshmem_long_get_nbi
+#define shmem_float_get_nbi              pshmem_float_get_nbi
+#define shmem_double_get_nbi             pshmem_double_get_nbi
+#define shmem_longlong_get_nbi           pshmem_longlong_get_nbi
+#define shmem_schar_get_nbi              pshmem_schar_get_nbi
+#define shmem_uchar_get_nbi              pshmem_uchar_get_nbi
+#define shmem_ushort_get_nbi             pshmem_ushort_get_nbi
+#define shmem_uint_get_nbi               pshmem_uint_get_nbi
+#define shmem_ulong_get_nbi              pshmem_ulong_get_nbi
+#define shmem_ulonglong_get_nbi          pshmem_ulonglong_get_nbi
+#define shmem_longdouble_get_nbi         pshmem_longdouble_get_nbi
 
 #define shmem_ctx_get8_nbi           pshmem_ctx_get8_nbi
 #define shmem_ctx_get16_nbi          pshmem_ctx_get16_nbi
@@ -319,11 +415,17 @@
 #define shmem_ctx_int_atomic_swap    pshmem_ctx_int_atomic_swap
 #define shmem_ctx_long_atomic_swap   pshmem_ctx_long_atomic_swap
 #define shmem_ctx_longlong_atomic_swap pshmem_ctx_longlong_atomic_swap
+#define shmem_ctx_uint_atomic_swap   pshmem_ctx_uint_atomic_swap
+#define shmem_ctx_ulong_atomic_swap  pshmem_ctx_ulong_atomic_swap
+#define shmem_ctx_ulonglong_atomic_swap pshmem_ctx_ulonglong_atomic_swap
 #define shmem_double_atomic_swap     pshmem_double_atomic_swap
 #define shmem_float_atomic_swap      pshmem_float_atomic_swap
 #define shmem_int_atomic_swap        pshmem_int_atomic_swap
 #define shmem_long_atomic_swap       pshmem_long_atomic_swap
 #define shmem_longlong_atomic_swap   pshmem_longlong_atomic_swap
+#define shmem_uint_atomic_swap       pshmem_uint_atomic_swap
+#define shmem_ulong_atomic_swap      pshmem_ulong_atomic_swap
+#define shmem_ulonglong_atomic_swap  pshmem_ulonglong_atomic_swap
 #define shmem_double_swap            pshmem_double_swap
 #define shmem_float_swap             pshmem_float_swap
 #define shmem_int_swap               pshmem_int_swap
@@ -338,11 +440,17 @@
 #define shmem_ctx_int_atomic_set    pshmem_ctx_int_atomic_set
 #define shmem_ctx_long_atomic_set   pshmem_ctx_long_atomic_set
 #define shmem_ctx_longlong_atomic_set pshmem_ctx_longlong_atomic_set
+#define shmem_ctx_uint_atomic_set   pshmem_ctx_uint_atomic_set
+#define shmem_ctx_ulong_atomic_set  pshmem_ctx_ulong_atomic_set
+#define shmem_ctx_ulonglong_atomic_set pshmem_ctx_ulonglong_atomic_set
 #define shmem_double_atomic_set     pshmem_double_atomic_set
 #define shmem_float_atomic_set      pshmem_float_atomic_set
 #define shmem_int_atomic_set        pshmem_int_atomic_set
 #define shmem_long_atomic_set       pshmem_long_atomic_set
 #define shmem_longlong_atomic_set   pshmem_longlong_atomic_set
+#define shmem_uint_atomic_set       pshmem_uint_atomic_set
+#define shmem_ulong_atomic_set      pshmem_ulong_atomic_set
+#define shmem_ulonglong_atomic_set  pshmem_ulonglong_atomic_set
 #define shmem_double_set            pshmem_double_set
 #define shmem_float_set             pshmem_float_set
 #define shmem_int_set               pshmem_int_set
@@ -355,9 +463,15 @@
 #define shmem_ctx_int_atomic_compare_swap   pshmem_ctx_int_atomic_compare_swap
 #define shmem_ctx_long_atomic_compare_swap  pshmem_ctx_long_atomic_compare_swap
 #define shmem_ctx_longlong_atomic_compare_swap pshmem_ctx_longlong_atomic_compare_swap
+#define shmem_ctx_uint_atomic_compare_swap  pshmem_ctx_uint_atomic_compare_swap
+#define shmem_ctx_ulong_atomic_compare_swap pshmem_ctx_ulong_atomic_compare_swap
+#define shmem_ctx_ulonglong_atomic_compare_swap pshmem_ctx_ulonglong_atomic_compare_swap
 #define shmem_int_atomic_compare_swap       pshmem_int_atomic_compare_swap
 #define shmem_long_atomic_compare_swap      pshmem_long_atomic_compare_swap
 #define shmem_longlong_atomic_compare_swap  pshmem_longlong_atomic_compare_swap
+#define shmem_uint_atomic_compare_swap      pshmem_uint_atomic_compare_swap
+#define shmem_ulong_atomic_compare_swap     pshmem_ulong_atomic_compare_swap
+#define shmem_ulonglong_atomic_compare_swap pshmem_ulonglong_atomic_compare_swap
 #define shmem_int_cswap              pshmem_int_cswap
 #define shmem_long_cswap             pshmem_long_cswap
 #define shmem_longlong_cswap         pshmem_longlong_cswap
@@ -365,22 +479,34 @@
 #define shmemx_int64_cswap           pshmemx_int64_cswap
 
 /* Atomic Fetch&Add */
-#define shmem_ctx_int_atomic_fetch_add    pshmem_ctx_int_atomic_fetch_add
-#define shmem_ctx_long_atomic_fetch_add   pshmem_ctx_long_atomic_fetch_add
-#define shmem_ctx_longlong_atomic_fetch_add pshmem_ctx_longlong_atomic_fetch_add
-#define shmem_int_atomic_fetch_add        pshmem_int_atomic_fetch_add
-#define shmem_long_atomic_fetch_add       pshmem_long_atomic_fetch_add
-#define shmem_longlong_atomic_fetch_add   pshmem_longlong_atomic_fetch_add
-#define shmem_int_fadd               pshmem_int_fadd
-#define shmem_long_fadd              pshmem_long_fadd
-#define shmem_longlong_fadd          pshmem_longlong_fadd
-#define shmemx_int32_fadd            pshmemx_int32_fadd
-#define shmemx_int64_fadd            pshmemx_int64_fadd
+#define shmem_ctx_int_atomic_fetch_add       pshmem_ctx_int_atomic_fetch_add
+#define shmem_ctx_long_atomic_fetch_add      pshmem_ctx_long_atomic_fetch_add
+#define shmem_ctx_longlong_atomic_fetch_add  pshmem_ctx_longlong_atomic_fetch_add
+#define shmem_ctx_uint_atomic_fetch_add      pshmem_ctx_uint_atomic_fetch_add
+#define shmem_ctx_ulong_atomic_fetch_add     pshmem_ctx_ulong_atomic_fetch_add
+#define shmem_ctx_ulonglong_atomic_fetch_add pshmem_ctx_ulonglong_atomic_fetch_add
+#define shmem_int_atomic_fetch_add           pshmem_int_atomic_fetch_add
+#define shmem_long_atomic_fetch_add          pshmem_long_atomic_fetch_add
+#define shmem_longlong_atomic_fetch_add      pshmem_longlong_atomic_fetch_add
+#define shmem_uint_atomic_fetch_add          pshmem_uint_atomic_fetch_add
+#define shmem_ulong_atomic_fetch_add         pshmem_ulong_atomic_fetch_add
+#define shmem_ulonglong_atomic_fetch_add     pshmem_ulonglong_atomic_fetch_add
+#define shmem_int_fadd                       pshmem_int_fadd
+#define shmem_long_fadd                      pshmem_long_fadd
+#define shmem_longlong_fadd                  pshmem_longlong_fadd
+#define shmemx_int32_fadd                    pshmemx_int32_fadd
+#define shmemx_int64_fadd                    pshmemx_int64_fadd
 
 /* Atomic Fetch&And */
+#define shmem_int_atomic_fetch_and        pshmem_int_atomic_fetch_and
+#define shmem_long_atomic_fetch_and       pshmem_long_atomic_fetch_and
+#define shmem_longlong_atomic_fetch_and   pshmem_longlong_atomic_fetch_and
 #define shmem_uint_atomic_fetch_and       pshmem_uint_atomic_fetch_and
 #define shmem_ulong_atomic_fetch_and      pshmem_ulong_atomic_fetch_and
 #define shmem_ulonglong_atomic_fetch_and  pshmem_ulonglong_atomic_fetch_and
+#define shmem_ctx_int_atomic_fetch_and    pshmem_ctx_int_atomic_fetch_and
+#define shmem_ctx_long_atomic_fetch_and   pshmem_ctx_long_atomic_fetch_and
+#define shmem_ctx_longlong_atomic_fetch_and pshmem_ctx_longlong_atomic_fetch_and
 #define shmem_ctx_uint_atomic_fetch_and   pshmem_ctx_uint_atomic_fetch_and
 #define shmem_ctx_ulong_atomic_fetch_and  pshmem_ctx_ulong_atomic_fetch_and
 #define shmem_ctx_ulonglong_atomic_fetch_and pshmem_ctx_ulonglong_atomic_fetch_and
@@ -390,9 +516,15 @@
 #define shmemx_uint64_atomic_fetch_and    pshmemx_uint64_atomic_fetch_and
 
 /* Atomic Fetch&Or */
+#define shmem_int_atomic_fetch_or         pshmem_int_atomic_fetch_or
+#define shmem_long_atomic_fetch_or        pshmem_long_atomic_fetch_or
+#define shmem_longlong_atomic_fetch_or    pshmem_longlong_atomic_fetch_or
 #define shmem_uint_atomic_fetch_or        pshmem_uint_atomic_fetch_or
 #define shmem_ulong_atomic_fetch_or       pshmem_ulong_atomic_fetch_or
 #define shmem_ulonglong_atomic_fetch_or   pshmem_ulonglong_atomic_fetch_or
+#define shmem_ctx_int_atomic_fetch_or     pshmem_ctx_int_atomic_fetch_or
+#define shmem_ctx_long_atomic_fetch_or    pshmem_ctx_long_atomic_fetch_or
+#define shmem_ctx_longlong_atomic_fetch_or pshmem_ctx_longlong_atomic_fetch_or
 #define shmem_ctx_uint_atomic_fetch_or    pshmem_ctx_uint_atomic_fetch_or
 #define shmem_ctx_ulong_atomic_fetch_or   pshmem_ctx_ulong_atomic_fetch_or
 #define shmem_ctx_ulonglong_atomic_fetch_or pshmem_ctx_ulonglong_atomic_fetch_or
@@ -402,9 +534,15 @@
 #define shmemx_uint64_atomic_fetch_or     pshmemx_uint64_atomic_fetch_or
 
 /* Atomic Fetch&Xor */
+#define shmem_int_atomic_fetch_xor        pshmem_int_atomic_fetch_xor
+#define shmem_long_atomic_fetch_xor       pshmem_long_atomic_fetch_xor
+#define shmem_longlong_atomic_fetch_xor   pshmem_longlong_atomic_fetch_xor
 #define shmem_uint_atomic_fetch_xor       pshmem_uint_atomic_fetch_xor
 #define shmem_ulong_atomic_fetch_xor      pshmem_ulong_atomic_fetch_xor
 #define shmem_ulonglong_atomic_fetch_xor  pshmem_ulonglong_atomic_fetch_xor
+#define shmem_ctx_int_atomic_fetch_xor    pshmem_ctx_int_atomic_fetch_xor
+#define shmem_ctx_long_atomic_fetch_xor   pshmem_ctx_long_atomic_fetch_xor
+#define shmem_ctx_longlong_atomic_fetch_xor pshmem_ctx_longlong_atomic_fetch_xor
 #define shmem_ctx_uint_atomic_fetch_xor   pshmem_ctx_uint_atomic_fetch_xor
 #define shmem_ctx_ulong_atomic_fetch_xor  pshmem_ctx_ulong_atomic_fetch_xor
 #define shmem_ctx_ulonglong_atomic_fetch_xor pshmem_ctx_ulonglong_atomic_fetch_xor
@@ -419,11 +557,17 @@
 #define shmem_ctx_int_atomic_fetch    pshmem_ctx_int_atomic_fetch
 #define shmem_ctx_long_atomic_fetch   pshmem_ctx_long_atomic_fetch
 #define shmem_ctx_longlong_atomic_fetch pshmem_ctx_longlong_atomic_fetch
+#define shmem_ctx_uint_atomic_fetch   pshmem_ctx_uint_atomic_fetch
+#define shmem_ctx_ulong_atomic_fetch  pshmem_ctx_ulong_atomic_fetch
+#define shmem_ctx_ulonglong_atomic_fetch pshmem_ctx_ulonglong_atomic_fetch
 #define shmem_double_atomic_fetch     pshmem_double_atomic_fetch
 #define shmem_float_atomic_fetch      pshmem_float_atomic_fetch
 #define shmem_int_atomic_fetch        pshmem_int_atomic_fetch
 #define shmem_long_atomic_fetch       pshmem_long_atomic_fetch
 #define shmem_longlong_atomic_fetch   pshmem_longlong_atomic_fetch
+#define shmem_uint_atomic_fetch       pshmem_uint_atomic_fetch
+#define shmem_ulong_atomic_fetch      pshmem_ulong_atomic_fetch
+#define shmem_ulonglong_atomic_fetch  pshmem_ulonglong_atomic_fetch
 #define shmem_double_fetch            pshmem_double_fetch
 #define shmem_float_fetch             pshmem_float_fetch
 #define shmem_int_fetch               pshmem_int_fetch
@@ -436,6 +580,12 @@
 #define shmem_ctx_int_atomic_fetch_inc    pshmem_ctx_int_atomic_fetch_inc
 #define shmem_ctx_long_atomic_fetch_inc   pshmem_ctx_long_atomic_fetch_inc
 #define shmem_ctx_longlong_atomic_fetch_inc pshmem_ctx_longlong_atomic_fetch_inc
+#define shmem_ctx_uint_atomic_fetch_inc    pshmem_ctx_uint_atomic_fetch_inc
+#define shmem_ctx_ulong_atomic_fetch_inc   pshmem_ctx_ulong_atomic_fetch_inc
+#define shmem_ctx_ulonglong_atomic_fetch_inc pshmem_ctx_ulonglong_atomic_fetch_inc
+#define shmem_uint_atomic_fetch_inc        pshmem_uint_atomic_fetch_inc
+#define shmem_ulong_atomic_fetch_inc       pshmem_ulong_atomic_fetch_inc
+#define shmem_ulonglong_atomic_fetch_inc   pshmem_ulonglong_atomic_fetch_inc
 #define shmem_int_atomic_fetch_inc        pshmem_int_atomic_fetch_inc
 #define shmem_long_atomic_fetch_inc       pshmem_long_atomic_fetch_inc
 #define shmem_longlong_atomic_fetch_inc   pshmem_longlong_atomic_fetch_inc
@@ -449,9 +599,15 @@
 #define shmem_ctx_int_atomic_add     pshmem_ctx_int_atomic_add
 #define shmem_ctx_long_atomic_add    pshmem_ctx_long_atomic_add
 #define shmem_ctx_longlong_atomic_add pshmem_ctx_longlong_atomic_add
+#define shmem_ctx_uint_atomic_add    pshmem_ctx_uint_atomic_add
+#define shmem_ctx_ulong_atomic_add   pshmem_ctx_ulong_atomic_add
+#define shmem_ctx_ulonglong_atomic_add pshmem_ctx_ulonglong_atomic_add
 #define shmem_int_atomic_add         pshmem_int_atomic_add
 #define shmem_long_atomic_add        pshmem_long_atomic_add
 #define shmem_longlong_atomic_add    pshmem_longlong_atomic_add
+#define shmem_uint_atomic_add        pshmem_uint_atomic_add
+#define shmem_ulong_atomic_add       pshmem_ulong_atomic_add
+#define shmem_ulonglong_atomic_add   pshmem_ulonglong_atomic_add
 #define shmem_int_add                pshmem_int_add
 #define shmem_long_add               pshmem_long_add
 #define shmem_longlong_add           pshmem_longlong_add
@@ -459,9 +615,15 @@
 #define shmemx_int64_add             pshmemx_int64_add
 
 /* Atomic And */
+#define shmem_int_atomic_and         pshmem_int_atomic_and
+#define shmem_long_atomic_and        pshmem_long_atomic_and
+#define shmem_longlong_atomic_and    pshmem_longlong_atomic_and
 #define shmem_uint_atomic_and        pshmem_uint_atomic_and
 #define shmem_ulong_atomic_and       pshmem_ulong_atomic_and
 #define shmem_ulonglong_atomic_and   pshmem_ulonglong_atomic_and
+#define shmem_ctx_int_atomic_and     pshmem_ctx_int_atomic_and
+#define shmem_ctx_long_atomic_and    pshmem_ctx_long_atomic_and
+#define shmem_ctx_longlong_atomic_and pshmem_ctx_longlong_atomic_and
 #define shmem_ctx_uint_atomic_and    pshmem_ctx_uint_atomic_and
 #define shmem_ctx_ulong_atomic_and   pshmem_ctx_ulong_atomic_and
 #define shmem_ctx_ulonglong_atomic_and pshmem_ctx_ulonglong_atomic_and
@@ -471,9 +633,15 @@
 #define shmemx_uint64_atomic_and     pshmemx_uint64_atomic_and
 
 /* Atomic Or */
+#define shmem_int_atomic_or          pshmem_int_atomic_or
+#define shmem_long_atomic_or         pshmem_long_atomic_or
+#define shmem_longlong_atomic_or     pshmem_longlong_atomic_or
 #define shmem_uint_atomic_or         pshmem_uint_atomic_or
 #define shmem_ulong_atomic_or        pshmem_ulong_atomic_or
 #define shmem_ulonglong_atomic_or    pshmem_ulonglong_atomic_or
+#define shmem_ctx_int_atomic_or      pshmem_ctx_int_atomic_or
+#define shmem_ctx_long_atomic_or     pshmem_ctx_long_atomic_or
+#define shmem_ctx_longlong_atomic_or pshmem_ctx_longlong_atomic_or
 #define shmem_ctx_uint_atomic_or     pshmem_ctx_uint_atomic_or
 #define shmem_ctx_ulong_atomic_or    pshmem_ctx_ulong_atomic_or
 #define shmem_ctx_ulonglong_atomic_or pshmem_ctx_ulonglong_atomic_or
@@ -483,9 +651,15 @@
 #define shmemx_uint64_atomic_or      pshmemx_uint64_atomic_or
 
 /* Atomic Xor */
+#define shmem_int_atomic_xor         pshmem_int_atomic_xor
+#define shmem_long_atomic_xor        pshmem_long_atomic_xor
+#define shmem_longlong_atomic_xor    pshmem_longlong_atomic_xor
 #define shmem_uint_atomic_xor        pshmem_uint_atomic_xor
 #define shmem_ulong_atomic_xor       pshmem_ulong_atomic_xor
 #define shmem_ulonglong_atomic_xor   pshmem_ulonglong_atomic_xor
+#define shmem_ctx_int_atomic_xor     pshmem_ctx_int_atomic_xor
+#define shmem_ctx_long_atomic_xor    pshmem_ctx_long_atomic_xor
+#define shmem_ctx_longlong_atomic_xor pshmem_ctx_longlong_atomic_xor
 #define shmem_ctx_uint_atomic_xor    pshmem_ctx_uint_atomic_xor
 #define shmem_ctx_ulong_atomic_xor   pshmem_ctx_ulong_atomic_xor
 #define shmem_ctx_ulonglong_atomic_xor pshmem_ctx_ulonglong_atomic_xor
@@ -498,9 +672,15 @@
 #define shmem_ctx_int_atomic_inc     pshmem_ctx_int_atomic_inc
 #define shmem_ctx_long_atomic_inc    pshmem_ctx_long_atomic_inc
 #define shmem_ctx_longlong_atomic_inc pshmem_ctx_longlong_atomic_inc
+#define shmem_ctx_uint_atomic_inc    pshmem_ctx_uint_atomic_inc
+#define shmem_ctx_ulong_atomic_inc   pshmem_ctx_ulong_atomic_inc
+#define shmem_ctx_ulonglong_atomic_inc pshmem_ctx_ulonglong_atomic_inc
 #define shmem_int_atomic_inc         pshmem_int_atomic_inc
 #define shmem_long_atomic_inc        pshmem_long_atomic_inc
 #define shmem_longlong_atomic_inc    pshmem_longlong_atomic_inc
+#define shmem_uint_atomic_inc        pshmem_uint_atomic_inc
+#define shmem_ulong_atomic_inc       pshmem_ulong_atomic_inc
+#define shmem_ulonglong_atomic_inc   pshmem_ulonglong_atomic_inc
 #define shmem_int_inc                pshmem_int_inc
 #define shmem_long_inc               pshmem_long_inc
 #define shmem_longlong_inc           pshmem_longlong_inc

--- a/oshmem/shmem/c/profile/defines.h
+++ b/oshmem/shmem/c/profile/defines.h
@@ -87,6 +87,7 @@
 #define shmem_ctx_ulong_p            pshmem_ctx_ulong_p
 #define shmem_ctx_ulonglong_p        pshmem_ctx_ulonglong_p
 #define shmem_ctx_longdouble_p       pshmem_ctx_longdouble_p
+
 #define shmem_char_p                 pshmem_char_p
 #define shmem_short_p                pshmem_short_p
 #define shmem_int_p                  pshmem_int_p
@@ -101,6 +102,7 @@
 #define shmem_ulong_p                pshmem_ulong_p
 #define shmem_ulonglong_p            pshmem_ulonglong_p
 #define shmem_longdouble_p           pshmem_longdouble_p
+
 #define shmemx_int16_p               pshmemx_int16_p
 #define shmemx_int32_p               pshmemx_int32_p
 #define shmemx_int64_p               pshmemx_int64_p
@@ -122,6 +124,7 @@
 #define shmem_ctx_ulong_put          pshmem_ctx_ulong_put
 #define shmem_ctx_ulonglong_put      pshmem_ctx_ulonglong_put
 #define shmem_ctx_longdouble_put     pshmem_ctx_longdouble_put
+
 #define shmem_char_put               pshmem_char_put /* shmem-compat.h */
 #define shmem_short_put              pshmem_short_put
 #define shmem_int_put                pshmem_int_put
@@ -143,6 +146,7 @@
 #define shmem_ctx_put64              pshmem_ctx_put64
 #define shmem_ctx_put128             pshmem_ctx_put128
 #define shmem_ctx_putmem             pshmem_ctx_putmem
+
 #define shmem_put8                   pshmem_put8
 #define shmem_put16                  pshmem_put16
 #define shmem_put32                  pshmem_put32
@@ -167,6 +171,7 @@
 #define shmem_ctx_ulong_iput          pshmem_ctx_ulong_iput
 #define shmem_ctx_ulonglong_iput      pshmem_ctx_ulonglong_iput
 #define shmem_ctx_longdouble_iput     pshmem_ctx_longdouble_iput
+
 #define shmem_char_iput               pshmem_char_iput
 #define shmem_short_iput              pshmem_short_iput
 #define shmem_int_iput                pshmem_int_iput
@@ -187,6 +192,7 @@
 #define shmem_ctx_iput32             pshmem_ctx_iput32
 #define shmem_ctx_iput64             pshmem_ctx_iput64
 #define shmem_ctx_iput128            pshmem_ctx_iput128
+
 #define shmem_iput8                  pshmem_iput8
 #define shmem_iput16                 pshmem_iput16
 #define shmem_iput32                 pshmem_iput32
@@ -210,6 +216,7 @@
 #define shmem_ctx_ulong_put_nbi          pshmem_ctx_ulong_put_nbi
 #define shmem_ctx_ulonglong_put_nbi      pshmem_ctx_ulonglong_put_nbi
 #define shmem_ctx_longdouble_put_nbi     pshmem_ctx_longdouble_put_nbi
+
 #define shmem_char_put_nbi               pshmem_char_put_nbi
 #define shmem_short_put_nbi              pshmem_short_put_nbi
 #define shmem_int_put_nbi                pshmem_int_put_nbi
@@ -231,6 +238,7 @@
 #define shmem_ctx_put64_nbi          pshmem_ctx_put64_nbi
 #define shmem_ctx_put128_nbi         pshmem_ctx_put128_nbi
 #define shmem_ctx_putmem_nbi         pshmem_ctx_putmem_nbi
+
 #define shmem_put8_nbi               pshmem_put8_nbi
 #define shmem_put16_nbi              pshmem_put16_nbi
 #define shmem_put32_nbi              pshmem_put32_nbi
@@ -255,6 +263,7 @@
 #define shmem_ctx_ulong_g            pshmem_ctx_ulong_g
 #define shmem_ctx_ulonglong_g        pshmem_ctx_ulonglong_g
 #define shmem_ctx_longdouble_g       pshmem_ctx_longdouble_g
+
 #define shmem_char_g                 pshmem_char_g
 #define shmem_short_g                pshmem_short_g
 #define shmem_int_g                  pshmem_int_g
@@ -269,6 +278,7 @@
 #define shmem_ulong_g                pshmem_ulong_g
 #define shmem_ulonglong_g            pshmem_ulonglong_g
 #define shmem_longdouble_g           pshmem_longdouble_g
+
 #define shmemx_int16_g               pshmemx_int16_g
 #define shmemx_int32_g               pshmemx_int32_g
 #define shmemx_int64_g               pshmemx_int64_g
@@ -290,6 +300,7 @@
 #define shmem_ctx_ulong_get          pshmem_ctx_ulong_get
 #define shmem_ctx_ulonglong_get      pshmem_ctx_ulonglong_get
 #define shmem_ctx_longdouble_get     pshmem_ctx_longdouble_get
+
 #define shmem_char_get               pshmem_char_get /* shmem-compat.h */
 #define shmem_short_get              pshmem_short_get
 #define shmem_int_get                pshmem_int_get
@@ -311,6 +322,7 @@
 #define shmem_ctx_get64              pshmem_ctx_get64
 #define shmem_ctx_get128             pshmem_ctx_get128
 #define shmem_ctx_getmem             pshmem_ctx_getmem
+
 #define shmem_get8                   pshmem_get8
 #define shmem_get16                  pshmem_get16
 #define shmem_get32                  pshmem_get32
@@ -335,6 +347,7 @@
 #define shmem_ctx_ulong_iget          pshmem_ctx_ulong_iget
 #define shmem_ctx_ulonglong_iget      pshmem_ctx_ulonglong_iget
 #define shmem_ctx_longdouble_iget     pshmem_ctx_longdouble_iget
+
 #define shmem_char_iget               pshmem_char_iget
 #define shmem_short_iget              pshmem_short_iget
 #define shmem_int_iget                pshmem_int_iget
@@ -355,6 +368,7 @@
 #define shmem_ctx_iget32             pshmem_ctx_iget32
 #define shmem_ctx_iget64             pshmem_ctx_iget64
 #define shmem_ctx_iget128            pshmem_ctx_iget128
+
 #define shmem_iget8                  pshmem_iget8
 #define shmem_iget16                 pshmem_iget16
 #define shmem_iget32                 pshmem_iget32
@@ -378,6 +392,7 @@
 #define shmem_ctx_ulong_get_nbi          pshmem_ctx_ulong_get_nbi
 #define shmem_ctx_ulonglong_get_nbi      pshmem_ctx_ulonglong_get_nbi
 #define shmem_ctx_longdouble_get_nbi     pshmem_ctx_longdouble_get_nbi
+
 #define shmem_char_get_nbi               pshmem_char_get_nbi
 #define shmem_short_get_nbi              pshmem_short_get_nbi
 #define shmem_int_get_nbi                pshmem_int_get_nbi
@@ -399,6 +414,7 @@
 #define shmem_ctx_get64_nbi          pshmem_ctx_get64_nbi
 #define shmem_ctx_get128_nbi         pshmem_ctx_get128_nbi
 #define shmem_ctx_getmem_nbi         pshmem_ctx_getmem_nbi
+
 #define shmem_get8_nbi               pshmem_get8_nbi
 #define shmem_get16_nbi              pshmem_get16_nbi
 #define shmem_get32_nbi              pshmem_get32_nbi
@@ -418,6 +434,7 @@
 #define shmem_ctx_uint_atomic_swap   pshmem_ctx_uint_atomic_swap
 #define shmem_ctx_ulong_atomic_swap  pshmem_ctx_ulong_atomic_swap
 #define shmem_ctx_ulonglong_atomic_swap pshmem_ctx_ulonglong_atomic_swap
+
 #define shmem_double_atomic_swap     pshmem_double_atomic_swap
 #define shmem_float_atomic_swap      pshmem_float_atomic_swap
 #define shmem_int_atomic_swap        pshmem_int_atomic_swap
@@ -426,11 +443,13 @@
 #define shmem_uint_atomic_swap       pshmem_uint_atomic_swap
 #define shmem_ulong_atomic_swap      pshmem_ulong_atomic_swap
 #define shmem_ulonglong_atomic_swap  pshmem_ulonglong_atomic_swap
+
 #define shmem_double_swap            pshmem_double_swap
 #define shmem_float_swap             pshmem_float_swap
 #define shmem_int_swap               pshmem_int_swap
 #define shmem_long_swap              pshmem_long_swap
 #define shmem_longlong_swap          pshmem_longlong_swap
+
 #define shmemx_int32_swap            pshmemx_int32_swap
 #define shmemx_int64_swap            pshmemx_int64_swap
 
@@ -443,6 +462,7 @@
 #define shmem_ctx_uint_atomic_set   pshmem_ctx_uint_atomic_set
 #define shmem_ctx_ulong_atomic_set  pshmem_ctx_ulong_atomic_set
 #define shmem_ctx_ulonglong_atomic_set pshmem_ctx_ulonglong_atomic_set
+
 #define shmem_double_atomic_set     pshmem_double_atomic_set
 #define shmem_float_atomic_set      pshmem_float_atomic_set
 #define shmem_int_atomic_set        pshmem_int_atomic_set
@@ -451,11 +471,13 @@
 #define shmem_uint_atomic_set       pshmem_uint_atomic_set
 #define shmem_ulong_atomic_set      pshmem_ulong_atomic_set
 #define shmem_ulonglong_atomic_set  pshmem_ulonglong_atomic_set
+
 #define shmem_double_set            pshmem_double_set
 #define shmem_float_set             pshmem_float_set
 #define shmem_int_set               pshmem_int_set
 #define shmem_long_set              pshmem_long_set
 #define shmem_longlong_set          pshmem_longlong_set
+
 #define shmemx_int32_set            pshmemx_int32_set
 #define shmemx_int64_set            pshmemx_int64_set
 
@@ -466,15 +488,18 @@
 #define shmem_ctx_uint_atomic_compare_swap  pshmem_ctx_uint_atomic_compare_swap
 #define shmem_ctx_ulong_atomic_compare_swap pshmem_ctx_ulong_atomic_compare_swap
 #define shmem_ctx_ulonglong_atomic_compare_swap pshmem_ctx_ulonglong_atomic_compare_swap
+
 #define shmem_int_atomic_compare_swap       pshmem_int_atomic_compare_swap
 #define shmem_long_atomic_compare_swap      pshmem_long_atomic_compare_swap
 #define shmem_longlong_atomic_compare_swap  pshmem_longlong_atomic_compare_swap
 #define shmem_uint_atomic_compare_swap      pshmem_uint_atomic_compare_swap
 #define shmem_ulong_atomic_compare_swap     pshmem_ulong_atomic_compare_swap
 #define shmem_ulonglong_atomic_compare_swap pshmem_ulonglong_atomic_compare_swap
+
 #define shmem_int_cswap              pshmem_int_cswap
 #define shmem_long_cswap             pshmem_long_cswap
 #define shmem_longlong_cswap         pshmem_longlong_cswap
+
 #define shmemx_int32_cswap           pshmemx_int32_cswap
 #define shmemx_int64_cswap           pshmemx_int64_cswap
 
@@ -485,15 +510,18 @@
 #define shmem_ctx_uint_atomic_fetch_add      pshmem_ctx_uint_atomic_fetch_add
 #define shmem_ctx_ulong_atomic_fetch_add     pshmem_ctx_ulong_atomic_fetch_add
 #define shmem_ctx_ulonglong_atomic_fetch_add pshmem_ctx_ulonglong_atomic_fetch_add
+
 #define shmem_int_atomic_fetch_add           pshmem_int_atomic_fetch_add
 #define shmem_long_atomic_fetch_add          pshmem_long_atomic_fetch_add
 #define shmem_longlong_atomic_fetch_add      pshmem_longlong_atomic_fetch_add
 #define shmem_uint_atomic_fetch_add          pshmem_uint_atomic_fetch_add
 #define shmem_ulong_atomic_fetch_add         pshmem_ulong_atomic_fetch_add
 #define shmem_ulonglong_atomic_fetch_add     pshmem_ulonglong_atomic_fetch_add
+
 #define shmem_int_fadd                       pshmem_int_fadd
 #define shmem_long_fadd                      pshmem_long_fadd
 #define shmem_longlong_fadd                  pshmem_longlong_fadd
+
 #define shmemx_int32_fadd                    pshmemx_int32_fadd
 #define shmemx_int64_fadd                    pshmemx_int64_fadd
 
@@ -504,12 +532,14 @@
 #define shmem_uint_atomic_fetch_and       pshmem_uint_atomic_fetch_and
 #define shmem_ulong_atomic_fetch_and      pshmem_ulong_atomic_fetch_and
 #define shmem_ulonglong_atomic_fetch_and  pshmem_ulonglong_atomic_fetch_and
+
 #define shmem_ctx_int_atomic_fetch_and    pshmem_ctx_int_atomic_fetch_and
 #define shmem_ctx_long_atomic_fetch_and   pshmem_ctx_long_atomic_fetch_and
 #define shmem_ctx_longlong_atomic_fetch_and pshmem_ctx_longlong_atomic_fetch_and
 #define shmem_ctx_uint_atomic_fetch_and   pshmem_ctx_uint_atomic_fetch_and
 #define shmem_ctx_ulong_atomic_fetch_and  pshmem_ctx_ulong_atomic_fetch_and
 #define shmem_ctx_ulonglong_atomic_fetch_and pshmem_ctx_ulonglong_atomic_fetch_and
+
 #define shmemx_int32_atomic_fetch_and     pshmemx_int32_atomic_fetch_and
 #define shmemx_int64_atomic_fetch_and     pshmemx_int64_atomic_fetch_and
 #define shmemx_uint32_atomic_fetch_and    pshmemx_uint32_atomic_fetch_and
@@ -522,12 +552,14 @@
 #define shmem_uint_atomic_fetch_or        pshmem_uint_atomic_fetch_or
 #define shmem_ulong_atomic_fetch_or       pshmem_ulong_atomic_fetch_or
 #define shmem_ulonglong_atomic_fetch_or   pshmem_ulonglong_atomic_fetch_or
+
 #define shmem_ctx_int_atomic_fetch_or     pshmem_ctx_int_atomic_fetch_or
 #define shmem_ctx_long_atomic_fetch_or    pshmem_ctx_long_atomic_fetch_or
 #define shmem_ctx_longlong_atomic_fetch_or pshmem_ctx_longlong_atomic_fetch_or
 #define shmem_ctx_uint_atomic_fetch_or    pshmem_ctx_uint_atomic_fetch_or
 #define shmem_ctx_ulong_atomic_fetch_or   pshmem_ctx_ulong_atomic_fetch_or
 #define shmem_ctx_ulonglong_atomic_fetch_or pshmem_ctx_ulonglong_atomic_fetch_or
+
 #define shmemx_int32_atomic_fetch_or      pshmemx_int32_atomic_fetch_or
 #define shmemx_int64_atomic_fetch_or      pshmemx_int64_atomic_fetch_or
 #define shmemx_uint32_atomic_fetch_or     pshmemx_uint32_atomic_fetch_or
@@ -540,12 +572,14 @@
 #define shmem_uint_atomic_fetch_xor       pshmem_uint_atomic_fetch_xor
 #define shmem_ulong_atomic_fetch_xor      pshmem_ulong_atomic_fetch_xor
 #define shmem_ulonglong_atomic_fetch_xor  pshmem_ulonglong_atomic_fetch_xor
+
 #define shmem_ctx_int_atomic_fetch_xor    pshmem_ctx_int_atomic_fetch_xor
 #define shmem_ctx_long_atomic_fetch_xor   pshmem_ctx_long_atomic_fetch_xor
 #define shmem_ctx_longlong_atomic_fetch_xor pshmem_ctx_longlong_atomic_fetch_xor
 #define shmem_ctx_uint_atomic_fetch_xor   pshmem_ctx_uint_atomic_fetch_xor
 #define shmem_ctx_ulong_atomic_fetch_xor  pshmem_ctx_ulong_atomic_fetch_xor
 #define shmem_ctx_ulonglong_atomic_fetch_xor pshmem_ctx_ulonglong_atomic_fetch_xor
+
 #define shmemx_int32_atomic_fetch_xor     pshmemx_int32_atomic_fetch_xor
 #define shmemx_int64_atomic_fetch_xor     pshmemx_int64_atomic_fetch_xor
 #define shmemx_uint32_atomic_fetch_xor    pshmemx_uint32_atomic_fetch_xor
@@ -560,6 +594,7 @@
 #define shmem_ctx_uint_atomic_fetch   pshmem_ctx_uint_atomic_fetch
 #define shmem_ctx_ulong_atomic_fetch  pshmem_ctx_ulong_atomic_fetch
 #define shmem_ctx_ulonglong_atomic_fetch pshmem_ctx_ulonglong_atomic_fetch
+
 #define shmem_double_atomic_fetch     pshmem_double_atomic_fetch
 #define shmem_float_atomic_fetch      pshmem_float_atomic_fetch
 #define shmem_int_atomic_fetch        pshmem_int_atomic_fetch
@@ -568,11 +603,13 @@
 #define shmem_uint_atomic_fetch       pshmem_uint_atomic_fetch
 #define shmem_ulong_atomic_fetch      pshmem_ulong_atomic_fetch
 #define shmem_ulonglong_atomic_fetch  pshmem_ulonglong_atomic_fetch
+
 #define shmem_double_fetch            pshmem_double_fetch
 #define shmem_float_fetch             pshmem_float_fetch
 #define shmem_int_fetch               pshmem_int_fetch
 #define shmem_long_fetch              pshmem_long_fetch
 #define shmem_longlong_fetch          pshmem_longlong_fetch
+
 #define shmemx_int32_fetch            pshmemx_int32_fetch
 #define shmemx_int64_fetch            pshmemx_int64_fetch
 
@@ -583,15 +620,18 @@
 #define shmem_ctx_uint_atomic_fetch_inc    pshmem_ctx_uint_atomic_fetch_inc
 #define shmem_ctx_ulong_atomic_fetch_inc   pshmem_ctx_ulong_atomic_fetch_inc
 #define shmem_ctx_ulonglong_atomic_fetch_inc pshmem_ctx_ulonglong_atomic_fetch_inc
+
 #define shmem_uint_atomic_fetch_inc        pshmem_uint_atomic_fetch_inc
 #define shmem_ulong_atomic_fetch_inc       pshmem_ulong_atomic_fetch_inc
 #define shmem_ulonglong_atomic_fetch_inc   pshmem_ulonglong_atomic_fetch_inc
 #define shmem_int_atomic_fetch_inc        pshmem_int_atomic_fetch_inc
 #define shmem_long_atomic_fetch_inc       pshmem_long_atomic_fetch_inc
 #define shmem_longlong_atomic_fetch_inc   pshmem_longlong_atomic_fetch_inc
+
 #define shmem_int_finc               pshmem_int_finc
 #define shmem_long_finc              pshmem_long_finc
 #define shmem_longlong_finc          pshmem_longlong_finc
+
 #define shmemx_int32_finc            pshmemx_int32_finc
 #define shmemx_int64_finc            pshmemx_int64_finc
 
@@ -602,15 +642,18 @@
 #define shmem_ctx_uint_atomic_add    pshmem_ctx_uint_atomic_add
 #define shmem_ctx_ulong_atomic_add   pshmem_ctx_ulong_atomic_add
 #define shmem_ctx_ulonglong_atomic_add pshmem_ctx_ulonglong_atomic_add
+
 #define shmem_int_atomic_add         pshmem_int_atomic_add
 #define shmem_long_atomic_add        pshmem_long_atomic_add
 #define shmem_longlong_atomic_add    pshmem_longlong_atomic_add
 #define shmem_uint_atomic_add        pshmem_uint_atomic_add
 #define shmem_ulong_atomic_add       pshmem_ulong_atomic_add
 #define shmem_ulonglong_atomic_add   pshmem_ulonglong_atomic_add
+
 #define shmem_int_add                pshmem_int_add
 #define shmem_long_add               pshmem_long_add
 #define shmem_longlong_add           pshmem_longlong_add
+
 #define shmemx_int32_add             pshmemx_int32_add
 #define shmemx_int64_add             pshmemx_int64_add
 
@@ -621,14 +664,17 @@
 #define shmem_uint_atomic_and        pshmem_uint_atomic_and
 #define shmem_ulong_atomic_and       pshmem_ulong_atomic_and
 #define shmem_ulonglong_atomic_and   pshmem_ulonglong_atomic_and
+
 #define shmem_ctx_int_atomic_and     pshmem_ctx_int_atomic_and
 #define shmem_ctx_long_atomic_and    pshmem_ctx_long_atomic_and
 #define shmem_ctx_longlong_atomic_and pshmem_ctx_longlong_atomic_and
 #define shmem_ctx_uint_atomic_and    pshmem_ctx_uint_atomic_and
 #define shmem_ctx_ulong_atomic_and   pshmem_ctx_ulong_atomic_and
 #define shmem_ctx_ulonglong_atomic_and pshmem_ctx_ulonglong_atomic_and
+
 #define shmemx_int32_atomic_and      pshmemx_int32_atomic_and
 #define shmemx_int64_atomic_and      pshmemx_int64_atomic_and
+
 #define shmemx_uint32_atomic_and     pshmemx_uint32_atomic_and
 #define shmemx_uint64_atomic_and     pshmemx_uint64_atomic_and
 
@@ -639,14 +685,17 @@
 #define shmem_uint_atomic_or         pshmem_uint_atomic_or
 #define shmem_ulong_atomic_or        pshmem_ulong_atomic_or
 #define shmem_ulonglong_atomic_or    pshmem_ulonglong_atomic_or
+
 #define shmem_ctx_int_atomic_or      pshmem_ctx_int_atomic_or
 #define shmem_ctx_long_atomic_or     pshmem_ctx_long_atomic_or
 #define shmem_ctx_longlong_atomic_or pshmem_ctx_longlong_atomic_or
 #define shmem_ctx_uint_atomic_or     pshmem_ctx_uint_atomic_or
 #define shmem_ctx_ulong_atomic_or    pshmem_ctx_ulong_atomic_or
 #define shmem_ctx_ulonglong_atomic_or pshmem_ctx_ulonglong_atomic_or
+
 #define shmemx_int32_atomic_or       pshmemx_int32_atomic_or
 #define shmemx_int64_atomic_or       pshmemx_int64_atomic_or
+
 #define shmemx_uint32_atomic_or      pshmemx_uint32_atomic_or
 #define shmemx_uint64_atomic_or      pshmemx_uint64_atomic_or
 
@@ -657,14 +706,17 @@
 #define shmem_uint_atomic_xor        pshmem_uint_atomic_xor
 #define shmem_ulong_atomic_xor       pshmem_ulong_atomic_xor
 #define shmem_ulonglong_atomic_xor   pshmem_ulonglong_atomic_xor
+
 #define shmem_ctx_int_atomic_xor     pshmem_ctx_int_atomic_xor
 #define shmem_ctx_long_atomic_xor    pshmem_ctx_long_atomic_xor
 #define shmem_ctx_longlong_atomic_xor pshmem_ctx_longlong_atomic_xor
 #define shmem_ctx_uint_atomic_xor    pshmem_ctx_uint_atomic_xor
 #define shmem_ctx_ulong_atomic_xor   pshmem_ctx_ulong_atomic_xor
 #define shmem_ctx_ulonglong_atomic_xor pshmem_ctx_ulonglong_atomic_xor
+
 #define shmemx_int32_atomic_xor      pshmemx_int32_atomic_xor
 #define shmemx_int64_atomic_xor      pshmemx_int64_atomic_xor
+
 #define shmemx_uint32_atomic_xor     pshmemx_uint32_atomic_xor
 #define shmemx_uint64_atomic_xor     pshmemx_uint64_atomic_xor
 
@@ -675,15 +727,18 @@
 #define shmem_ctx_uint_atomic_inc    pshmem_ctx_uint_atomic_inc
 #define shmem_ctx_ulong_atomic_inc   pshmem_ctx_ulong_atomic_inc
 #define shmem_ctx_ulonglong_atomic_inc pshmem_ctx_ulonglong_atomic_inc
+
 #define shmem_int_atomic_inc         pshmem_int_atomic_inc
 #define shmem_long_atomic_inc        pshmem_long_atomic_inc
 #define shmem_longlong_atomic_inc    pshmem_longlong_atomic_inc
 #define shmem_uint_atomic_inc        pshmem_uint_atomic_inc
 #define shmem_ulong_atomic_inc       pshmem_ulong_atomic_inc
 #define shmem_ulonglong_atomic_inc   pshmem_ulonglong_atomic_inc
+
 #define shmem_int_inc                pshmem_int_inc
 #define shmem_long_inc               pshmem_long_inc
 #define shmem_longlong_inc           pshmem_longlong_inc
+
 #define shmemx_int32_inc             pshmemx_int32_inc
 #define shmemx_int64_inc             pshmemx_int64_inc
 

--- a/oshmem/shmem/c/shmem_add.c
+++ b/oshmem/shmem/c/shmem_add.c
@@ -63,9 +63,15 @@
 #pragma weak shmem_ctx_int_atomic_add = pshmem_ctx_int_atomic_add
 #pragma weak shmem_ctx_long_atomic_add = pshmem_ctx_long_atomic_add
 #pragma weak shmem_ctx_longlong_atomic_add = pshmem_ctx_longlong_atomic_add
+#pragma weak shmem_ctx_uint_atomic_add = pshmem_ctx_uint_atomic_add
+#pragma weak shmem_ctx_ulong_atomic_add = pshmem_ctx_ulong_atomic_add
+#pragma weak shmem_ctx_ulonglong_atomic_add = pshmem_ctx_ulonglong_atomic_add
 #pragma weak shmem_int_atomic_add = pshmem_int_atomic_add
 #pragma weak shmem_long_atomic_add = pshmem_long_atomic_add
 #pragma weak shmem_longlong_atomic_add = pshmem_longlong_atomic_add
+#pragma weak shmem_uint_atomic_add = pshmem_uint_atomic_add
+#pragma weak shmem_ulong_atomic_add = pshmem_ulong_atomic_add
+#pragma weak shmem_ulonglong_atomic_add = pshmem_ulonglong_atomic_add
 #pragma weak shmem_int_add = pshmem_int_add
 #pragma weak shmem_long_add = pshmem_long_add
 #pragma weak shmem_longlong_add = pshmem_longlong_add
@@ -74,12 +80,18 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+SHMEM_CTX_TYPE_ATOMIC_ADD(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_ADD(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_ADD(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_ADD(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_ADD(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_ADD(_longlong, long long, shmem)
 SHMEM_TYPE_ATOMIC_ADD(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_ADD(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_ADD(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_ADD(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_ADD(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_ADD(_ulonglong, unsigned long long, shmem)
 
 /* deprecated APIs */
 #define SHMEM_TYPE_ADD(type_name, type, prefix)                     \

--- a/oshmem/shmem/c/shmem_add.c
+++ b/oshmem/shmem/c/shmem_add.c
@@ -66,15 +66,18 @@
 #pragma weak shmem_ctx_uint_atomic_add = pshmem_ctx_uint_atomic_add
 #pragma weak shmem_ctx_ulong_atomic_add = pshmem_ctx_ulong_atomic_add
 #pragma weak shmem_ctx_ulonglong_atomic_add = pshmem_ctx_ulonglong_atomic_add
+
 #pragma weak shmem_int_atomic_add = pshmem_int_atomic_add
 #pragma weak shmem_long_atomic_add = pshmem_long_atomic_add
 #pragma weak shmem_longlong_atomic_add = pshmem_longlong_atomic_add
 #pragma weak shmem_uint_atomic_add = pshmem_uint_atomic_add
 #pragma weak shmem_ulong_atomic_add = pshmem_ulong_atomic_add
 #pragma weak shmem_ulonglong_atomic_add = pshmem_ulonglong_atomic_add
+
 #pragma weak shmem_int_add = pshmem_int_add
 #pragma weak shmem_long_add = pshmem_long_add
 #pragma weak shmem_longlong_add = pshmem_longlong_add
+
 #pragma weak shmemx_int32_add = pshmemx_int32_add
 #pragma weak shmemx_int64_add = pshmemx_int64_add
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_and.c
+++ b/oshmem/shmem/c/shmem_and.c
@@ -25,9 +25,15 @@
  */
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
+#pragma weak shmem_int_atomic_and       = pshmem_int_atomic_and
+#pragma weak shmem_long_atomic_and      = pshmem_long_atomic_and
+#pragma weak shmem_longlong_atomic_and  = pshmem_longlong_atomic_and
 #pragma weak shmem_uint_atomic_and      = pshmem_uint_atomic_and
 #pragma weak shmem_ulong_atomic_and     = pshmem_ulong_atomic_and
 #pragma weak shmem_ulonglong_atomic_and = pshmem_ulonglong_atomic_and
+#pragma weak shmem_ctx_int_atomic_and   = pshmem_ctx_int_atomic_and
+#pragma weak shmem_ctx_long_atomic_and  = pshmem_ctx_long_atomic_and
+#pragma weak shmem_ctx_longlong_atomic_and = pshmem_ctx_longlong_atomic_and
 #pragma weak shmem_ctx_uint_atomic_and  = pshmem_ctx_uint_atomic_and
 #pragma weak shmem_ctx_ulong_atomic_and = pshmem_ctx_ulong_atomic_and
 #pragma weak shmem_ctx_ulonglong_atomic_and = pshmem_ctx_ulonglong_atomic_and
@@ -38,9 +44,15 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+OSHMEM_TYPE_OP(int, int, shmem, and)
+OSHMEM_TYPE_OP(long, long, shmem, and)
+OSHMEM_TYPE_OP(longlong, long long, shmem, and)
 OSHMEM_TYPE_OP(uint, unsigned int, shmem, and)
 OSHMEM_TYPE_OP(ulong, unsigned long, shmem, and)
 OSHMEM_TYPE_OP(ulonglong, unsigned long long, shmem, and)
+OSHMEM_CTX_TYPE_OP(int, int, shmem, and)
+OSHMEM_CTX_TYPE_OP(long, long, shmem, and)
+OSHMEM_CTX_TYPE_OP(longlong, long long, shmem, and)
 OSHMEM_CTX_TYPE_OP(uint, unsigned int, shmem, and)
 OSHMEM_CTX_TYPE_OP(ulong, unsigned long, shmem, and)
 OSHMEM_CTX_TYPE_OP(ulonglong, unsigned long long, shmem, and)

--- a/oshmem/shmem/c/shmem_and.c
+++ b/oshmem/shmem/c/shmem_and.c
@@ -31,12 +31,14 @@
 #pragma weak shmem_uint_atomic_and      = pshmem_uint_atomic_and
 #pragma weak shmem_ulong_atomic_and     = pshmem_ulong_atomic_and
 #pragma weak shmem_ulonglong_atomic_and = pshmem_ulonglong_atomic_and
+
 #pragma weak shmem_ctx_int_atomic_and   = pshmem_ctx_int_atomic_and
 #pragma weak shmem_ctx_long_atomic_and  = pshmem_ctx_long_atomic_and
 #pragma weak shmem_ctx_longlong_atomic_and = pshmem_ctx_longlong_atomic_and
 #pragma weak shmem_ctx_uint_atomic_and  = pshmem_ctx_uint_atomic_and
 #pragma weak shmem_ctx_ulong_atomic_and = pshmem_ctx_ulong_atomic_and
 #pragma weak shmem_ctx_ulonglong_atomic_and = pshmem_ctx_ulonglong_atomic_and
+
 #pragma weak shmemx_int32_atomic_and    = pshmemx_int32_atomic_and
 #pragma weak shmemx_int64_atomic_and    = pshmemx_int64_atomic_and
 #pragma weak shmemx_uint32_atomic_and   = pshmemx_uint32_atomic_and

--- a/oshmem/shmem/c/shmem_cswap.c
+++ b/oshmem/shmem/c/shmem_cswap.c
@@ -71,15 +71,18 @@
 #pragma weak shmem_ctx_int_atomic_compare_swap = pshmem_ctx_int_atomic_compare_swap
 #pragma weak shmem_ctx_long_atomic_compare_swap = pshmem_ctx_long_atomic_compare_swap
 #pragma weak shmem_ctx_longlong_atomic_compare_swap = pshmem_ctx_longlong_atomic_compare_swap
+
 #pragma weak shmem_int_atomic_compare_swap = pshmem_int_atomic_compare_swap
 #pragma weak shmem_long_atomic_compare_swap = pshmem_long_atomic_compare_swap
 #pragma weak shmem_longlong_atomic_compare_swap = pshmem_longlong_atomic_compare_swap
 #pragma weak shmem_uint_atomic_compare_swap = pshmem_uint_atomic_compare_swap
 #pragma weak shmem_ulong_atomic_compare_swap = pshmem_ulong_atomic_compare_swap
 #pragma weak shmem_ulonglong_atomic_compare_swap = pshmem_ulonglong_atomic_compare_swap
+
 #pragma weak shmem_int_cswap = pshmem_int_cswap
 #pragma weak shmem_long_cswap = pshmem_long_cswap
 #pragma weak shmem_longlong_cswap = pshmem_longlong_cswap
+
 #pragma weak shmemx_int32_cswap = pshmemx_int32_cswap
 #pragma weak shmemx_int64_cswap = pshmemx_int64_cswap
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_cswap.c
+++ b/oshmem/shmem/c/shmem_cswap.c
@@ -65,12 +65,18 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
+#pragma weak shmem_ctx_uint_atomic_compare_swap = pshmem_ctx_uint_atomic_compare_swap
+#pragma weak shmem_ctx_ulong_atomic_compare_swap = pshmem_ctx_ulong_atomic_compare_swap
+#pragma weak shmem_ctx_ulonglong_atomic_compare_swap = pshmem_ctx_ulonglong_atomic_compare_swap
 #pragma weak shmem_ctx_int_atomic_compare_swap = pshmem_ctx_int_atomic_compare_swap
 #pragma weak shmem_ctx_long_atomic_compare_swap = pshmem_ctx_long_atomic_compare_swap
 #pragma weak shmem_ctx_longlong_atomic_compare_swap = pshmem_ctx_longlong_atomic_compare_swap
 #pragma weak shmem_int_atomic_compare_swap = pshmem_int_atomic_compare_swap
 #pragma weak shmem_long_atomic_compare_swap = pshmem_long_atomic_compare_swap
 #pragma weak shmem_longlong_atomic_compare_swap = pshmem_longlong_atomic_compare_swap
+#pragma weak shmem_uint_atomic_compare_swap = pshmem_uint_atomic_compare_swap
+#pragma weak shmem_ulong_atomic_compare_swap = pshmem_ulong_atomic_compare_swap
+#pragma weak shmem_ulonglong_atomic_compare_swap = pshmem_ulonglong_atomic_compare_swap
 #pragma weak shmem_int_cswap = pshmem_int_cswap
 #pragma weak shmem_long_cswap = pshmem_long_cswap
 #pragma weak shmem_longlong_cswap = pshmem_longlong_cswap
@@ -82,9 +88,15 @@
 SHMEM_CTX_TYPE_ATOMIC_COMPARE_SWAP(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_COMPARE_SWAP(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_COMPARE_SWAP(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_COMPARE_SWAP(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_COMPARE_SWAP(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_COMPARE_SWAP(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_ATOMIC_COMPARE_SWAP(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_COMPARE_SWAP(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_COMPARE_SWAP(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_COMPARE_SWAP(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_COMPARE_SWAP(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_COMPARE_SWAP(_ulonglong, unsigned long long, shmem)
 
 /* deprecated APIs */
 #define SHMEM_TYPE_CSWAP(type_name, type, prefix)                   \

--- a/oshmem/shmem/c/shmem_fadd.c
+++ b/oshmem/shmem/c/shmem_fadd.c
@@ -67,9 +67,15 @@
 #pragma weak shmem_ctx_int_atomic_fetch_add = pshmem_ctx_int_atomic_fetch_add
 #pragma weak shmem_ctx_long_atomic_fetch_add = pshmem_ctx_long_atomic_fetch_add
 #pragma weak shmem_ctx_longlong_atomic_fetch_add = pshmem_ctx_longlong_atomic_fetch_add
+#pragma weak shmem_ctx_uint_atomic_fetch_add = pshmem_ctx_uint_atomic_fetch_add
+#pragma weak shmem_ctx_ulong_atomic_fetch_add = pshmem_ctx_ulong_atomic_fetch_add
+#pragma weak shmem_ctx_ulonglong_atomic_fetch_add = pshmem_ctx_ulonglong_atomic_fetch_add
 #pragma weak shmem_int_atomic_fetch_add = pshmem_int_atomic_fetch_add
 #pragma weak shmem_long_atomic_fetch_add = pshmem_long_atomic_fetch_add
 #pragma weak shmem_longlong_atomic_fetch_add = pshmem_longlong_atomic_fetch_add
+#pragma weak shmem_uint_atomic_fetch_add = pshmem_uint_atomic_fetch_add
+#pragma weak shmem_ulong_atomic_fetch_add = pshmem_ulong_atomic_fetch_add
+#pragma weak shmem_ulonglong_atomic_fetch_add = pshmem_ulonglong_atomic_fetch_add
 #pragma weak shmem_int_fadd = pshmem_int_fadd
 #pragma weak shmem_long_fadd = pshmem_long_fadd
 #pragma weak shmem_longlong_fadd = pshmem_longlong_fadd
@@ -81,9 +87,15 @@
 SHMEM_CTX_TYPE_ATOMIC_FETCH_ADD(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH_ADD(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH_ADD(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH_ADD(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH_ADD(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH_ADD(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_ATOMIC_FETCH_ADD(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_FETCH_ADD(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_FETCH_ADD(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_FETCH_ADD(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_FETCH_ADD(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_FETCH_ADD(_ulonglong, unsigned long long, shmem)
 
 /* deprecated APIs */
 #define SHMEM_TYPE_FADD(type_name, type, prefix)                    \

--- a/oshmem/shmem/c/shmem_fadd.c
+++ b/oshmem/shmem/c/shmem_fadd.c
@@ -70,15 +70,18 @@
 #pragma weak shmem_ctx_uint_atomic_fetch_add = pshmem_ctx_uint_atomic_fetch_add
 #pragma weak shmem_ctx_ulong_atomic_fetch_add = pshmem_ctx_ulong_atomic_fetch_add
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_add = pshmem_ctx_ulonglong_atomic_fetch_add
+
 #pragma weak shmem_int_atomic_fetch_add = pshmem_int_atomic_fetch_add
 #pragma weak shmem_long_atomic_fetch_add = pshmem_long_atomic_fetch_add
 #pragma weak shmem_longlong_atomic_fetch_add = pshmem_longlong_atomic_fetch_add
 #pragma weak shmem_uint_atomic_fetch_add = pshmem_uint_atomic_fetch_add
 #pragma weak shmem_ulong_atomic_fetch_add = pshmem_ulong_atomic_fetch_add
 #pragma weak shmem_ulonglong_atomic_fetch_add = pshmem_ulonglong_atomic_fetch_add
+
 #pragma weak shmem_int_fadd = pshmem_int_fadd
 #pragma weak shmem_long_fadd = pshmem_long_fadd
 #pragma weak shmem_longlong_fadd = pshmem_longlong_fadd
+
 #pragma weak shmemx_int32_fadd = pshmemx_int32_fadd
 #pragma weak shmemx_int64_fadd = pshmemx_int64_fadd
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_fand.c
+++ b/oshmem/shmem/c/shmem_fand.c
@@ -33,12 +33,14 @@
 #pragma weak shmem_uint_atomic_fetch_and      = pshmem_uint_atomic_fetch_and
 #pragma weak shmem_ulong_atomic_fetch_and     = pshmem_ulong_atomic_fetch_and
 #pragma weak shmem_ulonglong_atomic_fetch_and = pshmem_ulonglong_atomic_fetch_and
+
 #pragma weak shmem_ctx_int_atomic_fetch_and   = pshmem_ctx_int_atomic_fetch_and
 #pragma weak shmem_ctx_long_atomic_fetch_and  = pshmem_ctx_long_atomic_fetch_and
 #pragma weak shmem_ctx_longlong_atomic_fetch_and = pshmem_ctx_longlong_atomic_fetch_and
 #pragma weak shmem_ctx_uint_atomic_fetch_and  = pshmem_ctx_uint_atomic_fetch_and
 #pragma weak shmem_ctx_ulong_atomic_fetch_and = pshmem_ctx_ulong_atomic_fetch_and
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_and = pshmem_ctx_ulonglong_atomic_fetch_and
+
 #pragma weak shmemx_int32_atomic_fetch_and    = pshmemx_int32_atomic_fetch_and
 #pragma weak shmemx_int64_atomic_fetch_and    = pshmemx_int64_atomic_fetch_and
 #pragma weak shmemx_uint32_atomic_fetch_and   = pshmemx_uint32_atomic_fetch_and

--- a/oshmem/shmem/c/shmem_fand.c
+++ b/oshmem/shmem/c/shmem_fand.c
@@ -27,9 +27,15 @@
  */
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
+#pragma weak shmem_int_atomic_fetch_and       = pshmem_int_atomic_fetch_and
+#pragma weak shmem_long_atomic_fetch_and      = pshmem_long_atomic_fetch_and
+#pragma weak shmem_longlong_atomic_fetch_and  = pshmem_longlong_atomic_fetch_and
 #pragma weak shmem_uint_atomic_fetch_and      = pshmem_uint_atomic_fetch_and
 #pragma weak shmem_ulong_atomic_fetch_and     = pshmem_ulong_atomic_fetch_and
 #pragma weak shmem_ulonglong_atomic_fetch_and = pshmem_ulonglong_atomic_fetch_and
+#pragma weak shmem_ctx_int_atomic_fetch_and   = pshmem_ctx_int_atomic_fetch_and
+#pragma weak shmem_ctx_long_atomic_fetch_and  = pshmem_ctx_long_atomic_fetch_and
+#pragma weak shmem_ctx_longlong_atomic_fetch_and = pshmem_ctx_longlong_atomic_fetch_and
 #pragma weak shmem_ctx_uint_atomic_fetch_and  = pshmem_ctx_uint_atomic_fetch_and
 #pragma weak shmem_ctx_ulong_atomic_fetch_and = pshmem_ctx_ulong_atomic_fetch_and
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_and = pshmem_ctx_ulonglong_atomic_fetch_and
@@ -42,9 +48,15 @@
 
  unsigned int shmem_uint_atomic_fand(unsigned int *target, unsigned int value, int pe);
 
+OSHMEM_TYPE_FOP(int, int, shmem, and)
+OSHMEM_TYPE_FOP(long, long, shmem, and)
+OSHMEM_TYPE_FOP(longlong, long long, shmem, and)
 OSHMEM_TYPE_FOP(uint, unsigned int, shmem, and)
 OSHMEM_TYPE_FOP(ulong, unsigned long, shmem, and)
 OSHMEM_TYPE_FOP(ulonglong, unsigned long long, shmem, and)
+OSHMEM_CTX_TYPE_FOP(int, int, shmem, and)
+OSHMEM_CTX_TYPE_FOP(long, long, shmem, and)
+OSHMEM_CTX_TYPE_FOP(longlong, long long, shmem, and)
 OSHMEM_CTX_TYPE_FOP(uint, unsigned int, shmem, and)
 OSHMEM_CTX_TYPE_FOP(ulong, unsigned long, shmem, and)
 OSHMEM_CTX_TYPE_FOP(ulonglong, unsigned long long, shmem, and)

--- a/oshmem/shmem/c/shmem_fetch.c
+++ b/oshmem/shmem/c/shmem_fetch.c
@@ -73,6 +73,7 @@
 #pragma weak shmem_ctx_ulonglong_atomic_fetch = pshmem_ctx_ulonglong_atomic_fetch
 #pragma weak shmem_ctx_double_atomic_fetch = pshmem_ctx_double_atomic_fetch
 #pragma weak shmem_ctx_float_atomic_fetch = pshmem_ctx_float_atomic_fetch
+
 #pragma weak shmem_int_atomic_fetch = pshmem_int_atomic_fetch
 #pragma weak shmem_long_atomic_fetch = pshmem_long_atomic_fetch
 #pragma weak shmem_longlong_atomic_fetch = pshmem_longlong_atomic_fetch
@@ -81,11 +82,13 @@
 #pragma weak shmem_ulonglong_atomic_fetch = pshmem_ulonglong_atomic_fetch
 #pragma weak shmem_double_atomic_fetch = pshmem_double_atomic_fetch
 #pragma weak shmem_float_atomic_fetch = pshmem_float_atomic_fetch
+
 #pragma weak shmem_int_fetch = pshmem_int_fetch
 #pragma weak shmem_long_fetch = pshmem_long_fetch
 #pragma weak shmem_longlong_fetch = pshmem_longlong_fetch
 #pragma weak shmem_double_fetch = pshmem_double_fetch
 #pragma weak shmem_float_fetch = pshmem_float_fetch
+
 #pragma weak shmemx_int32_fetch = pshmemx_int32_fetch
 #pragma weak shmemx_int64_fetch = pshmemx_int64_fetch
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_fetch.c
+++ b/oshmem/shmem/c/shmem_fetch.c
@@ -68,11 +68,17 @@
 #pragma weak shmem_ctx_int_atomic_fetch = pshmem_ctx_int_atomic_fetch
 #pragma weak shmem_ctx_long_atomic_fetch = pshmem_ctx_long_atomic_fetch
 #pragma weak shmem_ctx_longlong_atomic_fetch = pshmem_ctx_longlong_atomic_fetch
+#pragma weak shmem_ctx_uint_atomic_fetch = pshmem_ctx_uint_atomic_fetch
+#pragma weak shmem_ctx_ulong_atomic_fetch = pshmem_ctx_ulong_atomic_fetch
+#pragma weak shmem_ctx_ulonglong_atomic_fetch = pshmem_ctx_ulonglong_atomic_fetch
 #pragma weak shmem_ctx_double_atomic_fetch = pshmem_ctx_double_atomic_fetch
 #pragma weak shmem_ctx_float_atomic_fetch = pshmem_ctx_float_atomic_fetch
 #pragma weak shmem_int_atomic_fetch = pshmem_int_atomic_fetch
 #pragma weak shmem_long_atomic_fetch = pshmem_long_atomic_fetch
 #pragma weak shmem_longlong_atomic_fetch = pshmem_longlong_atomic_fetch
+#pragma weak shmem_uint_atomic_fetch = pshmem_uint_atomic_fetch
+#pragma weak shmem_ulong_atomic_fetch = pshmem_ulong_atomic_fetch
+#pragma weak shmem_ulonglong_atomic_fetch = pshmem_ulonglong_atomic_fetch
 #pragma weak shmem_double_atomic_fetch = pshmem_double_atomic_fetch
 #pragma weak shmem_float_atomic_fetch = pshmem_float_atomic_fetch
 #pragma weak shmem_int_fetch = pshmem_int_fetch
@@ -88,11 +94,17 @@
 SHMEM_CTX_TYPE_ATOMIC_FETCH(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH(_double, double, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH(_float, float, shmem)
 SHMEM_TYPE_ATOMIC_FETCH(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_FETCH(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_FETCH(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_FETCH(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_FETCH(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_FETCH(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_ATOMIC_FETCH(_double, double, shmem)
 SHMEM_TYPE_ATOMIC_FETCH(_float, float, shmem)
 

--- a/oshmem/shmem/c/shmem_finc.c
+++ b/oshmem/shmem/c/shmem_finc.c
@@ -71,15 +71,18 @@
 #pragma weak shmem_ctx_uint_atomic_fetch_inc = pshmem_ctx_uint_atomic_fetch_inc
 #pragma weak shmem_ctx_ulong_atomic_fetch_inc = pshmem_ctx_ulong_atomic_fetch_inc
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_inc = pshmem_ctx_ulonglong_atomic_fetch_inc
+
 #pragma weak shmem_int_atomic_fetch_inc = pshmem_int_atomic_fetch_inc
 #pragma weak shmem_long_atomic_fetch_inc = pshmem_long_atomic_fetch_inc
 #pragma weak shmem_longlong_atomic_fetch_inc = pshmem_longlong_atomic_fetch_inc
 #pragma weak shmem_uint_atomic_fetch_inc = pshmem_uint_atomic_fetch_inc
 #pragma weak shmem_ulong_atomic_fetch_inc = pshmem_ulong_atomic_fetch_inc
 #pragma weak shmem_ulonglong_atomic_fetch_inc = pshmem_ulonglong_atomic_fetch_inc
+
 #pragma weak shmem_int_finc = pshmem_int_finc
 #pragma weak shmem_long_finc = pshmem_long_finc
 #pragma weak shmem_longlong_finc = pshmem_longlong_finc
+
 #pragma weak shmemx_int32_finc = pshmemx_int32_finc
 #pragma weak shmemx_int64_finc = pshmemx_int64_finc
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_finc.c
+++ b/oshmem/shmem/c/shmem_finc.c
@@ -68,9 +68,15 @@
 #pragma weak shmem_ctx_int_atomic_fetch_inc = pshmem_ctx_int_atomic_fetch_inc
 #pragma weak shmem_ctx_long_atomic_fetch_inc = pshmem_ctx_long_atomic_fetch_inc
 #pragma weak shmem_ctx_longlong_atomic_fetch_inc = pshmem_ctx_longlong_atomic_fetch_inc
+#pragma weak shmem_ctx_uint_atomic_fetch_inc = pshmem_ctx_uint_atomic_fetch_inc
+#pragma weak shmem_ctx_ulong_atomic_fetch_inc = pshmem_ctx_ulong_atomic_fetch_inc
+#pragma weak shmem_ctx_ulonglong_atomic_fetch_inc = pshmem_ctx_ulonglong_atomic_fetch_inc
 #pragma weak shmem_int_atomic_fetch_inc = pshmem_int_atomic_fetch_inc
 #pragma weak shmem_long_atomic_fetch_inc = pshmem_long_atomic_fetch_inc
 #pragma weak shmem_longlong_atomic_fetch_inc = pshmem_longlong_atomic_fetch_inc
+#pragma weak shmem_uint_atomic_fetch_inc = pshmem_uint_atomic_fetch_inc
+#pragma weak shmem_ulong_atomic_fetch_inc = pshmem_ulong_atomic_fetch_inc
+#pragma weak shmem_ulonglong_atomic_fetch_inc = pshmem_ulonglong_atomic_fetch_inc
 #pragma weak shmem_int_finc = pshmem_int_finc
 #pragma weak shmem_long_finc = pshmem_long_finc
 #pragma weak shmem_longlong_finc = pshmem_longlong_finc
@@ -82,9 +88,15 @@
 SHMEM_CTX_TYPE_ATOMIC_FETCH_INC(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH_INC(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_FETCH_INC(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH_INC(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH_INC(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_FETCH_INC(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_ATOMIC_FETCH_INC(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_FETCH_INC(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_FETCH_INC(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_FETCH_INC(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_FETCH_INC(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_FETCH_INC(_ulonglong, unsigned long long, shmem)
 
 /* deprecated APIs */
 #define SHMEM_TYPE_FINC(type_name, type, prefix)                    \

--- a/oshmem/shmem/c/shmem_for.c
+++ b/oshmem/shmem/c/shmem_for.c
@@ -27,9 +27,15 @@
  */
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
+#pragma weak shmem_int_atomic_fetch_or       = pshmem_int_atomic_fetch_or
+#pragma weak shmem_long_atomic_fetch_or      = pshmem_long_atomic_fetch_or
+#pragma weak shmem_longlong_atomic_fetch_or  = pshmem_longlong_atomic_fetch_or
 #pragma weak shmem_uint_atomic_fetch_or      = pshmem_uint_atomic_fetch_or
 #pragma weak shmem_ulong_atomic_fetch_or     = pshmem_ulong_atomic_fetch_or
 #pragma weak shmem_ulonglong_atomic_fetch_or = pshmem_ulonglong_atomic_fetch_or
+#pragma weak shmem_ctx_int_atomic_fetch_or   = pshmem_ctx_int_atomic_fetch_or
+#pragma weak shmem_ctx_long_atomic_fetch_or  = pshmem_ctx_long_atomic_fetch_or
+#pragma weak shmem_ctx_longlong_atomic_fetch_or = pshmem_ctx_longlong_atomic_fetch_or
 #pragma weak shmem_ctx_uint_atomic_fetch_or  = pshmem_ctx_uint_atomic_fetch_or
 #pragma weak shmem_ctx_ulong_atomic_fetch_or = pshmem_ctx_ulong_atomic_fetch_or
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_or = pshmem_ctx_ulonglong_atomic_fetch_or
@@ -40,9 +46,15 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+OSHMEM_TYPE_FOP(int, int, shmem, or)
+OSHMEM_TYPE_FOP(long, long, shmem, or)
+OSHMEM_TYPE_FOP(longlong, long long, shmem, or)
 OSHMEM_TYPE_FOP(uint, unsigned int, shmem, or)
 OSHMEM_TYPE_FOP(ulong, unsigned long, shmem, or)
 OSHMEM_TYPE_FOP(ulonglong, unsigned long long, shmem, or)
+OSHMEM_CTX_TYPE_FOP(int, int, shmem, or)
+OSHMEM_CTX_TYPE_FOP(long, long, shmem, or)
+OSHMEM_CTX_TYPE_FOP(longlong, long long, shmem, or)
 OSHMEM_CTX_TYPE_FOP(uint, unsigned int, shmem, or)
 OSHMEM_CTX_TYPE_FOP(ulong, unsigned long, shmem, or)
 OSHMEM_CTX_TYPE_FOP(ulonglong, unsigned long long, shmem, or)

--- a/oshmem/shmem/c/shmem_for.c
+++ b/oshmem/shmem/c/shmem_for.c
@@ -33,12 +33,14 @@
 #pragma weak shmem_uint_atomic_fetch_or      = pshmem_uint_atomic_fetch_or
 #pragma weak shmem_ulong_atomic_fetch_or     = pshmem_ulong_atomic_fetch_or
 #pragma weak shmem_ulonglong_atomic_fetch_or = pshmem_ulonglong_atomic_fetch_or
+
 #pragma weak shmem_ctx_int_atomic_fetch_or   = pshmem_ctx_int_atomic_fetch_or
 #pragma weak shmem_ctx_long_atomic_fetch_or  = pshmem_ctx_long_atomic_fetch_or
 #pragma weak shmem_ctx_longlong_atomic_fetch_or = pshmem_ctx_longlong_atomic_fetch_or
 #pragma weak shmem_ctx_uint_atomic_fetch_or  = pshmem_ctx_uint_atomic_fetch_or
 #pragma weak shmem_ctx_ulong_atomic_fetch_or = pshmem_ctx_ulong_atomic_fetch_or
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_or = pshmem_ctx_ulonglong_atomic_fetch_or
+
 #pragma weak shmemx_int32_atomic_fetch_or    = pshmemx_int32_atomic_fetch_or
 #pragma weak shmemx_int64_atomic_fetch_or    = pshmemx_int64_atomic_fetch_or
 #pragma weak shmemx_uint32_atomic_fetch_or   = pshmemx_uint32_atomic_fetch_or

--- a/oshmem/shmem/c/shmem_fxor.c
+++ b/oshmem/shmem/c/shmem_fxor.c
@@ -33,12 +33,14 @@
 #pragma weak shmem_uint_atomic_fetch_xor      = pshmem_uint_atomic_fetch_xor
 #pragma weak shmem_ulong_atomic_fetch_xor     = pshmem_ulong_atomic_fetch_xor
 #pragma weak shmem_ulonglong_atomic_fetch_xor = pshmem_ulonglong_atomic_fetch_xor
+
 #pragma weak shmem_ctx_int_atomic_fetch_xor   = pshmem_ctx_int_atomic_fetch_xor
 #pragma weak shmem_ctx_long_atomic_fetch_xor  = pshmem_ctx_long_atomic_fetch_xor
 #pragma weak shmem_ctx_longlong_atomic_fetch_xor = pshmem_ctx_longlong_atomic_fetch_xor
 #pragma weak shmem_ctx_uint_atomic_fetch_xor  = pshmem_ctx_uint_atomic_fetch_xor
 #pragma weak shmem_ctx_ulong_atomic_fetch_xor = pshmem_ctx_ulong_atomic_fetch_xor
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_xor = pshmem_ctx_ulonglong_atomic_fetch_xor
+
 #pragma weak shmemx_int32_atomic_fetch_xor    = pshmemx_int32_atomic_fetch_xor
 #pragma weak shmemx_int64_atomic_fetch_xor    = pshmemx_int64_atomic_fetch_xor
 #pragma weak shmemx_uint32_atomic_fetch_xor   = pshmemx_uint32_atomic_fetch_xor

--- a/oshmem/shmem/c/shmem_fxor.c
+++ b/oshmem/shmem/c/shmem_fxor.c
@@ -27,9 +27,15 @@
  */
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
+#pragma weak shmem_int_atomic_fetch_xor       = pshmem_int_atomic_fetch_xor
+#pragma weak shmem_long_atomic_fetch_xor      = pshmem_long_atomic_fetch_xor
+#pragma weak shmem_longlong_atomic_fetch_xor  = pshmem_longlong_atomic_fetch_xor
 #pragma weak shmem_uint_atomic_fetch_xor      = pshmem_uint_atomic_fetch_xor
 #pragma weak shmem_ulong_atomic_fetch_xor     = pshmem_ulong_atomic_fetch_xor
 #pragma weak shmem_ulonglong_atomic_fetch_xor = pshmem_ulonglong_atomic_fetch_xor
+#pragma weak shmem_ctx_int_atomic_fetch_xor   = pshmem_ctx_int_atomic_fetch_xor
+#pragma weak shmem_ctx_long_atomic_fetch_xor  = pshmem_ctx_long_atomic_fetch_xor
+#pragma weak shmem_ctx_longlong_atomic_fetch_xor = pshmem_ctx_longlong_atomic_fetch_xor
 #pragma weak shmem_ctx_uint_atomic_fetch_xor  = pshmem_ctx_uint_atomic_fetch_xor
 #pragma weak shmem_ctx_ulong_atomic_fetch_xor = pshmem_ctx_ulong_atomic_fetch_xor
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_xor = pshmem_ctx_ulonglong_atomic_fetch_xor
@@ -40,9 +46,15 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+OSHMEM_TYPE_FOP(int, int, shmem, xor)
+OSHMEM_TYPE_FOP(long, long, shmem, xor)
+OSHMEM_TYPE_FOP(longlong, long long, shmem, xor)
 OSHMEM_TYPE_FOP(uint, unsigned int, shmem, xor)
 OSHMEM_TYPE_FOP(ulong, unsigned long, shmem, xor)
 OSHMEM_TYPE_FOP(ulonglong, unsigned long long, shmem, xor)
+OSHMEM_CTX_TYPE_FOP(int, int, shmem, xor)
+OSHMEM_CTX_TYPE_FOP(long, long, shmem, xor)
+OSHMEM_CTX_TYPE_FOP(longlong, long long, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(uint, unsigned int, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(ulong, unsigned long, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(ulonglong, unsigned long long, shmem, xor)

--- a/oshmem/shmem/c/shmem_g.c
+++ b/oshmem/shmem/c/shmem_g.c
@@ -63,6 +63,11 @@
 #pragma weak shmem_ctx_int_g = pshmem_ctx_int_g
 #pragma weak shmem_ctx_long_g = pshmem_ctx_long_g
 #pragma weak shmem_ctx_longlong_g = pshmem_ctx_longlong_g
+#pragma weak shmem_ctx_uchar_g = pshmem_ctx_uchar_g
+#pragma weak shmem_ctx_ushort_g = pshmem_ctx_ushort_g
+#pragma weak shmem_ctx_uint_g = pshmem_ctx_uint_g
+#pragma weak shmem_ctx_ulong_g = pshmem_ctx_ulong_g
+#pragma weak shmem_ctx_ulonglong_g = pshmem_ctx_ulonglong_g
 #pragma weak shmem_ctx_float_g = pshmem_ctx_float_g
 #pragma weak shmem_ctx_double_g = pshmem_ctx_double_g
 #pragma weak shmem_ctx_longdouble_g = pshmem_ctx_longdouble_g
@@ -71,6 +76,11 @@
 #pragma weak shmem_int_g = pshmem_int_g
 #pragma weak shmem_long_g = pshmem_long_g
 #pragma weak shmem_longlong_g = pshmem_longlong_g
+#pragma weak shmem_uchar_g = pshmem_uchar_g
+#pragma weak shmem_ushort_g = pshmem_ushort_g
+#pragma weak shmem_uint_g = pshmem_uint_g
+#pragma weak shmem_ulong_g = pshmem_ulong_g
+#pragma weak shmem_ulonglong_g = pshmem_ulonglong_g
 #pragma weak shmem_float_g = pshmem_float_g
 #pragma weak shmem_double_g = pshmem_double_g
 #pragma weak shmem_longdouble_g = pshmem_longdouble_g
@@ -85,6 +95,12 @@ SHMEM_CTX_TYPE_G(_short, short, shmem)
 SHMEM_CTX_TYPE_G(_int, int, shmem)
 SHMEM_CTX_TYPE_G(_long, long, shmem)
 SHMEM_CTX_TYPE_G(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_G(_schar, signed char, shmem)
+SHMEM_CTX_TYPE_G(_uchar, unsigned char, shmem)
+SHMEM_CTX_TYPE_G(_ushort, unsigned short, shmem)
+SHMEM_CTX_TYPE_G(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_G(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_G(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_G(_float, float, shmem)
 SHMEM_CTX_TYPE_G(_double, double, shmem)
 SHMEM_CTX_TYPE_G(_longdouble, long double, shmem)
@@ -93,6 +109,12 @@ SHMEM_TYPE_G(_short, short, shmem)
 SHMEM_TYPE_G(_int, int, shmem)
 SHMEM_TYPE_G(_long, long, shmem)
 SHMEM_TYPE_G(_longlong, long long, shmem)
+SHMEM_TYPE_G(_schar, signed char, shmem)
+SHMEM_TYPE_G(_uchar, unsigned char, shmem)
+SHMEM_TYPE_G(_ushort, unsigned short, shmem)
+SHMEM_TYPE_G(_uint, unsigned int, shmem)
+SHMEM_TYPE_G(_ulong, unsigned long, shmem)
+SHMEM_TYPE_G(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_G(_float, float, shmem)
 SHMEM_TYPE_G(_double, double, shmem)
 SHMEM_TYPE_G(_longdouble, long double, shmem)

--- a/oshmem/shmem/c/shmem_g.c
+++ b/oshmem/shmem/c/shmem_g.c
@@ -71,6 +71,7 @@
 #pragma weak shmem_ctx_float_g = pshmem_ctx_float_g
 #pragma weak shmem_ctx_double_g = pshmem_ctx_double_g
 #pragma weak shmem_ctx_longdouble_g = pshmem_ctx_longdouble_g
+
 #pragma weak shmem_char_g = pshmem_char_g
 #pragma weak shmem_short_g = pshmem_short_g
 #pragma weak shmem_int_g = pshmem_int_g
@@ -84,6 +85,7 @@
 #pragma weak shmem_float_g = pshmem_float_g
 #pragma weak shmem_double_g = pshmem_double_g
 #pragma weak shmem_longdouble_g = pshmem_longdouble_g
+
 #pragma weak shmemx_int16_g = pshmemx_int16_g
 #pragma weak shmemx_int32_g = pshmemx_int32_g
 #pragma weak shmemx_int64_g = pshmemx_int64_g

--- a/oshmem/shmem/c/shmem_get.c
+++ b/oshmem/shmem/c/shmem_get.c
@@ -71,6 +71,7 @@
 #pragma weak shmem_ctx_float_get = pshmem_ctx_float_get
 #pragma weak shmem_ctx_double_get = pshmem_ctx_double_get
 #pragma weak shmem_ctx_longdouble_get = pshmem_ctx_longdouble_get
+
 #pragma weak shmem_char_get = pshmem_char_get
 #pragma weak shmem_short_get = pshmem_short_get
 #pragma weak shmem_int_get = pshmem_int_get
@@ -85,12 +86,14 @@
 #pragma weak shmem_float_get = pshmem_float_get
 #pragma weak shmem_double_get = pshmem_double_get
 #pragma weak shmem_longdouble_get = pshmem_longdouble_get
+
 #pragma weak shmem_ctx_getmem = pshmem_ctx_getmem
 #pragma weak shmem_ctx_get8 = pshmem_ctx_get8
 #pragma weak shmem_ctx_get16 = pshmem_ctx_get16
 #pragma weak shmem_ctx_get32 = pshmem_ctx_get32
 #pragma weak shmem_ctx_get64 = pshmem_ctx_get64
 #pragma weak shmem_ctx_get128 = pshmem_ctx_get128
+
 #pragma weak shmem_getmem = pshmem_getmem
 #pragma weak shmem_get8 = pshmem_get8
 #pragma weak shmem_get16 = pshmem_get16

--- a/oshmem/shmem/c/shmem_get.c
+++ b/oshmem/shmem/c/shmem_get.c
@@ -62,6 +62,12 @@
 #pragma weak shmem_ctx_int_get = pshmem_ctx_int_get
 #pragma weak shmem_ctx_long_get = pshmem_ctx_long_get
 #pragma weak shmem_ctx_longlong_get = pshmem_ctx_longlong_get
+#pragma weak shmem_ctx_schar_get = pshmem_ctx_schar_get
+#pragma weak shmem_ctx_uchar_get = pshmem_ctx_uchar_get
+#pragma weak shmem_ctx_ushort_get = pshmem_ctx_ushort_get
+#pragma weak shmem_ctx_uint_get = pshmem_ctx_uint_get
+#pragma weak shmem_ctx_ulong_get = pshmem_ctx_ulong_get
+#pragma weak shmem_ctx_ulonglong_get = pshmem_ctx_ulonglong_get
 #pragma weak shmem_ctx_float_get = pshmem_ctx_float_get
 #pragma weak shmem_ctx_double_get = pshmem_ctx_double_get
 #pragma weak shmem_ctx_longdouble_get = pshmem_ctx_longdouble_get
@@ -70,6 +76,12 @@
 #pragma weak shmem_int_get = pshmem_int_get
 #pragma weak shmem_long_get = pshmem_long_get
 #pragma weak shmem_longlong_get = pshmem_longlong_get
+#pragma weak shmem_schar_get = pshmem_schar_get
+#pragma weak shmem_uchar_get = pshmem_uchar_get
+#pragma weak shmem_ushort_get = pshmem_ushort_get
+#pragma weak shmem_uint_get = pshmem_uint_get
+#pragma weak shmem_ulong_get = pshmem_ulong_get
+#pragma weak shmem_ulonglong_get = pshmem_ulonglong_get
 #pragma weak shmem_float_get = pshmem_float_get
 #pragma weak shmem_double_get = pshmem_double_get
 #pragma weak shmem_longdouble_get = pshmem_longdouble_get
@@ -93,6 +105,12 @@ SHMEM_CTX_TYPE_GET(_short, short)
 SHMEM_CTX_TYPE_GET(_int, int)
 SHMEM_CTX_TYPE_GET(_long, long)
 SHMEM_CTX_TYPE_GET(_longlong, long long)
+SHMEM_CTX_TYPE_GET(_schar, signed char)
+SHMEM_CTX_TYPE_GET(_uchar, unsigned char)
+SHMEM_CTX_TYPE_GET(_ushort, unsigned short)
+SHMEM_CTX_TYPE_GET(_uint, unsigned int)
+SHMEM_CTX_TYPE_GET(_ulong, unsigned long)
+SHMEM_CTX_TYPE_GET(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_GET(_float, float)
 SHMEM_CTX_TYPE_GET(_double, double)
 SHMEM_CTX_TYPE_GET(_longdouble, long double)
@@ -101,6 +119,12 @@ SHMEM_TYPE_GET(_short, short)
 SHMEM_TYPE_GET(_int, int)
 SHMEM_TYPE_GET(_long, long)
 SHMEM_TYPE_GET(_longlong, long long)
+SHMEM_TYPE_GET(_schar, signed char)
+SHMEM_TYPE_GET(_uchar, unsigned char)
+SHMEM_TYPE_GET(_ushort, unsigned short)
+SHMEM_TYPE_GET(_uint, unsigned int)
+SHMEM_TYPE_GET(_ulong, unsigned long)
+SHMEM_TYPE_GET(_ulonglong, unsigned long long)
 SHMEM_TYPE_GET(_float, float)
 SHMEM_TYPE_GET(_double, double)
 SHMEM_TYPE_GET(_longdouble, long double)

--- a/oshmem/shmem/c/shmem_get_nb.c
+++ b/oshmem/shmem/c/shmem_get_nb.c
@@ -62,6 +62,12 @@
 #pragma weak shmem_ctx_int_get_nbi = pshmem_ctx_int_get_nbi
 #pragma weak shmem_ctx_long_get_nbi = pshmem_ctx_long_get_nbi
 #pragma weak shmem_ctx_longlong_get_nbi = pshmem_ctx_longlong_get_nbi
+#pragma weak shmem_ctx_schar_get_nbi = pshmem_ctx_schar_get_nbi
+#pragma weak shmem_ctx_uchar_get_nbi = pshmem_ctx_uchar_get_nbi
+#pragma weak shmem_ctx_ushort_get_nbi = pshmem_ctx_ushort_get_nbi
+#pragma weak shmem_ctx_uint_get_nbi = pshmem_ctx_uint_get_nbi
+#pragma weak shmem_ctx_ulong_get_nbi = pshmem_ctx_ulong_get_nbi
+#pragma weak shmem_ctx_ulonglong_get_nbi = pshmem_ctx_ulonglong_get_nbi
 #pragma weak shmem_ctx_float_get_nbi = pshmem_ctx_float_get_nbi
 #pragma weak shmem_ctx_double_get_nbi = pshmem_ctx_double_get_nbi
 #pragma weak shmem_ctx_longdouble_get_nbi = pshmem_ctx_longdouble_get_nbi
@@ -70,6 +76,12 @@
 #pragma weak shmem_int_get_nbi = pshmem_int_get_nbi
 #pragma weak shmem_long_get_nbi = pshmem_long_get_nbi
 #pragma weak shmem_longlong_get_nbi = pshmem_longlong_get_nbi
+#pragma weak shmem_schar_get_nbi = pshmem_schar_get_nbi
+#pragma weak shmem_uchar_get_nbi = pshmem_uchar_get_nbi
+#pragma weak shmem_ushort_get_nbi = pshmem_ushort_get_nbi
+#pragma weak shmem_uint_get_nbi = pshmem_uint_get_nbi
+#pragma weak shmem_ulong_get_nbi = pshmem_ulong_get_nbi
+#pragma weak shmem_ulonglong_get_nbi = pshmem_ulonglong_get_nbi
 #pragma weak shmem_float_get_nbi = pshmem_float_get_nbi
 #pragma weak shmem_double_get_nbi = pshmem_double_get_nbi
 #pragma weak shmem_longdouble_get_nbi = pshmem_longdouble_get_nbi
@@ -93,6 +105,12 @@ SHMEM_CTX_TYPE_GET_NB(_short, short)
 SHMEM_CTX_TYPE_GET_NB(_int, int)
 SHMEM_CTX_TYPE_GET_NB(_long, long)
 SHMEM_CTX_TYPE_GET_NB(_longlong, long long)
+SHMEM_CTX_TYPE_GET_NB(_schar, signed char)
+SHMEM_CTX_TYPE_GET_NB(_uchar, unsigned char)
+SHMEM_CTX_TYPE_GET_NB(_ushort, unsigned short)
+SHMEM_CTX_TYPE_GET_NB(_uint, unsigned int)
+SHMEM_CTX_TYPE_GET_NB(_ulong, unsigned long)
+SHMEM_CTX_TYPE_GET_NB(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_GET_NB(_float, float)
 SHMEM_CTX_TYPE_GET_NB(_double, double)
 SHMEM_CTX_TYPE_GET_NB(_longdouble, long double)
@@ -101,6 +119,12 @@ SHMEM_TYPE_GET_NB(_short, short)
 SHMEM_TYPE_GET_NB(_int, int)
 SHMEM_TYPE_GET_NB(_long, long)
 SHMEM_TYPE_GET_NB(_longlong, long long)
+SHMEM_TYPE_GET_NB(_schar, signed char)
+SHMEM_TYPE_GET_NB(_uchar, unsigned char)
+SHMEM_TYPE_GET_NB(_ushort, unsigned short)
+SHMEM_TYPE_GET_NB(_uint, unsigned int)
+SHMEM_TYPE_GET_NB(_ulong, unsigned long)
+SHMEM_TYPE_GET_NB(_ulonglong, unsigned long long)
 SHMEM_TYPE_GET_NB(_float, float)
 SHMEM_TYPE_GET_NB(_double, double)
 SHMEM_TYPE_GET_NB(_longdouble, long double)

--- a/oshmem/shmem/c/shmem_get_nb.c
+++ b/oshmem/shmem/c/shmem_get_nb.c
@@ -71,6 +71,7 @@
 #pragma weak shmem_ctx_float_get_nbi = pshmem_ctx_float_get_nbi
 #pragma weak shmem_ctx_double_get_nbi = pshmem_ctx_double_get_nbi
 #pragma weak shmem_ctx_longdouble_get_nbi = pshmem_ctx_longdouble_get_nbi
+
 #pragma weak shmem_char_get_nbi = pshmem_char_get_nbi
 #pragma weak shmem_short_get_nbi = pshmem_short_get_nbi
 #pragma weak shmem_int_get_nbi = pshmem_int_get_nbi
@@ -85,12 +86,14 @@
 #pragma weak shmem_float_get_nbi = pshmem_float_get_nbi
 #pragma weak shmem_double_get_nbi = pshmem_double_get_nbi
 #pragma weak shmem_longdouble_get_nbi = pshmem_longdouble_get_nbi
+
 #pragma weak shmem_ctx_get8_nbi = pshmem_ctx_get8_nbi
 #pragma weak shmem_ctx_get16_nbi = pshmem_ctx_get16_nbi
 #pragma weak shmem_ctx_get32_nbi = pshmem_ctx_get32_nbi
 #pragma weak shmem_ctx_get64_nbi = pshmem_ctx_get64_nbi
 #pragma weak shmem_ctx_get128_nbi = pshmem_ctx_get128_nbi
 #pragma weak shmem_ctx_getmem_nbi = pshmem_ctx_getmem_nbi
+
 #pragma weak shmem_get8_nbi = pshmem_get8_nbi
 #pragma weak shmem_get16_nbi = pshmem_get16_nbi
 #pragma weak shmem_get32_nbi = pshmem_get32_nbi

--- a/oshmem/shmem/c/shmem_iget.c
+++ b/oshmem/shmem/c/shmem_iget.c
@@ -67,6 +67,12 @@
 #pragma weak shmem_ctx_int_iget = pshmem_ctx_int_iget
 #pragma weak shmem_ctx_long_iget = pshmem_ctx_long_iget
 #pragma weak shmem_ctx_longlong_iget = pshmem_ctx_longlong_iget
+#pragma weak shmem_ctx_schar_iget = pshmem_ctx_schar_iget
+#pragma weak shmem_ctx_uchar_iget = pshmem_ctx_uchar_iget
+#pragma weak shmem_ctx_ushort_iget = pshmem_ctx_ushort_iget
+#pragma weak shmem_ctx_uint_iget = pshmem_ctx_uint_iget
+#pragma weak shmem_ctx_ulong_iget = pshmem_ctx_ulong_iget
+#pragma weak shmem_ctx_ulonglong_iget = pshmem_ctx_ulonglong_iget
 #pragma weak shmem_ctx_float_iget = pshmem_ctx_float_iget
 #pragma weak shmem_ctx_double_iget = pshmem_ctx_double_iget
 #pragma weak shmem_ctx_longdouble_iget = pshmem_ctx_longdouble_iget
@@ -75,6 +81,12 @@
 #pragma weak shmem_int_iget = pshmem_int_iget
 #pragma weak shmem_long_iget = pshmem_long_iget
 #pragma weak shmem_longlong_iget = pshmem_longlong_iget
+#pragma weak shmem_schar_iget = pshmem_schar_iget
+#pragma weak shmem_uchar_iget = pshmem_uchar_iget
+#pragma weak shmem_ushort_iget = pshmem_ushort_iget
+#pragma weak shmem_uint_iget = pshmem_uint_iget
+#pragma weak shmem_ulong_iget = pshmem_ulong_iget
+#pragma weak shmem_ulonglong_iget = pshmem_ulonglong_iget
 #pragma weak shmem_float_iget = pshmem_float_iget
 #pragma weak shmem_double_iget = pshmem_double_iget
 #pragma weak shmem_longdouble_iget = pshmem_longdouble_iget
@@ -96,6 +108,12 @@ SHMEM_CTX_TYPE_IGET(_short, short)
 SHMEM_CTX_TYPE_IGET(_int, int)
 SHMEM_CTX_TYPE_IGET(_long, long)
 SHMEM_CTX_TYPE_IGET(_longlong, long long)
+SHMEM_CTX_TYPE_IGET(_schar, signed char)
+SHMEM_CTX_TYPE_IGET(_uchar, unsigned char)
+SHMEM_CTX_TYPE_IGET(_ushort, unsigned short)
+SHMEM_CTX_TYPE_IGET(_uint, unsigned int)
+SHMEM_CTX_TYPE_IGET(_ulong, unsigned long)
+SHMEM_CTX_TYPE_IGET(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_IGET(_float, float)
 SHMEM_CTX_TYPE_IGET(_double, double)
 SHMEM_CTX_TYPE_IGET(_longdouble, long double)
@@ -104,6 +122,12 @@ SHMEM_TYPE_IGET(_short, short)
 SHMEM_TYPE_IGET(_int, int)
 SHMEM_TYPE_IGET(_long, long)
 SHMEM_TYPE_IGET(_longlong, long long)
+SHMEM_TYPE_IGET(_schar, signed char)
+SHMEM_TYPE_IGET(_uchar, unsigned char)
+SHMEM_TYPE_IGET(_ushort, unsigned short)
+SHMEM_TYPE_IGET(_uint, unsigned int)
+SHMEM_TYPE_IGET(_ulong, unsigned long)
+SHMEM_TYPE_IGET(_ulonglong, unsigned long long)
 SHMEM_TYPE_IGET(_float, float)
 SHMEM_TYPE_IGET(_double, double)
 SHMEM_TYPE_IGET(_longdouble, long double)

--- a/oshmem/shmem/c/shmem_iget.c
+++ b/oshmem/shmem/c/shmem_iget.c
@@ -76,6 +76,7 @@
 #pragma weak shmem_ctx_float_iget = pshmem_ctx_float_iget
 #pragma weak shmem_ctx_double_iget = pshmem_ctx_double_iget
 #pragma weak shmem_ctx_longdouble_iget = pshmem_ctx_longdouble_iget
+
 #pragma weak shmem_char_iget = pshmem_char_iget
 #pragma weak shmem_short_iget = pshmem_short_iget
 #pragma weak shmem_int_iget = pshmem_int_iget
@@ -90,11 +91,13 @@
 #pragma weak shmem_float_iget = pshmem_float_iget
 #pragma weak shmem_double_iget = pshmem_double_iget
 #pragma weak shmem_longdouble_iget = pshmem_longdouble_iget
+
 #pragma weak shmem_ctx_iget8 = pshmem_ctx_iget8
 #pragma weak shmem_ctx_iget16 = pshmem_ctx_iget16
 #pragma weak shmem_ctx_iget32 = pshmem_ctx_iget32
 #pragma weak shmem_ctx_iget64 = pshmem_ctx_iget64
 #pragma weak shmem_ctx_iget128 = pshmem_ctx_iget128
+
 #pragma weak shmem_iget8 = pshmem_iget8
 #pragma weak shmem_iget16 = pshmem_iget16
 #pragma weak shmem_iget32 = pshmem_iget32

--- a/oshmem/shmem/c/shmem_inc.c
+++ b/oshmem/shmem/c/shmem_inc.c
@@ -63,9 +63,15 @@
 #pragma weak shmem_ctx_int_atomic_inc = pshmem_ctx_int_atomic_inc
 #pragma weak shmem_ctx_long_atomic_inc = pshmem_ctx_long_atomic_inc
 #pragma weak shmem_ctx_longlong_atomic_inc = pshmem_ctx_longlong_atomic_inc
+#pragma weak shmem_ctx_uint_atomic_inc = pshmem_ctx_uint_atomic_inc
+#pragma weak shmem_ctx_ulong_atomic_inc = pshmem_ctx_ulong_atomic_inc
+#pragma weak shmem_ctx_ulonglong_atomic_inc = pshmem_ctx_ulonglong_atomic_inc
 #pragma weak shmem_int_atomic_inc = pshmem_int_atomic_inc
 #pragma weak shmem_long_atomic_inc = pshmem_long_atomic_inc
 #pragma weak shmem_longlong_atomic_inc = pshmem_longlong_atomic_inc
+#pragma weak shmem_uint_atomic_inc = pshmem_uint_atomic_inc
+#pragma weak shmem_ulong_atomic_inc = pshmem_ulong_atomic_inc
+#pragma weak shmem_ulonglong_atomic_inc = pshmem_ulonglong_atomic_inc
 #pragma weak shmem_int_inc = pshmem_int_inc
 #pragma weak shmem_long_inc = pshmem_long_inc
 #pragma weak shmem_longlong_inc = pshmem_longlong_inc
@@ -77,14 +83,20 @@
 SHMEM_CTX_TYPE_ATOMIC_INC(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_INC(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_INC(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_INC(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_INC(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_INC(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_ATOMIC_INC(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_INC(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_INC(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_INC(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_INC(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_INC(_ulonglong, unsigned long long, shmem)
 
 #define SHMEM_TYPE_INC(type_name, type, prefix)                     \
     void prefix##type_name##_inc(type *target, int pe)              \
     {                                                               \
-        DO_SHMEM_TYPE_ATOMIC_INC(oshmem_ctx_default, type_name,      \
+        DO_SHMEM_TYPE_ATOMIC_INC(oshmem_ctx_default, type_name,     \
                                  type, target, pe);                 \
         return ;                                                    \
     }

--- a/oshmem/shmem/c/shmem_inc.c
+++ b/oshmem/shmem/c/shmem_inc.c
@@ -66,15 +66,18 @@
 #pragma weak shmem_ctx_uint_atomic_inc = pshmem_ctx_uint_atomic_inc
 #pragma weak shmem_ctx_ulong_atomic_inc = pshmem_ctx_ulong_atomic_inc
 #pragma weak shmem_ctx_ulonglong_atomic_inc = pshmem_ctx_ulonglong_atomic_inc
+
 #pragma weak shmem_int_atomic_inc = pshmem_int_atomic_inc
 #pragma weak shmem_long_atomic_inc = pshmem_long_atomic_inc
 #pragma weak shmem_longlong_atomic_inc = pshmem_longlong_atomic_inc
 #pragma weak shmem_uint_atomic_inc = pshmem_uint_atomic_inc
 #pragma weak shmem_ulong_atomic_inc = pshmem_ulong_atomic_inc
 #pragma weak shmem_ulonglong_atomic_inc = pshmem_ulonglong_atomic_inc
+
 #pragma weak shmem_int_inc = pshmem_int_inc
 #pragma weak shmem_long_inc = pshmem_long_inc
 #pragma weak shmem_longlong_inc = pshmem_longlong_inc
+
 #pragma weak shmemx_int32_inc = pshmemx_int32_inc
 #pragma weak shmemx_int64_inc = pshmemx_int64_inc
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_iput.c
+++ b/oshmem/shmem/c/shmem_iput.c
@@ -77,6 +77,7 @@
 #pragma weak shmem_ctx_float_iput = pshmem_ctx_float_iput
 #pragma weak shmem_ctx_double_iput = pshmem_ctx_double_iput
 #pragma weak shmem_ctx_longdouble_iput = pshmem_ctx_longdouble_iput
+
 #pragma weak shmem_char_iput = pshmem_char_iput
 #pragma weak shmem_short_iput = pshmem_short_iput
 #pragma weak shmem_int_iput = pshmem_int_iput
@@ -91,11 +92,13 @@
 #pragma weak shmem_float_iput = pshmem_float_iput
 #pragma weak shmem_double_iput = pshmem_double_iput
 #pragma weak shmem_longdouble_iput = pshmem_longdouble_iput
+
 #pragma weak shmem_ctx_iput8 = pshmem_ctx_iput8
 #pragma weak shmem_ctx_iput16 = pshmem_ctx_iput16
 #pragma weak shmem_ctx_iput32 = pshmem_ctx_iput32
 #pragma weak shmem_ctx_iput64 = pshmem_ctx_iput64
 #pragma weak shmem_ctx_iput128 = pshmem_ctx_iput128
+
 #pragma weak shmem_iput8 = pshmem_iput8
 #pragma weak shmem_iput16 = pshmem_iput16
 #pragma weak shmem_iput32 = pshmem_iput32

--- a/oshmem/shmem/c/shmem_iput.c
+++ b/oshmem/shmem/c/shmem_iput.c
@@ -68,6 +68,12 @@
 #pragma weak shmem_ctx_int_iput = pshmem_ctx_int_iput
 #pragma weak shmem_ctx_long_iput = pshmem_ctx_long_iput
 #pragma weak shmem_ctx_longlong_iput = pshmem_ctx_longlong_iput
+#pragma weak shmem_ctx_schar_iput = pshmem_ctx_schar_iput
+#pragma weak shmem_ctx_uchar_iput = pshmem_ctx_uchar_iput
+#pragma weak shmem_ctx_ushort_iput = pshmem_ctx_ushort_iput
+#pragma weak shmem_ctx_uint_iput = pshmem_ctx_uint_iput
+#pragma weak shmem_ctx_ulong_iput = pshmem_ctx_ulong_iput
+#pragma weak shmem_ctx_ulonglong_iput = pshmem_ctx_ulonglong_iput
 #pragma weak shmem_ctx_float_iput = pshmem_ctx_float_iput
 #pragma weak shmem_ctx_double_iput = pshmem_ctx_double_iput
 #pragma weak shmem_ctx_longdouble_iput = pshmem_ctx_longdouble_iput
@@ -76,6 +82,12 @@
 #pragma weak shmem_int_iput = pshmem_int_iput
 #pragma weak shmem_long_iput = pshmem_long_iput
 #pragma weak shmem_longlong_iput = pshmem_longlong_iput
+#pragma weak shmem_schar_iput = pshmem_schar_iput
+#pragma weak shmem_uchar_iput = pshmem_uchar_iput
+#pragma weak shmem_ushort_iput = pshmem_ushort_iput
+#pragma weak shmem_uint_iput = pshmem_uint_iput
+#pragma weak shmem_ulong_iput = pshmem_ulong_iput
+#pragma weak shmem_ulonglong_iput = pshmem_ulonglong_iput
 #pragma weak shmem_float_iput = pshmem_float_iput
 #pragma weak shmem_double_iput = pshmem_double_iput
 #pragma weak shmem_longdouble_iput = pshmem_longdouble_iput
@@ -97,6 +109,12 @@ SHMEM_CTX_TYPE_IPUT(_short, short)
 SHMEM_CTX_TYPE_IPUT(_int, int)
 SHMEM_CTX_TYPE_IPUT(_long, long)
 SHMEM_CTX_TYPE_IPUT(_longlong, long long)
+SHMEM_CTX_TYPE_IPUT(_schar, signed char)
+SHMEM_CTX_TYPE_IPUT(_uchar, unsigned char)
+SHMEM_CTX_TYPE_IPUT(_ushort, unsigned short)
+SHMEM_CTX_TYPE_IPUT(_uint, unsigned int)
+SHMEM_CTX_TYPE_IPUT(_ulong, unsigned long)
+SHMEM_CTX_TYPE_IPUT(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_IPUT(_float, float)
 SHMEM_CTX_TYPE_IPUT(_double, double)
 SHMEM_CTX_TYPE_IPUT(_longdouble, long double)
@@ -105,6 +123,12 @@ SHMEM_TYPE_IPUT(_short, short)
 SHMEM_TYPE_IPUT(_int, int)
 SHMEM_TYPE_IPUT(_long, long)
 SHMEM_TYPE_IPUT(_longlong, long long)
+SHMEM_TYPE_IPUT(_schar, signed char)
+SHMEM_TYPE_IPUT(_uchar, unsigned char)
+SHMEM_TYPE_IPUT(_ushort, unsigned short)
+SHMEM_TYPE_IPUT(_uint, unsigned int)
+SHMEM_TYPE_IPUT(_ulong, unsigned long)
+SHMEM_TYPE_IPUT(_ulonglong, unsigned long long)
 SHMEM_TYPE_IPUT(_float, float)
 SHMEM_TYPE_IPUT(_double, double)
 SHMEM_TYPE_IPUT(_longdouble, long double)

--- a/oshmem/shmem/c/shmem_or.c
+++ b/oshmem/shmem/c/shmem_or.c
@@ -31,12 +31,14 @@
 #pragma weak shmem_uint_atomic_or      = pshmem_uint_atomic_or
 #pragma weak shmem_ulong_atomic_or     = pshmem_ulong_atomic_or
 #pragma weak shmem_ulonglong_atomic_or = pshmem_ulonglong_atomic_or
+
 #pragma weak shmem_ctx_int_atomic_or   = pshmem_ctx_int_atomic_or
 #pragma weak shmem_ctx_long_atomic_or  = pshmem_ctx_long_atomic_or
 #pragma weak shmem_ctx_longlong_atomic_or = pshmem_ctx_longlong_atomic_or
 #pragma weak shmem_ctx_uint_atomic_or  = pshmem_ctx_uint_atomic_or
 #pragma weak shmem_ctx_ulong_atomic_or = pshmem_ctx_ulong_atomic_or
 #pragma weak shmem_ctx_ulonglong_atomic_or = pshmem_ctx_ulonglong_atomic_or
+
 #pragma weak shmemx_int32_atomic_or    = pshmemx_int32_atomic_or
 #pragma weak shmemx_int64_atomic_or    = pshmemx_int64_atomic_or
 #pragma weak shmemx_uint32_atomic_or   = pshmemx_uint32_atomic_or

--- a/oshmem/shmem/c/shmem_or.c
+++ b/oshmem/shmem/c/shmem_or.c
@@ -25,9 +25,15 @@
  */
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
+#pragma weak shmem_int_atomic_or       = pshmem_int_atomic_or
+#pragma weak shmem_long_atomic_or      = pshmem_long_atomic_or
+#pragma weak shmem_longlong_atomic_or  = pshmem_longlong_atomic_or
 #pragma weak shmem_uint_atomic_or      = pshmem_uint_atomic_or
 #pragma weak shmem_ulong_atomic_or     = pshmem_ulong_atomic_or
 #pragma weak shmem_ulonglong_atomic_or = pshmem_ulonglong_atomic_or
+#pragma weak shmem_ctx_int_atomic_or   = pshmem_ctx_int_atomic_or
+#pragma weak shmem_ctx_long_atomic_or  = pshmem_ctx_long_atomic_or
+#pragma weak shmem_ctx_longlong_atomic_or = pshmem_ctx_longlong_atomic_or
 #pragma weak shmem_ctx_uint_atomic_or  = pshmem_ctx_uint_atomic_or
 #pragma weak shmem_ctx_ulong_atomic_or = pshmem_ctx_ulong_atomic_or
 #pragma weak shmem_ctx_ulonglong_atomic_or = pshmem_ctx_ulonglong_atomic_or
@@ -38,9 +44,15 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+OSHMEM_TYPE_OP(int, int, shmem, or)
+OSHMEM_TYPE_OP(long, long, shmem, or)
+OSHMEM_TYPE_OP(longlong, long long, shmem, or)
 OSHMEM_TYPE_OP(uint, unsigned int, shmem, or)
 OSHMEM_TYPE_OP(ulong, unsigned long, shmem, or)
 OSHMEM_TYPE_OP(ulonglong, unsigned long long, shmem, or)
+OSHMEM_CTX_TYPE_OP(int, int, shmem, or)
+OSHMEM_CTX_TYPE_OP(long, long, shmem, or)
+OSHMEM_CTX_TYPE_OP(longlong, long long, shmem, or)
 OSHMEM_CTX_TYPE_OP(uint, unsigned int, shmem, or)
 OSHMEM_CTX_TYPE_OP(ulong, unsigned long, shmem, or)
 OSHMEM_CTX_TYPE_OP(ulonglong, unsigned long long, shmem, or)

--- a/oshmem/shmem/c/shmem_p.c
+++ b/oshmem/shmem/c/shmem_p.c
@@ -73,6 +73,7 @@
 #pragma weak shmem_ctx_float_p = pshmem_ctx_float_p
 #pragma weak shmem_ctx_double_p = pshmem_ctx_double_p
 #pragma weak shmem_ctx_longdouble_p = pshmem_ctx_longdouble_p
+
 #pragma weak shmem_char_p = pshmem_char_p
 #pragma weak shmem_short_p = pshmem_short_p
 #pragma weak shmem_int_p = pshmem_int_p
@@ -87,6 +88,7 @@
 #pragma weak shmem_float_p = pshmem_float_p
 #pragma weak shmem_double_p = pshmem_double_p
 #pragma weak shmem_longdouble_p = pshmem_longdouble_p
+
 #pragma weak shmemx_int16_p = pshmemx_int16_p
 #pragma weak shmemx_int32_p = pshmemx_int32_p
 #pragma weak shmemx_int64_p = pshmemx_int64_p

--- a/oshmem/shmem/c/shmem_p.c
+++ b/oshmem/shmem/c/shmem_p.c
@@ -64,6 +64,12 @@
 #pragma weak shmem_ctx_int_p = pshmem_ctx_int_p
 #pragma weak shmem_ctx_long_p = pshmem_ctx_long_p
 #pragma weak shmem_ctx_longlong_p = pshmem_ctx_longlong_p
+#pragma weak shmem_ctx_schar_p = pshmem_ctx_schar_p
+#pragma weak shmem_ctx_uchar_p = pshmem_ctx_uchar_p
+#pragma weak shmem_ctx_ushort_p = pshmem_ctx_ushort_p
+#pragma weak shmem_ctx_uint_p = pshmem_ctx_uint_p
+#pragma weak shmem_ctx_ulong_p = pshmem_ctx_ulong_p
+#pragma weak shmem_ctx_ulonglong_p = pshmem_ctx_ulonglong_p
 #pragma weak shmem_ctx_float_p = pshmem_ctx_float_p
 #pragma weak shmem_ctx_double_p = pshmem_ctx_double_p
 #pragma weak shmem_ctx_longdouble_p = pshmem_ctx_longdouble_p
@@ -72,6 +78,12 @@
 #pragma weak shmem_int_p = pshmem_int_p
 #pragma weak shmem_long_p = pshmem_long_p
 #pragma weak shmem_longlong_p = pshmem_longlong_p
+#pragma weak shmem_schar_p = pshmem_schar_p
+#pragma weak shmem_uchar_p = pshmem_uchar_p
+#pragma weak shmem_ushort_p = pshmem_ushort_p
+#pragma weak shmem_uint_p = pshmem_uint_p
+#pragma weak shmem_ulong_p = pshmem_ulong_p
+#pragma weak shmem_ulonglong_p = pshmem_ulonglong_p
 #pragma weak shmem_float_p = pshmem_float_p
 #pragma weak shmem_double_p = pshmem_double_p
 #pragma weak shmem_longdouble_p = pshmem_longdouble_p
@@ -86,6 +98,12 @@ SHMEM_CTX_TYPE_P(_short, short, shmem)
 SHMEM_CTX_TYPE_P(_int, int, shmem)
 SHMEM_CTX_TYPE_P(_long, long, shmem)
 SHMEM_CTX_TYPE_P(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_P(_schar, signed char, shmem)
+SHMEM_CTX_TYPE_P(_uchar, unsigned char, shmem)
+SHMEM_CTX_TYPE_P(_ushort, unsigned short, shmem)
+SHMEM_CTX_TYPE_P(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_P(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_P(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_P(_float, float, shmem)
 SHMEM_CTX_TYPE_P(_double, double, shmem)
 SHMEM_CTX_TYPE_P(_longdouble, long double, shmem)
@@ -94,6 +112,12 @@ SHMEM_TYPE_P(_short, short, shmem)
 SHMEM_TYPE_P(_int, int, shmem)
 SHMEM_TYPE_P(_long, long, shmem)
 SHMEM_TYPE_P(_longlong, long long, shmem)
+SHMEM_TYPE_P(_schar, signed char, shmem)
+SHMEM_TYPE_P(_uchar, unsigned char, shmem)
+SHMEM_TYPE_P(_ushort, unsigned short, shmem)
+SHMEM_TYPE_P(_uint, unsigned int, shmem)
+SHMEM_TYPE_P(_ulong, unsigned long, shmem)
+SHMEM_TYPE_P(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_P(_float, float, shmem)
 SHMEM_TYPE_P(_double, double, shmem)
 SHMEM_TYPE_P(_longdouble, long double, shmem)

--- a/oshmem/shmem/c/shmem_put.c
+++ b/oshmem/shmem/c/shmem_put.c
@@ -74,6 +74,7 @@
 #pragma weak shmem_ctx_float_put = pshmem_ctx_float_put
 #pragma weak shmem_ctx_double_put = pshmem_ctx_double_put
 #pragma weak shmem_ctx_longdouble_put = pshmem_ctx_longdouble_put
+
 #pragma weak shmem_char_put = pshmem_char_put
 #pragma weak shmem_short_put = pshmem_short_put
 #pragma weak shmem_int_put = pshmem_int_put
@@ -88,12 +89,14 @@
 #pragma weak shmem_float_put = pshmem_float_put
 #pragma weak shmem_double_put = pshmem_double_put
 #pragma weak shmem_longdouble_put = pshmem_longdouble_put
+
 #pragma weak shmem_ctx_putmem = pshmem_ctx_putmem
 #pragma weak shmem_ctx_put8 = pshmem_ctx_put8
 #pragma weak shmem_ctx_put16 = pshmem_ctx_put16
 #pragma weak shmem_ctx_put32 = pshmem_ctx_put32
 #pragma weak shmem_ctx_put64 = pshmem_ctx_put64
 #pragma weak shmem_ctx_put128 = pshmem_ctx_put128
+
 #pragma weak shmem_putmem = pshmem_putmem
 #pragma weak shmem_put8 = pshmem_put8
 #pragma weak shmem_put16 = pshmem_put16

--- a/oshmem/shmem/c/shmem_put.c
+++ b/oshmem/shmem/c/shmem_put.c
@@ -65,6 +65,12 @@
 #pragma weak shmem_ctx_int_put = pshmem_ctx_int_put
 #pragma weak shmem_ctx_long_put = pshmem_ctx_long_put
 #pragma weak shmem_ctx_longlong_put = pshmem_ctx_longlong_put
+#pragma weak shmem_ctx_schar_put = pshmem_ctx_schar_put
+#pragma weak shmem_ctx_uchar_put = pshmem_ctx_uchar_put
+#pragma weak shmem_ctx_ushort_put = pshmem_ctx_ushort_put
+#pragma weak shmem_ctx_uint_put = pshmem_ctx_uint_put
+#pragma weak shmem_ctx_ulong_put = pshmem_ctx_ulong_put
+#pragma weak shmem_ctx_ulonglong_put = pshmem_ctx_ulonglong_put
 #pragma weak shmem_ctx_float_put = pshmem_ctx_float_put
 #pragma weak shmem_ctx_double_put = pshmem_ctx_double_put
 #pragma weak shmem_ctx_longdouble_put = pshmem_ctx_longdouble_put
@@ -73,6 +79,12 @@
 #pragma weak shmem_int_put = pshmem_int_put
 #pragma weak shmem_long_put = pshmem_long_put
 #pragma weak shmem_longlong_put = pshmem_longlong_put
+#pragma weak shmem_schar_put = pshmem_schar_put
+#pragma weak shmem_uchar_put = pshmem_uchar_put
+#pragma weak shmem_ushort_put = pshmem_ushort_put
+#pragma weak shmem_uint_put = pshmem_uint_put
+#pragma weak shmem_ulong_put = pshmem_ulong_put
+#pragma weak shmem_ulonglong_put = pshmem_ulonglong_put
 #pragma weak shmem_float_put = pshmem_float_put
 #pragma weak shmem_double_put = pshmem_double_put
 #pragma weak shmem_longdouble_put = pshmem_longdouble_put
@@ -96,6 +108,12 @@ SHMEM_CTX_TYPE_PUT(_short, short)
 SHMEM_CTX_TYPE_PUT(_int, int)
 SHMEM_CTX_TYPE_PUT(_long, long)
 SHMEM_CTX_TYPE_PUT(_longlong, long long)
+SHMEM_CTX_TYPE_PUT(_schar, signed char)
+SHMEM_CTX_TYPE_PUT(_uchar, unsigned char)
+SHMEM_CTX_TYPE_PUT(_ushort, unsigned short)
+SHMEM_CTX_TYPE_PUT(_uint, unsigned int)
+SHMEM_CTX_TYPE_PUT(_ulong, unsigned long)
+SHMEM_CTX_TYPE_PUT(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_PUT(_float, float)
 SHMEM_CTX_TYPE_PUT(_double, double)
 SHMEM_CTX_TYPE_PUT(_longdouble, long double)
@@ -104,6 +122,12 @@ SHMEM_TYPE_PUT(_short, short)
 SHMEM_TYPE_PUT(_int, int)
 SHMEM_TYPE_PUT(_long, long)
 SHMEM_TYPE_PUT(_longlong, long long)
+SHMEM_TYPE_PUT(_schar, signed char)
+SHMEM_TYPE_PUT(_uchar, unsigned char)
+SHMEM_TYPE_PUT(_ushort, unsigned short)
+SHMEM_TYPE_PUT(_uint, unsigned int)
+SHMEM_TYPE_PUT(_ulong, unsigned long)
+SHMEM_TYPE_PUT(_ulonglong, unsigned long long)
 SHMEM_TYPE_PUT(_float, float)
 SHMEM_TYPE_PUT(_double, double)
 SHMEM_TYPE_PUT(_longdouble, long double)

--- a/oshmem/shmem/c/shmem_put_nb.c
+++ b/oshmem/shmem/c/shmem_put_nb.c
@@ -69,6 +69,12 @@
 #pragma weak shmem_int_put_nbi = pshmem_int_put_nbi
 #pragma weak shmem_long_put_nbi = pshmem_long_put_nbi
 #pragma weak shmem_longlong_put_nbi = pshmem_longlong_put_nbi
+#pragma weak shmem_schar_put_nbi = pshmem_schar_put_nbi
+#pragma weak shmem_uchar_put_nbi = pshmem_uchar_put_nbi
+#pragma weak shmem_ushort_put_nbi = pshmem_ushort_put_nbi
+#pragma weak shmem_uint_put_nbi = pshmem_uint_put_nbi
+#pragma weak shmem_ulong_put_nbi = pshmem_ulong_put_nbi
+#pragma weak shmem_ulonglong_put_nbi = pshmem_ulonglong_put_nbi
 #pragma weak shmem_float_put_nbi = pshmem_float_put_nbi
 #pragma weak shmem_double_put_nbi = pshmem_double_put_nbi
 #pragma weak shmem_longdouble_put_nbi = pshmem_longdouble_put_nbi
@@ -83,6 +89,12 @@
 #pragma weak shmem_ctx_int_put_nbi = pshmem_ctx_int_put_nbi
 #pragma weak shmem_ctx_long_put_nbi = pshmem_ctx_long_put_nbi
 #pragma weak shmem_ctx_longlong_put_nbi = pshmem_ctx_longlong_put_nbi
+#pragma weak shmem_ctx_schar_put_nbi = pshmem_ctx_schar_put_nbi
+#pragma weak shmem_ctx_uchar_put_nbi = pshmem_ctx_uchar_put_nbi
+#pragma weak shmem_ctx_ushort_put_nbi = pshmem_ctx_ushort_put_nbi
+#pragma weak shmem_ctx_uint_put_nbi = pshmem_ctx_uint_put_nbi
+#pragma weak shmem_ctx_ulong_put_nbi = pshmem_ctx_ulong_put_nbi
+#pragma weak shmem_ctx_ulonglong_put_nbi = pshmem_ctx_ulonglong_put_nbi
 #pragma weak shmem_ctx_float_put_nbi = pshmem_ctx_float_put_nbi
 #pragma weak shmem_ctx_double_put_nbi = pshmem_ctx_double_put_nbi
 #pragma weak shmem_ctx_longdouble_put_nbi = pshmem_ctx_longdouble_put_nbi
@@ -100,6 +112,12 @@ SHMEM_CTX_TYPE_PUT_NB(_short, short)
 SHMEM_CTX_TYPE_PUT_NB(_int, int)
 SHMEM_CTX_TYPE_PUT_NB(_long, long)
 SHMEM_CTX_TYPE_PUT_NB(_longlong, long long)
+SHMEM_CTX_TYPE_PUT_NB(_schar, signed char)
+SHMEM_CTX_TYPE_PUT_NB(_uchar, unsigned char)
+SHMEM_CTX_TYPE_PUT_NB(_ushort, unsigned short)
+SHMEM_CTX_TYPE_PUT_NB(_uint, unsigned int)
+SHMEM_CTX_TYPE_PUT_NB(_ulong, unsigned long)
+SHMEM_CTX_TYPE_PUT_NB(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_PUT_NB(_float, float)
 SHMEM_CTX_TYPE_PUT_NB(_double, double)
 SHMEM_CTX_TYPE_PUT_NB(_longdouble, long double)
@@ -108,6 +126,12 @@ SHMEM_TYPE_PUT_NB(_short, short)
 SHMEM_TYPE_PUT_NB(_int, int)
 SHMEM_TYPE_PUT_NB(_long, long)
 SHMEM_TYPE_PUT_NB(_longlong, long long)
+SHMEM_TYPE_PUT_NB(_schar, signed char)
+SHMEM_TYPE_PUT_NB(_uchar, unsigned char)
+SHMEM_TYPE_PUT_NB(_ushort, unsigned short)
+SHMEM_TYPE_PUT_NB(_uint, unsigned int)
+SHMEM_TYPE_PUT_NB(_ulong, unsigned long)
+SHMEM_TYPE_PUT_NB(_ulonglong, unsigned long long)
 SHMEM_TYPE_PUT_NB(_float, float)
 SHMEM_TYPE_PUT_NB(_double, double)
 SHMEM_TYPE_PUT_NB(_longdouble, long double)

--- a/oshmem/shmem/c/shmem_put_nb.c
+++ b/oshmem/shmem/c/shmem_put_nb.c
@@ -78,12 +78,14 @@
 #pragma weak shmem_float_put_nbi = pshmem_float_put_nbi
 #pragma weak shmem_double_put_nbi = pshmem_double_put_nbi
 #pragma weak shmem_longdouble_put_nbi = pshmem_longdouble_put_nbi
+
 #pragma weak shmem_put8_nbi = pshmem_put8_nbi
 #pragma weak shmem_put16_nbi = pshmem_put16_nbi
 #pragma weak shmem_put32_nbi = pshmem_put32_nbi
 #pragma weak shmem_put64_nbi = pshmem_put64_nbi
 #pragma weak shmem_put128_nbi = pshmem_put128_nbi
 #pragma weak shmem_putmem_nbi = pshmem_putmem_nbi
+
 #pragma weak shmem_ctx_char_put_nbi = pshmem_ctx_char_put_nbi
 #pragma weak shmem_ctx_short_put_nbi = pshmem_ctx_short_put_nbi
 #pragma weak shmem_ctx_int_put_nbi = pshmem_ctx_int_put_nbi
@@ -98,6 +100,7 @@
 #pragma weak shmem_ctx_float_put_nbi = pshmem_ctx_float_put_nbi
 #pragma weak shmem_ctx_double_put_nbi = pshmem_ctx_double_put_nbi
 #pragma weak shmem_ctx_longdouble_put_nbi = pshmem_ctx_longdouble_put_nbi
+
 #pragma weak shmem_ctx_put8_nbi = pshmem_ctx_put8_nbi
 #pragma weak shmem_ctx_put16_nbi = pshmem_ctx_put16_nbi
 #pragma weak shmem_ctx_put32_nbi = pshmem_ctx_put32_nbi

--- a/oshmem/shmem/c/shmem_set.c
+++ b/oshmem/shmem/c/shmem_set.c
@@ -67,6 +67,7 @@
 #pragma weak shmem_ctx_ulonglong_atomic_set = pshmem_ctx_ulonglong_atomic_set
 #pragma weak shmem_ctx_float_atomic_set = pshmem_ctx_float_atomic_set
 #pragma weak shmem_ctx_double_atomic_set = pshmem_ctx_double_atomic_set
+
 #pragma weak shmem_int_atomic_set = pshmem_int_atomic_set
 #pragma weak shmem_long_atomic_set = pshmem_long_atomic_set
 #pragma weak shmem_longlong_atomic_set = pshmem_longlong_atomic_set
@@ -75,11 +76,13 @@
 #pragma weak shmem_ulonglong_atomic_set = pshmem_ulonglong_atomic_set
 #pragma weak shmem_float_atomic_set = pshmem_float_atomic_set
 #pragma weak shmem_double_atomic_set = pshmem_double_atomic_set
+
 #pragma weak shmem_int_set = pshmem_int_set
 #pragma weak shmem_long_set = pshmem_long_set
 #pragma weak shmem_longlong_set = pshmem_longlong_set
 #pragma weak shmem_float_set = pshmem_float_set
 #pragma weak shmem_double_set = pshmem_double_set
+
 #pragma weak shmemx_int32_set = pshmemx_int32_set
 #pragma weak shmemx_int64_set = pshmemx_int64_set
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_set.c
+++ b/oshmem/shmem/c/shmem_set.c
@@ -62,11 +62,17 @@
 #pragma weak shmem_ctx_int_atomic_set = pshmem_ctx_int_atomic_set
 #pragma weak shmem_ctx_long_atomic_set = pshmem_ctx_long_atomic_set
 #pragma weak shmem_ctx_longlong_atomic_set = pshmem_ctx_longlong_atomic_set
+#pragma weak shmem_ctx_uint_atomic_set = pshmem_ctx_uint_atomic_set
+#pragma weak shmem_ctx_ulong_atomic_set = pshmem_ctx_ulong_atomic_set
+#pragma weak shmem_ctx_ulonglong_atomic_set = pshmem_ctx_ulonglong_atomic_set
 #pragma weak shmem_ctx_float_atomic_set = pshmem_ctx_float_atomic_set
 #pragma weak shmem_ctx_double_atomic_set = pshmem_ctx_double_atomic_set
 #pragma weak shmem_int_atomic_set = pshmem_int_atomic_set
 #pragma weak shmem_long_atomic_set = pshmem_long_atomic_set
 #pragma weak shmem_longlong_atomic_set = pshmem_longlong_atomic_set
+#pragma weak shmem_uint_atomic_set = pshmem_uint_atomic_set
+#pragma weak shmem_ulong_atomic_set = pshmem_ulong_atomic_set
+#pragma weak shmem_ulonglong_atomic_set = pshmem_ulonglong_atomic_set
 #pragma weak shmem_float_atomic_set = pshmem_float_atomic_set
 #pragma weak shmem_double_atomic_set = pshmem_double_atomic_set
 #pragma weak shmem_int_set = pshmem_int_set
@@ -82,11 +88,17 @@
 SHMEM_CTX_TYPE_ATOMIC_SET(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SET(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SET(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_SET(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_SET(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_SET(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SET(_float, float, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SET(_double, double, shmem)
 SHMEM_TYPE_ATOMIC_SET(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_SET(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_SET(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_SET(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_SET(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_SET(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_ATOMIC_SET(_float, float, shmem)
 SHMEM_TYPE_ATOMIC_SET(_double, double, shmem)
 

--- a/oshmem/shmem/c/shmem_swap.c
+++ b/oshmem/shmem/c/shmem_swap.c
@@ -70,6 +70,7 @@
 #pragma weak shmem_ctx_ulonglong_atomic_swap = pshmem_ctx_ulonglong_atomic_swap
 #pragma weak shmem_ctx_float_atomic_swap = pshmem_ctx_float_atomic_swap
 #pragma weak shmem_ctx_double_atomic_swap = pshmem_ctx_double_atomic_swap
+
 #pragma weak shmem_int_atomic_swap = pshmem_int_atomic_swap
 #pragma weak shmem_long_atomic_swap = pshmem_long_atomic_swap
 #pragma weak shmem_longlong_atomic_swap = pshmem_longlong_atomic_swap
@@ -78,11 +79,13 @@
 #pragma weak shmem_ulonglong_atomic_swap = pshmem_ulonglong_atomic_swap
 #pragma weak shmem_float_atomic_swap = pshmem_float_atomic_swap
 #pragma weak shmem_double_atomic_swap = pshmem_double_atomic_swap
+
 #pragma weak shmem_int_swap = pshmem_int_swap
 #pragma weak shmem_long_swap = pshmem_long_swap
 #pragma weak shmem_longlong_swap = pshmem_longlong_swap
 #pragma weak shmem_float_swap = pshmem_float_swap
 #pragma weak shmem_double_swap = pshmem_double_swap
+
 #pragma weak shmemx_int32_swap = pshmemx_int32_swap
 #pragma weak shmemx_int64_swap = pshmemx_int64_swap
 #include "oshmem/shmem/c/profile/defines.h"

--- a/oshmem/shmem/c/shmem_swap.c
+++ b/oshmem/shmem/c/shmem_swap.c
@@ -65,11 +65,17 @@
 #pragma weak shmem_ctx_int_atomic_swap = pshmem_ctx_int_atomic_swap
 #pragma weak shmem_ctx_long_atomic_swap = pshmem_ctx_long_atomic_swap
 #pragma weak shmem_ctx_longlong_atomic_swap = pshmem_ctx_longlong_atomic_swap
+#pragma weak shmem_ctx_uint_atomic_swap = pshmem_ctx_uint_atomic_swap
+#pragma weak shmem_ctx_ulong_atomic_swap = pshmem_ctx_ulong_atomic_swap
+#pragma weak shmem_ctx_ulonglong_atomic_swap = pshmem_ctx_ulonglong_atomic_swap
 #pragma weak shmem_ctx_float_atomic_swap = pshmem_ctx_float_atomic_swap
 #pragma weak shmem_ctx_double_atomic_swap = pshmem_ctx_double_atomic_swap
 #pragma weak shmem_int_atomic_swap = pshmem_int_atomic_swap
 #pragma weak shmem_long_atomic_swap = pshmem_long_atomic_swap
 #pragma weak shmem_longlong_atomic_swap = pshmem_longlong_atomic_swap
+#pragma weak shmem_uint_atomic_swap = pshmem_uint_atomic_swap
+#pragma weak shmem_ulong_atomic_swap = pshmem_ulong_atomic_swap
+#pragma weak shmem_ulonglong_atomic_swap = pshmem_ulonglong_atomic_swap
 #pragma weak shmem_float_atomic_swap = pshmem_float_atomic_swap
 #pragma weak shmem_double_atomic_swap = pshmem_double_atomic_swap
 #pragma weak shmem_int_swap = pshmem_int_swap
@@ -85,11 +91,17 @@
 SHMEM_CTX_TYPE_ATOMIC_SWAP(_int, int, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SWAP(_long, long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SWAP(_longlong, long long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_SWAP(_uint, unsigned int, shmem)
+SHMEM_CTX_TYPE_ATOMIC_SWAP(_ulong, unsigned long, shmem)
+SHMEM_CTX_TYPE_ATOMIC_SWAP(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SWAP(_float, float, shmem)
 SHMEM_CTX_TYPE_ATOMIC_SWAP(_double, double, shmem)
 SHMEM_TYPE_ATOMIC_SWAP(_int, int, shmem)
 SHMEM_TYPE_ATOMIC_SWAP(_long, long, shmem)
 SHMEM_TYPE_ATOMIC_SWAP(_longlong, long long, shmem)
+SHMEM_TYPE_ATOMIC_SWAP(_uint, unsigned int, shmem)
+SHMEM_TYPE_ATOMIC_SWAP(_ulong, unsigned long, shmem)
+SHMEM_TYPE_ATOMIC_SWAP(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_ATOMIC_SWAP(_float, float, shmem)
 SHMEM_TYPE_ATOMIC_SWAP(_double, double, shmem)
 

--- a/oshmem/shmem/c/shmem_xor.c
+++ b/oshmem/shmem/c/shmem_xor.c
@@ -31,12 +31,14 @@
 #pragma weak shmem_uint_atomic_xor      = pshmem_uint_atomic_xor
 #pragma weak shmem_ulong_atomic_xor     = pshmem_ulong_atomic_xor
 #pragma weak shmem_ulonglong_atomic_xor = pshmem_ulonglong_atomic_xor
+
 #pragma weak shmem_ctx_int_atomic_xor   = pshmem_ctx_int_atomic_xor
 #pragma weak shmem_ctx_long_atomic_xor  = pshmem_ctx_long_atomic_xor
 #pragma weak shmem_ctx_longlong_atomic_xor = pshmem_ctx_longlong_atomic_xor
 #pragma weak shmem_ctx_uint_atomic_xor  = pshmem_ctx_uint_atomic_xor
 #pragma weak shmem_ctx_ulong_atomic_xor = pshmem_ctx_ulong_atomic_xor
 #pragma weak shmem_ctx_ulonglong_atomic_xor = pshmem_ctx_ulonglong_atomic_xor
+
 #pragma weak shmemx_int32_atomic_xor    = pshmemx_int32_atomic_xor
 #pragma weak shmemx_int64_atomic_xor    = pshmemx_int64_atomic_xor
 #pragma weak shmemx_uint32_atomic_xor   = pshmemx_uint32_atomic_xor

--- a/oshmem/shmem/c/shmem_xor.c
+++ b/oshmem/shmem/c/shmem_xor.c
@@ -25,9 +25,15 @@
  */
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
+#pragma weak shmem_int_atomic_xor       = pshmem_int_atomic_xor
+#pragma weak shmem_long_atomic_xor      = pshmem_long_atomic_xor
+#pragma weak shmem_longlong_atomic_xor  = pshmem_longlong_atomic_xor
 #pragma weak shmem_uint_atomic_xor      = pshmem_uint_atomic_xor
 #pragma weak shmem_ulong_atomic_xor     = pshmem_ulong_atomic_xor
 #pragma weak shmem_ulonglong_atomic_xor = pshmem_ulonglong_atomic_xor
+#pragma weak shmem_ctx_int_atomic_xor   = pshmem_ctx_int_atomic_xor
+#pragma weak shmem_ctx_long_atomic_xor  = pshmem_ctx_long_atomic_xor
+#pragma weak shmem_ctx_longlong_atomic_xor = pshmem_ctx_longlong_atomic_xor
 #pragma weak shmem_ctx_uint_atomic_xor  = pshmem_ctx_uint_atomic_xor
 #pragma weak shmem_ctx_ulong_atomic_xor = pshmem_ctx_ulong_atomic_xor
 #pragma weak shmem_ctx_ulonglong_atomic_xor = pshmem_ctx_ulonglong_atomic_xor
@@ -38,9 +44,15 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
+OSHMEM_TYPE_OP(int, int, shmem, xor)
+OSHMEM_TYPE_OP(long, long, shmem, xor)
+OSHMEM_TYPE_OP(longlong, long long, shmem, xor)
 OSHMEM_TYPE_OP(uint, unsigned int, shmem, xor)
 OSHMEM_TYPE_OP(ulong, unsigned long, shmem, xor)
 OSHMEM_TYPE_OP(ulonglong, unsigned long long, shmem, xor)
+OSHMEM_CTX_TYPE_OP(int, int, shmem, xor)
+OSHMEM_CTX_TYPE_OP(long, long, shmem, xor)
+OSHMEM_CTX_TYPE_OP(longlong, long long, shmem, xor)
 OSHMEM_CTX_TYPE_OP(uint, unsigned int, shmem, xor)
 OSHMEM_CTX_TYPE_OP(ulong, unsigned long, shmem, xor)
 OSHMEM_CTX_TYPE_OP(ulonglong, unsigned long long, shmem, xor)


### PR DESCRIPTION
- added signed datatypes for atomic_add calls
- added unsigned datatypes for atomic put/inc/get/fetch calls
- fixed incorrect SHMEM_CTX_DEFAULT macro, added
  external declaration of oshmem_ctx_default variable

backport from https://github.com/open-mpi/ompi/pull/6000