### PR TITLE
Correctly set baseptr in contiguous shared memory window with local size zero

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -340,7 +340,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
             }
 
             module->sizes[i] = rbuf[i];
-            if (module->sizes[i]) {
+            if (module->sizes[i] || !module->noncontig) {
                 module->bases[i] = ((char *) module->segment_base) + total;
                 total += rbuf[i];
             } else {


### PR DESCRIPTION
The MPI standard mandates that for contiguous shared memory windows the returned `baseptr` can be used to directly calculate the remote addresses on other processes so we cannot return `NULL` if `size == 0`.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>