### PR TITLE
Grammatical Fix in README

### DIFF
--- a/README
+++ b/README
@@ -181,7 +181,7 @@ General notes
 
   (*) Be sure to read the Compiler Notes, below.
 
-- Other systems have been lightly (but not fully tested):
+- Other systems have been lightly (but not fully) tested:
   - Linux (various flavors/distros), 32 bit, with gcc
   - Cygwin 32 & 64 bit with gcc
   - ARMv6, ARMv7


### PR DESCRIPTION
Signed-off-by: rlangefe <langrc18@wfu.edu>

Fixed misplaced closing parenthesis on line 184 of the README file