### PR TITLE
mpi/c: add back (some more) deprecated subroutines

### DIFF
--- a/ompi/mpi/c/attr_fn.c
+++ b/ompi/mpi/c/attr_fn.c
@@ -9,6 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -131,11 +133,6 @@ int OMPI_C_MPI_COMM_DUP_FN( MPI_Comm comm, int comm_keyval, void* extra_state,
    return MPI_SUCCESS;
 }
 
-#if !defined(OMPI_ENABLE_MPI1_COMPAT)
-
-#error "Need to delete the code below now that the removed functions are no longer shipping"
-
-#elif OMPI_ENABLE_MPI1_COMPAT
 int OMPI_C_MPI_NULL_DELETE_FN( MPI_Comm comm, int comm_keyval,
                                void* attribute_val_out,
                                void* extra_state )
@@ -159,4 +156,3 @@ int OMPI_C_MPI_DUP_FN( MPI_Comm comm, int comm_keyval, void* extra_state,
    *(void**)attribute_val_out = attribute_val_in;
    return MPI_SUCCESS;
 }
-#endif


### PR DESCRIPTION
 - MPI_NULL_DELETE_FN
 - MPI_NULL_COPY_FN
 - MPI_DUP_FN

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>