### PR TITLE
dist: Rotate branch to 3.0.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,9 @@ This file contains notable changes between releases for each release since
 Open MPI 1.0.  Because Open MPI maintains multiple release branches at any time,
 it is possible for items to appear more than once in the list.
 
+3.0.5 -- October, 2019
+----------------------
+
 3.0.4 -- April, 2019
 --------------------
 

--- a/VERSION
+++ b/VERSION
@@ -15,7 +15,7 @@
 
 major=3
 minor=0
-release=4
+release=5
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -24,7 +24,7 @@ release=4
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
v3.0.4 has shipped; on to 3.0.5.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>