### PR TITLE
configury: try if -fpp flag is needed to preprocess .F90 files

### DIFF
--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -14,8 +14,8 @@ dnl Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2015-2016 Research Organization for Information Science
-dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2015-2020 Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -138,6 +138,24 @@ AC_DEFUN([OMPI_SETUP_FC],[
     AS_IF([test $ompi_fc_happy -eq 1],
            [AC_FC_SRCEXT(f)
             AC_FC_SRCEXT(f90)])
+
+    AC_MSG_CHECKING([if Fortran compilers preprocess .F90 files without additional flag])
+    cat > conftest_f.F90 << EOF
+#if 0
+#error The source file was not preprocessed
+#endif
+      program bogus
+      end program
+EOF
+    OPAL_LOG_COMMAND([$FC $FCFLAGS -c conftest_f.F90],
+                     [AC_MSG_RESULT(["yes"])],
+                     [AC_MSG_CHECKING([if -fpp flag works])
+                      OPAL_LOG_COMMAND([$FC $FCFLAGS -fpp -c conftest_f.F90],
+                                       [AC_MSG_RESULT(["yes"])
+                                        FCFLAGS="$FCFLAGS -fpp"],
+                                       [AC_MSG_RESULT("no")
+                                        AC_MSG_ERROR(["cannot preprocess Fortran files, Aborting"])])])
+    rm -f conftest*
 
     # Per trac #1982, on OS X, we may need some esoteric linker flags
     # in the wrapper compilers.  However, per


### PR DESCRIPTION
.F90 files are preprocessed by gfortran and other compilers.
NAG compilers only preprocess .{ff,ff90,ff95} files, and the -fpp
flag is required to process .F90 files.

Fixes open-mpi/ompi#7583

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>