### PR TITLE
MTL/PSM2: Do not lower the priority when all processes are local.

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -249,10 +249,6 @@ ompi_mtl_psm2_component_register(void)
          * process assume it is ompi_info or this is most likely going to spawn, for
          * which all PSM2 devices are needed */
         setenv("PSM2_DEVICES", "self,shm", 0);
-        /* ob1 is much faster than psm2 with shared memory */
-        param_priority = 10;
-    } else {
-        param_priority = 40;
     }
 
     (void) mca_base_component_var_register (&mca_mtl_psm2_component.super.mtl_version,


### PR DESCRIPTION
The intention of lowering the priority when all processes are local
was to favor Vader BTL. However, in builds including the OFI MTL it
gets selected instead.

Reviewed-by: Spruit, Neil R <neil.r.spruit@intel.com>
Reviewed-by: Gopalakrishnan, Aravind <aravind.gopalakrishnan@intel.com>
Signed-off-by: Matias Cabral <matias.a.cabral@intel.com>