### PR TITLE
btl/openib: delay UCX warning to add_procs()

### DIFF
--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -19,8 +19,8 @@
  * Copyright (c) 2009      IBM Corporation.  All rights reserved.
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * Copyright (c) 2013-2015 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Bull SAS.  All rights reserved
  * $COPYRIGHT$
  *
@@ -1040,6 +1040,14 @@ int mca_btl_openib_add_procs(
     int btl_rank = 0;
     volatile mca_btl_base_endpoint_t* endpoint;
 
+
+    if (! openib_btl->allowed) {
+        opal_bitmap_clear_all_bits(reachable);
+        opal_show_help("help-mpi-btl-openib.txt", "ib port not selected",
+                       true, opal_process_info.nodename,
+                       ibv_get_device_name(openib_btl->device->ib_dev), openib_btl->port_num);
+    }
+
     btl_rank = get_openib_btl_params(openib_btl, &lcl_subnet_id_port_cnt);
     if( 0 > btl_rank ){
         return OPAL_ERR_NOT_FOUND;
@@ -1639,75 +1647,77 @@ static int mca_btl_openib_finalize_resources(struct mca_btl_base_module_t* btl) 
         return OPAL_SUCCESS;
     }
 
-    /* Release all QPs */
-    if (NULL != openib_btl->device->endpoints) {
-        for (ep_index=0;
-             ep_index < opal_pointer_array_get_size(openib_btl->device->endpoints);
-             ep_index++) {
-            endpoint=(mca_btl_openib_endpoint_t *)opal_pointer_array_get_item(openib_btl->device->endpoints,
+    if (openib_btl->allowed) {
+        /* Release all QPs */
+        if (NULL != openib_btl->device->endpoints) {
+            for (ep_index=0;
+                 ep_index < opal_pointer_array_get_size(openib_btl->device->endpoints);
+                 ep_index++) {
+                endpoint=(mca_btl_openib_endpoint_t *)opal_pointer_array_get_item(openib_btl->device->endpoints,
                                                                               ep_index);
-            if(!endpoint) {
-                BTL_VERBOSE(("In finalize, got another null endpoint"));
-                continue;
-            }
-            if(endpoint->endpoint_btl != openib_btl) {
-                continue;
-            }
-            for(i = 0; i < openib_btl->device->eager_rdma_buffers_count; i++) {
-                if(openib_btl->device->eager_rdma_buffers[i] == endpoint) {
-                    openib_btl->device->eager_rdma_buffers[i] = NULL;
-                    OBJ_RELEASE(endpoint);
+                if(!endpoint) {
+                    BTL_VERBOSE(("In finalize, got another null endpoint"));
+                    continue;
                 }
-            }
-            opal_pointer_array_set_item(openib_btl->device->endpoints,
-                                        ep_index, NULL);
-            assert(((opal_object_t*)endpoint)->obj_reference_count == 1);
-            OBJ_RELEASE(endpoint);
-        }
-    }
-
-    /* Release SRQ resources */
-    for(qp = 0; qp < mca_btl_openib_component.num_qps; qp++) {
-        if(!BTL_OPENIB_QP_TYPE_PP(qp)) {
-            MCA_BTL_OPENIB_CLEAN_PENDING_FRAGS(
-                    &openib_btl->qps[qp].u.srq_qp.pending_frags[0]);
-            MCA_BTL_OPENIB_CLEAN_PENDING_FRAGS(
-                    &openib_btl->qps[qp].u.srq_qp.pending_frags[1]);
-            if (NULL != openib_btl->qps[qp].u.srq_qp.srq) {
-                opal_mutex_t *lock =
-                             &mca_btl_openib_component.srq_manager.lock;
-
-                opal_hash_table_t *srq_addr_table =
-                            &mca_btl_openib_component.srq_manager.srq_addr_table;
-
-                opal_mutex_lock(lock);
-                if (OPAL_SUCCESS !=
-                        opal_hash_table_remove_value_ptr(srq_addr_table,
-                                    &openib_btl->qps[qp].u.srq_qp.srq,
-                                    sizeof(struct ibv_srq *))) {
-                    BTL_VERBOSE(("Failed to remove SRQ  %d entry from hash table.", qp));
-                    rc = OPAL_ERROR;
+                if(endpoint->endpoint_btl != openib_btl) {
+                    continue;
                 }
-                opal_mutex_unlock(lock);
-                if (0 != ibv_destroy_srq(openib_btl->qps[qp].u.srq_qp.srq)) {
-                    BTL_VERBOSE(("Failed to close SRQ %d", qp));
-                    rc = OPAL_ERROR;
+                for(i = 0; i < openib_btl->device->eager_rdma_buffers_count; i++) {
+                    if(openib_btl->device->eager_rdma_buffers[i] == endpoint) {
+                        openib_btl->device->eager_rdma_buffers[i] = NULL;
+                        OBJ_RELEASE(endpoint);
+                    }
                 }
+                opal_pointer_array_set_item(openib_btl->device->endpoints,
+                                            ep_index, NULL);
+                assert(((opal_object_t*)endpoint)->obj_reference_count == 1);
+                OBJ_RELEASE(endpoint);
             }
-
-            OBJ_DESTRUCT(&openib_btl->qps[qp].u.srq_qp.pending_frags[0]);
-            OBJ_DESTRUCT(&openib_btl->qps[qp].u.srq_qp.pending_frags[1]);
         }
-    }
 
-    /* Finalize the CPC modules on this openib module */
-    for (i = 0; i < openib_btl->num_cpcs; ++i) {
-        if (NULL != openib_btl->cpcs[i]->cbm_finalize) {
-            openib_btl->cpcs[i]->cbm_finalize(openib_btl, openib_btl->cpcs[i]);
+        /* Release SRQ resources */
+        for(qp = 0; qp < mca_btl_openib_component.num_qps; qp++) {
+            if(!BTL_OPENIB_QP_TYPE_PP(qp)) {
+                MCA_BTL_OPENIB_CLEAN_PENDING_FRAGS(
+                        &openib_btl->qps[qp].u.srq_qp.pending_frags[0]);
+                MCA_BTL_OPENIB_CLEAN_PENDING_FRAGS(
+                        &openib_btl->qps[qp].u.srq_qp.pending_frags[1]);
+                if (NULL != openib_btl->qps[qp].u.srq_qp.srq) {
+                    opal_mutex_t *lock =
+                                 &mca_btl_openib_component.srq_manager.lock;
+
+                    opal_hash_table_t *srq_addr_table =
+                                &mca_btl_openib_component.srq_manager.srq_addr_table;
+
+                    opal_mutex_lock(lock);
+                    if (OPAL_SUCCESS !=
+                            opal_hash_table_remove_value_ptr(srq_addr_table,
+                                        &openib_btl->qps[qp].u.srq_qp.srq,
+                                        sizeof(struct ibv_srq *))) {
+                        BTL_VERBOSE(("Failed to remove SRQ  %d entry from hash table.", qp));
+                        rc = OPAL_ERROR;
+                    }
+                    opal_mutex_unlock(lock);
+                    if (0 != ibv_destroy_srq(openib_btl->qps[qp].u.srq_qp.srq)) {
+                        BTL_VERBOSE(("Failed to close SRQ %d", qp));
+                        rc = OPAL_ERROR;
+                    }
+                }
+
+                OBJ_DESTRUCT(&openib_btl->qps[qp].u.srq_qp.pending_frags[0]);
+                OBJ_DESTRUCT(&openib_btl->qps[qp].u.srq_qp.pending_frags[1]);
+            }
         }
-        free(openib_btl->cpcs[i]);
+
+        /* Finalize the CPC modules on this openib module */
+        for (i = 0; i < openib_btl->num_cpcs; ++i) {
+            if (NULL != openib_btl->cpcs[i]->cbm_finalize) {
+                openib_btl->cpcs[i]->cbm_finalize(openib_btl, openib_btl->cpcs[i]);
+            }
+            free(openib_btl->cpcs[i]);
+        }
+        free(openib_btl->cpcs);
     }
-    free(openib_btl->cpcs);
 
     /* Release device if there are no more users */
     if(!(--openib_btl->device->btls)) {

--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1046,6 +1046,7 @@ int mca_btl_openib_add_procs(
         opal_show_help("help-mpi-btl-openib.txt", "ib port not selected",
                        true, opal_process_info.nodename,
                        ibv_get_device_name(openib_btl->device->ib_dev), openib_btl->port_num);
+        return OPAL_SUCCESS;
     }
 
     btl_rank = get_openib_btl_params(openib_btl, &lcl_subnet_id_port_cnt);

--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1045,7 +1045,7 @@ int mca_btl_openib_add_procs(
         opal_bitmap_clear_all_bits(reachable);
         opal_show_help("help-mpi-btl-openib.txt", "ib port not selected",
                        true, opal_process_info.nodename,
-                       ibv_get_device_name(openib_btl->device->ib_dev), openib_btl->port_num);
+                       openib_btl->device_name, openib_btl->port_num);
         return OPAL_SUCCESS;
     }
 
@@ -1718,11 +1718,11 @@ static int mca_btl_openib_finalize_resources(struct mca_btl_base_module_t* btl) 
             free(openib_btl->cpcs[i]);
         }
         free(openib_btl->cpcs);
-    }
 
-    /* Release device if there are no more users */
-    if(!(--openib_btl->device->btls)) {
-        OBJ_RELEASE(openib_btl->device);
+        /* Release device if there are no more users */
+        if(!(--openib_btl->device->allowed_btls)) {
+            OBJ_RELEASE(openib_btl->device);
+        }
     }
 
     if (NULL != openib_btl->qps) {

--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -392,6 +392,7 @@ typedef struct mca_btl_openib_device_t {
     /* Whether this device supports eager RDMA */
     uint8_t use_eager_rdma;
     uint8_t btls;              /** < number of btls using this device */
+    uint8_t allowed_btls;      /** < number of allowed btls using this device */
     opal_pointer_array_t *endpoints;
     opal_pointer_array_t *device_btls;
     uint16_t hp_cq_polls;
@@ -483,6 +484,7 @@ struct mca_btl_openib_module_t {
     uint8_t num_cpcs;
 
     mca_btl_openib_device_t *device;
+    char * device_name;
     uint8_t port_num;                  /**< ID of the PORT */
     uint16_t pkey_index;
     struct ibv_port_attr ib_port_attr;

--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -18,8 +18,8 @@
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2013-2014 NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014      Bull SAS.  All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -163,6 +163,9 @@ struct mca_btl_openib_component_t {
 
     int                                ib_num_btls;
     /**< number of devices available to the openib component */
+
+    int                                ib_allowed_btls;
+    /**< number of devices allowed to the openib component */
 
     struct mca_btl_openib_module_t             **openib_btls;
     /**< array of available BTLs */
@@ -501,6 +504,8 @@ struct mca_btl_openib_module_t {
     int local_procs;                   /** number of local procs */
 
     bool atomic_ops_be;                /** atomic result is big endian */
+
+    bool allowed;                      /** is this port allowed */
 };
 typedef struct mca_btl_openib_module_t mca_btl_openib_module_t;
 

--- a/opal/mca/btl/openib/btl_openib_component.c
+++ b/opal/mca/btl/openib/btl_openib_component.c
@@ -648,9 +648,10 @@ static int init_one_port(opal_list_t *btl_list, mca_btl_openib_device_t *device,
                 sizeof(mca_btl_openib_module));
         ib_selected = OBJ_NEW(mca_btl_base_selected_module_t);
         ib_selected->btl_module = (mca_btl_base_module_t*) openib_btl;
-        openib_btl->device = device;
         openib_btl->port_num = (uint8_t) port_num;
         openib_btl->allowed = false;
+        openib_btl->device = NULL;
+        openib_btl->device_name = strdup(ibv_get_device_name(device->ib_dev));
         OBJ_CONSTRUCT(&openib_btl->ib_lock, opal_mutex_t);
         opal_list_append(btl_list, (opal_list_item_t*) ib_selected);
         opal_pointer_array_add(device->device_btls, (void*) openib_btl);
@@ -784,6 +785,7 @@ static int init_one_port(opal_list_t *btl_list, mca_btl_openib_device_t *device,
             ib_selected = OBJ_NEW(mca_btl_base_selected_module_t);
             ib_selected->btl_module = (mca_btl_base_module_t*) openib_btl;
             openib_btl->device = device;
+            openib_btl->device_name = NULL;
             openib_btl->port_num = (uint8_t) port_num;
             openib_btl->pkey_index = pkey_index;
             openib_btl->lid = lid;
@@ -904,6 +906,7 @@ static int init_one_port(opal_list_t *btl_list, mca_btl_openib_device_t *device,
             opal_list_append(btl_list, (opal_list_item_t*) ib_selected);
             opal_pointer_array_add(device->device_btls, (void*) openib_btl);
             ++device->btls;
+            ++device->allowed_btls;
             ++mca_btl_openib_component.ib_num_btls;
             ++mca_btl_openib_component.ib_allowed_btls;
             if (-1 != mca_btl_openib_component.ib_max_btls &&
@@ -1933,7 +1936,7 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
             if (ib_port_attr.active_mtu < device->mtu){
                 device->mtu = ib_port_attr.active_mtu;
             }
-            if (mca_btl_openib_component.apm_ports && device->btls > 0) {
+            if (mca_btl_openib_component.apm_ports && device->allowed_btls > 0) {
                 init_apm_port(device, i, ib_port_attr.lid);
                 break;
             }
@@ -1969,7 +1972,7 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
 
     /* If we made a BTL, check APM status and return.  Otherwise, fall
        through and destroy everything */
-    if (device->btls > 0) {
+    if (device->allowed_btls > 0) {
         /* if apm was enabled it should be > 1 */
         if (1 == mca_btl_openib_component.apm_ports) {
             opal_show_help("help-mpi-btl-openib.txt",
@@ -2289,6 +2292,11 @@ static int init_one_device(opal_list_t *btl_list, struct ibv_device* ib_dev)
 
     good:
         mca_btl_openib_component.devices_count++;
+        return OPAL_SUCCESS;
+    } else if (device->btls > 0) {
+        /* no port is allowed to be used by btl/openib,
+         * so release the device right away */
+        OBJ_RELEASE(device);
         return OPAL_SUCCESS;
     }
 

--- a/opal/mca/btl/openib/btl_openib_proc.c
+++ b/opal/mca/btl/openib/btl_openib_proc.c
@@ -277,7 +277,6 @@ mca_btl_openib_proc_t* mca_btl_openib_proc_get_locked(opal_proc_t* proc)
 
     if (0 == ib_proc->proc_port_count) {
         ib_proc->proc_endpoints = NULL;
-        goto no_err_exit;
     } else {
         ib_proc->proc_endpoints = (volatile mca_btl_base_endpoint_t**)
             malloc(ib_proc->proc_port_count *

--- a/opal/mca/btl/openib/btl_openib_proc.c
+++ b/opal/mca/btl/openib/btl_openib_proc.c
@@ -13,8 +13,8 @@
  * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2006-2007 Voltaire All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -277,6 +277,7 @@ mca_btl_openib_proc_t* mca_btl_openib_proc_get_locked(opal_proc_t* proc)
 
     if (0 == ib_proc->proc_port_count) {
         ib_proc->proc_endpoints = NULL;
+        goto no_err_exit;
     } else {
         ib_proc->proc_endpoints = (volatile mca_btl_base_endpoint_t**)
             malloc(ib_proc->proc_port_count *


### PR DESCRIPTION
If UCX is available, then pml/ucx will be used instead of
pml/ob1 + btl/openib, so there is no need to warn about
btl/openib not supporting Infiniband.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@0a2ce580405ae86788e5f0e7d5264fce162e73c8)