### PR TITLE
opal/util: revamp opal_output_verbose()

### DIFF
--- a/opal/util/output.c
+++ b/opal/util/output.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
@@ -388,17 +388,12 @@ void opal_output(int output_id, const char *format, ...)
 
 
 /*
- * Send a message to a stream if the verbose level is high enough
+ * Check whether the verbose level is high enough for the given stream
  */
-void opal_output_verbose(int level, int output_id, const char *format, ...)
+bool opal_output_check_verbosity(int level, int output_id)
 {
-    if (output_id >= 0 && output_id < OPAL_OUTPUT_MAX_STREAMS &&
-        info[output_id].ldi_verbose_level >= level) {
-        va_list arglist;
-        va_start(arglist, format);
-        output(output_id, format, arglist);
-        va_end(arglist);
-    }
+    return (output_id >= 0 && output_id < OPAL_OUTPUT_MAX_STREAMS &&
+        info[output_id].ldi_verbose_level >= level);
 }
 
 

--- a/opal/util/output.h
+++ b/opal/util/output.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -402,8 +404,14 @@ struct opal_output_stream_t {
      *
      * @see opal_output_set_verbosity()
      */
-    OPAL_DECLSPEC void opal_output_verbose(int verbose_level, int output_id,
-                                           const char *format, ...) __opal_attribute_format__(__printf__, 3, 4);
+#define opal_output_verbose(verbose_level, output_id, ...)           \
+    do {                                                             \
+        if (opal_output_check_verbosity(verbose_level, output_id)) { \
+            opal_output(output_id, __VA_ARGS__);                     \
+        }                                                            \
+    } while(0)
+
+    OPAL_DECLSPEC bool opal_output_check_verbosity(int verbose_level, int output_id);
 
    /**
     * Same as opal_output_verbose(), but takes a va_list form of varargs.


### PR DESCRIPTION
A typical parameter of opal_output_verbose() is ORTE_NAME_PRINT(...),
which is an expensive macro.
Most of the time, this is unnecessary since the verbosity level is too high.

Make opal_output_verbose() a macro so such arguments are only evaluated if the
verbosity is low enough.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>