### PR TITLE
v3.0.x: pmix2x: fix potential memory barrier bug with __atomic builtin atomics

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/atomics/sys/gcc_builtin/atomic.h
+++ b/opal/mca/pmix/pmix2x/pmix/src/atomics/sys/gcc_builtin/atomic.h
@@ -16,6 +16,8 @@
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,7 +60,14 @@ static inline void pmix_atomic_mb(void)
 
 static inline void pmix_atomic_rmb(void)
 {
+#if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
+    /* work around a bug in older gcc versions where ACQUIRE seems to get
+     * treated as a no-op instead of being equivalent to
+     * __asm__ __volatile__("": : :"memory") */
+    __atomic_thread_fence (__ATOMIC_SEQ_CST);
+#else
     __atomic_thread_fence (__ATOMIC_ACQUIRE);
+#endif
 }
 
 static inline void pmix_atomic_wmb(void)


### PR DESCRIPTION
See open-mpi/ompi#6014 for more information.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>