### PR TITLE
btl tcp: Use reachability and graph solving for global interface matching

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -89,12 +91,6 @@ int mca_btl_tcp_add_procs( struct mca_btl_base_module_t* btl,
         if(NULL == (tcp_proc = mca_btl_tcp_proc_create(opal_proc))) {
             continue;
         }
-
-        /*
-         * Check to make sure that the peer has at least as many interface
-         * addresses exported as we are trying to use. If not, then
-         * don't bind this BTL instance to the proc.
-         */
 
         OPAL_THREAD_LOCK(&tcp_proc->proc_lock);
 

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -15,6 +15,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -107,6 +109,7 @@ struct mca_btl_tcp_component_t {
     uint32_t tcp_num_btls;                  /**< number of interfaces available to the TCP component */
     unsigned int tcp_num_links;             /**< number of logical links per physical device */
     struct mca_btl_tcp_module_t **tcp_btls; /**< array of available BTL modules */
+    opal_list_t local_ifs;		    /**< opal list of local opal_if_t interfaces */
     int tcp_free_list_num;                  /**< initial size of free lists */
     int tcp_free_list_max;                  /**< maximum size of free lists */
     int tcp_free_list_inc;                  /**< number of elements to alloc when growing free lists */
@@ -163,6 +166,9 @@ OPAL_MODULE_DECLSPEC extern mca_btl_tcp_component_t mca_btl_tcp_component;
  */
 struct mca_btl_tcp_module_t {
     mca_btl_base_module_t  super;  /**< base BTL interface */
+    uint32_t           btl_index;  /**< Local BTL module index, used for vertex
+                                        data and used as a hash key when
+                                        solving module matching problem */
     uint16_t           tcp_ifkindex; /** <BTL kernel interface index */
     struct sockaddr_storage tcp_ifaddr;   /**< First address
                                              discovered for this

--- a/opal/mca/btl/tcp/btl_tcp_addr.h
+++ b/opal/mca/btl/tcp/btl_tcp_addr.h
@@ -9,6 +9,9 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ *
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,37 +33,43 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-
+#include <assert.h>
 
 /**
  * Modex address structure.
  *
  * One of these structures will be sent for every btl module in use by
- * the local BTL TCP component.
+ * the local BTL TCP component. This is used to construct an opal_if_t
+ * structure for the reachability component as well as populate the
+ * mca_btl_tcp_addr_t structure on remote procs. These will be used
+ * for interface matching and filling out the mca_btl_base_endpoint_t
+ * structure.
  */
 struct mca_btl_tcp_modex_addr_t {
     uint8_t     addr[16];       /* endpoint address.  for addr_family
                                    of MCA_BTL_TCP_AF_INET, only the
                                    first 4 bytes have meaning. */
     uint32_t    addr_ifkindex;  /* endpoint kernel index */
+    uint32_t    addr_mask;      /* ip mask */
+    uint32_t    addr_bandwidth; /* interface bandwidth */
     uint16_t    addr_port;      /* endpoint listen port */
     uint8_t     addr_family;    /* endpoint address family.  Note that
                                    this is
                                    MCA_BTL_TCP_AF_{INET,INET6}, not
                                    the traditional
                                    AF_INET/AF_INET6. */
-    uint8_t     padding[1];     /* padd out to an 8-byte word */
+    uint8_t     padding[1];     /* pad out to an 8-byte word */
 };
 typedef struct mca_btl_tcp_modex_addr_t mca_btl_tcp_modex_addr_t;
 
+_Static_assert(sizeof(struct mca_btl_tcp_modex_addr_t) == 32, "mca_btl_tcp_modex_addr_t");
 
 /**
  * Remote peer address structure
  *
  * One of these structures will be allocated for every remote endpoint
  * associated with a remote proc.  The data is pulled from the
- * mca_btl_tcp_modex_addr_t structure, except for the addr_inuse
- * field, which is local.
+ * mca_btl_tcp_modex_addr_t structure.
  */
 struct mca_btl_tcp_addr_t {
     union {
@@ -73,7 +82,6 @@ struct mca_btl_tcp_addr_t {
     int         addr_ifkindex; /**< remote interface index assigned with
                                     this address */
     uint8_t     addr_family;   /**< AF_INET or AF_INET6 */
-    bool        addr_inuse;    /**< local meaning only */
 };
 typedef struct mca_btl_tcp_addr_t mca_btl_tcp_addr_t;
 

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -16,8 +16,11 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015-2018 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2018-2019 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2013-2018 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2018-2019 Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ * Copyright (c) 2006      Sandia National Laboratories. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +39,7 @@
 
 #include "opal/class/opal_hash_table.h"
 #include "opal/mca/btl/base/btl_base_error.h"
+#include "opal/mca/reachable/base/base.h"
 #include "opal/mca/pmix/pmix.h"
 #include "opal/util/arch.h"
 #include "opal/util/argv.h"
@@ -44,27 +48,14 @@
 #include "opal/util/proc.h"
 #include "opal/util/show_help.h"
 #include "opal/util/printf.h"
+#include "opal/util/string_copy.h"
+#include "opal/util/bipartite_graph.h"
 
 #include "btl_tcp.h"
 #include "btl_tcp_proc.h"
 
 static void mca_btl_tcp_proc_construct(mca_btl_tcp_proc_t* proc);
 static void mca_btl_tcp_proc_destruct(mca_btl_tcp_proc_t* proc);
-
-struct mca_btl_tcp_proc_data_t {
-    mca_btl_tcp_interface_t** local_interfaces;
-    opal_hash_table_t local_kindex_to_index;
-    size_t num_local_interfaces, max_local_interfaces;
-    size_t num_peer_interfaces;
-    opal_hash_table_t peer_kindex_to_index;
-    unsigned int *best_assignment;
-    int max_assignment_weight;
-    int max_assignment_cardinality;
-    enum mca_btl_tcp_connection_quality **weights;
-    struct mca_btl_tcp_addr_t ***best_addr;
-};
-
-typedef struct mca_btl_tcp_proc_data_t mca_btl_tcp_proc_data_t;
 
 OBJ_CLASS_INSTANCE( mca_btl_tcp_proc_t,
                     opal_list_item_t,
@@ -79,6 +70,8 @@ void mca_btl_tcp_proc_construct(mca_btl_tcp_proc_t* tcp_proc)
     tcp_proc->proc_endpoints      = NULL;
     tcp_proc->proc_endpoint_count = 0;
     OBJ_CONSTRUCT(&tcp_proc->proc_lock, opal_mutex_t);
+    OBJ_CONSTRUCT(&tcp_proc->btl_index_to_endpoint, opal_hash_table_t);
+    opal_hash_table_init(&tcp_proc->btl_index_to_endpoint, mca_btl_tcp_component.tcp_num_btls);
 }
 
 /*
@@ -103,7 +96,268 @@ void mca_btl_tcp_proc_destruct(mca_btl_tcp_proc_t* tcp_proc)
     if(NULL != tcp_proc->proc_addrs) {
         free(tcp_proc->proc_addrs);
     }
+    OBJ_DESTRUCT(&tcp_proc->btl_index_to_endpoint);
     OBJ_DESTRUCT(&tcp_proc->proc_lock);
+}
+
+static inline int mca_btl_tcp_proc_is_proc_left(opal_process_name_t a,
+                                                opal_process_name_t b)
+{
+    if (a.jobid != b.jobid) {
+        return (a.jobid < b.jobid);
+    } else {
+        return (a.vpid < b.vpid);
+    }
+}
+
+#define MCA_BTL_TCP_PROC_LOCAL_VERTEX(index) (index)
+#define MCA_BTL_TCP_PROC_REMOTE_VERTEX(index) (index + mca_btl_tcp_component.tcp_num_btls)
+
+/* This function builds a graph to match local and remote interfaces
+ * together. It also populates the remote proc object.
+ *
+ * @param btl_proc (IN)           Remote proc information
+ * @param remote_addrs (IN)       List of addresses from remote interfaces
+ * @param local_proc_is_left (IN) Boolean indicator. If true, we set local process
+ *                                interfaces to be on the left side of the graph.
+ *                                If false, we set remote process interfaces to
+ *                                be on the left side of the graph.
+ * @param graph_out (OUT)         Constructed and populated bipartite interface
+ *                                graph with vertices as interfaces and negative
+ *                                reachability weights as costs for the edges.
+ * @return                        OPAL error code or success
+ *
+ * The vertices of this graph are the local and remote interfaces. Edges in
+ * this graph are connections between the interfaces. Costs are computed as
+ * negative weight which is calculated using the reachability framework.
+ *
+ * In order to mirror inputs on both the local and remote side when solving
+ * interface matching from both sides, we require local_proc_is_left to
+ * indicate whether the local interfaces should be on the left of the graph
+ * or not.
+ *
+ * The remote list and proc_addrs are assembled and populated here so that
+ * we can ensure that the vertex ordering matches the proc_addr ordering.
+ * This allows us to pass the correct pointers to the vertex data for storage.
+ *
+ */
+static int mca_btl_tcp_proc_create_interface_graph(mca_btl_tcp_proc_t* btl_proc,
+                                                   mca_btl_tcp_modex_addr_t* remote_addrs,
+                                                   int local_proc_is_left,
+                                                   opal_bp_graph_t **graph_out)
+{
+    opal_bp_graph_t *graph = NULL;
+    opal_reachable_t *results = NULL;
+    opal_list_t *local_list = &mca_btl_tcp_component.local_ifs;
+    opal_list_t *remote_list;
+    int rc, v_index, x, y, cost, u, v, num_edges = 0;
+    size_t i;
+
+    remote_list = OBJ_NEW(opal_list_t);
+    if (NULL == remote_list) {
+        rc = OPAL_ERR_OUT_OF_RESOURCE;
+        goto out;
+    }
+
+    /* the modex and proc structures differ slightly, so copy the
+       fields needed in the proc version */
+    for (i = 0 ; i < btl_proc->proc_addr_count ; i++) {
+        /* Construct opal_if_t objects for the remote interfaces */
+        opal_if_t *interface = OBJ_NEW(opal_if_t);
+        if (NULL == interface) {
+            rc = OPAL_ERR_OUT_OF_RESOURCE;
+            goto out;
+        }
+
+        if (MCA_BTL_TCP_AF_INET == remote_addrs[i].addr_family) {
+            memcpy(&btl_proc->proc_addrs[i].addr_union.addr_inet,
+                   remote_addrs[i].addr, sizeof(struct in_addr));
+            btl_proc->proc_addrs[i].addr_family = AF_INET;
+
+            memcpy(&((struct sockaddr_in *)&(interface->if_addr))->sin_addr,
+                   remote_addrs[i].addr, sizeof(struct in_addr));
+           ((struct sockaddr *)&(interface->if_addr))->sa_family = AF_INET;
+           interface->af_family = AF_INET;
+        } else if (MCA_BTL_TCP_AF_INET6 == remote_addrs[i].addr_family) {
+#if OPAL_ENABLE_IPV6
+            memcpy(&btl_proc->proc_addrs[i].addr_union.addr_inet6,
+                   remote_addrs[i].addr, sizeof(struct in6_addr));
+            btl_proc->proc_addrs[i].addr_family = AF_INET6;
+
+            memcpy(&((struct sockaddr_in6 *)&(interface->if_addr))->sin6_addr,
+                   remote_addrs[i].addr, sizeof(struct in6_addr));
+           ((struct sockaddr *)&(interface->if_addr))->sa_family = AF_INET6;
+           interface->af_family = AF_INET6;
+#else
+            rc = OPAL_ERR_NOT_SUPPORTED;
+            OBJ_RELEASE(interface);
+            goto out;
+#endif
+        } else {
+            BTL_ERROR(("Unexpected address family %d",
+                       (int)remote_addrs[i].addr_family));
+            rc = OPAL_ERR_BAD_PARAM;
+            OBJ_RELEASE(interface);
+            goto out;
+        }
+
+        btl_proc->proc_addrs[i].addr_port = remote_addrs[i].addr_port;
+        btl_proc->proc_addrs[i].addr_ifkindex = remote_addrs[i].addr_ifkindex;
+
+        interface->if_mask = remote_addrs[i].addr_mask;
+        interface->if_bandwidth = remote_addrs[i].addr_bandwidth;
+
+        opal_list_append(remote_list, &(interface->super));
+    }
+
+    rc = opal_bp_graph_create(NULL, NULL, &graph);
+    if (OPAL_SUCCESS != rc) {
+        goto out;
+    }
+    results = opal_reachable.reachable(local_list, remote_list);
+    if (NULL == results) {
+        rc = OPAL_ERROR;
+        goto err_graph;
+    }
+
+    /* Add vertices for each local node. These will store the btl index */
+    for (x = 0; x < results->num_local; x++) {
+        rc = opal_bp_graph_add_vertex(graph, &mca_btl_tcp_component.tcp_btls[x]->btl_index, &v_index);
+        if (OPAL_SUCCESS != rc) {
+            goto err_graph;
+        }
+    }
+
+    /* Add vertices for each remote node. These will store remote interface information */
+    for (y = 0; y < results->num_remote; y++) {
+        rc = opal_bp_graph_add_vertex(graph, &btl_proc->proc_addrs[y], &v_index);
+        if (OPAL_SUCCESS != rc) {
+            goto err_graph;
+        }
+    }
+
+    /* Add edges */
+    for (x = 0; x < results->num_local; x++) {
+        for (y = 0; y < results->num_remote; y++) {
+            /* The bipartite assignment solver will optimize a graph for
+             * least cost. Since weights vary from 0 as no connection and
+             * higher weights as better connections (multiplied by some other
+             * factors), higher weight is better. Thus, to achieve least cost,
+             * we set cost as negative weight.
+             */
+            cost = -results->weights[x][y];
+            /* Skip edges with no connections */
+            if (0 == cost) {
+                continue;
+            }
+            if (local_proc_is_left) {
+                u = MCA_BTL_TCP_PROC_LOCAL_VERTEX(x);
+                v = MCA_BTL_TCP_PROC_REMOTE_VERTEX(y);
+            } else {
+                u = MCA_BTL_TCP_PROC_REMOTE_VERTEX(y);
+                v = MCA_BTL_TCP_PROC_LOCAL_VERTEX(x);
+            }
+            rc = opal_bp_graph_add_edge(graph, u, v, cost, 1, NULL);
+            if (OPAL_SUCCESS != rc) {
+                goto err_graph;
+            }
+            num_edges++;
+        }
+    }
+
+    if (0 == num_edges) {
+        BTL_ERROR(("Unable to find reachable pairing between local and remote interfaces"));
+        rc = OPAL_ERR_UNREACH;
+    }
+
+    *graph_out = graph;
+    goto out;
+
+err_graph:
+    if (NULL != graph) {
+        opal_bp_graph_free(graph);
+    }
+out:
+    if (NULL != results) {
+        free(results);
+    }
+    if (NULL != remote_list) {
+        OBJ_RELEASE(remote_list);
+    }
+    return rc;
+}
+
+/* We store the matched interface data by using the btl_index as the key and
+ * a pointer to a mca_btl_tcp_addr_t struct.
+ */
+static int mca_btl_tcp_proc_store_matched_interfaces(mca_btl_tcp_proc_t *btl_proc,
+                                                     int local_proc_is_left,
+                                                     opal_bp_graph_t *graph,
+                                                     int num_matched, int *matched_edges)
+{
+    int rc = OPAL_SUCCESS;
+    int i, left, right;
+    uint32_t* local_index;
+    struct mca_btl_tcp_addr_t *remote_addr;
+
+    for (i = 0; i < num_matched; i++) {
+        left  = matched_edges[2 * i + 0];
+        right = matched_edges[2 * i + 1];
+        if (local_proc_is_left) {
+            rc = opal_bp_graph_get_vertex_data(graph, left, (void *)&local_index);
+            if (OPAL_SUCCESS != rc) {
+                goto out;
+            }
+            rc = opal_bp_graph_get_vertex_data(graph, right, (void *)&remote_addr);
+            if (OPAL_SUCCESS != rc) {
+                goto out;
+            }
+        } else {
+            rc = opal_bp_graph_get_vertex_data(graph, right, (void *)&local_index);
+            if (OPAL_SUCCESS != rc) {
+                goto out;
+            }
+            rc = opal_bp_graph_get_vertex_data(graph, left, (void *)&remote_addr);
+            if (OPAL_SUCCESS != rc) {
+                goto out;
+            }
+        }
+        opal_hash_table_set_value_uint32(&btl_proc->btl_index_to_endpoint, *local_index, (void *)remote_addr);
+    }
+out:
+    return rc;
+}
+
+static int mca_btl_tcp_proc_handle_modex_addresses(mca_btl_tcp_proc_t* btl_proc,
+                                                   mca_btl_tcp_modex_addr_t* remote_addrs,
+                                                   int local_proc_is_left)
+{
+    opal_bp_graph_t *graph = NULL;
+    int rc = OPAL_SUCCESS;
+    int num_matched = 0;
+    int *matched_edges = NULL;
+
+    rc = mca_btl_tcp_proc_create_interface_graph(btl_proc, remote_addrs, local_proc_is_left, &graph);
+    if (rc) {
+        goto cleanup;
+    }
+
+    rc = opal_bp_graph_solve_bipartite_assignment(graph, &num_matched, &matched_edges);
+    if (rc) {
+        goto cleanup;
+    }
+
+    rc = mca_btl_tcp_proc_store_matched_interfaces(btl_proc, local_proc_is_left,
+                                                   graph, num_matched, matched_edges);
+    if (rc) {
+        goto cleanup;
+    }
+
+cleanup:
+    if (NULL != graph) {
+        opal_bp_graph_free(graph);
+    }
+    return rc;
 }
 
 /*
@@ -117,9 +371,9 @@ void mca_btl_tcp_proc_destruct(mca_btl_tcp_proc_t* tcp_proc)
 mca_btl_tcp_proc_t* mca_btl_tcp_proc_create(opal_proc_t* proc)
 {
     mca_btl_tcp_proc_t* btl_proc;
-    int rc;
+    int rc, local_proc_is_left;
     mca_btl_tcp_modex_addr_t *remote_addrs = NULL;
-    size_t i, size;
+    size_t size;
 
     OPAL_THREAD_LOCK(&mca_btl_tcp_component.tcp_lock);
     rc = opal_proc_table_get_value(&mca_btl_tcp_component.tcp_procs,
@@ -168,34 +422,20 @@ mca_btl_tcp_proc_t* mca_btl_tcp_proc_create(opal_proc_t* proc)
         goto cleanup;
     }
 
-    /* the modex and proc structures differ slightly, so copy the
-       fields needed in the proc version */
-    for (i = 0 ; i < btl_proc->proc_addr_count ; i++) {
-        if (MCA_BTL_TCP_AF_INET == remote_addrs[i].addr_family) {
-            memcpy(&btl_proc->proc_addrs[i].addr_union.addr_inet,
-                   remote_addrs[i].addr, sizeof(struct in_addr));
-            btl_proc->proc_addrs[i].addr_port = remote_addrs[i].addr_port;
-            btl_proc->proc_addrs[i].addr_ifkindex = remote_addrs[i].addr_ifkindex;
-            btl_proc->proc_addrs[i].addr_family = AF_INET;
-            btl_proc->proc_addrs[i].addr_inuse = false;
-        } else if (MCA_BTL_TCP_AF_INET6 == remote_addrs[i].addr_family) {
-#if OPAL_ENABLE_IPV6
-            memcpy(&btl_proc->proc_addrs[i].addr_union.addr_inet6,
-                   remote_addrs[i].addr, sizeof(struct in6_addr));
-            btl_proc->proc_addrs[i].addr_port = remote_addrs[i].addr_port;
-            btl_proc->proc_addrs[i].addr_ifkindex = remote_addrs[i].addr_ifkindex;
-            btl_proc->proc_addrs[i].addr_family = AF_INET6;
-            btl_proc->proc_addrs[i].addr_inuse = false;
-#else
-            rc = OPAL_ERR_NOT_SUPPORTED;
-            goto cleanup;
-#endif
-        } else {
-            BTL_ERROR(("Unexpected address family %d",
-                       (int)remote_addrs[i].addr_family));
-            rc = OPAL_ERR_BAD_PARAM;
-            goto cleanup;
-        }
+    /* When solving for bipartite assignment, a graph with equal weights
+     * can provide different outputs depending on the input parameters.
+     * Thus two processes can construct different interface matchings.
+     * To avoid this case, we put the process with the lower jobid on the
+     * left or if they are equal, we use the lower vpid on the left.
+     *
+     * The concept of mirroring the local and remote sides is borrowed
+     * from the usnic btl implementation of its bipartite assignment solver.
+     */
+    local_proc_is_left = mca_btl_tcp_proc_is_proc_left(proc->proc_name, opal_proc_local_get()->proc_name);
+    rc = mca_btl_tcp_proc_handle_modex_addresses(btl_proc, remote_addrs, local_proc_is_left);
+
+    if (OPAL_SUCCESS != rc) {
+        goto cleanup;
     }
 
     /* allocate space for endpoint array - one for each exported address */
@@ -230,236 +470,33 @@ cleanup:
     return btl_proc;
 }
 
-
-
-static void evaluate_assignment(mca_btl_tcp_proc_data_t *proc_data, int *a) {
-    size_t i;
-    unsigned int max_interfaces = proc_data->num_local_interfaces;
-    int assignment_weight = 0;
-    int assignment_cardinality = 0;
-
-    if(max_interfaces < proc_data->num_peer_interfaces) {
-        max_interfaces = proc_data->num_peer_interfaces;
-    }
-
-    for(i = 0; i < max_interfaces; ++i) {
-        if(0 < proc_data->weights[i][a[i]-1]) {
-            ++assignment_cardinality;
-            assignment_weight += proc_data->weights[i][a[i]-1];
-        }
-    }
-
-    /*
-     * check wether current solution beats all previous solutions
-     */
-    if(assignment_cardinality > proc_data->max_assignment_cardinality
-            || (assignment_cardinality == proc_data->max_assignment_cardinality
-                && assignment_weight > proc_data->max_assignment_weight)) {
-
-        for(i = 0; i < max_interfaces; ++i) {
-             proc_data->best_assignment[i] = a[i]-1;
-        }
-        proc_data->max_assignment_weight = assignment_weight;
-        proc_data->max_assignment_cardinality = assignment_cardinality;
-    }
-}
-
-static void visit(mca_btl_tcp_proc_data_t *proc_data, int k, int level, int siz, int *a)
-{
-    level = level+1; a[k] = level;
-
-    if (level == siz) {
-        evaluate_assignment(proc_data, a);
-    } else {
-        int i;
-        for ( i = 0; i < siz; i++)
-            if (a[i] == 0)
-                visit(proc_data, i, level, siz, a);
-    }
-
-    level = level-1; a[k] = 0;
-}
-
-
-static void mca_btl_tcp_initialise_interface(mca_btl_tcp_interface_t* tcp_interface,
-        int ifk_index, int index)
-{
-    tcp_interface->kernel_index = ifk_index;
-    tcp_interface->peer_interface = -1;
-    tcp_interface->ipv4_address = NULL;
-    tcp_interface->ipv6_address =  NULL;
-    tcp_interface->index = index;
-    tcp_interface->inuse = 0;
-}
-
-static mca_btl_tcp_interface_t** mca_btl_tcp_retrieve_local_interfaces(mca_btl_tcp_proc_data_t *proc_data)
-{
-    struct sockaddr_storage local_addr;
-    char local_if_name[OPAL_IF_NAMESIZE];
-    char **include, **exclude, **argv;
-    int idx;
-    mca_btl_tcp_interface_t * local_interface;
-
-    assert (NULL == proc_data->local_interfaces);
-    if( NULL != proc_data->local_interfaces )
-        return proc_data->local_interfaces;
-
-    proc_data->max_local_interfaces = MAX_KERNEL_INTERFACES;
-    proc_data->num_local_interfaces = 0;
-    proc_data->local_interfaces = (mca_btl_tcp_interface_t**)calloc( proc_data->max_local_interfaces, sizeof(mca_btl_tcp_interface_t*) );
-    if( NULL == proc_data->local_interfaces )
-        return NULL;
-
-    /* Collect up the list of included and excluded interfaces, if any */
-    include = opal_argv_split(mca_btl_tcp_component.tcp_if_include,',');
-    exclude = opal_argv_split(mca_btl_tcp_component.tcp_if_exclude,',');
-
-    /*
-     * identify all kernel interfaces and the associated addresses of
-     * the local node
-     */
-    for( idx = opal_ifbegin(); idx >= 0; idx = opal_ifnext (idx) ) {
-        int kindex;
-        uint64_t index;
-        bool skip = false;
-
-        opal_ifindextoaddr (idx, (struct sockaddr*) &local_addr, sizeof (local_addr));
-        opal_ifindextoname (idx, local_if_name, sizeof (local_if_name));
-
-        /* If we were given a list of included interfaces, then check
-         * to see if the current one is a member of this set.  If so,
-         * drop down and complete processing.  If not, skip it and
-         * continue on to the next one.  Note that providing an include
-         * list will override providing an exclude list as the two are
-         * mutually exclusive.  This matches how it works in
-         * mca_btl_tcp_component_create_instances() which is the function
-         * that exports the interfaces.  */
-        if(NULL != include) {
-            argv = include;
-            skip = true;
-            while(argv && *argv) {
-                /* When comparing included interfaces, we look for exact matches.
-                   That is why we are using strcmp() here. */
-                if (0 == strcmp(*argv, local_if_name)) {
-                    skip = false;
-                    break;
-                }
-                argv++;
-            }
-        } else if (NULL != exclude) {
-            /* If we were given a list of excluded interfaces, then check to see if the
-             * current one is a member of this set.  If not, drop down and complete
-             * processing.  If so, skip it and continue on to the next one. */
-            argv = exclude;
-            while(argv && *argv) {
-                /* When looking for interfaces to exclude, we only look at
-                 * the number of characters equal to what the user provided.
-                 * For example, excluding "lo" excludes "lo", "lo0" and
-                 * anything that starts with "lo" */
-                if(0 == strncmp(*argv, local_if_name, strlen(*argv))) {
-                    skip = true;
-                    break;
-                }
-                argv++;
-            }
-        }
-        if (true == skip) {
-            /* This interface is not part of the requested set, so skip it */
-            continue;
-        }
-
-        kindex = opal_ifindextokindex(idx);
-        int rc = opal_hash_table_get_value_uint32(&proc_data->local_kindex_to_index, kindex, (void**) &index);
-
-        /* create entry for this kernel index previously not seen */
-        if (OPAL_SUCCESS != rc) {
-            index = proc_data->num_local_interfaces++;
-            opal_hash_table_set_value_uint32(&proc_data->local_kindex_to_index, kindex, (void*)(uintptr_t) index);
-
-            if( proc_data->num_local_interfaces == proc_data->max_local_interfaces ) {
-                proc_data->max_local_interfaces <<= 1;
-                proc_data->local_interfaces = (mca_btl_tcp_interface_t**)realloc( proc_data->local_interfaces,
-                                                                                  proc_data->max_local_interfaces * sizeof(mca_btl_tcp_interface_t*) );
-                if( NULL == proc_data->local_interfaces )
-                    goto cleanup;
-            }
-            proc_data->local_interfaces[index] = (mca_btl_tcp_interface_t *) malloc(sizeof(mca_btl_tcp_interface_t));
-            assert(NULL != proc_data->local_interfaces[index]);
-            mca_btl_tcp_initialise_interface(proc_data->local_interfaces[index], kindex, index);
-        }
-
-        local_interface = proc_data->local_interfaces[index];
-        switch(local_addr.ss_family) {
-        case AF_INET:
-            /* if AF is disabled, skip it completely */
-            if (4 == mca_btl_tcp_component.tcp_disable_family) {
-                continue;
-            }
-
-            local_interface->ipv4_address =
-                (struct sockaddr_storage*) malloc(sizeof(local_addr));
-            memcpy(local_interface->ipv4_address,
-                   &local_addr, sizeof(local_addr));
-            opal_ifindextomask(idx,
-                               &local_interface->ipv4_netmask,
-                               sizeof(int));
-            break;
-        case AF_INET6:
-            /* if AF is disabled, skip it completely */
-            if (6 == mca_btl_tcp_component.tcp_disable_family) {
-                continue;
-            }
-
-            local_interface->ipv6_address
-                = (struct sockaddr_storage*) malloc(sizeof(local_addr));
-            memcpy(local_interface->ipv6_address,
-                   &local_addr, sizeof(local_addr));
-            opal_ifindextomask(idx,
-                               &local_interface->ipv6_netmask,
-                               sizeof(int));
-            break;
-        default:
-            opal_output(0, "unknown address family for tcp: %d\n",
-                        local_addr.ss_family);
-        }
-    }
-cleanup:
-    if (NULL != include) {
-        opal_argv_free(include);
-    }
-    if (NULL != exclude) {
-        opal_argv_free(exclude);
-    }
-
-    return proc_data->local_interfaces;
-}
 /*
  * Note that this routine must be called with the lock on the process
  * already held.  Insert a btl instance into the proc array and assign
  * it an address.
  */
-int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
-                             mca_btl_base_endpoint_t* btl_endpoint )
+int mca_btl_tcp_proc_insert(mca_btl_tcp_proc_t* btl_proc,
+                            mca_btl_base_endpoint_t* btl_endpoint)
 {
-    struct sockaddr_storage endpoint_addr_ss;
+    mca_btl_tcp_module_t* tcp_btl = btl_endpoint->endpoint_btl;
     const char *proc_hostname;
-    unsigned int perm_size = 0;
-    int rc, *a = NULL;
-    size_t i, j;
-    mca_btl_tcp_interface_t** peer_interfaces = NULL;
-    mca_btl_tcp_proc_data_t _proc_data, *proc_data=&_proc_data;
-    size_t max_peer_interfaces;
-    char str_local[128], str_remote[128];
+    mca_btl_tcp_addr_t *remote_addr;
+    int rc = OPAL_SUCCESS;
 
     if (NULL == (proc_hostname = opal_get_proc_hostname(btl_proc->proc_opal))) {
-        return OPAL_ERR_UNREACH;
+        rc = OPAL_ERR_UNREACH;
+        goto out;
     }
 
-    memset(proc_data, 0, sizeof(mca_btl_tcp_proc_data_t));
-    OBJ_CONSTRUCT(&_proc_data.local_kindex_to_index, opal_hash_table_t);
-    opal_hash_table_init(&_proc_data.local_kindex_to_index, 8);
-    OBJ_CONSTRUCT(&_proc_data.peer_kindex_to_index, opal_hash_table_t);
-    opal_hash_table_init(&_proc_data.peer_kindex_to_index, 8);
+    rc = opal_hash_table_get_value_uint32(&btl_proc->btl_index_to_endpoint, tcp_btl->btl_index, (void **)&remote_addr);
+    if (OPAL_SUCCESS != rc) {
+        opal_output_verbose(10, opal_btl_base_framework.framework_output,
+                            "btl:tcp: host %s, process %s UNREACHABLE",
+                            proc_hostname,
+                            OPAL_NAME_PRINT(btl_proc->proc_opal->proc_name));
+        goto out;
+    }
+    btl_endpoint->endpoint_addr = remote_addr;
 
 #ifndef WORDS_BIGENDIAN
     /* if we are little endian and our peer is not so lucky, then we
@@ -476,304 +513,7 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
     btl_endpoint->endpoint_proc = btl_proc;
     btl_proc->proc_endpoints[btl_proc->proc_endpoint_count++] = btl_endpoint;
 
-    /* sanity checks */
-    if( NULL == mca_btl_tcp_retrieve_local_interfaces(proc_data) )
-        return OPAL_ERR_OUT_OF_RESOURCE;
-    if( 0 == proc_data->num_local_interfaces ) {
-        return OPAL_ERR_UNREACH;
-    }
-
-    max_peer_interfaces = proc_data->max_local_interfaces;
-    peer_interfaces = (mca_btl_tcp_interface_t**)calloc( max_peer_interfaces, sizeof(mca_btl_tcp_interface_t*) );
-    if (NULL == peer_interfaces) {
-        max_peer_interfaces = 0;
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        goto exit;
-    }
-    proc_data->num_peer_interfaces = 0;
-
-    /*
-     * identify all kernel interfaces and the associated addresses of
-     * the peer
-     */
-
-    for( i = 0; i < btl_proc->proc_addr_count; i++ ) {
-
-        uint64_t index;
-
-        mca_btl_tcp_addr_t* endpoint_addr = btl_proc->proc_addrs + i;
-
-        mca_btl_tcp_proc_tosocks (endpoint_addr, &endpoint_addr_ss);
-
-        rc = opal_hash_table_get_value_uint32(&proc_data->peer_kindex_to_index, endpoint_addr->addr_ifkindex, (void**) &index);
-
-        if (OPAL_SUCCESS != rc) {
-            index = proc_data->num_peer_interfaces++;
-            opal_hash_table_set_value_uint32(&proc_data->peer_kindex_to_index, endpoint_addr->addr_ifkindex, (void*)(uintptr_t) index);
-            if( proc_data->num_peer_interfaces == max_peer_interfaces ) {
-                max_peer_interfaces <<= 1;
-                peer_interfaces = (mca_btl_tcp_interface_t**)realloc( peer_interfaces,
-                                                                      max_peer_interfaces * sizeof(mca_btl_tcp_interface_t*) );
-                if( NULL == peer_interfaces ) {
-                    return OPAL_ERR_OUT_OF_RESOURCE;
-                }
-            }
-            peer_interfaces[index] = (mca_btl_tcp_interface_t *) malloc(sizeof(mca_btl_tcp_interface_t));
-            mca_btl_tcp_initialise_interface(peer_interfaces[index],
-                                             endpoint_addr->addr_ifkindex, index);
-        }
-
-        /*
-         * in case the peer address has created all intended connections,
-         * mark the complete peer interface as 'not available'
-         */
-        if(endpoint_addr->addr_inuse >=  mca_btl_tcp_component.tcp_num_links) {
-            peer_interfaces[index]->inuse = 1;
-        }
-
-        switch(endpoint_addr_ss.ss_family) {
-        case AF_INET:
-            peer_interfaces[index]->ipv4_address = (struct sockaddr_storage*) malloc(sizeof(endpoint_addr_ss));
-            peer_interfaces[index]->ipv4_endpoint_addr = endpoint_addr;
-            memcpy(peer_interfaces[index]->ipv4_address,
-                   &endpoint_addr_ss, sizeof(endpoint_addr_ss));
-            break;
-        case AF_INET6:
-            peer_interfaces[index]->ipv6_address = (struct sockaddr_storage*) malloc(sizeof(endpoint_addr_ss));
-            peer_interfaces[index]->ipv6_endpoint_addr = endpoint_addr;
-            memcpy(peer_interfaces[index]->ipv6_address,
-                   &endpoint_addr_ss, sizeof(endpoint_addr_ss));
-            break;
-        default:
-            opal_output(0, "unknown address family for tcp: %d\n",
-                        endpoint_addr_ss.ss_family);
-            return OPAL_ERR_UNREACH;
-        }
-    }
-
-    /*
-     * assign weights to each possible pair of interfaces
-     */
-
-    perm_size = proc_data->num_local_interfaces;
-    if(proc_data->num_peer_interfaces > perm_size) {
-        perm_size = proc_data->num_peer_interfaces;
-    }
-
-    proc_data->weights = (enum mca_btl_tcp_connection_quality**) malloc(perm_size
-                                                             * sizeof(enum mca_btl_tcp_connection_quality*));
-    assert(NULL != proc_data->weights);
-
-    proc_data->best_addr = (mca_btl_tcp_addr_t ***) malloc(perm_size
-                                                * sizeof(mca_btl_tcp_addr_t **));
-    assert(NULL != proc_data->best_addr);
-    for(i = 0; i < perm_size; ++i) {
-        proc_data->weights[i] = (enum mca_btl_tcp_connection_quality*) calloc(perm_size,
-                                                                   sizeof(enum mca_btl_tcp_connection_quality));
-        assert(NULL != proc_data->weights[i]);
-
-        proc_data->best_addr[i] = (mca_btl_tcp_addr_t **) calloc(perm_size,
-                                                      sizeof(mca_btl_tcp_addr_t *));
-        assert(NULL != proc_data->best_addr[i]);
-    }
-
-
-    for( i = 0; i < proc_data->num_local_interfaces; ++i ) {
-        mca_btl_tcp_interface_t* local_interface = proc_data->local_interfaces[i];
-        for( j = 0; j < proc_data->num_peer_interfaces; ++j ) {
-
-            /*  initially, assume no connection is possible */
-            proc_data->weights[i][j] = CQ_NO_CONNECTION;
-
-            /* check state of ipv4 address pair */
-            if(NULL != proc_data->local_interfaces[i]->ipv4_address &&
-               NULL != peer_interfaces[j]->ipv4_address) {
-
-                /* Convert the IPv4 addresses into nicely-printable strings for verbose debugging output */
-                inet_ntop(AF_INET, &(((struct sockaddr_in*) proc_data->local_interfaces[i]->ipv4_address))->sin_addr,
-                          str_local, sizeof(str_local));
-                inet_ntop(AF_INET, &(((struct sockaddr_in*) peer_interfaces[j]->ipv4_address))->sin_addr,
-                          str_remote, sizeof(str_remote));
-
-                if(opal_net_addr_isipv4public((struct sockaddr*) local_interface->ipv4_address) &&
-                   opal_net_addr_isipv4public((struct sockaddr*) peer_interfaces[j]->ipv4_address)) {
-                    if(opal_net_samenetwork((struct sockaddr*) local_interface->ipv4_address,
-                                            (struct sockaddr*) peer_interfaces[j]->ipv4_address,
-                                            local_interface->ipv4_netmask)) {
-                        proc_data->weights[i][j] = CQ_PUBLIC_SAME_NETWORK;
-                        opal_output_verbose(20, opal_btl_base_framework.framework_output,
-                                            "btl:tcp: path from %s to %s: IPV4 PUBLIC SAME NETWORK",
-                                            str_local, str_remote);
-                    } else {
-                        proc_data->weights[i][j] = CQ_PUBLIC_DIFFERENT_NETWORK;
-                        opal_output_verbose(20, opal_btl_base_framework.framework_output,
-                                            "btl:tcp: path from %s to %s: IPV4 PUBLIC DIFFERENT NETWORK",
-                                            str_local, str_remote);
-                    }
-                    proc_data->best_addr[i][j] = peer_interfaces[j]->ipv4_endpoint_addr;
-                    continue;
-                }
-                if(opal_net_samenetwork((struct sockaddr*) local_interface->ipv4_address,
-                                        (struct sockaddr*) peer_interfaces[j]->ipv4_address,
-                                        local_interface->ipv4_netmask)) {
-                    proc_data->weights[i][j] = CQ_PRIVATE_SAME_NETWORK;
-                    opal_output_verbose(20, opal_btl_base_framework.framework_output,
-                                       "btl:tcp: path from %s to %s: IPV4 PRIVATE SAME NETWORK",
-                                       str_local, str_remote);
-                } else {
-                    proc_data->weights[i][j] = CQ_PRIVATE_DIFFERENT_NETWORK;
-                    opal_output_verbose(20, opal_btl_base_framework.framework_output,
-                                       "btl:tcp: path from %s to %s: IPV4 PRIVATE DIFFERENT NETWORK",
-                                       str_local, str_remote);
-                }
-                proc_data->best_addr[i][j] = peer_interfaces[j]->ipv4_endpoint_addr;
-                continue;
-            }
-
-            /* check state of ipv6 address pair - ipv6 is always public,
-             * since link-local addresses are skipped in opal_ifinit()
-             */
-            if(NULL != local_interface->ipv6_address &&
-               NULL != peer_interfaces[j]->ipv6_address) {
-
-                /* Convert the IPv6 addresses into nicely-printable strings for verbose debugging output */
-                inet_ntop(AF_INET6, &(((struct sockaddr_in6*) local_interface->ipv6_address))->sin6_addr,
-                          str_local, sizeof(str_local));
-                inet_ntop(AF_INET6, &(((struct sockaddr_in6*) peer_interfaces[j]->ipv6_address))->sin6_addr,
-                          str_remote, sizeof(str_remote));
-
-                if(opal_net_samenetwork((struct sockaddr*) local_interface->ipv6_address,
-                                         (struct sockaddr*) peer_interfaces[j]->ipv6_address,
-                                         local_interface->ipv6_netmask)) {
-                    proc_data->weights[i][j] = CQ_PUBLIC_SAME_NETWORK;
-                    opal_output_verbose(20, opal_btl_base_framework.framework_output,
-                                       "btl:tcp: path from %s to %s: IPV6 PUBLIC SAME NETWORK",
-                                       str_local, str_remote);
-                } else {
-                    proc_data->weights[i][j] = CQ_PUBLIC_DIFFERENT_NETWORK;
-                    opal_output_verbose(20, opal_btl_base_framework.framework_output,
-                                       "btl:tcp: path from %s to %s: IPV6 PUBLIC DIFFERENT NETWORK",
-                                       str_local, str_remote);
-                }
-                proc_data->best_addr[i][j] = peer_interfaces[j]->ipv6_endpoint_addr;
-                continue;
-            }
-
-        } /* for each peer interface */
-    } /* for each local interface */
-
-    /*
-     * determine the size of the set to permute (max number of
-     * interfaces
-     */
-
-    proc_data->best_assignment = (unsigned int *) malloc (perm_size * sizeof(int));
-
-    a = (int *) malloc(perm_size * sizeof(int));
-    if (NULL == a) {
-        rc = OPAL_ERR_OUT_OF_RESOURCE;
-        goto exit;
-    }
-
-    /* Can only find the best set of connections when the number of
-     * interfaces is not too big.  When it gets larger, we fall back
-     * to a simpler and faster (and not as optimal) algorithm.
-     * See ticket https://svn.open-mpi.org/trac/ompi/ticket/2031
-     * for more details about this issue.  */
-    if (perm_size <= MAX_PERMUTATION_INTERFACES) {
-        memset(a, 0, perm_size * sizeof(int));
-        proc_data->max_assignment_cardinality = -1;
-        proc_data->max_assignment_weight = -1;
-        visit(proc_data, 0, -1, perm_size, a);
-
-        rc = OPAL_ERR_UNREACH;
-        for(i = 0; i < perm_size; ++i) {
-            unsigned int best = proc_data->best_assignment[i];
-            if(best > proc_data->num_peer_interfaces
-               || proc_data->weights[i][best] == CQ_NO_CONNECTION
-               || peer_interfaces[best]->inuse
-               || NULL == peer_interfaces[best]) {
-                continue;
-            }
-            peer_interfaces[best]->inuse++;
-            btl_endpoint->endpoint_addr = proc_data->best_addr[i][best];
-            btl_endpoint->endpoint_addr->addr_inuse = true;
-            rc = OPAL_SUCCESS;
-            break;
-        }
-    } else {
-        enum mca_btl_tcp_connection_quality max;
-        int i_max = 0, j_max = 0;
-        /* Find the best connection that is not in use.  Save away
-         * the indices of the best location. */
-        max = CQ_NO_CONNECTION;
-        for(i=0; i<proc_data->num_local_interfaces; ++i) {
-            for(j=0; j<proc_data->num_peer_interfaces; ++j) {
-                if (!peer_interfaces[j]->inuse) {
-                    if (proc_data->weights[i][j] > max) {
-                        max = proc_data->weights[i][j];
-                        i_max = i;
-                        j_max = j;
-                    }
-                }
-            }
-        }
-        /* Now see if there is a some type of connection available. */
-        rc = OPAL_ERR_UNREACH;
-        if (CQ_NO_CONNECTION != max) {
-            peer_interfaces[j_max]->inuse++;
-            btl_endpoint->endpoint_addr = proc_data->best_addr[i_max][j_max];
-            btl_endpoint->endpoint_addr->addr_inuse = true;
-            rc = OPAL_SUCCESS;
-        }
-    }
-    if (OPAL_ERR_UNREACH == rc) {
-        opal_output_verbose(10, opal_btl_base_framework.framework_output,
-                            "btl:tcp: host %s, process %s UNREACHABLE",
-                            proc_hostname,
-                            OPAL_NAME_PRINT(btl_proc->proc_opal->proc_name));
-    }
-
- exit:
-    // Ok to always free because proc_data() was memset() to 0 before
-    // any possible return (and free(NULL) is fine).
-    for(i = 0; i < perm_size; ++i) {
-        free(proc_data->weights[i]);
-        free(proc_data->best_addr[i]);
-    }
-
-    for(i = 0; i < proc_data->num_peer_interfaces; ++i) {
-        if(NULL != peer_interfaces[i]->ipv4_address) {
-            free(peer_interfaces[i]->ipv4_address);
-        }
-        if(NULL != peer_interfaces[i]->ipv6_address) {
-            free(peer_interfaces[i]->ipv6_address);
-        }
-        free(peer_interfaces[i]);
-    }
-    free(peer_interfaces);
-
-    for(i = 0; i < proc_data->num_local_interfaces; ++i) {
-        if(NULL != proc_data->local_interfaces[i]->ipv4_address) {
-            free(proc_data->local_interfaces[i]->ipv4_address);
-        }
-        if(NULL != proc_data->local_interfaces[i]->ipv6_address) {
-            free(proc_data->local_interfaces[i]->ipv6_address);
-        }
-        free(proc_data->local_interfaces[i]);
-    }
-    free(proc_data->local_interfaces); proc_data->local_interfaces = NULL;
-    proc_data->max_local_interfaces = 0;
-
-    free(proc_data->weights); proc_data->weights = NULL;
-    free(proc_data->best_addr); proc_data->best_addr = NULL;
-    free(proc_data->best_assignment); proc_data->best_assignment = NULL;
-
-    OBJ_DESTRUCT(&_proc_data.local_kindex_to_index);
-    OBJ_DESTRUCT(&_proc_data.peer_kindex_to_index);
-
-    free(a);
-
+out:
     return rc;
 }
 
@@ -795,12 +535,6 @@ int mca_btl_tcp_proc_remove(mca_btl_tcp_proc_t* btl_proc, mca_btl_base_endpoint_
                     OPAL_THREAD_UNLOCK(&btl_proc->proc_lock);
                     OBJ_RELEASE(btl_proc);
                     return OPAL_SUCCESS;
-                }
-                /* The endpoint_addr may still be NULL if this endpoint is
-                   being removed early in the wireup sequence (e.g., if it
-                   is unreachable by all other procs) */
-                if (NULL != btl_endpoint->endpoint_addr) {
-                    btl_endpoint->endpoint_addr->addr_inuse = false;
                 }
                 break;
             }

--- a/opal/mca/btl/tcp/btl_tcp_proc.h
+++ b/opal/mca/btl/tcp/btl_tcp_proc.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved
+ * Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,56 +55,14 @@ struct mca_btl_tcp_proc_t {
     size_t proc_endpoint_count;
     /**< number of endpoints */
 
+    opal_hash_table_t btl_index_to_endpoint;
+    /**< interface match table, matches btl_index to remote addresses of type mca_btl_tcp_addr_t */
+
     opal_mutex_t proc_lock;
     /**< lock to protect against concurrent access to proc state */
 };
 typedef struct mca_btl_tcp_proc_t mca_btl_tcp_proc_t;
 OBJ_CLASS_DECLARATION(mca_btl_tcp_proc_t);
-
-/*	the highest possible interface kernel index we can handle */
-#define MAX_KERNEL_INTERFACE_INDEX 65536
-
-/*	the maximum number of kernel interfaces we can handle */
-#define MAX_KERNEL_INTERFACES 8
-
-/* The maximum number of interfaces that we can have and use the
- * recursion code for determining the best set of connections.  When
- * the number is greater than this, we switch to a simpler algorithm
- * to speed things up. */
-#define MAX_PERMUTATION_INTERFACES 8
-
-/*
- * FIXME: this should probably be part of an ompi list, so we need the
- * appropriate definitions
- */
-
-struct mca_btl_tcp_interface_t {
-	struct sockaddr_storage* ipv4_address;
-	struct sockaddr_storage* ipv6_address;
-	mca_btl_tcp_addr_t* ipv4_endpoint_addr;
-	mca_btl_tcp_addr_t* ipv6_endpoint_addr;
-	uint32_t ipv4_netmask;
-	uint32_t ipv6_netmask;
-	int kernel_index;
-	int peer_interface;
-	int index;
-	int inuse;
-};
-
-typedef struct mca_btl_tcp_interface_t mca_btl_tcp_interface_t;
-
-/*
- * describes the quality of a possible connection between a local and
- * a remote network interface
- */
-enum mca_btl_tcp_connection_quality {
-	CQ_NO_CONNECTION,
-	CQ_PRIVATE_DIFFERENT_NETWORK,
-	CQ_PRIVATE_SAME_NETWORK,
-	CQ_PUBLIC_DIFFERENT_NETWORK,
-	CQ_PUBLIC_SAME_NETWORK
-};
-
 
 mca_btl_tcp_proc_t* mca_btl_tcp_proc_create(opal_proc_t* proc);
 mca_btl_tcp_proc_t* mca_btl_tcp_proc_lookup(const opal_process_name_t* name);


### PR DESCRIPTION
Previously we used a fairly simple algorithm in
mca_btl_tcp_proc_insert() to pair local and remote modules. This was a
point in time solution rather than a global optimization problem (where
global means all modules between two peers). The selection logic would
often fail due to pairing interfaces that are not routable for traffic.
The complexity of the selection logic was Θ(n^n), which was expensive.
Due to poor scalability, this logic was only used when the number of
interfaces was less than MAX_PERMUTATION_INTERFACES (default 8). More
details can be found in this ticket:
https://svn.open-mpi.org/trac/ompi/ticket/2031 (The complexity estimates
in the ticket do not match what I calculated from the function)
As a fallback, when interfaces surpassed this threshold, a brute force
O(n^2) double for loop was used to match interfaces.

This commit solves two problems. First, the point-in-time solution is
turned into a global optimization solution. Second, the reachability
framework was used to create a more realistic reachability map. We
switched from using IP/netmask to using the reachability framework,
which supports route lookup. This will help many corner cases as well as
utilize any future development of the reachability framework.

The solution implemented in this commit has a complexity mainly derived
from the bipartite assignment solver. If the local and remote peer both
have the same number of interfaces (n), the complexity of matching will
be O(n^5).

With the decrease in complexity to O(n^5), I calculated and tested
that initialization costs would be 5000 microseconds with 30 interfaces
per node (Likely close to the maximum realistic number of interfaces we
will encounter). For additional datapoints, data up to 300 (a very
unrealistic number) of interfaces was simulated. Up until 150
interfaces, the matching costs will be less than 1 second, climbing to
10 seconds with 300 interfaces. Reflecting on these results, I removed
the suboptimal O(n^2) fallback logic, as it no longer seems necessary.

Data was gathered comparing the scaling of initialization costs with
ranks. For low number of interfaces, the impact of initialization is
negligible. At an interface count of 7-8, the new code has slightly
faster initialization costs. At an interface count of 15, the new code
has slower initialization costs. However, all initialization costs
scale linearly with the number of ranks.

In order to use the reachable function, we populate local and remote
lists of interfaces. We then convert the interface matching problem
into a graph problem. We create a bipartite graph with the local and
remote interfaces as vertices and use negative reachability weights as
costs. Using the bipartite assignment solver, we generate the matches
for the graph. To ensure that both the local and remote process have
the same output, we ensure we mirror their respective inputs for the
graphs. Finally, we store the endpoint matches that we created earlier
in a hash table. This is stored with the btl_index as the key and a
struct mca_btl_tcp_addr_t* as the value. This is then retrieved during
insertion time to set the endpoint address.

Signed-off-by: William Zhang <wilzhang@amazon.com>