### PR TITLE
mca/plm/rsh: close only opened descriptors using /proc/self/fd

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -780,8 +780,9 @@ static void ssh_child(int argc, char **argv)
 
     /* close all file descriptors w/ exception of stdin/stdout/stderr */
     if(close_open_file_descriptors() != ORTE_SUCCESS) {
-        for(fd=3; fd<fdmax; fd++)
+        for(fd=3; fd<fdmax; fd++) {
             close(fd);
+        }
     }
 
     /* Set signal handlers back to the default.  Do this close


### PR DESCRIPTION
It takes a long time to call 'close' on all possible descriptor numbers
when _SC_OPEN_MAX is set to a high value.

Try to close only opened descriptors with the information provided from
procfs. If it fails, fallback to closing all possible descriptors.