### PR TITLE
Actually Updating VERSION to v4.0.3rc3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -30,7 +30,7 @@ release=3
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=rc3
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"


### PR DESCRIPTION
Oops, last Commit said it set the greek to rc3, but it actually set it to rc2.... sigh.

Fortunately we haven't yet tagged or built 4.0.3rc3, so there's time to fix this today.

[skip ci]

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>