### PR TITLE
ompi: open/close the bml framework in the pml/ob1 component

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_component.c
+++ b/ompi/mca/pml/ob1/pml_ob1_component.c
@@ -244,11 +244,15 @@ static int mca_pml_ob1_component_register(void)
 
 static int mca_pml_ob1_component_open(void)
 {
+    int rc;
     mca_pml_ob1_output = opal_output_open(NULL);
     opal_output_set_verbosity(mca_pml_ob1_output, mca_pml_ob1_verbose);
 
     mca_pml_ob1.enabled = false;
-    return mca_base_framework_open(&ompi_bml_base_framework, 0);
+    if (OMPI_SUCCESS != (rc = mca_base_framework_open(&ompi_bml_base_framework, 0))) {
+        return rc;
+    }
+    return mca_bml_base_init (1, ompi_mpi_thread_multiple);
 }
 
 

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -17,8 +17,8 @@
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2016      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  *
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
@@ -444,9 +444,6 @@ int ompi_mpi_finalize(void)
         goto done;
     }
     if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_coll_base_framework))) {
-        goto done;
-    }
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_bml_base_framework))) {
         goto done;
     }
     if (OMPI_SUCCESS != (ret = mca_base_framework_close(&opal_mpool_base_framework))) {

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -18,8 +18,8 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2014-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies Ltd. All rights reserved.
  *
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
@@ -604,14 +604,6 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     }
     if (OMPI_SUCCESS != (ret = mca_base_framework_open(&opal_mpool_base_framework, 0))) {
         error = "mca_mpool_base_open() failed";
-        goto error;
-    }
-    if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_bml_base_framework, 0))) {
-        error = "mca_bml_base_open() failed";
-        goto error;
-    }
-    if (OMPI_SUCCESS != (ret = mca_bml_base_init (1, ompi_mpi_thread_multiple))) {
-        error = "mca_bml_base_init() failed";
         goto error;
     }
     if (OMPI_SUCCESS != (ret = mca_base_framework_open(&ompi_pml_base_framework, 0))) {


### PR DESCRIPTION
Since only the pml/ob1 component is using the bml framework,
this component can open/close the bml framework instead of ompi/runtime.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>