### PR TITLE
Pr/v4.0.x floating point division problem

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -896,11 +896,14 @@ int mca_common_ompio_split_initial_groups(ompio_file_t *fh,
     int size_smallest_group = 0;
     int num_groups = 0;
     int ret = OMPI_SUCCESS;
+    OMPI_MPI_COUNT_TYPE bytes_per_agg_group = 0;
 
     OMPI_MPI_OFFSET_TYPE max_cci = 0;
     OMPI_MPI_OFFSET_TYPE min_cci = 0;
 
-    size_new_group = ceil ((float)OMPIO_MCA_GET(fh, bytes_per_agg) * fh->f_init_procs_per_group/ bytes_per_group);
+    bytes_per_agg_group = (OMPI_MPI_COUNT_TYPE)OMPIO_MCA_GET(fh, bytes_per_agg);
+    // integer round up
+    size_new_group = (int)(bytes_per_agg_group / bytes_per_group + (bytes_per_agg_group % bytes_per_group ? 1u : 0u));
     size_old_group = fh->f_init_procs_per_group;
 
     ret = mca_common_ompio_split_a_group(fh,
@@ -948,7 +951,7 @@ int mca_common_ompio_split_initial_groups(ompio_file_t *fh,
 		 if((max_cci < OMPIO_CONTG_THRESHOLD) &&
 		    (size_new_group < size_old_group)){
 
-		    size_new_group = floor( (float) (size_new_group + size_old_group ) / 2 );
+		    size_new_group = (size_new_group + size_old_group ) / 2;
   	            ret = mca_common_ompio_split_a_group(fh,
                                                          start_offsets_lens,
                                                          end_offsets,
@@ -976,7 +979,9 @@ int mca_common_ompio_split_initial_groups(ompio_file_t *fh,
 	            (size_new_group < size_old_group)){  //can be a better condition
                  //monitor the previous iteration
 		 //break if it has not changed.
-	      	     size_new_group = ceil( (float) (size_new_group + size_old_group ) / 2 );
+	      	     size_new_group = size_new_group + size_old_group;
+	      	     // integer round up
+	      	     size_new_group = size_new_group / 2 + (size_new_group % 2 ? 1 : 0);
 		     ret = mca_common_ompio_split_a_group(fh,
                                                           start_offsets_lens,
                                                           end_offsets,

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -9,7 +9,7 @@
  *                          University of Stuttgart.  All rights reserved.
  *  Copyright (c) 2004-2005 The Regents of the University of California.
  *                          All rights reserved.
- *  Copyright (c) 2008-2018 University of Houston. All rights reserved.
+ *  Copyright (c) 2008-2019 University of Houston. All rights reserved.
  *  Copyright (c) 2018      Research Organization for Information Science
  *                          and Technology (RIST). All rights reserved.
  *  $COPYRIGHT$
@@ -33,8 +33,8 @@
 
 #include "common_ompio.h"
 #include "common_ompio_request.h"
-#include "math.h"
 #include <unistd.h>
+#include <math.h>
 
 #if OPAL_CUDA_SUPPORT
 #include "common_ompio_cuda.h"
@@ -132,8 +132,8 @@ int mca_common_ompio_file_read (ompio_file_t *fh,
     else {
 	bytes_per_cycle = OMPIO_MCA_GET(fh, cycle_buffer_size);
     }
-    cycles = ceil((float)max_data/bytes_per_cycle);
-
+    cycles = ceil((double)max_data/bytes_per_cycle);
+    
 #if 0
 	printf ("Bytes per Cycle: %d   Cycles: %d max_data:%d \n",bytes_per_cycle, cycles, max_data);
 #endif

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2018 University of Houston. All rights reserved.
+ * Copyright (c) 2008-2019 University of Houston. All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -31,8 +31,8 @@
 
 #include "common_ompio.h"
 #include "common_ompio_request.h"
-#include "math.h"
 #include <unistd.h>
+#include <math.h>
 
 #if OPAL_CUDA_SUPPORT
 #include "common_ompio_cuda.h"
@@ -116,7 +116,7 @@ int mca_common_ompio_file_write (ompio_file_t *fh,
     else {
 	bytes_per_cycle = OMPIO_MCA_GET(fh, cycle_buffer_size);
     }
-    cycles = ceil((float)max_data/bytes_per_cycle);
+    cycles = ceil((double)max_data/bytes_per_cycle);
 
 #if 0
     printf ("Bytes per Cycle: %d   Cycles: %d\n", bytes_per_cycle, cycles);
@@ -409,7 +409,7 @@ int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp,
 /**************************************************************/
 
 int mca_common_ompio_build_io_array ( ompio_file_t *fh, int index, int cycles,
-                                      size_t bytes_per_cycle, int max_data, uint32_t iov_count,
+                                      size_t bytes_per_cycle, int  max_data, uint32_t iov_count,
                                       struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw, 
                                       size_t *spc)
 {


### PR DESCRIPTION
common/ompio: Bring the two commits that fixes the problem with rounding up or down some values that was triggered by a typecast to a single precision float over to the v4.0.x branch.,