### PR TITLE
PML/UCX: suppressed multi-thread warning

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -454,6 +454,7 @@ int mca_pml_ucx_enable(bool enable)
     PML_UCX_FREELIST_INIT(&ompi_pml_ucx.convs,
                           mca_pml_ucx_convertor_t,
                           128, -1, 128);
+    ompi_pml_ucx.enabled = enable;
     return OMPI_SUCCESS;
 }
 
@@ -1019,5 +1020,7 @@ int mca_pml_ucx_dump(struct ompi_communicator_t* comm, int verbose)
 
 static void mca_pml_ucx_mpi_init_bottom(int argc, char **argv, int requested, int *provided)
 {
-    *provided = MPI_THREAD_SINGLE;
+    if (ompi_pml_ucx.enabled) {
+        *provided = MPI_THREAD_SINGLE;
+    }
 }

--- a/ompi/mca/pml/ucx/pml_ucx.h
+++ b/ompi/mca/pml/ucx/pml_ucx.h
@@ -57,6 +57,7 @@ struct mca_pml_ucx_module {
     mca_pml_ucx_freelist_t    convs;
 
     int                       priority;
+    bool                      enabled;
 };
 
 extern mca_pml_base_component_2_0_0_t mca_pml_ucx_component;

--- a/ompi/mca/pml/ucx/pml_ucx.h
+++ b/ompi/mca/pml/ucx/pml_ucx.h
@@ -64,7 +64,7 @@ extern mca_pml_ucx_module_t ompi_pml_ucx;
 
 int mca_pml_ucx_open(void);
 int mca_pml_ucx_close(void);
-int mca_pml_ucx_init(void);
+int mca_pml_ucx_init(int enable_mpi_threads);
 int mca_pml_ucx_cleanup(void);
 
 int mca_pml_ucx_add_procs(struct ompi_proc_t **procs, size_t nprocs);

--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -90,11 +90,11 @@ static int mca_pml_ucx_component_close(void)
 
 static mca_pml_base_module_t*
 mca_pml_ucx_component_init(int* priority, bool enable_progress_threads,
-                             bool enable_mpi_threads)
+                           bool enable_mpi_threads)
 {
     int ret;
 
-    if ( (ret = mca_pml_ucx_init()) != 0) {
+    if ( (ret = mca_pml_ucx_init(enable_mpi_threads)) != 0) {
         return NULL;
     }
 


### PR DESCRIPTION
- in case if UCX doesn't support for multi-thread mode
  then PML UCX fallback into single thread mode and
  reduce priority of component

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>