### PR TITLE
OMPI/OSHMEM: bug-fix: store mkeys for each oshmem ctx.

### DIFF
--- a/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_cswap.c
@@ -40,7 +40,7 @@ int mca_atomic_ucx_cswap(shmem_ctx_t ctx,
     assert(NULL != prev);
 
     *prev      = value;
-    ucx_mkey   = mca_spml_ucx_get_mkey(ucx_ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey   = mca_spml_ucx_get_mkey(ctx, pe, target, (void *)&rva, mca_spml_self);
     status_ptr = ucp_atomic_fetch_nb(ucx_ctx->ucp_peers[pe].ucp_conn,
                                      UCP_ATOMIC_FETCH_OP_CSWAP, cond, prev, size,
                                      rva, ucx_mkey->rkey,

--- a/oshmem/mca/atomic/ucx/atomic_ucx_module.c
+++ b/oshmem/mca/atomic/ucx/atomic_ucx_module.c
@@ -47,7 +47,7 @@ int mca_atomic_ucx_op(shmem_ctx_t ctx,
 
     assert((8 == size) || (4 == size));
 
-    ucx_mkey = mca_spml_ucx_get_mkey(ucx_ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey = mca_spml_ucx_get_mkey(ctx, pe, target, (void *)&rva, mca_spml_self);
     status = ucp_atomic_post(ucx_ctx->ucp_peers[pe].ucp_conn,
                              op, value, size, rva,
                              ucx_mkey->rkey);
@@ -70,7 +70,7 @@ int mca_atomic_ucx_fop(shmem_ctx_t ctx,
 
     assert((8 == size) || (4 == size));
 
-    ucx_mkey = mca_spml_ucx_get_mkey(ucx_ctx, pe, target, (void *)&rva, mca_spml_self);
+    ucx_mkey = mca_spml_ucx_get_mkey(ctx, pe, target, (void *)&rva, mca_spml_self);
     status_ptr = ucp_atomic_fetch_nb(ucx_ctx->ucp_peers[pe].ucp_conn,
                                      op, value, prev, size,
                                      rva, ucx_mkey->rkey,

--- a/oshmem/mca/memheap/base/base.h
+++ b/oshmem/mca/memheap/base/base.h
@@ -69,7 +69,8 @@ void memheap_oob_destruct(void);
 OSHMEM_DECLSPEC int mca_memheap_base_is_symmetric_addr(const void* va);
 OSHMEM_DECLSPEC sshmem_mkey_t *mca_memheap_base_get_mkey(void* va,
                                                            int tr_id);
-OSHMEM_DECLSPEC sshmem_mkey_t * mca_memheap_base_get_cached_mkey_slow(map_segment_t *s,
+OSHMEM_DECLSPEC sshmem_mkey_t * mca_memheap_base_get_cached_mkey_slow(shmem_ctx_t ctx,
+                                                                      map_segment_t *s,
                                                                       int pe,
                                                                       void* va,
                                                                       int btl_id,
@@ -243,7 +244,8 @@ static inline map_segment_t *memheap_find_va(void* va)
     return s;
 }
 
-static inline  sshmem_mkey_t *mca_memheap_base_get_cached_mkey(int pe,
+static inline  sshmem_mkey_t *mca_memheap_base_get_cached_mkey(shmem_ctx_t ctx,
+                                                               int pe,
                                                                 void* va,
                                                                 int btl_id,
                                                                 void** rva)
@@ -273,7 +275,7 @@ static inline  sshmem_mkey_t *mca_memheap_base_get_cached_mkey(int pe,
         return mkey;
     }
 
-    return mca_memheap_base_get_cached_mkey_slow(s, pe, va, btl_id, rva);
+    return mca_memheap_base_get_cached_mkey_slow(ctx, s, pe, va, btl_id, rva);
 }
 
 static inline int mca_memheap_base_num_transports(void) 

--- a/oshmem/mca/spml/base/base.h
+++ b/oshmem/mca/spml/base/base.h
@@ -72,11 +72,12 @@ OSHMEM_DECLSPEC int mca_spml_base_test(void* addr,
                                        void* value,
                                        int datatype,
                                        int *out_value);
-OSHMEM_DECLSPEC int mca_spml_base_oob_get_mkeys(int pe,
+OSHMEM_DECLSPEC int mca_spml_base_oob_get_mkeys(shmem_ctx_t ctx,
+                                                int pe,
                                                 uint32_t seg,
                                                 sshmem_mkey_t *mkeys);
 
-OSHMEM_DECLSPEC void mca_spml_base_rmkey_unpack(sshmem_mkey_t *mkey, uint32_t seg, int pe, int tr_id);
+OSHMEM_DECLSPEC void mca_spml_base_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t seg, int pe, int tr_id);
 OSHMEM_DECLSPEC void mca_spml_base_rmkey_free(sshmem_mkey_t *mkey);
 OSHMEM_DECLSPEC void *mca_spml_base_rmkey_ptr(const void *dst_addr, sshmem_mkey_t *mkey, int pe);
 

--- a/oshmem/mca/spml/base/spml_base.c
+++ b/oshmem/mca/spml/base/spml_base.c
@@ -247,12 +247,12 @@ int mca_spml_base_wait_nb(void* handle)
     return OSHMEM_SUCCESS;
 }
 
-int mca_spml_base_oob_get_mkeys(int pe, uint32_t segno, sshmem_mkey_t *mkeys)
+int mca_spml_base_oob_get_mkeys(shmem_ctx_t ctx, int pe, uint32_t segno, sshmem_mkey_t *mkeys)
 {
     return OSHMEM_ERROR;
 }
 
-void mca_spml_base_rmkey_unpack(sshmem_mkey_t *mkey, uint32_t segno, int pe, int tr_id)
+void mca_spml_base_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t segno, int pe, int tr_id)
 {
 }
 

--- a/oshmem/mca/spml/ikrit/spml_ikrit.c
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.c
@@ -151,7 +151,7 @@ int mca_spml_ikrit_put_simple(void* dst_addr,
                               void* src_addr,
                               int dst);
 
-static void mca_spml_ikrit_cache_mkeys(sshmem_mkey_t *, uint32_t seg, int remote_pe, int tr_id);
+static void mca_spml_ikrit_cache_mkeys(shmem_ctx_t ctx, sshmem_mkey_t *, uint32_t seg, int remote_pe, int tr_id);
 
 static mxm_mem_key_t *mca_spml_ikrit_get_mkey_slow(int pe, void *va, int ptl_id, void **rva);
 
@@ -187,7 +187,7 @@ mca_spml_ikrit_t mca_spml_ikrit = {
     mca_spml_ikrit_get_mkey_slow
 };
 
-static void mca_spml_ikrit_cache_mkeys(sshmem_mkey_t *mkey, uint32_t seg, int dst_pe, int tr_id)
+static void mca_spml_ikrit_cache_mkeys(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t seg, int dst_pe, int tr_id)
 {
     mxm_peer_t *peer;
 
@@ -506,7 +506,7 @@ sshmem_mkey_t *mca_spml_ikrit_register(void* addr,
                      my_rank, i, addr, (unsigned long long)size,
                      mca_spml_base_mkey2str(&mkeys[i]));
 
-        mca_spml_ikrit_cache_mkeys(&mkeys[i], memheap_find_segnum(addr), my_rank, i);
+        mca_spml_ikrit_cache_mkeys(NULL, &mkeys[i], memheap_find_segnum(addr), my_rank, i);
     }
     *count = MXM_PTL_LAST;
 
@@ -550,7 +550,7 @@ int mca_spml_ikrit_deregister(sshmem_mkey_t *mkeys)
 
 }
 
-int mca_spml_ikrit_oob_get_mkeys(int pe, uint32_t seg, sshmem_mkey_t *mkeys)
+int mca_spml_ikrit_oob_get_mkeys(shmem_ctx_t ctx, int pe, uint32_t seg, sshmem_mkey_t *mkeys)
 {
     int ptl;
 
@@ -569,7 +569,7 @@ int mca_spml_ikrit_oob_get_mkeys(int pe, uint32_t seg, sshmem_mkey_t *mkeys)
         mkeys[ptl].len     = 0;
         mkeys[ptl].va_base = mca_memheap_seg2base_va(seg);
         mkeys[ptl].u.key   = MAP_SEGMENT_SHM_INVALID;
-        mca_spml_ikrit_cache_mkeys(&mkeys[ptl], seg, pe, ptl);
+        mca_spml_ikrit_cache_mkeys(NULL, &mkeys[ptl], seg, pe, ptl);
         return OSHMEM_SUCCESS;
     }
 

--- a/oshmem/mca/spml/ikrit/spml_ikrit.h
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.h
@@ -183,7 +183,7 @@ extern sshmem_mkey_t *mca_spml_ikrit_register(void* addr,
                                                 uint64_t shmid,
                                                 int *count);
 extern int mca_spml_ikrit_deregister(sshmem_mkey_t *mkeys);
-extern int mca_spml_ikrit_oob_get_mkeys(int pe,
+extern int mca_spml_ikrit_oob_get_mkeys(shmem_ctx_t ctx, int pe,
                                         uint32_t segno,
                                         sshmem_mkey_t *mkeys);
 

--- a/oshmem/mca/spml/spml.h
+++ b/oshmem/mca/spml/spml.h
@@ -132,7 +132,7 @@ typedef int (*mca_spml_base_module_test_fn_t)(void* addr,
  *
  * @param mkey remote mkey
  */
-typedef void (*mca_spml_base_module_mkey_unpack_fn_t)(sshmem_mkey_t *, uint32_t segno, int remote_pe, int tr_id);
+typedef void (*mca_spml_base_module_mkey_unpack_fn_t)(shmem_ctx_t ctx, sshmem_mkey_t *, uint32_t segno, int remote_pe, int tr_id);
 
 /**
  * If possible, get a pointer to the remote memory described by the mkey
@@ -180,7 +180,7 @@ typedef int (*mca_spml_base_module_deregister_fn_t)(sshmem_mkey_t *mkeys);
  *
  * @return OSHMEM_SUCCSESS if keys are found
  */
-typedef int (*mca_spml_base_module_oob_get_mkeys_fn_t)(int pe,
+typedef int (*mca_spml_base_module_oob_get_mkeys_fn_t)(shmem_ctx_t ctx, int pe,
                                                        uint32_t seg,
                                                        sshmem_mkey_t *mkeys);
 

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -81,7 +81,7 @@ struct mca_spml_ucx_ctx_list_item {
 };
 typedef struct mca_spml_ucx_ctx_list_item mca_spml_ucx_ctx_list_item_t;
 
-typedef spml_ucx_mkey_t * (*mca_spml_ucx_get_mkey_slow_fn_t)(int pe, void *va, void **rva);
+typedef spml_ucx_mkey_t * (*mca_spml_ucx_get_mkey_slow_fn_t)(shmem_ctx_t ctx, int pe, void *va, void **rva);
 
 struct mca_spml_ucx {
     mca_spml_base_module_t   super;
@@ -143,7 +143,7 @@ extern int mca_spml_ucx_deregister(sshmem_mkey_t *mkeys);
 
 extern void mca_spml_ucx_memuse_hook(void *addr, size_t length);
 
-extern void mca_spml_ucx_rmkey_unpack(sshmem_mkey_t *mkey, uint32_t segno, int pe, int tr_id);
+extern void mca_spml_ucx_rmkey_unpack(shmem_ctx_t ctx, sshmem_mkey_t *mkey, uint32_t segno, int pe, int tr_id);
 extern void mca_spml_ucx_rmkey_free(sshmem_mkey_t *mkey);
 extern void *mca_spml_ucx_rmkey_ptr(const void *dst_addr, sshmem_mkey_t *, int pe);
 
@@ -153,17 +153,52 @@ extern int mca_spml_ucx_fence(shmem_ctx_t ctx);
 extern int mca_spml_ucx_quiet(shmem_ctx_t ctx);
 extern int spml_ucx_progress(void);
 
+static void mca_spml_ucx_cache_mkey(mca_spml_ucx_ctx_t *ucx_ctx, sshmem_mkey_t *mkey, uint32_t segno, int dst_pe)
+{
+    ucp_peer_t *peer;
+
+    peer = &(ucx_ctx->ucp_peers[dst_pe]);
+    mkey_segment_init(&peer->mkeys[segno].super, mkey, segno);
+}
 
 static inline spml_ucx_mkey_t * 
-mca_spml_ucx_get_mkey(mca_spml_ucx_ctx_t *ucx_ctx, int pe, void *va, void **rva, mca_spml_ucx_t* module)
+mca_spml_ucx_get_mkey(shmem_ctx_t ctx, int pe, void *va, void **rva, mca_spml_ucx_t* module)
 {
     spml_ucx_cached_mkey_t *mkey;
+    mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 
     mkey = ucx_ctx->ucp_peers[pe].mkeys;
     mkey = (spml_ucx_cached_mkey_t *)map_segment_find_va(&mkey->super.super, sizeof(*mkey), va);
     if (OPAL_UNLIKELY(NULL == mkey)) {
-        assert(module->get_mkey_slow);
-        return module->get_mkey_slow(pe, va, rva);
+        if (ucx_ctx != &mca_spml_ucx_ctx_default && pe == oshmem_my_proc_id()) {
+            mkey = mca_spml_ucx_ctx_default.ucp_peers[pe].mkeys;
+            mkey = (spml_ucx_cached_mkey_t *)map_segment_find_va(&mkey->super.super, sizeof(*mkey), va);
+            if (OPAL_UNLIKELY(NULL == mkey)) {
+                assert(module->get_mkey_slow);
+                return module->get_mkey_slow(ctx, pe, va, rva);
+            } else {
+                uint32_t segno = memheap_find_segnum(va);
+                sshmem_mkey_t *new_mkey = (sshmem_mkey_t *)calloc(1, sizeof(*new_mkey));
+                spml_ucx_mkey_t *new_ucx_mkey = &(ucx_ctx->ucp_peers[pe].mkeys[segno].key);
+                size_t len;
+
+                new_mkey->spml_context = new_ucx_mkey;
+
+                ucp_rkey_pack(mca_spml_ucx.ucp_context, mkey->key.mem_h, 
+                              &(new_mkey->u.data), &len);
+                
+                ucp_ep_rkey_unpack(ucx_ctx->ucp_peers[pe].ucp_conn,
+                                   new_mkey->u.data, &new_ucx_mkey->rkey);
+                new_mkey->len = len;
+                new_mkey->va_base = va;
+
+                *rva = map_segment_va2rva(&mkey->super, va);
+                return new_ucx_mkey;
+            }
+        } else {
+            assert(module->get_mkey_slow);
+            return module->get_mkey_slow(ctx, pe, va, rva);
+        }
     }
     *rva = map_segment_va2rva(&mkey->super, va);
     return &mkey->key;

--- a/oshmem/shmem/c/shmem_addr_accessible.c
+++ b/oshmem/shmem/c/shmem_addr_accessible.c
@@ -31,7 +31,8 @@ int shmem_addr_accessible(const void *addr, int pe)
     RUNTIME_CHECK_INIT();
 
     for (i = 0; i < mca_memheap_base_num_transports(); i++) {
-        mkey = mca_memheap_base_get_cached_mkey(pe, (void *)addr, i, &rva);
+        /* TODO: iterate on all ctxs, try to get cached mkey */
+        mkey = mca_memheap_base_get_cached_mkey(oshmem_ctx_default, pe, (void *)addr, i, &rva);
         if (mkey) {
             return 1;
         }

--- a/oshmem/shmem/c/shmem_ptr.c
+++ b/oshmem/shmem/c/shmem_ptr.c
@@ -52,7 +52,8 @@ void *shmem_ptr(const void *dst_addr, int pe)
     }
 
     for (i = 0; i < mca_memheap_base_num_transports(); i++) {
-        mkey = mca_memheap_base_get_cached_mkey(pe, (void *)dst_addr, i, &rva);
+        /* TODO: iterate on all ctxs, try to get cached mkeys */
+        mkey = mca_memheap_base_get_cached_mkey(oshmem_ctx_default, pe, (void *)dst_addr, i, &rva);
         if (!mkey) {
             continue;
         }


### PR DESCRIPTION
Signed-off-by: Xin Zhao <xinz@mellanox.com>