### PR TITLE
v3.1.x: REF6976 Silent failure of OMPI over OFI with large messages sizes

### DIFF
--- a/ompi/mca/mtl/ofi/help-mtl-ofi.txt
+++ b/ompi/mca/mtl/ofi/help-mtl-ofi.txt
@@ -16,3 +16,6 @@ unusual; your job may behave unpredictably (and/or abort) after this.
   Local host: %s
   Location: %s:%d
   Error: %s (%zd)
+#
+[message too big]
+Message size %llu bigger than supported by selected transport. Max = %llu

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -466,9 +466,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
     }
 
     /**
-     * Save the maximum inject size.
+     * Save the maximum sizes.
      */
     ompi_mtl_ofi.max_inject_size = prov->tx_attr->inject_size;
+    ompi_mtl_ofi.max_msg_size = prov->ep_attr->max_msg_size;
 
     /**
      * Create the objects that will be bound to the endpoint.

--- a/ompi/mca/mtl/ofi/mtl_ofi_types.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_types.h
@@ -49,6 +49,9 @@ typedef struct mca_mtl_ofi_module_t {
     /** Maximum inject size */
     size_t max_inject_size;
 
+    /** Largest message that can be sent in a single send. */
+    size_t max_msg_size;
+
     /** Maximum number of CQ events to read in OFI Progress */
     int ofi_progress_event_count;
 


### PR DESCRIPTION
INTERNAL: STL-59403

The OFI (libfabric) MTL does not respect the maximum message size
parameter that OFI provides in the fi_info data.

This patch adds this missing max_msg_size field to the mca_ofi_module_t
structure and adds a length check to the low-level send routines.

(cherry-picked from commit 3aca4af548a3d781b6b52f89f4d6c7e66d379609)
Change-Id: I65ab130794574393edab4a318365c1c125e50712
Signed-off-by: Michael Heinz <michael.william.heinz@intel.com>
Reviewed-by: Adam Goldman <adam.goldman@intel.com>
Reviewed-by: Brendan Cunningham <brendan.cunningham@intel.com>