### PR TITLE
Fix intercomm operations

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -20,7 +20,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
@@ -672,7 +672,7 @@ static int ompi_comm_split_type_get_part (ompi_group_t *group, const int split_t
 
             u16ptr = &locality;
 
-            OPAL_MODEX_RECV_VALUE(ret, OPAL_PMIX_LOCALITY, &proc_name, &u16ptr, OPAL_UINT16);
+            OPAL_MODEX_RECV_VALUE_OPTIONAL(ret, OPAL_PMIX_LOCALITY, &proc_name, &u16ptr, OPAL_UINT16);
             if (OPAL_SUCCESS != ret) {
                 continue;
             }
@@ -1648,7 +1648,7 @@ ompi_proc_t **ompi_comm_get_rprocs ( ompi_communicator_t *local_comm,
          * to provide this information at startup */
         uint16_t *u16ptr, u16;
         u16ptr = &u16;
-        OPAL_MODEX_RECV_VALUE(rc, OPAL_PMIX_LOCALITY, &rprocs[i]->super.proc_name, &u16ptr, OPAL_UINT16);
+        OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, OPAL_PMIX_LOCALITY, &rprocs[i]->super.proc_name, &u16ptr, OPAL_UINT16);
         if (OPAL_SUCCESS == rc) {
             rprocs[i]->super.proc_flags = u16;
         } else {


### PR DESCRIPTION
The locality for remote procs is not provided as it is only a local
concept. Thus, you must always use modex_recv_optional to ensure you
don't hang waiting for a response until dmodex times out.

Fixes https://github.com/openpmix/openpmix/issues/1712

Signed-off-by: Ralph Castain <rhc@pmix.org>