### PR TITLE
btl/openib: do not initialize device with not allowed ports

### DIFF
--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1048,6 +1048,7 @@ int mca_btl_openib_add_procs(
         opal_show_help("help-mpi-btl-openib.txt", "ib port not selected",
                        true, opal_process_info.nodename,
                        ibv_get_device_name(openib_btl->device->ib_dev), openib_btl->port_num);
+        return OPAL_SUCCESS;
     }
 
     btl_rank = get_openib_btl_params(openib_btl, &lcl_subnet_id_port_cnt);

--- a/opal/mca/btl/openib/btl_openib.c
+++ b/opal/mca/btl/openib/btl_openib.c
@@ -1047,7 +1047,7 @@ int mca_btl_openib_add_procs(
         opal_bitmap_clear_all_bits(reachable);
         opal_show_help("help-mpi-btl-openib.txt", "ib port not selected",
                        true, opal_process_info.nodename,
-                       ibv_get_device_name(openib_btl->device->ib_dev), openib_btl->port_num);
+                       openib_btl->device_name, openib_btl->port_num);
         return OPAL_SUCCESS;
     }
 
@@ -1720,11 +1720,11 @@ static int mca_btl_openib_finalize_resources(struct mca_btl_base_module_t* btl) 
             free(openib_btl->cpcs[i]);
         }
         free(openib_btl->cpcs);
-    }
 
-    /* Release device if there are no more users */
-    if(!(--openib_btl->device->btls)) {
-        OBJ_RELEASE(openib_btl->device);
+        /* Release device if there are no more users */
+        if(!(--openib_btl->device->allowed_btls)) {
+            OBJ_RELEASE(openib_btl->device);
+        }
     }
 
     if (NULL != openib_btl->qps) {

--- a/opal/mca/btl/openib/btl_openib.h
+++ b/opal/mca/btl/openib/btl_openib.h
@@ -392,6 +392,7 @@ typedef struct mca_btl_openib_device_t {
     /* Whether this device supports eager RDMA */
     uint8_t use_eager_rdma;
     uint8_t btls;              /** < number of btls using this device */
+    uint8_t allowed_btls;      /** < number of allowed btls using this device */
     opal_pointer_array_t *endpoints;
     opal_pointer_array_t *device_btls;
     uint16_t hp_cq_polls;
@@ -483,6 +484,7 @@ struct mca_btl_openib_module_t {
     uint8_t num_cpcs;
 
     mca_btl_openib_device_t *device;
+    char * device_name;
     uint8_t port_num;                  /**< ID of the PORT */
     uint16_t pkey_index;
     struct ibv_port_attr ib_port_attr;

--- a/opal/mca/btl/openib/btl_openib_proc.c
+++ b/opal/mca/btl/openib/btl_openib_proc.c
@@ -277,7 +277,6 @@ mca_btl_openib_proc_t* mca_btl_openib_proc_get_locked(opal_proc_t* proc)
 
     if (0 == ib_proc->proc_port_count) {
         ib_proc->proc_endpoints = NULL;
-        goto no_err_exit;
     } else {
         ib_proc->proc_endpoints = (volatile mca_btl_base_endpoint_t**)
             malloc(ib_proc->proc_port_count *


### PR DESCRIPTION
Refs. open-mpi/ompi#6137