### PR TITLE
pmix/ext3x: fix support for external PMIx v3.1

### DIFF
--- a/opal/mca/pmix/ext3x/ext3x.c
+++ b/opal/mca/pmix/ext3x/ext3x.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2014-2018 Research Organization for Information Science
+ * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -1107,10 +1107,12 @@ int ext3x_value_unload(opal_value_t *kv,
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#ifdef PMIX_MODEX
     case PMIX_MODEX:
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#endif /* PMIX_MODEX */
     case PMIX_PERSIST:
         kv->type = OPAL_PERSIST;
         kv->data.uint8 = ext3x_convert_persist(v->data.persist);
@@ -1221,10 +1223,12 @@ int ext3x_value_unload(opal_value_t *kv,
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#ifdef PMIX_INFO_ARRAY
     case PMIX_INFO_ARRAY:
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#endif /* PMIX_INFO_ARRAY */
     case PMIX_IOF_CHANNEL:
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;


### PR DESCRIPTION
The PMIX_MODEX and PMIX_INFO_ARRAY macros were removed from the PMIx 3.1 standard.
Open MPI does not really need them (they are only used to be reported as not supported),
so smply #ifdef protect them to support an external PMIx v3.1

Refs. open-mpi/ompi#6247

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>