### PR TITLE
v3.1.x: Fix incorrect behavior with length == 0

### DIFF
--- a/ompi/datatype/ompi_datatype_create_contiguous.c
+++ b/ompi/datatype/ompi_datatype_create_contiguous.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -29,13 +29,12 @@ int32_t ompi_datatype_create_contiguous( int count, const ompi_datatype_t* oldTy
 {
     ompi_datatype_t* pdt;
 
-    if( 0 == count ) {
-        pdt = ompi_datatype_create( 0 );
-        ompi_datatype_add( pdt, &ompi_mpi_datatype_null.dt, 0, 0, 0 );
-    } else {
-        pdt = ompi_datatype_create( oldType->super.desc.used + 2 );
-        opal_datatype_add( &(pdt->super), &(oldType->super), count, 0, (oldType->super.ub - oldType->super.lb) );
+    if( (0 == count) || (0 == oldType->super.size) ) {
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
+
+    pdt = ompi_datatype_create( oldType->super.desc.used + 2 );
+    opal_datatype_add( &(pdt->super), &(oldType->super), count, 0, (oldType->super.ub - oldType->super.lb) );
     *newType = pdt;
     return OMPI_SUCCESS;
 }

--- a/ompi/datatype/ompi_datatype_create_darray.c
+++ b/ompi/datatype/ompi_datatype_create_darray.c
@@ -192,9 +192,7 @@ int32_t ompi_datatype_create_darray(int size,
     if (ndims < 1) {
         /* Don't just return MPI_DATATYPE_NULL as that can't be
            MPI_TYPE_FREE()ed, and that seems bad */
-        *newtype = ompi_datatype_create(0);
-        ompi_datatype_add(*newtype, &ompi_mpi_datatype_null.dt, 0, 0, 0);
-        return MPI_SUCCESS;
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newtype);
     }
 
     rc = ompi_datatype_type_extent(oldtype, &orig_extent);

--- a/ompi/datatype/ompi_datatype_create_vector.c
+++ b/ompi/datatype/ompi_datatype_create_vector.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -28,23 +28,14 @@
 
 #include "ompi/datatype/ompi_datatype.h"
 
-/* Open questions ...
- *  - how to improuve the handling of these vectors (creating a temporary datatype
- *    can be ONLY a initial solution.
- *
- */
-
 int32_t ompi_datatype_create_vector( int count, int bLength, int stride,
                                      const ompi_datatype_t* oldType, ompi_datatype_t** newType )
 {
     ompi_datatype_t *pTempData, *pData;
     ptrdiff_t extent = oldType->super.ub - oldType->super.lb;
 
-
-    if( 0 == count ) {
-        *newType = ompi_datatype_create( 0 );
-        ompi_datatype_add( *newType, &ompi_mpi_datatype_null.dt, 0, 0, 0);
-        return OMPI_SUCCESS;
+    if( (0 == count) || (0 == bLength) ) {
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
 
     pData = ompi_datatype_create( oldType->super.desc.used + 2 );
@@ -72,10 +63,8 @@ int32_t ompi_datatype_create_hvector( int count, int bLength, ptrdiff_t stride,
     ompi_datatype_t *pTempData, *pData;
     ptrdiff_t extent = oldType->super.ub - oldType->super.lb;
 
-    if( 0 == count ) {
-        *newType = ompi_datatype_create( 0 );
-        ompi_datatype_add( *newType, &ompi_mpi_datatype_null.dt, 0, 0, 0);
-        return OMPI_SUCCESS;
+    if( (0 == count) || (0 == bLength) ) {
+        return ompi_datatype_duplicate( &ompi_mpi_datatype_null.dt, newType);
     }
 
     pTempData = ompi_datatype_create( oldType->super.desc.used + 2 );


### PR DESCRIPTION
Cherry-pick f68b06e9 on the 3.1.
Fixes #6575.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>