### PR TITLE
Pr/v3.1.x floating point division problem

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -9,7 +9,9 @@
  *                          University of Stuttgart.  All rights reserved.
  *  Copyright (c) 2004-2005 The Regents of the University of California.
  *                          All rights reserved.
- *  Copyright (c) 2008-2016 University of Houston. All rights reserved.
+ *  Copyright (c) 2008-2019 University of Houston. All rights reserved.
+ *  Copyright (c) 2018      Research Organization for Information Science
+ *                          and Technology (RIST). All rights reserved.
  *  $COPYRIGHT$
  *
  *  Additional copyrights may follow
@@ -34,6 +36,7 @@
 #include "ompi/mca/io/ompio/io_ompio_request.h"
 #include "math.h"
 #include <unistd.h>
+#include <math.h>
 
 /* Read and write routines are split into two interfaces.
 **   The
@@ -99,8 +102,8 @@ int mca_common_ompio_file_read (mca_io_ompio_file_t *fh,
     else {
 	bytes_per_cycle = mca_io_ompio_cycle_buffer_size;
     }
-    cycles = ceil((float)max_data/bytes_per_cycle);
-
+    cycles = ceil((double)max_data/bytes_per_cycle);
+    
 #if 0
 	printf ("Bytes per Cycle: %d   Cycles: %d max_data:%d \n",bytes_per_cycle, cycles, max_data);
 #endif

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -9,8 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2008-2016 University of Houston. All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
+ * Copyright (c) 2008-2019 University of Houston. All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -34,6 +34,7 @@
 #include "ompi/mca/io/ompio/io_ompio_request.h"
 #include "math.h"
 #include <unistd.h>
+#include <math.h>
 
 int mca_common_ompio_file_write (mca_io_ompio_file_t *fh,
 			       const void *buf,
@@ -76,7 +77,7 @@ int mca_common_ompio_file_write (mca_io_ompio_file_t *fh,
     else {
 	bytes_per_cycle = mca_io_ompio_cycle_buffer_size;
     }
-    cycles = ceil((float)max_data/bytes_per_cycle);
+    cycles = ceil((double)max_data/bytes_per_cycle);
 
 #if 0
     printf ("Bytes per Cycle: %d   Cycles: %d\n", bytes_per_cycle, cycles);

--- a/ompi/mca/io/ompio/io_ompio_aggregators.c
+++ b/ompi/mca/io/ompio/io_ompio_aggregators.c
@@ -865,11 +865,12 @@ int mca_io_ompio_split_initial_groups(mca_io_ompio_file_t *fh,
     int size_smallest_group = 0;
     int num_groups = 0;
     int ret = OMPI_SUCCESS;
-
+    
     OMPI_MPI_OFFSET_TYPE max_cci = 0;
     OMPI_MPI_OFFSET_TYPE min_cci = 0;
 
-    size_new_group = ceil ((float)mca_io_ompio_bytes_per_agg * fh->f_init_procs_per_group/ bytes_per_group);
+    // integer round up
+    size_new_group = (int)(mca_io_ompio_bytes_per_agg / bytes_per_group + (mca_io_ompio_bytes_per_agg % bytes_per_group ? 1u : 0u));
     size_old_group = fh->f_init_procs_per_group;
 
     ret = mca_io_ompio_split_a_group(fh,
@@ -917,7 +918,7 @@ int mca_io_ompio_split_initial_groups(mca_io_ompio_file_t *fh,
 		 if((max_cci < OMPIO_CONTG_THRESHOLD) &&
 		    (size_new_group < size_old_group)){
 
-		    size_new_group = floor( (float) (size_new_group + size_old_group ) / 2 );
+                    size_new_group = (size_new_group + size_old_group ) / 2;
   	            ret = mca_io_ompio_split_a_group(fh,
                                                      start_offsets_lens,
                                                      end_offsets,
@@ -945,7 +946,9 @@ int mca_io_ompio_split_initial_groups(mca_io_ompio_file_t *fh,
 	            (size_new_group < size_old_group)){  //can be a better condition
                  //monitor the previous iteration
 		 //break if it has not changed.
-	      	     size_new_group = ceil( (float) (size_new_group + size_old_group ) / 2 );
+                     size_new_group = size_new_group + size_old_group;
+                     // integer round up
+                     size_new_group = size_new_group / 2 + (size_new_group % 2 ? 1 : 0);
 		     ret = mca_io_ompio_split_a_group(fh,
                                                       start_offsets_lens,
                                                       end_offsets,


### PR DESCRIPTION
bring the two commits related to possible rounding problems due to an erroneous typecast to a float over to the 3.1 branch. Note, that one of the two commits could not be directly cherry-picked.