### PR TITLE
opal/atomics: Add acquire semantics back for spinlocks

### DIFF
--- a/opal/include/opal/sys/atomic_impl.h
+++ b/opal/include/opal/sys/atomic_impl.h
@@ -495,7 +495,7 @@ static inline int
 opal_atomic_trylock(opal_atomic_lock_t *lock)
 {
     int32_t unlocked = OPAL_ATOMIC_LOCK_UNLOCKED;
-    bool ret = opal_atomic_compare_exchange_strong_32 (&lock->u.lock, &unlocked, OPAL_ATOMIC_LOCK_LOCKED);
+    bool ret = opal_atomic_compare_exchange_strong_acq_32 (&lock->u.lock, &unlocked, OPAL_ATOMIC_LOCK_LOCKED);
     return (ret == false) ? 1 : 0;
 }
 


### PR DESCRIPTION
This was introduced in commit 9d0b3fe9

Signed-off-by: Nysal Jan K.A <jnysal@in.ibm.com>
(cherry picked from commit 00f27a80fc63053db1aeb42140148d7a3d1379b3)