### PR TITLE
Trap wrong parameters to MPI_Init_thread.

### DIFF
--- a/ompi/errhandler/errhandler_predefined.c
+++ b/ompi/errhandler/errhandler_predefined.c
@@ -61,7 +61,7 @@ void ompi_mpi_errors_are_fatal_comm_handler(struct ompi_communicator_t **comm,
 
   va_start(arglist, error_code);
 
-  if (NULL != comm) {
+  if ( (NULL != comm) && (NULL != *comm) ) {
       name = (*comm)->c_name;
       abort_comm = *comm;
   } else {


### PR DESCRIPTION
Instead of triggering the errhandler early in the initialization process, do
a serialized initialization and report the error once all the supporting
infrastructure is up and running.

Fixes #7320 

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>