### PR TITLE
README: Updated Tested Systems

### DIFF
--- a/README
+++ b/README
@@ -176,8 +176,9 @@ General notes
 
 - Systems that have been tested are:
   - Linux (various flavors/distros), 64 bit (x86, ppc, aarch64),
-    with gcc (4.8.x+), Absoft (fortran), Intel, and Portland (*)
-  - macOS (10.12), 64 bit (x85_64) with XCode compilers
+    with gcc (>=4.8.x+), clang (>=3.6.0), Absoft (fortran), Intel,
+    and Portland (*)
+  - macOS (10.14-10.15), 64 bit (x86_64) with XCode compilers
 
   (*) Be sure to read the Compiler Notes, below.
 


### PR DESCRIPTION
Added clang version to linux system requirements.
Changed macOS version from 10.12 to 10.14-10.15.
Fixed a minor mistake where the architecture was labeled as x85_64
instead of x86_64

#daemondeacons

Signed-off-by: Alex Ross <rossaj16@wfu.edu>