### PR TITLE
romio info: letting romio keep its internal setup

### DIFF
--- a/ompi/mca/io/io.h
+++ b/ompi/mca/io/io.h
@@ -16,7 +16,7 @@
  * Copyright (c) 2015      University of Houston. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -153,6 +153,10 @@ typedef int (*mca_io_base_module_file_get_size_fn_t)
     (struct ompi_file_t *fh, MPI_Offset *size);
 typedef int (*mca_io_base_module_file_get_amode_fn_t)
     (struct ompi_file_t *fh, int *amode);
+typedef int (*mca_io_base_module_file_set_info_fn_t)
+    (struct ompi_file_t *fh, struct ompi_info_t *info);
+typedef int (*mca_io_base_module_file_get_info_fn_t)
+    (struct ompi_file_t *fh, struct ompi_info_t **info_used);
 
 typedef int (*mca_io_base_module_file_set_view_fn_t)
     (struct ompi_file_t *fh, MPI_Offset disp, struct ompi_datatype_t *etype,
@@ -307,6 +311,8 @@ struct mca_io_base_module_2_0_0_t {
     mca_io_base_module_file_preallocate_fn_t io_module_file_preallocate;
     mca_io_base_module_file_get_size_fn_t    io_module_file_get_size;
     mca_io_base_module_file_get_amode_fn_t   io_module_file_get_amode;
+    mca_io_base_module_file_set_info_fn_t    io_module_file_set_info;
+    mca_io_base_module_file_get_info_fn_t    io_module_file_get_info;
 
     mca_io_base_module_file_set_view_fn_t    io_module_file_set_view;
     mca_io_base_module_file_get_view_fn_t    io_module_file_get_view;

--- a/ompi/mca/io/ompio/io_ompio_module.c
+++ b/ompi/mca/io/ompio/io_ompio_module.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 University of Houston. All rights reserved.
- * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +36,8 @@ mca_io_base_module_2_0_0_t mca_io_ompio_module = {
     mca_io_ompio_file_preallocate,
     mca_io_ompio_file_get_size,
     mca_io_ompio_file_get_amode,
+    NULL,
+    NULL,
 
     mca_io_ompio_file_set_view,
     mca_io_ompio_file_get_view,

--- a/ompi/mca/io/romio321/src/io_romio321.h
+++ b/ompi/mca/io/romio321/src/io_romio321.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,9 +81,9 @@ int mca_io_romio321_file_get_size (struct ompi_file_t *fh,
 int mca_io_romio321_file_get_amode (struct ompi_file_t *fh,
                                  int *amode);
 int mca_io_romio321_file_set_info (struct ompi_file_t *fh,
-                                struct opal_info_t *info);
+                                struct ompi_info_t *info);
 int mca_io_romio321_file_get_info (struct ompi_file_t *fh,
-                                struct opal_info_t ** info_used);
+                                struct ompi_info_t ** info_used);
 
 /* Section 9.3 */
 int mca_io_romio321_file_set_view (struct ompi_file_t *fh,

--- a/ompi/mca/io/romio321/src/io_romio321_file_open.c
+++ b/ompi/mca/io/romio321/src/io_romio321_file_open.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -162,51 +162,32 @@ mca_io_romio321_file_get_amode (ompi_file_t *fh,
 
 int
 mca_io_romio321_file_set_info (ompi_file_t *fh,
-                            opal_info_t *info)
+                            ompi_info_t *info)
 {
     int ret;
     mca_io_romio321_data_t *data;
 
-// An opal_info_t isn't a full ompi_info_t. so if we're using an MPI call
-// below with an MPI_Info, we need to create an equivalent MPI_Info. This
-// isn't ideal but it only happens a few places.
-    ompi_info_t *ompi_info;
-    ompi_info = OBJ_NEW(ompi_info_t);
-    if (!ompi_info) { return(MPI_ERR_NO_MEM); }
-    opal_info_t *opal_info = &(ompi_info->super);
-    opal_info_dup (info, &opal_info);
-
     data = (mca_io_romio321_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio321_mutex);
-    ret = ROMIO_PREFIX(MPI_File_set_info) (data->romio_fh, ompi_info);
+    ret = ROMIO_PREFIX(MPI_File_set_info) (data->romio_fh, info);
     OPAL_THREAD_UNLOCK (&mca_io_romio321_mutex);
 
-    ompi_info_free(&ompi_info);
     return ret;
 }
 
 
 int
 mca_io_romio321_file_get_info (ompi_file_t *fh,
-                            opal_info_t ** info_used)
+                            ompi_info_t ** info_used)
 {
     int ret;
     mca_io_romio321_data_t *data;
 
-// An opal_info_t isn't a full ompi_info_t. so if we're using an MPI call
-// below with an MPI_Info, we need to create an equivalent MPI_Info. This
-// isn't ideal but it only happens a few places.
-    ompi_info_t *ompi_info;
-    ompi_info = OBJ_NEW(ompi_info_t);
-    if (!ompi_info) { return(MPI_ERR_NO_MEM); }
-
     data = (mca_io_romio321_data_t *) fh->f_io_selected_data;
     OPAL_THREAD_LOCK (&mca_io_romio321_mutex);
-    ret = ROMIO_PREFIX(MPI_File_get_info) (data->romio_fh, &ompi_info);
+    ret = ROMIO_PREFIX(MPI_File_get_info) (data->romio_fh, info_used);
     OPAL_THREAD_UNLOCK (&mca_io_romio321_mutex);
 
-    opal_info_dup (&(ompi_info->super), info_used);
-    ompi_info_free(&ompi_info);
     return ret;
 }
 

--- a/ompi/mca/io/romio321/src/io_romio321_module.c
+++ b/ompi/mca/io/romio321/src/io_romio321_module.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation. All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -50,6 +50,8 @@ mca_io_base_module_2_0_0_t mca_io_romio321_module = {
     mca_io_romio321_file_preallocate,
     mca_io_romio321_file_get_size,
     mca_io_romio321_file_get_amode,
+    mca_io_romio321_file_set_info,
+    mca_io_romio321_file_get_info,
     mca_io_romio321_file_set_view,
     mca_io_romio321_file_get_view,
 

--- a/ompi/mpi/c/file_get_info.c
+++ b/ompi/mpi/c/file_get_info.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,6 +51,24 @@ int MPI_File_get_info(MPI_File fh, MPI_Info *info_used)
             return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM,
                                           FUNC_NAME);
         }
+    }
+
+// Some components we're still letting handle info internally, eg romio321.
+// Components that want to handle it themselves will fill in the get/set
+// info function pointers, components that don't will use NULL.
+    if (fh->f_io_selected_module.v2_0_0.io_module_file_get_info != NULL) {
+        int rc;
+        switch (fh->f_io_version) {
+        case MCA_IO_BASE_V_2_0_0:
+            rc = fh->f_io_selected_module.v2_0_0.
+              io_module_file_get_info(fh, info_used);
+            break;
+
+        default:
+            rc = MPI_ERR_INTERN;
+            break;
+        }
+        OMPI_ERRHANDLER_RETURN(rc, fh, rc, FUNC_NAME);
     }
 
     if (NULL == fh->super.s_info) {

--- a/ompi/mpi/c/file_set_info.c
+++ b/ompi/mpi/c/file_set_info.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,6 +61,24 @@ int MPI_File_set_info(MPI_File fh, MPI_Info info)
     }
 
     OPAL_CR_ENTER_LIBRARY();
+
+// Some components we're still letting handle info internally, eg romio321.
+// Components that want to handle it themselves will fill in the get/set
+// info function pointers, components that don't will use NULL.
+    if (fh->f_io_selected_module.v2_0_0.io_module_file_set_info != NULL) {
+        int rc;
+        switch (fh->f_io_version) {
+        case MCA_IO_BASE_V_2_0_0:
+            rc = fh->f_io_selected_module.v2_0_0.
+              io_module_file_set_info(fh, info);
+            break;
+
+        default:
+            rc = MPI_ERR_INTERN;
+            break;
+        }
+        OMPI_ERRHANDLER_RETURN(rc, fh, rc, FUNC_NAME);
+    }
 
     ret = opal_infosubscribe_change_info(&fh->super, &info->super);
 


### PR DESCRIPTION
I'm restoring the info function pointers to the IO module
but allowing the function pointers to be NULL (eg in ompio).
And letting romio321 set its function pointers for those
routines.

This means the info system uses the new OMPI-level info
system for most things, but skips it and uses the pre-existing
romio info system just for the romio module.

It's possible to convert romio, but I went a ways down that
path and found it kind of convoluted.  Having pointers from
the lower level ADIO_File back to the higher level ompi_file_t
wasn't too bad, but I got stuck trying to figure out where/how
to register the infosubscribe_subscribe callbacks vs the way
initial k/v values are scattered around the romio code currently.

Signed-off-by: Mark Allen <markalle@us.ibm.com>