### PR TITLE
--report_bindings on whole machine, plus numa markers

### DIFF
--- a/opal/mca/hwloc/base/base.h
+++ b/opal/mca/hwloc/base/base.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -277,6 +278,9 @@ OPAL_DECLSPEC int opal_hwloc_base_cset2str(char *str, int len,
  *        B - signifies PU a process is bound to
  */
 OPAL_DECLSPEC int opal_hwloc_base_cset2mapstr(char *str, int len,
+                                              hwloc_topology_t topo,
+                                              hwloc_cpuset_t cpuset);
+OPAL_DECLSPEC int opal_hwloc_base_cset2mapstr_with_numa(char *str, int len,
                                               hwloc_topology_t topo,
                                               hwloc_cpuset_t cpuset);
 

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -1680,6 +1680,26 @@ static int build_map(int *num_sockets_arg, int *num_cores_arg,
 }
 
 /*
+ * use a cached WHOLE_SYSTEM topology in cset2str / cset2mapstr
+ * if the input topology is this system (hwloc_topology_is_thissystem())
+*/
+static hwloc_topology_t cached_whole_system_topology = NULL;
+
+static int
+conditionally_modify_the_topology_to_whole_system(hwloc_topology_t *ptopo)
+{
+    if (hwloc_topology_is_thissystem(*ptopo)) {
+        if (cached_whole_system_topology == NULL) {
+            hwloc_topology_init(&cached_whole_system_topology);
+            hwloc_topology_set_flags(cached_whole_system_topology,
+                HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM);
+            hwloc_topology_load(cached_whole_system_topology);
+        }
+        *ptopo = cached_whole_system_topology;
+    }
+}
+
+/*
  * Make a prettyprint string for a hwloc_cpuset_t
  */
 int opal_hwloc_base_cset2str(char *str, int len,
@@ -1694,6 +1714,8 @@ int opal_hwloc_base_cset2str(char *str, int len,
     int **map=NULL;
     hwloc_obj_t root;
     opal_hwloc_topo_data_t *sum;
+
+    conditionally_modify_the_topology_to_whole_system(&topo);
 
     str[0] = tmp[stmp] = '\0';
 
@@ -1745,16 +1767,82 @@ int opal_hwloc_base_cset2str(char *str, int len,
 }
 
 /*
+ * given an input obj somewhere in the hwloc tree, look for a
+ * numa object that contains it
+ */
+static hwloc_obj_t
+find_my_numa(hwloc_obj_t obj)
+{
+    hwloc_obj_t p, numa;
+    int i;
+
+    p = obj;
+    while (p && p->memory_arity == 0) {
+        p = p->parent;
+    }   
+    /* p should have either found a level that contains numas or reached NULL */
+    if (p == NULL) { return NULL; }
+    for (i=0; i<p->memory_arity; ++i) {
+        numa = &(p->memory_first_child[i]);
+
+        if (hwloc_bitmap_isincluded(obj->cpuset, numa->cpuset)) {
+            return numa;
+        }   
+    }
+    return NULL;
+}
+
+/*
+ * which level from the set {socket, core, pu} has
+ * the first descendent underneath the lowest numa level.
+ * returns MACHINE if there is no numa level
+ *
+ * Eg if an hwloc tree had numas containing sockets like this
+ *   <[../..][../..]><[../..][../..]>
+ * the tree would be
+ *   mach               +memory_children: n n
+ *   s   s   s   s
+ *   c c c c c c c c
+ *   pppppppppppppppp
+ * so this should return SOCKET
+ */
+static hwloc_obj_type_t
+first_type_under_a_numa(hwloc_topology_t topo)
+{
+    hwloc_obj_t p;
+    hwloc_obj_type_t type;
+
+    p = hwloc_get_obj_by_type(topo, HWLOC_OBJ_PU, 0);
+    while (p && p->memory_arity == 0) {
+        if (p->type == HWLOC_OBJ_PU ||
+            p->type == HWLOC_OBJ_CORE ||
+            p->type == HWLOC_OBJ_SOCKET)
+        {
+            type = p->type;
+        }
+        p = p->parent;
+    }
+    if (p && p->memory_arity > 0) {
+        return type;
+    }
+
+    return HWLOC_OBJ_MACHINE;
+}
+
+/*
  * Make a prettyprint string for a cset in a map format.
  * Example: [B./..]
  * Key:  [] - signifies socket
+ *       <> - signifies numa
  *        / - divider between cores
  *        . - signifies PU a process not bound to
  *        B - signifies PU a process is bound to
+ *        ~ - signifies PU that is disallowed, eg not in our cgroup:
  */
-int opal_hwloc_base_cset2mapstr(char *str, int len,
+static int cset2mapstr(char *str, int len,
                                 hwloc_topology_t topo,
-                                hwloc_cpuset_t cpuset)
+                                hwloc_cpuset_t cpuset,
+                                bool print_numa_markers)
 {
     char tmp[BUFSIZ];
     int core_index, pu_index;
@@ -1762,6 +1850,18 @@ int opal_hwloc_base_cset2mapstr(char *str, int len,
     hwloc_obj_t socket, core, pu;
     hwloc_obj_t root;
     opal_hwloc_topo_data_t *sum;
+    hwloc_cpuset_t allowed;
+    hwloc_obj_t prev_numa = NULL;
+    hwloc_obj_t cur_numa = NULL;
+    hwloc_obj_type_t type_under_numa;
+    int a_numa_marker_is_open = 0;
+
+    conditionally_modify_the_topology_to_whole_system(&topo);
+
+    allowed = hwloc_topology_get_allowed_cpuset(topo);
+    if (print_numa_markers) {
+        type_under_numa = first_type_under_a_numa(topo);
+    }
 
     str[0] = tmp[stmp] = '\0';
 
@@ -1781,48 +1881,155 @@ int opal_hwloc_base_cset2mapstr(char *str, int len,
             return OPAL_ERR_NOT_BOUND;
         }
     }
+/*
+ * As far as I know hwloc trees aren't required to have sockets and cores,
+ * just a MACHINE at the top and PU at the bottom. The 'fake_*' vars make
+ * the loops always iterate at least once, even if the initial socket = ...
+ * etc lookup is NULL.
+ */
+    int fake_on_first_socket;
+    int fake_on_first_core;
+    hwloc_cpuset_t cpuset_for_socket; /* can be fake, eg the machine's
+                                         cpuset if there are no sockets */
+    hwloc_cpuset_t cpuset_for_core;
 
     /* Iterate over all existing sockets */
+    fake_on_first_socket = 1;
     for (socket = hwloc_get_obj_by_type(topo, HWLOC_OBJ_SOCKET, 0);
-         NULL != socket;
+         NULL != socket || fake_on_first_socket;
          socket = socket->next_cousin) {
-        strncat(str, "[", len - strlen(str) - 1);
+        fake_on_first_socket = 0;
+
+/* if numas contain sockets, example output <[../..][../..]><[../..][../..]> */
+        if (print_numa_markers && type_under_numa == HWLOC_OBJ_SOCKET) {
+            prev_numa = cur_numa;
+            cur_numa = find_my_numa(socket);
+            if (cur_numa && cur_numa != prev_numa) {
+                if (a_numa_marker_is_open) {
+                    strncat(str, ">", len - strlen(str) - 1);
+                }
+                strncat(str, "<", len - strlen(str) - 1);
+                a_numa_marker_is_open = 1;
+            }
+        }
+
+        if (socket != NULL) { strncat(str, "[", len - strlen(str) - 1); }
+
+        if (socket != NULL) {
+            cpuset_for_socket = socket->cpuset;
+        } else {
+            cpuset_for_socket = root->cpuset;
+        }
 
         /* Iterate over all existing cores in this socket */
+        fake_on_first_core = 1;
         core_index = 0;
         for (core = hwloc_get_obj_inside_cpuset_by_type(topo,
-                                                        socket->cpuset,
+                                                        cpuset_for_socket,
                                                         HWLOC_OBJ_CORE, core_index);
-             NULL != core;
+             NULL != core || fake_on_first_core;
              core = hwloc_get_obj_inside_cpuset_by_type(topo,
-                                                        socket->cpuset,
+                                                        cpuset_for_socket,
                                                         HWLOC_OBJ_CORE, ++core_index)) {
+            fake_on_first_core = 0;
+/*
+ * if numas contain cores and are contained by sockets,
+ * example output [<../..><../..>][<../../../..>]
+ */
+            if (print_numa_markers && type_under_numa == HWLOC_OBJ_CORE) {
+                prev_numa = cur_numa;
+                cur_numa = find_my_numa(core);
+                if (cur_numa && cur_numa != prev_numa) {
+                    if (a_numa_marker_is_open) {
+                        strncat(str, ">", len - strlen(str) - 1);
+                    }
+                    strncat(str, "<", len - strlen(str) - 1);
+                    a_numa_marker_is_open = 1;
+                }
+            }
+
+
             if (core_index > 0) {
                 strncat(str, "/", len - strlen(str) - 1);
+            }
+
+            if (core != NULL) {
+                cpuset_for_core = core->cpuset;
+            } else {
+                cpuset_for_core = cpuset_for_socket;
             }
 
             /* Iterate over all existing PUs in this core */
             pu_index = 0;
             for (pu = hwloc_get_obj_inside_cpuset_by_type(topo,
-                                                          core->cpuset,
+                                                          cpuset_for_core,
                                                           HWLOC_OBJ_PU, pu_index);
                  NULL != pu;
                  pu = hwloc_get_obj_inside_cpuset_by_type(topo,
-                                                          core->cpuset,
+                                                          cpuset_for_core,
                                                           HWLOC_OBJ_PU, ++pu_index)) {
+/*
+ * if numas contain PU and are contained by cores (seems unlikely)
+ * example output [<.....><....>/<....><....>]
+ */
+                if (print_numa_markers && type_under_numa == HWLOC_OBJ_PU) {
+                    prev_numa = cur_numa;
+                    cur_numa = find_my_numa(pu);
+                    if (cur_numa && cur_numa != prev_numa) {
+                        if (a_numa_marker_is_open) {
+                            strncat(str, ">", len - strlen(str) - 1);
+                        }
+                        strncat(str, "<", len - strlen(str) - 1);
+                        a_numa_marker_is_open = 1;
+                    }
+                }
 
                 /* Is this PU in the cpuset? */
                 if (hwloc_bitmap_isset(cpuset, pu->os_index)) {
                     strncat(str, "B", len - strlen(str) - 1);
                 } else {
-                    strncat(str, ".", len - strlen(str) - 1);
+                    if (hwloc_bitmap_isset(allowed, pu->os_index)) {
+                        strncat(str, ".", len - strlen(str) - 1);
+                    } else {
+                        strncat(str, "~", len - strlen(str) - 1);
+                    }
+                }
+            }
+            if (print_numa_markers && type_under_numa == HWLOC_OBJ_PU) {
+                if (a_numa_marker_is_open) {
+                    strncat(str, ">", len - strlen(str) - 1);
+                    a_numa_marker_is_open = 0;
                 }
             }
         }
-        strncat(str, "]", len - strlen(str) - 1);
+        if (print_numa_markers && type_under_numa == HWLOC_OBJ_CORE) {
+            if (a_numa_marker_is_open) {
+                strncat(str, ">", len - strlen(str) - 1);
+                a_numa_marker_is_open = 0;
+            }
+        }
+        if (socket != NULL) { strncat(str, "]", len - strlen(str) - 1); }
+    }
+    if (print_numa_markers && type_under_numa == HWLOC_OBJ_SOCKET) {
+        if (a_numa_marker_is_open) {
+            strncat(str, ">", len - strlen(str) - 1);
+            a_numa_marker_is_open = 0;
+        }
     }
 
     return OPAL_SUCCESS;
+}
+int opal_hwloc_base_cset2mapstr(char *str, int len,
+                                hwloc_topology_t topo,
+                                hwloc_cpuset_t cpuset)
+{
+    return cset2mapstr(str, len, topo, cpuset, false);
+}
+int opal_hwloc_base_cset2mapstr_with_numa(char *str, int len,
+                                hwloc_topology_t topo,
+                                hwloc_cpuset_t cpuset)
+{
+    return cset2mapstr(str, len, topo, cpuset, true);
 }
 
 static int dist_cmp_fn (opal_list_item_t **a, opal_list_item_t **b)

--- a/orte/mca/rtc/hwloc/rtc_hwloc.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2017      Inria.  All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -410,9 +411,15 @@ static void set(orte_job_t *jobdat,
                 if (OPAL_ERR_NOT_BOUND == opal_hwloc_base_cset2str(tmp1, sizeof(tmp1), opal_hwloc_topology, mycpus)) {
                     opal_output(0, "MCW rank %d is not bound (or bound to all available processors)", child->name.vpid);
                 } else {
-                    opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), opal_hwloc_topology, mycpus);
-                    opal_output(0, "MCW rank %d bound to %s: %s",
+                    if (!orte_report_bindings_use_hwview) {
+                        opal_hwloc_base_cset2mapstr(tmp2, sizeof(tmp2), opal_hwloc_topology, mycpus);
+                        opal_output(0, "MCW rank %d bound to %s: %s",
                                 child->name.vpid, tmp1, tmp2);
+                    } else {
+                        opal_hwloc_base_cset2mapstr_with_numa(tmp2, sizeof(tmp2), opal_hwloc_topology, mycpus);
+                        opal_output(0, "MCW rank %d bound to %s",
+                                child->name.vpid, tmp2);
+                    }
                 }
             }
             hwloc_bitmap_free(mycpus);

--- a/orte/mca/rtc/hwloc/rtc_hwloc.h
+++ b/orte/mca/rtc/hwloc/rtc_hwloc.h
@@ -45,7 +45,7 @@ typedef struct {
 ORTE_MODULE_DECLSPEC extern orte_rtc_hwloc_component_t mca_rtc_hwloc_component;
 
 extern orte_rtc_base_module_t orte_rtc_hwloc_module;
-
+extern bool orte_report_bindings_use_hwview;
 
 END_C_DECLS
 

--- a/orte/mca/rtc/hwloc/rtc_hwloc_component.c
+++ b/orte/mca/rtc/hwloc/rtc_hwloc_component.c
@@ -50,6 +50,7 @@ orte_rtc_hwloc_component_t mca_rtc_hwloc_component = {
 
 static char *biggest = "biggest";
 static char *vmhole;
+bool orte_report_bindings_use_hwview = false;
 
 static int rtc_hwloc_register(void)
 {
@@ -87,6 +88,13 @@ static int rtc_hwloc_register(void)
         opal_output(0, "INVALID VM HOLE TYPE");
         return ORTE_ERROR;
     }
+
+    (void) mca_base_component_var_register(c, "report_bindings_use_hwview",
+        "Use logical hardware view in --report-bindings output",
+        MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+        OPAL_INFO_LVL_2,
+        MCA_BASE_VAR_SCOPE_READONLY,
+        &orte_report_bindings_use_hwview);
 
     return ORTE_SUCCESS;
 }


### PR DESCRIPTION
This PR combines a few related issues and enhancements on --report-bindings
1. --report-bindings on WHOLE_SYSTEM like 3.x did
2. mark unallowed (eg cgroup) parts of the whole machine with ~
3. optional numa markers
4. allow hwloc tree to not have sockets/cores
----

1. whole machine:

The topology sent to the pretty-print functions doesn't have the WHOLE_SYSTEM
flag, and in general we don't want WHOLE_SYSTEM.  But for pretty-printing I
think it makes more sense, and should be considered a regression vs 3.x where
the topologies had been loaded with WHOLE_SYSTEM and output looked more like
the second section in the below example.

Example of what pretty-printing looks like with/without whole system:

Suppose the machine is
```
    [..../..../..../....][..../..../..../....]
     0    4    8    12    16   20   24   28
```
and we run with
```
    cgset -r cpuset.cpus=24,25,28,29 mycgroup1
    cgset -r cpuset.cpus=26,27,30,31 mycgroup2
```
to leave only these hardware threads active:
```
    mycgroup1: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/..~~/..~~]
    mycgroup2: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/~~../~~..]
```
(here "~" is outside the cgroup and "." is in the allowed mask)

Without whole-system the printout would be
```
mycgroup1 (-np 2):
    MCW rank 0 bound to socket 1[core 0[hwt 0-1]]: [][BB/..]
    MCW rank 1 bound to socket 1[core 1[hwt 0-1]]: [][../BB]
mycgroup2 (-np 2):
    MCW rank 0 bound to socket 1[core 0[hwt 0-1]]: [][BB/..]
    MCW rank 1 bound to socket 1[core 1[hwt 0-1]]: [][../BB]
```

With whole-system the output is this, which I think is more informative
```
mycgroup1 (-np 2):
    MCW rank 0 bound to socket 1[core 6[hwt 0-1]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/BB~~/..~~]
    MCW rank 1 bound to socket 1[core 7[hwt 0-1]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/..~~/BB~~]
mycgroup2 (-np 2):
    MCW rank 0 bound to socket 1[core 6[hwt 2-3]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/~~BB/~~..]
    MCW rank 1 bound to socket 1[core 7[hwt 2-3]]: [~~~~/~~~~/~~~~/~~~~][~~~~/~~~~/~~../~~BB]
```

2. mark unallowed (~)

When using the whole-machine option there's a bitmask available to identify
the allowed PUs, eg omitting PUs not in our cgroup.  To distinguish those
PUs I'm using "~"

On the affinity phone call there was a question if we can distinguish "outside
the cgroup" vs "hardware configured off" or other states and I don't know of
hwloc info to distinguish those.  The current code uses
hwloc_topology_get_allowed_cpuset() so anything not in the allowed mask for
whatever reason gets the "~" character.

3. numa markers (<>)

I like having numa markers as well as the existing separators between
sockets and cores.  They're a little harder to code since the numas are more
fluid, eg sockets always contain cores not vice versa, so you can hard code a
loop over sockets follwed by a loop over cores. But numas might be be above or
below sockets in the tree.

This code identifies which level should be considered the child of the
numas, and has each of the hard coded loops capable of adding numa markers.

The feature is off by default and can be turned on with
   --mca rtc_hwloc_report_bindings_use_hwview 1
which puts the numa markers <> in and also shortens the output by omitting
the first part that looks like "socket 0[core 1[hwt 0-3]]" and only includes
the graphical view of the hardware.

```
Eg it shortens
> MCW rank 0 bound to socket 0[core 1[hwt 0-3]]: [BBBB/....][..../....]
to
> MCW rank 0 bound to [BBBB/....][..../....]
```

4. allow hwloc tree to not have sockets/cores

I may be behind the times on hwloc development, but as far as I know
hwloc trees aren't guaranteed to have sockets and cores, just a MACHINE
at the top and PU at the bottom. So I added a little code to the loops
so it would still print the PUs on a hypothetical machine that lacked any
structuring of the PUs into cores/sockets.

Signed-off-by: Mark Allen <markalle@us.ibm.com>