### PR TITLE
info_get: ensure to copy all requested characters

### DIFF
--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -106,7 +106,13 @@ static void opal_info_get_nolock (opal_info_t *info, const char *key, int valuel
          * Set the flag and value
          */
         *flag = 1;
-        opal_string_copy(value, search->ie_value, valuelen);
+        // Note: we copy exactly (valuelen) characters, because that's
+        // what the caller asked for.  Don't use opal_string_copy()
+        // here, because that will guarantee to \0-terminate what is
+        // copied (i.e., potentially copy (valuelen-1) chars and then
+        // an additional \0).  Instead: copy over exactly (valuelen)
+        // characters, and if that's not \0-terminated, then so be it.
+        memcpy(value, search->ie_value, valuelen);
     }
 }
 


### PR DESCRIPTION
When querying an info value, copy out exactly as many characters as
the caller asked for -- do not artificially truncate the target just
to ensure that it is \0-terminated.

Specifically: do not use opal_string_copy() to copy info values,
because opal_string_copy() will guarantee to \0-terminate the target,
even if it means truncating the target.  E.g., if the caller calls
opal_info_get_nolock() with valuelen=5, opal_string_copy() will return
"1234\0" -- which is wrong.  This commit fixes the behavior to return
"12345".

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fixes #6206