### PR TITLE
Remove some IMPI attributes that were never implemented.

### DIFF
--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -74,11 +74,6 @@
  * doesn't make sense to copy them to new windows (because they're
  * values specific and unique to each window) -- especially when
  * WIN_CREATE will explicitly set them on new windows anyway.
- *
- * These are not supported yet, but are included here for consistency:
- *
- * MPI_IMPI_CLIENT_SIZE, MPI_IMPI_CLIENT_COLOR, MPI_IMPI_HOST_SIZE,
- * and MPI_IMPI_HOST_COLOR are integer-valued attributes.
  */
 
 #include "ompi_config.h"
@@ -128,15 +123,7 @@ int ompi_attr_create_predefined(void)
         OMPI_SUCCESS != (ret = create_win(MPI_WIN_SIZE)) ||
         OMPI_SUCCESS != (ret = create_win(MPI_WIN_DISP_UNIT)) ||
         OMPI_SUCCESS != (ret = create_win(MPI_WIN_CREATE_FLAVOR)) ||
-        OMPI_SUCCESS != (ret = create_win(MPI_WIN_MODEL)) ||
-#if 0
-        /* JMS For when we implement IMPI */
-        OMPI_SUCCESS != (ret = create_comm(IMPI_CLIENT_SIZE, true)) ||
-        OMPI_SUCCESS != (ret = create_comm(IMPI_CLIENT_COLOR, true)) ||
-        OMPI_SUCCESS != (ret = create_comm(IMPI_HOST_SIZE, true)) ||
-        OMPI_SUCCESS != (ret = create_comm(IMPI_HOST_COLOR, true)) ||
-#endif
-        0) {
+        OMPI_SUCCESS != (ret = create_win(MPI_WIN_MODEL))) {
         return ret;
     }
 
@@ -147,19 +134,7 @@ int ompi_attr_create_predefined(void)
         OMPI_SUCCESS != (ret = set_f(MPI_IO, MPI_ANY_SOURCE)) ||
         OMPI_SUCCESS != (ret = set_f(MPI_WTIME_IS_GLOBAL, 0)) ||
         OMPI_SUCCESS != (ret = set_f(MPI_LASTUSEDCODE,
-                                     ompi_mpi_errcode_lastused)) ||
-#if 0
-        /* JMS For when we implement IMPI */
-        OMPI_SUCCESS != (ret = set(IMPI_CLIENT_SIZE,
-                                   &attr_impi_client_size)) ||
-        OMPI_SUCCESS != (ret = set(IMPI_CLIENT_COLOR,
-                                   &attr_impi_client_color)) ||
-        OMPI_SUCCESS != (ret = set(IMPI_HOST_SIZE,
-                                   &attr_impi_host_size)) ||
-        OMPI_SUCCESS != (ret = set(IMPI_HOST_COLOR,
-                                   &attr_impi_host_color)) ||
-#endif
-        0) {
+                                     ompi_mpi_errcode_lastused))) {
         return ret;
     }
 
@@ -196,15 +171,7 @@ int ompi_attr_free_predefined(void)
         OMPI_SUCCESS != (ret = free_win(MPI_WIN_SIZE)) ||
         OMPI_SUCCESS != (ret = free_win(MPI_WIN_DISP_UNIT)) ||
         OMPI_SUCCESS != (ret = free_win(MPI_WIN_CREATE_FLAVOR)) ||
-        OMPI_SUCCESS != (ret = free_win(MPI_WIN_MODEL)) ||
-#if 0
-        /* JMS For when we implement IMPI */
-        OMPI_SUCCESS != (ret = free_comm(IMPI_CLIENT_SIZE)) ||
-        OMPI_SUCCESS != (ret = free_comm(IMPI_CLIENT_COLOR)) ||
-        OMPI_SUCCESS != (ret = free_comm(IMPI_HOST_SIZE)) ||
-        OMPI_SUCCESS != (ret = free_comm(IMPI_HOST_COLOR)) ||
-#endif
-        0) {
+        OMPI_SUCCESS != (ret = free_win(MPI_WIN_MODEL))) {
         return ret;
     }
     return OMPI_SUCCESS;

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -521,13 +521,6 @@ enum {
     MPI_WIN_DISP_UNIT,
     MPI_WIN_CREATE_FLAVOR,
     MPI_WIN_MODEL,
-
-    /* Even though these four are IMPI attributes, they need to be there
-       for all MPI jobs */
-    IMPI_CLIENT_SIZE,
-    IMPI_CLIENT_COLOR,
-    IMPI_HOST_SIZE,
-    IMPI_HOST_COLOR
 };
 
 /*


### PR DESCRIPTION
This is a holdover from LAM/MPI that was never implemented here in
Open MPI (and never will be).  Might as well remove this dead code.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>