### PR TITLE
pmix/ext2x: fix support for external PMIx v3.1

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix2x.c
+++ b/opal/mca/pmix/pmix2x/pmix2x.c
@@ -1,8 +1,8 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2014-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
@@ -1001,10 +1001,12 @@ int pmix2x_value_unload(opal_value_t *kv,
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#ifdef PMIX_MODEX
     case PMIX_MODEX:
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#endif /* PMIX_MODEX */
     case PMIX_PERSIST:
         kv->type = OPAL_PERSIST;
         kv->data.uint8 = pmix2x_convert_persist(v->data.persist);
@@ -1111,10 +1113,12 @@ int pmix2x_value_unload(opal_value_t *kv,
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#ifdef PMIX_INFO_ARRAY
     case PMIX_INFO_ARRAY:
         OPAL_ERROR_LOG(OPAL_ERR_NOT_SUPPORTED);
         rc = OPAL_ERR_NOT_SUPPORTED;
         break;
+#endif /* PMIX_INFO_ARRAY */
 
     default:
         /* silence warnings */


### PR DESCRIPTION
The PMIX_MODEX and PMIX_INFO_ARRAY macros were removed from the PMIx 3.1 standard.
Open MPI does not really need them (they are only used to be reported as not supported),
so smply #ifdef protect them to support an external PMIx v3.1

external PMIx v3 is supported via the pmix/ext2x component, and it has worked so far
until PMIx v3.1 removed some macros, the change to support external PMIx v3.1 is minimal,
so we do not need to bother creating a new pmix/ext3x component.

The change only need to be done in ext2x/ext2x.c.
But since this file is automatically generated from pmix2x/pmix2x.c, we have to update
the latter file.

Refs. open-mpi/ompi#6247

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@950ba16aa16576582eb71941ec45996239c10a46)