### PR TITLE
UCX osc: add support for acc_single_intrinsic

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -34,6 +34,7 @@ typedef struct ompi_osc_ucx_component {
     int num_incomplete_req_ops;
     int num_modules;
     bool no_locks; /* Default value of the no_locks info key for new windows */
+    bool acc_single_intrinsic;
     unsigned int priority;
 } ompi_osc_ucx_component_t;
 
@@ -115,6 +116,7 @@ typedef struct ompi_osc_ucx_module {
     int *start_grp_ranks;
     bool lock_all_is_nocheck;
     bool no_locks;
+    bool acc_single_intrinsic;
     opal_common_ucx_ctx_t *ctx;
     opal_common_ucx_wpmem_t *mem;
     opal_common_ucx_wpmem_t *state_mem;

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -816,8 +816,9 @@ int ompi_osc_ucx_fetch_and_op(const void *origin_addr, void *result_addr,
             }
         }
 
-        ret = opal_common_ucx_wpmem_fetch(module->mem, opcode, value, target,
-                                        (void *)result_addr, dt_bytes, remote_addr);
+        ret = opal_common_ucx_wpmem_fetch_nb(module->mem, opcode, value, target,
+                                             (void *)result_addr, dt_bytes,
+                                             remote_addr, NULL, NULL);
 
         if (module->acc_single_intrinsic) {
             return ret;

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) Mellanox Technologies Ltd. 2001-2017. ALL RIGHTS RESERVED.
+ * Copyright (C) 2001-2017 Mellanox Technologies Ltd. ALL RIGHTS RESERVED.
+ * Copyright (c) 2019-2020 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -998,6 +998,7 @@ int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
                                          sizeof(uint64_t), remote_addr,
                                          req_completion, ucx_req);
     if (ret != OMPI_SUCCESS) {
+        OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
         return ret;
     }
 
@@ -1049,6 +1050,7 @@ int ompi_osc_ucx_rget(void *origin_addr, int origin_count,
                                          sizeof(uint64_t), remote_addr,
                                          req_completion, ucx_req);
     if (ret != OMPI_SUCCESS) {
+        OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
         return ret;
     }
 
@@ -1077,6 +1079,7 @@ int ompi_osc_ucx_raccumulate(const void *origin_addr, int origin_count,
     ret = ompi_osc_ucx_accumulate(origin_addr, origin_count, origin_dt, target, target_disp,
                                   target_count, target_dt, op, win);
     if (ret != OMPI_SUCCESS) {
+        OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
         return ret;
     }
 
@@ -1111,6 +1114,7 @@ int ompi_osc_ucx_rget_accumulate(const void *origin_addr, int origin_count,
                                       target, target_disp, target_count,
                                       target_datatype, op, win);
     if (ret != OMPI_SUCCESS) {
+        OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
         return ret;
     }
 

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -417,21 +417,22 @@ static int atomic_op_cswap(
     for (int i = 0; i < origin_count; ++i) {
 
         uint64_t tmp_val;
+        uint64_t target_val = 0;
+
+        // get the value from the origin
+        ret = opal_common_ucx_wpmem_putget(module->mem, OPAL_COMMON_UCX_GET,
+                                            target, &target_val, origin_dt_bytes,
+                                            remote_addr);
+        if (ret != OMPI_SUCCESS) {
+            return ret;
+        }
+
+        ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_EP, target);
+        if (ret != OMPI_SUCCESS) {
+            return ret;
+          }
+
         do {
-            uint64_t target_val = 0;
-
-            // get the value from the origin
-            ret = opal_common_ucx_wpmem_putget(module->mem, OPAL_COMMON_UCX_GET,
-                                               target, &target_val, origin_dt_bytes,
-                                               remote_addr);
-            if (ret != OMPI_SUCCESS) {
-                return ret;
-            }
-
-            ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_EP, target);
-            if (ret != OMPI_SUCCESS) {
-                return ret;
-            }
 
             tmp_val = target_val;
             // compute the result value

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -369,7 +369,11 @@ static int do_atomic_op_replace_sum(
     }
 
     opal_common_ucx_user_req_handler_t user_req_cb = NULL;
-    void* user_req_ptr = NULL;
+    void *user_req_ptr = NULL;
+    void *output_addr  = &(module->req_result);
+    if( result_addr ) {
+        output_addr = result_addr;
+    }
     for (int i = 0; i < origin_count; ++i) {
         uint64_t value = 0;
         if ((origin_count - 1) == i && NULL != ucx_req) {
@@ -391,14 +395,14 @@ static int do_atomic_op_replace_sum(
             memcpy(&value, origin_addr, origin_dt_bytes);
         }
         ret = opal_common_ucx_wpmem_fetch_nb(module->mem, opcode, value, target,
-                                             result_addr ? result_addr : &(module->req_result),
-                                             origin_dt_bytes, remote_addr, user_req_cb, user_req_ptr);
+                                             output_addr, origin_dt_bytes, remote_addr,
+                                             user_req_cb, user_req_ptr);
 
         // advance origin and remote address
         origin_addr  = (void*)((intptr_t)origin_addr + origin_dt_bytes);
         remote_addr += origin_dt_bytes;
         if (result_addr) {
-            result_addr = (void*)((intptr_t)result_addr + origin_dt_bytes);
+            output_addr = (void*)((intptr_t)output_addr + origin_dt_bytes);
         }
     }
 

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -323,7 +323,7 @@ static inline int get_dynamic_win_info(uint64_t remote_addr, ompi_osc_ucx_module
     return ret;
 }
 
-static int atomic_op_replace_sum(
+static int do_atomic_op_replace_sum(
     ompi_osc_ucx_module_t  *module,
     struct ompi_op_t       *op,
     int                     target,
@@ -333,7 +333,8 @@ static int atomic_op_replace_sum(
     ptrdiff_t               target_disp,
     int                     target_count,
     struct ompi_datatype_t *target_dt,
-    void                   *result_addr)
+    void                   *result_addr,
+    ompi_osc_ucx_request_t *ucx_req)
 {
     int ret = OMPI_SUCCESS;
     size_t origin_dt_bytes;
@@ -363,12 +364,27 @@ static int atomic_op_replace_sum(
         opcode = UCP_ATOMIC_FETCH_OP_FADD;
     }
 
+    opal_common_ucx_user_req_handler_t user_req_cb = NULL;
+    void* user_req_ptr = NULL;
     for (int i = 0; i < origin_count; ++i) {
         uint64_t value = 0;
+        if ((origin_count - 1) == i && NULL != ucx_req) {
+            // the last item is used to feed the request, if needed
+            user_req_cb = &req_completion;
+            user_req_ptr = ucx_req;
+            // issue a fence if this is the last but not the only element
+            if (0 < i) {
+                ret = opal_common_ucx_wpmem_fence(module->mem);
+                if (ret != OMPI_SUCCESS) {
+                    OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_fence failed: %d", ret);
+                    return OMPI_ERROR;
+                }
+            }
+        }
         memcpy(&value, origin_addr, origin_dt_bytes);
         ret = opal_common_ucx_wpmem_fetch_nb(module->mem, opcode, value, target,
                                              result_addr ? result_addr : &(module->req_result),
-                                             origin_dt_bytes, remote_addr, NULL, NULL);
+                                             origin_dt_bytes, remote_addr, user_req_cb, user_req_ptr);
 
         // advance origin and remote address
         origin_addr  = (void*)((intptr_t)origin_addr + origin_dt_bytes);
@@ -381,7 +397,7 @@ static int atomic_op_replace_sum(
     return ret;
 }
 
-static int atomic_op_cswap(
+static int do_atomic_op_cswap(
     ompi_osc_ucx_module_t  *module,
     struct ompi_op_t       *op,
     int                     target,
@@ -391,7 +407,8 @@ static int atomic_op_cswap(
     ptrdiff_t               target_disp,
     int                     target_count,
     struct ompi_datatype_t *target_dt,
-    void                   *result_addr)
+    void                   *result_addr,
+    ompi_osc_ucx_request_t *ucx_req)
 {
     int ret = OMPI_SUCCESS;
     size_t origin_dt_bytes;
@@ -432,6 +449,7 @@ static int atomic_op_cswap(
             return ret;
           }
 
+        /* JS: move this loop into the request to overlap multiple cas operations? */
         do {
 
             tmp_val = target_val;
@@ -451,6 +469,8 @@ static int atomic_op_cswap(
               break;
             }
 
+            target_val = tmp_val;
+
         } while (1);
 
         // store the result if necessary
@@ -463,6 +483,41 @@ static int atomic_op_cswap(
         remote_addr += origin_dt_bytes;
     }
 
+    if (NULL != ucx_req) {
+        // nothing to wait for so mark the request as completed
+        ompi_request_complete(&ucx_req->super, true);
+    }
+
+    return ret;
+}
+
+static inline
+int do_atomic_op(
+    ompi_osc_ucx_module_t  *module,
+    struct ompi_op_t       *op,
+    int                     target,
+    const void             *origin_addr,
+    int                     origin_count,
+    struct ompi_datatype_t *origin_dt,
+    ptrdiff_t               target_disp,
+    int                     target_count,
+    struct ompi_datatype_t *target_dt,
+    void                   *result_addr,
+    ompi_osc_ucx_request_t *ucx_req)
+{
+    int ret;
+
+    if (op == &ompi_mpi_op_replace.op || op == &ompi_mpi_op_sum.op) {
+        ret = do_atomic_op_replace_sum(module, op, target,
+                                       origin_addr, origin_count, origin_dt,
+                                       target_disp, target_count, target_dt,
+                                       result_addr, ucx_req);
+    } else {
+        ret = do_atomic_op_cswap(module, op, target,
+                                 origin_addr, origin_count, origin_dt,
+                                 target_disp, target_count, target_dt,
+                                 result_addr, ucx_req);
+    }
     return ret;
 }
 
@@ -576,11 +631,14 @@ int ompi_osc_ucx_get(void *origin_addr, int origin_count,
     }
 }
 
-int ompi_osc_ucx_accumulate(const void *origin_addr, int origin_count,
-                            struct ompi_datatype_t *origin_dt,
-                            int target, ptrdiff_t target_disp, int target_count,
-                            struct ompi_datatype_t *target_dt,
-                            struct ompi_op_t *op, struct ompi_win_t *win) {
+static
+int accumulate_req(const void *origin_addr, int origin_count,
+                   struct ompi_datatype_t *origin_dt,
+                   int target, ptrdiff_t target_disp, int target_count,
+                   struct ompi_datatype_t *target_dt,
+                   struct ompi_op_t *op, struct ompi_win_t *win,
+                   ompi_osc_ucx_request_t *ucx_req) {
+
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int ret = OMPI_SUCCESS;
 
@@ -594,18 +652,10 @@ int ompi_osc_ucx_accumulate(const void *origin_addr, int origin_count,
     }
 
     if (module->acc_single_intrinsic) {
-        if (op == &ompi_mpi_op_replace.op || op == &ompi_mpi_op_sum.op) {
-            ret = atomic_op_replace_sum(module, op, target,
-                                        origin_addr, origin_count, origin_dt,
-                                        target_disp, target_count, target_dt,
-                                        &(module->req_result));
-        } else {
-            ret = atomic_op_cswap(module, op, target,
-                                  origin_addr, origin_count, origin_dt,
-                                  target_disp, target_count, target_dt,
-                                  &(module->req_result));
-        }
-        return ret;
+        return do_atomic_op(module, op, target,
+                            origin_addr, origin_count, origin_dt,
+                            target_disp, target_count, target_dt,
+                            NULL, ucx_req);
     }
 
 
@@ -712,7 +762,21 @@ int ompi_osc_ucx_accumulate(const void *origin_addr, int origin_count,
         free(temp_addr_holder);
     }
 
+    if (NULL != ucx_req) {
+        // nothing to wait for, mark request as completed
+        ompi_request_complete(&ucx_req->super, true);
+    }
+
     return end_atomicity(module, target);
+}
+
+int ompi_osc_ucx_accumulate(const void *origin_addr, int origin_count,
+                            struct ompi_datatype_t *origin_dt,
+                            int target, ptrdiff_t target_disp, int target_count,
+                            struct ompi_datatype_t *target_dt,
+                            struct ompi_op_t *op, struct ompi_win_t *win) {
+    return accumulate_req(origin_addr, origin_count, origin_dt, target,
+                          target_disp, target_count, target_dt, op, win, NULL);
 }
 
 int ompi_osc_ucx_compare_and_swap(const void *origin_addr, const void *compare_addr,
@@ -813,13 +877,15 @@ int ompi_osc_ucx_fetch_and_op(const void *origin_addr, void *result_addr,
     }
 }
 
-int ompi_osc_ucx_get_accumulate(const void *origin_addr, int origin_count,
-                                struct ompi_datatype_t *origin_dt,
-                                void *result_addr, int result_count,
-                                struct ompi_datatype_t *result_dt,
-                                int target, ptrdiff_t target_disp,
-                                int target_count, struct ompi_datatype_t *target_dt,
-                                struct ompi_op_t *op, struct ompi_win_t *win) {
+static
+int get_accumulate_req(const void *origin_addr, int origin_count,
+                       struct ompi_datatype_t *origin_dt,
+                       void *result_addr, int result_count,
+                       struct ompi_datatype_t *result_dt,
+                       int target, ptrdiff_t target_disp,
+                       int target_count, struct ompi_datatype_t *target_dt,
+                       struct ompi_op_t *op, struct ompi_win_t *win,
+                       ompi_osc_ucx_request_t *ucx_req) {
     ompi_osc_ucx_module_t *module = (ompi_osc_ucx_module_t*) win->w_osc_module;
     int ret = OMPI_SUCCESS;
 
@@ -829,18 +895,11 @@ int ompi_osc_ucx_get_accumulate(const void *origin_addr, int origin_count,
     }
 
     if (module->acc_single_intrinsic) {
-        if (op == &ompi_mpi_op_replace.op || op == &ompi_mpi_op_sum.op) {
-            ret = atomic_op_replace_sum(module, op, target,
-                                        origin_addr, origin_count, origin_dt,
-                                        target_disp, target_count, target_dt, result_addr);
-        } else {
-            ret = atomic_op_cswap(module, op, target,
-                                  origin_addr, origin_count, origin_dt,
-                                  target_disp, target_count, target_dt, result_addr);
-        }
-        return ret;
+        return do_atomic_op(module, op, target,
+                            origin_addr, origin_count, origin_dt,
+                            target_disp, target_count, target_dt,
+                            result_addr, ucx_req);
     }
-
 
     ret = start_atomicity(module, target);
     if (ret != OMPI_SUCCESS) {
@@ -953,7 +1012,26 @@ int ompi_osc_ucx_get_accumulate(const void *origin_addr, int origin_count,
         }
     }
 
+    if (NULL != ucx_req) {
+        // nothing to wait for, mark request as completed
+        ompi_request_complete(&ucx_req->super, true);
+    }
+
+
     return end_atomicity(module, target);
+}
+
+int ompi_osc_ucx_get_accumulate(const void *origin_addr, int origin_count,
+                                struct ompi_datatype_t *origin_dt,
+                                void *result_addr, int result_count,
+                                struct ompi_datatype_t *result_dt,
+                                int target, ptrdiff_t target_disp,
+                                int target_count, struct ompi_datatype_t *target_dt,
+                                struct ompi_op_t *op, struct ompi_win_t *win) {
+
+    return get_accumulate_req(origin_addr, origin_count, origin_dt, result_addr,
+                              result_count, result_dt, target, target_disp,
+                              target_count, target_dt, op, win, NULL);
 }
 
 int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
@@ -1077,14 +1155,13 @@ int ompi_osc_ucx_raccumulate(const void *origin_addr, int origin_count,
     OMPI_OSC_UCX_REQUEST_ALLOC(win, ucx_req);
     assert(NULL != ucx_req);
 
-    ret = ompi_osc_ucx_accumulate(origin_addr, origin_count, origin_dt, target, target_disp,
-                                  target_count, target_dt, op, win);
+    ret = accumulate_req(origin_addr, origin_count, origin_dt, target, target_disp,
+                         target_count, target_dt, op, win, ucx_req);
     if (ret != OMPI_SUCCESS) {
         OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
         return ret;
     }
 
-    ompi_request_complete(&ucx_req->super, true);
     *request = &ucx_req->super;
 
     return ret;
@@ -1110,16 +1187,14 @@ int ompi_osc_ucx_rget_accumulate(const void *origin_addr, int origin_count,
     OMPI_OSC_UCX_REQUEST_ALLOC(win, ucx_req);
     assert(NULL != ucx_req);
 
-    ret = ompi_osc_ucx_get_accumulate(origin_addr, origin_count, origin_datatype,
-                                      result_addr, result_count, result_datatype,
-                                      target, target_disp, target_count,
-                                      target_datatype, op, win);
+    ret = get_accumulate_req(origin_addr, origin_count, origin_datatype,
+                             result_addr, result_count, result_datatype,
+                             target, target_disp, target_count,
+                             target_datatype, op, win, ucx_req);
     if (ret != OMPI_SUCCESS) {
         OMPI_OSC_UCX_REQUEST_RETURN(ucx_req);
         return ret;
     }
-
-    ompi_request_complete(&ucx_req->super, true);
 
     *request = &ucx_req->super;
 

--- a/ompi/mca/osc/ucx/osc_ucx_request.h
+++ b/ompi/mca/osc/ucx/osc_ucx_request.h
@@ -43,7 +43,7 @@ OBJ_CLASS_DECLARATION(ompi_osc_ucx_request_t);
 
 #define OMPI_OSC_UCX_REQUEST_RETURN(req)                                \
     do {                                                                \
-        OMPI_REQUEST_FINI(&request->super);                             \
+        OMPI_REQUEST_FINI(&req->super);                                 \
         opal_free_list_return (&mca_osc_ucx_component.requests,         \
                                (opal_free_list_item_t*) req);           \
     } while (0)

--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -206,22 +206,33 @@ int opal_common_ucx_atomic_cswap(ucp_ep_h ep, uint64_t compare,
                                  uint64_t remote_addr, ucp_rkey_h rkey,
                                  ucp_worker_h worker)
 {
-    uint64_t tmp = value;
-    int ret;
-
-    ret = opal_common_ucx_atomic_fetch(ep, UCP_ATOMIC_FETCH_OP_CSWAP, compare, &tmp,
-                                       op_size, remote_addr, rkey, worker);
-    if (OPAL_LIKELY(OPAL_SUCCESS == ret)) {
-        /* in case if op_size is constant (like sizeof(type)) then this condition
-         * is evaluated in compile time */
-        if (op_size == sizeof(uint64_t)) {
-            *(uint64_t*)result = tmp;
-        } else {
-            assert(op_size == sizeof(uint32_t));
-            *(uint32_t*)result = tmp;
-        }
+    if (op_size == sizeof(uint64_t)) {
+        *(uint64_t*)result = value;
+    } else {
+        assert(op_size == sizeof(uint32_t));
+        *(uint32_t*)result = value;
     }
-    return ret;
+
+    return opal_common_ucx_atomic_fetch(ep, UCP_ATOMIC_FETCH_OP_CSWAP, compare, result,
+                                        op_size, remote_addr, rkey, worker);
+}
+
+static inline
+ucs_status_ptr_t opal_common_ucx_atomic_cswap_nb(ucp_ep_h ep, uint64_t compare,
+                                                 uint64_t value, void *result, size_t op_size,
+                                                 uint64_t remote_addr, ucp_rkey_h rkey,
+                                                 ucp_send_callback_t req_handler,
+                                                 ucp_worker_h worker)
+{
+    if (op_size == sizeof(uint64_t)) {
+        *(uint64_t*)result = value;
+    } else {
+        assert(op_size == sizeof(uint32_t));
+        *(uint32_t*)result = value;
+    }
+
+    return opal_common_ucx_atomic_fetch_nb(ep, UCP_ATOMIC_FETCH_OP_CSWAP, compare, result,
+                                           op_size, remote_addr, rkey, req_handler, worker);
 }
 
 END_C_DECLS

--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -120,7 +120,7 @@ OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *
  * Load an integer value of \c size bytes from \c ptr and cast it to uint64_t.
  */
 static inline
-uint64_t opal_common_ucx_load_uint64(void *ptr, size_t size)
+uint64_t opal_common_ucx_load_uint64(const void *ptr, size_t size)
 {
     if (sizeof(uint8_t) == size) {
       return *(uint8_t*)ptr;

--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -115,6 +115,42 @@ OPAL_DECLSPEC int opal_common_ucx_del_procs_nofence(opal_common_ucx_del_proc_t *
                                                size_t my_rank, size_t max_disconnect, ucp_worker_h worker);
 OPAL_DECLSPEC void opal_common_ucx_mca_var_register(const mca_base_component_t *component);
 
+
+/**
+ * Load an integer value of \c size bytes from \c ptr and cast it to uint64_t.
+ */
+static inline
+uint64_t opal_common_ucx_load_uint64(void *ptr, size_t size)
+{
+    if (sizeof(uint8_t) == size) {
+      return *(uint8_t*)ptr;
+    } else if (sizeof(uint16_t) == size) {
+      return *(uint16_t*)ptr;
+    } else if (sizeof(uint32_t) == size) {
+      return *(uint32_t*)ptr;
+    } else {
+      return *(uint64_t*)ptr;
+    }
+}
+
+/**
+ * Cast and store a uint64_t value to a value of \c size bytes pointed to by \c ptr.
+ */
+static inline
+void opal_common_ucx_store_uint64(uint64_t value, void *ptr, size_t size)
+{
+    if (sizeof(uint8_t) == size) {
+      *(uint8_t*)ptr  = value;
+    } else if (sizeof(uint16_t) == size) {
+      *(uint16_t*)ptr = value;
+    } else if (sizeof(uint32_t) == size) {
+      *(uint32_t*)ptr = value;
+    } else {
+      *(uint64_t*)ptr = value;
+    }
+}
+
+
 static inline
 ucs_status_t opal_common_ucx_request_status(ucs_status_ptr_t request)
 {
@@ -206,13 +242,7 @@ int opal_common_ucx_atomic_cswap(ucp_ep_h ep, uint64_t compare,
                                  uint64_t remote_addr, ucp_rkey_h rkey,
                                  ucp_worker_h worker)
 {
-    if (op_size == sizeof(uint64_t)) {
-        *(uint64_t*)result = value;
-    } else {
-        assert(op_size == sizeof(uint32_t));
-        *(uint32_t*)result = value;
-    }
-
+    opal_common_ucx_store_uint64(value, result, op_size);
     return opal_common_ucx_atomic_fetch(ep, UCP_ATOMIC_FETCH_OP_CSWAP, compare, result,
                                         op_size, remote_addr, rkey, worker);
 }
@@ -224,13 +254,7 @@ ucs_status_ptr_t opal_common_ucx_atomic_cswap_nb(ucp_ep_h ep, uint64_t compare,
                                                  ucp_send_callback_t req_handler,
                                                  ucp_worker_h worker)
 {
-    if (op_size == sizeof(uint64_t)) {
-        *(uint64_t*)result = value;
-    } else {
-        assert(op_size == sizeof(uint32_t));
-        *(uint32_t*)result = value;
-    }
-
+    opal_common_ucx_store_uint64(value, result, op_size);
     return opal_common_ucx_atomic_fetch_nb(ep, UCP_ATOMIC_FETCH_OP_CSWAP, compare, result,
                                            op_size, remote_addr, rkey, req_handler, worker);
 }

--- a/opal/mca/common/ucx/common_ucx.h
+++ b/opal/mca/common/ucx/common_ucx.h
@@ -3,6 +3,8 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019-2020 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (C) 2001-2017 Mellanox Technologies Ltd. ALL RIGHTS RESERVED.
+ * Copyright (c) 2019-2020 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
 #ifndef COMMON_UCX_WPOOL_H
 #define COMMON_UCX_WPOOL_H
 

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -418,6 +418,56 @@ opal_common_ucx_wpmem_cmpswp(opal_common_ucx_wpmem_t *mem, uint64_t compare,
     return rc;
 }
 
+
+static inline int
+opal_common_ucx_wpmem_cmpswp_nb(opal_common_ucx_wpmem_t *mem, uint64_t compare,
+                                uint64_t value, int target, void *buffer, size_t len,
+                                uint64_t rem_addr,
+                                opal_common_ucx_user_req_handler_t user_req_cb,
+                                void *user_req_ptr)
+{
+    ucp_ep_h ep;
+    ucp_rkey_h rkey;
+    opal_common_ucx_winfo_t *winfo = NULL;
+    opal_common_ucx_request_t *req;
+    int rc = OPAL_SUCCESS;
+
+    rc = opal_common_ucx_tlocal_fetch(mem, target, &ep, &rkey, &winfo);
+    if (OPAL_UNLIKELY(OPAL_SUCCESS != rc)) {
+        MCA_COMMON_UCX_ERROR("opal_common_ucx_tlocal_fetch failed: %d", rc);
+        return rc;
+    }
+
+    /* Perform the operation */
+    opal_mutex_lock(&winfo->mutex);
+    req = opal_common_ucx_atomic_cswap_nb(ep, compare, value,
+                                          buffer, len,
+                                          rem_addr, rkey, opal_common_ucx_req_completion,
+                                          winfo->worker);
+
+    if (UCS_PTR_IS_PTR(req)) {
+        req->ext_req = user_req_ptr;
+        req->ext_cb = user_req_cb;
+        req->winfo = winfo;
+    } else {
+        if (user_req_cb != NULL) {
+            (*user_req_cb)(user_req_ptr);
+        }
+    }
+
+
+    rc = _periodical_flush_nb(mem, winfo, target);
+    if(OPAL_UNLIKELY(OPAL_SUCCESS != rc)){
+        MCA_COMMON_UCX_VERBOSE(1, "_incr_and_check_inflight_ops failed: %d", rc);
+        return rc;
+    }
+
+    opal_mutex_unlock(&winfo->mutex);
+
+    return rc;
+}
+
+
 static inline int
 opal_common_ucx_wpmem_post(opal_common_ucx_wpmem_t *mem, ucp_atomic_post_op_t opcode,
                          uint64_t value, int target, size_t len, uint64_t rem_addr)


### PR DESCRIPTION
This PR adds support for the `acc_single_intrinsic` info key / mca parameter that allows the user to specify that only a single intrinsic type will be used in accumulate operations to avoid taking the accumulate lock for every operation. It also enables asynchronicity for accumulate operations that do not require emulation through compare-and-swap (currently only `replace` and `sum` and `compare-and-swap` itself).

Limitations:

- ~128 bit types are not supported and lead to an error if this info key is set (not sure how to handle 128 bit values that with the current UCX API)~
- ~Operations other than `replace` and `sum` in `MPI_Accumulate` require a `get` followed by a `cas` loop until successful replacement. This loop is currently executed directly but could be encapsulated in a UCX completion request, issuing a new cas if the previous one failed. Not sure whether UCX allows new operations to be issued from within a completion callback though.~
- ~After merging of #6933 there might be a few more chances to reduce latency, e.g., by fencing the release of the accumulate lock with the completion of the final put (if `acc_single_intrinsic` is not enabled).~