### PR TITLE
Nidmap.c and onesided_aggregation.c Compiler Warnings fix

### DIFF
--- a/ompi/mca/io/romio321/romio/adio/common/onesided_aggregation.c
+++ b/ompi/mca/io/romio321/romio/adio/common/onesided_aggregation.c
@@ -1966,7 +1966,7 @@ printf("iAmUsedAgg - currentRoundFDStart initialized "
       int *sourceAggBlockLengths=NULL;
       MPI_Aint *sourceAggDisplacements=NULL, *recvBufferDisplacements=NULL;
       MPI_Datatype *sourceAggDataTypes=NULL;
-      char *derivedTypePackedSourceBuffer;
+      char *derivedTypePackedSourceBuffer=NULL;
       int derivedTypePackedSourceBufferOffset = 0;
       int allocatedDerivedTypeArrays = 0;
       ADIO_Offset amountOfDataReadThisRoundAgg = 0;

--- a/orte/util/nidmap.c
+++ b/orte/util/nidmap.c
@@ -1123,7 +1123,7 @@ int orte_util_decode_ppn(orte_job_t *jdata,
 {
     orte_std_cntr_t index;
     orte_app_idx_t n;
-    int cnt, rc, m;
+    int cnt, rc=0, m;
     opal_byte_object_t *boptr;
     bool compressed;
     uint8_t *bytes;


### PR DESCRIPTION
There are some compiler warning messages that appear for uninitialized values for both nidmap.c and onesided_aggregation.c . I found the variables causing these issues.

For nidmap.c there was a declared variable rc which was not initialized so I set it = 0.

For onesided_aggregation.c there was a declared variable *derivedTypePackedSourceBuffer but not initialized. I found the variable declartion and initialized it to = NULL.

Signed-off-by: William Bailey <wbailey2@nd.edu>