### PR TITLE
v4.0.x OSC: Reset external request to NULL

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_request.c
+++ b/ompi/mca/osc/ucx/osc_ucx_request.c
@@ -55,6 +55,7 @@ void req_completion(void *request, ucs_status_t status) {
 
     if(req->external_req != NULL) {
         ompi_request_complete(&(req->external_req->super), true);
+        req->external_req = NULL;
         ucp_request_release(req);
         mca_osc_ucx_component.num_incomplete_req_ops--;
         assert(mca_osc_ucx_component.num_incomplete_req_ops >= 0);


### PR DESCRIPTION
Addresses issue #6552 (Not reproduced in master).
Reset external request to NULL to avoid double request completion.
Co-authored with Artem Polyakov <artemp@mellanox.com>

Signed-off-by: Tomislav Janjusic <tomislavj@mellanox.com>