### PR TITLE
platform/mellanox: disable missing libcuda warning

### DIFF
--- a/contrib/platform/mellanox/optimized.conf
+++ b/contrib/platform/mellanox/optimized.conf
@@ -76,6 +76,8 @@ oob_tcp_rcvbuf = 32768
 
 opal_event_include=epoll
 
+opal_warn_on_missing_libcuda = 0
+
 bml_r2_show_unreach_errors = 0
 
 # alltoall algorithm selection settings for tuned coll mca


### PR DESCRIPTION
cc @yosefe 