### PR TITLE
Disabled Mellanox Open MPI per-commit CI (as redundant) - v4.0.x

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,6 +1,5 @@
 # Open MPI Continuous Integration (CI) Services
 ## Mellanox Open MPI CI
-[![Build Status](https://dev.azure.com/mlnx-swx/mellanox-ompi/_apis/build/status/Mellanox%20CI?branchName=v4.0.x)](https://dev.azure.com/mlnx-swx/mellanox-ompi/_build/latest?definitionId=12&branchName=v4.0.x)
 ### Scope
 [Mellanox](https://www.mellanox.com/) Open MPI CI is intended to verify Open MPI with recent Mellanox SW components ([Mellanox OFED](https://www.mellanox.com/page/products_dyn?product_family=26), [UCX](https://www.mellanox.com/page/products_dyn?product_family=281&mtag=ucx) and other [HPC-X](https://www.mellanox.com/page/products_dyn?product_family=189&mtag=hpc-x) components) in the Mellanox lab environment.
 
@@ -11,7 +10,6 @@ Mellanox Open MPI CI includes:
 * Sanity functional testing.
 ### How to Run CI
 Mellanox Open MPI CI is triggered upon the following events:
-* Push a commit into the master branch or release branches (starting from v4.0.x). CI is started automatically. CI status and log files are available on the Azure DevOps server.
 * Create a pull request (PR). CI status is visible in the PR status. CI is restarted automatically upon each new commit within the PR. CI status and log files are also available on the Azure DevOps server.
 * Trigger CI with special PR comments (for example, `/azp run`). Comment triggers are available only if the comment author has write permission to the PR target repo. Detailed information about comment triggers is available in the official Azure DevOps [documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers).
 ### Support

--- a/.ci/mellanox/azure-pipelines.yml
+++ b/.ci/mellanox/azure-pipelines.yml
@@ -1,6 +1,4 @@
-trigger:
-  - master
-  - v*.*.x
+trigger: none
 pr:
   - master
   - v*.*.x


### PR DESCRIPTION
The CI is triggered only upon a PR creation or by special PR comments.

Signed-off-by: Artem Ryabov <artemry@mellanox.com>