### PR TITLE
btl/vader: modify how the max attachment address is determined

### DIFF
--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -82,6 +83,7 @@ union vader_modex_t {
     struct vader_modex_xpmem_t {
         xpmem_segid_t seg_id;
         void *segment_base;
+        uintptr_t address_max;
     } xpmem;
 #endif
     struct vader_modex_other_t {
@@ -113,6 +115,7 @@ struct mca_btl_vader_component_t {
     int vader_free_list_inc;                /**< number of elements to alloc when growing free lists */
 #if OPAL_BTL_VADER_HAVE_XPMEM
     xpmem_segid_t my_seg_id;                /**< this rank's xpmem segment id */
+    uintptr_t my_address_max;               /**< largest address */
     mca_rcache_base_vma_module_t *vma_module; /**< registration cache for xpmem segments */
 #endif
     opal_shmem_ds_t seg_ds;                 /**< this rank's shared memory segment (when not using xpmem) */

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -21,7 +21,7 @@
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019      Google, Inc. All rights reserved.
+ * Copyright (c) 2019-2020 Google, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -382,6 +382,7 @@ static int mca_btl_base_vader_modex_send (void)
     if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
         modex.xpmem.seg_id = mca_btl_vader_component.my_seg_id;
         modex.xpmem.segment_base = mca_btl_vader_component.my_segment;
+        modex.xpmem.address_max = mca_btl_vader_component.my_address_max;
 
         modex_size = sizeof (modex.xpmem);
     } else {

--- a/opal/mca/btl/vader/btl_vader_endpoint.h
+++ b/opal/mca/btl/vader/btl_vader_endpoint.h
@@ -78,6 +78,7 @@ typedef struct mca_btl_base_endpoint_t {
 #if OPAL_BTL_VADER_HAVE_XPMEM
         struct {
             xpmem_apid_t    apid;       /**< xpmem apid for remote peer */
+            uintptr_t       address_max; /**< largest address that can be attached */
         } xpmem;
 #endif
         struct {

--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -19,6 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -216,6 +217,7 @@ static int init_vader_endpoint (struct mca_btl_base_endpoint_t *ep, struct opal_
         if (MCA_BTL_VADER_XPMEM == mca_btl_vader_component.single_copy_mechanism) {
             /* always use xpmem if it is available */
             ep->segment_data.xpmem.apid = xpmem_get (modex->xpmem.seg_id, XPMEM_RDWR, XPMEM_PERMIT_MODE, (void *) 0666);
+            ep->segment_data.xpmem.address_max = modex->xpmem.address_max;
             (void) vader_get_registation (ep, modex->xpmem.segment_base, mca_btl_vader_component.segment_size,
                                           MCA_RCACHE_FLAGS_PERSIST, (void **) &ep->segment_base);
         } else {

--- a/opal/mca/btl/vader/btl_vader_xpmem.h
+++ b/opal/mca/btl/vader/btl_vader_xpmem.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2013-2014 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      ARM, Inc. All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,13 +32,6 @@
 
 /* look up the remote pointer in the peer rcache and attach if
  * necessary */
-
-/* largest address we can attach to using xpmem */
-#if defined(__x86_64__)
-#define VADER_MAX_ADDRESS ((uintptr_t)0x7ffffffff000ul)
-#else
-#define VADER_MAX_ADDRESS XPMEM_MAXADDR_SIZE
-#endif
 
 struct mca_btl_base_endpoint_t;
 


### PR DESCRIPTION
This PR removes the constant defining the max attachment address and
replaces it with the largest address that shows up in /proc/self/maps.
This should address issues found on AARCH64 where the max address
may differ based on the configuration.

Since the calculated max address may differ between processes the
max address is sent as part of the modex and stored in the endpoint
data.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>
(cherry picked from commit 728d51f9f3f2df6577e5f9729b9d6a0fe9441d37)