### PR TITLE
PML/UCX: disable PML UCX if MT is requested but not supported - v4.0

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -245,7 +245,7 @@ int mca_pml_ucx_close(void)
     return OMPI_SUCCESS;
 }
 
-int mca_pml_ucx_init(void)
+int mca_pml_ucx_init(int enable_mpi_threads)
 {
     ucp_worker_params_t params;
     ucp_worker_attr_t attr;
@@ -256,8 +256,7 @@ int mca_pml_ucx_init(void)
 
     /* TODO check MPI thread mode */
     params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-    params.thread_mode = UCS_THREAD_MODE_SINGLE;
-    if (ompi_mpi_thread_multiple) {
+    if (enable_mpi_threads) {
         params.thread_mode = UCS_THREAD_MODE_MULTI;
     } else {
         params.thread_mode = UCS_THREAD_MODE_SINGLE;
@@ -279,10 +278,11 @@ int mca_pml_ucx_init(void)
         goto err_destroy_worker;
     }
 
-    if (ompi_mpi_thread_multiple && (attr.thread_mode != UCS_THREAD_MODE_MULTI)) {
+    if (enable_mpi_threads && (attr.thread_mode != UCS_THREAD_MODE_MULTI)) {
         /* UCX does not support multithreading, disqualify current PML for now */
         /* TODO: we should let OMPI to fallback to THREAD_SINGLE mode */
-        PML_UCX_ERROR("UCP worker does not support MPI_THREAD_MULTIPLE");
+        PML_UCX_VERBOSE(1, "UCP worker does not support MPI_THREAD_MULTIPLE. "
+                           "PML UCX could not be selected");
         rc = OMPI_ERR_NOT_SUPPORTED;
         goto err_destroy_worker;
     }

--- a/ompi/mca/pml/ucx/pml_ucx.h
+++ b/ompi/mca/pml/ucx/pml_ucx.h
@@ -64,7 +64,7 @@ extern mca_pml_ucx_module_t ompi_pml_ucx;
 
 int mca_pml_ucx_open(void);
 int mca_pml_ucx_close(void);
-int mca_pml_ucx_init(void);
+int mca_pml_ucx_init(int enable_mpi_threads);
 int mca_pml_ucx_cleanup(void);
 
 int mca_pml_ucx_add_procs(struct ompi_proc_t **procs, size_t nprocs);

--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -90,11 +90,11 @@ static int mca_pml_ucx_component_close(void)
 
 static mca_pml_base_module_t*
 mca_pml_ucx_component_init(int* priority, bool enable_progress_threads,
-                             bool enable_mpi_threads)
+                           bool enable_mpi_threads)
 {
     int ret;
 
-    if ( (ret = mca_pml_ucx_init()) != 0) {
+    if ( (ret = mca_pml_ucx_init(enable_mpi_threads)) != 0) {
         return NULL;
     }
 


### PR DESCRIPTION
- in case if multithreading requested but not supported
  disable PML UCX

backport from https://github.com/open-mpi/ompi/pull/6680

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit a3578d9ece2b40a349529e7b223df50b0aac64aa)