### PR TITLE
Add --enable-mpi1-compatibility configure option back

### DIFF
--- a/README
+++ b/README
@@ -586,6 +586,11 @@ MPI Functionality and Features
       examples of how to update legacy MPI applications using these
       deleted symbols to use the "new" symbols.
 
+  All that being said, if you are unable to immediately update your
+  application to stop using these legacy MPI-1 symbols, you can
+  re-enable them in mpi.h by configuring Open MPI with the
+  --enable-mpi1-compatibility flag.
+
 - Rank reordering support is available using the TreeMatch library. It
   is activated for the graph and dist_graph topologies.
 

--- a/config/ompi_config_files.m4
+++ b/config/ompi_config_files.m4
@@ -36,6 +36,7 @@ AC_DEFUN([OMPI_CONFIG_FILES],[
         ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile
         ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h
         ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-file-interfaces.h
+        ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-removed-interfaces.h
         ompi/mpi/fortran/use-mpi-f08/Makefile
         ompi/mpi/fortran/use-mpi-f08/bindings/Makefile
         ompi/mpi/fortran/use-mpi-f08/mod/Makefile

--- a/config/ompi_configure_options.m4
+++ b/config/ompi_configure_options.m4
@@ -196,6 +196,22 @@ fi
 AC_DEFINE_UNQUOTED([OMPI_WANT_MPI_CXX_SEEK], [$OMPI_WANT_MPI_CXX_SEEK],
     [do we want to try to work around C++ bindings SEEK_* issue?])
 
+# Remove these when we finally kill them once and for all
+AC_ARG_ENABLE([mpi1-compatibility],
+    [AC_HELP_STRING([--enable-mpi1-compatibility],
+                    [Enable support for MPI-1.x functions removed from the current MPI standard (MPI-3.x). This option will go away in a future release of Open MPI (default: disabled)])])
+
+if test "x$enable_mpi1_compatibility" = "xyes" ; then
+ompi_mpi1_support=1
+else
+ompi_mpi1_support=0
+fi
+
+
+AC_DEFINE_UNQUOTED([OMPI_ENABLE_MPI1_COMPAT], [$ompi_mpi1_support], [whether we want MPI-1.x support])
+AC_SUBST([OMPI_ENABLE_MPI1_COMPAT], [$ompi_mpi1_support])
+AM_CONDITIONAL([OMPI_ENABLE_MPI1_COMPAT],[test $ompi_mpi1_support = 1])
+
 AC_ARG_ENABLE([grequest-extensions],
     [AC_HELP_STRING([--enable-grequest-extensions],
                     [Enable support for Grequest extensions (default: disabled)])])

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -841,19 +841,25 @@ ompi_datatype_t* ompi_datatype_get_single_predefined_type_from_args( ompi_dataty
                 return NULL;
             }
         }
-        if( NULL == predef ) {  /* This is the first iteration */
-            predef = current_predef;
-        } else {
-            /**
-             *  What exactly should we consider as identical types?
-             *  If they are the same MPI level type, or if they map
-             *  to the same OPAL datatype? In other words, MPI_FLOAT
-             *  and MPI_REAL4 are they identical?
-             */
-            if( predef != current_predef ) {
-                return NULL;
+#if OMPI_ENABLE_MPI1_COMPAT
+        if (current_predef != MPI_LB && current_predef != MPI_UB) {
+#endif
+            if( NULL == predef ) {  /* This is the first iteration */
+                predef = current_predef;
+            } else {
+                /**
+                 *  What exactly should we consider as identical types?
+                 *  If they are the same MPI level type, or if they map
+                 *  to the same OPAL datatype? In other words, MPI_FLOAT
+                 *  and MPI_REAL4 are they identical?
+                 */
+                if( predef != current_predef ) {
+                    return NULL;
+                }
             }
+#if OMPI_ENABLE_MPI1_COMPAT
         }
+#endif
     }
     return predef;
 }

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1037,7 +1037,13 @@ OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUSES_IGNORE;
 #define MPI_LONG_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_long_int)
 #define MPI_SHORT_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_short_int)
 #define MPI_2INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_2int)
-
+#if !OMPI_OMIT_MPI1_COMPAT_DECLS
+/*
+ * Removed datatypes
+ */
+#define MPI_UB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_ub)
+#define MPI_LB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_lb)
+#endif
 #define MPI_WCHAR OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_wchar)
 #if OPAL_HAVE_LONG_LONG
 #define MPI_LONG_LONG_INT OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_long_long_int)

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -137,6 +137,9 @@
 /* Whether we have FORTRAN REAL*8 or not */
 #undef OMPI_HAVE_FORTRAN_REAL8
 
+/* Whether in include MPI-1 compatibility */
+#undef OMPI_ENABLE_MPI1_COMPAT
+
 /* Whether we have float _Complex  or not */
 #undef HAVE_FLOAT__COMPLEX
 
@@ -278,6 +281,50 @@
 #                endif
 #            endif
 #        endif
+
+         /* For MPI removed APIs, there is no generally portable way to cause
+          * the C compiler to error with a nice message, on the _usage_ of
+          * one of these symbols.  We've gone with tiered appraoch:
+          *
+          * If the user configured with --enable-mpi1-compatibility,
+          * just emit a compiletime warning (via the deprecation function
+          * attribute) that they're using an MPI1 removed function.
+          *
+          * Otherwise, we'd like to issue a fatal error directing the user
+          * that they've used an MPI1 removed function.  If the user's
+          * compiler supports C11 _Static_assert feature, we #define
+          * the MPI routines to instead be a call to _Static_assert
+          * with an appropreate message suggesting the new MPI3 equivalent.
+          *
+          * Otherwise, if the user's compiler supports the error function
+          * attribute, define the MPI routines with that error attribute.
+          * This is supported by most modern GNU compilers.
+          *
+          * Finally if the compiler doesn't support any of those, just
+          * Don't declare those MPI routines at all in mpi.h
+          *
+          * Don't do MACRO magic for building Profiling library as it
+          * interferes with the above.
+          */
+#        if (OMPI_ENABLE_MPI1_COMPAT || OMPI_BUILDING)
+#            define OMPI_OMIT_MPI1_COMPAT_DECLS 0
+#            define OMPI_REMOVED_USE_STATIC_ASSERT 0
+#            define __mpi_interface_removed__(func, newfunc) __mpi_interface_deprecated__(#func " was removed in MPI-3.0.  Use " #newfunc " instead.  continuing...")
+#        elif (__STDC_VERSION__ >= 201112L)
+#            define OMPI_OMIT_MPI1_COMPAT_DECLS 1
+#            define OMPI_REMOVED_USE_STATIC_ASSERT 1
+// This macro definition may show up in compiler output.  So we both
+// outdent it back to column 0 and give it a user-friendly name to
+// help users grok what we are trying to tell them here.
+#define THIS_SYMBOL_WAS_REMOVED_IN_MPI30(func, newfunc) _Static_assert(0, #func " was removed in MPI-3.0.  Use " #newfunc " instead.")
+#        elif OPAL_HAVE_ATTRIBUTE_ERROR
+#            define OMPI_OMIT_MPI1_COMPAT_DECLS 0
+#            define OMPI_REMOVED_USE_STATIC_ASSERT 0
+#            define __mpi_interface_removed__(func, newfunc) __attribute__((__error__(#func " was removed in MPI-3.0.  Use " #newfunc " instead.")))
+#        else
+#            define OMPI_OMIT_MPI1_COMPAT_DECLS 1
+#            define OMPI_REMOVED_USE_STATIC_ASSERT 0
+#        endif
 #    endif
 #endif
 
@@ -288,6 +335,22 @@
  */
 #if !defined(__mpi_interface_deprecated__)
 #    define __mpi_interface_deprecated__(msg)
+#endif
+
+#if !defined(__mpi_interface_removed__)
+#    define __mpi_interface_removed__(A,B)
+#endif
+
+#if !defined(THIS_SYMBOL_WAS_REMOVED_IN_MPI30)
+#    define THIS_SYMBOL_WAS_REMOVED_IN_MPI30(func, newfunc)
+#endif
+
+#if !defined(OMPI_REMOVED_USE_STATIC_ASSERT)
+#    define OMPI_REMOVED_USE_STATIC_ASSERT 0
+#endif
+
+#if !defined(OMPI_OMIT_MPI1_COMPAT_DECLS)
+#    define OMPI_OMIT_MPI1_COMPAT_DECLS !OMPI_ENABLE_MPI1_COMPAT
 #endif
 
 /*
@@ -989,6 +1052,33 @@ OMPI_DECLSPEC extern struct ompi_predefined_info_t ompi_mpi_info_env;
 
 OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUS_IGNORE;
 OMPI_DECLSPEC extern MPI_Fint *MPI_F_STATUSES_IGNORE;
+
+/*
+ * Removed datatypes.  These datatypes are only available if Open MPI
+ * was configured with --enable-mpi1-compatibility.
+ *
+ * These datatypes were formally removed from the MPI specification
+ * and should no longer be used in MPI applications.
+ */
+#if (OMPI_ENABLE_MPI1_COMPAT || OMPI_BUILDING)
+#    define MPI_UB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_ub)
+#    define MPI_LB OMPI_PREDEFINED_GLOBAL(MPI_Datatype, ompi_mpi_lb)
+
+OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_lb;
+OMPI_DECLSPEC extern struct ompi_predefined_datatype_t ompi_mpi_ub;
+
+#else
+/* If not building or configured --enable-mpi1-compatibility, then
+ * we don't want these datatypes, instead we define MPI_UB and
+ * MPI_LB to our Static Assert message if the compiler supports
+ * that staticly assert with a nice message.
+ */
+#    if (OMPI_REMOVED_USE_STATIC_ASSERT)
+#        define MPI_UB THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_UB, MPI_Type_create_resized);
+#        define MPI_LB THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_LB, MPI_Type_create_resized);
+#    endif /* OMPI_REMOVED_USE_STATIC_ASSERT */
+#endif /* Removed datatypes */
+
 
 /*
  * MPI predefined handles
@@ -2645,6 +2735,98 @@ OMPI_DECLSPEC int OMPI_C_MPI_NULL_DELETE_FN( MPI_Comm comm, int comm_keyval,
                                              void* attribute_val_out,
                                              void* extra_state )
             __mpi_interface_deprecated__("MPI_NULL_DELETE_FN was deprecated in MPI-2.0; use MPI_COMM_NULL_DELETE_FN instead.");
+
+#if !OMPI_OMIT_MPI1_COMPAT_DECLS
+/*
+ * Removed typedefs.  These typedefs are only available if Open MPI
+ * was configured with --enable-mpi1-compatibility.
+ *
+ * These typedefs were formally removed from the MPI specification
+ * and should no longer be used in MPI applications.
+ *
+ * Even though MPI_Handler_function is removed, we do not use the
+ * attributes marking it as such, because otherwise the compiler
+ * will warn for all the functions that are declared using them
+ * (e.g., MPI_Errhandler_create).
+ */
+typedef void (MPI_Handler_function)(MPI_Comm *, int *, ...);
+/* MPI_Handler_function was removed in MPI-3.0; use MPI_Comm_use_errhandler_function instead. */
+
+/*
+ * Removed prototypes.  These prototypes are only available if Open
+ * MPI was configured with --enable-mpi1-compatibility.
+ *
+ * These functions were formally removed from the MPI specification
+ * and should no longer be used in MPI applications.
+ */
+OMPI_DECLSPEC  int MPI_Address(void *location, MPI_Aint *address)
+                   __mpi_interface_removed__(MPI_Address, MPI_Get_address);
+OMPI_DECLSPEC  int PMPI_Address(void *location, MPI_Aint *address)
+                   __mpi_interface_removed__(PMPI_Address, PMPI_Get_address);
+OMPI_DECLSPEC  int MPI_Errhandler_create(MPI_Handler_function *function,
+                                         MPI_Errhandler *errhandler)
+                   __mpi_interface_removed__(MPI_Errhandler_create, MPI_Comm_create_errhandler);
+OMPI_DECLSPEC  int PMPI_Errhandler_create(MPI_Handler_function *function,
+                                          MPI_Errhandler *errhandler)
+                   __mpi_interface_removed__(PMPI_Errhandler_create, PMPI_Comm_create_errhandler);
+OMPI_DECLSPEC  int MPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
+                   __mpi_interface_removed__(MPI_Errhandler_get, MPI_Comm_get_errhandler);
+OMPI_DECLSPEC  int PMPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
+                   __mpi_interface_removed__(PMPI_Errhandler_get, PMPI_Comm_get_errhandler);
+OMPI_DECLSPEC  int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
+                   __mpi_interface_removed__(MPI_Errhandler_set, MPI_Comm_set_errhandler);
+OMPI_DECLSPEC  int PMPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
+                   __mpi_interface_removed__(PMPI_Errhandler_set, PMPI_Comm_set_errhandler);
+OMPI_DECLSPEC  int MPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
+                   __mpi_interface_removed__(MPI_Type_extent, MPI_Type_get_extent);
+OMPI_DECLSPEC  int PMPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
+                   __mpi_interface_removed__(PMPI_Type_extent, PMPI_Type_get_extent);
+OMPI_DECLSPEC  int MPI_Type_hindexed(int count, int array_of_blocklengths[],
+                                     MPI_Aint array_of_displacements[],
+                                     MPI_Datatype oldtype, MPI_Datatype *newtype)
+                   __mpi_interface_removed__(MPI_Type_hindexed, MPI_Type_create_hindexed);
+OMPI_DECLSPEC  int PMPI_Type_hindexed(int count, int array_of_blocklengths[],
+                                      MPI_Aint array_of_displacements[],
+                                      MPI_Datatype oldtype, MPI_Datatype *newtype)
+                   __mpi_interface_removed__(PMPI_Type_hindexed, PMPI_Type_create_hindexed);
+OMPI_DECLSPEC  int MPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
+                                    MPI_Datatype oldtype, MPI_Datatype *newtype)
+                   __mpi_interface_removed__(MPI_Type_hvector, MPI_Type_create_hvector);
+OMPI_DECLSPEC  int PMPI_Type_hvector(int count, int blocklength, MPI_Aint stride,
+                                     MPI_Datatype oldtype, MPI_Datatype *newtype)
+                   __mpi_interface_removed__(PMPI_Type_hvector, PMPI_Type_create_hvector);
+OMPI_DECLSPEC  int MPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
+                   __mpi_interface_removed__(MPI_Type_lb, MPI_Type_get_extent);
+OMPI_DECLSPEC  int PMPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
+                   __mpi_interface_removed__(PMPI_Type_lb, PMPI_Type_get_extent);
+OMPI_DECLSPEC  int MPI_Type_struct(int count, int array_of_blocklengths[],
+                                   MPI_Aint array_of_displacements[],
+                                   MPI_Datatype array_of_types[],
+                                   MPI_Datatype *newtype)
+                   __mpi_interface_removed__(MPI_Type_struct, MPI_Type_create_struct);
+OMPI_DECLSPEC  int PMPI_Type_struct(int count, int array_of_blocklengths[],
+                                    MPI_Aint array_of_displacements[],
+                                    MPI_Datatype array_of_types[],
+                                    MPI_Datatype *newtype)
+                   __mpi_interface_removed__(PMPI_Type_struct, PMPI_Type_create_struct);
+OMPI_DECLSPEC  int MPI_Type_ub(MPI_Datatype mtype, MPI_Aint *ub)
+                   __mpi_interface_removed__(MPI_Type_ub, MPI_Type_get_extent);
+OMPI_DECLSPEC  int PMPI_Type_ub(MPI_Datatype mtype, MPI_Aint *ub)
+                   __mpi_interface_removed__(PMPI_Type_ub, PMPI_Type_get_extent);
+#endif /* !OMPI_OMIT_MPI1_COMPAT_DECLS */
+
+#if OMPI_REMOVED_USE_STATIC_ASSERT
+#define MPI_Address(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Address, MPI_Get_address)
+#define MPI_Errhandler_create(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Errhandler_create, MPI_Comm_create_errhandler)
+#define MPI_Errhandler_get(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Errhandler_get, MPI_Comm_get_errhandler)
+#define MPI_Errhandler_set(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Errhandler_set, MPI_Comm_set_errhandler)
+#define MPI_Type_extent(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_extent, MPI_Type_get_extent)
+#define MPI_Type_hindexed(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_hindexed, MPI_Type_create_hindexed)
+#define MPI_Type_hvector(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_hvector, MPI_Type_create_hvector)
+#define MPI_Type_lb(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_lb, MPI_Type_get_extent)
+#define MPI_Type_struct(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_struct, MPI_Type_create_struct)
+#define MPI_Type_ub(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_ub, MPI_Type_get_extent)
+#endif
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -437,6 +437,20 @@ libmpi_c_mpi_la_SOURCES = \
         win_wait.c
 
 
+if OMPI_ENABLE_MPI1_COMPAT
+libmpi_c_mpi_la_SOURCES += \
+        address.c \
+        errhandler_create.c \
+        errhandler_get.c \
+        errhandler_set.c \
+        type_extent.c \
+        type_hindexed.c \
+        type_hvector.c \
+        type_lb.c \
+        type_struct.c \
+        type_ub.c
+endif
+
 # Conditionally install the header files
 
 if WANT_INSTALL_HEADERS

--- a/ompi/mpi/c/address.c
+++ b/ompi/mpi/c/address.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include <stdio.h>
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Address = PMPI_Address
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Address
+#define MPI_Address PMPI_Address
+#endif
+
+static const char FUNC_NAME[] = "MPI_Address";
+
+
+int MPI_Address(void *location, MPI_Aint *address)
+{
+
+    OPAL_CR_NOOP_PROGRESS();
+
+    if( MPI_PARAM_CHECK ) {
+      OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+      if (NULL == location || NULL == address) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
+      }
+    }
+
+    *address = (MPI_Aint)location;
+    return MPI_SUCCESS;
+}

--- a/ompi/mpi/c/errhandler_create.c
+++ b/ompi/mpi/c/errhandler_create.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Errhandler_create = PMPI_Errhandler_create
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Errhandler_create
+#define MPI_Errhandler_create PMPI_Errhandler_create
+#endif
+
+int MPI_Errhandler_create(MPI_Handler_function *function,
+                          MPI_Errhandler *errhandler)
+{
+
+    /* This is a deprecated -- just turn around and call the real
+       function */
+
+    return PMPI_Comm_create_errhandler(function, errhandler);
+}

--- a/ompi/mpi/c/errhandler_get.c
+++ b/ompi/mpi/c/errhandler_get.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Errhandler_get = PMPI_Errhandler_get
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Errhandler_get
+#define MPI_Errhandler_get PMPI_Errhandler_get
+#endif
+
+static const char FUNC_NAME[] = "MPI_Errhandler_get";
+
+
+int MPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler *errhandler)
+{
+    MEMCHECKER(
+        memchecker_comm(comm);
+    );
+
+    OPAL_CR_NOOP_PROGRESS();
+
+  if (MPI_PARAM_CHECK) {
+    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+  }
+
+  /* This is a deprecated -- just turn around and call the real
+     function */
+
+  return PMPI_Comm_get_errhandler(comm, errhandler);
+}

--- a/ompi/mpi/c/errhandler_set.c
+++ b/ompi/mpi/c/errhandler_set.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Errhandler_set = PMPI_Errhandler_set
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Errhandler_set
+#define MPI_Errhandler_set PMPI_Errhandler_set
+#endif
+
+static const char FUNC_NAME[] = "MPI_Errhandler_set";
+
+
+int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
+{
+    MEMCHECKER(
+        memchecker_comm(comm);
+    );
+
+    OPAL_CR_NOOP_PROGRESS();
+
+  if (MPI_PARAM_CHECK) {
+    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+  }
+
+  /* This is a deprecated -- just turn around and call the real
+     function */
+
+  return PMPI_Comm_set_errhandler(comm, errhandler);
+}

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -416,6 +416,20 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
 	pwin_unlock_all.c \
         pwin_wait.c
 
+if OMPI_ENABLE_MPI1_COMPAT
+nodist_libmpi_c_pmpi_la_SOURCES += \
+        paddress.c \
+        perrhandler_create.c \
+        perrhandler_get.c \
+        perrhandler_set.c \
+        ptype_extent.c \
+        ptype_hindexed.c \
+        ptype_hvector.c \
+        ptype_lb.c \
+        ptype_struct.c \
+        ptype_ub.c
+endif
+
 #
 # Sym link in the sources from the real MPI directory
 #

--- a/ompi/mpi/c/type_extent.c
+++ b/ompi/mpi/c/type_extent.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Type_extent = PMPI_Type_extent
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Type_extent
+#define MPI_Type_extent PMPI_Type_extent
+#endif
+
+static const char FUNC_NAME[] = "MPI_Type_extent";
+
+
+int MPI_Type_extent(MPI_Datatype type, MPI_Aint *extent)
+{
+  int rc;
+  MPI_Aint lb;
+
+  MEMCHECKER(
+    memchecker_datatype(type);
+  );
+
+  if (MPI_PARAM_CHECK) {
+    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+    if (NULL == type || MPI_DATATYPE_NULL == type) {
+      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE, FUNC_NAME);
+    } else if (NULL == extent) {
+      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
+    }
+  }
+
+  OPAL_CR_ENTER_LIBRARY();
+
+  rc = ompi_datatype_get_extent( type, &lb, extent );
+  OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
+}

--- a/ompi/mpi/c/type_hindexed.c
+++ b/ompi/mpi/c/type_hindexed.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Type_hindexed = PMPI_Type_hindexed
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Type_hindexed
+#define MPI_Type_hindexed PMPI_Type_hindexed
+#endif
+
+static const char FUNC_NAME[] = "MPI_Type_hindexed";
+
+
+int MPI_Type_hindexed(int count,
+                      int array_of_blocklengths[],
+                      MPI_Aint array_of_displacements[],
+                      MPI_Datatype oldtype,
+                      MPI_Datatype *newtype)
+{
+   int i;
+
+    MEMCHECKER(
+        memchecker_datatype(oldtype);
+    );
+
+   if ( MPI_PARAM_CHECK ) {
+      OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+      if (NULL == oldtype || MPI_DATATYPE_NULL == oldtype ||
+          NULL == newtype) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE,
+                                      FUNC_NAME );
+      } else if (count < 0) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COUNT,
+                                      FUNC_NAME );
+      } else if ((count > 0) && (NULL == array_of_blocklengths ||
+                                 NULL == array_of_displacements) ) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
+                                      FUNC_NAME );
+      }
+      for (i = 0; i < count; ++i) {
+        if (array_of_blocklengths[i] < 0) {
+          return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
+                                        FUNC_NAME );
+        }
+      }
+   }
+
+   return PMPI_Type_create_hindexed(count,
+                                   array_of_blocklengths,
+                                   array_of_displacements,
+                                   oldtype,
+                                   newtype);
+}

--- a/ompi/mpi/c/type_hvector.c
+++ b/ompi/mpi/c/type_hvector.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Type_hvector = PMPI_Type_hvector
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Type_hvector
+#define MPI_Type_hvector PMPI_Type_hvector
+#endif
+
+static const char FUNC_NAME[] = "MPI_Type_hvector";
+
+
+int MPI_Type_hvector(int count,
+                     int blocklength,
+                     MPI_Aint stride,
+                     MPI_Datatype oldtype,
+                     MPI_Datatype *newtype)
+{
+    MEMCHECKER(
+        memchecker_datatype(oldtype);
+    );
+
+   if ( MPI_PARAM_CHECK ) {
+      OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+      if (NULL == oldtype || MPI_DATATYPE_NULL == oldtype ||
+          NULL == newtype) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE,
+                                      FUNC_NAME );
+      } else if (count < 0) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COUNT,
+                                      FUNC_NAME );
+      } else if (blocklength < 0) {
+        return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
+                                      FUNC_NAME );
+      }
+   }
+
+   return PMPI_Type_create_hvector(count,
+                                  blocklength,
+                                  stride,
+                                  oldtype,
+                                  newtype);
+}

--- a/ompi/mpi/c/type_lb.c
+++ b/ompi/mpi/c/type_lb.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Type_lb = PMPI_Type_lb
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Type_lb
+#define MPI_Type_lb PMPI_Type_lb
+#endif
+
+static const char FUNC_NAME[] = "MPI_Type_lb";
+
+
+int MPI_Type_lb(MPI_Datatype type, MPI_Aint *lb)
+{
+  int rc;
+  MPI_Aint extent;
+
+  MEMCHECKER(
+    memchecker_datatype(type);
+  );
+
+  if (MPI_PARAM_CHECK) {
+    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+    if (NULL == type || MPI_DATATYPE_NULL == type) {
+      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE, FUNC_NAME);
+    } else if (NULL == lb) {
+      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
+    }
+  }
+
+  OPAL_CR_ENTER_LIBRARY();
+
+  rc = ompi_datatype_get_extent( type, lb, &extent );
+  OMPI_ERRHANDLER_RETURN(rc, MPI_COMM_WORLD, rc, FUNC_NAME );
+}

--- a/ompi/mpi/c/type_struct.c
+++ b/ompi/mpi/c/type_struct.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Type_struct = PMPI_Type_struct
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Type_struct
+#define MPI_Type_struct PMPI_Type_struct
+#endif
+
+int MPI_Type_struct(int count,
+                    int array_of_blocklengths[],
+                    MPI_Aint array_of_displacements[],
+                    MPI_Datatype array_of_types[],
+                    MPI_Datatype *newtype)
+{
+    /* the param check will be done if necessary on the MPI_Type_create_struct */
+    return PMPI_Type_create_struct(count,
+                                  array_of_blocklengths,
+                                  array_of_displacements,
+                                  array_of_types,
+                                  newtype);
+}

--- a/ompi/mpi/c/type_ub.c
+++ b/ompi/mpi/c/type_ub.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+/* This implementation has been removed from the MPI 3.0 standard.
+ * Open MPI v4.0.x is keeping the implementation in the library, but
+ * removing the prototypes from the headers, unless the user configures
+ * with --enable-mpi1-compatibility.
+ */
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/errhandler/errhandler.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/memchecker.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_Type_ub = PMPI_Type_ub
+#endif
+/* undef before defining, to prevent possible redefinition when
+ * using _Static_assert to error on usage of removed functions.
+ */
+#undef MPI_Type_ub
+#define MPI_Type_ub PMPI_Type_ub
+#endif
+
+static const char FUNC_NAME[] = "MPI_Type_ub";
+
+
+int MPI_Type_ub(MPI_Datatype mtype, MPI_Aint *ub)
+{
+  MPI_Aint lb;
+  MPI_Aint extent;
+  int status;
+
+  MEMCHECKER(
+      memchecker_datatype(mtype);
+  );
+
+  if (MPI_PARAM_CHECK) {
+    OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+    if (NULL == mtype || MPI_DATATYPE_NULL == mtype) {
+      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_TYPE, FUNC_NAME);
+    } else if (NULL == ub) {
+      return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG, FUNC_NAME);
+    }
+  }
+
+  OPAL_CR_ENTER_LIBRARY();
+
+  status = ompi_datatype_get_extent( mtype, &lb, &extent );
+  if (MPI_SUCCESS == status) {
+    *ub = lb + extent;
+  }
+  OMPI_ERRHANDLER_RETURN(status, MPI_COMM_WORLD, status, FUNC_NAME);
+}

--- a/ompi/mpi/cxx/mpicxx.cc
+++ b/ompi/mpi/cxx/mpicxx.cc
@@ -163,4 +163,10 @@ const char***      ARGVS_NULL = (const char***) MPI_ARGVS_NULL;
 // empty group
 const Group GROUP_EMPTY(MPI_GROUP_EMPTY);
 
+#if OMPI_ENABLE_MPI1_COMPAT
+// special datatypes for contstruction of derived datatypes
+const Datatype UB(MPI_UB);
+const Datatype LB(MPI_LB);
+#endif
+
 } /* namespace MPI */

--- a/ompi/mpi/fortran/configure-fortran-output.h.in
+++ b/ompi/mpi/fortran/configure-fortran-output.h.in
@@ -106,6 +106,8 @@
 #define OMPI_KIND_FORTRAN_COMPLEX32 @OMPI_KIND_FORTRAN_COMPLEX32@
 #define OMPI_SIZEOF_FORTRAN_COMPLEX32 @OMPI_SIZEOF_FORTRAN_COMPLEX32@
 
+#define OMPI_ENABLE_MPI1_COMPAT @OMPI_ENABLE_MPI1_COMPAT@
+
 ! Include some post-processing, based on the values from above
 
 #include "ompi/mpi/fortran/configure-fortran-output-bottom.h"

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -483,6 +483,21 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         win_flush_all_f.c \
         win_flush_local_f.c \
         win_flush_local_all_f.c
+
+
+if OMPI_ENABLE_MPI1_COMPAT
+lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
+        address_f.c \
+        errhandler_create_f.c \
+        errhandler_get_f.c \
+        errhandler_set_f.c \
+        type_extent_f.c \
+        type_hindexed_f.c \
+        type_hvector_f.c \
+        type_lb_f.c \
+        type_struct_f.c \
+        type_ub_f.c
+endif
 endif
 
 #

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -398,6 +398,20 @@ linked_files = \
         pwin_flush_local_f.c \
         pwin_flush_local_all_f.c
 
+if OMPI_ENABLE_MPI1_COMPAT
+linked_files += \
+        paddress_f.c \
+        perrhandler_create_f.c \
+        perrhandler_get_f.c \
+        perrhandler_set_f.c \
+        ptype_extent_f.c \
+        ptype_hindexed_f.c \
+        ptype_hvector_f.c \
+        ptype_lb_f.c \
+        ptype_struct_f.c \
+        ptype_ub_f.c
+endif
+
 #
 # Sym link in the sources from the real MPI directory
 #

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/Makefile.am
@@ -28,11 +28,13 @@ lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr.la
 
 mpi-ignore-tkr-interfaces.h: mpi-ignore-tkr-interfaces.h.in
 mpi-ignore-tkr-file-interfaces.h: mpi-ignore-tkr-file-interfaces.h.in
+mpi-ignore-tkr-removed-interfaces.h: mpi-ignore-tkr-removed-interfaces.h.in
 
 mpi-ignore-tkr.lo: $(top_srcdir)/ompi/mpi/fortran/base/attr-fn-int-callback-interfaces.h
 mpi-ignore-tkr.lo: $(top_srcdir)/ompi/mpi/fortran/base/conversion-fn-null-int-interface.h
 mpi-ignore-tkr.lo: mpi-ignore-tkr-interfaces.h
 mpi-ignore-tkr.lo: mpi-ignore-tkr-file-interfaces.h
+mpi-ignore-tkr.lo: mpi-ignore-tkr-removed-interfaces.h
 mpi-ignore-tkr.lo: mpi-ignore-tkr-sizeof.h
 mpi-ignore-tkr.lo: mpi-ignore-tkr-sizeof.f90
 mpi-ignore-tkr.lo: mpi-ignore-tkr.F90
@@ -41,7 +43,8 @@ lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_SOURCES = \
         mpi-ignore-tkr.F90
 nodist_lib@OMPI_LIBMPI_NAME@_usempi_ignore_tkr_la_SOURCES = \
         mpi-ignore-tkr-interfaces.h \
-        mpi-ignore-tkr-file-interfaces.h
+        mpi-ignore-tkr-file-interfaces.h \
+        mpi-ignore-tkr-removed-interfaces.h
 
 if BUILD_FORTRAN_SIZEOF
 # These files are generated; do not distribute them

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr.F90
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr.F90
@@ -43,6 +43,14 @@ module mpi
 
   include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h"
   include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-file-interfaces.h"
+#if !defined(OMPI_ENABLE_MPI1_COMPAT)
+
+#error "Remove MPI-1 compat code"
+
+#elif OMPI_ENABLE_MPI1_COMPAT
+  include "ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-removed-interfaces.h"
+#endif
+
   include 'mpi-ignore-tkr-sizeof.h'
 
 end module mpi

--- a/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-tkr/Makefile.am
@@ -60,10 +60,12 @@ lib_LTLIBRARIES += lib@OMPI_LIBMPI_NAME@_usempi.la
 mpi.lo: mpi.F90
 mpi.lo: mpi-f90-interfaces.h
 mpi.lo: mpi-f90-file-interfaces.h
+mpi.lo: mpi-f90-removed-interfaces.h
 mpi.lo: $(top_builddir)/ompi/mpi/fortran/configure-fortran-output.h
 mpi.lo: mpi-f90-cptr-interfaces.h
 mpi.lo: pmpi-f90-interfaces.h
 mpi.lo: pmpi-f90-file-interfaces.h
+mpi.lo: pmpi-f90-removed-interfaces.h
 mpi.lo: pmpi-f90-cptr-interfaces.h
 
 # Per MPI-3 p610:34-41, if we're building a TKR mpi module, we should
@@ -173,8 +175,10 @@ endif
 EXTRA_DIST = \
      mpi-f90-interfaces.h \
      mpi-f90-file-interfaces.h \
+     mpi-f90-removed-interfaces.h \
      mpi-f90-cptr-interfaces.h \
      pmpi-f90-interfaces.h \
      pmpi-f90-file-interfaces.h \
+     pmpi-f90-removed-interfaces.h \
      pmpi-f90-cptr-interfaces.h
 

--- a/ompi/mpi/fortran/use-mpi-tkr/mpi.F90
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi.F90
@@ -60,4 +60,13 @@ module mpi
   include "mpi-tkr-sizeof.h"
 #endif
 
+#if !defined(OMPI_ENABLE_MPI1_COMPAT)
+
+#error "Remove MPI-1 compat code"
+
+#elif OMPI_ENABLE_MPI1_COMPAT
+  include "mpi-f90-removed-interfaces.h"
+  include "pmpi-f90-removed-interfaces.h"
+#endif
+
 end module mpi

--- a/ompi/mpi/man/man3/MPI_Address.3in
+++ b/ompi/mpi/man/man3/MPI_Address.3in
@@ -1,0 +1,93 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Address 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Address\fP \- Gets the address of a location in memory -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Address(void *\fIlocation\fP, MPI_Aint\fP *address\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_ADDRESS(\fILOCATION\fP,\fI ADDRESS\fP,\fI IERROR\fP)
+	<type>	\fILOCATION\fP (*)
+	INTEGER	\fIADDRESS\fP,\fI IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETER
+.ft R
+.TP 1i
+location
+Location in caller memory (choice).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+address
+Address of location (integer).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Get_address instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+The address of a location in memory can be found by invoking this function. Returns the (byte) address of location.
+.sp
+Example: Using MPI_Address for an array.
+.sp
+.nf
+REAL A(100,100)
+.fi
+.br
+   INTEGER I1, I2, DIFF
+.br
+   CALL MPI_ADDRESS(A(1,1), I1, IERROR)
+.br
+   CALL MPI_ADDRESS(A(10,10), I2, IERROR)
+.br
+   DIFF = I2 - I1
+.br
+! The value of DIFF is 909*sizeofreal; the values of I1 and I2 are
+.br
+! implementation dependent.
+.fi
+
+.SH NOTES
+.ft R
+This routine is provided for both Fortran and C programmers and may be useful when writing portable code. In the current release, the address returned by this routine will be the same as that produced by the C & operator.
+.sp
+C users may be tempted to avoid using
+MPI_Address and rely on the availability of the address operator &.
+Note, however, that & cast-expression is a pointer, not an address.
+ANSI C does not require that the value of a pointer (or the pointer
+cast to int) be the absolute address of the object pointed at although
+this is commonly the case. Furthermore, referencing may not have a unique
+definition on machines with a segmented address space. The use of
+MPI_Address to "reference" C variables guarantees portability to
+such machines as well.
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler
+may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+MPI_Get_address
+.br

--- a/ompi/mpi/man/man3/MPI_Errhandler_create.3in
+++ b/ompi/mpi/man/man3/MPI_Errhandler_create.3in
@@ -1,0 +1,80 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Errhandler_create 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Errhandler_create \fP \- Creates an MPI-style error handler -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Errhandler_create(MPI_Handler_function *\fIfunction\fP,
+	MPI_Errhandler *\fIerrhandler\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_ERRHANDLER_CREATE(\fIFUNCTION, ERRHANDLER, IERROR\fP)
+	EXTERNAL	\fIFUNCTION\fP
+	INTEGER	\fIERRHANDLER, IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETER
+.ft R
+.TP 1i
+function
+User-defined error handling procedure.
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+errhandler
+MPI error handler (handle).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Comm_create_errhandler instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+Registers the user routine function for use as an MPI exception handler. Returns in errhandler a handle to the registered exception handler.
+.sp
+In the C language, the user routine should be a C function of type MPI_Handler_function, which is defined as
+.sp
+.nf
+    typedef void (MPI_Handler_function)(MPI_Comm *, int *, \&...);
+.fi
+.sp
+The first argument is the communicator in use. The second is the error code
+to be returned by the MPI routine that raised the error. If the routine would have returned MPI_ERR_IN_STATUS, it is the error code returned in the status for the request that caused the error handler to be invoked. The remaining arguments are stdargs arguments whose number and meaning is implementation-dependent. An implementation should clearly document these arguments. Addresses are used so that the handler may be written in Fortran.
+
+.SH NOTE
+.ft R
+The MPI-1 Standard states that an implementation may make the output value (errhandler) simply the address of the function. However, the action of MPI_Errhandler_ free makes this impossible, since it is required to set the value of the argument to MPI_ERRHANDLER_NULL. In addition, the actual error handler must remain until all communicators that use it are freed.
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.br
+MPI_Comm_create_errhandler
+.br
+MPI_Comm_get_errhandler
+.br
+MPI_Comm_set_errhandler
+
+
+

--- a/ompi/mpi/man/man3/MPI_Errhandler_get.3in
+++ b/ompi/mpi/man/man3/MPI_Errhandler_get.3in
@@ -1,0 +1,67 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Errhandler_get 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Errhandler_get \fP \- Gets the error handler for a communicator -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Errhandler_get(MPI_Comm \fIcomm\fP, MPI_Errhandler\fI *errhandler\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_ERRHANDLER_GET(\fICOMM, ERRHANDLER, IERROR\fP)
+	INTEGER	\fICOMM, ERRHANDLER, IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETER
+.ft R
+.TP 1i
+comm
+Communicator to get the error handler from (handle).
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+errhandler
+MPI error handler currently associated with communicator (handle).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Comm_get_errhandler instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+Returns in errhandler (a handle to) the error handler that is currently associated with communicator comm.
+.sp
+\fBExample:\fP A library function may register at its entry point the current error handler for a communicator, set its own private error handler for this communicator, and restore before exiting the previous error handler.
+
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Comm_create_errhandler
+.br
+MPI_Comm_get_errhandler
+.br
+MPI_Comm_set_errhandler
+

--- a/ompi/mpi/man/man3/MPI_Errhandler_set.3in
+++ b/ompi/mpi/man/man3/MPI_Errhandler_set.3in
@@ -1,0 +1,63 @@
+.\" -*- nroff -*-
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Errhandler_set 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Errhandler_set \fP \- Sets the error handler for a communicator -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Errhandler_set(MPI_Comm \fIcomm\fP, MPI_Errhandler \fIerrhandler\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_ERRHANDLER_SET(\fICOMM, ERRHANDLER, IERROR\fP)
+	INTEGER	\fICOMM, ERRHANDLER, IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+comm
+Communicator to set the error handler for (handle).
+.TP 1i
+errhandler
+New MPI error handler for communicator (handle).
+
+.SH OUTPUT PARAMETER
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Comm_set_errhandler instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+Associates the new error handler errhandler with communicator comm at the calling process. Note that an error handler is always associated with the communicator.
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Comm_create_errhandler
+.br
+MPI_Comm_get_errhandler
+.br
+MPI_Comm_set_errhandler
+
+

--- a/ompi/mpi/man/man3/MPI_Type_extent.3in
+++ b/ompi/mpi/man/man3/MPI_Type_extent.3in
@@ -1,0 +1,93 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Type_extent 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Type_extent\fP \- Returns the extent of a data type, the difference between the upper and lower bounds of the data type -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Type_extent(MPI_Datatype \fIdatatype\fP, MPI_Aint\fI *extent\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_TYPE_EXTENT(\fIDATATYPE, EXTENT, IERROR\fP)
+	INTEGER	\fIDATATYPE, EXTENT, IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETER
+.ft R
+.TP 1i
+datatype
+Datatype (handle).
+.sp
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+extent
+Datatype extent (integer).
+.sp
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Type_get_extent instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+MPI_Type_extent returns the extent of a data type, the difference between the upper and lower bounds of the data type.
+.sp
+In general, if
+.sp
+.nf
+    Typemap = {(type(0), disp(0)), ..., (type(n-1), disp(n-1))}
+.fi
+.sp
+then the lower bound of Typemap is defined to be
+.sp
+.nf
+              ( min(j) disp(j)                         if no entry has
+  lb(Typemap)=(                                        basic type lb
+              (min(j) {disp(j) such that type(j) = lb} otherwise
+
+.fi
+.sp
+Similarly, the upper bound of Typemap is defined to be
+.sp
+.nf
+              (max(j) disp(j) + sizeof(type(j)) + e    if no entry has
+  ub(Typemap)=(                                        basic type ub
+              (max(j) {disp(j) such that type(j) = ub} otherwise
+.fi
+.sp
+Then
+.sp
+.nf
+    extent(Typemap) = ub(Typemap) - lb(Typemap)
+.fi
+.sp
+If type(i) requires alignment to a byte address that is a multiple of k(i), then e is the least nonnegative increment needed to round extent(Typemap) to the next multiple of max(i) k(i).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Type_get_extent
+.br
+

--- a/ompi/mpi/man/man3/MPI_Type_get_envelope.3in
+++ b/ompi/mpi/man/man3/MPI_Type_get_envelope.3in
@@ -84,11 +84,20 @@ MPI_COMBINER_NAMED              a named predefined data type
 MPI_COMBINER_DUP                MPI_Type_dup
 MPI_COMBINER_CONTIGUOUS         MPI_Type_contiguous
 MPI_COMBINER_VECTOR             MPI_Type_vector
-MPI_COMBINER_HVECTOR            MPI_Type_hvector
+MPI_COMBINER_HVECTOR_INTEGER    MPI_Type_hvector from Fortran
+MPI_COMBINER_HVECTOR            MPI_Type_hvector from C or C++
+                                  and MPI_Type_create for
+                                  all languages
 MPI_COMBINER_INDEXED            MPI_Type_indexed
-MPI_COMBINER_HINDEXED           MPI_Type_hindexed
+MPI_COMBINER_HINDEXED_INTEGER   MPI_Type_hindexed from Fortran
+MPI_COMBINER_HINDEXED           MPI_Type_hindexed from C or C++
+                                  and MPI_Type_create_hindexed
+                                  for all languages
 MPI_COMBINER_INDEXED_BLOCK      MPI_Type_create_indexed_block
-MPI_COMBINER_STRUCT             MPI_Type_struct
+MPI_COMBINER_STRUCT_INTEGER     MPI_Type_struct from Fortran
+MPI_COMBINER_STRUCT             MPI_Type_struct from C or C++
+                                  and MPI_Type_create_struct
+                                  for all languages
 MPI_COMBINER_SUBARRAY           MPI_Type_create_subarray
 MPI_COMBINER_DARRAY             MPI_Type_create_darray
 MPI_COMBINER_F90_REAL           MPI_Type_create_f90_real

--- a/ompi/mpi/man/man3/MPI_Type_hindexed.3in
+++ b/ompi/mpi/man/man3/MPI_Type_hindexed.3in
@@ -1,0 +1,100 @@
+.\" -*- nroff -*-
+.\" Copyright 2010-2014 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Type_hindexed 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Type_hindexed\fP \- Creates an indexed datatype with offsets in bytes -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Type_hindexed(int \fIcount\fP, int\fI *array_of_blocklengths\fP,
+	MPI_Aint\fI *array_of_displacements\fP, MPI_Datatype\fI oldtype\fP,
+	MPI_Datatype\fI *newtype\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_TYPE_HINDEXED(\fICOUNT, ARRAY_OF_BLOCKLENGTHS,
+		ARRAY_OF_DISPLACEMENTS, OLDTYPE, NEWTYPE, IERROR\fP)
+	INTEGER	\fICOUNT, ARRAY_OF_BLOCKLENGTHS(*)\fP
+	INTEGER	\fIARRAY_OF_DISPLACEMENTS(*), OLDTYPE, NEWTYPE\fP
+	INTEGER	\fIIERROR\fP
+
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+count
+Number of blocks -- also number of entries in array_of_displacements  and
+array_of_blocklengths  (integer).
+.TP 1i
+array_of_blocklengths
+Number of elements in each block (array of nonnegative integers).
+.TP 1i
+array_of_displacements
+Byte displacement of each block (C: array of
+.IR MPI_Aint ,
+Fortran: array of integer).
+.TP 1i
+oldtype
+Old datatype (handle).
+.sp
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+newtype
+New datatype (handle).
+.sp
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Use MPI_Type_create_hindexed instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+The function is identical to MPI_Type_indexed, except that block displacements in array_of_displacements are specified in bytes, rather than in multiples of the oldtype extent.
+.sp
+Assume that oldtype has type map
+.sp
+.nf
+    {(type(0), disp(0)), ..., (type(n-1), disp(n-1))},
+.fi
+.sp
+with extent ex. Let B be the array_of_blocklength argument and D be the
+array_of_displacements argument. The newly created datatype has
+.nf
+n x S^count-1
+    (i=0)        B[i]  entries:
+
+  {(type(0), disp(0) + D[0]),...,(type(n-1), disp(n-1) + D[0]),...,
+  (type(0), disp(0) + (D[0] + B[0]-1)* ex),...,
+  type(n-1), disp(n-1) + (D[0]+ B[0]-1)* ex),...,
+  (type(0), disp(0) + D[count-1]),...,(type(n-1), disp(n-1) + D[count-1]),...,
+  (type(0), disp(0) +  D[count-1] + (B[count-1] -1)* ex),...,
+  (type(n-1), disp(n-1) + D[count-1] + (B[count-1] -1)* ex)}
+.fi
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+MPI_Type_create_hindexed
+.br
+MPI_Type_indexed
+.br
+

--- a/ompi/mpi/man/man3/MPI_Type_hvector.3in
+++ b/ompi/mpi/man/man3/MPI_Type_hvector.3in
@@ -1,0 +1,98 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Type_hvector 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Type_hvector\fP \- Creates a vector (strided) datatype with offset in bytes -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Type_hvector(int \fIcount\fP, int\fI blocklength\fP, MPI_Aint\fI stride\fP,
+	MPI_Datatype\fI oldtype\fP, MPI_Datatype\fI *newtype\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_TYPE_HVECTOR(\fICOUNT, BLOCKLENGTH, STRIDE, OLDTYPE, NEWTYPE,
+		IERROR\fP)
+	INTEGER	\fICOUNT, BLOCKLENGTH, STRIDE, OLDTYPE\fP
+	INTEGER	\fINEWTYPE, IERROR\fP
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+count
+Number of blocks (nonnegative integer).
+.TP 1i
+blocklength
+Number of elements in each block (nonnegative integer).
+.TP 1i
+stride
+Number of bytes between start of each block (integer).
+.TP 1i
+oldtype
+Old datatype (handle).
+.sp
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+newtype
+New datatype (handle).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Use MPI_Type_create_hvector instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+The function MPI_Type_hvector is identical to MPI_Type_vector, except that
+stride is given in bytes, rather than in elements. The use for both types
+of vector constructors is illustrated in the examples in Section 3.12.7 of the MPI-1 Standard.
+.sp
+Assume that oldtype has type map
+.sp
+.nf
+    {(type(0), disp(0)), ..., (type(n-1), disp(n-1))}
+.fi
+.sp
+with extent ex. Let bl be the blocklength. The newly created datatype has a type map with   count * bl * n  entries:
+.sp
+.nf
+  {(type(0), disp(0)), ..., (type(n-1), disp(n-1)),
+  (type(0), disp(0) + ex), ..., (type(n-1), disp(n-1) + ex),
+  ..., (type(0), disp(0) + (bl -1) * ex),...,(type(n-1),
+  disp(n-1) + (bl -1) * ex), (type(0), disp(0) + stride),
+  ...,(type(n-1), disp(n-1) + stride), ..., (type(0),
+  disp(0) + stride + (bl - 1) * ex), ..., (type(n-1),
+  disp(n-1) + stride + (bl -1) * ex), ..., (type(0),
+  disp(0) + stride * (count -1)), ...,(type(n-1),
+  disp(n-1) + stride * (count -1)), ..., (type(0),
+  disp(0) + stride * (count -1) + (bl -1) * ex), ...,
+  (type(n-1), disp(n-1) + stride * (count -1) + (bl -1) * ex)}
+
+.fi
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Type_create_hvector
+.br
+MPI_Type_vector
+.br
+

--- a/ompi/mpi/man/man3/MPI_Type_lb.3in
+++ b/ompi/mpi/man/man3/MPI_Type_lb.3in
@@ -1,0 +1,92 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Type_lb 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Type_lb\fP \- Returns the lower bound of a data type -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Type_lb(MPI_Datatype \fIdatatype\fP, MPI_Aint\fI *displacement\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_TYPE_LB(\fIDATATYPE, DISPLACEMENT, IERROR\fP)
+	INTEGER	\fIDATATYPE, DISPLACEMENT, IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETER
+.ft R
+.TP 1i
+datatype
+Datatype (handle).
+.sp
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+displacement
+Displacement of lower bound from origin, in bytes (integer).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Type_get_extent instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+MPI_Type_lb returns the lower bound of a data type. This may differ from zero if the type was constructed using MPI_LB.
+.sp
+The "pseudo-datatypes," MPI_LB and MPI_UB, can be used, respectively, to mark the lower bound (or the upper bound) of a datatype. These pseudo-datatypes occupy no space (extent (MPI_LB) = extent (MPI_UB) =0. They do not affect the size or count of a datatype, and do not affect the context of a message created with this datatype. However, they do affect the definition of the extent of a datatype and, therefore, affect the outcome of a replication of this datatype by a datatype constructor.
+.sp
+In general, if
+.sp
+.nf
+    Typemap = {(type0, disp0), ..., (type(n-1), disp(n-1)}
+.fi
+.sp
+then the lower bound of Typemap is defined to be
+.nf
+
+                  (min(j) disp(j)                          if no entry has
+    lb(Typemap) = (                                        basic type lb
+                  (min(j) {disp(j) such that type(j) = lb} otherwise
+
+.fi
+Similarly, the upper bound of Typemap is defined to be
+.nf
+
+                  (max(j) disp(j) + sizeof((type(j)) + e   if no entry has
+    ub(Typemap) = (                                        basic type ub
+                  (max(j) {disp(j) such that type(j) = ub} otherwise
+
+Then
+
+    extent(Typemap) = ub(Typemap) - lb(Typemap)
+.fi
+.sp
+If type(i) requires alignment to a byte address that is a multiple of k(i),
+then e is the least nonnegative increment needed to round extent(Typemap) to the next multiple of max(i) k(i).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Type_get_extent
+.br
+

--- a/ompi/mpi/man/man3/MPI_Type_struct.3in
+++ b/ompi/mpi/man/man3/MPI_Type_struct.3in
@@ -1,0 +1,118 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Type_struct 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Type_struct\fP \- Creates a \fIstruct\fP data type -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Type_struct(int \fIcount\fP, int\fI *array_of_blocklengths\fP,
+	MPI_Aint\fI *array_of_displacements\fP, MPI_Datatype\fI *array_of_types\fP,
+	MPI_Datatype\fI *newtype\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_TYPE_STRUCT(\fICOUNT, ARRAY_OF_BLOCKLENGTHS,
+		ARRAY_OF_DISPLACEMENTS, ARRAY_OF_TYPES,
+		NEWTYPE, IERROR\fP)
+	INTEGER	\fICOUNT, ARRAY_OF_BLOCKLENGTHS(*)\fP
+	INTEGER	\fIARRAY_OF_DISPLACEMENTS(*)\fP
+	INTEGER	\fIARRAY_OF_TYPES(*), NEWTYPE, IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETERS
+.ft R
+.TP 1i
+count
+Number of blocks (integer)  also number of entries in arrays
+array_of_types,  array_of_displacements, and array_of_blocklengths.
+.TP 1i
+array_of_blocklengths
+Number of elements in each block (array).
+.TP 1i
+array_of_displacements
+Byte displacement of each block (array).
+.TP 1i
+array_of_types
+Type of elements in each block (array of handles to datatype objects).
+.sp
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+newtype
+New datatype (handle).
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Use MPI_Type_create_struct instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+MPI_Type_struct is the most general type constructor. It further generalizes MPI_Type_hindexed in that it allows each block to consist of replications of different datatypes.
+.sp
+\fBExample:\fP Let type1 have type map
+.nf
+
+    {(double, 0), (char, 8)}
+
+.fi
+with extent 16. Let B = (2, 1, 3), D = (0, 16, 26), and T = (MPI_FLOAT, type1, MPI_CHAR). Then a call to MPI_Type_struct(3, B, D, T, newtype) returns a datatype with type map
+.nf
+
+    {(float, 0), (float,4), (double, 16), (char, 24),
+    (char, 26), (char, 27), (char, 28)}
+
+.fi
+That is, two copies of MPI_FLOAT starting at 0, followed by one copy of type1 starting at 16, followed by three copies of MPI_CHAR, starting at 26. (We assume that a float occupies 4 bytes.)
+.sp
+For more information, see section 3.12.1 of the MPI-1.1 Standard.
+
+.SH NOTES
+If an upperbound is set explicitly by using the MPI datatype MPI_UB, the corresponding index must be positive.
+.sp
+The MPI-1 Standard originally made vague statements about padding and alignment; this was intended to allow the simple definition of structures that could be sent with a count greater than one. For example,
+.nf
+    struct {int a; char b;} foo;
+.fi
+may have
+.nf
+    sizeof(foo) = sizeof(int) + sizeof(char);
+.fi
+defining the extent of a datatype as including an epsilon, which would have allowed an implementation to make the extent an MPI datatype for this structure equal to 2*sizeof(int). However, since different systems might define different paddings, a clarification to the standard made epsilon zero. Thus, if you define a structure datatype and wish to send or receive multiple items, you should explicitly include an MPI_UB entry as the last member of the structure.  For example, the following code can be used for the structure foo:
+.nf
+
+    blen[0] = 1; indices[0] = 0; oldtypes[0] = MPI_INT;
+    blen[1] = 1; indices[1] = &foo.b - &foo; oldtypes[1] = MPI_CHAR;
+    blen[2] = 1; indices[2] = sizeof(foo); oldtypes[2] = MPI_UB;
+    MPI_Type_struct( 3, blen, indices, oldtypes, &newtype );
+
+.fi
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Type_create_struct
+.br
+MPI_Type_create_hindexed
+.br
+

--- a/ompi/mpi/man/man3/MPI_Type_ub.3in
+++ b/ompi/mpi/man/man3/MPI_Type_ub.3in
@@ -1,0 +1,95 @@
+.\" -*- nroff -*-
+.\" Copyright 2010 Cisco Systems, Inc.  All rights reserved.
+.\" Copyright 2006-2008 Sun Microsystems, Inc.
+.\" Copyright (c) 1996 Thinking Machines Corporation
+.\" $COPYRIGHT$
+.TH MPI_Type_ub 3 "#OMPI_DATE#" "#PACKAGE_VERSION#" "#PACKAGE_NAME#"
+.SH NAME
+\fBMPI_Type_ub\fP \- Returns the upper bound of a datatype -- use of this routine is deprecated.
+
+.SH SYNTAX
+.ft R
+.SH C Syntax
+.nf
+#include <mpi.h>
+int MPI_Type_ub(MPI_Datatype \fIdatatype\fP, MPI_Aint\fI *displacement\fP)
+
+.fi
+.SH Fortran Syntax
+.nf
+INCLUDE 'mpif.h'
+MPI_TYPE_UB(\fIDATATYPE, DISPLACEMENT, IERROR\fP)
+	INTEGER	\fIDATATYPE, DISPLACEMENT, IERROR\fP
+
+
+.fi
+.SH INPUT PARAMETER
+.ft R
+.TP 1i
+datatype
+Datatype (handle).
+.sp
+
+.SH OUTPUT PARAMETERS
+.ft R
+.TP 1i
+displacement
+Displacement of upper bound from origin, in bytes (integer).
+.sp
+.ft R
+.TP 1i
+IERROR
+Fortran only: Error status (integer).
+
+.SH DESCRIPTION
+.ft R
+Note that use of this routine is \fIdeprecated\fP as of MPI-2. Please use MPI_Type_get_extent instead.
+.sp
+This deprecated routine is not available in C++.
+.sp
+MPI_Type_ub returns the upper bound of a data type. This will differ from zero if the type was constructed using MPI_UB. The upper bound will take into account any alignment considerations.
+.sp
+The "pseudo-datatypes," MPI_LB and MPI_UB, can be used, respectively, to mark the upper bound (or the lower bound) of a datatype. These pseudo-datatypes occupy no space (extent (MPI_LB) = extent (MPI_UB) =0. They do not affect the size or count of a datatype, and do not affect the context of a message created with this datatype. However, they do affect the definition of the extent of a datatype and, therefore, affect the outcome of a replication of this datatype by a datatype constructor.
+.sp
+In general, if
+.nf
+
+    Typemap = {(type(0), disp(0)), ..., (type(n-1), disp(n-1))}
+
+.fi
+then the lower bound of Typemap is defined to be
+.nf
+
+                  (min(j) disp(j)                          if no entry has
+    lb(Typemap) = (                                        basic type lb
+                  (min(j) {disp(j) such that type(j) = lb} otherwise
+
+.fi
+Similarly, the upper bound of Typemap is defined to be
+.nf
+
+                  (max(j) disp(j) + sizeof(type(j) = lb}   if no entry has
+    ub(Typemap) = (                                        basic type ub
+                  (max(j) {disp(j) such that type(j) = ub} otherwise
+
+.fi
+Then
+.nf
+
+    extent(Typemap) = ub(Typemap) - lb(Typemap)
+
+.fi
+If type(i) requires alignment to a byte address that is a multiple of k(i), then e is the least nonnegative increment needed to round extent(Typemap) to the next multiple of max(i) k(i).
+
+.SH ERRORS
+Almost all MPI routines return an error value; C routines as the value of the function and Fortran routines in the last argument. C++ functions do not return errors. If the default error handler is set to MPI::ERRORS_THROW_EXCEPTIONS, then on error the C++ exception mechanism will be used to throw an MPI::Exception object.
+.sp
+Before the error value is returned, the current MPI error handler is
+called. By default, this error handler aborts the MPI job, except for I/O function errors. The error handler may be changed with MPI_Comm_set_errhandler; the predefined error handler MPI_ERRORS_RETURN may be used to cause error values to be returned. Note that MPI does not guarantee that an MPI program can continue past an error.
+
+.SH SEE ALSO
+.ft R
+.sp
+MPI_Type_get_extent
+.br
+

--- a/ompi/mpi/man/man3/Makefile.extra
+++ b/ompi/mpi/man/man3/Makefile.extra
@@ -18,6 +18,7 @@ mpi_api_man_pages = \
         mpi/man/man3/MPI_Add_error_class.3 \
         mpi/man/man3/MPI_Add_error_code.3 \
         mpi/man/man3/MPI_Add_error_string.3 \
+        mpi/man/man3/MPI_Address.3 \
 	mpi/man/man3/MPI_Aint_add.3 \
 	mpi/man/man3/MPI_Aint_diff.3 \
         mpi/man/man3/MPI_Allgather.3 \
@@ -97,7 +98,10 @@ mpi_api_man_pages = \
         mpi/man/man3/MPI_Dist_graph_create_adjacent.3 \
         mpi/man/man3/MPI_Dist_graph_neighbors.3 \
         mpi/man/man3/MPI_Dist_graph_neighbors_count.3 \
+        mpi/man/man3/MPI_Errhandler_create.3 \
         mpi/man/man3/MPI_Errhandler_free.3 \
+        mpi/man/man3/MPI_Errhandler_get.3 \
+        mpi/man/man3/MPI_Errhandler_set.3 \
         mpi/man/man3/MPI_Error_class.3 \
         mpi/man/man3/MPI_Error_string.3 \
         mpi/man/man3/MPI_Exscan.3 \
@@ -351,6 +355,7 @@ mpi_api_man_pages = \
         mpi/man/man3/MPI_Type_create_subarray.3 \
         mpi/man/man3/MPI_Type_delete_attr.3 \
         mpi/man/man3/MPI_Type_dup.3 \
+        mpi/man/man3/MPI_Type_extent.3 \
         mpi/man/man3/MPI_Type_f2c.3 \
         mpi/man/man3/MPI_Type_free.3 \
         mpi/man/man3/MPI_Type_free_keyval.3 \
@@ -362,12 +367,17 @@ mpi_api_man_pages = \
         mpi/man/man3/MPI_Type_get_name.3 \
         mpi/man/man3/MPI_Type_get_true_extent.3 \
         mpi/man/man3/MPI_Type_get_true_extent_x.3 \
+        mpi/man/man3/MPI_Type_hindexed.3 \
+        mpi/man/man3/MPI_Type_hvector.3 \
         mpi/man/man3/MPI_Type_indexed.3 \
+        mpi/man/man3/MPI_Type_lb.3 \
         mpi/man/man3/MPI_Type_match_size.3 \
         mpi/man/man3/MPI_Type_set_attr.3 \
         mpi/man/man3/MPI_Type_set_name.3 \
         mpi/man/man3/MPI_Type_size.3 \
         mpi/man/man3/MPI_Type_size_x.3 \
+        mpi/man/man3/MPI_Type_struct.3 \
+        mpi/man/man3/MPI_Type_ub.3 \
         mpi/man/man3/MPI_Type_vector.3 \
         mpi/man/man3/MPI_Unpack.3 \
         mpi/man/man3/MPI_Unpack_external.3 \

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -16,7 +16,6 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
- * Copyright (c) 2019      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,7 +134,6 @@ void ompi_info_do_config(bool want_all)
     char *crdebug_support;
     char *topology_support;
     char *ipv6_support;
-    char *mpi1_compat_support;
 
     /* Do a little preprocessor trickery here to figure opal_info_out the
      * tri-state of MPI_PARAM_CHECK (which will be either 0, 1, or
@@ -289,10 +287,6 @@ void ompi_info_do_config(bool want_all)
     symbol_visibility = OPAL_C_HAVE_VISIBILITY ? "yes" : "no";
     topology_support = "yes";
     ipv6_support = OPAL_ENABLE_IPV6 ? "yes" : "no";
-    /*
-     * hardwire to no since we don't have MPI1 compat post v4.0.x
-     */
-    mpi1_compat_support = "no";
 
     /* setup strings that require allocation */
     if (OMPI_BUILD_FORTRAN_BINDINGS >= OMPI_FORTRAN_MPIFH_BINDINGS) {
@@ -675,8 +669,6 @@ void ompi_info_do_config(bool want_all)
     opal_info_out("Host topology support", "options:host-topology",
                   topology_support);
     opal_info_out("IPv6 support", "options:ipv6", ipv6_support);
-    opal_info_out("MPI1 compatibility", "options:mpi1-compatibility",
-                  mpi1_compat_support);
 
     opal_info_out("MPI extensions", "options:mpi_ext", OMPI_MPIEXT_COMPONENTS);
 


### PR DESCRIPTION
This PR includes 7 reverted commits to restore master's `--enable-mpi1-compatibility` functionality.

These 7 are the obvious reverts, and seem to work, but I'm not quite ready to have this reviewed and Pulled in yet, as I'd like to do some more analysis and testing.