### PR TITLE
Add compilation flag to allow unwinding through files that are present in the stack when attaching with MPIR

### DIFF
--- a/ompi/runtime/Makefile.am
+++ b/ompi/runtime/Makefile.am
@@ -33,10 +33,19 @@ headers += \
 lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         runtime/ompi_mpi_abort.c \
         runtime/ompi_mpi_dynamics.c \
-        runtime/ompi_mpi_init.c \
         runtime/ompi_mpi_finalize.c \
         runtime/ompi_mpi_params.c \
         runtime/ompi_mpi_preconnect.c \
 	runtime/ompi_cr.c \
 	runtime/ompi_info_support.c \
 	runtime/ompi_spc.c
+
+# The MPIR portion of the library must be built with flags to
+# enable stepping out of MPI_INIT into main.
+# Use an intermediate library to isolate the debug object.
+noinst_LTLIBRARIES += libompi_mpir.la
+libompi_mpir_la_SOURCES = \
+	runtime/ompi_mpi_init.c
+libompi_mpir_la_CFLAGS = $(MPIR_UNWIND_CFLAGS)
+
+lib@OMPI_LIBMPI_NAME@_la_LIBADD += libompi_mpir.la

--- a/orte/mca/ess/Makefile.am
+++ b/orte/mca/ess/Makefile.am
@@ -19,6 +19,10 @@
 
 AM_CPPFLAGS = $(LTDLINCL)
 
+# Add unwind flags because files in this tree are
+# involved in startup.
+AM_CFLAGS = $(MPIR_UNWIND_CFLAGS)
+
 # main library setup
 noinst_LTLIBRARIES = libmca_ess.la
 libmca_ess_la_SOURCES =

--- a/orte/mca/ess/pmi/Makefile.am
+++ b/orte/mca/ess/pmi/Makefile.am
@@ -11,6 +11,12 @@
 # $HEADER$
 #
 
+# Add MPIR unwind flags because files in this tree are
+# involved in startup. This is not needed in the other
+# subdirs in orte/mca/ess because the other components are
+# solely used by daemons and thus are not accessible by the debugger.
+AM_CFLAGS = $(MPIR_UNWIND_CFLAGS)
+
 AM_CPPFLAGS = $(ess_pmi_CPPFLAGS)
 
 sources = \

--- a/orte/runtime/Makefile.am
+++ b/orte/runtime/Makefile.am
@@ -38,7 +38,6 @@ headers += \
 
 lib@ORTE_LIB_PREFIX@open_rte_la_SOURCES += \
         runtime/orte_finalize.c \
-        runtime/orte_init.c \
         runtime/orte_locks.c \
         runtime/orte_globals.c \
         runtime/orte_quit.c \
@@ -52,3 +51,12 @@ lib@ORTE_LIB_PREFIX@open_rte_la_SOURCES += \
         runtime/orte_cr.c \
         runtime/orte_data_server.c \
         runtime/orte_info_support.c
+
+# The MPIR portion of the library must be built with flags to
+# enable stepping out of MPI_INIT into main.
+# Use an intermediate library to isolate the debug object.
+noinst_LTLIBRARIES += libruntime_mpir.la
+libruntime_mpir_la_SOURCES = \
+        runtime/orte_init.c
+libruntime_mpir_la_CFLAGS = $(MPIR_UNWIND_CFLAGS)
+lib@ORTE_LIB_PREFIX@open_rte_la_LIBADD += libruntime_mpir.la


### PR DESCRIPTION
This is a rebase onto master of this pull request: https://github.com/open-mpi/ompi/pull/6357