### PR TITLE
MTL/PSM2: add missing default priority

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -251,6 +251,7 @@ ompi_mtl_psm2_component_register(void)
         setenv("PSM2_DEVICES", "self,shm", 0);
     }
 
+    param_priority = 40;
     (void) mca_base_component_var_register (&mca_mtl_psm2_component.super.mtl_version,
                                             "priority", "Priority of the PSM2 MTL component",
                                             MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,


### PR DESCRIPTION
Missing default priority after PR #6153

Signed-off-by: Matias Cabral <matias.a.cabral@intel.com>