### PR TITLE
Enable build against PMIx v2.2 without internal PRRTE

### DIFF
--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -45,6 +45,7 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
     AC_MSG_CHECKING([if RTE support is enabled])
     if test "$enable_internal_rte" != "no"; then
         AC_MSG_RESULT([yes])
+        ompi_want_prrte=yes
         if test -z $with_libevent || test "$with_libevent" = "internal" || test "$with_libevent" = "yes"; then
             opal_prrte_libevent_arg="--with-libevent-header=$OMPI_TOP_SRCDIR/opal/mca/event/event.h"
         elif test "$with_libevent" = "external"; then
@@ -96,6 +97,7 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
     else
         OPAL_SUMMARY_ADD([[Miscellaneous]],[[PRRTE]],[prrte],[no (disabled)])
         AC_MSG_RESULT([no (disabled)])
+        ompi_want_prrte=no
     fi
 
     CFLAGS=$opal_prrte_save_CFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 # Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
@@ -1463,8 +1463,7 @@ OPAL_CHECK_LIBNL_SUMMARY
 opal_show_title "Setup PRRTE support"
 
 m4_ifdef([project_prrte],
-         [OMPI_SETUP_PRRTE
-          ompi_want_prrte=yes],
+         [OMPI_SETUP_PRRTE],
          [ompi_want_prrte=no])
 AM_CONDITIONAL(OMPI_WANT_PRRTE, test "$ompi_want_prrte" = "yes")
 

--- a/opal/mca/pmix/base/pmix_base_fns.c
+++ b/opal/mca/pmix/base/pmix_base_fns.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -526,6 +526,7 @@ void opal_pmix_value_load(pmix_value_t *v,
             v->data.pinfo->exit_code = kv->data.pinfo.exit_code;
             v->data.pinfo->state = opal_pmix_convert_state(kv->data.pinfo.state);
             break;
+#if PMIX_NUMERIC_VERSION >= 0x00030000
         case OPAL_ENVAR:
             v->type = PMIX_ENVAR;
             PMIX_ENVAR_CONSTRUCT(&v->data.envar);
@@ -537,6 +538,7 @@ void opal_pmix_value_load(pmix_value_t *v,
             }
             v->data.envar.separator = kv->data.envar.separator;
             break;
+#endif
         default:
             /* silence warnings */
             break;
@@ -722,6 +724,7 @@ int opal_pmix_value_unload(opal_value_t *kv,
         kv->data.pinfo.exit_code = v->data.pinfo->exit_code;
         kv->data.pinfo.state = opal_pmix_convert_pstate(v->data.pinfo->state);
         break;
+#if PMIX_NUMERIC_VERSION >= 0x00030000
     case PMIX_ENVAR:
         kv->type = OPAL_ENVAR;
         OBJ_CONSTRUCT(&kv->data.envar, opal_envar_t);
@@ -733,6 +736,7 @@ int opal_pmix_value_unload(opal_value_t *kv,
         }
         kv->data.envar.separator = v->data.envar.separator;
         break;
+#endif
     default:
         /* silence warnings */
         rc = OPAL_ERROR;
@@ -740,6 +744,8 @@ int opal_pmix_value_unload(opal_value_t *kv,
     }
     return rc;
 }
+
+#if PMIX_NUMERIC_VERSION >= 0x00030000
 
 static void cleanup_cbfunc(pmix_status_t status,
                            pmix_info_t *info, size_t ninfo,
@@ -761,9 +767,11 @@ static void cleanup_cbfunc(pmix_status_t status,
     lk->status = status;
     OPAL_PMIX_WAKEUP_THREAD(lk);
 }
+#endif
 
 int opal_pmix_register_cleanup(char *path, bool directory, bool ignore, bool jobscope)
 {
+#if PMIX_NUMERIC_VERSION >= 0x00030000
     opal_pmix_lock_t lk;
     pmix_info_t pinfo[3];
     size_t n, ninfo=0;
@@ -816,6 +824,9 @@ int opal_pmix_register_cleanup(char *path, bool directory, bool ignore, bool job
         PMIX_INFO_DESTRUCT(&pinfo[n]);
     }
     return ret;
+#else
+    return OPAL_SUCCESS;
+#endif
 }
 
 
@@ -824,7 +835,11 @@ static void dsicon(opal_ds_info_t *p)
 {
     PMIX_PROC_CONSTRUCT(&p->source);
     p->info = NULL;
+#if PMIX_NUMERIC_VERSION >= 0x00030000
     p->persistence = PMIX_PERSIST_INVALID;
+#else
+    p->persistence = PMIX_PERSIST_INDEF;
+#endif
 }
 OBJ_CLASS_INSTANCE(opal_ds_info_t,
                    opal_list_item_t,


### PR DESCRIPTION
If you autogen.pl --without-prrte, we wouldn't configure or build PRRTE
support. However, configuring with --disable-internal-rte wasn't working
as it was being ignored. This led to some false errors when compiling
with an earlier PMIx v2.2 release.

That said, there were a couple of places that needed protection against
PMIx v2.2.

Fixes #7405 

Signed-off-by: Ralph Castain <rhc@pmix.org>