### PR TITLE
v3.1.x: Fix segv in btl/vader.

### DIFF
--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -118,6 +118,7 @@ struct mca_btl_vader_component_t {
     size_t segment_size;                    /**< size of my_segment */
     size_t segment_offset;                  /**< start of unused portion of my_segment */
     int32_t num_smp_procs;                  /**< current number of smp procs on this host */
+    int32_t local_rank;                     /**< current rank index at add_procs() time */
     opal_free_list_t vader_frags_eager;     /**< free list of vader send frags */
     opal_free_list_t vader_frags_max_send;  /**< free list of vader max send frags (large fragments) */
     opal_free_list_t vader_frags_user;      /**< free list of small inline frags */

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -531,6 +531,7 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
 #if OPAL_BTL_VADER_HAVE_XPMEM || OPAL_BTL_VADER_HAVE_CMA || OPAL_BTL_VADER_HAVE_KNEM
     mca_btl_vader_check_single_copy ();
 #endif
+    component->local_rank = 0;
 
     if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
         char *sm_file;

--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -333,7 +333,7 @@ static int vader_add_procs (struct mca_btl_base_module_t* btl,
         }
     }
 
-    for (int32_t proc = 0, local_rank = 0 ; proc < (int32_t) nprocs ; ++proc) {
+    for (int32_t proc = 0; proc < (int32_t) nprocs; ++proc) {
         /* check to see if this proc can be reached via shmem (i.e.,
            if they're on my local host and in my job) */
         if (procs[proc]->proc_name.jobid != my_proc->proc_name.jobid ||
@@ -351,8 +351,11 @@ static int vader_add_procs (struct mca_btl_base_module_t* btl,
         }
 
         /* setup endpoint */
-        peers[proc] = component->endpoints + local_rank;
-        rc = init_vader_endpoint (peers[proc], procs[proc], local_rank++);
+        int rank = opal_atomic_add_32(&component -> local_rank, 1);
+        rank--;
+
+        peers[proc] = component->endpoints + rank;
+        rc = init_vader_endpoint (peers[proc], procs[proc], rank);
         if (OPAL_SUCCESS != rc) {
             break;
         }


### PR DESCRIPTION
Keep track of the connected procs in vader_add_procs().
Otherwise, the same rank will reconnect the same shmem
segment (rank 0+...) multiple times instead of the next
one as intended.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit f69c8d6819dcc14f471cea90b50dc8ca98de12d4)

Conflicts:
	opal/mca/btl/vader/btl_vader_component.c