### PR TITLE
Update slurm pmi configury to account for pmix

### DIFF
--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -243,6 +243,7 @@ AC_DEFUN([OPAL_CHECK_PMI],[
 # OPAL_CHECK_PMIX_LIB(installdir, libdir, [action-if-valid], [action-if-not-valid])
 AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
 
+    OPAL_VAR_SCOPE_PUSH([opal_external_pmix_save_CPPFLAGS opal_external_pmix_save_LDFLAGS opal_external_pmix_save_LIBS])
     opal_external_pmix_happy=no
 
     # Make sure we have the headers and libs in the correct location
@@ -386,12 +387,12 @@ AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
     ])
     AS_IF([test "$opal_external_pmix_happy" = "yes"],
           [$3], [$4])
+
+    OPAL_VAR_SCOPE_POP
 ])
 
 
 AC_DEFUN([OPAL_CHECK_PMIX],[
-
-    OPAL_VAR_SCOPE_PUSH([opal_external_pmix_save_CPPFLAGS opal_external_pmix_save_LDFLAGS opal_external_pmix_save_LIBS])
 
     AC_ARG_WITH([pmix],
                 [AC_HELP_STRING([--with-pmix(=DIR)],
@@ -469,6 +470,4 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
                  [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PMIx support]], [opal_pmix], [External (1.2.5) WARNING - DYNAMIC OPS NOT SUPPORTED])],
                  [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PMIx support]], [opal_pmix], [External ($opal_external_pmix_version)])])],
           [OPAL_SUMMARY_ADD([[Miscellaneous]], [[PMIx support]], [opal_pmix], [Internal])])
-
-    OPAL_VAR_SCOPE_POP
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 # Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
@@ -260,6 +260,7 @@ m4_ifdef([project_oshmem],
 OPAL_CONFIGURE_OPTIONS
 OPAL_CHECK_OS_FLAVORS
 OPAL_CHECK_CUDA
+OPAL_CHECK_PMI
 OPAL_CHECK_PMIX
 m4_ifdef([project_orte], [ORTE_CONFIGURE_OPTIONS])
 m4_ifdef([project_ompi], [OMPI_CONFIGURE_OPTIONS])

--- a/opal/mca/pmix/s1/configure.m4
+++ b/opal/mca/pmix/s1/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -14,7 +14,6 @@ AC_DEFUN([MCA_opal_pmix_s1_CONFIG], [
     AC_CONFIG_FILES([opal/mca/pmix/s1/Makefile])
 
     AC_REQUIRE([OPAL_CHECK_UGNI])
-    AC_REQUIRE([OPAL_CHECK_PMI])
 
     # Evaluate succeed / fail
     AS_IF([test "$opal_enable_pmi1" = "yes" && test "$opal_check_ugni_happy" = "no"],

--- a/opal/mca/pmix/s2/configure.m4
+++ b/opal/mca/pmix/s2/configure.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2014      Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -14,7 +14,6 @@ AC_DEFUN([MCA_opal_pmix_s2_CONFIG], [
     AC_CONFIG_FILES([opal/mca/pmix/s2/Makefile])
 
     AC_REQUIRE([OPAL_CHECK_UGNI])
-    AC_REQUIRE([OPAL_CHECK_PMI])
 
     # Evaluate succeed / fail
     AS_IF([test "$opal_enable_pmi2" = "yes" && test "$opal_check_ugni_happy" = "no"],


### PR DESCRIPTION
When Slurm is built against PMIx, some installations place a copy of the
PMIx library that Slurm is linking against in the Slurm PMI location.
Current configury ignores that location. The desired behavior is to look
for a PMIx lib in that location when --with-pmi is given. If the user
also specifies --with-pmix and gives a different location, then override
anything previously found and look for it where the user directed.

Signed-off-by: Ralph Castain <rhc@pmix.org>