### PR TITLE
Shmem: use bitwise and instead of logical and to check for allocator capabilities

### DIFF
--- a/oshmem/mca/memheap/base/memheap_base_alloc.c
+++ b/oshmem/mca/memheap/base/memheap_base_alloc.c
@@ -70,7 +70,7 @@ int mca_memheap_alloc_with_hint(size_t size, long hint, void** ptr)
 
     for (i = 0; i < mca_memheap_base_map.n_segments; i++) {
         map_segment_t *s = &mca_memheap_base_map.mem_segs[i];
-        if (s->allocator && (hint && s->alloc_hints)) {
+        if (s->allocator && (hint & s->alloc_hints)) {
             /* Do not fall back to default allocator since it will break the
              * symmetry between PEs
              */


### PR DESCRIPTION
Found this while browsing the code. I believe the flags should be checked using bitwise and (&) instead of logical and (&&).

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>