### PR TITLE
--report-bindings on whole machine, plus numa markers

### DIFF
--- a/ompi/mca/hook/report_bindings_full/Makefile.am
+++ b/ompi/mca/hook/report_bindings_full/Makefile.am
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2019      IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+	hook_report_bindings_full.h \
+	hook_report_bindings_full_component.c \
+	hook_report_bindings_full_fns.c
+
+# This component will only ever be built statically -- never as a DSO.
+
+noinst_LTLIBRARIES = libmca_hook_report_bindings_full.la
+
+libmca_hook_report_bindings_full_la_SOURCES = $(sources)
+libmca_hook_report_bindings_full_la_LDFLAGS = -module -avoid-version

--- a/ompi/mca/hook/report_bindings_full/configure.m4
+++ b/ompi/mca/hook/report_bindings_full/configure.m4
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2019      IBM Corporation.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# Make this a static component
+AC_DEFUN([MCA_ompi_hook_report_bindings_full_COMPILE_MODE], [
+    AC_MSG_CHECKING([for MCA component $2:$3 compile mode])
+    $4="static"
+    AC_MSG_RESULT([$$4])
+])
+
+# MCA_hook_report_bindings_full_CONFIG([action-if-can-compile],
+#                      [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_hook_report_bindings_full_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/hook/report_bindings_full/Makefile])
+
+    $1
+])

--- a/ompi/mca/hook/report_bindings_full/hook_report_bindings_full.h
+++ b/ompi/mca/hook/report_bindings_full/hook_report_bindings_full.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#ifndef MCA_HOOK_REPORT_BINDINGS_FULL_H
+#define MCA_HOOK_REPORT_BINDINGS_FULL_H
+
+#include "ompi_config.h"
+
+#include "ompi/constants.h"
+
+#include "ompi/mca/hook/hook.h"
+#include "ompi/mca/hook/base/base.h"
+
+BEGIN_C_DECLS
+
+OMPI_MODULE_DECLSPEC extern const ompi_hook_base_component_1_0_0_t mca_hook_report_bindings_full_component;
+
+extern int mca_hook_report_bindings_full_verbose;
+extern int mca_hook_report_bindings_full_output;
+extern bool hook_report_bindings_full_enable_mpi_init;
+
+void ompi_hook_report_bindings_full_mpi_init_bottom(int argc, char **argv, int requested, int *provided);
+
+END_C_DECLS
+
+#endif /* MCA_HOOK_REPORT_BINDINGS_FULL_H */

--- a/ompi/mca/hook/report_bindings_full/hook_report_bindings_full_component.c
+++ b/ompi/mca/hook/report_bindings_full/hook_report_bindings_full_component.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "hook_report_bindings_full.h"
+
+static int ompi_hook_report_bindings_full_component_open(void);
+static int ompi_hook_report_bindings_full_component_close(void);
+static int ompi_hook_report_bindings_full_component_register(void);
+
+/*
+ * Public string showing the component version number
+ */
+const char *mca_hook_report_bindings_full_component_version_string =
+    "Open MPI 'report_bindings_full' hook MCA component version " OMPI_VERSION;
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+const ompi_hook_base_component_1_0_0_t mca_hook_report_bindings_full_component = {
+
+    /* First, the mca_component_t struct containing meta information
+     * about the component itself */
+    .hookm_version = {
+        OMPI_HOOK_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .mca_component_name = "report_bindings_full",
+        MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
+                              OMPI_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .mca_open_component = ompi_hook_report_bindings_full_component_open,
+        .mca_close_component = ompi_hook_report_bindings_full_component_close,
+        .mca_register_component_params = ompi_hook_report_bindings_full_component_register,
+
+        // Force this component to always be considered - component must be static
+        //.mca_component_flags = MCA_BASE_COMPONENT_FLAG_ALWAYS_CONSIDER,
+    },
+    .hookm_data = {
+        /* The component is checkpoint ready */
+        MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+
+    /* Component functions */
+    .hookm_mpi_initialized_top = NULL,
+    .hookm_mpi_initialized_bottom = NULL,
+
+    .hookm_mpi_finalized_top = NULL,
+    .hookm_mpi_finalized_bottom = NULL,
+
+    .hookm_mpi_init_top = NULL,
+    .hookm_mpi_init_top_post_opal = NULL,
+    .hookm_mpi_init_bottom = ompi_hook_report_bindings_full_mpi_init_bottom,
+    .hookm_mpi_init_error = NULL,
+
+    .hookm_mpi_finalize_top = NULL,
+    .hookm_mpi_finalize_bottom = NULL,
+};
+
+int mca_hook_report_bindings_full_verbose = 0;
+int mca_hook_report_bindings_full_output  = -1;
+bool hook_report_bindings_full_enable_mpi_init = false;
+bool hook_report_bindings_full = false;
+
+static int ompi_hook_report_bindings_full_component_open(void)
+{
+    // Nothing to do
+    return OMPI_SUCCESS;
+}
+
+static int ompi_hook_report_bindings_full_component_close(void)
+{
+    // Nothing to do
+    return OMPI_SUCCESS;
+}
+
+static int ompi_hook_report_bindings_full_component_register(void)
+{
+
+    /*
+     * Component verbosity level
+     */
+    // Inherit the verbosity of the base framework, but also allow this to be overridden
+    if( ompi_hook_base_framework.framework_verbose > MCA_BASE_VERBOSE_NONE ) {
+        mca_hook_report_bindings_full_verbose = ompi_hook_base_framework.framework_verbose;
+    }
+    else {
+        mca_hook_report_bindings_full_verbose = MCA_BASE_VERBOSE_NONE;
+    }
+    (void) mca_base_component_var_register(&mca_hook_report_bindings_full_component.hookm_version, "verbose",
+                                           NULL,
+                                           MCA_BASE_VAR_TYPE_INT, NULL,
+                                           0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_hook_report_bindings_full_verbose);
+
+    mca_hook_report_bindings_full_output = opal_output_open(NULL);
+    opal_output_set_verbosity(mca_hook_report_bindings_full_output, mca_hook_report_bindings_full_verbose);
+
+    /*
+     * If the component is active for mpi_init
+     */
+    hook_report_bindings_full_enable_mpi_init = false;
+    (void) mca_base_component_var_register(&mca_hook_report_bindings_full_component.hookm_version, "enable_mpi_init",
+                                           "Enable report_bindings_full behavior on mpi_init",
+                                           MCA_BASE_VAR_TYPE_BOOL, NULL,
+                                           0, 0,
+                                           OPAL_INFO_LVL_3,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &hook_report_bindings_full_enable_mpi_init);
+
+    // User can set OMPI_MCA_report_bindings_full too
+    int hook_report_bindings_full = false;
+    (void) mca_base_var_register("ompi", NULL, NULL, "report_bindings_full",
+                                 "Enable report_bindings_full behavior at mpi_init",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL,
+                                 0, 0,
+                                 OPAL_INFO_LVL_3,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &hook_report_bindings_full);
+
+    if (hook_report_bindings_full) {
+        hook_report_bindings_full_enable_mpi_init = true;
+    }
+
+    return OMPI_SUCCESS;
+}
+

--- a/ompi/mca/hook/report_bindings_full/hook_report_bindings_full_fns.c
+++ b/ompi/mca/hook/report_bindings_full/hook_report_bindings_full_fns.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "hook_report_bindings_full.h"
+
+#ifdef HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif
+
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/pml/pml.h"
+#include "ompi/mca/pml/base/base.h"
+//#include "opal/mca/dl/base/base.h" -- was going to use opal_dl_open etc
+#include "opal/mca/hwloc/base/base.h"
+
+typedef void (*VoidFuncPtr)(void); // a function pointer to a function that takes no arguments and returns void.
+static void ompi_report_bindings();
+
+void ompi_hook_report_bindings_full_mpi_init_bottom(int argc, char **argv, int requested, int *provided)
+{
+    if( hook_report_bindings_full_enable_mpi_init ) {
+        ompi_report_bindings();
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+static void
+ompi_report_bindings()
+{
+    int myrank, nranks;
+    int ret, i;
+    char binding_string[1024];
+    int len;
+    int *lens, *disps;
+    MPI_Comm active_comm = MPI_COMM_WORLD;
+    char **all_binding_strings = NULL;
+
+// early return in the case of spawn
+    if (ompi_mpi_comm_parent != MPI_COMM_NULL) { return; }
+
+// pick a comm, probably COMM_WORLD, only shrink it if it's quite large
+    myrank = ompi_comm_rank(active_comm);
+    nranks = ompi_comm_size(active_comm);
+    if (nranks > 16*1024) {
+        ret = ompi_comm_split(MPI_COMM_WORLD, (myrank<=16*1024)?1:MPI_UNDEFINED, 0, &active_comm, false);
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != ret)) {
+            return;
+        }
+        if (active_comm == MPI_COMM_NULL) { return; }
+        myrank = ompi_comm_rank(active_comm);
+        nranks = ompi_comm_size(active_comm);
+    }
+
+// produce binding string for the current rank
+    hwloc_topology_t whole_system = NULL;
+    hwloc_cpuset_t mycpus;
+    hwloc_topology_init(&whole_system);
+    hwloc_topology_set_flags(whole_system, HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM);
+    hwloc_topology_load(whole_system);
+    mycpus = hwloc_bitmap_alloc();
+    hwloc_get_cpubind(whole_system, mycpus, HWLOC_CPUBIND_PROCESS);
+    opal_hwloc_base_cset2mapstr_with_numa(binding_string, sizeof(binding_string), whole_system, mycpus);
+    hwloc_bitmap_free(mycpus);
+    hwloc_topology_destroy(whole_system);
+
+// Collecting the data at rank 0 to print it in an ordered manner isn't totally
+// necessary, but makes the output a little nicer.
+    len = strlen(binding_string) + 1;
+    lens = malloc(nranks * sizeof(int));
+    disps = malloc(nranks * sizeof(int));
+
+    active_comm->c_coll->coll_gather(
+        &len, 1, MPI_INT,
+        lens, 1, MPI_INT,
+        0, active_comm, active_comm->c_coll->coll_gather_module);
+    if (myrank == 0) {
+        int tlen = 0;
+        char *p;
+        for (i=0; i<nranks; ++i) {
+            disps[i] = tlen;
+            tlen += lens[i];
+        }
+        all_binding_strings = malloc(nranks * sizeof(char*)  +  tlen);
+        p = (char*) (all_binding_strings + nranks);
+        for (i=0; i<nranks; ++i) {
+            all_binding_strings[i] = p;
+            p += lens[i];
+        }
+        active_comm->c_coll->coll_gatherv(
+            binding_string, strlen(binding_string) + 1, MPI_CHAR,
+            &all_binding_strings[0][0], lens, disps, MPI_CHAR,
+            0, active_comm, active_comm->c_coll->coll_gatherv_module);
+    } else {
+        // matching above call from rank 0, just &all_binding_strings[0][0]
+        // isn't legal here, and those args aren't used at non-root anyway
+        active_comm->c_coll->coll_gatherv(
+            binding_string, strlen(binding_string) + 1, MPI_CHAR,
+            NULL, NULL, NULL, MPI_CHAR,
+            0, active_comm, active_comm->c_coll->coll_gatherv_module);
+    }
+
+// print them from rank 0
+    if (myrank == 0) {
+        for (i=0; i<nranks; ++i) {
+            printf("MCW %d: %s\n", i, all_binding_strings[i]);
+        }
+    }
+
+    if (active_comm != MPI_COMM_WORLD) { ompi_comm_free(&active_comm); }
+    free(lens);
+    free(disps);
+    if (myrank == 0) { free(all_binding_strings); }
+}

--- a/opal/mca/hwloc/base/base.h
+++ b/opal/mca/hwloc/base/base.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -277,6 +278,9 @@ OPAL_DECLSPEC int opal_hwloc_base_cset2str(char *str, int len,
  *        B - signifies PU a process is bound to
  */
 OPAL_DECLSPEC int opal_hwloc_base_cset2mapstr(char *str, int len,
+                                              hwloc_topology_t topo,
+                                              hwloc_cpuset_t cpuset);
+OPAL_DECLSPEC int opal_hwloc_base_cset2mapstr_with_numa(char *str, int len,
                                               hwloc_topology_t topo,
                                               hwloc_cpuset_t cpuset);
 

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -2273,6 +2273,254 @@ int opal_hwloc_get_sorted_numa_list(hwloc_topology_t topo, char* device_name, op
     return OPAL_ERR_NOT_FOUND;
 }
 
+static int
+mycompare(const void* inta, const void* intb)
+{
+    if (*(int*)inta < *(int*)intb) { return -1; }
+    if (*(int*)inta > *(int*)intb) { return 1; }
+    return 0;
+}
+
+// Patterns to compress adequately:
+// 1. basic 0,1,2,3 to 0-3
+// 2. repeated ranges of same len at same offset, eg 0,1,2 10,11,12 20,21,22 = 0,1,2+10*3
+// note: assumes input is already sorted
+static char*
+mycompress1(int *a, int n)
+{
+    char *str;
+    int i, maxlen, len;
+
+    maxlen = 128;
+    len = 0;
+    str = malloc(maxlen);
+    if (!str) { return NULL; }
+    str[0] = 0;
+
+    // start with "L" followed by the list
+    str[len++] = 'L';
+    str[len] = 0;
+
+    int pattern_blocksize = 0; // contiguous elements per block
+    int pattern_blockcount = 0; // number of blocks
+    int pattern_stride = 0;
+    int pattern_first_block_starting_offset = -1;
+    int pattern_prev_block_starting_offset = -1;
+    int pattern_nelements = 0;
+    int is_start_of_new_pattern = 0;
+    for (i=0; i<n; ++i) {
+        // see if this element a[i] is the start of a new pattern or
+        // if it's adding to the previous, we may increment i further
+        // processing multiple elements into the previous pattern
+        // only update the pattern_* data for the previous pattern
+        // (if we're starting a new pattern, we put it into pattern_*,
+        // later, after printing what was already in pattern_*)
+
+        // start by supposing it is a new pattern, change that decision
+        // if we process it into the existing pattern_* below
+        is_start_of_new_pattern = 1;
+
+        if (pattern_blocksize > 0) {
+            // detect [pppx]
+            if (pattern_blockcount == 1 &&
+                a[i] == pattern_prev_block_starting_offset + pattern_blocksize)
+            {
+                ++pattern_blocksize;
+                ++pattern_nelements;
+                is_start_of_new_pattern = 0;
+            } else {
+                // detect [pppp  xxxx]   or   [pppp  pppp  xxxx]   etc
+                if (pattern_blockcount == 1 ||
+                   (pattern_blockcount > 1 &&
+                    (a[i] == pattern_prev_block_starting_offset + pattern_stride)))
+                {
+                    // this a[i] starts at the right offset, now does it contain
+                    // pattern_blocksize contiguous entries?
+                    int j, has_enough_entries = 1;
+                    for (j=1; j<pattern_blocksize; ++j) {
+                        if (i+j >= n) { has_enough_entries = 0; }
+                        else if (a[i+j] != a[i] + j) { has_enough_entries = 0; }
+                    }
+                    if (has_enough_entries) {
+                        pattern_stride = a[i] - pattern_prev_block_starting_offset;
+                        pattern_prev_block_starting_offset = a[i];
+                        ++pattern_blockcount;
+                        pattern_nelements += pattern_blocksize;
+                        is_start_of_new_pattern = 0;
+                        i = i+j-1;
+                    }
+                }
+            }
+        }
+
+        // if started_new_pattern || i is the last element
+        //   if previous pattern exists
+        //     print previous pattern
+        //   record new pattern
+        if (is_start_of_new_pattern || i==n-1) {
+            if (pattern_blocksize > 0) {
+                // print previous pattern
+                // make sure there's room for 4 ints plus some punctuation
+                // being conservative in supposing all ints used are <8 chars
+                if (len + 40 >= maxlen) {
+                    maxlen *= 1.15;
+                    maxlen += 128;
+                    str = realloc(str, maxlen);
+                    if (!str) { return NULL; }
+                }
+                // If the string isn't 'long enough' for compressed notation to be worthwhile:
+                if (!(pattern_nelements > 4 || (pattern_nelements >= 2 && pattern_blockcount == 1))) {
+                    int j, k;
+                    for (j=0; j<pattern_blockcount; ++j) {
+                        for (k=0; k<pattern_blocksize; ++k) {
+                            if (len != 1) { // the string starts with "L" for list
+                                sprintf(&str[len], ",");
+                                ++len;
+                            }
+                            sprintf(&str[len], "%d", pattern_first_block_starting_offset + j*pattern_stride + k);
+                            len = strlen(str);
+                        }
+                    }
+                }
+                else {
+                    if (len != 1) { // the string starts with "L" for list
+                        sprintf(&str[len], ",");
+                        ++len;
+                    }
+                    if (pattern_blockcount > 1) {
+                        sprintf(&str[len], "%d-%d+%d*%d",
+                            pattern_first_block_starting_offset,
+                            pattern_first_block_starting_offset + pattern_blocksize - 1,
+                            pattern_stride, pattern_blockcount);
+                    } else {
+                        sprintf(&str[len], "%d-%d",
+                            pattern_first_block_starting_offset,
+                            pattern_first_block_starting_offset + pattern_blocksize - 1);
+                    }
+                    len = strlen(str);
+
+                }
+            }
+
+            // record new pattern
+            pattern_first_block_starting_offset = a[i];
+            pattern_prev_block_starting_offset = a[i];
+            pattern_blocksize = 1;
+            pattern_blockcount = 1;
+            pattern_stride = 0;
+            pattern_nelements = 1;
+        }
+        // The overall logic till this point is
+        // loop i over some of a[], and either
+        // 1. put a[i] in the previous pattern (and print if it's end of a[])
+        // 2. put a[i] in a new pattern and print the previous pattern
+        // This leaves out printing in the case of a[i] being a new pattern
+        // and also being the end of a[]
+        if (is_start_of_new_pattern && i==n-1) {
+            if (len != 0) {
+                sprintf(&str[len], ",");
+                ++len;
+            }
+            sprintf(&str[len], "%d", pattern_first_block_starting_offset);
+            len = strlen(str);
+        }
+    }   
+            
+    return str;
+}
+// This one just makes a hex string of the available bits
+// update: and does a tiny bit of trivial compression of adjacent
+// hex characters
+// note: assumes input is already sorted
+static char*
+mycompress2(int *a, int n)
+{
+    unsigned char *hex_values;
+    char *str, prev_char, *p;
+    int i, len, max, count;
+
+    max = a[n-1];
+    hex_values = malloc((max / 4 + 4) * sizeof(unsigned char));
+    str = malloc(max/4 + 32);
+    if (!str || !hex_values) { return NULL; }
+
+    // start with "X" followed by the hex bitmask
+    len = 0;
+    str[len++] = 'X';
+
+    for (i=0; i<=max/4; ++i) {
+        hex_values[i] = 0;
+    }
+    for (i=0; i<n; ++i) {
+        int bit = a[i];
+
+        hex_values[bit/4] |= (unsigned char)(8>>(bit % 4));
+        // eg if bit = 11 then hex_values[2] |= 8>>3, eg [0000;0000;0001]
+    }
+
+    for (i=0; i<=max/4; ++i) {
+        sprintf(&str[len], "%x", hex_values[i]);
+        ++len;
+    }
+    free(hex_values);
+    str[len++] = 0;
+
+    // Add a trivial compression of adjacent chars that are the same so 0000 = 0*4,
+    p = str;
+    count = 0;
+    prev_char = (char)0;
+    for (i=0; i<len+1; ++i) {
+        if (i==len || str[i] != prev_char) {
+            // new section, so print pattern for previously stored stuff,
+            // then store new section
+            if (prev_char != (char)0) {
+                if (count <= 4) {
+                    int j;
+                    for (j=0; j<count; ++j) {
+                        *p = prev_char;
+                        ++p;
+                    }   
+                } else {
+                    sprintf(p, "%c*%d", prev_char, count);
+                    p += strlen(p);
+                    if (i < len-1) {
+                        *p = ',';
+                        ++p;
+                    }
+                }   
+            }   
+            prev_char = str[i];
+            count = 1;
+        } else {
+            // new char is part of previous section
+            ++count;
+        }   
+    }
+    *p = 0;
+
+    return str;
+}
+
+// Use two completely different compressions and pick the shorter
+static char*
+mycompress(int *a, int n)
+{
+    char *str1, *str2;
+
+    str1 = mycompress1(a, n);
+    str2 = mycompress2(a, n);
+
+    if (strlen(str2) < strlen(str1)) {
+        free(str1);
+        return str2;
+    }
+    free(str2);
+    return str1;
+}
+
+// The only parsing of this string I can find is a strrchr(str,":")
+// to evaluate the endianness of the nodes, so we have to let that
+// remain as the last entry 
 char* opal_hwloc_base_get_topo_signature(hwloc_topology_t topo)
 {
     int nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt;
@@ -2310,8 +2558,47 @@ char* opal_hwloc_base_get_topo_signature(hwloc_topology_t topo)
     endian = "unknown";
 #endif
 
-    opal_asprintf(&sig, "%dN:%dS:%dL3:%dL2:%dL1:%dC:%dH:%s:%s",
-             nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt, arch, endian);
+// The signature used to just contain number of nodes, sockets, cores,
+// hardware threads, etc.  With heterogeneous cgroups it's not hard to
+// have the counts come out the same even though the topologies of the
+// available elements are different enough to matter
+//
+// Example hardware:
+//    [..../..../..../....][..../..../..../....]
+//     0    4    8    12    16   20   24   28
+// cgset -r cpuset.cpus=10,11,14,15 mycgroup1
+// cgset -r cpuset.cpus=26,27,30,31 mycgroup2
+// the above cgroups would leave only these hardware threads active:
+//     mycgroup1: [~~~~/~~~~/~~HH/~~HH][~~~~/~~~~/~~~~/~~~~]
+//     mycgroup2: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/~~HH/~~HH]
+// The non-WHOLE-SYSTEM topology would only contain the availabe part
+// of the tree and each host would report as 1 socket, 2 cores, etc
+//
+// I think a compressed list of the os_indexes in the available mask
+// should be a modest-sized addition to the string that would suffice
+// to make the signatures differ for different cgroups
+
+    int npu;
+    int *avail_pus;
+    char *avail_pus_string;
+    obj = NULL;
+    npu = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
+    avail_pus = malloc(npu * sizeof(int));
+    if (!avail_pus) { return strdup("malloc failed"); }
+    npu = 0;
+    while ((obj = hwloc_get_next_obj_by_type(topo, HWLOC_OBJ_PU, obj)) != NULL) {
+        avail_pus[npu++] = obj->os_index;
+    }
+    qsort(avail_pus, npu, sizeof(int), &mycompare);
+
+    avail_pus_string = mycompress(avail_pus, npu);
+    opal_asprintf(&sig, "%dN:%dS:%dL3:%dL2:%dL1:%dC:%dH:H%s:%s:%s",
+             nnuma, nsocket, nl3, nl2, nl1, ncore, nhwt,
+             avail_pus_string?avail_pus_string:"", arch, endian);
+
+    free(avail_pus);
+    if (avail_pus_string) { free(avail_pus_string); }
+
     return sig;
 }
 

--- a/orte/mca/rtc/hwloc/rtc_hwloc.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2017      Inria.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -410,9 +411,15 @@ static void set(orte_job_t *jobdat,
                 if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2str(tmp1, sizeof(tmp1), opal_hwloc_topology, mycpus)) {
                     opal_output(0, "MCW rank %d is not bound (or bound to all available processors)", child->name.vpid);
                 } else {
-                    opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), opal_hwloc_topology, mycpus);
-                    opal_output(0, "MCW rank %d bound to %s: %s",
+                    if (!orte_report_bindings_use_hwview) {
+                        opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), opal_hwloc_topology, mycpus);
+                        opal_output(0, "MCW rank %d bound to %s: %s",
                                 child->name.vpid, tmp1, tmp2);
+                    } else {
+                        opal_hwloc_base_cset2mapstr_with_numa(tmp2, sizeof(tmp2), opal_hwloc_topology, mycpus);
+                        opal_output(0, "MCW rank %d bound to %s",
+                                child->name.vpid, tmp2);
+                    }
                 }
             }
             hwloc_bitmap_free(mycpus);

--- a/orte/mca/rtc/hwloc/rtc_hwloc.h
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.h
@@ -45,7 +45,7 @@ typedef struct {
 ORTE_MODULE_DECLSPEC extern orte_rtc_hwloc_component_t mca_rtc_hwloc_component;
 
 extern orte_rtc_base_module_t orte_rtc_hwloc_module;
-
+extern bool orte_report_bindings_use_hwview;
 
 END_C_DECLS
 

--- a/orte/mca/rtc/hwloc/rtc_hwloc_component.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc_component.c
@@ -50,6 +50,7 @@ orte_rtc_hwloc_component_t mca_rtc_hwloc_component = {
 
 static char *biggest = "biggest";
 static char *vmhole;
+bool orte_report_bindings_use_hwview = false;
 
 static int rtc_hwloc_register(void)
 {
@@ -87,6 +88,13 @@ static int rtc_hwloc_register(void)
         opal_output(0, "INVALID VM HOLE TYPE");
         return ORTE_ERROR;
     }
+
+    (void) mca_base_component_var_register(c, "report_bindings_hwview",
+        "Use logical hardware view in --report-bindings output",
+        MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+        OPAL_INFO_LVL_2,
+        MCA_BASE_VAR_SCOPE_READONLY,
+        &orte_report_bindings_use_hwview);
 
     return ORTE_SUCCESS;
 }


### PR DESCRIPTION
I combined a few related features here:
1. --report-bindings on whole machine
2. mark unallowed (eg cgroup) parts of the whole machine with ~
3. numa markers
4. allow hwloc tree to not have sockets/cores

----------------------------------------------------
1. whole machine:

The incoming topology to the pretty-print functions probably didn't use the WHOLE_SYSTEM flag. In general we don't want WHOLE_SYSTEM, but for pretty printing I think it makes more sense. So I'm caching a WHOLE_SYSTEM load of the current machine and using it if the incoming topology also identifies as the current machine.

Examples of what pretty-printing looks like with/without whole system:

Suppose the machine is
```
    [..../..../..../....][..../..../..../....]
     0    4    8    12    16   20   24   28
````
and we run with
```
    cgset -r cpuset.cpus=24,25,28,29 mycgroup1
    cgset -r cpuset.cpus=26,27,30,31 mycgroup2
to leave only these hardware threads active:
    mycgroup1: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/..~~/..~~]
    mycgroup2: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/~~../~~..]
```

Without whole-system the printout (for both of the above) would be
(-np 2)
```
    MCW rank 0 bound to socket 1[core 0[hwt 0-1]]: [][BB/..]
    MCW rank 1 bound to socket 1[core 1[hwt 0-1]]: [][../BB]
```

With whole-system the output is this, which I think is more informative
```
mycgroup1 (-np 2):
    MCW rank 0 bound to socket 1[core 6[hwt 0-1]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/BB~~/..~~]
    MCW rank 1 bound to socket 1[core 7[hwt 0-1]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/..~~/BB~~]
mycgroup2 (-np 2):
    MCW rank 0 bound to socket 1[core 6[hwt 2-3]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/~~BB/~~..]
    MCW rank 1 bound to socket 1[core 7[hwt 2-3]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/~~../~~BB]
```

2. mark unallowed (```~```)

When using the whole-machine option there's a bitmask available to identify
the allowed PUs, eg omitting PUs not in our cgroup.  To distinguish those
PUs I'm using "~"

3. numa markers (```<>```)

I like having numa markers as well as the existing separators between sockets and cores.  They're a little harder since the numas are more fluid, eg sockets always contain cores not vice versa, so you can hard code a loop over sockets follwed by a loop over cores. But numas might be be above or below sockets in the tree.

This code identifies which level should be considered the child of the numas, and has each of the hard coded loops capable of adding numa markers.

Currently I don't have any tunable to turn off the numa markers. A lot of machines have fairly simple numa output where each socket contains one numa, and that ends up looking like this:
    [<..../..../..../....>][<..../..../..../....>]
If others feel that's too cluttered I'm okay with having some tunable so people would have to ask for numa markers.

4. allow hwloc tree to not have sockets/cores

I may be behind the times on hwloc development, but as far as I know hwloc trees aren't guaranteed to have sockets and cores, just a MACHINE at the top and PU at the bottom. So I added a little code to the loops so it would still print the PUs on a hypothetical machine that lacked any structuring of the PUs into cores/sockets.

Signed-off-by: Mark Allen <markalle@us.ibm.com>