### PR TITLE
master: README: Clarify that only IB->openib is deprecated

### DIFF
--- a/README
+++ b/README
@@ -731,8 +731,8 @@ Network Support
 
 - In prior versions of Open MPI, InfiniBand and RoCE support was
   provided through the openib BTL and ob1 PML plugins.  Starting with
-  Open MPI 4.0.0, InfiniBand support through the openib+ob1 plugins is
-  both deprecated and superseded by the ucx PML component.
+  Open MPI 4.0.0, InfiniBand support through the openib plugin is both
+  deprecated and superseded by the ucx PML component.
 
   While the openib BTL depended on libibverbs, the UCX PML depends on
   the UCX library.


### PR DESCRIPTION
Per feedback from https://github.com/open-mpi/ompi/pull/6028, remove
"+ob1" from the sentence to emphasize that it's only IB usage through
openib that is deprecated/superceded (i.e., ob1 is definitely not
deprecated).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

This PR is for master, and will be added to #6027 when merged.