### PR TITLE
v4.0.x: ess/pmi: Fix `--enable-timing` compilation error

### DIFF
--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -464,7 +465,7 @@ static int rte_init(void)
         error = "orte_state_base_select";
         goto error;
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "state_framework_open");
+    OPAL_TIMING_ENV_NEXT(rte_init, "state_framework_open");
 
     /* open the errmgr */
     if (ORTE_SUCCESS != (ret = mca_base_framework_open(&orte_errmgr_base_framework, 0))) {
@@ -472,7 +473,7 @@ static int rte_init(void)
         error = "orte_errmgr_base_open";
         goto error;
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "errmgr_framework_open");
+    OPAL_TIMING_ENV_NEXT(rte_init, "errmgr_framework_open");
 
     /* setup my session directory */
     if (orte_create_session_dirs) {
@@ -508,7 +509,7 @@ static int rte_init(void)
             }
         }
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "create_session_dirs");
+    OPAL_TIMING_ENV_NEXT(rte_init, "create_session_dirs");
 
     /* if we have info on the HNP and local daemon, process it */
     if (NULL != orte_process_info.my_hnp_uri) {
@@ -560,7 +561,7 @@ static int rte_init(void)
         error = "orte_errmgr_base_select";
         goto error;
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "errmgr_select");
+    OPAL_TIMING_ENV_NEXT(rte_init, "errmgr_select");
 
     /* setup process binding */
     if (ORTE_SUCCESS != (ret = orte_ess_base_proc_binding())) {

--- a/orte/mca/ess/singleton/ess_singleton_module.c
+++ b/orte/mca/ess/singleton/ess_singleton_module.c
@@ -321,7 +321,6 @@ static int rte_init(void)
         error = "orte_state_base_select";
         goto error;
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "state_framework_open");
 
     /* open the errmgr */
     if (ORTE_SUCCESS != (ret = mca_base_framework_open(&orte_errmgr_base_framework, 0))) {
@@ -329,7 +328,6 @@ static int rte_init(void)
         error = "orte_errmgr_base_open";
         goto error;
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "errmgr_framework_open");
 
     /* setup my session directory */
     if (orte_create_session_dirs) {
@@ -365,7 +363,6 @@ static int rte_init(void)
             }
         }
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "create_session_dirs");
 
     /* if we have info on the HNP and local daemon, process it */
     if (NULL != orte_process_info.my_hnp_uri) {
@@ -417,14 +414,12 @@ static int rte_init(void)
         error = "orte_errmgr_base_select";
         goto error;
     }
-    OPAL_TIMING_ENV_NEXT(ess_base_setup, "errmgr_select");
 
     /* setup process binding */
     if (ORTE_SUCCESS != (ret = orte_ess_base_proc_binding())) {
         error = "proc_binding";
         goto error;
     }
-    OPAL_TIMING_ENV_NEXT(rte_init, "ess_base_proc_binding");
 
     /* this needs to be set to enable debugger use when direct launched */
     if (NULL == orte_process_info.my_daemon_uri) {
@@ -463,7 +458,6 @@ static int rte_init(void)
             goto error;
         }
     }
-    OPAL_TIMING_ENV_NEXT(rte_init, "rte_init_done");
 
     return ORTE_SUCCESS;
 


### PR DESCRIPTION
This commit fixes an compilation error when configured
with `--enable-timing`.

Procedures in the function `orte_ess_base_app_setup`
in `orte/mca/ess/base/ess_base_std_app.c` are moved
to `orte/mca/ess/pmi/ess_pmi_module.c`
and `orte/mca/ess/singleton/ess_singleton_module.c`
in the recent commit 57f6b94fa5.

In `ess_pmi_module.c`, the first argument of the
`OPAL_TIMING_ENV_NEXT` macro should have been adapted
to the destination function but was not.

In `ess_singleton_module.c`, `OPAL_TIMING_ENV_INIT`
was not used in the destination function originally.
So `OPAL_TIMING_ENV_NEXT` cannot be used in the function.

Signed-off-by: KAWASHIMA Takahiro <t-kawashima@jp.fujitsu.com>
(cherry picked from commit 8e7d874e14a5485dceff836419e36b6b24a66f48)