### PR TITLE
Backport a fix for checking locking support in PMIx

### DIFF
--- a/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -808,6 +808,8 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     pmix_show_title "Dstore Locking"
 
     PMIX_CHECK_DSTOR_LOCK
+
+
 
     ############################################################################
     # final compiler config

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix_check_lock.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix_check_lock.m4
@@ -5,7 +5,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2017      IBM Corporation.  All rights reserved.
 dnl Copyright (c) 2017      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -14,35 +14,61 @@ dnl $HEADER$
 dnl
 
 AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
+
+    PMIX_VAR_SCOPE_PUSH(orig_libs pmix_prefer_write_nonrecursive)
+
     orig_libs=$LIBS
     LIBS="-lpthread $LIBS"
 
-    _x_ac_pthread_lock_found="0"
-    _x_ac_fcntl_lock_found="0"
+    _x_ac_pthread_lock_found=0
+    _x_ac_fcntl_lock_found=0
+    pmix_prefer_write_nonrecursive=0
 
-    AC_CHECK_MEMBERS([struct flock.l_type],
-    [
-        AC_DEFINE([HAVE_FCNTL_FLOCK], [1],
-        [Define to 1 if you have the locking by fcntl.])
-        _x_ac_fcntl_lock_found="1"
-    ], [], [#include <fcntl.h>])
+    AC_CHECK_MEMBER([struct flock.l_type],
+                    [pmix_fcntl_flock_happy=yes
+                     _x_ac_fcntl_lock_found=1],
+                    [pmix_fcntl_flock_happy=no],
+                    [#include <fcntl.h>])
 
     if test "$DSTORE_PTHREAD_LOCK" = "1"; then
+
+        AC_MSG_CHECKING([pthread_process_shared])
+        AC_EGREP_CPP([yes],
+                     [#include <pthread.h>
+                      #ifdef PTHREAD_PROCESS_SHARED
+                        yes
+                      #endif
+                     ],
+                     [AC_MSG_RESULT(yes)
+                      pmix_pthread_process_shared=yes],
+                     [AC_MSG_RESULT(no)
+                      pmix_pthread_process_shared=no])
+
         AC_CHECK_FUNC([pthread_rwlockattr_setkind_np],
-            [AC_EGREP_HEADER([PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP],
-                    [pthread.h],[
-                        AC_DEFINE([HAVE_PTHREAD_SETKIND], [1],
-                            [Define to 1 if you have the `pthread_rwlockattr_setkind_np` function.])])])
+                      [pmix_pthread_rwlockattr_setkind_np=yes
+                       AC_EGREP_CPP([yes],
+                                    [#include <pthread.h>
+                                     #ifdef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
+                                       yes
+                                     #endif
+                                    ],
+                                    [pmix_pthread_rwlock_prefer_writer_nonrecursive_np=yes],
+                                    [pmix_pthread_rwlock_prefer_writer_nonrecursive_np=no])],
+            [pmix_pthread_rwlockattr_setkind_np=no])
 
         AC_CHECK_FUNC([pthread_rwlockattr_setpshared],
-            [AC_EGREP_HEADER([PTHREAD_PROCESS_SHARED],
-                    [pthread.h],[
-                        AC_DEFINE([HAVE_PTHREAD_SHARED], [1],
-                            [Define to 1 if you have the `PTHREAD_PROCESS_SHARED` definition.
-                        ])
-                        _x_ac_pthread_lock_found="1"
-            ])
-        ])
+                      [pmix_pthread_rwlockattr_setpshared=yes
+                       AS_IF([test "$pmix_pthread_process_shared" = "yes"],
+                            [_x_ac_pthread_lock_found=1]]),
+                      [pmix_pthread_rwlockattr_setpshared=no])
+
+        AC_CHECK_FUNC([pthread_mutexattr_setpshared],
+                      [pmix_pthread_mutexattr_setpshared=yes],
+                      [pmix_pthread_mutexattr_setpshared=no])
+
+        AS_IF([test "$pmix_pthread_rwlockattr_setkind_np" = "yes" && test "$pmix_pthread_rwlock_prefer_writer_nonrecursive_np" = "yes"],
+              [pmix_prefer_write_nonrecursive=1],
+              [pmix_prefer_write_nonrecursive=0])
 
         if test "$_x_ac_pthread_lock_found" = "0"; then
             if test "$_x_ac_fcntl_lock_found" = "1"; then
@@ -57,6 +83,12 @@ AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
         fi
     fi
     LIBS="$orig_libs"
+
+    AC_DEFINE_UNQUOTED([PMIX_PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP],
+                       [$pmix_prefer_write_nonrecursive],
+                       [Whether or not we found the optional write_nonrecursive_np flag])
     AM_CONDITIONAL([HAVE_DSTORE_PTHREAD_LOCK], [test "$_x_ac_pthread_lock_found" = "1"])
     AM_CONDITIONAL([HAVE_DSTORE_FCNTL_LOCK], [test "$_x_ac_fcntl_lock_found" = "1"])
+
+    PMIX_VAR_SCOPE_POP
 ])

--- a/opal/mca/pmix/pmix2x/pmix/config/pmix_config_pthreads.m4
+++ b/opal/mca/pmix/pmix2x/pmix/config/pmix_config_pthreads.m4
@@ -10,7 +10,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2014-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
@@ -272,11 +272,6 @@ PMIX_INTL_POSIX_THREADS_SPECIAL_FLAGS
 
 # Try the normal linking methods (that's no fun)
 PMIX_INTL_POSIX_THREADS_LIBS
-
-#
-# check to see if we can create shared memory mutexes and conditions
-#
-AC_CHECK_FUNCS([pthread_mutexattr_setpshared pthread_condattr_setpshared])
 
 #
 # check to see if we can set error checking mutexes

--- a/opal/mca/pmix/pmix2x/pmix/src/mca/gds/ds12/configure.m4
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/gds/ds12/configure.m4
@@ -1,0 +1,34 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_gds_ds12_CONFIG([action-if-can-compile],
+#                     [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_gds_ds12_CONFIG],[
+    AC_CONFIG_FILES([src/mca/gds/ds12/Makefile])
+
+    AS_IF([test "$pmix_fcntl_flock_happy" = "yes"],
+          [$1],
+          [AS_IF([test "$pmix_pthread_rwlockattr_setpshared" = "yes" && test "$pmix_pthread_process_shared" = "yes"],
+                 [$1], [$2])])
+
+])dnl

--- a/opal/mca/pmix/pmix2x/pmix/src/mca/gds/ds12/gds_ds12_lock_pthread.c
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/gds/ds12/gds_ds12_lock_pthread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -138,7 +138,7 @@ pmix_status_t pmix_gds_ds12_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
             PMIX_ERROR_LOG(rc);
             goto error;
         }
-#ifdef HAVE_PTHREAD_SETKIND
+#ifdef PMIX_PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
         if (0 != pthread_rwlockattr_setkind_np(&attr,
                                 PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)) {
             pthread_rwlockattr_destroy(&attr);

--- a/opal/mca/pmix/pmix2x/pmix/src/mca/gds/ds21/configure.m4
+++ b/opal/mca/pmix/pmix2x/pmix/src/mca/gds/ds21/configure.m4
@@ -1,0 +1,32 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_gds_ds21_CONFIG([action-if-can-compile],
+#                     [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_gds_ds21_CONFIG],[
+    AC_CONFIG_FILES([src/mca/gds/ds21/Makefile])
+
+    AS_IF([test "$pmix_pthread_mutexattr_setpshared" = "yes" && test "$pmix_pthread_process_shared" = "yes"],
+          [$1], [$2])
+
+])dnl


### PR DESCRIPTION
Thanks to the problem report from Marco Atzeri: https://www.mail-archive.com/devel@lists.open-mpi.org//msg21000.html

Refs https://github.com/openpmix/openpmix/pull/1580

Signed-off-by: Ralph Castain <rhc@pmix.org>