### PR TITLE
Pickup change in check for deleted vs deprecated options and add deprecated ones

### DIFF
--- a/config/ompi_deleted_options.m4
+++ b/config/ompi_deleted_options.m4
@@ -8,17 +8,18 @@
 # $HEADER$
 #
 
-AC_DEFUN([OMPI_CHECK_DEPRECATED_OPTIONS],[
-    OPAL_VAR_SCOPE_PUSH(with_pmi_given with_pmi_libdir_given)
+AC_DEFUN([OMPI_CHECK_DELETED_OPTIONS],[
+    OPAL_VAR_SCOPE_PUSH([with_pmi_given with_pmi_libdir_given cxx])
 
+    # --with-pmi options were removed in v5.0
     AC_ARG_WITH([pmi],
                 [AC_HELP_STRING([--with-pmi(=DIR)],
-                                [*DEPRECATED* Build PMI support, optionally adding DIR to the search path (default: no)])],
+                                [*DELETED* Build PMI support, optionally adding DIR to the search path (default: no)])],
                 [with_pmi_given=yes])
 
     AC_ARG_WITH([pmi-libdir],
                 [AC_HELP_STRING([--with-pmi-libdir=DIR],
-                                [*DEPRECATED* Look for libpmi or libpmi2 in the given directory DIR, DIR/lib or DIR/lib64])],
+                                [*DELETED* Look for libpmi or libpmi2 in the given directory DIR, DIR/lib or DIR/lib64])],
                 [with_pmi_libdir_given=yes])
 
     if test "$with_pmi_given" = "yes" || test "$with_pmi_libdir_given" = "yes"; then

--- a/config/ompi_deprecated_options.m4
+++ b/config/ompi_deprecated_options.m4
@@ -1,0 +1,34 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AC_DEFUN([OMPI_CHECK_DEPRECATED_OPTIONS],[
+    OPAL_VAR_SCOPE_PUSH([enable_orterun_prefix_given])
+
+    # --enable-orterun-prefix-by-default was deprecated in v5 in favor of --enable-prte-prefix-by-default
+    AC_ARG_ENABLE([orterun-prefix-by-default],
+        [AC_HELP_STRING([--enable-orterun-prefix-by-default],
+            [*DEPRECATED* Please use --enable-prte-prefix-by-default in the future)])],
+        [enable_orterun_prefix_given=yes])
+    AC_ARG_ENABLE([mpirun-prefix-by-default],
+        [AC_HELP_STRING([--enable-mpirun-prefix-by-default],
+            [*DEPRECATED* Please use --enable-prte-prefix-by-default in the future])],
+        [enable_orterun_prefix_given=yes])
+
+    if test "$enable_orterun_prefix_given" = "yes"; then
+        AC_MSG_WARN([Open MPI no longer uses the ORTE environment - it has been])
+        AC_MSG_WARN([replaced by PRRTE. Accordingly, the "--enable-orterun-prefix-by-default"])
+        AC_MSG_WARN([and "--enable-mpirun-prefix-by-default" options have been replaced])
+        AC_MSG_WARN([by "--enable-prte-prefix-by-default". We will do the translation for])
+        AC_MSG_WARN([you now, but these older options are deprecated and will be removed])
+        AC_MSG_WARN([in a later release, so please update your build scripts.])
+    fi
+
+    OPAL_VAR_SCOPE_POP
+])

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -42,6 +42,10 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
                 [AC_HELP_STRING([--with-prrte-platform],
                                 [Platform file to use when building the internal PRRTE runtime support])])
 
+    AC_ARG_ENABLE([prte-prefix-by-default],
+        [AC_HELP_STRING([--enable-prte-prefix-by-default],
+            [Make "mpirun ..." behave exactly the same as "mpirun --prefix \$prefix" (where \$prefix is the value given to --prefix in configure) (default:enabled)])])
+
     AC_MSG_CHECKING([if RTE support is enabled])
     if test "$enable_internal_rte" != "no"; then
         AC_MSG_RESULT([yes])
@@ -70,7 +74,14 @@ AC_DEFUN([OMPI_SETUP_PRRTE],[
             opal_prrte_pmix_arg="--with-pmix=$with_pmix"
         fi
 
-        opal_prrte_args="--prefix=$prefix --disable-dlopen $opal_prrte_libevent_arg $opal_prrte_hwloc_arg $opal_prrte_pmix_arg"
+        if test -z $enable_prte_prefix_by_default || test "$enable_prte_prefix_by_default" = "yes" ||
+           test "$enable_orterun_prefix_given" = "yes"; then
+           opal_prrte_prefix_arg="--enable-prte-prefix-by-default"
+        else
+            opal_prrte_prefix_arg=
+        fi
+
+        opal_prrte_args="--prefix=$prefix --disable-dlopen $opal_prrte_prefix_arg $opal_prrte_libevent_arg $opal_prrte_hwloc_arg $opal_prrte_pmix_arg"
         AS_IF([test "$enable_debug" = "yes"],
               [opal_prrte_args="--enable-debug $opal_prrte_args"
                CFLAGS="$OPAL_CFLAGS_BEFORE_PICKY $OPAL_VISIBILITY_CFLAGS -g"],

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,7 @@ fi
 
 # Check for deprecated/deleted options
 OMPI_CHECK_DELETED_OPTIONS
+OMPI_CHECK_DEPRECATED_OPTIONS
 
 # Setup the top of the opal/include/opal_config.h file
 

--- a/configure.ac
+++ b/configure.ac
@@ -192,8 +192,8 @@ if test "$OMPI_TOP_BUILDDIR" != "$OMPI_TOP_SRCDIR"; then
     AC_MSG_NOTICE([Detected VPATH build])
 fi
 
-# Check for deprecated options
-OMPI_CHECK_DEPRECATED_OPTIONS
+# Check for deprecated/deleted options
+OMPI_CHECK_DELETED_OPTIONS
 
 # Setup the top of the opal/include/opal_config.h file
 


### PR DESCRIPTION
 Tweak: rename "deprecated" --> "deleted"
We're dealing with CLI options that have been deleted, not
deprecated.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 5aea444)

--------------------

 Deprecate the enable-orterun-prefix-by-default options
Mark the --enable-orterun-prefix-by-default and
--enable-mpirun-prefix-by-default options as deprecated, but continue to
honor them by translating them to the new
--enable-prte-prefix-by-default option.

Signed-off-by: Ralph Castain <rhc@pmix.org>