### PR TITLE
v4.0.x: oshmem/ucx: Fix progress in iput/iget: periodically poke progress to prevent hardware stalls when using DCT transport.

### DIFF
--- a/oshmem/mca/spml/ucx/spml_ucx.h
+++ b/oshmem/mca/spml/ucx/spml_ucx.h
@@ -72,6 +72,7 @@ struct mca_spml_ucx_ctx {
     ucp_peer_t              *ucp_peers;
     long                     options;
     opal_bitmap_t            put_op_bitmap;
+    unsigned long            nb_progress_cnt;
     int                     *put_proc_indexes;
     unsigned                 put_proc_count;
 };
@@ -109,6 +110,10 @@ struct mca_spml_ucx {
     pthread_spinlock_t       async_lock;
     int                      aux_refcnt;
     bool                     synchronized_quiet;
+    unsigned long            nb_progress_thresh_global;
+    unsigned long            nb_put_progress_thresh;
+    unsigned long            nb_get_progress_thresh;
+    unsigned long            nb_ucp_worker_progress;
 };
 typedef struct mca_spml_ucx mca_spml_ucx_t;
 
@@ -123,7 +128,15 @@ extern int mca_spml_ucx_get(shmem_ctx_t ctx,
                               size_t size,
                               void* src_addr,
                               int src);
+
 extern int mca_spml_ucx_get_nb(shmem_ctx_t ctx,
+                              void* dst_addr,
+                              size_t size,
+                              void* src_addr,
+                              int src,
+                              void **handle);
+
+extern int mca_spml_ucx_get_nb_wprogress(shmem_ctx_t ctx,
                               void* dst_addr,
                               size_t size,
                               void* src_addr,
@@ -137,6 +150,13 @@ extern int mca_spml_ucx_put(shmem_ctx_t ctx,
                             int dst);
 
 extern int mca_spml_ucx_put_nb(shmem_ctx_t ctx,
+                               void* dst_addr,
+                               size_t size,
+                               void* src_addr,
+                               int dst,
+                               void **handle);
+
+extern int mca_spml_ucx_put_nb_wprogress(shmem_ctx_t ctx,
                                void* dst_addr,
                                size_t size,
                                void* src_addr,


### PR DESCRIPTION
Fixes a progress issue when excess iput/iget operations are issued when using DC, by periodically calling progress on ucx workers.

Co-authored with:
Artem Y. Polyakov <artemp@mellanox.com>,
Manjunath Gorentla Venkata <manjunath@mellanox.com>

Signed-off-by: Tomislav Janjusic <tomislavj@mellanox.com>
(cherry picked from commit 1b58e3d07388c8c63d485fe308589009279c1f4f)