### PR TITLE
memory/patcher: fix compiler warning

### DIFF
--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -450,7 +450,7 @@ static void *_intercept_shmat(int shmid, const void *shmaddr, int shmflg)
 
     if (!original_shmat) {
 #if defined(SYS_shmat)
-        result = memory_patcher_syscall(SYS_shmat, shmid, shmaddr, shmflg);
+        result = (void*) memory_patcher_syscall(SYS_shmat, shmid, shmaddr, shmflg);
 #else // IPCOP_shmat
         unsigned long ret;
         ret = memory_patcher_syscall(SYS_ipc, IPCOP_shmat,


### PR DESCRIPTION
syscall() returns a long, but we are invoking shmat(), which returns
a void*.

Signed-off-by: Maxwell Coil <mcoil@nd.edu>