### PR TITLE
fortran/use-mpi-f08: Add C++ datatypes and MPI_NO_OP

### DIFF
--- a/ompi/mpi/fortran/common_sym_whitelist.txt
+++ b/ompi/mpi/fortran/common_sym_whitelist.txt
@@ -14,15 +14,11 @@ ompi_f08_mpi_byte
 ompi_f08_mpi_c_bool
 ompi_f08_mpi_c_complex
 ompi_f08_mpi_count
-ompi_f08_mpi_c_double
 ompi_f08_mpi_c_double_complex
-ompi_f08_mpi_c_float
 ompi_f08_mpi_c_float_complex
 ompi_f08_mpi_char
 ompi_f08_mpi_character
-ompi_f08_mpi_c_long_double
 ompi_f08_mpi_c_long_double_complex
-ompi_f08_mpi_c_offset
 ompi_f08_mpi_comm_null
 ompi_f08_mpi_comm_self
 ompi_f08_mpi_comm_world
@@ -30,6 +26,11 @@ ompi_f08_mpi_complex
 ompi_f08_mpi_complex16
 ompi_f08_mpi_complex32
 ompi_f08_mpi_complex8
+ompi_f08_mpi_cxx_bool
+ompi_f08_mpi_cxx_complex
+ompi_f08_mpi_cxx_double_complex
+ompi_f08_mpi_cxx_float_complex
+ompi_f08_mpi_cxx_long_double_complex
 ompi_f08_mpi_datatype_null
 ompi_f08_mpi_double
 ompi_f08_mpi_double_complex
@@ -77,6 +78,7 @@ ompi_f08_mpi_message_no_proc
 ompi_f08_mpi_message_null
 ompi_f08_mpi_min
 ompi_f08_mpi_minloc
+ompi_f08_mpi_no_op
 ompi_f08_mpi_offset
 ompi_f08_mpi_op_null
 ompi_f08_mpi_packed

--- a/ompi/mpi/fortran/use-mpi-f08/constants.c
+++ b/ompi/mpi/fortran/use-mpi-f08/constants.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * This file provides symbols for the derived type values needed
@@ -49,6 +50,7 @@ OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_bxor
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_maxloc   = {OMPI_MPI_MAXLOC};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_minloc   = {OMPI_MPI_MINLOC};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_replace  = {OMPI_MPI_REPLACE};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_no_op    = {OMPI_MPI_NO_OP};
 
 /*
  * NULL "handles" (indices)
@@ -113,6 +115,10 @@ OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_c_co
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_c_float_complex   = {OMPI_MPI_C_FLOAT_COMPLEX};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_c_double_complex  = {OMPI_MPI_C_DOUBLE_COMPLEX};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_c_long_double_complex  = {OMPI_MPI_C_LONG_DOUBLE_COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_cxx_complex       = {OMPI_MPI_CXX_COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_cxx_float_complex = {OMPI_MPI_CXX_FLOAT_COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_cxx_double_complex = {OMPI_MPI_CXX_DOUBLE_COMPLEX};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_cxx_long_double_complex = {OMPI_MPI_CXX_LONG_DOUBLE_COMPLEX};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_complex           = {OMPI_MPI_COMPLEX};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_complex8          = {OMPI_MPI_COMPLEX8};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_complex16         = {OMPI_MPI_COMPLEX16};
@@ -135,5 +141,6 @@ OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logi
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logical4          = {OMPI_MPI_LOGICAL4};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_logical8          = {OMPI_MPI_LOGICAL8};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_c_bool            = {OMPI_MPI_C_BOOL};
+OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_cxx_bool          = {OMPI_MPI_CXX_BOOL};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_count             = {OMPI_MPI_COUNT};
 OMPI_DECLSPEC ompi_fortran_08_handle_t OMPI_F08_HANDLE_ALIGNED ompi_f08_mpi_offset            = {OMPI_MPI_OFFSET};

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
@@ -107,16 +107,16 @@ module mpi_f08_types
   !  NULL "handles" (indices)
   !
 
-  type(MPI_Comm),       bind(C, name="ompi_f08_mpi_comm_null") OMPI_PROTECTED       :: MPI_COMM_NULL;
-  type(MPI_Datatype),   bind(C, name="ompi_f08_mpi_datatype_null") OMPI_PROTECTED   :: MPI_DATATYPE_NULL;
-  type(MPI_Errhandler), bind(C, name="ompi_f08_mpi_errhandler_null") OMPI_PROTECTED :: MPI_ERRHANDLER_NULL;
-  type(MPI_Group),      bind(C, name="ompi_f08_mpi_group_null") OMPI_PROTECTED      :: MPI_GROUP_NULL;
-  type(MPI_Info),       bind(C, name="ompi_f08_mpi_info_null") OMPI_PROTECTED       :: MPI_INFO_NULL;
-  type(MPI_Message),    bind(C, name="ompi_f08_mpi_message_null") OMPI_PROTECTED    :: MPI_MESSAGE_NULL;
-  type(MPI_Op),         bind(C, name="ompi_f08_mpi_op_null") OMPI_PROTECTED         :: MPI_OP_NULL;
-  type(MPI_Request),    bind(C, name="ompi_f08_mpi_request_null") OMPI_PROTECTED    :: MPI_REQUEST_NULL;
-  type(MPI_Win),        bind(C, name="ompi_f08_mpi_win_null") OMPI_PROTECTED        :: MPI_WIN_NULL;
-  type(MPI_File),       bind(C, name="ompi_f08_mpi_file_null") OMPI_PROTECTED       :: MPI_FILE_NULL;
+  type(MPI_Comm),       bind(C, name="ompi_f08_mpi_comm_null") OMPI_PROTECTED       :: MPI_COMM_NULL
+  type(MPI_Datatype),   bind(C, name="ompi_f08_mpi_datatype_null") OMPI_PROTECTED   :: MPI_DATATYPE_NULL
+  type(MPI_Errhandler), bind(C, name="ompi_f08_mpi_errhandler_null") OMPI_PROTECTED :: MPI_ERRHANDLER_NULL
+  type(MPI_Group),      bind(C, name="ompi_f08_mpi_group_null") OMPI_PROTECTED      :: MPI_GROUP_NULL
+  type(MPI_Info),       bind(C, name="ompi_f08_mpi_info_null") OMPI_PROTECTED       :: MPI_INFO_NULL
+  type(MPI_Message),    bind(C, name="ompi_f08_mpi_message_null") OMPI_PROTECTED    :: MPI_MESSAGE_NULL
+  type(MPI_Op),         bind(C, name="ompi_f08_mpi_op_null") OMPI_PROTECTED         :: MPI_OP_NULL
+  type(MPI_Request),    bind(C, name="ompi_f08_mpi_request_null") OMPI_PROTECTED    :: MPI_REQUEST_NULL
+  type(MPI_Win),        bind(C, name="ompi_f08_mpi_win_null") OMPI_PROTECTED        :: MPI_WIN_NULL
+  type(MPI_File),       bind(C, name="ompi_f08_mpi_file_null") OMPI_PROTECTED       :: MPI_FILE_NULL
 
   !
   ! Pre-defined datatype bindings

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
@@ -5,6 +5,7 @@
 !                         All rights reserved.
 ! Copyright (c) 2015-2018 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
+! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 ! $COPYRIGHT$
 !
 ! This file creates mappings between MPI C types (e.g., MPI_Comm) and
@@ -102,6 +103,7 @@ module mpi_f08_types
   type(MPI_Op), bind(C, name="ompi_f08_mpi_maxloc"  ) OMPI_PROTECTED ::  MPI_MAXLOC
   type(MPI_Op), bind(C, name="ompi_f08_mpi_minloc"  ) OMPI_PROTECTED ::  MPI_MINLOC
   type(MPI_Op), bind(C, name="ompi_f08_mpi_replace" ) OMPI_PROTECTED ::  MPI_REPLACE
+  type(MPI_Op), bind(C, name="ompi_f08_mpi_no_op"   ) OMPI_PROTECTED ::  MPI_NO_OP
 
   !
   !  NULL "handles" (indices)
@@ -171,6 +173,10 @@ module mpi_f08_types
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_c_float_complex") OMPI_PROTECTED   :: MPI_C_FLOAT_COMPLEX
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_c_double_complex") OMPI_PROTECTED  :: MPI_C_DOUBLE_COMPLEX
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_c_long_double_complex") OMPI_PROTECTED :: MPI_C_LONG_DOUBLE_COMPLEX
+  type(MPI_Datatype), bind(C, name="ompi_f08_mpi_cxx_complex") OMPI_PROTECTED         :: MPI_CXX_COMPLEX
+  type(MPI_Datatype), bind(C, name="ompi_f08_mpi_cxx_float_complex") OMPI_PROTECTED   :: MPI_CXX_FLOAT_COMPLEX
+  type(MPI_Datatype), bind(C, name="ompi_f08_mpi_cxx_double_complex") OMPI_PROTECTED  :: MPI_CXX_DOUBLE_COMPLEX
+  type(MPI_Datatype), bind(C, name="ompi_f08_mpi_cxx_long_double_complex") OMPI_PROTECTED :: MPI_CXX_LONG_DOUBLE_COMPLEX
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_complex") OMPI_PROTECTED           :: MPI_COMPLEX
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_complex8") OMPI_PROTECTED          :: MPI_COMPLEX8
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_complex16") OMPI_PROTECTED         :: MPI_COMPLEX16
@@ -193,6 +199,7 @@ module mpi_f08_types
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_logical4") OMPI_PROTECTED          :: MPI_LOGICAL4
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_logical8") OMPI_PROTECTED          :: MPI_LOGICAL8
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_c_bool") OMPI_PROTECTED            :: MPI_C_BOOL
+  type(MPI_Datatype), bind(C, name="ompi_f08_mpi_cxx_bool") OMPI_PROTECTED          :: MPI_CXX_BOOL
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_count") OMPI_PROTECTED             :: MPI_COUNT
   type(MPI_Datatype), bind(C, name="ompi_f08_mpi_offset") OMPI_PROTECTED            :: MPI_OFFSET
 


### PR DESCRIPTION
The following handles were missing in Fortran 2008 bindings.

- `MPI_CXX_BOOL`
- `MPI_CXX_COMPLEX`
- `MPI_CXX_FLOAT_COMPLEX`
- `MPI_CXX_DOUBLE_COMPLEX`
- `MPI_CXX_LONG_DOUBLE_COMPLEX`
- `MPI_NO_OP`

Though the MPI standard does not have `MPI_CXX_COMPLEX`, `mpi.h`, `mpif.h`, and `mpi.mod` have it. So I added it to `mpi_f08.mod` for consistency.

Need PRs to release branches.
