### PR TITLE
configury: add option to disable enable-new-dtags

### DIFF
--- a/README
+++ b/README
@@ -831,6 +831,10 @@ INSTALLATION OPTIONS
   This rpath/runpath behavior can be disabled via
   --disable-wrapper-rpath.
 
+  If you would like to keep the rpath option, but not enable runpath
+  a different configure option is avalabile
+  --disable-wrapper-runpath.
+
 --enable-dlopen
   Build all of Open MPI's components as standalone Dynamic Shared
   Objects (DSO's) that are loaded at run-time (this is the default).


### PR DESCRIPTION
The --enable-new-dtags option for the compiler wrappers is
often great, but for some particular install/usage scenarios
causes issues.

This commit provides a new configury option to use of rpath
in the compiler wrappers, but disables the
use of --enable-new-dtags in the link line.

The new configury option is

--enable-wrappers-runpath

To disable use of --enable-new-dtags in the wrappers, add

--disable-wrappers-runpath

to the Open MPI configury line.

Fixes #1089

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ebb30c15f2a3808a51c94bf7e0f382ba096ade2f)