### PR TITLE
configure: use -iquote for non-system include paths

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -399,7 +399,7 @@ sub mca_generate_framework_header(\$\@) {
 #ifndef $ifdef_string
 #define $ifdef_string
 
-#include <opal/mca/base/mca_base_framework.h>
+#include \"opal/mca/base/mca_base_framework.h\"
 
 $framework_decl_output
 static mca_base_framework_t *${project}_frameworks[] = {

--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -117,6 +117,26 @@ AC_DEFUN([OPAL_PROG_CC_C11],[
     OPAL_VAR_SCOPE_POP
 ])
 
+# OPAL_CHECK_CC_IQUOTE()
+# ----------------------
+# Check if the compiler supports the -iquote option. This options
+# removes the specified directory from the search path when using
+# #include <>. This check works around an issue caused by C++20
+# which added a <version> header. This conflicts with the
+# VERSION file at the base of our source directory on case-
+# insensitive filesystems.
+AC_DEFUN([OPAL_CHECK_CC_IQUOTE],[
+    OPAL_VAR_SCOPE_PUSH([opal_check_cc_iquote_CFLAGS_save])
+    opal_check_cc_iquote_CFLAGS_save=${CFLAGS}
+    CFLAGS="${CFLAGS} -iquote ."
+    AC_MSG_CHECKING([for $CC option to add a directory only to the search path for the quote form of include])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[])],
+		      [opal_cc_iquote="-iquote"],
+		      [opal_cc_iquote="-I"])
+    CFLAGS=${opal_check_cc_iquote_CFLAGS_save}
+    OPAL_VAR_SCOPE_POP
+    AC_MSG_RESULT([$opal_cc_iquote])
+])
 
 # OPAL_SETUP_CC()
 # ---------------
@@ -139,6 +159,8 @@ AC_DEFUN([OPAL_SETUP_CC],[
     AC_SUBST([WRAPPER_CC])
 
     OPAL_PROG_CC_C11
+
+    OPAL_CHECK_CC_IQUOTE
 
     if test $opal_cv_c11_supported = no ; then
         # It is not currently an error if C11 support is not available. Uncomment the

--- a/config/opal_setup_cxx.m4
+++ b/config/opal_setup_cxx.m4
@@ -1,0 +1,251 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2006 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2006 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2006      Los Alamos National Security, LLC.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2007-2009 Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2008-2013 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015-2016 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# This macro is necessary to get the title to be displayed first.  :-)
+AC_DEFUN([OPAL_SETUP_CXX_BANNER],[
+    opal_show_subtitle "C++ compiler and preprocessor"
+])
+
+# This macro is necessary because PROG_CXX* is REQUIREd by multiple
+# places in SETUP_CXX.
+AC_DEFUN([OPAL_PROG_CXX],[
+    OPAL_VAR_SCOPE_PUSH([opal_cxxflags_save])
+    opal_cxxflags_save="$CXXFLAGS"
+    AC_PROG_CXX
+    AC_PROG_CXXCPP
+    CXXFLAGS="$opal_cxxflags_save"
+    OPAL_VAR_SCOPE_POP
+])
+
+# OPAL_SETUP_CXX()
+# ----------------
+# Do everything required to setup the C++ compiler.  Safe to AC_REQUIRE
+# this macro.
+AC_DEFUN([OPAL_SETUP_CXX],[
+    AC_REQUIRE([OPAL_SETUP_CXX_BANNER])
+
+    _OPAL_SETUP_CXX_COMPILER
+
+    OPAL_CXX_COMPILER_VENDOR([opal_cxx_vendor])
+
+    _OPAL_SETUP_CXX_COMPILER_BACKEND
+])
+
+# _OPAL_SETUP_CXX_COMPILER()
+# --------------------------
+# Setup the CXX compiler
+AC_DEFUN([_OPAL_SETUP_CXX_COMPILER],[
+    OPAL_VAR_SCOPE_PUSH(opal_cxx_compiler_works)
+
+    # Must REQUIRE the PROG_CXX macro and not call it directly here for
+    # reasons well-described in the AC2.64 (and beyond) docs.
+    AC_REQUIRE([OPAL_PROG_CXX])
+    BASECXX="`basename $CXX`"
+
+    AS_IF([test "x$CXX" = "x"], [CXX=none])
+    set dummy $CXX
+    opal_cxx_argv0=[$]2
+    OPAL_WHICH([$opal_cxx_argv0], [OPAL_CXX_ABSOLUTE])
+    AS_IF([test "x$OPAL_CXX_ABSOLUTE" = "x"], [OPAL_CXX_ABSOLUTE=none])
+
+    AC_DEFINE_UNQUOTED(OPAL_CXX, "$CXX", [OPAL underlying C++ compiler])
+    AC_SUBST(OPAL_CXX_ABSOLUTE)
+
+    OPAL_VAR_SCOPE_POP
+])
+
+# OPAL_CHECK_CXX_IQUOTE()
+# ----------------------
+# Check if the compiler supports the -iquote option. This options
+# removes the specified directory from the search path when using
+# #include <>. This check works around an issue caused by C++20
+# which added a <version> header. This conflicts with the
+# VERSION file at the base of our source directory on case-
+# insensitive filesystems.
+AC_DEFUN([OPAL_CHECK_CXX_IQUOTE],[
+    OPAL_VAR_SCOPE_PUSH([opal_check_cxx_iquote_CFLAGS_save])
+    opal_check_cxx_iquote_CFLAGS_save=${CFLAGS}
+    CXXFLAGS="${CFLAGS} -iquote ."
+    AC_MSG_CHECKING([for $CXX option to add a directory only to the search path for the quote form of include])
+    AC_LANG_PUSH(C++)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[])],
+		      [opal_cxx_iquote="-iquote"],
+		      [opal_cxx_iquote="-I"])
+    CXXFLAGS=${opal_check_cxx_iquote_CFLAGS_save}
+    AC_LANG_POP(C++)
+    OPAL_VAR_SCOPE_POP
+    AC_MSG_RESULT([$opal_cxx_iquote])
+])
+
+# _OPAL_SETUP_CXX_COMPILER_BACKEND()
+# ----------------------------------
+# Back end of _OPAL_SETUP_CXX_COMPILER_BACKEND()
+AC_DEFUN([_OPAL_SETUP_CXX_COMPILER_BACKEND],[
+    # Do we want code coverage
+    if test "$WANT_COVERAGE" = "1"; then
+        if test "$opal_cxx_vendor" = "gnu" ; then
+            AC_MSG_WARN([$OPAL_COVERAGE_FLAGS has been added to CFLAGS (--enable-coverage)])
+            WANT_DEBUG=1
+            CXXFLAGS="${CXXFLAGS} $OPAL_COVERAGE_FLAGS"
+            OPAL_WRAPPER_FLAGS_ADD([CXXFLAGS], [$OPAL_COVERAGE_FLAGS])
+        else
+            AC_MSG_WARN([Code coverage functionality is currently available only with GCC suite])
+            AC_MSG_ERROR([Configure: cannot continue])
+        fi
+    fi
+
+    # Do we want debugging?
+    if test "$WANT_DEBUG" = "1" && test "$enable_debug_symbols" != "no" ; then
+        CXXFLAGS="$CXXFLAGS -g"
+        OPAL_FLAGS_UNIQ(CXXFLAGS)
+        AC_MSG_WARN([-g has been added to CXXFLAGS (--enable-debug)])
+    fi
+
+    # These flags are generally g++-specific; even the g++-impersonating
+    # compilers won't accept them.
+    OPAL_CXXFLAGS_BEFORE_PICKY="$CXXFLAGS"
+    if test "$WANT_PICKY_COMPILER" = 1 && test "$opal_cxx_vendor" = "gnu"; then
+        add="-Wall -Wundef -Wno-long-long"
+
+        # see if -Wno-long-double works...
+        AC_LANG_PUSH(C++)
+        CXXFLAGS_orig="$CXXFLAGS"
+        CXXFLAGS="$CXXFLAGS $add -Wno-long-double -fstrict-prototype"
+        AC_CACHE_CHECK([if $CXX supports -Wno-long-double],
+            [opal_cv_cxx_wno_long_double],
+            [AC_TRY_COMPILE([], [],
+                [
+                 dnl So -Wno-long-double did not produce any errors...
+                 dnl We will try to extract a warning regarding
+                 dnl unrecognized or ignored options
+                 AC_TRY_COMPILE([], [long double test;],
+                     [
+                      opal_cv_cxx_wno_long_double="yes"
+                      if test -s conftest.err ; then
+                          dnl Yes, it should be "ignor", in order to catch ignoring and ignore
+                          for i in unknown invalid ignor unrecognized ; do
+                              $GREP -iq $i conftest.err
+                              if test "$?" = "0" ; then
+                                  opal_cv_cxx_wno_long_double="no"
+                                  break;
+                              fi
+                          done
+                      fi
+                     ],
+                     [opal_cv_cxx_wno_long_double="no"])],
+                [opal_cv_cxx_wno_long_double="no"])
+            ])
+
+        CXXFLAGS="$CXXFLAGS_orig"
+        AC_LANG_POP(C++)
+        if test "$opal_cv_cxx_wno_long_double" = "yes" ; then
+            add="$add -Wno-long-double"
+        fi
+
+        CXXFLAGS="$CXXFLAGS $add"
+        OPAL_FLAGS_UNIQ(CXXFLAGS)
+        if test "$add" != "" ; then
+            AC_MSG_WARN([$add has been added to CXXFLAGS (--enable-picky)])
+        fi
+        unset add
+    fi
+
+    # See if this version of g++ allows -finline-functions
+    if test "$GXX" = "yes"; then
+        CXXFLAGS_orig="$CXXFLAGS"
+        CXXFLAGS="$CXXFLAGS -finline-functions"
+        add=
+        AC_LANG_PUSH(C++)
+        AC_CACHE_CHECK([if $CXX supports -finline-functions],
+                   [opal_cv_cxx_finline_functions],
+                   [AC_TRY_COMPILE([], [],
+                                   [opal_cv_cxx_finline_functions="yes"],
+                                   [opal_cv_cxx_finline_functions="no"])])
+        AC_LANG_POP(C++)
+        if test "$opal_cv_cxx_finline_functions" = "yes" ; then
+            add=" -finline-functions"
+        fi
+        CXXFLAGS="$CXXFLAGS_orig$add"
+        OPAL_FLAGS_UNIQ(CXXFLAGS)
+        if test "$add" != "" ; then
+            AC_MSG_WARN([$add has been added to CXXFLAGS])
+        fi
+        unset add
+    fi
+
+    # Make sure we can link with the C compiler
+    if test "$opal_cv_cxx_compiler_vendor" != "microsoft"; then
+      OPAL_LANG_LINK_WITH_C([C++], [],
+        [cat <<EOF >&2
+**********************************************************************
+* It appears that your C++ compiler is unable to link against object
+* files created by your C compiler.  This generally indicates either
+* a conflict between the options specified in CFLAGS and CXXFLAGS
+* or a problem with the local compiler installation.  More
+* information (including exactly what command was given to the
+* compilers and what error resulted when the commands were executed) is
+* available in the config.log file in this directory.
+**********************************************************************
+EOF
+         AC_MSG_ERROR([C and C++ compilers are not link compatible.  Can not continue.])])
+    fi
+
+    # If we are on HP-UX, ensure that we're using aCC
+    case "$host" in
+    *hpux*)
+        if test "$BASECXX" = "CC"; then
+            AC_MSG_WARN([*** You will probably have problems compiling the MPI 2])
+            AC_MSG_WARN([*** C++ bindings with the HP-UX CC compiler.  You should])
+            AC_MSG_WARN([*** probably be using the aCC compiler.  Re-run configure])
+            AC_MSG_WARN([*** with the environment variable "CXX=aCC".])
+        fi
+        ;;
+    esac
+
+    # Note: gcc-imperonating compilers accept -O3
+    if test "$WANT_DEBUG" = "1"; then
+        OPTFLAGS=
+    else
+        if test "$GXX" = yes; then
+            OPTFLAGS="-O3"
+        else
+            OPTFLAGS="-O"
+        fi
+    fi
+
+    # config/opal_ensure_contains_optflags.m4
+    OPAL_ENSURE_CONTAINS_OPTFLAGS(["$CXXFLAGS"])
+    AC_MSG_CHECKING([for C++ optimization flags])
+    AC_MSG_RESULT([$co_result])
+    CXXFLAGS="$co_result"
+
+    # bool type size and alignment
+    AC_LANG_PUSH(C++)
+    AC_CHECK_SIZEOF(bool)
+    OPAL_C_GET_ALIGNMENT(bool, OPAL_ALIGNMENT_CXX_BOOL)
+    AC_LANG_POP(C++)
+
+    OPAL_CHECK_CXX_IQUOTE
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1266,10 +1266,16 @@ if test "$OMPI_TOP_BUILDDIR" != "$OMPI_TOP_SRCDIR"; then
     # rather than have successive assignments to these shell
     # variables, lest the $(foo) names try to get evaluated here.
     # Yuck!
-    CPPFLAGS='-I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/opal/include m4_ifdef([project_ompi], [-I$(top_srcdir)/ompi/include]) m4_ifdef([project_oshmem], [-I$(top_srcdir)/oshmem/include])'" $CPPFLAGS"
+    cpp_includes='$(top_srcdir) $(top_builddir) $(top_srcdir)/opal/include m4_ifdef([project_ompi], [$(top_srcdir)/ompi/include]) m4_ifdef([project_oshmem], [$(top_srcdir)/oshmem/include])'
 else
-    CPPFLAGS='-I$(top_srcdir)'" $CPPFLAGS"
+    cpp_includes='$(top_srcdir)'
 fi
+
+CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$opal_cc_iquote"'&/g')"
+CXX_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$opal_cxx_iquote"'&/g')"
+CPPFLAGS="$CPP_INCLUDES $CPPFLAGS"
+# C++ is only relevant if we're building OMPI
+m4_ifdef([project_ompi],[CXXCPPFLAGS="$CXX_INCLUDES $CXXCPPFLAGS"])
 
 # OMPI needs some additional processing of the flags (e.g., get
 # versions without optimization for debugger modules).

--- a/ompi/mca/coll/monitoring/coll_monitoring.h
+++ b/ompi/mca/coll/monitoring/coll_monitoring.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016      Inria.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -16,13 +16,13 @@
 
 BEGIN_C_DECLS
 
-#include <ompi_config.h>
-#include <ompi/mca/coll/coll.h>
-#include <ompi/op/op.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/mca/common/monitoring/common_monitoring.h>
+#include "ompi_config.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/common/monitoring/common_monitoring.h"
 
 struct mca_coll_monitoring_component_t {
     mca_coll_base_component_t super;

--- a/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allgather.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_allgather(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_allgatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allgatherv.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_allgatherv(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_allreduce.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/op/op.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_allreduce(const void *sbuf, void *rbuf, int count,

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoall.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_alltoall(const void *sbuf, int scount, struct ompi_datatype_t *sdtype,

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoallv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoallv.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_alltoallv(const void *sbuf, const int *scounts, const int *sdisps,

--- a/ompi/mca/coll/monitoring/coll_monitoring_alltoallw.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_alltoallw.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_alltoallw(const void *sbuf, const int *scounts,

--- a/ompi/mca/coll/monitoring/coll_monitoring_barrier.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_barrier.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,9 +9,9 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_barrier(struct ompi_communicator_t *comm,

--- a/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_bcast.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_bcast(void *buff, int count,

--- a/ompi/mca/coll/monitoring/coll_monitoring_component.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_component.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2016-2017 Inria.  All rights reserved.
  * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,12 +11,12 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "coll_monitoring.h"
-#include <ompi/constants.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/mca/coll/coll.h>
-#include <opal/mca/base/mca_base_component_repository.h>
+#include "ompi/constants.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/coll/coll.h"
+#include "opal/mca/base/mca_base_component_repository.h"
 
 #define MONITORING_SAVE_PREV_COLL_API(__module, __comm, __api)          \
     do {                                                                \

--- a/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_exscan.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/op/op.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_exscan(const void *sbuf, void *rbuf, int count,

--- a/ompi/mca/coll/monitoring/coll_monitoring_gather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_gather.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_gather(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_gatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_gatherv.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_gatherv(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgather.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/mca/topo/base/base.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_neighbor_allgather(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgatherv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_allgatherv.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -9,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/mca/topo/base/base.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_neighbor_allgatherv(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoall.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/mca/topo/base/base.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_neighbor_alltoall(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallv.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/mca/topo/base/base.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_neighbor_alltoallv(const void *sbuf, const int *scounts,

--- a/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallw.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_neighbor_alltoallw.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/mca/topo/base/base.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/topo/base/base.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_neighbor_alltoallw(const void *sbuf, const int *scounts,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/op/op.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_reduce(const void *sbuf, void *rbuf, int count,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/op/op.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_reduce_scatter(const void *sbuf, void *rbuf,

--- a/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_reduce_scatter_block.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/op/op.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_reduce_scatter_block(const void *sbuf, void *rbuf,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scan.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scan.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,11 +9,11 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/op/op.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/op/op.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_scan(const void *sbuf, void *rbuf, int count,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scatter.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_scatter(const void *sbuf, int scount,

--- a/ompi/mca/coll/monitoring/coll_monitoring_scatterv.c
+++ b/ompi/mca/coll/monitoring/coll_monitoring_scatterv.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,10 +9,10 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/communicator/communicator.h>
+#include "ompi_config.h"
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/communicator/communicator.h"
 #include "coll_monitoring.h"
 
 int mca_coll_monitoring_scatterv(const void *sbuf, const int *scounts, const int *disps,

--- a/ompi/mca/common/monitoring/common_monitoring.c
+++ b/ompi/mca/common/monitoring/common_monitoring.c
@@ -5,8 +5,8 @@
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
  * Copyright (c) 2015      Bull SAS.  All rights reserved.
- * Copyright (c) 2016-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
@@ -18,14 +18,14 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "common_monitoring.h"
 #include "common_monitoring_coll.h"
-#include <ompi/constants.h>
-#include <ompi/communicator/communicator.h>
-#include <opal/mca/base/mca_base_component_repository.h>
-#include <opal/class/opal_hash_table.h>
-#include <opal/util/output.h>
+#include "ompi/constants.h"
+#include "ompi/communicator/communicator.h"
+#include "opal/mca/base/mca_base_component_repository.h"
+#include "opal/class/opal_hash_table.h"
+#include "opal/util/output.h"
 #include "opal/util/printf.h"
 #include "opal/runtime/opal.h"
 #include <math.h>

--- a/ompi/mca/common/monitoring/common_monitoring.h
+++ b/ompi/mca/common/monitoring/common_monitoring.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,12 +14,12 @@
 
 BEGIN_C_DECLS
 
-#include <ompi_config.h>
-#include <ompi/proc/proc.h>
-#include <ompi/group/group.h>
-#include <ompi/communicator/communicator.h>
-#include <opal/class/opal_hash_table.h>
-#include <opal/mca/base/mca_base_pvar.h>
+#include "ompi_config.h"
+#include "ompi/proc/proc.h"
+#include "ompi/group/group.h"
+#include "ompi/communicator/communicator.h"
+#include "opal/class/opal_hash_table.h"
+#include "opal/mca/base/mca_base_pvar.h"
 
 #define MCA_MONITORING_MAKE_VERSION                                     \
     MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION)

--- a/ompi/mca/common/monitoring/common_monitoring_coll.c
+++ b/ompi/mca/common/monitoring/common_monitoring_coll.c
@@ -4,8 +4,8 @@
  *                         reserved.
  * Copyright (c) 2013-2018 Inria.  All rights reserved.
  * Copyright (c) 2015      Bull SAS.  All rights reserved.
- * Copyright (c) 2016-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -13,13 +13,13 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "common_monitoring.h"
 #include "common_monitoring_coll.h"
-#include <ompi/constants.h>
-#include <ompi/communicator/communicator.h>
-#include <opal/mca/base/mca_base_component_repository.h>
-#include <opal/class/opal_hash_table.h>
+#include "ompi/constants.h"
+#include "ompi/communicator/communicator.h"
+#include "opal/mca/base/mca_base_component_repository.h"
+#include "opal/class/opal_hash_table.h"
 #include <assert.h>
 
 /*** Monitoring specific variables ***/

--- a/ompi/mca/common/monitoring/common_monitoring_coll.h
+++ b/ompi/mca/common/monitoring/common_monitoring_coll.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2017      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,8 +17,8 @@
 
 BEGIN_C_DECLS
 
-#include <ompi_config.h>
-#include <opal/mca/base/mca_base_pvar.h>
+#include "ompi_config.h"
+#include "opal/mca/base/mca_base_pvar.h"
 
 OMPI_DECLSPEC void mca_common_monitoring_coll_flush(FILE *pf, mca_monitoring_coll_data_t*data);
 

--- a/ompi/mca/osc/monitoring/configure.m4
+++ b/ompi/mca/osc/monitoring/configure.m4
@@ -1,6 +1,8 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2016-2018 Inria.  All rights reserved.
+dnl Copyright (c) 2019      Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -45,9 +47,9 @@ AC_DEFUN(
 #ifndef MCA_OSC_MONITORING_GEN_TEMPLATE_H
 #define MCA_OSC_MONITORING_GEN_TEMPLATE_H
 
-#include <ompi_config.h>
-#include <ompi/mca/osc/osc.h>
-#include <ompi/mca/osc/monitoring/osc_monitoring_template.h>
+#include "ompi_config.h"
+#include "ompi/mca/osc/osc.h"
+#include "ompi/mca/osc/monitoring/osc_monitoring_template.h"
 
 /************************************************************/
 /* Include template generating macros and inlined functions */

--- a/ompi/mca/osc/monitoring/osc_monitoring.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2017 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,9 +14,9 @@
 
 BEGIN_C_DECLS
 
-#include <ompi_config.h>
-#include <ompi/mca/osc/osc.h>
-#include <ompi/mca/common/monitoring/common_monitoring.h>
+#include "ompi_config.h"
+#include "ompi/mca/osc/osc.h"
+#include "ompi/mca/common/monitoring/common_monitoring.h"
 
 struct ompi_osc_monitoring_component_t {
     ompi_osc_base_component_t super;

--- a/ompi/mca/osc/monitoring/osc_monitoring_accumulate.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_accumulate.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,9 +12,9 @@
 #ifndef MCA_OSC_MONITORING_ACCUMULATE_H
 #define MCA_OSC_MONITORING_ACCUMULATE_H
 
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/op/op.h>
-#include <ompi/win/win.h>
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/op/op.h"
+#include "ompi/win/win.h"
 
 #define OSC_MONITORING_GENERATE_TEMPLATE_ACCUMULATE(template)           \
                                                                         \

--- a/ompi/mca/osc/monitoring/osc_monitoring_active_target.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_active_target.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,8 +12,8 @@
 #ifndef MCA_OSC_MONITORING_ACTIVE_TARGET_H
 #define MCA_OSC_MONITORING_ACTIVE_TARGET_H
 
-#include <ompi/group/group.h>
-#include <ompi/win/win.h>
+#include "ompi/group/group.h"
+#include "ompi/win/win.h"
 
 #define OSC_MONITORING_GENERATE_TEMPLATE_ACTIVE_TARGET(template)        \
                                                                         \

--- a/ompi/mca/osc/monitoring/osc_monitoring_comm.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_comm.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2018 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,9 +12,9 @@
 #ifndef MCA_OSC_MONITORING_COMM_H
 #define MCA_OSC_MONITORING_COMM_H
 
-#include <ompi/request/request.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/win/win.h>
+#include "ompi/request/request.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/win/win.h"
 
 #define OSC_MONITORING_GENERATE_TEMPLATE_COMM(template)                 \
                                                                         \

--- a/ompi/mca/osc/monitoring/osc_monitoring_component.c
+++ b/ompi/mca/osc/monitoring/osc_monitoring_component.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016-2017 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -7,17 +9,17 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include <string.h>
 #include "osc_monitoring.h"
-#include <ompi/constants.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/info/info.h>
-#include <ompi/win/win.h>
-#include <ompi/info/info.h>
-#include <ompi/mca/osc/osc.h>
-#include <ompi/mca/osc/base/base.h>
-#include <opal/mca/base/mca_base_component_repository.h>
+#include "ompi/constants.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/info/info.h"
+#include "ompi/win/win.h"
+#include "ompi/info/info.h"
+#include "ompi/mca/osc/osc.h"
+#include "ompi/mca/osc/base/base.h"
+#include "opal/mca/base/mca_base_component_repository.h"
 
 /**************************************************/
 /* Include templated macros and inlined functions */

--- a/ompi/mca/osc/monitoring/osc_monitoring_dynamic.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_dynamic.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +12,7 @@
 #ifndef MCA_OSC_MONITORING_DYNAMIC_H
 #define MCA_OSC_MONITORING_DYNAMIC_H
 
-#include <ompi/win/win.h>
+#include "ompi/win/win.h"
 
 #define OSC_MONITORING_GENERATE_TEMPLATE_DYNAMIC(template)              \
                                                                         \

--- a/ompi/mca/osc/monitoring/osc_monitoring_module.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_module.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016-2017 Inria.  All rights reserved.
- * Copyright (c) 2017      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -14,9 +14,9 @@
 #ifndef MCA_OSC_MONITORING_MODULE_H
 #define MCA_OSC_MONITORING_MODULE_H
 
-#include <ompi/info/info.h>
-#include <ompi/win/win.h>
-#include <ompi/mca/osc/osc.h>
+#include "ompi/info/info.h"
+#include "ompi/win/win.h"
+#include "ompi/mca/osc/osc.h"
 
 /* Define once and for all the module_template variable name */
 #define OMPI_OSC_MONITORING_MODULE_VARIABLE(template)	\

--- a/ompi/mca/osc/monitoring/osc_monitoring_passive_target.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_passive_target.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +12,7 @@
 #ifndef MCA_OSC_MONITORING_PASSIVE_TARGET_H
 #define MCA_OSC_MONITORING_PASSIVE_TARGET_H
 
-#include <ompi/win/win.h>
+#include "ompi/win/win.h"
 
 #define OSC_MONITORING_GENERATE_TEMPLATE_PASSIVE_TARGET(template)       \
                                                                         \

--- a/ompi/mca/osc/monitoring/osc_monitoring_template.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_template.h
@@ -2,6 +2,8 @@
  * Copyright (c) 2016-2017 Inria.  All rights reserved.
  * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,10 +14,10 @@
 #ifndef MCA_OSC_MONITORING_TEMPLATE_H
 #define MCA_OSC_MONITORING_TEMPLATE_H
 
-#include <ompi_config.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/win/win.h>
-#include <opal/sys/atomic.h>
+#include "ompi_config.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/win/win.h"
+#include "opal/sys/atomic.h"
 #include "osc_monitoring_accumulate.h"
 #include "osc_monitoring_active_target.h"
 #include "osc_monitoring_comm.h"

--- a/ompi/mca/pml/monitoring/pml_monitoring.h
+++ b/ompi/mca/pml/monitoring/pml_monitoring.h
@@ -4,6 +4,8 @@
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
  * Copyright (c) 2015      Bull SAS.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,13 +18,13 @@
 
 BEGIN_C_DECLS
 
-#include <ompi_config.h>
-#include <ompi/communicator/communicator.h>
-#include <ompi/datatype/ompi_datatype.h>
-#include <ompi/mca/pml/pml.h>
-#include <ompi/mca/pml/base/base.h>
-#include <ompi/mca/common/monitoring/common_monitoring.h>
-#include <opal/mca/base/mca_base_pvar.h>
+#include "ompi_config.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/mca/pml/pml.h"
+#include "ompi/mca/pml/base/base.h"
+#include "ompi/mca/common/monitoring/common_monitoring.h"
+#include "opal/mca/base/mca_base_pvar.h"
 
 typedef mca_pml_base_module_t mca_pml_monitoring_module_t;
 

--- a/ompi/mca/pml/monitoring/pml_monitoring_comm.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_comm.c
@@ -3,6 +3,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +12,7 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "pml_monitoring.h"
 
 int mca_pml_monitoring_add_comm(struct ompi_communicator_t* comm)

--- a/ompi/mca/pml/monitoring/pml_monitoring_component.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_component.c
@@ -4,8 +4,8 @@
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
  * Copyright (c) 2015      Bull SAS.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
@@ -14,12 +14,12 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "pml_monitoring.h"
-#include <ompi/constants.h>
-#include <ompi/mca/pml/base/base.h>
-#include <ompi/mca/common/monitoring/common_monitoring.h>
-#include <opal/mca/base/mca_base_component_repository.h>
+#include "ompi/constants.h"
+#include "ompi/mca/pml/base/base.h"
+#include "ompi/mca/common/monitoring/common_monitoring.h"
+#include "opal/mca/base/mca_base_component_repository.h"
 
 static int mca_pml_monitoring_active = 0;
 

--- a/ompi/mca/pml/monitoring/pml_monitoring_iprobe.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_iprobe.c
@@ -3,6 +3,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +12,7 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "pml_monitoring.h"
 
 

--- a/ompi/mca/pml/monitoring/pml_monitoring_irecv.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_irecv.c
@@ -3,6 +3,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +12,7 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "pml_monitoring.h"
 
 

--- a/ompi/mca/pml/monitoring/pml_monitoring_isend.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_isend.c
@@ -3,6 +3,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2018 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,7 +12,7 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "pml_monitoring.h"
 
 int mca_pml_monitoring_isend_init(const void *buf,

--- a/ompi/mca/pml/monitoring/pml_monitoring_start.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_start.c
@@ -3,6 +3,8 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2018 Inria.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -10,9 +12,9 @@
  * $HEADER$
  */
 
-#include <ompi_config.h>
+#include "ompi_config.h"
 #include "pml_monitoring.h"
-#include <ompi/mca/pml/base/pml_base_request.h>
+#include "ompi/mca/pml/base/pml_base_request.h"
 
 /* manage persistant requests*/
 int mca_pml_monitoring_start(size_t count,

--- a/ompi/mpi/fortran/use-mpi-tkr/mpi.F90
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi.F90
@@ -11,8 +11,8 @@
 ! Copyright (c) 2004-2005 The Regents of the University of California.
 !                         All rights reserved.
 ! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
-! Copyright (c) 2016-2017 Research Organization for Information Science
-!                         and Technology (RIST). All rights reserved.
+! Copyright (c) 2016-2019 Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
 ! $COPYRIGHT$
 !
 ! Additional copyrights may follow
@@ -33,11 +33,11 @@ module mpi
 
 ! The MPI attribute callback functions
 
-  include "ompi/mpi/fortran/base/attr-fn-int-callback-interfaces.h"
+  include "../base/attr-fn-int-callback-interfaces.h"
 
 ! The MPI_CONVERSION_FN_NULL function
 
-  include "ompi/mpi/fortran/base/conversion-fn-null-int-interface.h"
+  include "../base/conversion-fn-null-int-interface.h"
 
 ! Functions that have overloaded interfaces with TYPE(C_PTR) (which
 ! this compiler may or may not support).  We use an "if" preprocessor

--- a/opal/mca/btl/vader/btl_vader_xpmem.h
+++ b/opal/mca/btl/vader/btl_vader_xpmem.h
@@ -27,8 +27,8 @@
   typedef int64_t xpmem_apid_t;
 #endif
 
-#include <opal/mca/rcache/base/rcache_base_vma.h>
-#include <opal/mca/rcache/rcache.h>
+#include "opal/mca/rcache/base/rcache_base_vma.h"
+#include "opal/mca/rcache/rcache.h"
 
 /* look up the remote pointer in the peer rcache and attach if
  * necessary */

--- a/opal/mca/hwloc/external/external.h
+++ b/opal/mca/hwloc/external/external.h
@@ -20,7 +20,7 @@
 
 BEGIN_C_DECLS
 
-#include <opal_config.h>
+#include "opal_config.h"
 
 /* Top-level configure will always configure the embedded hwloc
  * component, even if we already know that we'll be using an external

--- a/opal/mca/timer/altix/timer_altix.h
+++ b/opal/mca/timer/altix/timer_altix.h
@@ -19,7 +19,7 @@
 #ifndef OPAL_MCA_TIMER_ALTIX_TIMER_ALTIX_H
 #define OPAL_MCA_TIMER_ALTIX_TIMER_ALTIX_H
 
-#include <opal/sys/timer.h>
+#include "opal/sys/timer.h"
 
 extern opal_timer_t opal_timer_altix_freq;
 extern opal_timer_t opal_timer_altix_usec_conv;

--- a/opal/mca/timer/linux/timer_linux.h
+++ b/opal/mca/timer/linux/timer_linux.h
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +23,7 @@
 #define OPAL_MCA_TIMER_LINUX_TIMER_LINUX_H
 
 #include "opal_config.h"
-#include <opal/sys/timer.h>
+#include "opal/sys/timer.h"
 
 OPAL_DECLSPEC extern opal_timer_t (*opal_timer_base_get_cycles)(void);
 OPAL_DECLSPEC extern opal_timer_t (*opal_timer_base_get_usec)(void);

--- a/oshmem/include/pshmem.h
+++ b/oshmem/include/pshmem.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2014-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved
- * Copyright (c) 2016-2018 Research Organization for Information Science
+ * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
@@ -15,7 +15,7 @@
 #define PSHMEM_SHMEM_H
 
 #include <shmem.h>
-#include <pshmemx.h>
+#include "pshmemx.h"
 
 #if defined(c_plusplus) || defined(__cplusplus)
 extern "C" {

--- a/oshmem/include/shmem.h.in
+++ b/oshmem/include/shmem.h.in
@@ -2,8 +2,8 @@
  * Copyright (c) 2014-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved
- * Copyright (c) 2016      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -48,7 +48,7 @@
 #define OSHMEM_HAVE_C11 0
 #endif
 
-#include <shmem-compat.h>
+#include "shmem-compat.h"
 
 #if defined(c_plusplus) || defined(__cplusplus)
 extern "C" {

--- a/test/event/event-test.c
+++ b/test/event/event-test.c
@@ -27,7 +27,7 @@
 #include <errno.h>
 #include <unistd.h>
 
-#include <opal/mca/event/event.h>
+#include "opal/mca/event/event.h"
 #include "opal/runtime/opal.h"
 
 static void

--- a/test/event/signal-test.c
+++ b/test/event/signal-test.c
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <errno.h>
 
-#include <opal/mca/event/event.h>
+#include "opal/mca/event/event.h"
 #include "opal/runtime/opal.h"
 
 int called = 0;

--- a/test/event/time-test.c
+++ b/test/event/time-test.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <errno.h>
 
-#include <opal/event/event.h>
+#include "opal/event/event.h"
 
 int lasttime;
 


### PR DESCRIPTION
This fixes a bug in the configuration system identified by a
change in the C++ standard. C++20 adds a new mandatory header
named version. This (and any system) header will always be
included with <> and not "". On case-insensitive filesystems
this new header conflicts with the VERSION file at the top
level of the build tree.

To fix this issue Open MPI needs to use -iquote instead of -I
for non-system include paths to ensure that these include are
only searched for the quote form of include. This commit also
adds a check to ensure that if the compiler does not support
-iquote that it falls back to -I until support can be added.

Fixes #7155

Signed-off-by: Nathan Hjelm <hjelmn@google.com>