### PR TITLE
v3.1.x: datatype_optimize: keep 0-extent instances

### DIFF
--- a/opal/datatype/opal_datatype_optimize.c
+++ b/opal/datatype/opal_datatype_optimize.c
@@ -210,7 +210,8 @@ opal_datatype_optimize_short( opal_datatype_t* pData,
             continuity = ((last_disp + (ptrdiff_t)last_length * (ptrdiff_t)opal_datatype_basicDatatypes[last_type]->size)
                           == (total_disp + pData->desc.desc[pos_desc].elem.disp));
 
-            if( (pData->desc.desc[pos_desc].elem.common.flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) && continuity &&
+            if( ((pData->desc.desc[pos_desc].elem.common.flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) && continuity) &&
+                ((0 == last_length) || (last_extent == (int32_t)opal_datatype_basicDatatypes[last_type]->size)) &&
                 (pData->desc.desc[pos_desc].elem.extent == (int32_t)opal_datatype_basicDatatypes[type]->size) ) {
                 if( type == last_type ) {
                     last_length += pData->desc.desc[pos_desc].elem.count;


### PR DESCRIPTION
Do not remove 0-extent instances while optimizing the datatype.  This
is a distillation of a larger set of DDT bug fixes and optimizations
from master.  George tried to cherry-pick these fixes+optimizations
back to the v3.0.x/v3.1.x branches and it resulted in a giant list of
heavily-modified cherry-picked commits (see
https://github.com/open-mpi/ompi/pull/6978).  This did not seem like a
good idea.

George therefore distilled the critical bug fix down to this small
commit, suitable for both the v3.0.x/v3.1.x branches.  See
https://github.com/open-mpi/ompi/issues/7019#issuecomment-536114609
for details.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #7019 