### PR TITLE
Clean up ompi_mpi_init and ompi_mpi_finalize.

### DIFF
--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -14,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -424,6 +427,7 @@ static MPI_Fint translate_to_fint(attribute_value_t *val);
 static MPI_Aint translate_to_aint(attribute_value_t *val);
 
 static int compare_attr_sequence(const void *attr1, const void *attr2);
+static void ompi_attr_finalize(void);
 
 
 /*
@@ -556,9 +560,8 @@ int ompi_attr_init(void)
                                                     ATTR_TABLE_SIZE))) {
         return ret;
     }
-    if (OMPI_SUCCESS != (ret = ompi_attr_create_predefined())) {
-        return ret;
-    }
+
+    opal_finalize_register_cleanup (ompi_attr_finalize);
 
     return OMPI_SUCCESS;
 }
@@ -567,14 +570,11 @@ int ompi_attr_init(void)
 /*
  * Cleanup everything during MPI_Finalize().
  */
-int ompi_attr_finalize(void)
+static void ompi_attr_finalize(void)
 {
-    ompi_attr_free_predefined();
     OBJ_DESTRUCT(&attribute_lock);
     OBJ_RELEASE(keyval_hash);
     OBJ_RELEASE(key_bitmap);
-
-    return OMPI_SUCCESS;
 }
 
 /*****************************************************************************/

--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -12,6 +13,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -207,12 +210,6 @@ int ompi_attr_hash_init(opal_hash_table_t **hash)
  */
 
 int ompi_attr_init(void);
-
-/**
- * Destroy the main attribute hash that stores the keyvals and meta data
- */
-
-int ompi_attr_finalize(void);
 
 
 /**
@@ -534,22 +531,11 @@ int ompi_attr_delete_all(ompi_attribute_type_t type, void *object,
 
 
 /**
- * \internal
- *
  * Create all the predefined attributes
  *
  * @returns OMPI_SUCCESS
  */
 int ompi_attr_create_predefined(void);
-
-/**
- * \internal
- *
- * Free all the predefined attributes
- *
- * @returns OMPI_SUCCESS
- */
-int ompi_attr_free_predefined(void);
 
 
 END_C_DECLS

--- a/ompi/attribute/attribute_predefined.c
+++ b/ompi/attribute/attribute_predefined.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +14,8 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,6 +94,7 @@
 /*
  * Private functions
  */
+static void ompi_attr_free_predefined(void);
 static int create_comm(int target_keyval, bool want_inherit);
 static int free_comm(int keyval);
 
@@ -98,7 +102,6 @@ static int create_win(int target_keyval);
 static int free_win(int keyval);
 
 static int set_f(int keyval, MPI_Fint value);
-
 
 int ompi_attr_create_predefined(void)
 {
@@ -155,26 +158,20 @@ int ompi_attr_create_predefined(void)
     return ret;
 }
 
-
-int ompi_attr_free_predefined(void)
+static void ompi_attr_free_predefined(void)
 {
-    int ret;
-
-    if (OMPI_SUCCESS != (ret = free_comm(MPI_TAG_UB)) ||
-        OMPI_SUCCESS != (ret = free_comm(MPI_HOST)) ||
-        OMPI_SUCCESS != (ret = free_comm(MPI_IO)) ||
-        OMPI_SUCCESS != (ret = free_comm(MPI_WTIME_IS_GLOBAL)) ||
-        OMPI_SUCCESS != (ret = free_comm(MPI_APPNUM)) ||
-        OMPI_SUCCESS != (ret = free_comm(MPI_LASTUSEDCODE)) ||
-        OMPI_SUCCESS != (ret = free_comm(MPI_UNIVERSE_SIZE)) ||
-        OMPI_SUCCESS != (ret = free_win(MPI_WIN_BASE)) ||
-        OMPI_SUCCESS != (ret = free_win(MPI_WIN_SIZE)) ||
-        OMPI_SUCCESS != (ret = free_win(MPI_WIN_DISP_UNIT)) ||
-        OMPI_SUCCESS != (ret = free_win(MPI_WIN_CREATE_FLAVOR)) ||
-        OMPI_SUCCESS != (ret = free_win(MPI_WIN_MODEL))) {
-        return ret;
-    }
-    return OMPI_SUCCESS;
+    (void) free_comm(MPI_TAG_UB);
+    (void) free_comm(MPI_HOST);
+    (void) free_comm(MPI_IO);
+    (void) free_comm(MPI_WTIME_IS_GLOBAL);
+    (void) free_comm(MPI_APPNUM);
+    (void) free_comm(MPI_LASTUSEDCODE);
+    (void) free_comm(MPI_UNIVERSE_SIZE);
+    (void) free_win(MPI_WIN_BASE);
+    (void) free_win(MPI_WIN_SIZE);
+    (void) free_win(MPI_WIN_DISP_UNIT);
+    (void) free_win(MPI_WIN_CREATE_FLAVOR);
+    (void) free_win(MPI_WIN_MODEL);
 }
 
 

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -22,6 +22,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,6 +76,8 @@ static void ompi_comm_destruct(ompi_communicator_t* comm);
 OBJ_CLASS_INSTANCE(ompi_communicator_t, opal_infosubscriber_t,
                    ompi_comm_construct,
                    ompi_comm_destruct);
+
+static void ompi_comm_finalize (void);
 
 /* This is the counter for the number of communicators, which contain
    process with more than one jobid. This counter is a usefull
@@ -231,6 +235,7 @@ int ompi_comm_init(void)
 
     /* initialize communicator requests (for ompi_comm_idup) */
     ompi_comm_request_init ();
+    opal_finalize_register_cleanup (ompi_comm_finalize);
 
     return OMPI_SUCCESS;
 }
@@ -262,7 +267,7 @@ ompi_communicator_t *ompi_comm_allocate ( int local_size, int remote_size )
     return new_comm;
 }
 
-int ompi_comm_finalize(void)
+static void ompi_comm_finalize (void)
 {
     int max, i;
     ompi_communicator_t *comm;
@@ -353,8 +358,6 @@ int ompi_comm_finalize(void)
 
     /* finalize communicator requests */
     ompi_comm_request_fini ();
-
-    return OMPI_SUCCESS;
 }
 
 /********************************************************************************/

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -21,6 +21,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -580,11 +582,6 @@ OMPI_DECLSPEC int ompi_comm_nextcid (ompi_communicator_t *newcomm, ompi_communic
 OMPI_DECLSPEC int ompi_comm_nextcid_nb (ompi_communicator_t *newcomm, ompi_communicator_t *comm,
                                         ompi_communicator_t *bridgecomm, const void *arg0, const void *arg1,
                                         bool send_first, int mode, ompi_request_t **req);
-
-/**
- * shut down the communicator infrastructure.
- */
-int ompi_comm_finalize (void);
 
 /**
  * This is THE routine, where all the communicator stuff

--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -9,6 +9,8 @@
  *                         reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -116,7 +118,6 @@ OMPI_DECLSPEC extern opal_convertor_t* ompi_mpi_local_convertor;
 extern struct opal_pointer_array_t ompi_datatype_f_to_c_table;
 
 OMPI_DECLSPEC int32_t ompi_datatype_init( void );
-OMPI_DECLSPEC int32_t ompi_datatype_finalize( void );
 
 OMPI_DECLSPEC int32_t ompi_datatype_default_convertors_init( void );
 OMPI_DECLSPEC int32_t ompi_datatype_default_convertors_fini( void );

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -18,6 +18,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,8 +38,11 @@
 #include "opal/class/opal_pointer_array.h"
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
+#include "opal/runtime/opal.h"
 
 #include "mpi.h"
+
+static void ompi_datatype_finalize( void );
 
 /**
  * This is the number of predefined datatypes. It is different than the MAX_PREDEFINED
@@ -625,11 +630,13 @@ int32_t ompi_datatype_init( void )
         }
     }
     ompi_datatype_default_convertors_init();
+    opal_finalize_register_cleanup (ompi_datatype_finalize);
+
     return OMPI_SUCCESS;
 }
 
 
-int32_t ompi_datatype_finalize( void )
+static void ompi_datatype_finalize( void )
 {
     /* As the synonyms are just copies of the internal data we should not free them.
      * Anyway they are over the limit of OMPI_DATATYPE_MPI_MAX_PREDEFINED so they will never get freed.
@@ -648,11 +655,6 @@ int32_t ompi_datatype_finalize( void )
 
     /* release the local convertors (external32 and local) */
     ompi_datatype_default_convertors_fini();
-
-    /* don't call opal_datatype_finalize () as it no longer exists. the function will be called
-     * opal_finalize_util (). */
-
-    return OMPI_SUCCESS;
 }
 
 

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -19,6 +19,8 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1025,16 +1027,6 @@ int ompi_dpm_dyn_init(void)
 
     return OMPI_SUCCESS;
 }
-
-
-/*
- * finalize the module
- */
-int ompi_dpm_finalize(void)
-{
-    return OMPI_SUCCESS;
-}
-
 
 /**********************************************************************/
 /**********************************************************************/

--- a/ompi/dpm/dpm.h
+++ b/ompi/dpm/dpm.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,11 +97,6 @@ int ompi_dpm_open_port(char *port_name);
  * Unpublish the rendezvous point
  */
 int ompi_dpm_close_port(const char *port_name);
-
-/*
- * Finalize the DPM
- */
-int ompi_dpm_finalize(void);
 
 END_C_DECLS
 

--- a/ompi/errhandler/errcode-internal.c
+++ b/ompi/errhandler/errcode-internal.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reseved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,6 +33,7 @@
 #include "opal/util/string_copy.h"
 
 #include "ompi/errhandler/errcode-internal.h"
+#include "opal/runtime/opal.h"
 
 /* Table holding all error codes */
 opal_pointer_array_t ompi_errcodes_intern = {{0}};
@@ -62,6 +65,7 @@ static ompi_errcode_intern_t ompi_err_rma_flavor_intern;
 
 static void ompi_errcode_intern_construct(ompi_errcode_intern_t* errcode);
 static void ompi_errcode_intern_destruct(ompi_errcode_intern_t* errcode);
+static void ompi_errcode_intern_finalize (void);
 
 OBJ_CLASS_INSTANCE(ompi_errcode_intern_t,opal_object_t,ompi_errcode_intern_construct, ompi_errcode_intern_destruct);
 
@@ -286,10 +290,11 @@ int ompi_errcode_intern_init (void)
                                 &ompi_err_rma_flavor_intern);
 
     ompi_errcode_intern_lastused=pos;
+    opal_finalize_register_cleanup (ompi_errcode_intern_finalize);
     return OMPI_SUCCESS;
 }
 
-int ompi_errcode_intern_finalize(void)
+static void ompi_errcode_intern_finalize (void)
 {
 
     OBJ_DESTRUCT(&ompi_success_intern);
@@ -317,7 +322,6 @@ int ompi_errcode_intern_finalize(void)
     OBJ_DESTRUCT(&ompi_err_rma_flavor_intern);
 
     OBJ_DESTRUCT(&ompi_errcodes_intern);
-    return OMPI_SUCCESS;
 }
 
 static void ompi_errcode_intern_construct(ompi_errcode_intern_t *errcode)

--- a/ompi/errhandler/errcode-internal.h
+++ b/ompi/errhandler/errcode-internal.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -13,6 +13,8 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -86,15 +88,6 @@ static inline int ompi_errcode_get_mpi_code(int errcode)
  * Invoked from ompi_mpi_init(); sets up all static MPI error codes,
  */
 int ompi_errcode_intern_init(void);
-
-/**
- * Finalize the error codes.
- *
- * @returns OMPI_SUCCESS Always
- *
- * Invokes from ompi_mpi_finalize(); tears down the error code array.
- */
-int ompi_errcode_intern_finalize(void);
 
 END_C_DECLS
 

--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -16,6 +16,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +35,7 @@
 #include "opal/util/string_copy.h"
 
 #include "ompi/errhandler/errcode.h"
+#include "opal/runtime/opal.h"
 #include "ompi/constants.h"
 
 /* Table holding all error codes */
@@ -118,6 +121,7 @@ static ompi_mpi_errcode_t ompi_t_err_invalid_name;
 
 static void ompi_mpi_errcode_construct(ompi_mpi_errcode_t* errcode);
 static void ompi_mpi_errcode_destruct(ompi_mpi_errcode_t* errcode);
+static void ompi_mpi_errcode_finalize (void);
 
 OBJ_CLASS_INSTANCE(ompi_mpi_errcode_t,opal_object_t,ompi_mpi_errcode_construct, ompi_mpi_errcode_destruct);
 
@@ -221,10 +225,13 @@ int ompi_mpi_errcode_init (void)
        MPI_ERR_LASTCODE.  So just start it as == MPI_ERR_LASTCODE. */
     ompi_mpi_errcode_lastused = MPI_ERR_LASTCODE;
     ompi_mpi_errcode_lastpredefined = MPI_ERR_LASTCODE;
+
+    opal_finalize_register_cleanup (ompi_mpi_errcode_finalize);
+
     return OMPI_SUCCESS;
 }
 
-int ompi_mpi_errcode_finalize(void)
+static void ompi_mpi_errcode_finalize (void)
 {
     int i;
     ompi_mpi_errcode_t *errc;
@@ -314,7 +321,6 @@ int ompi_mpi_errcode_finalize(void)
     OBJ_DESTRUCT(&ompi_t_err_invalid_name);
 
     OBJ_DESTRUCT(&ompi_mpi_errcodes);
-    return OMPI_SUCCESS;
 }
 
 int ompi_mpi_errcode_add(int errclass )

--- a/ompi/errhandler/errcode.h
+++ b/ompi/errhandler/errcode.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2007-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -151,15 +153,6 @@ static inline char* ompi_mpi_errnum_get_string (int errnum)
  * Invoked from ompi_mpi_init(); sets up all static MPI error codes,
  */
 int ompi_mpi_errcode_init(void);
-
-/**
- * Finalize the error codes.
- *
- * @returns OMPI_SUCCESS Always
- *
- * Invokes from ompi_mpi_finalize(); tears down the error code array.
- */
-int ompi_mpi_errcode_finalize(void);
 
 /**
  * Add an error code

--- a/ompi/errhandler/errhandler.c
+++ b/ompi/errhandler/errhandler.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,6 +46,8 @@ opal_pointer_array_t ompi_errhandler_f_to_c_table = {{0}};
  * default errhandler id
  */
 static size_t default_errhandler_id = SIZE_MAX;
+
+static void ompi_errhandler_finalize(void);
 
 /*
  * Class information
@@ -148,6 +152,7 @@ int ompi_errhandler_init(void)
                    sizeof(ompi_mpi_errors_throw_exceptions.eh.eh_name));
 
   /* All done */
+  opal_finalize_register_cleanup (ompi_errhandler_finalize);
 
   return OMPI_SUCCESS;
 }
@@ -156,7 +161,7 @@ int ompi_errhandler_init(void)
 /*
  * Clean up the errorhandler resources
  */
-int ompi_errhandler_finalize(void)
+static void ompi_errhandler_finalize(void)
 {
     OBJ_DESTRUCT(&ompi_mpi_errhandler_null.eh);
     OBJ_DESTRUCT(&ompi_mpi_errors_return.eh);
@@ -170,10 +175,6 @@ int ompi_errhandler_finalize(void)
     /* Remove errhandler F2C table */
 
     OBJ_DESTRUCT(&ompi_errhandler_f_to_c_table);
-
-    /* All done */
-
-    return OMPI_SUCCESS;
 }
 
 

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -17,6 +17,8 @@
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -299,16 +301,6 @@ struct ompi_request_t;
    * corresopnding F2C translation table.
    */
   int ompi_errhandler_init(void);
-
-  /**
-   * Finalize the error handler interface.
-   *
-   * @returns OMPI_SUCCESS Always
-   *
-   * Invokes from ompi_mpi_finalize(); tears down the error handler
-   * interface, and destroys the F2C translation table.
-   */
-  int ompi_errhandler_finalize(void);
 
   /**
    * \internal

--- a/ompi/file/file.c
+++ b/ompi/file/file.c
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -16,6 +16,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      University of Houston. All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +56,7 @@ ompi_predefined_file_t  *ompi_mpi_file_null_addr = &ompi_mpi_file_null;
  */
 static void file_constructor(ompi_file_t *obj);
 static void file_destructor(ompi_file_t *obj);
+static void ompi_file_finalize (void);
 
 
 /*
@@ -89,6 +92,7 @@ int ompi_file_init(void)
                                 &ompi_mpi_file_null.file);
 
     /* All done */
+    opal_finalize_register_cleanup (ompi_file_finalize);
 
     return OMPI_SUCCESS;
 }
@@ -163,7 +167,7 @@ int ompi_file_close(ompi_file_t **file)
 /*
  * Shut down the MPI_File bookkeeping
  */
-int ompi_file_finalize(void)
+static void ompi_file_finalize (void)
 {
     int i, max;
     size_t num_unnamed;
@@ -213,10 +217,6 @@ int ompi_file_finalize(void)
         opal_output(0, "WARNING: %lu unnamed MPI_File handles still allocated at MPI_FINALIZE", (unsigned long)num_unnamed);
     }
     OBJ_DESTRUCT(&ompi_file_f_to_c_table);
-
-    /* All done */
-
-    return OMPI_SUCCESS;
 }
 
 

--- a/ompi/file/file.h
+++ b/ompi/file/file.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -16,6 +16,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      University of Houston. All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -184,15 +186,6 @@ int ompi_file_set_name(ompi_file_t *file, char *name);
  * also does some additional handling for error checking, etc.
  */
 int ompi_file_close(ompi_file_t **file);
-
-/**
- * Tear down MPI_File handling.
- *
- * @retval OMPI_SUCCESS Always.
- *
- * Invoked during ompi_mpi_finalize().
- */
-int ompi_file_finalize(void);
 
 /**
  * Check to see if an MPI_File handle is valid.

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -18,6 +18,8 @@
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -183,14 +185,6 @@ OMPI_DECLSPEC void ompi_group_decrement_proc_count(ompi_group_t *group);
  * @return Error code
  */
 int ompi_group_init(void);
-
-
-/**
- * Clean up OMPI group infrastructure.
- *
- * @return Error code
- */
-int ompi_group_finalize(void);
 
 
 /**

--- a/ompi/group/group_init.c
+++ b/ompi/group/group_init.c
@@ -16,6 +16,8 @@
  * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,6 +29,8 @@
 #include "ompi/group/group.h"
 #include "ompi/constants.h"
 #include "mpi.h"
+
+static void ompi_group_finalize(void);
 
 /* define class information */
 static void ompi_group_construct(ompi_group_t *);
@@ -340,6 +344,8 @@ int ompi_group_init(void)
     ompi_mpi_group_empty.group.grp_flags            |= OMPI_GROUP_DENSE;
     ompi_mpi_group_empty.group.grp_flags            |= OMPI_GROUP_INTRINSIC;
 
+    opal_finalize_register_cleanup (ompi_group_finalize);
+
     return OMPI_SUCCESS;
 }
 
@@ -347,7 +353,7 @@ int ompi_group_init(void)
 /*
  * Clean up group infrastructure
  */
-int ompi_group_finalize(void)
+static void ompi_group_finalize(void)
 {
     ompi_mpi_group_null.group.grp_flags = 0;
     OBJ_DESTRUCT(&ompi_mpi_group_null);
@@ -356,6 +362,4 @@ int ompi_group_finalize(void)
     OBJ_DESTRUCT(&ompi_mpi_group_empty);
 
     OBJ_DESTRUCT(&ompi_group_f_to_c_table);
-
-    return OMPI_SUCCESS;
 }

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,6 +46,7 @@
 #include "opal/util/opal_getcwd.h"
 #include "opal/util/output.h"
 #include "opal/util/info.h"
+#include "opal/runtime/opal.h"
 
 #include "ompi/info/info.h"
 #include "ompi/runtime/mpiruntime.h"
@@ -61,6 +64,7 @@ ompi_predefined_info_t ompi_mpi_info_env = {{{{{0}}}}};
  */
 static void info_constructor(ompi_info_t *info);
 static void info_destructor(ompi_info_t *info);
+static void ompi_mpiinfo_finalize(void);
 
 /*
  * ompi_info_t classes
@@ -191,6 +195,7 @@ int ompi_mpiinfo_init(void)
     }
 
     /* All done */
+    opal_finalize_register_cleanup (ompi_mpiinfo_finalize);
 
     return OMPI_SUCCESS;
 }
@@ -250,7 +255,7 @@ int ompi_info_get_nkeys(ompi_info_t *info, int *nkeys)
 /*
  * Shut down MPI_Info handling
  */
-int ompi_mpiinfo_finalize(void)
+static void ompi_mpiinfo_finalize(void)
 {
     size_t i, max;
     ompi_info_t *info;
@@ -316,7 +321,6 @@ int ompi_mpiinfo_finalize(void)
     /* All done -- destroy the table */
 
     OBJ_DESTRUCT(&ompi_info_f_to_c_table);
-    return OPAL_SUCCESS;
 }
 
 

--- a/ompi/info/info.h
+++ b/ompi/info/info.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,13 +93,6 @@ int ompi_mpiinfo_init(void);
  * This function is used to free a ompi level info
  */
 int ompi_info_free (ompi_info_t **info);
-
-
-/**
- * This functions is called during ompi_mpi_finalize() and shuts
- * down MPI_Info handling.
- */
-int ompi_mpiinfo_finalize(void);
 
 /**
  * ompi_info_foo() wrapper around various opal_info_foo() calls

--- a/ompi/mca/osc/base/base.h
+++ b/ompi/mca/osc/base/base.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University.
  *                         All rights reserved.
@@ -8,6 +9,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,8 +48,6 @@ int ompi_osc_base_select(ompi_win_t *win,
                          opal_info_t *info,
                          int flavor,
                          int *model);
-
-int ompi_osc_base_finalize(void);
 
 OMPI_DECLSPEC extern mca_base_framework_t ompi_osc_base_framework;
 

--- a/ompi/mca/osc/base/osc_base_frame.c
+++ b/ompi/mca/osc/base/osc_base_frame.c
@@ -36,6 +36,8 @@
 
 #include "ompi/mca/osc/base/static-components.h"
 
+static void ompi_osc_base_finalize (void);
+
 int
 ompi_osc_base_find_available(bool enable_progress_threads,
                             bool enable_mpi_threads)
@@ -56,11 +58,13 @@ ompi_osc_base_find_available(bool enable_progress_threads,
             OBJ_RELEASE(cli);
         }
     }
+
+    opal_finalize_register_cleanup (ompi_osc_base_finalize);
+
     return OMPI_SUCCESS;
 }
 
-int
-ompi_osc_base_finalize(void)
+static void ompi_osc_base_finalize (void)
 {
     opal_list_item_t* item;
 
@@ -72,7 +76,6 @@ ompi_osc_base_finalize(void)
         component->osc_finalize();
         OBJ_RELEASE(item);
     }
-    return OMPI_SUCCESS;
 }
 
 MCA_BASE_FRAMEWORK_DECLARE(ompi, osc, "One-sided communication", NULL, NULL, NULL,

--- a/ompi/mca/pml/base/base.h
+++ b/ompi/mca/pml/base/base.h
@@ -1,4 +1,4 @@
-/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -11,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,8 +61,6 @@ OMPI_DECLSPEC int mca_pml_base_pml_selected(const char *name);
 OMPI_DECLSPEC int mca_pml_base_pml_check_selected(const char *my_pml,
                                                   struct ompi_proc_t **procs,
                                                   size_t nprocs);
-
-OMPI_DECLSPEC int mca_pml_base_finalize(void);
 
 OMPI_DECLSPEC int mca_pml_base_ft_event(int state);
 

--- a/ompi/mca/pml/base/pml_base_bsend.h
+++ b/ompi/mca/pml/base/pml_base_bsend.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -10,6 +11,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +29,6 @@
 BEGIN_C_DECLS
 
 OMPI_DECLSPEC int mca_pml_base_bsend_init(bool enable_mpi_threads);
-OMPI_DECLSPEC int mca_pml_base_bsend_fini(void);
 
 int mca_pml_base_bsend_attach(void* addr, int size);
 int mca_pml_base_bsend_detach(void* addr, int* size);

--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -15,6 +15,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -115,14 +117,6 @@ static int mca_pml_base_register(mca_base_register_flag_t flags)
 
     return OMPI_SUCCESS;
 }
-
-int mca_pml_base_finalize(void) {
-  if (NULL != mca_pml_base_selected_component.pmlm_finalize) {
-    return mca_pml_base_selected_component.pmlm_finalize();
-  }
-  return OMPI_SUCCESS;
-}
-
 
 static int mca_pml_base_close(void)
 {

--- a/ompi/mca/pml/base/pml_base_select.c
+++ b/ompi/mca/pml/base/pml_base_select.c
@@ -46,6 +46,15 @@ typedef struct opened_component_t {
 
 static bool modex_reqd=false;
 
+static void mca_pml_base_finalize(void)
+{
+    if (NULL != mca_pml_base_selected_component.pmlm_finalize) {
+        (void) mca_pml_base_selected_component.pmlm_finalize();
+    }
+}
+
+
+
 /**
  * Function for selecting one component from all those that are
  * available.
@@ -292,6 +301,7 @@ int mca_pml_base_select(bool enable_progress_threads,
     }
 
     /* All done */
+    opal_finalize_register_cleanup (mca_pml_base_finalize);
 
     return OMPI_SUCCESS;
 }

--- a/ompi/message/message.c
+++ b/ompi/message/message.c
@@ -6,6 +6,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,6 +21,7 @@
 
 #include "opal/class/opal_object.h"
 #include "ompi/message/message.h"
+#include "opal/runtime/opal.h"
 #include "ompi/constants.h"
 
 static void ompi_message_constructor(ompi_message_t *msg);
@@ -26,6 +29,8 @@ static void ompi_message_constructor(ompi_message_t *msg);
 OBJ_CLASS_INSTANCE(ompi_message_t,
                    opal_free_list_item_t,
                    ompi_message_constructor, NULL);
+
+static void ompi_message_finalize(void);
 
 opal_free_list_t ompi_message_free_list = {{{0}}};
 opal_pointer_array_t  ompi_message_f_to_c_table = {{0}};
@@ -67,15 +72,14 @@ ompi_message_init(void)
         return OMPI_ERR_NOT_FOUND;
     }
 
+    opal_finalize_register_cleanup (ompi_message_finalize);
+
     return rc;
 }
 
-int
-ompi_message_finalize(void)
+static void ompi_message_finalize(void)
 {
     OBJ_DESTRUCT(&ompi_message_no_proc);
     OBJ_DESTRUCT(&ompi_message_free_list);
     OBJ_DESTRUCT(&ompi_message_f_to_c_table);
-
-    return OMPI_SUCCESS;
 }

--- a/ompi/message/message.h
+++ b/ompi/message/message.h
@@ -4,6 +4,8 @@
  * Copyright (c) 2012-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,8 +50,6 @@ struct ompi_predefined_message_t {
 typedef struct ompi_predefined_message_t ompi_predefined_message_t;
 
 int ompi_message_init(void);
-
-int ompi_message_finalize(void);
 
 OMPI_DECLSPEC extern opal_free_list_t ompi_message_free_list;
 OMPI_DECLSPEC extern opal_pointer_array_t  ompi_message_f_to_c_table;

--- a/ompi/mpiext/mpiext.c
+++ b/ompi/mpiext/mpiext.c
@@ -1,3 +1,13 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
 #include "ompi_config.h"
 
 #include <stdlib.h>
@@ -5,6 +15,9 @@
 #include "ompi/constants.h"
 #include "ompi/mpiext/mpiext.h"
 #include "ompi/mpiext/static-components.h"
+#include "opal/runtime/opal.h"
+
+static void ompi_mpiext_fini (void);
 
 
 int
@@ -21,23 +34,21 @@ ompi_mpiext_init(void)
         tmp++;
     }
 
+    opal_finalize_register_cleanup (ompi_mpiext_fini);
+
     return OMPI_SUCCESS;
 }
 
 
-int
-ompi_mpiext_fini(void)
+static void ompi_mpiext_fini (void)
 {
     const ompi_mpiext_component_t **tmp = ompi_mpiext_components;
     int ret;
 
     while (NULL != (*tmp)) {
         if (NULL != (*tmp)->fini) {
-            ret = (*tmp)->fini();
-            if (OMPI_SUCCESS != ret) return ret;
+            (void) (*tmp)->fini();
         }
         tmp++;
     }
-
-    return OMPI_SUCCESS;
 }

--- a/ompi/mpiext/mpiext.h
+++ b/ompi/mpiext/mpiext.h
@@ -1,6 +1,14 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
  * $HEADER$
  */
+
 #if defined(c_plusplus) || defined(__cplusplus)
 extern "C" {
 #endif
@@ -8,7 +16,6 @@ extern "C" {
 #include "ompi_config.h"
 
 OMPI_DECLSPEC int ompi_mpiext_init(void);
-OMPI_DECLSPEC int ompi_mpiext_fini(void);
 
 typedef int (*ompi_mpiext_init_fn_t)(void);
 typedef int (*ompi_mpiext_fini_fn_t)(void);

--- a/ompi/op/op.c
+++ b/ompi/op/op.c
@@ -16,6 +16,8 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +34,7 @@
 #include "ompi/op/op.h"
 #include "ompi/mca/op/base/base.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
+#include "opal/runtime/opal.h"
 
 
 /*
@@ -39,6 +42,7 @@
  */
 opal_pointer_array_t *ompi_op_f_to_c_table = {0};
 
+static void ompi_op_finalize(void);
 
 /*
  * Create intrinsic op
@@ -286,6 +290,8 @@ int ompi_op_init(void)
         ompi_mpi_op_replace.op.op_type = OMPI_OP_REPLACE;
     }
 
+    opal_finalize_register_cleanup (ompi_op_finalize);
+
     /* All done */
     return OMPI_SUCCESS;
 }
@@ -294,7 +300,7 @@ int ompi_op_init(void)
 /*
  * Clean up the op resources
  */
-int ompi_op_finalize(void)
+static void ompi_op_finalize(void)
 {
     /* clean up the intrinsic ops */
     OBJ_DESTRUCT(&ompi_mpi_op_no_op);
@@ -316,10 +322,6 @@ int ompi_op_finalize(void)
     /* Remove op F2C table */
 
     OBJ_RELEASE(ompi_op_f_to_c_table);
-
-    /* All done */
-
-    return OMPI_SUCCESS;
 }
 
 

--- a/ompi/op/op.h
+++ b/ompi/op/op.h
@@ -16,6 +16,8 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -347,16 +349,6 @@ extern struct opal_pointer_array_t *ompi_op_f_to_c_table;
  * translation table.
  */
 int ompi_op_init(void);
-
-/**
- * Finalize the op interface.
- *
- * @returns OMPI_SUCCESS Always
- *
- * Invokes from ompi_mpi_finalize(); tears down the op interface, and
- * destroys the F2C translation table.
- */
-int ompi_op_finalize(void);
 
 /**
  * Create a ompi_op_t with a user-defined callback (vs. creating an

--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2017 Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -55,6 +57,7 @@ ompi_proc_t* ompi_proc_local_proc = NULL;
 static void ompi_proc_construct(ompi_proc_t* proc);
 static void ompi_proc_destruct(ompi_proc_t* proc);
 static ompi_proc_t *ompi_proc_for_name_nolock (const opal_process_name_t proc_name);
+static void ompi_proc_finalize (void);
 
 OBJ_CLASS_INSTANCE(
     ompi_proc_t,
@@ -277,6 +280,8 @@ int ompi_proc_init(void)
     }
 #endif
 
+    opal_finalize_register_cleanup (ompi_proc_finalize);
+
     return OMPI_SUCCESS;
 }
 
@@ -379,7 +384,7 @@ int ompi_proc_complete_init(void)
     return errcode;
 }
 
-int ompi_proc_finalize (void)
+static void ompi_proc_finalize (void)
 {
     ompi_proc_t *proc;
 
@@ -412,8 +417,6 @@ int ompi_proc_finalize (void)
     OBJ_DESTRUCT(&ompi_proc_list);
     OBJ_DESTRUCT(&ompi_proc_lock);
     OBJ_DESTRUCT(&ompi_proc_hash);
-
-    return OMPI_SUCCESS;
 }
 
 int ompi_proc_world_size (void)

--- a/ompi/proc/proc.h
+++ b/ompi/proc/proc.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -15,6 +16,8 @@
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,18 +139,6 @@ OMPI_DECLSPEC int ompi_proc_complete_init(void);
  * @retval OMPI_ERROR   Some info could not be initialized.
  */
 OMPI_DECLSPEC int ompi_proc_complete_init_single(ompi_proc_t* proc);
-
-/**
- * Finalize the OMPI Process subsystem
- *
- * Finalize the Open MPI process subsystem.  This function will
- * release all memory created during the life of the application,
- * including all ompi_proc_t structures.
- *
- * @retval OMPI_SUCCESS  System successfully finalized
- */
-OMPI_DECLSPEC int ompi_proc_finalize(void);
-
 
 /**
  * Returns the list of proc instances associated with this job.

--- a/ompi/request/request.c
+++ b/ompi/request/request.c
@@ -18,6 +18,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +50,8 @@ ompi_request_fns_t               ompi_request_functions = {
     ompi_request_default_wait_all,
     ompi_request_default_wait_some
 };
+
+static void ompi_request_finalize(void);
 
 static void ompi_request_construct(ompi_request_t* req)
 {
@@ -173,18 +177,19 @@ int ompi_request_init(void)
     ompi_status_empty._ucount = 0;
     ompi_status_empty._cancelled = 0;
 
+    opal_finalize_register_cleanup (ompi_request_finalize);
+
     return OMPI_SUCCESS;
 }
 
 
-int ompi_request_finalize(void)
+static void ompi_request_finalize(void)
 {
     OMPI_REQUEST_FINI( &ompi_request_null.request );
     OBJ_DESTRUCT( &ompi_request_null.request );
     OMPI_REQUEST_FINI( &ompi_request_empty );
     OBJ_DESTRUCT( &ompi_request_empty );
     OBJ_DESTRUCT( &ompi_request_f_to_c_table );
-    return OMPI_SUCCESS;
 }
 
 

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -16,6 +16,8 @@
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -348,11 +350,6 @@ OMPI_DECLSPEC extern ompi_request_fns_t     ompi_request_functions;
  * Initialize the MPI_Request subsystem; invoked during MPI_INIT.
  */
 int ompi_request_init(void);
-
-/**
- * Shut down the MPI_Request subsystem; invoked during MPI_FINALIZE.
- */
-int ompi_request_finalize(void);
 
 /**
  * Create a persistent request that does nothing (e.g., to MPI_PROC_NULL).

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -19,8 +19,9 @@
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- *
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,46 +53,24 @@
 #include "opal/util/show_help.h"
 #include "opal/mca/mpool/base/base.h"
 #include "opal/mca/mpool/base/mpool_base_tree.h"
-#include "opal/mca/rcache/base/base.h"
-#include "opal/mca/allocator/base/base.h"
 #include "opal/mca/pmix/pmix.h"
 #include "opal/util/timings.h"
 
 #include "mpi.h"
 #include "ompi/constants.h"
-#include "ompi/errhandler/errcode.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/datatype/ompi_datatype.h"
-#include "ompi/message/message.h"
-#include "ompi/op/op.h"
-#include "ompi/file/file.h"
-#include "ompi/info/info.h"
 #include "ompi/runtime/mpiruntime.h"
 #include "ompi/attribute/attribute.h"
-#include "ompi/mca/pml/pml.h"
-#include "ompi/mca/bml/bml.h"
-#include "ompi/mca/pml/base/base.h"
-#include "ompi/mca/bml/base/base.h"
-#include "ompi/mca/osc/base/base.h"
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/mca/rte/rte.h"
 #include "ompi/mca/rte/base/base.h"
-#include "ompi/mca/topo/base/base.h"
-#include "ompi/mca/io/io.h"
-#include "ompi/mca/io/base/base.h"
 #include "ompi/mca/pml/base/pml_base_bsend.h"
 #include "ompi/runtime/params.h"
-#include "ompi/dpm/dpm.h"
-#include "ompi/mpiext/mpiext.h"
 #include "ompi/mca/hook/base/base.h"
 
-#if OPAL_ENABLE_FT_CR == 1
-#include "ompi/mca/crcp/crcp.h"
-#include "ompi/mca/crcp/base/base.h"
-#endif
-#include "ompi/runtime/ompi_cr.h"
-
 extern bool ompi_enable_timing;
+extern opal_finalize_domain_t ompi_mpi_init_domain;
 
 static void fence_cbfunc(int status, void *cbdata)
 {
@@ -105,8 +84,6 @@ int ompi_mpi_finalize(void)
 {
     int ret = MPI_SUCCESS;
     opal_list_item_t *item;
-    ompi_proc_t** procs;
-    size_t nprocs;
     volatile bool active;
     uint32_t key;
     ompi_datatype_t * datatype;
@@ -136,8 +113,6 @@ int ompi_mpi_finalize(void)
     }
     opal_atomic_wmb();
     opal_atomic_swap_32(&ompi_mpi_state, OMPI_MPI_STATE_FINALIZE_STARTED);
-
-    ompi_mpiext_fini();
 
     /* Per MPI-2:4.8, we have to free MPI_COMM_SELF before doing
        anything else in MPI_FINALIZE (to include setting up such that
@@ -280,23 +255,13 @@ int ompi_mpi_finalize(void)
         }
     }
 
-    /*
-     * Shutdown the Checkpoint/Restart Mech.
-     */
-    if (OMPI_SUCCESS != (ret = ompi_cr_finalize())) {
-        OMPI_ERROR_LOG(ret);
-    }
-
     /* Shut down any bindings-specific issues: C++, F77, F90 */
 
     /* Remove all memory associated by MPI_REGISTER_DATAREP (per
        MPI-2:9.5.3, there is no way for an MPI application to
        *un*register datareps, but we don't want the OMPI layer causing
        memory leaks). */
-    while (NULL != (item = opal_list_remove_first(&ompi_registered_datareps))) {
-        OBJ_RELEASE(item);
-    }
-    OBJ_DESTRUCT(&ompi_registered_datareps);
+    OPAL_LIST_DESTRUCT(&ompi_registered_datareps);
 
     /* Remove all F90 types from the hash tables */
     OPAL_HASH_TABLE_FOREACH(key, uint32, datatype, &ompi_mpi_f90_integer_hashtable)
@@ -309,160 +274,13 @@ int ompi_mpi_finalize(void)
         OBJ_RELEASE(datatype);
     OBJ_DESTRUCT(&ompi_mpi_f90_complex_hashtable);
 
-    /* Free communication objects */
-
-    /* free file resources */
-    if (OMPI_SUCCESS != (ret = ompi_file_finalize())) {
-        goto done;
-    }
-
-    /* free window resources */
-    if (OMPI_SUCCESS != (ret = ompi_win_finalize())) {
-        goto done;
-    }
-    if (OMPI_SUCCESS != (ret = ompi_osc_base_finalize())) {
-        goto done;
-    }
-
-    /* free communicator resources. this MUST come before finalizing the PML
-     * as this will call into the pml */
-    if (OMPI_SUCCESS != (ret = ompi_comm_finalize())) {
-        goto done;
-    }
-
-    /* call del_procs on all allocated procs even though some may not be known
-     * to the pml layer. the pml layer is expected to be resilient and ignore
-     * any unknown procs. */
-    nprocs = 0;
-    procs = ompi_proc_get_allocated (&nprocs);
-    MCA_PML_CALL(del_procs(procs, nprocs));
-    free(procs);
-
-    /* free pml resource */
-    if(OMPI_SUCCESS != (ret = mca_pml_base_finalize())) {
-        goto done;
-    }
-
-    /* free requests */
-    if (OMPI_SUCCESS != (ret = ompi_request_finalize())) {
-        goto done;
-    }
-
-    if (OMPI_SUCCESS != (ret = ompi_message_finalize())) {
-        goto done;
-    }
-
     /* If requested, print out a list of memory allocated by ALLOC_MEM
        but not freed by FREE_MEM */
     if (0 != ompi_debug_show_mpi_alloc_mem_leaks) {
         mca_mpool_base_tree_print(ompi_debug_show_mpi_alloc_mem_leaks);
     }
 
-    /* Now that all MPI objects dealing with communications are gone,
-       shut down MCA types having to do with communications */
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_pml_base_framework) ) ) {
-        OMPI_ERROR_LOG(ret);
-        goto done;
-    }
-
-    /* shut down buffered send code */
-    mca_pml_base_bsend_fini();
-
-#if OPAL_ENABLE_FT_CR == 1
-    /*
-     * Shutdown the CRCP Framework, must happen after PML shutdown
-     */
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_crcp_base_framework) ) ) {
-        OMPI_ERROR_LOG(ret);
-        goto done;
-    }
-#endif
-
-    /* Free secondary resources */
-
-    /* free attr resources */
-    if (OMPI_SUCCESS != (ret = ompi_attr_finalize())) {
-        goto done;
-    }
-
-    /* free group resources */
-    if (OMPI_SUCCESS != (ret = ompi_group_finalize())) {
-        goto done;
-    }
-
-    /* finalize the DPM subsystem */
-    if ( OMPI_SUCCESS != (ret = ompi_dpm_finalize())) {
-        goto done;
-    }
-
-    /* free internal error resources */
-    if (OMPI_SUCCESS != (ret = ompi_errcode_intern_finalize())) {
-        goto done;
-    }
-
-    /* free error code resources */
-    if (OMPI_SUCCESS != (ret = ompi_mpi_errcode_finalize())) {
-        goto done;
-    }
-
-    /* free errhandler resources */
-    if (OMPI_SUCCESS != (ret = ompi_errhandler_finalize())) {
-        goto done;
-    }
-
     /* Free all other resources */
-
-    /* free op resources */
-    if (OMPI_SUCCESS != (ret = ompi_op_finalize())) {
-        goto done;
-    }
-
-    /* free ddt resources */
-    if (OMPI_SUCCESS != (ret = ompi_datatype_finalize())) {
-        goto done;
-    }
-
-    /* free info resources */
-    if (OMPI_SUCCESS != (ret = ompi_mpiinfo_finalize())) {
-        goto done;
-    }
-
-    /* Close down MCA modules */
-
-    /* io is opened lazily, so it's only necessary to close it if it
-       was actually opened */
-    if (0 < ompi_io_base_framework.framework_refcnt) {
-        /* May have been "opened" multiple times. We want it closed now */
-        ompi_io_base_framework.framework_refcnt = 1;
-
-        if (OMPI_SUCCESS != mca_base_framework_close(&ompi_io_base_framework)) {
-            goto done;
-        }
-    }
-    (void) mca_base_framework_close(&ompi_topo_base_framework);
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_osc_base_framework))) {
-        goto done;
-    }
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_coll_base_framework))) {
-        goto done;
-    }
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_bml_base_framework))) {
-        goto done;
-    }
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&opal_mpool_base_framework))) {
-        goto done;
-    }
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&opal_rcache_base_framework))) {
-        goto done;
-    }
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&opal_allocator_base_framework))) {
-        goto done;
-    }
-
-    /* free proc resources */
-    if ( OMPI_SUCCESS != (ret = ompi_proc_finalize())) {
-        goto done;
-    }
 
     if (NULL != ompi_mpi_main_thread) {
         OBJ_RELEASE(ompi_mpi_main_thread);
@@ -473,24 +291,15 @@ int ompi_mpi_finalize(void)
        functionality checker */
     ompi_mpi_dynamics_finalize();
 
+    opal_finalize_pop_domain ();
+    opal_finalize_cleanup_domain (&ompi_mpi_init_domain);
+
     /* Leave the RTE */
 
     if (OMPI_SUCCESS != (ret = ompi_rte_finalize())) {
         goto done;
     }
     ompi_rte_initialized = false;
-
-    /* now close the rte framework */
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_rte_base_framework) ) ) {
-        OMPI_ERROR_LOG(ret);
-        goto done;
-    }
-
-    /* Now close the hook framework */
-    if (OMPI_SUCCESS != (ret = mca_base_framework_close(&ompi_hook_base_framework) ) ) {
-        OMPI_ERROR_LOG(ret);
-        goto done;
-    }
 
     if (OPAL_SUCCESS != (ret = opal_finalize_util())) {
         goto done;

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -292,7 +292,11 @@ int ompi_mpi_finalize(void)
     ompi_mpi_dynamics_finalize();
 
     opal_finalize_pop_domain ();
-    opal_finalize_cleanup_domain (&ompi_mpi_init_domain);
+    ret = opal_finalize_cleanup_domain (&ompi_mpi_init_domain);
+    if (OMPI_SUCCESS != ret) {
+        /* for now we abandon cleanup on any failure */
+        goto done;
+    }
 
     /* Leave the RTE */
 

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,8 +76,9 @@ static void ompi_win_destruct(ompi_win_t *win);
 OBJ_CLASS_INSTANCE(ompi_win_t, opal_infosubscriber_t,
                    ompi_win_construct, ompi_win_destruct);
 
-int
-ompi_win_init(void)
+static void ompi_win_finalize (void);
+
+int ompi_win_init (void)
 {
     int ret;
 
@@ -106,6 +109,8 @@ ompi_win_init(void)
         return ret;
     }
 
+    opal_finalize_register_cleanup (ompi_win_finalize);
+
     return OMPI_SUCCESS;
 }
 
@@ -116,7 +121,7 @@ static void ompi_win_dump (ompi_win_t *win)
                 win->w_f_to_c_index, ompi_group_size (win->w_group));
 }
 
-int ompi_win_finalize(void)
+static void ompi_win_finalize (void)
 {
     size_t size = opal_pointer_array_get_size (&ompi_mpi_windows);
     /* start at 1 to skip win null */
@@ -136,8 +141,6 @@ int ompi_win_finalize(void)
     OBJ_DESTRUCT(&ompi_mpi_windows);
     OBJ_RELEASE(ompi_win_accumulate_ops);
     OBJ_RELEASE(ompi_win_accumulate_order);
-
-    return OMPI_SUCCESS;
 }
 
 static int alloc_window(struct ompi_communicator_t *comm, opal_info_t *info, int flavor, ompi_win_t **win_out)

--- a/ompi/win/win.h
+++ b/ompi/win/win.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2013-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -131,7 +133,6 @@ OMPI_DECLSPEC extern ompi_predefined_win_t ompi_mpi_win_null;
 OMPI_DECLSPEC extern ompi_predefined_win_t *ompi_mpi_win_null_addr;
 
 int ompi_win_init(void);
-int ompi_win_finalize(void);
 
 int ompi_win_create(void *base, size_t size, int disp_unit,
                     ompi_communicator_t *comm, opal_info_t *info,

--- a/opal/runtime/opal_finalize.c
+++ b/opal/runtime/opal_finalize.c
@@ -48,7 +48,6 @@ extern int opal_util_initialized;
 extern bool opal_init_called;
 
 static opal_mutex_t opal_finalize_cleanup_fns_lock = OPAL_MUTEX_STATIC_INIT;
-opal_list_t opal_finalize_cleanup_fns = {{0}};
 
 struct opal_cleanup_fn_item_t {
     opal_list_item_t  super;
@@ -84,6 +83,7 @@ OBJ_CLASS_INSTANCE(opal_cleanup_fn_item_t, opal_list_item_t,
 static void opal_finalize_domain_construct (opal_finalize_domain_t *domain)
 {
     domain->domain_name = NULL;
+    domain->domain_was_allocated = false;
 }
 
 static void opal_finalize_domain_destruct (opal_finalize_domain_t *domain)
@@ -95,7 +95,12 @@ static void opal_finalize_domain_destruct (opal_finalize_domain_t *domain)
 OBJ_CLASS_INSTANCE(opal_finalize_domain_t, opal_list_t, opal_finalize_domain_construct,
                    opal_finalize_domain_destruct);
 
-static opal_finalize_domain_t *current_finalize_domain;
+/* NTH: probably much larger than needed but should be fine */
+#define OPAL_FINALIZE_DOMAIN_MAX 16
+
+static opal_finalize_domain_t *opal_finalize_domain_stack[OPAL_FINALIZE_DOMAIN_MAX];
+static int opal_finalize_domain_stack_index = -1;
+
 opal_finalize_domain_t opal_init_util_domain = {{{0}}};
 opal_finalize_domain_t opal_init_domain = {{{0}}};
 
@@ -112,20 +117,45 @@ void opal_finalize_append_cleanup (opal_cleanup_fn_t cleanup_fn, const char *fn_
     (void) fn_name;
 #endif
 
+    assert (opal_finalize_domain_stack_index >= 0);
+
     opal_mutex_lock (&opal_finalize_cleanup_fns_lock);
-    opal_list_append (&current_finalize_domain->super, &cleanup_item->super);
+    opal_list_append (&opal_finalize_domain_stack[opal_finalize_domain_stack_index]->super, &cleanup_item->super);
     opal_mutex_unlock (&opal_finalize_cleanup_fns_lock);
 }
 
 void opal_finalize_domain_init (opal_finalize_domain_t *domain, const char *domain_name)
 {
-    free (domain->domain_name);
-    domain->domain_name = domain_name ? strdup (domain_name) : NULL;
+    OBJ_CONSTRUCT(domain, opal_finalize_domain_t);
+    if (domain_name) {
+        domain->domain_name = strdup (domain_name);
+    }
 }
 
-void opal_finalize_set_domain (opal_finalize_domain_t *domain)
+opal_finalize_domain_t *opal_finalize_domain_create (const char *domain_name)
 {
-    current_finalize_domain = domain;
+    opal_finalize_domain_t *domain = OBJ_NEW(opal_finalize_domain_t);
+    if (OPAL_UNLIKELY(NULL == domain)) {
+        return NULL;
+    }
+    if (domain_name) {
+        domain->domain_name = strdup (domain_name);
+    }
+    domain->domain_was_allocated = true;
+    return domain;
+}
+
+
+void opal_finalize_push_domain (opal_finalize_domain_t *domain)
+{
+    assert (opal_finalize_domain_stack_index < (OPAL_FINALIZE_DOMAIN_MAX -1));
+    opal_finalize_domain_stack[++opal_finalize_domain_stack_index] = domain;
+}
+
+void opal_finalize_pop_domain (void)
+{
+    assert (opal_finalize_domain_stack_index >= 0);
+    --opal_finalize_domain_stack_index;
 }
 
 void opal_finalize_cleanup_domain (opal_finalize_domain_t *domain)
@@ -137,6 +167,21 @@ void opal_finalize_cleanup_domain (opal_finalize_domain_t *domain)
         opal_list_remove_item (&domain->super, &cleanup_item->super);
         OBJ_RELEASE(cleanup_item);
     }
+
+    if (domain->domain_was_allocated) {
+        OBJ_RELEASE(domain);
+    } else {
+        OBJ_DESTRUCT(domain);
+    }
+}
+
+void opal_finalize_cleanup_and_pop_domain (void)
+{
+    opal_finalize_domain_t *domain;
+    assert (opal_finalize_domain_stack_index >= 0);
+    domain = opal_finalize_domain_stack[opal_finalize_domain_stack_index];
+    opal_finalize_pop_domain ();
+    opal_finalize_cleanup_domain (domain);
 }
 
 int opal_finalize_util (void)
@@ -149,7 +194,6 @@ int opal_finalize_util (void)
     }
 
     opal_finalize_cleanup_domain (&opal_init_util_domain);
-    OBJ_DESTRUCT(&opal_init_util_domain);
 
     /* finalize the class/object system */
     opal_class_finalize();
@@ -171,7 +215,6 @@ int opal_finalize(void)
     }
 
     opal_finalize_cleanup_domain (&opal_init_domain);
-    OBJ_DESTRUCT(&opal_init_domain);
 
     /* finalize util code */
     opal_finalize_util();

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -357,6 +357,9 @@ static int opal_init_error (const char *error, int ret)
                         "opal_init:startup:internal-failure", true,
                         error, ret );
     }
+
+    opal_finalize_cleanup_and_pop_domain ();
+
     return ret;
 }
 
@@ -380,9 +383,8 @@ opal_init_util(int* pargc, char*** pargv)
     }
 
 
-    OBJ_CONSTRUCT(&opal_init_util_domain, opal_finalize_domain_t);
     (void) opal_finalize_domain_init (&opal_init_util_domain, "opal_init_util");
-    opal_finalize_set_domain (&opal_init_util_domain);
+    opal_finalize_push_domain (&opal_init_util_domain);
 
     opal_thread_set_main();
 
@@ -407,6 +409,7 @@ opal_init_util(int* pargc, char*** pargv)
     if (OPAL_SUCCESS != (ret = mca_base_framework_open(&opal_installdirs_base_framework, 0))) {
         fprintf(stderr, "opal_installdirs_base_open() failed -- process will likely abort (%s:%d, returned %d instead of OPAL_SUCCESS)\n",
                 __FILE__, __LINE__, ret);
+        opal_finalize_cleanup_and_pop_domain ();
         return ret;
     }
 
@@ -513,6 +516,8 @@ opal_init_util(int* pargc, char*** pargv)
 
     OPAL_TIMING_ENV_NEXT(otmng, "opal_if_init");
 
+    opal_finalize_pop_domain ();
+
     return OPAL_SUCCESS;
 }
 
@@ -544,9 +549,8 @@ opal_init(int* pargc, char*** pargv)
         return ret;
     }
 
-    OBJ_CONSTRUCT(&opal_init_domain, opal_finalize_domain_t);
     (void) opal_finalize_domain_init (&opal_init_domain, "opal_init");
-    opal_finalize_set_domain (&opal_init_domain);
+    opal_finalize_push_domain (&opal_init_domain);
 
     opal_finalize_register_cleanup_arg (mca_base_framework_close_list, opal_init_frameworks);
     opal_finalize_register_cleanup (opal_tsd_keys_destruct);
@@ -584,6 +588,8 @@ opal_init(int* pargc, char*** pargv)
     if (OPAL_SUCCESS != (ret = opal_reachable_base_select())) {
         return opal_init_error ("opal_reachable_base_select", ret);
     }
+
+    opal_finalize_pop_domain ();
 
     return OPAL_SUCCESS;
 }

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -358,7 +358,7 @@ static int opal_init_error (const char *error, int ret)
                         error, ret );
     }
 
-    opal_finalize_cleanup_and_pop_domain ();
+    (void) opal_finalize_cleanup_and_pop_domain ();
 
     return ret;
 }


### PR DESCRIPTION
This commit updates ompi_mpi_init and ompi_mpi_finalize to use the
opal finalize domain functionality. All subsystem initialization
functions have been updated to append their finalize function to the
current opal_finalize_domain_t. The ompi finalize domain is left open
when ompi_mpi_init returns to allow additional cleanup functions to be
registered between MPI_Init/MPI_Finalize.
    
One note on this commit: attribute initialization has been broken down
to seperate the initialization of the subsystem and creating the
predefined attributes. The subsystem is now initialized before the
communicator system and the predefined attributes are created after
the MPI window subsystem. This change fixed a teardown ordering
issue.
