### PR TITLE
Create a hack to protect against non-integer jobids

### DIFF
--- a/opal/mca/pmix/pmix-internal.h
+++ b/opal/mca/pmix/pmix-internal.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2019      Research Organization for Information Science
@@ -442,9 +442,13 @@ OPAL_DECLSPEC pmix_proc_state_t opal_pmix_convert_state(int state);
 OPAL_DECLSPEC int opal_pmix_convert_pstate(pmix_proc_state_t);
 OPAL_DECLSPEC pmix_status_t opal_pmix_convert_rc(int rc);
 OPAL_DECLSPEC int opal_pmix_convert_status(pmix_status_t status);
+OPAL_DECLSPEC int opal_pmix_convert_jobid(pmix_nspace_t nspace, opal_jobid_t jobid);
+OPAL_DECLSPEC int opal_pmix_convert_nspace(opal_jobid_t *jobid, pmix_nspace_t nspace);
+OPAL_DECLSPEC void opal_pmix_setup_nspace_tracker(void);
+OPAL_DECLSPEC void opal_pmix_finalize_nspace_tracker(void);
 
 #define OPAL_PMIX_CONVERT_JOBID(n, j) \
-    (void)opal_snprintf_jobid((n), PMIX_MAX_NSLEN, (j))
+    opal_pmix_convert_jobid((n), (j))
 
 #define OPAL_PMIX_CONVERT_VPID(r, v)        \
     do {                                    \
@@ -454,6 +458,7 @@ OPAL_DECLSPEC int opal_pmix_convert_status(pmix_status_t status);
             (r) = (v);                      \
         }                                   \
     } while(0)
+
 #define OPAL_PMIX_CONVERT_NAME(p, n)                        \
     do {                                                    \
         OPAL_PMIX_CONVERT_JOBID((p)->nspace, (n)->jobid);   \
@@ -462,15 +467,17 @@ OPAL_DECLSPEC int opal_pmix_convert_status(pmix_status_t status);
 
 
 #define OPAL_PMIX_CONVERT_NSPACE(r, j, n)       \
-    (r) = opal_convert_string_to_jobid((j), (n))
+    (r) = opal_pmix_convert_nspace((j), (n))
 
-#define OPAL_PMIX_CONVERT_RANK(v, r)        \
-    do {                                    \
-        if (PMIX_RANK_WILDCARD == (r)) {    \
-            (v) = OPAL_VPID_WILDCARD;       \
-        } else {                            \
-            (v) = (r);                      \
-        }                                   \
+#define OPAL_PMIX_CONVERT_RANK(v, r)            \
+    do {                                        \
+        if (PMIX_RANK_WILDCARD == (r)) {        \
+            (v) = OPAL_VPID_WILDCARD;           \
+        } else if (PMIX_RANK_INVALID == (r)) {  \
+            (v) = OPAL_VPID_INVALID;            \
+        } else {                                \
+            (v) = (r);                          \
+        }                                       \
     } while(0)
 
 #define OPAL_PMIX_CONVERT_PROCT(r, n, p)                            \

--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -28,6 +28,7 @@ opal_process_name_t opal_name_wildcard = {OPAL_JOBID_WILDCARD, OPAL_VPID_WILDCAR
 opal_process_name_t opal_name_invalid = {OPAL_JOBID_INVALID, OPAL_VPID_INVALID};
 
 opal_process_info_t opal_process_info = {
+    .nativelaunch = false,
     .nodename = NULL,
     .top_session_dir = NULL,
     .job_session_dir = NULL,

--- a/opal/util/proc.h
+++ b/opal/util/proc.h
@@ -23,7 +23,6 @@
 #include "opal/types.h"
 #include "opal/dss/dss.h"
 
-
 #if OPAL_ENABLE_HETEROGENEOUS_SUPPORT
 #include <arpa/inet.h>
 #endif
@@ -105,6 +104,7 @@ typedef struct {
 OBJ_CLASS_DECLARATION(opal_namelist_t);
 
 typedef struct opal_process_info_t {
+    bool nativelaunch;                  /**< launched by mpirun */
     char *nodename;                     /**< string name for this node */
     char *top_session_dir;              /**< Top-level session directory */
     char *job_session_dir;              /**< Session directory for job */


### PR DESCRIPTION
If someone gives us a namespace that doesn't easily translate to an
integer, we have to create a mechanism for working around the
disconnect. PRRTE has been updated to give us a flag so we know we were
"natively" launched. If we don't see it, then fall back to generating a
hash of the nspace as our jobid. We then have to translate back/forth
between nspace and jobid using a lookup table.

Probably not the right long-term solution, but hopefully helps get us
thru for a bit.

Signed-off-by: Ralph Castain <rhc@pmix.org>