### PR TITLE
CONTRIBUTING: fix a spelling error

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ contributions are compatible with that license.
 To that end, we require that all Git commits contributed to Open MPI
 have a "Signed-off-by" token indicating that the commit author agrees
 with [Open MPI's Contributor's
-Declaration](https://github.com/open-mpi/ompi/wiki/Admistrative-rules#contributors-declaration).
+Declaration](https://github.com/open-mpi/ompi/wiki/Administrative-rules#contributors-declaration).
 
 If you have not already done so, please ensure that:
 


### PR DESCRIPTION
As pointed out in issue #6186 we have some challenges with
English spelling.  Fixing title in the wiki page resulted
in it being renamed.  So fix links to the now correctly
spelled title.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>