### PR TITLE
master: add missing #include to oshmem/shmem/c/shmem_context.c

### DIFF
--- a/oshmem/shmem/c/shmem_context.c
+++ b/oshmem/shmem/c/shmem_context.c
@@ -19,6 +19,7 @@
 
 #include "oshmem/constants.h"
 #include "oshmem/include/shmem.h"
+#include "oshmem/mca/spml/spml.h"
 #include "oshmem/runtime/params.h"
 #include "oshmem/runtime/runtime.h"
 #include "oshmem/shmem/shmem_api_logger.h"


### PR DESCRIPTION
This file uses `MCA_SPML_CALL` but doesn't #include the header that defines this macro.

Refs: #6562

Signed-off-by: Ben Menadue <ben.menadue@nci.org.au>