### PR TITLE
adding OMP_PLACES%d and basic CUDA_VISIBLE_DEVICES for LSF

### DIFF
--- a/orte/runtime/orte_globals.c
+++ b/orte/runtime/orte_globals.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -131,6 +131,7 @@ float orte_max_timeout = -1.0;
 orte_timer_t *orte_mpiexec_timeout = NULL;
 
 int orte_stack_trace_wait_timeout = 30;
+char *orte_ncuda_per_rank = "all";
 
 /* global arrays for data storage */
 opal_hash_table_t *orte_job_data = NULL;

--- a/orte/runtime/orte_globals.h
+++ b/orte/runtime/orte_globals.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation. All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -580,6 +580,8 @@ ORTE_DECLSPEC extern char *orte_daemon_cores;
 
 /* Max time to wait for stack straces to return */
 ORTE_DECLSPEC extern int orte_stack_trace_wait_timeout;
+/* Split CUDA_VISIBLE_DEVICES between ranks */
+ORTE_DECLSPEC extern char * orte_ncuda_per_rank;
 
 END_C_DECLS
 

--- a/orte/runtime/orte_mca_params.c
+++ b/orte/runtime/orte_mca_params.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -762,6 +762,14 @@ int orte_register_params(void)
                                   MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                   OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_ALL,
                                   &orte_data_server_uri);
+
+    /* Split CUDA_VISIBLE_DEVICES between ranks */
+    orte_ncuda_per_rank = "all";
+    (void) mca_base_var_register ("orte", NULL, NULL, "ncuda_per_rank",
+                                  "Number of GPUs to assign to each rank from CUDA_VISIBLE_DEVICES",
+                                  MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,
+                                  &orte_ncuda_per_rank);
 
     return ORTE_SUCCESS;
 }


### PR DESCRIPTION
LSF can set OMP_PLACES%d for each rank, with the expectation that
MPI will set OMP_PLACES to the corresponding value (where %d is
a 1-based  host-local index of the rank). LSF also can provide a list
of CUDA_VISIBLE_DEVICES that it might want split between the ranks.

This checkin looks for an OMP_PLACES%d for each rank, and also
parses the CUDA_VISIBLE_DEVICES to be handed out to the ranks in a
round robin manner.

We support a comma separated list of somewhat arbitrary strings
like GPU-1234-abcd in CUDA_VISIZBLE_DEVICES. An invalid GPU entry
in the list is used to signify that all entries past that point are
to be ignored.  We can't really recognize all invalid GPU strings,
but we will recognize negative integers as invalid.

We also use
    --mca ncuda_per_rank <number>
as the control for how many GPUs to hand out to each rank, with
the option
    --mca ncuda_per_rank all
which assignes the full list of CUDA_VISIBLE_DEVICES to each rank.

Also LSF will support multiple MPS on one host, so we translate
CUDA_MPS_PIPE_DIRECTORY1/2/3... to a CUDA_MPS_PIPE_DIRECTORY
environment variable per specified rank.

Signed-off-by: Mark Allen <markalle@us.ibm.com>