### PR TITLE
Add Probots: Stale and Lock

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,45 @@
+# Lock bot: https://github.com/apps/lock
+# Lock prbot: https://probot.github.io/apps/lock/
+# Main code repo: https://github.com/dessant/lock-threads
+
+# Open MPI policy:
+# - Lock issues and pull requests 6 months after they have been closed
+
+############################################################################
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 180
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,35 @@
+# Stale bot: https://github.com/apps/stale
+# Stale probot: https://probot.github.io/apps/stale/
+# Main code repo: 
+
+# Open MPI policy:
+# - Warn of pending closure for issues/pull requests if there is no
+#   activity on them for 90 days.
+# - If there's no more activity for 7 more days, close the issue.
+# - Never auto-close issues/pull requests with the label "pinned" or
+#   "security" on them.
+
+############################################################################
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in 7 days if no further activity occurs.
+  Thank you for your contributions!
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Let's discuss this at the first webex in 2020:

Finally make up a proposed config for ProBot's Stale and Lock bots:

* https://probot.github.io/apps/stale/
* https://probot.github.io/apps/lock/

The proposed config would work like this for abandoned issues/PRs:

1. Someone opens an issue
1. Nothing happens on it for 90 days.
1. The Stale bot adds a comment saying "Hey, nothing has happened; I'm going to close this in 7 days if nothing continues to happen."
1. Nothing continues to happen for 7 more days.
1. The Stale bot closes the issue.
1. Nothing continues to happen for 180 more days.
1. The Lock bot locks the issue (i.e., anyone who does not have write access on the repo can no longer comment on the issue).

There's currently one exception:

* An issue/PR will not be auto-closed if it has the label "pinned" or "security" set on it.