### PR TITLE
Harmonize return values of progress callbacks

### DIFF
--- a/ompi/communicator/comm_request.c
+++ b/ompi/communicator/comm_request.c
@@ -100,6 +100,7 @@ static int ompi_comm_request_progress (void)
 {
     ompi_comm_request_t *request, *next;
     static opal_atomic_int32_t progressing = 0;
+    int completed = 0;
 
     /* don't allow re-entry */
     if (opal_atomic_swap_32 (&progressing, 1)) {
@@ -126,6 +127,7 @@ static int ompi_comm_request_progress (void)
                     }
                     ompi_request_free (&subreq);
                     request_item->subreq_count--;
+                    completed++;
                 } else {
                     item_complete = false;
                     break;
@@ -163,7 +165,7 @@ static int ompi_comm_request_progress (void)
     opal_mutex_unlock (&ompi_comm_request_mutex);
     progressing = 0;
 
-    return 1;
+    return completed;
 }
 
 void ompi_comm_request_start (ompi_comm_request_t *request)

--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -427,6 +427,7 @@ ompi_coll_libnbc_progress(void)
 {
     ompi_coll_libnbc_request_t* request, *next;
     int res;
+    int completed = 0;
 
     if (0 == opal_list_get_size (&mca_coll_libnbc_component.active_requests)) {
         /* no requests -- nothing to do. do not grab a lock */
@@ -464,6 +465,7 @@ ompi_coll_libnbc_progress(void)
                 if(!request->super.super.req_persistent || !REQUEST_COMPLETE(&request->super.super)) {
             	    ompi_request_complete(&request->super.super, true);
                 }
+                completed++;
             }
             OPAL_THREAD_LOCK(&mca_coll_libnbc_component.lock);
         }
@@ -471,7 +473,7 @@ ompi_coll_libnbc_progress(void)
     }
     OPAL_THREAD_UNLOCK(&mca_coll_libnbc_component.lock);
 
-    return 0;
+    return completed;
 }
 
 

--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -403,7 +403,7 @@ int ompi_mtl_psm2_progress( void ) {
     mca_mtl_psm2_request_t* mtl_psm2_request;
     psm2_mq_status2_t psm2_status;
     psm2_mq_req_t req;
-    int completed = 1;
+    int completed = 0;
 
     do {
         OPAL_THREAD_LOCK(&mtl_psm2_mq_mutex);

--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -469,5 +469,5 @@ int ompi_mtl_psm2_progress( void ) {
     opal_show_help("help-mtl-psm2.txt",
 		   "error polling network", true,
 		   psm2_error_get_string(err));
-    return 1;
+    return OMPI_ERROR;
 }

--- a/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
+++ b/ompi/mca/osc/pt2pt/osc_pt2pt_component.c
@@ -153,6 +153,7 @@ static int component_register (void)
 
 static int component_progress (void)
 {
+    int completed = 0;
     int pending_count = opal_list_get_size (&mca_osc_pt2pt_component.pending_operations);
     int recv_count = opal_list_get_size (&mca_osc_pt2pt_component.pending_receives);
     ompi_osc_pt2pt_pending_t *pending, *next;
@@ -167,6 +168,7 @@ static int component_progress (void)
             }
 
             (void) ompi_osc_pt2pt_process_receive (recv);
+            completed++;
         }
     }
 
@@ -194,12 +196,13 @@ static int component_progress (void)
             if (OMPI_SUCCESS == ret) {
                 opal_list_remove_item (&mca_osc_pt2pt_component.pending_operations, &pending->super);
                 OBJ_RELEASE(pending);
+                completed++;
             }
         }
         OPAL_THREAD_UNLOCK(&mca_osc_pt2pt_component.pending_operations_lock);
     }
 
-    return 1;
+    return completed;
 }
 
 static int

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -514,8 +514,7 @@ int mca_pml_ucx_enable(bool enable)
 
 int mca_pml_ucx_progress(void)
 {
-    ucp_worker_progress(ompi_pml_ucx.ucp_worker);
-    return OMPI_SUCCESS;
+    return ucp_worker_progress(ompi_pml_ucx.ucp_worker);
 }
 
 int mca_pml_ucx_add_comm(struct ompi_communicator_t* comm)

--- a/ompi/request/grequestx.c
+++ b/ompi/request/grequestx.c
@@ -44,13 +44,11 @@ static int grequestx_progress(void) {
             MPI_Status status;
             OPAL_THREAD_UNLOCK(&lock);
             request->greq_poll.c_poll(request->greq_state, &status);
+            OPAL_THREAD_LOCK(&lock);
             if (REQUEST_COMPLETE(&request->greq_base)) {
-                OPAL_THREAD_LOCK(&lock);
                 opal_list_remove_item(&requests, &request->greq_base.super.super);
-                OPAL_THREAD_UNLOCK(&lock);
                 completed++;
             }
-            OPAL_THREAD_LOCK(&lock);
         }
         in_progress = false;
     }

--- a/ompi/request/grequestx.c
+++ b/ompi/request/grequestx.c
@@ -34,6 +34,7 @@ static opal_mutex_t lock;
 
 static int grequestx_progress(void) {
     ompi_grequest_t *request, *next;
+    int completed = 0;
 
     OPAL_THREAD_LOCK(&lock);
     if (!in_progress) {
@@ -47,6 +48,7 @@ static int grequestx_progress(void) {
                 OPAL_THREAD_LOCK(&lock);
                 opal_list_remove_item(&requests, &request->greq_base.super.super);
                 OPAL_THREAD_UNLOCK(&lock);
+                completed++;
             }
             OPAL_THREAD_LOCK(&lock);
         }
@@ -54,7 +56,7 @@ static int grequestx_progress(void) {
     }
     OPAL_THREAD_UNLOCK(&lock);
 
-    return OMPI_SUCCESS;
+    return completed;
 }
 
 int ompi_grequestx_start(

--- a/opal/mca/btl/uct/btl_uct_component.c
+++ b/opal/mca/btl/uct/btl_uct_component.c
@@ -563,6 +563,7 @@ static int mca_btl_uct_tl_progress (mca_btl_uct_tl_t *tl, int starting_index)
 static int mca_btl_uct_component_progress_pending (mca_btl_uct_module_t *uct_btl)
 {
     mca_btl_uct_base_frag_t *frag, *next;
+    int completed = 0;
     size_t count;
 
     if (0 == (count = opal_list_get_size (&uct_btl->pending_frags))) {
@@ -579,11 +580,13 @@ static int mca_btl_uct_component_progress_pending (mca_btl_uct_module_t *uct_btl
 
         if (OPAL_SUCCESS > mca_btl_uct_send_frag (uct_btl, frag, false)) {
             opal_list_prepend (&uct_btl->pending_frags, (opal_list_item_t *) frag);
+        } else {
+            completed++;
         }
     }
     OPAL_THREAD_UNLOCK(&uct_btl->lock);
 
-    return OPAL_SUCCESS;
+    return completed;
 }
 
 /**

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -165,7 +165,7 @@ OPAL_DECLSPEC void opal_common_ucx_wpool_free(opal_common_ucx_wpool_t *wpool);
 OPAL_DECLSPEC int opal_common_ucx_wpool_init(opal_common_ucx_wpool_t *wpool,
                                              int proc_world_size, bool enable_mt);
 OPAL_DECLSPEC void opal_common_ucx_wpool_finalize(opal_common_ucx_wpool_t *wpool);
-OPAL_DECLSPEC void opal_common_ucx_wpool_progress(opal_common_ucx_wpool_t *wpool);
+OPAL_DECLSPEC int opal_common_ucx_wpool_progress(opal_common_ucx_wpool_t *wpool);
 
 /* Manage Communication context */
 OPAL_DECLSPEC int opal_common_ucx_wpctx_create(opal_common_ucx_wpool_t *wpool, int comm_size,

--- a/oshmem/mca/spml/ucx/spml_ucx_component.c
+++ b/oshmem/mca/spml/ucx/spml_ucx_component.c
@@ -187,20 +187,21 @@ static int mca_spml_ucx_component_register(void)
 
 int spml_ucx_ctx_progress(void)
 {
-    int i;
+    int i, completed = 0;
     for (i = 0; i < mca_spml_ucx.active_array.ctxs_count; i++) {
-        ucp_worker_progress(mca_spml_ucx.active_array.ctxs[i]->ucp_worker[0]);
+        completed += ucp_worker_progress(mca_spml_ucx.active_array.ctxs[i]->ucp_worker[0]);
     }
-    return 1;
+    return completed;
 }
 
 int spml_ucx_default_progress(void)
 {
     unsigned int i=0;
+    int completed = 0;
     for (i = 0; i < mca_spml_ucx.ucp_workers; i++) {
-        ucp_worker_progress(mca_spml_ucx_ctx_default.ucp_worker[i]);
+        completed += ucp_worker_progress(mca_spml_ucx_ctx_default.ucp_worker[i]);
     }
-    return 1;
+    return completed;
 }
 
 int spml_ucx_progress_aux_ctx(void)


### PR DESCRIPTION
The logic in `opal_progress` expects a callback to return "the number of events progressed" and based on that determines whether or not to yield the CPU. Most components track the number of completed operations for that matter. However, some return a fixed value instead. The problem is that if a callback always returns a positive value (`psm2` mtl, `pt2pt` osc) the process will never yield if these components are active. Similarly, if the callback always returns `OMPI_SUCCESS` (or zero; `libnbc`, `ucx` pml, `uct` btl, `grequestx`), the process will yield unconditionally even if it wasn't necessary (plus, there is a mismatch in semantics in the first place). This PR tries to adapt the components in question to try to track whether progress has been made and signal it accordingly.

These changes should have no impact unless `yield_when_idle` is enabled.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>