### PR TITLE
Check the return from "chdir" to avoid infinite loop

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -4,7 +4,7 @@
 # Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2015      IBM Corporation.  All rights reserved.
@@ -172,7 +172,10 @@ sub process_subdir {
     # Chdir to the subdir
     print "\n=== Processing subdir: $dir\n";
     my $start = Cwd::cwd();
-    chdir($dir);
+    my $check = chdir($dir);
+    if (0 == $check) {
+        my_die "Could not change to $dir\n";
+    }
 
     # Run an action depending on what we find in that subdir
     if (-x "autogen.pl") {


### PR DESCRIPTION
When autogen attempts to change to a new directory while processing a
subdirectory, it can get into an infinite loop if that directory
doesn't exist as it will remain in the top-level directory, see itself
there (as "autogen.pl"), and re-execute itself. Check the return code on
"chdir" and error out if it fails.

Signed-off-by: Ralph Castain <rhc@pmix.org>