### PR TITLE
Fix Bcast scatter_allgather

### DIFF
--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -903,7 +903,7 @@ int ompi_coll_base_bcast_intra_scatter_allgather(
                 } else if ((vremote < vrank) && (vremote < tree_root + nprocs_alldata)
                            && (vrank >= tree_root + nprocs_alldata)) {
                     err = MCA_PML_CALL(recv((char *)buf + (ptrdiff_t)offset * extent,
-                                            count - offset, datatype, remote,
+                                            count, datatype, remote,
                                             MCA_COLL_BASE_TAG_BCAST,
                                             comm, &status));
                     if (MPI_SUCCESS != err) { goto cleanup_and_return; }


### PR DESCRIPTION
Fix Issue #7410 with incorrect size of receiving message on the recursive doubling phase (in the case of non-power-of-two number of processes).

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>