### PR TITLE
OSHMEM: added missing API for get/put operations

### DIFF
--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -87,6 +87,16 @@ OSHMEM_DECLSPEC  void pshmem_ctx_uint_p(shmem_ctx_t ctx, unsigned int* addr, uns
 OSHMEM_DECLSPEC  void pshmem_ctx_ulong_p(shmem_ctx_t ctx, unsigned long* addr, unsigned long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_p(shmem_ctx_t ctx, unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_p(shmem_ctx_t ctx, long double* addr, long double value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int8_p(shmem_ctx_t ctx, int8_t* addr, int8_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int16_p(shmem_ctx_t ctx, int16_t* addr, int16_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int32_p(shmem_ctx_t ctx, int32_t* addr, int32_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int64_p(shmem_ctx_t ctx, int64_t* addr, int64_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint8_p(shmem_ctx_t ctx, uint8_t* addr, uint8_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint16_p(shmem_ctx_t ctx, uint16_t* addr, uint16_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint32_p(shmem_ctx_t ctx, uint32_t* addr, uint32_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint64_p(shmem_ctx_t ctx, uint64_t* addr, uint64_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_size_p(shmem_ctx_t ctx, size_t* addr, size_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ptrdiff_p(shmem_ctx_t ctx, ptrdiff_t* addr, ptrdiff_t value, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_char_p(char* addr, char value, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_p(short* addr, short value, int pe);
@@ -102,6 +112,16 @@ OSHMEM_DECLSPEC  void pshmem_uint_p(unsigned int* addr, unsigned int value, int 
 OSHMEM_DECLSPEC  void pshmem_ulong_p(unsigned long* addr, unsigned long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_p(unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_p(long double* addr, long double value, int pe);
+OSHMEM_DECLSPEC  void pshmem_int8_p(int8_t* addr, int8_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_int16_p(int16_t* addr, int16_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_int32_p(int32_t* addr, int32_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_int64_p(int64_t* addr, int64_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint8_p(uint8_t* addr, uint8_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint16_p(uint16_t* addr, uint16_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint32_p(uint32_t* addr, uint32_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint64_p(uint64_t* addr, uint64_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_size_p(size_t* addr, size_t value, int pe);
+OSHMEM_DECLSPEC  void pshmem_ptrdiff_p(ptrdiff_t* addr, ptrdiff_t value, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_p(...)                                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -154,6 +174,16 @@ OSHMEM_DECLSPEC  void pshmem_ctx_uint_put(shmem_ctx_t ctx, unsigned int *target,
 OSHMEM_DECLSPEC  void pshmem_ctx_ulong_put(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_put(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_put(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int8_put(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int16_put(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int32_put(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int64_put(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint8_put(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint16_put(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint32_put(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint64_put(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_size_put(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ptrdiff_put(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_char_put(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_put(short *target, const short *source, size_t len, int pe);
@@ -169,6 +199,16 @@ OSHMEM_DECLSPEC  void pshmem_uint_put(unsigned int *target, const unsigned int *
 OSHMEM_DECLSPEC  void pshmem_ulong_put(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_put(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int8_put(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int16_put(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int32_put(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int64_put(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint8_put(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint16_put(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint32_put(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint64_put(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_size_put(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ptrdiff_put(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_put(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -235,6 +275,16 @@ OSHMEM_DECLSPEC void pshmem_ctx_uint_iput(shmem_ctx_t ctx, unsigned int* target,
 OSHMEM_DECLSPEC void pshmem_ctx_ulong_iput(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_iput(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ctx_longdouble_iput(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int8_iput(shmem_ctx_t ctx, int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int16_iput(shmem_ctx_t ctx, int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int32_iput(shmem_ctx_t ctx, int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int64_iput(shmem_ctx_t ctx, int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint8_iput(shmem_ctx_t ctx, uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint16_iput(shmem_ctx_t ctx, uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint32_iput(shmem_ctx_t ctx, uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint64_iput(shmem_ctx_t ctx, uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_size_iput(shmem_ctx_t ctx, size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ptrdiff_iput(shmem_ctx_t ctx, ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 OSHMEM_DECLSPEC void pshmem_char_iput(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_short_iput(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -250,6 +300,16 @@ OSHMEM_DECLSPEC void pshmem_uint_iput(unsigned int* target, const unsigned int* 
 OSHMEM_DECLSPEC void pshmem_ulong_iput(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_iput(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_longdouble_iput(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int8_iput(int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int16_iput(int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int32_iput(int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int64_iput(int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint8_iput(uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint16_iput(uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint32_iput(uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint64_iput(uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_size_iput(size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ptrdiff_iput(ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_iput(...)                                             \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -314,8 +374,17 @@ OSHMEM_DECLSPEC  void pshmem_ctx_uint_put_nbi(shmem_ctx_t ctx, unsigned int *tar
 OSHMEM_DECLSPEC  void pshmem_ctx_ulong_put_nbi(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_put_nbi(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_put_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int8_put_nbi(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int16_put_nbi(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int32_put_nbi(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int64_put_nbi(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint8_put_nbi(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint16_put_nbi(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint32_put_nbi(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint64_put_nbi(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_size_put_nbi(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ptrdiff_put_nbi(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
-OSHMEM_DECLSPEC  void pshmem_putmem_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_put_nbi(short *target, const short *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_int_put_nbi(int *target, const int *source, size_t len, int pe);
@@ -330,6 +399,16 @@ OSHMEM_DECLSPEC  void pshmem_uint_put_nbi(unsigned int *target, const unsigned i
 OSHMEM_DECLSPEC  void pshmem_ulong_put_nbi(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_put_nbi(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int8_put_nbi(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int16_put_nbi(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int32_put_nbi(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int64_put_nbi(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint8_put_nbi(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint16_put_nbi(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint32_put_nbi(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint64_put_nbi(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_size_put_nbi(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ptrdiff_put_nbi(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_put_nbi(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -377,6 +456,7 @@ OSHMEM_DECLSPEC  void pshmem_put16_nbi(void *target, const void *source, size_t 
 OSHMEM_DECLSPEC  void pshmem_put32_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_put64_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_put128_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_putmem_nbi(void *target, const void *source, size_t len, int pe);
 
 /*
  * Elemental get routines
@@ -395,6 +475,16 @@ OSHMEM_DECLSPEC  unsigned short pshmem_ctx_ushort_g(shmem_ctx_t ctx, const unsig
 OSHMEM_DECLSPEC  unsigned int pshmem_ctx_uint_g(shmem_ctx_t ctx, const unsigned int* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long pshmem_ctx_ulong_g(shmem_ctx_t ctx, const unsigned long* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long long pshmem_ctx_ulonglong_g(shmem_ctx_t ctx, const unsigned long long* addr, int pe);
+OSHMEM_DECLSPEC  int8_t pshmem_ctx_int8_g(shmem_ctx_t ctx, const int8_t* addr, int pe);
+OSHMEM_DECLSPEC  int16_t pshmem_ctx_int16_g(shmem_ctx_t ctx, const int16_t* addr, int pe);
+OSHMEM_DECLSPEC  int32_t pshmem_ctx_int32_g(shmem_ctx_t ctx, const int32_t* addr, int pe);
+OSHMEM_DECLSPEC  int64_t pshmem_ctx_int64_g(shmem_ctx_t ctx, const int64_t* addr, int pe);
+OSHMEM_DECLSPEC  uint8_t pshmem_ctx_uint8_g(shmem_ctx_t ctx, const uint8_t* addr, int pe);
+OSHMEM_DECLSPEC  uint16_t pshmem_ctx_uint16_g(shmem_ctx_t ctx, const uint16_t* addr, int pe);
+OSHMEM_DECLSPEC  uint32_t pshmem_ctx_uint32_g(shmem_ctx_t ctx, const uint32_t* addr, int pe);
+OSHMEM_DECLSPEC  uint64_t pshmem_ctx_uint64_g(shmem_ctx_t ctx, const uint64_t* addr, int pe);
+OSHMEM_DECLSPEC  size_t pshmem_ctx_size_g(shmem_ctx_t ctx, const size_t* addr, int pe);
+OSHMEM_DECLSPEC  ptrdiff_t pshmem_ctx_ptrdiff_g(shmem_ctx_t ctx, const ptrdiff_t* addr, int pe);
 
 OSHMEM_DECLSPEC  char pshmem_char_g(const char* addr, int pe);
 OSHMEM_DECLSPEC  short pshmem_short_g(const short* addr, int pe);
@@ -410,6 +500,16 @@ OSHMEM_DECLSPEC  unsigned short pshmem_ushort_g(const unsigned short* addr, int 
 OSHMEM_DECLSPEC  unsigned int pshmem_uint_g(const unsigned int* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long pshmem_ulong_g(const unsigned long* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long long pshmem_ulonglong_g(const unsigned long long* addr, int pe);
+OSHMEM_DECLSPEC  int8_t pshmem_int8_g(const int8_t* addr, int pe);
+OSHMEM_DECLSPEC  int16_t pshmem_int16_g(const int16_t* addr, int pe);
+OSHMEM_DECLSPEC  int32_t pshmem_int32_g(const int32_t* addr, int pe);
+OSHMEM_DECLSPEC  int64_t pshmem_int64_g(const int64_t* addr, int pe);
+OSHMEM_DECLSPEC  uint8_t pshmem_uint8_g(const uint8_t* addr, int pe);
+OSHMEM_DECLSPEC  uint16_t pshmem_uint16_g(const uint16_t* addr, int pe);
+OSHMEM_DECLSPEC  uint32_t pshmem_uint32_g(const uint32_t* addr, int pe);
+OSHMEM_DECLSPEC  uint64_t pshmem_uint64_g(const uint64_t* addr, int pe);
+OSHMEM_DECLSPEC  size_t pshmem_size_g(const size_t* addr, int pe);
+OSHMEM_DECLSPEC  ptrdiff_t pshmem_ptrdiff_g(const ptrdiff_t* addr, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_g(...)                                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -462,6 +562,16 @@ OSHMEM_DECLSPEC  void pshmem_ctx_uint_get(shmem_ctx_t ctx, unsigned int *target,
 OSHMEM_DECLSPEC  void pshmem_ctx_ulong_get(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_get(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_get(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int8_get(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int16_get(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int32_get(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int64_get(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint8_get(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint16_get(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint32_get(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint64_get(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_size_get(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ptrdiff_get(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_char_get(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_short_get(short *target, const short *source, size_t len, int pe);
@@ -477,6 +587,16 @@ OSHMEM_DECLSPEC  void pshmem_uint_get(unsigned int *target, const unsigned int *
 OSHMEM_DECLSPEC  void pshmem_ulong_get(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_get(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int8_get(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int16_get(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int32_get(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int64_get(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint8_get(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint16_get(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint32_get(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint64_get(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_size_get(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ptrdiff_get(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_get(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -529,35 +649,55 @@ OSHMEM_DECLSPEC  void pshmem_getmem(void *target, const void *source, size_t len
 /*
  * Strided get routines
  */
-OSHMEM_DECLSPEC void pshmem_ctx_char_iget(shmem_ctx_t ctx, char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_short_iget(shmem_ctx_t ctx, short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_int_iget(shmem_ctx_t ctx, int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_schar_iget(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_uchar_iget(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_ushort_iget(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_uint_iget(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_ulong_iget(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_iget(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_float_iget(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_double_iget(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_char_iget(shmem_ctx_t ctx, char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_short_iget(shmem_ctx_t ctx, short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int_iget(shmem_ctx_t ctx, int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_schar_iget(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uchar_iget(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ushort_iget(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint_iget(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulong_iget(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ulonglong_iget(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_float_iget(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_double_iget(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int8_iget(shmem_ctx_t ctx, int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int16_iget(shmem_ctx_t ctx, int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int32_iget(shmem_ctx_t ctx, int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_int64_iget(shmem_ctx_t ctx, int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint8_iget(shmem_ctx_t ctx, uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint16_iget(shmem_ctx_t ctx, uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint32_iget(shmem_ctx_t ctx, uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_uint64_iget(shmem_ctx_t ctx, uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_size_iget(shmem_ctx_t ctx, size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ctx_ptrdiff_iget(shmem_ctx_t ctx, ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
 
-OSHMEM_DECLSPEC void pshmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_int_iget(int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_float_iget(float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_double_iget(double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_longlong_iget(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_schar_iget(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_uchar_iget(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ushort_iget(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_uint_iget(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ulong_iget(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void pshmem_ulonglong_iget(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int_iget(int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_float_iget(float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_double_iget(double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_longlong_iget(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_schar_iget(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uchar_iget(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ushort_iget(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint_iget(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ulong_iget(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ulonglong_iget(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int8_iget(int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int16_iget(int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int32_iget(int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_int64_iget(int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint8_iget(uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint16_iget(uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint32_iget(uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_uint64_iget(uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_size_iget(size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void pshmem_ptrdiff_iget(ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_iget(...)                                             \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -622,6 +762,16 @@ OSHMEM_DECLSPEC  void pshmem_ctx_ulonglong_get_nbi(shmem_ctx_t ctx, unsigned lon
 OSHMEM_DECLSPEC  void pshmem_ctx_float_get_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_double_get_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ctx_longdouble_get_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int8_get_nbi(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int16_get_nbi(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int32_get_nbi(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_int64_get_nbi(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint8_get_nbi(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint16_get_nbi(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint32_get_nbi(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_uint64_get_nbi(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_size_get_nbi(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ctx_ptrdiff_get_nbi(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void pshmem_getmem_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_char_get_nbi(char *target, const char *source, size_t len, int pe);
@@ -638,6 +788,16 @@ OSHMEM_DECLSPEC  void pshmem_ulonglong_get_nbi(unsigned long long *target, const
 OSHMEM_DECLSPEC  void pshmem_float_get_nbi(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int8_get_nbi(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int16_get_nbi(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int32_get_nbi(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_int64_get_nbi(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint8_get_nbi(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint16_get_nbi(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint32_get_nbi(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_uint64_get_nbi(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_size_get_nbi(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void pshmem_ptrdiff_get_nbi(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define pshmem_get_nbi(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \

--- a/oshmem/include/pshmemx.h
+++ b/oshmem/include/pshmemx.h
@@ -184,14 +184,6 @@ OSHMEM_DECLSPEC void pshmemx_int64_prod_to_all(int64_t *target, const int64_t *s
 /*
  * Backward compatibility section
  */
-#define pshmem_int16_p               pshmemx_int16_p
-#define pshmem_int32_p               pshmemx_int32_p
-#define pshmem_int64_p               pshmemx_int64_p
-
-#define pshmem_int16_g               pshmemx_int16_g
-#define pshmem_int32_g               pshmemx_int32_g
-#define pshmem_int64_g               pshmemx_int64_g
-
 #define pshmem_int32_swap            pshmemx_int32_swap
 #define pshmem_int64_swap            pshmemx_int64_swap
 

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -224,6 +224,16 @@ OSHMEM_DECLSPEC  void shmem_ctx_uint_p(shmem_ctx_t ctx, unsigned int* addr, unsi
 OSHMEM_DECLSPEC  void shmem_ctx_ulong_p(shmem_ctx_t ctx, unsigned long* addr, unsigned long value, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_p(shmem_ctx_t ctx, unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_p(shmem_ctx_t ctx, long double* addr, long double value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int8_p(shmem_ctx_t ctx, int8_t* addr, int8_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int16_p(shmem_ctx_t ctx, int16_t* addr, int16_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int32_p(shmem_ctx_t ctx, int32_t* addr, int32_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int64_p(shmem_ctx_t ctx, int64_t* addr, int64_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint8_p(shmem_ctx_t ctx, uint8_t* addr, uint8_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint16_p(shmem_ctx_t ctx, uint16_t* addr, uint16_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint32_p(shmem_ctx_t ctx, uint32_t* addr, uint32_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint64_p(shmem_ctx_t ctx, uint64_t* addr, uint64_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_size_p(shmem_ctx_t ctx, size_t* addr, size_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ptrdiff_p(shmem_ctx_t ctx, ptrdiff_t* addr, ptrdiff_t value, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_p(char* addr, char value, int pe);
 OSHMEM_DECLSPEC  void shmem_short_p(short* addr, short value, int pe);
@@ -239,6 +249,16 @@ OSHMEM_DECLSPEC  void shmem_uint_p(unsigned int* addr, unsigned int value, int p
 OSHMEM_DECLSPEC  void shmem_ulong_p(unsigned long* addr, unsigned long value, int pe);
 OSHMEM_DECLSPEC  void shmem_ulonglong_p(unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_p(long double* addr, long double value, int pe);
+OSHMEM_DECLSPEC  void shmem_int8_p(int8_t* addr, int8_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_int16_p(int16_t* addr, int16_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_int32_p(int32_t* addr, int32_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_int64_p(int64_t* addr, int64_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_uint8_p(uint8_t* addr, uint8_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_uint16_p(uint16_t* addr, uint16_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_uint32_p(uint32_t* addr, uint32_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_uint64_p(uint64_t* addr, uint64_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_size_p(size_t* addr, size_t value, int pe);
+OSHMEM_DECLSPEC  void shmem_ptrdiff_p(ptrdiff_t* addr, ptrdiff_t value, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_p(...)                                                 \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -291,6 +311,16 @@ OSHMEM_DECLSPEC  void shmem_ctx_uint_put(shmem_ctx_t ctx, unsigned int *target, 
 OSHMEM_DECLSPEC  void shmem_ctx_ulong_put(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_put(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_put(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int8_put(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int16_put(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int32_put(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int64_put(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint8_put(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint16_put(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint32_put(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint64_put(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_size_put(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ptrdiff_put(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_put(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_put(short *target, const short *source, size_t len, int pe);
@@ -306,6 +336,16 @@ OSHMEM_DECLSPEC  void shmem_uint_put(unsigned int *target, const unsigned int *s
 OSHMEM_DECLSPEC  void shmem_ulong_put(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ulonglong_put(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_put(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int8_put(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int16_put(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int32_put(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int64_put(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint8_put(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint16_put(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint32_put(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint64_put(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_size_put(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ptrdiff_put(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_put(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
@@ -373,6 +413,16 @@ OSHMEM_DECLSPEC void shmem_ctx_uint_iput(shmem_ctx_t ctx, unsigned int* target, 
 OSHMEM_DECLSPEC void shmem_ctx_ulong_iput(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_ulonglong_iput(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ctx_longdouble_iput(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int8_iput(shmem_ctx_t ctx, int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int16_iput(shmem_ctx_t ctx, int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int32_iput(shmem_ctx_t ctx, int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int64_iput(shmem_ctx_t ctx, int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint8_iput(shmem_ctx_t ctx, uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint16_iput(shmem_ctx_t ctx, uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint32_iput(shmem_ctx_t ctx, uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint64_iput(shmem_ctx_t ctx, uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_size_iput(shmem_ctx_t ctx, size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ptrdiff_iput(shmem_ctx_t ctx, ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 
 OSHMEM_DECLSPEC void shmem_char_iput(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_short_iput(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
@@ -388,6 +438,16 @@ OSHMEM_DECLSPEC void shmem_uint_iput(unsigned int* target, const unsigned int* s
 OSHMEM_DECLSPEC void shmem_ulong_iput(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_ulonglong_iput(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void shmem_longdouble_iput(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int8_iput(int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int16_iput(int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int32_iput(int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int64_iput(int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint8_iput(uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint16_iput(uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint32_iput(uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint64_iput(uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_size_iput(size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ptrdiff_iput(ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_iput(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -452,6 +512,16 @@ OSHMEM_DECLSPEC  void shmem_ctx_uint_put_nbi(shmem_ctx_t ctx, unsigned int *targ
 OSHMEM_DECLSPEC  void shmem_ctx_ulong_put_nbi(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_put_nbi(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_put_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int8_put_nbi(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int16_put_nbi(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int32_put_nbi(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int64_put_nbi(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint8_put_nbi(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint16_put_nbi(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint32_put_nbi(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint64_put_nbi(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_size_put_nbi(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ptrdiff_put_nbi(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_put_nbi(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_put_nbi(short *target, const short *source, size_t len, int pe);
@@ -467,6 +537,16 @@ OSHMEM_DECLSPEC  void shmem_uint_put_nbi(unsigned int *target, const unsigned in
 OSHMEM_DECLSPEC  void shmem_ulong_put_nbi(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ulonglong_put_nbi(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int8_put_nbi(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int16_put_nbi(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int32_put_nbi(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int64_put_nbi(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint8_put_nbi(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint16_put_nbi(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint32_put_nbi(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint64_put_nbi(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_size_put_nbi(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ptrdiff_put_nbi(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_put_nbi(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
@@ -533,6 +613,16 @@ OSHMEM_DECLSPEC  unsigned short shmem_ctx_ushort_g(shmem_ctx_t ctx, const unsign
 OSHMEM_DECLSPEC  unsigned int shmem_ctx_uint_g(shmem_ctx_t ctx, const unsigned int* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long shmem_ctx_ulong_g(shmem_ctx_t ctx, const unsigned long* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long long shmem_ctx_ulonglong_g(shmem_ctx_t ctx, const unsigned long long* addr, int pe);
+OSHMEM_DECLSPEC  int8_t shmem_ctx_int8_g(shmem_ctx_t ctx, const int8_t* addr, int pe);
+OSHMEM_DECLSPEC  int16_t shmem_ctx_int16_g(shmem_ctx_t ctx, const int16_t* addr, int pe);
+OSHMEM_DECLSPEC  int32_t shmem_ctx_int32_g(shmem_ctx_t ctx, const int32_t* addr, int pe);
+OSHMEM_DECLSPEC  int64_t shmem_ctx_int64_g(shmem_ctx_t ctx, const int64_t* addr, int pe);
+OSHMEM_DECLSPEC  uint8_t shmem_ctx_uint8_g(shmem_ctx_t ctx, const uint8_t* addr, int pe);
+OSHMEM_DECLSPEC  uint16_t shmem_ctx_uint16_g(shmem_ctx_t ctx, const uint16_t* addr, int pe);
+OSHMEM_DECLSPEC  uint32_t shmem_ctx_uint32_g(shmem_ctx_t ctx, const uint32_t* addr, int pe);
+OSHMEM_DECLSPEC  uint64_t shmem_ctx_uint64_g(shmem_ctx_t ctx, const uint64_t* addr, int pe);
+OSHMEM_DECLSPEC  size_t shmem_ctx_size_g(shmem_ctx_t ctx, const size_t* addr, int pe);
+OSHMEM_DECLSPEC  ptrdiff_t shmem_ctx_ptrdiff_g(shmem_ctx_t ctx, const ptrdiff_t* addr, int pe);
 
 OSHMEM_DECLSPEC  char shmem_char_g(const char* addr, int pe);
 OSHMEM_DECLSPEC  short shmem_short_g(const short* addr, int pe);
@@ -548,6 +638,16 @@ OSHMEM_DECLSPEC  unsigned short shmem_ushort_g(const unsigned short* addr, int p
 OSHMEM_DECLSPEC  unsigned int shmem_uint_g(const unsigned int* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long shmem_ulong_g(const unsigned long* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long long shmem_ulonglong_g(const unsigned long long* addr, int pe);
+OSHMEM_DECLSPEC  int8_t shmem_int8_g(const int8_t* addr, int pe);
+OSHMEM_DECLSPEC  int16_t shmem_int16_g(const int16_t* addr, int pe);
+OSHMEM_DECLSPEC  int32_t shmem_int32_g(const int32_t* addr, int pe);
+OSHMEM_DECLSPEC  int64_t shmem_int64_g(const int64_t* addr, int pe);
+OSHMEM_DECLSPEC  uint8_t shmem_uint8_g(const uint8_t* addr, int pe);
+OSHMEM_DECLSPEC  uint16_t shmem_uint16_g(const uint16_t* addr, int pe);
+OSHMEM_DECLSPEC  uint32_t shmem_uint32_g(const uint32_t* addr, int pe);
+OSHMEM_DECLSPEC  uint64_t shmem_uint64_g(const uint64_t* addr, int pe);
+OSHMEM_DECLSPEC  size_t shmem_size_g(const size_t* addr, int pe);
+OSHMEM_DECLSPEC  ptrdiff_t shmem_ptrdiff_g(const ptrdiff_t* addr, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_g(...)                                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
@@ -600,6 +700,16 @@ OSHMEM_DECLSPEC  void shmem_ctx_uint_get(shmem_ctx_t ctx, unsigned int *target, 
 OSHMEM_DECLSPEC  void shmem_ctx_ulong_get(shmem_ctx_t ctx, unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_get(shmem_ctx_t ctx, unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_get(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int8_get(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int16_get(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int32_get(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int64_get(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint8_get(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint16_get(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint32_get(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint64_get(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_size_get(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ptrdiff_get(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
 OSHMEM_DECLSPEC  void shmem_char_get(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_get(short *target, const short *source, size_t len, int pe);
@@ -615,6 +725,16 @@ OSHMEM_DECLSPEC  void shmem_uint_get(unsigned int *target, const unsigned int *s
 OSHMEM_DECLSPEC  void shmem_ulong_get(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ulonglong_get(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_get(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int8_get(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int16_get(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int32_get(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int64_get(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint8_get(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint16_get(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint32_get(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint64_get(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_size_get(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ptrdiff_get(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_get(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                    \
@@ -667,35 +787,55 @@ OSHMEM_DECLSPEC  void shmem_getmem(void *target, const void *source, size_t len,
 /*
  * Strided get routines
  */
-OSHMEM_DECLSPEC void shmem_ctx_char_iget(shmem_ctx_t ctx, char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_short_iget(shmem_ctx_t ctx, short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_int_iget(shmem_ctx_t ctx, int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_schar_iget(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_uchar_iget(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_ushort_iget(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_uint_iget(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_ulong_iget(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_ulonglong_iget(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_float_iget(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_double_iget(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_char_iget(shmem_ctx_t ctx, char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_short_iget(shmem_ctx_t ctx, short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int_iget(shmem_ctx_t ctx, int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_long_iget(shmem_ctx_t ctx, long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_longlong_iget(shmem_ctx_t ctx, long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_schar_iget(shmem_ctx_t ctx, signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uchar_iget(shmem_ctx_t ctx, unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ushort_iget(shmem_ctx_t ctx, unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint_iget(shmem_ctx_t ctx, unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulong_iget(shmem_ctx_t ctx, unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ulonglong_iget(shmem_ctx_t ctx, unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_float_iget(shmem_ctx_t ctx, float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_double_iget(shmem_ctx_t ctx, double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_longdouble_iget(shmem_ctx_t ctx, long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int8_iget(shmem_ctx_t ctx, int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int16_iget(shmem_ctx_t ctx, int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int32_iget(shmem_ctx_t ctx, int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_int64_iget(shmem_ctx_t ctx, int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint8_iget(shmem_ctx_t ctx, uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint16_iget(shmem_ctx_t ctx, uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint32_iget(shmem_ctx_t ctx, uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_uint64_iget(shmem_ctx_t ctx, uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_size_iget(shmem_ctx_t ctx, size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ctx_ptrdiff_iget(shmem_ctx_t ctx, ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
 
-OSHMEM_DECLSPEC void shmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_int_iget(int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_float_iget(float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_double_iget(double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_longlong_iget(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_schar_iget(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_uchar_iget(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ushort_iget(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_uint_iget(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ulong_iget(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-OSHMEM_DECLSPEC void shmem_ulonglong_iget(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_char_iget(char* target, const char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_short_iget(short* target, const short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int_iget(int* target, const int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_float_iget(float* target, const float* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_double_iget(double* target, const double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_longlong_iget(long long* target, const long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_longdouble_iget(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_long_iget(long* target, const long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_schar_iget(signed char* target, const signed char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uchar_iget(unsigned char* target, const unsigned char* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ushort_iget(unsigned short* target, const unsigned short* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint_iget(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ulong_iget(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ulonglong_iget(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int8_iget(int8_t* target, const int8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int16_iget(int16_t* target, const int16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int32_iget(int32_t* target, const int32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_int64_iget(int64_t* target, const int64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint8_iget(uint8_t* target, const uint8_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint16_iget(uint16_t* target, const uint16_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint32_iget(uint32_t* target, const uint32_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_uint64_iget(uint64_t* target, const uint64_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_size_iget(size_t* target, const size_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
+OSHMEM_DECLSPEC void shmem_ptrdiff_iget(ptrdiff_t* target, const ptrdiff_t* source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_iget(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -760,8 +900,17 @@ OSHMEM_DECLSPEC  void shmem_ctx_ulonglong_get_nbi(shmem_ctx_t ctx, unsigned long
 OSHMEM_DECLSPEC  void shmem_ctx_float_get_nbi(shmem_ctx_t ctx, float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_double_get_nbi(shmem_ctx_t ctx, double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_ctx_longdouble_get_nbi(shmem_ctx_t ctx, long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int8_get_nbi(shmem_ctx_t ctx, int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int16_get_nbi(shmem_ctx_t ctx, int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int32_get_nbi(shmem_ctx_t ctx, int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_int64_get_nbi(shmem_ctx_t ctx, int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint8_get_nbi(shmem_ctx_t ctx, uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint16_get_nbi(shmem_ctx_t ctx, uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint32_get_nbi(shmem_ctx_t ctx, uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_uint64_get_nbi(shmem_ctx_t ctx, uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_size_get_nbi(shmem_ctx_t ctx, size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ctx_ptrdiff_get_nbi(shmem_ctx_t ctx, ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 
-OSHMEM_DECLSPEC  void shmem_getmem_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_char_get_nbi(char *target, const char *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_short_get_nbi(short *target, const short *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_int_get_nbi(int *target, const int *source, size_t len, int pe);
@@ -776,6 +925,16 @@ OSHMEM_DECLSPEC  void shmem_ulonglong_get_nbi(unsigned long long *target, const 
 OSHMEM_DECLSPEC  void shmem_float_get_nbi(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int8_get_nbi(int8_t *target, const int8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int16_get_nbi(int16_t *target, const int16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int32_get_nbi(int32_t *target, const int32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_int64_get_nbi(int64_t *target, const int64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint8_get_nbi(uint8_t *target, const uint8_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint16_get_nbi(uint16_t *target, const uint16_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint32_get_nbi(uint32_t *target, const uint32_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_uint64_get_nbi(uint64_t *target, const uint64_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_size_get_nbi(size_t *target, const size_t *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_ptrdiff_get_nbi(ptrdiff_t *target, const ptrdiff_t *source, size_t len, int pe);
 #if OSHMEM_HAVE_C11
 #define shmem_get_nbi(...)                                           \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
@@ -823,6 +982,7 @@ OSHMEM_DECLSPEC  void shmem_get16_nbi(void *target, const void *source, size_t l
 OSHMEM_DECLSPEC  void shmem_get32_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_get64_nbi(void *target, const void *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void shmem_get128_nbi(void *target, const void *source, size_t len, int pe);
+OSHMEM_DECLSPEC  void shmem_getmem_nbi(void *target, const void *source, size_t len, int pe);
 
 /*
  * Atomic operations

--- a/oshmem/include/shmemx.h
+++ b/oshmem/include/shmemx.h
@@ -171,14 +171,6 @@ OSHMEM_DECLSPEC void shmemx_int64_prod_to_all(int64_t *target, const int64_t *so
 /*
  * Backward compatibility section
  */
-#define shmem_int16_p               shmemx_int16_p
-#define shmem_int32_p               shmemx_int32_p
-#define shmem_int64_p               shmemx_int64_p
-
-#define shmem_int16_g               shmemx_int16_g
-#define shmem_int32_g               shmemx_int32_g
-#define shmem_int64_g               shmemx_int64_g
-
 #define shmem_int32_swap            shmemx_int32_swap
 #define shmem_int64_swap            shmemx_int64_swap
 

--- a/oshmem/shmem/c/profile/defines.h
+++ b/oshmem/shmem/c/profile/defines.h
@@ -72,7 +72,6 @@
 /*
  * Elemental put routines
  */
-
 #define shmem_ctx_char_p             pshmem_ctx_char_p
 #define shmem_ctx_short_p            pshmem_ctx_short_p
 #define shmem_ctx_int_p              pshmem_ctx_int_p
@@ -87,6 +86,16 @@
 #define shmem_ctx_ulong_p            pshmem_ctx_ulong_p
 #define shmem_ctx_ulonglong_p        pshmem_ctx_ulonglong_p
 #define shmem_ctx_longdouble_p       pshmem_ctx_longdouble_p
+#define shmem_ctx_int8_p             pshmem_ctx_int8_p
+#define shmem_ctx_int16_p            pshmem_ctx_int16_p
+#define shmem_ctx_int32_p            pshmem_ctx_int32_p
+#define shmem_ctx_int64_p            pshmem_ctx_int64_p
+#define shmem_ctx_uint8_p            pshmem_ctx_uint8_p
+#define shmem_ctx_uint16_p           pshmem_ctx_uint16_p
+#define shmem_ctx_uint32_p           pshmem_ctx_uint32_p
+#define shmem_ctx_uint64_p           pshmem_ctx_uint64_p
+#define shmem_ctx_size_p             pshmem_ctx_size_p
+#define shmem_ctx_ptrdiff_p          pshmem_ctx_ptrdiff_p
 
 #define shmem_char_p                 pshmem_char_p
 #define shmem_short_p                pshmem_short_p
@@ -102,6 +111,16 @@
 #define shmem_ulong_p                pshmem_ulong_p
 #define shmem_ulonglong_p            pshmem_ulonglong_p
 #define shmem_longdouble_p           pshmem_longdouble_p
+#define shmem_int8_p                 pshmem_int8_p
+#define shmem_int16_p                pshmem_int16_p
+#define shmem_int32_p                pshmem_int32_p
+#define shmem_int64_p                pshmem_int64_p
+#define shmem_uint8_p                pshmem_uint8_p
+#define shmem_uint16_p               pshmem_uint16_p
+#define shmem_uint32_p               pshmem_uint32_p
+#define shmem_uint64_p               pshmem_uint64_p
+#define shmem_size_p                 pshmem_size_p
+#define shmem_ptrdiff_p              pshmem_ptrdiff_p
 
 #define shmemx_int16_p               pshmemx_int16_p
 #define shmemx_int32_p               pshmemx_int32_p
@@ -124,6 +143,16 @@
 #define shmem_ctx_ulong_put          pshmem_ctx_ulong_put
 #define shmem_ctx_ulonglong_put      pshmem_ctx_ulonglong_put
 #define shmem_ctx_longdouble_put     pshmem_ctx_longdouble_put
+#define shmem_ctx_int8_put           pshmem_ctx_int8_put
+#define shmem_ctx_int16_put          pshmem_ctx_int16_put
+#define shmem_ctx_int32_put          pshmem_ctx_int32_put
+#define shmem_ctx_int64_put          pshmem_ctx_int64_put
+#define shmem_ctx_uint8_put          pshmem_ctx_uint8_put
+#define shmem_ctx_uint16_put         pshmem_ctx_uint16_put
+#define shmem_ctx_uint32_put         pshmem_ctx_uint32_put
+#define shmem_ctx_uint64_put         pshmem_ctx_uint64_put
+#define shmem_ctx_size_put           pshmem_ctx_size_put
+#define shmem_ctx_ptrdiff_put        pshmem_ctx_ptrdiff_put
 
 #define shmem_char_put               pshmem_char_put /* shmem-compat.h */
 #define shmem_short_put              pshmem_short_put
@@ -139,6 +168,16 @@
 #define shmem_ulong_put              pshmem_ulong_put
 #define shmem_ulonglong_put          pshmem_ulonglong_put
 #define shmem_longdouble_put         pshmem_longdouble_put
+#define shmem_int8_put               pshmem_int8_put
+#define shmem_int16_put              pshmem_int16_put
+#define shmem_int32_put              pshmem_int32_put
+#define shmem_int64_put              pshmem_int64_put
+#define shmem_uint8_put              pshmem_uint8_put
+#define shmem_uint16_put             pshmem_uint16_put
+#define shmem_uint32_put             pshmem_uint32_put
+#define shmem_uint64_put             pshmem_uint64_put
+#define shmem_size_put               pshmem_size_put
+#define shmem_ptrdiff_put            pshmem_ptrdiff_put
 
 #define shmem_ctx_put8               pshmem_ctx_put8
 #define shmem_ctx_put16              pshmem_ctx_put16
@@ -171,6 +210,16 @@
 #define shmem_ctx_ulong_iput          pshmem_ctx_ulong_iput
 #define shmem_ctx_ulonglong_iput      pshmem_ctx_ulonglong_iput
 #define shmem_ctx_longdouble_iput     pshmem_ctx_longdouble_iput
+#define shmem_ctx_int8_iput           pshmem_ctx_int8_iput
+#define shmem_ctx_int16_iput          pshmem_ctx_int16_iput
+#define shmem_ctx_int32_iput          pshmem_ctx_int32_iput
+#define shmem_ctx_int64_iput          pshmem_ctx_int64_iput
+#define shmem_ctx_uint8_iput          pshmem_ctx_uint8_iput
+#define shmem_ctx_uint16_iput         pshmem_ctx_uint16_iput
+#define shmem_ctx_uint32_iput         pshmem_ctx_uint32_iput
+#define shmem_ctx_uint64_iput         pshmem_ctx_uint64_iput
+#define shmem_ctx_size_iput           pshmem_ctx_size_iput
+#define shmem_ctx_ptrdiff_iput        pshmem_ctx_ptrdiff_iput
 
 #define shmem_char_iput               pshmem_char_iput
 #define shmem_short_iput              pshmem_short_iput
@@ -186,6 +235,16 @@
 #define shmem_ulong_iput              pshmem_ulong_iput
 #define shmem_ulonglong_iput          pshmem_ulonglong_iput
 #define shmem_longdouble_iput         pshmem_longdouble_iput
+#define shmem_int8_iput               pshmem_int8_iput
+#define shmem_int16_iput              pshmem_int16_iput
+#define shmem_int32_iput              pshmem_int32_iput
+#define shmem_int64_iput              pshmem_int64_iput
+#define shmem_uint8_iput              pshmem_uint8_iput
+#define shmem_uint16_iput             pshmem_uint16_iput
+#define shmem_uint32_iput             pshmem_uint32_iput
+#define shmem_uint64_iput             pshmem_uint64_iput
+#define shmem_size_iput               pshmem_size_iput
+#define shmem_ptrdiff_iput            pshmem_ptrdiff_iput
 
 #define shmem_ctx_iput8              pshmem_ctx_iput8
 #define shmem_ctx_iput16             pshmem_ctx_iput16
@@ -216,6 +275,16 @@
 #define shmem_ctx_ulong_put_nbi          pshmem_ctx_ulong_put_nbi
 #define shmem_ctx_ulonglong_put_nbi      pshmem_ctx_ulonglong_put_nbi
 #define shmem_ctx_longdouble_put_nbi     pshmem_ctx_longdouble_put_nbi
+#define shmem_ctx_int8_put_nbi           pshmem_ctx_int8_put_nbi
+#define shmem_ctx_int16_put_nbi          pshmem_ctx_int16_put_nbi
+#define shmem_ctx_int32_put_nbi          pshmem_ctx_int32_put_nbi
+#define shmem_ctx_int64_put_nbi          pshmem_ctx_int64_put_nbi
+#define shmem_ctx_uint8_put_nbi          pshmem_ctx_uint8_put_nbi
+#define shmem_ctx_uint16_put_nbi         pshmem_ctx_uint16_put_nbi
+#define shmem_ctx_uint32_put_nbi         pshmem_ctx_uint32_put_nbi
+#define shmem_ctx_uint64_put_nbi         pshmem_ctx_uint64_put_nbi
+#define shmem_ctx_size_put_nbi           pshmem_ctx_size_put_nbi
+#define shmem_ctx_ptrdiff_put_nbi        pshmem_ctx_ptrdiff_put_nbi
 
 #define shmem_char_put_nbi               pshmem_char_put_nbi
 #define shmem_short_put_nbi              pshmem_short_put_nbi
@@ -231,6 +300,16 @@
 #define shmem_ulong_put_nbi              pshmem_ulong_put_nbi
 #define shmem_ulonglong_put_nbi          pshmem_ulonglong_put_nbi
 #define shmem_longdouble_put_nbi         pshmem_longdouble_put_nbi
+#define shmem_int8_put_nbi               pshmem_int8_put_nbi
+#define shmem_int16_put_nbi              pshmem_int16_put_nbi
+#define shmem_int32_put_nbi              pshmem_int32_put_nbi
+#define shmem_int64_put_nbi              pshmem_int64_put_nbi
+#define shmem_uint8_put_nbi              pshmem_uint8_put_nbi
+#define shmem_uint16_put_nbi             pshmem_uint16_put_nbi
+#define shmem_uint32_put_nbi             pshmem_uint32_put_nbi
+#define shmem_uint64_put_nbi             pshmem_uint64_put_nbi
+#define shmem_size_put_nbi               pshmem_size_put_nbi
+#define shmem_ptrdiff_put_nbi            pshmem_ptrdiff_put_nbi
 
 #define shmem_ctx_put8_nbi           pshmem_ctx_put8_nbi
 #define shmem_ctx_put16_nbi          pshmem_ctx_put16_nbi
@@ -263,6 +342,16 @@
 #define shmem_ctx_ulong_g            pshmem_ctx_ulong_g
 #define shmem_ctx_ulonglong_g        pshmem_ctx_ulonglong_g
 #define shmem_ctx_longdouble_g       pshmem_ctx_longdouble_g
+#define shmem_ctx_int8_g             pshmem_ctx_int8_g
+#define shmem_ctx_int16_g            pshmem_ctx_int16_g
+#define shmem_ctx_int32_g            pshmem_ctx_int32_g
+#define shmem_ctx_int64_g            pshmem_ctx_int64_g
+#define shmem_ctx_uint8_g            pshmem_ctx_uint8_g
+#define shmem_ctx_uint16_g           pshmem_ctx_uint16_g
+#define shmem_ctx_uint32_g           pshmem_ctx_uint32_g
+#define shmem_ctx_uint64_g           pshmem_ctx_uint64_g
+#define shmem_ctx_size_g             pshmem_ctx_size_g
+#define shmem_ctx_ptrdiff_g          pshmem_ctx_ptrdiff_g
 
 #define shmem_char_g                 pshmem_char_g
 #define shmem_short_g                pshmem_short_g
@@ -278,6 +367,16 @@
 #define shmem_ulong_g                pshmem_ulong_g
 #define shmem_ulonglong_g            pshmem_ulonglong_g
 #define shmem_longdouble_g           pshmem_longdouble_g
+#define shmem_int8_g                 pshmem_int8_g
+#define shmem_int16_g                pshmem_int16_g
+#define shmem_int32_g                pshmem_int32_g
+#define shmem_int64_g                pshmem_int64_g
+#define shmem_uint8_g                pshmem_uint8_g
+#define shmem_uint16_g               pshmem_uint16_g
+#define shmem_uint32_g               pshmem_uint32_g
+#define shmem_uint64_g               pshmem_uint64_g
+#define shmem_size_g                 pshmem_size_g
+#define shmem_ptrdiff_g              pshmem_ptrdiff_g
 
 #define shmemx_int16_g               pshmemx_int16_g
 #define shmemx_int32_g               pshmemx_int32_g
@@ -300,6 +399,16 @@
 #define shmem_ctx_ulong_get          pshmem_ctx_ulong_get
 #define shmem_ctx_ulonglong_get      pshmem_ctx_ulonglong_get
 #define shmem_ctx_longdouble_get     pshmem_ctx_longdouble_get
+#define shmem_ctx_int8_get           pshmem_ctx_int8_get
+#define shmem_ctx_int16_get          pshmem_ctx_int16_get
+#define shmem_ctx_int32_get          pshmem_ctx_int32_get
+#define shmem_ctx_int64_get          pshmem_ctx_int64_get
+#define shmem_ctx_uint8_get          pshmem_ctx_uint8_get
+#define shmem_ctx_uint16_get         pshmem_ctx_uint16_get
+#define shmem_ctx_uint32_get         pshmem_ctx_uint32_get
+#define shmem_ctx_uint64_get         pshmem_ctx_uint64_get
+#define shmem_ctx_size_get           pshmem_ctx_size_get
+#define shmem_ctx_ptrdiff_get        pshmem_ctx_ptrdiff_get
 
 #define shmem_char_get               pshmem_char_get /* shmem-compat.h */
 #define shmem_short_get              pshmem_short_get
@@ -315,6 +424,16 @@
 #define shmem_ulong_get              pshmem_ulong_get
 #define shmem_ulonglong_get          pshmem_ulonglong_get
 #define shmem_longdouble_get         pshmem_longdouble_get
+#define shmem_int8_get               pshmem_int8_get
+#define shmem_int16_get              pshmem_int16_get
+#define shmem_int32_get              pshmem_int32_get
+#define shmem_int64_get              pshmem_int64_get
+#define shmem_uint8_get              pshmem_uint8_get
+#define shmem_uint16_get             pshmem_uint16_get
+#define shmem_uint32_get             pshmem_uint32_get
+#define shmem_uint64_get             pshmem_uint64_get
+#define shmem_size_get               pshmem_size_get
+#define shmem_ptrdiff_get            pshmem_ptrdiff_get
 
 #define shmem_ctx_get8               pshmem_ctx_get8
 #define shmem_ctx_get16              pshmem_ctx_get16
@@ -347,6 +466,16 @@
 #define shmem_ctx_ulong_iget          pshmem_ctx_ulong_iget
 #define shmem_ctx_ulonglong_iget      pshmem_ctx_ulonglong_iget
 #define shmem_ctx_longdouble_iget     pshmem_ctx_longdouble_iget
+#define shmem_ctx_int8_iget           pshmem_ctx_int8_iget
+#define shmem_ctx_int16_iget          pshmem_ctx_int16_iget
+#define shmem_ctx_int32_iget          pshmem_ctx_int32_iget
+#define shmem_ctx_int64_iget          pshmem_ctx_int64_iget
+#define shmem_ctx_uint8_iget          pshmem_ctx_uint8_iget
+#define shmem_ctx_uint16_iget         pshmem_ctx_uint16_iget
+#define shmem_ctx_uint32_iget         pshmem_ctx_uint32_iget
+#define shmem_ctx_uint64_iget         pshmem_ctx_uint64_iget
+#define shmem_ctx_size_iget           pshmem_ctx_size_iget
+#define shmem_ctx_ptrdiff_iget        pshmem_ctx_ptrdiff_iget
 
 #define shmem_char_iget               pshmem_char_iget
 #define shmem_short_iget              pshmem_short_iget
@@ -362,6 +491,16 @@
 #define shmem_ulong_iget              pshmem_ulong_iget
 #define shmem_ulonglong_iget          pshmem_ulonglong_iget
 #define shmem_longdouble_iget         pshmem_longdouble_iget
+#define shmem_int8_iget               pshmem_int8_iget
+#define shmem_int16_iget              pshmem_int16_iget
+#define shmem_int32_iget              pshmem_int32_iget
+#define shmem_int64_iget              pshmem_int64_iget
+#define shmem_uint8_iget              pshmem_uint8_iget
+#define shmem_uint16_iget             pshmem_uint16_iget
+#define shmem_uint32_iget             pshmem_uint32_iget
+#define shmem_uint64_iget             pshmem_uint64_iget
+#define shmem_size_iget               pshmem_size_iget
+#define shmem_ptrdiff_iget            pshmem_ptrdiff_iget
 
 #define shmem_ctx_iget8              pshmem_ctx_iget8
 #define shmem_ctx_iget16             pshmem_ctx_iget16
@@ -392,6 +531,16 @@
 #define shmem_ctx_ulong_get_nbi          pshmem_ctx_ulong_get_nbi
 #define shmem_ctx_ulonglong_get_nbi      pshmem_ctx_ulonglong_get_nbi
 #define shmem_ctx_longdouble_get_nbi     pshmem_ctx_longdouble_get_nbi
+#define shmem_ctx_int8_get_nbi           pshmem_ctx_int8_get_nbi
+#define shmem_ctx_int16_get_nbi          pshmem_ctx_int16_get_nbi
+#define shmem_ctx_int32_get_nbi          pshmem_ctx_int32_get_nbi
+#define shmem_ctx_int64_get_nbi          pshmem_ctx_int64_get_nbi
+#define shmem_ctx_uint8_get_nbi          pshmem_ctx_uint8_get_nbi
+#define shmem_ctx_uint16_get_nbi         pshmem_ctx_uint16_get_nbi
+#define shmem_ctx_uint32_get_nbi         pshmem_ctx_uint32_get_nbi
+#define shmem_ctx_uint64_get_nbi         pshmem_ctx_uint64_get_nbi
+#define shmem_ctx_size_get_nbi           pshmem_ctx_size_get_nbi
+#define shmem_ctx_ptrdiff_get_nbi        pshmem_ctx_ptrdiff_get_nbi
 
 #define shmem_char_get_nbi               pshmem_char_get_nbi
 #define shmem_short_get_nbi              pshmem_short_get_nbi
@@ -407,6 +556,16 @@
 #define shmem_ulong_get_nbi              pshmem_ulong_get_nbi
 #define shmem_ulonglong_get_nbi          pshmem_ulonglong_get_nbi
 #define shmem_longdouble_get_nbi         pshmem_longdouble_get_nbi
+#define shmem_int8_get_nbi               pshmem_int8_get_nbi
+#define shmem_int16_get_nbi              pshmem_int16_get_nbi
+#define shmem_int32_get_nbi              pshmem_int32_get_nbi
+#define shmem_int64_get_nbi              pshmem_int64_get_nbi
+#define shmem_uint8_get_nbi              pshmem_uint8_get_nbi
+#define shmem_uint16_get_nbi             pshmem_uint16_get_nbi
+#define shmem_uint32_get_nbi             pshmem_uint32_get_nbi
+#define shmem_uint64_get_nbi             pshmem_uint64_get_nbi
+#define shmem_size_get_nbi               pshmem_size_get_nbi
+#define shmem_ptrdiff_get_nbi            pshmem_ptrdiff_get_nbi
 
 #define shmem_ctx_get8_nbi           pshmem_ctx_get8_nbi
 #define shmem_ctx_get16_nbi          pshmem_ctx_get16_nbi

--- a/oshmem/shmem/c/shmem_g.c
+++ b/oshmem/shmem/c/shmem_g.c
@@ -58,35 +58,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_ctx_char_g = pshmem_ctx_char_g
-#pragma weak shmem_ctx_short_g = pshmem_ctx_short_g
-#pragma weak shmem_ctx_int_g = pshmem_ctx_int_g
-#pragma weak shmem_ctx_long_g = pshmem_ctx_long_g
-#pragma weak shmem_ctx_longlong_g = pshmem_ctx_longlong_g
-#pragma weak shmem_ctx_schar_g = pshmem_ctx_schar_g
-#pragma weak shmem_ctx_uchar_g = pshmem_ctx_uchar_g
-#pragma weak shmem_ctx_ushort_g = pshmem_ctx_ushort_g
-#pragma weak shmem_ctx_uint_g = pshmem_ctx_uint_g
-#pragma weak shmem_ctx_ulong_g = pshmem_ctx_ulong_g
-#pragma weak shmem_ctx_ulonglong_g = pshmem_ctx_ulonglong_g
-#pragma weak shmem_ctx_float_g = pshmem_ctx_float_g
-#pragma weak shmem_ctx_double_g = pshmem_ctx_double_g
+#pragma weak shmem_ctx_char_g       = pshmem_ctx_char_g
+#pragma weak shmem_ctx_short_g      = pshmem_ctx_short_g
+#pragma weak shmem_ctx_int_g        = pshmem_ctx_int_g
+#pragma weak shmem_ctx_long_g       = pshmem_ctx_long_g
+#pragma weak shmem_ctx_float_g      = pshmem_ctx_float_g
+#pragma weak shmem_ctx_double_g     = pshmem_ctx_double_g
+#pragma weak shmem_ctx_longlong_g   = pshmem_ctx_longlong_g
+#pragma weak shmem_ctx_schar_g      = pshmem_ctx_schar_g
+#pragma weak shmem_ctx_uchar_g      = pshmem_ctx_uchar_g
+#pragma weak shmem_ctx_ushort_g     = pshmem_ctx_ushort_g
+#pragma weak shmem_ctx_uint_g       = pshmem_ctx_uint_g
+#pragma weak shmem_ctx_ulong_g      = pshmem_ctx_ulong_g
+#pragma weak shmem_ctx_ulonglong_g  = pshmem_ctx_ulonglong_g
 #pragma weak shmem_ctx_longdouble_g = pshmem_ctx_longdouble_g
+#pragma weak shmem_ctx_int8_g       = pshmem_ctx_int8_g
+#pragma weak shmem_ctx_int16_g      = pshmem_ctx_int16_g
+#pragma weak shmem_ctx_int32_g      = pshmem_ctx_int32_g
+#pragma weak shmem_ctx_int64_g      = pshmem_ctx_int64_g
+#pragma weak shmem_ctx_uint8_g      = pshmem_ctx_uint8_g
+#pragma weak shmem_ctx_uint16_g     = pshmem_ctx_uint16_g
+#pragma weak shmem_ctx_uint32_g     = pshmem_ctx_uint32_g
+#pragma weak shmem_ctx_uint64_g     = pshmem_ctx_uint64_g
+#pragma weak shmem_ctx_size_g       = pshmem_ctx_size_g
+#pragma weak shmem_ctx_ptrdiff_g    = pshmem_ctx_ptrdiff_g
 
-#pragma weak shmem_char_g = pshmem_char_g
-#pragma weak shmem_short_g = pshmem_short_g
-#pragma weak shmem_int_g = pshmem_int_g
-#pragma weak shmem_long_g = pshmem_long_g
-#pragma weak shmem_longlong_g = pshmem_longlong_g
-#pragma weak shmem_schar_g = pshmem_schar_g
-#pragma weak shmem_uchar_g = pshmem_uchar_g
-#pragma weak shmem_ushort_g = pshmem_ushort_g
-#pragma weak shmem_uint_g = pshmem_uint_g
-#pragma weak shmem_ulong_g = pshmem_ulong_g
-#pragma weak shmem_ulonglong_g = pshmem_ulonglong_g
-#pragma weak shmem_float_g = pshmem_float_g
-#pragma weak shmem_double_g = pshmem_double_g
-#pragma weak shmem_longdouble_g = pshmem_longdouble_g
+#pragma weak shmem_char_g           = pshmem_char_g
+#pragma weak shmem_short_g          = pshmem_short_g
+#pragma weak shmem_int_g            = pshmem_int_g
+#pragma weak shmem_long_g           = pshmem_long_g
+#pragma weak shmem_float_g          = pshmem_float_g
+#pragma weak shmem_double_g         = pshmem_double_g
+#pragma weak shmem_longlong_g       = pshmem_longlong_g
+#pragma weak shmem_schar_g          = pshmem_schar_g
+#pragma weak shmem_uchar_g          = pshmem_uchar_g
+#pragma weak shmem_ushort_g         = pshmem_ushort_g
+#pragma weak shmem_uint_g           = pshmem_uint_g
+#pragma weak shmem_ulong_g          = pshmem_ulong_g
+#pragma weak shmem_ulonglong_g      = pshmem_ulonglong_g
+#pragma weak shmem_longdouble_g     = pshmem_longdouble_g
+#pragma weak shmem_int8_g           = pshmem_int8_g
+#pragma weak shmem_int16_g          = pshmem_int16_g
+#pragma weak shmem_int32_g          = pshmem_int32_g
+#pragma weak shmem_int64_g          = pshmem_int64_g
+#pragma weak shmem_uint8_g          = pshmem_uint8_g
+#pragma weak shmem_uint16_g         = pshmem_uint16_g
+#pragma weak shmem_uint32_g         = pshmem_uint32_g
+#pragma weak shmem_uint64_g         = pshmem_uint64_g
+#pragma weak shmem_size_g           = pshmem_size_g
+#pragma weak shmem_ptrdiff_g        = pshmem_ptrdiff_g
 
 #pragma weak shmemx_int16_g = pshmemx_int16_g
 #pragma weak shmemx_int32_g = pshmemx_int32_g
@@ -108,6 +128,17 @@ SHMEM_CTX_TYPE_G(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_G(_float, float, shmem)
 SHMEM_CTX_TYPE_G(_double, double, shmem)
 SHMEM_CTX_TYPE_G(_longdouble, long double, shmem)
+SHMEM_CTX_TYPE_G(_int8, int8_t, shmem)
+SHMEM_CTX_TYPE_G(_int16, int16_t, shmem)
+SHMEM_CTX_TYPE_G(_int32, int32_t, shmem)
+SHMEM_CTX_TYPE_G(_int64, int64_t, shmem)
+SHMEM_CTX_TYPE_G(_uint8, uint8_t, shmem)
+SHMEM_CTX_TYPE_G(_uint16, uint16_t, shmem)
+SHMEM_CTX_TYPE_G(_uint32, uint32_t, shmem)
+SHMEM_CTX_TYPE_G(_uint64, uint64_t, shmem)
+SHMEM_CTX_TYPE_G(_size, size_t, shmem)
+SHMEM_CTX_TYPE_G(_ptrdiff, ptrdiff_t, shmem)
+
 SHMEM_TYPE_G(_char, char, shmem)
 SHMEM_TYPE_G(_short, short, shmem)
 SHMEM_TYPE_G(_int, int, shmem)
@@ -122,6 +153,17 @@ SHMEM_TYPE_G(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_G(_float, float, shmem)
 SHMEM_TYPE_G(_double, double, shmem)
 SHMEM_TYPE_G(_longdouble, long double, shmem)
+SHMEM_TYPE_G(_int8, int8_t, shmem)
+SHMEM_TYPE_G(_int16, int16_t, shmem)
+SHMEM_TYPE_G(_int32, int32_t, shmem)
+SHMEM_TYPE_G(_int64, int64_t, shmem)
+SHMEM_TYPE_G(_uint8, uint8_t, shmem)
+SHMEM_TYPE_G(_uint16, uint16_t, shmem)
+SHMEM_TYPE_G(_uint32, uint32_t, shmem)
+SHMEM_TYPE_G(_uint64, uint64_t, shmem)
+SHMEM_TYPE_G(_size, size_t, shmem)
+SHMEM_TYPE_G(_ptrdiff, ptrdiff_t, shmem)
+
 SHMEM_TYPE_G(_int16, int16_t, shmemx)
 SHMEM_TYPE_G(_int32, int32_t, shmemx)
 SHMEM_TYPE_G(_int64, int64_t, shmemx)

--- a/oshmem/shmem/c/shmem_get.c
+++ b/oshmem/shmem/c/shmem_get.c
@@ -57,35 +57,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_ctx_char_get = pshmem_ctx_char_get
-#pragma weak shmem_ctx_short_get = pshmem_ctx_short_get
-#pragma weak shmem_ctx_int_get = pshmem_ctx_int_get
-#pragma weak shmem_ctx_long_get = pshmem_ctx_long_get
-#pragma weak shmem_ctx_longlong_get = pshmem_ctx_longlong_get
-#pragma weak shmem_ctx_schar_get = pshmem_ctx_schar_get
-#pragma weak shmem_ctx_uchar_get = pshmem_ctx_uchar_get
-#pragma weak shmem_ctx_ushort_get = pshmem_ctx_ushort_get
-#pragma weak shmem_ctx_uint_get = pshmem_ctx_uint_get
-#pragma weak shmem_ctx_ulong_get = pshmem_ctx_ulong_get
-#pragma weak shmem_ctx_ulonglong_get = pshmem_ctx_ulonglong_get
-#pragma weak shmem_ctx_float_get = pshmem_ctx_float_get
-#pragma weak shmem_ctx_double_get = pshmem_ctx_double_get
+#pragma weak shmem_ctx_char_get       = pshmem_ctx_char_get
+#pragma weak shmem_ctx_short_get      = pshmem_ctx_short_get
+#pragma weak shmem_ctx_int_get        = pshmem_ctx_int_get
+#pragma weak shmem_ctx_long_get       = pshmem_ctx_long_get
+#pragma weak shmem_ctx_float_get      = pshmem_ctx_float_get
+#pragma weak shmem_ctx_double_get     = pshmem_ctx_double_get
+#pragma weak shmem_ctx_longlong_get   = pshmem_ctx_longlong_get
+#pragma weak shmem_ctx_schar_get      = pshmem_ctx_schar_get
+#pragma weak shmem_ctx_uchar_get      = pshmem_ctx_uchar_get
+#pragma weak shmem_ctx_ushort_get     = pshmem_ctx_ushort_get
+#pragma weak shmem_ctx_uint_get       = pshmem_ctx_uint_get
+#pragma weak shmem_ctx_ulong_get      = pshmem_ctx_ulong_get
+#pragma weak shmem_ctx_ulonglong_get  = pshmem_ctx_ulonglong_get
 #pragma weak shmem_ctx_longdouble_get = pshmem_ctx_longdouble_get
+#pragma weak shmem_ctx_int8_get       = pshmem_ctx_int8_get
+#pragma weak shmem_ctx_int16_get      = pshmem_ctx_int16_get
+#pragma weak shmem_ctx_int32_get      = pshmem_ctx_int32_get
+#pragma weak shmem_ctx_int64_get      = pshmem_ctx_int64_get
+#pragma weak shmem_ctx_uint8_get      = pshmem_ctx_uint8_get
+#pragma weak shmem_ctx_uint16_get     = pshmem_ctx_uint16_get
+#pragma weak shmem_ctx_uint32_get     = pshmem_ctx_uint32_get
+#pragma weak shmem_ctx_uint64_get     = pshmem_ctx_uint64_get
+#pragma weak shmem_ctx_size_get       = pshmem_ctx_size_get
+#pragma weak shmem_ctx_ptrdiff_get    = pshmem_ctx_ptrdiff_get
 
-#pragma weak shmem_char_get = pshmem_char_get
-#pragma weak shmem_short_get = pshmem_short_get
-#pragma weak shmem_int_get = pshmem_int_get
-#pragma weak shmem_long_get = pshmem_long_get
-#pragma weak shmem_longlong_get = pshmem_longlong_get
-#pragma weak shmem_schar_get = pshmem_schar_get
-#pragma weak shmem_uchar_get = pshmem_uchar_get
-#pragma weak shmem_ushort_get = pshmem_ushort_get
-#pragma weak shmem_uint_get = pshmem_uint_get
-#pragma weak shmem_ulong_get = pshmem_ulong_get
-#pragma weak shmem_ulonglong_get = pshmem_ulonglong_get
-#pragma weak shmem_float_get = pshmem_float_get
-#pragma weak shmem_double_get = pshmem_double_get
-#pragma weak shmem_longdouble_get = pshmem_longdouble_get
+#pragma weak shmem_char_get           = pshmem_char_get
+#pragma weak shmem_short_get          = pshmem_short_get
+#pragma weak shmem_int_get            = pshmem_int_get
+#pragma weak shmem_long_get           = pshmem_long_get
+#pragma weak shmem_float_get          = pshmem_float_get
+#pragma weak shmem_double_get         = pshmem_double_get
+#pragma weak shmem_longlong_get       = pshmem_longlong_get
+#pragma weak shmem_schar_get          = pshmem_schar_get
+#pragma weak shmem_uchar_get          = pshmem_uchar_get
+#pragma weak shmem_ushort_get         = pshmem_ushort_get
+#pragma weak shmem_uint_get           = pshmem_uint_get
+#pragma weak shmem_ulong_get          = pshmem_ulong_get
+#pragma weak shmem_ulonglong_get      = pshmem_ulonglong_get
+#pragma weak shmem_longdouble_get     = pshmem_longdouble_get
+#pragma weak shmem_int8_get           = pshmem_int8_get
+#pragma weak shmem_int16_get          = pshmem_int16_get
+#pragma weak shmem_int32_get          = pshmem_int32_get
+#pragma weak shmem_int64_get          = pshmem_int64_get
+#pragma weak shmem_uint8_get          = pshmem_uint8_get
+#pragma weak shmem_uint16_get         = pshmem_uint16_get
+#pragma weak shmem_uint32_get         = pshmem_uint32_get
+#pragma weak shmem_uint64_get         = pshmem_uint64_get
+#pragma weak shmem_size_get           = pshmem_size_get
+#pragma weak shmem_ptrdiff_get        = pshmem_ptrdiff_get
 
 #pragma weak shmem_ctx_getmem = pshmem_ctx_getmem
 #pragma weak shmem_ctx_get8 = pshmem_ctx_get8
@@ -117,6 +137,17 @@ SHMEM_CTX_TYPE_GET(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_GET(_float, float)
 SHMEM_CTX_TYPE_GET(_double, double)
 SHMEM_CTX_TYPE_GET(_longdouble, long double)
+SHMEM_CTX_TYPE_GET(_int8, int8_t)
+SHMEM_CTX_TYPE_GET(_int16, int16_t)
+SHMEM_CTX_TYPE_GET(_int32, int32_t)
+SHMEM_CTX_TYPE_GET(_int64, int64_t)
+SHMEM_CTX_TYPE_GET(_uint8, uint8_t)
+SHMEM_CTX_TYPE_GET(_uint16, uint16_t)
+SHMEM_CTX_TYPE_GET(_uint32, uint32_t)
+SHMEM_CTX_TYPE_GET(_uint64, uint64_t)
+SHMEM_CTX_TYPE_GET(_size, size_t)
+SHMEM_CTX_TYPE_GET(_ptrdiff, ptrdiff_t)
+
 SHMEM_TYPE_GET(_char, char)
 SHMEM_TYPE_GET(_short, short)
 SHMEM_TYPE_GET(_int, int)
@@ -131,6 +162,16 @@ SHMEM_TYPE_GET(_ulonglong, unsigned long long)
 SHMEM_TYPE_GET(_float, float)
 SHMEM_TYPE_GET(_double, double)
 SHMEM_TYPE_GET(_longdouble, long double)
+SHMEM_TYPE_GET(_int8, int8_t)
+SHMEM_TYPE_GET(_int16, int16_t)
+SHMEM_TYPE_GET(_int32, int32_t)
+SHMEM_TYPE_GET(_int64, int64_t)
+SHMEM_TYPE_GET(_uint8, uint8_t)
+SHMEM_TYPE_GET(_uint16, uint16_t)
+SHMEM_TYPE_GET(_uint32, uint32_t)
+SHMEM_TYPE_GET(_uint64, uint64_t)
+SHMEM_TYPE_GET(_size, size_t)
+SHMEM_TYPE_GET(_ptrdiff, ptrdiff_t)
 
 #define DO_SHMEM_GETMEM(ctx, target, source, element_size, nelems, pe) do { \
         int rc = OSHMEM_SUCCESS;                                    \

--- a/oshmem/shmem/c/shmem_get_nb.c
+++ b/oshmem/shmem/c/shmem_get_nb.c
@@ -57,35 +57,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_ctx_char_get_nbi = pshmem_ctx_char_get_nbi
-#pragma weak shmem_ctx_short_get_nbi = pshmem_ctx_short_get_nbi
-#pragma weak shmem_ctx_int_get_nbi = pshmem_ctx_int_get_nbi
-#pragma weak shmem_ctx_long_get_nbi = pshmem_ctx_long_get_nbi
-#pragma weak shmem_ctx_longlong_get_nbi = pshmem_ctx_longlong_get_nbi
-#pragma weak shmem_ctx_schar_get_nbi = pshmem_ctx_schar_get_nbi
-#pragma weak shmem_ctx_uchar_get_nbi = pshmem_ctx_uchar_get_nbi
-#pragma weak shmem_ctx_ushort_get_nbi = pshmem_ctx_ushort_get_nbi
-#pragma weak shmem_ctx_uint_get_nbi = pshmem_ctx_uint_get_nbi
-#pragma weak shmem_ctx_ulong_get_nbi = pshmem_ctx_ulong_get_nbi
-#pragma weak shmem_ctx_ulonglong_get_nbi = pshmem_ctx_ulonglong_get_nbi
-#pragma weak shmem_ctx_float_get_nbi = pshmem_ctx_float_get_nbi
-#pragma weak shmem_ctx_double_get_nbi = pshmem_ctx_double_get_nbi
+#pragma weak shmem_ctx_char_get_nbi       = pshmem_ctx_char_get_nbi
+#pragma weak shmem_ctx_short_get_nbi      = pshmem_ctx_short_get_nbi
+#pragma weak shmem_ctx_int_get_nbi        = pshmem_ctx_int_get_nbi
+#pragma weak shmem_ctx_long_get_nbi       = pshmem_ctx_long_get_nbi
+#pragma weak shmem_ctx_float_get_nbi      = pshmem_ctx_float_get_nbi
+#pragma weak shmem_ctx_double_get_nbi     = pshmem_ctx_double_get_nbi
+#pragma weak shmem_ctx_longlong_get_nbi   = pshmem_ctx_longlong_get_nbi
+#pragma weak shmem_ctx_schar_get_nbi      = pshmem_ctx_schar_get_nbi
+#pragma weak shmem_ctx_uchar_get_nbi      = pshmem_ctx_uchar_get_nbi
+#pragma weak shmem_ctx_ushort_get_nbi     = pshmem_ctx_ushort_get_nbi
+#pragma weak shmem_ctx_uint_get_nbi       = pshmem_ctx_uint_get_nbi
+#pragma weak shmem_ctx_ulong_get_nbi      = pshmem_ctx_ulong_get_nbi
+#pragma weak shmem_ctx_ulonglong_get_nbi  = pshmem_ctx_ulonglong_get_nbi
 #pragma weak shmem_ctx_longdouble_get_nbi = pshmem_ctx_longdouble_get_nbi
+#pragma weak shmem_ctx_int8_get_nbi       = pshmem_ctx_int8_get_nbi
+#pragma weak shmem_ctx_int16_get_nbi      = pshmem_ctx_int16_get_nbi
+#pragma weak shmem_ctx_int32_get_nbi      = pshmem_ctx_int32_get_nbi
+#pragma weak shmem_ctx_int64_get_nbi      = pshmem_ctx_int64_get_nbi
+#pragma weak shmem_ctx_uint8_get_nbi      = pshmem_ctx_uint8_get_nbi
+#pragma weak shmem_ctx_uint16_get_nbi     = pshmem_ctx_uint16_get_nbi
+#pragma weak shmem_ctx_uint32_get_nbi     = pshmem_ctx_uint32_get_nbi
+#pragma weak shmem_ctx_uint64_get_nbi     = pshmem_ctx_uint64_get_nbi
+#pragma weak shmem_ctx_size_get_nbi       = pshmem_ctx_size_get_nbi
+#pragma weak shmem_ctx_ptrdiff_get_nbi    = pshmem_ctx_ptrdiff_get_nbi
 
-#pragma weak shmem_char_get_nbi = pshmem_char_get_nbi
-#pragma weak shmem_short_get_nbi = pshmem_short_get_nbi
-#pragma weak shmem_int_get_nbi = pshmem_int_get_nbi
-#pragma weak shmem_long_get_nbi = pshmem_long_get_nbi
-#pragma weak shmem_longlong_get_nbi = pshmem_longlong_get_nbi
-#pragma weak shmem_schar_get_nbi = pshmem_schar_get_nbi
-#pragma weak shmem_uchar_get_nbi = pshmem_uchar_get_nbi
-#pragma weak shmem_ushort_get_nbi = pshmem_ushort_get_nbi
-#pragma weak shmem_uint_get_nbi = pshmem_uint_get_nbi
-#pragma weak shmem_ulong_get_nbi = pshmem_ulong_get_nbi
-#pragma weak shmem_ulonglong_get_nbi = pshmem_ulonglong_get_nbi
-#pragma weak shmem_float_get_nbi = pshmem_float_get_nbi
-#pragma weak shmem_double_get_nbi = pshmem_double_get_nbi
-#pragma weak shmem_longdouble_get_nbi = pshmem_longdouble_get_nbi
+#pragma weak shmem_char_get_nbi           = pshmem_char_get_nbi
+#pragma weak shmem_short_get_nbi          = pshmem_short_get_nbi
+#pragma weak shmem_int_get_nbi            = pshmem_int_get_nbi
+#pragma weak shmem_long_get_nbi           = pshmem_long_get_nbi
+#pragma weak shmem_float_get_nbi          = pshmem_float_get_nbi
+#pragma weak shmem_double_get_nbi         = pshmem_double_get_nbi
+#pragma weak shmem_longlong_get_nbi       = pshmem_longlong_get_nbi
+#pragma weak shmem_schar_get_nbi          = pshmem_schar_get_nbi
+#pragma weak shmem_uchar_get_nbi          = pshmem_uchar_get_nbi
+#pragma weak shmem_ushort_get_nbi         = pshmem_ushort_get_nbi
+#pragma weak shmem_uint_get_nbi           = pshmem_uint_get_nbi
+#pragma weak shmem_ulong_get_nbi          = pshmem_ulong_get_nbi
+#pragma weak shmem_ulonglong_get_nbi      = pshmem_ulonglong_get_nbi
+#pragma weak shmem_longdouble_get_nbi     = pshmem_longdouble_get_nbi
+#pragma weak shmem_int8_get_nbi           = pshmem_int8_get_nbi
+#pragma weak shmem_int16_get_nbi          = pshmem_int16_get_nbi
+#pragma weak shmem_int32_get_nbi          = pshmem_int32_get_nbi
+#pragma weak shmem_int64_get_nbi          = pshmem_int64_get_nbi
+#pragma weak shmem_uint8_get_nbi          = pshmem_uint8_get_nbi
+#pragma weak shmem_uint16_get_nbi         = pshmem_uint16_get_nbi
+#pragma weak shmem_uint32_get_nbi         = pshmem_uint32_get_nbi
+#pragma weak shmem_uint64_get_nbi         = pshmem_uint64_get_nbi
+#pragma weak shmem_size_get_nbi           = pshmem_size_get_nbi
+#pragma weak shmem_ptrdiff_get_nbi        = pshmem_ptrdiff_get_nbi
 
 #pragma weak shmem_ctx_get8_nbi = pshmem_ctx_get8_nbi
 #pragma weak shmem_ctx_get16_nbi = pshmem_ctx_get16_nbi
@@ -117,6 +137,17 @@ SHMEM_CTX_TYPE_GET_NB(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_GET_NB(_float, float)
 SHMEM_CTX_TYPE_GET_NB(_double, double)
 SHMEM_CTX_TYPE_GET_NB(_longdouble, long double)
+SHMEM_CTX_TYPE_GET_NB(_int8, int8_t)
+SHMEM_CTX_TYPE_GET_NB(_int16, int16_t)
+SHMEM_CTX_TYPE_GET_NB(_int32, int32_t)
+SHMEM_CTX_TYPE_GET_NB(_int64, int64_t)
+SHMEM_CTX_TYPE_GET_NB(_uint8, uint8_t)
+SHMEM_CTX_TYPE_GET_NB(_uint16, uint16_t)
+SHMEM_CTX_TYPE_GET_NB(_uint32, uint32_t)
+SHMEM_CTX_TYPE_GET_NB(_uint64, uint64_t)
+SHMEM_CTX_TYPE_GET_NB(_size, size_t)
+SHMEM_CTX_TYPE_GET_NB(_ptrdiff, ptrdiff_t)
+
 SHMEM_TYPE_GET_NB(_char, char)
 SHMEM_TYPE_GET_NB(_short, short)
 SHMEM_TYPE_GET_NB(_int, int)
@@ -131,6 +162,16 @@ SHMEM_TYPE_GET_NB(_ulonglong, unsigned long long)
 SHMEM_TYPE_GET_NB(_float, float)
 SHMEM_TYPE_GET_NB(_double, double)
 SHMEM_TYPE_GET_NB(_longdouble, long double)
+SHMEM_TYPE_GET_NB(_int8, int8_t)
+SHMEM_TYPE_GET_NB(_int16, int16_t)
+SHMEM_TYPE_GET_NB(_int32, int32_t)
+SHMEM_TYPE_GET_NB(_int64, int64_t)
+SHMEM_TYPE_GET_NB(_uint8, uint8_t)
+SHMEM_TYPE_GET_NB(_uint16, uint16_t)
+SHMEM_TYPE_GET_NB(_uint32, uint32_t)
+SHMEM_TYPE_GET_NB(_uint64, uint64_t)
+SHMEM_TYPE_GET_NB(_size, size_t)
+SHMEM_TYPE_GET_NB(_ptrdiff, ptrdiff_t)
 
 #define DO_SHMEM_GETMEM_NB(ctx, target, source, element_size, nelems, pe) do { \
         int rc = OSHMEM_SUCCESS;                                    \

--- a/oshmem/shmem/c/shmem_iget.c
+++ b/oshmem/shmem/c/shmem_iget.c
@@ -62,35 +62,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_ctx_char_iget = pshmem_ctx_char_iget
-#pragma weak shmem_ctx_short_iget = pshmem_ctx_short_iget
-#pragma weak shmem_ctx_int_iget = pshmem_ctx_int_iget
-#pragma weak shmem_ctx_long_iget = pshmem_ctx_long_iget
-#pragma weak shmem_ctx_longlong_iget = pshmem_ctx_longlong_iget
-#pragma weak shmem_ctx_schar_iget = pshmem_ctx_schar_iget
-#pragma weak shmem_ctx_uchar_iget = pshmem_ctx_uchar_iget
-#pragma weak shmem_ctx_ushort_iget = pshmem_ctx_ushort_iget
-#pragma weak shmem_ctx_uint_iget = pshmem_ctx_uint_iget
-#pragma weak shmem_ctx_ulong_iget = pshmem_ctx_ulong_iget
-#pragma weak shmem_ctx_ulonglong_iget = pshmem_ctx_ulonglong_iget
-#pragma weak shmem_ctx_float_iget = pshmem_ctx_float_iget
-#pragma weak shmem_ctx_double_iget = pshmem_ctx_double_iget
+#pragma weak shmem_ctx_char_iget       = pshmem_ctx_char_iget
+#pragma weak shmem_ctx_short_iget      = pshmem_ctx_short_iget
+#pragma weak shmem_ctx_int_iget        = pshmem_ctx_int_iget
+#pragma weak shmem_ctx_long_iget       = pshmem_ctx_long_iget
+#pragma weak shmem_ctx_float_iget      = pshmem_ctx_float_iget
+#pragma weak shmem_ctx_double_iget     = pshmem_ctx_double_iget
+#pragma weak shmem_ctx_longlong_iget   = pshmem_ctx_longlong_iget
+#pragma weak shmem_ctx_schar_iget      = pshmem_ctx_schar_iget
+#pragma weak shmem_ctx_uchar_iget      = pshmem_ctx_uchar_iget
+#pragma weak shmem_ctx_ushort_iget     = pshmem_ctx_ushort_iget
+#pragma weak shmem_ctx_uint_iget       = pshmem_ctx_uint_iget
+#pragma weak shmem_ctx_ulong_iget      = pshmem_ctx_ulong_iget
+#pragma weak shmem_ctx_ulonglong_iget  = pshmem_ctx_ulonglong_iget
 #pragma weak shmem_ctx_longdouble_iget = pshmem_ctx_longdouble_iget
+#pragma weak shmem_ctx_int8_iget       = pshmem_ctx_int8_iget
+#pragma weak shmem_ctx_int16_iget      = pshmem_ctx_int16_iget
+#pragma weak shmem_ctx_int32_iget      = pshmem_ctx_int32_iget
+#pragma weak shmem_ctx_int64_iget      = pshmem_ctx_int64_iget
+#pragma weak shmem_ctx_uint8_iget      = pshmem_ctx_uint8_iget
+#pragma weak shmem_ctx_uint16_iget     = pshmem_ctx_uint16_iget
+#pragma weak shmem_ctx_uint32_iget     = pshmem_ctx_uint32_iget
+#pragma weak shmem_ctx_uint64_iget     = pshmem_ctx_uint64_iget
+#pragma weak shmem_ctx_size_iget       = pshmem_ctx_size_iget
+#pragma weak shmem_ctx_ptrdiff_iget    = pshmem_ctx_ptrdiff_iget
 
-#pragma weak shmem_char_iget = pshmem_char_iget
-#pragma weak shmem_short_iget = pshmem_short_iget
-#pragma weak shmem_int_iget = pshmem_int_iget
-#pragma weak shmem_long_iget = pshmem_long_iget
-#pragma weak shmem_longlong_iget = pshmem_longlong_iget
-#pragma weak shmem_schar_iget = pshmem_schar_iget
-#pragma weak shmem_uchar_iget = pshmem_uchar_iget
-#pragma weak shmem_ushort_iget = pshmem_ushort_iget
-#pragma weak shmem_uint_iget = pshmem_uint_iget
-#pragma weak shmem_ulong_iget = pshmem_ulong_iget
-#pragma weak shmem_ulonglong_iget = pshmem_ulonglong_iget
-#pragma weak shmem_float_iget = pshmem_float_iget
-#pragma weak shmem_double_iget = pshmem_double_iget
-#pragma weak shmem_longdouble_iget = pshmem_longdouble_iget
+#pragma weak shmem_char_iget           = pshmem_char_iget
+#pragma weak shmem_short_iget          = pshmem_short_iget
+#pragma weak shmem_int_iget            = pshmem_int_iget
+#pragma weak shmem_long_iget           = pshmem_long_iget
+#pragma weak shmem_float_iget          = pshmem_float_iget
+#pragma weak shmem_double_iget         = pshmem_double_iget
+#pragma weak shmem_longlong_iget       = pshmem_longlong_iget
+#pragma weak shmem_schar_iget          = pshmem_schar_iget
+#pragma weak shmem_uchar_iget          = pshmem_uchar_iget
+#pragma weak shmem_ushort_iget         = pshmem_ushort_iget
+#pragma weak shmem_uint_iget           = pshmem_uint_iget
+#pragma weak shmem_ulong_iget          = pshmem_ulong_iget
+#pragma weak shmem_ulonglong_iget      = pshmem_ulonglong_iget
+#pragma weak shmem_longdouble_iget     = pshmem_longdouble_iget
+#pragma weak shmem_int8_iget           = pshmem_int8_iget
+#pragma weak shmem_int16_iget          = pshmem_int16_iget
+#pragma weak shmem_int32_iget          = pshmem_int32_iget
+#pragma weak shmem_int64_iget          = pshmem_int64_iget
+#pragma weak shmem_uint8_iget          = pshmem_uint8_iget
+#pragma weak shmem_uint16_iget         = pshmem_uint16_iget
+#pragma weak shmem_uint32_iget         = pshmem_uint32_iget
+#pragma weak shmem_uint64_iget         = pshmem_uint64_iget
+#pragma weak shmem_size_iget           = pshmem_size_iget
+#pragma weak shmem_ptrdiff_iget        = pshmem_ptrdiff_iget
 
 #pragma weak shmem_ctx_iget8 = pshmem_ctx_iget8
 #pragma weak shmem_ctx_iget16 = pshmem_ctx_iget16
@@ -120,6 +140,17 @@ SHMEM_CTX_TYPE_IGET(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_IGET(_float, float)
 SHMEM_CTX_TYPE_IGET(_double, double)
 SHMEM_CTX_TYPE_IGET(_longdouble, long double)
+SHMEM_CTX_TYPE_IGET(_int8, int8_t)
+SHMEM_CTX_TYPE_IGET(_int16, int16_t)
+SHMEM_CTX_TYPE_IGET(_int32, int32_t)
+SHMEM_CTX_TYPE_IGET(_int64, int64_t)
+SHMEM_CTX_TYPE_IGET(_uint8, uint8_t)
+SHMEM_CTX_TYPE_IGET(_uint16, uint16_t)
+SHMEM_CTX_TYPE_IGET(_uint32, uint32_t)
+SHMEM_CTX_TYPE_IGET(_uint64, uint64_t)
+SHMEM_CTX_TYPE_IGET(_size, size_t)
+SHMEM_CTX_TYPE_IGET(_ptrdiff, ptrdiff_t)
+
 SHMEM_TYPE_IGET(_char, char)
 SHMEM_TYPE_IGET(_short, short)
 SHMEM_TYPE_IGET(_int, int)
@@ -134,6 +165,16 @@ SHMEM_TYPE_IGET(_ulonglong, unsigned long long)
 SHMEM_TYPE_IGET(_float, float)
 SHMEM_TYPE_IGET(_double, double)
 SHMEM_TYPE_IGET(_longdouble, long double)
+SHMEM_TYPE_IGET(_int8, int8_t)
+SHMEM_TYPE_IGET(_int16, int16_t)
+SHMEM_TYPE_IGET(_int32, int32_t)
+SHMEM_TYPE_IGET(_int64, int64_t)
+SHMEM_TYPE_IGET(_uint8, uint8_t)
+SHMEM_TYPE_IGET(_uint16, uint16_t)
+SHMEM_TYPE_IGET(_uint32, uint32_t)
+SHMEM_TYPE_IGET(_uint64, uint64_t)
+SHMEM_TYPE_IGET(_size, size_t)
+SHMEM_TYPE_IGET(_ptrdiff, ptrdiff_t)
 
 #define DO_SHMEM_IGETMEM(ctx, target, source, tst, sst, element_size, nelems, pe) do { \
         int rc = OSHMEM_SUCCESS;                                    \

--- a/oshmem/shmem/c/shmem_iput.c
+++ b/oshmem/shmem/c/shmem_iput.c
@@ -63,35 +63,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_ctx_char_iput = pshmem_ctx_char_iput
-#pragma weak shmem_ctx_short_iput = pshmem_ctx_short_iput
-#pragma weak shmem_ctx_int_iput = pshmem_ctx_int_iput
-#pragma weak shmem_ctx_long_iput = pshmem_ctx_long_iput
-#pragma weak shmem_ctx_longlong_iput = pshmem_ctx_longlong_iput
-#pragma weak shmem_ctx_schar_iput = pshmem_ctx_schar_iput
-#pragma weak shmem_ctx_uchar_iput = pshmem_ctx_uchar_iput
-#pragma weak shmem_ctx_ushort_iput = pshmem_ctx_ushort_iput
-#pragma weak shmem_ctx_uint_iput = pshmem_ctx_uint_iput
-#pragma weak shmem_ctx_ulong_iput = pshmem_ctx_ulong_iput
-#pragma weak shmem_ctx_ulonglong_iput = pshmem_ctx_ulonglong_iput
-#pragma weak shmem_ctx_float_iput = pshmem_ctx_float_iput
-#pragma weak shmem_ctx_double_iput = pshmem_ctx_double_iput
+#pragma weak shmem_ctx_char_iput       = pshmem_ctx_char_iput
+#pragma weak shmem_ctx_short_iput      = pshmem_ctx_short_iput
+#pragma weak shmem_ctx_int_iput        = pshmem_ctx_int_iput
+#pragma weak shmem_ctx_long_iput       = pshmem_ctx_long_iput
+#pragma weak shmem_ctx_float_iput      = pshmem_ctx_float_iput
+#pragma weak shmem_ctx_double_iput     = pshmem_ctx_double_iput
+#pragma weak shmem_ctx_longlong_iput   = pshmem_ctx_longlong_iput
+#pragma weak shmem_ctx_schar_iput      = pshmem_ctx_schar_iput
+#pragma weak shmem_ctx_uchar_iput      = pshmem_ctx_uchar_iput
+#pragma weak shmem_ctx_ushort_iput     = pshmem_ctx_ushort_iput
+#pragma weak shmem_ctx_uint_iput       = pshmem_ctx_uint_iput
+#pragma weak shmem_ctx_ulong_iput      = pshmem_ctx_ulong_iput
+#pragma weak shmem_ctx_ulonglong_iput  = pshmem_ctx_ulonglong_iput
 #pragma weak shmem_ctx_longdouble_iput = pshmem_ctx_longdouble_iput
+#pragma weak shmem_ctx_int8_iput       = pshmem_ctx_int8_iput
+#pragma weak shmem_ctx_int16_iput      = pshmem_ctx_int16_iput
+#pragma weak shmem_ctx_int32_iput      = pshmem_ctx_int32_iput
+#pragma weak shmem_ctx_int64_iput      = pshmem_ctx_int64_iput
+#pragma weak shmem_ctx_uint8_iput      = pshmem_ctx_uint8_iput
+#pragma weak shmem_ctx_uint16_iput     = pshmem_ctx_uint16_iput
+#pragma weak shmem_ctx_uint32_iput     = pshmem_ctx_uint32_iput
+#pragma weak shmem_ctx_uint64_iput     = pshmem_ctx_uint64_iput
+#pragma weak shmem_ctx_size_iput       = pshmem_ctx_size_iput
+#pragma weak shmem_ctx_ptrdiff_iput    = pshmem_ctx_ptrdiff_iput
 
-#pragma weak shmem_char_iput = pshmem_char_iput
-#pragma weak shmem_short_iput = pshmem_short_iput
-#pragma weak shmem_int_iput = pshmem_int_iput
-#pragma weak shmem_long_iput = pshmem_long_iput
-#pragma weak shmem_longlong_iput = pshmem_longlong_iput
-#pragma weak shmem_schar_iput = pshmem_schar_iput
-#pragma weak shmem_uchar_iput = pshmem_uchar_iput
-#pragma weak shmem_ushort_iput = pshmem_ushort_iput
-#pragma weak shmem_uint_iput = pshmem_uint_iput
-#pragma weak shmem_ulong_iput = pshmem_ulong_iput
-#pragma weak shmem_ulonglong_iput = pshmem_ulonglong_iput
-#pragma weak shmem_float_iput = pshmem_float_iput
-#pragma weak shmem_double_iput = pshmem_double_iput
-#pragma weak shmem_longdouble_iput = pshmem_longdouble_iput
+#pragma weak shmem_char_iput           = pshmem_char_iput
+#pragma weak shmem_short_iput          = pshmem_short_iput
+#pragma weak shmem_int_iput            = pshmem_int_iput
+#pragma weak shmem_long_iput           = pshmem_long_iput
+#pragma weak shmem_float_iput          = pshmem_float_iput
+#pragma weak shmem_double_iput         = pshmem_double_iput
+#pragma weak shmem_longlong_iput       = pshmem_longlong_iput
+#pragma weak shmem_schar_iput          = pshmem_schar_iput
+#pragma weak shmem_uchar_iput          = pshmem_uchar_iput
+#pragma weak shmem_ushort_iput         = pshmem_ushort_iput
+#pragma weak shmem_uint_iput           = pshmem_uint_iput
+#pragma weak shmem_ulong_iput          = pshmem_ulong_iput
+#pragma weak shmem_ulonglong_iput      = pshmem_ulonglong_iput
+#pragma weak shmem_longdouble_iput     = pshmem_longdouble_iput
+#pragma weak shmem_int8_iput           = pshmem_int8_iput
+#pragma weak shmem_int16_iput          = pshmem_int16_iput
+#pragma weak shmem_int32_iput          = pshmem_int32_iput
+#pragma weak shmem_int64_iput          = pshmem_int64_iput
+#pragma weak shmem_uint8_iput          = pshmem_uint8_iput
+#pragma weak shmem_uint16_iput         = pshmem_uint16_iput
+#pragma weak shmem_uint32_iput         = pshmem_uint32_iput
+#pragma weak shmem_uint64_iput         = pshmem_uint64_iput
+#pragma weak shmem_size_iput           = pshmem_size_iput
+#pragma weak shmem_ptrdiff_iput        = pshmem_ptrdiff_iput
 
 #pragma weak shmem_ctx_iput8 = pshmem_ctx_iput8
 #pragma weak shmem_ctx_iput16 = pshmem_ctx_iput16
@@ -121,6 +141,17 @@ SHMEM_CTX_TYPE_IPUT(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_IPUT(_float, float)
 SHMEM_CTX_TYPE_IPUT(_double, double)
 SHMEM_CTX_TYPE_IPUT(_longdouble, long double)
+SHMEM_CTX_TYPE_IPUT(_int8, int8_t)
+SHMEM_CTX_TYPE_IPUT(_int16, int16_t)
+SHMEM_CTX_TYPE_IPUT(_int32, int32_t)
+SHMEM_CTX_TYPE_IPUT(_int64, int64_t)
+SHMEM_CTX_TYPE_IPUT(_uint8, uint8_t)
+SHMEM_CTX_TYPE_IPUT(_uint16, uint16_t)
+SHMEM_CTX_TYPE_IPUT(_uint32, uint32_t)
+SHMEM_CTX_TYPE_IPUT(_uint64, uint64_t)
+SHMEM_CTX_TYPE_IPUT(_size, size_t)
+SHMEM_CTX_TYPE_IPUT(_ptrdiff, ptrdiff_t)
+
 SHMEM_TYPE_IPUT(_char, char)
 SHMEM_TYPE_IPUT(_short, short)
 SHMEM_TYPE_IPUT(_int, int)
@@ -135,6 +166,16 @@ SHMEM_TYPE_IPUT(_ulonglong, unsigned long long)
 SHMEM_TYPE_IPUT(_float, float)
 SHMEM_TYPE_IPUT(_double, double)
 SHMEM_TYPE_IPUT(_longdouble, long double)
+SHMEM_TYPE_IPUT(_int8, int8_t)
+SHMEM_TYPE_IPUT(_int16, int16_t)
+SHMEM_TYPE_IPUT(_int32, int32_t)
+SHMEM_TYPE_IPUT(_int64, int64_t)
+SHMEM_TYPE_IPUT(_uint8, uint8_t)
+SHMEM_TYPE_IPUT(_uint16, uint16_t)
+SHMEM_TYPE_IPUT(_uint32, uint32_t)
+SHMEM_TYPE_IPUT(_uint64, uint64_t)
+SHMEM_TYPE_IPUT(_size, size_t)
+SHMEM_TYPE_IPUT(_ptrdiff, ptrdiff_t)
 
 #define DO_SHMEM_IPUTMEM(ctx, target, source, tst, sst, element_size, nelems, pe) do { \
         int rc = OSHMEM_SUCCESS;                                    \

--- a/oshmem/shmem/c/shmem_p.c
+++ b/oshmem/shmem/c/shmem_p.c
@@ -59,35 +59,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_ctx_char_p = pshmem_ctx_char_p
-#pragma weak shmem_ctx_short_p = pshmem_ctx_short_p
-#pragma weak shmem_ctx_int_p = pshmem_ctx_int_p
-#pragma weak shmem_ctx_long_p = pshmem_ctx_long_p
-#pragma weak shmem_ctx_longlong_p = pshmem_ctx_longlong_p
-#pragma weak shmem_ctx_schar_p = pshmem_ctx_schar_p
-#pragma weak shmem_ctx_uchar_p = pshmem_ctx_uchar_p
-#pragma weak shmem_ctx_ushort_p = pshmem_ctx_ushort_p
-#pragma weak shmem_ctx_uint_p = pshmem_ctx_uint_p
-#pragma weak shmem_ctx_ulong_p = pshmem_ctx_ulong_p
-#pragma weak shmem_ctx_ulonglong_p = pshmem_ctx_ulonglong_p
-#pragma weak shmem_ctx_float_p = pshmem_ctx_float_p
-#pragma weak shmem_ctx_double_p = pshmem_ctx_double_p
+#pragma weak shmem_ctx_char_p       = pshmem_ctx_char_p
+#pragma weak shmem_ctx_short_p      = pshmem_ctx_short_p
+#pragma weak shmem_ctx_int_p        = pshmem_ctx_int_p
+#pragma weak shmem_ctx_long_p       = pshmem_ctx_long_p
+#pragma weak shmem_ctx_float_p      = pshmem_ctx_float_p
+#pragma weak shmem_ctx_double_p     = pshmem_ctx_double_p
+#pragma weak shmem_ctx_longlong_p   = pshmem_ctx_longlong_p
+#pragma weak shmem_ctx_schar_p      = pshmem_ctx_schar_p
+#pragma weak shmem_ctx_uchar_p      = pshmem_ctx_uchar_p
+#pragma weak shmem_ctx_ushort_p     = pshmem_ctx_ushort_p
+#pragma weak shmem_ctx_uint_p       = pshmem_ctx_uint_p
+#pragma weak shmem_ctx_ulong_p      = pshmem_ctx_ulong_p
+#pragma weak shmem_ctx_ulonglong_p  = pshmem_ctx_ulonglong_p
 #pragma weak shmem_ctx_longdouble_p = pshmem_ctx_longdouble_p
+#pragma weak shmem_ctx_int8_p       = pshmem_ctx_int8_p
+#pragma weak shmem_ctx_int16_p      = pshmem_ctx_int16_p
+#pragma weak shmem_ctx_int32_p      = pshmem_ctx_int32_p
+#pragma weak shmem_ctx_int64_p      = pshmem_ctx_int64_p
+#pragma weak shmem_ctx_uint8_p      = pshmem_ctx_uint8_p
+#pragma weak shmem_ctx_uint16_p     = pshmem_ctx_uint16_p
+#pragma weak shmem_ctx_uint32_p     = pshmem_ctx_uint32_p
+#pragma weak shmem_ctx_uint64_p     = pshmem_ctx_uint64_p
+#pragma weak shmem_ctx_size_p       = pshmem_ctx_size_p
+#pragma weak shmem_ctx_ptrdiff_p    = pshmem_ctx_ptrdiff_p
 
-#pragma weak shmem_char_p = pshmem_char_p
-#pragma weak shmem_short_p = pshmem_short_p
-#pragma weak shmem_int_p = pshmem_int_p
-#pragma weak shmem_long_p = pshmem_long_p
-#pragma weak shmem_longlong_p = pshmem_longlong_p
-#pragma weak shmem_schar_p = pshmem_schar_p
-#pragma weak shmem_uchar_p = pshmem_uchar_p
-#pragma weak shmem_ushort_p = pshmem_ushort_p
-#pragma weak shmem_uint_p = pshmem_uint_p
-#pragma weak shmem_ulong_p = pshmem_ulong_p
-#pragma weak shmem_ulonglong_p = pshmem_ulonglong_p
-#pragma weak shmem_float_p = pshmem_float_p
-#pragma weak shmem_double_p = pshmem_double_p
-#pragma weak shmem_longdouble_p = pshmem_longdouble_p
+#pragma weak shmem_char_p           = pshmem_char_p
+#pragma weak shmem_short_p          = pshmem_short_p
+#pragma weak shmem_int_p            = pshmem_int_p
+#pragma weak shmem_long_p           = pshmem_long_p
+#pragma weak shmem_float_p          = pshmem_float_p
+#pragma weak shmem_double_p         = pshmem_double_p
+#pragma weak shmem_longlong_p       = pshmem_longlong_p
+#pragma weak shmem_schar_p          = pshmem_schar_p
+#pragma weak shmem_uchar_p          = pshmem_uchar_p
+#pragma weak shmem_ushort_p         = pshmem_ushort_p
+#pragma weak shmem_uint_p           = pshmem_uint_p
+#pragma weak shmem_ulong_p          = pshmem_ulong_p
+#pragma weak shmem_ulonglong_p      = pshmem_ulonglong_p
+#pragma weak shmem_longdouble_p     = pshmem_longdouble_p
+#pragma weak shmem_int8_p           = pshmem_int8_p
+#pragma weak shmem_int16_p          = pshmem_int16_p
+#pragma weak shmem_int32_p          = pshmem_int32_p
+#pragma weak shmem_int64_p          = pshmem_int64_p
+#pragma weak shmem_uint8_p          = pshmem_uint8_p
+#pragma weak shmem_uint16_p         = pshmem_uint16_p
+#pragma weak shmem_uint32_p         = pshmem_uint32_p
+#pragma weak shmem_uint64_p         = pshmem_uint64_p
+#pragma weak shmem_size_p           = pshmem_size_p
+#pragma weak shmem_ptrdiff_p        = pshmem_ptrdiff_p
 
 #pragma weak shmemx_int16_p = pshmemx_int16_p
 #pragma weak shmemx_int32_p = pshmemx_int32_p
@@ -109,6 +129,17 @@ SHMEM_CTX_TYPE_P(_ulonglong, unsigned long long, shmem)
 SHMEM_CTX_TYPE_P(_float, float, shmem)
 SHMEM_CTX_TYPE_P(_double, double, shmem)
 SHMEM_CTX_TYPE_P(_longdouble, long double, shmem)
+SHMEM_CTX_TYPE_P(_int8, int8_t, shmem)
+SHMEM_CTX_TYPE_P(_int16, int16_t, shmem)
+SHMEM_CTX_TYPE_P(_int32, int32_t, shmem)
+SHMEM_CTX_TYPE_P(_int64, int64_t, shmem)
+SHMEM_CTX_TYPE_P(_uint8, uint8_t, shmem)
+SHMEM_CTX_TYPE_P(_uint16, uint16_t, shmem)
+SHMEM_CTX_TYPE_P(_uint32, uint32_t, shmem)
+SHMEM_CTX_TYPE_P(_uint64, uint64_t, shmem)
+SHMEM_CTX_TYPE_P(_size, size_t, shmem)
+SHMEM_CTX_TYPE_P(_ptrdiff, ptrdiff_t, shmem)
+
 SHMEM_TYPE_P(_char, char, shmem)
 SHMEM_TYPE_P(_short, short, shmem)
 SHMEM_TYPE_P(_int, int, shmem)
@@ -123,6 +154,17 @@ SHMEM_TYPE_P(_ulonglong, unsigned long long, shmem)
 SHMEM_TYPE_P(_float, float, shmem)
 SHMEM_TYPE_P(_double, double, shmem)
 SHMEM_TYPE_P(_longdouble, long double, shmem)
+SHMEM_TYPE_P(_int8, int8_t, shmem)
+SHMEM_TYPE_P(_int16, int16_t, shmem)
+SHMEM_TYPE_P(_int32, int32_t, shmem)
+SHMEM_TYPE_P(_int64, int64_t, shmem)
+SHMEM_TYPE_P(_uint8, uint8_t, shmem)
+SHMEM_TYPE_P(_uint16, uint16_t, shmem)
+SHMEM_TYPE_P(_uint32, uint32_t, shmem)
+SHMEM_TYPE_P(_uint64, uint64_t, shmem)
+SHMEM_TYPE_P(_size, size_t, shmem)
+SHMEM_TYPE_P(_ptrdiff, ptrdiff_t, shmem)
+
 SHMEM_TYPE_P(_int16, int16_t, shmemx)
 SHMEM_TYPE_P(_int32, int32_t, shmemx)
 SHMEM_TYPE_P(_int64, int64_t, shmemx)

--- a/oshmem/shmem/c/shmem_put.c
+++ b/oshmem/shmem/c/shmem_put.c
@@ -60,35 +60,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_ctx_char_put = pshmem_ctx_char_put
-#pragma weak shmem_ctx_short_put = pshmem_ctx_short_put
-#pragma weak shmem_ctx_int_put = pshmem_ctx_int_put
-#pragma weak shmem_ctx_long_put = pshmem_ctx_long_put
-#pragma weak shmem_ctx_longlong_put = pshmem_ctx_longlong_put
-#pragma weak shmem_ctx_schar_put = pshmem_ctx_schar_put
-#pragma weak shmem_ctx_uchar_put = pshmem_ctx_uchar_put
-#pragma weak shmem_ctx_ushort_put = pshmem_ctx_ushort_put
-#pragma weak shmem_ctx_uint_put = pshmem_ctx_uint_put
-#pragma weak shmem_ctx_ulong_put = pshmem_ctx_ulong_put
-#pragma weak shmem_ctx_ulonglong_put = pshmem_ctx_ulonglong_put
-#pragma weak shmem_ctx_float_put = pshmem_ctx_float_put
-#pragma weak shmem_ctx_double_put = pshmem_ctx_double_put
+#pragma weak shmem_ctx_char_put       = pshmem_ctx_char_put
+#pragma weak shmem_ctx_short_put      = pshmem_ctx_short_put
+#pragma weak shmem_ctx_int_put        = pshmem_ctx_int_put
+#pragma weak shmem_ctx_long_put       = pshmem_ctx_long_put
+#pragma weak shmem_ctx_float_put      = pshmem_ctx_float_put
+#pragma weak shmem_ctx_double_put     = pshmem_ctx_double_put
+#pragma weak shmem_ctx_longlong_put   = pshmem_ctx_longlong_put
+#pragma weak shmem_ctx_schar_put      = pshmem_ctx_schar_put
+#pragma weak shmem_ctx_uchar_put      = pshmem_ctx_uchar_put
+#pragma weak shmem_ctx_ushort_put     = pshmem_ctx_ushort_put
+#pragma weak shmem_ctx_uint_put       = pshmem_ctx_uint_put
+#pragma weak shmem_ctx_ulong_put      = pshmem_ctx_ulong_put
+#pragma weak shmem_ctx_ulonglong_put  = pshmem_ctx_ulonglong_put
 #pragma weak shmem_ctx_longdouble_put = pshmem_ctx_longdouble_put
+#pragma weak shmem_ctx_int8_put       = pshmem_ctx_int8_put
+#pragma weak shmem_ctx_int16_put      = pshmem_ctx_int16_put
+#pragma weak shmem_ctx_int32_put      = pshmem_ctx_int32_put
+#pragma weak shmem_ctx_int64_put      = pshmem_ctx_int64_put
+#pragma weak shmem_ctx_uint8_put      = pshmem_ctx_uint8_put
+#pragma weak shmem_ctx_uint16_put     = pshmem_ctx_uint16_put
+#pragma weak shmem_ctx_uint32_put     = pshmem_ctx_uint32_put
+#pragma weak shmem_ctx_uint64_put     = pshmem_ctx_uint64_put
+#pragma weak shmem_ctx_size_put       = pshmem_ctx_size_put
+#pragma weak shmem_ctx_ptrdiff_put    = pshmem_ctx_ptrdiff_put
 
-#pragma weak shmem_char_put = pshmem_char_put
-#pragma weak shmem_short_put = pshmem_short_put
-#pragma weak shmem_int_put = pshmem_int_put
-#pragma weak shmem_long_put = pshmem_long_put
-#pragma weak shmem_longlong_put = pshmem_longlong_put
-#pragma weak shmem_schar_put = pshmem_schar_put
-#pragma weak shmem_uchar_put = pshmem_uchar_put
-#pragma weak shmem_ushort_put = pshmem_ushort_put
-#pragma weak shmem_uint_put = pshmem_uint_put
-#pragma weak shmem_ulong_put = pshmem_ulong_put
-#pragma weak shmem_ulonglong_put = pshmem_ulonglong_put
-#pragma weak shmem_float_put = pshmem_float_put
-#pragma weak shmem_double_put = pshmem_double_put
-#pragma weak shmem_longdouble_put = pshmem_longdouble_put
+#pragma weak shmem_char_put           = pshmem_char_put
+#pragma weak shmem_short_put          = pshmem_short_put
+#pragma weak shmem_int_put            = pshmem_int_put
+#pragma weak shmem_long_put           = pshmem_long_put
+#pragma weak shmem_float_put          = pshmem_float_put
+#pragma weak shmem_double_put         = pshmem_double_put
+#pragma weak shmem_longlong_put       = pshmem_longlong_put
+#pragma weak shmem_schar_put          = pshmem_schar_put
+#pragma weak shmem_uchar_put          = pshmem_uchar_put
+#pragma weak shmem_ushort_put         = pshmem_ushort_put
+#pragma weak shmem_uint_put           = pshmem_uint_put
+#pragma weak shmem_ulong_put          = pshmem_ulong_put
+#pragma weak shmem_ulonglong_put      = pshmem_ulonglong_put
+#pragma weak shmem_longdouble_put     = pshmem_longdouble_put
+#pragma weak shmem_int8_put           = pshmem_int8_put
+#pragma weak shmem_int16_put          = pshmem_int16_put
+#pragma weak shmem_int32_put          = pshmem_int32_put
+#pragma weak shmem_int64_put          = pshmem_int64_put
+#pragma weak shmem_uint8_put          = pshmem_uint8_put
+#pragma weak shmem_uint16_put         = pshmem_uint16_put
+#pragma weak shmem_uint32_put         = pshmem_uint32_put
+#pragma weak shmem_uint64_put         = pshmem_uint64_put
+#pragma weak shmem_size_put           = pshmem_size_put
+#pragma weak shmem_ptrdiff_put        = pshmem_ptrdiff_put
 
 #pragma weak shmem_ctx_putmem = pshmem_ctx_putmem
 #pragma weak shmem_ctx_put8 = pshmem_ctx_put8
@@ -120,6 +140,17 @@ SHMEM_CTX_TYPE_PUT(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_PUT(_float, float)
 SHMEM_CTX_TYPE_PUT(_double, double)
 SHMEM_CTX_TYPE_PUT(_longdouble, long double)
+SHMEM_CTX_TYPE_PUT(_int8, int8_t)
+SHMEM_CTX_TYPE_PUT(_int16, int16_t)
+SHMEM_CTX_TYPE_PUT(_int32, int32_t)
+SHMEM_CTX_TYPE_PUT(_int64, int64_t)
+SHMEM_CTX_TYPE_PUT(_uint8, uint8_t)
+SHMEM_CTX_TYPE_PUT(_uint16, uint16_t)
+SHMEM_CTX_TYPE_PUT(_uint32, uint32_t)
+SHMEM_CTX_TYPE_PUT(_uint64, uint64_t)
+SHMEM_CTX_TYPE_PUT(_size, size_t)
+SHMEM_CTX_TYPE_PUT(_ptrdiff, ptrdiff_t)
+
 SHMEM_TYPE_PUT(_char, char)
 SHMEM_TYPE_PUT(_short, short)
 SHMEM_TYPE_PUT(_int, int)
@@ -134,6 +165,16 @@ SHMEM_TYPE_PUT(_ulonglong, unsigned long long)
 SHMEM_TYPE_PUT(_float, float)
 SHMEM_TYPE_PUT(_double, double)
 SHMEM_TYPE_PUT(_longdouble, long double)
+SHMEM_TYPE_PUT(_int8, int8_t)
+SHMEM_TYPE_PUT(_int16, int16_t)
+SHMEM_TYPE_PUT(_int32, int32_t)
+SHMEM_TYPE_PUT(_int64, int64_t)
+SHMEM_TYPE_PUT(_uint8, uint8_t)
+SHMEM_TYPE_PUT(_uint16, uint16_t)
+SHMEM_TYPE_PUT(_uint32, uint32_t)
+SHMEM_TYPE_PUT(_uint64, uint64_t)
+SHMEM_TYPE_PUT(_size, size_t)
+SHMEM_TYPE_PUT(_ptrdiff, ptrdiff_t)
 
 #define DO_SHMEM_PUTMEM(ctx, target, source, element_size, nelems, pe) do { \
         int rc = OSHMEM_SUCCESS;                                    \

--- a/oshmem/shmem/c/shmem_put_nb.c
+++ b/oshmem/shmem/c/shmem_put_nb.c
@@ -64,20 +64,55 @@
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
-#pragma weak shmem_char_put_nbi = pshmem_char_put_nbi
-#pragma weak shmem_short_put_nbi = pshmem_short_put_nbi
-#pragma weak shmem_int_put_nbi = pshmem_int_put_nbi
-#pragma weak shmem_long_put_nbi = pshmem_long_put_nbi
-#pragma weak shmem_longlong_put_nbi = pshmem_longlong_put_nbi
-#pragma weak shmem_schar_put_nbi = pshmem_schar_put_nbi
-#pragma weak shmem_uchar_put_nbi = pshmem_uchar_put_nbi
-#pragma weak shmem_ushort_put_nbi = pshmem_ushort_put_nbi
-#pragma weak shmem_uint_put_nbi = pshmem_uint_put_nbi
-#pragma weak shmem_ulong_put_nbi = pshmem_ulong_put_nbi
-#pragma weak shmem_ulonglong_put_nbi = pshmem_ulonglong_put_nbi
-#pragma weak shmem_float_put_nbi = pshmem_float_put_nbi
-#pragma weak shmem_double_put_nbi = pshmem_double_put_nbi
-#pragma weak shmem_longdouble_put_nbi = pshmem_longdouble_put_nbi
+#pragma weak shmem_ctx_char_put_nbi       = pshmem_ctx_char_put_nbi
+#pragma weak shmem_ctx_short_put_nbi      = pshmem_ctx_short_put_nbi
+#pragma weak shmem_ctx_int_put_nbi        = pshmem_ctx_int_put_nbi
+#pragma weak shmem_ctx_long_put_nbi       = pshmem_ctx_long_put_nbi
+#pragma weak shmem_ctx_float_put_nbi      = pshmem_ctx_float_put_nbi
+#pragma weak shmem_ctx_double_put_nbi     = pshmem_ctx_double_put_nbi
+#pragma weak shmem_ctx_longlong_put_nbi   = pshmem_ctx_longlong_put_nbi
+#pragma weak shmem_ctx_schar_put_nbi      = pshmem_ctx_schar_put_nbi
+#pragma weak shmem_ctx_uchar_put_nbi      = pshmem_ctx_uchar_put_nbi
+#pragma weak shmem_ctx_ushort_put_nbi     = pshmem_ctx_ushort_put_nbi
+#pragma weak shmem_ctx_uint_put_nbi       = pshmem_ctx_uint_put_nbi
+#pragma weak shmem_ctx_ulong_put_nbi      = pshmem_ctx_ulong_put_nbi
+#pragma weak shmem_ctx_ulonglong_put_nbi  = pshmem_ctx_ulonglong_put_nbi
+#pragma weak shmem_ctx_longdouble_put_nbi = pshmem_ctx_longdouble_put_nbi
+#pragma weak shmem_ctx_int8_put_nbi       = pshmem_ctx_int8_put_nbi
+#pragma weak shmem_ctx_int16_put_nbi      = pshmem_ctx_int16_put_nbi
+#pragma weak shmem_ctx_int32_put_nbi      = pshmem_ctx_int32_put_nbi
+#pragma weak shmem_ctx_int64_put_nbi      = pshmem_ctx_int64_put_nbi
+#pragma weak shmem_ctx_uint8_put_nbi      = pshmem_ctx_uint8_put_nbi
+#pragma weak shmem_ctx_uint16_put_nbi     = pshmem_ctx_uint16_put_nbi
+#pragma weak shmem_ctx_uint32_put_nbi     = pshmem_ctx_uint32_put_nbi
+#pragma weak shmem_ctx_uint64_put_nbi     = pshmem_ctx_uint64_put_nbi
+#pragma weak shmem_ctx_size_put_nbi       = pshmem_ctx_size_put_nbi
+#pragma weak shmem_ctx_ptrdiff_put_nbi    = pshmem_ctx_ptrdiff_put_nbi
+
+#pragma weak shmem_char_put_nbi           = pshmem_char_put_nbi
+#pragma weak shmem_short_put_nbi          = pshmem_short_put_nbi
+#pragma weak shmem_int_put_nbi            = pshmem_int_put_nbi
+#pragma weak shmem_long_put_nbi           = pshmem_long_put_nbi
+#pragma weak shmem_float_put_nbi          = pshmem_float_put_nbi
+#pragma weak shmem_double_put_nbi         = pshmem_double_put_nbi
+#pragma weak shmem_longlong_put_nbi       = pshmem_longlong_put_nbi
+#pragma weak shmem_schar_put_nbi          = pshmem_schar_put_nbi
+#pragma weak shmem_uchar_put_nbi          = pshmem_uchar_put_nbi
+#pragma weak shmem_ushort_put_nbi         = pshmem_ushort_put_nbi
+#pragma weak shmem_uint_put_nbi           = pshmem_uint_put_nbi
+#pragma weak shmem_ulong_put_nbi          = pshmem_ulong_put_nbi
+#pragma weak shmem_ulonglong_put_nbi      = pshmem_ulonglong_put_nbi
+#pragma weak shmem_longdouble_put_nbi     = pshmem_longdouble_put_nbi
+#pragma weak shmem_int8_put_nbi           = pshmem_int8_put_nbi
+#pragma weak shmem_int16_put_nbi          = pshmem_int16_put_nbi
+#pragma weak shmem_int32_put_nbi          = pshmem_int32_put_nbi
+#pragma weak shmem_int64_put_nbi          = pshmem_int64_put_nbi
+#pragma weak shmem_uint8_put_nbi          = pshmem_uint8_put_nbi
+#pragma weak shmem_uint16_put_nbi         = pshmem_uint16_put_nbi
+#pragma weak shmem_uint32_put_nbi         = pshmem_uint32_put_nbi
+#pragma weak shmem_uint64_put_nbi         = pshmem_uint64_put_nbi
+#pragma weak shmem_size_put_nbi           = pshmem_size_put_nbi
+#pragma weak shmem_ptrdiff_put_nbi        = pshmem_ptrdiff_put_nbi
 
 #pragma weak shmem_put8_nbi = pshmem_put8_nbi
 #pragma weak shmem_put16_nbi = pshmem_put16_nbi
@@ -85,21 +120,6 @@
 #pragma weak shmem_put64_nbi = pshmem_put64_nbi
 #pragma weak shmem_put128_nbi = pshmem_put128_nbi
 #pragma weak shmem_putmem_nbi = pshmem_putmem_nbi
-
-#pragma weak shmem_ctx_char_put_nbi = pshmem_ctx_char_put_nbi
-#pragma weak shmem_ctx_short_put_nbi = pshmem_ctx_short_put_nbi
-#pragma weak shmem_ctx_int_put_nbi = pshmem_ctx_int_put_nbi
-#pragma weak shmem_ctx_long_put_nbi = pshmem_ctx_long_put_nbi
-#pragma weak shmem_ctx_longlong_put_nbi = pshmem_ctx_longlong_put_nbi
-#pragma weak shmem_ctx_schar_put_nbi = pshmem_ctx_schar_put_nbi
-#pragma weak shmem_ctx_uchar_put_nbi = pshmem_ctx_uchar_put_nbi
-#pragma weak shmem_ctx_ushort_put_nbi = pshmem_ctx_ushort_put_nbi
-#pragma weak shmem_ctx_uint_put_nbi = pshmem_ctx_uint_put_nbi
-#pragma weak shmem_ctx_ulong_put_nbi = pshmem_ctx_ulong_put_nbi
-#pragma weak shmem_ctx_ulonglong_put_nbi = pshmem_ctx_ulonglong_put_nbi
-#pragma weak shmem_ctx_float_put_nbi = pshmem_ctx_float_put_nbi
-#pragma weak shmem_ctx_double_put_nbi = pshmem_ctx_double_put_nbi
-#pragma weak shmem_ctx_longdouble_put_nbi = pshmem_ctx_longdouble_put_nbi
 
 #pragma weak shmem_ctx_put8_nbi = pshmem_ctx_put8_nbi
 #pragma weak shmem_ctx_put16_nbi = pshmem_ctx_put16_nbi
@@ -124,6 +144,17 @@ SHMEM_CTX_TYPE_PUT_NB(_ulonglong, unsigned long long)
 SHMEM_CTX_TYPE_PUT_NB(_float, float)
 SHMEM_CTX_TYPE_PUT_NB(_double, double)
 SHMEM_CTX_TYPE_PUT_NB(_longdouble, long double)
+SHMEM_CTX_TYPE_PUT_NB(_int8, int8_t)
+SHMEM_CTX_TYPE_PUT_NB(_int16, int16_t)
+SHMEM_CTX_TYPE_PUT_NB(_int32, int32_t)
+SHMEM_CTX_TYPE_PUT_NB(_int64, int64_t)
+SHMEM_CTX_TYPE_PUT_NB(_uint8, uint8_t)
+SHMEM_CTX_TYPE_PUT_NB(_uint16, uint16_t)
+SHMEM_CTX_TYPE_PUT_NB(_uint32, uint32_t)
+SHMEM_CTX_TYPE_PUT_NB(_uint64, uint64_t)
+SHMEM_CTX_TYPE_PUT_NB(_size, size_t)
+SHMEM_CTX_TYPE_PUT_NB(_ptrdiff, ptrdiff_t)
+
 SHMEM_TYPE_PUT_NB(_char, char)
 SHMEM_TYPE_PUT_NB(_short, short)
 SHMEM_TYPE_PUT_NB(_int, int)
@@ -138,6 +169,16 @@ SHMEM_TYPE_PUT_NB(_ulonglong, unsigned long long)
 SHMEM_TYPE_PUT_NB(_float, float)
 SHMEM_TYPE_PUT_NB(_double, double)
 SHMEM_TYPE_PUT_NB(_longdouble, long double)
+SHMEM_TYPE_PUT_NB(_int8, int8_t)
+SHMEM_TYPE_PUT_NB(_int16, int16_t)
+SHMEM_TYPE_PUT_NB(_int32, int32_t)
+SHMEM_TYPE_PUT_NB(_int64, int64_t)
+SHMEM_TYPE_PUT_NB(_uint8, uint8_t)
+SHMEM_TYPE_PUT_NB(_uint16, uint16_t)
+SHMEM_TYPE_PUT_NB(_uint32, uint32_t)
+SHMEM_TYPE_PUT_NB(_uint64, uint64_t)
+SHMEM_TYPE_PUT_NB(_size, size_t)
+SHMEM_TYPE_PUT_NB(_ptrdiff, ptrdiff_t)
 
 #define DO_SHMEM_PUTMEM_NB(ctx, target, source, element_size, nelems, pe) do { \
         int rc = OSHMEM_SUCCESS;                                    \


### PR DESCRIPTION
- added calls for datatypes int/uint/8/16/32/size/ptrdiff
  for shmem_g/get/iget/get_nbi/_p/put/iput/put_nbi

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>