### PR TITLE
v4.0.x: Fix mmap infinite recurse in memory patcher

### DIFF
--- a/opal/mca/memory/patcher/configure.m4
+++ b/opal/mca/memory/patcher/configure.m4
@@ -40,10 +40,6 @@ AC_DEFUN([MCA_opal_memory_patcher_CONFIG],[
 
     AC_CHECK_HEADERS([linux/mman.h sys/syscall.h])
 
-    AC_CHECK_DECLS([__mmap], [], [], [#include <sys/mman.h>])
-
-    AC_CHECK_FUNCS([__mmap])
-
     AC_CHECK_DECLS([__syscall], [], [], [#include <sys/syscall.h>])
 
     AC_CHECK_FUNCS([__syscall])

--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -125,12 +125,7 @@ static void *_intercept_mmap(void *start, size_t length, int prot, int flags, in
     }
 
     if (!original_mmap) {
-#ifdef HAVE___MMAP
-        /* the darwin syscall returns an int not a long so call the underlying __mmap function */
-        result = __mmap (start, length, prot, flags, fd, offset);
-#else
         result = (void*)(intptr_t) memory_patcher_syscall(SYS_mmap, start, length, prot, flags, fd, offset);
-#endif
     } else {
         result = original_mmap (start, length, prot, flags, fd, offset);
     }


### PR DESCRIPTION
This commit fixes issue #6853 by removing
MacOS/Darwin-specific logic from intercept_mmap.

Signed-off-by: Harumi Kuno <harumi.kuno@hpe.com>
 (cherry picked from commit fca843606462f0e5d2d5d59cd2de025b1a819a58)