### PR TITLE
v3.1.x: Conform MPIR_Breakpoint to MPIR standard.

### DIFF
--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -191,7 +191,7 @@ ORTE_DECLSPEC void __opal_attribute_optnone__ MPIR_Breakpoint(void);
  * See the following git issue for more discussion:
  * https://github.com/open-mpi/ompi/issues/5501
  */
-volatile void* volatile noop_mpir_breakpoint_ptr = NULL;
+volatile void* volatile orte_noop_mpir_breakpoint_ptr = NULL;
 
 /*
  * Breakpoint function for parallel debuggers
@@ -209,7 +209,7 @@ void MPIR_Breakpoint(void)
      * *should not* be used anywhere else in the code.
      * So pointing this to the weeds should be OK.
      */
-    noop_mpir_breakpoint_ptr = (volatile void *) 0x42;
+    orte_noop_mpir_breakpoint_ptr = (volatile void *) 0x42;
     return;
 }
 

--- a/orte/orted/orted_submit.c
+++ b/orte/orted/orted_submit.c
@@ -173,7 +173,7 @@ char MPIR_attach_fifo[MPIR_MAX_PATH_LENGTH] = {0};
 int MPIR_force_to_main = 0;
 static void orte_debugger_init_before_spawn(orte_job_t *jdata);
 
-ORTE_DECLSPEC void* __opal_attribute_optnone__ MPIR_Breakpoint(void);
+ORTE_DECLSPEC void __opal_attribute_optnone__ MPIR_Breakpoint(void);
 
 /* 
  * Attempt to prevent the compiler from optimizing out
@@ -191,14 +191,26 @@ ORTE_DECLSPEC void* __opal_attribute_optnone__ MPIR_Breakpoint(void);
  * See the following git issue for more discussion:
  * https://github.com/open-mpi/ompi/issues/5501
  */
-static volatile void* volatile noop_mpir_breakpoint_ptr = NULL;
+volatile void* volatile noop_mpir_breakpoint_ptr = NULL;
 
 /*
  * Breakpoint function for parallel debuggers
  */
-void* MPIR_Breakpoint(void)
+void MPIR_Breakpoint(void)
 {
-    return noop_mpir_breakpoint_ptr;
+    /* 
+     * Actually do something with this pointer to make
+     * sure the compiler does not optimize out this function.
+     * The compiler should be forced to keep this
+     * function around due to the volatile void* type.
+     *
+     * This pointer doesn't actually do anything other than
+     * prevent unwanted optimization, and
+     * *should not* be used anywhere else in the code.
+     * So pointing this to the weeds should be OK.
+     */
+    noop_mpir_breakpoint_ptr = (volatile void *) 0x42;
+    return;
 }
 
 /* local objects */


### PR DESCRIPTION
- Fix MPIR_Breakpoint standard violation by returning void
  instead of a void*.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 067adfa417f95396c713f6e6597619fac94f0048)