### PR TITLE
v3.1.x: pmix2x: add PMIX_EXPORT decoration to mca_psensor_file_component

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/mca/psensor/file/psensor_file.h
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/psensor/file/psensor_file.h
@@ -29,7 +29,7 @@ typedef struct {
     pmix_list_t trackers;
 } pmix_psensor_file_component_t;
 
-extern pmix_psensor_file_component_t mca_psensor_file_component;
+PMIX_EXPORT extern pmix_psensor_file_component_t mca_psensor_file_component;
 extern pmix_psensor_base_module_t pmix_psensor_file_module;
 
 


### PR DESCRIPTION
`mca_psensor_file_component` needs to be decorated with `PMIX_EXPORT` so that it can be found by `dlsym` when opening the component.

Refs #6056.