### PR TITLE
Follow the MPI_T guidelines on return errors.

### DIFF
--- a/examples/spc_example.c
+++ b/examples/spc_example.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018      The University of Tennessee and The University
+ * Copyright (c) 2018-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -37,7 +37,7 @@ void message_exchange(int num_messages, int message_size)
 
 int main(int argc, char **argv)
 {
-    int num_messages, message_size;
+    int num_messages, message_size, rc;
 
     if(argc < 3) {
         printf("Usage: mpirun -np 2 --mca mpi_spc_attach all --mca mpi_spc_dump_enabled true ./spc_example [num_messages] [message_size]\n");
@@ -72,9 +72,11 @@ int main(int argc, char **argv)
     MPI_T_pvar_get_num(&num);
     for(i = 0; i < num; i++) {
         name_len = desc_len = 256;
-        PMPI_T_pvar_get_info(i, name, &name_len, &verbosity,
-                             &var_class, &datatype, &enumtype, description, &desc_len, &bind,
-                             &readonly, &continuous, &atomic);
+        rc = PMPI_T_pvar_get_info(i, name, &name_len, &verbosity,
+                                  &var_class, &datatype, &enumtype, description, &desc_len, &bind,
+                                  &readonly, &continuous, &atomic);
+        if( MPI_SUCCESS != rc )
+            continue;
         if(strcmp(name, counter_names[rank]) == 0) {
             index = i;
             printf("[%d] %s -> %s\n", rank, name, description);

--- a/ompi/mpi/tool/category_get_categories.c
+++ b/ompi/mpi/tool/category_get_categories.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +41,7 @@ int MPI_T_category_get_categories(int cat_index, int len, int indices[])
     do {
         rc = mca_base_var_group_get (cat_index, &group);
         if (0 > rc) {
-            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_ERR_OTHER;
+            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
             break;
         }
 

--- a/ompi/mpi/tool/category_get_cvars.c
+++ b/ompi/mpi/tool/category_get_cvars.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +41,7 @@ int MPI_T_category_get_cvars(int cat_index, int len, int indices[])
     do {
         rc = mca_base_var_group_get (cat_index, &group);
         if (0 > rc) {
-            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_ERR_OTHER;
+            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
             break;
         }
 

--- a/ompi/mpi/tool/category_get_index.c
+++ b/ompi/mpi/tool/category_get_index.c
@@ -4,6 +4,10 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +35,7 @@ int MPI_T_category_get_index (const char *name, int *category_index)
     }
 
     if (MPI_PARAM_CHECK && (NULL == category_index || NULL == name)) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();

--- a/ompi/mpi/tool/category_get_info.c
+++ b/ompi/mpi/tool/category_get_info.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +41,7 @@ int MPI_T_category_get_info(int cat_index, char *name, int *name_len,
     do {
         rc = mca_base_var_group_get (cat_index, &group);
         if (0 > rc) {
-            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_ERR_OTHER;
+            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
             break;
         }
 

--- a/ompi/mpi/tool/category_get_num.c
+++ b/ompi/mpi/tool/category_get_num.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,7 +32,7 @@ int MPI_T_category_get_num (int *num_cat)
     }
 
     if (MPI_PARAM_CHECK && NULL == num_cat) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();

--- a/ompi/mpi/tool/category_get_pvars.c
+++ b/ompi/mpi/tool/category_get_pvars.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +41,7 @@ int MPI_T_category_get_pvars(int cat_index, int len, int indices[])
     do {
         rc = mca_base_var_group_get (cat_index, &group);
         if (0 > rc) {
-            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_ERR_OTHER;
+            rc = (OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
             break;
         }
 

--- a/ompi/mpi/tool/cvar_get_index.c
+++ b/ompi/mpi/tool/cvar_get_index.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +34,7 @@ int MPI_T_cvar_get_index (const char *name, int *cvar_index)
     }
 
     if (MPI_PARAM_CHECK && (NULL == cvar_index || NULL == name)) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();

--- a/ompi/mpi/tool/cvar_get_info.c
+++ b/ompi/mpi/tool/cvar_get_info.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +42,7 @@ int MPI_T_cvar_get_info(int cvar_index, char *name, int *name_len, int *verbosit
         rc = mca_base_var_get (cvar_index, &var);
         if (OPAL_SUCCESS != rc) {
             rc = (OPAL_ERR_VALUE_OUT_OF_BOUNDS == rc || OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX :
-                MPI_ERR_OTHER;
+                MPI_T_ERR_INVALID;
             break;
         }
 
@@ -49,6 +52,8 @@ int MPI_T_cvar_get_info(int cvar_index, char *name, int *name_len, int *verbosit
         /* find the corresponding mpi type for an mca type */
         rc = ompit_var_type_to_datatype (var->mbv_type, datatype);
         if (OMPI_SUCCESS != rc) {
+            rc = MPI_T_ERR_INVALID;  /* can't really happen as MPI_SUCCESS is the only
+                                        possible return from ompit_var_type_to_datatype */
             break;
         }
 

--- a/ompi/mpi/tool/cvar_get_num.c
+++ b/ompi/mpi/tool/cvar_get_num.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,7 +31,7 @@ int MPI_T_cvar_get_num (int *num_cvar) {
     }
 
     if (MPI_PARAM_CHECK && NULL == num_cvar) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();

--- a/ompi/mpi/tool/cvar_handle_alloc.c
+++ b/ompi/mpi/tool/cvar_handle_alloc.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +36,7 @@ int MPI_T_cvar_handle_alloc (int cvar_index, void *obj_handle,
     }
 
     if (MPI_PARAM_CHECK && (NULL == handle || NULL == count)) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();
@@ -50,7 +53,7 @@ int MPI_T_cvar_handle_alloc (int cvar_index, void *obj_handle,
         rc = mca_base_var_get(cvar_index, &new_handle->var);
         if (OPAL_SUCCESS != rc) {
             rc = (OPAL_ERR_VALUE_OUT_OF_BOUNDS == rc || OPAL_ERR_NOT_FOUND == rc) ? MPI_T_ERR_INVALID_INDEX:
-                MPI_ERR_OTHER;
+                MPI_T_ERR_INVALID;
             free (new_handle);
             break;
         }

--- a/ompi/mpi/tool/cvar_read.c
+++ b/ompi/mpi/tool/cvar_read.c
@@ -5,6 +5,9 @@
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +36,7 @@ int MPI_T_cvar_read (MPI_T_cvar_handle handle, void *buf)
     }
 
     if (MPI_PARAM_CHECK && NULL == buf) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();
@@ -41,8 +44,8 @@ int MPI_T_cvar_read (MPI_T_cvar_handle handle, void *buf)
     do {
         rc = mca_base_var_get_value(handle->var->mbv_index, &value, NULL, NULL);
         if (OPAL_SUCCESS != rc || NULL == value) {
-            /* shouldn't happen */
-            rc = MPI_ERR_OTHER;
+            /* invalid or discarded cvar, ignore */
+            rc = MPI_T_ERR_INVALID_INDEX;
             break;
         }
 
@@ -84,7 +87,7 @@ int MPI_T_cvar_read (MPI_T_cvar_handle handle, void *buf)
 
             break;
         default:
-            rc = MPI_ERR_OTHER;
+            rc = MPI_T_ERR_INVALID;
         }
     } while (0);
 

--- a/ompi/mpi/tool/cvar_write.c
+++ b/ompi/mpi/tool/cvar_write.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +34,7 @@ int MPI_T_cvar_write (MPI_T_cvar_handle handle, const void *buf)
     }
 
     if (MPI_PARAM_CHECK && NULL == buf) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();

--- a/ompi/mpi/tool/enum_get_info.c
+++ b/ompi/mpi/tool/enum_get_info.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,7 +39,7 @@ int MPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *name, int *name_len
         if (num) {
             rc = enumtype->get_count (enumtype, num);
             if (OPAL_SUCCESS != rc) {
-                rc = MPI_ERR_OTHER;
+                rc = MPI_T_ERR_INVALID;
                 break;
             }
         }

--- a/ompi/mpi/tool/enum_get_item.c
+++ b/ompi/mpi/tool/enum_get_item.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +40,7 @@ int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name,
     do {
         rc = enumtype->get_count (enumtype, &count);
         if (OPAL_SUCCESS != rc) {
-            rc = MPI_ERR_OTHER;
+            rc = MPI_T_ERR_INVALID;
             break;
         }
 
@@ -48,7 +51,7 @@ int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name,
 
         rc = enumtype->get_value(enumtype, index, value, &tmp);
         if (OPAL_SUCCESS != rc) {
-            rc = MPI_ERR_OTHER;
+            rc = MPI_T_ERR_INVALID;
             break;
         }
 

--- a/ompi/mpi/tool/init_thread.c
+++ b/ompi/mpi/tool/init_thread.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,14 +48,14 @@ int MPI_T_init_thread (int required, int *provided)
         /* call opal_init_util to intialize the MCA system */
         rc = opal_init_util (NULL, NULL);
         if (OPAL_SUCCESS != rc) {
-            rc = MPI_ERR_OTHER;
+            rc = MPI_T_ERR_INVALID;
             break;
         }
 
         /* register all parameters */
         rc = ompi_info_register_framework_params (NULL);
         if (OMPI_SUCCESS != rc) {
-            rc = MPI_ERR_OTHER;
+            rc = MPI_T_ERR_INVALID;
             break;
         }
 

--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -5,6 +5,9 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -81,6 +84,6 @@ int ompit_opal_to_mpit_error (int rc)
     case OPAL_ERR_NOT_BOUND:
         return MPI_T_ERR_INVALID_HANDLE;
     default:
-        return MPI_ERR_UNKNOWN;
+        return MPI_T_ERR_INVALID;
     }
 }

--- a/ompi/mpi/tool/pvar_get_index.c
+++ b/ompi/mpi/tool/pvar_get_index.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,7 +34,7 @@ int MPI_T_pvar_get_index (const char *name, int var_class, int *pvar_index)
     }
 
     if (MPI_PARAM_CHECK && (NULL == pvar_index || NULL == name)) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     ompi_mpit_lock ();

--- a/ompi/mpi/tool/pvar_get_info.c
+++ b/ompi/mpi/tool/pvar_get_info.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +44,7 @@ int MPI_T_pvar_get_info(int pvar_index, char *name, int *name_len,
            bounds checking. */
         ret = mca_base_pvar_get (pvar_index, &pvar);
         if (OMPI_SUCCESS != ret) {
+            ret = (OPAL_ERR_NOT_FOUND == ret) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
             break;
         }
 
@@ -65,7 +69,8 @@ int MPI_T_pvar_get_info(int pvar_index, char *name, int *name_len,
 
         ret = ompit_var_type_to_datatype (pvar->type, datatype);
         if (OMPI_SUCCESS != ret) {
-            break;
+            ret = MPI_T_ERR_INVALID;  /* can't really happen as MPI_SUCCESS is the only
+                                         possible return from ompit_var_type_to_datatype */
         }
 
         if (NULL != enumtype) {

--- a/ompi/mpi/tool/pvar_get_num.c
+++ b/ompi/mpi/tool/pvar_get_num.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,7 +31,7 @@ int MPI_T_pvar_get_num(int *num_pvar)
     }
 
     if (MPI_PARAM_CHECK && NULL == num_pvar) {
-        return MPI_ERR_ARG;
+        return MPI_T_ERR_INVALID;
     }
 
     return mca_base_pvar_get_count (num_pvar);

--- a/ompi/mpi/tool/pvar_handle_alloc.c
+++ b/ompi/mpi/tool/pvar_handle_alloc.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,6 +42,7 @@ int MPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index,
            bounds checking. */
         ret = mca_base_pvar_get (pvar_index, &pvar);
         if (OMPI_SUCCESS != ret) {
+            ret = (OPAL_ERR_NOT_FOUND == ret) ? MPI_T_ERR_INVALID_INDEX : MPI_T_ERR_INVALID;
             break;
         }
 

--- a/ompi/mpi/tool/pvar_handle_free.c
+++ b/ompi/mpi/tool/pvar_handle_free.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,7 +47,7 @@ int MPI_T_pvar_handle_free(MPI_T_pvar_session session, MPI_T_pvar_handle *handle
 
         ret = mca_base_pvar_handle_free (*handle);
         if (OPAL_SUCCESS != ret) {
-            ret = MPI_ERR_UNKNOWN;
+            ret = MPI_T_ERR_INVALID;
         }
 
         *handle = MPI_T_PVAR_HANDLE_NULL;

--- a/ompi/mpi/tool/pvar_session_create.c
+++ b/ompi/mpi/tool/pvar_session_create.c
@@ -4,6 +4,9 @@
  *                         reserved.
  * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +37,7 @@ int MPI_T_pvar_session_create(MPI_T_pvar_session *session)
 
     *session = OBJ_NEW(mca_base_pvar_session_t);
     if (NULL == *session) {
-        ret = MPI_ERR_NO_MEM;
+        ret = MPI_T_ERR_MEMORY;
     }
 
     ompi_mpit_unlock ();

--- a/test/spc/spc_test.c
+++ b/test/spc/spc_test.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 The University of Tennessee and The University
- *                    of Tennessee Research Foundation.  All rights
- *                    reserved.
+ * Copyright (c) 2018-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * Simple example usage of SPCs through MPI_T.
  */
@@ -71,9 +71,9 @@ int main(int argc, char **argv)
 
     for(i = 0; i < num; i++) {
         name_len = desc_len = 256;
-        MPI_T_pvar_get_info(i, name, &name_len, &verbosity,
-                             &var_class, &datatype, &enumtype, description, &desc_len, &bind,
-                             &readonly, &continuous, &atomic);
+        MPI_result = MPI_T_pvar_get_info(i, name, &name_len, &verbosity,
+                                         &var_class, &datatype, &enumtype, description, &desc_len, &bind,
+                                         &readonly, &continuous, &atomic);
         if(MPI_result != MPI_SUCCESS || MPI_result == MPI_T_ERR_PVAR_NO_STARTSTOP) {
             fprintf(stderr, "Failed to get pvar info.\n");
             MPI_Abort(MPI_COMM_WORLD, MPI_result);


### PR DESCRIPTION
As indicated in the MPI3.2 document 14.3.10 page 599 line 1, the only
MPI error code possible is MPI_SUCCESS. All other errors must be in the
error class MPI_T_ERR*.
Fix the return of few pvar/cvar function that failed to correctly
convert to an MPI error code.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>