### PR TITLE
osc/rdma: fix when determining the node with the rank_array info for a peer

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -50,6 +50,8 @@
 
 #include "opal_stdint.h"
 
+#define RANK_ARRAY_COUNT(module) ((ompi_comm_size ((module)->comm) + (module)->node_count - 1) / (module)->node_count)
+
 enum {
     OMPI_OSC_RDMA_LOCKING_TWO_LEVEL,
     OMPI_OSC_RDMA_LOCKING_ON_DEMAND,

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -382,8 +382,6 @@ static int ompi_osc_rdma_component_query (struct ompi_win_t *win, void **base, s
     return mca_osc_rdma_component.priority;
 }
 
-#define RANK_ARRAY_COUNT(module) ((ompi_comm_size ((module)->comm) + (module)->node_count - 1) / (module)->node_count)
-
 static int ompi_osc_rdma_initialize_region (ompi_osc_rdma_module_t *module, void **base, size_t size) {
     ompi_osc_rdma_region_t *region = (ompi_osc_rdma_region_t *) module->state->regions;
     int ret;


### PR DESCRIPTION
This is a fix for the following issue.

When creating a new window, we create groups (ompi_osc_rdma_create_groups) and each local leader keeps a part of the module->rank_array, with size RANK_ARRAY_COUNT(module) = (comm_size + node_count -1) / node_count, being RANK_ARRAY_COUNT the number of process in a leader rank_array (built in ompi_osc_rdma_share_data). 

If we have a non-uniform distribution of processes in the local groups, first time we want to access a target peer, in ompi_osc_rdma_peer_setup, we calculate which leader has the rank_array for that peer, calculating the node of that leader as: 
```
          node_id = (peer->rank * module->node_count) / comm_size;
```
which I believe is incorrect and instead it should be calculated as:
```
          node_id = peer->rank / RANK_ARRAY_COUNT(module);
```
Otherwise, in the reproducer code attached, the mapping information is obtained from an incorrect group leader and subsequent calls to MPI_Get end up in MPI_ERR_RMA_RANGE.


[reproducer.gz](https://github.com/open-mpi/ompi/files/2886204/reproducer.gz)


Signed-off-by: Nuria Losada <nlosada@icl.utk.edu>