### PR TITLE
pml_ucx: initialize req_mpi_object.comm for error handler

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx_request.c
+++ b/ompi/mca/pml/ucx/pml_ucx_request.c
@@ -228,7 +228,7 @@ void mca_pml_ucx_completed_request_init(ompi_request_t *ompi_req)
     mca_pml_ucx_request_init_common(ompi_req, false, OMPI_REQUEST_ACTIVE,
                                     mca_pml_completed_request_free,
                                     mca_pml_completed_request_cancel);
+    ompi_req->req_mpi_object.comm = &ompi_mpi_comm_world.comm;
     ompi_request_complete(ompi_req, false);
-
 }
 


### PR DESCRIPTION
without this fix, an error handler invoked on pml_ucx request would
segfault while trying to dereference requests[i]->req_mpi_object.comm

(picked from master f36eeef)

Signed-off-by: Yossi Itigin <yosefe@mellanox.com>