### PR TITLE
opal/util: Add function to get vertex data from bipartite graph

### DIFF
--- a/opal/util/bipartite_graph.c
+++ b/opal/util/bipartite_graph.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+ * Copyright (c) 2017-2019 Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -407,6 +407,21 @@ int opal_bp_graph_add_vertex(opal_bp_graph_t *g,
     if (NULL != index_out) {
         *index_out = v->v_index;
     }
+
+    return OPAL_SUCCESS;
+}
+
+int opal_bp_graph_get_vertex_data(opal_bp_graph_t *g,
+                                  int v_index,
+                                  void** v_data_out)
+{
+    opal_bp_graph_vertex_t* v;
+
+    v = V_ID_TO_PTR(g, v_index);
+    if (NULL == v) {
+        return OPAL_ERR_BAD_PARAM;
+    }
+    *v_data_out = v->v_data;
 
     return OPAL_SUCCESS;
 }

--- a/opal/util/bipartite_graph.h
+++ b/opal/util/bipartite_graph.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
+ * Copyright (c) 2017-2019 Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -125,6 +125,20 @@ int opal_bp_graph_add_edge(opal_bp_graph_t *g,
 int opal_bp_graph_add_vertex(opal_bp_graph_t *g,
 			     void *v_data,
 			     int *index_out);
+
+/**
+ * Get a pointer to the vertex data given the graph and vertex index
+ * associated with the vertex.
+ *
+ * @param[in]  g          graph the vertex belongs to
+ * @param[in]  v_index    integer index of the vertex
+ * @param[out] v_data_out data associated with the new vertex, may be NULL.
+ *
+ * @returns OPAL_SUCCESS or an OMPI error code
+ */
+int opal_bp_graph_get_vertex_data(opal_bp_graph_t *g,
+                                  int v_index,
+                                  void** v_data_out);
 
 /**
  * compute the order of a graph (number of vertices)


### PR DESCRIPTION
Currently, there is no function that allows the user to retrieve the
data they have stored in a vertex easily. Using the internal macros and
knowledge of the structures, the new function will return a pointer to
the user provided vertex data.

Signed-off-by: William Zhang <wilzhang@amazon.com>