### PR TITLE
common/ompio: fix coverty warnings

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -130,6 +130,10 @@ int mca_common_ompio_file_read (ompio_file_t *fh,
         if ( MPI_STATUS_IGNORE != status ) {
             status->_ucount = 0;
         }
+        if (NULL != decoded_iov) {
+            free (decoded_iov);
+            decoded_iov = NULL;
+        }
         return OMPI_SUCCESS;
     }
 
@@ -309,6 +313,11 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
             ompio_req->req_ompi.req_status._ucount = 0;
             ompi_request_complete (&ompio_req->req_ompi, false);
             *request = (ompi_request_t *) ompio_req;
+            if (NULL != decoded_iov) {
+                free (decoded_iov);
+                decoded_iov = NULL;
+            }
+
             return OMPI_SUCCESS;
         }
 

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -115,6 +115,10 @@ int mca_common_ompio_file_write (ompio_file_t *fh,
         if ( MPI_STATUS_IGNORE != status ) {
             status->_ucount = 0;
         }
+        if (NULL != decoded_iov) {
+            free (decoded_iov);
+            decoded_iov = NULL;
+        }
         return OMPI_SUCCESS;
     }
 
@@ -288,6 +292,11 @@ int mca_common_ompio_file_iwrite (ompio_file_t *fh,
             ompio_req->req_ompi.req_status._ucount = 0;
             ompi_request_complete (&ompio_req->req_ompi, false);
             *request = (ompi_request_t *) ompio_req;
+            if (NULL != decoded_iov) {
+                free (decoded_iov);
+                decoded_iov = NULL;
+            }
+
             return OMPI_SUCCESS;
         }
 


### PR DESCRIPTION
this commmit fixes coverty warnings CID 1445198 and CID 1445197
For a reason that is a bit unclear to me, coverty only complained about the read
files, but the write operations had the same issue, so I fixed that within the
same commit as well.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>