### PR TITLE
slurm-19.05.0-0rc1 srun needs dash

### DIFF
--- a/orte/mca/plm/slurm/plm_slurm_module.c
+++ b/orte/mca/plm/slurm/plm_slurm_module.c
@@ -278,7 +278,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * constraint, but will ensure it doesn't get
      * bound to only one processor
      */
-    opal_argv_append(&argc, &argv, "--cpu_bind=none");
+    opal_argv_append(&argc, &argv, "--cpu-bind=none");
 
 #if SLURM_CRAY_ENV
     /*


### PR DESCRIPTION
The underscore (--cpu_bind) is no longer recognized as a valid srun option.
I changed this to be a dash (--cpu-bind), which is now supported.