### PR TITLE
Fix OPAL_ALIGN_MIN to work on 32-bit systems

### DIFF
--- a/opal/include/opal/align.h
+++ b/opal/include/opal/align.h
@@ -32,7 +32,15 @@
 #include <stddef.h>
 #define OPAL_ALIGN_MIN (_Alignof(max_align_t))
 #else
-#define OPAL_ALIGN_MIN (sizeof(long double))
+#if defined(OPAL_ALIGNMENT___FLOAT128)
+#define OPAL_ALIGN_MIN (OPAL_ALIGNMENT___FLOAT128)
+#elif defined(OPAL_ALIGNMENT_LONG_DOUBLE_COMPLEX)
+#define OPAL_ALIGN_MIN (OPAL_ALIGNMENT_LONG_DOUBLE_COMPLEX)
+#elif defined (OPAL_ALIGNMENT_LONG_DOUBLE)
+#define OPAL_ALIGN_MIN (OPAL_ALIGNMENT_LONG_DOUBLE)
+#else
+#define OPAL_ALIGN_MIN (OPAL_ALIGNMENT_DOUBLE)
+#endif
 #endif /* __STDC_VERSION__ >= 201101L */
 
 #endif /* OPAL_ALIGN_H */


### PR DESCRIPTION
Use `sizeof(_Complex)` instead of `sizeof(long double)` for `OPAL_ALIGN_MIN`. On 32-bit systems the former yields `16` while the latter yields `12` and leads to compiler errors, as reported in #7121.

This assumes that at least C99 is available. Is that a valid assumption?

Fixes #7121 

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>