### PR TITLE
man: Fix typo of MPI_TYPE_GET_NAME

### DIFF
--- a/ompi/mpi/man/man3/MPI_Type_get_name.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_name.3in
@@ -20,7 +20,7 @@ int MPI_Type_get_name(MPI_Datatype \fItype\fP, char *\fItype_name\fP,
 .nf
 USE MPI
 ! or the older form: INCLUDE 'mpif.h'
-TYPE_GET_NAME(\fITYPE, TYPE_NAME, RESULTLEN, IERROR\fP)
+MPI_TYPE_GET_NAME(\fITYPE, TYPE_NAME, RESULTLEN, IERROR\fP)
 	INTEGER	\fITYPE, RESULTLEN, IERROR \fP
 	CHARACTER*(*) \fITYPE_NAME\fP
 


### PR DESCRIPTION
no code change; minor man typo fix

[skip ci]
bot:notest
