### PR TITLE
roll to v4.0.1a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -16,7 +16,7 @@
 # <major>.<minor>.<release>.
 
 major=4
-minor=0
+minor=1
 release=0
 
 # greek is generally used for alpha or beta release tags.  If it is
@@ -26,7 +26,7 @@ release=0
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc5
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
long live 4.0.1!

Signed-off-by: Howard Pritchard <howardp@lanl.gov>