### PR TITLE
PML/UCX: Don't destroy UCP worker if it wasn't created

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -257,8 +257,8 @@ int mca_pml_ucx_init(void)
 
 err_destroy_worker:
     ucp_worker_destroy(ompi_pml_ucx.ucp_worker);
-    ompi_pml_ucx.ucp_worker = NULL;
 err:
+    ompi_pml_ucx.ucp_worker = NULL;
     return rc;
 }
 
@@ -288,7 +288,7 @@ int mca_pml_ucx_cleanup(void)
     OBJ_DESTRUCT(&ompi_pml_ucx.convs);
     OBJ_DESTRUCT(&ompi_pml_ucx.persistent_reqs);
 
-    if (ompi_pml_ucx.ucp_worker) {
+    if (ompi_pml_ucx.ucp_worker != NULL) {
         ucp_worker_destroy(ompi_pml_ucx.ucp_worker);
         ompi_pml_ucx.ucp_worker = NULL;
     }


### PR DESCRIPTION
If `ucp_worker_create` wasn't successful, PML UCX has to not call `ucp_worker_destroy`
when such case happens, user can see the following output:
```
Mon Jun  3 10:38:52 2019[1,0]<stdout>:[1559547531.449203] [jazz07:169494:0]     ucp_worker.c:1126 UCX  WARN  failed to remove event handler for fd -1: No such element
Mon Jun  3 10:38:52 2019[1,0]<stdout>:[1559547531.449543] [jazz07:169494:0]     ucp_worker.c:1126 UCX  WARN  failed to remove event handler for fd -1: No such element
Mon Jun  3 10:38:52 2019[1,0]<stdout>:[1559547531.449702] [jazz07:169494:0]     ucp_worker.c:1126 UCX  WARN  failed to remove event handler for fd -1: No such element
Mon Jun  3 10:38:52 2019[1,0]<stdout>:[1559547531.449714] [jazz07:169494:0]     ucp_worker.c:1126 UCX  WARN  failed to remove event handler for fd -1: No such element
Mon Jun  3 10:38:52 2019[1,0]<stdout>:[1559547531.449720] [jazz07:169494:0]     ucp_worker.c:1126 UCX  WARN  failed to remove event handler for fd -1: No such element
Mon Jun  3 10:38:52 2019[1,0]<stderr>:[jazz07:169494] pml_ucx.c:268  Error: Failed to create UCP worker

```

Solution: set `ucp_worker` to `NULL`, if `ucp_worker_create` fails to avoid calling `ucp_worker_destroy` inside `mca_pml_ucx_cleanup` function.

Signed-off-by: Dmitry Gladkov <dmitrygla@mellanox.com>