### PR TITLE
comomn_ompio_file_read/write: fix 2GB limiting issue

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -269,7 +269,7 @@ OMPI_DECLSPEC int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp, OMPI_MP
                                                        int count, struct ompi_datatype_t *datatype, ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_build_io_array ( ompio_file_t *fh, int index, int cycles,
-                                                    size_t bytes_per_cycle, int max_data, uint32_t iov_count,
+                                                    size_t bytes_per_cycle, size_t max_data, uint32_t iov_count,
                                                     struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw,
                                                     size_t *spc, mca_common_ompio_io_array_t **io_array,
                                                     int *num_io_entries );

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -533,8 +533,8 @@ int mca_common_ompio_file_iread_at_all (ompio_file_t *fp,
 int mca_common_ompio_set_explicit_offset (ompio_file_t *fh,
                                           OMPI_MPI_OFFSET_TYPE offset)
 {
-    int i = 0;
-    int k = 0;
+    size_t i = 0;
+    size_t k = 0;
 
     if ( fh->f_view_size  > 0 ) {
 	/* starting offset of the current copy of the filew view */

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -511,7 +511,7 @@ int mca_common_ompio_file_iwrite_at_all (ompio_file_t *fp,
 /**************************************************************/
 
 int mca_common_ompio_build_io_array ( ompio_file_t *fh, int index, int cycles,
-                                      size_t bytes_per_cycle, int  max_data, uint32_t iov_count,
+                                      size_t bytes_per_cycle, size_t  max_data, uint32_t iov_count,
                                       struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw, 
                                       size_t *spc, mca_common_ompio_io_array_t **io_array,
                                       int *num_io_entries)


### PR DESCRIPTION
individual read/write operations exceeding 2GB fail in ompio
due to improper conversions from size_t to int in two different
locations. This commit fixes an issue reported by Richard Warren
from the HDF5 group.

Fixes Issue #397

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>