### PR TITLE
Error on usage of removed symbols without --enable-mpi1-compatibility configure flag.

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -19,7 +19,7 @@
  * Copyright (c) 2015      University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017-2018 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -279,8 +279,12 @@
 #                    define __mpi_interface_deprecated__(msg) __attribute__((__deprecated__))
 #                endif
 #            endif
+             /* For removed API, there is no portable way to cause the
+              * C compiler to error with a nice message on the usage of
+              * one of these symbols, so instead we use a C syntax-error
+              */
 #            if (OMPI_ENABLE_MPI1_COMPAT && !OMPI_BUILDING)
-#                    define __mpi_interface_removed__(msg) __mpi_interface_deprecated__(msg)
+#                    define __mpi_interface_removed__(msg) error-(msg)
 #                    define OMPI_OMIT_MPI1_COMPAT_DECLS 0
 #            endif
 #        endif

--- a/ompi/mpi/c/address.c
+++ b/ompi/mpi/c/address.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,12 +26,7 @@
  * Open MPI v4.0.x is keeping the implementation in the library, but
  * removing the prototypes from the headers, unless the user configures
  * with --enable-mpi1-compatibility.
- *
- * To prevent having to port these implementations of removed functions
- * to the newer MPI calls, we are defining ENABLE_MPI1_COMPAT to 1
- * before including the c bindings.
  */
-#define ENABLE_MPI1_COMPAT 1
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/c/errhandler_create.c
+++ b/ompi/mpi/c/errhandler_create.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/communicator/communicator.h"

--- a/ompi/mpi/c/errhandler_get.c
+++ b/ompi/mpi/c/errhandler_get.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/c/errhandler_set.c
+++ b/ompi/mpi/c/errhandler_set.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/c/type_extent.c
+++ b/ompi/mpi/c/type_extent.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/c/type_hindexed.c
+++ b/ompi/mpi/c/type_hindexed.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/c/type_hvector.c
+++ b/ompi/mpi/c/type_hvector.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/c/type_lb.c
+++ b/ompi/mpi/c/type_lb.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/c/type_struct.c
+++ b/ompi/mpi/c/type_struct.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 

--- a/ompi/mpi/c/type_ub.c
+++ b/ompi/mpi/c/type_ub.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,9 +21,11 @@
 
 #include "ompi_config.h"
 
-/* defining ENABLE_MPI1_COMPAT to 1 for removed implementations here.
- * see comments in address.c for more information. */
-#define ENABLE_MPI1_COMPAT 1
+/* This implementation has been removed from the MPI 3.1 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+*/
 
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"

--- a/ompi/mpi/fortran/mpif-h/address_f.c
+++ b/ompi/mpi/fortran/mpif-h/address_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/errhandler_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_create_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/errhandler_get_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_get_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/errhandler_set_f.c
+++ b/ompi/mpi/fortran/mpif-h/errhandler_set_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2008-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_extent_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_extent_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_hindexed_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_hindexed_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_hvector_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_hvector_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_lb_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_lb_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_struct_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_struct_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mpi/fortran/mpif-h/type_ub_f.c
+++ b/ompi/mpi/fortran/mpif-h/type_ub_f.c
@@ -12,7 +12,6 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow


### PR DESCRIPTION
1) Correctly updates IBM Copyrights on files changes in PR6120
2) Added an intentional C syntax error in mpi.h.in to cause an
   error on usage of a removed API, while still printing a
   useful error message for MPI users.