### PR TITLE
fortran/use-mpi-f08: slurp missing code

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -40,11 +40,11 @@ CLEANFILES += *.i90
 
 lib_LTLIBRARIES = lib@OMPI_LIBMPI_NAME@_usempif08.la
 
-module_sentinel_file = \
+module_sentinel_files = \
         mod/libforce_usempif08_internal_modules_to_be_built.la \
         bindings/libforce_usempif08_internal_bindings_to_be_built.la
 
-mpi-f08.lo: $(module_sentinel_file)
+mpi-f08.lo: $(module_sentinel_files)
 mpi-f08.lo: mpi-f08.F90
 mpi-f08.lo: sizeof_f08.h
 
@@ -824,8 +824,9 @@ endif
 lib@OMPI_LIBMPI_NAME@_usempif08_la_LIBADD = \
         $(OMPI_MPIEXT_USEMPIF08_LIBS) \
         $(top_builddir)/ompi/mpi/fortran/mpif-h/lib@OMPI_LIBMPI_NAME@_mpifh.la \
-        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
-lib@OMPI_LIBMPI_NAME@_usempif08_la_DEPENDENCIES = $(module_sentinel_file)
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        mod/libusempif08_internal_modules.la
+lib@OMPI_LIBMPI_NAME@_usempif08_la_DEPENDENCIES = $(module_sentinel_files)
 lib@OMPI_LIBMPI_NAME@_usempif08_la_LDFLAGS = -version-info $(libmpi_usempif08_so_version)
 
 #
@@ -839,7 +840,7 @@ pmpi_api_lo_files = $(pmpi_api_files:.F90=.lo)
 $(mpi_api_lo_files): mpi-f08.lo bindings/libforce_usempif08_internal_bindings_to_be_built.la
 $(pmpi_api_lo_files): mpi-f08.lo bindings/libforce_usempif08_internal_bindings_to_be_built.la
 
-mpi-f08.lo: $(module_sentinel_file) $(SIZEOF_H)
+mpi-f08.lo: $(module_sentinel_files) $(SIZEOF_H)
 
 ###########################################################################
 

--- a/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/Makefile.am
@@ -7,8 +7,8 @@
 # Copyright (c) 2012-2013 Inria.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2015-2018 Research Organization for Information Science
-#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2015-2019 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
@@ -36,19 +36,21 @@ CLEANFILES += *.i90
 
 ###########################################################################
 
-module_sentinel_file = \
-        libforce_usempif08_internal_modules_to_be_built.la
 
-noinst_LTLIBRARIES = $(module_sentinel_file)
+noinst_LTLIBRARIES = libusempif08_internal_modules.la libforce_usempif08_internal_modules_to_be_built.la
 
 # f08 support modules
 
-libforce_usempif08_internal_modules_to_be_built_la_SOURCES = \
+libusempif08_internal_modules_la_SOURCES = \
         mpi-f08-types.F90 \
+        mpi-f08-callbacks.F90
+
+libforce_usempif08_internal_modules_to_be_built_la_SOURCES = \
         mpi-f08-interfaces.F90 \
-        mpi-f08-interfaces-callbacks.F90 \
-        mpi-f08-callbacks.F90 \
-        pmpi-f08-interfaces.F90
+        pmpi-f08-interfaces.F90 \
+        mpi-f08-interfaces-callbacks.F90
+
+libforce_usempi_internal_modules_to_be_built.la: libusempif08_internal_modules.la
 
 config_h = \
     $(top_builddir)/ompi/mpi/fortran/configure-fortran-output.h \


### PR DESCRIPTION
Split the sentinel library in ompi/mpi/fortran/use-mpi-f08 into
 - the real sentinel that contains no code (only used to build the .mod files)
 - an internal library that does contain some code
and have libmpi_usempif08.la slurp the latter.

This fixes a regression introduced in open-mpi/ompi@5de5e751edcce3eed46dda1a6dfca12d6bd2ec57

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>