### PR TITLE
shmem/fortran: Fix invalid datatype size in call to atomic cswap

### DIFF
--- a/oshmem/shmem/fortran/shmem_int4_cswap_f.c
+++ b/oshmem/shmem/fortran/shmem_int4_cswap_f.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +43,7 @@ ompi_fortran_integer4_t shmem_int4_cswap_f(FORTRAN_POINTER_T target, MPI_Fint *c
         (void *)&out_value,
         FPTR_2_INT(cond, sizeof(ompi_fortran_integer4_t)),
         FPTR_2_INT(value, sizeof(ompi_fortran_integer4_t)),
-        sizeof(out_value),
+        sizeof(ompi_fortran_integer4_t),
         OMPI_FINT_2_INT(*pe)));
 
     return out_value;


### PR DESCRIPTION
Sending in a size of 8 for a 4 byte cswap causes problems in a couple of the atomic components. In particular, with `atomic/ucx` component, this causes ucx completion errors and wrong data. This test can be used as a reproducer for the issue: https://github.com/openshmem-org/tests-cray/blob/master/smaf/shmem_finc_inc_cswap.F90

As for the compiler optimization that is mentioned in the git blame of this file, I am not sure of this fix's effect on performance. But it is needed for correctness. 

It looks like only the v4.0.x and master branches are affected by this bug. I'll PR to v4.0.x once we approve this fix. Thanks.