### PR TITLE
Cpu set v40x

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -217,7 +218,15 @@ static int opal_hwloc_base_open(mca_base_open_flag_t flags)
          * we do bind to the given cpus if provided, otherwise this would be
          * ignored if someone didn't also specify a binding policy
          */
-        OPAL_SET_BINDING_POLICY(opal_hwloc_binding_policy, OPAL_BIND_TO_CPUSET);
+// I think the below became wrong in ef86707fbe3392c8ed15f79cc4892f0313b409af.
+// Before that point -cpu-set #,#,# along with -use_hwthread-cpus resulted
+// in the binding policy staying OPAL_BIND_TO_HWTHREAD I think that should
+// be right because it should be possible to use -cpu-set as a contraint
+// you put on another binding policy (eg like a cgroup), not only used as
+// a binding policy in itself.
+        if (!OPAL_BINDING_POLICY_IS_SET(opal_hwloc_binding_policy)) {
+            OPAL_SET_BINDING_POLICY(opal_hwloc_binding_policy, OPAL_BIND_TO_CPUSET);
+        }
     }
 
     /* if we are binding to hwthreads, then we must use hwthreads as cpus */

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -228,6 +228,10 @@ int opal_hwloc_base_filter_cpus(hwloc_topology_t topo)
     /* cache this info */
     sum->available = avail;
 
+    /* Treat --cpu-set analogously to how a cgroup is treated, eg make
+     * the loaded topolog only contain what is available. */
+    hwloc_topology_restrict(topo, avail, 0);
+
     return OPAL_SUCCESS;
 }
 

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -321,7 +321,7 @@ int opal_hwloc_base_get_topology(void)
                                                 0, (void*)addr, size, 0)) {
                 if (4 < opal_output_get_verbosity(opal_hwloc_base_framework.framework_output)) {
                     FILE *file = fopen("/proc/self/maps", "r");
-                    if (file) {
+                    if (NULL != file) {
                         char line[256];
                         opal_output(0, "Dumping /proc/self/maps");
 
@@ -725,17 +725,20 @@ static hwloc_obj_t df_search(hwloc_topology_t topo,
 #if HWLOC_API_VERSION >= 0x20000
         return NULL;
 #else
-        if (cache_level != HWLOC_OBJ_CACHE)
+        if (cache_level != HWLOC_OBJ_CACHE) {
             return NULL;
+        }
         search_depth = hwloc_get_cache_type_depth(topo, cache_level, (hwloc_obj_cache_type_t) -1);
 #endif
     }
-    if (HWLOC_TYPE_DEPTH_UNKNOWN == search_depth)
+    if (HWLOC_TYPE_DEPTH_UNKNOWN == search_depth) {
         return NULL;
+    }
 
     if (OPAL_HWLOC_LOGICAL == rtype) {
-        if (num_objs)
+        if (NULL != num_objs) {
             *num_objs = hwloc_get_nbobjs_by_depth(topo, search_depth);
+        }
         return hwloc_get_obj_by_depth(topo, search_depth, nobj);
     }
     if (OPAL_HWLOC_PHYSICAL == rtype) {
@@ -752,24 +755,29 @@ static hwloc_obj_t df_search(hwloc_topology_t topo,
          */
         hwloc_obj_t found = NULL;
         obj = NULL;
-        if (num_objs)
+        if (NULL != num_objs) {
             *num_objs = 0;
+        }
         while ((obj = hwloc_get_next_obj_by_depth(topo, search_depth, obj)) != NULL) {
-            if (num_objs && obj->os_index > *num_objs)
+            if (num_objs && obj->os_index > *num_objs) {
                 *num_objs = obj->os_index;
-            if (obj->os_index == nobj)
+            }
+            if (obj->os_index == nobj) {
                 found = obj;
+            }
         }
         return found;
     }
     if (OPAL_HWLOC_AVAILABLE == rtype) {
         unsigned idx = 0;
-        if (num_objs)
+        if (NULL != num_objs) {
             *num_objs = hwloc_get_nbobjs_inside_cpuset_by_depth(topo, start->cpuset, search_depth);
+        }
         obj = NULL;
         while ((obj = hwloc_get_next_obj_inside_cpuset_by_depth(topo, start->cpuset, search_depth, obj)) != NULL) {
-            if (idx == nobj)
+            if (idx == nobj) {
                 return obj;
+            }
             idx++;
         }
         return NULL;

--- a/orte/mca/rmaps/base/rmaps_base_binding.c
+++ b/orte/mca/rmaps/base/rmaps_base_binding.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Inria.  All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -168,8 +169,9 @@ static int bind_generic(orte_job_t *jdata,
         trg_obj = NULL;
         min_bound = UINT_MAX;
         while (NULL != (tmp_obj = hwloc_get_next_obj_by_depth(node->topology->topo, target_depth, tmp_obj))) {
-            if (!hwloc_bitmap_intersects(locale->cpuset, tmp_obj->cpuset))
+            if (!hwloc_bitmap_intersects(locale->cpuset, tmp_obj->cpuset)) {
                 continue;
+            }
             data = (opal_hwloc_obj_data_t*)tmp_obj->userdata;
             if (NULL == data) {
                 data = OBJ_NEW(opal_hwloc_obj_data_t);

--- a/orte/mca/rmaps/rank_file/rmaps_rank_file_component.c
+++ b/orte/mca/rmaps/rank_file/rmaps_rank_file_component.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,7 +107,8 @@ static int orte_rmaps_rank_file_register(void)
 static int orte_rmaps_rank_file_open(void)
 {
     /* ensure we flag mapping by user */
-    if ((NULL != opal_hwloc_base_cpu_list && !OPAL_BIND_ORDERED_REQUESTED(opal_hwloc_binding_policy)) ||
+    if ((OPAL_BIND_TO_CPUSET == OPAL_GET_BINDING_POLICY(opal_hwloc_binding_policy) &&
+        !OPAL_BIND_ORDERED_REQUESTED(opal_hwloc_binding_policy)) ||
         NULL != orte_rankfile) {
         if (ORTE_MAPPING_GIVEN & ORTE_GET_MAPPING_DIRECTIVE(orte_rmaps_base.mapping)) {
             /* if a non-default mapping is already specified, then we


### PR DESCRIPTION
This is a redo of
https://github.com/open-mpi/ompi/pull/6755
just for 4.x.

From our phone call about affinity my understanding is we want to keep the --cpu-set option where it functions like a lightweight cgroup.  And I'd prefer to consider this a bugfix that restores the old feature rather than an enhancement that's adding a new feature.

I admittedly had to go back to a pretty old OMPI tree (2.1.6) to find one that had that feature working.

The timeline was roughly
2.x : --cpu-set could be used like a cgroup, the implementation was complex and had the whole hwloc tree present, but every mapping option that involved iterating over the tree elements had extra logic in place to skip over elements that weren't inside the allowed mask
3.x : the core functionality of skipping over disallowed hwloc tree elements was still in place, but the error checking was made too aggressive so any command line that tried to use --cpu-set along side other misc binding/mapping options was rejected
4.x : with the switch to hwloc2 a bunch of code was simplified and the core functionality of skipping over disallowed elements was removed because it was unnecessary for cases like cgroups because the hwloc tree itself was being loaded without WHOLE_SYSTEM so it would already only contain the right elements

This PR changes the error checking back so that --cpu-set is allowed with the other mapping options, and uses hwloc_topology_restrict() to make the --cpu-set mask get used the same way that a cgroup would: the hwloc tree gets whittled to only contain elements in the allowed mask.