### PR TITLE
Prepare for 3.1.6rc2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,9 +55,11 @@ included in the vX.Y.Z section and be denoted as:
    (** also appeared: A.B.C)  -- indicating that this item was previously
                                  included in release version vA.B.C.
 
-3.1.6 -- January, 2020
-----------------------
+3.1.6 -- February, 2020
+-----------------------
 
+- Fix issue with zero-length blockLength in MPI_TYPE_INDEXED.
+- Fix run-time linker issues with OMPIO on newer Linux distros.
 - Fix PMIX dstore locking compilation issue.  Thanks to Marco Atzeri
   for reporting the issue.
 - Allow the user to override modulefile_path in the Open MPI SRPM,

--- a/VERSION
+++ b/VERSION
@@ -26,7 +26,7 @@ release=6
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -102,7 +102,7 @@ libompitrace_so_version=50:1:10
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=50:2:9
+libmca_ompi_common_ompio_so_version=50:3:9
 libmca_ompi_common_monitoring_so_version=50:1:0
 
 # ORTE layer


### PR DESCRIPTION
We added an OMPIO fix, so note that in the NEWS and bump its common .so
Librtool c:r:a number.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>