### PR TITLE
Add .mailmap entry for Harumi Kuno

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -111,3 +111,5 @@ Geoffrey Paulsen <gpaulsen@us.ibm.com> <gpaulsen@users.noreply.github.com>
 Anandhi S Jayakumar <anandhi.s.jayakumar@intel.com>
 
 Mohan Gandhi <mohgan@amazon.com>
+
+Harumi Kuno <harumi.kuno@hpe.com>


### PR DESCRIPTION
Avoid the problem of someone using caps in their name from one machine
and not using caps in their name when committing from another. This
generates a false error when making the tarball.

Signed-off-by: Ralph Castain <rhc@pmix.org>