### PR TITLE
opal/mca: check if the user home directory is NULL

### DIFF
--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -403,9 +403,6 @@ int mca_base_var_cache_files(bool rel_path_search)
     char *tmp;
     int ret;
 
-    /* We may need this later */
-    home = (char*)opal_home_directory();
-
     if (NULL == cwd) {
         cwd = (char *) malloc(sizeof(char) * MAXPATHLEN);
         if( NULL == (cwd = getcwd(cwd, MAXPATHLEN) )) {
@@ -415,6 +412,13 @@ int mca_base_var_cache_files(bool rel_path_search)
     }
 
 #if OPAL_WANT_HOME_CONFIG_FILES
+    /* We may need this later */
+    home = (char*)opal_home_directory();
+    if (NULL == home) {
+        opal_output(0, "Error: Unable to get the user home directory\n");
+        return OPAL_ERROR;
+    }
+
     opal_asprintf(&mca_base_var_files, "%s"OPAL_PATH_SEP".openmpi" OPAL_PATH_SEP
              "mca-params.conf%c%s" OPAL_PATH_SEP "openmpi-mca-params.conf",
              home, ',', opal_install_dirs.sysconfdir);


### PR DESCRIPTION
This commit fixes an issue in the MCA base variable system. The
code was retrieving the user home directory (from HOME) and
attempting to use it to build a search path for config files.
In this case user-level configuration directories have been
enabled so the appropriate thing to do is to print an error
message and return. This commit makes that change. It does not
ensure that HOME is set correctly.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>