### PR TITLE
opal_summary.m4: make message consistent with others

### DIFF
--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -70,7 +70,7 @@ EOF
         if test $WANT_MPI_JAVA_BINDINGS -eq 1 ; then
             echo "Build MPI Java bindings (experimental): yes"
         else
-            echo "MPI Build Java bindings (experimental): no"
+            echo "Build MPI Java bindings (experimental): no"
         fi
     fi
 


### PR DESCRIPTION
Fix one message in opal_summary.m4 be consistent with other messages
in the same area of opal_summary.m4.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>