### PR TITLE
btl/vader: fix finalize sequence

### DIFF
--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -16,8 +16,8 @@
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2014-2018 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
@@ -341,6 +341,11 @@ static int mca_btl_vader_component_close(void)
 #if OPAL_BTL_VADER_HAVE_KNEM
     mca_btl_vader_knem_fini ();
 #endif
+
+    if (mca_btl_vader_component.mpool) {
+        mca_btl_vader_component.mpool->mpool_finalize (mca_btl_vader_component.mpool);
+        mca_btl_vader_component.mpool = NULL;
+    }
 
     return OPAL_SUCCESS;
 }

--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -15,8 +15,8 @@
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
- * Copyright (c) 2014-2015 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -379,11 +379,6 @@ static int vader_finalize(struct mca_btl_base_module_t *btl)
         OBJ_RELEASE(mca_btl_vader_component.vma_module);
     }
 #endif
-
-    if (component->mpool) {
-        component->mpool->mpool_finalize (component->mpool);
-        component->mpool = NULL;
-    }
 
     return OPAL_SUCCESS;
 }


### PR DESCRIPTION
free the component mpool in mca_btl_vader_component_close()
and after freeing soem objects that depend on it such as
mca_btl_vader_component.vader_frags_user

Thanks Christoph Niethammer for reporting this.

Refs. open-mpi/ompi#6524

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>