### PR TITLE
hwloc/external.h: fix a clash with external HWLOC_VERSION

### DIFF
--- a/opal/mca/hwloc/external/external.h
+++ b/opal/mca/hwloc/external/external.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2011-2019 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
@@ -21,6 +21,17 @@
 BEGIN_C_DECLS
 
 #include <opal_config.h>
+
+// Need to undef HWLOC_VERSION here because configure will *always*
+// configure the embedded hwloc (for complicated reasons), even if we
+// know that the external hwloc will be used.  This will cause the
+// embedded hwloc to define HWLOC_VERSION.  And if it's different than
+// the HWLOC_VERSION value from the external hwloc, we'll get oodles
+// of warnings about how HWLOC_VERSION is re-defined.  So just
+// undefine it here after we've included <opal_config.h> and before we
+// include the external <hwloc.h>.
+#undef HWLOC_VERSION
+
 #include MCA_hwloc_external_header
 
 /* If the including file requested it, also include the hwloc verbs


### PR DESCRIPTION
Top-level configure will *always* configure the embedded hwloc
component, even if we already know that we'll be using an external
hwloc (because of complicated reasons).  A side-effect of this is that
the embedded hwloc will AC_DEFINE HWLOC_VERSION in opal_config.h.  If
the external hwloc defines a different value of HWLOC_VERSION, we'll
get zillions of warnings about the two HWLOC_VERSION values not
matching.

So in hwloc/external.h, #undef HWLOC_VERSION after including
<opal_config.h>, but before including the external <hwloc.h>.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>