### PR TITLE
Fix the PVAR allocation usage.

### DIFF
--- a/ompi/mca/common/monitoring/HowTo_pml_monitoring.tex
+++ b/ompi/mca/common/monitoring/HowTo_pml_monitoring.tex
@@ -490,7 +490,7 @@ int main(int argc, char* argv[])
   int rank, size, n, to, from, tagno, MPIT_result, provided, count;
   MPI_T_pvar_session session;
   MPI_Status status;
-  MPI_Comm newcomm;
+  MPI_Comm comm = MPI_COMM_WORLD;
   MPI_Request request;
   char filename[1024];
 
@@ -530,7 +530,7 @@ int main(int argc, char* argv[])
   /* Allocating a new PVAR in a session will reset the counters */
 
   MPIT_result = MPI_T_pvar_handle_alloc(session, flush_pvar_idx,
-                                        MPI_COMM_WORLD, 
+                                        &comm, 
                                         &flush_handle, 
                                         &count);
   if (MPIT_result != MPI_SUCCESS) {
@@ -690,7 +690,7 @@ if (MPIT_result != MPI_SUCCESS) {
 
 /* Allocating a new PVAR in a session will reset the counters */
 MPIT_result = MPI_T_pvar_handle_alloc(session, count_pvar_idx,
-                                      MPI_COMM_WORLD, &count_handle, &count);
+                                      &comm, &count_handle, &count);
 if (MPIT_result != MPI_SUCCESS) {
     printf("failed to allocate handle on \"%s\" pvar, check that you have monitoring pml\n",
            count_pvar_name);

--- a/test/monitoring/check_monitoring.c
+++ b/test/monitoring/check_monitoring.c
@@ -43,6 +43,7 @@
     static inline int pvar_prefix ## _init(MPI_T_pvar_session session)  \
     {                                                                   \
         int MPIT_result;                                                \
+        MPI_Comm comm = MPI_COMM_WORLD;                                 \
         /* Get index */                                                 \
         MPIT_result = MPI_T_pvar_get_index(pvar_prefix ## _pvar_name,   \
                                            pvar_class,                  \
@@ -57,7 +58,7 @@
         /* Allocating a new PVAR in a session will reset the counters */ \
         int count;                                                      \
         MPIT_result = MPI_T_pvar_handle_alloc(session, pvar_prefix ## _pvar_idx, \
-                                              MPI_COMM_WORLD, &(pvar_prefix ## _handle), \
+                                              &comm, &(pvar_prefix ## _handle), \
                                               &count);                  \
         if( MPI_SUCCESS != MPIT_result ) {                              \
             fprintf(stderr, "Failed to allocate handle on \"%s\" pvar, check that you have " \

--- a/test/monitoring/example_reduce_count.c
+++ b/test/monitoring/example_reduce_count.c
@@ -21,6 +21,7 @@ int main(int argc, char**argv)
     MPI_T_pvar_session session;
     MPI_Status status;
     MPI_Request request;
+    MPI_Comm comm = MPI_COMM_WORLD;
     size_t*counts;
 
     n = -1;
@@ -50,7 +51,7 @@ int main(int argc, char**argv)
 
     /* Allocating a new PVAR in a session will reset the counters */
     MPIT_result = MPI_T_pvar_handle_alloc(session, count_pvar_idx,
-					  MPI_COMM_WORLD, &count_handle, &count);
+					  &comm, &count_handle, &count);
     if (MPIT_result != MPI_SUCCESS) {
 	printf("failed to allocate handle on \"%s\" pvar, check that you have monitoring pml\n",
 	       count_pvar_name);

--- a/test/monitoring/monitoring_test.c
+++ b/test/monitoring/monitoring_test.c
@@ -78,6 +78,7 @@ int main(int argc, char* argv[])
     int rank, size, n, to, from, tagno, MPIT_result, provided, count, world_rank;
     MPI_T_pvar_session session;
     MPI_Comm newcomm;
+    MPI_Comm comm = MPI_COMM_WORLD;
     char filename[1024];
     
     for ( int arg_it = 1; argc > 1 && arg_it < argc; ++arg_it ) {
@@ -120,7 +121,7 @@ int main(int argc, char* argv[])
 
         /* Allocating a new PVAR in a session will reset the counters */
         MPIT_result = MPI_T_pvar_handle_alloc(session, flush_pvar_idx,
-                                              MPI_COMM_WORLD, &flush_handle, &count);
+                                              &comm, &flush_handle, &count);
         if (MPIT_result != MPI_SUCCESS) {
             printf("failed to allocate handle on \"%s\" pvar, check that you have monitoring pml\n",
                    flush_pvar_name);

--- a/test/monitoring/test_pvar_access.c
+++ b/test/monitoring/test_pvar_access.c
@@ -67,6 +67,7 @@ int main(int argc, char* argv[])
     MPI_T_pvar_session session;
     MPI_Status status;
     MPI_Comm newcomm;
+    MPI_Comm comm = MPI_COMM_WORLD;
     MPI_Request request;
     size_t*msg_count_p1, *msg_size_p1;
     size_t*msg_count_p2, *msg_size_p2;
@@ -110,14 +111,14 @@ int main(int argc, char* argv[])
 
     /* Allocating a new PVAR in a session will reset the counters */
     MPIT_result = MPI_T_pvar_handle_alloc(session, count_pvar_idx,
-                                          MPI_COMM_WORLD, &count_handle, &count);
+                                          &comm, &count_handle, &count);
     if (MPIT_result != MPI_SUCCESS) {
         printf("failed to allocate handle on \"%s\" pvar, check that you have monitoring pml\n",
                count_pvar_name);
         MPI_Abort(MPI_COMM_WORLD, MPIT_result);
     }
     MPIT_result = MPI_T_pvar_handle_alloc(session, msize_pvar_idx,
-                                          MPI_COMM_WORLD, &msize_handle, &count);
+                                          &comm, &msize_handle, &count);
     if (MPIT_result != MPI_SUCCESS) {
         printf("failed to allocate handle on \"%s\" pvar, check that you have monitoring pml\n",
                msize_pvar_name);


### PR DESCRIPTION
According to the MPI standard the obj_handle is a pointer to an MPI
object, and therefore cannot be MPI_COMM_WORLD. The MPI standard example
14.6 highlight this usage.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>