### PR TITLE
PT2PT osc: don't extra retain datatype

### DIFF
--- a/ompi/mca/osc/base/osc_base_obj_convert.h
+++ b/ompi/mca/osc/base/osc_base_obj_convert.h
@@ -59,9 +59,9 @@ ompi_osc_base_datatype_create(ompi_proc_t *remote_proc,  void **payload)
 
 
 /**
- * Create datatype based on Fortran Index
+ * Create operation based on Fortran Index
  *
- * Create a useable MPI datatype based on it's Fortran index, which is
+ * Create a useable MPI operation based on it's Fortran index, which is
  * globally the same for predefined operations.  The op handle is
  * owned by the calling process and must be OBJ_RELEASEd when no
  * longer in use.

--- a/ompi/mca/osc/base/osc_base_obj_convert.h
+++ b/ompi/mca/osc/base/osc_base_obj_convert.h
@@ -54,7 +54,6 @@ ompi_osc_base_datatype_create(ompi_proc_t *remote_proc,  void **payload)
     struct ompi_datatype_t *datatype =
         ompi_datatype_create_from_packed_description(payload, remote_proc);
     if (NULL == datatype) return NULL;
-    OMPI_DATATYPE_RETAIN(datatype);
     return datatype;
 }
 


### PR DESCRIPTION
Removes `OMPI_DATATYPE_RETAIN` from `ompi_osc_base_datatype_create`. The datatype is explicitly retained where necessary.

Fixes #7617