### PR TITLE
ompi_info: report whether MPI1 compat is enabled

### DIFF
--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -14,6 +14,9 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -132,6 +135,7 @@ void ompi_info_do_config(bool want_all)
     char *crdebug_support;
     char *topology_support;
     char *ipv6_support;
+    char *mpi1_compat_support;
 
     /* Do a little preprocessor trickery here to figure opal_info_out the
      * tri-state of MPI_PARAM_CHECK (which will be either 0, 1, or
@@ -285,6 +289,7 @@ void ompi_info_do_config(bool want_all)
     symbol_visibility = OPAL_C_HAVE_VISIBILITY ? "yes" : "no";
     topology_support = "yes";
     ipv6_support = OPAL_ENABLE_IPV6 ? "yes" : "no";
+    mpi1_compat_support = OMPI_ENABLE_MPI1_COMPAT ? "yes" : "no";
 
     /* setup strings that require allocation */
     if (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_MPIFH_BINDINGS) {
@@ -643,6 +648,8 @@ void ompi_info_do_config(bool want_all)
     opal_info_out("Host topology support", "options:host-topology",
                   topology_support);
     opal_info_out("IPv6 support", "options:ipv6", ipv6_support);
+    opal_info_out("MPI1 compatibility", "options:mpi1-compatibility",
+                  mpi1_compat_support);
 
     opal_info_out("MPI extensions", "options:mpi_ext", OMPI_MPIEXT_COMPONENTS);
 


### PR DESCRIPTION
Its so easy to misspell compatability (sic) that we need
to have ompi_info help us out.

Related to #6470

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit a5ba48c21839e0aab4c96afa97466a10f8bdc721)