### PR TITLE
hwloc/base: fix hwloc_topology_set_xmlbuffer() usage

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_dt.c
+++ b/opal/mca/hwloc/base/hwloc_base_dt.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  *
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * $COPYRIGHT$
@@ -98,7 +98,7 @@ int opal_hwloc_unpack(opal_buffer_t *buffer, void *dest,
             free(xmlbuffer);
             goto cleanup;
         }
-        if (0 != hwloc_topology_set_xmlbuffer(t, xmlbuffer, strlen(xmlbuffer))) {
+        if (0 != hwloc_topology_set_xmlbuffer(t, xmlbuffer, strlen(xmlbuffer)+1)) {
             rc = OPAL_ERROR;
             free(xmlbuffer);
             hwloc_topology_destroy(t);

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -14,8 +14,8 @@
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (C) 2018      Mellanox Technologies, Ltd. 
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
@@ -371,7 +371,7 @@ int opal_hwloc_base_get_topology(void)
             free(val);
             return OPAL_ERROR;
         }
-        if (0 != hwloc_topology_set_xmlbuffer(opal_hwloc_topology, val, strlen(val))) {
+        if (0 != hwloc_topology_set_xmlbuffer(opal_hwloc_topology, val, strlen(val)+1)) {
             free(val);
             hwloc_topology_destroy(opal_hwloc_topology);
             return OPAL_ERROR;


### PR DESCRIPTION
pass the length of the xml buffer plus one in order to
include the NULL termination character.

The buffer is then sscanf'ed and a NULL terminated string
is expected here.

This fixes an out-of-bound error reported by valgrind.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>