### PR TITLE
Tweak the C++ binding deprecation check

### DIFF
--- a/config/ompi_deleted_options.m4
+++ b/config/ompi_deleted_options.m4
@@ -37,6 +37,8 @@ AC_DEFUN([OMPI_CHECK_DELETED_OPTIONS],[
 
     # Open MPI C++ bindings were removed in v5.0
     cxx=0
+    cxxseek=0
+    cxxex=0
     AC_ARG_ENABLE([mpi-cxx],
                   [AC_HELP_STRING([--enable-mpi-cxx],
                                   [*DELETED* Build the MPI C++ bindings])],
@@ -44,13 +46,22 @@ AC_DEFUN([OMPI_CHECK_DELETED_OPTIONS],[
     AC_ARG_ENABLE([mpi-cxx-seek],
                   [AC_HELP_STRING([--enable-mpi-cxx-seek],
                                   [*DELETED* Build support for MPI::SEEK])],
-                  [cxx=1])
+                  [cxxseek=1])
     AC_ARG_ENABLE([cxx-exceptions],
                   [AC_HELP_STRING([--enable-cxx-exceptions],
                                   [*DELETED* Build support for C++ exceptions in the MPI C++ bindings])],
-                  [cxx=1])
+                  [cxxex=1])
 
-    AS_IF([test $cxx -eq 1],
+    AS_IF([test "$enable_mpi_cxx" = "no" ],
+          [cxx=0])
+
+    AS_IF([test "$enable_mpi_cxx_seek" = "no" ],
+          [cxxseek=0])
+
+    AS_IF([test "$enable_cxx_exceptions" = "no" ],
+          [cxxex=0])
+
+    AS_IF([test $cxx -eq 1 || test $cxxseek -eq 1 || test $cxxex -eq 1],
           [AC_MSG_WARN([The MPI C++ bindings have been removed from Open MPI.])
            AC_MSG_WARN([If you need support for the MPI C++ bindings, you])
            AC_MSG_WARN([will need to use an older version of Open MPI.])

--- a/config/ompi_deleted_options.m4
+++ b/config/ompi_deleted_options.m4
@@ -23,6 +23,12 @@ AC_DEFUN([OMPI_CHECK_DELETED_OPTIONS],[
                                 [*DELETED* Look for libpmi or libpmi2 in the given directory DIR, DIR/lib or DIR/lib64])],
                 [with_pmi_libdir_given=yes])
 
+    AS_IF([test "$with_pmi" = "no"],
+          [with_pmi_given=no])
+
+    AS_IF([test "$with_pmi_libdir" = "no"],
+          [with_pmi_libdir_given=no])
+
     if test "$with_pmi_given" = "yes" || test "$with_pmi_libdir_given" = "yes"; then
         AC_MSG_WARN([Open MPI no longer supports PMI-1 or PMI-2 libraries.])
         AC_MSG_WARN([PMIx is now required. Either the internal version or an])

--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +33,7 @@
 #include <unistd.h>
 #endif  /* HAVE_UNIST_H */
 #include "ompi/mca/mca.h"
+#include "opal/util/argv.h"
 #include "opal/util/output.h"
 #include "opal/mca/base/base.h"
 
@@ -214,7 +216,6 @@ static int mca_pml_base_open(mca_base_open_flag_t flags)
         if( (NULL == default_pml || NULL == default_pml[0] ||
              0 == strlen(default_pml[0])) || (default_pml[0][0] == '^') ) {
             opal_pointer_array_add(&mca_pml_base_pml, strdup("ob1"));
-            opal_pointer_array_add(&mca_pml_base_pml, strdup("yalla"));
             opal_pointer_array_add(&mca_pml_base_pml, strdup("ucx"));
             opal_pointer_array_add(&mca_pml_base_pml, strdup("cm"));
         } else {


### PR DESCRIPTION
Some of us have platform files that expressly disabled C++ support.
While it is true that v5 no longer supports C++ and thus no longer needs
us to disable it, there seems no reason to make us create platform files
that differentiate based on OMPI version just for that reason.

So if someone asks to "disable" the no-longer-existing support, just
ignore it.

Signed-off-by: Ralph Castain <rhc@pmix.org>