### PR TITLE
Mark predefined empty datatype contiguous.

### DIFF
--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -60,7 +60,7 @@ int32_t ompi_datatype_number_of_predefined_data = 0;
 ompi_predefined_datatype_t ompi_mpi_datatype_null =
     {
         {
-            OPAL_DATATYPE_INITIALIZER_EMPTY(OMPI_DATATYPE_FLAG_PREDEFINED),
+            OPAL_DATATYPE_INITIALIZER_EMPTY(OMPI_DATATYPE_FLAG_PREDEFINED|OPAL_DATATYPE_FLAG_CONTIGUOUS),
             OMPI_DATATYPE_EMPTY_DATA(EMPTY),
         },
         {0, } /* padding */

--- a/opal/datatype/opal_datatype_module.c
+++ b/opal/datatype/opal_datatype_module.c
@@ -56,7 +56,7 @@ extern int opal_cuda_verbose;
  * into an array, which is initialized at runtime.
  * Everything is constant.
  */
-OPAL_DECLSPEC const opal_datatype_t opal_datatype_empty =       OPAL_DATATYPE_INITIALIZER_EMPTY(0);
+OPAL_DECLSPEC const opal_datatype_t opal_datatype_empty =       OPAL_DATATYPE_INITIALIZER_EMPTY(OPAL_DATATYPE_FLAG_CONTIGUOUS);
 
 OPAL_DECLSPEC const opal_datatype_t opal_datatype_loop =        OPAL_DATATYPE_INITIALIZER_LOOP(0);
 OPAL_DECLSPEC const opal_datatype_t opal_datatype_end_loop =    OPAL_DATATYPE_INITIALIZER_END_LOOP(0);


### PR DESCRIPTION
Thanks @edgargabriel for the bug report.
This should fix some spurious error from ROMIO.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>