### PR TITLE
opal: ensure opal_gethostname() always returns a value

### DIFF
--- a/opal/runtime/opal.h
+++ b/opal/runtime/opal.h
@@ -115,15 +115,31 @@ OPAL_DECLSPEC void opal_warn_fork(void);
 OPAL_DECLSPEC int opal_register_params(void);
 
 /**
- * Wrapper to return the hostname value that is in
-   opal_process_info.nodename, as opposed to calling gethostname()
-   directly, which is not guaranteed to be null-terminated and
-   varies in its behavior depending on implementation. The 
-   opal_process_info.nodename value is first populated in 
-   opal/runtime/opal_init.c
+ * Internal function.  Should not be called directly (should only be
+ * invoked internally by opal_init() and opal_gethostname()).
  */
-static inline const char *opal_gethostname( void ) {
-    assert( NULL != opal_process_info.nodename );
+OPAL_DECLSPEC int opal_init_gethostname(void);
+
+/**
+ * Wrapper to return the hostname value that is in
+ * opal_process_info.nodename, as opposed to calling gethostname()
+ * directly, which is not guaranteed to be null-terminated and varies
+ * in its behavior depending on implementation. The
+ * opal_process_info.nodename value is first populated in
+ * opal/runtime/opal_init.c.
+ *
+ * NOTE: In some cases (usually: developer debugging), it is possible
+ * that this function is invoked (e.g., via opal_output()) before
+ * opal_init() has been invoked, and therefore
+ * opal_process_info.nodename is still NULL.  In those cases, just
+ * call opal_init_gethostname() directly to fill in
+ * opal_process_info.nodename.
+ */
+static inline const char *opal_gethostname(void)
+{
+    if (NULL == opal_process_info.nodename) {
+        opal_init_gethostname();
+    }
     return opal_process_info.nodename;
 }
 

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -110,7 +110,7 @@ bool opal_warn_on_fork = true;
  * truncated. It also tries again in the case where gethostname returns an
  * error because the buffer is initially too short.
  */
-static int opal_init_gethostname(void)
+int opal_init_gethostname(void)
 {
     size_t count, length = OPAL_LOCAL_MAXHOSTNAMELEN;
     int ret_val, num_tries = 0;


### PR DESCRIPTION
We initially thought it was a safe bet that opal_gethostname() would
never be called before opal_init().  However, it turns out that there
are some cases -- e.g., developer debugging -- where it is useful to
call opal_output() (which calls opal_gethostname()) before
opal_init().

Hence, we need to guarantee that opal_gethostname() always returns a
valid value.  If opal_gethostname() finds NULL in
opal_process_info.nodename, simply call the internal function to
initialize opal_process_info.nodename.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fixes #7322.