### PR TITLE
opal: add basic memory accounting for free lists and objects

### DIFF
--- a/opal/class/opal_free_list.h
+++ b/opal/class/opal_free_list.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -369,6 +371,8 @@ static inline void opal_free_list_return (opal_free_list_t *flist,
 /** compatibility macro */
 #define OPAL_FREE_LIST_RETURN(fl, item)         \
     opal_free_list_return (fl, item)
+
+extern opal_atomic_int64_t opal_free_list_memory_allocated;
 
 END_C_DECLS
 #endif

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -513,17 +513,45 @@ opal_atomic_fetch_sub_size_t(opal_atomic_size_t *addr, size_t delta)
 #endif
 }
 
+static inline size_t
+opal_atomic_fetch_max_size_t(opal_atomic_size_t *addr, size_t value)
+{
+#if SIZEOF_SIZE_T == 4
+    return (size_t) opal_atomic_fetch_max_32((int32_t*) addr, value);
+#elif SIZEOF_SIZE_T == 8
+    return (size_t) opal_atomic_fetch_max_64((int64_t*) addr, value);
+#else
+#error "Unknown size_t size"
+#endif
+}
+
+static inline size_t
+opal_atomic_max_fetch_size_t(opal_atomic_size_t *addr, size_t value)
+{
+#if SIZEOF_SIZE_T == 4
+    return (size_t) opal_atomic_max_fetch_32((int32_t*) addr, value);
+#elif SIZEOF_SIZE_T == 8
+    return (size_t) opal_atomic_max_fetch_64((int64_t*) addr, value);
+#else
+#error "Unknown size_t size"
+#endif
+}
+
 #else
 #if SIZEOF_SIZE_T == 4
 #define opal_atomic_add_fetch_size_t(addr, delta) ((size_t) opal_atomic_add_fetch_32((opal_atomic_int32_t *) addr, delta))
 #define opal_atomic_fetch_add_size_t(addr, delta) ((size_t) opal_atomic_fetch_add_32((opal_atomic_int32_t *) addr, delta))
 #define opal_atomic_sub_fetch_size_t(addr, delta) ((size_t) opal_atomic_sub_fetch_32((opal_atomic_int32_t *) addr, delta))
 #define opal_atomic_fetch_sub_size_t(addr, delta) ((size_t) opal_atomic_fetch_sub_32((opal_atomic_int32_t *) addr, delta))
+#define opal_atomic_fetch_max_size_t(addr, value) ((size_t) opal_atomic_fetch_max_32((opal_atomic_int32_t *) addr, value))
+#define opal_atomic_max_fetch_size_t(addr, value) ((size_t) opal_atomic_max_fetch_32((opal_atomic_int32_t *) addr, value))
 #elif SIZEOF_SIZE_T == 8
 #define opal_atomic_add_fetch_size_t(addr, delta) ((size_t) opal_atomic_add_fetch_64((opal_atomic_int64_t *) addr, delta))
 #define opal_atomic_fetch_add_size_t(addr, delta) ((size_t) opal_atomic_fetch_add_64((opal_atomic_int64_t *) addr, delta))
 #define opal_atomic_sub_fetch_size_t(addr, delta) ((size_t) opal_atomic_sub_fetch_64((opal_atomic_int64_t *) addr, delta))
 #define opal_atomic_fetch_sub_size_t(addr, delta) ((size_t) opal_atomic_fetch_sub_64((opal_atomic_int64_t *) addr, delta))
+#define opal_atomic_fetch_max_size_t(addr, value) ((size_t) opal_atomic_fetch_max_64((opal_atomic_int64_t *) addr, value))
+#define opal_atomic_max_fetch_size_t(addr, value) ((size_t) opal_atomic_max_fetch_64((opal_atomic_int64_t *) addr, value))
 #else
 #error "Unknown size_t size"
 #endif

--- a/opal/include/opal/sys/atomic_stdc.h
+++ b/opal/include/opal/sys/atomic_stdc.h
@@ -173,6 +173,17 @@ static inline int64_t opal_atomic_fetch_max_64 (opal_atomic_int64_t *addr, int64
     return old;
 }
 
+static inline size_t opal_atomic_fetch_max_size_t (opal_atomic_size_t *addr, size_t value)
+{
+#if SIZEOF_SIZE_T == 4
+    return opal_atomic_fetch_max_32 ((opal_atomic_int32_t *)addr, value);
+#elif SIZEOF_SIZE_T == 8
+    return opal_atomic_fetch_max_64 ((opal_atomic_int64_t *) addr, value);
+#else
+#error "Unknown size_t size"
+#endif
+}
+
 static inline int32_t opal_atomic_min_fetch_32 (opal_atomic_int32_t *addr, int32_t value)
 {
     int32_t old = opal_atomic_fetch_min_32 (addr, value);
@@ -194,6 +205,12 @@ static inline int64_t opal_atomic_min_fetch_64 (opal_atomic_int64_t *addr, int64
 static inline int64_t opal_atomic_max_fetch_64 (opal_atomic_int64_t *addr, int64_t value)
 {
     int64_t old = opal_atomic_fetch_max_64 (addr, value);
+    return old >= value ? old : value;
+}
+
+static inline size_t opal_atomic_max_fetch_size_t (opal_atomic_size_t *addr, size_t value)
+{
+    size_t old = opal_atomic_fetch_max_size_t (addr, value);
     return old >= value ? old : value;
 }
 

--- a/opal/mca/base/mca_base_pvar.h
+++ b/opal/mca/base/mca_base_pvar.h
@@ -116,33 +116,38 @@ enum {
 };
 
 struct mca_base_pvar_t;
+struct mca_base_pvar_handle_t;
 
 /**
  * Function to retrieve the current value of a variable.
  *
- * @param[in]  pvar  Performance variable to get the value of.
+ * @param[in]  pvar  Performance variable handle to get the value of.
  * @param[out] value Current value of the variable.
  * @param[in]  obj   Bound object
  *
  * This function will be called to get the current value of a variable. The value
  * pointer will be large enough to hold the datatype and count specified when this
- * variable was created and bound.
+ * variable was created and bound. This function has been updated to take the pvar
+ * handle instead of the pvar. This allows the function to check the count returned
+ * when the handle was bound.
  */
-typedef int (*mca_base_get_value_fn_t) (const struct mca_base_pvar_t *pvar, void *value, void *obj);
+typedef int (*mca_base_get_value_fn_t) (const struct mca_base_pvar_handle_t *pvar_handle, void *value, void *obj);
 
 /**
  * Function to set the current value of a variable.
  *
- * @param[in] pvar  Performance variable to set the value of.
+ * @param[in] pvar  Performance variable handle to set the value of.
  * @param[in] value Value to write.
  * @param[in] obj   Bound object.
  *
  * This function will be called to set the current value of a variable. The value
  * pointer will be large enough to hold the datatype and count specified when this
  * variable was created and bound. Read-only variables are not expected to provide
- * this function.
+ * this function. This function has been updated to take the pvar handle instead of
+ * the pvar. This allows the function to check the count returned when the handle was
+ * bound.
  */
-typedef int (*mca_base_set_value_fn_t) (struct mca_base_pvar_t *pvar, const void *value, void *obj);
+typedef int (*mca_base_set_value_fn_t) (struct mca_base_pvar_handle_t *pvar_handle, const void *value, void *obj);
 
 /**
  * Function to notify of a pvar handle event.

--- a/opal/mca/btl/usnic/btl_usnic_stats.c
+++ b/opal/mca/btl/usnic/btl_usnic_stats.c
@@ -279,10 +279,10 @@ static int usnic_pvar_notify(struct mca_base_pvar_t *pvar,
  * Function called by the pvar base when a user wants to read the
  * value of an MPI_T performance variable.
  */
-static int usnic_pvar_read(const struct mca_base_pvar_t *pvar,
+static int usnic_pvar_read(const struct mca_base_pvar_handle_t *pvar_handle,
                            void *value, void *bound_obj)
 {
-    size_t offset = (size_t) pvar->ctx;
+    size_t offset = (size_t) pvar_handler->pvar->ctx;
     uint64_t *array = (uint64_t*) value;
 
     for (int i = 0; i < mca_btl_usnic_component.num_modules; ++i) {
@@ -324,7 +324,7 @@ static void register_pvar_highwater(char *name, char *desc, size_t offset)
  * which will map to the strings in the devices_enum
  * setup_mpit_pvar_type().
  */
-static int usnic_pvar_enum_read(const struct mca_base_pvar_t *pvar,
+static int usnic_pvar_enum_read(const struct mca_base_pvar_handle_t *pvar_handle,
                                 void *value, void *bound_obj)
 {
     int *array = (int *) value;

--- a/opal/runtime/opal_params.c
+++ b/opal/runtime/opal_params.c
@@ -23,6 +23,8 @@
  *                         All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -386,6 +388,8 @@ int opal_register_params(void)
     if (OPAL_SUCCESS != ret) {
         return ret;
     }
+
+    opal_object_register_variables ();
 
     opal_finalize_register_cleanup (opal_deregister_params);
 


### PR DESCRIPTION
This commit adds support for exposing free list and object memory
allocation through the MPI_T pvar interface. Memory tracking of free
list memory is enabled by default for all builds. OPAL object memory
tracking is only enabled for debug builds.

In addition this commit updates the pvar interface to pass the pvar
handle to the read function instead of the pvar. This gives the read
function access to the count returned when the handle was bound.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>