### PR TITLE
OSC/UCX: Fix deadlock with atomic lock - v4.0

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_active_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_active_target.c
@@ -276,6 +276,7 @@ int ompi_osc_ucx_post(struct ompi_group_t *group, int assert, struct ompi_win_t 
                     ompi_osc_ucx_handle_incoming_post(module, &(module->state.post_state[j]), NULL, 0);
                 }
 
+                ucp_worker_progress(mca_osc_ucx_component.ucp_worker);
                 usleep(100);
             } while (1);
         }


### PR DESCRIPTION
Atomic lock must progress local worker while obtaining the remote lock,
otherwise an active message which actually releases the lock might not
be processed while polling on local memory location.

(picked from master 9d1994b)

Fixes #6546 