### PR TITLE
ompi/op: fix support of non predefined datatypes with predefined oper…

### DIFF
--- a/ompi/op/op.h
+++ b/ompi/op/op.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -569,9 +571,16 @@ static inline void ompi_op_reduce(ompi_op_t * op, void *source,
 
     /* For intrinsics, we also pass the corresponding op module */
     if (0 != (op->o_flags & OMPI_OP_FLAGS_INTRINSIC)) {
-        op->o_func.intrinsic.fns[ompi_op_ddt_map[dtype->id]](source, target,
-                                                             &count, &dtype,
-                                                             op->o_func.intrinsic.modules[ompi_op_ddt_map[dtype->id]]);
+        int dtype_id;
+        if (!ompi_datatype_is_predefined(dtype)) {
+            ompi_datatype_t *dt = ompi_datatype_get_single_predefined_type_from_args(dtype);
+            dtype_id = ompi_op_ddt_map[dt->id];
+        } else {
+            dtype_id = ompi_op_ddt_map[dtype->id];
+        }
+        op->o_func.intrinsic.fns[dtype_id](source, target,
+                                           &count, &dtype,
+                                           op->o_func.intrinsic.modules[dtype_id]);
         return;
     }
 


### PR DESCRIPTION
…ators

ACCUMULATE, unlike REDUCE, can use with derived
datatypes with predefinied operations, with some
restrictions outlined in MPI-3:11.3.4.  The derived
datatype must be composed entierly from one predefined
datatype (so you can do all the construction you want,
but at the bottom, you can only use one datatype, say,
MPI_INT).

Refs. open-mpi/ompi#6275

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@bc1cab549883f199d54b302f44da18e430234eeb)