### PR TITLE
dist: Prep for 3.1.6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,8 +55,11 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
+3.1.6 -- TBD
+------------
+
 3.1.5 -- November, 2019
-----------------------
+-----------------------
 
 - Fix OMPIO issue limiting file reads/writes to 2GB.  Thanks to
   Richard Warren for reporting the issue.

--- a/VERSION
+++ b/VERSION
@@ -17,7 +17,7 @@
 
 major=3
 minor=1
-release=5
+release=6
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not
@@ -26,7 +26,7 @@ release=5
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=a1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
3.1.5 has shipped, on to 3.1.6

Signed-off-by: Brian Barrett <bbarrett@amazon.com>