### PR TITLE
configury: fix auto-generated mpi-[f08-]ext-module.F90

### DIFF
--- a/config/ompi_ext.m4
+++ b/config/ompi_ext.m4
@@ -5,8 +5,8 @@ dnl                         University Research and Technology
 dnl                         Corporation.  All rights reserved.
 dnl Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2011-2012 Oak Ridge National Labs.  All rights reserved.
-dnl Copyright (c) 2015-2017 Research Organization for Information Science
-dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2015-2018 Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2017      The University of Tennessee and The University
 dnl                         of Tennessee Research Foundation.  All rights
 dnl                         reserved.
@@ -568,7 +568,7 @@ EOF
         if test "$enabled_mpifh" = 1; then
             mpifh_component_header="mpiext_${component}_mpifh.h"
             cat >> $mpiusempi_ext_h <<EOF
-      include '${srcdir}/ompi/mpiext/$component/mpif-h/$mpifh_component_header'
+#include "${srcdir}/ompi/mpiext/$component/mpif-h/$mpifh_component_header"
 EOF
         fi
 
@@ -621,7 +621,7 @@ EOF
         if test "$enabled_mpifh" = 1; then
             mpifh_component_header="mpiext_${component}_mpifh.h"
             cat >> $mpiusempif08_ext_h <<EOF
-      include '${srcdir}/ompi/mpiext/$component/mpif-h/$mpifh_component_header'
+#include "${srcdir}/ompi/mpiext/$component/mpif-h/$mpifh_component_header"
 EOF
         fi
 


### PR DESCRIPTION
prefer #include vs include in order to correctly handle long Fortran lines.
We use the full path, and it can be very long, this is why
it cannot be passed to the Fortran compiler.

Thanks Igor Andriyash and Axel Huebl for reporting this issue.

Refs open-mpi/ompi#6106

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>