### PR TITLE
minor hwloc configure fixes

### DIFF
--- a/opal/mca/hwloc/configure.m4
+++ b/opal/mca/hwloc/configure.m4
@@ -89,9 +89,6 @@ AC_DEFUN([MCA_opal_hwloc_CONFIG_REQUIRE],[
     # REQUIRE.
     MCA_CONFIGURE_FRAMEWORK([opal], [hwloc], 1)
 
-    # Restore the --enable-pci flag
-    enable_pci=$opal_hwloc_hwloc132_save_enable_pci
-
     # Give a blank line to separate these messages from the last
     # component's configure.m4 output.
     echo " "

--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -173,18 +173,6 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                   AC_CHECK_DECLS([HWLOC_OBJ_OSDEV_COPROC], [], [], [#include <hwloc.h>])
                   AC_CHECK_FUNCS([hwloc_topology_dup])
 
-                  # See if the external hwloc supports XML
-                  AC_MSG_CHECKING([if external hwloc supports XML])
-                  AS_IF([test "$opal_hwloc_dir" != ""],
-                        [opal_hwloc_external_lstopo="$opal_hwloc_dir/bin/lstopo"],
-                        [OPAL_WHICH(lstopo, opal_hwloc_external_lstopo)])
-                  opal_hwloc_external_tmp=`$opal_hwloc_external_lstopo --help | $GREP "Supported output file formats" | grep xml`
-                  AS_IF([test "$opal_hwloc_external_tmp" = ""],
-                        [opal_hwloc_external_enable_xml=0
-                         AC_MSG_RESULT([no])],
-                        [opal_hwloc_external_enable_xml=1
-                         AC_MSG_RESULT([yes])])
-
                   AC_CHECK_HEADERS([infiniband/verbs.h])
 
                   # These flags need to get passed to the wrapper compilers

--- a/opal/mca/hwloc/external/external.h
+++ b/opal/mca/hwloc/external/external.h
@@ -56,7 +56,7 @@ BEGIN_C_DECLS
 #    if defined(HAVE_INFINIBAND_VERBS_H)
 #        include MCA_hwloc_external_openfabrics_header
 #    else
-#        error Tried to include hwloc verbs helper file, but hwloc was compiled with no OpenFabrics support
+#        error Tried to include hwloc verbs helper file, but <infiniband/verbs.h> is missing
 #    endif
 #endif
 

--- a/opal/mca/hwloc/hwloc2/hwloc2.h
+++ b/opal/mca/hwloc/hwloc2/hwloc2.h
@@ -42,7 +42,7 @@ BEGIN_C_DECLS
 #    if defined(HAVE_INFINIBAND_VERBS_H)
 #        include "hwloc/include/hwloc/openfabrics-verbs.h"
 #    else
-#        error Tried to include hwloc verbs helper file, but hwloc was compiled with no OpenFabrics support
+#        error Tried to include hwloc verbs helper file, but <infiniband/verbs.h> is missing
 #    endif
 #endif
 


### PR DESCRIPTION
Remove some stale configure checks and fix some build error messages.
Those were found while looking at bumping hwloc requirement to 1.11 (#7367) but they are actually unrelated.