### PR TITLE
opal/sys: Native timer cleanup

### DIFF
--- a/opal/include/opal/sys/arm64/timer.h
+++ b/opal/include/opal/sys/arm64/timer.h
@@ -16,8 +16,6 @@
 #ifndef OPAL_SYS_ARCH_TIMER_H
 #define OPAL_SYS_ARCH_TIMER_H 1
 
-#include <sys/times.h>
-
 typedef uint64_t opal_timer_t;
 
 static inline opal_timer_t

--- a/opal/include/opal/sys/arm64/timer.h
+++ b/opal/include/opal/sys/arm64/timer.h
@@ -31,7 +31,7 @@ opal_sys_timer_get_cycles(void)
 
 
 static inline opal_timer_t
-opal_sys_timer_freq(void)
+opal_sys_timer_get_freq(void)
 {
     opal_timer_t freq;
     __asm__ __volatile__ ("mrs %0,  CNTFRQ_EL0" : "=r" (freq));
@@ -39,5 +39,6 @@ opal_sys_timer_freq(void)
 }
 
 #define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1
+#define OPAL_HAVE_SYS_TIMER_GET_FREQ 1
 
 #endif /* ! OPAL_SYS_ARCH_TIMER_H */

--- a/opal/include/opal/sys/ia32/timer.h
+++ b/opal/include/opal/sys/ia32/timer.h
@@ -49,9 +49,7 @@ opal_sys_timer_get_cycles(void)
 
 #else
 
-opal_timer_t opal_sys_timer_get_cycles(void);
-
-#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1
+#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 0
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 

--- a/opal/include/opal/sys/powerpc/timer.h
+++ b/opal/include/opal/sys/powerpc/timer.h
@@ -43,9 +43,7 @@ opal_sys_timer_get_cycles(void)
 
 #else
 
-opal_timer_t opal_sys_timer_get_cycles(void);
-
-#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1
+#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 0
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 

--- a/opal/include/opal/sys/timer.h
+++ b/opal/include/opal/sys/timer.h
@@ -98,6 +98,10 @@ BEGIN_C_DECLS
 
 typedef long opal_timer_t;
 #endif
+
+#ifndef OPAL_HAVE_SYS_TIMER_GET_FREQ
+#define OPAL_HAVE_SYS_TIMER_GET_FREQ 0
+#endif
 #endif
 
 #ifndef OPAL_HAVE_SYS_TIMER_IS_MONOTONIC

--- a/opal/include/opal/sys/x86_64/timer.h
+++ b/opal/include/opal/sys/x86_64/timer.h
@@ -65,9 +65,7 @@ static inline bool opal_sys_timer_is_monotonic (void)
 
 #else
 
-opal_timer_t opal_sys_timer_get_cycles(void);
-
-#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 1
+#define OPAL_HAVE_SYS_TIMER_GET_CYCLES 0
 
 #endif /* OPAL_GCC_INLINE_ASSEMBLY */
 

--- a/opal/mca/timer/linux/timer_linux_component.c
+++ b/opal/mca/timer/linux/timer_linux_component.c
@@ -117,8 +117,8 @@ static int opal_timer_linux_find_freq(void)
 
     opal_timer_linux_freq = 0;
 
-#if OPAL_ASSEMBLY_ARCH == OPAL_ARM64
-	opal_timer_linux_freq = opal_sys_timer_freq();
+#if OPAL_HAVE_SYS_TIMER_GET_FREQ
+    opal_timer_linux_freq = opal_sys_timer_get_freq();
 #endif
 
     if (0 == opal_timer_linux_freq) {


### PR DESCRIPTION
Just code cleanup. See commit comment for meanings.