### PR TITLE
v3.1.x: mpi/fortran: Fix valgrind warnings for type create

### DIFF
--- a/ompi/mpi/fortran/mpif-h/type_create_f90_complex_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_f90_complex_f.c
@@ -70,7 +70,7 @@ void ompi_type_create_f90_complex_f(MPI_Fint *p, MPI_Fint *r,
 				   MPI_Fint *newtype, MPI_Fint *ierr)
 {
     int c_ierr;
-    MPI_Datatype c_newtype = PMPI_Type_f2c(*newtype);
+    MPI_Datatype c_newtype;
 
     c_ierr = PMPI_Type_create_f90_complex(OMPI_FINT_2_INT(*p),
                                          OMPI_FINT_2_INT(*r),

--- a/ompi/mpi/fortran/mpif-h/type_create_f90_integer_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_f90_integer_f.c
@@ -70,7 +70,7 @@ void ompi_type_create_f90_integer_f(MPI_Fint *r, MPI_Fint *newtype,
 				   MPI_Fint *ierr)
 {
     int c_ierr;
-    MPI_Datatype c_new = PMPI_Type_f2c(*newtype);
+    MPI_Datatype c_new;
 
     c_ierr = PMPI_Type_create_f90_integer(OMPI_FINT_2_INT(*r), &c_new);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);

--- a/ompi/mpi/fortran/mpif-h/type_create_f90_real_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_f90_real_f.c
@@ -70,7 +70,7 @@ void ompi_type_create_f90_real_f(MPI_Fint *p, MPI_Fint *r,
 				MPI_Fint *newtype, MPI_Fint *ierr)
 {
     int c_ierr;
-    MPI_Datatype c_new = PMPI_Type_f2c(*newtype);
+    MPI_Datatype c_new;
 
     c_ierr = PMPI_Type_create_f90_real(OMPI_FINT_2_INT(*p),
                                       OMPI_FINT_2_INT(*r),

--- a/ompi/mpi/fortran/mpif-h/type_create_hindexed_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_create_hindexed_f.c
@@ -75,7 +75,7 @@ void ompi_type_create_hindexed_f(MPI_Fint *count,
 {
     int c_ierr;
     MPI_Datatype c_old = PMPI_Type_f2c(*oldtype);
-    MPI_Datatype c_new = PMPI_Type_f2c(*newtype);
+    MPI_Datatype c_new;
     OMPI_ARRAY_NAME_DECL(array_of_blocklengths);
 
     OMPI_ARRAY_FINT_2_INT(array_of_blocklengths, *count);


### PR DESCRIPTION
Valgrind warns that *newtype is uninitialized when calling from
Fortran as e.g.
```fortran
    use mpi
    integer :: t, err
    call MPI_Type_create_f90_integer(5, t, err)
```

Since newtype is intent(out), this should not happen. There is
no reason to convert the type using PMPI_Type_f2c, only to over-
write it immediately afterwards. The other type_create_* functions
did not convert newtype.

The valgrind warnings:
```
==28441== Conditional jump or move depends on uninitialised value(s)
==28441==    at 0x581B555: PMPI_Type_f2c (in [...]/lib/libmpi.so.0.0.0)
==28441==    by 0x4E87AB7: MPI_TYPE_CREATE_F90_INTEGER (in [...]/lib/libmpi_mpifh.so.0.0.0)
==28441==    by 0x400BA1: MAIN__ (in [...])
==28441==    by 0x400C46: main (in [...])
==28441==
==28441== Conditional jump or move depends on uninitialised value(s)
==28441==    at 0x581B563: PMPI_Type_f2c (in [...]/lib/libmpi.so.0.0.0)
==28441==    by 0x4E87AB7: MPI_TYPE_CREATE_F90_INTEGER (in [...]/lib/libmpi_mpifh.so.0.0.0)
==28441==    by 0x400BA1: MAIN__ (in [..])
==28441==    by 0x400C46: main (in [...])
==28441==
==28441== Use of uninitialised value of size 8
==28441==    at 0x581B577: PMPI_Type_f2c (in [...]/lib/libmpi.so.0.0.0)
==28441==    by 0x4E87AB7: MPI_TYPE_CREATE_F90_INTEGER (in [...]/lib/libmpi_mpifh.so.0.0.0)
==28441==    by 0x400BA1: MAIN__ (in [...])
==28441==    by 0x400C46: main (in [...])
==28441==
```

Signed-off-by: Risto Toijala <risto.toijala@gmail.com>
(cherry picked from commit f14a0f4fc981a488150ac7426683e94645f9fdf7)

Refs #6254