### PR TITLE
Updating VERSION to v4.0.3rc3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -7,7 +7,7 @@
 #                         reserved.
 # Copyright (c) 2019      Triad National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2018-2019 IBM Corporation.  All rights reserved.
+# Copyright (c) 2018-2020 IBM Corporation.  All rights reserved.
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 
@@ -30,7 +30,7 @@ release=3
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
We tried doing an RC2 built without updating the greek,
and found where that failed in build automation.
Reving again for rc3, as we've already applied the rc2 tag.

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>