### PR TITLE
MTL/OFI: Fix segfault when ompi_mtl_ofi_add_procs fails

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_endpoint.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_endpoint.h
@@ -41,7 +41,13 @@ typedef struct mca_mtl_ofi_endpoint_t  mca_mtl_ofi_endpoint_t;
 static inline mca_mtl_ofi_endpoint_t *ompi_mtl_ofi_get_endpoint (struct mca_mtl_base_module_t* mtl, ompi_proc_t *ompi_proc)
 {
     if (OPAL_UNLIKELY(NULL == ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL])) {
-        ompi_mtl_ofi_add_procs(mtl, 1, &ompi_proc);
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != ompi_mtl_ofi_add_procs(mtl, 1, &ompi_proc))) {
+            /* Fatal error. exit() out */
+            opal_output(0, "%s:%d: *** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
+                           __FILE__, __LINE__);
+            fflush(stderr);
+            exit(1);
+        }
     }
 
     return ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];


### PR DESCRIPTION
A segfault occurs when the return value of the function is not checked.
This code comes from 5cf43de which fixes the bug. The rest of the commit
did not cleanly apply.

Signed-off-by: William Zhang <wilzhang@amazon.com>