### PR TITLE
CONTRIBUTING.md: Fix "our open source license" link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ and deliver to our users.
 ## Contributor's Declaration
 
 In order to ensure that we can keep distributing Open MPI under our
-[open source license](LICENSE), we need to ensure that all
+[open source license](/LICENSE), we need to ensure that all
 contributions are compatible with that license.
 
 To that end, we require that all Git commits contributed to Open MPI


### PR DESCRIPTION
Fixes #6188.

Fixes the broken "open source license" link in `.github/CONTRIBUTING.md` by prepending a "/" so it's an absolute instead of relative path.

This probably just broke back in https://github.com/open-mpi/ompi/commit/8ada4e48a580380d7262a4d5a4d54c7572c2f420#diff-8cc7b2b0d78dd2501610391c086a8516 when `/CONTRIBUTING.md` got merged into `/.github/CONTRIBUTING.md` so the relative link was no longer valid.