### PR TITLE
opal_check_alps: fix configure output

### DIFF
--- a/config/opal_check_alps.m4
+++ b/config/opal_check_alps.m4
@@ -101,6 +101,7 @@ AC_DEFUN([OPAL_CHECK_ALPS],[
                                     [opal_check_cray_alps_happy="no"])],
               [AS_IF([test "$with_alps" = "no"],
                      [AC_MSG_RESULT([no])
+                      opal_check_cray_alps_happy=no
                       $3],
                      [AS_IF([test "$with_alps" = "auto" || test "$with_alps" = "yes"],
                             [PKG_CHECK_MODULES_STATIC([CRAY_ALPSLLI], [cray-alpslli],


### PR DESCRIPTION
There was a path where OPAL_CHECK_ALPS would exit its testing but
still leave `opal_check_cray_alps_happy` blank.  Fix that by setting
it to "no".

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 26705efad0ab539031049d50f5e21775d9c3f84f)