### PR TITLE
Be a little less restrictive on interface requirements

### DIFF
--- a/orte/mca/oob/tcp/help-oob-tcp.txt
+++ b/orte/mca/oob/tcp/help-oob-tcp.txt
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015-2018 Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
@@ -132,3 +132,7 @@ up aborting your job.
   Peer host:              %s
   Peer process name:      %s
   Peer Open MPI version:  %s
+#
+[no-listeners]
+No sockets were able to be opened on the available protocols
+(IPv4 and/or IPv6). Please check your network and retry.

--- a/orte/mca/oob/tcp/oob_tcp_listener.c
+++ b/orte/mca/oob/tcp/oob_tcp_listener.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -98,7 +98,7 @@ static void connection_event_handler(int sd, short flags, void* cbdata);
  */
 int orte_oob_tcp_start_listening(void)
 {
-    int rc;
+    int rc = ORTE_SUCCESS, rc2 = ORTE_SUCCESS;
     mca_oob_tcp_listener_t *listener;
 
     /* if we don't have any TCP interfaces, we shouldn't be here */
@@ -112,18 +112,18 @@ int orte_oob_tcp_start_listening(void)
     }
 
     /* create listen socket(s) for incoming connection attempts */
-    if (ORTE_SUCCESS != (rc = create_listen())) {
-        ORTE_ERROR_LOG(rc);
-        return rc;
-    }
+    rc = create_listen();
 
 #if OPAL_ENABLE_IPV6
     /* create listen socket(s) for incoming connection attempts */
-    if (ORTE_SUCCESS != (rc = create_listen6())) {
-        ORTE_ERROR_LOG(rc);
-        return rc;
-    }
+    rc2 = create_listen6();
 #endif
+
+    if (ORTE_SUCCESS != rc && ORTE_SUCCESS != rc2) {
+        /* we were unable to open any listening sockets */
+        opal_show_help("help-oob-tcp.txt", "no-listeners", true);
+        return ORTE_ERR_FATAL;
+    }
 
     /* if I am the HNP, start a listening thread so we can
      * harvest connection requests as rapidly as possible


### PR DESCRIPTION
If both types of interfaces are enabled, don't error out if one of them
isn't able to open listener sockets. Only one interface family may be
available on some machines, but someone might want to build the code to
run more generally.

Refs https://github.com/pmix/prrte/pull/249
Fixes #6960 

Signed-off-by: Ralph Castain <rhc@pmix.org>