### PR TITLE
osc/ucx: Fix error path

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -356,7 +356,7 @@ static int component_select(struct ompi_win_t *win, void **base, size_t size, in
         ret = opal_progress_register(progress_callback);
         if (OMPI_SUCCESS != ret) {
             OSC_UCX_VERBOSE(1, "opal_progress_register failed: %d", ret);
-            goto error;
+            goto select_unlock;
         }
     }
 


### PR DESCRIPTION
Missing error path change in: #6754 (6678ac0f557935b291ec2310216b7ea46e0c13b1)

Signed-off-by: Tomislav Janjusic <tomislavj@mellanox.com>