### PR TITLE
common/ompio: fix a floating point division problem

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -9,7 +9,7 @@
  *                          University of Stuttgart.  All rights reserved.
  *  Copyright (c) 2004-2005 The Regents of the University of California.
  *                          All rights reserved.
- *  Copyright (c) 2008-2018 University of Houston. All rights reserved.
+ *  Copyright (c) 2008-2019 University of Houston. All rights reserved.
  *  Copyright (c) 2018      Research Organization for Information Science
  *                          and Technology (RIST). All rights reserved.
  *  $COPYRIGHT$
@@ -33,8 +33,8 @@
 
 #include "common_ompio.h"
 #include "common_ompio_request.h"
-#include "math.h"
 #include <unistd.h>
+#include <math.h>
 
 #if OPAL_CUDA_SUPPORT
 #include "common_ompio_cuda.h"
@@ -132,8 +132,8 @@ int mca_common_ompio_file_read (ompio_file_t *fh,
     else {
 	bytes_per_cycle = OMPIO_MCA_GET(fh, cycle_buffer_size);
     }
-    cycles = ceil((float)max_data/bytes_per_cycle);
-
+    cycles = ceil((double)max_data/bytes_per_cycle);
+    
 #if 0
 	printf ("Bytes per Cycle: %d   Cycles: %d max_data:%d \n",bytes_per_cycle, cycles, max_data);
 #endif

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2018 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2019 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -31,8 +31,8 @@
 
 #include "common_ompio.h"
 #include "common_ompio_request.h"
-#include "math.h"
 #include <unistd.h>
+#include <math.h>
 
 #if OPAL_CUDA_SUPPORT
 #include "common_ompio_cuda.h"
@@ -116,7 +116,7 @@ int mca_common_ompio_file_write (ompio_file_t *fh,
     else {
 	bytes_per_cycle = OMPIO_MCA_GET(fh, cycle_buffer_size);
     }
-    cycles = ceil((float)max_data/bytes_per_cycle);
+    cycles = ceil((double)max_data/bytes_per_cycle);
 
 #if 0
     printf ("Bytes per Cycle: %d   Cycles: %d\n", bytes_per_cycle, cycles);
@@ -409,7 +409,7 @@ int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp,
 /**************************************************************/
 
 int mca_common_ompio_build_io_array ( ompio_file_t *fh, int index, int cycles,
-                                      size_t bytes_per_cycle, int max_data, uint32_t iov_count,
+                                      size_t bytes_per_cycle, int  max_data, uint32_t iov_count,
                                       struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw, 
                                       size_t *spc)
 {


### PR DESCRIPTION
This commit fixes  a problem reported on the mailing list with
individual writes larger than 512 MB.

The culprit is a floating point division of two large, close values.
Changing the datatypes from float to double (which is what is being
used in the fcoll components) fixes the problem.

See issue #6285 and

 https://forum.hdfgroup.org/t/cannot-write-more-than-512-mb-in-1d/5118

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>