### PR TITLE
Ensure proper alignment of memory provided by MPI

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -430,6 +430,7 @@ static int allocate_state_single (ompi_osc_rdma_module_t *module, void **base, s
      * registration handles needed to access this data. */
     total_size = local_rank_array_size + module->region_size +
         module->state_size + leader_peer_data_size;
+    total_size += OPAL_ALIGN_PAD_AMOUNT(total_size, OPAL_ALIGN_MIN);
 
     if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
         total_size += size;
@@ -571,6 +572,12 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
     /* calculate base offsets */
     module->state_offset = state_base = local_rank_array_size + module->region_size;
     data_base = state_base + leader_peer_data_size + module->state_size * local_size;
+
+    /* ensure proper alignment */
+    data_base += OPAL_ALIGN_PAD_AMOUNT(data_base, OPAL_ALIGN_MIN);
+    if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
+        size += OPAL_ALIGN_PAD_AMOUNT(size, OPAL_ALIGN_MIN);
+    }
 
     do {
         temp = calloc (local_size, sizeof (temp[0]));

--- a/opal/include/opal/align.h
+++ b/opal/include/opal/align.h
@@ -28,4 +28,11 @@
 #define OPAL_ALIGN_PTR(x,a,t) ((t)OPAL_ALIGN((uintptr_t)x, a, uintptr_t))
 #define OPAL_ALIGN_PAD_AMOUNT(x,s) ((~((uintptr_t)(x))+1) & ((uintptr_t)(s)-1))
 
+#if __STDC_VERSION__ >= 201101L
+#include <stddef.h>
+#define OPAL_ALIGN_MIN (_Alignof(max_align_t))
+#else
+#define OPAL_ALIGN_MIN (sizeof(long double))
+#endif /* __STDC_VERSION__ >= 201101L */
+
 #endif /* OPAL_ALIGN_H */

--- a/opal/mca/mpool/base/mpool_base_alloc.c
+++ b/opal/mca/mpool/base/mpool_base_alloc.c
@@ -31,6 +31,7 @@
 #include "mpool_base_tree.h"
 #include "opal/threads/mutex.h"
 #include "opal/util/info.h"
+#include "opal/align.h"
 
 
 static void unregister_tree_item(mca_mpool_base_tree_item_t *mpool_tree_item)
@@ -76,7 +77,7 @@ void *mca_mpool_base_alloc(size_t size, opal_info_t *info, const char *hints)
 
     mpool = mca_mpool_base_module_lookup (hints);
     if (NULL != mpool) {
-        mem = mpool->mpool_alloc (mpool, size, sizeof(void *), 0);
+        mem = mpool->mpool_alloc (mpool, size, OPAL_ALIGN_MIN, 0);
     }
 
     if (NULL == mem) {

--- a/opal/mca/shmem/shmem_types.h
+++ b/opal/mca/shmem/shmem_types.h
@@ -32,6 +32,7 @@
 #define OPAL_SHMEM_TYPES_H
 
 #include "opal_config.h"
+#include "opal/align.h"
 
 #include <stddef.h>
 #include <string.h>
@@ -103,7 +104,7 @@ struct opal_shmem_seg_hdr_t {
     opal_atomic_lock_t lock;
     /* pid of the segment creator */
     pid_t cpid;
-};
+} __opal_attribute_aligned__(OPAL_ALIGN_MIN);
 typedef struct opal_shmem_seg_hdr_t opal_shmem_seg_hdr_t;
 
 struct opal_shmem_ds_t {

--- a/test/mpool/mpool_memkind.c
+++ b/test/mpool/mpool_memkind.c
@@ -29,6 +29,7 @@
 #include "opal_config.h"
 #ifdef HAVE_MEMKIND_H
 #include "opal/constants.h"
+#include "opal/align.h"
 #include "opal/mca/mpool/mpool.h"
 #include "opal/include/opal/frameworks.h"
 #include "opal/runtime/opal.h"
@@ -99,6 +100,11 @@ int main (int argc, char* argv[])
         goto error;
     }
 
+    if (0 != ((uintptr_t)ptr % OPAL_ALIGN_MIN)) {
+        error = "improper memory alignment detected";
+        goto error;
+    }
+
     /*
      * now try policies
      */
@@ -121,6 +127,11 @@ int main (int argc, char* argv[])
 
                 if (OPAL_SUCCESS != mca_mpool_base_free(ptr)) {
                     error = "mca_mpool_base_free() failed";
+                    goto error;
+                }
+
+                if (0 != ((uintptr_t)ptr % OPAL_ALIGN_MIN)) {
+                    error = "improper memory alignment detected";
                     goto error;
                 }
                 mk_ptr++;


### PR DESCRIPTION
This PR adds proper alignment of all memory provided to the user by Open MPI. On 64-bit systems, Open MPI so far hands out memory aligned to 8B but certain types require a 16B alignment, e.g., `long double`. This PR adds padding for the memory allocated for `MPI_Win_allocate[_shared]` and corrects the alignment requested from `mpool_alloc` for `MPI_Alloc_mem`. Proper alignment is determined through `_Alignof(max_align_t)` (provided by C11).

Fixes #4952 

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>