### PR TITLE
Bump hwloc requirement from 1.5 to 1.11

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_dt.c
+++ b/opal/mca/hwloc/base/hwloc_base_dt.c
@@ -151,14 +151,8 @@ int opal_hwloc_unpack(opal_buffer_t *buffer, void *dest,
 
 int opal_hwloc_copy(hwloc_topology_t *dest, hwloc_topology_t src, opal_data_type_t type)
 {
-#ifdef HAVE_HWLOC_TOPOLOGY_DUP
     /* use the hwloc dup function */
     return hwloc_topology_dup(dest, src);
-#else
-    /* hwloc_topology_dup() was introduced in hwloc v1.8.0.
-     * Note that as of March 2017, opal_hwloc_copy() is not (yet?) used in the code base anywhere. */
-    return OPAL_ERR_NOT_SUPPORTED;
-#endif
 }
 
 int opal_hwloc_compare(const hwloc_topology_t topo1,

--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      Inria.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,8 +50,8 @@ char *opal_hwloc_base_cpu_list=NULL;
 bool opal_hwloc_report_bindings=false;
 hwloc_obj_type_t opal_hwloc_levels[] = {
     HWLOC_OBJ_MACHINE,
-    HWLOC_OBJ_NODE,
-    HWLOC_OBJ_SOCKET,
+    HWLOC_OBJ_NUMANODE,
+    HWLOC_OBJ_PACKAGE,
     HWLOC_OBJ_L3CACHE,
     HWLOC_OBJ_L2CACHE,
     HWLOC_OBJ_L1CACHE,

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -1388,10 +1388,8 @@ opal_hwloc_locality_t opal_hwloc_base_get_relative_locality(hwloc_topology_t top
  */
 char* opal_hwloc_base_find_coprocessors(hwloc_topology_t topo)
 {
-#if HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC
     hwloc_obj_t osdev;
     char **cps = NULL;
-#endif
     char *cpstring = NULL;
     int depth;
 
@@ -1403,7 +1401,6 @@ char* opal_hwloc_base_find_coprocessors(hwloc_topology_t topo)
                              "hwloc:base:find_coprocessors: NONE FOUND IN TOPO"));
         return NULL;
     }
-#if HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC
     /* check the device objects for coprocessors */
     osdev = hwloc_get_obj_by_depth(topo, depth, 0);
     while (NULL != osdev) {
@@ -1428,11 +1425,6 @@ char* opal_hwloc_base_find_coprocessors(hwloc_topology_t topo)
     OPAL_OUTPUT_VERBOSE((5, opal_hwloc_base_framework.framework_output,
                          "hwloc:base:find_coprocessors: hosting coprocessors %s",
                          (NULL == cpstring) ? "NONE" : cpstring));
-#else
-    OPAL_OUTPUT_VERBOSE((5, opal_hwloc_base_framework.framework_output,
-                         "hwloc:base:find_coprocessors: the version of hwloc that Open MPI was built against (v%d.%d.%d) does not support detecting coprocessors",
-                         (HWLOC_API_VERSION>>16)&&0xFF, (HWLOC_API_VERSION>>8)&0xFF, HWLOC_API_VERSION&&0xFF));
-#endif
     return cpstring;
 }
 

--- a/opal/mca/hwloc/configure.m4
+++ b/opal/mca/hwloc/configure.m4
@@ -1,6 +1,7 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2010-2017 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2020      Inria.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -88,9 +89,6 @@ AC_DEFUN([MCA_opal_hwloc_CONFIG_REQUIRE],[
     # "opal" and "hwloc", because this macro is invoked via AC
     # REQUIRE.
     MCA_CONFIGURE_FRAMEWORK([opal], [hwloc], 1)
-
-    # Restore the --enable-pci flag
-    enable_pci=$opal_hwloc_hwloc132_save_enable_pci
 
     # Give a blank line to separate these messages from the last
     # component's configure.m4 output.

--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -5,6 +5,7 @@
 #                         and Technology (RIST). All rights reserved.
 #
 # Copyright (c) 2018      Intel, Inc. All rights reserved.
+# Copyright (c) 2020      Inria.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -134,12 +135,12 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                   LDFLAGS="$LDFLAGS $opal_hwloc_external_LDFLAGS"
                   LIBS="$LIBS $opal_hwloc_external_LIBS"
 
-                  AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
+                  AC_MSG_CHECKING([if external hwloc version is 1.11 or greater])
                   AC_COMPILE_IFELSE(
                       [AC_LANG_PROGRAM([[#include <hwloc.h>]],
                           [[
-#if HWLOC_API_VERSION < 0x00010500
-#error "hwloc API version is less than 0x00010500"
+#if HWLOC_API_VERSION < 0x00010b00
+#error "hwloc API version is less than 0x00010b00"
 #endif
                           ]])],
                       [AC_MSG_RESULT([yes])],

--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -171,7 +171,6 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                                      [external],
                                      [Version of hwloc])
 
-                  AC_CHECK_DECLS([HWLOC_OBJ_OSDEV_COPROC], [], [], [#include <hwloc.h>])
                   AC_CHECK_FUNCS([hwloc_topology_dup])
 
                   # See if the external hwloc supports XML

--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -171,8 +171,6 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                                      [external],
                                      [Version of hwloc])
 
-                  AC_CHECK_FUNCS([hwloc_topology_dup])
-
                   # See if the external hwloc supports XML
                   AC_MSG_CHECKING([if external hwloc supports XML])
                   AS_IF([test "$opal_hwloc_dir" != ""],

--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -171,18 +171,6 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                                      [external],
                                      [Version of hwloc])
 
-                  # See if the external hwloc supports XML
-                  AC_MSG_CHECKING([if external hwloc supports XML])
-                  AS_IF([test "$opal_hwloc_dir" != ""],
-                        [opal_hwloc_external_lstopo="$opal_hwloc_dir/bin/lstopo"],
-                        [OPAL_WHICH(lstopo, opal_hwloc_external_lstopo)])
-                  opal_hwloc_external_tmp=`$opal_hwloc_external_lstopo --help | $GREP "Supported output file formats" | grep xml`
-                  AS_IF([test "$opal_hwloc_external_tmp" = ""],
-                        [opal_hwloc_external_enable_xml=0
-                         AC_MSG_RESULT([no])],
-                        [opal_hwloc_external_enable_xml=1
-                         AC_MSG_RESULT([yes])])
-
                   AC_CHECK_HEADERS([infiniband/verbs.h])
 
                   # These flags need to get passed to the wrapper compilers

--- a/opal/mca/hwloc/external/external.h
+++ b/opal/mca/hwloc/external/external.h
@@ -57,7 +57,7 @@ BEGIN_C_DECLS
 #    if defined(HAVE_INFINIBAND_VERBS_H)
 #        include MCA_hwloc_external_openfabrics_header
 #    else
-#        error Tried to include hwloc verbs helper file, but hwloc was compiled with no OpenFabrics support
+#        error Tried to include hwloc verbs helper file, but <infiniband/verbs.h> is missing
 #    endif
 #endif
 

--- a/opal/mca/hwloc/external/external.h
+++ b/opal/mca/hwloc/external/external.h
@@ -4,6 +4,7 @@
  *                         and Technology (RIST). All rights reserved.
  *
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2020      Inria.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,11 +68,6 @@ BEGIN_C_DECLS
 /* Do nothing in the 1.x case because the caller doesn't know HWLOC_API_VERSION when it sets OPAL_HWLOC_WANT_SHMEM.
  * Calls to hwloc/shmem.h are protected by HWLOC_API_VERSION >= 0x20000 in the actual code.
  */
-#endif
-
-#if HWLOC_API_VERSION < 0x00010b00
-#define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
-#define HWLOC_OBJ_PACKAGE HWLOC_OBJ_SOCKET
 #endif
 
 END_C_DECLS

--- a/opal/mca/hwloc/hwloc2/configure.m4
+++ b/opal/mca/hwloc/hwloc2/configure.m4
@@ -202,8 +202,7 @@ AC_DEFUN([MCA_opal_hwloc_hwloc2_CONFIG],[
     AS_IF([test "$opal_hwloc_external_support" = "yes"],
           [AC_MSG_NOTICE([using an external hwloc; disqualifying this component])
            opal_hwloc_hwloc2_support=no],
-          [AC_DEFINE([HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC], [1])
-           AC_DEFINE([HAVE_HWLOC_TOPOLOGY_DUP], [1])])
+          [AC_DEFINE([HAVE_HWLOC_TOPOLOGY_DUP], [1])])
 
     # Done!
     AS_IF([test "$opal_hwloc_hwloc2_support" = "yes"],

--- a/opal/mca/hwloc/hwloc2/configure.m4
+++ b/opal/mca/hwloc/hwloc2/configure.m4
@@ -201,8 +201,7 @@ AC_DEFUN([MCA_opal_hwloc_hwloc2_CONFIG],[
     # distclean" infrastructure to work properly).
     AS_IF([test "$opal_hwloc_external_support" = "yes"],
           [AC_MSG_NOTICE([using an external hwloc; disqualifying this component])
-           opal_hwloc_hwloc2_support=no],
-          [AC_DEFINE([HAVE_HWLOC_TOPOLOGY_DUP], [1])])
+           opal_hwloc_hwloc2_support=no])
 
     # Done!
     AS_IF([test "$opal_hwloc_hwloc2_support" = "yes"],

--- a/opal/mca/hwloc/hwloc2/hwloc2.h
+++ b/opal/mca/hwloc/hwloc2/hwloc2.h
@@ -7,6 +7,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
+ * Copyright (c) 2020      Inria.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +43,7 @@ BEGIN_C_DECLS
 #    if defined(HAVE_INFINIBAND_VERBS_H)
 #        include "hwloc/include/hwloc/openfabrics-verbs.h"
 #    else
-#        error Tried to include hwloc verbs helper file, but hwloc was compiled with no OpenFabrics support
+#        error Tried to include hwloc verbs helper file, but <infiniband/verbs.h> is missing
 #    endif
 #endif
 


### PR DESCRIPTION
As discussed in #7362 and in preparation for discussing at the F2F meeting, I am removing some old configure checks for early hwloc versions, bumping the minimal supported release to 1.11 and removing some other unneeded configury.

According to https://repology.org/project/hwloc/versions all major distros switched to 1.11.x, and basically all of them except Centos8 are even at 2.x.

For the record 1.5.2 was released in 2013, 1.10.1 in 2015 and 1.11.0 in 2015/06.