### PR TITLE
Do not force 'hash' gds on direct modex

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix3x_client.c
+++ b/opal/mca/pmix/pmix3x/pmix3x_client.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2017-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,11 +100,6 @@ int pmix3x_client_init(opal_list_t *ilist)
     } else {
         pinfo = NULL;
         ninfo = 0;
-    }
-
-    /* check for direct modex use-case */
-    if (opal_pmix_base_async_modex && !opal_pmix_collect_all_data) {
-        opal_setenv("PMIX_MCA_gds", "hash", true, &environ);
     }
 
     OPAL_PMIX_RELEASE_THREAD(&opal_pmix_base.lock);

--- a/opal/mca/pmix/pmix3x/pmix3x_server_south.c
+++ b/opal/mca/pmix/pmix3x/pmix3x_server_south.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2017-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -130,11 +131,6 @@ int pmix3x_server_init(opal_pmix_server_module_t *module,
             pmix3x_value_load(&pinfo[n].value, kv);
             ++n;
         }
-    }
-
-    /* check for direct modex use-case */
-    if (opal_pmix_base_async_modex && !opal_pmix_collect_all_data) {
-        opal_setenv("PMIX_MCA_gds", "hash", true, &environ);
     }
 
     /* insert ourselves into our list of jobids - it will be the


### PR DESCRIPTION
 * Forcing the 'hash' gds component should not be necessary any more.

Port of PR #6498 (component names changed so a cherry-pick would not work)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>