### PR TITLE
v4.0.x: btl/vader: don't try to set reachabilty in add_procs if not requested

### DIFF
--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -17,6 +17,8 @@
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -276,7 +278,7 @@ static int vader_add_procs (struct mca_btl_base_module_t* btl,
             continue;
         }
 
-        if (my_proc != procs[proc]) {
+        if (my_proc != procs[proc] && reachability) {
             /* add this proc to shared memory accessibility list */
             rc = opal_bitmap_set_bit (reachability, proc);
             if(OPAL_SUCCESS != rc) {

--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -278,7 +278,7 @@ static int vader_add_procs (struct mca_btl_base_module_t* btl,
             continue;
         }
 
-        if (my_proc != procs[proc] && reachability) {
+        if (my_proc != procs[proc] && NULL != reachability) {
             /* add this proc to shared memory accessibility list */
             rc = opal_bitmap_set_bit (reachability, proc);
             if(OPAL_SUCCESS != rc) {


### PR DESCRIPTION
This commit fixes a bug where add_procs can incorrectly return an
error when going through the dynamic add_procs path. This doesn't
happen normally, only when pml/ob1 is not in use.

References #6201

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>
(cherry picked from commit 30b8336cb40e586e5d926b2b52cd78bf3751e5d3)