### PR TITLE
v4.0.x: regx/naive: add regx/naive component

### DIFF
--- a/orte/mca/regx/fwd/regx_fwd.c
+++ b/orte/mca/regx/fwd/regx_fwd.c
@@ -296,5 +296,9 @@ static int nidmap_create(opal_pointer_array_t *pool, char **regex)
     free(nodenames);
     free(tmp);
     *regex = tmp2;
+    opal_output_verbose(5, orte_regx_base_framework.framework_output,
+                        "%s Final regex: <%s>",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                        *regex);
     return ORTE_SUCCESS;
 }

--- a/orte/mca/regx/naive/Makefile.am
+++ b/orte/mca/regx/naive/Makefile.am
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2019      IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+          regx_naive_component.c \
+          regx_naive.h \
+          regx_naive.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_orte_regx_naive_DSO
+component_noinst =
+component_install = mca_regx_naive.la
+else
+component_noinst = libmca_regx_naive.la
+component_install =
+endif
+
+mcacomponentdir = $(ortelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_regx_naive_la_SOURCES = $(sources)
+mca_regx_naive_la_LDFLAGS = -module -avoid-version
+mca_regx_naive_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_regx_naive_la_SOURCES = $(sources)
+libmca_regx_naive_la_LDFLAGS = -module -avoid-version

--- a/orte/mca/regx/naive/owner.txt
+++ b/orte/mca/regx/naive/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IBM
+status: active

--- a/orte/mca/regx/naive/regx_naive.c
+++ b/orte/mca/regx/naive/regx_naive.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "orte_config.h"
+#include "orte/types.h"
+#include "opal/types.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <ctype.h>
+
+#include "opal/util/argv.h"
+#include "opal/util/basename.h"
+#include "opal/util/opal_environ.h"
+
+#include "orte/runtime/orte_globals.h"
+#include "orte/util/name_fns.h"
+#include "orte/util/show_help.h"
+#include "orte/mca/errmgr/errmgr.h"
+#include "orte/mca/rmaps/base/base.h"
+#include "orte/mca/routed/routed.h"
+#include "orte/mca/regx/base/base.h"
+
+#include "regx_naive.h"
+
+static int nidmap_create(opal_pointer_array_t *pool, char **regex);
+
+orte_regx_base_module_t orte_regx_naive_module = {
+    .nidmap_create = nidmap_create,
+    .nidmap_parse = orte_regx_base_nidmap_parse,
+    .extract_node_names = orte_regx_base_extract_node_names,
+    .encode_nodemap = orte_regx_base_encode_nodemap,
+    .decode_daemon_nodemap = orte_regx_base_decode_daemon_nodemap,
+    .generate_ppn = orte_regx_base_generate_ppn,
+    .parse_ppn = orte_regx_base_parse_ppn
+};
+
+static int nidmap_create(opal_pointer_array_t *pool, char **regex)
+{
+    char *node;
+    int n;
+    char *nodenames;
+    orte_regex_range_t *rng;
+    opal_list_t dvpids;
+    opal_list_item_t *item;
+    char **regexargs = NULL, **vpidargs = NULL, *tmp, *tmp2;
+    orte_node_t *nptr;
+    orte_vpid_t vpid;
+
+    if (mca_regx_naive_component.compress_vpids) {
+        OBJ_CONSTRUCT(&dvpids, opal_list_t);
+    }
+
+    rng = NULL;
+    for (n=0; n < pool->size; n++) {
+        if (NULL == (nptr = (orte_node_t*)opal_pointer_array_get_item(pool, n))) {
+            continue;
+        }
+        /* if no daemon has been assigned, then this node is not being used */
+        if (NULL == nptr->daemon) {
+            vpid = -1;  // indicates no daemon assigned
+        } else {
+            vpid = nptr->daemon->name.vpid;
+        }
+
+        if (mca_regx_naive_component.compress_vpids) {
+            /* deal with the daemon vpid - see if it is next in the
+             * current range */
+            if (NULL == rng) {
+                /* just starting */
+                rng = OBJ_NEW(orte_regex_range_t);
+                rng->vpid = vpid;
+                rng->cnt = 1;
+                opal_list_append(&dvpids, &rng->super);
+            } else if (UINT32_MAX == vpid) {
+                if (-1 == rng->vpid) {
+                    rng->cnt++;
+                } else {
+                    /* need to start another range */
+                    rng = OBJ_NEW(orte_regex_range_t);
+                    rng->vpid = vpid;
+                    rng->cnt = 1;
+                    opal_list_append(&dvpids, &rng->super);
+                }
+            } else if (-1 == rng->vpid) {
+                /* need to start another range */
+                rng = OBJ_NEW(orte_regex_range_t);
+                rng->vpid = vpid;
+                rng->cnt = 1;
+                opal_list_append(&dvpids, &rng->super);
+            } else {
+                /* is this the next in line */
+                if (vpid == (orte_vpid_t)(rng->vpid + rng->cnt)) {
+                    rng->cnt++;
+                } else {
+                    /* need to start another range */
+                    rng = OBJ_NEW(orte_regex_range_t);
+                    rng->vpid = vpid;
+                    rng->cnt = 1;
+                    opal_list_append(&dvpids, &rng->super);
+                }
+            }
+        }
+        else {
+            asprintf(&tmp, "%u", vpid);
+            opal_argv_append_nosize(&vpidargs, tmp);
+            free(tmp);
+        }
+
+        node = nptr->name;
+        opal_output_verbose(5, orte_regx_base_framework.framework_output,
+                            "%s PROCESS NODE <%s>",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                            node);
+
+        /* Don't compress the name - just add it to the list */
+        if (NULL != node) {
+            /* solitary node */
+            opal_argv_append_nosize(&regexargs, node);
+        }
+    }
+
+    /* assemble final result */
+    nodenames = opal_argv_join(regexargs, ',');
+    /* cleanup */
+    opal_argv_free(regexargs);
+
+    if (mca_regx_naive_component.compress_vpids) {
+        /* do the same for the vpids */
+        tmp = NULL;
+        while (NULL != (item = opal_list_remove_first(&dvpids))) {
+            rng = (orte_regex_range_t*)item;
+            if (1 < rng->cnt) {
+                if (NULL == tmp) {
+                    asprintf(&tmp, "%u(%u)", rng->vpid, rng->cnt);
+                } else {
+                    asprintf(&tmp2, "%s,%u(%u)", tmp, rng->vpid, rng->cnt);
+                    free(tmp);
+                    tmp = tmp2;
+                }
+            } else {
+                if (NULL == tmp) {
+                    asprintf(&tmp, "%u", rng->vpid);
+                } else {
+                    asprintf(&tmp2, "%s,%u", tmp, rng->vpid);
+                    free(tmp);
+                    tmp = tmp2;
+                }
+            }
+            OBJ_RELEASE(rng);
+        }
+        OPAL_LIST_DESTRUCT(&dvpids);
+    }
+    else {
+        tmp = opal_argv_join(vpidargs, ',');
+        /* cleanup */
+        opal_argv_free(vpidargs);
+    }
+
+    /* now concatenate the results into one string */
+    asprintf(&tmp2, "%s@%s", nodenames, tmp);
+    free(nodenames);
+    free(tmp);
+    *regex = tmp2;
+    opal_output_verbose(5, orte_regx_base_framework.framework_output,
+                        "%s Final regex: <%s>",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                        *regex);
+    return ORTE_SUCCESS;
+}

--- a/orte/mca/regx/naive/regx_naive.h
+++ b/orte/mca/regx/naive/regx_naive.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef _MCA_REGX_NONE_H_
+#define _MCA_REGX_NONE_H_
+
+#include "orte_config.h"
+
+#include "orte/types.h"
+
+#include "opal/mca/base/base.h"
+#include "orte/mca/regx/regx.h"
+
+
+BEGIN_C_DECLS
+
+struct orte_regx_naive_component_t {
+    orte_regx_base_component_t super;
+    bool compress_vpids;
+};
+typedef struct orte_regx_naive_component_t orte_regx_naive_component_t;
+
+ORTE_MODULE_DECLSPEC extern orte_regx_naive_component_t mca_regx_naive_component;
+extern orte_regx_base_module_t orte_regx_naive_module;
+
+END_C_DECLS
+
+#endif /* MCA_REGX_ORTE_H_ */

--- a/orte/mca/regx/naive/regx_naive_component.c
+++ b/orte/mca/regx/naive/regx_naive_component.c
@@ -1,0 +1,62 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "orte_config.h"
+#include "orte/types.h"
+#include "opal/types.h"
+
+#include "opal/util/show_help.h"
+
+#include "orte/mca/regx/regx.h"
+#include "regx_naive.h"
+
+static int component_query(mca_base_module_t **module, int *priority);
+static int component_register(void);
+
+/*
+ * Struct of function pointers and all that to let us be initialized
+ */
+orte_regx_naive_component_t mca_regx_naive_component = {
+    {
+        .base_version = {
+            MCA_REGX_BASE_VERSION_1_0_0,
+            .mca_component_name = "naive",
+            MCA_BASE_MAKE_VERSION(component, ORTE_MAJOR_VERSION, ORTE_MINOR_VERSION,
+                    ORTE_RELEASE_VERSION),
+            .mca_query_component = component_query,
+            .mca_register_component_params = component_register,
+        },
+        .base_data = {
+            /* The component is checkpoint ready */
+            MCA_BASE_METADATA_PARAM_CHECKPOINT
+        },
+    }
+};
+
+static int component_query(mca_base_module_t **module, int *priority)
+{
+    *module = (mca_base_module_t*)&orte_regx_naive_module;
+    *priority = 1;
+    return ORTE_SUCCESS;
+}
+
+static int component_register(void)
+{
+    mca_base_component_t *c = &mca_regx_naive_component.super.base_version;
+
+    mca_regx_naive_component.compress_vpids = false;
+    (void) mca_base_component_var_register (c, "compress_vpids", "Enable compression of vpids (default: false)",
+                                            MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                            OPAL_INFO_LVL_9,
+                                            MCA_BASE_VAR_SCOPE_READONLY,
+                                            &mca_regx_naive_component.compress_vpids);
+
+    return ORTE_SUCCESS;
+}

--- a/orte/mca/regx/reverse/regx_reverse.c
+++ b/orte/mca/regx/reverse/regx_reverse.c
@@ -315,5 +315,9 @@ static int nidmap_create(opal_pointer_array_t *pool, char **regex)
     free(nodenames);
     free(tmp);
     *regex = tmp2;
+    opal_output_verbose(5, orte_regx_base_framework.framework_output,
+                        "%s Final regex: <%s>",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                        *regex);
     return ORTE_SUCCESS;
 }


### PR DESCRIPTION
This PR provides a new nidmap regx component that should never fail. We have seen instances where both the fwd and reverse regx components fail and result in launch failure when hostnames are randomly generated (`regx/fwd` failing hostfile: https://gist.github.com/sam6258/1089ff67eec9882a8029abf4c365f1da).

Adding `regx/none` provides a new debug path for the other regx components as well as a functional solution when the others fail. This PR is only intended for v4.0.x and v3.1.x since the regx component does not exist in master (now uses zlib) or earlier versions.