### PR TITLE
v4.0.x buildrpm.sh no longer respects the value of rpmtopdir

### DIFF
--- a/contrib/dist/linux/README
+++ b/contrib/dist/linux/README
@@ -86,6 +86,9 @@ Please, do NOT set the same settings with parameters and config vars.
    file from the tarball specified on the command line. By default,
    the script will look for the specfile in the current directory.
 
+-R directory
+   Specifies the top level RPM build direcotry.
+
 -h
    Prints script usage information.
 

--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -58,6 +58,9 @@
 #    file from the tarball specified on the command line. By default,
 #    the script will look for the specfile in the current directory.
 #
+# -R directory
+#    Specifies the top level RPM build direcotry.
+#
 # -h
 #    Prints script usage information.
 #
@@ -107,7 +110,7 @@ orig_param="$@"
 #
 # usage information
 #
-usage="Usage: $0 [-b][-o][-m][-d][-u][-s][-h] [-n name][-f lf_location][-t tm_location] tarball
+usage="Usage: $0 [-b][-o][-m][-d][-u][-s][-h] [-n name][-f lf_location][-t tm_location][-R directory] tarball
 
   -b
              build all-in-one binary RPM only (required for all other flags to work)
@@ -146,6 +149,9 @@ usage="Usage: $0 [-b][-o][-m][-d][-u][-s][-h] [-n name][-f lf_location][-t tm_lo
   -r parameter
              add custom RPM build parameter
 
+  -R directory
+             Specifies the top level RPM build direcotry.
+
   -h         print this message and exit
 
   tarball    path to Open MPI source tarball
@@ -155,8 +161,9 @@ usage="Usage: $0 [-b][-o][-m][-d][-u][-s][-h] [-n name][-f lf_location][-t tm_lo
 # parse args
 #
 libfabric_path=""
+rpmtopdir=
 
-while getopts bn:omif:t:dc:r:sh flag; do
+while getopts bn:omif:t:dc:r:sR:h flag; do
     case "$flag" in
       b) build_srpm="no"
          build_single="yes"
@@ -179,6 +186,8 @@ while getopts bn:omif:t:dc:r:sh flag; do
       c) configure_options="$configure_options $OPTARG"
          ;;
       r) configure_options="$rpmbuild_options $OPTARG"
+         ;;
+      R) rpmtopdir="$OPTARG"
          ;;
       s) unpack_spec="1"
          ;;
@@ -267,10 +276,16 @@ fi
 # Find where the top RPM-building directory is
 #
 
-file=~/.rpmmacros
-if test -r $file; then
-    rpmtopdir=${rpmtopdir:-"`grep %_topdir $file | awk '{ print $2 }'`"}
+# if the user did not specify an $rpmtopdir, check for an .rpmmacros file.
+if test "$rpmtopdir" == ""; then
+    file=~/.rpmmacros
+    if test -r $file; then
+        rpmtopdir=${rpmtopdir:-"`grep %_topdir $file | awk '{ print $2 }'`"}
+    fi
 fi
+
+# If needed, initialize the $rpmtopdir directory. If no $rpmtopdir was
+# specified, try various system-level defaults.
 if test "$rpmtopdir" != ""; then
 	rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
     if test ! -d "$rpmtopdir"; then

--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -287,19 +287,19 @@ fi
 # If needed, initialize the $rpmtopdir directory. If no $rpmtopdir was
 # specified, try various system-level defaults.
 if test "$rpmtopdir" != ""; then
-	rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
+    rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
     if test ! -d "$rpmtopdir"; then
-	mkdir -p "$rpmtopdir"
-	mkdir -p "$rpmtopdir/BUILD"
-	mkdir -p "$rpmtopdir/RPMS"
-	mkdir -p "$rpmtopdir/RPMS/i386"
-	mkdir -p "$rpmtopdir/RPMS/i586"
-	mkdir -p "$rpmtopdir/RPMS/i686"
-	mkdir -p "$rpmtopdir/RPMS/noarch"
-	mkdir -p "$rpmtopdir/RPMS/athlon"
-	mkdir -p "$rpmtopdir/SOURCES"
-	mkdir -p "$rpmtopdir/SPECS"
-	mkdir -p "$rpmtopdir/SRPMS"
+        mkdir -p "$rpmtopdir"
+        mkdir -p "$rpmtopdir/BUILD"
+        mkdir -p "$rpmtopdir/RPMS"
+        mkdir -p "$rpmtopdir/RPMS/i386"
+        mkdir -p "$rpmtopdir/RPMS/i586"
+        mkdir -p "$rpmtopdir/RPMS/i686"
+        mkdir -p "$rpmtopdir/RPMS/noarch"
+        mkdir -p "$rpmtopdir/RPMS/athlon"
+        mkdir -p "$rpmtopdir/SOURCES"
+        mkdir -p "$rpmtopdir/SPECS"
+        mkdir -p "$rpmtopdir/SRPMS"
     fi
     need_root=0
 elif test -d /usr/src/RPM; then


### PR DESCRIPTION
Ref #6628 

In OMPI 2.1.2, buildrpm.sh could work with a value of rpmtopdir that was
set in the environment. In newer versions this is no longer true,
causing such values to be ignored. This patch adds a new argument to
buildrpm.sh, -R, which allows the user to specify where to build the
RPMs.
