### PR TITLE
mtl/ofi: Fix crash if no providers found

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -927,6 +927,7 @@ error:
         (void) fi_close((fid_t)ompi_mtl_ofi.av);
     }
     if ((false == ompi_mtl_ofi.sep_supported) &&
+        ompi_mtl_ofi.ofi_ctxt != NULL &&
          ompi_mtl_ofi.ofi_ctxt[0].cq) {
         /* Check if CQ[0] was created for non-SEP case and close if needed */
         (void) fi_close((fid_t)ompi_mtl_ofi.ofi_ctxt[0].cq);


### PR DESCRIPTION
Commit 109d0569ffd introduced a crash when an error occurred
before ofi_ctxt was allocated, including when no providers
passed the selection logic.  Properly check that the pointer
is not NULL in the error cleanup code before dereferencing
the pointer.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>