### PR TITLE
Run-as-root env vars in orterun.c

### DIFF
--- a/orte/tools/orterun/orterun.c
+++ b/orte/tools/orterun/orterun.c
@@ -142,6 +142,14 @@ int orterun(int argc, char *argv[])
      * exit with a giant warning flag
      */
     if (0 == geteuid() && !orte_cmd_options.run_as_root) {
+        char *r1, *r2;
+        if (NULL != (r1 = getenv("OMPI_ALLOW_RUN_AS_ROOT")) &&
+            NULL != (r2 = getenv("OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"))) {
+            if (0 == strcmp(r1, "1") && 0 == strcmp(r2, "1")) {
+                goto moveon;
+            }
+        }
+
         fprintf(stderr, "--------------------------------------------------------------------------\n");
         if (NULL != orte_cmd_options.help) {
             fprintf(stderr, "%s cannot provide the help message when run as root.\n", orte_basename);
@@ -159,6 +167,7 @@ int orterun(int argc, char *argv[])
         exit(1);
     }
 
+  moveon:
     /* setup to listen for commands sent specifically to me, even though I would probably
      * be the one sending them! Unfortunately, since I am a participating daemon,
      * there are times I need to send a command to "all daemons", and that means *I* have


### PR DESCRIPTION
I found that I needed to apply the same change as #5597/#5598 to orterun.c for the environment variables to work correctly.