### PR TITLE
Remove the pml check_selected code.

### DIFF
--- a/ompi/mca/pml/base/base.h
+++ b/ompi/mca/pml/base/base.h
@@ -53,12 +53,6 @@ OMPI_DECLSPEC extern mca_base_framework_t ompi_pml_base_framework;
 OMPI_DECLSPEC  int mca_pml_base_select(bool enable_progress_threads,
                                        bool enable_mpi_threads);
 OMPI_DECLSPEC  int mca_pml_base_progress(void);
-    /* share in modex the name of the selected component */
-OMPI_DECLSPEC int mca_pml_base_pml_selected(const char *name);
-    /* verify that all new procs are using the currently selected component */
-OMPI_DECLSPEC int mca_pml_base_pml_check_selected(const char *my_pml,
-                                                  struct ompi_proc_t **procs,
-                                                  size_t nprocs);
 
 OMPI_DECLSPEC int mca_pml_base_finalize(void);
 

--- a/ompi/mca/pml/cm/pml_cm.c
+++ b/ompi/mca/pml/cm/pml_cm.c
@@ -127,13 +127,6 @@ mca_pml_cm_add_procs(struct ompi_proc_t** procs, size_t nprocs)
     }
 #endif
 
-    /* make sure remote procs are using the same PML as us */
-    if (OMPI_SUCCESS != (ret = mca_pml_base_pml_check_selected("cm",
-                                                              procs,
-                                                              nprocs))) {
-        return ret;
-    }
-
     ret = OMPI_MTL_CALL(add_procs(ompi_mtl, nprocs, procs));
     return ret;
 }

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -320,21 +320,6 @@ int mca_pml_ob1_add_procs(ompi_proc_t** procs, size_t nprocs)
     if(OMPI_SUCCESS != rc)
         return rc;
 
-    /*
-     * JJH: Disable this in FT enabled builds since
-     * we use a wrapper PML. It will cause this check to
-     * return failure as all processes will return the wrapper PML
-     * component in use instead of the wrapped PML component underneath.
-     */
-#if OPAL_ENABLE_FT_CR == 0
-    /* make sure remote procs are using the same PML as us */
-    if (OMPI_SUCCESS != (rc = mca_pml_base_pml_check_selected("ob1",
-                                                              procs,
-                                                              nprocs))) {
-        return rc;
-    }
-#endif
-
     rc = mca_bml.bml_add_procs( nprocs,
                                 procs,
                                 &reachable );

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -395,18 +395,7 @@ static ucp_ep_h mca_pml_ucx_add_proc_common(ompi_proc_t *proc)
 
 static ucp_ep_h mca_pml_ucx_add_proc(ompi_communicator_t *comm, int dst)
 {
-    ompi_proc_t *proc0     = ompi_comm_peer_lookup(comm, 0);
-    ompi_proc_t *proc_peer = ompi_comm_peer_lookup(comm, dst);
-    int ret;
-
-    /* Note, mca_pml_base_pml_check_selected, doesn't use 3rd argument */
-    if (OMPI_SUCCESS != (ret = mca_pml_base_pml_check_selected("ucx",
-                                                               &proc0,
-                                                               dst))) {
-        return NULL;
-    }
-
-    return mca_pml_ucx_add_proc_common(proc_peer);
+    return mca_pml_ucx_add_proc_common(ompi_comm_peer_lookup(comm, dst));
 }
 
 int mca_pml_ucx_add_procs(struct ompi_proc_t **procs, size_t nprocs)
@@ -414,13 +403,6 @@ int mca_pml_ucx_add_procs(struct ompi_proc_t **procs, size_t nprocs)
     ompi_proc_t *proc;
     ucp_ep_h ep;
     size_t i;
-    int ret;
-
-    if (OMPI_SUCCESS != (ret = mca_pml_base_pml_check_selected("ucx",
-                                                               procs,
-                                                               nprocs))) {
-        return ret;
-    }
 
     for (i = 0; i < nprocs; ++i) {
         proc = procs[(i + OMPI_PROC_MY_NAME->vpid) % nprocs];


### PR DESCRIPTION
The current logic is broken - this only works from the
node which has rank 0 on it. All other processes will fail
trying to fetch the data from rank 0 on a PMIx_Get().

Since this has been broken for what is probably a long time with no
complaints, it is probably safe to remove completely
and gain back some of the lost performance.

Fixes #7475

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>