### PR TITLE
pml/ucx: Add MCA_PML_BASE_FLAG_REQUIRE_WORLD flag.

### DIFF
--- a/ompi/mca/pml/ucx/pml_ucx_component.c
+++ b/ompi/mca/pml/ucx/pml_ucx_component.c
@@ -98,6 +98,8 @@ mca_pml_ucx_component_init(int* priority, bool enable_progress_threads,
         return NULL;
     }
 
+    ompi_pml_ucx.super.pml_flags |= MCA_PML_BASE_FLAG_REQUIRE_WORLD;
+
     *priority = ompi_pml_ucx.priority;
     return &ompi_pml_ucx.super;
 }


### PR DESCRIPTION
In MPI_Init(), the UCX pml calls PMIx_Get()
on rank 0 to verify that it is using the UCX pml in
mca_pml_ucx_add_proc(). However, without this flag, remote ranks
will be performing this on their local rank 0, which doesn't
have this information - so they will be stuck until PMIx_Get()
hits a timeout.

This patch should give the ranks the correct information,
and most importantly eliminate the time spent idling in MPI_Init()
when using UCX.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>