### PR TITLE
oshmem/ucx: Fix progress in iput/iget: periodically poke progress to prevent hardware stalls when using DCT transport.

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.c
+++ b/oshmem/mca/spml/ucx/spml_ucx.c
@@ -774,6 +774,30 @@ int mca_spml_ucx_get_nb(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_
     return ucx_status_to_oshmem_nb(status);
 }
 
+int mca_spml_ucx_get_nb_wprogress(shmem_ctx_t ctx, void *src_addr, size_t size, void *dst_addr, int src, void **handle)
+{
+    unsigned int i;
+    void *rva;
+    ucs_status_t status;
+    spml_ucx_mkey_t *ucx_mkey;
+    mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
+
+    ucx_mkey = mca_spml_ucx_get_mkey(ctx, src, src_addr, &rva, &mca_spml_ucx);
+    status = ucp_get_nbi(ucx_ctx->ucp_peers[src].ucp_conn, dst_addr, size,
+                     (uint64_t)rva, ucx_mkey->rkey);
+
+    if (++ucx_ctx->nb_progress_cnt > mca_spml_ucx.nb_get_progress_thresh) {
+        for (i = 0; i < mca_spml_ucx.nb_ucp_worker_progress; i++) {
+            if (!ucp_worker_progress(ucx_ctx->ucp_worker)) {
+                ucx_ctx->nb_progress_cnt = 0;
+                break;
+            }
+        }
+    }
+
+    return ucx_status_to_oshmem_nb(status);
+}
+
 int mca_spml_ucx_put(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_addr, int dst)
 {
     void *rva;
@@ -822,7 +846,33 @@ int mca_spml_ucx_put_nb(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_
     return ucx_status_to_oshmem_nb(status);
 }
 
+int mca_spml_ucx_put_nb_wprogress(shmem_ctx_t ctx, void* dst_addr, size_t size, void* src_addr, int dst, void **handle)
+{
+    unsigned int i;
+    void *rva;
+    ucs_status_t status;
+    spml_ucx_mkey_t *ucx_mkey;
+    mca_spml_ucx_ctx_t *ucx_ctx = (mca_spml_ucx_ctx_t *)ctx;
 
+    ucx_mkey = mca_spml_ucx_get_mkey(ctx, dst, dst_addr, &rva, &mca_spml_ucx);
+    status = ucp_put_nbi(ucx_ctx->ucp_peers[dst].ucp_conn, src_addr, size,
+                     (uint64_t)rva, ucx_mkey->rkey);
+
+    if (OPAL_LIKELY(status >= 0)) {
+        mca_spml_ucx_remote_op_posted(ucx_ctx, dst);
+    }
+
+    if (++ucx_ctx->nb_progress_cnt > mca_spml_ucx.nb_put_progress_thresh) {
+        for (i = 0; i < mca_spml_ucx.nb_ucp_worker_progress; i++) {
+            if (!ucp_worker_progress(ucx_ctx->ucp_worker)) {
+                ucx_ctx->nb_progress_cnt = 0;
+                break;
+            }
+        }
+    }
+
+    return ucx_status_to_oshmem_nb(status);
+}
 
 int mca_spml_ucx_fence(shmem_ctx_t ctx)
 {
@@ -879,6 +929,8 @@ int mca_spml_ucx_quiet(shmem_ctx_t ctx)
             opal_progress();
         }
     }
+
+    ucx_ctx->nb_progress_cnt = 0;
 
     return OSHMEM_SUCCESS;
 }

--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -71,6 +71,7 @@ struct mca_spml_ucx_ctx {
     ucp_peer_t              *ucp_peers;
     long                     options;
     opal_bitmap_t            put_op_bitmap;
+    unsigned long            nb_progress_cnt;
     int                     *put_proc_indexes;
     unsigned                 put_proc_count;
 };
@@ -108,6 +109,10 @@ struct mca_spml_ucx {
     pthread_spinlock_t       async_lock;
     int                      aux_refcnt;
     bool                     synchronized_quiet;
+    unsigned long            nb_progress_thresh_global;
+    unsigned long            nb_put_progress_thresh;
+    unsigned long            nb_get_progress_thresh;
+    unsigned long            nb_ucp_worker_progress;
 };
 typedef struct mca_spml_ucx mca_spml_ucx_t;
 
@@ -122,7 +127,15 @@ extern int mca_spml_ucx_get(shmem_ctx_t ctx,
                               size_t size,
                               void* src_addr,
                               int src);
+
 extern int mca_spml_ucx_get_nb(shmem_ctx_t ctx,
+                              void* dst_addr,
+                              size_t size,
+                              void* src_addr,
+                              int src,
+                              void **handle);
+
+extern int mca_spml_ucx_get_nb_wprogress(shmem_ctx_t ctx,
                               void* dst_addr,
                               size_t size,
                               void* src_addr,
@@ -136,6 +149,13 @@ extern int mca_spml_ucx_put(shmem_ctx_t ctx,
                             int dst);
 
 extern int mca_spml_ucx_put_nb(shmem_ctx_t ctx,
+                               void* dst_addr,
+                               size_t size,
+                               void* src_addr,
+                               int dst,
+                               void **handle);
+
+extern int mca_spml_ucx_put_nb_wprogress(shmem_ctx_t ctx,
                                void* dst_addr,
                                size_t size,
                                void* src_addr,


### PR DESCRIPTION
Fixes a progress issue when excess iput/iget operations are issued when using DC, by periodically calling progress on ucx workers.

Co-authored with:
Artem Y. Polyakov <artemp@mellanox.com>,
Manjunath Gorentla Venkata <manjunath@mellanox.com>

Signed-off-by:
Tomislav Janjusic <tomislavj@mellanox.com>