### PR TITLE
configury: fix ofi components dependencies

### DIFF
--- a/ompi/mca/mtl/ofi/Makefile.am
+++ b/ompi/mca/mtl/ofi/Makefile.am
@@ -5,6 +5,8 @@
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2019      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,7 +20,7 @@ EXTRA_DIST = post_configure.sh \
 MAINTAINERCLEANFILES = \
 	$(generated_sources)
 
-AM_CPPFLAGS = $(ompi_mtl_ofi_CPPFLAGS) $(opal_common_ofi_CPPFLAGS)
+AM_CPPFLAGS = $(opal_common_ofi_CPPFLAGS)
 
 dist_ompidata_DATA = help-mtl-ofi.txt
 
@@ -73,15 +75,15 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_mtl_ofi_la_SOURCES = $(mtl_ofi_sources)
 mca_mtl_ofi_la_LDFLAGS = \
-        $(ompi_mtl_ofi_LDFLAGS) \
+        $(opal_common_ofi_LDFLAGS) \
         -module -avoid-version
 mca_mtl_ofi_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
-	$(ompi_mtl_ofi_LIBS) \
+        $(opal_common_ofi_LIBS) \
         $(OPAL_TOP_BUILDDIR)/opal/mca/common/ofi/lib@OPAL_LIB_PREFIX@mca_common_ofi.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_mtl_ofi_la_SOURCES = $(mtl_ofi_sources)
 libmca_mtl_ofi_la_LDFLAGS = \
-        $(ompi_mtl_ofi_LDFLAGS) \
+        $(opal_common_ofi_LDFLAGS) \
         -module -avoid-version
-libmca_mtl_ofi_la_LIBADD = $(ompi_mtl_ofi_LIBS)
+libmca_mtl_ofi_la_LIBADD = $(opal_common_ofi_LIBS)

--- a/orte/mca/rml/ofi/Makefile.am
+++ b/orte/mca/rml/ofi/Makefile.am
@@ -14,6 +14,8 @@
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2019      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,10 +46,16 @@ endif
 mcacomponentdir = $(ortelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_rml_ofi_la_SOURCES = $(sources)
-mca_rml_ofi_la_LDFLAGS = -module -avoid-version
+mca_rml_ofi_la_LDFLAGS = \
+        $(opal_common_ofi_LDFLAGS) \
+        -module -avoid-version
 mca_rml_ofi_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la \
+        $(opal_common_ofi_LIBS) \
 	$(OPAL_TOP_BUILDDIR)/opal/mca/common/ofi/lib@OPAL_LIB_PREFIX@mca_common_ofi.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_rml_ofi_la_SOURCES = $(sources)
-libmca_rml_ofi_la_LDFLAGS = -module -avoid-version
+libmca_rml_ofi_la_LDFLAGS = \
+        $(opal_common_ofi_LDFLAGS) \
+        -module -avoid-version
+libmca_rml_ofi_la_LIBADD = $(opal_common_ofi_LIBS)


### PR DESCRIPTION
use $(opal_common_ofi_*) variables since these are the only
one defined (by opal/mca/common/ofi/configure.m4)

Refs. open-mpi/ompi#2519

Thanks Alastair McKinstry for the report and initial fix.
Thanks Rashika Kheria for the reminder.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>