### PR TITLE
Prepare for 3.0.6rc2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,9 +36,10 @@ This file contains notable changes between releases for each release since
 Open MPI 1.0.  Because Open MPI maintains multiple release branches at any time,
 it is possible for items to appear more than once in the list.
 
-3.0.6 -- January, 2020
-----------------------
+3.0.6 -- February, 2020
+-----------------------
 
+- Fix run-time linker issues with OMPIO on newer Linux distros.
 - Allow the user to override modulefile_path in the Open MPI SRPM,
   even if install_in_opt is set to 1.
 - Properly detect ConnectX-6 HCAs in the openib BTL.

--- a/VERSION
+++ b/VERSION
@@ -24,7 +24,7 @@ release=6
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -100,7 +100,7 @@ libompitrace_so_version=40:1:0
 # components-don't-affect-the-build-system abstraction.
 
 # OMPI layer
-libmca_ompi_common_ompio_so_version=41:3:0
+libmca_ompi_common_ompio_so_version=41:4:0
 
 # ORTE layer
 libmca_orte_common_alps_so_version=40:1:0


### PR DESCRIPTION
We added an OMPIO fix, so note that in the NEWS and bump its common
.so Librtool c:r:a number.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>