### PR TITLE
mpiext/shortfloat: Work around empty archives

### DIFF
--- a/ompi/mpiext/shortfloat/c/Makefile.am
+++ b/ompi/mpiext/shortfloat/c/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2018-2019 FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,5 +18,7 @@ ompidir = $(ompiincludedir)/mpiext
 ompi_HEADERS = mpiext_shortfloat_c.h
 
 # Sources for the convenience libtool library.
-libmpiext_shortfloat_c_la_SOURCES = $(ompi_HEADERS)
+libmpiext_shortfloat_c_la_SOURCES = \
+        $(ompi_HEADERS) \
+        mpiext_shortfloat_c.c
 libmpiext_shortfloat_c_la_LDFLAGS = -module -avoid-version

--- a/ompi/mpiext/shortfloat/c/mpiext_shortfloat_c.c
+++ b/ompi/mpiext/shortfloat/c/mpiext_shortfloat_c.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019      FUJITSU LIMITED.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+// This dummy function is required for the following reason.
+//
+//   - The libmpiext_shortfloat_c.la file must be built because the
+//     OMPI_EXT_MAKE_LISTS macro in the config/ompi_ext.m4 file adds
+//     the file to the list of the OMPI_MPIEXT_C_LIBS output variable
+//     and the ompi/Makefile.am file uses the output variable.
+//   - The ar command of OS X refuses to create an archive file which
+//     does not contain any object files.
+//
+// See https://github.com/open-mpi/ompi/pull/6205#issuecomment-466363071
+
+void mpiext_shortfloat_dummy(void);
+
+void mpiext_shortfloat_dummy() {
+}

--- a/ompi/mpiext/shortfloat/mpif-h/Makefile.am
+++ b/ompi/mpiext/shortfloat/mpif-h/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2018-2019 FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +30,9 @@ if OMPI_BUILD_FORTRAN_MPIFH_BINDINGS
 ompi_HEADERS += mpiext_shortfloat_mpifh.h
 
 # Sources for the convenience libtool library.
-libmpiext_shortfloat_mpifh_la_SOURCES = $(ompi_HEADERS)
+libmpiext_shortfloat_mpifh_la_SOURCES = \
+        $(ompi_HEADERS) \
+        mpiext_shortfloat_mpifh.c
 libmpiext_shortfloat_mpifh_la_LDFLAGS = -module -avoid-version
 
 endif

--- a/ompi/mpiext/shortfloat/mpif-h/mpiext_shortfloat_mpifh.c
+++ b/ompi/mpiext/shortfloat/mpif-h/mpiext_shortfloat_mpifh.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019      FUJITSU LIMITED.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+// The reason why this dummy function is required is explained in comment
+// of the ompi/mpiext/shortfloat/c/mpiext_shortfloat_c.c file.
+
+void mpiext_shortfloat_mpifh_dummy(void);
+
+void mpiext_shortfloat_mpifh_dummy() {
+}

--- a/ompi/mpiext/shortfloat/use-mpi-f08/Makefile.am
+++ b/ompi/mpiext/shortfloat/use-mpi-f08/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2018-2019 FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -36,7 +36,9 @@ noinst_LTLIBRARIES += libmpiext_shortfloat_usempif08.la
 noinst_HEADERS = mpiext_shortfloat_usempif08.h
 
 # Sources for the convenience libtool library.
-libmpiext_shortfloat_usempif08_la_SOURCES = $(ompi_HEADERS)
+libmpiext_shortfloat_usempif08_la_SOURCES = \
+        $(ompi_HEADERS) \
+        mpiext_shortfloat_usempif08.c
 libmpiext_shortfloat_usempif08_la_LDFLAGS = -module -avoid-version
 
 endif

--- a/ompi/mpiext/shortfloat/use-mpi-f08/mpiext_shortfloat_usempif08.c
+++ b/ompi/mpiext/shortfloat/use-mpi-f08/mpiext_shortfloat_usempif08.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019      FUJITSU LIMITED.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+// The reason why this dummy function is required is explained in comment
+// of the ompi/mpiext/shortfloat/c/mpiext_shortfloat_c.c file.
+
+void mpiext_shortfloat_usempif08_dummy(void);
+
+void mpiext_shortfloat_usempif08_dummy() {
+}


### PR DESCRIPTION
These dummy functions are required for the following reason.

- The `libmpiext_shortfloat_{c,mpifh,usempif08}.la` files must be built because the `OMPI_EXT_MAKE_LISTS` macro in the `config/ompi_ext.m4` file adds the files to the lists of the `OMPI_MPIEXT_{C,MPIFH,USEMPIF08}_LIBS` output variables and the following files use the output variable.
    * `ompi/Makefile.am`
    * `ompi/mpi/fortran/mpif-h/Makefile.am`
    * `ompi/mpi/fortran/use-mpi-f08/Makefile.am`
- The ar command of OS X refuses to create an archive file which does not contain any object files.

The `usempi` binding is not affected because `OMPI_MPIEXT_USEMPIF_LIBS` is not used anywhere by nature. Generally it only includes `mpifh`.

See https://github.com/open-mpi/ompi/pull/6205#issuecomment-466363071

@ggouaillardet I cannot access a macOS machine. Could you test this PR?
