### PR TITLE
configury: Remove --enable-mpi1-compatibility

### DIFF
--- a/README
+++ b/README
@@ -586,11 +586,6 @@ MPI Functionality and Features
       examples of how to update legacy MPI applications using these
       deleted symbols to use the "new" symbols.
 
-  All that being said, if you are unable to immediately update your
-  application to stop using these legacy MPI-1 symbols, you can
-  re-enable them in mpi.h by configuring Open MPI with the
-  --enable-mpi1-compatibility flag.
-
 - Rank reordering support is available using the TreeMatch library. It
   is activated for the graph and dist_graph topologies.
 

--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -196,22 +196,6 @@ fi
 AC_DEFINE_UNQUOTED([OMPI_WANT_MPI_CXX_SEEK], [$OMPI_WANT_MPI_CXX_SEEK],
     [do we want to try to work around C++ bindings SEEK_* issue?])
 
-# Remove these when we finally kill them once and for all
-AC_ARG_ENABLE([mpi1-compatibility],
-    [AC_HELP_STRING([--enable-mpi1-compatibility],
-                    [Enable support for MPI-1.x functions removed from the current MPI standard (MPI-3.x). This option will go away in a future release of Open MPI (default: disabled)])])
-
-if test "x$enable_mpi1_compatibility" = "xyes" ; then
-ompi_mpi1_support=1
-else
-ompi_mpi1_support=0
-fi
-
-
-AC_DEFINE_UNQUOTED([OMPI_ENABLE_MPI1_COMPAT], [$ompi_mpi1_support], [whether we want MPI-1.x support])
-AC_SUBST([OMPI_ENABLE_MPI1_COMPAT], [$ompi_mpi1_support])
-AM_CONDITIONAL([OMPI_ENABLE_MPI1_COMPAT],[test $ompi_mpi1_support = 1])
-
 AC_ARG_ENABLE([grequest-extensions],
     [AC_HELP_STRING([--enable-grequest-extensions],
                     [Enable support for Grequest extensions (default: disabled)])])


### PR DESCRIPTION
This configure CLI option should probably have been removed as part of
a6d6be2853488cfb20128f97b381b3c94a921cd7.  Regardless, the #defines it
sets no longer exist in the code base at all, so they should be
removed.  Also remove the text about it in README.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>