### PR TITLE
mpiext/cuda: fix mpiext_cuda_c.h install path

### DIFF
--- a/ompi/mpiext/cuda/c/Makefile.am
+++ b/ompi/mpiext/cuda/c/Makefile.am
@@ -30,13 +30,13 @@ noinst_LTLIBRARIES = libmpiext_cuda_c.la
 ompidir = $(ompiincludedir)/ompi/mpiext/cuda/c
 
 # This is the header file that is installed.
-nodist_include_HEADERS = \
-        mpiext_cuda_c.h
+nodist_ompi_HEADERS = mpiext_cuda_c.h
 
 # Sources for the convenience libtool library.  Other than the one
 # header file, all source files in the extension have no file naming
 # conventions.
 libmpiext_cuda_c_la_SOURCES = \
+        $(ompi_HEADERS) \
         mpiext_cuda.c
 libmpiext_cuda_c_la_LDFLAGS = -module -avoid-version
 


### PR DESCRIPTION
This fixes a regression introduced in commit open-mpi/ompi@f8318f0a8ffa9d0ca109a7fbb6ebec9f5522a687.

Fixes open-mpi/ompi#6069

Thanks Kawashima-san for the heads up !


Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>