### PR TITLE
coll/base: only retain datatypes/op if the request has not yet completed

### DIFF
--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -141,6 +141,9 @@ int ompi_coll_base_retain_op( ompi_request_t *req, ompi_op_t *op,
                               ompi_datatype_t *type) {
     ompi_coll_base_nbc_request_t *request = (ompi_coll_base_nbc_request_t *)req;
     bool retain = false;
+    if (REQUEST_COMPLETE(req)) {
+        return OMPI_SUCCESS;
+    }
     if (!ompi_op_is_intrinsic(op)) {
         OBJ_RETAIN(op);
         request->data.op.op = op;
@@ -177,6 +180,9 @@ int ompi_coll_base_retain_datatypes( ompi_request_t *req, ompi_datatype_t *stype
                                      ompi_datatype_t *rtype) {
     ompi_coll_base_nbc_request_t *request = (ompi_coll_base_nbc_request_t *)req;
     bool retain = false;
+    if (REQUEST_COMPLETE(req)) {
+        return OMPI_SUCCESS;
+    }
     if (NULL != stype && !ompi_datatype_is_predefined(stype)) {
         OBJ_RETAIN(stype);
         request->data.types.stype = stype;
@@ -254,6 +260,9 @@ int ompi_coll_base_retain_datatypes_w( ompi_request_t *req,
     bool retain = false;
     ompi_communicator_t *comm = request->super.req_mpi_object.comm;
     int scount, rcount;
+    if (REQUEST_COMPLETE(req)) {
+        return OMPI_SUCCESS;
+    }
     if (OMPI_COMM_IS_TOPO(comm)) {
         (void)mca_topo_base_neighbor_count (comm, &rcount, &scount);
     } else {

--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -108,9 +108,11 @@ int ompi_rounddown(int num, int factor)
 static void release_objs_callback(struct ompi_coll_base_nbc_request_t *request) {
     if (NULL != request->data.objs.objs[0]) {
         OBJ_RELEASE(request->data.objs.objs[0]);
+        request->data.objs.objs[0] = NULL;
     }
     if (NULL != request->data.objs.objs[1]) {
         OBJ_RELEASE(request->data.objs.objs[1]);
+        request->data.objs.objs[1] = NULL;
     }
 }
 
@@ -207,15 +209,21 @@ static void release_vecs_callback(ompi_coll_base_nbc_request_t *request) {
     } else {
         scount = rcount = OMPI_COMM_IS_INTER(comm)?ompi_comm_remote_size(comm):ompi_comm_size(comm);
     }
-    for (int i=0; i<scount; i++) {
-        if (NULL != request->data.vecs.stypes && NULL != request->data.vecs.stypes[i]) {
-            OMPI_DATATYPE_RELEASE(request->data.vecs.stypes[i]);
+    if (NULL != request->data.vecs.stypes) {
+        for (int i=0; i<scount; i++) {
+            if (NULL != request->data.vecs.stypes[i]) {
+                OMPI_DATATYPE_RELEASE(request->data.vecs.stypes[i]);
+            }
         }
+        request->data.vecs.stypes = NULL;
     }
-    for (int i=0; i<rcount; i++) {
-        if (NULL != request->data.vecs.rtypes && NULL != request->data.vecs.rtypes[i]) {
-            OMPI_DATATYPE_RELEASE(request->data.vecs.rtypes[i]);
+    if (NULL != request->data.vecs.rtypes) {
+        for (int i=0; i<rcount; i++) {
+            if (NULL != request->data.vecs.rtypes[i]) {
+                OMPI_DATATYPE_RELEASE(request->data.vecs.rtypes[i]);
+            }
         }
+        request->data.vecs.rtypes = NULL;
     }
 }
 

--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -460,6 +460,6 @@ request_construct(ompi_coll_libnbc_request_t *request)
 
 
 OBJ_CLASS_INSTANCE(ompi_coll_libnbc_request_t,
-                   ompi_request_t,
+                   ompi_coll_base_nbc_request_t,
                    request_construct,
                    NULL);


### PR DESCRIPTION
a non blocking collective might return ompi_request_null, so we should not
retain anything in that case.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(cherry picked from commit open-mpi/ompi@63d3ccde9ddc922737fe3e307cc1af3a70474265)