### PR TITLE
mpi/c: Fix MPI_TYPE_CREATE_F90_{REAL,COMPLEX}

### DIFF
--- a/ompi/mpi/c/type_create_f90_complex.c
+++ b/ompi/mpi/c/type_create_f90_complex.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,10 +84,10 @@ int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype)
      * cache.
      */
 
-    if( (LDBL_DIG < p) || (LDBL_MAX_10_EXP < r) )    *newtype = &ompi_mpi_datatype_null.dt;
-    else if( (DBL_DIG < p) || (DBL_MAX_10_EXP < r) ) *newtype = &ompi_mpi_ldblcplex.dt;
-    else if( (FLT_DIG < p) || (FLT_MAX_10_EXP < r) ) *newtype = &ompi_mpi_dblcplex.dt;
-    else                                             *newtype = &ompi_mpi_cplex.dt;
+    if     ( (LDBL_DIG < p) || (LDBL_MAX_10_EXP < r) || (-LDBL_MIN_10_EXP < r) ) *newtype = &ompi_mpi_datatype_null.dt;
+    else if( (DBL_DIG  < p) || (DBL_MAX_10_EXP  < r) || (-DBL_MIN_10_EXP  < r) ) *newtype = &ompi_mpi_ldblcplex.dt;
+    else if( (FLT_DIG  < p) || (FLT_MAX_10_EXP  < r) || (-FLT_MIN_10_EXP  < r) ) *newtype = &ompi_mpi_dblcplex.dt;
+    else                                                                         *newtype = &ompi_mpi_cplex.dt;
 
     if( *newtype != &ompi_mpi_datatype_null.dt ) {
         ompi_datatype_t* datatype;

--- a/ompi/mpi/c/type_create_f90_real.c
+++ b/ompi/mpi/c/type_create_f90_real.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,10 +84,10 @@ int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype)
      * cache.
      */
 
-    if( (LDBL_DIG < p) || (LDBL_MAX_10_EXP < r) )    *newtype = &ompi_mpi_datatype_null.dt;
-    else if( (DBL_DIG < p) || (DBL_MAX_10_EXP < r) ) *newtype = &ompi_mpi_long_double.dt;
-    else if( (FLT_DIG < p) || (FLT_MAX_10_EXP < r) ) *newtype = &ompi_mpi_double.dt;
-    else                                             *newtype = &ompi_mpi_float.dt;
+    if     ( (LDBL_DIG < p) || (LDBL_MAX_10_EXP < r) || (-LDBL_MIN_10_EXP < r) ) *newtype = &ompi_mpi_datatype_null.dt;
+    else if( (DBL_DIG  < p) || (DBL_MAX_10_EXP  < r) || (-DBL_MIN_10_EXP  < r) ) *newtype = &ompi_mpi_long_double.dt;
+    else if( (FLT_DIG  < p) || (FLT_MAX_10_EXP  < r) || (-FLT_MIN_10_EXP  < r) ) *newtype = &ompi_mpi_double.dt;
+    else                                                                         *newtype = &ompi_mpi_float.dt;
 
     if( *newtype != &ompi_mpi_datatype_null.dt ) {
         ompi_datatype_t* datatype;


### PR DESCRIPTION
This commit fixes edge cases of `r = 38` and `r = 308`.

As defined in the MPI standard, `TYPE_CREATE_F90_REAL` and `TYPE_CREATE_F90_COMPLEX` must be consistent with the Fortran `SELECTED_REAL_KIND` function. The `SELECTED_REAL_KIND` function is defined based on the `RANGE` function. The `RANGE` function returns `INT(MIN(LOG10(HUGE(X)), -LOG10(TINY(X))))` for a real value `X`.

The old code considers only `INT(LOG10(HUGE(X)))` using `*_MAX_10_EXP`. This commit adds `INT(-LOG10(TINY(X)))` part using `*_MIN_10_EXP`.

This bug affected the following `p`-`r` combinations.

| p             | r   | expected  | returned  | expected  | returned  |
| :------------ | --: | :-------- | :-------- | :-------  | :-------- |
| MPI_UNDEFINED |  38 | REAL8     | REAL4     | COMPLEX16 | COMPLEX8  |
| 0 <= p <= 6   |  38 | REAL8     | REAL4     | COMPLEX16 | COMPLEX8  |
| MPI_UNDEFINED | 308 | REAL16    | REAL8     | COMPLEX32 | COMPLEX16 |
| 0 <= p <= 15  | 308 | REAL16    | REAL8     | COMPLEX32 | COMPLEX16 |

MPICH returns the same result as Open MPI with this fix.

I don't know who uses these MPI routines. I found this bug during FP16 support development.

Need PR to release branches.
