### PR TITLE
v3.1.x buildrpm.sh no longer respects the value of rpmtopdir

### DIFF
--- a/contrib/dist/linux/README
+++ b/contrib/dist/linux/README
@@ -86,6 +86,9 @@ Please, do NOT set the same settings with parameters and config vars.
    file from the tarball specified on the command line. By default,
    the script will look for the specfile in the current directory.
 
+-R directory
+   Specifies the top level RPM build direcotry.
+
 -h
    Prints script usage information.
 

--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -287,19 +287,19 @@ fi
 # If needed, initialize the $rpmtopdir directory. If no $rpmtopdir was
 # specified, try various system-level defaults.
 if test "$rpmtopdir" != ""; then
-	rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
+    rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
     if test ! -d "$rpmtopdir"; then
-	mkdir -p "$rpmtopdir"
-	mkdir -p "$rpmtopdir/BUILD"
-	mkdir -p "$rpmtopdir/RPMS"
-	mkdir -p "$rpmtopdir/RPMS/i386"
-	mkdir -p "$rpmtopdir/RPMS/i586"
-	mkdir -p "$rpmtopdir/RPMS/i686"
-	mkdir -p "$rpmtopdir/RPMS/noarch"
-	mkdir -p "$rpmtopdir/RPMS/athlon"
-	mkdir -p "$rpmtopdir/SOURCES"
-	mkdir -p "$rpmtopdir/SPECS"
-	mkdir -p "$rpmtopdir/SRPMS"
+        mkdir -p "$rpmtopdir"
+        mkdir -p "$rpmtopdir/BUILD"
+        mkdir -p "$rpmtopdir/RPMS"
+        mkdir -p "$rpmtopdir/RPMS/i386"
+        mkdir -p "$rpmtopdir/RPMS/i586"
+        mkdir -p "$rpmtopdir/RPMS/i686"
+        mkdir -p "$rpmtopdir/RPMS/noarch"
+        mkdir -p "$rpmtopdir/RPMS/athlon"
+        mkdir -p "$rpmtopdir/SOURCES"
+        mkdir -p "$rpmtopdir/SPECS"
+        mkdir -p "$rpmtopdir/SRPMS"
     fi
     need_root=0
 elif test -d /usr/src/RPM; then


### PR DESCRIPTION
Refs #6628

In OMPI 2.1.2, buildrpm.sh could work with a value of rpmtopdir that was
set in the environment. In newer versions this is no longer true,
causing such values to be ignored. This patch adds a new argument to
buildrpm.sh, -R, which allows the user to specify where to build the
RPMs.