### PR TITLE
fortran/use-mpi-f08: restore ABI compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,8 +214,8 @@ ompi/mpi/fortran/mpif-h/sizeof_f.f90
 ompi/mpi/fortran/mpif-h/profile/p*.c
 ompi/mpi/fortran/mpif-h/profile/psizeof_f.f90
 
+ompi/mpi/fortran/use-mpi-f08/base/constants.h
 ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-constants.h
-ompi/mpi/fortran/use-mpi-f08/constants.h
 ompi/mpi/fortran/use-mpi-f08/sizeof_f08.f90
 ompi/mpi/fortran/use-mpi-f08/sizeof_f08.h
 ompi/mpi/fortran/use-mpi-f08/profile/psizeof_f08.f90

--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 #
 # Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2016-2019 Research Organization for Information Science
+# Copyright (c) 2016-2020 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      FUJITSU LIMITED.  All rights reserved.
 # $COPYRIGHT$
@@ -489,8 +489,8 @@ my $output = '/* WARNING! THIS IS A GENERATED FILE!!
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2009-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2016      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -498,8 +498,8 @@ my $output = '/* WARNING! THIS IS A GENERATED FILE!!
  * $HEADER$
  */
 
-#ifndef USE_MPI_F08_CONSTANTS_H
-#define USE_MPI_F08_CONSTANTS_H
+#ifndef USE_MPI_F08_BASE_CONSTANTS_H
+#define USE_MPI_F08_BASE_CONSTANTS_H
 
 ';
 
@@ -522,9 +522,9 @@ foreach my $key (sort(keys(%{$io_handles}))) {
     $output .= "#define OMPI_$key $io_handles->{$key}\n";
 }
 $output .= "\n";
-$output .= "#endif /* USE_MPI_F08_CONSTANTS_H */\n";
+$output .= "#endif /* USE_MPI_F08_BASE_CONSTANTS_H */\n";
 
-write_file("$topdir/ompi/mpi/fortran/use-mpi-f08/constants.h", $output);
+write_file("$topdir/ompi/mpi/fortran/use-mpi-f08/base/constants.h", $output);
 
 $output = '! WARNING! THIS IS A GENERATED FILE!!
 ! ANY EDITS YOU PUT HERE WILL BE LOST!

--- a/ompi/mpi/fortran/use-mpi-f08/base/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/base/Makefile.am
@@ -1,6 +1,8 @@
 # -*- makefile -*-
 #
 # Copyright (c) 2019 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2020      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -29,6 +31,8 @@ if OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS
 noinst_LTLIBRARIES = libusempif08_ccode.la
 
 libusempif08_ccode_la_SOURCES = \
-        buffer_detach.c
+        buffer_detach.c \
+        constants.c \
+        constants.h
 
 endif


### PR DESCRIPTION
An incorrect backport in open-mpi/ompi#7360 removed
constants.c from ompi/mpi/fortran/use-mpi-f08/base/Makefile.am

This one off commit fixes that, and move constants.h from
ompi/mpi/fortran/use-mpi-f08 to ompi/mpi/fortran/use-mpi-f08/base

Fixes open-mpi/ompi#7616

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>