### PR TITLE
lustre: squash some compiler warnings

### DIFF
--- a/ompi/mca/fs/lustre/fs_lustre.c
+++ b/ompi/mca/fs/lustre/fs_lustre.c
@@ -92,7 +92,7 @@ mca_fs_lustre_component_file_query (ompio_file_t *fh, int *priority)
     if (!tmp) {
         /* The communicator might be NULL if we only want to delete the file */
         if (OMPIO_ROOT == fh->f_rank || MPI_COMM_NULL == fh->f_comm) {
-            fh->f_fstype = mca_fs_base_get_fstype ( fh->f_filename );
+            fh->f_fstype = mca_fs_base_get_fstype ( (char *)fh->f_filename );
         }
         if (fh->f_comm != MPI_COMM_NULL) {
             fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),

--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -34,11 +34,11 @@
 
 #include <sys/ioctl.h>
 
-static void *alloc_lum();
+static void *alloc_lum(void);
 
-static void *alloc_lum()
+static void *alloc_lum(void)
 {
-  int v1, v3, join;
+  int v1, v3;
 
   v1 = sizeof(struct lov_user_md_v1) +
     LOV_MAX_STRIPE_COUNT * sizeof(struct lov_user_ost_data_v1);


### PR DESCRIPTION
Compiling OMPI on cray systems using latest Cray compilers (clang based)
yielded some compiler warnings from ompio/lustre.  Squash these warnings.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>