### PR TITLE
fix an issue with configuring with external pmix

### DIFF
--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -17,6 +17,9 @@
 # Copyright (c) 2014-2018 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Triad National Security, LLC. All rights
+#                         reserved.
+#
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -180,14 +183,17 @@ AC_DEFUN([OPAL_CHECK_PMIX_LIB],[
           [$3
            # add the new flags to our wrapper compilers
            AS_IF([test "$pmix_ext_install_incdir" != "/usr" && test "$pmix_ext_install_incdir" != "/usr/include"],
-                 [pmix_pmix4x_WRAPPER_EXTRA_CPPFLAGS="-I$pmix_ext_install_incdir"])
+                 [pmix_external_WRAPPER_EXTRA_CPPFLAGS="-I$pmix_ext_install_incdir"])
            AS_IF([test "$pmix_ext_install_libdir" != "/usr" && test "$pmix_ext_install_libdir" != "/usr/include"],
-                 [pmix_external_WRAPPER_EXTRA_LDFLAGS="-L$pmix_ext_install_libdir"])
-           pmix_external_WRAPPER_EXTRA_LIBS=-lpmix],
-          [CPPFLAGS=$opal_external_pmix_save_CPPFLAGS
-           LDFLAGS=$opal_external_pmix_save_LDFLAGS
-           LIBS=$opal_external_pmix_save_LIBS
-           $4])
+                 [pmix_external_WRAPPER_EXTRA_LDFLAGS="-L$pmix_ext_install_libdir"
+                  pmix_external_WRAPPER_EXTRA_LIBS="-lpmix"])],
+          [$4])
+
+dnl swap back in original LDFLAGS, LIBS to avoid messing up subsequent configury checks
+dnl don't swap back in orig CFLAGS as there are lots of places where the external pmix
+dnl header file location needs to be known
+    LDFLAGS=$opal_external_pmix_save_LDFLAGS
+    LIBS=$opal_external_pmix_save_LIBS
 
     OPAL_VAR_SCOPE_POP
 ])
@@ -257,11 +263,14 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
            AS_IF([test "$pmix_ext_install_dir" != "/usr"],
                  [opal_external_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
                   opal_external_pmix_LDFLAGS=-L$pmix_ext_install_libdir])
-           opal_external_pmix_LIBS=-lpmix],
+           opal_external_pmix_LIBS="-lpmix"],
           [AC_MSG_RESULT([internal])])
 
     AC_DEFINE_UNQUOTED([OPAL_PMIX_V1],[$opal_external_have_pmix1],
                        [Whether the external PMIx library is v1])
+
+    AC_SUBST(opal_external_pmix_LDFLAGS)
+    AC_SUBST(opal_external_pmix_LIBS)
 
     AS_IF([test "$opal_external_pmix_happy" = "yes"],
           [AS_IF([test "$opal_external_pmix_version" = "1x"],

--- a/opal/mca/pmix/external/Makefile.am
+++ b/opal/mca/pmix/external/Makefile.am
@@ -1,6 +1,9 @@
 #
 # Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      Triad National Security, LLC. All rights
+#                         reserved.
+#
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -19,8 +22,10 @@ noinst_LTLIBRARIES = libmca_pmix_external.la
 libmca_pmix_external_la_SOURCES = \
         external.h \
         pmix_external_component.c
+
+libmca_pmix_external_la_LIBADD = $(opal_external_pmix_LIBS)
 libmca_pmix_external_la_LDFLAGS = \
-    -module -avoid-version
+    -module -avoid-version $(opal_external_pmix_LDFLAGS)
 
 # Conditionally install the header files
 if WANT_INSTALL_HEADERS


### PR DESCRIPTION
External pmix installs are frequently in non-standard locations and
the path to their shared libraries are not ldconfig'd in because
there may be multiple pmix installs.

The way the configury was set up prior to this patch, the configuration
would fail soon after the PMIX config stuff was called because it
added some pmix lib stuff to the LDFLAGS, resulting in configury tests
for things that require running the configure test to fail.

This patch avoids this problem by resetting the LDFLAGS and LIBS back
to what they were prior to the run of the external PMIX detection.

The CFLAGS setting is left because there are many places in the ompi
and opal source code where pmix_common.h needs to be included.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>