### PR TITLE
opal/util: Change opal/util/if.h macro IF_NAMESIZE to OPAL_IF_NAMESIZE

### DIFF
--- a/contrib/build-mca-comps-outside-of-tree/btl_tcp2_component.c
+++ b/contrib/build-mca-comps-outside-of-tree/btl_tcp2_component.c
@@ -401,7 +401,7 @@ static char **split_and_resolve(char **orig_str, char *name)
 {
     int i, ret, save, if_index;
     char **argv, *str, *tmp;
-    char if_name[IF_NAMESIZE];
+    char if_name[OPAL_IF_NAMESIZE];
     struct sockaddr_storage argv_inaddr, if_inaddr;
     uint32_t argv_prefix;
 
@@ -593,8 +593,8 @@ static int mca_btl_tcp2_component_create_instances(void)
     {
         int i;
         for(i = 0; i < kif_count; i++) {
-            /* IF_NAMESIZE is defined in opal/util/if.h */
-            char if_name[IF_NAMESIZE];
+            /* OPAL_IF_NAMESIZE is defined in opal/util/if.h */
+            char if_name[OPAL_IF_NAMESIZE];
             if_index = kindexes[i];
 
             opal_ifkindextoname(if_index, if_name, sizeof(if_name));

--- a/contrib/build-mca-comps-outside-of-tree/btl_tcp2_proc.c
+++ b/contrib/build-mca-comps-outside-of-tree/btl_tcp2_proc.c
@@ -235,7 +235,7 @@ static void mca_btl_tcp2_initialise_interface(mca_btl_tcp2_interface_t* interfac
 static mca_btl_tcp2_interface_t** mca_btl_tcp2_retrieve_local_interfaces(void)
 {
     struct sockaddr_storage local_addr;
-    char local_if_name[IF_NAMESIZE];
+    char local_if_name[OPAL_IF_NAMESIZE];
     char **include, **exclude, **argv;
     int idx;
 

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -622,7 +622,7 @@ static char **split_and_resolve(char **orig_str, char *name, bool reqd)
 {
     int i, ret, save, if_index;
     char **argv, *str, *tmp;
-    char if_name[IF_NAMESIZE];
+    char if_name[OPAL_IF_NAMESIZE];
     struct sockaddr_storage argv_inaddr, if_inaddr;
     uint32_t argv_prefix;
 
@@ -821,8 +821,8 @@ static int mca_btl_tcp_component_create_instances(void)
     {
         int i;
         for(i = 0; i < kif_count; i++) {
-            /* IF_NAMESIZE is defined in opal/util/if.h */
-            char if_name[IF_NAMESIZE];
+            /* OPAL_IF_NAMESIZE is defined in opal/util/if.h */
+            char if_name[OPAL_IF_NAMESIZE];
             if_index = kindexes[i];
 
             opal_ifkindextoname(if_index, if_name, sizeof(if_name));

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -295,7 +295,7 @@ static void mca_btl_tcp_initialise_interface(mca_btl_tcp_interface_t* tcp_interf
 static mca_btl_tcp_interface_t** mca_btl_tcp_retrieve_local_interfaces(mca_btl_tcp_proc_data_t *proc_data)
 {
     struct sockaddr_storage local_addr;
-    char local_if_name[IF_NAMESIZE];
+    char local_if_name[OPAL_IF_NAMESIZE];
     char **include, **exclude, **argv;
     int idx;
     mca_btl_tcp_interface_t * local_interface;

--- a/opal/mca/if/bsdx_ipv4/if_bsdx.c
+++ b/opal/mca/if/bsdx_ipv4/if_bsdx.c
@@ -126,7 +126,7 @@ static int if_bsdx_open(void)
         /* fill values into the opal_if_t */
         memcpy(&a4, &(sin_addr->sin_addr), sizeof(struct in_addr));
 
-        opal_string_copy(intf->if_name, cur_ifaddrs->ifa_name, IF_NAMESIZE);
+        opal_string_copy(intf->if_name, cur_ifaddrs->ifa_name, OPAL_IF_NAMESIZE);
         intf->if_index = opal_list_get_size(&opal_if_list) + 1;
         ((struct sockaddr_in*) &intf->if_addr)->sin_addr = a4;
         ((struct sockaddr_in*) &intf->if_addr)->sin_family = AF_INET;

--- a/opal/mca/if/bsdx_ipv6/if_bsdx_ipv6.c
+++ b/opal/mca/if/bsdx_ipv6/if_bsdx_ipv6.c
@@ -185,7 +185,7 @@ static int if_bsdx_ipv6_open(void)
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
         intf->af_family = AF_INET6;
-        opal_string_copy(intf->if_name, cur_ifaddrs->ifa_name, IF_NAMESIZE);
+        opal_string_copy(intf->if_name, cur_ifaddrs->ifa_name, OPAL_IF_NAMESIZE);
         intf->if_index = opal_list_get_size(&opal_if_list) + 1;
         ((struct sockaddr_in6*) &intf->if_addr)->sin6_addr = a6;
         ((struct sockaddr_in6*) &intf->if_addr)->sin6_family = AF_INET6;

--- a/opal/mca/if/if.h
+++ b/opal/mca/if/if.h
@@ -74,7 +74,7 @@ BEGIN_C_DECLS
 
 typedef struct opal_if_t {
     opal_list_item_t     super;
-    char                if_name[IF_NAMESIZE];
+    char                if_name[OPAL_IF_NAMESIZE];
     int                 if_index;
     uint16_t            if_kernel_index;
     uint16_t            af_family;

--- a/opal/mca/if/linux_ipv6/if_linux_ipv6.c
+++ b/opal/mca/if/linux_ipv6/if_linux_ipv6.c
@@ -115,7 +115,7 @@ static int if_linux_ipv6_open(void)
 #if OPAL_ENABLE_IPV6
     FILE *f;
     if ((f = fopen("/proc/net/if_inet6", "r"))) {
-        char ifname[IF_NAMESIZE];
+        char ifname[OPAL_IF_NAMESIZE];
         unsigned int idx, pfxlen, scope, dadstat;
         struct in6_addr a6;
         uint32_t flag;
@@ -158,7 +158,7 @@ static int if_linux_ipv6_open(void)
             intf->af_family = AF_INET6;
 
             /* now construct the opal_if_t */
-            opal_string_copy(intf->if_name, ifname, IF_NAMESIZE);
+            opal_string_copy(intf->if_name, ifname, OPAL_IF_NAMESIZE);
             intf->if_index = opal_list_get_size(&opal_if_list)+1;
             intf->if_kernel_index = (uint16_t) idx;
             ((struct sockaddr_in6*) &intf->if_addr)->sin6_addr = a6;

--- a/opal/mca/if/solaris_ipv6/if_solaris_ipv6.c
+++ b/opal/mca/if/solaris_ipv6/if_solaris_ipv6.c
@@ -141,7 +141,7 @@ static int if_solaris_ipv6_open(void)
                 }
                 intf->af_family = AF_INET6;
 
-                opal_string_copy (intf->if_name, lifreq->lifr_name, IF_NAMESIZE);
+                opal_string_copy (intf->if_name, lifreq->lifr_name, OPAL_IF_NAMESIZE);
                 intf->if_index = opal_list_get_size(&opal_if_list)+1;
                 memcpy(&intf->if_addr, my_addr, sizeof (*my_addr));
                 intf->if_mask = 64;

--- a/opal/test/reachable/reachable_shared.h
+++ b/opal/test/reachable/reachable_shared.h
@@ -24,7 +24,7 @@ BEGIN_C_DECLS
 opal_if_t* create_if(int af_family, char *address, int mask, int bandwidth)
 {
     opal_if_t *interface = OBJ_NEW(opal_if_t);
-    opal_string_copy(interface->if_name, "interface0", IF_NAMESIZE);
+    opal_string_copy(interface->if_name, "interface0", OPAL_IF_NAMESIZE);
     interface->af_family = af_family;
     ((struct sockaddr *)&(interface->if_addr))->sa_family = af_family; 
 

--- a/opal/util/ethtool.c
+++ b/opal/util/ethtool.c
@@ -64,7 +64,7 @@ opal_ethtool_get_speed (const char *if_name)
     }
 
     memset(&ifr, 0, sizeof(struct ifreq));
-    opal_string_copy(ifr.ifr_name, if_name, IF_NAMESIZE);
+    opal_string_copy(ifr.ifr_name, if_name, OPAL_IF_NAMESIZE);
     ifr.ifr_data = (char *)&edata;
 
     if (ioctl(sockfd, SIOCETHTOOL, &ifr) < 0) {

--- a/opal/util/if.h
+++ b/opal/util/if.h
@@ -37,9 +37,15 @@
 #include <netinet/in.h>
 #endif
 
-#ifndef IF_NAMESIZE
-#define IF_NAMESIZE 32
-#endif
+/*
+ * We previously defined IF_NAMESIZE to 32 if not already defined.
+ * Due to this macro being reused from net/if.h, we could encounter
+ * a macro mismatch. In particular, in cases where opal/util/if.h was
+ * included, but net/if.h was not, IF_NAMESIZE would be 32. If net/if.h
+ * was included on Linux systems, IF_NAMESIZE would be 16. To avoid this
+ * issue, we define our own OPAL_IF_NAMESIZE macro instead.
+ */
+#define OPAL_IF_NAMESIZE 32
 
 BEGIN_C_DECLS
 

--- a/orte/mca/oob/tcp/oob_tcp_component.c
+++ b/orte/mca/oob/tcp/oob_tcp_component.c
@@ -1227,7 +1227,7 @@ static char **split_and_resolve(char **orig_str, char *name)
 {
     int i, ret, save, if_index;
     char **argv, *str, *tmp;
-    char if_name[IF_NAMESIZE];
+    char if_name[OPAL_IF_NAMESIZE];
     struct sockaddr_storage argv_inaddr, if_inaddr;
     uint32_t argv_prefix;
 


### PR DESCRIPTION
Due to IF_NAMESIZE being a reused and conditionally defined macro,
issues could arise from macro mismatches. In particular, in cases where
opal/util/if.h is included, but net/if.h is not, IF_NAMESIZE will be 32.
If net/if.h is included on Linux systems, IF_NAMESIZE will be 16. This
can cause a mismatch when using the same macro on a system. Thus
different parts of the code can have differring ideas on the size of a
structure containing a char name[IF_NAMESIZE]. To avoid this error case,
we avoid reusing the IF_NAMESIZE macro and instead define our own as
OPAL_IF_NAMESIZE.

Signed-off-by: William Zhang <wilzhang@amazon.com>