### PR TITLE
 orte/mca/regx/base:fixed orted double free or corruption 

### DIFF
--- a/orte/mca/regx/base/regx_base_default_fns.c
+++ b/orte/mca/regx/base/regx_base_default_fns.c
@@ -1056,7 +1056,7 @@ static int regex_parse_node_range(char *base, char *range, int num_digits, char 
     for (found = false, i = 0; i < len; ++i) {
         if (isdigit((int) range[i])) {
             if (!found) {
-                start = atoi(range + i);
+		start = strtol(range + i, NULL, 10);
                 found = true;
                 break;
             }


### PR DESCRIPTION
@ggouaillardet   I fixed it on v4.0.x
- orte/mca/regx/base/regx_base_default_fns.c  cause double  free vs 0.4.x version
- 0.4.x version for openmpi  used in our production