### PR TITLE
v3.0.x: Fix pgcc18 support.

### DIFF
--- a/config/opal_check_vendor.m4
+++ b/config/opal_check_vendor.m4
@@ -102,13 +102,19 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
     opal_check_compiler_vendor_result="unknown"
 
     # GNU is probably the most common, so check that one as soon as
-    # possible.  Intel pretends to be GNU, so need to check Intel
-    # before checking for GNU.
+    # possible.  Intel and PGI18 pretends to be GNU, so need to check Intel
+    # and PGI before checking for GNU.
 
     # Intel
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
           [OPAL_IF_IFELSE([defined(__INTEL_COMPILER) || defined(__ICC)],
                [opal_check_compiler_vendor_result="intel"])])
+
+    # Portland Group
+    AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
+          [OPAL_IFDEF_IFELSE([__PGI],
+               [opal_check_compiler_vendor_result="portland group"])])
+
 
     # Fujitsu
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
@@ -242,11 +248,6 @@ AC_DEFUN([_OPAL_CHECK_COMPILER_VENDOR], [
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
           [OPAL_IFDEF_IFELSE([__POCC__],
                [opal_check_compiler_vendor_result="pelles"])])
-
-    # Portland Group
-    AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],
-          [OPAL_IFDEF_IFELSE([__PGI],
-               [opal_check_compiler_vendor_result="portland group"])])
 
     # SAS/C
     AS_IF([test "$opal_check_compiler_vendor_result" = "unknown"],


### PR DESCRIPTION
- pgcc18 defines __GNUC__ similar to Intel compilers. So we must
  check for pgi higher up, or else configury will mistake
  it for gcc.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 14785deb3c6609cb3f6763d0e07a49e86588c4da)