### PR TITLE
Update minimum versions of automake and libtool

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -61,9 +61,9 @@ my $include_list;
 my $exclude_list;
 
 # Minimum versions
-my $ompi_automake_version = "1.13.4";
+my $ompi_automake_version = "1.15";
 my $ompi_autoconf_version = "2.69";
-my $ompi_libtool_version = "2.4.2";
+my $ompi_libtool_version = "2.4.6";
 
 # Search paths
 my $ompi_autoconf_search = "autoconf";


### PR DESCRIPTION
Recently we ran into a strange issue where incorrect CFLAGS were added
to makefiles for various source files when incorrect minimum version
of Automake was used (see some discussion near the end of PR #6828 -- 
specifically https://github.com/open-mpi/ompi/pull/6828#issuecomment-514315352).

Versions taken from (https://www.open-mpi.org/source/building.php)

This change will create a hard error if the user is trying to run
with too early of versions, rather than confusing runtime behavior.

This Commit should be PRed back to v3.0.x, v3.1.x and v4.0.x

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>