### PR TITLE
SPML/UCX: added registration of static segments on context creation

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -69,6 +69,8 @@ typedef struct ucp_peer ucp_peer_t;
 struct mca_spml_ucx_ctx {
     ucp_worker_h             ucp_worker;
     ucp_peer_t              *ucp_peers;
+    sshmem_mkey_t          **mkeys; /* mkeys used to register static segments
+                                       for self communications */
     long                     options;
 };
 typedef struct mca_spml_ucx_ctx mca_spml_ucx_ctx_t;


### PR DESCRIPTION
- there is an issue in access of local memory using non-default context.
  due to some reasons UCX used incorrect RKEY for such operations which
  caused seg-fault.
- added workaround: static segments are registered using newly created
  context infrastructure

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>