### PR TITLE
v4.0.x: README & man: Update pcollreq documentation

### DIFF
--- a/README
+++ b/README
@@ -815,14 +815,14 @@ Open MPI Extensions
 
 - The following extensions are included in this version of Open MPI:
 
-  - pcollreq: Provides routines for persistent collective
-    communication operations and persistent neighborhood collective
-    communication operations, which are proposed in the MPI Forum as
-    of June 2018.  The function names are prefixed with MPIX_ instead
-    of MPI_, like MPIX_Barrier_init, because they are not standardized
-    yet.  Future versions of Open MPI will switch to the MPI_ prefix
-    once the MPI Standard which includes this feature is published.
-    See their man page for more details.
+  - pcollreq: Provides routines for persistent collective communication
+    operations and persistent neighborhood collective communication
+    operations, which are planned to be included in the next MPI
+    Standard after MPI-3.1 as of Nov. 2018.  The function names are
+    prefixed with MPIX_ instead of MPI_, like MPIX_Barrier_init,
+    because they are not standardized yet.  Future versions of Open MPI
+    will switch to the MPI_ prefix once the MPI Standard which includes
+    this feature is published.  See their man page for more details.
   - affinity: Provides the OMPI_Affinity_str() routine on retrieving
     a string that contains what resources a process is bound to.  See
     its man page for more details.

--- a/ompi/mpiext/pcollreq/README.txt
+++ b/ompi/mpiext/pcollreq/README.txt
@@ -4,7 +4,8 @@ $COPYRIGHT$
 
 This extension provides the feature of persistent collective communication
 operations and persistent neighborhood collective communication operations,
-which is proposed in the MPI Forum as of June 2018.
+which is planned to be included in the next MPI Standard after MPI-3.1 as
+of Nov. 2018.
 
 See MPIX_Barrier_init(3) for more details.
 

--- a/ompi/mpiext/pcollreq/c/MPIX_Barrier_init.3in
+++ b/ompi/mpiext/pcollreq/c/MPIX_Barrier_init.3in
@@ -529,16 +529,16 @@ MPIX_Neighbor_alltoallw_init(\fIsendbuf\fP, \fIsendcounts\fP, \fIsdispls\fP, \fI
 .ft R
 Creates a persistent communication request for a collective operation or neighborhood collective operation.
 
-As of Sept. 2018, the feature of persistent collective communication operations and persistent collective neighborhood communication operations is planned to be included in the next MPI Standerd after MPI-3.1.
+As of Nov. 2018, the feature of persistent collective communication operations and persistent collective neighborhood communication operations is planned to be included in the next MPI Standard after MPI-3.1.
 .nf
 
     https://github.com/mpi-forum/mpi-issues/issues/25
 .fi
 
-Open MPI implements its draft version shown in the following URL.
+Open MPI implements 2018 Draft Specification of the MPI standard shown in the following URL.
 .nf
 
-    https://github.com/mpi-forum/mpi-issues/files/2078076/mpi32-report-ticket25-austin-vote-june2018.pdf
+    https://www.mpi-forum.org/docs/drafts/mpi-2018-draft-report.pdf
 .fi
 
 The interface may still change in the standard. Therefore the prefix \fIMPIX_\fP is used instead of \fIMPI_\fP for these request creation routines. To start, complete, and free the created request, usual MPI routines (\fIMPI_Start\fP etc.) can be used.


### PR DESCRIPTION
The feature of persistent collectives is approved in the Sept. 2018 MPI Forum meeting and 2018 Draft Specification of the MPI standard is published during SC18.

@jsquyres  please review.

(cherry picked from commit 5f0fcf0f456aaa43f36215859412f33f79ac91f9)
