### PR TITLE
Add detection for JSM direct launch

### DIFF
--- a/orte/mca/schizo/jsm/Makefile.am
+++ b/orte/mca/schizo/jsm/Makefile.am
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+          schizo_jsm_component.c \
+          schizo_jsm.h \
+          schizo_jsm.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_orte_schizo_jsm_DSO
+component_noinst =
+component_install = mca_schizo_jsm.la
+else
+component_noinst = libmca_schizo_jsm.la
+component_install =
+endif
+
+mcacomponentdir = $(ortelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_schizo_jsm_la_SOURCES = $(sources)
+mca_schizo_jsm_la_LDFLAGS = -module -avoid-version
+mca_schizo_jsm_la_LIBADD = $(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_schizo_jsm_la_SOURCES = $(sources)
+libmca_schizo_jsm_la_LDFLAGS = -module -avoid-version
+

--- a/orte/mca/schizo/jsm/configure.m4
+++ b/orte/mca/schizo/jsm/configure.m4
@@ -1,0 +1,31 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2016      Intel, Inc. All rights reserved
+# Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_schizo_jsm_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_orte_schizo_jsm_CONFIG],[
+    AC_CONFIG_FILES([orte/mca/schizo/jsm/Makefile])
+
+    # Nothing to do for now.
+])dnl

--- a/orte/mca/schizo/jsm/owner.txt
+++ b/orte/mca/schizo/jsm/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: IBM
+status: active

--- a/orte/mca/schizo/jsm/schizo_jsm.c
+++ b/orte/mca/schizo/jsm/schizo_jsm.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies Ltd.  All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "orte_config.h"
+#include "orte/types.h"
+#include "opal/types.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <ctype.h>
+
+#include "opal/util/argv.h"
+#include "opal/util/basename.h"
+#include "opal/util/opal_environ.h"
+
+#include "orte/runtime/orte_globals.h"
+#include "orte/util/name_fns.h"
+#include "orte/mca/schizo/base/base.h"
+
+#include "schizo_jsm.h"
+
+static orte_schizo_launch_environ_t check_launch_environment(void);
+static void finalize(void);
+
+orte_schizo_base_module_t orte_schizo_jsm_module = {
+    .check_launch_environment = check_launch_environment,
+    .finalize = finalize
+};
+
+static char **pushed_envs = NULL;
+static char **pushed_vals = NULL;
+static orte_schizo_launch_environ_t myenv;
+static bool myenvdefined = false;
+
+static orte_schizo_launch_environ_t check_launch_environment(void)
+{
+    int i;
+
+    if (myenvdefined) {
+        return myenv;
+    }
+    myenvdefined = true;
+
+    /* we were only selected because JSM was detected
+     * and we are an app, so no need to further check
+     * that here. Instead, see if we were direct launched
+     * vs launched via mpirun ('native') */
+    if (NULL != orte_process_info.my_daemon_uri) {
+        /* Use PMI(x) for daemon interactions */
+        myenv = ORTE_SCHIZO_NATIVE_LAUNCHED;
+        opal_argv_append_nosize(&pushed_envs, OPAL_MCA_PREFIX"ess");
+        opal_argv_append_nosize(&pushed_vals, "pmi");
+        /* mark that we are native */
+        opal_argv_append_nosize(&pushed_envs, "ORTE_SCHIZO_DETECTION");
+        opal_argv_append_nosize(&pushed_vals, "NATIVE");
+    }
+    else {
+        /* Use PMI(x) for daemon interactions */
+        myenv = ORTE_SCHIZO_DIRECT_LAUNCHED;
+        opal_argv_append_nosize(&pushed_envs, OPAL_MCA_PREFIX"ess");
+        opal_argv_append_nosize(&pushed_vals, "pmi");
+        /* mark that we are JSM */
+        opal_argv_append_nosize(&pushed_envs, "ORTE_SCHIZO_DETECTION");
+        opal_argv_append_nosize(&pushed_vals, "JSM");
+    }
+
+    /* We don't support singleton launch by JSM.
+     * If we did then the logic should be placed here.
+     */
+
+    opal_output_verbose(1, orte_schizo_base_framework.framework_output,
+                        "schizo:jsm DECLARED AS %s", orte_schizo_base_print_env(myenv));
+    if (NULL != pushed_envs) {
+        for (i=0; NULL != pushed_envs[i]; i++) {
+            opal_setenv(pushed_envs[i], pushed_vals[i], true, &environ);
+        }
+    }
+
+    return myenv;
+}
+
+
+static void finalize(void)
+{
+    int i;
+
+    if (NULL != pushed_envs) {
+        for (i=0; NULL != pushed_envs[i]; i++) {
+            opal_unsetenv(pushed_envs[i], &environ);
+        }
+        opal_argv_free(pushed_envs);
+        opal_argv_free(pushed_vals);
+    }
+}

--- a/orte/mca/schizo/jsm/schizo_jsm.h
+++ b/orte/mca/schizo/jsm/schizo_jsm.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef _MCA_SCHIZO_JSM_H_
+#define _MCA_SCHIZO_JSM_H_
+
+#include "orte_config.h"
+
+#include "orte/types.h"
+
+#include "opal/mca/base/base.h"
+#include "orte/mca/schizo/schizo.h"
+
+
+BEGIN_C_DECLS
+
+ORTE_MODULE_DECLSPEC extern orte_schizo_base_component_t mca_schizo_jsm_component;
+extern orte_schizo_base_module_t orte_schizo_jsm_module;
+
+END_C_DECLS
+
+#endif /* MCA_SCHIZO_JSM_H_ */
+

--- a/orte/mca/schizo/jsm/schizo_jsm_component.c
+++ b/orte/mca/schizo/jsm/schizo_jsm_component.c
@@ -1,0 +1,52 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "orte_config.h"
+#include "orte/types.h"
+#include "opal/types.h"
+
+#include "opal/util/show_help.h"
+
+#include "orte/mca/schizo/schizo.h"
+#include "schizo_jsm.h"
+
+static int component_query(mca_base_module_t **module, int *priority);
+
+/*
+ * Struct of function pointers and all that to let us be initialized
+ */
+orte_schizo_base_component_t mca_schizo_jsm_component = {
+    .base_version = {
+        MCA_SCHIZO_BASE_VERSION_1_0_0,
+        .mca_component_name = "jsm",
+        MCA_BASE_MAKE_VERSION(component, ORTE_MAJOR_VERSION, ORTE_MINOR_VERSION,
+                              ORTE_RELEASE_VERSION),
+        .mca_query_component = component_query,
+    },
+    .base_data = {
+        /* The component is checkpoint ready */
+        MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+};
+
+static int component_query(mca_base_module_t **module, int *priority)
+{
+    /* disqualify ourselves if we are not under jsm */
+    if (NULL == getenv("JSM_JSRUN_PORT")) {
+        *priority = 0;
+        *module = NULL;
+        return OPAL_ERROR;
+    }
+
+    *module = (mca_base_module_t*)&orte_schizo_jsm_module;
+    *priority = 80;
+    return ORTE_SUCCESS;
+}


### PR DESCRIPTION
 * Adds the `schizo/jsm` component that detects if the process was
   direct launched with IBM's Job Step Manager (JSM). JSM is a PMIx
   enhanced runtime environment so flag it as such.