### PR TITLE
travis: fix make distcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ addons:
 env:
     global:
         - AM_MAKEFLAGS="-j4"
-        - CPPFLAGS="-I$HOME/bogus/include"
-        - LDFLAGS="-L$HOME/bogus/lib"
         - LD_LIBRARY_PATH="$HOME/bogus/lib"
     matrix:
         - GCC_VERSION=default
@@ -51,7 +49,7 @@ env:
 # well not build it.
 before_install:
     - if [[ "GCC_VERSION" == "6" ]]; then COMPILERS="CC=gcc-6 CXX=g++-6 FC=gfortran-6"; fi
-    - export CONFIGURE_ARGS="--prefix=$HOME/bogus $COMPILERS" DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
+    - export CONFIGURE_ARGS="--prefix=$HOME/bogus $COMPILERS CPPFLAGS=-I$HOME/bogus/include LDFLAGS=-L$HOME/bogus/lib" DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - export DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git clone https://github.com/ofiwg/libfabric.git ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$GCC_VERSION" == "6" ]] ; then sudo apt-get --assume-yes install gcc-6 g++-6 gfortran-6; fi


### PR DESCRIPTION
bad side effect occurs when CPPFLAGS is set in the environment,
so set it (and LDFLAGS too) on the configure command line.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>