### PR TITLE
pmix/pmix4x: refresh to the latest PMIx

### DIFF
--- a/opal/mca/pmix/pmix4x/pmix/VERSION
+++ b/opal/mca/pmix/pmix4x/pmix/VERSION
@@ -30,7 +30,7 @@ greek=a1
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=git0c93c13f
+repo_rev=git20cc9c04
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Mar 19, 2019"
+date="Mar 25, 2019"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/opal/mca/pmix/pmix4x/pmix/src/atomics/sys/atomic_impl.h
+++ b/opal/mca/pmix/pmix4x/pmix/src/atomics/sys/atomic_impl.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -496,7 +496,7 @@ static inline int
 pmix_atomic_trylock(pmix_atomic_lock_t *lock)
 {
     int32_t unlocked = PMIX_ATOMIC_LOCK_UNLOCKED;
-    bool ret = pmix_atomic_compare_exchange_strong_32 (&lock->u.lock, &unlocked, PMIX_ATOMIC_LOCK_LOCKED);
+    bool ret = pmix_atomic_compare_exchange_strong_acq_32 (&lock->u.lock, &unlocked, PMIX_ATOMIC_LOCK_LOCKED);
     return (ret == false) ? 1 : 0;
 }
 

--- a/opal/mca/pmix/pmix4x/pmix/src/common/pmix_attributes.c
+++ b/opal/mca/pmix/pmix4x/pmix/src/common/pmix_attributes.c
@@ -664,6 +664,7 @@ static void _get_attrs(pmix_list_t *lst,
         }
         pmix_list_append(lst, &ip->super);
     }
+    pmix_argv_free(fns);
 }
 
 static void _get_fns(pmix_list_t *lst,

--- a/opal/mca/pmix/pmix4x/pmix/src/mca/bfrops/base/base.h
+++ b/opal/mca/pmix/pmix4x/pmix/src/mca/bfrops/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -227,8 +227,10 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
         int32_t i;                                                          \
         tmptype *tmpbuf = (tmptype*)malloc(sizeof(tmptype) * (*num_vals));  \
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, tmpbuf, num_vals, tmpbfroptype, reg_types);        \
-        for (i = 0 ; i < *num_vals ; ++i) {                                 \
-            ((unpack_type*) dest)[i] = (unpack_type)(tmpbuf[i]);            \
+        if (PMIX_ERR_UNKNOWN_DATA_TYPE != ret) {                            \
+            for (i = 0 ; i < *num_vals ; ++i) {                             \
+                ((unpack_type*) dest)[i] = (unpack_type)(tmpbuf[i]);        \
+            }                                                               \
         }                                                                   \
         free(tmpbuf);                                                       \
     } while (0)

--- a/opal/mca/pmix/pmix4x/pmix/src/mca/bfrops/base/bfrop_base_print.c
+++ b/opal/mca/pmix/pmix4x/pmix/src/mca/bfrops/base/bfrop_base_print.c
@@ -1031,7 +1031,7 @@ int pmix_bfrops_base_print_status(char **output, char *prefix,
             r = (pmix_regattr_t*)src->data.ptr;
             rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_REGATTR\tName: %s\tString: %s",
                           prefx, (NULL == r->name) ? "NULL" : r->name,
-                          (NULL == r->string) ? "NULL" : r->string);
+                          (0 == strlen(r->string)) ? "NULL" : r->string);
             break;
 
         default:
@@ -1751,7 +1751,7 @@ pmix_status_t pmix_bfrops_base_print_regattr(char **output, char *prefix,
 
     ret = asprintf(output, "%sData type: PMIX_REGATTR\tName: %s\tString: %s",
                    prefx, (NULL == src->name) ? "NULL" : src->name,
-                   (NULL == src->string) ? "NULL" : src->string);
+                   (0 == strlen(src->string)) ? "NULL" : src->string);
 
     if (prefx != prefix) {
         free(prefx);

--- a/opal/mca/pmix/pmix4x/pmix/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/opal/mca/pmix/pmix4x/pmix/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -11,8 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -904,7 +904,7 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_pointer_array_t *regtypes,
         if (0 < ptr[i].ninfo) {
             PMIX_INFO_CREATE(ptr[i].info, ptr[i].ninfo);
             m = ptr[i].ninfo;
-            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].info, &m, PMIX_INFO, regtypes);
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].info, &m, PMIX_INFO, regtypes);
             if (PMIX_SUCCESS != ret) {
                 return ret;
             }

--- a/opal/mca/pmix/pmix4x/pmix/src/mca/gds/ds21/gds_ds21_lock_pthread.c
+++ b/opal/mca/pmix/pmix4x/pmix/src/mca/gds/ds21/gds_ds21_lock_pthread.c
@@ -234,6 +234,7 @@ pmix_status_t pmix_gds_ds21_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
                 rc = PMIX_ERR_NOT_FOUND;
                 goto error;
             }
+            seg_hdr = (segment_hdr_t*)lock_item->seg_desc->seg_info.seg_base_addr;
         }
 
         lock_item->num_locks = seg_hdr->num_locks;

--- a/opal/mca/pmix/pmix4x/pmix/src/mca/ptl/tcp/ptl_tcp.c
+++ b/opal/mca/pmix/pmix4x/pmix/src/mca/ptl/tcp/ptl_tcp.c
@@ -427,7 +427,6 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             nspace = NULL;
             rc = parse_uri_file(&suri[5], &suri2, &nspace, &rank);
             if (PMIX_SUCCESS != rc) {
-                free(suri);
                 rc = PMIX_ERR_UNREACH;
                 goto cleanup;
             }
@@ -437,7 +436,6 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             /* we need to extract the nspace/rank of the server from the string */
             p = strchr(suri, ';');
             if (NULL == p) {
-                free(suri);
                 rc = PMIX_ERR_BAD_PARAM;
                 goto cleanup;
             }
@@ -449,7 +447,6 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             p = strchr(suri, '.');
             if (NULL == p) {
                 free(suri2);
-                free(suri);
                 rc = PMIX_ERR_BAD_PARAM;
                 goto cleanup;
             }
@@ -465,9 +462,6 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                             "ptl:tcp:tool attempt connect using given URI %s", suri);
         /* go ahead and try to connect */
         if (PMIX_SUCCESS != (rc = try_connect(suri, &sd, iptr, niptr))) {
-            if (NULL != nspace) {
-                free(nspace);
-            }
             goto cleanup;
         }
         /* cleanup */
@@ -486,9 +480,6 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             /* go ahead and try to connect */
             if (PMIX_SUCCESS == try_connect(suri, &sd, iptr, niptr)) {
                 /* don't free nspace - we will use it below */
-                if (NULL != rendfile) {
-                    free(rendfile);
-                }
                 if (NULL != iptr) {
                     PMIX_INFO_FREE(iptr, niptr);
                 }
@@ -522,6 +513,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                 goto complete;
             }
             free(nspace);
+            nspace = NULL;
         }
     }
 
@@ -683,7 +675,6 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     }
     if (NULL != server_nspace) {
         free(server_nspace);
-        server_nspace = NULL;
     }
     return rc;
 }

--- a/opal/mca/pmix/pmix4x/pmix/src/tools/pattrs/pattrs.c
+++ b/opal/mca/pmix/pmix4x/pmix/src/tools/pattrs/pattrs.c
@@ -355,7 +355,11 @@ int main(int argc, char **argv)
         pmix_pattrs_globals.client || pmix_pattrs_globals.server || pmix_pattrs_globals.tool) {
         PMIX_INFO_CREATE(info, 1);
         PMIX_INFO_LOAD(&info[0], PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
-        PMIx_tool_init(&myproc, info, 1);
+        rc = PMIx_tool_init(&myproc, info, 1);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+            exit(rc);
+        }
         if (pmix_pattrs_globals.clientfns) {
             pmix_register_client_attrs();
             fns = pmix_attributes_print_functions(PMIX_CLIENT_FUNCTIONS);


### PR DESCRIPTION
refrest pmi4x to pmix/pmix@20cc9c041ec8f37f32e36b4606e42d725f79107a

Fixes open-mpi/ompi#6513

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>