### PR TITLE
osc/rdma: fix bug in attach for non-debug builds

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_dynamic.c
+++ b/ompi/mca/osc/rdma/osc_rdma_dynamic.c
@@ -261,8 +261,8 @@ int ompi_osc_rdma_attach (struct ompi_win_t *win, void *base, size_t len)
         rdma_region_handle->btl_handle = NULL;
     }
 
-    assert(OMPI_SUCCESS == ompi_osc_rdma_add_attachment (rdma_region_handle, (intptr_t) base, len));
-
+    ret = ompi_osc_rdma_add_attachment (rdma_region_handle, (intptr_t) base, len);
+    assert(OMPI_SUCCESS == ret);
     module->dynamic_handles[region_index] = rdma_region_handle;
 
 #if OPAL_ENABLE_DEBUG


### PR DESCRIPTION
This commit fixes an issue with non-debug builds where adding an
attachment to the attachment list doesn't actually happen. This
causes all MPI_Win_detach calls to fail. The call was within an
assert which is optimized out in optimized builds.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>