### PR TITLE
v3.1.x: opal_hwloc_base_cset2str() off-by-1 in its strncat()

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -18,6 +18,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (C) 2018      Mellanox Technologies, Ltd. 
  *                         All rights reserved.
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1920,14 +1922,14 @@ int opal_hwloc_base_cset2str(char *str, int len,
         for (core_index = 0; core_index < num_cores; ++core_index) {
             if (map[socket_index][core_index] > 0) {
                 if (!first) {
-                    strncat(str, ", ", len - strlen(str));
+                    strncat(str, ", ", len - strlen(str) - 1);
                 }
                 first = false;
 
                 snprintf(tmp, stmp, "socket %d[core %d[hwt %s]]",
                          socket_index, core_index,
                          bitmap2rangestr(map[socket_index][core_index]));
-                strncat(str, tmp, len - strlen(str));
+                strncat(str, tmp, len - strlen(str) - 1);
             }
         }
     }
@@ -1983,7 +1985,7 @@ int opal_hwloc_base_cset2mapstr(char *str, int len,
     for (socket = hwloc_get_obj_by_type(topo, HWLOC_OBJ_SOCKET, 0);
          NULL != socket;
          socket = socket->next_cousin) {
-        strncat(str, "[", len - strlen(str));
+        strncat(str, "[", len - strlen(str) - 1);
 
         /* Iterate over all existing cores in this socket */
         core_index = 0;
@@ -1995,7 +1997,7 @@ int opal_hwloc_base_cset2mapstr(char *str, int len,
                                                         socket->cpuset,
                                                         HWLOC_OBJ_CORE, ++core_index)) {
             if (core_index > 0) {
-                strncat(str, "/", len - strlen(str));
+                strncat(str, "/", len - strlen(str) - 1);
             }
 
             /* Iterate over all existing PUs in this core */
@@ -2010,13 +2012,13 @@ int opal_hwloc_base_cset2mapstr(char *str, int len,
 
                 /* Is this PU in the cpuset? */
                 if (hwloc_bitmap_isset(cpuset, pu->os_index)) {
-                    strncat(str, "B", len - strlen(str));
+                    strncat(str, "B", len - strlen(str) - 1);
                 } else {
-                    strncat(str, ".", len - strlen(str));
+                    strncat(str, ".", len - strlen(str) - 1);
                 }
             }
         }
-        strncat(str, "]", len - strlen(str));
+        strncat(str, "]", len - strlen(str) - 1);
     }
 
     return OPAL_SUCCESS;


### PR DESCRIPTION
I think the strncat() calls here need to be of the form
    strncat(str, new_str_to_add, len - strlen(new_str_to_addstr) - 1);
since in the OMPI calls len is being used as total number of bytes
in str.

strncat(dest,src,n) on the other hand is documented as writing up to
n chars from the incoming string plus 1 for the null, for n+1 total
bytes it can write.

Signed-off-by: Mark Allen <markalle@us.ibm.com>
(cherry picked from commit 30d60994d258f5f0b7c432efd284d1b6b8333faf)

Conflicts:
	opal/mca/hwloc/base/hwloc_base_util.c