### PR TITLE
v3.1.x: Add PMIX_EXPORT decoration to mca_psensor_file_component

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/mca/psensor/file/psensor_file.h
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/psensor/file/psensor_file.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved.
  *
  * Copyright (c) 2017      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -29,7 +29,7 @@ typedef struct {
     pmix_list_t trackers;
 } pmix_psensor_file_component_t;
 
-extern pmix_psensor_file_component_t mca_psensor_file_component;
+PMIX_EXPORT extern pmix_psensor_file_component_t mca_psensor_file_component;
 extern pmix_psensor_base_module_t pmix_psensor_file_module;
 
 


### PR DESCRIPTION
This symbol needs to be public.  Thanks to @benmenadue for reporting
and providing the fix.

Signed-off-by: Ben Menadue <ben.menadue@nci.org.au>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #6056 