### PR TITLE
oshmem: fix macro usage in pshmem.h

### DIFF
--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -2,8 +2,8 @@
  * Copyright (c) 2014-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved
- * Copyright (c) 2016      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -102,7 +102,7 @@ OSHMEM_DECLSPEC  void pshmem_uint_p(unsigned int* addr, unsigned int value, int 
 OSHMEM_DECLSPEC  void pshmem_ulong_p(unsigned long* addr, unsigned long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_p(unsigned long long* addr, unsigned long long value, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_p(long double* addr, long double value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_p(...)                                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -169,7 +169,7 @@ OSHMEM_DECLSPEC  void pshmem_uint_put(unsigned int *target, const unsigned int *
 OSHMEM_DECLSPEC  void pshmem_ulong_put(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_put(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put(long double *target, const long double *source, size_t len, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_put(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
@@ -250,7 +250,7 @@ OSHMEM_DECLSPEC void pshmem_uint_iput(unsigned int* target, const unsigned int* 
 OSHMEM_DECLSPEC void pshmem_ulong_iput(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_iput(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_longdouble_iput(long double* target, const long double* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_iput(...)                                             \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -330,7 +330,7 @@ OSHMEM_DECLSPEC  void pshmem_uint_put_nbi(unsigned int *target, const unsigned i
 OSHMEM_DECLSPEC  void pshmem_ulong_put_nbi(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_put_nbi(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_put_nbi(long double *target, const long double *source, size_t len, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_put_nbi(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t: _Generic(&*(__OSHMEM_VAR_ARG2(__VA_ARGS__)),\
@@ -410,7 +410,7 @@ OSHMEM_DECLSPEC  unsigned short pshmem_ushort_g(const unsigned short* addr, int 
 OSHMEM_DECLSPEC  unsigned int pshmem_uint_g(const unsigned int* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long pshmem_ulong_g(const unsigned long* addr, int pe);
 OSHMEM_DECLSPEC  unsigned long long pshmem_ulonglong_g(const unsigned long long* addr, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_g(...)                                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -477,7 +477,7 @@ OSHMEM_DECLSPEC  void pshmem_uint_get(unsigned int *target, const unsigned int *
 OSHMEM_DECLSPEC  void pshmem_ulong_get(unsigned long *target, const unsigned long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_ulonglong_get(unsigned long long *target, const unsigned long long *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get(long double *target, const long double *source, size_t len, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_get(...)                                              \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -558,7 +558,7 @@ OSHMEM_DECLSPEC void pshmem_ushort_iget(unsigned short* target, const unsigned s
 OSHMEM_DECLSPEC void pshmem_uint_iget(unsigned int* target, const unsigned int* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_iget(unsigned long* target, const unsigned long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_iget(unsigned long long* target, const unsigned long long* source, ptrdiff_t tst, ptrdiff_t sst,size_t len, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_iget(...)                                             \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -638,7 +638,7 @@ OSHMEM_DECLSPEC  void pshmem_ulonglong_get_nbi(unsigned long long *target, const
 OSHMEM_DECLSPEC  void pshmem_float_get_nbi(float *target, const float *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_double_get_nbi(double *target, const double *source, size_t len, int pe);
 OSHMEM_DECLSPEC  void pshmem_longdouble_get_nbi(long double *target, const long double *source, size_t len, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_get_nbi(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -707,7 +707,7 @@ OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_swap(unsigned long *target, un
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_swap(unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC float pshmem_float_atomic_swap(float *target, float value, int pe);
 OSHMEM_DECLSPEC double pshmem_double_atomic_swap(double *target, double value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_swap(...)                                       \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
@@ -735,7 +735,7 @@ OSHMEM_DECLSPEC long pshmem_long_swap(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_swap(long long*target, long long value, int pe);
 OSHMEM_DECLSPEC float pshmem_float_swap(float *target, float value, int pe);
 OSHMEM_DECLSPEC double pshmem_double_swap(double *target, double value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_swap(dst, val, pe)               \
     _Generic(&*(dst),                           \
             int*:         pshmem_int_swap,      \
@@ -763,7 +763,7 @@ OSHMEM_DECLSPEC void pshmem_ulong_atomic_set(unsigned long *target, unsigned lon
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_set(unsigned long long *target, unsigned long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_float_atomic_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void pshmem_double_atomic_set(double *target, double value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_set(...)                                       \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -791,7 +791,7 @@ OSHMEM_DECLSPEC void pshmem_long_set(long *target, long value, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_set(long long *target, long long value, int pe);
 OSHMEM_DECLSPEC void pshmem_float_set(float *target, float value, int pe);
 OSHMEM_DECLSPEC void pshmem_double_set(double *target, double value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_set(dst, val, pe)                             \
     _Generic(&*(dst),                                        \
             int*:         pshmem_int_set,                    \
@@ -816,7 +816,7 @@ OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_compare_swap(unsigned int *targe
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_compare_swap(unsigned long *target, unsigned long cond, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_compare_swap(unsigned long long *target, unsigned long long cond, unsigned long long value, int pe);
 
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_compare_swap(...)                                \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
@@ -838,7 +838,7 @@ OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_compare_swap(unsigned
 OSHMEM_DECLSPEC int pshmem_int_cswap(int *target, int cond, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_cswap(long *target, long cond, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_cswap(long long *target, long long cond, long long value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_cswap(dst, cond, val, pe)                       \
     _Generic(&*(dst),                                          \
             int*:         pshmem_int_cswap,                    \
@@ -860,7 +860,7 @@ OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_add(long long *target, lo
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_add(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_add(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_add(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_fetch_add(...)                                        \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                            \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),        \
@@ -882,7 +882,7 @@ OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_add(unsigned lo
 OSHMEM_DECLSPEC int pshmem_int_fadd(int *target, int value, int pe);
 OSHMEM_DECLSPEC long pshmem_long_fadd(long *target, long value, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_fadd(long long *target, long long value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_fadd(dst, val, pe)                             \
     _Generic(&*(dst),                                         \
             int*:         pshmem_int_fadd,                    \
@@ -912,7 +912,7 @@ OSHMEM_DECLSPEC int32_t pshmem_int32_atomic_fetch_and(int32_t *target, int32_t v
 OSHMEM_DECLSPEC int64_t pshmem_int64_atomic_fetch_and(int64_t *target, int64_t value, int pe);
 OSHMEM_DECLSPEC uint32_t pshmem_uint32_atomic_fetch_and(uint32_t *target, uint32_t value, int pe);
 OSHMEM_DECLSPEC uint64_t pshmem_uint64_atomic_fetch_and(uint64_t *target, uint64_t value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_fetch_and(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
@@ -961,7 +961,7 @@ OSHMEM_DECLSPEC int32_t pshmem_int32_atomic_fetch_or(int32_t *target, int32_t va
 OSHMEM_DECLSPEC int64_t pshmem_int64_atomic_fetch_or(int64_t *target, int64_t value, int pe);
 OSHMEM_DECLSPEC uint32_t pshmem_uint32_atomic_fetch_or(uint32_t *target, uint32_t value, int pe);
 OSHMEM_DECLSPEC uint64_t pshmem_uint64_atomic_fetch_or(uint64_t *target, uint64_t value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_fetch_or(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                             \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),         \
@@ -1010,7 +1010,7 @@ OSHMEM_DECLSPEC int32_t pshmem_int32_atomic_fetch_xor(int32_t *target, int32_t v
 OSHMEM_DECLSPEC int64_t pshmem_int64_atomic_fetch_xor(int64_t *target, int64_t value, int pe);
 OSHMEM_DECLSPEC uint32_t pshmem_uint32_atomic_fetch_xor(uint32_t *target, uint32_t value, int pe);
 OSHMEM_DECLSPEC uint64_t pshmem_uint64_atomic_fetch_xor(uint64_t *target, uint64_t value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_fetch_xor(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                              \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),          \
@@ -1055,7 +1055,7 @@ OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch(const unsigned long *tar
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch(const unsigned long long *target, int pe);
 OSHMEM_DECLSPEC float pshmem_float_atomic_fetch(const float *target, int pe);
 OSHMEM_DECLSPEC double pshmem_double_atomic_fetch(const double *target, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_fetch(...)                                        \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
@@ -1083,7 +1083,7 @@ OSHMEM_DECLSPEC long pshmem_long_fetch(const long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_fetch(const long long *target, int pe);
 OSHMEM_DECLSPEC float pshmem_float_fetch(const float *target, int pe);
 OSHMEM_DECLSPEC double pshmem_double_fetch(const double *target, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_fetch(dst, pe)                            \
     _Generic(&*(dst),                                    \
             int*:        pshmem_int_fetch,               \
@@ -1107,7 +1107,7 @@ OSHMEM_DECLSPEC long long pshmem_longlong_atomic_fetch_inc(long long *target, in
 OSHMEM_DECLSPEC unsigned int pshmem_uint_atomic_fetch_inc(unsigned int *target, int pe);
 OSHMEM_DECLSPEC unsigned long pshmem_ulong_atomic_fetch_inc(unsigned long *target, int pe);
 OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_inc(unsigned long long *target, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_fetch_inc(...)                                 \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -1129,7 +1129,7 @@ OSHMEM_DECLSPEC unsigned long long pshmem_ulonglong_atomic_fetch_inc(unsigned lo
 OSHMEM_DECLSPEC int pshmem_int_finc(int *target, int pe);
 OSHMEM_DECLSPEC long pshmem_long_finc(long *target, int pe);
 OSHMEM_DECLSPEC long long pshmem_longlong_finc(long long *target, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_finc(dst, pe)                                  \
     _Generic(&*(dst),                                         \
             int*:         pshmem_int_finc,                    \
@@ -1151,7 +1151,7 @@ OSHMEM_DECLSPEC void pshmem_longlong_atomic_add(long long *target, long long val
 OSHMEM_DECLSPEC void pshmem_uint_atomic_add(unsigned int *target, unsigned int value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_add(unsigned long *target, unsigned long value, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_add(unsigned long long *target, unsigned long long value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_add(...)                                        \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                      \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),  \
@@ -1173,7 +1173,7 @@ OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_add(unsigned long long *target, uns
 OSHMEM_DECLSPEC void pshmem_int_add(int *target, int value, int pe);
 OSHMEM_DECLSPEC void pshmem_long_add(long *target, long value, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_add(long long *target, long long value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_add(dst, val, pe)                             \
     _Generic(&*(dst),                                        \
             int*:         pshmem_int_add,                    \
@@ -1203,7 +1203,7 @@ OSHMEM_DECLSPEC void pshmem_int32_atomic_and(int32_t *target, int32_t value, int
 OSHMEM_DECLSPEC void pshmem_int64_atomic_and(int64_t *target, int64_t value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint32_atomic_and(uint32_t *target, uint32_t value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint64_atomic_and(uint64_t *target, uint64_t value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_and(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
@@ -1244,7 +1244,7 @@ OSHMEM_DECLSPEC void pshmem_int32_atomic_or(int32_t *target, int32_t value, int 
 OSHMEM_DECLSPEC void pshmem_int64_atomic_or(int64_t *target, int64_t value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint32_atomic_or(uint32_t *target, uint32_t value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint64_atomic_or(uint64_t *target, uint64_t value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_or(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                       \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),   \
@@ -1285,7 +1285,7 @@ OSHMEM_DECLSPEC void pshmem_int32_atomic_xor(int32_t *target, int32_t value, int
 OSHMEM_DECLSPEC void pshmem_int64_atomic_xor(int64_t *target, int64_t value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint32_atomic_xor(uint32_t *target, uint32_t value, int pe);
 OSHMEM_DECLSPEC void pshmem_uint64_atomic_xor(uint64_t *target, uint64_t value, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_xor(...)                                          \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                        \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)),    \
@@ -1318,7 +1318,7 @@ OSHMEM_DECLSPEC void pshmem_longlong_atomic_inc(long long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_uint_atomic_inc(unsigned int *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ulong_atomic_inc(unsigned long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_inc(unsigned long long *target, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_atomic_inc(...)                                       \
     _Generic(&*(__OSHMEM_VAR_ARG1(__VA_ARGS__)),                     \
             shmem_ctx_t:  _Generic((__OSHMEM_VAR_ARG2(__VA_ARGS__)), \
@@ -1340,7 +1340,7 @@ OSHMEM_DECLSPEC void pshmem_ulonglong_atomic_inc(unsigned long long *target, int
 OSHMEM_DECLSPEC void pshmem_int_inc(int *target, int pe);
 OSHMEM_DECLSPEC void pshmem_long_inc(long *target, int pe);
 OSHMEM_DECLSPEC void pshmem_longlong_inc(long long *target, int pe);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_inc(dst, pe)                            \
     _Generic(&*(dst),                                  \
             int*:         pshmem_int_inc,              \
@@ -1378,7 +1378,7 @@ OSHMEM_DECLSPEC  void pshmem_uint32_wait_until(volatile uint32_t *addr, int cmp,
 OSHMEM_DECLSPEC  void pshmem_uint64_wait_until(volatile uint64_t *addr, int cmp, uint64_t value);
 OSHMEM_DECLSPEC  void pshmem_size_wait_until(volatile size_t *addr, int cmp, size_t value);
 OSHMEM_DECLSPEC  void pshmem_ptrdiff_wait_until(volatile ptrdiff_t *addr, int cmp, ptrdiff_t value);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_wait_until(addr, cmp, value)                  \
     _Generic(&*(addr),                                       \
         short*:       pshmem_short_wait_until,               \
@@ -1405,7 +1405,7 @@ OSHMEM_DECLSPEC  int pshmem_uint32_test(volatile uint32_t *addr, int cmp, uint32
 OSHMEM_DECLSPEC  int pshmem_uint64_test(volatile uint64_t *addr, int cmp, uint64_t value);
 OSHMEM_DECLSPEC  int pshmem_size_test(volatile size_t *addr, int cmp, size_t value);
 OSHMEM_DECLSPEC  int pshmem_ptrdiff_test(volatile ptrdiff_t *addr, int cmp, ptrdiff_t value);
-#if OSHMEMP_HAVE_C11
+#if OSHMEM_HAVE_C11
 #define pshmem_test(addr, cmp, value)                  \
     _Generic(&*(addr),                                 \
         short*:       pshmem_short_test,               \


### PR DESCRIPTION
pshmem.h now includes shmem.h (since open-mpi/ompi@f46130cd20914a3c60b19c3b2ed7c4b380319ee9) and some macros were removed at that time.

Use the OSHMEM_HAVE_C11 macro (defined in shmem.h) instead of the
previous OSHMEMP_HAVE_C11 macrso previously defined in pshmem.h

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>