### PR TITLE
pml/ucx: Fix the max tag and context id values - v4.0

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -72,8 +72,8 @@ mca_pml_ucx_module_t ompi_pml_ucx = {
         .pml_mrecv         = mca_pml_ucx_mrecv,
         .pml_dump          = mca_pml_ucx_dump,
         .pml_ft_event      = NULL,
-        .pml_max_contextid = 1ul << (PML_UCX_CONTEXT_BITS),
-        .pml_max_tag       = 1ul << (PML_UCX_TAG_BITS - 1)
+        .pml_max_contextid = (1ul << (PML_UCX_CONTEXT_BITS)) - 1,
+        .pml_max_tag       = (1ul << (PML_UCX_TAG_BITS - 1)) - 1
     },
     .ucp_context           = NULL,
     .ucp_worker            = NULL


### PR DESCRIPTION
backport from https://github.com/open-mpi/ompi/pull/6791

Signed-off-by: Nysal Jan K.A <jnysal@in.ibm.com>
(cherry picked from commit fe4ef147f81b2ac56661175005de6c330eace690)