### PR TITLE
ALLOC_WITH_HINT: added inplace realloc

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -551,7 +551,8 @@ static int mca_spml_ucx_ctx_create_common(long options, mca_spml_ucx_ctx_t **ucx
 {
     ucp_worker_params_t params;
     ucp_ep_params_t ep_params;
-    size_t i, j, nprocs = oshmem_num_procs();
+    size_t i, nprocs = oshmem_num_procs();
+    int j;
     ucs_status_t err;
     spml_ucx_mkey_t *ucx_mkey;
     sshmem_mkey_t *mkey;

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx.h
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx.h
@@ -49,10 +49,19 @@ sshmem_ucx_shadow_allocator_t *sshmem_ucx_shadow_create(unsigned count);
 void sshmem_ucx_shadow_destroy(sshmem_ucx_shadow_allocator_t *allocator);
 int sshmem_ucx_shadow_alloc(sshmem_ucx_shadow_allocator_t *allocator,
                             unsigned count, unsigned *index);
+
+/* reallocate existing allocated buffer. if possible - used inplace
+ * reallocation.
+ * parameter 'inplace' - out, in case if zero - new buffer was allocated
+ * (inplace is not possible), user should remove original buffer after data
+ * is copied, else (if inplace == 0) - no additional action required */
+int sshmem_ucx_shadow_realloc(sshmem_ucx_shadow_allocator_t *allocator,
+                              unsigned count, unsigned old_index, unsigned *index,
+                              int *inplace);
 int sshmem_ucx_shadow_free(sshmem_ucx_shadow_allocator_t *allocator,
                            unsigned index);
-size_t sshmem_ucx_shadow_size(sshmem_ucx_shadow_allocator_t *allocator,
-                              unsigned index);
+unsigned sshmem_ucx_shadow_size(sshmem_ucx_shadow_allocator_t *allocator,
+                                unsigned index);
 
 END_C_DECLS
 

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx.h
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx.h
@@ -50,9 +50,9 @@ void sshmem_ucx_shadow_destroy(sshmem_ucx_shadow_allocator_t *allocator);
 int sshmem_ucx_shadow_alloc(sshmem_ucx_shadow_allocator_t *allocator,
                             unsigned count, unsigned *index);
 
-/* reallocate existing allocated buffer. if possible - used inplace
+/* Reallocate existing allocated buffer. If possible - used inplace
  * reallocation.
- * parameter 'inplace' - out, in case if zero - new buffer was allocated
+ * Parameter 'inplace' - out, in case if zero - new buffer was allocated
  * (inplace is not possible), user should remove original buffer after data
  * is copied, else (if inplace == 0) - no additional action required */
 int sshmem_ucx_shadow_realloc(sshmem_ucx_shadow_allocator_t *allocator,

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
@@ -336,7 +336,7 @@ static unsigned sshmem_ucx_memheap_ptr2index(map_segment_t *s, void *ptr)
     return ((char*)ptr - (char*)s->super.va_base) / ALLOC_ELEM_SIZE;
 }
 
-void sshmem_ucx_memheap_wordcopy(void *dst, void *src, size_t size)
+static void sshmem_ucx_memheap_wordcopy(void *dst, void *src, size_t size)
 {
     const size_t count = (size + sizeof(uint64_t) - 1) / sizeof(uint64_t);
     uint64_t *dst64 = (uint64_t*)dst;

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx_shadow.c
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx_shadow.c
@@ -128,7 +128,7 @@ int sshmem_ucx_shadow_realloc(sshmem_ucx_shadow_allocator_t *allocator,
         return OSHMEM_SUCCESS;
     }
 
-    if (count < elem->block_size) {
+    if (count < old_count) {
         /* requested block is shorter than allocated block
          * then just cut current buffer */
         sshmem_ucx_shadow_set_elem(elem + count,

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx_shadow.c
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx_shadow.c
@@ -113,10 +113,10 @@ int sshmem_ucx_shadow_realloc(sshmem_ucx_shadow_allocator_t *allocator,
                               unsigned count, unsigned old_index, unsigned *index,
                               int *inplace)
 {
-    sshmem_ucx_shadow_alloc_elem_t *end  = &allocator->elems[allocator->num_elems];
     sshmem_ucx_shadow_alloc_elem_t *elem = &allocator->elems[old_index];
-    sshmem_ucx_shadow_alloc_elem_t *next = &elem[elem->block_size];
     unsigned old_count                   = elem->block_size;
+    sshmem_ucx_shadow_alloc_elem_t *end;
+    sshmem_ucx_shadow_alloc_elem_t *next;
 
     assert(count > 0);
     assert(!sshmem_ucx_shadow_is_free(elem));
@@ -142,8 +142,10 @@ int sshmem_ucx_shadow_realloc(sshmem_ucx_shadow_allocator_t *allocator,
 
     assert(count > old_count);
 
+    end  = &allocator->elems[allocator->num_elems];
+    next = &elem[old_count];
     /* try to check if next element is free & has enough length */
-    if ((next < end)                    && /* non-last element? */
+    if ((next < end) &&                    /* non-last element? */
         sshmem_ucx_shadow_is_free(next) && /* next is free */
         (old_count + next->block_size >= count))
     {


### PR DESCRIPTION
- in some cases realloc operation may be completed without
  allocation of new buffer (and without additional data copy)
- added logic to reallocate buffer inplace if possible

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>