### PR TITLE
Daemonize the orteds during tree-spawn

### DIFF
--- a/orte/mca/plm/rsh/plm_rsh_module.c
+++ b/orte/mca/plm/rsh/plm_rsh_module.c
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2011-2019 IBM Corporation.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -614,6 +614,7 @@ static int setup_launch(int *argcptr, char ***argvptr,
          (mca_plm_rsh_component.using_qrsh && mca_plm_rsh_component.daemonize_qrsh)) &&
         ((!mca_plm_rsh_component.using_llspawn) ||
          (mca_plm_rsh_component.using_llspawn && mca_plm_rsh_component.daemonize_llspawn))) {
+        opal_argv_append(&argc, &argv, "--daemonize");
     }
 
     if (!mca_plm_rsh_component.no_tree_spawn) {


### PR DESCRIPTION
Somehow, the line of code that actually added the daemonize option to
the orted cmd line was removed.

Fixes #7562 

Signed-off-by: Ralph Castain <rhc@pmix.org>