### PR TITLE
osc/ucx: Add support for the no_locks info key

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -33,6 +33,7 @@ typedef struct ompi_osc_ucx_component {
     bool env_initialized; /* UCX environment is initialized or not */
     int num_incomplete_req_ops;
     int num_modules;
+    bool no_locks; /* Default value of the no_locks info key for new windows */
     unsigned int priority;
 } ompi_osc_ucx_component_t;
 
@@ -113,6 +114,7 @@ typedef struct ompi_osc_ucx_module {
     uint64_t req_result;
     int *start_grp_ranks;
     bool lock_all_is_nocheck;
+    bool no_locks;
     opal_common_ucx_ctx_t *ctx;
     opal_common_ucx_wpmem_t *mem;
     opal_common_ucx_wpmem_t *state_mem;

--- a/ompi/mca/osc/ucx/osc_ucx_passive_target.c
+++ b/ompi/mca/osc/ucx/osc_ucx_passive_target.c
@@ -99,6 +99,11 @@ int ompi_osc_ucx_lock(int lock_type, int target, int assert, struct ompi_win_t *
     ompi_osc_ucx_epoch_t original_epoch = module->epoch_type.access;
     int ret = OMPI_SUCCESS;
 
+    if (module->no_locks) {
+        OSC_UCX_VERBOSE(1, "attempted to lock with no_locks set");
+        return OMPI_ERR_RMA_SYNC;
+    }
+
     if (module->lock_count == 0) {
         if (module->epoch_type.access != NONE_EPOCH &&
             module->epoch_type.access != FENCE_EPOCH) {
@@ -187,6 +192,11 @@ int ompi_osc_ucx_unlock(int target, struct ompi_win_t *win) {
 int ompi_osc_ucx_lock_all(int assert, struct ompi_win_t *win) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int ret = OMPI_SUCCESS;
+
+    if (module->no_locks) {
+        OSC_UCX_VERBOSE(1, "attempted to lock with no_locks set");
+        return OMPI_ERR_RMA_SYNC;
+    }
 
     if (module->epoch_type.access != NONE_EPOCH &&
         module->epoch_type.access != FENCE_EPOCH) {


### PR DESCRIPTION
If no_locks info key is set to "true", we can avoid initializing the outstanding_locks hash table