### PR TITLE
v3.1.x: Cleanup stale code in ORTE/OOB

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/src/mca/pnet/base/pnet_base_fns.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/pnet/base/pnet_base_fns.c
@@ -110,7 +110,6 @@ void pmix_pnet_base_child_finalized(pmix_peer_t *peer)
 
     /* protect against bozo inputs */
     if (NULL == peer) {
-        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return;
     }
 
@@ -133,7 +132,6 @@ void pmix_pnet_base_local_app_finalized(char *nspace)
 
     /* protect against bozo inputs */
     if (NULL == nspace) {
-        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return;
     }
 

--- a/orte/mca/oob/base/base.h
+++ b/orte/mca/oob/base/base.h
@@ -55,14 +55,12 @@ BEGIN_C_DECLS
  * Convenience Typedef
  */
 typedef struct {
-    opal_event_base_t *ev_base;
     char *include;
     char *exclude;
     opal_list_t components;
     opal_list_t actives;
     int max_uri_length;
     opal_hash_table_t peers;
-    int num_threads;
 #if OPAL_ENABLE_TIMING
     bool timing;
 #endif
@@ -121,7 +119,7 @@ ORTE_DECLSPEC void orte_oob_base_send_nb(int fd, short args, void *cbdata);
                             __FILE__, __LINE__);                        \
         cd = OBJ_NEW(orte_oob_send_t);                                  \
         cd->msg = (m);                                                  \
-        ORTE_THREADSHIFT(cd, orte_oob_base.ev_base,                     \
+        ORTE_THREADSHIFT(cd, orte_event_base,                           \
                          orte_oob_base_send_nb, ORTE_MSG_PRI);          \
     }while(0)
 

--- a/orte/mca/oob/base/oob_base_frame.c
+++ b/orte/mca/oob/base/oob_base_frame.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,14 +55,6 @@ orte_oob_base_t orte_oob_base = {0};
 
 static int orte_oob_base_register(mca_base_register_flag_t flags)
 {
-    orte_oob_base.num_threads = 0;
-    (void)mca_base_var_register("orte", "oob", "base", "num_progress_threads",
-                                "Number of independent progress OOB messages for each interface",
-                                MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                OPAL_INFO_LVL_9,
-                                MCA_BASE_VAR_SCOPE_READONLY,
-                                &orte_oob_base.num_threads);
-
 #if OPAL_ENABLE_TIMING
     /* Detailed timing setup */
     orte_oob_base.timing = false;
@@ -91,10 +83,6 @@ static int orte_oob_base_close(void)
         OBJ_RELEASE(cli);
     }
 
-    if (!ORTE_PROC_IS_APP && !ORTE_PROC_IS_TOOL) {
-        opal_progress_thread_finalize("OOB-BASE");
-    }
-
     /* destruct our internal lists */
     OBJ_DESTRUCT(&orte_oob_base.actives);
 
@@ -121,13 +109,6 @@ static int orte_oob_base_open(mca_base_open_flag_t flags)
     OBJ_CONSTRUCT(&orte_oob_base.peers, opal_hash_table_t);
     opal_hash_table_init(&orte_oob_base.peers, 128);
     OBJ_CONSTRUCT(&orte_oob_base.actives, opal_list_t);
-
-    if (ORTE_PROC_IS_APP || ORTE_PROC_IS_TOOL) {
-        orte_oob_base.ev_base = orte_event_base;
-    } else {
-        orte_oob_base.ev_base = opal_progress_thread_init("OOB-BASE");
-    }
-
 
 #if OPAL_ENABLE_FT_CR == 1
     /* register the FT events callback */

--- a/orte/mca/oob/tcp/oob_tcp.c
+++ b/orte/mca/oob/tcp/oob_tcp.c
@@ -141,12 +141,6 @@ static void ping(const orte_process_name_t *proc)
         return;
     }
 
-    /* has this peer had a progress thread assigned yet? */
-    if (NULL == peer->ev_base) {
-        /* nope - assign one */
-        ORTE_OOB_TCP_NEXT_BASE(peer);
-    }
-
     /* if we are already connected, there is nothing to do */
     if (MCA_OOB_TCP_CONNECTED == peer->state) {
         opal_output_verbose(2, orte_oob_base_framework.framework_output,
@@ -204,11 +198,7 @@ static void send_nb(orte_rml_send_t *msg)
                         __FILE__, __LINE__,
                         ORTE_NAME_PRINT(&msg->dst), msg->tag, msg->seq_num,
                         ORTE_NAME_PRINT(&peer->name));
-    /* has this peer had a progress thread assigned yet? */
-    if (NULL == peer->ev_base) {
-        /* nope - assign one */
-        ORTE_OOB_TCP_NEXT_BASE(peer);
-    }
+
     /* add the msg to the hop's send queue */
     if (MCA_OOB_TCP_CONNECTED == peer->state) {
         opal_output_verbose(2, orte_oob_base_framework.framework_output,

--- a/orte/mca/oob/tcp/oob_tcp_component.h
+++ b/orte/mca/oob/tcp/oob_tcp_component.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,9 +48,6 @@ typedef struct {
     int                  max_retries;        /**< max number of retries before declaring peer gone */
     opal_list_t          events;             /**< events for monitoring connections */
     int                  peer_limit;         /**< max size of tcp peer cache */
-    opal_pointer_array_t ev_bases;           // event base array for progress threads
-    char**               ev_threads;         // event progress thread names
-    int                  next_base;          // counter to load-level thread use
     opal_hash_table_t    peers;              // connection addresses for peers
 
     /* Port specifications */
@@ -95,14 +92,5 @@ ORTE_MODULE_DECLSPEC void mca_oob_tcp_component_lost_connection(int fd, short ar
 ORTE_MODULE_DECLSPEC void mca_oob_tcp_component_failed_to_connect(int fd, short args, void *cbdata);
 ORTE_MODULE_DECLSPEC void mca_oob_tcp_component_no_route(int fd, short args, void *cbdata);
 ORTE_MODULE_DECLSPEC void mca_oob_tcp_component_hop_unknown(int fd, short args, void *cbdata);
-
-#define ORTE_OOB_TCP_NEXT_BASE(p)                                                       \
-    do {                                                                                \
-        ++mca_oob_tcp_component.next_base;                                              \
-        if (orte_oob_base.num_threads <= mca_oob_tcp_component.next_base) {             \
-            mca_oob_tcp_component.next_base = 0;                                        \
-        }                                                                               \
-        (p)->ev_base = (opal_event_base_t*)opal_pointer_array_get_item(&mca_oob_tcp_component.ev_bases, mca_oob_tcp_component.next_base); \
-    } while(0)
 
 #endif /* _MCA_OOB_TCP_COMPONENT_H_ */

--- a/orte/mca/oob/tcp/oob_tcp_connection.c
+++ b/orte/mca/oob/tcp/oob_tcp_connection.c
@@ -492,10 +492,7 @@ static void tcp_peer_event_init(mca_oob_tcp_peer_t* peer)
 {
     if (peer->sd >= 0) {
         assert(!peer->send_ev_active && !peer->recv_ev_active);
-        if (NULL == peer->ev_base) {
-            ORTE_OOB_TCP_NEXT_BASE(peer);
-        }
-        opal_event_set(peer->ev_base,
+        opal_event_set(orte_event_base,
                        &peer->recv_event,
                        peer->sd,
                        OPAL_EV_READ|OPAL_EV_PERSIST,
@@ -507,7 +504,7 @@ static void tcp_peer_event_init(mca_oob_tcp_peer_t* peer)
             peer->recv_ev_active = false;
         }
 
-        opal_event_set(peer->ev_base,
+        opal_event_set(orte_event_base,
                        &peer->send_event,
                        peer->sd,
                        OPAL_EV_WRITE|OPAL_EV_PERSIST,
@@ -787,7 +784,6 @@ int mca_oob_tcp_peer_recv_connect_ack(mca_oob_tcp_peer_t* pr,
                                 ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
             peer = OBJ_NEW(mca_oob_tcp_peer_t);
             peer->name = hdr.origin;
-            ORTE_OOB_TCP_NEXT_BASE(peer);  // assign it an event base
             peer->state = MCA_OOB_TCP_ACCEPTING;
             ui64 = (uint64_t*)(&peer->name);
             if (OPAL_SUCCESS != opal_hash_table_set_value_uint64(&mca_oob_tcp_component.peers, (*ui64), peer)) {

--- a/orte/mca/oob/tcp/oob_tcp_connection.h
+++ b/orte/mca/oob/tcp/oob_tcp_connection.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,14 +60,14 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_conn_op_t);
                             ORTE_NAME_PRINT((&(p)->name)));             \
         cop = OBJ_NEW(mca_oob_tcp_conn_op_t);                           \
         cop->peer = (p);                                                \
-        ORTE_THREADSHIFT(cop, (p)->ev_base, (cbfunc), ORTE_MSG_PRI);    \
+        ORTE_THREADSHIFT(cop, orte_event_base, (cbfunc), ORTE_MSG_PRI);    \
     } while(0);
 
 #define ORTE_ACTIVATE_TCP_ACCEPT_STATE(s, a, cbfunc)            \
     do {                                                        \
         mca_oob_tcp_conn_op_t *cop;                             \
         cop = OBJ_NEW(mca_oob_tcp_conn_op_t);                   \
-        opal_event_set(orte_oob_base.ev_base, &cop->ev, s,      \
+        opal_event_set(orte_event_base, &cop->ev, s,            \
                        OPAL_EV_READ, (cbfunc), cop);            \
         opal_event_set_priority(&cop->ev, ORTE_MSG_PRI);        \
         ORTE_POST_OBJECT(cop);                                  \
@@ -84,7 +84,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_conn_op_t);
                             ORTE_NAME_PRINT((&(p)->name)));             \
         cop = OBJ_NEW(mca_oob_tcp_conn_op_t);                           \
         cop->peer = (p);                                                \
-        opal_event_evtimer_set((p)->ev_base,                            \
+        opal_event_evtimer_set(orte_event_base,                         \
                                &cop->ev,                                \
                                (cbfunc), cop);                          \
         ORTE_POST_OBJECT(cop);                                          \

--- a/orte/mca/oob/tcp/oob_tcp_listener.c
+++ b/orte/mca/oob/tcp/oob_tcp_listener.c
@@ -157,7 +157,7 @@ int orte_oob_tcp_start_listening(void)
     /* otherwise, setup to listen via the event lib */
     OPAL_LIST_FOREACH(listener, &mca_oob_tcp_component.listeners, mca_oob_tcp_listener_t) {
         listener->ev_active = true;
-        opal_event_set(orte_oob_base.ev_base, &listener->event,
+        opal_event_set(orte_event_base, &listener->event,
                        listener->sd,
                        OPAL_EV_READ|OPAL_EV_PERSIST,
                        connection_event_handler,
@@ -742,7 +742,7 @@ static void* listen_thread(opal_object_t *obj)
                  * OS might start rejecting connections due to timeout.
                  */
                 pending_connection = OBJ_NEW(mca_oob_tcp_pending_connection_t);
-                opal_event_set(orte_oob_base.ev_base, &pending_connection->ev, -1,
+                opal_event_set(orte_event_base, &pending_connection->ev, -1,
                                OPAL_EV_WRITE, connection_handler, pending_connection);
                 opal_event_set_priority(&pending_connection->ev, ORTE_MSG_PRI);
                 pending_connection->fd = accept(sd,

--- a/orte/mca/oob/tcp/oob_tcp_peer.h
+++ b/orte/mca/oob/tcp/oob_tcp_peer.h
@@ -52,7 +52,6 @@ typedef struct {
     mca_oob_tcp_addr_t *active_addr;
     mca_oob_tcp_state_t state;
     int num_retries;
-    opal_event_base_t *ev_base; // progress thread this peer is assigned to
     opal_event_t send_event;    /**< registration with event thread for send events */
     bool send_ev_active;
     opal_event_t recv_event;    /**< registration with event thread for recv events */
@@ -88,7 +87,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_peer_op_t);
         if (NULL != proxy) {                                            \
             pop->rtmod = strdup(proxy);                                 \
         }                                                               \
-        ORTE_THREADSHIFT(pop, orte_oob_base.ev_base,                    \
+        ORTE_THREADSHIFT(pop, orte_event_base,                          \
                          (cbfunc), ORTE_MSG_PRI);                       \
     } while(0);
 

--- a/orte/mca/oob/tcp/oob_tcp_sendrecv.h
+++ b/orte/mca/oob/tcp/oob_tcp_sendrecv.h
@@ -82,7 +82,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_recv_t);
     do {                                                                \
         (s)->peer = (struct mca_oob_tcp_peer_t*)(p);                    \
         (s)->activate = (f);                                            \
-        ORTE_THREADSHIFT((s), (p)->ev_base,                             \
+        ORTE_THREADSHIFT((s), orte_event_base,                          \
                          mca_oob_tcp_queue_msg, ORTE_MSG_PRI);          \
     } while(0)
 
@@ -235,7 +235,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_msg_op_t);
                             ORTE_NAME_PRINT(&((ms)->dst)));             \
         mop = OBJ_NEW(mca_oob_tcp_msg_op_t);                            \
         mop->msg = (ms);                                                \
-        ORTE_THREADSHIFT(mop, (ms)->peer->ev_base,                      \
+        ORTE_THREADSHIFT(mop, orte_event_base,                          \
                          (cbfunc), ORTE_MSG_PRI);                       \
     } while(0);
 
@@ -281,7 +281,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_msg_error_t);
         mop->hop.jobid = (h)->jobid;                                    \
         mop->hop.vpid = (h)->vpid;                                      \
         /* this goes to the OOB framework, so use that event base */    \
-        ORTE_THREADSHIFT(mop, orte_oob_base.ev_base,                    \
+        ORTE_THREADSHIFT(mop, orte_event_base,                          \
                          (cbfunc), ORTE_MSG_PRI);                       \
     } while(0)
 
@@ -299,7 +299,7 @@ OBJ_CLASS_DECLARATION(mca_oob_tcp_msg_error_t);
         mop->hop.vpid = (h)->vpid;                                      \
         /* this goes to the component, so use the framework             \
          * event base */                                                \
-        ORTE_THREADSHIFT(mop, orte_oob_base.ev_base,                    \
+        ORTE_THREADSHIFT(mop, orte_event_base,                          \
                          (c), ORTE_MSG_PRI);                            \
     } while(0)
 


### PR DESCRIPTION
Remove code for multiple OOB progress threads as it is an optimization
nobody uses. Also turns out to have a race condition that can cause
segfault on finalize, so maybe good that nobody is using it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 41eb41c3f224abcacec78f4d77c138197c36f172)