### PR TITLE
v4.0.x: Allow user to overwrite `OMPI_ENABLE_MPI1_COMPAT`

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -306,7 +306,9 @@
           * Don't do MACRO magic for building Profiling library as it
           * interferes with the above.
           */
-#        if (OMPI_ENABLE_MPI1_COMPAT || OMPI_BUILDING)
+#        if defined(OMPI_OMIT_MPI1_COMPAT_DECLS)
+             /* The user set OMPI_OMIT_MPI1_COMPAT_DECLS, do what he commands */
+#        elif (OMPI_ENABLE_MPI1_COMPAT || OMPI_BUILDING)
 #            define OMPI_OMIT_MPI1_COMPAT_DECLS 0
 #            define OMPI_REMOVED_USE_STATIC_ASSERT 0
 #            define __mpi_interface_removed__(func, newfunc) __mpi_interface_deprecated__(#func " was removed in MPI-3.0.  Use " #newfunc " instead.  continuing...")


### PR DESCRIPTION
Follow-up to #6120.

As mentioned in [1], it may be desirable to nevertheless get the hidden
MPI 1 prototypes, for users who know what they are doing, i.e., the tools
guys. @ggouaillardet mentioned in [2], that `-DOMPI_OMIT_MPI1_COMPAT_DECLS=0`
should work, but it does not, as than we only get redefinition warnings.
See [3].

This topic does not relate to master, as we can remove the actual symbols
there, but here in v4.0.x land, the symbols are always there.

[1] https://github.com/open-mpi/ompi/pull/6120#issuecomment-443104700
[2] https://github.com/open-mpi/ompi/pull/6120#issuecomment-443117892
[3] https://github.com/open-mpi/ompi/pull/6120#issuecomment-468962596

Signed-off-by: Bert Wesarg <bert.wesarg@tu-dresden.de>