### PR TITLE
v3.1.x: Fix typo in PMIx atomics

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/atomics/sys/gcc_builtin/atomic.h
+++ b/opal/mca/pmix/pmix2x/pmix/src/atomics/sys/gcc_builtin/atomic.h
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -60,7 +60,7 @@ static inline void pmix_atomic_mb(void)
 
 static inline void pmix_atomic_rmb(void)
 {
-#if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
+#if PMIX_ASSEMBLY_ARCH == PMIX_X86_64
     /* work around a bug in older gcc versions where ACQUIRE seems to get
      * treated as a no-op instead of being equivalent to
      * __asm__ __volatile__("": : :"memory") */


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 77130996ecee0b8c0f9b6a844738b3e25fbb0fbc)