### PR TITLE
v3.0.x: make-authors.pl script not compatible with being a submodule.

### DIFF
--- a/contrib/dist/make-authors.pl
+++ b/contrib/dist/make-authors.pl
@@ -29,7 +29,7 @@ GetOptions("skip-ok" => \$skip_ok,
 # directory and make life easier.
 chdir($srcdir);
 
-if (! -d ".git") {
+if (! -e ".git") {
     if ($skip_ok == 0) {
 	print STDERR "I don't seem to be in a git repo :(\n";
 	exit(1);


### PR DESCRIPTION
make-authors.pl checks that .git exists and is a directory before
getting the git log - but when a repo is checked out as a submodule of a
larger repository, .git is not a directory, it's just a text file.  This
can cause make-authors.pl to terminate inappropriately.

Author: Michael Heinz <michael.william.heinz@intel.com>
Signed-off-by: Michael Heinz <michael.william.heinz@intel.com>
(cherry picked from commit 0a8fa5439c626c01a68fd9cebda8f00597500f51)

Refs #6614