### PR TITLE
Prevent EPIPE on OSX.

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -184,7 +184,7 @@ struct mca_btl_tcp_module_t {
 typedef struct mca_btl_tcp_module_t mca_btl_tcp_module_t;
 extern mca_btl_tcp_module_t mca_btl_tcp_module;
 
-#define CLOSE_THE_SOCKET(socket)   {(void)shutdown(socket, SHUT_RDWR); (void)close(socket);}
+#define CLOSE_THE_SOCKET(socket)   {OPAL_OUTPUT_VERBOSE((20, opal_btl_base_framework.framework_output, "CLOSE FD %d at %s:%d", socket, __FILE__, __LINE__)); (void)shutdown(socket, SHUT_RDWR); (void)close(socket);}
 
 /**
  * TCP component initialization.

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -660,6 +660,17 @@ void mca_btl_tcp_set_socket_options(int sd)
                    strerror(opal_socket_errno), opal_socket_errno));
     }
 #endif
+#if defined(SO_NOSIGPIPE)
+    /* Some BSD flavors generate EPIPE when we write to a disconnected peer. We need
+     * the prevent this signal to be able to trap socket shutdown and cleanly release
+     * the endpoint.
+     */
+    int optval2 = 1;
+    if(setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, (char *)&optval2, sizeof(optval2)) < 0) {
+        BTL_ERROR(("setsockopt(SO_NOSIGPIPE) failed: %s (%d)",
+                   strerror(opal_socket_errno), opal_socket_errno));
+    }
+#endif
 }
 
 

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -1729,9 +1729,10 @@ void orte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
         proc->exit_code = WTERMSIG(proc->exit_code) + 128;
 
         OPAL_OUTPUT_VERBOSE((5, orte_odls_base_framework.framework_output,
-                             "%s odls:waitpid_fired child process %s terminated with signal",
+                             "%s odls:waitpid_fired child process %s terminated with signal (%d)",
                              ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                             ORTE_NAME_PRINT(&proc->name) ));
+                             ORTE_NAME_PRINT(&proc->name),
+                             proc->exit_code  ));
         /* Do not decrement the number of local procs here. That is handled in the errmgr */
     }
 


### PR DESCRIPTION
Some BSD flavors generate EPIPE when we write to a disconnected peer. We need the prevent this signal to be able to trap socket shutdown and cleanly release the endpoint.


Signed-off-by: George Bosilca <bosilca@icl.utk.edu>