### PR TITLE
 COMMON/UCX: init memhooks infra on external hooks only - v4.0

### DIFF
--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -16,7 +16,6 @@
 #include "opal/memoryhooks/memory.h"
 
 #include <ucm/api/ucm.h>
-#include <ucs/sys/math.h>
 
 /***********************************************************************/
 
@@ -102,8 +101,9 @@ OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
             return;
         }
 
-        if (ucs_test_all_flags(opal_mem_hooks_support_level(),
-                               OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT)) {
+        if ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) ==
+            ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) &
+             opal_mem_hooks_support_level())) {
             MCA_COMMON_UCX_VERBOSE(1, "%s", "using OPAL memory hooks as external events");
             ucm_set_external_event(UCM_EVENT_VM_UNMAPPED);
             opal_mem_hooks_register_release(opal_common_ucx_mem_release_cb, NULL);

--- a/opal/mca/common/ucx/common_ucx.c
+++ b/opal/mca/common/ucx/common_ucx.c
@@ -16,6 +16,7 @@
 #include "opal/memoryhooks/memory.h"
 
 #include <ucm/api/ucm.h>
+#include <ucs/sys/math.h>
 
 /***********************************************************************/
 
@@ -91,23 +92,22 @@ OPAL_DECLSPEC void opal_common_ucx_mca_register(void)
     opal_common_ucx.output = opal_output_open(NULL);
     opal_output_set_verbosity(opal_common_ucx.output, opal_common_ucx.verbose);
 
-    ret = mca_base_framework_open(&opal_memory_base_framework, 0);
-    if (OPAL_SUCCESS != ret) {
-        /* failed to initialize memory framework - just exit */
-        MCA_COMMON_UCX_VERBOSE(1, "failed to initialize memory base framework: %d, "
-                                  "memory hooks will not be used", ret);
-        return;
-    }
-
     /* Set memory hooks */
-    if (opal_common_ucx.opal_mem_hooks &&
-        (OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) ==
-        ((OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT) &
-         opal_mem_hooks_support_level()))
-    {
-        MCA_COMMON_UCX_VERBOSE(1, "%s", "using OPAL memory hooks as external events");
-        ucm_set_external_event(UCM_EVENT_VM_UNMAPPED);
-        opal_mem_hooks_register_release(opal_common_ucx_mem_release_cb, NULL);
+    if (opal_common_ucx.opal_mem_hooks) {
+        ret = mca_base_framework_open(&opal_memory_base_framework, 0);
+        if (OPAL_SUCCESS != ret) {
+            /* failed to initialize memory framework - just exit */
+            MCA_COMMON_UCX_VERBOSE(1, "failed to initialize memory base framework: %d, "
+                                      "memory hooks will not be used", ret);
+            return;
+        }
+
+        if (ucs_test_all_flags(opal_mem_hooks_support_level(),
+                               OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_MUNMAP_SUPPORT)) {
+            MCA_COMMON_UCX_VERBOSE(1, "%s", "using OPAL memory hooks as external events");
+            ucm_set_external_event(UCM_EVENT_VM_UNMAPPED);
+            opal_mem_hooks_register_release(opal_common_ucx_mem_release_cb, NULL);
+        }
     }
 }
 


### PR DESCRIPTION
- initialize memory hooks infrastructure only in case
  if external memory hooks are requested

backport from https://github.com/open-mpi/ompi/pull/6675