### PR TITLE
v3.1.x: OPAL/MCA/BTL/OPENIB: Detect ConnectX-6 HCAs

### DIFF
--- a/opal/mca/btl/openib/mca-btl-openib-device-params.ini
+++ b/opal/mca/btl/openib/mca-btl-openib-device-params.ini
@@ -190,6 +190,15 @@ max_inline_data = 256
 
 ############################################################################
 
+[Mellanox ConnectX6]
+vendor_id = 0x2c9,0x5ad,0x66a,0x8f1,0x1708,0x03ba,0x15b3,0x119f
+vendor_part_id = 4123
+use_eager_rdma = 1
+mtu = 4096
+max_inline_data = 256
+
+############################################################################
+
 [IBM eHCA 4x and 12x]
 vendor_id = 0x5076
 vendor_part_id = 0

--- a/opal/mca/common/verbs/common_verbs_port.c
+++ b/opal/mca/common/verbs/common_verbs_port.c
@@ -94,6 +94,10 @@ int opal_common_verbs_port_bw(struct ibv_port_attr *port_attr,
         /* 12x */
         *bandwidth *= 12;
         break;
+    case 16:
+        /* 16x */
+        *bandwidth *= 16;
+        break;
     default:
         /* Who knows? */
         return OPAL_ERR_NOT_FOUND;


### PR DESCRIPTION
Equivalent of https://github.com/open-mpi/ompi/pull/7175 for 3.1.x