### PR TITLE
Update OPAL DDT variable names

### DIFF
--- a/test/datatype/position.c
+++ b/test/datatype/position.c
@@ -200,9 +200,9 @@ static void dump_ldi( ddt_ldi_t* buffer, int start_pos, int end_pos )
 #endif
 
 #if (OPAL_ENABLE_DEBUG == 1) && (OPAL_C_HAVE_VISIBILITY == 0)
-extern bool opal_unpack_debug;
-extern bool opal_pack_debug;
-extern bool opal_position_debug ;
+extern bool opal_ddt_unpack_debug;
+extern bool opal_ddt_pack_debug;
+extern bool opal_ddt_position_debug ;
 #endif  /* OPAL_ENABLE_DEBUG */
 
 static char* bytes_dump( void* src, size_t cnt )
@@ -238,9 +238,9 @@ int main( int argc, char* argv[] )
     ompi_datatype_init();
 
 #if (OPAL_ENABLE_DEBUG == 1) && (OPAL_C_HAVE_VISIBILITY == 0)
-    opal_unpack_debug   = false;
-    opal_pack_debug     = false;
-    opal_position_debug = false;
+    opal_ddt_unpack_debug   = false;
+    opal_ddt_pack_debug     = false;
+    opal_ddt_position_debug = false;
 #endif  /* OPAL_ENABLE_DEBUG */
 
     create_segments( datatype, data_count, fragment_size,

--- a/test/datatype/position_noncontig.c
+++ b/test/datatype/position_noncontig.c
@@ -181,9 +181,9 @@ unpack_segments( ompi_datatype_t* datatype, int count,
 }
 
 #if (OPAL_ENABLE_DEBUG == 1) && (OPAL_C_HAVE_VISIBILITY == 0)
-extern bool opal_unpack_debug;
-extern bool opal_pack_debug;
-extern bool opal_position_debug ;
+extern bool opal_ddt_unpack_debug;
+extern bool opal_ddt_pack_debug;
+extern bool opal_ddt_position_debug ;
 #endif  /* OPAL_ENABLE_DEBUG */
 
 int main( int argc, char* argv[] )
@@ -209,9 +209,9 @@ int main( int argc, char* argv[] )
     ompi_datatype_commit(&datatype);
 
 #if (OPAL_ENABLE_DEBUG == 1) && (OPAL_C_HAVE_VISIBILITY == 0)
-    opal_unpack_debug   = false;
-    opal_pack_debug     = false;
-    opal_position_debug = false;
+    opal_ddt_unpack_debug   = false;
+    opal_ddt_pack_debug     = false;
+    opal_ddt_position_debug = false;
 #endif  /* OPAL_ENABLE_DEBUG */
 
     create_segments( datatype, 1, fragment_size,


### PR DESCRIPTION
These variables were renamed in 904276bb44caec207638247f23139bc21bc6a09e; update them to use the new names.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>