### PR TITLE
v4.0.x: btl/uct: fix a typo in configure.m4

### DIFF
--- a/opal/mca/btl/uct/configure.m4
+++ b/opal/mca/btl/uct/configure.m4
@@ -47,7 +47,7 @@ AC_DEFUN([MCA_opal_btl_uct_CONFIG],[
 
     AS_IF([test "$btl_uct_happy" = "yes"],
           [$1
-           btl_uct_LIBS = "$btl_uct_LIBS -luct"
+           btl_uct_LIBS="$btl_uct_LIBS -luct"
           ],
           [$2])
 


### PR DESCRIPTION
remove whitespace around '=' when setting btl_uct_LIBS

Thanks Ake Sandgren for reporting this

Refs. open-mpi/ompi#6173

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@b89deeb1bbd21eda73414b3f51f1d2ab3529dc42)