### PR TITLE
Re-add removed deprecate-only MPI-2.0 symbols

### DIFF
--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -78,6 +78,9 @@ libmpi_c_mpi_la_SOURCES = \
         ialltoallv.c \
         alltoallw.c \
         ialltoallw.c \
+        attr_delete.c \
+        attr_get.c \
+        attr_put.c \
         barrier.c \
         ibarrier.c \
         bcast.c \
@@ -285,6 +288,8 @@ libmpi_c_mpi_la_SOURCES = \
         ineighbor_alltoallv.c \
         neighbor_alltoallw.c \
         ineighbor_alltoallw.c \
+        keyval_create.c \
+        keyval_free.c \
         op_c2f.c \
         op_commutative.c \
         op_create.c \
@@ -431,17 +436,13 @@ libmpi_c_mpi_la_SOURCES = \
 	win_unlock_all.c \
         win_wait.c
 
+
 if OMPI_ENABLE_MPI1_COMPAT
 libmpi_c_mpi_la_SOURCES += \
         address.c \
-        attr_delete.c \
-        attr_get.c \
-        attr_put.c \
         errhandler_create.c \
         errhandler_get.c \
         errhandler_set.c \
-        keyval_create.c \
-        keyval_free.c \
         type_extent.c \
         type_hindexed.c \
         type_hvector.c \

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -58,6 +58,9 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pialltoallv.c \
         palltoallw.c \
         pialltoallw.c \
+        pattr_delete.c \
+        pattr_get.c \
+        pattr_put.c \
         pbarrier.c \
         pibarrier.c \
         pbcast.c \
@@ -265,6 +268,8 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pineighbor_alltoallv.c \
         pneighbor_alltoallw.c \
         pineighbor_alltoallw.c \
+        pkeyval_create.c \
+        pkeyval_free.c \
         pop_c2f.c \
         pop_create.c \
         pop_commutative.c \
@@ -414,14 +419,9 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
 if OMPI_ENABLE_MPI1_COMPAT
 nodist_libmpi_c_pmpi_la_SOURCES += \
         paddress.c \
-        pattr_delete.c \
-        pattr_get.c \
-        pattr_put.c \
         perrhandler_create.c \
         perrhandler_get.c \
         perrhandler_set.c \
-        pkeyval_create.c \
-        pkeyval_free.c \
         ptype_extent.c \
         ptype_hindexed.c \
         ptype_hvector.c \

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -138,6 +138,9 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         alltoall_f.c \
         alltoallv_f.c \
         alltoallw_f.c \
+        attr_delete_f.c \
+        attr_get_f.c \
+        attr_put_f.c \
         barrier_f.c \
         bcast_f.c \
         bsend_f.c \
@@ -335,6 +338,8 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         iscatterv_f.c \
         issend_f.c \
         is_thread_main_f.c \
+        keyval_create_f.c \
+        keyval_free_f.c \
         lookup_name_f.c \
         mprobe_f.c \
         mrecv_f.c \
@@ -480,14 +485,9 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
 if OMPI_ENABLE_MPI1_COMPAT
 lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         address_f.c \
-        attr_delete_f.c \
-        attr_get_f.c \
-        attr_put_f.c \
         errhandler_create_f.c \
         errhandler_get_f.c \
         errhandler_set_f.c \
-        keyval_create_f.c \
-        keyval_free_f.c \
         type_extent_f.c \
         type_hindexed_f.c \
         type_hvector_f.c \

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -54,6 +54,9 @@ linked_files = \
         palltoall_f.c \
         palltoallv_f.c \
         palltoallw_f.c \
+        pattr_delete_f.c \
+        pattr_get_f.c \
+        pattr_put_f.c \
         pbarrier_f.c \
         pbcast_f.c \
         pbsend_f.c \
@@ -251,6 +254,8 @@ linked_files = \
         pisend_f.c \
         pissend_f.c \
         pis_thread_main_f.c \
+        pkeyval_create_f.c \
+        pkeyval_free_f.c \
         plookup_name_f.c \
         pmprobe_f.c \
         pmrecv_f.c \
@@ -395,14 +400,9 @@ linked_files = \
 if OMPI_ENABLE_MPI1_COMPAT
 linked_files += \
         paddress_f.c \
-        pattr_delete_f.c \
-        pattr_get_f.c \
-        pattr_put_f.c \
         perrhandler_create_f.c \
         perrhandler_get_f.c \
         perrhandler_set_f.c \
-        pkeyval_create_f.c \
-        pkeyval_free_f.c \
         ptype_extent_f.c \
         ptype_hindexed_f.c \
         ptype_hvector_f.c \


### PR DESCRIPTION
See #6114