### PR TITLE
config: Clean Fortran type check code

### DIFF
--- a/config/ompi_fortran_check.m4
+++ b/config/ompi_fortran_check.m4
@@ -13,6 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -38,8 +39,8 @@ AC_DEFUN([OMPI_FORTRAN_CHECK], [
     ofc_expected_size=$4
     ofc_define_type=$5
     ofc_have_type=0
-    ofc_type_size=$ac_cv_sizeof_int
-    ofc_type_alignment=$ac_cv_sizeof_int
+    ofc_type_size=0
+    ofc_type_alignment=0
     ofc_c_type=ompi_fortran_bogus_type_t
     ofc_type_kind=0
 

--- a/config/ompi_fortran_get_kind_value.m4
+++ b/config/ompi_fortran_get_kind_value.m4
@@ -13,6 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -38,6 +39,7 @@ AC_DEFUN([OMPI_FORTRAN_GET_KIND_VALUE],[
              value=
              AC_RUN_IFELSE(AC_LANG_PROGRAM(, [[
         use, intrinsic :: ISO_C_BINDING
+        implicit none
         open(unit = 7, file = "conftest.out")
         write(7, *) $1
         close(7)


### PR DESCRIPTION
If the default value of `ofc_type_size` is `$ac_cv_sizeof_int`, `OMPI_SIZEOF_FORTRAN_*` of all unavailable types become `sizeof(int)`. This leads `OMPI_SIZEOF_FORTRAN_REAL2 == OMPI_SIZEOF_FORTRAN_REAL` to become true unintentionally and `OMPI_DATATYPE_MPI_REAL2` has a wrong value in `ompi/datatype/ompi_datatype_internal.h`. This is not an actual bug because datatypes for unavailable types are not used. However it is confusing. I looked the source tree and the history but could find any basis of `$ac_cv_sizeof_int`.

If we don't use `implicit none` in `OMPI_FORTRAN_GET_KIND_VALUE`, and if a Fortran compiler does not support `ISO_C_BINDING` completely, a random value is set in `value` and the fallback route is not used. It is not our intention.
