### PR TITLE
adding NUMA_RANK to process metadata

### DIFF
--- a/ompi/runtime/ompi_rte.h
+++ b/ompi/runtime/ompi_rte.h
@@ -8,6 +8,8 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -253,6 +255,8 @@ typedef struct {
     char *proc_session_dir;
     uint16_t my_local_rank;
     uint16_t my_node_rank;
+    /* process rank on local NUMA node. Set to UINT16_MAX if NUMA rank is unavailable */
+    uint16_t my_numa_rank;
     int32_t num_local_peers;
     uint32_t num_procs;
     uint32_t app_num;

--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -9,6 +9,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +37,7 @@ opal_process_info_t opal_process_info = {
     .proc_session_dir = NULL,
     .num_local_peers = 0,  /* there is nobody else but me */
     .my_local_rank = 0,    /* I'm the only process around here */
+    .my_numa_rank = UINT16_MAX,     /* Assume numa_rank is unavailable, set to UINT16_MAX */
     .cpuset = NULL,
 };
 

--- a/opal/util/proc.h
+++ b/opal/util/proc.h
@@ -7,6 +7,8 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -108,6 +110,7 @@ typedef struct opal_process_info_t {
     char *proc_session_dir;             /**< Session directory for the process */
     int32_t num_local_peers;            /**< number of procs from my job that share my node with me */
     int32_t my_local_rank;              /**< local rank on this node within my job */
+    int16_t my_numa_rank;               /**< rank on this processes NUMA node. A value of UINT16_MAX indicates unavailable numa_rank */
     char *cpuset;                       /**< String-representation of bitmap where we are bound */
 } opal_process_info_t;
 OPAL_DECLSPEC extern opal_process_info_t opal_process_info;


### PR DESCRIPTION
adding PMIX_NUMA_RANK info to process metadata so that the local NUMA
rank can be accessed through the opal_process_info object.

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>