### PR TITLE
PR 7268 follow-up

### DIFF
--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -234,7 +234,8 @@ AC_DEFUN([OPAL_SETUP_RUNPATH],[
                      [OPAL_LIBTOOL_CONFIG([wl],[wl_fc],[--tag=FC],[])
                       LDFLAGS="$LDFLAGS_save ${wl_fc}--enable-new-dtags"
                       AC_LANG_PUSH([Fortran])
-                      AC_LINK_IFELSE([AC_LANG_SOURCE([[program test end program]])],
+                      AC_LINK_IFELSE([AC_LANG_SOURCE([[program test 
+end program]])],
                                      [runpath_fc_args="${wl_fc}--enable-new-dtags"
                                       AC_MSG_RESULT([yes (-Wl,--enable-new-dtags)])],
                                      [AC_MSG_RESULT([no])])


### PR DESCRIPTION
Forgot to include a fix for the fortran test used to check if
new dtags is supported.

Related to #7268

This patch is already included on v4.0.x branch.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>