### PR TITLE
Fix Fortran st_size fields of mpi_fortran_argv_null_, mpi_fortran_weights_empty_, mpi_fortran_unweighted_, mpi_fortran_errcodes_ignore_, and mpi_fortran_argvs_null_

### DIFF
--- a/ompi/mpi/fortran/base/gen-mpi-mangling.pl
+++ b/ompi/mpi/fortran/base/gen-mpi-mangling.pl
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Subroutine to generate a bunch of Fortran declarations and symbols
@@ -62,33 +62,33 @@ $fortran->{in_place} = {
     f_name => "MPI_IN_PLACE",
 };
 $fortran->{unweighted} = {
-    c_type => "int *",
+    c_type => "int",
     c_name => "mpi_fortran_unweighted",
-    f_type => "integer",
+    f_type => "integer, dimension(1)",
     f_name => "MPI_UNWEIGHTED",
 };
 $fortran->{weights_empty} = {
-    c_type => "int *",
+    c_type => "int",
     c_name => "mpi_fortran_weights_empty",
-    f_type => "integer",
+    f_type => "integer, dimension(1)",
     f_name => "MPI_WEIGHTS_EMPTY",
 };
 
 $fortran->{argv_null} = {
-    c_type => "char *",
+    c_type => "char",
     c_name => "mpi_fortran_argv_null",
     f_type => "character, dimension(1)",
     f_name => "MPI_ARGV_NULL",
 };
 $fortran->{argvs_null} = {
-    c_type => "char *",
+    c_type => "char",
     c_name => "mpi_fortran_argvs_null",
     f_type => "character, dimension(1, 1)",
     f_name => "MPI_ARGVS_NULL",
 };
 
 $fortran->{errcodes_ignore} = {
-    c_type => "int *",
+    c_type => "int",
     c_name => "mpi_fortran_errcodes_ignore",
     f_type => "integer, dimension(1)",
     f_name => "MPI_ERRCODES_IGNORE",


### PR DESCRIPTION
Due to a GNU ld bug (https://sourceware.org/bugzilla/show_bug.cgi?id=25236),
the 5 common symbols are incorrectly versioned VER_NDX_LOCAL
because their definitions in Fortran sources have smaller st_size than
those in libmpi.so.

This makes the Fortran library not linkable with lld in distributions
that ship openmpi built with -Wl,--version-script
(https://bugs.llvm.org/show_bug.cgi?id=43748):

```
% mpifort -fuse-ld=lld /dev/null
ld.lld: error: corrupt input file: version definition index 0 for symbol
mpi_fortran_argv_null_ is out of bounds
>>> defined in /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_usempif08.so
...
```

Work around it by changing dimensions so that st_size of Fortran sources
are at least as large as those in libmpi.so (equal on 64-bit platforms).

This also fixes a minor issue that MPI_UNWEIGHTED and
MPI_WEIGHTS_EMPTY were not declared as arrays (not fully fixed by commit
107c0073dd11fb90d18122c521686f692a32cdd8).

Fixes open-mpi/ompi#7209