### PR TITLE
cray ftn: modify fortran module loc checker

### DIFF
--- a/config/ompi_fortran_find_module_include_flag.m4
+++ b/config/ompi_fortran_find_module_include_flag.m4
@@ -11,6 +11,8 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2019      Triad National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -67,7 +69,12 @@ EOF
             if test "$ofi_module_flag" = ""; then
                 OPAL_LOG_COMMAND([$FC $FCFLAGS $FCFLAGS_f90 conftest.f90 ${flag}subdir $LDFLAGS $LIBS],
                         [AS_VAR_SET(fortran_inc_var, [$flag])
-                        ofi_module_flag="$flag"])
+                        ofi_module_flag="$flag"],
+dnl try and see if we need to link in a possible object file
+                        [OPAL_LOG_COMMAND([$FC $FCFLAGS $FCFLAGS_f90 conftest.f90 subdir/conftest-module.o \
+                                          ${flag}subdir $LDFLAGS $LIBS],
+                                          [AS_VAR_SET(fortran_inc_var, [$flag])
+                                           ofi_module_flag="$flag"],[])])
             fi
         done
         cd ..

--- a/config/ompi_fortran_find_module_include_flag.m4
+++ b/config/ompi_fortran_find_module_include_flag.m4
@@ -68,15 +68,15 @@ EOF
         for flag in $ofi_possible_flags; do
             if test "$ofi_module_flag" = ""; then
                 OPAL_LOG_COMMAND([$FC $FCFLAGS $FCFLAGS_f90 conftest.f90 ${flag}subdir $LDFLAGS $LIBS],
-                        [AS_VAR_SET(fortran_inc_var, [$flag])
-                        ofi_module_flag="$flag"],
+                        [ofi_module_flag=$flag],
 dnl try and see if we need to link in a possible object file
                         [OPAL_LOG_COMMAND([$FC $FCFLAGS $FCFLAGS_f90 conftest.f90 subdir/conftest-module.o \
                                           ${flag}subdir $LDFLAGS $LIBS],
-                                          [AS_VAR_SET(fortran_inc_var, [$flag])
-                                           ofi_module_flag="$flag"],[])])
+                                          [ofi_module_flag=$flag])])
             fi
         done
+        AS_IF([test -n "$ofi_module_flag"],
+              [AS_VAR_SET(fortran_inc_var, [$ofi_module_flag])])
         cd ..
         rm -rf conftest.$$
     ])


### PR DESCRIPTION
to support the Cray Fortran compiler.  Cray Fortran compiler does not
contain all symbol info in the module file, have to link with the *.o
created as part of module file compilation.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>