### PR TITLE
Fix some compiler warnings.

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -304,8 +304,8 @@ static int ompi_comm_allreduce_getnextcid (ompi_comm_request_t *request)
     ompi_comm_cid_context_t *context = (ompi_comm_cid_context_t *) request->context;
     int64_t my_id = ((int64_t) ompi_comm_get_cid (context->comm) << 32 | context->pml_tag);
     ompi_request_t *subreq;
-    bool flag;
-    int ret;
+    bool flag = false;
+    int ret = OMPI_SUCCESS;
     int participate = (context->newcomm->c_local_group->grp_my_rank != MPI_UNDEFINED);
 
     if (OPAL_THREAD_TRYLOCK(&ompi_cid_lock)) {

--- a/ompi/mca/coll/base/coll_base_util.c
+++ b/ompi/mca/coll/base/coll_base_util.c
@@ -255,7 +255,7 @@ static int free_vecs_callback(struct ompi_request_t **rptr) {
 }
 
 int ompi_coll_base_retain_datatypes_w( ompi_request_t *req,
-                                       ompi_datatype_t *stypes[], ompi_datatype_t *rtypes[]) {
+                                       ompi_datatype_t * const stypes[], ompi_datatype_t * const rtypes[]) {
     ompi_coll_base_nbc_request_t *request = (ompi_coll_base_nbc_request_t *)req;
     bool retain = false;
     ompi_communicator_t *comm = request->super.req_mpi_object.comm;
@@ -282,8 +282,8 @@ int ompi_coll_base_retain_datatypes_w( ompi_request_t *req,
         }
     }
     if (OPAL_UNLIKELY(retain)) {
-        request->data.vecs.stypes = stypes;
-        request->data.vecs.rtypes = rtypes;
+        request->data.vecs.stypes = (ompi_datatype_t **) stypes;
+        request->data.vecs.rtypes = (ompi_datatype_t **) rtypes;
         if (req->req_persistent) {
             request->cb.req_free = req->req_free;
             req->req_free = free_vecs_callback;

--- a/ompi/mca/coll/base/coll_base_util.h
+++ b/ompi/mca/coll/base/coll_base_util.h
@@ -124,8 +124,8 @@ int ompi_coll_base_retain_datatypes( ompi_request_t *request,
                                      ompi_datatype_t *rtype);
 
 int ompi_coll_base_retain_datatypes_w( ompi_request_t *request,
-                                       ompi_datatype_t *stypes[],
-                                       ompi_datatype_t *rtypes[]);
+                                       ompi_datatype_t * const stypes[],
+                                       ompi_datatype_t * const rtypes[]);
 
 END_C_DECLS
 #endif /* MCA_COLL_BASE_UTIL_EXPORT_H */

--- a/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
+++ b/ompi/mca/coll/tuned/coll_tuned_decision_fixed.c
@@ -806,8 +806,10 @@ int ompi_coll_tuned_scatter_intra_dec_fixed(const void *sbuf, int scount,
                                                      root, comm, module);
     } else if ((communicator_size < ompi_coll_tuned_scatter_min_procs) &&
                (communicator_size > intermediate_comm_size) &&
-               (block_size >= ompi_coll_tuned_scatter_intermediate_msg) &&
-               (block_size < ompi_coll_tuned_scatter_large_msg)) {
+               (ompi_coll_tuned_scatter_intermediate_msg > -1) &&
+               (block_size >= (size_t) ompi_coll_tuned_scatter_intermediate_msg) &&
+               (ompi_coll_tuned_scatter_large_msg > -1) &&
+               (block_size < (size_t) ompi_coll_tuned_scatter_large_msg)) {
         return ompi_coll_base_scatter_intra_linear_nb(sbuf, scount, sdtype,
                                                       rbuf, rcount, rdtype,
                                                       root, comm, module,

--- a/ompi/mca/io/ompio/io_ompio_file_read.c
+++ b/ompi/mca/io/ompio/io_ompio_file_read.c
@@ -161,10 +161,8 @@ int mca_io_ompio_file_iread_all (ompi_file_t *fh,
 {
     int ret = OMPI_SUCCESS;
     mca_common_ompio_data_t *data=NULL;
-    ompio_file_t *fp=NULL;
 
     data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
-    fp = &data->ompio_fh;
 
     OPAL_THREAD_LOCK(&fh->f_lock);
     ret = mca_common_ompio_file_iread_all (&data->ompio_fh,

--- a/ompi/mca/io/ompio/io_ompio_file_write.c
+++ b/ompi/mca/io/ompio/io_ompio_file_write.c
@@ -185,10 +185,8 @@ int mca_io_ompio_file_iwrite_all (ompi_file_t *fh,
 {
     int ret = OMPI_SUCCESS;
     mca_common_ompio_data_t *data=NULL;
-    ompio_file_t *fp=NULL;
 
     data = (mca_common_ompio_data_t *) fh->f_io_selected_data;
-    fp = &data->ompio_fh;
 
     OPAL_THREAD_LOCK(&fh->f_lock);
     ret = mca_common_ompio_file_iwrite_all (&data->ompio_fh,

--- a/ompi/mca/topo/treematch/treematch/tm_tree.c
+++ b/ompi/mca/topo/treematch/treematch/tm_tree.c
@@ -1769,7 +1769,6 @@ void group_nodes(tm_affinity_mat_t *aff_mat, tm_tree_t *tab_node, tm_tree_t *new
   int mat_order = aff_mat -> order;
   tm_tree_t **cur_group = NULL;
   int j, l;
-  unsigned long int list_size;
   unsigned long int  i;
   group_list_t list, **best_selection = NULL, **tab_group = NULL;
   double best_val, last_best;
@@ -1829,8 +1828,7 @@ void group_nodes(tm_affinity_mat_t *aff_mat, tm_tree_t *tab_node, tm_tree_t *new
     best_selection = (group_list_t **)MALLOC(sizeof(group_list_t*)*solution_size);
 
     list_all_possible_groups(cost_mat, tab_node, 0, arity, 0, cur_group, &list);
-    list_size = (int)list.val;
-    assert( list_size == nb_groups);
+    assert( (int)list.val == nb_groups);
     tab_group = (group_list_t**)MALLOC(sizeof(group_list_t*)*nb_groups);
     list_to_tab(list.next, tab_group, nb_groups);
     if(verbose_level>=INFO)

--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -330,7 +330,7 @@ static inline opal_object_t *opal_obj_new_debug(opal_class_t* type, const char* 
             OBJ_SET_MAGIC_ID((object), 0);                              \
             opal_obj_run_destructors((opal_object_t *) (object));       \
             OBJ_REMEMBER_FILE_AND_LINENO( object, __FILE__, __LINE__ ); \
-            free(object);                                               \
+            free((void *) object);                                      \
             object = NULL;                                              \
         }                                                               \
     } while (0)
@@ -339,7 +339,7 @@ static inline opal_object_t *opal_obj_new_debug(opal_class_t* type, const char* 
     do {                                                                \
         if (0 == opal_obj_update((opal_object_t *) (object), -1)) {     \
             opal_obj_run_destructors((opal_object_t *) (object));       \
-            free(object);                                               \
+            free((void *) object);                                      \
             object = NULL;                                              \
         }                                                               \
     } while (0)

--- a/opal/util/cmd_line.c
+++ b/opal/util/cmd_line.c
@@ -237,6 +237,8 @@ int opal_cmd_line_make_opt3(opal_cmd_line_t *cmd, char short_name,
 
     e.ocl_description = desc;
 
+    e.ocl_otype = OPAL_CMD_LINE_TYPE_NULL;
+
     return make_opt(cmd, &e);
 }
 

--- a/orte/util/nidmap.c
+++ b/orte/util/nidmap.c
@@ -231,7 +231,7 @@ int orte_util_decode_nidmap(opal_buffer_t *buf)
     orte_node_t *nd;
     orte_job_t *daemons;
     orte_proc_t *proc;
-    orte_topology_t *t;
+    orte_topology_t *t = NULL;
 
     /* unpack the flag indicating if HNP is in allocation */
     cnt = 1;


### PR DESCRIPTION
Silence unused variables, incompatible pointer types,
un-initialized variables, and signed/unsigned comparisons.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>