### PR TITLE
plm/rsh: Fix segv on missing agent.

### DIFF
--- a/orte/mca/errmgr/base/errmgr_base_fns.c
+++ b/orte/mca/errmgr/base/errmgr_base_fns.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,7 +119,9 @@ void orte_errmgr_base_abort(int error_code, char *fmt, ...)
     /* if I am a daemon or the HNP... */
     if (ORTE_PROC_IS_HNP || ORTE_PROC_IS_DAEMON) {
         /* whack my local procs */
-        orte_odls.kill_local_procs(NULL);
+        if( NULL != orte_odls.kill_local_procs ) {
+            orte_odls.kill_local_procs(NULL);
+        }
         /* whack any session directories */
         orte_session_dir_cleanup(ORTE_JOBID_WILDCARD);
     }

--- a/orte/mca/plm/rsh/plm_rsh_component.c
+++ b/orte/mca/plm/rsh/plm_rsh_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights
  *                         reserved.
  * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2011-2019 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2011-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -370,6 +370,10 @@ char **orte_plm_rsh_search(const char* agent_list, const char *path)
     char **tokens, *tmp;
     char cwd[OPAL_PATH_MAX];
 
+    if (NULL == agent_list && NULL == mca_plm_rsh_component.agent) {
+        return NULL;
+    }
+
     if (NULL == path) {
         getcwd(cwd, OPAL_PATH_MAX);
     } else {
@@ -420,6 +424,14 @@ static int rsh_launch_agent_lookup(const char *agent_list, char *path)
 {
     char *bname;
     int i;
+
+    if (NULL == agent_list && NULL == mca_plm_rsh_component.agent) {
+        OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
+                             "%s plm:rsh_lookup on agent (null) path %s - No agent specified.",
+                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                             (NULL == path) ? "NULL" : path));
+        return ORTE_ERR_NOT_FOUND;
+    }
 
     OPAL_OUTPUT_VERBOSE((5, orte_plm_base_framework.framework_output,
                          "%s plm:rsh_lookup on agent %s path %s",


### PR DESCRIPTION
 * Additionally, fixes the `NULL` option to `OMPI_MCA_plm_rsh_agent`
   would would also lead to a segv. Now it operates as intended by
   disqualifying the `rsh` component and falling back onto the `isolated`
   component.
 * Fixes #7330