### PR TITLE
Update two orte specific env's to be more generic

### DIFF
--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -117,7 +117,7 @@ int ompi_mpiinfo_init(void)
     }
 
     /* max procs for the entire job */
-    if (NULL != (cptr = getenv("OMPI_MCA_orte_ess_num_procs"))) {
+    if (NULL != (cptr = getenv("OMPI_MCA_num_procs"))) {
         opal_info_set(&ompi_mpi_info_env.info.super, "maxprocs", cptr);
         /* Open MPI does not support the "soft" option, so set it to maxprocs */
         opal_info_set(&ompi_mpi_info_env.info.super, "soft", cptr);
@@ -128,7 +128,7 @@ int ompi_mpiinfo_init(void)
     opal_info_set(&ompi_mpi_info_env.info.super, "host", val);
 
     /* architecture name */
-    if (NULL != (cptr = getenv("OMPI_MCA_orte_cpu_type"))) {
+    if (NULL != (cptr = getenv("OMPI_MCA_cpu_type"))) {
         opal_info_set(&ompi_mpi_info_env.info.super, "arch", cptr);
     }
 #ifdef HAVE_SYS_UTSNAME_H


### PR DESCRIPTION
orte is gone, and we don't want to require other
RM's to either use a prrte specific env, or to
set their own.

OMPI_MCA_orte_ess_num_procs -> OMPI_MCA_num_procs
OMPI_MCA_orte_cpu_type -> OMPI_MCA_cpu_type

See PRRTE PR's:

openpmix/prrte#443
openpmix/prrte#440

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>