### PR TITLE
Correctly set baseptr in contiguous shared memory window with local size zero (v3.1.x)

### DIFF
--- a/ompi/mca/osc/sm/osc_sm_component.c
+++ b/ompi/mca/osc/sm/osc_sm_component.c
@@ -338,7 +338,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
             }
 
             module->sizes[i] = rbuf[i];
-            if (module->sizes[i]) {
+            if (module->sizes[i] || !module->noncontig) {
                 module->bases[i] = ((char *) module->segment_base) + total;
                 total += rbuf[i];
             } else {


### PR DESCRIPTION
The MPI standard mandates that for contiguous shared memory windows the returned `baseptr` can be used to directly calculate the remote addresses on other processes so we cannot return `NULL` if `size == 0`.

Cherry-pick of #7204 to the v3.1.x branch.

Signed-off-by: Joseph Schuchart schuchart@hlrs.de
(cherry picked from commit 06bbcf4fd63dd184cf22f8bcad007c4b8b991a3c)