### PR TITLE
v4.0.x: opal/asm: work around possible gcc compiler bug

### DIFF
--- a/opal/include/opal/sys/gcc_builtin/atomic.h
+++ b/opal/include/opal/sys/gcc_builtin/atomic.h
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +59,14 @@ static inline void opal_atomic_mb(void)
 
 static inline void opal_atomic_rmb(void)
 {
+#if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
+    /* work around a bug in older gcc versions where ACQUIRE seems to get
+     * treated as a no-op instead of being equivalent to
+     * __asm__ __volatile__("": : :"memory") */
+    __atomic_thread_fence (__ATOMIC_SEQ_CST);
+#else
     __atomic_thread_fence (__ATOMIC_ACQUIRE);
+#endif
 }
 
 static inline void opal_atomic_wmb(void)


### PR DESCRIPTION
It seems in some cases (gcc older than v6.0.0) the __atomic_thread_fence is a
no-op with __ATOMIC_ACQUIRE. This appears to be the case with X86_64 so go
ahead and use __ATOMIC_SEQ_CST for the x86_64 read memory barrier. This should
not cause any performance issues as it is equivalent to the memory barrier
in the hand-written atomics.

References #6014

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 30119ee339eea086f43e3392352899187a4a73c7)
Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>