### PR TITLE
fortran/mpif-h: fix C to Fortran error code conversion

### DIFF
--- a/ompi/mpi/fortran/mpif-h/comm_split_type_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_split_type_f.c
@@ -11,8 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,11 +77,11 @@ void ompi_comm_split_type_f(MPI_Fint *comm, MPI_Fint *split_type, MPI_Fint *key,
 
     c_info = PMPI_Info_f2c(*info);
 
-    c_ierr = OMPI_INT_2_FINT(PMPI_Comm_split_type(c_comm,
-                                                  OMPI_FINT_2_INT(*split_type),
-                                                  OMPI_FINT_2_INT(*key),
-                                                  c_info,
-                                                  &c_newcomm ));
+    c_ierr = PMPI_Comm_split_type(c_comm,
+                                  OMPI_FINT_2_INT(*split_type),
+                                  OMPI_FINT_2_INT(*key),
+                                  c_info,
+                                  &c_newcomm);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/dist_graph_create_adjacent_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_create_adjacent_f.c
@@ -8,8 +8,8 @@
  * Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,6 +78,7 @@ void ompi_dist_graph_create_adjacent_f(MPI_Fint *comm_old, MPI_Fint *indegree,
     MPI_Info c_info;
     MPI_Comm c_comm_old, c_comm_graph;
     int *c_destweights, *c_sourceweights;
+    int c_ierr;
 
     OMPI_ARRAY_NAME_DECL(sources);
     OMPI_ARRAY_NAME_DECL(destinations);
@@ -105,16 +106,17 @@ void ompi_dist_graph_create_adjacent_f(MPI_Fint *comm_old, MPI_Fint *indegree,
         c_destweights = OMPI_ARRAY_NAME_CONVERT(destweights);
     }
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_create_adjacent(c_comm_old, OMPI_FINT_2_INT(*indegree),
-                                                            OMPI_ARRAY_NAME_CONVERT(sources),
-                                                            c_sourceweights,
-                                                            OMPI_FINT_2_INT(*outdegree),
-                                                            OMPI_ARRAY_NAME_CONVERT(destinations),
-                                                            c_destweights,
-                                                            c_info,
-                                                            OMPI_LOGICAL_2_INT(*reorder),
-                                                            &c_comm_graph));
-    if (OMPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+    c_ierr = PMPI_Dist_graph_create_adjacent(c_comm_old, OMPI_FINT_2_INT(*indegree),
+                                             OMPI_ARRAY_NAME_CONVERT(sources),
+                                             c_sourceweights,
+                                             OMPI_FINT_2_INT(*outdegree),
+                                             OMPI_ARRAY_NAME_CONVERT(destinations),
+                                             c_destweights,
+                                             c_info,
+                                             OMPI_LOGICAL_2_INT(*reorder),
+                                             &c_comm_graph);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+    if (OMPI_SUCCESS == c_ierr) {
         *comm_graph = PMPI_Comm_c2f(c_comm_graph);
     }
 

--- a/ompi/mpi/fortran/mpif-h/dist_graph_create_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_create_f.c
@@ -7,8 +7,8 @@
  * Copyright (c) 2011-2013 Université Bordeaux 1
  * Copyright (c) 2014      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,6 +75,7 @@ void ompi_dist_graph_create_f(MPI_Fint *comm_old, MPI_Fint *n, MPI_Fint *sources
     int count = 0, i;
     MPI_Info c_info;
     int *c_weights;
+    int c_ierr;
 
     OMPI_ARRAY_NAME_DECL(sources);
     OMPI_ARRAY_NAME_DECL(degrees);
@@ -98,10 +99,11 @@ void ompi_dist_graph_create_f(MPI_Fint *comm_old, MPI_Fint *n, MPI_Fint *sources
     }
 
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_create(c_comm_old, OMPI_FINT_2_INT(*n), OMPI_ARRAY_NAME_CONVERT(sources),
-                                                   OMPI_ARRAY_NAME_CONVERT(degrees), OMPI_ARRAY_NAME_CONVERT(destinations),
-                                                   c_weights, c_info, OMPI_LOGICAL_2_INT(*reorder), &c_comm_graph));
-    if (OMPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+    c_ierr = PMPI_Dist_graph_create(c_comm_old, OMPI_FINT_2_INT(*n), OMPI_ARRAY_NAME_CONVERT(sources),
+                                    OMPI_ARRAY_NAME_CONVERT(degrees), OMPI_ARRAY_NAME_CONVERT(destinations),
+                                    c_weights, c_info, OMPI_LOGICAL_2_INT(*reorder), &c_comm_graph);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+    if (OMPI_SUCCESS == c_ierr) {
         *comm_graph = PMPI_Comm_c2f(c_comm_graph);
     }
 

--- a/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_count_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_count_f.c
@@ -4,7 +4,7 @@
  *                         reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
  * Copyright (c) 2011-2013 Université Bordeaux 1
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -69,15 +69,17 @@ void ompi_dist_graph_neighbors_count_f(MPI_Fint *comm, MPI_Fint *inneighbors,
     OMPI_SINGLE_NAME_DECL(inneighbors);
     OMPI_SINGLE_NAME_DECL(outneighbors);
     OMPI_LOGICAL_NAME_DECL(weighted);
+    int c_ierr;
 
     c_comm = PMPI_Comm_f2c(*comm);
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_neighbors_count(c_comm,
-                                                            OMPI_SINGLE_NAME_CONVERT(inneighbors),
-                                                            OMPI_SINGLE_NAME_CONVERT(outneighbors),
-                                                            OMPI_LOGICAL_SINGLE_NAME_CONVERT(weighted)));
+    c_ierr = PMPI_Dist_graph_neighbors_count(c_comm,
+                                             OMPI_SINGLE_NAME_CONVERT(inneighbors),
+                                             OMPI_SINGLE_NAME_CONVERT(outneighbors),
+                                             OMPI_LOGICAL_SINGLE_NAME_CONVERT(weighted));
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
     OMPI_SINGLE_INT_2_LOGICAL(weighted);
-    if (OMPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+    if (OMPI_SUCCESS == c_ierr) {
           OMPI_SINGLE_INT_2_FINT(inneighbors);
           OMPI_SINGLE_INT_2_FINT(outneighbors);
     }

--- a/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_f.c
+++ b/ompi/mpi/fortran/mpif-h/dist_graph_neighbors_f.c
@@ -4,8 +4,8 @@
  *                         reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
  * Copyright (c) 2011-2013 Université Bordeaux 1
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,6 +74,7 @@ void ompi_dist_graph_neighbors_f(MPI_Fint* comm, MPI_Fint* maxindegree,
     OMPI_ARRAY_NAME_DECL(sourceweights);
     OMPI_ARRAY_NAME_DECL(destinations);
     OMPI_ARRAY_NAME_DECL(destweights);
+    int c_ierr;
 
     c_comm = PMPI_Comm_f2c(*comm);
 
@@ -86,12 +87,14 @@ void ompi_dist_graph_neighbors_f(MPI_Fint* comm, MPI_Fint* maxindegree,
         OMPI_ARRAY_FINT_2_INT_ALLOC(destweights, *maxoutdegree);
     }
 
-    *ierr = OMPI_INT_2_FINT(PMPI_Dist_graph_neighbors(c_comm, OMPI_FINT_2_INT(*maxindegree),
-                                                      OMPI_ARRAY_NAME_CONVERT(sources),
-                                                      OMPI_IS_FORTRAN_UNWEIGHTED(sourceweights) ? MPI_UNWEIGHTED : OMPI_ARRAY_NAME_CONVERT(sourceweights),
-                                                      OMPI_FINT_2_INT(*maxoutdegree), OMPI_ARRAY_NAME_CONVERT(destinations),
-                                                      OMPI_IS_FORTRAN_UNWEIGHTED(destweights) ? MPI_UNWEIGHTED : OMPI_ARRAY_NAME_CONVERT(destweights)));
-    if (OMPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+    c_ierr = PMPI_Dist_graph_neighbors(c_comm, OMPI_FINT_2_INT(*maxindegree),
+                                       OMPI_ARRAY_NAME_CONVERT(sources),
+                                       OMPI_IS_FORTRAN_UNWEIGHTED(sourceweights) ? MPI_UNWEIGHTED : OMPI_ARRAY_NAME_CONVERT(sourceweights),
+                                       OMPI_FINT_2_INT(*maxoutdegree), OMPI_ARRAY_NAME_CONVERT(destinations),
+                                       OMPI_IS_FORTRAN_UNWEIGHTED(destweights) ? MPI_UNWEIGHTED : OMPI_ARRAY_NAME_CONVERT(destweights));
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (OMPI_SUCCESS == c_ierr) {
         OMPI_ARRAY_INT_2_FINT(sources, *maxindegree);
         if( !OMPI_IS_FORTRAN_UNWEIGHTED(sourceweights) ) {
             OMPI_ARRAY_INT_2_FINT(sourceweights, *maxindegree);

--- a/ompi/mpi/fortran/mpif-h/improbe_f.c
+++ b/ompi/mpi/fortran/mpif-h/improbe_f.c
@@ -11,8 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -87,10 +87,10 @@ void ompi_improbe_f(MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = OMPI_INT_2_FINT(PMPI_Improbe(OMPI_FINT_2_INT(*source),
-                                          OMPI_FINT_2_INT(*tag),
-                                          c_comm, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
-                                          &c_message, c_status));
+    c_ierr = PMPI_Improbe(OMPI_FINT_2_INT(*source),
+                          OMPI_FINT_2_INT(*tag),
+                          c_comm, OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
+                          &c_message, c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/imrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/imrecv_f.c
@@ -10,8 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -80,8 +80,8 @@ void ompi_imrecv_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
 
    c_message = PMPI_Message_f2c(*message);
 
-   c_ierr = OMPI_INT_2_FINT(PMPI_Imrecv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
-                                        c_type, &c_message, &c_req));
+   c_ierr = PMPI_Imrecv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+                        c_type, &c_message, &c_req);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
    if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/mprobe_f.c
+++ b/ompi/mpi/fortran/mpif-h/mprobe_f.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
+ * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
@@ -86,10 +86,10 @@ void ompi_mprobe_f(MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm,
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
-    c_ierr = OMPI_INT_2_FINT(PMPI_Mprobe(OMPI_FINT_2_INT(*source),
-                                         OMPI_FINT_2_INT(*tag),
-                                         c_comm, &c_message,
-                                         c_status));
+    c_ierr = PMPI_Mprobe(OMPI_FINT_2_INT(*source),
+                         OMPI_FINT_2_INT(*tag),
+                         c_comm, &c_message,
+                         c_status);
     if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
     if (MPI_SUCCESS == c_ierr) {

--- a/ompi/mpi/fortran/mpif-h/mrecv_f.c
+++ b/ompi/mpi/fortran/mpif-h/mrecv_f.c
@@ -77,16 +77,16 @@ void ompi_mrecv_f(char *buf, MPI_Fint *count, MPI_Fint *datatype,
                   MPI_Fint *message, MPI_Fint *status, MPI_Fint *ierr)
 {
    int c_ierr;
-    OMPI_FORTRAN_STATUS_DECLARATION(c_status,c_status2)
+   OMPI_FORTRAN_STATUS_DECLARATION(c_status,c_status2)
    MPI_Message c_message = PMPI_Message_f2c(*message);
    MPI_Datatype c_type = PMPI_Type_f2c(*datatype);
 
     OMPI_FORTRAN_STATUS_SET_POINTER(c_status,c_status2,status)
 
    /* Call the C function */
-   c_ierr = OMPI_INT_2_FINT(PMPI_Mrecv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
-                                       c_type, &c_message,
-                                       c_status));
+   c_ierr = PMPI_Mrecv(OMPI_F2C_BOTTOM(buf), OMPI_FINT_2_INT(*count),
+                       c_type, &c_message,
+                       c_status);
    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
 
    if (MPI_SUCCESS == c_ierr) {


### PR DESCRIPTION
 - remove incorrect use of OMPI_INT_2_FINT()
 - use homogenous syntax (e.g. c_ierr = PMPI_...())

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>