### PR TITLE
Fix inherited_linker_flags processing when building with NAG compiler

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -1038,10 +1038,28 @@ sub patch_autotools_output {
 	  whole_archive_flag_spec${tag}=
 	  tmp_sharedflag='--shared' ;;
 	nagfor*)			# NAGFOR 5.3
-	  tmp_sharedflag='-Wl,-shared';;
+	  tmp_sharedflag='-Wl,-shared' ;;
 	xl";
 
-        push(@verbose_out, $indent_str . "Patching configure for NAG compiler ($tag)\n");
+        push(@verbose_out, $indent_str . "Patching configure for NAG compiler #1 ($tag)\n");
+        $c =~ s/$search_string/$replace_string/;
+
+        # Newer versions of Libtool have the previous patch already. Therefore,
+        # we add the support for convenience libraries separetly
+        my $search_string = "whole_archive_flag_spec${tag}=" . '\n\s+' .
+            "tmp_sharedflag='--shared' ;;" . '\n\s+' .
+            'nagfor\052.*# NAGFOR 5.3\n\s+' .
+            "tmp_sharedflag='-Wl,-shared' ;;" . '\n\s+' .
+            'xl';
+        my $replace_string = "whole_archive_flag_spec${tag}=
+	  tmp_sharedflag='--shared' ;;
+        nagfor*)                        # NAGFOR 5.3
+          whole_archive_flag_spec${tag}='\$wl--whole-archive`for conv in \$convenience\\\"\\\"; do test  -n \\\"\$conv\\\" && new_convenience=\\\"\$new_convenience,\$conv\\\"; done; func_echo_all \\\"\$new_convenience\\\"` \$wl--no-whole-archive'
+          compiler_needs_object=yes
+          tmp_sharedflag='-Wl,-shared' ;;
+	xl";
+
+        push(@verbose_out, $indent_str . "Patching configure for NAG compiler #2 ($tag)\n");
         $c =~ s/$search_string/$replace_string/;
     }
 

--- a/config/ltmain_nag_pthread.diff
+++ b/config/ltmain_nag_pthread.diff
@@ -1,18 +1,40 @@
 --- config/ltmain.sh
 +++ config/ltmain.sh
-@@ -6417,8 +6417,14 @@
- 	func_source "$lib"
-
+@@ -7862,6 +7862,13 @@ func_mode_link ()
  	# Convert "-framework foo" to "foo.ltframework"
-+        # and "-pthread" to "-Wl,-pthread" if NAG compiler
  	if test -n "$inherited_linker_flags"; then
--	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
-+          case "$CC" in
-+            *nagfor*)
-+	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g' | $SED 's/-pthread/-Wl,-pthread/g'`;;
-+            *)
-+	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`;;
-+          esac
+ 	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
++
++	  # Additionally convert " -pthread" to " -Wl,-pthread" for nagfor
++	  func_cc_basename $CC
++	  case $func_cc_basename_result in
++	    nagfor*) tmp_inherited_linker_flags=`$ECHO "$tmp_inherited_linker_flags" | $SED 's/ -pthread/ -Wl,-pthread/g'` ;;
++	  esac
++
  	  for tmp_inherited_linker_flag in $tmp_inherited_linker_flags; do
  	    case " $new_inherited_linker_flags " in
  	      *" $tmp_inherited_linker_flag "*) ;;
+@@ -8881,7 +8888,8 @@ func_mode_link ()
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
+           # On Darwin other compilers
+-          case $CC in
++          func_cc_basename $CC
++          case $func_cc_basename_result in
+               nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+@@ -9493,6 +9501,13 @@ EOF
+ 	  ;;
+       esac
+ 
++      # Time to revert the changes made for nagfor.
++      func_cc_basename $CC
++      case $func_cc_basename_result in
++        nagfor*)
++          new_inherited_linker_flags=`$ECHO " $new_inherited_linker_flags" | $SED 's% -Wl,-pthread% -pthread%g'` ;;
++      esac
++
+       # move library search paths that coincide with paths to not yet
+       # installed libraries to the beginning of the library search list
+       new_libs=


### PR DESCRIPTION
If we build OpenMPI with a combination of GCC and NAG and need to link to an external Libtool library that has `-pthread` in the `inherited_linker_flags` variable, we might get the following problem. For example, we link to an external hwloc, and `libhwloc.la` contains the mentioned `-pthread` entry.  Apparently, this particular problem was addressed with a [patch for libtool](https://github.com/open-mpi/ompi/blob/c5709663b6acc5b8c08295b06e6c4eda3d58da41/config/ltmain_nag_pthread.diff). The patch changes ` -pthread`, which NAG compiler does not understand to ` -Wl,-pthread`, which NAG does understand. Now, `libmpi_mpifh.la` is linked with the C compiler (gcc in this case), which (conditionally) requires a convenience library `libmpi_mpifh_sizeof.la`, which is linked with the Fortran (nagfor) compiler. As a result, `libmpi_mpifh_sizeof.la` inherits the `-pthread` flag from `libhwloc.la` but stores it in the modified form as `-Wl,-pthread`. In turn, `libmpi_mpifh.la` inherits `-Wl,-pthread`, but it is linked with gcc, which interprets this as a flag to be passed to ld, and for ld, of course, `-pthread` is an invalid flag. So, we get an error.

There are two solutions (with variations) that I found for this problem. The first one, which this PR offers, is fast and simple: update the patch, so Libtool would revert `-Wl,-pthread` back to `-pthread`. The drawback of this solution is that `libmpi_usempi.la`, which is linked with the Fortran compiler, would have the original `-pthread` entry but this would also introduce the consistency between both of the Fortran interface libraries. Given that most of the users would use the MPI wrappers for linking to the MPI libraries, the contents of the `*.la` files that correspond to them are not so important (at least they are correct since the original `-pthread` inherited from hwloc remains unchanged).

The second possible solution questions the necessity of the convenience library `libmpi_mpifh_sizeof.la`. The [comment](https://github.com/open-mpi/ompi/blob/c5709663b6acc5b8c08295b06e6c4eda3d58da41/ompi/mpi/fortran/mpif-h/Makefile.am#L87-L106) says that the reason for having this library is to enforce usage of the C compiler for linking. But, as far as I know, there is a more [straightforward way](https://www.gnu.org/software/automake/manual/html_node/How-the-Linker-is-Chosen.html#How-the-Linker-is-Chosen) to do this. [Here is the implementation of that approach](https://github.com/skosukhin/ompi/commit/a35cfc3e4721d05717f1c634516e1f5e61710ce3). The only drawback of this solution that I found is that the silent rule reports `GEN libmpi_mpifh.la` instead of `CCLD libmpi_mpifh.la` but the actual actions are the same. Another way of doing almost the same but keep the message intact is to declare `libmpi_mpifh_sizeof.la` as an `EXTRA` library and link `libmpi_mpifh.la` directly to `sizeof_f.lo`. [Here is the implementation of this](https://github.com/skosukhin/ompi/commit/ca733f9f2250e40aef28b03d6c13ee5ea72155cc).

If you are interested at all, please, let me know which of the solutions you prefer and I will update the branch of this PR with the solution of choice. 