### PR TITLE
v4.0.x: ob1 get_frag fail fix

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -330,7 +330,9 @@ static int mca_pml_ob1_recv_request_get_frag_failed (mca_pml_ob1_rdma_frag_t *fr
     if (OMPI_ERR_NOT_AVAILABLE == rc) {
         /* get isn't supported for this transfer. tell peer to fallback on put */
         rc = mca_pml_ob1_recv_request_put_frag (frag);
-        if (OMPI_ERR_OUT_OF_RESOURCE == rc) {
+        if (OMPI_SUCCESS == rc){
+            return OMPI_SUCCESS;
+        } else if (OMPI_ERR_OUT_OF_RESOURCE == rc) {
             OPAL_THREAD_LOCK(&mca_pml_ob1.lock);
             opal_list_append (&mca_pml_ob1.rdma_pending, (opal_list_item_t*)frag);
             OPAL_THREAD_UNLOCK(&mca_pml_ob1.lock);


### PR DESCRIPTION
In the case the btl_get fails Ob1 tries to fallback on btl_put first but
the return code was ignored. So the code fell back on both btl_put and
btl_send.

Signed-off-by: Brelle Emmanuel <emmanuel.brelle@atos.net>
(cherry picked from commit 9c689f2225d29aa152627f39bab841afead254af)

This was submitted by a user on master; @hjelmn and I reviewed it.  If @hjelmn isn't able to review it here, can an OMPI v4.0.x RM review/approve this for the v4.0.x branch?  It's kinda trivial.