### PR TITLE
common/ompio: refactor the build_io_array function

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -264,7 +264,8 @@ OMPI_DECLSPEC int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp, OMPI_MP
 OMPI_DECLSPEC int mca_common_ompio_build_io_array ( ompio_file_t *fh, int index, int cycles,
                                                     size_t bytes_per_cycle, int max_data, uint32_t iov_count,
                                                     struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw,
-                                                    size_t *spc );
+                                                    size_t *spc, mca_common_ompio_io_array_t **io_array,
+                                                    int *num_io_entries );
 
 
 OMPI_DECLSPEC int mca_common_ompio_file_read (ompio_file_t *fh,  void *buf,  int count,

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -152,7 +152,9 @@ int mca_common_ompio_file_read (ompio_file_t *fh,
                                           &i,
                                           &j,
                                           &total_bytes_read, 
-                                          &spc);
+                                          &spc,
+                                          &fh->f_io_array,
+                                          &fh->f_num_of_io_entries);
 
         if (fh->f_num_of_io_entries) {
             ret_code = fh->f_fbtl->fbtl_preadv (fh);
@@ -305,7 +307,9 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
                                           &i,
                                           &j,
                                           &total_bytes_read, 
-                                          &spc);
+                                          &spc,
+                                          &fh->f_io_array,
+                                          &fh->f_num_of_io_entries);
 
 	if (fh->f_num_of_io_entries) {
 	  fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);


### PR DESCRIPTION
abstract out the io_array structure to be used in common_ompio_build_io_array function.
This is preparation for a future component that would like to use the same function,
but not modify the io_array stored on the file handle itself.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>