### PR TITLE
Fix if_linux_ipv6 verbose output of interface addresses

### DIFF
--- a/opal/mca/if/linux_ipv6/Makefile.am
+++ b/opal/mca/if/linux_ipv6/Makefile.am
@@ -1,11 +1,13 @@
 #
-# Copyright (c) 2010     Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2019 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+dist_opaldata_DATA = help-opal-if-linux-ipv6.txt
 
 noinst_LTLIBRARIES = libmca_if_linux_ipv6.la
 

--- a/opal/mca/if/linux_ipv6/help-opal-if-linux-ipv6.txt
+++ b/opal/mca/if/linux_ipv6/help-opal-if-linux-ipv6.txt
@@ -1,0 +1,17 @@
+# -*- text -*-
+#
+# Copyright (c) 2019 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+[fail to parse if_inet6]
+Open MPI failed to parse at least one of the lines in
+/proc/net/if_inet6.  This is extremely unusual and should never
+happen.  Open MPI will skip this interface and attempt to continue.
+
+  Host:      %s
+  Interface: %s
+  Hex:       %s


### PR DESCRIPTION
Previously verbose output of `if_linux_ipv6_open` looked like this:

    found interface ab c: 0ab: a b: abc: 0 0: a 0:abcd: 0 0 scope 0

This changes the output to:

    found interface eth0 inet6 ab0c:ab:a0b:abc:0:a00:abcd:0 scope 0
