### PR TITLE
v4.0.x: mpi.h.in: use C++ static_cast<> where appropriate

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2007-2019 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009-2012 Oak Rigde National Laboratory.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
@@ -325,7 +325,11 @@
  * when building OMPI).
  */
 #if !OMPI_BUILDING
+#if defined(c_plusplus) || defined(__cplusplus)
+#define OMPI_PREDEFINED_GLOBAL(type, global) (static_cast<type> (static_cast<void *> (&(global))))
+#else
 #define OMPI_PREDEFINED_GLOBAL(type, global) ((type) ((void *) &(global)))
+#endif
 #else
 #define OMPI_PREDEFINED_GLOBAL(type, global) ((type) &(global))
 #endif
@@ -765,8 +769,13 @@ enum {
  */
 #define MPI_INFO_ENV OMPI_PREDEFINED_GLOBAL(MPI_Info, ompi_mpi_info_env)
 
+#if defined(c_plusplus) || defined(__cplusplus)
+#define MPI_STATUS_IGNORE (static_cast<MPI_Status *> (0))
+#define MPI_STATUSES_IGNORE (static_cast<MPI_Status *> (0))
+#else
 #define MPI_STATUS_IGNORE ((MPI_Status *) 0)
 #define MPI_STATUSES_IGNORE ((MPI_Status *) 0)
+#endif
 
 /*
  * Special MPI_T handles


### PR DESCRIPTION
When compiling mpi.h with a modern C++ compiler and a high degree of
pickyness (e.g., -Wold-style-cast), casting using (void*) in the
OMPI_PREDEFINED_GLOBAL and MPI_STATUS*_IGNORE macros will emit
warnings.  So if we're compiling with a C++ compiler, use C++'s
static_cast<> instead of (void*).

Thanks to @shadow-fax for identifying the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 30afdcead915c9c5a62305b93460e2ba8cc6f801)

Refs #6316 