### PR TITLE
Fix/length 0

### DIFF
--- a/ompi/datatype/ompi_datatype_create_contiguous.c
+++ b/ompi/datatype/ompi_datatype_create_contiguous.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -29,13 +29,12 @@ int32_t ompi_datatype_create_contiguous( int count, const ompi_datatype_t* oldTy
 {
     ompi_datatype_t* pdt;
 
-    if( 0 == count ) {
-        pdt = ompi_datatype_create( 0 );
-        ompi_datatype_add( pdt, &ompi_mpi_datatype_null.dt, 0, 0, 0 );
-    } else {
-        pdt = ompi_datatype_create( oldType->super.desc.used + 2 );
-        opal_datatype_add( &(pdt->super), &(oldType->super), count, 0, (oldType->super.ub - oldType->super.lb) );
+    if( (0 == count) || (0 == oldType->super.size) ) {
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
+
+    pdt = ompi_datatype_create( oldType->super.desc.used + 2 );
+    opal_datatype_add( &(pdt->super), &(oldType->super), count, 0, (oldType->super.ub - oldType->super.lb) );
     *newType = pdt;
     return OMPI_SUCCESS;
 }

--- a/ompi/datatype/ompi_datatype_create_darray.c
+++ b/ompi/datatype/ompi_datatype_create_darray.c
@@ -192,9 +192,7 @@ int32_t ompi_datatype_create_darray(int size,
     if (ndims < 1) {
         /* Don't just return MPI_DATATYPE_NULL as that can't be
            MPI_TYPE_FREE()ed, and that seems bad */
-        *newtype = ompi_datatype_create(0);
-        ompi_datatype_add(*newtype, &ompi_mpi_datatype_null.dt, 0, 0, 0);
-        return MPI_SUCCESS;
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newtype);
     }
 
     rc = ompi_datatype_type_extent(oldtype, &orig_extent);

--- a/ompi/datatype/ompi_datatype_create_vector.c
+++ b/ompi/datatype/ompi_datatype_create_vector.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -28,23 +28,14 @@
 
 #include "ompi/datatype/ompi_datatype.h"
 
-/* Open questions ...
- *  - how to improuve the handling of these vectors (creating a temporary datatype
- *    can be ONLY a initial solution.
- *
- */
-
 int32_t ompi_datatype_create_vector( int count, int bLength, int stride,
                                      const ompi_datatype_t* oldType, ompi_datatype_t** newType )
 {
     ompi_datatype_t *pTempData, *pData;
     ptrdiff_t extent = oldType->super.ub - oldType->super.lb;
 
-
-    if( 0 == count ) {
-        *newType = ompi_datatype_create( 0 );
-        ompi_datatype_add( *newType, &ompi_mpi_datatype_null.dt, 0, 0, 0);
-        return OMPI_SUCCESS;
+    if( (0 == count) || (0 == bLength) ) {
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
 
     pData = ompi_datatype_create( oldType->super.desc.used + 2 );
@@ -72,10 +63,8 @@ int32_t ompi_datatype_create_hvector( int count, int bLength, ptrdiff_t stride,
     ompi_datatype_t *pTempData, *pData;
     ptrdiff_t extent = oldType->super.ub - oldType->super.lb;
 
-    if( 0 == count ) {
-        *newType = ompi_datatype_create( 0 );
-        ompi_datatype_add( *newType, &ompi_mpi_datatype_null.dt, 0, 0, 0);
-        return OMPI_SUCCESS;
+    if( (0 == count) || (0 == bLength) ) {
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
 
     pTempData = ompi_datatype_create( oldType->super.desc.used + 2 );

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -759,14 +759,14 @@ void ompi_datatype_dump( const ompi_datatype_t* pData )
     length = length * 100 + 500;
     buffer = (char*)malloc( length );
     index += snprintf( buffer, length - index,
-                       "Datatype %p[%s] id %d size %ld align %d opal_id %d length %d used %d\n"
-                       "true_lb %ld true_ub %ld (true_extent %ld) lb %ld ub %ld (extent %ld)\n"
-                       "nbElems %d loops %d flags %X (",
-                     (void*)pData, pData->name, pData->id,
-                     (long)pData->super.size, (int)pData->super.align, pData->super.id, (int)pData->super.desc.length, (int)pData->super.desc.used,
-                     (long)pData->super.true_lb, (long)pData->super.true_ub, (long)(pData->super.true_ub - pData->super.true_lb),
-                     (long)pData->super.lb, (long)pData->super.ub, (long)(pData->super.ub - pData->super.lb),
-                     (int)pData->super.nbElems, (int)pData->super.loops, (int)pData->super.flags );
+                       "Datatype %p[%s] id %d size %" PRIsize_t " align %u opal_id %u length %" PRIsize_t " used %" PRIsize_t "\n"
+                       "true_lb %td true_ub %td (true_extent %td) lb %td ub %td (extent %td)\n"
+                       "nbElems %" PRIsize_t " loops %u flags %X (",
+                       (void*)pData, pData->name, pData->id,
+                       pData->super.size, pData->super.align, (uint32_t)pData->super.id, pData->super.desc.length, pData->super.desc.used,
+                       pData->super.true_lb, pData->super.true_ub, pData->super.true_ub - pData->super.true_lb,
+                       pData->super.lb, pData->super.ub, pData->super.ub - pData->super.lb,
+                       pData->super.nbElems, pData->super.loops, (int)pData->super.flags );
     /* dump the flags */
     if( ompi_datatype_is_predefined(pData) ) {
         index += snprintf( buffer + index, length - index, "predefined " );

--- a/opal/datatype/opal_convertor.c
+++ b/opal/datatype/opal_convertor.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2018 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -699,12 +699,12 @@ int opal_convertor_clone( const opal_convertor_t* source,
 
 void opal_convertor_dump( opal_convertor_t* convertor )
 {
-    opal_output( 0, "Convertor %p count %" PRIsize_t" stack position %d bConverted %" PRIsize_t "\n"
-                 "\tlocal_size %ld remote_size %ld flags %X stack_size %d pending_length %" PRIsize_t "\n"
+    opal_output( 0, "Convertor %p count %" PRIsize_t " stack position %u bConverted %" PRIsize_t "\n"
+                 "\tlocal_size %" PRIsize_t " remote_size %" PRIsize_t " flags %X stack_size %u pending_length %" PRIsize_t "\n"
                  "\tremote_arch %u local_arch %u\n",
                  (void*)convertor,
                  convertor->count, convertor->stack_pos, convertor->bConverted,
-                 (unsigned long)convertor->local_size, (unsigned long)convertor->remote_size,
+                 convertor->local_size, convertor->remote_size,
                  convertor->flags, convertor->stack_size, convertor->partial_length,
                  convertor->remoteArch, opal_local_arch );
     if( convertor->flags & CONVERTOR_RECV ) opal_output( 0, "unpack ");

--- a/opal/datatype/opal_convertor_raw.c
+++ b/opal/datatype/opal_convertor_raw.c
@@ -32,13 +32,13 @@
 
 /**
  * This function always work in local representation. This means no representation
- * conversion (i.e. no heterogeneity) has to be taken into account, and that all
+ * conversion (i.e. no heterogeneity) is taken into account, and that all
  * length we're working on are local.
  */
 int32_t
 opal_convertor_raw( opal_convertor_t* pConvertor,
-		    struct iovec* iov, uint32_t* iov_count,
-		    size_t* length )
+                    struct iovec* iov, uint32_t* iov_count,
+                    size_t* length )
 {
     const opal_datatype_t *pData = pConvertor->pDesc;
     dt_stack_t* pStack;       /* pointer to the position on the stack */
@@ -77,9 +77,9 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
     description = pConvertor->use_desc->desc;
 
     /* For the first step we have to add both displacement to the source. After in the
-    * main while loop we will set back the source_base to the correct value. This is
-    * due to the fact that the convertor can stop in the middle of a data with a count
-    */
+     * main while loop we will set back the source_base to the correct value. This is
+     * due to the fact that the convertor can stop in the middle of a data with a count
+     */
     pStack = pConvertor->pStack + pConvertor->stack_pos;
     pos_desc     = pStack->index;
     source_base  = pConvertor->pBaseBuf + pStack->disp;
@@ -101,9 +101,9 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
                     blength *= count_desc;
                     /* now here we have a basic datatype */
                     OPAL_DATATYPE_SAFEGUARD_POINTER( source_base, blength, pConvertor->pBaseBuf,
-                                                pConvertor->pDesc, pConvertor->count );
+                                                     pConvertor->pDesc, pConvertor->count );
                     DO_DEBUG( opal_output( 0, "raw 1. iov[%d] = {base %p, length %" PRIsize_t "}\n",
-                                           index, (void*)source_base, (unsigned long)blength ); );
+                                           index, (void*)source_base, blength ); );
                     iov[index].iov_base = (IOVBASE_TYPE *) source_base;
                     iov[index].iov_len  = blength;
                     source_base += blength;
@@ -114,9 +114,9 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
             } else {
                 for(size_t i = count_desc; (i > 0) && (index < *iov_count); i--, index++ ) {
                     OPAL_DATATYPE_SAFEGUARD_POINTER( source_base, blength, pConvertor->pBaseBuf,
-                                                pConvertor->pDesc, pConvertor->count );
+                                                     pConvertor->pDesc, pConvertor->count );
                     DO_DEBUG( opal_output( 0, "raw 2. iov[%d] = {base %p, length %" PRIsize_t "}\n",
-                                           index, (void*)source_base, (unsigned long)blength ); );
+                                           index, (void*)source_base, blength ); );
                     iov[index].iov_base = (IOVBASE_TYPE *) source_base;
                     iov[index].iov_len  = blength;
                     source_base += pElem->elem.extent;
@@ -141,8 +141,8 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
             if( --(pStack->count) == 0 ) { /* end of loop */
                 if( pConvertor->stack_pos == 0 ) {
                     /* we lie about the size of the next element in order to
-                    * make sure we exit the main loop.
-                    */
+                     * make sure we exit the main loop.
+                     */
                     *iov_count = index;
                     goto complete_loop;  /* completed */
                 }
@@ -174,7 +174,7 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
                 source_base += offset;
                 for(size_t i = MIN(count_desc, *iov_count - index); i > 0; i--, index++ ) {
                     OPAL_DATATYPE_SAFEGUARD_POINTER( source_base, end_loop->size, pConvertor->pBaseBuf,
-                                                pConvertor->pDesc, pConvertor->count );
+                                                     pConvertor->pDesc, pConvertor->count );
                     iov[index].iov_base = (IOVBASE_TYPE *) source_base;
                     iov[index].iov_len  = end_loop->size;
                     source_base += pElem->loop.extent;
@@ -198,14 +198,14 @@ opal_convertor_raw( opal_convertor_t* pConvertor,
             PUSH_STACK( pStack, pConvertor->stack_pos, pos_desc, OPAL_DATATYPE_LOOP, count_desc,
                         pStack->disp + local_disp);
             pos_desc++;
-          update_loop_description:  /* update the current state */
+        update_loop_description:  /* update the current state */
             source_base = pConvertor->pBaseBuf + pStack->disp;
             UPDATE_INTERNAL_COUNTERS( description, pos_desc, pElem, count_desc );
             DDT_DUMP_STACK( pConvertor->pStack, pConvertor->stack_pos, pElem, "advance loop" );
             continue;
         }
     }
-complete_loop:
+ complete_loop:
     pConvertor->bConverted += raw_data;  /* update the already converted bytes */
     *length = raw_data;
     *iov_count = index;

--- a/opal/datatype/opal_datatype_dump.c
+++ b/opal/datatype/opal_datatype_dump.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -64,7 +64,7 @@ int opal_datatype_dump_data_flags( unsigned short usflags, char* ptr, size_t len
     int index = 0;
     if( length < 22 ) return 0;
     index = snprintf( ptr, 22, "-----------[---][---]" );  /* set everything to - */
-    if( usflags & OPAL_DATATYPE_FLAG_COMMITTED )   ptr[1]  = 'c';
+    if( usflags & OPAL_DATATYPE_FLAG_COMMITTED )  ptr[1]  = 'c';
     if( usflags & OPAL_DATATYPE_FLAG_CONTIGUOUS ) ptr[2]  = 'C';
     if( usflags & OPAL_DATATYPE_FLAG_OVERLAP )    ptr[3]  = 'o';
     if( usflags & OPAL_DATATYPE_FLAG_USER_LB )    ptr[4]  = 'l';
@@ -90,17 +90,17 @@ int opal_datatype_dump_data_desc( dt_elem_desc_t* pDesc, int nbElems, char* ptr,
         index += snprintf( ptr + index, length - index, "%15s ", opal_datatype_basicDatatypes[pDesc->elem.common.type]->name );
         if( length <= (size_t)index ) break;
         if( OPAL_DATATYPE_LOOP == pDesc->elem.common.type )
-            index += snprintf( ptr + index, length - index, "%d times the next %d elements extent %d\n",
-                               (int)pDesc->loop.loops, (int)pDesc->loop.items,
-                               (int)pDesc->loop.extent );
+            index += snprintf( ptr + index, length - index, "%u times the next %u elements extent %td\n",
+                               pDesc->loop.loops, pDesc->loop.items,
+                               pDesc->loop.extent );
         else if( OPAL_DATATYPE_END_LOOP == pDesc->elem.common.type )
-            index += snprintf( ptr + index, length - index, "prev %d elements first elem displacement %ld size of data %d\n",
-                           (int)pDesc->end_loop.items, (long)pDesc->end_loop.first_elem_disp,
-                           (int)pDesc->end_loop.size );
+            index += snprintf( ptr + index, length - index, "prev %u elements first elem displacement %td size of data %" PRIsize_t "\n",
+                               pDesc->end_loop.items, pDesc->end_loop.first_elem_disp,
+                               pDesc->end_loop.size );
         else
-            index += snprintf( ptr + index, length - index, "count %" PRIsize_t " disp 0x%lx (%ld) blen %d extent %ld (size %ld)\n",
-                               pDesc->elem.count, (long)pDesc->elem.disp, (long)pDesc->elem.disp, (int)pDesc->elem.blocklen,
-                               pDesc->elem.extent, (long)(pDesc->elem.count * opal_datatype_basicDatatypes[pDesc->elem.common.type]->size) );
+            index += snprintf( ptr + index, length - index, "count %" PRIsize_t " disp 0x%tx (%td) blen %u extent %td (size %zd)\n",
+                               pDesc->elem.count, pDesc->elem.disp, pDesc->elem.disp, pDesc->elem.blocklen,
+                               pDesc->elem.extent, (pDesc->elem.count * pDesc->elem.blocklen * opal_datatype_basicDatatypes[pDesc->elem.common.type]->size) );
         pDesc++;
 
         if( length <= (size_t)index ) break;
@@ -118,13 +118,13 @@ void opal_datatype_dump( const opal_datatype_t* pData )
     length = pData->opt_desc.used + pData->desc.used;
     length = length * 100 + 500;
     buffer = (char*)malloc( length );
-    index += snprintf( buffer, length - index, "Datatype %p[%s] size %ld align %d id %d length %d used %d\n"
-                                               "true_lb %ld true_ub %ld (true_extent %ld) lb %ld ub %ld (extent %ld)\n"
-                                               "nbElems %" PRIsize_t " loops %d flags %X (",
-                     (void*)pData, pData->name, (long)pData->size, (int)pData->align, pData->id, (int)pData->desc.length, (int)pData->desc.used,
-                     (long)pData->true_lb, (long)pData->true_ub, (long)(pData->true_ub - pData->true_lb),
-                     (long)pData->lb, (long)pData->ub, (long)(pData->ub - pData->lb),
-                     pData->nbElems, (int)pData->loops, (int)pData->flags );
+    index += snprintf( buffer, length - index, "Datatype %p[%s] size %" PRIsize_t " align %u id %u length %" PRIsize_t " used %" PRIsize_t "\n"
+                                               "true_lb %td true_ub %td (true_extent %td) lb %td ub %td (extent %td)\n"
+                                               "nbElems %" PRIsize_t " loops %u flags %X (",
+                       (void*)pData, pData->name, pData->size, pData->align, (uint32_t)pData->id, pData->desc.length, pData->desc.used,
+                       pData->true_lb, pData->true_ub, pData->true_ub - pData->true_lb,
+                       pData->lb, pData->ub, pData->ub - pData->lb,
+                       pData->nbElems, pData->loops, (int)pData->flags );
     /* dump the flags */
     if( pData->flags == OPAL_DATATYPE_FLAG_PREDEFINED )
         index += snprintf( buffer + index, length - index, "predefined " );

--- a/test/datatype/ddt_raw.c
+++ b/test/datatype/ddt_raw.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -75,7 +75,7 @@ static int test_upper( unsigned int length )
         iov_count = 5;
         max_data = 0;
         opal_convertor_raw( pConv, iov, &iov_count, &max_data );
-	i -= max_data;
+        i -= max_data;
     }
     GET_TIME( end );
     total_time = ELAPSED_TIME( start, end );
@@ -89,12 +89,12 @@ static int test_upper( unsigned int length )
 }
 
 /**
- *  Conversion function. They deal with data-types in 3 ways, always making local copies.
+ * Conversion function. They deal with datatypes in 3 ways, always making local copies.
  * In order to allow performance testings, there are 3 functions:
  *  - one copying directly from one memory location to another one using the
- *    data-type copy function.
- *  - one which use a 2 convertors created with the same data-type
- *  - and one using 2 convertors created from different data-types.
+ *    datatype copy function.
+ *  - one which use a 2 convertors created with the same datatype
+ *  - and one using 2 convertors created from different datatypes.
  *
  */
 static int local_copy_ddt_raw( ompi_datatype_t* pdt, int count, int iov_num )
@@ -118,13 +118,13 @@ static int local_copy_ddt_raw( ompi_datatype_t* pdt, int count, int iov_num )
     GET_TIME( start );
     while( 0 == opal_convertor_raw(convertor, iov, &iov_count, &max_data) ) {
 #if 0
-	printf( "New raw extraction (iov_count = %d, max_data = %zu)\n",
-		iov_count, max_data );
-	for( i = 0; i < iov_count; i++ ) {
-	    printf( "\t{%p, %d}\n", iov[i].iov_base, iov[i].iov_len );
-	}
+        printf( "New raw extraction (iov_count = %d, max_data = %zu)\n",
+                iov_count, max_data );
+        for( i = 0; i < iov_count; i++ ) {
+            printf( "\t{%p, %d}\n", iov[i].iov_base, iov[i].iov_len );
+        }
 #endif
-	remaining_length -= max_data;
+        remaining_length -= max_data;
         iov_count = iov_num;
     }
     remaining_length -= max_data;
@@ -133,19 +133,23 @@ static int local_copy_ddt_raw( ompi_datatype_t* pdt, int count, int iov_num )
     printf( "raw extraction in %ld microsec\n", total_time );
     OBJ_RELEASE( convertor );
     if( remaining_length != 0 ) {
-	printf( "Not all raw description was been extracted (%lu bytes missing)\n",
-		(unsigned long) remaining_length );
+        printf( "Not all raw description was been extracted (%lu bytes missing)\n",
+                (unsigned long) remaining_length );
     }
     free(iov);
     return OMPI_SUCCESS;
 }
 
 /**
- * Main function. Call several tests and print-out the results. It try to stress the convertor
- * using difficult data-type constructions as well as strange segment sizes for the conversion.
- * Usually, it is able to detect most of the data-type and convertor problems. Any modifications
- * on the data-type engine should first pass all the tests from this file, before going into other
- * tests.
+ * Go over a set of datatypes and copy them using the raw functionality provided by the
+ * convertor. The goal of this test is to stress the convertor using several more or less
+ * difficult datatype, with a large set of segment sizes for the conversion. It can be used
+ * to highlight the raw capability of the convertor as well as detecting datatype convertor
+ * problems.
+ *
+ * This test is part of the testing infrastructure for the core datatype engine. As such any
+ * modifications on the datatype engine should first pass all the tests from this file,
+ * before going into other tests.
  */
 int main( int argc, char* argv[] )
 {
@@ -231,7 +235,7 @@ int main( int argc, char* argv[] )
     OBJ_RELEASE( pdt3 ); assert( pdt3 == NULL );
 
     printf( ">>--------------------------------------------<<\n" );
-    printf( " Contiguous data-type (MPI_DOUBLE)\n" );
+    printf( " Contiguous datatype (MPI_DOUBLE)\n" );
     pdt = MPI_DOUBLE;
     if( outputFlags & CHECK_PACK_UNPACK ) {
         local_copy_ddt_raw(pdt, 4500, iov_num);
@@ -240,37 +244,37 @@ int main( int argc, char* argv[] )
 
     printf( ">>--------------------------------------------<<\n" );
     if( outputFlags & CHECK_PACK_UNPACK ) {
-        printf( "Contiguous multiple data-type (4500*1)\n" );
+        printf( "Contiguous multiple datatype (4500*1)\n" );
         pdt = create_contiguous_type( MPI_DOUBLE, 4500 );
         local_copy_ddt_raw(pdt, 1, iov_num);
         OBJ_RELEASE( pdt ); assert( pdt == NULL );
-        printf( "Contiguous multiple data-type (450*10)\n" );
+        printf( "Contiguous multiple datatype (450*10)\n" );
         pdt = create_contiguous_type( MPI_DOUBLE, 450 );
         local_copy_ddt_raw(pdt, 10, iov_num);
         OBJ_RELEASE( pdt ); assert( pdt == NULL );
-        printf( "Contiguous multiple data-type (45*100)\n" );
+        printf( "Contiguous multiple datatype (45*100)\n" );
         pdt = create_contiguous_type( MPI_DOUBLE, 45 );
         local_copy_ddt_raw(pdt, 100, iov_num);
         OBJ_RELEASE( pdt ); assert( pdt == NULL );
-        printf( "Contiguous multiple data-type (100*45)\n" );
+        printf( "Contiguous multiple datatype (100*45)\n" );
         pdt = create_contiguous_type( MPI_DOUBLE, 100 );
         local_copy_ddt_raw(pdt, 45, iov_num);
         OBJ_RELEASE( pdt ); assert( pdt == NULL );
-        printf( "Contiguous multiple data-type (10*450)\n" );
+        printf( "Contiguous multiple datatype (10*450)\n" );
         pdt = create_contiguous_type( MPI_DOUBLE, 10 );
         local_copy_ddt_raw(pdt, 450, iov_num);
         OBJ_RELEASE( pdt ); assert( pdt == NULL );
-        printf( "Contiguous multiple data-type (1*4500)\n" );
+        printf( "Contiguous multiple datatype (1*4500)\n" );
         pdt = create_contiguous_type( MPI_DOUBLE, 1 );
         local_copy_ddt_raw(pdt, 4500, iov_num);
         OBJ_RELEASE( pdt ); assert( pdt == NULL );
     }
     printf( ">>--------------------------------------------<<\n" );
     printf( ">>--------------------------------------------<<\n" );
-    printf( "Vector data-type (450 times 10 double stride 11)\n" );
+    printf( "Vector datatype (450 times 10 double stride 11)\n" );
     pdt = create_vector_type( MPI_DOUBLE, 450, 10, 11 );
     if( outputFlags & DUMP_DATA_AFTER_COMMIT ) {
-	ompi_datatype_dump( pdt );
+        ompi_datatype_dump( pdt );
     }
     if( outputFlags & CHECK_PACK_UNPACK ) {
         local_copy_ddt_raw(pdt, 1, iov_num);
@@ -297,9 +301,9 @@ int main( int argc, char* argv[] )
     printf( ">>--------------------------------------------<<\n" );
     pdt = test_create_blacs_type();
     if( outputFlags & CHECK_PACK_UNPACK ) {
-	if( outputFlags & DUMP_DATA_AFTER_COMMIT ) {
-	    ompi_datatype_dump( pdt );
-	}
+        if( outputFlags & DUMP_DATA_AFTER_COMMIT ) {
+            ompi_datatype_dump( pdt );
+        }
         local_copy_ddt_raw(pdt, 4500, iov_num);
     }
     printf( ">>--------------------------------------------<<\n" );


### PR DESCRIPTION
Change the datatype creation function to return a duplicate of MPI_DATATYPE_NULL if the count or the blockLength for the datatype is 0. Fix the format in the datatype_dump function to prevent any compile warnings.

Provide a fix for #6575.