### PR TITLE
pcollreq/mpif-h: fix MPIX_Alltoallw_init() binding

### DIFF
--- a/ompi/mpiext/pcollreq/mpif-h/alltoallw_init_f.c
+++ b/ompi/mpiext/pcollreq/mpif-h/alltoallw_init_f.c
@@ -76,7 +76,7 @@ void ompix_alltoallw_init_f(char *sendbuf, MPI_Fint *sendcounts,
                             MPI_Fint *comm, MPI_Fint *info, MPI_Fint *request, MPI_Fint *ierr)
 {
     MPI_Comm c_comm;
-    MPI_Datatype *c_sendtypes, *c_recvtypes;
+    MPI_Datatype *c_sendtypes = NULL, *c_recvtypes;
     MPI_Info c_info;
     MPI_Request c_request;
     int size, c_ierr;
@@ -86,6 +86,7 @@ void ompix_alltoallw_init_f(char *sendbuf, MPI_Fint *sendcounts,
     OMPI_ARRAY_NAME_DECL(rdispls);
 
     c_comm = PMPI_Comm_f2c(*comm);
+    c_info = PMPI_Info_f2c(*info);
     size = OMPI_COMM_IS_INTER(c_comm)?ompi_comm_remote_size(c_comm):ompi_comm_size(c_comm);
 
     if (!OMPI_IS_FORTRAN_IN_PLACE(sendbuf)) {


### PR DESCRIPTION
These issues were introduced in the recent commit b71af0eca0.
This commit fixes Coverity CID 1451661 and 1451660.

Though `c_info` part was an actual bug, the `c_sendtypes` part was not.

@jsquyres @ggouaillardet I lost `ompi-devel-merge` right (accidentally). Could you merge?
