### PR TITLE
v3.0.x: portals4: fix flow control bugs

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4.c
+++ b/ompi/mca/mtl/portals4/mtl_portals4.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010-2015 Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2010-2019 Sandia National Laboratories.  All rights reserved.
  * Copyright (c) 2014      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -551,12 +551,12 @@ ompi_mtl_portals4_finalize(struct mca_mtl_base_module_t *mtl)
     if (0 == ompi_mtl_portals4.need_init) {
         opal_progress_unregister(ompi_mtl_portals4_progress);
         while (0 != ompi_mtl_portals4_progress()) { }
-    }
 
 #if OMPI_MTL_PORTALS4_FLOW_CONTROL
-    ompi_mtl_portals4_flowctl_fini();
+        ompi_mtl_portals4_flowctl_fini();
 #endif
-    ompi_mtl_portals4_recv_short_fini();
+        ompi_mtl_portals4_recv_short_fini();
+    }
 
     if (!PtlHandleIsEqual(ompi_mtl_portals4.long_overflow_me_h, PTL_INVALID_HANDLE)) {
         PtlMEUnlink(ompi_mtl_portals4.long_overflow_me_h);

--- a/opal/mca/btl/portals4/configure.m4
+++ b/opal/mca/btl/portals4/configure.m4
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2010      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2010-2019 Sandia National Laboratories.  All rights reserved.
 # Copyright (c) 2014      Bull SAS.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -44,9 +44,9 @@ AC_DEFUN([MCA_opal_btl_portals4_CONFIG],[
        [AC_HELP_STRING([--enable-btl-portals4-flow-control],
            [enable flow control for Portals 4 BTL (default: disabled)])])
     AC_MSG_CHECKING([whether to enable flow control])
-    if test "$enable_btl_portals4_flow_control" != "yes"; then
-        AC_MSG_RESULT([no])
-        btl_portals4_flow_control_enabled=0
+    if test "$enable_btl_portals4_flow_control" != "no"; then
+        AC_MSG_RESULT([yes])
+        btl_portals4_flow_control_enabled=1
     else
         AC_MSG_RESULT([no])
         btl_portals4_flow_control_enabled=0


### PR DESCRIPTION
This PR fixes two flow control related bugs:
* a configure bug that caused btl-portals4 flow control to be disabled regardless of the configure options used.
* resolves an mtl-portals4 segfault by skipping the flow control fini() call if Portals4 was not initialized.
