### PR TITLE
mtl/ofi: ignore case when comparing provider names

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -330,7 +330,7 @@ is_in_list(char **list, char *item)
     }
 
     while (NULL != list[i]) {
-        if (0 == strncmp(item, list[i], strlen(list[i]))) {
+        if (0 == strncasecmp(item, list[i], strlen(list[i]))) {
             return 1;
         } else {
             i++;


### PR DESCRIPTION
Change the provider include and exclude list name comparison check to
ignore case. The UDP provider's name is uppercase and was being selected
despite being in the exclude list.

Signed-off-by: Robert Wespetal <wesper@amazon.com>