### PR TITLE
roll to v4.0.1a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -3,9 +3,11 @@
 # Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2018      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
+# Copyright (c) 2018      IBM Corporation.  All rights reserved.
+# Copyright (c) 2018      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 
 # This is the VERSION file for Open MPI, describing the precise
 # version of Open MPI in this distribution.  The various components of
@@ -16,8 +18,8 @@
 # <major>.<minor>.<release>.
 
 major=4
-minor=1
-release=0
+minor=0
+release=1
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not


### PR DESCRIPTION
fixes previous commit open-mpi/ompi@116a140be8cce39a5c07ce6db19a6426ae48f276
that incorrectly rolled to v4.1.0a1

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>