### PR TITLE
ofi: Call add_procs through PML

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -4,8 +4,9 @@
  *                         reserved.
  * Copyright (c) 2019      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates. All rights
+ *                         reserved.
  *
- * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,6 +50,10 @@ BEGIN_C_DECLS
 
 extern mca_mtl_ofi_module_t ompi_mtl_ofi;
 extern mca_base_framework_t ompi_mtl_base_framework;
+
+extern int ompi_mtl_ofi_add_procs(struct mca_mtl_base_module_t *mtl,
+                                  size_t nprocs,
+                                  struct ompi_proc_t** procs);
 
 extern int ompi_mtl_ofi_del_procs(struct mca_mtl_base_module_t *mtl,
                                   size_t nprocs,

--- a/ompi/mca/mtl/ofi/mtl_ofi_endpoint.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi_endpoint.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -11,11 +13,9 @@
 #ifndef OMPI_MTL_OFI_ENDPOINT_H
 #define OMPI_MTL_OFI_ENDPOINT_H
 
-BEGIN_C_DECLS
+#include "ompi/mca/pml/pml.h"
 
-extern int ompi_mtl_ofi_add_procs(struct mca_mtl_base_module_t *mtl,
-                                  size_t nprocs,
-                                  struct ompi_proc_t **procs);
+BEGIN_C_DECLS
 
 OBJ_CLASS_DECLARATION(mca_mtl_ofi_endpoint_t);
 
@@ -38,10 +38,12 @@ struct mca_mtl_ofi_endpoint_t {
 
 typedef struct mca_mtl_ofi_endpoint_t  mca_mtl_ofi_endpoint_t;
 
-static inline mca_mtl_ofi_endpoint_t *ompi_mtl_ofi_get_endpoint (struct mca_mtl_base_module_t* mtl, ompi_proc_t *ompi_proc)
+static inline mca_mtl_ofi_endpoint_t *
+ompi_mtl_ofi_get_endpoint(struct mca_mtl_base_module_t* mtl,
+                          ompi_proc_t *ompi_proc)
 {
     if (OPAL_UNLIKELY(NULL == ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL])) {
-        if (OPAL_UNLIKELY(OMPI_SUCCESS != ompi_mtl_ofi_add_procs(mtl, 1, &ompi_proc))) {
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != MCA_PML_CALL(add_procs(&ompi_proc, 1)))) {
             /* Fatal error. exit() out */
             opal_output(0, "%s:%d: *** The Open MPI OFI MTL is aborting the MPI job (via exit(3)).\n",
                            __FILE__, __LINE__);


### PR DESCRIPTION
Change ompi_mtl_ofi_get_endpoint() to call the active PML's
add_procs() rather than the OFI MTL add_procs() directly when
discovering a new process during operation.

Functionally, this has no impact in correct operation.  However,
the current behavior means that the heterogenous and active PML
checks are not being executed in the dynamic discovery case.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>