### PR TITLE
regex: fixed host ordering for different prefixes

### DIFF
--- a/orte/mca/regx/reverse/regx_reverse.c
+++ b/orte/mca/regx/reverse/regx_reverse.c
@@ -142,7 +142,9 @@ static int nidmap_create(opal_pointer_array_t *pool, char **regex)
                 for( j = 0; j <= i; ++j) {
                     prefix[j] = node[j];
                 }
-                startnum = j;
+                if (numdigits) {
+                    startnum = j;
+                }
                 break;
             }
         }

--- a/orte/mca/regx/reverse/regx_reverse.c
+++ b/orte/mca/regx/reverse/regx_reverse.c
@@ -170,35 +170,25 @@ static int nidmap_create(opal_pointer_array_t *pool, char **regex)
         }
         /* is this node name already on our list? */
         found = false;
-        for (item = opal_list_get_first(&nodenms);
-             !found && item != opal_list_get_end(&nodenms);
-             item = opal_list_get_next(item)) {
-            ndreg = (orte_regex_node_t*)item;
-            if (0 < strlen(prefix) && NULL == ndreg->prefix) {
-                continue;
+        if (0 != opal_list_get_size(&nodenms)) {
+            ndreg = (orte_regex_node_t*)opal_list_get_last(&nodenms);
+
+            if ((0 < strlen(prefix) && NULL == ndreg->prefix) ||
+                (0 == strlen(prefix) && NULL != ndreg->prefix) ||
+                (0 < strlen(prefix) && NULL != ndreg->prefix &&
+                    0 != strcmp(prefix, ndreg->prefix)) ||
+                (NULL == suffix && NULL != ndreg->suffix) ||
+                (NULL != suffix && NULL == ndreg->suffix) ||
+                (NULL != suffix && NULL != ndreg->suffix &&
+                    0 != strcmp(suffix, ndreg->suffix)) ||
+                (numdigits != ndreg->num_digits)) {
+                found = false;
+            } else {
+                /* found a match - flag it */
+                found = true;
             }
-            if (0 == strlen(prefix) && NULL != ndreg->prefix) {
-                continue;
-            }
-            if (0 < strlen(prefix) && NULL != ndreg->prefix
-                && 0 != strcmp(prefix, ndreg->prefix)) {
-                continue;
-            }
-            if (NULL == suffix && NULL != ndreg->suffix) {
-                continue;
-            }
-            if (NULL != suffix && NULL == ndreg->suffix) {
-                continue;
-            }
-            if (NULL != suffix && NULL != ndreg->suffix &&
-                0 != strcmp(suffix, ndreg->suffix)) {
-                continue;
-            }
-            if (numdigits != ndreg->num_digits) {
-                continue;
-            }
-            /* found a match - flag it */
-            found = true;
+        }
+        if (found) {
             /* get the last range on this nodeid - we do this
              * to preserve order
              */
@@ -209,22 +199,18 @@ static int nidmap_create(opal_pointer_array_t *pool, char **regex)
                 range->vpid = nodenum;
                 range->cnt = 1;
                 opal_list_append(&ndreg->ranges, &range->super);
-                break;
-            }
             /* see if the node number is out of sequence */
-            if (nodenum != (range->vpid + range->cnt)) {
+            } else if (nodenum != (range->vpid + range->cnt)) {
                 /* start a new range */
                 range = OBJ_NEW(orte_regex_range_t);
                 range->vpid = nodenum;
                 range->cnt = 1;
                 opal_list_append(&ndreg->ranges, &range->super);
-                break;
+            } else {
+                /* everything matches - just increment the cnt */
+                range->cnt++;
             }
-            /* everything matches - just increment the cnt */
-            range->cnt++;
-            break;
-        }
-        if (!found) {
+        } else {
             /* need to add it */
             ndreg = OBJ_NEW(orte_regex_node_t);
             if (0 < strlen(prefix)) {

--- a/orte/test/system/regex.c
+++ b/orte/test/system/regex.c
@@ -13,16 +13,19 @@
 #include "opal/util/argv.h"
 
 #include "orte/util/proc_info.h"
-#include "orte/util/regex.h"
 #include "orte/mca/errmgr/errmgr.h"
 #include "orte/runtime/runtime.h"
+#include "orte/mca/regx/regx.h"
+#include "orte/mca/regx/base/base.h"
 
 int main(int argc, char **argv)
 {
     int rc;
-    char *regex, *save;
+    char *regex, **nodelist;
     char **nodes=NULL;
     int i;
+    opal_pointer_array_t *node_pool;
+    orte_node_t *nptr;
 
     if (argc < 1 || NULL == argv[1]) {
         fprintf(stderr, "usage: regex <comma-separated list of nodes>\n");
@@ -31,10 +34,19 @@ int main(int argc, char **argv)
 
     orte_init(&argc, &argv, ORTE_PROC_NON_MPI);
 
+    if (ORTE_SUCCESS != (rc = mca_base_framework_open(&orte_regx_base_framework, 0))) {
+        ORTE_ERROR_LOG(rc);
+        return rc;
+    }
+    if (ORTE_SUCCESS != (rc = orte_regx_base_select())) {
+        ORTE_ERROR_LOG(rc);
+        return rc;
+    }
+
     if (NULL != strchr(argv[1], '[')) {
         /* given a regex to analyze */
         fprintf(stderr, "ANALYZING REGEX: %s\n", argv[1]);
-        if (ORTE_SUCCESS != (rc = orte_regex_extract_node_names(argv[1], &nodes))) {
+        if (ORTE_SUCCESS != (rc = orte_regx.extract_node_names(argv[1], &nodes))) {
             ORTE_ERROR_LOG(rc);
         }
         for (i=0; NULL != nodes[i]; i++) {
@@ -45,12 +57,30 @@ int main(int argc, char **argv)
         return 0;
     }
 
-    save = strdup(argv[1]);
-    if (ORTE_SUCCESS != (rc = orte_regex_create(save, &regex))) {
+    node_pool = OBJ_NEW(opal_pointer_array_t);
+    nodelist = opal_argv_split(argv[1], ',');
+    for (i=0; NULL != nodelist[i]; i++) {
+        orte_proc_t *daemon = NULL;
+
+        nptr = OBJ_NEW(orte_node_t);
+        nptr->name = strdup(nodelist[i]);
+        daemon = OBJ_NEW(orte_proc_t);
+        daemon->name.jobid = 123;
+        daemon->name.vpid = i;
+        nptr->daemon = daemon;
+
+        nptr->index = opal_pointer_array_add(node_pool, nptr);
+    }
+    opal_argv_free(nodelist);
+
+
+    if (ORTE_SUCCESS != (rc = orte_regx.nidmap_create(node_pool, &regex))) {
         ORTE_ERROR_LOG(rc);
     } else {
+        char *vpids = strchr(regex, '@');
+        vpids[0] = '\0';
         fprintf(stderr, "REGEX: %s\n", regex);
-        if (ORTE_SUCCESS != (rc = orte_regex_extract_node_names(regex, &nodes))) {
+        if (ORTE_SUCCESS != (rc = orte_regx.extract_node_names(regex, &nodes))) {
             ORTE_ERROR_LOG(rc);
         }
         free(regex);
@@ -63,5 +93,10 @@ int main(int argc, char **argv)
         }
         free(regex);
     }
-    free(save);
+
+    for (i=0; (nptr = opal_pointer_array_get_item(node_pool, i)) != NULL; i++) {
+        free(nptr->name);
+        OBJ_RELEASE(nptr->daemon);
+    }
+    OBJ_RELEASE(node_pool);
 }


### PR DESCRIPTION
This PR fixes a couple bugs:
1) **Wrong host ordering**:
```bash
user@jjssjb ~/ompi $ mpirun --np 3 -H jjss0000001,jjss000000A,jjss0000002 --mca regx fwd --mca routed radix --mca routed_radix 2 --map-by node hostname
jjss0000001
jjss000000A
jjss000000A <-- orted run twice this node
```
Regex test:
```bash
user@jjssjb ~/ompi/system $ export OMPI_MCA_regx=fwd
user@jjssjb ~/ompi/system $ ./regex jjss,jjss0000001,jjss000000A,jjss0000002
REGEX: jjss,jjss[7:1-2],jjss[6:0]A
ERROR: jjss,jjss0000001,jjss0000002,jjss000000A 
                                    ^^^^^^^^^^^ wrong hosts ordering
```


2) **Wrong regex for regx/reverse component**:
```
user@jjssjb ~/ompi $ mpirun --np 3 -H jjss0000001,jjss000000A,jjss0000002 --mca regx reverse --mca routed radix --mca routed_radix 2 -mca regx_base_verbose 5 --map-by node hostname
...
[jjss000000A:03220] [[24634,0],2] node[1].name jjss0000001 daemon 1
[jjss000000A:03220] [[24634,0],2] node[2].name jjss0000002 daemon 2
[jjss000000A:03220] [[24634,0],2] node[3].name jjss0000000 daemon 3 <--  this node is not existed
[jjss0000001:02888] [[24634,0],1] node[0].name jjssj0 daemon 0
[jjss0000001:02888] [[24634,0],1] node[1].name jjss0000001 daemon 1
[jjss0000001:02888] [[24634,0],1] node[2].name jjss0000002 daemon 2
[jjss0000001:02888] [[24634,0],1] node[3].name jjss0000000 daemon 3 <--  this node is not existed
...
ssh: Could not resolve hostname jjss0000000: Name or service not known      
                                ^^^^^^^^^^^ attempt connect to not existed host
...
```
```bash
user@jjssjb ~/ompi/system $ export OMPI_MCA_regx=reverse
user@jjssjb ~/ompi/system $ ./regex jjss,jjss0000001,jjss000000A,jjss0000002
REGEX: jjss[0:0],jjss[7:1-2],jjss000000A[0:0]
ERROR: jjs0,jjss0000001,jjss0000002,jjss0000000
       ^^^^                         ^^^^^^^^^^^ hosts not exist
```
Also updated the regex (orte/test/system/regex.c) test, that allows to reproduce those issues.

Fixes #6288