### PR TITLE
dims_create: fix calculation of factors for odd squares (v3.0.x)

### DIFF
--- a/ompi/mpi/c/dims_create.c
+++ b/ompi/mpi/c/dims_create.c
@@ -240,7 +240,7 @@ getfactors(int num, int *nfactors, int **factors) {
     }
     /* determine all occurences of uneven prime numbers up to sqrt(num) */
     d = 3;
-    for(d = 3; (num > 1) && (d < sqrtnum); d += 2) {
+    for(d = 3; (num > 1) && (d <= sqrtnum); d += 2) {
         while((num % d) == 0) {
             num /= d;
             (*factors)[i++] = d;


### PR DESCRIPTION
This is a backport of #7189 onto the v3.0.x stable branch.

Until now sqrt(n) was missed as a factor for odd square numbers n. This
lead to suboptimal results of MPI_Dims_create for input numbers like 9,
25, 49, ... Fix the results by including sqrt(n) in the search for
factors.

Refs: #7186

Signed-off-by: Michael Lass <bevan@bi-co.net>
(cherry picked from commit 67490118adb8372d2aefe1d2d923432e51e100cd)