### PR TITLE
v3.1.x: common_ompio_file_read/write: fix 2GB limiting issue

### DIFF
--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -48,7 +48,7 @@ OMPI_DECLSPEC int mca_common_ompio_file_iwrite_at_all (mca_io_ompio_file_t *fp, 
                                                        int count, struct ompi_datatype_t *datatype, ompi_request_t **request);
 
 OMPI_DECLSPEC int mca_common_ompio_build_io_array ( mca_io_ompio_file_t *fh, int index, int cycles,
-                                                    size_t bytes_per_cycle, int max_data, uint32_t iov_count,
+                                                    size_t bytes_per_cycle, size_t max_data, uint32_t iov_count,
                                                     struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw,
                                                     size_t *spc );
 

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -362,8 +362,8 @@ int mca_common_ompio_file_iread_at_all (mca_io_ompio_file_t *fp,
 int mca_common_ompio_set_explicit_offset (mca_io_ompio_file_t *fh,
                                           OMPI_MPI_OFFSET_TYPE offset)
 {
-    int i = 0;
-    int k = 0;
+    size_t i = 0;
+    size_t k = 0;
 
     if ( fh->f_view_size  > 0 ) {
 	/* starting offset of the current copy of the filew view */

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -331,7 +331,7 @@ int mca_common_ompio_file_iwrite_at_all (mca_io_ompio_file_t *fp,
 /**************************************************************/
 
 int mca_common_ompio_build_io_array ( mca_io_ompio_file_t *fh, int index, int cycles,
-                                      size_t bytes_per_cycle, int max_data, uint32_t iov_count,
+                                      size_t bytes_per_cycle, size_t max_data, uint32_t iov_count,
                                       struct iovec *decoded_iov, int *ii, int *jj, size_t *tbw, 
                                       size_t *spc)
 {


### PR DESCRIPTION
individual read/write operations exceeding 2GB fail in ompio
due to improper conversions from size_t to int in two different
locations. This commit fixes an issue reported by Richard Warren
from the HDF5 group.

Fixes Issue #397

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>
(cherry picked from commit a130f569df6badebe639d17c0a1a0cb79a596094)