### PR TITLE
opal/atomic: work around memory barrier bug in older gcc

### DIFF
--- a/opal/include/opal/sys/atomic_stdc.h
+++ b/opal/include/opal/sys/atomic_stdc.h
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,7 +74,14 @@ static inline void opal_atomic_wmb (void)
 
 static inline void opal_atomic_rmb (void)
 {
+#if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
+    /* work around a bug in older gcc versions (observed in gcc 6.x)
+     * where acquire seems to get treated as a no-op instead of being
+     * equivalent to __asm__ __volatile__("": : :"memory") on x86_64 */
+    opal_atomic_mb ();
+#else
     atomic_thread_fence (memory_order_acquire);
+#endif
 }
 
 #define opal_atomic_compare_exchange_strong_32(addr, compare, value) atomic_compare_exchange_strong_explicit (addr, compare, value, memory_order_relaxed, memory_order_relaxed)


### PR DESCRIPTION
This commit fixes an issue seem with some older versions of gcc
(verified to occur in gcc 6.x) where on x86_64 systems the
acquire memory barrier in C11 atomics acts as a no-op. On these
systems the three memory barriers should all be equivalent.

This is related to the error fixed in open-mpi/ompi@30119ee.

References #6655.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>