### PR TITLE
opal/if/linux_ipv6: unify gethostname() call behavior

### DIFF
--- a/opal/mca/if/linux_ipv6/if_linux_ipv6.c
+++ b/opal/mca/if/linux_ipv6/if_linux_ipv6.c
@@ -127,7 +127,7 @@ static int if_linux_ipv6_open(void)
             opal_if_t *intf;
 
             if (!hexdecode(addrhex, a6.s6_addr, sizeof a6.s6_addr)) {
-                char hostname[OPAL_MAXHOSTNAMELEN] = {0};
+                char hostname[OPAL_MAXHOSTNAMELEN];
                 gethostname(hostname, sizeof(hostname));
                 opal_show_help("help-opal-if-linux-ipv6.txt",
                                "fail to parse if_inet6", true,


### PR DESCRIPTION
Unfortunately, https://github.com/open-mpi/ompi/pull/6797 was merged
before all feedback was received (39b799d936).  This PR is a minor
addendum to that commit.

This PR simply removes a meaningless `= {0}` operation.

The use of gethostname() here -- and many other places in the code
base -- is technically unsafe.  See
https://github.com/open-mpi/ompi/issues/6801 for a further description
of the issue and a suggested fix.  But the risk is quite low;
real-world hostnames are usually much shorter than
OPAL_MAXHOSTNAMELEN.  Hence, this PR just removes the meaningless
operation and leaves a real fix for gethostname() usage to a potential
future PR.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

FYI @orivej