### PR TITLE
opal/datatype: correctly handle large datatypes - v4.0

### DIFF
--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2013-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2013-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
@@ -330,7 +330,7 @@ static inline int opal_convertor_create_stack_with_pos_contig( opal_convertor_t*
     dt_stack_t* pStack;   /* pointer to the position on the stack */
     const opal_datatype_t* pData = pConvertor->pDesc;
     dt_elem_desc_t* pElems;
-    uint32_t count;
+    size_t count;
     ptrdiff_t extent;
 
     pStack = pConvertor->pStack;
@@ -340,7 +340,7 @@ static inline int opal_convertor_create_stack_with_pos_contig( opal_convertor_t*
      */
     pElems = pConvertor->use_desc->desc;
 
-    count = (uint32_t)(starting_point / pData->size);
+    count = starting_point / pData->size;
     extent = pData->ub - pData->lb;
 
     pStack[0].type     = OPAL_DATATYPE_LOOP;  /* the first one is always the loop */
@@ -349,7 +349,7 @@ static inline int opal_convertor_create_stack_with_pos_contig( opal_convertor_t*
     pStack[0].disp     = count * extent;
 
     /* now compute the number of pending bytes */
-    count = (uint32_t)(starting_point - count * pData->size);
+    count = starting_point - count * pData->size;
     /**
      * We save the current displacement starting from the begining
      * of this data.
@@ -563,7 +563,7 @@ size_t opal_convertor_compute_remote_size( opal_convertor_t* pConvertor )
 
 int32_t opal_convertor_prepare_for_recv( opal_convertor_t* convertor,
                                          const struct opal_datatype_t* datatype,
-                                         int32_t count,
+                                         size_t count,
                                          const void* pUserBuf )
 {
     /* Here I should check that the data is not overlapping */
@@ -605,7 +605,7 @@ int32_t opal_convertor_prepare_for_recv( opal_convertor_t* convertor,
 
 int32_t opal_convertor_prepare_for_send( opal_convertor_t* convertor,
                                          const struct opal_datatype_t* datatype,
-                                         int32_t count,
+                                         size_t count,
                                          const void* pUserBuf )
 {
     convertor->flags |= CONVERTOR_SEND;
@@ -699,11 +699,11 @@ int opal_convertor_clone( const opal_convertor_t* source,
 
 void opal_convertor_dump( opal_convertor_t* convertor )
 {
-    opal_output( 0, "Convertor %p count %d stack position %d bConverted %ld\n"
-                 "\tlocal_size %ld remote_size %ld flags %X stack_size %d pending_length %d\n"
+    opal_output( 0, "Convertor %p count %" PRIsize_t" stack position %d bConverted %" PRIsize_t "\n"
+                 "\tlocal_size %ld remote_size %ld flags %X stack_size %d pending_length %" PRIsize_t "\n"
                  "\tremote_arch %u local_arch %u\n",
                  (void*)convertor,
-                 convertor->count, convertor->stack_pos, (unsigned long)convertor->bConverted,
+                 convertor->count, convertor->stack_pos, convertor->bConverted,
                  (unsigned long)convertor->local_size, (unsigned long)convertor->remote_size,
                  convertor->flags, convertor->stack_size, convertor->partial_length,
                  convertor->remoteArch, opal_local_arch );
@@ -734,8 +734,8 @@ void opal_datatype_dump_stack( const dt_stack_t* pStack, int stack_pos,
 {
     opal_output( 0, "\nStack %p stack_pos %d name %s\n", (void*)pStack, stack_pos, name );
     for( ; stack_pos >= 0; stack_pos-- ) {
-        opal_output( 0, "%d: pos %d count %d disp %ld ", stack_pos, pStack[stack_pos].index,
-                     (int)pStack[stack_pos].count, (long)pStack[stack_pos].disp );
+        opal_output( 0, "%d: pos %d count %" PRIsize_t " disp %ld ", stack_pos, pStack[stack_pos].index,
+                     pStack[stack_pos].count, pStack[stack_pos].disp );
         if( pStack->index != -1 )
             opal_output( 0, "\t[desc count %lu disp %ld extent %ld]\n",
                          (unsigned long)pDesc[pStack[stack_pos].index].elem.count,

--- a/opal/datatype/opal_convertor.h
+++ b/opal/datatype/opal_convertor.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
@@ -74,6 +74,7 @@ struct opal_convertor_master_t;
 struct dt_stack_t {
     int32_t           index;    /**< index in the element description */
     int16_t           type;     /**< the type used for the last pack/unpack (original or OPAL_DATATYPE_UINT1) */
+    int16_t           padding;
     size_t            count;    /**< number of times we still have to do it */
     ptrdiff_t         disp;     /**< actual displacement depending on the count field */
 };
@@ -94,7 +95,8 @@ struct opal_convertor_t {
     const dt_type_desc_t*         use_desc;       /**< the version used by the convertor (normal or optimized) */
     opal_datatype_count_t         count;          /**< the total number of full datatype elements */
     uint32_t                      stack_size;     /**< size of the allocated stack */
-    /* --- cacheline 1 boundary (64 bytes) --- */
+
+    /* --- cacheline boundary (64 bytes - if 64bits arch and !OPAL_ENABLE_DEBUG) --- */
     unsigned char*                pBaseBuf;       /**< initial buffer as supplied by the user */
     dt_stack_t*                   pStack;         /**< the local stack for the actual conversion */
     convertor_advance_fct_t       fAdvance;       /**< pointer to the pack/unpack functions */
@@ -102,21 +104,19 @@ struct opal_convertor_t {
 
     /* All others fields get modified for every call to pack/unpack functions */
     uint32_t                      stack_pos;      /**< the actual position on the stack */
-    uint32_t                      partial_length; /**< amount of data left over from the last unpack */
+    size_t                        partial_length; /**< amount of data left over from the last unpack */
     size_t                        bConverted;     /**< # of bytes already converted */
     uint32_t                      checksum;       /**< checksum computed by pack/unpack operation */
     uint32_t                      csum_ui1;       /**< partial checksum computed by pack/unpack operation */
     size_t                        csum_ui2;       /**< partial checksum computed by pack/unpack operation */
-     /* --- cacheline 2 boundary (128 bytes) --- */
+
+    /* --- fields are no more aligned on cacheline --- */
     dt_stack_t                    static_stack[DT_STATIC_STACK_SIZE];  /**< local stack for small datatypes */
-    /* --- cacheline 3 boundary (192 bytes) was 56 bytes ago --- */
 
 #if OPAL_CUDA_SUPPORT
     memcpy_fct_t                  cbmemcpy;       /**< memcpy or cuMemcpy */
     void *                        stream;         /**< CUstream for async copy */
 #endif
-    /* size: 248, cachelines: 4, members: 20 */
-    /* last cacheline: 56 bytes */
 };
 OPAL_DECLSPEC OBJ_CLASS_DECLARATION( opal_convertor_t );
 
@@ -251,12 +251,12 @@ static inline void opal_convertor_get_offset_pointer( const opal_convertor_t* pC
  */
 OPAL_DECLSPEC int32_t opal_convertor_prepare_for_send( opal_convertor_t* convertor,
                                                        const struct opal_datatype_t* datatype,
-                                                       int32_t count,
+                                                       size_t count,
                                                        const void* pUserBuf);
 
 static inline int32_t opal_convertor_copy_and_prepare_for_send( const opal_convertor_t* pSrcConv,
                                                                 const struct opal_datatype_t* datatype,
-                                                                int32_t count,
+                                                                size_t count,
                                                                 const void* pUserBuf,
                                                                 int32_t flags,
                                                                 opal_convertor_t* convertor )
@@ -273,11 +273,11 @@ static inline int32_t opal_convertor_copy_and_prepare_for_send( const opal_conve
  */
 OPAL_DECLSPEC int32_t opal_convertor_prepare_for_recv( opal_convertor_t* convertor,
                                                        const struct opal_datatype_t* datatype,
-                                                       int32_t count,
+                                                       size_t count,
                                                        const void* pUserBuf );
 static inline int32_t opal_convertor_copy_and_prepare_for_recv( const opal_convertor_t* pSrcConv,
                                                                 const struct opal_datatype_t* datatype,
-                                                                int32_t count,
+                                                                size_t count,
                                                                 const void* pUserBuf,
                                                                 int32_t flags,
                                                                 opal_convertor_t* convertor )

--- a/opal/datatype/opal_convertor.h
+++ b/opal/datatype/opal_convertor.h
@@ -94,18 +94,22 @@ struct opal_convertor_t {
     const opal_datatype_t*        pDesc;          /**< the datatype description associated with the convertor */
     const dt_type_desc_t*         use_desc;       /**< the version used by the convertor (normal or optimized) */
     opal_datatype_count_t         count;          /**< the total number of full datatype elements */
-    uint32_t                      stack_size;     /**< size of the allocated stack */
 
     /* --- cacheline boundary (64 bytes - if 64bits arch and !OPAL_ENABLE_DEBUG) --- */
+    uint32_t                      stack_size;     /**< size of the allocated stack */
     unsigned char*                pBaseBuf;       /**< initial buffer as supplied by the user */
     dt_stack_t*                   pStack;         /**< the local stack for the actual conversion */
     convertor_advance_fct_t       fAdvance;       /**< pointer to the pack/unpack functions */
+
+    /* --- cacheline boundary (96 bytes - if 64bits arch and !OPAL_ENABLE_DEBUG) --- */
     struct opal_convertor_master_t* master;       /**< the master convertor */
 
     /* All others fields get modified for every call to pack/unpack functions */
     uint32_t                      stack_pos;      /**< the actual position on the stack */
     size_t                        partial_length; /**< amount of data left over from the last unpack */
     size_t                        bConverted;     /**< # of bytes already converted */
+
+    /* --- cacheline boundary (128 bytes - if 64bits arch and !OPAL_ENABLE_DEBUG) --- */
     uint32_t                      checksum;       /**< checksum computed by pack/unpack operation */
     uint32_t                      csum_ui1;       /**< partial checksum computed by pack/unpack operation */
     size_t                        csum_ui2;       /**< partial checksum computed by pack/unpack operation */

--- a/opal/datatype/opal_convertor_raw.c
+++ b/opal/datatype/opal_convertor_raw.c
@@ -43,11 +43,11 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
     const opal_datatype_t *pData = pConvertor->pDesc;
     dt_stack_t* pStack;       /* pointer to the position on the stack */
     uint32_t pos_desc;        /* actual position in the description of the derived datatype */
-    uint32_t count_desc;      /* the number of items already done in the actual pos_desc */
+    size_t count_desc;        /* the number of items already done in the actual pos_desc */
     dt_elem_desc_t* description, *pElem;
     unsigned char *source_base;  /* origin of the data */
     size_t raw_data = 0;      /* sum of raw data lengths in the iov_len fields */
-    uint32_t index = 0, i;    /* the iov index and a simple counter */
+    uint32_t index = 0;       /* the iov index and a simple counter */
 
     assert( (*iov_count) > 0 );
     if( OPAL_LIKELY(pConvertor->flags & CONVERTOR_COMPLETED) ) {
@@ -83,15 +83,15 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
     pStack = pConvertor->pStack + pConvertor->stack_pos;
     pos_desc     = pStack->index;
     source_base  = pConvertor->pBaseBuf + pStack->disp;
-    count_desc   = (uint32_t)pStack->count;
+    count_desc   = pStack->count;
     pStack--;
     pConvertor->stack_pos--;
     pElem = &(description[pos_desc]);
     source_base += pStack->disp;
-    DO_DEBUG( opal_output( 0, "raw start pos_desc %d count_desc %d disp %ld\n"
-                           "stack_pos %d pos_desc %d count_desc %d disp %ld\n",
+    DO_DEBUG( opal_output( 0, "raw start pos_desc %d count_desc %" PRIsize_t " disp %ld\n"
+                           "stack_pos %d pos_desc %d count_desc %" PRIsize_t " disp %ld\n",
                            pos_desc, count_desc, (long)(source_base - pConvertor->pBaseBuf),
-                           pConvertor->stack_pos, pStack->index, (int)pStack->count, (long)pStack->disp ); );
+                           pConvertor->stack_pos, pStack->index, pStack->count, (long)pStack->disp ); );
     while( 1 ) {
         while( pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA ) {
             size_t blength = opal_datatype_basicDatatypes[pElem->elem.common.type]->size;
@@ -112,7 +112,7 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
                     count_desc = 0;
                 }
             } else {
-                for( i = count_desc; (i > 0) && (index < *iov_count); i--, index++ ) {
+                for(size_t i = count_desc; (i > 0) && (index < *iov_count); i--, index++ ) {
                     OPAL_DATATYPE_SAFEGUARD_POINTER( source_base, blength, pConvertor->pBaseBuf,
                                                 pConvertor->pDesc, pConvertor->count );
                     DO_DEBUG( opal_output( 0, "raw 2. iov[%d] = {base %p, length %" PRIsize_t "}\n",
@@ -134,9 +134,9 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
             goto complete_loop;
         }
         if( OPAL_DATATYPE_END_LOOP == pElem->elem.common.type ) { /* end of the current loop */
-            DO_DEBUG( opal_output( 0, "raw end_loop count %d stack_pos %d"
+            DO_DEBUG( opal_output( 0, "raw end_loop count %" PRIsize_t " stack_pos %d"
                                    " pos_desc %d disp %ld space %lu\n",
-                                   (int)pStack->count, pConvertor->stack_pos,
+                                   pStack->count, pConvertor->stack_pos,
                                    pos_desc, (long)pStack->disp, (unsigned long)raw_data ); );
             if( --(pStack->count) == 0 ) { /* end of loop */
                 if( pConvertor->stack_pos == 0 ) {
@@ -160,9 +160,9 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
             }
             source_base = pConvertor->pBaseBuf + pStack->disp;
             UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
-            DO_DEBUG( opal_output( 0, "raw new_loop count %d stack_pos %d "
+            DO_DEBUG( opal_output( 0, "raw new_loop count %" PRIsize_t " stack_pos %d "
                                    "pos_desc %d disp %ld space %lu\n",
-                                   (int)pStack->count, pConvertor->stack_pos,
+                                   pStack->count, pConvertor->stack_pos,
                                    pos_desc, (long)pStack->disp, (unsigned long)raw_data ); );
         }
         if( OPAL_DATATYPE_LOOP == pElem->elem.common.type ) {
@@ -170,9 +170,8 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
             ddt_endloop_desc_t* end_loop = (ddt_endloop_desc_t*)(pElem + pElem->loop.items);
 
             if( pElem->loop.common.flags & OPAL_DATATYPE_FLAG_CONTIGUOUS ) {
-                ptrdiff_t offset = end_loop->first_elem_disp;
-                source_base += offset;
-                for(uint32_t i = MIN(count_desc, *iov_count - index); i > 0; i--, index++ ) {
+                source_base += end_loop->first_elem_disp;
+                for(size_t i = count_desc; (i > 0) && (index < *iov_count); i--, index++ ) {
                     OPAL_DATATYPE_SAFEGUARD_POINTER( source_base, end_loop->size, pConvertor->pBaseBuf,
                                                 pConvertor->pDesc, pConvertor->count );
                     iov[index].iov_base = (IOVBASE_TYPE *) source_base;
@@ -185,7 +184,7 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
                                            index, iov[index].iov_base, iov[index].iov_len,
                                            (unsigned long)raw_data, pos_desc ); );
                 }
-                source_base -= offset;
+                source_base += end_loop->first_elem_disp;
                 if( 0 == count_desc ) {  /* completed */
                     pos_desc += pElem->loop.items + 1;
                     goto update_loop_description;
@@ -216,7 +215,7 @@ complete_loop:
     /* I complete an element, next step I should go to the next one */
     PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_UINT1, count_desc,
                 source_base - pStack->disp - pConvertor->pBaseBuf );
-    DO_DEBUG( opal_output( 0, "raw save stack stack_pos %d pos_desc %d count_desc %d disp %ld\n",
-                           pConvertor->stack_pos, pStack->index, (int)pStack->count, (long)pStack->disp ); );
+    DO_DEBUG( opal_output( 0, "raw save stack stack_pos %d pos_desc %d count_desc %" PRIsize_t " disp %ld\n",
+                           pConvertor->stack_pos, pStack->index, pStack->count, (long)pStack->disp ); );
     return 0;
 }

--- a/opal/datatype/opal_copy_functions.c
+++ b/opal/datatype/opal_copy_functions.c
@@ -4,8 +4,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -39,18 +39,17 @@
  * Return value: Number of elements of type TYPE copied
  */
 #define COPY_TYPE( TYPENAME, TYPE, COUNT )                                              \
-static int copy_##TYPENAME( opal_convertor_t *pConvertor, uint32_t count,               \
-                            char* from, size_t from_len, ptrdiff_t from_extent, \
-                            char* to, size_t to_len, ptrdiff_t to_extent,       \
-                            ptrdiff_t *advance)                                 \
+static int copy_##TYPENAME( opal_convertor_t *pConvertor, size_t count,                 \
+                            char* from, size_t from_len, ptrdiff_t from_extent,         \
+                            char* to, size_t to_len, ptrdiff_t to_extent,               \
+                            ptrdiff_t *advance)                                         \
 {                                                                                       \
-    uint32_t i;                                                                         \
     size_t remote_TYPE_size = sizeof(TYPE) * (COUNT); /* TODO */                        \
     size_t local_TYPE_size = (COUNT) * sizeof(TYPE);                                    \
                                                                                         \
     /* make sure the remote buffer is large enough to hold the data */                  \
     if( (remote_TYPE_size * count) > from_len ) {                                       \
-        count = (uint32_t)(from_len / remote_TYPE_size);                                \
+        count = from_len / remote_TYPE_size;                                            \
         if( (count * remote_TYPE_size) != from_len ) {                                  \
             DUMP( "oops should I keep this data somewhere (excedent %d bytes)?\n",      \
                   from_len - (count * remote_TYPE_size) );                              \
@@ -67,7 +66,7 @@ static int copy_##TYPENAME( opal_convertor_t *pConvertor, uint32_t count,       
         MEMCPY( to, from, count * local_TYPE_size );                                    \
     } else {                                                                            \
         /* source or destination are non-contigous */                                   \
-        for( i = 0; i < count; i++ ) {                                                  \
+        for(size_t i = 0; i < count; i++ ) {                                            \
             MEMCPY( to, from, local_TYPE_size );                                        \
             to += to_extent;                                                            \
             from += from_extent;                                                        \
@@ -92,17 +91,16 @@ static int copy_##TYPENAME( opal_convertor_t *pConvertor, uint32_t count,       
  * Return value: Number of elements of type TYPE copied
  */
 #define COPY_CONTIGUOUS_BYTES( TYPENAME, COUNT )                                          \
-static int copy_##TYPENAME##_##COUNT( opal_convertor_t *pConvertor, uint32_t count,       \
-                                      char* from, size_t from_len, ptrdiff_t from_extent, \
-                                      char* to, size_t to_len, ptrdiff_t to_extent,       \
-                                      ptrdiff_t *advance )              \
+static size_t copy_##TYPENAME##_##COUNT( opal_convertor_t *pConvertor, size_t count,         \
+                                         char* from, size_t from_len, ptrdiff_t from_extent, \
+                                         char* to, size_t to_len, ptrdiff_t to_extent,       \
+                                         ptrdiff_t *advance )              \
 {                                                                               \
-    uint32_t i;                                                                 \
     size_t remote_TYPE_size = (size_t)(COUNT); /* TODO */                       \
     size_t local_TYPE_size = (size_t)(COUNT);                                   \
                                                                                 \
     if( (remote_TYPE_size * count) > from_len ) {                               \
-        count = (uint32_t)(from_len / remote_TYPE_size);                        \
+        count = from_len / remote_TYPE_size;                                    \
         if( (count * remote_TYPE_size) != from_len ) {                          \
             DUMP( "oops should I keep this data somewhere (excedent %d bytes)?\n", \
                   from_len - (count * remote_TYPE_size) );                      \
@@ -117,7 +115,7 @@ static int copy_##TYPENAME##_##COUNT( opal_convertor_t *pConvertor, uint32_t cou
         (to_extent == (ptrdiff_t)remote_TYPE_size) ) {                  \
         MEMCPY( to, from, count * local_TYPE_size );                            \
     } else {                                                                    \
-        for( i = 0; i < count; i++ ) {                                          \
+        for(size_t i = 0; i < count; i++ ) {                                    \
             MEMCPY( to, from, local_TYPE_size );                                \
             to += to_extent;                                                    \
             from += from_extent;                                                \

--- a/opal/datatype/opal_copy_functions_heterogeneous.c
+++ b/opal/datatype/opal_copy_functions_heterogeneous.c
@@ -4,9 +4,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -140,12 +139,12 @@ opal_dt_swap_long_double(void *to_p, const void *from_p, const size_t size, size
 
 #define COPY_TYPE_HETEROGENEOUS_INTERNAL( TYPENAME, TYPE, LONG_DOUBLE )                   \
 static int32_t                                                                            \
-copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,             \
+copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, size_t count,               \
                                 const char* from, size_t from_len, ptrdiff_t from_extent, \
                                 char* to, size_t to_length, ptrdiff_t to_extent,          \
                                 ptrdiff_t *advance)             \
 {                                                                       \
-    uint32_t i;                                                         \
+    size_t i;                                                           \
                                                                         \
     datatype_check( #TYPE, sizeof(TYPE), sizeof(TYPE), &count,          \
                    from, from_len, from_extent,                         \
@@ -188,12 +187,12 @@ copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,   
 
 #define COPY_2SAMETYPE_HETEROGENEOUS_INTERNAL( TYPENAME, TYPE, LONG_DOUBLE)                 \
 static int32_t                                                                            \
-copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,             \
+copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, size_t count,               \
                                 const char* from, size_t from_len, ptrdiff_t from_extent, \
                                 char* to, size_t to_length, ptrdiff_t to_extent,          \
                                 ptrdiff_t *advance)             \
 {                                                                       \
-    uint32_t i;                                                         \
+    size_t i;                                                           \
                                                                         \
     datatype_check( #TYPE, sizeof(TYPE), sizeof(TYPE), &count,          \
                    from, from_len, from_extent,                         \
@@ -233,12 +232,12 @@ copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,   
 
 #define COPY_2TYPE_HETEROGENEOUS( TYPENAME, TYPE1, TYPE2 )              \
 static int32_t                                                          \
-copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count, \
-                                const char* from, uint32_t from_len, ptrdiff_t from_extent, \
-                                char* to, uint32_t to_length, ptrdiff_t to_extent, \
+copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, size_t count, \
+                                const char* from, size_t from_len, ptrdiff_t from_extent, \
+                                char* to, size_t to_length, ptrdiff_t to_extent, \
                                 ptrdiff_t *advance)             \
 {                                                                       \
-    uint32_t i;                                                         \
+    size_t i;                                                           \
                                                                         \
     datatype_check( #TYPENAME, sizeof(TYPE1) + sizeof(TYPE2),           \
                    sizeof(TYPE1) + sizeof(TYPE2), &count,               \
@@ -276,13 +275,13 @@ copy_##TYPENAME##_heterogeneous(opal_convertor_t *pConvertor, uint32_t count, \
 
 
 static inline void
-datatype_check(char *type, size_t local_size, size_t remote_size, uint32_t *count,
+datatype_check(char *type, size_t local_size, size_t remote_size, size_t *count,
                const char* from, size_t from_len, ptrdiff_t from_extent,
                char* to, size_t to_len, ptrdiff_t to_extent)
 {
     /* make sure the remote buffer is large enough to hold the data */
     if( (remote_size * *count) > from_len ) {
-        *count = (uint32_t)(from_len / remote_size);
+        *count = from_len / remote_size;
         if( (*count * remote_size) != from_len ) {
             DUMP( "oops should I keep this data somewhere (excedent %d bytes)?\n",
                   from_len - (*count * remote_size) );
@@ -296,20 +295,18 @@ datatype_check(char *type, size_t local_size, size_t remote_size, uint32_t *coun
 }
 
 #define CXX_BOOL_COPY_LOOP(TYPE)                        \
-    for( i = 0; i < count; i++ ) {                      \
+    for(size_t i = 0; i < count; i++ ) {                \
         bool *to_real = (bool*) to;                     \
         *to_real = *((TYPE*) from) == 0 ? false : true; \
         to += to_extent;                                \
         from += from_extent;                            \
     }
 static int32_t
-copy_cxx_bool_heterogeneous(opal_convertor_t *pConvertor, uint32_t count,
-                            const char* from, uint32_t from_len, ptrdiff_t from_extent,
-                            char* to, uint32_t to_length, ptrdiff_t to_extent,
+copy_cxx_bool_heterogeneous(opal_convertor_t *pConvertor, size_t count,
+                            const char* from, size_t from_len, ptrdiff_t from_extent,
+                            char* to, size_t to_length, ptrdiff_t to_extent,
                             ptrdiff_t *advance)
 {
-    uint32_t i;
-
     /* fix up the from extent */
     if ((pConvertor->remoteArch & OPAL_ARCH_BOOLISxx) !=
         (opal_local_arch & OPAL_ARCH_BOOLISxx)) {

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -86,7 +86,7 @@ BEGIN_C_DECLS
  * associated type.
  */
 #define MAX_DT_COMPONENT_COUNT UINT_MAX
-typedef uint32_t opal_datatype_count_t;
+typedef size_t opal_datatype_count_t;
 
 typedef union dt_elem_desc dt_elem_desc_t;
 

--- a/opal/datatype/opal_datatype.h
+++ b/opal/datatype/opal_datatype.h
@@ -119,7 +119,6 @@ struct opal_datatype_t {
 
     /* Attribute fields */
     char               name[OPAL_MAX_OBJECT_NAME];  /**< name of the datatype */
-    /* --- cacheline 2 boundary (128 bytes) was 8-12 bytes ago --- */
     dt_type_desc_t     desc;     /**< the data description */
     dt_type_desc_t     opt_desc; /**< short description of the data used when conversion is useless
                                       or in the send case (without conversion) */

--- a/opal/datatype/opal_datatype_copy.h
+++ b/opal/datatype/opal_datatype_copy.h
@@ -4,8 +4,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,12 +43,12 @@ static inline void _predefined_data( const dt_elem_desc_t* ELEM,
                                      const opal_datatype_t* DATATYPE,
                                      unsigned char* SOURCE_BASE,
                                      size_t TOTAL_COUNT,
-                                     uint32_t COUNT,
+                                     size_t COUNT,
                                      unsigned char* SOURCE,
                                      unsigned char* DESTINATION,
                                      size_t* SPACE )
 {
-    uint32_t _copy_count = (COUNT);
+    size_t _copy_count = (COUNT);
     size_t _copy_blength;
     const ddt_elem_desc_t* _elem = &((ELEM)->elem);
     unsigned char* _source = (SOURCE) + _elem->disp;
@@ -56,19 +56,18 @@ static inline void _predefined_data( const dt_elem_desc_t* ELEM,
 
     _copy_blength = opal_datatype_basicDatatypes[_elem->common.type]->size;
 
-    if( _copy_blength == (uint32_t)_elem->extent ) {
+    if( _copy_blength == (size_t)_elem->extent ) {
         _copy_blength *= _copy_count;
         OPAL_DATATYPE_SAFEGUARD_POINTER( _source, _copy_blength, (SOURCE_BASE),
                                     (DATATYPE), (TOTAL_COUNT) );
         /* the extent and the size of the basic datatype are equals */
-        DO_DEBUG( opal_output( 0, "copy 1. %s( %p, %p, %lu ) => space %lu\n",
-                               STRINGIFY(MEM_OP_NAME), (void*)_destination, (void*)_source, (unsigned long)_copy_blength, (unsigned long)(*(SPACE)) ); );
+        DO_DEBUG( opal_output( 0, "copy 1. %s( %p, %p, %" PRIsize_t " ) => space %" PRIsize_t "\n",
+                               STRINGIFY(MEM_OP_NAME), (void*)_destination, (void*)_source, _copy_blength, *(SPACE) ); );
         MEM_OP( _destination, _source, _copy_blength );
         _source      += _copy_blength;
         _destination += _copy_blength;
     } else {
-        uint32_t _i;
-        for( _i = 0; _i < _copy_count; _i++ ) {
+        for(size_t _i = 0; _i < _copy_count; _i++ ) {
             OPAL_DATATYPE_SAFEGUARD_POINTER( _source, _copy_blength, (SOURCE_BASE),
                                         (DATATYPE), (TOTAL_COUNT) );
             DO_DEBUG( opal_output( 0, "copy 2. %s( %p, %p, %lu ) => space %lu\n",
@@ -86,7 +85,7 @@ static inline void _contiguous_loop( const dt_elem_desc_t* ELEM,
                                      const opal_datatype_t* DATATYPE,
                                      unsigned char* SOURCE_BASE,
                                      size_t TOTAL_COUNT,
-                                     uint32_t COUNT,
+                                     size_t COUNT,
                                      unsigned char* SOURCE,
                                      unsigned char* DESTINATION,
                                      size_t* SPACE )
@@ -96,7 +95,6 @@ static inline void _contiguous_loop( const dt_elem_desc_t* ELEM,
     unsigned char* _source = (SOURCE) + _end_loop->first_elem_disp;
     unsigned char* _destination = (DESTINATION) + _end_loop->first_elem_disp;
     size_t _copy_loops = (COUNT);
-    uint32_t _i;
 
     if( _loop->extent == (ptrdiff_t)_end_loop->size ) {  /* the loop is contiguous */
         _copy_loops *= _end_loop->size;
@@ -104,11 +102,11 @@ static inline void _contiguous_loop( const dt_elem_desc_t* ELEM,
                                     (DATATYPE), (TOTAL_COUNT) );
         MEM_OP( _destination, _source, _copy_loops );
     } else {
-        for( _i = 0; _i < _copy_loops; _i++ ) {
+        for(size_t _i = 0; _i < _copy_loops; _i++ ) {
             OPAL_DATATYPE_SAFEGUARD_POINTER( _source, _end_loop->size, (SOURCE_BASE),
                                         (DATATYPE), (TOTAL_COUNT) );
-            DO_DEBUG( opal_output( 0, "copy 3. %s( %p, %p, %lu ) => space %lu\n",
-                                   STRINGIFY(MEM_OP_NAME), (void*)_destination, (void*)_source, (unsigned long)_end_loop->size, (unsigned long)(*(SPACE) - _i * _end_loop->size) ); );
+            DO_DEBUG( opal_output( 0, "copy 3. %s( %p, %p, %" PRIsize_t " ) => space %" PRIsize_t "\n",
+                                   STRINGIFY(MEM_OP_NAME), (void*)_destination, (void*)_source, _end_loop->size, *(SPACE) - _i * _end_loop->size ); );
             MEM_OP( _destination, _source, _end_loop->size );
             _source      += _loop->extent;
             _destination += _loop->extent;
@@ -207,8 +205,8 @@ static inline int32_t _copy_content_same_ddt( const opal_datatype_t* datatype, i
             UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
         }
         if( OPAL_DATATYPE_END_LOOP == pElem->elem.common.type ) { /* end of the current loop */
-            DO_DEBUG( opal_output( 0, "copy end_loop count %d stack_pos %d pos_desc %d disp %ld space %lu\n",
-                                   (int)pStack->count, stack_pos, pos_desc, (long)pStack->disp, (unsigned long)iov_len_local ); );
+            DO_DEBUG( opal_output( 0, "copy end_loop count %" PRIsize_t " stack_pos %d pos_desc %d disp %ld space %lu\n",
+                                   pStack->count, stack_pos, pos_desc, pStack->disp, (unsigned long)iov_len_local ); );
             if( --(pStack->count) == 0 ) { /* end of loop */
                 if( stack_pos == 0 ) {
                     assert( iov_len_local == 0 );
@@ -229,8 +227,8 @@ static inline int32_t _copy_content_same_ddt( const opal_datatype_t* datatype, i
             source      = (unsigned char*)source_base + pStack->disp;
             destination = (unsigned char*)destination_base + pStack->disp;
             UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
-            DO_DEBUG( opal_output( 0, "copy new_loop count %d stack_pos %d pos_desc %d disp %ld space %lu\n",
-                                   (int)pStack->count, stack_pos, pos_desc, (long)pStack->disp, (unsigned long)iov_len_local ); );
+            DO_DEBUG( opal_output( 0, "copy new_loop count %" PRIsize_t " stack_pos %d pos_desc %d disp %ld space %lu\n",
+                                   pStack->count, stack_pos, pos_desc, pStack->disp, (unsigned long)iov_len_local ); );
         }
         if( OPAL_DATATYPE_LOOP == pElem->elem.common.type ) {
             ptrdiff_t local_disp = (ptrdiff_t)source;

--- a/opal/datatype/opal_datatype_dump.c
+++ b/opal/datatype/opal_datatype_dump.c
@@ -13,6 +13,8 @@
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -96,9 +98,9 @@ int opal_datatype_dump_data_desc( dt_elem_desc_t* pDesc, int nbElems, char* ptr,
                            (int)pDesc->end_loop.items, (long)pDesc->end_loop.first_elem_disp,
                            (int)pDesc->end_loop.size );
         else
-            index += snprintf( ptr + index, length - index, "count %d disp 0x%lx (%ld) blen %d extent %d (size %ld)\n",
-                               (int)pDesc->elem.count, (long)pDesc->elem.disp, (long)pDesc->elem.disp, (int)pDesc->elem.blocklen,
-                               (int)pDesc->elem.extent, (long)(pDesc->elem.count * opal_datatype_basicDatatypes[pDesc->elem.common.type]->size) );
+            index += snprintf( ptr + index, length - index, "count %" PRIsize_t " disp 0x%lx (%ld) blen %d extent %ld (size %ld)\n",
+                               pDesc->elem.count, (long)pDesc->elem.disp, (long)pDesc->elem.disp, (int)pDesc->elem.blocklen,
+                               pDesc->elem.extent, (long)(pDesc->elem.count * opal_datatype_basicDatatypes[pDesc->elem.common.type]->size) );
         pDesc++;
 
         if( length <= (size_t)index ) break;
@@ -118,11 +120,11 @@ void opal_datatype_dump( const opal_datatype_t* pData )
     buffer = (char*)malloc( length );
     index += snprintf( buffer, length - index, "Datatype %p[%s] size %ld align %d id %d length %d used %d\n"
                                                "true_lb %ld true_ub %ld (true_extent %ld) lb %ld ub %ld (extent %ld)\n"
-                                               "nbElems %d loops %d flags %X (",
+                                               "nbElems %" PRIsize_t " loops %d flags %X (",
                      (void*)pData, pData->name, (long)pData->size, (int)pData->align, pData->id, (int)pData->desc.length, (int)pData->desc.used,
                      (long)pData->true_lb, (long)pData->true_ub, (long)(pData->true_ub - pData->true_lb),
                      (long)pData->lb, (long)pData->ub, (long)(pData->ub - pData->lb),
-                     (int)pData->nbElems, (int)pData->loops, (int)pData->flags );
+                     pData->nbElems, (int)pData->loops, (int)pData->flags );
     /* dump the flags */
     if( pData->flags == OPAL_DATATYPE_FLAG_PREDEFINED )
         index += snprintf( buffer + index, length - index, "predefined " );

--- a/opal/datatype/opal_datatype_fake_stack.c
+++ b/opal/datatype/opal_datatype_fake_stack.c
@@ -11,8 +11,8 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,7 +47,7 @@ int opal_convertor_create_stack_with_pos_general( opal_convertor_t* pConvertor,
 	size_t loop_length, *remoteLength, remote_size;
     size_t resting_place = starting_point;
     dt_elem_desc_t* pElems;
-    uint32_t count;
+    size_t count;
 
     assert( 0 != starting_point );
     assert( pConvertor->bConverted != starting_point );
@@ -93,7 +93,7 @@ int opal_convertor_create_stack_with_pos_general( opal_convertor_t* pConvertor,
     /* remove from the main loop all the complete datatypes */
     assert (! (pConvertor->flags & CONVERTOR_SEND));
     remote_size    = opal_convertor_compute_remote_size( pConvertor );
-    count          = (int32_t)(starting_point / remote_size);
+    count          = starting_point / remote_size;
     resting_place -= (remote_size * count);
     pStack->count  = pConvertor->count - count;
     pStack->index  = -1;

--- a/opal/datatype/opal_datatype_optimize.c
+++ b/opal/datatype/opal_datatype_optimize.c
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +42,7 @@
 
 static int32_t
 opal_datatype_optimize_short( opal_datatype_t* pData,
-                              int32_t count,
+                              size_t count,
                               dt_type_desc_t* pTypeDesc )
 {
     dt_elem_desc_t* pElemDesc;

--- a/opal/datatype/opal_datatype_pack.h
+++ b/opal/datatype/opal_datatype_pack.h
@@ -5,8 +5,8 @@
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,19 +30,19 @@
 
 static inline void pack_predefined_data( opal_convertor_t* CONVERTOR,
                                          const dt_elem_desc_t* ELEM,
-                                         uint32_t* COUNT,
+                                         size_t* COUNT,
                                          unsigned char** SOURCE,
                                          unsigned char** DESTINATION,
                                          size_t* SPACE )
 {
-    uint32_t _copy_count = *(COUNT);
+    size_t _copy_count = *(COUNT);
     size_t _copy_blength;
     const ddt_elem_desc_t* _elem = &((ELEM)->elem);
     unsigned char* _source = (*SOURCE) + _elem->disp;
 
     _copy_blength = opal_datatype_basicDatatypes[_elem->common.type]->size;
     if( (_copy_count * _copy_blength) > *(SPACE) ) {
-        _copy_count = (uint32_t)(*(SPACE) / _copy_blength);
+        _copy_count = (*(SPACE) / _copy_blength);
         if( 0 == _copy_count ) return;  /* nothing to do */
     }
 
@@ -57,8 +57,7 @@ static inline void pack_predefined_data( opal_convertor_t* CONVERTOR,
         _source        += _copy_blength;
         *(DESTINATION) += _copy_blength;
     } else {
-        uint32_t _i;
-        for( _i = 0; _i < _copy_count; _i++ ) {
+        for(size_t _i = 0; _i < _copy_count; _i++ ) {
             OPAL_DATATYPE_SAFEGUARD_POINTER( _source, _copy_blength, (CONVERTOR)->pBaseBuf,
                                         (CONVERTOR)->pDesc, (CONVERTOR)->count );
             DO_DEBUG( opal_output( 0, "pack 2. memcpy( %p, %p, %lu ) => space %lu\n",
@@ -76,7 +75,7 @@ static inline void pack_predefined_data( opal_convertor_t* CONVERTOR,
 
 static inline void pack_contiguous_loop( opal_convertor_t* CONVERTOR,
                                          const dt_elem_desc_t* ELEM,
-                                         uint32_t* COUNT,
+                                         size_t* COUNT,
                                          unsigned char** SOURCE,
                                          unsigned char** DESTINATION,
                                          size_t* SPACE )
@@ -84,12 +83,11 @@ static inline void pack_contiguous_loop( opal_convertor_t* CONVERTOR,
     const ddt_loop_desc_t *_loop = (ddt_loop_desc_t*)(ELEM);
     const ddt_endloop_desc_t* _end_loop = (ddt_endloop_desc_t*)((ELEM) + _loop->items);
     unsigned char* _source = (*SOURCE) + _end_loop->first_elem_disp;
-    uint32_t _copy_loops = *(COUNT);
-    uint32_t _i;
+    size_t _copy_loops = *(COUNT);
 
     if( (_copy_loops * _end_loop->size) > *(SPACE) )
-        _copy_loops = (uint32_t)(*(SPACE) / _end_loop->size);
-    for( _i = 0; _i < _copy_loops; _i++ ) {
+        _copy_loops = (*(SPACE) / _end_loop->size);
+    for(size_t _i = 0; _i < _copy_loops; _i++ ) {
         OPAL_DATATYPE_SAFEGUARD_POINTER( _source, _end_loop->size, (CONVERTOR)->pBaseBuf,
                                     (CONVERTOR)->pDesc, (CONVERTOR)->count );
         DO_DEBUG( opal_output( 0, "pack 3. memcpy( %p, %p, %lu ) => space %lu\n",

--- a/opal/datatype/opal_datatype_position.c
+++ b/opal/datatype/opal_datatype_position.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Research Organization for Information Science
+ * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -57,17 +57,17 @@
 static inline void
 position_predefined_data( opal_convertor_t* CONVERTOR,
                           dt_elem_desc_t* ELEM,
-                          uint32_t* COUNT,
+                          size_t* COUNT,
                           unsigned char** POINTER,
                           size_t* SPACE )
 {
-    uint32_t _copy_count = *(COUNT);
+    size_t _copy_count = *(COUNT);
     size_t _copy_blength;
     ddt_elem_desc_t* _elem = &((ELEM)->elem);
 
     _copy_blength =  opal_datatype_basicDatatypes[_elem->common.type]->size;
     if( (_copy_count * _copy_blength) > *(SPACE) ) {
-        _copy_count = (uint32_t)(*(SPACE) / _copy_blength);
+        _copy_count = *(SPACE) / _copy_blength;
         if( 0 == _copy_count ) return;  /* nothing to do */
     }
     _copy_blength *= _copy_count;
@@ -87,16 +87,16 @@ position_predefined_data( opal_convertor_t* CONVERTOR,
 static inline void
 position_contiguous_loop( opal_convertor_t* CONVERTOR,
                           dt_elem_desc_t* ELEM,
-                          uint32_t* COUNT,
+                          size_t* COUNT,
                           unsigned char** POINTER,
                           size_t* SPACE )
 {
     ddt_loop_desc_t *_loop = (ddt_loop_desc_t*)(ELEM);
     ddt_endloop_desc_t* _end_loop = (ddt_endloop_desc_t*)((ELEM) + (ELEM)->loop.items);
-    uint32_t _copy_loops = *(COUNT);
+    size_t _copy_loops = *(COUNT);
 
     if( (_copy_loops * _end_loop->size) > *(SPACE) )
-        _copy_loops = (uint32_t)(*(SPACE) / _end_loop->size);
+        _copy_loops = *(SPACE) / _end_loop->size;
     OPAL_DATATYPE_SAFEGUARD_POINTER( *(POINTER) + _end_loop->first_elem_disp,
                                 (_copy_loops - 1) * _loop->extent + _end_loop->size,
                                 (CONVERTOR)->pBaseBuf, (CONVERTOR)->pDesc, (CONVERTOR)->count );
@@ -116,7 +116,7 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
 {
     dt_stack_t* pStack;       /* pointer to the position on the stack */
     uint32_t pos_desc;        /* actual position in the description of the derived datatype */
-    uint32_t count_desc;      /* the number of items already done in the actual pos_desc */
+    size_t count_desc;       /* the number of items already done in the actual pos_desc */
     dt_elem_desc_t* description = pConvertor->use_desc->desc;
     dt_elem_desc_t* pElem;    /* current position */
     unsigned char *base_pointer = pConvertor->pBaseBuf;
@@ -134,9 +134,9 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
     iov_len_local = *position - pConvertor->bConverted;
     if( iov_len_local > pConvertor->pDesc->size ) {
         pStack = pConvertor->pStack;  /* we're working with the full stack */
-        count_desc = (uint32_t)(iov_len_local / pConvertor->pDesc->size);
+        count_desc = iov_len_local / pConvertor->pDesc->size;
         DO_DEBUG( opal_output( 0, "position before %lu asked %lu data size %lu"
-                               " iov_len_local %lu count_desc %d\n",
+                               " iov_len_local %lu count_desc %" PRIsize_t "\n",
                                (unsigned long)pConvertor->bConverted, (unsigned long)*position, (unsigned long)pConvertor->pDesc->size,
                                (unsigned long)iov_len_local, count_desc ); );
         /* Update all the stack including the last one */
@@ -152,15 +152,15 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
     pStack = pConvertor->pStack + pConvertor->stack_pos;
     pos_desc      = pStack->index;
     base_pointer += pStack->disp;
-    count_desc    = (uint32_t)pStack->count;
+    count_desc    = pStack->count;
     pStack--;
     pConvertor->stack_pos--;
     pElem = &(description[pos_desc]);
 
-    DO_DEBUG( opal_output( 0, "position start pos_desc %d count_desc %d disp %llx\n"
-                           "stack_pos %d pos_desc %d count_desc %d disp %llx\n",
+    DO_DEBUG( opal_output( 0, "position start pos_desc %d count_desc %" PRIsize_t " disp %llx\n"
+                           "stack_pos %d pos_desc %d count_desc %" PRIsize_t " disp %llx\n",
                            pos_desc, count_desc, (unsigned long long)(base_pointer - pConvertor->pBaseBuf),
-                           pConvertor->stack_pos, pStack->index, (int)pStack->count, (unsigned long long)pStack->disp ); );
+                           pConvertor->stack_pos, pStack->index, pStack->count, (unsigned long long)pStack->disp ); );
     /* Last data has been only partially converted. Compute the relative position */
     if( 0 != pConvertor->partial_length ) {
         size_t element_length = opal_datatype_basicDatatypes[pElem->elem.common.type]->size;
@@ -179,9 +179,9 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
     }
     while( 1 ) {
         if( OPAL_DATATYPE_END_LOOP == pElem->elem.common.type ) { /* end of the current loop */
-            DO_DEBUG( opal_output( 0, "position end_loop count %d stack_pos %d pos_desc %d disp %llx space %lu\n",
-                                   (int)pStack->count, pConvertor->stack_pos, pos_desc,
-                                   (unsigned long long)pStack->disp, (unsigned long)iov_len_local ); );
+            DO_DEBUG( opal_output( 0, "position end_loop count %" PRIsize_t " stack_pos %d pos_desc %d disp %lx space %lu\n",
+                                   pStack->count, pConvertor->stack_pos, pos_desc,
+                                   pStack->disp, (unsigned long)iov_len_local ); );
             if( --(pStack->count) == 0 ) { /* end of loop */
                 if( pConvertor->stack_pos == 0 ) {
                     pConvertor->flags |= CONVERTOR_COMPLETED;
@@ -202,9 +202,9 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
             }
             base_pointer = pConvertor->pBaseBuf + pStack->disp;
             UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
-            DO_DEBUG( opal_output( 0, "position new_loop count %d stack_pos %d pos_desc %d disp %llx space %lu\n",
-                                   (int)pStack->count, pConvertor->stack_pos, pos_desc,
-                                   (unsigned long long)pStack->disp, (unsigned long)iov_len_local ); );
+            DO_DEBUG( opal_output( 0, "position new_loop count %" PRIsize_t " stack_pos %d pos_desc %d disp %lx space %lu\n",
+                                   pStack->count, pConvertor->stack_pos, pos_desc,
+                                   pStack->disp, (unsigned long)iov_len_local ); );
         }
         if( OPAL_DATATYPE_LOOP == pElem->elem.common.type ) {
             ptrdiff_t local_disp = (ptrdiff_t)base_pointer;
@@ -225,9 +225,9 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
             base_pointer = pConvertor->pBaseBuf + pStack->disp;
             UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
             DDT_DUMP_STACK( pConvertor->pStack, pConvertor->stack_pos, pElem, "advance loop" );
-            DO_DEBUG( opal_output( 0, "position set loop count %d stack_pos %d pos_desc %d disp %llx space %lu\n",
-                                   (int)pStack->count, pConvertor->stack_pos, pos_desc,
-                                   (unsigned long long)pStack->disp, (unsigned long)iov_len_local ); );
+            DO_DEBUG( opal_output( 0, "position set loop count %" PRIsize_t " stack_pos %d pos_desc %d disp %lx space %lu\n",
+                                   pStack->count, pConvertor->stack_pos, pos_desc,
+                                   pStack->disp, (unsigned long)iov_len_local ); );
             continue;
         }
         while( pElem->elem.common.flags & OPAL_DATATYPE_FLAG_DATA ) {
@@ -235,15 +235,15 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
             POSITION_PREDEFINED_DATATYPE( pConvertor, pElem, count_desc,
                                           base_pointer, iov_len_local );
             if( 0 != count_desc ) {  /* completed */
-                pConvertor->partial_length = (uint32_t)iov_len_local;
+                pConvertor->partial_length = iov_len_local;
                 goto complete_loop;
             }
             base_pointer = pConvertor->pBaseBuf + pStack->disp;
             pos_desc++;  /* advance to the next data */
             UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
-            DO_DEBUG( opal_output( 0, "position set loop count %d stack_pos %d pos_desc %d disp %llx space %lu\n",
-                                   (int)pStack->count, pConvertor->stack_pos, pos_desc,
-                                   (unsigned long long)pStack->disp, (unsigned long)iov_len_local ); );
+            DO_DEBUG( opal_output( 0, "position set loop count %" PRIsize_t " stack_pos %d pos_desc %d disp %lx space %lu\n",
+                                   pStack->count, pConvertor->stack_pos, pos_desc,
+                                   pStack->disp, (unsigned long)iov_len_local ); );
         }
     }
  complete_loop:
@@ -253,8 +253,8 @@ int opal_convertor_generic_simple_position( opal_convertor_t* pConvertor,
         /* I complete an element, next step I should go to the next one */
         PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, pElem->elem.common.type, count_desc,
                     base_pointer - pConvertor->pBaseBuf );
-        DO_DEBUG( opal_output( 0, "position save stack stack_pos %d pos_desc %d count_desc %d disp %llx\n",
-                               pConvertor->stack_pos, pStack->index, (int)pStack->count, (unsigned long long)pStack->disp ); );
+        DO_DEBUG( opal_output( 0, "position save stack stack_pos %d pos_desc %d count_desc %" PRIsize_t " disp %llx\n",
+                               pConvertor->stack_pos, pStack->index, pStack->count, (unsigned long long)pStack->disp ); );
         return 0;
     }
     return 1;

--- a/opal/datatype/opal_datatype_unpack.h
+++ b/opal/datatype/opal_datatype_unpack.h
@@ -5,8 +5,8 @@
  *                         reserved.
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,19 +29,19 @@
 static inline void
 unpack_predefined_data( opal_convertor_t* CONVERTOR,  /* the convertor */
                         const dt_elem_desc_t* ELEM,   /* the element description */
-                        uint32_t* COUNT,              /* the number of elements */
+                        size_t* COUNT,                /* the number of elements */
                         unsigned char** SOURCE,       /* the source pointer */
                         unsigned char** DESTINATION,  /* the destination pointer */
                         size_t* SPACE )               /* the space in the destination buffer */
 {
-    uint32_t _copy_count = *(COUNT);
+    size_t _copy_count = *(COUNT);
     size_t _copy_blength;
     const ddt_elem_desc_t* _elem = &((ELEM)->elem);
     unsigned char* _destination = (*DESTINATION) + _elem->disp;
 
     _copy_blength = opal_datatype_basicDatatypes[_elem->common.type]->size;
     if( (_copy_count * _copy_blength) > *(SPACE) ) {
-        _copy_count = (uint32_t)(*(SPACE) / _copy_blength);
+        _copy_count = (*(SPACE) / _copy_blength);
         if( 0 == _copy_count ) return;  /* nothing to do */
     }
 
@@ -56,8 +56,7 @@ unpack_predefined_data( opal_convertor_t* CONVERTOR,  /* the convertor */
         *(SOURCE)    += _copy_blength;
         _destination += _copy_blength;
     } else {
-        uint32_t _i;
-        for( _i = 0; _i < _copy_count; _i++ ) {
+        for(size_t _i = 0; _i < _copy_count; _i++ ) {
             OPAL_DATATYPE_SAFEGUARD_POINTER( _destination, _copy_blength, (CONVERTOR)->pBaseBuf,
                                         (CONVERTOR)->pDesc, (CONVERTOR)->count );
             DO_DEBUG( opal_output( 0, "unpack 2. memcpy( %p, %p, %lu ) => space %lu\n",
@@ -75,7 +74,7 @@ unpack_predefined_data( opal_convertor_t* CONVERTOR,  /* the convertor */
 
 static inline void unpack_contiguous_loop( opal_convertor_t* CONVERTOR,
                                            const dt_elem_desc_t* ELEM,
-                                           uint32_t* COUNT,
+                                           size_t* COUNT,
                                            unsigned char** SOURCE,
                                            unsigned char** DESTINATION,
                                            size_t* SPACE )
@@ -83,12 +82,11 @@ static inline void unpack_contiguous_loop( opal_convertor_t* CONVERTOR,
     const ddt_loop_desc_t *_loop = (ddt_loop_desc_t*)(ELEM);
     const ddt_endloop_desc_t* _end_loop = (ddt_endloop_desc_t*)((ELEM) + _loop->items);
     unsigned char* _destination = (*DESTINATION) + _end_loop->first_elem_disp;
-    uint32_t _copy_loops = *(COUNT);
-    uint32_t _i;
+    size_t _copy_loops = *(COUNT);
 
     if( (_copy_loops * _end_loop->size) > *(SPACE) )
-        _copy_loops = (uint32_t)(*(SPACE) / _end_loop->size);
-    for( _i = 0; _i < _copy_loops; _i++ ) {
+        _copy_loops = (*(SPACE) / _end_loop->size);
+    for(size_t _i = 0; _i < _copy_loops; _i++ ) {
         OPAL_DATATYPE_SAFEGUARD_POINTER( _destination, _end_loop->size, (CONVERTOR)->pBaseBuf,
                                     (CONVERTOR)->pDesc, (CONVERTOR)->count );
         DO_DEBUG( opal_output( 0, "unpack 3. memcpy( %p, %p, %lu ) => space %lu\n",

--- a/test/datatype/Makefile.am
+++ b/test/datatype/Makefile.am
@@ -15,7 +15,7 @@
 #
 
 if PROJECT_OMPI
-    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32
+    MPI_TESTS = checksum position position_noncontig ddt_test ddt_raw ddt_raw2 unpack_ooo ddt_pack external32 large_data
     MPI_CHECKS = to_self
 endif
 TESTS = opal_datatype_test unpack_hetero $(MPI_TESTS)
@@ -73,6 +73,12 @@ position_noncontig_LDADD = \
 to_self_SOURCES = to_self.c
 to_self_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
 to_self_LDADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+
+large_data_SOURCES = large_data.c
+large_data_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)
+large_data_LDADD = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la
 
 opal_datatype_test_SOURCES = opal_datatype_test.c opal_ddt_lib.c opal_ddt_lib.h
 opal_datatype_test_LDFLAGS = $(OMPI_PKG_CONFIG_LDFLAGS)

--- a/test/datatype/large_data.c
+++ b/test/datatype/large_data.c
@@ -1,3 +1,20 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2018      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * This test check the correct OMPI datatype description for
+ * extremely large types (over 4GB).
+ */
+
 #include <mpi.h>
 #include <stdio.h>
 #include <stddef.h>
@@ -13,8 +30,11 @@
 #define MAX_IOVEC 10
 #define MAX_CHUNK (1024*1024*1024)  /* 1GB */
 
+static int verbose = 0;
+
 static size_t
-count_length_via_convertor_raw(MPI_Datatype dtype, int count)
+count_length_via_convertor_raw(char* msg,
+                               MPI_Datatype dtype, int count)
 {
     opal_convertor_t* pconv;
     struct iovec iov[MAX_IOVEC];
@@ -24,24 +44,41 @@ count_length_via_convertor_raw(MPI_Datatype dtype, int count)
     pconv = opal_convertor_create( opal_local_arch, 0 );
     opal_convertor_prepare_for_send(pconv, (const struct opal_datatype_t *)dtype, 1, NULL);
     while( 0 == opal_convertor_raw(pconv, iov, &iov_count, &length) ) {
-        printf("iov_count = %d packed_iovec = %"PRIsize_t"\n", iov_count, packed_iovec);
+        if( verbose ) {
+            printf("iov_count = %d packed_iovec = %"PRIsize_t" length = %"PRIsize_t"\n",
+                   iov_count, packed_iovec, length);
+        }
         packed += length;
         for( i = 0; i < iov_count; i++ ) {
             packed_iovec += iov[i].iov_len;
+            if( verbose ) {
+                printf("[%s] add %"PRIsize_t" bytes -> so far %"PRIsize_t" bytes\n",
+                       msg, iov[i].iov_len, packed_iovec);
+            }
         }
         if( packed != packed_iovec ) {
-            printf( "Packed send amount diverges %"PRIsize_t" != %"PRIsize_t"\n", packed, packed_iovec);
+            printf( "[%s] Raw data amount diverges %"PRIsize_t" != %"PRIsize_t"\n",
+                    msg, packed, packed_iovec);
             exit(-1);
         }
         iov_count = MAX_IOVEC;  /* number of available iov */
         length = MAX_CHUNK;
     }
+    if( verbose ) {
+        printf("iov_count = %d packed_iovec = %"PRIsize_t" length = %"PRIsize_t"\n",
+               iov_count, packed_iovec, length);
+    }
     packed += length;
     for( i = 0; i < iov_count; i++ ) {
         packed_iovec += iov[i].iov_len;
+        if( verbose ) {
+            printf("[%s] add %"PRIsize_t" bytes -> so far %"PRIsize_t" bytes\n",
+                   msg, iov[i].iov_len, packed_iovec);
+        }
     }
     if( packed != packed_iovec ) {
-        printf( "Packed send amount diverges %"PRIsize_t" != %"PRIsize_t"\n", packed, packed_iovec);
+        printf( "[%s] Raw data amount diverges %"PRIsize_t" != %"PRIsize_t"\n",
+                msg, packed, packed_iovec);
         exit(-1);
     }
     return packed_iovec;
@@ -52,6 +89,7 @@ int main(int argc, char * argv[])
 
     int const per_process = 192;
     int const per_type = 20000000;
+    int blocklen, stride, count;
 
     int scounts[2] = {per_process, per_process};
     int sdispls[2] = {3*per_process, 0*per_process};
@@ -59,35 +97,78 @@ int main(int argc, char * argv[])
     int rdispls[2] = {1*per_process, 2*per_process};
 
     MPI_Datatype ddt, stype, rtype;
+    size_t length, packed;
 
     opal_init_util(&argc, &argv);
     ompi_datatype_init();
 
     ompi_datatype_create_contiguous( per_type, MPI_FLOAT, &ddt);
+
+    /*
+     * Large sparse datatype: indexed contiguous
+     */
     ompi_datatype_create_indexed(2, scounts, sdispls, ddt, &stype);
     ompi_datatype_commit(&stype);
-    ompi_datatype_create_indexed(2, rcounts, rdispls, ddt, &rtype);
-    ompi_datatype_commit(&rtype);
 
-    size_t packed = count_length_via_convertor_raw(stype, 1);
-    size_t length;
+    packed = count_length_via_convertor_raw("1. INDEX", stype, 1);
     opal_datatype_type_size(&stype->super, &length);
     if( length != packed ) {
         printf("Mismatched length of packed data to datatype size (%"PRIsize_t" != %"PRIsize_t")\n",
                packed, length);
         exit(-2);
     }
+    ompi_datatype_destroy(&stype);
 
-    packed = count_length_via_convertor_raw(rtype, 1);
+    /*
+     * Large contiguous datatype: indexed contiguous
+     */
+    ompi_datatype_create_indexed(2, rcounts, rdispls, ddt, &rtype);
+    ompi_datatype_commit(&rtype);
+
+    packed = count_length_via_convertor_raw("2. INDEX", rtype, 1);
     opal_datatype_type_size(&rtype->super, &length);
     if( length != packed ) {
         printf("Mismatched length of packed data to datatype size (%"PRIsize_t" != %"PRIsize_t")\n",
                packed, length);
         exit(-2);
     }
-
-    ompi_datatype_destroy(&stype);
     ompi_datatype_destroy(&rtype);
+    ompi_datatype_destroy(&ddt);
+
+    /*
+     * Large sparse datatype: vector
+     */
+    count = INT_MAX / 2;
+    blocklen = stride = 4;
+    ompi_datatype_create_vector(count, blocklen, stride, MPI_FLOAT, &ddt);
+    ompi_datatype_commit(&ddt);
+
+    packed = count_length_via_convertor_raw("3. VECTOR", ddt, 1);
+    opal_datatype_type_size(&ddt->super, &length);
+    if( length != packed ) {
+        printf("Mismatched length of packed data to datatype size (%"PRIsize_t" != %"PRIsize_t")\n",
+               packed, length);
+        exit(-2);
+    }
+    ompi_datatype_destroy(&ddt);
+
+    /*
+     * Large sparse datatype: contiguous
+     */
+    MPI_Datatype tmp;
+    ompi_datatype_create_contiguous(stride, MPI_FLOAT, &tmp);
+    ompi_datatype_create_contiguous(count, tmp, &ddt);
+    ompi_datatype_commit(&ddt);
+
+    packed = count_length_via_convertor_raw("4. CONTIG", ddt, 1);
+    opal_datatype_type_size(&ddt->super, &length);
+    if( length != packed ) {
+        printf("Mismatched length of packed data to datatype size (%"PRIsize_t" != %"PRIsize_t")\n",
+               packed, length);
+        exit(-2);
+    }
+    ompi_datatype_destroy(&ddt);
+    ompi_datatype_destroy(&tmp);
 
     return 0;
 }

--- a/test/datatype/large_data.c
+++ b/test/datatype/large_data.c
@@ -1,0 +1,93 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ompi_config.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "opal/runtime/opal.h"
+#include "opal/datatype/opal_convertor.h"
+#include "opal/datatype/opal_datatype_internal.h"
+
+#define MAX_IOVEC 10
+#define MAX_CHUNK (1024*1024*1024)  /* 1GB */
+
+static size_t
+count_length_via_convertor_raw(MPI_Datatype dtype, int count)
+{
+    opal_convertor_t* pconv;
+    struct iovec iov[MAX_IOVEC];
+    uint32_t iov_count = MAX_IOVEC, i;
+    size_t length = MAX_CHUNK, packed_iovec = 0, packed = 0;
+
+    pconv = opal_convertor_create( opal_local_arch, 0 );
+    opal_convertor_prepare_for_send(pconv, (const struct opal_datatype_t *)dtype, 1, NULL);
+    while( 0 == opal_convertor_raw(pconv, iov, &iov_count, &length) ) {
+        printf("iov_count = %d packed_iovec = %"PRIsize_t"\n", iov_count, packed_iovec);
+        packed += length;
+        for( i = 0; i < iov_count; i++ ) {
+            packed_iovec += iov[i].iov_len;
+        }
+        if( packed != packed_iovec ) {
+            printf( "Packed send amount diverges %"PRIsize_t" != %"PRIsize_t"\n", packed, packed_iovec);
+            exit(-1);
+        }
+        iov_count = MAX_IOVEC;  /* number of available iov */
+        length = MAX_CHUNK;
+    }
+    packed += length;
+    for( i = 0; i < iov_count; i++ ) {
+        packed_iovec += iov[i].iov_len;
+    }
+    if( packed != packed_iovec ) {
+        printf( "Packed send amount diverges %"PRIsize_t" != %"PRIsize_t"\n", packed, packed_iovec);
+        exit(-1);
+    }
+    return packed_iovec;
+}
+
+int main(int argc, char * argv[])
+{
+
+    int const per_process = 192;
+    int const per_type = 20000000;
+
+    int scounts[2] = {per_process, per_process};
+    int sdispls[2] = {3*per_process, 0*per_process};
+    int rcounts[2] = {per_process, per_process};
+    int rdispls[2] = {1*per_process, 2*per_process};
+
+    MPI_Datatype ddt, stype, rtype;
+
+    opal_init_util(&argc, &argv);
+    ompi_datatype_init();
+
+    ompi_datatype_create_contiguous( per_type, MPI_FLOAT, &ddt);
+    ompi_datatype_create_indexed(2, scounts, sdispls, ddt, &stype);
+    ompi_datatype_commit(&stype);
+    ompi_datatype_create_indexed(2, rcounts, rdispls, ddt, &rtype);
+    ompi_datatype_commit(&rtype);
+
+    size_t packed = count_length_via_convertor_raw(stype, 1);
+    size_t length;
+    opal_datatype_type_size(&stype->super, &length);
+    if( length != packed ) {
+        printf("Mismatched length of packed data to datatype size (%"PRIsize_t" != %"PRIsize_t")\n",
+               packed, length);
+        exit(-2);
+    }
+
+    packed = count_length_via_convertor_raw(rtype, 1);
+    opal_datatype_type_size(&rtype->super, &length);
+    if( length != packed ) {
+        printf("Mismatched length of packed data to datatype size (%"PRIsize_t" != %"PRIsize_t")\n",
+               packed, length);
+        exit(-2);
+    }
+
+    ompi_datatype_destroy(&stype);
+    ompi_datatype_destroy(&rtype);
+
+    return 0;
+}


### PR DESCRIPTION
Always use size_t (instead of converting to an uint32_t) in order to
correctly support large datatypes.

backport from https://github.com/open-mpi/ompi/pull/6029

Refs #6016