### PR TITLE
opal/atomic: clean out s390(x)

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -17,6 +17,7 @@ dnl Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
 dnl                         reserved.
+dnl Copyright (c) 2020      Google, LLC. All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -1258,19 +1259,6 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
                 AC_MSG_ERROR([Could not determine PowerPC word size: $ac_cv_sizeof_long])
             fi
             OPAL_GCC_INLINE_ASSIGN='"1: li %0,0" : "=&r"(ret)'
-            ;;
-        # There is no current difference between s390 and s390x
-        # But use two different defines in case some come later
-        # as s390 is 31bits while s390x is 64bits
-        s390-*)
-            opal_cv_asm_arch="S390"
-            OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"],
-              [AC_MSG_ERROR([No atomic primitives available for $host])])
-            ;;
-        s390x-*)
-            opal_cv_asm_arch="S390X"
-            OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"],
-              [AC_MSG_ERROR([No atomic primitives available for $host])])
             ;;
         sparc*-*)
             # SPARC v9 (and above) are the only ones with 64bit support

--- a/opal/include/opal/sys/architecture.h
+++ b/opal/include/opal/sys/architecture.h
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,8 +43,6 @@
 #define OPAL_MIPS           0070
 #define OPAL_ARM            0100
 #define OPAL_ARM64          0101
-#define OPAL_S390           0110
-#define OPAL_S390X          0111
 #define OPAL_BUILTIN_SYNC   0200
 #define OPAL_BUILTIN_GCC    0202
 #define OPAL_BUILTIN_NO     0203

--- a/opal/include/opal/sys/cma.h
+++ b/opal/include/opal/sys/cma.h
@@ -4,6 +4,7 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -81,16 +82,6 @@
 #error "Unsupported MIPS architecture for process_vm_readv and process_vm_writev syscalls"
 
 #endif
-
-#elif OPAL_ASSEMBLY_ARCH == OPAL_S390
-
-#define __NR_process_vm_readv	340
-#define __NR_process_vm_writev	341
-
-#elif OPAL_ASSEMBLY_ARCH == OPAL_S390X
-
-#define __NR_process_vm_readv	340
-#define __NR_process_vm_writev	341
 
 #else
 #error "Unsupported architecture for process_vm_readv and process_vm_writev syscalls"


### PR DESCRIPTION
This commit removes the CMA support for s390 and s390x. These
architectures have been unsupported for awhile and no one has
verified that CMA actually works with Open MPI on these systems.

s390 and s390x will continue to work with Open MPI without CMA.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>