### PR TITLE
v4.0.x: Update IOF redirection options

### DIFF
--- a/orte/mca/iof/base/help-iof-base.txt
+++ b/orte/mca/iof/base/help-iof-base.txt
@@ -1,3 +1,4 @@
+# -*- text -*-
 #
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
@@ -9,23 +10,22 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2013      Los Alamos National Security, LLC. All rights reserved.
-# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2018      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+#
+[unrecognized-directive]
+The following directive was given to "--%s":
 
-dist_ortedata_DATA = base/help-iof-base.txt
+  Directive:     %s
 
-headers += \
-        base/base.h \
-	base/iof_base_setup.h
-
-libmca_iof_la_SOURCES += \
-        base/iof_base_frame.c \
-	base/iof_base_select.c \
-        base/iof_base_output.c \
-	base/iof_base_setup.c
+This directive is not recognized. Please check your spelling
+and/or use the "--help" option to find the supported values.
+#

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -14,9 +14,9 @@
  * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2017 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2017      UT-Battelle, LLC. All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -138,9 +138,13 @@ static opal_cmd_line_init_t cmd_line_init[] = {
     { "orte_timestamp_output", '\0', "timestamp-output", "timestamp-output", 0,
       &orte_cmd_options.timestamp_output, OPAL_CMD_LINE_TYPE_BOOL,
       "Timestamp all application process output", OPAL_CMD_LINE_OTYPE_OUTPUT },
+    { "orte_output_directory", '\0', "output-directory", "output-directory", 1,
+      &orte_cmd_options.output_directory, OPAL_CMD_LINE_TYPE_STRING,
+      "Redirect output from application processes into filename/job/rank/std[out,err,diag]. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOJOBID (do not include a job-id directory level) and NOCOPY (do not copy the output to the stdout/err streams)",
+      OPAL_CMD_LINE_OTYPE_OUTPUT },
     { "orte_output_filename", '\0', "output-filename", "output-filename", 1,
       &orte_cmd_options.output_filename, OPAL_CMD_LINE_TYPE_STRING,
-      "Redirect output from application processes into filename/job/rank/std[out,err,diag]. A relative path value will be converted to an absolute path",
+      "Redirect output from application processes into filename.rank. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOCOPY (do not copy the output to the stdout/err streams)",
       OPAL_CMD_LINE_OTYPE_OUTPUT },
     { NULL, '\0', "merge-stderr-to-stdout", "merge-stderr-to-stdout", 0,
       &orte_cmd_options.merge, OPAL_CMD_LINE_TYPE_BOOL,

--- a/orte/orted/help-orted.txt
+++ b/orte/orted/help-orted.txt
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -107,3 +107,12 @@ mechanisms.
 You may wish to contact your debugger vendor to inquire about support
 for PMIx-based debugger attachment mechanisms. Meantime, you can
 disable this warning by setting the OMPI_MPIR_DO_NOT_WARN envar to 1.
+#
+[both-file-and-dir-set]
+Both the "output-directory" and "output-filename" options have been
+set:
+
+  Directory:      %s
+  Filename:       %s
+
+Only one of these can be set - please fix the options and try again.

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -209,6 +209,10 @@ opal_cmd_line_init_t orte_cmd_line_opts[] = {
       &orted_globals.singleton_died_pipe, OPAL_CMD_LINE_TYPE_INT,
       "Watch on indicated pipe for singleton termination"},
 
+    { "orte_output_directory", '\0', "output-directory", "output-directory", 1,
+      NULL, OPAL_CMD_LINE_TYPE_STRING,
+      "Redirect output from application processes into filename/job/rank/std[out,err,diag]." },
+
     { "orte_output_filename", '\0', "output-filename", "output-filename", 1,
       NULL, OPAL_CMD_LINE_TYPE_STRING,
       "Redirect output from application processes into filename.rank" },

--- a/orte/orted/orted_submit.h
+++ b/orte/orted/orted_submit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -90,6 +90,7 @@ struct orte_cmd_options_t {
     bool debug;
     bool tag_output;
     bool timestamp_output;
+    char *output_directory;
     char *output_filename;
     bool merge;
     bool continuous;

--- a/orte/tools/orterun/orterun.1in
+++ b/orte/tools/orterun/orterun.1in
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
-.\" Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
+.\" Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 .\" Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
 .\"                         reserved.
 .\" $COPYRIGHT$
@@ -417,10 +417,25 @@ Redirect the stdout, stderr, and stddiag of all processes to a process-unique ve
 the specified filename. Any directories in the filename will automatically be created.
 Each output file will consist of filename.id, where the id will be the
 processes' rank in MPI_COMM_WORLD, left-filled with
-zero's for correct ordering in listings. A relative path value will be converted to an
+zero's for correct ordering in listings. Both stdout and stderr will be redirected to the file.
+A relative path value will be converted to an
 absolute path based on the cwd where mpirun is executed. Note that this \fIwill not\fP work
 on environments where the file system on compute nodes differs from that where mpirun
-is executed.
+is executed. This option accepts one case-insensitive directive, specified after a colon: NOCOPY
+indicates that the output is not to be echoed to the terminal.
+.
+.
+.TP
+.B -output-directory\fR,\fP --output-directory \fR<path>\fP
+Redirect the stdout, stderr, and stddiag of all processes to a process-unique location
+consisting of "<path>/<jobid>/rank.id/stdout[err]", where the id will be the
+processes' rank in MPI_COMM_WORLD, left-filled with
+zero's for correct ordering in listings. Any directories in the filename will automatically be created.
+A relative path value will be converted to an
+absolute path based on the cwd where mpirun is executed. Note that this \fIwill not\fP work
+on environments where the file system on compute nodes differs from that where mpirun
+is executed. This option also supports two case-insensitive directives, specified in comma-delimited form after a colon: NOJOBID (omits the jobid directory layer) and NOCOPY (do
+not copy the output to the terminal).
 .
 .
 .TP

--- a/orte/util/attr.c
+++ b/orte/util/attr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -379,6 +379,8 @@ const char *orte_attr_key_to_str(orte_attribute_key_t key)
             return "ORTE_APP_ADD_ENVAR";
         case ORTE_JOB_APP_SETUP_DATA:
             return "ORTE_JOB_APP_SETUP_DATA";
+        case ORTE_JOB_OUTPUT_TO_DIRECTORY:
+            return "ORTE_JOB_OUTPUT_TO_DIRECTORY";
 
         case ORTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/orte/util/attr.h
+++ b/orte/util/attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -140,7 +140,7 @@ typedef uint16_t orte_job_flags_t;
 #define ORTE_JOB_FIXED_DVM              (ORTE_JOB_START_KEY + 42)    // bool - do not change the size of the DVM for this job
 #define ORTE_JOB_DVM_JOB                (ORTE_JOB_START_KEY + 43)    // bool - job is using a DVM
 #define ORTE_JOB_CANCELLED              (ORTE_JOB_START_KEY + 44)    // bool - job was cancelled
-#define ORTE_JOB_OUTPUT_TO_FILE         (ORTE_JOB_START_KEY + 45)    // string - name of directory to which stdout/err is to be directed
+#define ORTE_JOB_OUTPUT_TO_FILE         (ORTE_JOB_START_KEY + 45)    // string - path to use as basename of files to which stdout/err is to be directed
 #define ORTE_JOB_MERGE_STDERR_STDOUT    (ORTE_JOB_START_KEY + 46)    // bool - merge stderr into stdout stream
 #define ORTE_JOB_TAG_OUTPUT             (ORTE_JOB_START_KEY + 47)    // bool - tag stdout/stderr
 #define ORTE_JOB_TIMESTAMP_OUTPUT       (ORTE_JOB_START_KEY + 48)    // bool - timestamp stdout/stderr
@@ -157,6 +157,7 @@ typedef uint16_t orte_job_flags_t;
 #define ORTE_JOB_APPEND_ENVAR           (ORTE_JOB_START_KEY + 58)    // opal_envar_t - append the specified value to the given envar
 #define ORTE_JOB_ADD_ENVAR              (ORTE_JOB_START_KEY + 59)    // opal_envar_t - add envar, do not override pre-existing one
 #define ORTE_JOB_APP_SETUP_DATA         (ORTE_JOB_START_KEY + 60)    // opal_byte_object_t - blob containing app setup data
+#define ORTE_JOB_OUTPUT_TO_DIRECTORY    (ORTE_JOB_START_KEY + 61)    // tring - path of directory to which stdout/err is to be directed
 
 #define ORTE_JOB_MAX_KEY   300
 


### PR DESCRIPTION
Provide both "--output-directory" and "--output-filename" options but do
not allow both to be given at the same time. Output-directory allows
specification of a directory, with output redirected into files of form
"\<directory>/\<jobid>/rank.\<vpid>/stdout[err]". This option also supports two
directives: nojobid (removes the jobid directory layer) and nocopy (do
not copy the output to the terminal).

Output-filename is the "old" behavior that names the output files as
"\<filename>.rank" with both stdout and stderr redirected into it. This
option only supports one directive: nocopy (do not copy the output to
the terminal).

Fix both the --help and man documentation.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit b0a487a3c7d463e63b9543f6c05c44a8d9cf7d36)