### PR TITLE
shortfloat MacOS / Fortran fixes

### DIFF
--- a/ompi/mpiext/shortfloat/c/Makefile.am
+++ b/ompi/mpiext/shortfloat/c/Makefile.am
@@ -18,5 +18,7 @@ ompidir = $(ompiincludedir)/mpiext
 ompi_HEADERS = mpiext_shortfloat_c.h
 
 # Sources for the convenience libtool library.
-libmpiext_shortfloat_c_la_SOURCES = $(ompi_HEADERS)
+libmpiext_shortfloat_c_la_SOURCES = \
+    $(ompi_HEADERS) \
+    mpiext_shortfloat_c_dummy.c
 libmpiext_shortfloat_c_la_LDFLAGS = -module -avoid-version

--- a/ompi/mpiext/shortfloat/c/mpiext_shortfloat_c_dummy.c
+++ b/ompi/mpiext/shortfloat/c/mpiext_shortfloat_c_dummy.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2019 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/* MacOS will not allow having an empty library file.
+ * So we must have at least one .c file with a function symbol in it,
+ * even if we don't use that function anywhere. */
+
+#include "ompi_config.h"
+
+int ompi_mpiexec_shortfloat_c_dummy(int i);
+
+int ompi_mpiexec_shortfloat_c_dummy(int i)
+{
+    return i + 1;
+}

--- a/ompi/mpiext/shortfloat/mpif-h/Makefile.am
+++ b/ompi/mpiext/shortfloat/mpif-h/Makefile.am
@@ -14,10 +14,6 @@ noinst_LTLIBRARIES =
 # installed.
 ompidir = $(ompiincludedir)/mpiext
 
-# If we are, build the convenience libtool library that will be
-# slurped up into libmpi_mpifh.la.
-noinst_LTLIBRARIES += libmpiext_shortfloat_mpifh.la
-
 # Just like noinst_LTLIBRARIES, set this macro to empty and
 # conditionally add to it later.
 ompi_HEADERS =
@@ -26,11 +22,16 @@ ompi_HEADERS =
 # bindings.
 if OMPI_BUILD_FORTRAN_MPIFH_BINDINGS
 
+# If we are, build the convenience libtool library that will be
+# slurped up into libmpi_mpifh.la.
+noinst_LTLIBRARIES += libmpiext_shortfloat_mpifh.la
+
 # This is the header file that is installed.
 ompi_HEADERS += mpiext_shortfloat_mpifh.h
 
 # Sources for the convenience libtool library.
-libmpiext_shortfloat_mpifh_la_SOURCES = $(ompi_HEADERS)
+libmpiext_shortfloat_mpifh_la_SOURCES = \
+    $(ompi_HEADERS) mpiext_shortfloat_mpifh_dummy.c
 libmpiext_shortfloat_mpifh_la_LDFLAGS = -module -avoid-version
 
 endif

--- a/ompi/mpiext/shortfloat/mpif-h/mpiext_shortfloat_mpifh_dummy.c
+++ b/ompi/mpiext/shortfloat/mpif-h/mpiext_shortfloat_mpifh_dummy.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+ * Copyright (c) 2019 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/* MacOS will not allow having an empty library file.
+ * So we must have at least one .c file with a function symbol in it,
+ * even if we don't use that function anywhere. */
+
+#include "ompi_config.h"
+
+int ompi_mpiexec_shortfloat_mpifh_dummy(int i);
+
+int ompi_mpiexec_shortfloat_mpifh_dummy(int i)
+{
+    return i + 1;
+}


### PR DESCRIPTION
Short build system fixes for the "shortfloat" MPI extension.