### PR TITLE
Cart/Graph create would not run the next_cid  algorithm

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1892,6 +1892,10 @@ int ompi_comm_enable(ompi_communicator_t *old_comm,
 {
     int ret = OMPI_SUCCESS;
 
+    /* set the rank information before calling nextcid */
+    new_comm->c_local_group->grp_my_rank = new_rank;
+    new_comm->c_my_rank = new_rank;
+
     /* Determine context id. It is identical to f_2_c_handle */
     ret = ompi_comm_nextcid (new_comm, old_comm, NULL, NULL, NULL, false,
                              OMPI_COMM_CID_INTRA);


### PR DESCRIPTION
Cart/Graph create would not run the next_cid algorithm and create disjoint communicator with inconsistent cid.

The problem arises from calling `comm_nextcid` before the `new_comm->c_local_grp->my_rank` is set to something else than `MPI_UNDEFINED`. This causes the nextcid algorithm to not "participate" and creates a `newcomm` with an inconsistent cid.



Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>