### PR TITLE
OSHMEM/AMO: added int/uint/32/64 atomics calls - v4.0

### DIFF
--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -922,6 +922,10 @@ OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_and(shmem_ctx_t ctx, 
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t pshmem_ctx_int32_atomic_fetch_and(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t pshmem_ctx_int64_atomic_fetch_and(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t pshmem_ctx_uint32_atomic_fetch_and(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t pshmem_ctx_uint64_atomic_fetch_and(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_and(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_and(long *target, long value, int pe);
@@ -929,23 +933,35 @@ OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_and(long long *target, lo
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_and(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t pshmem_int32_atomic_fetch_and(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t pshmem_int64_atomic_fetch_and(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t pshmem_uint32_atomic_fetch_and(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t pshmem_uint64_atomic_fetch_and(uint64_t *target, uint64_t value, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_atomic_fetch_and(...)                                           \
+#define pshmem_atomic_fetch_and(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
-                int*:         pshmem_ctx_int_atomic_fetch_and,                 \
-                long*:        pshmem_ctx_long_atomic_fetch_and,                \
-                long long*:   pshmem_ctx_longlong_atomic_fetch_and,            \
-                unsigned int*:         pshmem_ctx_uint_atomic_fetch_and,       \
-                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_and,      \
-                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_and,  \
-                default:               __opshmem_datatype_ignore),             \
-            int*:         pshmem_int_atomic_fetch_and,                         \
-            long*:        pshmem_long_atomic_fetch_and,                        \
-            long long*:   pshmem_longlong_atomic_fetch_and,                    \
-            unsigned int*:         pshmem_uint_atomic_fetch_and,               \
-            unsigned long*:        pshmem_ulong_atomic_fetch_and,              \
-            unsigned long long*:   pshmem_ulonglong_atomic_fetch_and)(__VA_ARGS__)
+                int*:         pshmem_ctx_int_atomic_fetch_and,                \
+                long*:        pshmem_ctx_long_atomic_fetch_and,               \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_and,           \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_and,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_and,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_and, \
+                int32_t*:              pshmem_ctx_int32_atomic_fetch_and,     \
+                int64_t*:              pshmem_ctx_int64_atomic_fetch_and,     \
+                uint32_t*:             pshmem_ctx_uint32_atomic_fetch_and,    \
+                uint64_t*:             pshmem_ctx_uint64_atomic_fetch_and,    \
+                default:               __opshmem_datatype_ignore),            \
+            int*:         pshmem_int_atomic_fetch_and,                        \
+            long*:        pshmem_long_atomic_fetch_and,                       \
+            long long*:   pshmem_longlong_atomic_fetch_and,                   \
+            unsigned int*:         pshmem_uint_atomic_fetch_and,              \
+            unsigned long*:        pshmem_ulong_atomic_fetch_and,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_fetch_and,         \
+            int32_t*:              pshmem_ctx_int32_atomic_fetch_and,         \
+            int64_t*:              pshmem_ctx_int64_atomic_fetch_and,         \
+            uint32_t*:             pshmem_ctx_uint32_atomic_fetch_and,        \
+            uint64_t*:             pshmem_ctx_uint64_atomic_fetch_and)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Or */
@@ -955,6 +971,10 @@ OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_or(shmem_ctx_t ctx, l
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t pshmem_ctx_int32_atomic_fetch_or(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t pshmem_ctx_int64_atomic_fetch_or(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t pshmem_ctx_uint32_atomic_fetch_or(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t pshmem_ctx_uint64_atomic_fetch_or(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_or(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_or(long *target, long value, int pe);
@@ -962,23 +982,35 @@ OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_or(long long *target, lon
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_or(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t pshmem_int32_atomic_fetch_or(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t pshmem_int64_atomic_fetch_or(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t pshmem_uint32_atomic_fetch_or(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t pshmem_uint64_atomic_fetch_or(uint64_t *target, uint64_t value, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_atomic_fetch_or(...)                                           \
+#define pshmem_atomic_fetch_or(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                             \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),         \
-                int*:         pshmem_ctx_int_atomic_fetch_or,                 \
-                long*:        pshmem_ctx_long_atomic_fetch_or,                \
-                long long*:   pshmem_ctx_longlong_atomic_fetch_or,            \
-                unsigned int*:         pshmem_ctx_uint_atomic_fetch_or,       \
-                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_or,      \
-                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_or,  \
-                default:               __opshmem_datatype_ignore),            \
-            int*:         pshmem_int_atomic_fetch_or,                         \
-            long*:        pshmem_long_atomic_fetch_or,                        \
-            long long*:   pshmem_longlong_atomic_fetch_or,                    \
-            unsigned int*:         pshmem_uint_atomic_fetch_or,               \
-            unsigned long*:        pshmem_ulong_atomic_fetch_or,              \
-            unsigned long long*:   pshmem_ulonglong_atomic_fetch_or)(__VA_ARGS__)
+                int*:         pshmem_ctx_int_atomic_fetch_or,                \
+                long*:        pshmem_ctx_long_atomic_fetch_or,               \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_or,           \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_or,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_or,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_or, \
+                int32_t*:              pshmem_ctx_int32_atomic_fetch_or,     \
+                int64_t*:              pshmem_ctx_int64_atomic_fetch_or,     \
+                uint32_t*:             pshmem_ctx_uint32_atomic_fetch_or,    \
+                uint64_t*:             pshmem_ctx_uint64_atomic_fetch_or,    \
+                default:               __opshmem_datatype_ignore),           \
+            int*:         pshmem_int_atomic_fetch_or,                        \
+            long*:        pshmem_long_atomic_fetch_or,                       \
+            long long*:   pshmem_longlong_atomic_fetch_or,                   \
+            unsigned int*:         pshmem_uint_atomic_fetch_or,              \
+            unsigned long*:        pshmem_ulong_atomic_fetch_or,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_fetch_or,         \
+            int32_t*:              pshmem_ctx_int32_atomic_fetch_or,         \
+            int64_t*:              pshmem_ctx_int64_atomic_fetch_or,         \
+            uint32_t*:             pshmem_ctx_uint32_atomic_fetch_or,        \
+            uint64_t*:             pshmem_ctx_uint64_atomic_fetch_or)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch&Xor */
@@ -988,6 +1020,10 @@ OSHMEM_DECLSPEC long long pshmem_ctx_longlong_atomic_fetch_xor(shmem_ctx_t ctx, 
 OSHMEM_DECLSPEC unsigned int pshmem_ctx_uint_atomic_fetch_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ctx_ulong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ctx_ulonglong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t pshmem_ctx_int32_atomic_fetch_xor(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t pshmem_ctx_int64_atomic_fetch_xor(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t pshmem_ctx_uint32_atomic_fetch_xor(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t pshmem_ctx_uint64_atomic_fetch_xor(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC int pshmem_int_atomic_fetch_xor(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_atomic_fetch_xor(long *target, long value, int pe);
@@ -995,23 +1031,35 @@ OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_xor(long long *target, lo
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_xor(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t pshmem_int32_atomic_fetch_xor(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t pshmem_int64_atomic_fetch_xor(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t pshmem_uint32_atomic_fetch_xor(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t pshmem_uint64_atomic_fetch_xor(uint64_t *target, uint64_t value, int pe);
 #if OSHMEMP_HAVE_C11
-#define pshmem_atomic_fetch_xor(...)                                           \
+#define pshmem_atomic_fetch_xor(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
-                int*:         pshmem_ctx_int_atomic_fetch_xor,                 \
-                long*:        pshmem_ctx_long_atomic_fetch_xor,                \
-                long long*:   pshmem_ctx_longlong_atomic_fetch_xor,            \
-                unsigned int*:         pshmem_ctx_uint_atomic_fetch_xor,       \
-                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_xor,      \
-                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_xor,  \
-                default:               __opshmem_datatype_ignore),             \
-            int*:         pshmem_int_atomic_fetch_xor,                         \
-            long*:        pshmem_long_atomic_fetch_xor,                        \
-            long long*:   pshmem_longlong_atomic_fetch_xor,                    \
-            unsigned int*:         pshmem_uint_atomic_fetch_xor,               \
-            unsigned long*:        pshmem_ulong_atomic_fetch_xor,              \
-            unsigned long long*:   pshmem_ulonglong_atomic_fetch_xor)(__VA_ARGS__)
+                int*:         pshmem_ctx_int_atomic_fetch_xor,                \
+                long*:        pshmem_ctx_long_atomic_fetch_xor,               \
+                long long*:   pshmem_ctx_longlong_atomic_fetch_xor,           \
+                unsigned int*:         pshmem_ctx_uint_atomic_fetch_xor,      \
+                unsigned long*:        pshmem_ctx_ulong_atomic_fetch_xor,     \
+                unsigned long long*:   pshmem_ctx_ulonglong_atomic_fetch_xor, \
+                int32_t*:              pshmem_ctx_int32_atomic_fetch_xor,     \
+                int64_t*:              pshmem_ctx_int64_atomic_fetch_xor,     \
+                uint32_t*:             pshmem_ctx_uint32_atomic_fetch_xor,    \
+                uint64_t*:             pshmem_ctx_uint64_atomic_fetch_xor,    \
+                default:               __opshmem_datatype_ignore),            \
+            int*:         pshmem_int_atomic_fetch_xor,                        \
+            long*:        pshmem_long_atomic_fetch_xor,                       \
+            long long*:   pshmem_longlong_atomic_fetch_xor,                   \
+            unsigned int*:         pshmem_uint_atomic_fetch_xor,              \
+            unsigned long*:        pshmem_ulong_atomic_fetch_xor,             \
+            unsigned long long*:   pshmem_ulonglong_atomic_fetch_xor,         \
+            int32_t*:              pshmem_ctx_int32_atomic_fetch_xor,         \
+            int64_t*:              pshmem_ctx_int64_atomic_fetch_xor,         \
+            uint32_t*:             pshmem_ctx_uint32_atomic_fetch_xor,        \
+            uint64_t*:             pshmem_ctx_uint64_atomic_fetch_xor)(__VA_ARGS__)
 #endif
 
 /* Atomic Fetch */
@@ -1165,6 +1213,10 @@ OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_and(shmem_ctx_t ctx, long long *
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int32_atomic_and(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int64_atomic_and(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint32_atomic_and(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint64_atomic_and(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_and(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_and(long *target, long value, int pe);
@@ -1172,6 +1224,10 @@ OSHMEM_DECLSPEC void pshmem_longlong_atomic_and(long long *target, long long val
 OSHMEM_DECLSPEC void pshmem_uint_atomic_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_and(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_int32_atomic_and(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_int64_atomic_and(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_uint32_atomic_and(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_uint64_atomic_and(uint64_t *target, uint64_t value, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_atomic_and(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
@@ -1198,6 +1254,10 @@ OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_or(shmem_ctx_t ctx, long long *t
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int32_atomic_or(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int64_atomic_or(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint32_atomic_or(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint64_atomic_or(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_or(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_or(long *target, long value, int pe);
@@ -1205,6 +1265,10 @@ OSHMEM_DECLSPEC void pshmem_longlong_atomic_or(long long *target, long long valu
 OSHMEM_DECLSPEC void pshmem_uint_atomic_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_or(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_int32_atomic_or(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_int64_atomic_or(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_uint32_atomic_or(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_uint64_atomic_or(uint64_t *target, uint64_t value, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_atomic_or(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
@@ -1231,6 +1295,10 @@ OSHMEM_DECLSPEC void pshmem_ctx_longlong_atomic_xor(shmem_ctx_t ctx, long long *
 OSHMEM_DECLSPEC void pshmem_ctx_uint_atomic_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_atomic_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_atomic_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int32_atomic_xor(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int64_atomic_xor(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint32_atomic_xor(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint64_atomic_xor(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC void pshmem_int_atomic_xor(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_atomic_xor(long *target, long value, int pe);
@@ -1238,6 +1306,10 @@ OSHMEM_DECLSPEC void pshmem_longlong_atomic_xor(long long *target, long long val
 OSHMEM_DECLSPEC void pshmem_uint_atomic_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_xor(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void pshmem_int32_atomic_xor(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_int64_atomic_xor(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_uint32_atomic_xor(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void pshmem_uint64_atomic_xor(uint64_t *target, uint64_t value, int pe);
 #if OSHMEMP_HAVE_C11
 #define pshmem_atomic_xor(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
@@ -1321,26 +1393,54 @@ OSHMEM_DECLSPEC  void pshmem_short_wait_until(volatile short *addr, int cmp, sho
 OSHMEM_DECLSPEC  void pshmem_int_wait_until(volatile int *addr, int cmp, int value);
 OSHMEM_DECLSPEC  void pshmem_long_wait_until(volatile long *addr, int cmp, long value);
 OSHMEM_DECLSPEC  void pshmem_longlong_wait_until(volatile long long *addr, int cmp, long long value);
+OSHMEM_DECLSPEC  void pshmem_ushort_wait_until(volatile unsigned short *addr, int cmp, unsigned short value);
+OSHMEM_DECLSPEC  void pshmem_uint_wait_until(volatile unsigned int *addr, int cmp, unsigned int value);
+OSHMEM_DECLSPEC  void pshmem_ulong_wait_until(volatile unsigned long *addr, int cmp, unsigned long value);
+OSHMEM_DECLSPEC  void pshmem_ulonglong_wait_until(volatile unsigned long long *addr, int cmp, unsigned long long value);
+OSHMEM_DECLSPEC  void pshmem_int32_wait_until(volatile int32_t *addr, int cmp, int32_t value);
+OSHMEM_DECLSPEC  void pshmem_int64_wait_until(volatile int64_t *addr, int cmp, int64_t value);
+OSHMEM_DECLSPEC  void pshmem_uint32_wait_until(volatile uint32_t *addr, int cmp, uint32_t value);
+OSHMEM_DECLSPEC  void pshmem_uint64_wait_until(volatile uint64_t *addr, int cmp, uint64_t value);
+OSHMEM_DECLSPEC  void pshmem_size_wait_until(volatile size_t *addr, int cmp, size_t value);
+OSHMEM_DECLSPEC  void pshmem_ptrdiff_wait_until(volatile ptrdiff_t *addr, int cmp, ptrdiff_t value);
 #if OSHMEMP_HAVE_C11
 #define pshmem_wait_until(addr, cmp, value)                  \
     _Generic(&*(addr),                                       \
         short*:       pshmem_short_wait_until,               \
         int*:         pshmem_int_wait_until,                 \
         long*:        pshmem_long_wait_until,                \
-        long long*:   pshmem_longlong_wait_until)(addr, cmp, value)
+        long long*:   pshmem_longlong_wait_until,            \
+        unsigned short*:       pshmem_short_wait_until,      \
+        unsigned int*:         pshmem_int_wait_until,        \
+        unsigned long*:        pshmem_long_wait_until,       \
+        unsigned long long*:   pshmem_longlong_wait_until)(addr, cmp, value)
 #endif
 
 OSHMEM_DECLSPEC  int pshmem_short_test(volatile short *addr, int cmp, short value);
 OSHMEM_DECLSPEC  int pshmem_int_test(volatile int *addr, int cmp, int value);
 OSHMEM_DECLSPEC  int pshmem_long_test(volatile long *addr, int cmp, long value);
 OSHMEM_DECLSPEC  int pshmem_longlong_test(volatile long long *addr, int cmp, long long value);
+OSHMEM_DECLSPEC  int pshmem_ushort_test(volatile unsigned short *addr, int cmp, unsigned short value);
+OSHMEM_DECLSPEC  int pshmem_uint_test(volatile unsigned int *addr, int cmp, unsigned int value);
+OSHMEM_DECLSPEC  int pshmem_ulong_test(volatile unsigned long *addr, int cmp, unsigned long value);
+OSHMEM_DECLSPEC  int pshmem_ulonglong_test(volatile unsigned long long *addr, int cmp, unsigned long long value);
+OSHMEM_DECLSPEC  int pshmem_int32_test(volatile int32_t *addr, int cmp, int32_t value);
+OSHMEM_DECLSPEC  int pshmem_int64_test(volatile int64_t *addr, int cmp, int64_t value);
+OSHMEM_DECLSPEC  int pshmem_uint32_test(volatile uint32_t *addr, int cmp, uint32_t value);
+OSHMEM_DECLSPEC  int pshmem_uint64_test(volatile uint64_t *addr, int cmp, uint64_t value);
+OSHMEM_DECLSPEC  int pshmem_size_test(volatile size_t *addr, int cmp, size_t value);
+OSHMEM_DECLSPEC  int pshmem_ptrdiff_test(volatile ptrdiff_t *addr, int cmp, ptrdiff_t value);
 #if OSHMEMP_HAVE_C11
-#define pshmem_test(addr, cmp, value)                        \
-    _Generic(&*(addr),                                       \
-        short*:       pshmem_short_test,                     \
-        int*:         pshmem_int_test,                       \
-        long*:        pshmem_long_test,                      \
-        long long*:   pshmem_longlong_test)(addr, cmp, value)
+#define pshmem_test(addr, cmp, value)                  \
+    _Generic(&*(addr),                                 \
+        short*:       pshmem_short_test,               \
+        int*:         pshmem_int_test,                 \
+        long*:        pshmem_long_test,                \
+        long long*:   pshmem_longlong_test,            \
+        unsigned short*:       pshmem_short_test,      \
+        unsigned int*:         pshmem_int_test,        \
+        unsigned long*:        pshmem_long_test,       \
+        unsigned long long*:   pshmem_longlong_test)(addr, cmp, value)
 #endif
 
 /*

--- a/oshmem/include/pshmemx.h
+++ b/oshmem/include/pshmemx.h
@@ -218,8 +218,6 @@ OSHMEM_DECLSPEC void pshmemx_int64_prod_to_all(int64_t *target, const int64_t *s
 
 #define pshmem_int32_wait            pshmemx_int32_wait
 #define pshmem_int64_wait            pshmemx_int64_wait
-#define pshmem_int32_wait_until      pshmemx_int32_wait_until
-#define pshmem_int64_wait_until      pshmemx_int64_wait_until
 
 #define pshmem_int16_and_to_all      pshmemx_int16_and_to_all
 #define pshmem_int32_and_to_all      pshmemx_int32_and_to_all

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -150,6 +150,7 @@ enum shmem_wait_ops {
 #define SHMEM_ALLTOALLS_SYNC_SIZE      _SHMEM_ALLTOALLS_SYNC_SIZE
 #define SHMEM_REDUCE_MIN_WRKDATA_SIZE  _SHMEM_REDUCE_MIN_WRKDATA_SIZE
 #define SHMEM_SYNC_VALUE               _SHMEM_SYNC_VALUE
+#define SHMEM_SYNC_SIZE                _SHMEM_COLLECT_SYNC_SIZE
 
 
 /*
@@ -1035,6 +1036,10 @@ OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_and(shmem_ctx_t ctx, l
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t shmem_ctx_int32_atomic_fetch_and(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t shmem_ctx_int64_atomic_fetch_and(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t shmem_ctx_uint32_atomic_fetch_and(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t shmem_ctx_uint64_atomic_fetch_and(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch_and(int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch_and(long *target, long value, int pe);
@@ -1042,6 +1047,10 @@ OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_and(long long *target, lon
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_and(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t shmem_int32_atomic_fetch_and(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t shmem_int64_atomic_fetch_and(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t shmem_uint32_atomic_fetch_and(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t shmem_uint64_atomic_fetch_and(uint64_t *target, uint64_t value, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_fetch_and(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
@@ -1068,6 +1077,10 @@ OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_or(shmem_ctx_t ctx, lo
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t shmem_ctx_int32_atomic_fetch_or(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t shmem_ctx_int64_atomic_fetch_or(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t shmem_ctx_uint32_atomic_fetch_or(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t shmem_ctx_uint64_atomic_fetch_or(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch_or(int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch_or(long *target, long value, int pe);
@@ -1075,6 +1088,10 @@ OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_or(long long *target, long
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_or(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t shmem_int32_atomic_fetch_or(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t shmem_int64_atomic_fetch_or(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t shmem_uint32_atomic_fetch_or(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t shmem_uint64_atomic_fetch_or(uint64_t *target, uint64_t value, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_fetch_or(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                             \
@@ -1101,6 +1118,10 @@ OSHMEM_DECLSPEC long long shmem_ctx_longlong_atomic_fetch_xor(shmem_ctx_t ctx, l
 OSHMEM_DECLSPEC unsigned int shmem_ctx_uint_atomic_fetch_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ctx_ulong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ctx_ulonglong_atomic_fetch_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t shmem_ctx_int32_atomic_fetch_xor(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t shmem_ctx_int64_atomic_fetch_xor(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t shmem_ctx_uint32_atomic_fetch_xor(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t shmem_ctx_uint64_atomic_fetch_xor(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC int shmem_int_atomic_fetch_xor(int *target, int value, int pe);
 OSHMEM_DECLSPEC long shmem_long_atomic_fetch_xor(long *target, long value, int pe);
@@ -1108,6 +1129,10 @@ OSHMEM_DECLSPEC long long shmem_longlong_atomic_fetch_xor(long long *target, lon
 OSHMEM_DECLSPEC unsigned int shmem_uint_atomic_fetch_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long shmem_ulong_atomic_fetch_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long shmem_ulonglong_atomic_fetch_xor(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC int32_t shmem_int32_atomic_fetch_xor(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC int64_t shmem_int64_atomic_fetch_xor(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC uint32_t shmem_uint32_atomic_fetch_xor(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC uint64_t shmem_uint64_atomic_fetch_xor(uint64_t *target, uint64_t value, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_fetch_xor(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
@@ -1278,6 +1303,10 @@ OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_and(shmem_ctx_t ctx, long long *t
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_and(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_and(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_and(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int32_atomic_and(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int64_atomic_and(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint32_atomic_and(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint64_atomic_and(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC void shmem_int_atomic_and(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_and(long *target, long value, int pe);
@@ -1285,6 +1314,11 @@ OSHMEM_DECLSPEC void shmem_longlong_atomic_and(long long *target, long long valu
 OSHMEM_DECLSPEC void shmem_uint_atomic_and(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_and(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_and(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void shmem_int32_atomic_and(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_int64_atomic_and(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void shmem_uint32_atomic_and(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_uint64_atomic_and(uint64_t *target, uint64_t value, int pe);
+
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_and(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
@@ -1311,6 +1345,10 @@ OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_or(shmem_ctx_t ctx, long long *ta
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_or(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_or(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_or(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int32_atomic_or(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int64_atomic_or(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint32_atomic_or(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint64_atomic_or(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC void shmem_int_atomic_or(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_or(long *target, long value, int pe);
@@ -1318,6 +1356,11 @@ OSHMEM_DECLSPEC void shmem_longlong_atomic_or(long long *target, long long value
 OSHMEM_DECLSPEC void shmem_uint_atomic_or(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_or(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_or(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void shmem_int32_atomic_or(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_int64_atomic_or(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void shmem_uint32_atomic_or(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_uint64_atomic_or(uint64_t *target, uint64_t value, int pe);
+
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_or(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
@@ -1344,6 +1387,10 @@ OSHMEM_DECLSPEC void shmem_ctx_longlong_atomic_xor(shmem_ctx_t ctx, long long *t
 OSHMEM_DECLSPEC void shmem_ctx_uint_atomic_xor(shmem_ctx_t ctx, unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulong_atomic_xor(shmem_ctx_t ctx, unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_atomic_xor(shmem_ctx_t ctx, unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int32_atomic_xor(shmem_ctx_t ctx, int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int64_atomic_xor(shmem_ctx_t ctx, int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint32_atomic_xor(shmem_ctx_t ctx, uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint64_atomic_xor(shmem_ctx_t ctx, uint64_t *target, uint64_t value, int pe);
 
 OSHMEM_DECLSPEC void shmem_int_atomic_xor(int *target, int value, int pe);
 OSHMEM_DECLSPEC void shmem_long_atomic_xor(long *target, long value, int pe);
@@ -1351,6 +1398,11 @@ OSHMEM_DECLSPEC void shmem_longlong_atomic_xor(long long *target, long long valu
 OSHMEM_DECLSPEC void shmem_uint_atomic_xor(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void shmem_ulong_atomic_xor(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_atomic_xor(unsigned long long *target, unsigned long long value, int pe);
+OSHMEM_DECLSPEC void shmem_int32_atomic_xor(int32_t *target, int32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_int64_atomic_xor(int64_t *target, int64_t value, int pe);
+OSHMEM_DECLSPEC void shmem_uint32_atomic_xor(uint32_t *target, uint32_t value, int pe);
+OSHMEM_DECLSPEC void shmem_uint64_atomic_xor(uint64_t *target, uint64_t value, int pe);
+
 #if OSHMEM_HAVE_C11
 #define shmem_atomic_xor(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
@@ -1434,26 +1486,54 @@ OSHMEM_DECLSPEC  void shmem_short_wait_until(volatile short *addr, int cmp, shor
 OSHMEM_DECLSPEC  void shmem_int_wait_until(volatile int *addr, int cmp, int value);
 OSHMEM_DECLSPEC  void shmem_long_wait_until(volatile long *addr, int cmp, long value);
 OSHMEM_DECLSPEC  void shmem_longlong_wait_until(volatile long long *addr, int cmp, long long value);
+OSHMEM_DECLSPEC  void shmem_ushort_wait_until(volatile unsigned short *addr, int cmp, unsigned short value);
+OSHMEM_DECLSPEC  void shmem_uint_wait_until(volatile unsigned int *addr, int cmp, unsigned int value);
+OSHMEM_DECLSPEC  void shmem_ulong_wait_until(volatile unsigned long *addr, int cmp, unsigned long value);
+OSHMEM_DECLSPEC  void shmem_ulonglong_wait_until(volatile unsigned long long *addr, int cmp, unsigned long long value);
+OSHMEM_DECLSPEC  void shmem_int32_wait_until(volatile int32_t *addr, int cmp, int32_t value);
+OSHMEM_DECLSPEC  void shmem_int64_wait_until(volatile int64_t *addr, int cmp, int64_t value);
+OSHMEM_DECLSPEC  void shmem_uint32_wait_until(volatile uint32_t *addr, int cmp, uint32_t value);
+OSHMEM_DECLSPEC  void shmem_uint64_wait_until(volatile uint64_t *addr, int cmp, uint64_t value);
+OSHMEM_DECLSPEC  void shmem_size_wait_until(volatile size_t *addr, int cmp, size_t value);
+OSHMEM_DECLSPEC  void shmem_ptrdiff_wait_until(volatile ptrdiff_t *addr, int cmp, ptrdiff_t value);
 #if OSHMEM_HAVE_C11
-#define shmem_wait_until(addr, cmp, value)                   \
-    _Generic(&*(addr),                                       \
-        short*:       shmem_short_wait_until,                \
-        int*:         shmem_int_wait_until,                  \
-        long*:        shmem_long_wait_until,                 \
-        long long*:   shmem_longlong_wait_until)(addr, cmp, value)
+#define shmem_wait_until(addr, cmp, value)                  \
+    _Generic(&*(addr),                                      \
+        short*:       shmem_short_wait_until,               \
+        int*:         shmem_int_wait_until,                 \
+        long*:        shmem_long_wait_until,                \
+        long long*:   shmem_longlong_wait_until,            \
+        unsigned short*:       shmem_ushort_wait_until,     \
+        unsigned int*:         shmem_uint_wait_until,       \
+        unsigned long*:        shmem_ulong_wait_until,      \
+        unsigned long long*:   shmem_ulonglong_wait_until)(addr, cmp, value)
 #endif
 
 OSHMEM_DECLSPEC  int shmem_short_test(volatile short *addr, int cmp, short value);
 OSHMEM_DECLSPEC  int shmem_int_test(volatile int *addr, int cmp, int value);
 OSHMEM_DECLSPEC  int shmem_long_test(volatile long *addr, int cmp, long value);
 OSHMEM_DECLSPEC  int shmem_longlong_test(volatile long long *addr, int cmp, long long value);
+OSHMEM_DECLSPEC  int shmem_ushort_test(volatile unsigned short *addr, int cmp, unsigned short value);
+OSHMEM_DECLSPEC  int shmem_uint_test(volatile unsigned int *addr, int cmp, unsigned int value);
+OSHMEM_DECLSPEC  int shmem_ulong_test(volatile unsigned long *addr, int cmp, unsigned long value);
+OSHMEM_DECLSPEC  int shmem_ulonglong_test(volatile unsigned long long *addr, int cmp, unsigned long long value);
+OSHMEM_DECLSPEC  int shmem_int32_test(volatile int32_t *addr, int cmp, int32_t value);
+OSHMEM_DECLSPEC  int shmem_int64_test(volatile int64_t *addr, int cmp, int64_t value);
+OSHMEM_DECLSPEC  int shmem_uint32_test(volatile uint32_t *addr, int cmp, uint32_t value);
+OSHMEM_DECLSPEC  int shmem_uint64_test(volatile uint64_t *addr, int cmp, uint64_t value);
+OSHMEM_DECLSPEC  int shmem_size_test(volatile size_t *addr, int cmp, size_t value);
+OSHMEM_DECLSPEC  int shmem_ptrdiff_test(volatile ptrdiff_t *addr, int cmp, ptrdiff_t value);
 #if OSHMEM_HAVE_C11
-#define shmem_test(addr, cmp, value)                         \
-    _Generic(&*(addr),                                       \
-        short*:       shmem_short_test,                      \
-        int*:         shmem_int_test,                        \
-        long*:        shmem_long_test,                       \
-        long long*:   shmem_longlong_test)(addr, cmp, value)
+#define shmem_test(addr, cmp, value)                  \
+    _Generic(&*(addr),                                \
+        short*:       shmem_short_test,               \
+        int*:         shmem_int_test,                 \
+        long*:        shmem_long_test,                \
+        long long*:   shmem_longlong_test,            \
+        unsigned short*:       shmem_ushort_test,     \
+        unsigned int*:         shmem_uint_test,       \
+        unsigned long*:        shmem_ulong_test,      \
+        unsigned long long*:   shmem_ulonglong_test)(addr, cmp, value)
 #endif
 
 /*

--- a/oshmem/include/shmemx.h
+++ b/oshmem/include/shmemx.h
@@ -204,8 +204,6 @@ OSHMEM_DECLSPEC void shmemx_int64_prod_to_all(int64_t *target, const int64_t *so
 
 #define shmem_int32_wait            shmemx_int32_wait
 #define shmem_int64_wait            shmemx_int64_wait
-#define shmem_int32_wait_until      shmemx_int32_wait_until
-#define shmem_int64_wait_until      shmemx_int64_wait_until
 
 #define shmem_int16_and_to_all      shmemx_int16_and_to_all
 #define shmem_int32_and_to_all      shmemx_int32_and_to_all

--- a/oshmem/shmem/c/profile/defines.h
+++ b/oshmem/shmem/c/profile/defines.h
@@ -532,6 +532,10 @@
 #define shmem_uint_atomic_fetch_and       pshmem_uint_atomic_fetch_and
 #define shmem_ulong_atomic_fetch_and      pshmem_ulong_atomic_fetch_and
 #define shmem_ulonglong_atomic_fetch_and  pshmem_ulonglong_atomic_fetch_and
+#define shmem_int32_atomic_fetch_and      pshmem_int32_atomic_fetch_and
+#define shmem_int64_atomic_fetch_and      pshmem_int64_atomic_fetch_and
+#define shmem_uint32_atomic_fetch_and     pshmem_uint32_atomic_fetch_and
+#define shmem_uint64_atomic_fetch_and     pshmem_uint64_atomic_fetch_and
 
 #define shmem_ctx_int_atomic_fetch_and    pshmem_ctx_int_atomic_fetch_and
 #define shmem_ctx_long_atomic_fetch_and   pshmem_ctx_long_atomic_fetch_and
@@ -539,6 +543,10 @@
 #define shmem_ctx_uint_atomic_fetch_and   pshmem_ctx_uint_atomic_fetch_and
 #define shmem_ctx_ulong_atomic_fetch_and  pshmem_ctx_ulong_atomic_fetch_and
 #define shmem_ctx_ulonglong_atomic_fetch_and pshmem_ctx_ulonglong_atomic_fetch_and
+#define shmem_ctx_int32_atomic_fetch_and  pshmem_ctx_int32_atomic_fetch_and
+#define shmem_ctx_int64_atomic_fetch_and  pshmem_ctx_int64_atomic_fetch_and
+#define shmem_ctx_uint32_atomic_fetch_and pshmem_ctx_uint32_atomic_fetch_and
+#define shmem_ctx_uint64_atomic_fetch_and pshmem_ctx_uint64_atomic_fetch_and
 
 #define shmemx_int32_atomic_fetch_and     pshmemx_int32_atomic_fetch_and
 #define shmemx_int64_atomic_fetch_and     pshmemx_int64_atomic_fetch_and
@@ -552,6 +560,10 @@
 #define shmem_uint_atomic_fetch_or        pshmem_uint_atomic_fetch_or
 #define shmem_ulong_atomic_fetch_or       pshmem_ulong_atomic_fetch_or
 #define shmem_ulonglong_atomic_fetch_or   pshmem_ulonglong_atomic_fetch_or
+#define shmem_int32_atomic_fetch_or       pshmem_int32_atomic_fetch_or
+#define shmem_int64_atomic_fetch_or       pshmem_int64_atomic_fetch_or
+#define shmem_uint32_atomic_fetch_or      pshmem_uint32_atomic_fetch_or
+#define shmem_uint64_atomic_fetch_or      pshmem_uint64_atomic_fetch_or
 
 #define shmem_ctx_int_atomic_fetch_or     pshmem_ctx_int_atomic_fetch_or
 #define shmem_ctx_long_atomic_fetch_or    pshmem_ctx_long_atomic_fetch_or
@@ -559,6 +571,10 @@
 #define shmem_ctx_uint_atomic_fetch_or    pshmem_ctx_uint_atomic_fetch_or
 #define shmem_ctx_ulong_atomic_fetch_or   pshmem_ctx_ulong_atomic_fetch_or
 #define shmem_ctx_ulonglong_atomic_fetch_or pshmem_ctx_ulonglong_atomic_fetch_or
+#define shmem_ctx_int32_atomic_fetch_or   pshmem_ctx_int32_atomic_fetch_or
+#define shmem_ctx_int64_atomic_fetch_or   pshmem_ctx_int64_atomic_fetch_or
+#define shmem_ctx_uint32_atomic_fetch_or  pshmem_ctx_uint32_atomic_fetch_or
+#define shmem_ctx_uint64_atomic_fetch_or  pshmem_ctx_uint64_atomic_fetch_or
 
 #define shmemx_int32_atomic_fetch_or      pshmemx_int32_atomic_fetch_or
 #define shmemx_int64_atomic_fetch_or      pshmemx_int64_atomic_fetch_or
@@ -572,6 +588,10 @@
 #define shmem_uint_atomic_fetch_xor       pshmem_uint_atomic_fetch_xor
 #define shmem_ulong_atomic_fetch_xor      pshmem_ulong_atomic_fetch_xor
 #define shmem_ulonglong_atomic_fetch_xor  pshmem_ulonglong_atomic_fetch_xor
+#define shmem_int32_atomic_fetch_xor      pshmem_int32_atomic_fetch_xor
+#define shmem_int64_atomic_fetch_xor      pshmem_int64_atomic_fetch_xor
+#define shmem_uint32_atomic_fetch_xor     pshmem_uint32_atomic_fetch_xor
+#define shmem_uint64_atomic_fetch_xor     pshmem_uint64_atomic_fetch_xor
 
 #define shmem_ctx_int_atomic_fetch_xor    pshmem_ctx_int_atomic_fetch_xor
 #define shmem_ctx_long_atomic_fetch_xor   pshmem_ctx_long_atomic_fetch_xor
@@ -579,6 +599,10 @@
 #define shmem_ctx_uint_atomic_fetch_xor   pshmem_ctx_uint_atomic_fetch_xor
 #define shmem_ctx_ulong_atomic_fetch_xor  pshmem_ctx_ulong_atomic_fetch_xor
 #define shmem_ctx_ulonglong_atomic_fetch_xor pshmem_ctx_ulonglong_atomic_fetch_xor
+#define shmem_ctx_int32_atomic_fetch_xor  pshmem_ctx_int32_atomic_fetch_xor
+#define shmem_ctx_int64_atomic_fetch_xor  pshmem_ctx_int64_atomic_fetch_xor
+#define shmem_ctx_uint32_atomic_fetch_xor pshmem_ctx_uint32_atomic_fetch_xor
+#define shmem_ctx_uint64_atomic_fetch_xor pshmem_ctx_uint64_atomic_fetch_xor
 
 #define shmemx_int32_atomic_fetch_xor     pshmemx_int32_atomic_fetch_xor
 #define shmemx_int64_atomic_fetch_xor     pshmemx_int64_atomic_fetch_xor
@@ -664,6 +688,10 @@
 #define shmem_uint_atomic_and        pshmem_uint_atomic_and
 #define shmem_ulong_atomic_and       pshmem_ulong_atomic_and
 #define shmem_ulonglong_atomic_and   pshmem_ulonglong_atomic_and
+#define shmem_int32_atomic_and       pshmem_int32_atomic_and
+#define shmem_int64_atomic_and       pshmem_int64_atomic_and
+#define shmem_uint32_atomic_and      pshmem_uint32_atomic_and
+#define shmem_uint64_atomic_and      pshmem_uint64_atomic_and
 
 #define shmem_ctx_int_atomic_and     pshmem_ctx_int_atomic_and
 #define shmem_ctx_long_atomic_and    pshmem_ctx_long_atomic_and
@@ -671,6 +699,10 @@
 #define shmem_ctx_uint_atomic_and    pshmem_ctx_uint_atomic_and
 #define shmem_ctx_ulong_atomic_and   pshmem_ctx_ulong_atomic_and
 #define shmem_ctx_ulonglong_atomic_and pshmem_ctx_ulonglong_atomic_and
+#define shmem_ctx_int32_atomic_and   pshmem_ctx_int32_atomic_and
+#define shmem_ctx_int64_atomic_and   pshmem_ctx_int64_atomic_and
+#define shmem_ctx_uint32_atomic_and  pshmem_ctx_uint32_atomic_and
+#define shmem_ctx_uint64_atomic_and  pshmem_ctx_uint64_atomic_and
 
 #define shmemx_int32_atomic_and      pshmemx_int32_atomic_and
 #define shmemx_int64_atomic_and      pshmemx_int64_atomic_and
@@ -685,6 +717,10 @@
 #define shmem_uint_atomic_or         pshmem_uint_atomic_or
 #define shmem_ulong_atomic_or        pshmem_ulong_atomic_or
 #define shmem_ulonglong_atomic_or    pshmem_ulonglong_atomic_or
+#define shmem_int32_atomic_or        pshmem_int32_atomic_or
+#define shmem_int64_atomic_or        pshmem_int64_atomic_or
+#define shmem_uint32_atomic_or       pshmem_uint32_atomic_or
+#define shmem_uint64_atomic_or       pshmem_uint64_atomic_or
 
 #define shmem_ctx_int_atomic_or      pshmem_ctx_int_atomic_or
 #define shmem_ctx_long_atomic_or     pshmem_ctx_long_atomic_or
@@ -692,6 +728,10 @@
 #define shmem_ctx_uint_atomic_or     pshmem_ctx_uint_atomic_or
 #define shmem_ctx_ulong_atomic_or    pshmem_ctx_ulong_atomic_or
 #define shmem_ctx_ulonglong_atomic_or pshmem_ctx_ulonglong_atomic_or
+#define shmem_ctx_int32_atomic_or    pshmem_ctx_int32_atomic_or
+#define shmem_ctx_int64_atomic_or    pshmem_ctx_int64_atomic_or
+#define shmem_ctx_uint32_atomic_or   pshmem_ctx_uint32_atomic_or
+#define shmem_ctx_uint64_atomic_or   pshmem_ctx_uint64_atomic_or
 
 #define shmemx_int32_atomic_or       pshmemx_int32_atomic_or
 #define shmemx_int64_atomic_or       pshmemx_int64_atomic_or
@@ -706,6 +746,10 @@
 #define shmem_uint_atomic_xor        pshmem_uint_atomic_xor
 #define shmem_ulong_atomic_xor       pshmem_ulong_atomic_xor
 #define shmem_ulonglong_atomic_xor   pshmem_ulonglong_atomic_xor
+#define shmem_int32_atomic_xor       pshmem_int32_atomic_xor
+#define shmem_int64_atomic_xor       pshmem_int64_atomic_xor
+#define shmem_uint32_atomic_xor      pshmem_uint32_atomic_xor
+#define shmem_uint64_atomic_xor      pshmem_uint64_atomic_xor
 
 #define shmem_ctx_int_atomic_xor     pshmem_ctx_int_atomic_xor
 #define shmem_ctx_long_atomic_xor    pshmem_ctx_long_atomic_xor
@@ -713,6 +757,10 @@
 #define shmem_ctx_uint_atomic_xor    pshmem_ctx_uint_atomic_xor
 #define shmem_ctx_ulong_atomic_xor   pshmem_ctx_ulong_atomic_xor
 #define shmem_ctx_ulonglong_atomic_xor pshmem_ctx_ulonglong_atomic_xor
+#define shmem_ctx_int32_atomic_xor   pshmem_ctx_int32_atomic_xor
+#define shmem_ctx_int64_atomic_xor   pshmem_ctx_int64_atomic_xor
+#define shmem_ctx_uint32_atomic_xor  pshmem_ctx_uint32_atomic_xor
+#define shmem_ctx_uint64_atomic_xor  pshmem_ctx_uint64_atomic_xor
 
 #define shmemx_int32_atomic_xor      pshmemx_int32_atomic_xor
 #define shmemx_int64_atomic_xor      pshmemx_int64_atomic_xor
@@ -764,6 +812,17 @@
 #define shmem_int_wait_until         pshmem_int_wait_until
 #define shmem_long_wait_until        pshmem_long_wait_until
 #define shmem_longlong_wait_until    pshmem_longlong_wait_until
+#define shmem_ushort_wait_until      pshmem_ushort_wait_until
+#define shmem_uint_wait_until        pshmem_uint_wait_until
+#define shmem_ulong_wait_until       pshmem_ulong_wait_until
+#define shmem_ulonglong_wait_until   pshmem_ulonglong_wait_until
+#define shmem_int32_wait_until       pshmem_int32_wait_until
+#define shmem_int64_wait_until       pshmem_int64_wait_until
+#define shmem_uint32_wait_until      pshmem_uint32_wait_until
+#define shmem_uint64_wait_until      pshmem_uint64_wait_until
+#define shmem_size_wait_until        pshmem_size_wait_until
+#define shmem_ptrdiff_wait_until     pshmem_ptrdiff_wait_until
+
 #define shmemx_int32_wait_until      pshmemx_int32_wait_until
 #define shmemx_int64_wait_until      pshmemx_int64_wait_until
 
@@ -771,6 +830,16 @@
 #define shmem_int_test               pshmem_int_test
 #define shmem_long_test              pshmem_long_test
 #define shmem_longlong_test          pshmem_longlong_test
+#define shmem_ushort_test            pshmem_ushort_test
+#define shmem_uint_test              pshmem_uint_test
+#define shmem_ulong_test             pshmem_ulong_test
+#define shmem_ulonglong_test         pshmem_ulonglong_test
+#define shmem_int32_test             pshmem_int32_test
+#define shmem_int64_test             pshmem_int64_test
+#define shmem_uint32_test            pshmem_uint32_test
+#define shmem_uint64_test            pshmem_uint64_test
+#define shmem_size_test              pshmem_size_test
+#define shmem_ptrdiff_test           pshmem_ptrdiff_test
 
 /*
  * Barrier sync routines

--- a/oshmem/shmem/c/shmem_and.c
+++ b/oshmem/shmem/c/shmem_and.c
@@ -31,6 +31,10 @@
 #pragma weak shmem_uint_atomic_and      = pshmem_uint_atomic_and
 #pragma weak shmem_ulong_atomic_and     = pshmem_ulong_atomic_and
 #pragma weak shmem_ulonglong_atomic_and = pshmem_ulonglong_atomic_and
+#pragma weak shmem_int32_atomic_and     = pshmem_int32_atomic_and
+#pragma weak shmem_int64_atomic_and     = pshmem_int64_atomic_and
+#pragma weak shmem_uint32_atomic_and    = pshmem_uint32_atomic_and
+#pragma weak shmem_uint64_atomic_and    = pshmem_uint64_atomic_and
 
 #pragma weak shmem_ctx_int_atomic_and   = pshmem_ctx_int_atomic_and
 #pragma weak shmem_ctx_long_atomic_and  = pshmem_ctx_long_atomic_and
@@ -38,6 +42,10 @@
 #pragma weak shmem_ctx_uint_atomic_and  = pshmem_ctx_uint_atomic_and
 #pragma weak shmem_ctx_ulong_atomic_and = pshmem_ctx_ulong_atomic_and
 #pragma weak shmem_ctx_ulonglong_atomic_and = pshmem_ctx_ulonglong_atomic_and
+#pragma weak shmem_ctx_int32_atomic_and  = pshmem_ctx_int32_atomic_and
+#pragma weak shmem_ctx_int64_atomic_and  = pshmem_ctx_int64_atomic_and
+#pragma weak shmem_ctx_uint32_atomic_and = pshmem_ctx_uint32_atomic_and
+#pragma weak shmem_ctx_uint64_atomic_and = pshmem_ctx_uint64_atomic_and
 
 #pragma weak shmemx_int32_atomic_and    = pshmemx_int32_atomic_and
 #pragma weak shmemx_int64_atomic_and    = pshmemx_int64_atomic_and
@@ -52,12 +60,22 @@ OSHMEM_TYPE_OP(longlong, long long, shmem, and)
 OSHMEM_TYPE_OP(uint, unsigned int, shmem, and)
 OSHMEM_TYPE_OP(ulong, unsigned long, shmem, and)
 OSHMEM_TYPE_OP(ulonglong, unsigned long long, shmem, and)
+OSHMEM_TYPE_OP(int32, int32_t, shmem, and)
+OSHMEM_TYPE_OP(int64, int64_t, shmem, and)
+OSHMEM_TYPE_OP(uint32, uint32_t, shmem, and)
+OSHMEM_TYPE_OP(uint64, uint64_t, shmem, and)
+
 OSHMEM_CTX_TYPE_OP(int, int, shmem, and)
 OSHMEM_CTX_TYPE_OP(long, long, shmem, and)
 OSHMEM_CTX_TYPE_OP(longlong, long long, shmem, and)
 OSHMEM_CTX_TYPE_OP(uint, unsigned int, shmem, and)
 OSHMEM_CTX_TYPE_OP(ulong, unsigned long, shmem, and)
 OSHMEM_CTX_TYPE_OP(ulonglong, unsigned long long, shmem, and)
+OSHMEM_CTX_TYPE_OP(int32, int32_t, shmem, and)
+OSHMEM_CTX_TYPE_OP(int64, int64_t, shmem, and)
+OSHMEM_CTX_TYPE_OP(uint32, uint32_t, shmem, and)
+OSHMEM_CTX_TYPE_OP(uint64, uint64_t, shmem, and)
+
 OSHMEM_TYPE_OP(int32, int32_t, shmemx, and)
 OSHMEM_TYPE_OP(int64, int64_t, shmemx, and)
 OSHMEM_TYPE_OP(uint32, uint32_t, shmemx, and)

--- a/oshmem/shmem/c/shmem_fand.c
+++ b/oshmem/shmem/c/shmem_fand.c
@@ -33,6 +33,10 @@
 #pragma weak shmem_uint_atomic_fetch_and      = pshmem_uint_atomic_fetch_and
 #pragma weak shmem_ulong_atomic_fetch_and     = pshmem_ulong_atomic_fetch_and
 #pragma weak shmem_ulonglong_atomic_fetch_and = pshmem_ulonglong_atomic_fetch_and
+#pragma weak shmem_int32_atomic_fetch_and     = pshmem_int32_atomic_fetch_and
+#pragma weak shmem_int64_atomic_fetch_and     = pshmem_int64_atomic_fetch_and
+#pragma weak shmem_uint32_atomic_fetch_and    = pshmem_uint32_atomic_fetch_and
+#pragma weak shmem_uint64_atomic_fetch_and    = pshmem_uint64_atomic_fetch_and
 
 #pragma weak shmem_ctx_int_atomic_fetch_and   = pshmem_ctx_int_atomic_fetch_and
 #pragma weak shmem_ctx_long_atomic_fetch_and  = pshmem_ctx_long_atomic_fetch_and
@@ -40,6 +44,10 @@
 #pragma weak shmem_ctx_uint_atomic_fetch_and  = pshmem_ctx_uint_atomic_fetch_and
 #pragma weak shmem_ctx_ulong_atomic_fetch_and = pshmem_ctx_ulong_atomic_fetch_and
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_and = pshmem_ctx_ulonglong_atomic_fetch_and
+#pragma weak shmem_ctx_int32_atomic_fetch_and  = pshmem_ctx_int32_atomic_fetch_and
+#pragma weak shmem_ctx_int64_atomic_fetch_and  = pshmem_ctx_int64_atomic_fetch_and
+#pragma weak shmem_ctx_uint32_atomic_fetch_and = pshmem_ctx_uint32_atomic_fetch_and
+#pragma weak shmem_ctx_uint64_atomic_fetch_and = pshmem_ctx_uint64_atomic_fetch_and
 
 #pragma weak shmemx_int32_atomic_fetch_and    = pshmemx_int32_atomic_fetch_and
 #pragma weak shmemx_int64_atomic_fetch_and    = pshmemx_int64_atomic_fetch_and
@@ -48,20 +56,28 @@
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
- unsigned int shmem_uint_atomic_fand(unsigned int *target, unsigned int value, int pe);
-
 OSHMEM_TYPE_FOP(int, int, shmem, and)
 OSHMEM_TYPE_FOP(long, long, shmem, and)
 OSHMEM_TYPE_FOP(longlong, long long, shmem, and)
 OSHMEM_TYPE_FOP(uint, unsigned int, shmem, and)
 OSHMEM_TYPE_FOP(ulong, unsigned long, shmem, and)
 OSHMEM_TYPE_FOP(ulonglong, unsigned long long, shmem, and)
+OSHMEM_TYPE_FOP(int32, int32_t, shmem, and)
+OSHMEM_TYPE_FOP(int64, int64_t, shmem, and)
+OSHMEM_TYPE_FOP(uint32, uint32_t, shmem, and)
+OSHMEM_TYPE_FOP(uint64, uint64_t, shmem, and)
+
 OSHMEM_CTX_TYPE_FOP(int, int, shmem, and)
 OSHMEM_CTX_TYPE_FOP(long, long, shmem, and)
 OSHMEM_CTX_TYPE_FOP(longlong, long long, shmem, and)
 OSHMEM_CTX_TYPE_FOP(uint, unsigned int, shmem, and)
 OSHMEM_CTX_TYPE_FOP(ulong, unsigned long, shmem, and)
 OSHMEM_CTX_TYPE_FOP(ulonglong, unsigned long long, shmem, and)
+OSHMEM_CTX_TYPE_FOP(int32, int32_t, shmem, and)
+OSHMEM_CTX_TYPE_FOP(int64, int64_t, shmem, and)
+OSHMEM_CTX_TYPE_FOP(uint32, uint32_t, shmem, and)
+OSHMEM_CTX_TYPE_FOP(uint64, uint64_t, shmem, and)
+
 OSHMEM_TYPE_FOP(int32, int32_t, shmemx, and)
 OSHMEM_TYPE_FOP(int64, int64_t, shmemx, and)
 OSHMEM_TYPE_FOP(uint32, uint32_t, shmemx, and)

--- a/oshmem/shmem/c/shmem_for.c
+++ b/oshmem/shmem/c/shmem_for.c
@@ -33,6 +33,10 @@
 #pragma weak shmem_uint_atomic_fetch_or      = pshmem_uint_atomic_fetch_or
 #pragma weak shmem_ulong_atomic_fetch_or     = pshmem_ulong_atomic_fetch_or
 #pragma weak shmem_ulonglong_atomic_fetch_or = pshmem_ulonglong_atomic_fetch_or
+#pragma weak shmem_int32_atomic_fetch_or     = pshmem_int32_atomic_fetch_or
+#pragma weak shmem_int64_atomic_fetch_or     = pshmem_int64_atomic_fetch_or
+#pragma weak shmem_uint32_atomic_fetch_or    = pshmem_uint32_atomic_fetch_or
+#pragma weak shmem_uint64_atomic_fetch_or    = pshmem_uint64_atomic_fetch_or
 
 #pragma weak shmem_ctx_int_atomic_fetch_or   = pshmem_ctx_int_atomic_fetch_or
 #pragma weak shmem_ctx_long_atomic_fetch_or  = pshmem_ctx_long_atomic_fetch_or
@@ -40,6 +44,10 @@
 #pragma weak shmem_ctx_uint_atomic_fetch_or  = pshmem_ctx_uint_atomic_fetch_or
 #pragma weak shmem_ctx_ulong_atomic_fetch_or = pshmem_ctx_ulong_atomic_fetch_or
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_or = pshmem_ctx_ulonglong_atomic_fetch_or
+#pragma weak shmem_ctx_int32_atomic_fetch_or  = pshmem_ctx_int32_atomic_fetch_or
+#pragma weak shmem_ctx_int64_atomic_fetch_or  = pshmem_ctx_int64_atomic_fetch_or
+#pragma weak shmem_ctx_uint32_atomic_fetch_or = pshmem_ctx_uint32_atomic_fetch_or
+#pragma weak shmem_ctx_uint64_atomic_fetch_or = pshmem_ctx_uint64_atomic_fetch_or
 
 #pragma weak shmemx_int32_atomic_fetch_or    = pshmemx_int32_atomic_fetch_or
 #pragma weak shmemx_int64_atomic_fetch_or    = pshmemx_int64_atomic_fetch_or
@@ -54,12 +62,22 @@ OSHMEM_TYPE_FOP(longlong, long long, shmem, or)
 OSHMEM_TYPE_FOP(uint, unsigned int, shmem, or)
 OSHMEM_TYPE_FOP(ulong, unsigned long, shmem, or)
 OSHMEM_TYPE_FOP(ulonglong, unsigned long long, shmem, or)
+OSHMEM_TYPE_FOP(int32, int32_t, shmem, or)
+OSHMEM_TYPE_FOP(int64, int64_t, shmem, or)
+OSHMEM_TYPE_FOP(uint32, uint32_t, shmem, or)
+OSHMEM_TYPE_FOP(uint64, uint64_t, shmem, or)
+
 OSHMEM_CTX_TYPE_FOP(int, int, shmem, or)
 OSHMEM_CTX_TYPE_FOP(long, long, shmem, or)
 OSHMEM_CTX_TYPE_FOP(longlong, long long, shmem, or)
 OSHMEM_CTX_TYPE_FOP(uint, unsigned int, shmem, or)
 OSHMEM_CTX_TYPE_FOP(ulong, unsigned long, shmem, or)
 OSHMEM_CTX_TYPE_FOP(ulonglong, unsigned long long, shmem, or)
+OSHMEM_CTX_TYPE_FOP(int32, int32_t, shmem, or)
+OSHMEM_CTX_TYPE_FOP(int64, int64_t, shmem, or)
+OSHMEM_CTX_TYPE_FOP(uint32, uint32_t, shmem, or)
+OSHMEM_CTX_TYPE_FOP(uint64, uint64_t, shmem, or)
+
 OSHMEM_TYPE_FOP(int32, int32_t, shmemx, or)
 OSHMEM_TYPE_FOP(int64, int64_t, shmemx, or)
 OSHMEM_TYPE_FOP(uint32, uint32_t, shmemx, or)

--- a/oshmem/shmem/c/shmem_fxor.c
+++ b/oshmem/shmem/c/shmem_fxor.c
@@ -33,6 +33,10 @@
 #pragma weak shmem_uint_atomic_fetch_xor      = pshmem_uint_atomic_fetch_xor
 #pragma weak shmem_ulong_atomic_fetch_xor     = pshmem_ulong_atomic_fetch_xor
 #pragma weak shmem_ulonglong_atomic_fetch_xor = pshmem_ulonglong_atomic_fetch_xor
+#pragma weak shmem_int32_atomic_fetch_xor     = pshmem_int32_atomic_fetch_xor
+#pragma weak shmem_int64_atomic_fetch_xor     = pshmem_int64_atomic_fetch_xor
+#pragma weak shmem_uint32_atomic_fetch_xor    = pshmem_uint32_atomic_fetch_xor
+#pragma weak shmem_uint64_atomic_fetch_xor    = pshmem_uint64_atomic_fetch_xor
 
 #pragma weak shmem_ctx_int_atomic_fetch_xor   = pshmem_ctx_int_atomic_fetch_xor
 #pragma weak shmem_ctx_long_atomic_fetch_xor  = pshmem_ctx_long_atomic_fetch_xor
@@ -40,6 +44,10 @@
 #pragma weak shmem_ctx_uint_atomic_fetch_xor  = pshmem_ctx_uint_atomic_fetch_xor
 #pragma weak shmem_ctx_ulong_atomic_fetch_xor = pshmem_ctx_ulong_atomic_fetch_xor
 #pragma weak shmem_ctx_ulonglong_atomic_fetch_xor = pshmem_ctx_ulonglong_atomic_fetch_xor
+#pragma weak shmem_ctx_int32_atomic_fetch_xor  = pshmem_ctx_int32_atomic_fetch_xor
+#pragma weak shmem_ctx_int64_atomic_fetch_xor  = pshmem_ctx_int64_atomic_fetch_xor
+#pragma weak shmem_ctx_uint32_atomic_fetch_xor = pshmem_ctx_uint32_atomic_fetch_xor
+#pragma weak shmem_ctx_uint64_atomic_fetch_xor = pshmem_ctx_uint64_atomic_fetch_xor
 
 #pragma weak shmemx_int32_atomic_fetch_xor    = pshmemx_int32_atomic_fetch_xor
 #pragma weak shmemx_int64_atomic_fetch_xor    = pshmemx_int64_atomic_fetch_xor
@@ -54,12 +62,22 @@ OSHMEM_TYPE_FOP(longlong, long long, shmem, xor)
 OSHMEM_TYPE_FOP(uint, unsigned int, shmem, xor)
 OSHMEM_TYPE_FOP(ulong, unsigned long, shmem, xor)
 OSHMEM_TYPE_FOP(ulonglong, unsigned long long, shmem, xor)
+OSHMEM_TYPE_FOP(int32, int32_t, shmem, xor)
+OSHMEM_TYPE_FOP(int64, int64_t, shmem, xor)
+OSHMEM_TYPE_FOP(uint32, uint32_t, shmem, xor)
+OSHMEM_TYPE_FOP(uint64, uint64_t, shmem, xor)
+
 OSHMEM_CTX_TYPE_FOP(int, int, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(long, long, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(longlong, long long, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(uint, unsigned int, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(ulong, unsigned long, shmem, xor)
 OSHMEM_CTX_TYPE_FOP(ulonglong, unsigned long long, shmem, xor)
+OSHMEM_CTX_TYPE_FOP(int32, int32_t, shmem, xor)
+OSHMEM_CTX_TYPE_FOP(int64, int64_t, shmem, xor)
+OSHMEM_CTX_TYPE_FOP(uint32, uint32_t, shmem, xor)
+OSHMEM_CTX_TYPE_FOP(uint64, uint64_t, shmem, xor)
+
 OSHMEM_TYPE_FOP(int32, int32_t, shmemx, xor)
 OSHMEM_TYPE_FOP(int64, int64_t, shmemx, xor)
 OSHMEM_TYPE_FOP(uint32, uint32_t, shmemx, xor)

--- a/oshmem/shmem/c/shmem_g.c
+++ b/oshmem/shmem/c/shmem_g.c
@@ -63,6 +63,7 @@
 #pragma weak shmem_ctx_int_g = pshmem_ctx_int_g
 #pragma weak shmem_ctx_long_g = pshmem_ctx_long_g
 #pragma weak shmem_ctx_longlong_g = pshmem_ctx_longlong_g
+#pragma weak shmem_ctx_schar_g = pshmem_ctx_schar_g
 #pragma weak shmem_ctx_uchar_g = pshmem_ctx_uchar_g
 #pragma weak shmem_ctx_ushort_g = pshmem_ctx_ushort_g
 #pragma weak shmem_ctx_uint_g = pshmem_ctx_uint_g
@@ -77,6 +78,7 @@
 #pragma weak shmem_int_g = pshmem_int_g
 #pragma weak shmem_long_g = pshmem_long_g
 #pragma weak shmem_longlong_g = pshmem_longlong_g
+#pragma weak shmem_schar_g = pshmem_schar_g
 #pragma weak shmem_uchar_g = pshmem_uchar_g
 #pragma weak shmem_ushort_g = pshmem_ushort_g
 #pragma weak shmem_uint_g = pshmem_uint_g

--- a/oshmem/shmem/c/shmem_or.c
+++ b/oshmem/shmem/c/shmem_or.c
@@ -31,6 +31,10 @@
 #pragma weak shmem_uint_atomic_or      = pshmem_uint_atomic_or
 #pragma weak shmem_ulong_atomic_or     = pshmem_ulong_atomic_or
 #pragma weak shmem_ulonglong_atomic_or = pshmem_ulonglong_atomic_or
+#pragma weak shmem_int32_atomic_or     = pshmem_int32_atomic_or
+#pragma weak shmem_int64_atomic_or     = pshmem_int64_atomic_or
+#pragma weak shmem_uint32_atomic_or    = pshmem_uint32_atomic_or
+#pragma weak shmem_uint64_atomic_or    = pshmem_uint64_atomic_or
 
 #pragma weak shmem_ctx_int_atomic_or   = pshmem_ctx_int_atomic_or
 #pragma weak shmem_ctx_long_atomic_or  = pshmem_ctx_long_atomic_or
@@ -38,6 +42,10 @@
 #pragma weak shmem_ctx_uint_atomic_or  = pshmem_ctx_uint_atomic_or
 #pragma weak shmem_ctx_ulong_atomic_or = pshmem_ctx_ulong_atomic_or
 #pragma weak shmem_ctx_ulonglong_atomic_or = pshmem_ctx_ulonglong_atomic_or
+#pragma weak shmem_ctx_int32_atomic_or  = pshmem_ctx_int32_atomic_or
+#pragma weak shmem_ctx_int64_atomic_or  = pshmem_ctx_int64_atomic_or
+#pragma weak shmem_ctx_uint32_atomic_or = pshmem_ctx_uint32_atomic_or
+#pragma weak shmem_ctx_uint64_atomic_or = pshmem_ctx_uint64_atomic_or
 
 #pragma weak shmemx_int32_atomic_or    = pshmemx_int32_atomic_or
 #pragma weak shmemx_int64_atomic_or    = pshmemx_int64_atomic_or
@@ -52,12 +60,22 @@ OSHMEM_TYPE_OP(longlong, long long, shmem, or)
 OSHMEM_TYPE_OP(uint, unsigned int, shmem, or)
 OSHMEM_TYPE_OP(ulong, unsigned long, shmem, or)
 OSHMEM_TYPE_OP(ulonglong, unsigned long long, shmem, or)
+OSHMEM_TYPE_OP(int32, int32_t, shmem, or)
+OSHMEM_TYPE_OP(int64, int64_t, shmem, or)
+OSHMEM_TYPE_OP(uint32, uint32_t, shmem, or)
+OSHMEM_TYPE_OP(uint64, uint64_t, shmem, or)
+
 OSHMEM_CTX_TYPE_OP(int, int, shmem, or)
 OSHMEM_CTX_TYPE_OP(long, long, shmem, or)
 OSHMEM_CTX_TYPE_OP(longlong, long long, shmem, or)
 OSHMEM_CTX_TYPE_OP(uint, unsigned int, shmem, or)
 OSHMEM_CTX_TYPE_OP(ulong, unsigned long, shmem, or)
 OSHMEM_CTX_TYPE_OP(ulonglong, unsigned long long, shmem, or)
+OSHMEM_CTX_TYPE_OP(int32, int32_t, shmem, or)
+OSHMEM_CTX_TYPE_OP(int64, int64_t, shmem, or)
+OSHMEM_CTX_TYPE_OP(uint32, uint32_t, shmem, or)
+OSHMEM_CTX_TYPE_OP(uint64, uint64_t, shmem, or)
+
 OSHMEM_TYPE_OP(int32, int32_t, shmemx, or)
 OSHMEM_TYPE_OP(int64, int64_t, shmemx, or)
 OSHMEM_TYPE_OP(uint32, uint32_t, shmemx, or)

--- a/oshmem/shmem/c/shmem_wait.c
+++ b/oshmem/shmem/c/shmem_wait.c
@@ -48,16 +48,39 @@
 #pragma weak shmem_longlong_wait = pshmem_longlong_wait
 #pragma weak shmemx_int32_wait = pshmemx_int32_wait
 #pragma weak shmemx_int64_wait = pshmemx_int64_wait
+
 #pragma weak shmem_short_wait_until = pshmem_short_wait_until
 #pragma weak shmem_int_wait_until = pshmem_int_wait_until
 #pragma weak shmem_long_wait_until = pshmem_long_wait_until
 #pragma weak shmem_longlong_wait_until = pshmem_longlong_wait_until
+#pragma weak shmem_ushort_wait_until = pshmem_ushort_wait_until
+#pragma weak shmem_uint_wait_until = pshmem_uint_wait_until
+#pragma weak shmem_ulong_wait_until = pshmem_ulong_wait_until
+#pragma weak shmem_ulonglong_wait_until = pshmem_ulonglong_wait_until
+#pragma weak shmem_int32_wait_until = pshmem_int32_wait_until
+#pragma weak shmem_int64_wait_until = pshmem_int64_wait_until
+#pragma weak shmem_uint32_wait_until = pshmem_uint32_wait_until
+#pragma weak shmem_uint64_wait_until = pshmem_uint64_wait_until
+#pragma weak shmem_size_wait_until = pshmem_size_wait_until
+#pragma weak shmem_ptrdiff_wait_until = pshmem_ptrdiff_wait_until
+
 #pragma weak shmemx_int32_wait_until = pshmemx_int32_wait_until
 #pragma weak shmemx_int64_wait_until = pshmemx_int64_wait_until
+
 #pragma weak shmem_short_test = pshmem_short_test
 #pragma weak shmem_int_test = pshmem_int_test
 #pragma weak shmem_long_test = pshmem_long_test
 #pragma weak shmem_longlong_test = pshmem_longlong_test
+#pragma weak shmem_ushort_test = pshmem_ushort_test
+#pragma weak shmem_uint_test = pshmem_uint_test
+#pragma weak shmem_ulong_test = pshmem_ulong_test
+#pragma weak shmem_ulonglong_test = pshmem_ulonglong_test
+#pragma weak shmem_int32_test = pshmem_int32_test
+#pragma weak shmem_int64_test = pshmem_int64_test
+#pragma weak shmem_uint32_test = pshmem_uint32_test
+#pragma weak shmem_uint64_test = pshmem_uint64_test
+#pragma weak shmem_size_test = pshmem_size_test
+#pragma weak shmem_ptrdiff_test = pshmem_ptrdiff_test
 #include "oshmem/shmem/c/profile/defines.h"
 #endif
 
@@ -90,6 +113,17 @@ SHMEM_TYPE_WAIT_UNTIL(_short, volatile short, SHMEM_SHORT, shmem)
 SHMEM_TYPE_WAIT_UNTIL(_int, volatile int, SHMEM_INT, shmem)
 SHMEM_TYPE_WAIT_UNTIL(_long, volatile long, SHMEM_LONG, shmem)
 SHMEM_TYPE_WAIT_UNTIL(_longlong, volatile long long, SHMEM_LLONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_ushort, volatile unsigned short, SHMEM_SHORT, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_uint, volatile unsigned int, SHMEM_INT, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_ulong, volatile unsigned long, SHMEM_LONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_ulonglong, volatile unsigned long long, SHMEM_LLONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_int32, volatile int32_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_int64, volatile int64_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_uint32, volatile uint32_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_uint64, volatile uint64_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_size, volatile size_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_WAIT_UNTIL(_ptrdiff, volatile ptrdiff_t, SHMEM_LLONG, shmem)
+
 SHMEM_TYPE_WAIT_UNTIL(_int32, int32_t, SHMEM_INT32_T, shmemx)
 SHMEM_TYPE_WAIT_UNTIL(_int64, int64_t, SHMEM_INT64_T, shmemx)
 
@@ -115,3 +149,13 @@ SHMEM_TYPE_TEST(_short, volatile short, SHMEM_SHORT, shmem)
 SHMEM_TYPE_TEST(_int, volatile int, SHMEM_INT, shmem)
 SHMEM_TYPE_TEST(_long, volatile long, SHMEM_LONG, shmem)
 SHMEM_TYPE_TEST(_longlong, volatile long long, SHMEM_LLONG, shmem)
+SHMEM_TYPE_TEST(_ushort, volatile unsigned short, SHMEM_SHORT, shmem)
+SHMEM_TYPE_TEST(_uint, volatile unsigned int, SHMEM_INT, shmem)
+SHMEM_TYPE_TEST(_ulong, volatile unsigned long, SHMEM_LONG, shmem)
+SHMEM_TYPE_TEST(_ulonglong, volatile unsigned long long, SHMEM_LLONG, shmem)
+SHMEM_TYPE_TEST(_int32, volatile int32_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_TEST(_int64, volatile int64_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_TEST(_uint32, volatile uint32_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_TEST(_uint64, volatile uint64_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_TEST(_size, volatile size_t, SHMEM_LLONG, shmem)
+SHMEM_TYPE_TEST(_ptrdiff, volatile ptrdiff_t, SHMEM_LLONG, shmem)

--- a/oshmem/shmem/c/shmem_xor.c
+++ b/oshmem/shmem/c/shmem_xor.c
@@ -31,6 +31,10 @@
 #pragma weak shmem_uint_atomic_xor      = pshmem_uint_atomic_xor
 #pragma weak shmem_ulong_atomic_xor     = pshmem_ulong_atomic_xor
 #pragma weak shmem_ulonglong_atomic_xor = pshmem_ulonglong_atomic_xor
+#pragma weak shmem_int32_atomic_xor     = pshmem_int32_atomic_xor
+#pragma weak shmem_int64_atomic_xor     = pshmem_int64_atomic_xor
+#pragma weak shmem_uint32_atomic_xor    = pshmem_uint32_atomic_xor
+#pragma weak shmem_uint64_atomic_xor    = pshmem_uint64_atomic_xor
 
 #pragma weak shmem_ctx_int_atomic_xor   = pshmem_ctx_int_atomic_xor
 #pragma weak shmem_ctx_long_atomic_xor  = pshmem_ctx_long_atomic_xor
@@ -38,6 +42,10 @@
 #pragma weak shmem_ctx_uint_atomic_xor  = pshmem_ctx_uint_atomic_xor
 #pragma weak shmem_ctx_ulong_atomic_xor = pshmem_ctx_ulong_atomic_xor
 #pragma weak shmem_ctx_ulonglong_atomic_xor = pshmem_ctx_ulonglong_atomic_xor
+#pragma weak shmem_ctx_int32_atomic_xor  = pshmem_ctx_int32_atomic_xor
+#pragma weak shmem_ctx_int64_atomic_xor  = pshmem_ctx_int64_atomic_xor
+#pragma weak shmem_ctx_uint32_atomic_xor = pshmem_ctx_uint32_atomic_xor
+#pragma weak shmem_ctx_uint64_atomic_xor = pshmem_ctx_uint64_atomic_xor
 
 #pragma weak shmemx_int32_atomic_xor    = pshmemx_int32_atomic_xor
 #pragma weak shmemx_int64_atomic_xor    = pshmemx_int64_atomic_xor
@@ -52,12 +60,22 @@ OSHMEM_TYPE_OP(longlong, long long, shmem, xor)
 OSHMEM_TYPE_OP(uint, unsigned int, shmem, xor)
 OSHMEM_TYPE_OP(ulong, unsigned long, shmem, xor)
 OSHMEM_TYPE_OP(ulonglong, unsigned long long, shmem, xor)
+OSHMEM_TYPE_OP(int32, int32_t, shmem, xor)
+OSHMEM_TYPE_OP(int64, int64_t, shmem, xor)
+OSHMEM_TYPE_OP(uint32, uint32_t, shmem, xor)
+OSHMEM_TYPE_OP(uint64, uint64_t, shmem, xor)
+
 OSHMEM_CTX_TYPE_OP(int, int, shmem, xor)
 OSHMEM_CTX_TYPE_OP(long, long, shmem, xor)
 OSHMEM_CTX_TYPE_OP(longlong, long long, shmem, xor)
 OSHMEM_CTX_TYPE_OP(uint, unsigned int, shmem, xor)
 OSHMEM_CTX_TYPE_OP(ulong, unsigned long, shmem, xor)
 OSHMEM_CTX_TYPE_OP(ulonglong, unsigned long long, shmem, xor)
+OSHMEM_CTX_TYPE_OP(int32, int32_t, shmem, xor)
+OSHMEM_CTX_TYPE_OP(int64, int64_t, shmem, xor)
+OSHMEM_CTX_TYPE_OP(uint32, uint32_t, shmem, xor)
+OSHMEM_CTX_TYPE_OP(uint64, uint64_t, shmem, xor)
+
 OSHMEM_TYPE_OP(int32, int32_t, shmemx, xor)
 OSHMEM_TYPE_OP(int64, int64_t, shmemx, xor)
 OSHMEM_TYPE_OP(uint32, uint32_t, shmemx, xor)


### PR DESCRIPTION
- added int/uint/32/64 atomics calls
- added SHMEM_SYNC_SIZE macro

backport from https://github.com/open-mpi/ompi/pull/6096

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit 4c071da565b152dbceb8f48368327bd0ae218942)