### PR TITLE
Ensure that nodes are always used in order provided

### DIFF
--- a/orte/util/dash_host/dash_host.c
+++ b/orte/util/dash_host/dash_host.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -52,7 +52,8 @@ int orte_util_dash_host_compute_slots(orte_node_t *node, char *hosts)
 
     /* see if this node appears in the list */
     for (n=0; NULL != specs[n]; n++) {
-        if (0 == strncmp(node->name, specs[n], strlen(node->name))) {
+        if (0 == strncmp(node->name, specs[n], strlen(node->name)) ||
+            (orte_ifislocal(node->name) && orte_ifislocal(specs[n]))) {
             /* check if the #slots was specified */
             if (NULL != (cptr = strchr(specs[n], ':'))) {
                 *cptr = '\0';

--- a/orte/util/nidmap.c
+++ b/orte/util/nidmap.c
@@ -1032,7 +1032,7 @@ int orte_util_decode_ppn(orte_job_t *jdata,
 {
     orte_std_cntr_t index;
     orte_app_idx_t n;
-    int cnt, rc;
+    int cnt, rc, m;
     opal_byte_object_t *boptr;
     bool compressed;
     uint8_t *bytes;
@@ -1043,8 +1043,8 @@ int orte_util_decode_ppn(orte_job_t *jdata,
     opal_buffer_t bucket;
 
     /* reset any flags */
-    for (n=0; n < orte_node_pool->size; n++) {
-        if (NULL != (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, n))) {
+    for (m=0; m < orte_node_pool->size; m++) {
+        if (NULL != (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, m))) {
             ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
         }
     }
@@ -1144,9 +1144,11 @@ int orte_util_decode_ppn(orte_job_t *jdata,
     }
 
     /* reset any flags */
-    for (n=0; n < jdata->map->nodes->size; n++) {
-        node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, n);
-        ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
+    for (m=0; m < jdata->map->nodes->size; m++) {
+        node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, m);
+        if (NULL != node) {
+            ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
+        }
     }
 
     return ORTE_SUCCESS;
@@ -1154,9 +1156,11 @@ int orte_util_decode_ppn(orte_job_t *jdata,
   error:
     OBJ_DESTRUCT(&bucket);
     /* reset any flags */
-    for (n=0; n < jdata->map->nodes->size; n++) {
-        node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, n);
-        ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
+    for (m=0; m < jdata->map->nodes->size; m++) {
+        node = (orte_node_t*)opal_pointer_array_get_item(jdata->map->nodes, m);
+        if (NULL != node) {
+            ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
+        }
     }
     return rc;
 }

--- a/orte/util/nidmap.c
+++ b/orte/util/nidmap.c
@@ -1088,6 +1088,7 @@ int orte_util_decode_ppn(orte_job_t *jdata,
             }
         } else {
             bytes = boptr->bytes;
+            sz = boptr->size;
             boptr->bytes = NULL;
             boptr->size = 0;
         }
@@ -1134,6 +1135,7 @@ int orte_util_decode_ppn(orte_job_t *jdata,
                 /* flag the proc as ready for launch */
                 proc->state = ORTE_PROC_STATE_INIT;
                 opal_pointer_array_add(node->procs, proc);
+                node->num_procs++;
                 /* we will add the proc to the jdata array when we
                  * compute its rank */
             }
@@ -1141,6 +1143,9 @@ int orte_util_decode_ppn(orte_job_t *jdata,
             cnt = 1;
         }
         OBJ_DESTRUCT(&bucket);
+    }
+    if (OPAL_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
+        ORTE_ERROR_LOG(rc);
     }
 
     /* reset any flags */
@@ -1150,7 +1155,6 @@ int orte_util_decode_ppn(orte_job_t *jdata,
             ORTE_FLAG_UNSET(node, ORTE_NODE_FLAG_MAPPED);
         }
     }
-
     return ORTE_SUCCESS;
 
   error:


### PR DESCRIPTION
If a user provides a list of nodes to use via -host or -hostfile, then
ensure that the ranks are placed according to that order. Also fix a bug
where the number of slots on a node was incorrectly computed for
localhost if the name given didn't exactly match the return from
get_hostname.

Fixes #6298 

Signed-off-by: Ralph Castain <rhc@pmix.org>