### PR TITLE
OSHMEM: added processing of multiple segments

### DIFF
--- a/oshmem/include/shmemx.h
+++ b/oshmem/include/shmemx.h
@@ -18,6 +18,19 @@
 extern "C" {
 #endif
 
+enum {
+    SHMEM_HINT_NONE,
+    SHMEM_HINT_LOW_LAT_MEM,
+    SHMEM_HINT_HIGH_BW_MEM,
+    SHMEM_HINT_NEAR_NIC_MEM,
+    SHMEM_HINT_DEVICE_GPU_MEM,
+    SHMEM_HINT_DEVICE_NIC_MEM,
+
+    SHMEM_HINT_PSYNC   = 1 << 16,
+    SHMEM_HINT_PWORK   = 1 << 17,
+    SHMEM_HINT_ATOMICS = 1 << 18
+};
+
 /*
  * All OpenSHMEM extension APIs that are not part of this specification must be defined in the shmemx.h include
  * file. These extensions shall use the shmemx_ prefix for all routine, variable, and constant names.

--- a/oshmem/mca/memheap/base/base.h
+++ b/oshmem/mca/memheap/base/base.h
@@ -41,7 +41,7 @@ OSHMEM_DECLSPEC int mca_memheap_base_select(void);
 extern int mca_memheap_base_already_opened;
 extern int mca_memheap_base_key_exchange;
 
-#define MCA_MEMHEAP_MAX_SEGMENTS    4 
+#define MCA_MEMHEAP_MAX_SEGMENTS    8
 #define HEAP_SEG_INDEX  0
 #define SYMB_SEG_INDEX  1
 #define MCA_MEMHEAP_SEG_COUNT  (SYMB_SEG_INDEX+1)
@@ -58,6 +58,7 @@ typedef struct mca_memheap_map {
 extern mca_memheap_map_t mca_memheap_base_map;
 
 int mca_memheap_base_alloc_init(mca_memheap_map_t *, size_t);
+int mca_memheap_base_hint_alloc_init(mca_memheap_map_t *map, size_t size, long hint);
 void mca_memheap_base_alloc_exit(mca_memheap_map_t *);
 int mca_memheap_base_static_init(mca_memheap_map_t *);
 void mca_memheap_base_static_exit(mca_memheap_map_t *);
@@ -173,10 +174,12 @@ static inline int memheap_is_va_in_segment(void *va, int segno)
 
 static inline int memheap_find_segnum(void *va)
 {
-    if (OPAL_LIKELY(memheap_is_va_in_segment(va, SYMB_SEG_INDEX))) {
-        return SYMB_SEG_INDEX;
-    } else if (memheap_is_va_in_segment(va, HEAP_SEG_INDEX)) {
-        return HEAP_SEG_INDEX;
+    int i;
+
+    for (i = 0; i < mca_memheap_base_map.n_segments; i++) {
+        if (memheap_is_va_in_segment(va, i)) {
+            return i;
+        }
     }
     return MEMHEAP_SEG_INVALID;
 }
@@ -193,18 +196,16 @@ static inline void *map_segment_va2rva(mkey_segment_t *seg, void *va)
     return memheap_va2rva(va, seg->super.va_base, seg->rva_base);
 }
 
-static inline map_base_segment_t *map_segment_find_va(map_base_segment_t *segs, size_t elem_size, void *va) 
+static inline map_base_segment_t *map_segment_find_va(map_base_segment_t *segs, size_t elem_size, void *va)
 {
     map_base_segment_t *rseg;
+    int i;
 
-    rseg = (map_base_segment_t *)((char *)segs + elem_size * HEAP_SEG_INDEX);
-    if (OPAL_LIKELY(map_segment_is_va_in(rseg, va))) {
-        return rseg;
-    } 
-
-    rseg = (map_base_segment_t *)((char *)segs + elem_size * SYMB_SEG_INDEX);
-    if (OPAL_LIKELY(map_segment_is_va_in(rseg, va))) {
-        return rseg;
+    for (i = 0; i < MCA_MEMHEAP_MAX_SEGMENTS; i++) {
+        rseg = (map_base_segment_t *)((char *)segs + elem_size * i);
+        if (OPAL_LIKELY(map_segment_is_va_in(rseg, va))) {
+            return rseg;
+        } 
     }
 
     return NULL;
@@ -221,10 +222,10 @@ static inline map_segment_t *memheap_find_va(void* va)
         s = &memheap_map->mem_segs[SYMB_SEG_INDEX];
     } else if (memheap_is_va_in_segment(va, HEAP_SEG_INDEX)) {
         s = &memheap_map->mem_segs[HEAP_SEG_INDEX];
-    } else if (memheap_map->n_segments - 2 > 0) {
+    } else if (memheap_map->n_segments >= MCA_MEMHEAP_SEG_COUNT) {
         s = bsearch(va,
-                    &memheap_map->mem_segs[SYMB_SEG_INDEX+1],
-                    memheap_map->n_segments - 2,
+                    &memheap_map->mem_segs[MCA_MEMHEAP_SEG_COUNT],
+                    memheap_map->n_segments - MCA_MEMHEAP_SEG_COUNT,
                     sizeof(*s),
                     mca_memheap_seg_cmp);
     } else {

--- a/oshmem/mca/memheap/base/memheap_base_alloc.c
+++ b/oshmem/mca/memheap/base/memheap_base_alloc.c
@@ -33,6 +33,31 @@ int mca_memheap_base_alloc_init(mca_memheap_map_t *map, size_t size)
 
     if (OSHMEM_SUCCESS == ret) {
         map->n_segments++;
+        s->memheap = &mca_memheap;
+        MEMHEAP_VERBOSE(1,
+                        "Memheap alloc memory: %llu byte(s), %d segments by method: %d",
+                        (unsigned long long)size, map->n_segments, s->type);
+    }
+
+    free(seg_filename);
+
+    return ret;
+}
+
+int mca_memheap_base_hint_alloc_init(mca_memheap_map_t *map, size_t size, long hint)
+{
+    int ret = OSHMEM_SUCCESS;
+    char * seg_filename = NULL;
+
+    assert(map);
+    assert(SYMB_SEG_INDEX <= map->n_segments);
+
+    map_segment_t *s = &map->mem_segs[map->n_segments];
+    seg_filename = oshmem_get_unique_file_name(oshmem_my_proc_id());
+    ret = mca_sshmem_segment_hint_create(s, seg_filename, size, hint);
+
+    if (OSHMEM_SUCCESS == ret) {
+        map->n_segments++;
         MEMHEAP_VERBOSE(1,
                         "Memheap alloc memory: %llu byte(s), %d segments by method: %d",
                         (unsigned long long)size, map->n_segments, s->type);

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -749,7 +749,7 @@ void mkey_segment_init(mkey_segment_t *seg, sshmem_mkey_t *mkey, uint32_t segno)
 {
     map_segment_t *s;
 
-    if (segno >= MCA_MEMHEAP_SEG_COUNT) {
+    if (segno >= MCA_MEMHEAP_MAX_SEGMENTS) {
         return;
     }
 

--- a/oshmem/mca/spml/ikrit/spml_ikrit.h
+++ b/oshmem/mca/spml/ikrit/spml_ikrit.h
@@ -75,7 +75,7 @@ struct mxm_peer {
     uint8_t             need_fence;
     int32_t             n_active_puts;
     opal_list_item_t    link;
-    spml_ikrit_mkey_t   mkeys[MCA_MEMHEAP_SEG_COUNT];
+    spml_ikrit_mkey_t   mkeys[MCA_MEMHEAP_MAX_SEGMENTS];
 };
 
 typedef struct mxm_peer mxm_peer_t;

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -61,7 +61,7 @@ typedef struct spml_ucx_cached_mkey spml_ucx_cached_mkey_t;
 
 struct ucp_peer {
     ucp_ep_h                 ucp_conn;
-    spml_ucx_cached_mkey_t   mkeys[MCA_MEMHEAP_SEG_COUNT];
+    spml_ucx_cached_mkey_t   mkeys[MCA_MEMHEAP_MAX_SEGMENTS];
 };
 typedef struct ucp_peer ucp_peer_t;
  
@@ -153,14 +153,6 @@ extern int mca_spml_ucx_fence(shmem_ctx_t ctx);
 extern int mca_spml_ucx_quiet(shmem_ctx_t ctx);
 extern int spml_ucx_default_progress(void);
 extern int spml_ucx_ctx_progress(void);
-
-static void mca_spml_ucx_cache_mkey(mca_spml_ucx_ctx_t *ucx_ctx, sshmem_mkey_t *mkey, uint32_t segno, int dst_pe)
-{
-    ucp_peer_t *peer;
-
-    peer = &(ucx_ctx->ucp_peers[dst_pe]);
-    mkey_segment_init(&peer->mkeys[segno].super, mkey, segno);
-}
 
 static inline spml_ucx_mkey_t * 
 mca_spml_ucx_get_mkey(shmem_ctx_t ctx, int pe, void *va, void **rva, mca_spml_ucx_t* module)

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -240,7 +240,7 @@ static void _ctx_cleanup(mca_spml_ucx_ctx_t *ctx)
     del_procs = malloc(sizeof(*del_procs) * nprocs);
 
     for (i = 0; i < nprocs; ++i) {
-        for (j = 0; j < MCA_MEMHEAP_SEG_COUNT; j++) {
+        for (j = 0; j < MCA_MEMHEAP_MAX_SEGMENTS; j++) {
             if (ctx->ucp_peers[i].mkeys[j].key.rkey != NULL) {
                 ucp_rkey_destroy(ctx->ucp_peers[i].mkeys[j].key.rkey);
             }

--- a/oshmem/mca/sshmem/base/base.h
+++ b/oshmem/mca/sshmem/base/base.h
@@ -33,6 +33,11 @@ mca_sshmem_segment_create(map_segment_t *ds_buf,
                           const char *file_name,
                           size_t size);
 
+OSHMEM_DECLSPEC int
+mca_sshmem_segment_hint_create(map_segment_t *ds_buf,
+                               const char *file_name,
+                               size_t size, long hint);
+
 OSHMEM_DECLSPEC void *
 mca_sshmem_segment_attach(map_segment_t *ds_buf, sshmem_mkey_t *mkey);
 

--- a/oshmem/mca/sshmem/base/sshmem_base_wrappers.c
+++ b/oshmem/mca/sshmem/base/sshmem_base_wrappers.c
@@ -29,6 +29,22 @@ mca_sshmem_segment_create(map_segment_t *ds_buf,
     return mca_sshmem_base_module->segment_create(ds_buf, file_name, size);
 }
 
+int
+mca_sshmem_segment_hint_create(map_segment_t *ds_buf,
+                               const char *file_name,
+                               size_t size, long hint)
+{
+    if (!mca_sshmem_base_selected) {
+        return OSHMEM_ERROR;
+    }
+
+    if (!mca_sshmem_base_module->segment_hint_create) {
+        return OSHMEM_ERR_NOT_IMPLEMENTED;
+    }
+
+    return mca_sshmem_base_module->segment_hint_create(ds_buf, file_name, size, hint);
+}
+
 void *
 mca_sshmem_segment_attach(map_segment_t *ds_buf, sshmem_mkey_t *mkey)
 {

--- a/oshmem/mca/sshmem/mmap/sshmem_mmap_module.c
+++ b/oshmem/mca/sshmem/mmap/sshmem_mmap_module.c
@@ -83,12 +83,12 @@ module_finalize(void);
 mca_sshmem_mmap_module_t mca_sshmem_mmap_module = {
     /* super */
     {
-        module_init,
-        segment_create,
-        segment_attach,
-        segment_detach,
-        segment_unlink,
-        module_finalize
+        .module_init     = module_init,
+        .segment_create  = segment_create,
+        .segment_attach  = segment_attach,
+        .segment_detach  = segment_detach,
+        .unlink          = segment_unlink,
+        .module_finalize = module_finalize
     }
 };
 

--- a/oshmem/mca/sshmem/sshmem.h
+++ b/oshmem/mca/sshmem/sshmem.h
@@ -93,6 +93,27 @@ typedef int
                                               size_t size);
 
 /**
+ * create a new shared memory segment with hint and initialize members
+ * in structure pointed to by ds_buf.
+ *
+ * @param ds_buf               pointer to map_segment_t typedef'd structure
+ *                             defined in shmem_types.h (OUT).
+ *
+ * @param file_name file_name  unique string identifier that must be a valid,
+ *                             writable path (IN).
+ *
+ * @param size                 size of the shared memory segment.
+ *
+ * @param size                 hint of the shared memory segment.
+ *
+ * @return OSHMEM_SUCCESS on success.
+ */
+typedef int
+(*mca_sshmem_base_module_segment_hint_create_fn_t)(map_segment_t *ds_buf,
+                                                   const char *file_name,
+                                                   size_t size, long hint);
+
+/**
  * attach to an existing shared memory segment initialized by segment_create.
  *
  * @param ds_buf  pointer to initialized map_segment_t typedef'd
@@ -136,12 +157,13 @@ typedef int (*mca_sshmem_base_module_finalize_fn_t)(void);
  * structure for shmem modules
  */
 struct mca_sshmem_base_module_2_0_0_t {
-    mca_sshmem_base_module_init_fn_t            module_init;
-    mca_sshmem_base_module_segment_create_fn_t  segment_create;
-    mca_sshmem_base_module_segment_attach_fn_t  segment_attach;
-    mca_sshmem_base_module_segment_detach_fn_t  segment_detach;
-    mca_sshmem_base_module_unlink_fn_t          unlink;
-    mca_sshmem_base_module_finalize_fn_t        module_finalize;
+    mca_sshmem_base_module_init_fn_t                 module_init;
+    mca_sshmem_base_module_segment_create_fn_t       segment_create;
+    mca_sshmem_base_module_segment_hint_create_fn_t  segment_hint_create;
+    mca_sshmem_base_module_segment_attach_fn_t       segment_attach;
+    mca_sshmem_base_module_segment_detach_fn_t       segment_detach;
+    mca_sshmem_base_module_unlink_fn_t               unlink;
+    mca_sshmem_base_module_finalize_fn_t             module_finalize;
 };
 
 /**

--- a/oshmem/mca/sshmem/sshmem_types.h
+++ b/oshmem/mca/sshmem/sshmem_types.h
@@ -117,6 +117,7 @@ typedef struct map_segment {
     segment_type_t       type;           /* type of the segment */
     void                *context;        /* allocator can use this field to store
                                             its own private data */
+    struct mca_memheap_base_module_t *memheap;  /* memheap interface to manage memory */
 } map_segment_t;
 
 END_C_DECLS

--- a/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
+++ b/oshmem/mca/sshmem/sysv/sshmem_sysv_module.c
@@ -79,12 +79,12 @@ module_finalize(void);
 mca_sshmem_sysv_module_t mca_sshmem_sysv_module = {
     /* super */
     {
-        module_init,
-        segment_create,
-        segment_attach,
-        segment_detach,
-        segment_unlink,
-        module_finalize
+        .module_init     = module_init,
+        .segment_create  = segment_create,
+        .segment_attach  = segment_attach,
+        .segment_detach  = segment_detach,
+        .unlink          = segment_unlink,
+        .module_finalize = module_finalize
     }
 };
 

--- a/oshmem/shmem/c/shmem_free.c
+++ b/oshmem/shmem/c/shmem_free.c
@@ -18,6 +18,7 @@
 #include "oshmem/runtime/runtime.h"
 
 #include "oshmem/mca/memheap/memheap.h"
+#include "oshmem/mca/memheap/base/base.h"
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
@@ -41,6 +42,7 @@ void shfree(void* ptr)
 static inline void _shfree(void* ptr)
 {
     int rc;
+    map_segment_t *s;
 
     RUNTIME_CHECK_INIT();
     if (NULL == ptr) {
@@ -55,7 +57,8 @@ static inline void _shfree(void* ptr)
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
 
-    rc = MCA_MEMHEAP_CALL(free(ptr));
+    s = memheap_find_va(ptr);
+    rc = s->memheap->memheap_free(ptr);
 
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 

--- a/oshmem/shmem/c/shmem_realloc.c
+++ b/oshmem/shmem/c/shmem_realloc.c
@@ -18,6 +18,7 @@
 
 #include "oshmem/shmem/shmem_api_logger.h"
 #include "oshmem/mca/memheap/memheap.h"
+#include "oshmem/mca/memheap/base/base.h"
 
 #if OSHMEM_PROFILING
 #include "oshmem/include/pshmem.h"
@@ -42,12 +43,14 @@ static inline void* _shrealloc(void *ptr, size_t size)
 {
     int rc;
     void* pBuff = NULL;
+    map_segment_t *s;
 
     RUNTIME_CHECK_INIT();
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
 
-    rc = MCA_MEMHEAP_CALL(realloc(size, ptr, &pBuff));
+    s = memheap_find_va(ptr);
+    rc = s->memheap->memheap_realloc(size, ptr, &pBuff);
 
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 


### PR DESCRIPTION
- original implementation allowed to have 2 active segments only,
  but it prevents adding of some features which require
  additional segments.
- added processing up to 8 segments

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>