### PR TITLE
v4.0.x: configury: try if -fpp flag is needed to preprocess .F90 files

### DIFF
--- a/config/ompi_fortran_check_preprocess_f90.m4
+++ b/config/ompi_fortran_check_preprocess_f90.m4
@@ -1,0 +1,43 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+dnl Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+AC_DEFUN([OMPI_FORTRAN_CHECK_PREPROCESS_F90], [
+    AC_MSG_CHECKING([if Fortran compilers preprocess .F90 files without additional flag])
+    cat > conftest_f.F90 << EOF
+#if 0
+#error The source file was not preprocessed
+#endif
+      program bogus
+      end program
+EOF
+    OPAL_LOG_COMMAND([$FC $FCFLAGS -c conftest_f.F90],
+                     [AC_MSG_RESULT([yes])],
+                     [AC_MSG_RESULT([no])
+                      AC_MSG_CHECKING([if -fpp flag works])
+                      OPAL_LOG_COMMAND([$FC $FCFLAGS -fpp -c conftest_f.F90],
+                                       [AC_MSG_RESULT([yes])
+                                        FCFLAGS="$FCFLAGS -fpp"],
+                                       [AC_MSG_RESULT(no)
+                                        AC_MSG_ERROR([cannot preprocess Fortran files, Aborting])])])
+    rm -f conftest*
+])dnl

--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -13,7 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
-dnl Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2020 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
 dnl $COPYRIGHT$
@@ -139,23 +139,10 @@ AC_DEFUN([OMPI_SETUP_FC],[
            [AC_FC_SRCEXT(f)
             AC_FC_SRCEXT(f90)])
 
-    AC_MSG_CHECKING([if Fortran compilers preprocess .F90 files without additional flag])
-    cat > conftest_f.F90 << EOF
-#if 0
-#error The source file was not preprocessed
-#endif
-      program bogus
-      end program
-EOF
-    OPAL_LOG_COMMAND([$FC $FCFLAGS -c conftest_f.F90],
-                     [AC_MSG_RESULT(["yes"])],
-                     [AC_MSG_CHECKING([if -fpp flag works])
-                      OPAL_LOG_COMMAND([$FC $FCFLAGS -fpp -c conftest_f.F90],
-                                       [AC_MSG_RESULT(["yes"])
-                                        FCFLAGS="$FCFLAGS -fpp"],
-                                       [AC_MSG_RESULT("no")
-                                        AC_MSG_ERROR(["cannot preprocess Fortran files, Aborting"])])])
-    rm -f conftest*
+    # Check to see if we need additional compiler flags for
+    # preprocessing .F90 files.
+    AS_IF([test $ompi_fc_happy -eq 1],
+          [OMPI_FORTRAN_CHECK_PREPROCESS_F90])
 
     # Per trac #1982, on OS X, we may need some esoteric linker flags
     # in the wrapper compilers.  However, per

--- a/config/ompi_setup_fc.m4
+++ b/config/ompi_setup_fc.m4
@@ -14,8 +14,8 @@ dnl Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2015-2016 Research Organization for Information Science
-dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2015-2020 Research Organization for Information Science
+dnl                         and Technology (RIST).  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -138,6 +138,24 @@ AC_DEFUN([OMPI_SETUP_FC],[
     AS_IF([test $ompi_fc_happy -eq 1],
            [AC_FC_SRCEXT(f)
             AC_FC_SRCEXT(f90)])
+
+    AC_MSG_CHECKING([if Fortran compilers preprocess .F90 files without additional flag])
+    cat > conftest_f.F90 << EOF
+#if 0
+#error The source file was not preprocessed
+#endif
+      program bogus
+      end program
+EOF
+    OPAL_LOG_COMMAND([$FC $FCFLAGS -c conftest_f.F90],
+                     [AC_MSG_RESULT(["yes"])],
+                     [AC_MSG_CHECKING([if -fpp flag works])
+                      OPAL_LOG_COMMAND([$FC $FCFLAGS -fpp -c conftest_f.F90],
+                                       [AC_MSG_RESULT(["yes"])
+                                        FCFLAGS="$FCFLAGS -fpp"],
+                                       [AC_MSG_RESULT("no")
+                                        AC_MSG_ERROR(["cannot preprocess Fortran files, Aborting"])])])
+    rm -f conftest*
 
     # Per trac #1982, on OS X, we may need some esoteric linker flags
     # in the wrapper compilers.  However, per


### PR DESCRIPTION
.F90 files are preprocessed by gfortran and other compilers.
NAG compilers only preprocess .{ff,ff90,ff95} files, and the -fpp
flag is required to process .F90 files.

Refs open-mpi/ompi#7583

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit a2c711b54b207d9228ca70fe08028614903c2bf6)

FYI @pbrady @nncarlson 