### PR TITLE
in-place conversion macro writes into INPUT argument

### DIFF
--- a/ompi/mpi/fortran/mpif-h/cart_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_create_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -96,5 +97,5 @@ void ompi_cart_create_f(MPI_Fint *old_comm, MPI_Fint *ndims, MPI_Fint *dims,
      * Need to convert back into Fortran, to not surprise the user
      */
     OMPI_ARRAY_FINT_2_INT_CLEANUP(dims);
-    OMPI_ARRAY_INT_2_LOGICAL(periods, size);
+    OMPI_ARRAY_LOGICAL_2_INT_CLEANUP(periods); 
 }

--- a/ompi/mpi/fortran/mpif-h/cart_map_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_map_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,6 +90,6 @@ void ompi_cart_map_f(MPI_Fint *comm, MPI_Fint *ndims, MPI_Fint *dims,
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     OMPI_ARRAY_FINT_2_INT_CLEANUP(dims);
-    OMPI_ARRAY_INT_2_LOGICAL(periods, size);
+    OMPI_ARRAY_LOGICAL_2_INT_CLEANUP(periods); 
     OMPI_SINGLE_INT_2_FINT(newrank);
 }

--- a/ompi/mpi/fortran/mpif-h/cart_sub_f.c
+++ b/ompi/mpi/fortran/mpif-h/cart_sub_f.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -101,5 +102,5 @@ void ompi_cart_sub_f(MPI_Fint *comm, ompi_fortran_logical_t *remain_dims,
         *new_comm = PMPI_Comm_c2f(c_new_comm);
     }
 
-    OMPI_ARRAY_INT_2_LOGICAL(remain_dims, ndims);
+    OMPI_ARRAY_LOGICAL_2_INT_CLEANUP(remain_dims); 
 }


### PR DESCRIPTION
In fint_2_int.h there are some conversion macros for logicals. It has
one path for OMPI_SIZEOF_FORTRAN_LOGICAL != SIZEOF_INT where a new array
would be allocated and the conversions then might expand to
```    c_array[i] = (array[i] == 0 ? 0 : 1)```
and another path for OMPI_SIZEOF_FORTRAN_LOGICAL == SIZEOF_INT where it
does things "in place", so the same conversion there would just be
```    array[i] = (array[i] == 0 ? 0 : 1)```

The problem is some of the logical arrays being converted are INPUT
arguments. And it's possible for some compilers to even put the argument
in read-only memory so the above "in place" conversion SEGV's.  A
testcase I have used
```    call MPI_CART_SUB(oldcomm, (/.true.,.false./), newcomm, ierr)```
and gfortran put the second arg in read-only mem.

In cart_sub_f.c you can trace the ompi_fortran_logical_t *remain_dims arg.
remain_dims[] is for input only, but the file uses
```
    OMPI_LOGICAL_ARRAY_NAME_DECL(remain_dims);
    OMPI_ARRAY_LOGICAL_2_INT(remain_dims, ndims);
    PMPI_Cart_sub(..., OMPI_LOGICAL_ARRAY_NAME_CONVERT(remain_dims), ...);
    OMPI_ARRAY_INT_2_LOGICAL(remain_dims, ndims);
```
to convert it to c-ints make a C call then restore it to Fortran logicals
before returning.

It's not always wrong to convert purely in-place, eg cart_get_f.c has
a periods[] that's exclusively for OUTPUT and it would be fine with the
macros as they were. But I still say the macros are invalid because they
don't distinguish whether they're being used on INPUT or OUTPUT args and
thus they can't be used in a way that's legal for both cases.

It might be possible to fix the macros by adding more of them so that
cart_create_f.c and cart_get_f.c would use different macros that give
more context. But my fix here is just to turn off the first block and
make all paths run as if OMPI_SIZEOF_FORTRAN_LOGICAL != SIZEOF_INT.

The main macros that get enlarged by this change are
```
    define OMPI_ARRAY_LOGICAL_2_INT_ALLOC : mallocs now
    define OMPI_ARRAY_LOGICAL_2_INT : also mallocs now
```
But these are only used in 4 places, three of which are the purpose of
this checkin, to avoid the former in-place expansion of an INPUT arg:
```
    cart_create_f.c
    cart_map_f.c
    cart_sub_f.c
```
and one of which is an OUPUT arg that was fine and that gets
unnecessarily expanded into a separate array by this checkin.
```
    cart_get_f.c
```

So I think an unnecessary malloc in cart_get_f.c is the only downside
to this change, where the logicals array argument could have been used
and converted in place.