### PR TITLE
REF6976 Silent failure of OMPI over OFI with large messages sizes

### DIFF
--- a/ompi/mca/mtl/ofi/help-mtl-ofi.txt
+++ b/ompi/mca/mtl/ofi/help-mtl-ofi.txt
@@ -75,3 +75,5 @@ recoverable and your application is likely to abort.
   Local host: %s
   Remote host: %s
   Error: %s (%d)
+[message too big]
+Message size %llu bigger than supported by selected transport. Max = %llu

--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -881,9 +881,10 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
     }
 
     /**
-     * Save the maximum inject size.
+     * Save the maximum sizes.
      */
     ompi_mtl_ofi.max_inject_size = prov->tx_attr->inject_size;
+    ompi_mtl_ofi.max_msg_size = prov->ep_attr->max_msg_size;
 
     /**
      * The user is not allowed to exceed MTL_OFI_MAX_PROG_EVENT_COUNT.

--- a/ompi/mca/mtl/ofi/mtl_ofi_types.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_types.h
@@ -70,6 +70,9 @@ typedef struct mca_mtl_ofi_module_t {
     /** Maximum inject size */
     size_t max_inject_size;
 
+    /** Largest message that can be sent in a single send. */
+    size_t max_msg_size;
+
     /** Maximum number of CQ events to read in OFI Progress */
     int ofi_progress_event_count;
 


### PR DESCRIPTION
INTERNAL: STL-59403

The OFI (libfabric) MTL does not respect the maximum message size
parameter that OFI provides in the fi_info data.

This patch adds this missing max_msg_size field to the mca_ofi_module_t
structure and adds a length check to the low-level send routines.

Change-Id: I05aa71d332f2df897133b30c28bf37d98f061996
Signed-off-by: Michael Heinz <michael.william.heinz@intel.com>
Reviewed-by: Adam Goldman <adam.goldman@intel.com>
Reviewed-by: Brendan Cunningham <brendan.cunningham@intel.com>