### PR TITLE
clang: pacify clang wrt ompi use of c11 atomics

### DIFF
--- a/opal/include/opal/sys/atomic_stdc.h
+++ b/opal/include/opal/sys/atomic_stdc.h
@@ -5,6 +5,8 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,9 +101,9 @@ static inline void opal_atomic_rmb (void)
 #define opal_atomic_compare_exchange_strong_acq(addr, oldval, newval)  atomic_compare_exchange_strong_explicit (addr, oldval, newval, memory_order_acquire, memory_order_relaxed)
 #define opal_atomic_compare_exchange_strong_rel(addr, oldval, newval)  atomic_compare_exchange_strong_explicit (addr, oldval, newval, memory_order_release, memory_order_relaxed)
 
-#define opal_atomic_swap_32(addr, value) atomic_exchange_explicit (addr, value, memory_order_relaxed)
-#define opal_atomic_swap_64(addr, value) atomic_exchange_explicit (addr, value, memory_order_relaxed)
-#define opal_atomic_swap_ptr(addr, value) atomic_exchange_explicit (addr, value, memory_order_relaxed)
+#define opal_atomic_swap_32(addr, value) atomic_exchange_explicit ((_Atomic unsigned int *)addr, value, memory_order_relaxed)
+#define opal_atomic_swap_64(addr, value) atomic_exchange_explicit ((_Atomic unsigned long *)addr, value, memory_order_relaxed)
+#define opal_atomic_swap_ptr(addr, value) atomic_exchange_explicit ((_Atomic unsigned long *)addr, value, memory_order_relaxed)
 
 #define OPAL_ATOMIC_STDC_DEFINE_FETCH_OP(op, bits, type, operator)      \
     static inline type opal_atomic_fetch_ ## op ##_## bits (opal_atomic_ ## type *addr, type value) \


### PR DESCRIPTION
The clang compiler (or at least the one used by the Cray CCE 9 and newer)
doesn't like what we're doing passing non _Atomic pointers to C11 atomics.
Fix the ones that keep vader from compiling using Cray CCE 9 and 10.

It generates errors like this

```
In file included from btl_ugni_frag.c:13:
./btl_ugni.h:518:29: error: address argument to atomic operation must be a pointer to _Atomic type ('volatile int32_t *' (aka 'volatile int *') invalid)
    return (device->lock || opal_atomic_swap_32 (&device->lock, 1));
                            ^                    ~~~~~~~~~~~~~
../../../../opal/include/opal/sys/atomic_stdc.h:102:42: note: expanded from macro 'opal_atomic_swap_32'
#define opal_atomic_swap_32(addr, value) atomic_exchange_explicit (addr, value, memory_order_relaxed)
                                         ^                         ~~~~
/opt/cray/pe/cce/10.0.0.491/cce-clang/x86_64/lib/clang/10.0.0/include/stdatomic.h:124:34: note: expanded from macro 'atomic_exchange_explicit'
#define atomic_exchange_explicit __c11_atomic_exchange
                                 ^
In file included from btl_ugni_module.c:18:
./btl_ugni.h:518:29: error: address argument to atomic operation must be a pointer to _Atomic type ('volatile int32_t *' (aka 'volatile int *') invalid)
    return (device->lock || opal_atomic_swap_32 (&device->lock, 1));
                            ^                    ~~~~~~~~~~~~~
../../../../opal/include/opal/sys/atomic_stdc.h:102:42: note: expanded from macro 'opal_atomic_swap_32'
#define opal_atomic_swap_32(addr, value) atomic_exchange_explicit (addr, value, memory_order_relaxed)
 ```
Signed-off-by: Howard Pritchard <howardp@lanl.gov>