### PR TITLE
NEWS: add a few news items for 4.0.1rc2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,6 +61,10 @@ included in the vX.Y.Z section and be denoted as:
 --------------------
 
 - Update embedded PMIx to 3.1.2.
+- Fix an issue with Vader (shared-memory) transport on OS-X. Thanks
+  to Daniel Vollmer for reporting.
+- Fix a problem with the usNIC BTL Makefile.  Thanks to George Marselis
+  for reporting.
 - Fix an issue when using --enable-visibility configure option
   and older versions of hwloc.  Thanks to Ben Menadue for reporting
   and providing a fix.


### PR DESCRIPTION
a little late, but a couple of bullets for the
4.0.1rc2 NEWS.

[skip ci]

Signed-off-by: Howard Pritchard <howardp@lanl.gov>