### PR TITLE
opal/util: Include net/if.h to prevent macro mismatch

### DIFF
--- a/opal/util/if.h
+++ b/opal/util/if.h
@@ -13,6 +13,7 @@
  *                         reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +36,9 @@
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#endif
+#ifdef HAVE_NET_IF_H
+#include <net/if.h>
 #endif
 
 #ifndef IF_NAMESIZE


### PR DESCRIPTION
In cases where opal/util/if.h is included but net/if.h is not,
IF_NAMESIZE will be 32. If net/if.h is included on Linux systems,
IF_NAMESIZE will be 16. This can cause a mismatch when using the same
macro macro on a system. To avoid this error case, we include this file
in util/if.h.

Signed-off-by: William Zhang <wilzhang@amazon.com>