### PR TITLE
Updates for v3.0.5rc1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,50 @@ it is possible for items to appear more than once in the list.
 3.0.5 -- October, 2019
 ----------------------
 
+- Fix OMPIO issue limiting file reads/writes to 2GB.  Thanks to
+  Richard Warren for reporting the issue.
+- At run time, automatically disable Linux cross-memory attach (CMA)
+  for vader BTL (shared memory) copies when running in user namespaces
+  (i.e., containers).  Many thanks to Adrian Reber for raising the
+  issue and providing the fix.
+- Sending very large MPI messages using the ofi MTL will fail with
+  some of the underlying Libfabric transports (e.g., PSM2 with
+  messages >=4GB, verbs with messages >=2GB).  Prior version of Open
+  MPI failed silently; this version of Open MPI invokes the
+  appropriate MPI error handler upon failure.  See
+  https://github.com/open-mpi/ompi/issues/7058 for more details.
+  Thanks to Emmanuel Thomé for raising the issue.
+- Fix case where 0-extent datatypes might be eliminated during
+  optimization.  Thanks to Github user @tjahns for raising the issue.
+- Ensure that the MPIR_Breakpoint symbol is not optimized out on
+  problematic platforms.
+- Fix OMPIO offset calculations with SEEK_END and SEEK_CUR in
+  MPI_FILE_GET_POSITION.  Thanks to Wei-keng Liao for raising the
+  issue.
+- Fix corner case for datatype extent computations.  Thanks to David
+  Dickenson for raising the issue.
+- Fix MPI buffered sends with the "cm" PML.
+- Update to PMIx v2.2.3.
+- Fix ssh-based tree-based spawning at scale.  Many thanks to Github
+  user @zrss for the report and diagnosis.
+- Fix the Open MPI RPM spec file to not abort when grep fails.  Thanks
+  to Daniel Letai for bringing this to our attention.
+- Handle new SLURM CLI options (SLURM 19 deprecated some options that
+  Open MPI was using).  Thanks to Jordan Hayes for the report and the
+  initial fix.
+- OMPI: fix division by zero with an empty file view.
+- Also handle shmat()/shmdt() memory patching with OS-bypass networks.
+- Add support for unwinding info to all files that are present in the
+  stack starting from MPI_Init, which is helpful with parallel
+  debuggers.  Thanks to James Clark for the report and initial fix.
+- Fixed inadvertant use of bitwise operators in the MPI C++ bindings
+  header files.  Thanks to Bert Wesarg for the report and the fix.
+- Added configure option --disable-wrappers-runpath (alongside the
+  already-existing --disable-wrappers-rpath option) to prevent Open
+  MPI's configure script from automatically adding runpath CLI options
+  to the wrapper compilers.
+
+
 3.0.4 -- April, 2019
 --------------------
 

--- a/README
+++ b/README
@@ -64,7 +64,7 @@ Much, much more information is also available in the Open MPI FAQ:
 ===========================================================================
 
 The following abbreviated list of release notes applies to this code
-base as of this writing (April 2019):
+base as of this writing (October 2019):
 
 General notes
 -------------

--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=5
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=a1
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -88,8 +88,8 @@ libmpi_mpifh_so_version=41:4:1
 libmpi_usempi_tkr_so_version=40:2:0
 libmpi_usempi_ignore_tkr_so_version=40:3:0
 libmpi_usempif08_so_version=40:3:0
-libopen_rte_so_version=40:5:0
-libopen_pal_so_version=42:1:0
+libopen_rte_so_version=40:6:0
+libopen_pal_so_version=42:2:0
 libmpi_java_so_version=40:1:0
 liboshmem_so_version=41:3:1
 libompitrace_so_version=40:1:0
@@ -100,7 +100,7 @@ libompitrace_so_version=40:1:0
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=41:2:0
+libmca_ompi_common_ompio_so_version=41:3:0
 
 # ORTE layer
 libmca_orte_common_alps_so_version=40:1:0


### PR DESCRIPTION
@bwbarrett Some notes:

* See the commit messages for more detail (e.g., about c:r:a)
* I included a NEWS bullet for the CMA/vader issue (#6999), because I'm assuming we'll review+merge it before making the RC
* This PR is marked WIP/DNM because comparing the NEWS items of v3.0.x and v3.1.x, I see that the v3.0.x branch is missing a few fixes that made it to the v3.1.x branch (I marked these as "NO" in the NEWS file, which needs to be cleaned up before we merge).
    * Specifically: we need to decide whether we want to chase down these fixes for the v3.0.x branch.
    * My $0.02: barring technical problems / significant reasons *not* to include these fixes in the v3.0.x branch, we should chase them down / get the v3.0.x PRs filed.
    * I did find one v3.1.x PR that can **not** be applied to v3.0.x: the new `regx/naive` component on the v3.1.x branch.  There is no `regx` framework here on the v3.0.x branch, so that PR is moot over here.

Refs #6591 