### PR TITLE
opal/util/error.c: fixed unused result message

### DIFF
--- a/opal/util/error.c
+++ b/opal/util/error.c
@@ -234,7 +234,10 @@ opal_delay_abort(void)
                      "[%s:%05d] Looping forever "
                      "(MCA parameter opal_abort_delay is < 0)\n",
                      opal_process_info.nodename, (int) pid);
-            write(STDERR_FILENO, msg, strlen(msg));
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wunused-result"
+            write(STDERR_FILENO, msg, strlen(msg)); /* this specific unused result warning gets ignored during compilation */
+        #pragma GCC diagnostic pop    
             while (1) {
                 sleep(5);
             }


### PR DESCRIPTION
Squashed compiler warning.
Ignoring the result is fine here because it is outputing an error so it doesn't matter if the write function fails.

Signed-off-by: William Bailey <wbailey2@nd.edu>