### PR TITLE
Ensure that grequestx continuously make progress

### DIFF
--- a/ompi/request/grequestx.c
+++ b/ompi/request/grequestx.c
@@ -50,6 +50,7 @@ static int grequestx_progress(void) {
             }
             OPAL_THREAD_LOCK(&lock);
         }
+        in_progress = false;
     }
     OPAL_THREAD_UNLOCK(&lock);
 


### PR DESCRIPTION
The handling of the grequest extensions is missing the release of the `in_progress` guard, causing requests not being polled after the first invocation.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>