### PR TITLE
v4.0.x: regx/base: fix an integer overflow

### DIFF
--- a/orte/mca/regx/base/regx_base_default_fns.c
+++ b/orte/mca/regx/base/regx_base_default_fns.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2018      Research Organization for Information Science
+ * Copyright (c) 2018-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -1056,7 +1056,7 @@ static int regex_parse_node_range(char *base, char *range, int num_digits, char 
     for (found = false, i = 0; i < len; ++i) {
         if (isdigit((int) range[i])) {
             if (!found) {
-                start = atoi(range + i);
+                start = strtol(range + i, NULL, 10);
                 found = true;
                 break;
             }


### PR DESCRIPTION
use strtol() instead of atoi() in order to handle hostnames
containing a large number.

Thanks perrynzhou for the report and fix.

This is a one-off commit for the release branches since
the regx framework has already been removed from master.

Refs. open-mpi/ompi#6729

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>