### PR TITLE
Ensure we get our local topology

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -747,6 +747,12 @@ int ompi_rte_init(int *pargc, char ***pargv)
         val = NULL;
     }
 
+    /* get our topology */
+    if (OPAL_SUCCESS != (rc = opal_hwloc_base_get_topology())) {
+        error = "hwloc_base_get_topology: failed";
+        goto error;
+    }
+
     /* identify our location */
     val = NULL;
     OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_LOCALITY_STRING,


### PR DESCRIPTION
Restore missing call to get_topology - others were doing it in their
components as repeated calls just return success, but let's ensure it is
always present.

Signed-off-by: Ralph Castain <rhc@pmix.org>