### PR TITLE
c++: ifdef protect the VERSION file

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,7 @@
+#ifdef OMPI_BUILDING_CXX_BINDINGS_LIBRARY
+#include_next <version>
+#else
+#
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2008-2019 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
@@ -6,6 +10,8 @@
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 #                         reserved.
+# Copyright (c) 2019      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 
 # This is the VERSION file for Open MPI, describing the precise
 # version of Open MPI in this distribution.  The various components of
@@ -114,3 +120,5 @@ libmca_opal_common_ofi_so_version=0:0:0
 libmca_opal_common_sm_so_version=0:0:0
 libmca_opal_common_ucx_so_version=0:0:0
 libmca_opal_common_ugni_so_version=0:0:0
+
+#endif


### PR DESCRIPTION
From libc++ 8.0, a header file named "version" is included by the libc++ headers.
On a case insensitive filesystem, the VERSION file from Open MPI is used
instead of the libc++ header.
This commit protects the Open MPI VERSION file and #include_next <version>
in order to end up using the libc++ header.

Thanks Isuru Fernando for reporting and explaining this issue.

Refs. open-mpi/ompi#7155

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>