### PR TITLE
opal/asm: remove MIPS

### DIFF
--- a/config/opal_config_asm.m4
+++ b/config/opal_config_asm.m4
@@ -1233,14 +1233,6 @@ AC_DEFUN([OPAL_CONFIG_ASM],[
               [AC_MSG_ERROR([No atomic primitives available for $host])])
             ;;
 
-        mips-*|mips64*)
-            # Should really find some way to make sure that we are on
-            # a MIPS III machine (r4000 and later)
-            opal_cv_asm_arch="MIPS"
-            OPAL_CHECK_SYNC_BUILTINS([opal_cv_asm_builtin="BUILTIN_SYNC"],
-              [AC_MSG_ERROR([No atomic primitives available for $host])])
-            ;;
-
         powerpc-*|powerpc64-*|powerpcle-*|powerpc64le-*|rs6000-*|ppc-*)
             OPAL_CHECK_POWERPC_REG
             if test "$ac_cv_sizeof_long" = "4" ; then

--- a/opal/include/opal/sys/architecture.h
+++ b/opal/include/opal/sys/architecture.h
@@ -39,7 +39,6 @@
 #define OPAL_SPARC          0060
 #define OPAL_SPARCV9_32     0061
 #define OPAL_SPARCV9_64     0062
-#define OPAL_MIPS           0070
 #define OPAL_ARM            0100
 #define OPAL_ARM64          0101
 #define OPAL_S390           0110

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -177,8 +177,6 @@ enum {
 #include "opal/sys/ia32/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_IA64
 #include "opal/sys/ia64/atomic.h"
-#elif OPAL_ASSEMBLY_ARCH == OPAL_MIPS
-#include "opal/sys/mips/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_POWERPC32
 #include "opal/sys/powerpc/atomic.h"
 #elif OPAL_ASSEMBLY_ARCH == OPAL_POWERPC64

--- a/opal/include/opal/sys/cma.h
+++ b/opal/include/opal/sys/cma.h
@@ -64,24 +64,6 @@
 #define __NR_process_vm_readv 270
 #define __NR_process_vm_writev 271
 
-#elif OPAL_ASSEMBLY_ARCH == OPAL_MIPS
-
-#if _MIPS_SIM == _MIPS_SIM_ABI64
-
-#define __NR_process_vm_readv 5304
-#define __NR_process_vm_writev 5305
-
-#elif _MIPS_SIM == _MIPS_SIM_NABI32
-
-#define __NR_process_vm_readv 6309
-#define __NR_process_vm_writev 6310
-
-#else
-
-#error "Unsupported MIPS architecture for process_vm_readv and process_vm_writev syscalls"
-
-#endif
-
 #elif OPAL_ASSEMBLY_ARCH == OPAL_S390
 
 #define __NR_process_vm_readv	340


### PR DESCRIPTION
This commit removes the code specific to MIPS. This architecture
has been unsupported for some time. Open MPI will continue to work
on MIPS with C11 and __atomic but will not longer use CMA for
shared memory.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>