### PR TITLE
usnic: remove typo

### DIFF
--- a/opal/mca/btl/usnic/btl_usnic_hwloc.c
+++ b/opal/mca/btl/usnic/btl_usnic_hwloc.c
@@ -201,7 +201,7 @@ int opal_btl_usnic_hwloc_distance(opal_btl_usnic_module_t *module)
                         "btl:usnic:filter_numa: filtering devices by NUMA distance");
 
     /* ensure we have the topology */
-    if (OPAL_SUCCESS !=- opal_hwloc_base_get_topology()) {
+    if (OPAL_SUCCESS != opal_hwloc_base_get_topology()) {
         opal_output_verbose(5, USNIC_OUT,
                             "btl:usnic:filter_numa: not sorting devices by NUMA distance (topology not available)");
         return OPAL_SUCCESS;


### PR DESCRIPTION
Remove an amusing -- but harmless -- typo.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>