### PR TITLE
common_ompio_file_open: logic for communicator management

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -171,7 +171,7 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
         ** are used by his application.	
         */
 	if ( NULL != ompio_fh->f_sharedfp ) {
-	    ret = ompio_fh->f_sharedfp->sharedfp_file_open(comm,
+	    ret = ompio_fh->f_sharedfp->sharedfp_file_open(ompio_fh->f_comm,
 							   filename,
 							   amode,
 							   info,
@@ -367,11 +367,8 @@ int mca_common_ompio_file_close (ompio_file_t *ompio_fh)
 	ompi_datatype_destroy (&ompio_fh->f_orig_filetype);
     }
 
-
-    if (MPI_COMM_NULL != ompio_fh->f_comm && !(ompio_fh->f_flags & OMPIO_SHAREDFP_IS_SET) )  {
-        ompi_comm_free (&ompio_fh->f_comm);
-    }
-
+    ompi_comm_free (&ompio_fh->f_comm);
+        
     return ret;
 }
 


### PR DESCRIPTION
the logic for when to dup a communicator and when to leave it
was exactly the opposite of what we inteded to do: dup upon the 'real' file open,
do not dup on the file_open called from the sharedfp component.

This has no impact for most codes, but could have some impact on
multi-threaded executions.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>