### PR TITLE
Release the vma_lock before deregistration to avoid deadlock

### DIFF
--- a/opal/mca/rcache/grdma/rcache_grdma_module.c
+++ b/opal/mca/rcache/grdma/rcache_grdma_module.c
@@ -175,15 +175,14 @@ static inline bool mca_rcache_grdma_evict_lru_local (mca_rcache_grdma_cache_t *c
     opal_mutex_lock (&cache->vma_module->vma_lock);
     old_reg = (mca_rcache_base_registration_t *)
         opal_list_remove_first (&cache->lru_list);
+    opal_mutex_unlock (&cache->vma_module->vma_lock);
     if (NULL == old_reg) {
-        opal_mutex_unlock (&cache->vma_module->vma_lock);
         return false;
     }
 
     rcache_grdma = (mca_rcache_grdma_module_t *) old_reg->rcache;
 
     (void) dereg_mem (old_reg);
-    opal_mutex_unlock (&cache->vma_module->vma_lock);
 
     rcache_grdma->stat_evicted++;
 


### PR DESCRIPTION
Don't hold the `vma_lock` while deregistering memory in `mca_rcache_grdma_evict_lru_local` as that may lead to a deadlock with other threads attempting to take the same lock while releasing memory.

See #7303 for more details.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>