### PR TITLE
Use mpi_f08 module in mpi_f08_ext module

### DIFF
--- a/config/ompi_ext.m4
+++ b/config/ompi_ext.m4
@@ -171,6 +171,9 @@ EOF
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 module mpi_ext
+!     Some mpi_ext extensions may require the mpi module.
+      use mpi
+!
 !     Even though this is not a useful parameter (cannot be used as a
 !     preprocessor catch) define it to keep the linker from complaining
 !     during the build.
@@ -213,6 +216,9 @@ EOF
 #include "ompi/mpi/fortran/configure-fortran-output.h"
 
 module mpi_f08_ext
+!     Some mpi_f08_ext extensions may require the mpi_f08 module.
+      use mpi_f08
+!
 !     Even though this is not a useful parameter (cannot be used as a
 !     preprocessor catch) define it to keep the linker from complaining
 !     during the build.

--- a/config/ompi_ext.m4
+++ b/config/ompi_ext.m4
@@ -601,9 +601,15 @@ EOF
         #
         # Include the mpif.h header if it is available.  Cannot do
         # this from inside the usempi.h since, for VPATH builds, the
-        # srcdir is needed to find the header.
+        # srcdir is needed to find the header.  Each extension can
+        # refuse it by defining the OMPI_MPIEXT_$1_INCLUDE_MPIFH_IN_USEMPI
+        # macro in its ompi/mpiext/*/configure.m4.  See
+        # ompi/mpiext/example/configure.m4 for an example.
         #
-        if test "$enabled_mpifh" = 1; then
+        m4_ifdef([OMPI_MPIEXT_]$1[_INCLUDE_MPIFH_IN_USEMPI],
+                 [include_mpifh=OMPI_MPIEXT_$1_INCLUDE_MPIFH_IN_USEMPI],
+                 [include_mpifh=1])
+        if test "$enabled_mpifh" = 1 && test "$include_mpifh" != 0; then
             mpifh_component_header="mpiext_${component}_mpifh.h"
             cat >> $mpiusempi_ext_h <<EOF
 #include "${mpifh_component_header_path}"
@@ -657,9 +663,15 @@ EOF
         #
         # Include the mpif.h header if it is available.  Cannot do
         # this from inside the usempif08.h since, for VPATH builds,
-        # the srcdir is needed to find the header.
+        # the srcdir is needed to find the header.  Each extension can
+        # refuse it by defining the OMPI_MPIEXT_$1_INCLUDE_MPIFH_IN_USEMPIF08
+        # macro in its ompi/mpiext/*/configure.m4.  See
+        # ompi/mpiext/example/configure.m4 for an example.
         #
-        if test "$enabled_mpifh" = 1; then
+        m4_ifdef([OMPI_MPIEXT_]$1[_INCLUDE_MPIFH_IN_USEMPIF08],
+                 [include_mpifh=OMPI_MPIEXT_$1_INCLUDE_MPIFH_IN_USEMPIF08],
+                 [include_mpifh=1])
+        if test "$enabled_mpifh" = 1 && test "$include_mpifh" != 0; then
             mpifh_component_header="mpiext_${component}_mpifh.h"
             cat >> $mpiusempif08_ext_h <<EOF
 #include "${mpifh_component_header_path}"

--- a/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi-f08/Makefile.am
@@ -22,6 +22,7 @@ if OMPI_BUILD_FORTRAN_USEMPI_OR_USEMPIF08_EXT
 AM_FCFLAGS = -I$(top_builddir)/ompi/include -I$(top_srcdir)/ompi/include \
              $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/base \
              $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/use-mpi-f08/mod \
+             $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/use-mpi-f08 \
              -I$(top_srcdir) $(FCFLAGS_f90)
 
 flibs =

--- a/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
+++ b/ompi/mpi/fortran/mpiext-use-mpi/Makefile.am
@@ -21,6 +21,7 @@ if OMPI_BUILD_FORTRAN_USEMPI_OR_USEMPIF08_EXT
 
 AM_FCFLAGS = -I$(top_builddir)/ompi/include -I$(top_srcdir)/ompi/include \
              $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/base \
+             $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/use-mpi-ignore-tkr \
              -I$(top_srcdir) $(FCFLAGS_f90)
 
 flibs =

--- a/ompi/mpiext/example/configure.m4
+++ b/ompi/mpiext/example/configure.m4
@@ -32,3 +32,11 @@ AC_DEFUN([OMPI_MPIEXT_example_CONFIG],[
 
 # only need to set this if the component needs init/finalize hooks
 AC_DEFUN([OMPI_MPIEXT_example_NEED_INIT], [1])
+
+# By default, mpiext_example_mpifh.h is included in the source file
+# of the mpi_ext module. To disable it, define this macro as 0.
+#AC_DEFUN([OMPI_MPIEXT_example_INCLUDE_MPIFH_IN_USEMPI], [0])
+
+# By default, mpiext_example_mpifh.h is included in the source file
+# of the mpi_f08_ext module. To disable it, define this macro as 0.
+#AC_DEFUN([OMPI_MPIEXT_example_INCLUDE_MPIFH_IN_USEMPIF08], [0])


### PR DESCRIPTION
I cannot add a new datatype in the `mpi_f08_ext` module without this change in PR #6205 .

@jsquyres Could you review? I'm not familiar with Fortran and Autoconf. Please see commit messages for details.

I'll merge this PR after receiving review and doing more build tests.
