### PR TITLE
v4.0.x: Correctly propagate the oversubscribe flag to the spawnees

### DIFF
--- a/orte/mca/rmaps/base/rmaps_base_map_job.c
+++ b/orte/mca/rmaps/base/rmaps_base_map_job.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,

--- a/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/orte/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -172,7 +172,14 @@ int orte_rmaps_rr_byslot(orte_job_t *jdata,
                 --nxtra_nodes;
             }
         }
-        num_procs_to_assign = node->slots - node->slots_inuse + extra_procs_to_assign;
+        if(node->slots <= node->slots_inuse) {
+            /* nodes are already oversubscribed */
+            num_procs_to_assign = extra_procs_to_assign;
+        }
+        else {
+            /* nodes have some room */
+            num_procs_to_assign = node->slots - node->slots_inuse + extra_procs_to_assign;
+        }
         opal_output_verbose(2, orte_rmaps_base_framework.framework_output,
                             "mca:rmaps:rr:slot adding up to %d procs to node %s",
                             num_procs_to_assign, node->name);


### PR DESCRIPTION
This is a cherry-pick of master (https://github.com/open-mpi/ompi/commit/2820aef5519c99d802c57b02721cdeb9f2f1d394 ). The propagation is intended to resolve issue #6130 

Signed-off-by: Aurélien Bouteiller <bouteill@icl.utk.edu>