### PR TITLE
ompio: fix abstraction violation in 3.0.x series

### DIFF
--- a/ompi/mca/common/ompio/Makefile.am
+++ b/ompi/mca/common/ompio/Makefile.am
@@ -23,10 +23,15 @@ if OMPI_PROVIDE_MPI_FILE_INTERFACE
 
 headers = \
 	common_ompio_print_queue.h \
+	common_ompio_aggregators.h \
+	common_ompio_request.h \
+	common_ompio_callbacks.h \
 	common_ompio.h
 
 sources = \
 	common_ompio_print_queue.c \
+	common_ompio_aggregators.c \
+	common_ompio_request.c \
 	common_ompio_file_open.c   \
 	common_ompio_file_view.c   \
 	common_ompio_file_read.c   \

--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -22,7 +22,11 @@
 #define MCA_COMMON_OMPIO_H
 
 #include "ompi/mca/common/ompio/common_ompio_print_queue.h"
+#include "common_ompio_aggregators.h"
 #include "ompi/mca/io/ompio/io_ompio.h"
+
+#define OMPIO_MCA_GET(fh, name) ((fh)->f_get_mca_parameter_value(#name, strlen(#name)+1))
+
 
 OMPI_DECLSPEC int mca_common_ompio_file_write (mca_io_ompio_file_t *fh, const void *buf,  int count,
                                                struct ompi_datatype_t *datatype, 
@@ -88,5 +92,10 @@ OMPI_DECLSPEC int mca_common_ompio_set_view (mca_io_ompio_file_t *fh,  OMPI_MPI_
                                              ompi_datatype_t *etype,  ompi_datatype_t *filetype, const char *datarep,
                                              ompi_info_t *info);
  
+OMPI_DECLSPEC int ompi_common_ompio_decode_datatype (struct mca_io_ompio_file_t *fh, ompi_datatype_t *datatype,
+                                                     int count, const void *buf,  size_t *max_data,  struct iovec **iov,
+                                                     uint32_t *iovec_count);
 
+OMPI_DECLSPEC int mca_common_ompio_file_delete (const char *filename,
+                                                struct ompi_info_t *info);
 #endif /* MCA_COMMON_OMPIO_H */

--- a/ompi/mca/common/ompio/common_ompio_aggregators.h
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.h
@@ -20,9 +20,10 @@
  */
 
 
-#ifndef MCA_IO_OMPIO_AGGREGATORS_H
-#define MCA_IO_OMPIO_AGGREGATORS_H
+#ifndef MCA_COMMON_OMPIO_AGGREGATORS_H
+#define MCA_COMMON_OMPIO_AGGREGATORS_H
 
+#include "ompi/mca/io/ompio/io_ompio.h"
 
 /*AGGREGATOR GROUPING DECISIONS*/
 #define OMPIO_MERGE                     1
@@ -35,35 +36,36 @@ typedef struct {
 	int *periods;
 	int *coords;
 	int reorder;
-} mca_io_ompio_cart_topo_components;
+} mca_common_ompio_cart_topo_components;
 
 
 typedef struct{
         OMPI_MPI_OFFSET_TYPE contg_chunk_size;
         int *procs_in_contg_group;
 	int procs_per_contg_group;
-} mca_io_ompio_contg;
+} mca_common_ompio_contg;
 
 
 
 /*Aggregator selection methods*/
-OMPI_DECLSPEC int mca_io_ompio_set_aggregator_props (struct mca_io_ompio_file_t *fh,
+OMPI_DECLSPEC int mca_common_ompio_set_aggregator_props (struct mca_io_ompio_file_t *fh,
                                                      int num_aggregators,
                                                      size_t bytes_per_proc);
 
-int mca_io_ompio_cart_based_grouping(mca_io_ompio_file_t *ompio_fh);
+int mca_common_ompio_cart_based_grouping(mca_io_ompio_file_t *ompio_fh, int *num_groups,
+                                      mca_common_ompio_contg *contg_groups);
 
-int mca_io_ompio_fview_based_grouping(mca_io_ompio_file_t *fh, int *num_groups,
-                                      mca_io_ompio_contg *contg_groups);
-int mca_io_ompio_simple_grouping(mca_io_ompio_file_t *fh, int *num_groups,
-                                 mca_io_ompio_contg *contg_groups);
+int mca_common_ompio_fview_based_grouping(mca_io_ompio_file_t *fh, int *num_groups,
+                                      mca_common_ompio_contg *contg_groups);
+int mca_common_ompio_simple_grouping(mca_io_ompio_file_t *fh, int *num_groups,
+                                 mca_common_ompio_contg *contg_groups);
 
-int mca_io_ompio_finalize_initial_grouping(mca_io_ompio_file_t *fh,  int num_groups,
-                                           mca_io_ompio_contg *contg_groups);
+int mca_common_ompio_finalize_initial_grouping(mca_io_ompio_file_t *fh,  int num_groups,
+                                           mca_common_ompio_contg *contg_groups);
 
-int mca_io_ompio_create_groups(mca_io_ompio_file_t *fh, size_t bytes_per_proc);
+int mca_common_ompio_create_groups(mca_io_ompio_file_t *fh, size_t bytes_per_proc);
 
-int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
+int mca_common_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
                                   OMPI_MPI_OFFSET_TYPE **start_offsets_lens,
                                   OMPI_MPI_OFFSET_TYPE **end_offsets,
                                   OMPI_MPI_OFFSET_TYPE **aggr_bytes_per_group,
@@ -73,16 +75,16 @@ int mca_io_ompio_prepare_to_group(mca_io_ompio_file_t *fh,
                                   int *is_aggregator,
                                   int *ompio_grouping_flag);
 
-int mca_io_ompio_retain_initial_groups(mca_io_ompio_file_t *fh);
+int mca_common_ompio_retain_initial_groups(mca_io_ompio_file_t *fh);
 
 
-int mca_io_ompio_split_initial_groups(mca_io_ompio_file_t *fh,
+int mca_common_ompio_split_initial_groups(mca_io_ompio_file_t *fh,
                                       OMPI_MPI_OFFSET_TYPE *start_offsets_lens,
                                       OMPI_MPI_OFFSET_TYPE *end_offsets,
                                       OMPI_MPI_OFFSET_TYPE bytes_per_group);
 
 
-int mca_io_ompio_split_a_group(mca_io_ompio_file_t *fh,
+int mca_common_ompio_split_a_group(mca_io_ompio_file_t *fh,
                                OMPI_MPI_OFFSET_TYPE *start_offsets_lens,
                                OMPI_MPI_OFFSET_TYPE *end_offsets,
                                int size_new_group,
@@ -90,14 +92,14 @@ int mca_io_ompio_split_a_group(mca_io_ompio_file_t *fh,
                                OMPI_MPI_OFFSET_TYPE *min_cci,
                                int *num_groups, int *size_smallest_group);
 
-int mca_io_ompio_finalize_split(mca_io_ompio_file_t *fh, int size_new_group,
+int mca_common_ompio_finalize_split(mca_io_ompio_file_t *fh, int size_new_group,
                                 int size_last_group);
 
-int mca_io_ompio_merge_initial_groups(mca_io_ompio_file_t *fh,
+int mca_common_ompio_merge_initial_groups(mca_io_ompio_file_t *fh,
                                       OMPI_MPI_OFFSET_TYPE *aggr_bytes_per_group,
                                       int *decision_list, int is_aggregator);
 
-int mca_io_ompio_merge_groups(mca_io_ompio_file_t *fh, int *merge_aggrs,
+int mca_common_ompio_merge_groups(mca_io_ompio_file_t *fh, int *merge_aggrs,
                               int num_merge_aggrs);
 
 

--- a/ompi/mca/common/ompio/common_ompio_callbacks.h
+++ b/ompi/mca/common/ompio/common_ompio_callbacks.h
@@ -1,0 +1,54 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2016 University of Houston. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef MCA_COMMON_OMPIO_CALLBACKS_H
+#define MCA_COMMON_OMPIO_CALLBACKS_H
+
+struct mca_io_ompio_file_t;
+
+/* functions to retrieve the number of aggregators and the size of the
+   temporary buffer on aggregators from the fcoll modules */
+typedef int (*mca_common_ompio_get_mca_parameter_value_fn_t) ( char *mca_parameter_name, int name_length );
+
+typedef int (*mca_common_ompio_generate_current_file_view_fn_t) (struct mca_io_ompio_file_t *fh,
+                                                                 size_t max_data,
+                                                                 struct iovec **f_iov,
+                                                                 int *iov_count);
+typedef void (*mca_common_ompio_get_num_aggregators_fn_t ) ( int *num_aggregators );
+typedef void (*mca_common_ompio_get_bytes_per_agg_fn_t ) ( int *bytes_per_agg );
+typedef int (*mca_common_ompio_decode_datatype_fn_t) (struct mca_io_ompio_file_t *fh,
+						  struct ompi_datatype_t *datatype,
+						  int count,  const void *buf,
+						  size_t *max_data,  struct iovec **iov,
+						  uint32_t *iov_count);
+
+typedef int (*mca_common_ompio_set_aggregator_props_fn_t) (struct mca_io_ompio_file_t *fh,
+                                                               int num_aggregators,
+                                                               size_t bytes_per_proc);
+
+
+
+
+OMPI_DECLSPEC int mca_common_ompio_set_callbacks(mca_common_ompio_generate_current_file_view_fn_t generate_current_file_view,
+                                                 mca_common_ompio_get_mca_parameter_value_fn_t get_mca_parameter_value,
+                                                 mca_common_ompio_get_num_aggregators_fn_t get_num_aggregators,
+                                                 mca_common_ompio_get_bytes_per_agg_fn_t get_bytes_per_agg );
+
+#endif

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -38,7 +38,13 @@
 #include <unistd.h>
 #include <math.h>
 #include "common_ompio.h"
+#include "common_ompio_callbacks.h"
 #include "ompi/mca/topo/topo.h"
+
+static mca_common_ompio_get_mca_parameter_value_fn_t get_mca_parameter_value_fn;
+static mca_common_ompio_generate_current_file_view_fn_t generate_current_file_view_fn;
+static mca_common_ompio_get_num_aggregators_fn_t get_num_aggregators_fn;
+static mca_common_ompio_get_bytes_per_agg_fn_t get_bytes_per_agg_fn;
 
 int mca_common_ompio_file_open (ompi_communicator_t *comm,
                               const char *filename,
@@ -91,6 +97,15 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
     ompio_fh->f_atomicity = 0;
     ompio_fh->f_fs_block_size = 4096;
 
+    /* set some function pointers required for fcoll, fbtls and sharedfp modules*/
+    ompio_fh->f_decode_datatype=ompi_common_ompio_decode_datatype;
+    ompio_fh->f_generate_current_file_view=generate_current_file_view_fn;
+
+    ompio_fh->f_get_num_aggregators=get_num_aggregators_fn;
+    ompio_fh->f_get_bytes_per_agg=get_bytes_per_agg_fn;
+    ompio_fh->f_set_aggregator_props=mca_common_ompio_set_aggregator_props;
+    ompio_fh->f_get_mca_parameter_value=get_mca_parameter_value_fn;
+        
     mca_common_ompio_set_file_defaults (ompio_fh);
     ompio_fh->f_filename = filename;
 
@@ -100,14 +115,6 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
     /*Initialize the print_queues queues here!*/
     mca_common_ompio_initialize_print_queue(&ompio_fh->f_coll_write_time);
     mca_common_ompio_initialize_print_queue(&ompio_fh->f_coll_read_time);
-
-    /* set some function pointers required for fcoll, fbtls and sharedfp modules*/
-    ompio_fh->f_decode_datatype=ompi_io_ompio_decode_datatype;
-    ompio_fh->f_generate_current_file_view=ompi_io_ompio_generate_current_file_view;
-
-    ompio_fh->f_get_num_aggregators=mca_io_ompio_get_num_aggregators;
-    ompio_fh->f_get_bytes_per_agg=mca_io_ompio_get_bytes_per_agg;
-    ompio_fh->f_set_aggregator_props=mca_io_ompio_set_aggregator_props;
 
     /* This fix is needed for data seiving to work with
        two-phase collective I/O */
@@ -176,7 +183,7 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
         ** are used by his application.	
         */
 	if ( NULL != ompio_fh->f_sharedfp &&
-	     !mca_io_ompio_sharedfp_lazy_open ) {
+	     !OMPIO_MCA_GET(ompio_fh, sharedfp_lazy_open )) {
 	    ret = ompio_fh->f_sharedfp->sharedfp_file_open(comm,
 							   filename,
 							   amode,
@@ -201,7 +208,7 @@ int mca_common_ompio_file_open (ompi_communicator_t *comm,
         mca_common_ompio_set_explicit_offset (ompio_fh, current_size);
         if ( true == use_sharedfp ) {
             if ( NULL != ompio_fh->f_sharedfp &&
-                 !mca_io_ompio_sharedfp_lazy_open  ) {                
+                 !OMPIO_MCA_GET(ompio_fh, sharedfp_lazy_open)  ) {                
                 shared_fp_base_module = ompio_fh->f_sharedfp;
                 ret = shared_fp_base_module->sharedfp_seek(ompio_fh,current_size, MPI_SEEK_SET);
                 if ( MPI_SUCCESS != ret  ) {
@@ -241,7 +248,7 @@ int mca_common_ompio_file_close (mca_io_ompio_file_t *ompio_fh)
     }
 
 
-    if(mca_io_ompio_coll_timing_info){
+    if(OMPIO_MCA_GET(ompio_fh, coll_timing_info)){
         strcpy (name, "WRITE");
         if (!mca_common_ompio_empty_print_queue(ompio_fh->f_coll_write_time)){
             ret = mca_common_ompio_print_time_info(ompio_fh->f_coll_write_time,
@@ -278,7 +285,7 @@ int mca_common_ompio_file_close (mca_io_ompio_file_t *ompio_fh)
 	ret = ompio_fh->f_fs->fs_file_close (ompio_fh);
     }
     if ( delete_flag && 0 == ompio_fh->f_rank ) {
-        mca_io_ompio_file_delete ( ompio_fh->f_filename, MPI_INFO_NULL );
+        mca_common_ompio_file_delete ( ompio_fh->f_filename, MPI_INFO_NULL );
     }
 
     if ( NULL != ompio_fh->f_fs ) {
@@ -410,7 +417,7 @@ int mca_common_ompio_set_file_defaults (mca_io_ompio_file_t *fh)
         fh->f_io_array = NULL;
         fh->f_perm = OMPIO_PERM_NULL;
         fh->f_flags = 0;
-        fh->f_bytes_per_agg = mca_io_ompio_bytes_per_agg;
+        fh->f_bytes_per_agg = OMPIO_MCA_GET(fh, bytes_per_agg);
         fh->f_datarep = strdup ("native");
 
         fh->f_offset = 0;
@@ -431,7 +438,7 @@ int mca_common_ompio_set_file_defaults (mca_io_ompio_file_t *fh)
 
         /* Default file View */
         fh->f_iov_type = MPI_DATATYPE_NULL;
-        fh->f_stripe_size = mca_io_ompio_bytes_per_agg;
+        fh->f_stripe_size = OMPIO_MCA_GET(fh, bytes_per_agg);
 	/*Decoded iovec of the file-view*/
 	fh->f_decoded_iov = NULL;
         fh->f_etype = NULL;
@@ -472,4 +479,157 @@ int mca_common_ompio_set_file_defaults (mca_io_ompio_file_t *fh)
     }
 }
 
+int mca_common_ompio_file_delete (const char *filename,
+                                  struct ompi_info_t *info)
+{
+    /* No locking required for file_delete according to my understanding.
+       One thread will succeed, the other ones silently ignore the
+       error that the file is already deleted.
+    */
+    int ret;
+    ret = unlink(filename);
 
+    if (0 > ret ) {
+        if ( ENOENT == errno ) {
+            return MPI_ERR_NO_SUCH_FILE;
+        } else {
+            opal_output (0, "mca_common_ompio_file_delete: Could not remove file %s errno = %d %s\n", filename,
+                         errno, strerror(errno));
+            return MPI_ERR_ACCESS;
+        }
+    }
+
+    return OMPI_SUCCESS;
+}
+
+int ompi_common_ompio_decode_datatype (struct mca_io_ompio_file_t *fh,
+                                       ompi_datatype_t *datatype,
+                                       int count,
+                                       const void *buf,
+                                       size_t *max_data,
+                                       struct iovec **iov,
+                                       uint32_t *iovec_count)
+{
+
+
+
+    opal_convertor_t convertor;
+    size_t remaining_length = 0;
+    uint32_t i;
+    uint32_t temp_count;
+    struct iovec *temp_iov=NULL;
+    size_t temp_data;
+
+
+    opal_convertor_clone (fh->f_convertor, &convertor, 0);
+
+    if (OMPI_SUCCESS != opal_convertor_prepare_for_send (&convertor,
+                                                         &(datatype->super),
+                                                         count,
+                                                         buf)) {
+        opal_output (1, "Cannot attach the datatype to a convertor\n");
+        return OMPI_ERROR;
+    }
+
+    if ( 0 == datatype->super.size ) {
+	*max_data = 0;
+	*iovec_count = 0;
+	*iov = NULL;
+	return OMPI_SUCCESS;
+    }
+
+    remaining_length = count * datatype->super.size;
+
+    temp_count = OMPIO_IOVEC_INITIAL_SIZE;
+    temp_iov = (struct iovec*)malloc(temp_count * sizeof(struct iovec));
+    if (NULL == temp_iov) {
+        opal_output (1, "OUT OF MEMORY\n");
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    while (0 == opal_convertor_raw(&convertor,
+				   temp_iov,
+                                   &temp_count,
+                                   &temp_data)) {
+#if 0
+        printf ("%d: New raw extraction (iovec_count = %d, max_data = %lu)\n",
+                fh->f_rank,temp_count, (unsigned long)temp_data);
+        for (i = 0; i < temp_count; i++) {
+            printf ("%d: \t{%p, %lu}\n",fh->f_rank,
+		    temp_iov[i].iov_base,
+		    (unsigned long)temp_iov[i].iov_len);
+        }
+#endif
+
+        *iovec_count = *iovec_count + temp_count;
+        *max_data = *max_data + temp_data;
+        *iov = (struct iovec *) realloc (*iov, *iovec_count * sizeof(struct iovec));
+        if (NULL == *iov) {
+            opal_output(1, "OUT OF MEMORY\n");
+            free(temp_iov);
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+        for (i=0 ; i<temp_count ; i++) {
+            (*iov)[i+(*iovec_count-temp_count)].iov_base = temp_iov[i].iov_base;
+            (*iov)[i+(*iovec_count-temp_count)].iov_len = temp_iov[i].iov_len;
+        }
+
+        remaining_length -= temp_data;
+        temp_count = OMPIO_IOVEC_INITIAL_SIZE;
+    }
+#if 0
+    printf ("%d: LAST raw extraction (iovec_count = %d, max_data = %d)\n",
+            fh->f_rank,temp_count, temp_data);
+    for (i = 0; i < temp_count; i++) {
+        printf ("%d: \t offset[%d]: %ld; length[%d]: %ld\n", fh->f_rank,i,temp_iov[i].iov_base, i,temp_iov[i].iov_len);
+    }
+#endif
+    *iovec_count = *iovec_count + temp_count;
+    *max_data = *max_data + temp_data;
+    if ( temp_count > 0 ) {
+	*iov = (struct iovec *) realloc (*iov, *iovec_count * sizeof(struct iovec));
+	if (NULL == *iov) {
+	    opal_output(1, "OUT OF MEMORY\n");
+            free(temp_iov);
+	    return OMPI_ERR_OUT_OF_RESOURCE;
+	}
+    }
+    for (i=0 ; i<temp_count ; i++) {
+        (*iov)[i+(*iovec_count-temp_count)].iov_base = temp_iov[i].iov_base;
+        (*iov)[i+(*iovec_count-temp_count)].iov_len = temp_iov[i].iov_len;
+    }
+
+    remaining_length -= temp_data;
+
+#if 0
+    if (0 == fh->f_rank) {
+        printf ("%d Entries: \n",*iovec_count);
+        for (i=0 ; i<*iovec_count ; i++) {
+            printf ("\t{%p, %d}\n",
+                    (*iov)[i].iov_base,
+                    (*iov)[i].iov_len);
+        }
+    }
+#endif
+    if (remaining_length != 0) {
+        printf( "Not all raw description was been extracted (%lu bytes missing)\n",
+                (unsigned long) remaining_length );
+    }
+
+    free (temp_iov);
+
+    return OMPI_SUCCESS;
+}
+
+
+int mca_common_ompio_set_callbacks(mca_common_ompio_generate_current_file_view_fn_t generate_current_file_view,
+                                   mca_common_ompio_get_mca_parameter_value_fn_t get_mca_parameter_value,
+                                   mca_common_ompio_get_num_aggregators_fn_t get_num_aggregators,
+                                   mca_common_ompio_get_bytes_per_agg_fn_t get_bytes_per_agg )
+{
+    generate_current_file_view_fn = generate_current_file_view;
+    get_mca_parameter_value_fn = get_mca_parameter_value;
+    get_num_aggregators_fn = get_num_aggregators;
+    get_bytes_per_agg_fn =  get_bytes_per_agg;
+    return OMPI_SUCCESS;
+}

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -33,7 +33,7 @@
 
 #include "common_ompio.h"
 #include "ompi/mca/io/ompio/io_ompio.h"
-#include "ompi/mca/io/ompio/io_ompio_request.h"
+#include "common_ompio_request.h"
 #include "math.h"
 #include <unistd.h>
 #include <math.h>
@@ -88,19 +88,19 @@ int mca_common_ompio_file_read (mca_io_ompio_file_t *fh,
       return ret;
     }
 
-    ompi_io_ompio_decode_datatype (fh,
-                                   datatype,
-                                   count,
-                                   buf,
-                                   &max_data,
-                                   &decoded_iov,
-                                   &iov_count);
+    ompi_common_ompio_decode_datatype (fh,
+                                       datatype,
+                                       count,
+                                       buf,
+                                       &max_data,
+                                       &decoded_iov,
+                                       &iov_count);
 
-    if ( -1 == mca_io_ompio_cycle_buffer_size ) {
+    if ( -1 == OMPIO_MCA_GET(fh, cycle_buffer_size) ) {
 	bytes_per_cycle = max_data;
     }
     else {
-	bytes_per_cycle = mca_io_ompio_cycle_buffer_size;
+	bytes_per_cycle = OMPIO_MCA_GET(fh, cycle_buffer_size);
     }
     cycles = ceil((double)max_data/bytes_per_cycle);
     
@@ -212,13 +212,13 @@ int mca_common_ompio_file_iread (mca_io_ompio_file_t *fh,
 	int i = 0; /* index into the decoded iovec of the buffer */
 	int j = 0; /* index into the file vie iovec */
 
-	ompi_io_ompio_decode_datatype (fh,
-				       datatype,
-				       count,
-				       buf,
-				       &max_data,
-				       &decoded_iov,
-				       &iov_count);
+	ompi_common_ompio_decode_datatype (fh,
+                                           datatype,
+                                           count,
+                                           buf,
+                                           &max_data,
+                                           &decoded_iov,
+                                           &iov_count);
 
 	// Non-blocking operations have to occur in a single cycle
 	j = fh->f_index_in_file_view;
@@ -239,11 +239,11 @@ int mca_common_ompio_file_iread (mca_io_ompio_file_t *fh,
 	  fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);
 	}
 
-	if ( false == mca_io_ompio_progress_is_registered ) {
+	if ( false == mca_common_ompio_progress_is_registered ) {
             // Lazy initialization of progress function to minimize impact
             // on other ompi functionality in case its not used.
-            opal_progress_register (mca_io_ompio_component_progress);
-            mca_io_ompio_progress_is_registered=true;
+            opal_progress_register (mca_common_ompio_component_progress);
+            mca_common_ompio_progress_is_registered=true;
         }
 
 	fh->f_num_of_io_entries = 0;

--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -62,7 +62,7 @@ int mca_common_ompio_set_view (mca_io_ompio_file_t *fh,
     size_t max_data = 0;
     int i;
     int num_groups = 0;
-    mca_io_ompio_contg *contg_groups;
+    mca_common_ompio_contg *contg_groups=NULL;
 
     size_t ftype_size;
     ptrdiff_t ftype_extent, lb, ub;
@@ -120,7 +120,7 @@ int mca_common_ompio_set_view (mca_io_ompio_file_t *fh,
     fh->f_index_in_file_view=0;
     fh->f_position_in_file_view=0;
 
-    ompi_io_ompio_decode_datatype (fh,
+    ompi_common_ompio_decode_datatype (fh,
                                    newfiletype,
                                    1,
                                    NULL,
@@ -137,7 +137,7 @@ int mca_common_ompio_set_view (mca_io_ompio_file_t *fh,
     // in orig_file type, No need to set args on this one.
     ompi_datatype_duplicate (newfiletype, &fh->f_filetype);
 
-    fh->f_cc_size = get_contiguous_chunk_size (fh);
+        fh->f_cc_size = get_contiguous_chunk_size (fh);
 
     if (opal_datatype_is_contiguous_memory_layout(&etype->super,1)) {
         if (opal_datatype_is_contiguous_memory_layout(&filetype->super,1) &&
@@ -146,7 +146,7 @@ int mca_common_ompio_set_view (mca_io_ompio_file_t *fh,
         }
     }
 
-    contg_groups = (mca_io_ompio_contg*) calloc ( 1, fh->f_size * sizeof(mca_io_ompio_contg));
+    contg_groups = (mca_common_ompio_contg*) calloc ( 1, fh->f_size * sizeof(mca_common_ompio_contg));
     if (NULL == contg_groups) {
         opal_output (1, "OUT OF MEMORY\n");
         return OMPI_ERR_OUT_OF_RESOURCE;
@@ -164,30 +164,30 @@ int mca_common_ompio_set_view (mca_io_ompio_file_t *fh,
        }
     }
 
-    if ( SIMPLE != mca_io_ompio_grouping_option ) {
-        if( OMPI_SUCCESS != mca_io_ompio_fview_based_grouping(fh,
-                                                              &num_groups,
-                                                              contg_groups)){
-            opal_output(1, "mca_common_ompio_set_view: mca_io_ompio_fview_based_grouping failed\n");
+    if ( SIMPLE != OMPIO_MCA_GET(fh, grouping_option )) {
+        if( OMPI_SUCCESS != mca_common_ompio_fview_based_grouping(fh,
+                                                                  &num_groups,
+                                                                  contg_groups)){
+            opal_output(1, "mca_common_ompio_set_view: mca_common_ompio_fview_based_grouping failed\n");
             free(contg_groups);
             return OMPI_ERROR;
         }
     }
     else {
-        if( OMPI_SUCCESS != mca_io_ompio_simple_grouping(fh,
-                                                         &num_groups,
-                                                         contg_groups)){
-            opal_output(1, "mca_common_ompio_set_view: mca_io_ompio_simple_grouping failed\n");
+        if( OMPI_SUCCESS != mca_common_ompio_simple_grouping(fh,
+                                                             &num_groups,
+                                                             contg_groups)){
+            opal_output(1, "mca_common_ompio_set_view: mca_common_ompio_simple_grouping failed\n");
             free(contg_groups);
             return OMPI_ERROR;
         }
     }
     
     
-    if ( OMPI_SUCCESS != mca_io_ompio_finalize_initial_grouping(fh,
-                                                                num_groups,
-                                                                contg_groups) ){
-        opal_output(1, "mca_common_ompio_set_view: mca_io_ompio_finalize_initial_grouping failed\n");
+    if ( OMPI_SUCCESS != mca_common_ompio_finalize_initial_grouping(fh,
+                                                                    num_groups,
+                                                                    contg_groups) ){
+        opal_output(1, "mca_common_ompio_set_view: mca_common_ompio_finalize_initial_grouping failed\n");
         free(contg_groups);
         return OMPI_ERROR;        
     }

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -31,7 +31,7 @@
 
 #include "common_ompio.h"
 #include "ompi/mca/io/ompio/io_ompio.h"
-#include "ompi/mca/io/ompio/io_ompio_request.h"
+#include "common_ompio_request.h"
 #include "math.h"
 #include <unistd.h>
 #include <math.h>
@@ -63,19 +63,19 @@ int mca_common_ompio_file_write (mca_io_ompio_file_t *fh,
 	return ret;
     }
 
-    ompi_io_ompio_decode_datatype (fh,
-                                   datatype,
-                                   count,
-                                   buf,
-                                   &max_data,
-                                   &decoded_iov,
-                                   &iov_count);
-
-    if ( -1 == mca_io_ompio_cycle_buffer_size ) {
+    ompi_common_ompio_decode_datatype (fh,
+                                       datatype,
+                                       count,
+                                       buf,
+                                       &max_data,
+                                       &decoded_iov,
+                                       &iov_count);
+    
+    if ( -1 == OMPIO_MCA_GET(fh, cycle_buffer_size) ) {
 	bytes_per_cycle = max_data;
     }
     else {
-	bytes_per_cycle = mca_io_ompio_cycle_buffer_size;
+	bytes_per_cycle = OMPIO_MCA_GET(fh, cycle_buffer_size);
     }
     cycles = ceil((double)max_data/bytes_per_cycle);
 
@@ -180,13 +180,13 @@ int mca_common_ompio_file_iwrite (mca_io_ompio_file_t *fh,
 	int i = 0; /* index into the decoded iovec of the buffer */
 	int j = 0; /* index into the file vie iovec */
 
-	ompi_io_ompio_decode_datatype (fh,
-				       datatype,
-				       count,
-				       buf,
-				       &max_data,
-				       &decoded_iov,
-				       &iov_count);
+	ompi_common_ompio_decode_datatype (fh,
+                                           datatype,
+                                           count,
+                                           buf,
+                                           &max_data,
+                                           &decoded_iov,
+                                           &iov_count);
 	j = fh->f_index_in_file_view;
 
 	/* Non blocking operations have to occur in a single cycle */
@@ -206,11 +206,11 @@ int mca_common_ompio_file_iwrite (mca_io_ompio_file_t *fh,
 	  fh->f_fbtl->fbtl_ipwritev (fh, (ompi_request_t *) ompio_req);
         }
 
-	if ( false == mca_io_ompio_progress_is_registered ) {
+	if ( false == mca_common_ompio_progress_is_registered ) {
 	    // Lazy initialization of progress function to minimize impact
 	    // on other ompi functionality in case its not used.
-	    opal_progress_register (mca_io_ompio_component_progress);
-	    mca_io_ompio_progress_is_registered=true;
+	    opal_progress_register (mca_common_ompio_component_progress);
+	    mca_common_ompio_progress_is_registered=true;
         }
 
         fh->f_num_of_io_entries = 0;

--- a/ompi/mca/common/ompio/common_ompio_print_queue.h
+++ b/ompi/mca/common/ompio/common_ompio_print_queue.h
@@ -26,7 +26,6 @@
 
 #include "mpi.h"
 
-OMPI_DECLSPEC extern int mca_io_ompio_coll_timing_info;
 struct mca_io_ompio_file_t;
 
 #define MCA_COMMON_OMPIO_QUEUESIZE 2048

--- a/ompi/mca/common/ompio/common_ompio_request.c
+++ b/ompi/mca/common/ompio/common_ompio_request.c
@@ -18,50 +18,56 @@
  * $HEADER$
  */
 
-#include "io_ompio_request.h"
+#include "common_ompio_request.h"
 
-static void mca_io_ompio_request_construct(mca_ompio_request_t* req);
-static void mca_io_ompio_request_destruct(mca_ompio_request_t *req);
+/*
+ * Global list of requests for this component
+ */
+opal_list_t mca_common_ompio_pending_requests = {{0}};
 
-bool mca_io_ompio_progress_is_registered=false;
 
-static int mca_io_ompio_request_free ( struct ompi_request_t **req)
+static void mca_common_ompio_request_construct(mca_ompio_request_t* req);
+static void mca_common_ompio_request_destruct(mca_ompio_request_t *req);
+
+bool mca_common_ompio_progress_is_registered=false;
+
+static int mca_common_ompio_request_free ( struct ompi_request_t **req)
 {
     mca_ompio_request_t *ompio_req = ( mca_ompio_request_t *)*req;
     if ( NULL != ompio_req->req_free_fn ) {
         ompio_req->req_free_fn (ompio_req );
     }
-    opal_list_remove_item (&mca_io_ompio_pending_requests, &ompio_req->req_item);
+    opal_list_remove_item (&mca_common_ompio_pending_requests, &ompio_req->req_item);
 
     OBJ_RELEASE (*req);
     *req = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;
 }
 
-static int mca_io_ompio_request_cancel ( struct ompi_request_t *req, int flag)
+static int mca_common_ompio_request_cancel ( struct ompi_request_t *req, int flag)
 {
     return OMPI_SUCCESS;
 }
 
 OBJ_CLASS_INSTANCE(mca_ompio_request_t, ompi_request_t,
-                   mca_io_ompio_request_construct,
-                   mca_io_ompio_request_destruct);
+                   mca_common_ompio_request_construct,
+                   mca_common_ompio_request_destruct);
 
-void mca_io_ompio_request_construct(mca_ompio_request_t* req)
+void mca_common_ompio_request_construct(mca_ompio_request_t* req)
 {
     OMPI_REQUEST_INIT (&(req->req_ompi), false );
-    req->req_ompi.req_free   = mca_io_ompio_request_free;
-    req->req_ompi.req_cancel = mca_io_ompio_request_cancel;
+    req->req_ompi.req_free   = mca_common_ompio_request_free;
+    req->req_ompi.req_cancel = mca_common_ompio_request_cancel;
     req->req_ompi.req_type   = OMPI_REQUEST_IO;
     req->req_data            = NULL;
     req->req_progress_fn     = NULL;
     req->req_free_fn         = NULL;
 
     OBJ_CONSTRUCT(&req->req_item, opal_list_item_t);
-    opal_list_append (&mca_io_ompio_pending_requests, &req->req_item);
+    opal_list_append (&mca_common_ompio_pending_requests, &req->req_item);
     return;
 }
-void mca_io_ompio_request_destruct(mca_ompio_request_t* req)
+void mca_common_ompio_request_destruct(mca_ompio_request_t* req)
 {
     OMPI_REQUEST_FINI ( &(req->req_ompi));
     OBJ_DESTRUCT (&req->req_item);
@@ -72,13 +78,30 @@ void mca_io_ompio_request_destruct(mca_ompio_request_t* req)
     return;
 }
 
-int mca_io_ompio_component_progress ( void )
+void mca_common_ompio_request_init ( void )
+{
+    /* Create the list of pending requests */
+    OBJ_CONSTRUCT(&mca_common_ompio_pending_requests, opal_list_t);
+    return;
+}
+
+void mca_common_ompio_request_fini ( void )
+{
+    /* Destroy the list of pending requests */
+    /* JMS: Good opprotunity here to list out all the IO requests that
+       were not destroyed / completed upon MPI_FINALIZE */
+
+    OBJ_DESTRUCT(&mca_common_ompio_pending_requests);
+    return;
+}
+
+int mca_common_ompio_component_progress ( void )
 {
     mca_ompio_request_t *req=NULL;
     opal_list_item_t *litem=NULL;
     int completed=0;
 
-    OPAL_LIST_FOREACH(litem, &mca_io_ompio_pending_requests, opal_list_item_t) {
+    OPAL_LIST_FOREACH(litem, &mca_common_ompio_pending_requests, opal_list_item_t) {
         req = GET_OMPIO_REQ_FROM_ITEM(litem);
         if( REQUEST_COMPLETE(&req->req_ompi) ) {
             continue;

--- a/ompi/mca/common/ompio/common_ompio_request.h
+++ b/ompi/mca/common/ompio/common_ompio_request.h
@@ -18,18 +18,18 @@
  * $HEADER$
  */
 
-#ifndef MCA_IO_OMPIO_REQUEST_H
-#define MCA_IO_OMPIO_REQUEST_H
+#ifndef MCA_COMMON_OMPIO_REQUEST_H
+#define MCA_COMMON_OMPIO_REQUEST_H
 
 #include "ompi_config.h"
 #include "ompi/request/request.h"
 #include "ompi/mca/fbtl/fbtl.h"
-#include "io_ompio.h"
+#include "common_ompio.h"
 
 BEGIN_C_DECLS
 
-extern opal_list_t mca_io_ompio_pending_requests;
-extern bool mca_io_ompio_progress_is_registered;
+extern opal_list_t mca_common_ompio_pending_requests;
+extern bool mca_common_ompio_progress_is_registered;
 
 /**
  * Type of request.
@@ -58,9 +58,10 @@ OBJ_CLASS_DECLARATION(mca_ompio_request_t);
 
 #define GET_OMPIO_REQ_FROM_ITEM(ITEM) ((mca_ompio_request_t *)((char *)ITEM - offsetof(struct mca_ompio_request_t,req_item)))
 
-
-OMPI_DECLSPEC int mca_io_ompio_component_progress ( void);
+OMPI_DECLSPEC void mca_common_ompio_request_init ( void);
+OMPI_DECLSPEC void mca_common_ompio_request_fini ( void );
+OMPI_DECLSPEC int mca_common_ompio_component_progress ( void);
 
 END_C_DECLS
 
-#endif /* MCA_IO_OMPIO_REQUEST_H */
+#endif /* MCA_COMMON_OMPIO_REQUEST_H */

--- a/ompi/mca/fbtl/posix/fbtl_posix.h
+++ b/ompi/mca/fbtl/posix/fbtl_posix.h
@@ -24,7 +24,7 @@
 #include "ompi/mca/mca.h"
 #include "ompi/mca/fbtl/fbtl.h"
 #include "ompi/mca/common/ompio/common_ompio.h"
-#include "ompi/mca/io/ompio/io_ompio_request.h"
+#include "ompi/mca/common/ompio/common_ompio_request.h"
 
 extern int mca_fbtl_posix_priority;
 

--- a/ompi/mca/fcoll/dynamic/Makefile.am
+++ b/ompi/mca/fcoll/dynamic/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -42,7 +42,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_dynamic_la_SOURCES = $(sources)
 mca_fcoll_dynamic_la_LDFLAGS = -module -avoid-version
-mca_fcoll_dynamic_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_fcoll_dynamic_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_dynamic_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/dynamic_gen2/Makefile.am
+++ b/ompi/mca/fcoll/dynamic_gen2/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -42,7 +42,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_dynamic_gen2_la_SOURCES = $(sources)
 mca_fcoll_dynamic_gen2_la_LDFLAGS = -module -avoid-version
-mca_fcoll_dynamic_gen2_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_fcoll_dynamic_gen2_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_dynamic_gen2_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/individual/Makefile.am
+++ b/ompi/mca/fcoll/individual/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -42,7 +42,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_individual_la_SOURCES = $(sources)
 mca_fcoll_individual_la_LDFLAGS = -module -avoid-version
-mca_fcoll_individual_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_fcoll_individual_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_individual_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/static/Makefile.am
+++ b/ompi/mca/fcoll/static/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -42,7 +42,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_static_la_SOURCES = $(sources)
 mca_fcoll_static_la_LDFLAGS = -module -avoid-version
-mca_fcoll_static_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_fcoll_static_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_static_la_SOURCES =$(sources)

--- a/ompi/mca/fcoll/two_phase/Makefile.am
+++ b/ompi/mca/fcoll/two_phase/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2008-2015 University of Houston. All rights reserved.
-# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -43,7 +43,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_fcoll_two_phase_la_SOURCES = $(sources)
 mca_fcoll_two_phase_la_LDFLAGS = -module -avoid-version
-mca_fcoll_two_phase_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_fcoll_two_phase_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_fcoll_two_phase_la_SOURCES =$(sources)

--- a/ompi/mca/io/ompio/Makefile.am
+++ b/ompi/mca/io/ompio/Makefile.am
@@ -44,18 +44,14 @@ libmca_io_ompio_la_LDFLAGS = -module -avoid-version
 
 # Source files
 
-headers = \
-	io_ompio.h \
-	io_ompio_request.h \
-	io_ompio_aggregators.h
+headers = io_ompio.h 
 
 sources = \
         io_ompio.c \
-        io_ompio_aggregators.c \
         io_ompio_component.c \
         io_ompio_module.c \
         io_ompio_file_set_view.c \
         io_ompio_file_open.c \
         io_ompio_file_write.c \
-        io_ompio_file_read.c \
-        io_ompio_request.c 
+        io_ompio_file_read.c 
+

--- a/ompi/mca/io/ompio/io_ompio.c
+++ b/ompi/mca/io/ompio/io_ompio.c
@@ -415,131 +415,10 @@ int ompi_io_ompio_generate_current_file_view (struct mca_io_ompio_file_t *fh,
 }
 
 
-int ompi_io_ompio_decode_datatype (struct mca_io_ompio_file_t *fh,
-                                   ompi_datatype_t *datatype,
-                                   int count,
-                                   const void *buf,
-                                   size_t *max_data,
-                                   struct iovec **iov,
-                                   uint32_t *iovec_count)
-{
-
-
-
-    opal_convertor_t convertor;
-    size_t remaining_length = 0;
-    uint32_t i;
-    uint32_t temp_count;
-    struct iovec *temp_iov=NULL;
-    size_t temp_data;
-
-
-    opal_convertor_clone (fh->f_convertor, &convertor, 0);
-
-    if (OMPI_SUCCESS != opal_convertor_prepare_for_send (&convertor,
-                                                         &(datatype->super),
-                                                         count,
-                                                         buf)) {
-        opal_output (1, "Cannot attach the datatype to a convertor\n");
-        return OMPI_ERROR;
-    }
-
-    if ( 0 == datatype->super.size ) {
-	*max_data = 0;
-	*iovec_count = 0;
-	*iov = NULL;
-	return OMPI_SUCCESS;
-    }
-
-    remaining_length = count * datatype->super.size;
-
-    temp_count = OMPIO_IOVEC_INITIAL_SIZE;
-    temp_iov = (struct iovec*)malloc(temp_count * sizeof(struct iovec));
-    if (NULL == temp_iov) {
-        opal_output (1, "OUT OF MEMORY\n");
-        return OMPI_ERR_OUT_OF_RESOURCE;
-    }
-
-    while (0 == opal_convertor_raw(&convertor,
-				   temp_iov,
-                                   &temp_count,
-                                   &temp_data)) {
-#if 0
-        printf ("%d: New raw extraction (iovec_count = %d, max_data = %lu)\n",
-                fh->f_rank,temp_count, (unsigned long)temp_data);
-        for (i = 0; i < temp_count; i++) {
-            printf ("%d: \t{%p, %lu}\n",fh->f_rank,
-		    temp_iov[i].iov_base,
-		    (unsigned long)temp_iov[i].iov_len);
-        }
-#endif
-
-        *iovec_count = *iovec_count + temp_count;
-        *max_data = *max_data + temp_data;
-        *iov = (struct iovec *) realloc (*iov, *iovec_count * sizeof(struct iovec));
-        if (NULL == *iov) {
-            opal_output(1, "OUT OF MEMORY\n");
-            free(temp_iov);
-            return OMPI_ERR_OUT_OF_RESOURCE;
-        }
-        for (i=0 ; i<temp_count ; i++) {
-            (*iov)[i+(*iovec_count-temp_count)].iov_base = temp_iov[i].iov_base;
-            (*iov)[i+(*iovec_count-temp_count)].iov_len = temp_iov[i].iov_len;
-        }
-
-        remaining_length -= temp_data;
-        temp_count = OMPIO_IOVEC_INITIAL_SIZE;
-    }
-#if 0
-    printf ("%d: LAST raw extraction (iovec_count = %d, max_data = %d)\n",
-            fh->f_rank,temp_count, temp_data);
-    for (i = 0; i < temp_count; i++) {
-        printf ("%d: \t offset[%d]: %ld; length[%d]: %ld\n", fh->f_rank,i,temp_iov[i].iov_base, i,temp_iov[i].iov_len);
-    }
-#endif
-    *iovec_count = *iovec_count + temp_count;
-    *max_data = *max_data + temp_data;
-    if ( temp_count > 0 ) {
-	*iov = (struct iovec *) realloc (*iov, *iovec_count * sizeof(struct iovec));
-	if (NULL == *iov) {
-	    opal_output(1, "OUT OF MEMORY\n");
-            free(temp_iov);
-	    return OMPI_ERR_OUT_OF_RESOURCE;
-	}
-    }
-    for (i=0 ; i<temp_count ; i++) {
-        (*iov)[i+(*iovec_count-temp_count)].iov_base = temp_iov[i].iov_base;
-        (*iov)[i+(*iovec_count-temp_count)].iov_len = temp_iov[i].iov_len;
-    }
-
-    remaining_length -= temp_data;
-
-#if 0
-    if (0 == fh->f_rank) {
-        printf ("%d Entries: \n",*iovec_count);
-        for (i=0 ; i<*iovec_count ; i++) {
-            printf ("\t{%p, %d}\n",
-                    (*iov)[i].iov_base,
-                    (*iov)[i].iov_len);
-        }
-    }
-#endif
-    if (remaining_length != 0) {
-        printf( "Not all raw description was been extracted (%lu bytes missing)\n",
-                (unsigned long) remaining_length );
-    }
-
-    free (temp_iov);
-
-    return OMPI_SUCCESS;
-}
-
-
-
 int ompi_io_ompio_sort_offlen (mca_io_ompio_offlen_array_t *io_array,
                                int num_entries,
                                int *sorted){
-
+    
     int i = 0;
     int j = 0;
     int left = 0;
@@ -639,7 +518,6 @@ int ompi_io_ompio_sort_offlen (mca_io_ompio_offlen_array_t *io_array,
     return OMPI_SUCCESS;
 }
 
-
 void mca_io_ompio_get_num_aggregators ( int *num_aggregators)
 {
     *num_aggregators = mca_io_ompio_num_aggregators;
@@ -651,6 +529,38 @@ void mca_io_ompio_get_bytes_per_agg ( int *bytes_per_agg)
     *bytes_per_agg = mca_io_ompio_bytes_per_agg;
     return;
 }
+
+int mca_io_ompio_get_mca_parameter_value ( char *mca_parameter_name, int name_length )
+{
+    if ( !strncmp ( mca_parameter_name, "num_aggregators", name_length )) {
+        return mca_io_ompio_num_aggregators;
+    }
+    else if ( !strncmp ( mca_parameter_name, "bytes_per_agg", name_length )) {
+        return mca_io_ompio_bytes_per_agg;
+    }
+    else if ( !strncmp ( mca_parameter_name, "cycle_buffer_size", name_length )) {
+        return mca_io_ompio_cycle_buffer_size;
+    }
+    else if ( !strncmp ( mca_parameter_name, "grouping_option", name_length )) {
+        return mca_io_ompio_grouping_option;
+    }
+    else if ( !strncmp ( mca_parameter_name, "coll_timing_info", name_length )) {
+        return mca_io_ompio_coll_timing_info;
+    }
+    else if ( !strncmp ( mca_parameter_name, "sharedfp_lazy_open", name_length )) {
+        return mca_io_ompio_sharedfp_lazy_open;
+    }
+    else {
+        opal_output (1, "Error in mca_io_ompio_get_mca_parameter_value: unknown parameter name %s",
+            mca_parameter_name);
+    }
+    /* Using here OMPI_ERROR_MAX instead of OMPI_ERROR, since -1 (which is OMPI_ERROR)
+    ** is a valid value for some mca parameters, indicating that the user did not set
+    ** that parameter value
+    */
+    return OMPI_ERR_MAX;
+}
+
 
 
 

--- a/ompi/mca/io/ompio/io_ompio.h
+++ b/ompi/mca/io/ompio/io_ompio.h
@@ -138,6 +138,11 @@ enum ompio_fs_type
     PLFS = 4
 };
 
+/* functions to retrieve the number of aggregators and the size of the
+   temporary buffer on aggregators from the fcoll modules */
+OMPI_DECLSPEC int  mca_io_ompio_get_mca_parameter_value ( char *mca_parameter_name, int name_length);
+
+
 OMPI_DECLSPEC extern mca_io_base_component_2_0_0_t mca_io_ompio_component;
 /*
  * global variables, instantiated in module.c
@@ -174,30 +179,9 @@ typedef struct mca_io_ompio_offlen_array_t{
  * Function that takes in a datatype and buffer, and decodes that datatype
  * into an iovec using the convertor_raw function
  */
+#include "ompi/mca/common/ompio/common_ompio_callbacks.h"
 
 /* forward declaration to keep the compiler happy. */
-struct mca_io_ompio_file_t;
-typedef int (*mca_io_ompio_decode_datatype_fn_t) (struct mca_io_ompio_file_t *fh,
-						  struct ompi_datatype_t *datatype,
-						  int count,
-						  const void *buf,
-						  size_t *max_data,
-						  struct iovec **iov,
-						  uint32_t *iov_count);
-typedef int (*mca_io_ompio_generate_current_file_view_fn_t) (struct mca_io_ompio_file_t *fh,
-							     size_t max_data,
-							     struct iovec **f_iov,
-							     int *iov_count);
-
-/* functions to retrieve the number of aggregators and the size of the
-   temporary buffer on aggregators from the fcoll modules */
-typedef void (*mca_io_ompio_get_num_aggregators_fn_t) ( int *num_aggregators);
-typedef void (*mca_io_ompio_get_bytes_per_agg_fn_t) ( int *bytes_per_agg);
-typedef int (*mca_io_ompio_set_aggregator_props_fn_t) (struct mca_io_ompio_file_t *fh,
-							int num_aggregators,
-							size_t bytes_per_proc);
-
-
 struct mca_common_ompio_print_queue;
 
 /**
@@ -283,12 +267,14 @@ struct mca_io_ompio_file_t {
     int f_final_num_aggrs;
 
     /* internal ompio functions required by fbtl and fcoll */
-    mca_io_ompio_decode_datatype_fn_t                       f_decode_datatype;
-    mca_io_ompio_generate_current_file_view_fn_t f_generate_current_file_view;
+    mca_common_ompio_decode_datatype_fn_t                       f_decode_datatype;
+    mca_common_ompio_generate_current_file_view_fn_t f_generate_current_file_view;
 
-    mca_io_ompio_get_num_aggregators_fn_t               f_get_num_aggregators;
-    mca_io_ompio_get_bytes_per_agg_fn_t                   f_get_bytes_per_agg;
-    mca_io_ompio_set_aggregator_props_fn_t             f_set_aggregator_props;
+    mca_common_ompio_get_num_aggregators_fn_t               f_get_num_aggregators;
+    mca_common_ompio_get_bytes_per_agg_fn_t                   f_get_bytes_per_agg;
+    mca_common_ompio_set_aggregator_props_fn_t             f_set_aggregator_props;
+
+    mca_common_ompio_get_mca_parameter_value_fn_t          f_get_mca_parameter_value;
 };
 typedef struct mca_io_ompio_file_t mca_io_ompio_file_t;
 
@@ -297,9 +283,8 @@ struct mca_io_ompio_data_t {
 };
 typedef struct mca_io_ompio_data_t mca_io_ompio_data_t;
 
-
 #include "ompi/mca/common/ompio/common_ompio.h"
-#include "io_ompio_aggregators.h"
+
 
 /* functions to retrieve the number of aggregators and the size of the
    temporary buffer on aggregators from the fcoll modules */
@@ -362,8 +347,6 @@ int mca_io_ompio_file_open (struct ompi_communicator_t *comm,
                             struct ompi_info_t *info,
                             struct ompi_file_t *fh);
 int mca_io_ompio_file_close (struct ompi_file_t *fh);
-int mca_io_ompio_file_delete (const char *filename,
-                              struct ompi_info_t *info);
 int mca_io_ompio_file_set_size (struct ompi_file_t *fh,
                                 OMPI_MPI_OFFSET_TYPE size);
 int mca_io_ompio_file_preallocate (struct ompi_file_t *fh,

--- a/ompi/mca/io/ompio/io_ompio_file_open.c
+++ b/ompi/mca/io/ompio/io_ompio_file_open.c
@@ -102,30 +102,6 @@ int mca_io_ompio_file_close (ompi_file_t *fh)
     return ret;
 }
 
-int mca_io_ompio_file_delete (const char *filename,
-                              struct ompi_info_t *info)
-{
-    int ret = OMPI_SUCCESS;
-
-    /* No locking required for file_delete according to my understanding.
-       One thread will succeed, the other ones silently ignore the 
-       error that the file is already deleted.
-    */
-    ret = unlink(filename);
-
-    if (0 > ret ) {
-        if ( ENOENT == errno ) {
-            return MPI_ERR_NO_SUCH_FILE;
-        } else {
-            opal_output (0, "mca_io_ompio_file_delete: Could not remove file %s errno = %d %s\n", filename,
-                         errno, strerror(errno));
-            return MPI_ERR_ACCESS;
-        }
-    }
-
-    return OMPI_SUCCESS;
-}
-
 int mca_io_ompio_file_preallocate (ompi_file_t *fh,
                                    OMPI_MPI_OFFSET_TYPE diskspace)
 {

--- a/ompi/mca/io/ompio/io_ompio_file_read.c
+++ b/ompi/mca/io/ompio/io_ompio_file_read.c
@@ -30,7 +30,7 @@
 #include "ompi/mca/fbtl/base/base.h"
 
 #include "io_ompio.h"
-#include "io_ompio_request.h"
+#include "ompi/mca/common/ompio/common_ompio_request.h"
 #include "math.h"
 #include <unistd.h>
 

--- a/ompi/mca/io/ompio/io_ompio_file_write.c
+++ b/ompi/mca/io/ompio/io_ompio_file_write.c
@@ -34,7 +34,7 @@
 #include "ompi/mca/sharedfp/base/base.h"
 
 #include "io_ompio.h"
-#include "io_ompio_request.h"
+#include "ompi/mca/common/ompio/common_ompio_request.h"
 #include "math.h"
 #include <unistd.h>
 

--- a/ompi/mca/sharedfp/individual/Makefile.am
+++ b/ompi/mca/sharedfp/individual/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008      University of Houston. All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +35,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sharedfp_individual_la_SOURCES = $(sources)
 mca_sharedfp_individual_la_LDFLAGS = -module -avoid-version
-mca_sharedfp_individual_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_sharedfp_individual_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sharedfp_individual_la_SOURCES = $(sources)

--- a/ompi/mca/sharedfp/lockedfile/Makefile.am
+++ b/ompi/mca/sharedfp/lockedfile/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008      University of Houston. All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +35,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sharedfp_lockedfile_la_SOURCES = $(sources)
 mca_sharedfp_lockedfile_la_LDFLAGS = -module -avoid-version
-mca_sharedfp_lockedfile_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_sharedfp_lockedfile_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sharedfp_lockedfile_la_SOURCES = $(sources)

--- a/ompi/mca/sharedfp/sm/Makefile.am
+++ b/ompi/mca/sharedfp/sm/Makefile.am
@@ -11,6 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008      University of Houston. All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,7 +35,9 @@ mcacomponentdir = $(ompilibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_sharedfp_sm_la_SOURCES = $(sources)
 mca_sharedfp_sm_la_LDFLAGS = -module -avoid-version
-mca_sharedfp_sm_la_LIBADD = $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la
+mca_sharedfp_sm_la_LIBADD = \
+    $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+    $(OMPI_TOP_BUILDDIR)/ompi/mca/common/ompio/libmca_common_ompio.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_sharedfp_sm_la_SOURCES = $(sources)


### PR DESCRIPTION
This commit is the minimum set required to fix the abstraction
violation in the ompio components for the 3.0.x series. This commit
does not change names of the structues (as it was done in the masters
and 4.x series), does also not address the compilation part (i.e.,
including headers of components). It should, however, take care of the
runtime loading problem of data from different components.

It is, to some extent, a simplified subset of pull request 5263.

Fixes issue https://github.com/open-mpi/ompi/issues/7309

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>