### PR TITLE
opal: clean up init/finalize

### DIFF
--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -649,7 +649,8 @@ int32_t ompi_datatype_finalize( void )
     /* release the local convertors (external32 and local) */
     ompi_datatype_default_convertors_fini();
 
-    opal_datatype_finalize();
+    /* don't call opal_datatype_finalize () as it no longer exists. the function will be called
+     * opal_finalize_util (). */
 
     return OMPI_SUCCESS;
 }

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -16,6 +16,8 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -181,7 +183,6 @@ OPAL_DECLSPEC extern const opal_datatype_t opal_datatype_wchar;
  */
 int opal_datatype_register_params(void);
 OPAL_DECLSPEC int32_t opal_datatype_init( void );
-OPAL_DECLSPEC int32_t opal_datatype_finalize( void );
 OPAL_DECLSPEC opal_datatype_t* opal_datatype_create( int32_t expectedSize );
 OPAL_DECLSPEC int32_t opal_datatype_create_desc( opal_datatype_t * datatype, int32_t expectedSize );
 OPAL_DECLSPEC int32_t opal_datatype_commit( opal_datatype_t * pData );

--- a/opal/dss/dss.h
+++ b/opal/dss/dss.h
@@ -1,5 +1,5 @@
-/* -*- C -*-
- *
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -356,12 +358,6 @@ OPAL_DECLSPEC int opal_dss_register_vars (void);
  * executed as part of the program startup.
  */
 OPAL_DECLSPEC int opal_dss_open(void);
-
-/**
- * DSS finalize function
- */
-OPAL_DECLSPEC int opal_dss_close(void);
-
 
 /**
  * Copy a data value from one location to another.

--- a/opal/mca/base/base.h
+++ b/opal/mca/base/base.h
@@ -16,6 +16,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -130,7 +132,7 @@ OPAL_DECLSPEC int mca_base_open(void);
  * It must be the last MCA function invoked.  It is normally invoked
  * during the finalize stage.
  */
-OPAL_DECLSPEC int mca_base_close(void);
+OPAL_DECLSPEC void mca_base_close(void);
 
 /**
  * A generic select function

--- a/opal/mca/base/mca_base_close.c
+++ b/opal/mca/base/mca_base_close.c
@@ -33,35 +33,34 @@ extern int mca_base_opened;
 /*
  * Main MCA shutdown.
  */
-int mca_base_close(void)
+
+void mca_base_close (void)
 {
     assert (mca_base_opened);
-    if (!--mca_base_opened) {
-        /* deregister all MCA base parameters */
-        int group_id = mca_base_var_group_find ("opal", "mca", "base");
-
-        if (-1 < group_id) {
-            mca_base_var_group_deregister (group_id);
-        }
-
-        /* release the default paths */
-        if (NULL != mca_base_system_default_path) {
-            free(mca_base_system_default_path);
-        }
-        if (NULL != mca_base_user_default_path) {
-            free(mca_base_user_default_path);
-        }
-
-        /* Close down the component repository */
-        mca_base_component_repository_finalize();
-
-        /* Shut down the dynamic component finder */
-        mca_base_component_find_finalize();
-
-        /* Close opal output stream 0 */
-        opal_output_close(0);
+    if (--mca_base_opened) {
+        return;
     }
 
-    /* All done */
-    return OPAL_SUCCESS;
+    /* deregister all MCA base parameters */
+    int group_id = mca_base_var_group_find ("opal", "mca", "base");
+
+    if (-1 < group_id) {
+        mca_base_var_group_deregister (group_id);
+    }
+
+    /* release the default paths */
+    free (mca_base_system_default_path);
+    mca_base_system_default_path = NULL;
+
+    free (mca_base_user_default_path);
+    mca_base_user_default_path = NULL;
+
+    /* Close down the component repository */
+    mca_base_component_repository_finalize();
+
+    /* Shut down the dynamic component finder */
+    mca_base_component_find_finalize();
+
+    /* Close opal output stream 0 */
+    opal_output_close(0);
 }

--- a/opal/mca/base/mca_base_framework.c
+++ b/opal/mca/base/mca_base_framework.c
@@ -5,6 +5,8 @@
  * Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -140,6 +142,22 @@ int mca_base_framework_register (struct mca_base_framework_t *framework,
     return OPAL_SUCCESS;
 }
 
+int mca_base_framework_register_list (mca_base_framework_t **frameworks, mca_base_register_flag_t flags)
+{
+    if (NULL == frameworks) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    for (int i = 0 ; frameworks[i] ; ++i) {
+        int ret = mca_base_framework_register (frameworks[i], flags);
+        if (OPAL_UNLIKELY(OPAL_SUCCESS != ret && OPAL_ERR_NOT_AVAILABLE != ret)) {
+            return ret;
+        }
+    }
+
+    return OPAL_SUCCESS;
+}
+
 int mca_base_framework_open (struct mca_base_framework_t *framework,
                              mca_base_open_flag_t flags) {
     int ret;
@@ -187,6 +205,22 @@ int mca_base_framework_open (struct mca_base_framework_t *framework,
     }
 
     return ret;
+}
+
+int mca_base_framework_open_list (mca_base_framework_t **frameworks, mca_base_open_flag_t flags)
+{
+    if (NULL == frameworks) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    for (int i = 0 ; frameworks[i] ; ++i) {
+        int ret = mca_base_framework_open (frameworks[i], flags);
+        if (OPAL_UNLIKELY(OPAL_SUCCESS != ret && OPAL_ERR_NOT_AVAILABLE != ret)) {
+            return ret;
+        }
+    }
+
+    return OPAL_SUCCESS;
 }
 
 int mca_base_framework_close (struct mca_base_framework_t *framework) {
@@ -246,4 +280,20 @@ int mca_base_framework_close (struct mca_base_framework_t *framework) {
     framework_close_output (framework);
 
     return ret;
+}
+
+int mca_base_framework_close_list (mca_base_framework_t **frameworks)
+{
+    if (NULL == frameworks) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+
+    for (int i = 0 ; frameworks[i] ; ++i) {
+        int ret = mca_base_framework_close (frameworks[i]);
+        if (OPAL_UNLIKELY(OPAL_SUCCESS != ret)) {
+            return ret;
+        }
+    }
+
+    return OPAL_SUCCESS;
 }

--- a/opal/mca/base/mca_base_framework.h
+++ b/opal/mca/base/mca_base_framework.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -174,6 +176,20 @@ OPAL_DECLSPEC int mca_base_framework_register (mca_base_framework_t *framework,
                                                mca_base_register_flag_t flags);
 
 /**
+ * Register frameworks with MCA.
+ *
+ * @param[in] framework NULL-terminated list of frameworks to register
+ *
+ * @retval OPAL_SUCCESS Upon success
+ * @retval OPAL_ERROR Upon failure
+ *
+ * Call the MCA variable registration functions of each framework in the
+ * frameworks array.
+ */
+OPAL_DECLSPEC int mca_base_framework_register_list (mca_base_framework_t **frameworks,
+                                                    mca_base_register_flag_t flags);
+
+/**
  * Open a framework
  *
  * @param[in] framework framework to open
@@ -187,6 +203,19 @@ OPAL_DECLSPEC int mca_base_framework_open (mca_base_framework_t *framework,
                                            mca_base_open_flag_t flags);
 
 /**
+ * Open frameworks
+ *
+ * @param[in] frameworks NULL-terminated array of framework to open
+ *
+ * @retval OPAL_SUCCESS Upon success
+ * @retval OPAL_ERROR Upon failure
+ *
+ * Call the open function on multiple frameworks
+ */
+OPAL_DECLSPEC int mca_base_framework_open_list (mca_base_framework_t **frameworks,
+                                                mca_base_open_flag_t flags);
+
+/**
  * Close a framework
  *
  * @param[in] framework framework to close
@@ -198,6 +227,17 @@ OPAL_DECLSPEC int mca_base_framework_open (mca_base_framework_t *framework,
  */
 OPAL_DECLSPEC int mca_base_framework_close (mca_base_framework_t *framework);
 
+/**
+ * Close frameworks
+ *
+ * @param[in] frameworks NULL-terminated array of framework to close
+ *
+ * @retval OPAL_SUCCESS Upon success
+ * @retval OPAL_ERROR Upon failure
+ *
+ * Call the close function on multiple frameworks
+ */
+OPAL_DECLSPEC int mca_base_framework_close_list (mca_base_framework_t **frameworks);
 
 /**
  * Check if a framework is already registered

--- a/opal/mca/base/mca_base_open.c
+++ b/opal/mca/base/mca_base_open.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +35,7 @@
 #include <unistd.h>
 #endif
 
+#include "opal/runtime/opal.h"
 #include "opal/mca/installdirs/installdirs.h"
 #include "opal/util/output.h"
 #include "opal/util/printf.h"
@@ -163,6 +166,8 @@ int mca_base_open(void)
     free(lds.lds_prefix);
 
     /* Open up the component repository */
+
+    opal_finalize_register_cleanup (mca_base_close);
 
     return mca_base_component_repository_init();
 }

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -18,6 +18,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -144,6 +146,7 @@ static int read_files (char *file_list, opal_list_t *file_values, char sep);
 static int var_set_initial (mca_base_var_t *var, mca_base_var_t *original);
 static int var_get (int vari, mca_base_var_t **var_out, bool original);
 static int var_value_string (mca_base_var_t *var, char **value_string);
+static void mca_base_var_finalize (void);
 
 /*
  * classes
@@ -292,6 +295,8 @@ int mca_base_var_init(void)
         mca_base_var_initialized = true;
 
     }
+
+    opal_finalize_register_cleanup (mca_base_var_finalize);
 
     return OPAL_SUCCESS;
 }
@@ -1103,7 +1108,7 @@ int mca_base_var_build_env(char ***env, int *num_env, bool internal)
  * Shut down the MCA parameter system (normally only invoked by the
  * MCA framework itself).
  */
-int mca_base_var_finalize(void)
+static void mca_base_var_finalize (void)
 {
     opal_object_t *object;
     opal_list_item_t *item;
@@ -1158,10 +1163,6 @@ int mca_base_var_finalize(void)
         free (mca_base_envar_files);
         mca_base_envar_files = NULL;
     }
-
-    /* All done */
-
-    return OPAL_SUCCESS;
 }
 
 

--- a/opal/mca/base/mca_base_var.h
+++ b/opal/mca/base/mca_base_var.h
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -708,22 +710,6 @@ OPAL_DECLSPEC int mca_base_var_get_count (void);
  */
 OPAL_DECLSPEC int mca_base_var_build_env(char ***env, int *num_env,
                                          bool internal);
-
-/**
- * Shut down the MCA variable system (normally only invoked by the
- * MCA framework itself).
- *
- * @returns OPAL_SUCCESS This function never fails.
- *
- * This function shuts down the MCA variable repository and frees all
- * associated memory.  No other mca_base_var*() functions can be
- * invoked after this function.
- *
- * This function is normally only invoked by the MCA framework itself
- * when the process is shutting down (e.g., during MPI_FINALIZE).  It
- * is only documented here for completeness.
- */
-OPAL_DECLSPEC int mca_base_var_finalize(void);
 
 typedef enum {
     /* Dump human-readable strings */

--- a/opal/memoryhooks/memory.h
+++ b/opal/memoryhooks/memory.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,24 +61,6 @@ BEGIN_C_DECLS
  * @retval OPAL_SUCCESS Initialization completed successfully
  */
 OPAL_DECLSPEC int opal_mem_hooks_init(void);
-
-
-/**
- * Finalize the memory hooks subsystem
- *
- * Finalize the memory hooks subsystem.  This is generally called
- * during opal_finalize() and no other memory hooks functions should
- * be called after this function is called.  opal_mem_hooks_finalize()
- * will automatically deregister any callbacks that have not already
- * been deregistered.  In a multi-threaded application, it is possible
- * that one thread will have a memory hook callback while the other
- * thread is in opal_mem_hooks_finalize(), however, no threads will
- * receive a callback once the calling thread has exited
- * opal_mem_hooks_finalize().
- *
- * @retval OPAL_SUCCESS Shutdown completed successfully
- */
-OPAL_DECLSPEC int opal_mem_hooks_finalize(void);
 
 
 /**

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -80,6 +80,13 @@ int opal_max_thread_in_progress = 1;
 
 static bool opal_register_done = false;
 
+static void opal_deregister_params (void)
+{
+    /* The MCA variable system will be torn down shortly so reset the registered
+     * flag. */
+    opal_register_done = false;
+}
+
 int opal_register_params(void)
 {
     int ret;
@@ -380,12 +387,7 @@ int opal_register_params(void)
         return ret;
     }
 
-    return OPAL_SUCCESS;
-}
-
-int opal_deregister_params(void)
-{
-    opal_register_done = false;
+    opal_finalize_register_cleanup (opal_deregister_params);
 
     return OPAL_SUCCESS;
 }

--- a/opal/runtime/opal_progress.h
+++ b/opal/runtime/opal_progress.h
@@ -11,6 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -32,6 +34,7 @@ BEGIN_C_DECLS
 
 #include "opal_config.h"
 #include "opal/threads/mutex.h"
+#include "opal/runtime/opal.h"
 
 /**
  * Initialize the progress engine
@@ -42,17 +45,6 @@ BEGIN_C_DECLS
  * interface may be called.
  */
 OPAL_DECLSPEC int opal_progress_init(void);
-
-
-/**
- * Shut down the progress engine
- *
- * Shut down the progress engine.  This includes deregistering all
- * registered callbacks and freeing all resources.  After finalize
- * returns, no calls into the progress interface are allowed.
- */
-OPAL_DECLSPEC int opal_progress_finalize(void);
-
 
 /**
  * Progress all pending events

--- a/opal/util/keyval_parse.c
+++ b/opal/util/keyval_parse.c
@@ -12,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,6 +24,7 @@
 #include "opal_config.h"
 
 #include "opal/constants.h"
+#include "opal/runtime/opal.h"
 #include "opal/util/keyval_parse.h"
 #include "opal/util/keyval/keyval_lex.h"
 #include "opal/util/output.h"
@@ -45,22 +48,20 @@ static void parse_error(int num);
 static char *env_str = NULL;
 static int envsize = 1024;
 
-int opal_util_keyval_parse_init(void)
+static void opal_util_keyval_parse_finalize (void)
 {
-    OBJ_CONSTRUCT(&keyval_mutex, opal_mutex_t);
-
-    return OPAL_SUCCESS;
-}
-
-
-int
-opal_util_keyval_parse_finalize(void)
-{
-    if (NULL != key_buffer) free(key_buffer);
+    free(key_buffer);
     key_buffer = NULL;
     key_buffer_len = 0;
 
     OBJ_DESTRUCT(&keyval_mutex);
+}
+
+int opal_util_keyval_parse_init(void)
+{
+    OBJ_CONSTRUCT(&keyval_mutex, opal_mutex_t);
+
+    opal_finalize_register_cleanup (opal_util_keyval_parse_finalize);
 
     return OPAL_SUCCESS;
 }

--- a/opal/util/keyval_parse.h
+++ b/opal/util/keyval_parse.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,8 +52,6 @@ OPAL_DECLSPEC int opal_util_keyval_parse(const char *filename,
                                          opal_keyval_parse_fn_t callback);
 
 OPAL_DECLSPEC int opal_util_keyval_parse_init(void);
-
-OPAL_DECLSPEC int opal_util_keyval_parse_finalize(void);
 
 OPAL_DECLSPEC int opal_util_keyval_save_internal_envars(opal_keyval_parse_fn_t callback);
 

--- a/opal/util/malloc.c
+++ b/opal/util/malloc.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,6 +25,7 @@
 
 #include "opal/util/malloc.h"
 #include "opal/util/output.h"
+#include "opal/runtime/opal.h"
 
 
 /*
@@ -54,26 +58,11 @@ int opal_malloc_output = -1;
 static opal_output_stream_t malloc_stream;
 
 
-/*
- * Initialize the malloc debug interface
- */
-void opal_malloc_init(void)
-{
 #if OPAL_ENABLE_DEBUG
-    OBJ_CONSTRUCT(&malloc_stream, opal_output_stream_t);
-    malloc_stream.lds_is_debugging = true;
-    malloc_stream.lds_verbose_level = 5;
-    malloc_stream.lds_prefix = "malloc debug: ";
-    malloc_stream.lds_want_stderr = true;
-    opal_malloc_output = opal_output_open(&malloc_stream);
-#endif  /* OPAL_ENABLE_DEBUG */
-}
-
-
 /*
  * Finalize the malloc debug interface
  */
-void opal_malloc_finalize(void)
+static void opal_malloc_finalize(void)
 {
     if (-1 != opal_malloc_output) {
         opal_output_close(opal_malloc_output);
@@ -82,6 +71,24 @@ void opal_malloc_finalize(void)
     }
 }
 
+/*
+ * Initialize the malloc debug interface
+ */
+void opal_malloc_init(void)
+{
+    OBJ_CONSTRUCT(&malloc_stream, opal_output_stream_t);
+    malloc_stream.lds_is_debugging = true;
+    malloc_stream.lds_verbose_level = 5;
+    malloc_stream.lds_prefix = "malloc debug: ";
+    malloc_stream.lds_want_stderr = true;
+    opal_malloc_output = opal_output_open(&malloc_stream);
+    opal_finalize_register_cleanup (opal_malloc_finalize);
+}
+#else
+void opal_malloc_init (void)
+{
+}
+#endif  /* OPAL_ENABLE_DEBUG */
 
 /*
  * Debug version of malloc

--- a/opal/util/malloc.h
+++ b/opal/util/malloc.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -9,6 +10,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,14 +62,6 @@ BEGIN_C_DECLS
    * unless this function is invoked first.
    */
 void opal_malloc_init(void);
-
-  /**
-   * Shut down malloc debug output.
-   *
-   * This function is invoked as part of opal_finalize() to shut down the
-   * output stream for malloc debug messages.
-   */
-void opal_malloc_finalize(void);
 
   /**
    * \internal

--- a/opal/util/net.h
+++ b/opal/util/net.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -49,19 +52,6 @@ BEGIN_C_DECLS
  *                        buffer creation
  */
 OPAL_DECLSPEC int opal_net_init(void);
-
-
-/**
- * Finalize the network helper subsystem
- *
- * Finalize the network helper subsystem.  Should be called exactly
- * once for any process that will use any function in the network
- * helper subsystem.
- *
- * @retval OPAL_SUCCESS   Success
- */
-OPAL_DECLSPEC int opal_net_finalize(void);
-
 
 /**
  * Calculate netmask in network byte order from CIDR notation

--- a/opal/util/output.h
+++ b/opal/util/output.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -263,14 +266,6 @@ struct opal_output_stream_t {
      * and has a verbose level of 0.
      */
     OPAL_DECLSPEC bool opal_output_init(void);
-
-    /**
-     * Shut down the output stream system.
-     *
-     * Shut down the output stream system, including the default verbose
-     * stream.
-     */
-    OPAL_DECLSPEC void opal_output_finalize(void);
 
     /**
      * Opens an output stream.

--- a/opal/util/show_help.c
+++ b/opal/util/show_help.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +30,7 @@
 #include <locale.h>
 #include <errno.h>
 
+#include "opal/runtime/opal.h"
 #include "opal/mca/installdirs/installdirs.h"
 #include "opal/util/show_help.h"
 #include "opal/util/show_help_lex.h"
@@ -52,6 +56,7 @@ static int opal_show_vhelp_internal(const char *filename, const char *topic,
                                     int want_error_header, va_list arglist);
 static int opal_show_help_internal(const char *filename, const char *topic,
                                    int want_error_header, ...);
+static void opal_show_help_finalize (void);
 
 opal_show_help_fn_t opal_show_help = opal_show_help_internal;
 opal_show_vhelp_fn_t opal_show_vhelp = opal_show_vhelp_internal;
@@ -67,10 +72,12 @@ int opal_show_help_init(void)
 
     opal_argv_append_nosize(&search_dirs, opal_install_dirs.opaldatadir);
 
+    opal_finalize_register_cleanup (opal_show_help_finalize);
+
     return OPAL_SUCCESS;
 }
 
-int opal_show_help_finalize(void)
+static void opal_show_help_finalize (void)
 {
     opal_output_close(output_stream);
     output_stream = -1;
@@ -79,9 +86,7 @@ int opal_show_help_finalize(void)
     if (NULL != search_dirs) {
         opal_argv_free(search_dirs);
         search_dirs = NULL;
-    };
-
-    return OPAL_SUCCESS;
+    }
 }
 
 /*

--- a/opal/util/show_help.h
+++ b/opal/util/show_help.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -101,15 +104,6 @@ BEGIN_C_DECLS
  * Initialization of show_help subsystem
  */
 OPAL_DECLSPEC int opal_show_help_init(void);
-
-
-/**
- * \internal
- *
- * Finalization of show_help subsystem
- */
-OPAL_DECLSPEC int opal_show_help_finalize(void);
-
 
 /**
  * Look up a text message in a text file and display it to the

--- a/test/datatype/checksum.c
+++ b/test/datatype/checksum.c
@@ -1,7 +1,9 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2006 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -14,6 +16,7 @@
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "opal/datatype/opal_datatype_checksum.h"
+#include "opal/runtime/opal.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -38,6 +41,7 @@ int main( int argc, char* argv[] )
     struct iovec iov[2];
     opal_convertor_t* convertor;
 
+    opal_init_util (NULL, NULL);
     ompi_datatype_init();
     srandom( (int)time(NULL) );
     /*srandomdev();*/
@@ -149,6 +153,7 @@ int main( int argc, char* argv[] )
 
     /* clean-ups all data allocations */
     ompi_datatype_finalize();
+    opal_finalize_util ();
 
     return 0;
 }

--- a/test/datatype/ddt_pack.c
+++ b/test/datatype/ddt_pack.c
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +13,8 @@
  * Copyright (c) 2006      Sun Microsystems Inc. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,6 +65,7 @@ main(int argc, char* argv[])
     int _dbg = 0;
     while (_dbg) poll(NULL, 0, 1);
 
+    opal_init_util (NULL, NULL);
     ompi_datatype_init();
 
     /**
@@ -397,6 +400,7 @@ main(int argc, char* argv[])
 
  cleanup:
     ompi_datatype_finalize();
+    opal_finalize_util ();
 
     return ret;
 }

--- a/test/datatype/ddt_raw.c
+++ b/test/datatype/ddt_raw.c
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +13,8 @@
  * Copyright (c) 2006      Sun Microsystems Inc. All rights reserved.
  * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,6 +25,8 @@
 #include "ompi_config.h"
 #include "ddt_lib.h"
 #include "opal/datatype/opal_convertor.h"
+#include "opal/runtime/opal.h"
+
 #include <time.h>
 #include <stdlib.h>
 #ifdef HAVE_SYS_TIME_H
@@ -148,6 +152,7 @@ int main( int argc, char* argv[] )
     ompi_datatype_t *pdt, *pdt1, *pdt2, *pdt3;
     int rc, length = 500, iov_num = 5;
 
+    opal_init_util (NULL, NULL);
     ompi_datatype_init();
 
     /**
@@ -310,6 +315,7 @@ int main( int argc, char* argv[] )
 
     /* clean-ups all data allocations */
     ompi_datatype_finalize();
+    opal_finalize_util ();
 
     return OMPI_SUCCESS;
 }

--- a/test/datatype/opal_datatype_test.c
+++ b/test/datatype/opal_datatype_test.c
@@ -503,7 +503,7 @@ int main( int argc, char* argv[] )
     opal_datatype_t *pdt, *pdt1, *pdt2, *pdt3;
     int rc, length = 500;
 
-    opal_datatype_init();
+    opal_init_util (NULL, NULL);
 
     /**
      * By default simulate homogeneous architectures.
@@ -717,7 +717,7 @@ int main( int argc, char* argv[] )
     OBJ_RELEASE( pdt2 ); assert( pdt2 == NULL );
 
     /* clean-ups all data allocations */
-    opal_datatype_finalize();
-    opal_finalize();
+    opal_finalize_util ();
+
     return OPAL_SUCCESS;
 }

--- a/test/datatype/position.c
+++ b/test/datatype/position.c
@@ -1,10 +1,12 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,6 +21,7 @@
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "opal/util/output.h"
+#include "opal/runtime/opal.h"
 
 /**
  * The purpose of this test is to simulate the multi-network packing and
@@ -231,7 +234,7 @@ int main( int argc, char* argv[] )
     }
     memcpy(recv_buffer, send_buffer, sizeof(ddt_ldi_t) * data_count );
 
-    opal_datatype_init();
+    opal_init_util (NULL, NULL);
     ompi_datatype_init();
 
 #if (OPAL_ENABLE_DEBUG == 1) && (OPAL_C_HAVE_VISIBILITY == 0)
@@ -278,6 +281,7 @@ int main( int argc, char* argv[] )
     free(segments);
 
     ompi_datatype_finalize();
+    opal_finalize_util ();
 
     return (0 == errors ? 0 : -1);
 }

--- a/test/datatype/position_noncontig.c
+++ b/test/datatype/position_noncontig.c
@@ -1,10 +1,12 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,6 +21,7 @@
 #include "opal/datatype/opal_convertor.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "opal/util/output.h"
+#include "opal/runtime/opal.h"
 
 /**
  * The purpose of this test is to simulate the multi-network packing and
@@ -199,7 +202,7 @@ int main( int argc, char* argv[] )
         recv_buffer[i] = 0xdeadbeef;
     }
 
-    opal_datatype_init();
+    opal_init_util (NULL, NULL);
     ompi_datatype_init();
 
     ompi_datatype_create_vector(NELT/2, 1, 2, MPI_INT, &datatype);
@@ -245,6 +248,7 @@ int main( int argc, char* argv[] )
     free(segments);
 
     ompi_datatype_finalize();
+    opal_finalize_util ();
 
     return (0 == errors ? 0 : -1);
 }

--- a/test/datatype/unpack_hetero.c
+++ b/test/datatype/unpack_hetero.c
@@ -39,7 +39,7 @@ uint32_t remote_arch = 0xffffffff;
  */
 int main( int argc, char* argv[] )
 {
-    opal_datatype_init();
+    opal_init_util (NULL, NULL);
 
     /**
      * By default simulate homogeneous architectures.
@@ -93,7 +93,7 @@ int main( int argc, char* argv[] )
     OBJ_RELEASE(pConv);
 
     /* clean-ups all data allocations */
-    opal_datatype_finalize();
-    opal_finalize();
+    opal_finalize_util ();
+
     return OPAL_SUCCESS;
 }


### PR DESCRIPTION
This commit contains the following changes:

 - Remove the unused opal_test_init/opal_test_finalize
   functions. These functions are not used by anything in the code
   base or MTT. Tests use opal_init_util/opal_finalize_util instead.

 - Get rid of gotos in opal_init_util and opal_init. Replaced them
   with a cleaner solution.

 - Automatically register cleanup functions in init functions. The
   cleanup functions are executed in the reverse order of the
   initialization functions. The cleanup functions are run in
   opal_finalize_util() before tearing down the class system.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>