### PR TITLE
Do not use CMA in user namespaces

### DIFF
--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -84,7 +84,12 @@ union vader_modex_t {
         void *segment_base;
     } xpmem;
 #endif
-    opal_shmem_ds_t seg_ds;
+    struct vader_modex_other_t {
+        ino_t user_ns_id;
+        int seg_ds_size;
+        /* seg_ds needs to be the last element */
+        opal_shmem_ds_t seg_ds;
+    } other;
 };
 
 /**
@@ -269,6 +274,8 @@ int mca_btl_vader_get_knem (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t 
                             mca_btl_base_registration_handle_t *remote_handle, size_t size, int flags,
                             int order, mca_btl_base_rdma_completion_fn_t cbfunc, void *cbcontext, void *cbdata);
 #endif
+
+ino_t mca_btl_vader_get_user_ns_id(void);
 
 int mca_btl_vader_get_sc_emu (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoint, void *local_address,
                                uint64_t remote_address, mca_btl_base_registration_handle_t *local_handle,

--- a/opal/mca/btl/vader/help-btl-vader.txt
+++ b/opal/mca/btl/vader/help-btl-vader.txt
@@ -126,6 +126,25 @@ mechanism if one is available. This may result in lower performance.
 
   Local host: %s
 #
+[cma-different-user-namespace-error]
+ERROR: Linux kernel CMA support was requested via the
+btl_vader_single_copy_mechanism MCA variable, but CMA support is
+not available due to different user namespaces.
+
+Your MPI job will abort now. Please select another value for
+btl_vader_single_copy_mechanism.
+
+  Local host: %s
+#
+[cma-different-user-namespace-warning]
+WARNING: The default btl_vader_single_copy_mechanism CMA is
+not available due to different user namespaces.
+
+The vader shared memory BTL will fall back on another single-copy
+mechanism if one is available. This may result in lower performance.
+
+  Local host: %s
+#
 [xpmem-make-failed]
 WARNING: Could not generate an xpmem segment id for this process'
 address space.


### PR DESCRIPTION
Trying out to run processes via mpirun in Podman containers has shown that the CMA btl_vader_single_copy_mechanism does not work when user namespaces are involved.

Creating containers with Podman requires at least user namespaces to be able to do unprivileged mounts in a container

Even if running the container with user namespace user ID mappings which result in the same user ID on the inside and outside of all involved containers, the check in the kernel to allow ptrace (and thus process_vm_{read,write}v()), fails if the same IDs are not in the same user namespace.

One workaround is to specify '--mca btl_vader_single_copy_mechanism none' and this commit adds code to automatically skip CMA if user namespaces are detected.

Preferred implementation would have been to detect if the other local processes are running in different user namespaces, but it was not clear how get the PIDs of the other involved processes in
mca_btl_vader_check_single_copy(). This is even more complicated if some processes would be running in the same user namespace, but not all of them. If one different user namespace is detected, CMA should be disabled for all involved processes. So if one local process detects that CMA is not working it would need to communicate this information to all local processes.

This implementation now checks during the first access of mca_btl_vader_{put,get}_cma() if the destination process is running in another user namespace and switches to MCA_BTL_VADER_EMUL if this is true.

So if the first access to process_vm_{read,write}v()) fails all further accesses are automatically no longer trying to use CMA.