### PR TITLE
Remove lingering ORTE references

### DIFF
--- a/Makefile.ompi-rules
+++ b/Makefile.ompi-rules
@@ -1,6 +1,7 @@
 # -*- makefile -*-
 # Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,7 +26,6 @@ endif
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \
 	  --opal-date='@OPAL_RELEASE_DATE@' \
-	  --orte-date='@ORTE_RELEASE_DATE@' \
 	  --input=$< \
 	  --output=$@
 
@@ -35,7 +35,6 @@ endif
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \
 	  --opal-date='@OPAL_RELEASE_DATE@' \
-	  --orte-date='@ORTE_RELEASE_DATE@' \
 	  $(TRIM_OPTIONS) \
 	  --input=$< \
 	  --output=$@
@@ -46,7 +45,6 @@ endif
 	  --package-version='@PACKAGE_VERSION@' \
 	  --ompi-date='@OMPI_RELEASE_DATE@' \
 	  --opal-date='@OPAL_RELEASE_DATE@' \
-	  --orte-date='@ORTE_RELEASE_DATE@' \
 	  --input=$< \
 	  --output=$@
 

--- a/config/make_manpage.pl
+++ b/config/make_manpage.pl
@@ -3,6 +3,7 @@
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Subroutine to generate a bunch of Fortran declarations and symbols
@@ -16,7 +17,6 @@ my $package_name;
 my $package_version;
 my $ompi_date;
 my $opal_date;
-my $orte_date;
 my $cxx = '1';
 my $fortran = '1';
 my $f08 = '1';
@@ -29,7 +29,6 @@ my $ok = Getopt::Long::GetOptions("package-name=s" => \$package_name,
                                   "package-version=s" => \$package_version,
                                   "ompi-date=s" => \$ompi_date,
                                   "opal-date=s" => \$opal_date,
-                                  "orte-date=s" => \$orte_date,
                                   "cxx!" => \$cxx,
                                   "fortran!" => \$fortran,
                                   "f08!" => \$f08,
@@ -42,9 +41,8 @@ if ($help_arg || !$ok ||
     !defined($package_name) ||
     !defined($package_version) ||
     !defined($ompi_date) ||
-    !defined($opal_date) ||
-    !defined($orte_date)) {
-    print "Usage: $0 --package-name=<package name> --package-version=<package version> --ompi-date=<ompi date> --opal-date=<opal date> --orte-date=<orte date> --input=<input file> --output=<output file> [--nocxx] [ --nofortran] [--nof08]\n";
+    !defined($opal_date)) {
+    print "Usage: $0 --package-name=<package name> --package-version=<package version> --ompi-date=<ompi date> --opal-date=<opal date> --input=<input file> --output=<output file> [--nocxx] [ --nofortran] [--nof08]\n";
     exit(1 - $ok);
 }
 
@@ -59,7 +57,6 @@ $file =~ s/#PACKAGE_NAME#/$package_name/g;
 $file =~ s/#PACKAGE_VERSION#/$package_version/g;
 $file =~ s/#OMPI_DATE#/$ompi_date/g;
 $file =~ s/#OPAL_DATE#/$opal_date/g;
-$file =~ s/#ORTE_DATE#/$orte_date/g;
 
 if ($cxx == 0) {
     $file =~ s/\n\.SH C\+\+ Syntax.+?\n\.SH/\n\.SH/s;

--- a/config/opal_set_lib_prefix.m4
+++ b/config/opal_set_lib_prefix.m4
@@ -1,7 +1,8 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,20 +25,6 @@ AC_DEFUN([OPAL_SET_LIB_PREFIX],[
     OPAL_LIB_PREFIX=$1
     opal_lib_prefix_set=yes
     AC_SUBST(OPAL_LIB_PREFIX)
-])dnl
-
-#
-# Same as OPAL LIB_PREFIX, but for the ORTE layer
-#
-AC_DEFUN([ORTE_SET_LIB_PREFIX],[
-    AS_IF([test "$orte_lib_prefix_set" = "yes"],
-          [AC_MSG_WARN([ORTE lib prefix was already set!])
-           AC_MSG_WARN([This is a configury programming error])
-           AC_MSG_ERROR([Cannot continue])])
-
-    ORTE_LIB_PREFIX=$1
-    orte_lib_prefix_set=yes
-    AC_SUBST(ORTE_LIB_PREFIX)
 ])dnl
 
 #

--- a/contrib/libadd_mca_comp_update.py
+++ b/contrib/libadd_mca_comp_update.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 # Copyright (c) 2017      IBM Corporation. All rights reserved.
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 
 import glob, os, re, shutil
 
 projects= {'opal' : ["$(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la"],
-           'orte' : ["$(top_builddir)/orte/lib@ORTE_LIB_PREFIX@open-rte.la"],
            'ompi' : ["$(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la"],
            'oshmem' : ["$(top_builddir)/oshmem/liboshmem.la"],
           }

--- a/ompi/tools/wrappers/mpic++-wrapper-data.txt.in
+++ b/ompi/tools/wrappers/mpic++-wrapper-data.txt.in
@@ -17,11 +17,11 @@ compiler_flags_prefix=@OMPI_WRAPPER_EXTRA_CXXFLAGS_PREFIX@
 compiler_flags=@OMPI_WRAPPER_EXTRA_CXXFLAGS@
 linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
 # Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
-# intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
+# intentionally only link in the MPI libraries (OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
 libs=@OMPI_WRAPPER_CXX_LIB@ -l@OMPI_LIBMPI_NAME@
-libs_static=@OMPI_WRAPPER_CXX_LIB@ -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs_static=@OMPI_WRAPPER_CXX_LIB@ -l@OMPI_LIBMPI_NAME@ -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=lib@OMPI_LIBMPI_NAME@.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=lib@OMPI_LIBMPI_NAME@.a
 required_file=@OMPI_WRAPPER_CXX_REQUIRED_FILE@

--- a/ompi/tools/wrappers/mpicc-wrapper-data.txt.in
+++ b/ompi/tools/wrappers/mpicc-wrapper-data.txt.in
@@ -17,11 +17,11 @@ compiler_flags_prefix=@OMPI_WRAPPER_EXTRA_CFLAGS_PREFIX@
 compiler_flags=@OMPI_WRAPPER_EXTRA_CFLAGS@
 linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
 # Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
-# intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
+# intentionally only link in the MPI libraries (OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
 libs=-l@OMPI_LIBMPI_NAME@
-libs_static=-l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs_static=-l@OMPI_LIBMPI_NAME@ -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=lib@OMPI_LIBMPI_NAME@.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=lib@OMPI_LIBMPI_NAME@.a
 required_file=

--- a/ompi/tools/wrappers/mpifort-wrapper-data.txt.in
+++ b/ompi/tools/wrappers/mpifort-wrapper-data.txt.in
@@ -16,11 +16,11 @@ preprocessor_flags=
 compiler_flags=@OMPI_WRAPPER_EXTRA_FCFLAGS@
 linker_flags=@OMPI_WRAPPER_EXTRA_FC_LDFLAGS@
 # Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
-# intentionally only link in the MPI libraries (ORTE, OPAL, etc. are
+# intentionally only link in the MPI libraries (OPAL, etc. are
 # pulled in implicitly) because we intend MPI applications to only use
 # the MPI API.
 libs=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@
-libs_static=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal  @OMPI_WRAPPER_EXTRA_LIBS@
+libs_static=@OMPI_FORTRAN_USEMPIF08_LIB@ @OMPI_FORTRAN_USEMPI_LIB@ -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@ -l@OPAL_LIB_PREFIX@open-pal  @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=lib@OMPI_LIBMPI_NAME@.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=lib@OMPI_LIBMPI_NAME@.a
 required_file=@OMPI_WRAPPER_FORTRAN_REQUIRED_FILE@

--- a/oshmem/tools/wrappers/shmemc++-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemc++-wrapper-data.txt.in
@@ -1,6 +1,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,11 +26,11 @@ preprocessor_flags=@OMPI_WRAPPER_EXTRA_CPPFLAGS@
 compiler_flags=@OMPI_WRAPPER_EXTRA_CXXFLAGS@
 linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
 # Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
-# intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
+# intentionally only link in the SHMEM and MPI libraries (OPAL,
 # etc. are pulled in implicitly) because we intend SHMEM/MPI
 # applications to only use the SHMEM and MPI APIs.
 libs=-loshmem -lmpi
-libs_static=-loshmem -lmpi -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs_static=-loshmem -lmpi -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=liboshmem.a
 required_file=

--- a/oshmem/tools/wrappers/shmemcc-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemcc-wrapper-data.txt.in
@@ -2,6 +2,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,11 +27,11 @@ preprocessor_flags=@OMPI_WRAPPER_EXTRA_CPPFLAGS@
 compiler_flags=@OMPI_WRAPPER_EXTRA_CFLAGS@
 linker_flags=@OMPI_WRAPPER_EXTRA_LDFLAGS@
 # Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
-# intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
+# intentionally only link in the SHMEM and MPI libraries (OPAL,
 # etc. are pulled in implicitly) because we intend SHMEM/MPI
 # applications to only use the SHMEM and MPI APIs.
 libs=-loshmem -l@OMPI_LIBMPI_NAME@
-libs_static=-loshmem -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs_static=-loshmem -l@OMPI_LIBMPI_NAME@ -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=liboshmem.a
 required_file=

--- a/oshmem/tools/wrappers/shmemfort-wrapper-data.txt.in
+++ b/oshmem/tools/wrappers/shmemfort-wrapper-data.txt.in
@@ -2,6 +2,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,11 +27,11 @@ preprocessor_flags=
 compiler_flags=@OMPI_WRAPPER_EXTRA_FCFLAGS@
 linker_flags=@OMPI_WRAPPER_EXTRA_FC_LDFLAGS@
 # Note that per https://svn.open-mpi.org/trac/ompi/ticket/3422, we
-# intentionally only link in the SHMEM and MPI libraries (ORTE, OPAL,
+# intentionally only link in the SHMEM and MPI libraries (OPAL,
 # etc. are pulled in implicitly) because we intend SHMEM/MPI
 # applications to only use the SHMEM and MPI APIs.
 libs=-loshmem -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@
-libs_static=-loshmem -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@ -l@ORTE_LIB_PREFIX@open-rte -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
+libs_static=-loshmem -l@OMPI_LIBMPI_NAME@_mpifh -l@OMPI_LIBMPI_NAME@ -l@OPAL_LIB_PREFIX@open-pal @OMPI_WRAPPER_EXTRA_LIBS@
 dyn_lib_file=liboshmem.@OPAL_DYN_LIB_SUFFIX@
 static_lib_file=liboshmem.a
 required_file=@OMPI_WRAPPER_FORTRAN_REQUIRED_FILE@


### PR DESCRIPTION
Wrapper compiler is trying to link in a libopen-rte. Man pages are
setting an ORTE release date.

Signed-off-by: Ralph Castain <rhc@pmix.org>