### PR TITLE
Suggestion to fix division by zero in file view.

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -1491,13 +1491,12 @@ static double cost_calc (int P, int P_a, size_t d_p, size_t b_c, int dim )
 	}	  
 	case DIM2:
 	{
-	    int P_x, P_y, c;
+	    int P_x, P_y;
 	    
 	    P_x = P_y = (int) sqrt(P);
-	    c = (float) P_a / (float)P_x;
+	    n_as = (float) P_a / (float)P_x;
 	    
 	    n_ar = (float) P_y;
-	    n_as = (float) c;
 	    if ( d_p > (P_a*b_c/P )) {
 		m_s = fmin(b_c / P_y, d_p);
 	    }


### PR DESCRIPTION
In common_ompi_aggregators calc_cost routine:
do not cast the real division to an int intermediately.
This patch removes the obsolete int variable c and assigns
the result of the P_a/P_x division directly to n_as.

With the intermediate int c variable, n_as gets 0 if P_a < P_x,
resulting in a division by 0 when computing n_s.

Signed-off-by: Harald Klimach <harald.klimach@uni-siegen.de>
(cherry picked from commit e222a04ae57e5d09b8559f3c111de1f10a47246a)