### PR TITLE
oshmem: fix make uninstall

### DIFF
--- a/oshmem/tools/wrappers/Makefile.am
+++ b/oshmem/tools/wrappers/Makefile.am
@@ -111,7 +111,7 @@ endif # CASE_SENSITIVE_FS
 
 if PROJECT_ORTE
 targets_install_exec += install-exec-rte
-targets_uninstall_local += uninstall-rte
+targets_uninstall_local += uninstall-local-rte
 endif # PROJECT_ORTE
 
 install-exec-hook: $(targets_install_exec)


### PR DESCRIPTION
This fixes a typo introduced in open-mpi/ompi@e0e924c4ed4fc98072a0876799cdbc64237295ed

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>