### PR TITLE
Remove stale references to orte_oob_base.ev_base

### DIFF
--- a/orte/mca/oob/base/base.h
+++ b/orte/mca/oob/base/base.h
@@ -56,7 +56,6 @@ BEGIN_C_DECLS
  * Convenience Typedef
  */
 typedef struct {
-    opal_event_base_t *ev_base;
     char *include;
     char *exclude;
     opal_list_t components;
@@ -121,7 +120,7 @@ ORTE_DECLSPEC void orte_oob_base_send_nb(int fd, short args, void *cbdata);
                             __FILE__, __LINE__);                        \
         cd = OBJ_NEW(orte_oob_send_t);                                  \
         cd->msg = (m);                                                  \
-        ORTE_THREADSHIFT(cd, orte_oob_base.ev_base,                     \
+        ORTE_THREADSHIFT(cd, orte_event_base,                           \
                          orte_oob_base_send_nb, ORTE_MSG_PRI);          \
     }while(0)
 

--- a/orte/mca/oob/tcp/oob_tcp_listener.c
+++ b/orte/mca/oob/tcp/oob_tcp_listener.c
@@ -157,7 +157,7 @@ int orte_oob_tcp_start_listening(void)
     /* otherwise, setup to listen via the event lib */
     OPAL_LIST_FOREACH(listener, &mca_oob_tcp_component.listeners, mca_oob_tcp_listener_t) {
         listener->ev_active = true;
-        opal_event_set(orte_oob_base.ev_base, &listener->event,
+        opal_event_set(orte_event_base, &listener->event,
                        listener->sd,
                        OPAL_EV_READ|OPAL_EV_PERSIST,
                        connection_event_handler,
@@ -744,7 +744,7 @@ static void* listen_thread(opal_object_t *obj)
                  * OS might start rejecting connections due to timeout.
                  */
                 pending_connection = OBJ_NEW(mca_oob_tcp_pending_connection_t);
-                opal_event_set(orte_oob_base.ev_base, &pending_connection->ev, -1,
+                opal_event_set(orte_event_base, &pending_connection->ev, -1,
                                OPAL_EV_WRITE, connection_handler, pending_connection);
                 opal_event_set_priority(&pending_connection->ev, ORTE_MSG_PRI);
                 pending_connection->fd = accept(sd,


### PR DESCRIPTION
The oob is restricted to the main event base

Signed-off-by: Ralph Castain <rhc@pmix.org>