### PR TITLE
config: Remove remaining HAVE_LONG_LONG

### DIFF
--- a/config/ompi_fortran_get_value_true.m4
+++ b/config/ompi_fortran_get_value_true.m4
@@ -68,10 +68,8 @@ void ompi_print_f(ompi_fortran_logical_t * logical)
         fprintf(f, "%d\n", (int)*logical);
     } else if (SIZEOF_LONG >= sizeof(ompi_fortran_logical_t) ) {
 	fprintf(f, "%ld\n", (long) *logical);
-#ifdef HAVE_LONG_LONG
     } else if (SIZEOF_LONG_LONG >= sizeof(ompi_fortran_logical_t) ) {
         fprintf(f, "%lld\n", (long long) *logical);
-#endif
     } else {
         exit(1);
     }


### PR DESCRIPTION
In the commit cacd6f389c, I removed `#if HAVE_[TYPE]` lines for types which are always available in C99 compilers. But I forgot to remove this line. The `HAVE_LONG_LONG` macro is still defined in `confdefs.h`. So this is not a bug but code cleanup.