### PR TITLE
plm/rsh: Add chdir option to change directory before orted exec

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh.h
+++ b/orte/mca/plm/rsh/plm_rsh.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2011      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2011      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2011-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -66,6 +66,7 @@ struct orte_plm_rsh_component_t {
     bool pass_environ_mca_params;
     char *ssh_args;
     char *pass_libpath;
+    char *chdir;
 };
 typedef struct orte_plm_rsh_component_t orte_plm_rsh_component_t;
 

--- a/orte/mca/plm/rsh/plm_rsh_component.c
+++ b/orte/mca/plm/rsh/plm_rsh_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights
  *                         reserved.
  * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2011      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2011-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -222,6 +222,14 @@ static int rsh_component_register(void)
                                             OPAL_INFO_LVL_2,
                                             MCA_BASE_VAR_SCOPE_READONLY,
                                             &mca_plm_rsh_component.pass_libpath);
+
+    mca_plm_rsh_component.chdir = NULL;
+    (void) mca_base_component_var_register (c, "chdir",
+                                            "Change working directory after rsh/ssh, but before exec of orted",
+                                            MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                            OPAL_INFO_LVL_2,
+                                            MCA_BASE_VAR_SCOPE_READONLY,
+                                            &mca_plm_rsh_component.chdir);
 
     return ORTE_SUCCESS;
 }

--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
- * Copyright (c) 2011-2017 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2011-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -497,10 +497,13 @@ static int setup_launch(int *argcptr, char ***argvptr,
              * we have to insert the orted_prefix in the right place
              */
             opal_asprintf (&final_cmd,
-                            "%s%s%s PATH=%s%s$PATH ; export PATH ; "
+                            "%s%s%s%s%s%s PATH=%s%s$PATH ; export PATH ; "
                             "LD_LIBRARY_PATH=%s%s$LD_LIBRARY_PATH ; export LD_LIBRARY_PATH ; "
                             "DYLD_LIBRARY_PATH=%s%s$DYLD_LIBRARY_PATH ; export DYLD_LIBRARY_PATH ; "
                             "%s %s",
+                            (NULL != mca_plm_rsh_component.chdir ? "cd " : " "),
+                            (NULL != mca_plm_rsh_component.chdir ? mca_plm_rsh_component.chdir : " "),
+                            (NULL != mca_plm_rsh_component.chdir ? " ; " : " "),
                             (opal_prefix != NULL ? "OPAL_PREFIX=" : " "),
                             (opal_prefix != NULL ? opal_prefix : " "),
                             (opal_prefix != NULL ? " ; export OPAL_PREFIX;" : " "),
@@ -527,7 +530,7 @@ static int setup_launch(int *argcptr, char ***argvptr,
              * we have to insert the orted_prefix in the right place
              */
             opal_asprintf (&final_cmd,
-                            "%s%s%s set path = ( %s $path ) ; "
+                            "%s%s%s%s%s%s set path = ( %s $path ) ; "
                             "if ( $?LD_LIBRARY_PATH == 1 ) "
                             "set OMPI_have_llp ; "
                             "if ( $?LD_LIBRARY_PATH == 0 ) "
@@ -541,6 +544,9 @@ static int setup_launch(int *argcptr, char ***argvptr,
                             "if ( $?OMPI_have_dllp == 1 ) "
                             "setenv DYLD_LIBRARY_PATH %s%s$DYLD_LIBRARY_PATH ; "
                             "%s %s",
+                            (NULL != mca_plm_rsh_component.chdir ? "cd " : " "),
+                            (NULL != mca_plm_rsh_component.chdir ? mca_plm_rsh_component.chdir : " "),
+                            (NULL != mca_plm_rsh_component.chdir ? " ; " : " "),
                             (opal_prefix != NULL ? "setenv OPAL_PREFIX " : " "),
                             (opal_prefix != NULL ? opal_prefix : " "),
                             (opal_prefix != NULL ? " ;" : " "),


### PR DESCRIPTION
Currently, there is no mechanism to tell the rsh/ssh launcher to change directories prior to exec'ing the `orted`. This is normally okay, as the `orted` will manage the working directory for the ranks of the user's application. This can be seen here:

```
[c712f6n01] (smiller_rsh_chdir *) [/smpi_dev/smiller/ompi]> $MPI_ROOT/bin/mpirun -host c712f6n02:1 pwd
/smpi_dev/smiller/ompi
```

However, launching `orted` inside of certain container technologies presents a new problem where the working directory of the user application can disappear during the container exec phase. This is because some container technologies like singularity mount the current working directory. But when exec'ing the `orted` from the rsh launcher, the current directory has changed to the user's home directory.

Using an `orte_launch_agent`, we can get `orted` to launch inside of a container and illustrate this problem: 

```
[c712f6n01] (smiller_rsh_chdir *) [/smpi_dev/smiller/ompi]> MY_IMG=/smpi_dev/smpi-container-test/singularity/spectrum_mpi-test_10.03.01.00rc03_mofed_4.7-1_cuda_10.1_centos_7.sif 
[c712f6n01] (smiller_rsh_chdir *) [/smpi_dev/smiller/ompi]> $MPI_ROOT/bin/mpirun -mca orte_launch_agent "singularity exec --bind $MPI_ROOT --bind /smpi_prebuilt $MY_IMG $MPI_ROOT/bin/orted" -host c712f6n02:1 pwd
/u/smiller
```

Our proposed solution is to introduce an mca parameter that allows users to change the working directory after `rsh/ssh`, but before the exec of `orted`. This should allow the launch agent to call `singularity exec` from the correct working directory and mount in that directory for the user application.

```
[c712f6n01] (smiller_rsh_chdir *) [/smpi_dev/smiller/ompi]> $MPI_ROOT/bin/mpirun -mca plm_rsh_chdir $PWD -mca orte_launch_agent "singularity exec --bind $MPI_ROOT --bind /smpi_prebuilt $MY_IMG $MPI_ROOT/bin/orted" -host c712f6n02:1 pwd
/smpi_dev/smiller/ompi
```