### PR TITLE
Revert "v4.0.x: Re-add removed deprecate-only MPI-2.0 symbols"

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -279,7 +279,7 @@
 #                    define __mpi_interface_deprecated__(msg) __attribute__((__deprecated__))
 #                endif
 #            endif
-#            if (OMPI_ENABLE_MPI1_COMPAT && !OMPI_BUILDING)
+#            if OMPI_ENABLE_MPI1_COMPAT
 #                    define __mpi_interface_removed__(msg) __mpi_interface_deprecated__(msg)
 #                    define OMPI_OMIT_MPI1_COMPAT_DECLS 0
 #            endif
@@ -1001,7 +1001,7 @@ OMPI_DECLSPEC extern struct ompi_predefined_info_t ompi_mpi_info_env;
 OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUS_IGNORE;
 OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUSES_IGNORE;
 
-#if (!OMPI_OMIT_MPI1_COMPAT_DECLS || OMPI_BUILDING)
+#if !OMPI_OMIT_MPI1_COMPAT_DECLS
 /*
  * Removed datatypes.  These datatypes are only available if Open MPI
  * was configured with --enable-mpi1-compatibility.
@@ -2662,7 +2662,7 @@ OMPI_DECLSPEC int OMPI_C_MPI_NULL_DELETE_FN( MPI_Comm comm, int comm_keyval,
                                              void* extra_state )
             __mpi_interface_deprecated__("MPI_NULL_DELETE_FN was deprecated in MPI-2.0; use MPI_COMM_NULL_DELETE_FN instead.");
 
-#if (!OMPI_OMIT_MPI1_COMPAT_DECLS || OMPI_BUILDING)
+#if !OMPI_OMIT_MPI1_COMPAT_DECLS
 /*
  * Removed typedefs.  These typedefs are only available if Open MPI
  * was configured with --enable-mpi1-compatibility.

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -78,9 +78,6 @@ libmpi_c_mpi_la_SOURCES = \
         ialltoallv.c \
         alltoallw.c \
         ialltoallw.c \
-        attr_delete.c \
-        attr_get.c \
-        attr_put.c \
         barrier.c \
         ibarrier.c \
         bcast.c \
@@ -288,8 +285,6 @@ libmpi_c_mpi_la_SOURCES = \
         ineighbor_alltoallv.c \
         neighbor_alltoallw.c \
         ineighbor_alltoallw.c \
-        keyval_create.c \
-        keyval_free.c \
         op_c2f.c \
         op_commutative.c \
         op_create.c \
@@ -436,20 +431,24 @@ libmpi_c_mpi_la_SOURCES = \
 	win_unlock_all.c \
         win_wait.c
 
-
-# include all of the removed MPI functions in library
-# for v4.0.x regardless of state of OMPI_ENABLE_MPI1_COMPAT
+if OMPI_ENABLE_MPI1_COMPAT
 libmpi_c_mpi_la_SOURCES += \
         address.c \
+        attr_delete.c \
+        attr_get.c \
+        attr_put.c \
         errhandler_create.c \
         errhandler_get.c \
         errhandler_set.c \
+        keyval_create.c \
+        keyval_free.c \
         type_extent.c \
         type_hindexed.c \
         type_hvector.c \
         type_lb.c \
         type_struct.c \
         type_ub.c
+endif
 
 # Conditionally install the header files
 

--- a/ompi/mpi/c/address.c
+++ b/ompi/mpi/c/address.c
@@ -21,17 +21,6 @@
 #include "ompi_config.h"
 #include <stdio.h>
 
-/* This implementation has been removed from the MPI 3.1 standard.
- * Open MPI v4.0.x is keeping the implementation in the library, but
- * removing the prototypes from the headers, unless the user configures
- * with --enable-mpi1-compatibility.
- *
- * To prevent having to port these implementations of removed functions
- * to the newer MPI calls, we are defining ENABLE_MPI1_COMPAT to 1
- * before including the c bindings.
- */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/attr_fn.c
+++ b/ompi/mpi/c/attr_fn.c
@@ -9,8 +9,6 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2018      Research Organization for Information Science
- *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -133,6 +131,11 @@ int OMPI_C_MPI_COMM_DUP_FN( MPI_Comm comm, int comm_keyval, void* extra_state,
    return MPI_SUCCESS;
 }
 
+#if !defined(OMPI_ENABLE_MPI1_COMPAT)
+
+#error "Need to delete the code below now that the removed functions are no longer shipping"
+
+#elif OMPI_ENABLE_MPI1_COMPAT
 int OMPI_C_MPI_NULL_DELETE_FN( MPI_Comm comm, int comm_keyval,
                                void* attribute_val_out,
                                void* extra_state )
@@ -156,3 +159,4 @@ int OMPI_C_MPI_DUP_FN( MPI_Comm comm, int comm_keyval, void* extra_state,
    *(void**)attribute_val_out = attribute_val_in;
    return MPI_SUCCESS;
 }
+#endif

--- a/ompi/mpi/c/errhandler_create.c
+++ b/ompi/mpi/c/errhandler_create.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/errhandler/errhandler.h"
@@ -35,7 +31,7 @@
 #define MPI_Errhandler_create PMPI_Errhandler_create
 #endif
 
-int MPI_Errhandler_create(MPI_Comm_errhandler_function *function,
+int MPI_Errhandler_create(MPI_Handler_function *function,
                           MPI_Errhandler *errhandler)
 {
 

--- a/ompi/mpi/c/errhandler_get.c
+++ b/ompi/mpi/c/errhandler_get.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/errhandler_set.c
+++ b/ompi/mpi/c/errhandler_set.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -58,9 +58,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pialltoallv.c \
         palltoallw.c \
         pialltoallw.c \
-        pattr_delete.c \
-        pattr_get.c \
-        pattr_put.c \
         pbarrier.c \
         pibarrier.c \
         pbcast.c \
@@ -268,8 +265,6 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pineighbor_alltoallv.c \
         pneighbor_alltoallw.c \
         pineighbor_alltoallw.c \
-        pkeyval_create.c \
-        pkeyval_free.c \
         pop_c2f.c \
         pop_create.c \
         pop_commutative.c \
@@ -416,19 +411,24 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
 	pwin_unlock_all.c \
         pwin_wait.c
 
-# include all of the removed MPI functions in library
-# for v4.0.x regardless of state of OMPI_ENABLE_MPI1_COMPAT
+if OMPI_ENABLE_MPI1_COMPAT
 nodist_libmpi_c_pmpi_la_SOURCES += \
         paddress.c \
+        pattr_delete.c \
+        pattr_get.c \
+        pattr_put.c \
         perrhandler_create.c \
         perrhandler_get.c \
         perrhandler_set.c \
+        pkeyval_create.c \
+        pkeyval_free.c \
         ptype_extent.c \
         ptype_hindexed.c \
         ptype_hvector.c \
         ptype_lb.c \
         ptype_struct.c \
         ptype_ub.c
+endif
 
 #
 # Sym link in the sources from the real MPI directory

--- a/ompi/mpi/c/type_extent.c
+++ b/ompi/mpi/c/type_extent.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/type_hindexed.c
+++ b/ompi/mpi/c/type_hindexed.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/type_hvector.c
+++ b/ompi/mpi/c/type_hvector.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/type_lb.c
+++ b/ompi/mpi/c/type_lb.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/type_struct.c
+++ b/ompi/mpi/c/type_struct.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 
 #if OMPI_BUILD_MPI_PROFILING

--- a/ompi/mpi/c/type_ub.c
+++ b/ompi/mpi/c/type_ub.c
@@ -20,10 +20,6 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
-
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -138,9 +138,6 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         alltoall_f.c \
         alltoallv_f.c \
         alltoallw_f.c \
-        attr_delete_f.c \
-        attr_get_f.c \
-        attr_put_f.c \
         barrier_f.c \
         bcast_f.c \
         bsend_f.c \
@@ -338,8 +335,6 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         iscatterv_f.c \
         issend_f.c \
         is_thread_main_f.c \
-        keyval_create_f.c \
-        keyval_free_f.c \
         lookup_name_f.c \
         mprobe_f.c \
         mrecv_f.c \
@@ -481,19 +476,25 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         win_flush_local_f.c \
         win_flush_local_all_f.c
 
-# include all of the removed MPI functions in library
-# for v4.0.x regardless of state of OMPI_ENABLE_MPI1_COMPAT
+
+if OMPI_ENABLE_MPI1_COMPAT
 lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         address_f.c \
+        attr_delete_f.c \
+        attr_get_f.c \
+        attr_put_f.c \
         errhandler_create_f.c \
         errhandler_get_f.c \
         errhandler_set_f.c \
+        keyval_create_f.c \
+        keyval_free_f.c \
         type_extent_f.c \
         type_hindexed_f.c \
         type_hvector_f.c \
         type_lb_f.c \
         type_struct_f.c \
         type_ub_f.c
+endif
 endif
 
 #

--- a/ompi/mpi/fortran/mpif-h/address_f.c
+++ b/ompi/mpi/fortran/mpif-h/address_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/errhandler_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_create_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/errhandler_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_get_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/errhandler_set_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_set_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -54,9 +54,6 @@ linked_files = \
         palltoall_f.c \
         palltoallv_f.c \
         palltoallw_f.c \
-        pattr_delete_f.c \
-        pattr_get_f.c \
-        pattr_put_f.c \
         pbarrier_f.c \
         pbcast_f.c \
         pbsend_f.c \
@@ -254,8 +251,6 @@ linked_files = \
         pisend_f.c \
         pissend_f.c \
         pis_thread_main_f.c \
-        pkeyval_create_f.c \
-        pkeyval_free_f.c \
         plookup_name_f.c \
         pmprobe_f.c \
         pmrecv_f.c \
@@ -397,19 +392,24 @@ linked_files = \
         pwin_flush_local_f.c \
         pwin_flush_local_all_f.c
 
-# include all of the removed MPI functions in library
-# for v4.0.x regardless of state of OMPI_ENABLE_MPI1_COMPAT
+if OMPI_ENABLE_MPI1_COMPAT
 linked_files += \
         paddress_f.c \
+        pattr_delete_f.c \
+        pattr_get_f.c \
+        pattr_put_f.c \
         perrhandler_create_f.c \
         perrhandler_get_f.c \
         perrhandler_set_f.c \
+        pkeyval_create_f.c \
+        pkeyval_free_f.c \
         ptype_extent_f.c \
         ptype_hindexed_f.c \
         ptype_hvector_f.c \
         ptype_lb_f.c \
         ptype_struct_f.c \
         ptype_ub_f.c
+endif
 
 #
 # Sym link in the sources from the real MPI directory

--- a/ompi/mpi/fortran/mpif-h/type_extent_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_extent_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_hindexed_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_hindexed_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_hvector_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_hvector_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_lb_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_lb_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_struct_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_struct_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_ub_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_ub_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow


### PR DESCRIPTION
Reverts open-mpi/ompi#6120