### PR TITLE
README: Remove SunCC bullet

### DIFF
--- a/README
+++ b/README
@@ -303,12 +303,6 @@ Compiler Notes
   are now preferred by the Solaris Studio compilers.  GCC may
   require either "-m32" or "-mcpu=v9 -m32", depending on GCC version.
 
-- It has been noticed that if one uses CXX=sunCC, in which sunCC
-  is a link in the Solaris Studio compiler release, that the OMPI
-  build system has issue with sunCC and does not build libmpi_cxx.so.
-  Therefore  the make install fails.  So we suggest that one should
-  use CXX=CC, which works, instead of CXX=sunCC.
-
 - If one tries to build OMPI on Ubuntu with Solaris Studio using the C++
   compiler and the -m32 option, you might see a warning:
 


### PR DESCRIPTION
This bullet can be removed since SunCC is no longer supported as of
version 5.0.0.

Signed-off-by: Paul Kefer <24892969+paulkefer@users.noreply.github.com>

#daemondeacons