### PR TITLE
sharedfp/individual: defer error when not being able to open datafile

### DIFF
--- a/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual_write.c
@@ -54,23 +54,25 @@ int mca_sharedfp_individual_write (ompio_file_t *fh,
     /*Retrieve data structure for shared file pointer operations*/
     sh = fh->f_sharedfp_data;
     headnode = (mca_sharedfp_individual_header_record*)sh->selected_module_data;
-
-    if (headnode)  {
-        /*Insert metadata record into a queue*/
-        mca_sharedfp_individual_insert_metadata(OMPI_FILE_WRITE_SHARED, totalbytes, sh);
-
-        /*Write the data into individual file*/
-        ret = mca_common_ompio_file_write_at ( headnode->datafilehandle,
-                                               headnode->datafile_offset,
-                                               buf, count, datatype, status);
-        if ( OMPI_SUCCESS != ret ) {
-            opal_output(0,"mca_sharedfp_individual_write: Error while writing the datafile \n");
-            return -1;
-        }
-
-        /* Update the datafileoffset*/
-        headnode->datafile_offset = headnode->datafile_offset + totalbytes;
+    if ( NULL == headnode)  {
+	opal_output (0, "sharedfp_individual_write_ordered: headnode is NULL but file is open\n");
+	return OMPI_ERROR;
     }
+
+    /*Insert metadata record into a queue*/
+    mca_sharedfp_individual_insert_metadata(OMPI_FILE_WRITE_SHARED, totalbytes, sh);
+    
+    /*Write the data into individual file*/
+    ret = mca_common_ompio_file_write_at ( headnode->datafilehandle,
+                                           headnode->datafile_offset,
+                                           buf, count, datatype, status);
+    if ( OMPI_SUCCESS != ret ) {
+        opal_output(0,"mca_sharedfp_individual_write: Error while writing the datafile \n");
+        return -1;
+    }
+
+    /* Update the datafileoffset*/
+    headnode->datafile_offset = headnode->datafile_offset + totalbytes;
 
     return ret;
 }


### PR DESCRIPTION
This commit changes the behavior of the individual sharedfp component. If
the component cannot create either the datafile or the metadatafile during File_open,
no error is being raised going forward. This allows applications that do not use shared
file pointer operations to continue execution without any issue.

If the user however subsequently calls MPI_File_write_shared or similar operations, an error
will be raised.

Fixes issue #7429

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>