### PR TITLE
configure: fix PRRTE conflict with -iquote

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1239,6 +1239,18 @@ AC_SUBST(OPAL_DYN_LIB_SUFFIX)
 # Need the libtool binary before the rpathify stuff
 LT_OUTPUT
 
+##################################
+# PRRTE support
+##################################
+
+opal_show_title "Setup PRRTE support"
+
+m4_ifdef([project_prrte],
+         [OMPI_SETUP_PRRTE],
+         [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PRRTE]],[prrte],[no (disabled)])
+          ompi_want_prrte=no])
+AM_CONDITIONAL(OMPI_WANT_PRRTE, test "$ompi_want_prrte" = "yes")
+
 ############################################################################
 # final compiler config
 ############################################################################
@@ -1446,18 +1458,6 @@ m4_ifdef([project_ompi], [OMPI_CONFIG_FILES])
 m4_ifdef([project_oshmem], [OSHMEM_CONFIG_FILES])
 
 OPAL_CHECK_LIBNL_SUMMARY
-
-##################################
-# PRRTE support
-##################################
-
-opal_show_title "Setup PRRTE support"
-
-m4_ifdef([project_prrte],
-         [OMPI_SETUP_PRRTE],
-         [OPAL_SUMMARY_ADD([[Miscellaneous]],[[PRRTE]],[prrte],[no (disabled)])
-          ompi_want_prrte=no])
-AM_CONDITIONAL(OMPI_WANT_PRRTE, test "$ompi_want_prrte" = "yes")
 
 # checkpoint results
 AC_CACHE_SAVE


### PR DESCRIPTION
PRRTE needs hwloc and libevent, so it needs to be setup "late" in
configure.ac.  However, we don't want to do it at the absolute bottom
of configure.ac, because right near the bottom, we setup CPPFLAGS (and
others) with values that are expected to be used only in
Makefile[.am]'s -- i.e., "$(foo)" values.  Such values are not able to
be used here in configure.

Hence, move the PRRTE setup up above where we do these "final"/
only-relevant-to-Makefile[.am] CPPFLAGS (etc.) updates occur.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>