### PR TITLE
Update dpm to handle deprecation of MPI_Info keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -464,6 +464,7 @@ test/simple/hello_output
 test/simple/hello_show_help
 test/simple/hello
 test/simple/hello++
+test/simple/intercomm1
 test/simple/interlib
 test/simple/loop_child
 test/simple/loop_spawn

--- a/ompi/dpm/Makefile.am
+++ b/ompi/dpm/Makefile.am
@@ -1,6 +1,6 @@
 # -*- makefile -*-
 #
-# Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -10,6 +10,8 @@
 #
 
 # This makefile.am does not stand on its own - it is included from ompi/Makefile.am
+
+dist_ompidata_DATA += dpm/help-dpm.txt
 
 headers += \
         dpm/dpm.h

--- a/ompi/dpm/help-dpm.txt
+++ b/ompi/dpm/help-dpm.txt
@@ -1,0 +1,46 @@
+# -*- text -*-
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+#
+#
+[deprecated-converted]
+WARNING: A deprecated MPI_Info key was used.
+
+  Deprecated key:   %s
+  Corrected key:    %s
+
+We have updated this for you and will proceed. However, this will be treated
+as an error in a future release. Please update your application.
+#
+[deprecated-inform]
+WARNING: A deprecated MPI_Info key was used.
+
+  Deprecated option:   %s
+  Reason: %s
+
+This has been ignored as it is no longer meaningful. Please update
+your application.
+#
+[deprecated-fail]
+WARNING: A deprecated MPI_Info key was used. It is unclear how to update
+this option. Please contact the community for how best to resolve this issue.
+
+  Deprecated info key:  %s
+  Updated option:   %s
+  Reason: %s
+
+We are not able to proceed. Please update your application.
+#
+[bad-ppr]
+The proc-per-resource MPI_Info key is not correct. The value must include both
+the number of procs for each resource and the type of resource to be used.
+
+  Specified value:  %s
+
+We are not able to proceed. Please correct your application.

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -230,7 +230,7 @@ int ompi_info_get_value_enum (ompi_info_t *info, const char *key, int *value,
     return opal_info_get_value_enum (&(info->super), key, value,
                               default_value, var_enum, flag);
 }
-int ompi_info_get_bool(ompi_info_t *info, char *key, bool *value, int *flag) {
+int ompi_info_get_bool(ompi_info_t *info, const char *key, bool *value, int *flag) {
     return opal_info_get_bool(&(info->super), key, value, flag);
 }
 int ompi_info_delete (ompi_info_t *info, const char *key) {

--- a/ompi/info/info.h
+++ b/ompi/info/info.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -119,7 +120,7 @@ OMPI_DECLSPEC int ompi_info_set_value_enum (ompi_info_t *info, const char *key, 
 /**
  * ompi_info_foo() wrapper around various opal_info_foo() calls
  */
-OMPI_DECLSPEC int ompi_info_get_bool (ompi_info_t *info, char *key, bool *value, int *flag);
+OMPI_DECLSPEC int ompi_info_get_bool (ompi_info_t *info, const char *key, bool *value, int *flag);
 /**
  * ompi_info_foo() wrapper around various opal_info_foo() calls
  */

--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -561,7 +561,6 @@ int ompi_rte_init(int *pargc, char ***pargv)
         }
         opal_process_info.nodename = ev1;  // ev1 is an allocated string
     }
-    opal_process_info.nodename = opal_process_info.nodename;
 
     /* get our local rank from PMIx */
     OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_LOCAL_RANK,

--- a/opal/mca/btl/vader/btl_vader_module.c
+++ b/opal/mca/btl/vader/btl_vader_module.c
@@ -337,11 +337,6 @@ static int vader_add_procs (struct mca_btl_base_module_t* btl,
         return OPAL_SUCCESS;
     }
 
-    /* make sure that my local rank has been defined */
-    if (0 > MCA_BTL_VADER_LOCAL_RANK) {
-        return OPAL_ERROR;
-    }
-
     if (!vader_btl->btl_inited) {
         rc = vader_btl_first_time_init (vader_btl, 1 + MCA_BTL_VADER_NUM_LOCAL_PEERS);
         if (rc != OPAL_SUCCESS) {

--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation. All rights reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -338,7 +338,7 @@ int opal_info_get_value_enum (opal_info_t *info, const char *key, int *value,
  * Similar to opal_info_get(), but cast the result into a boolean
  * using some well-defined rules.
  */
-int opal_info_get_bool(opal_info_t *info, char *key, bool *value, int *flag)
+int opal_info_get_bool(opal_info_t *info, const char *key, bool *value, int *flag)
 {
     char str[256];
 

--- a/opal/util/info.h
+++ b/opal/util/info.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017-2018 IBM Corporation. All rights reserved.
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -203,7 +204,7 @@ int opal_info_free (opal_info_t **info);
    *     result is false
    *   - All other values are false
    */
-OPAL_DECLSPEC int opal_info_get_bool (opal_info_t *info, char *key, bool *value,
+OPAL_DECLSPEC int opal_info_get_bool (opal_info_t *info, const char *key, bool *value,
                                       int *flag);
 
 /**

--- a/test/simple/intercomm1.c
+++ b/test/simple/intercomm1.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include "mpi.h"
+
+
+int main( int argc, char *argv[] )
+{
+    MPI_Status status;
+    MPI_Comm comm,scomm;
+    int rank, size, color, errs=0;
+    MPI_Init( 0, 0 );
+    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+    color = rank % 2;
+    printf("%d Calling split\n", rank);
+    MPI_Comm_split( MPI_COMM_WORLD, color, rank, &scomm );
+    printf("%d Calling Intercomm_create\n", rank);
+    MPI_Intercomm_create( scomm, 0, MPI_COMM_WORLD, 1-color, 1, &comm);
+    printf("%d Completet\n", rank);
+    MPI_Comm_rank( comm, &rank );
+    MPI_Comm_remote_size( comm, &size );
+    MPI_Comm_free(&scomm);
+    MPI_Comm_free(&comm);
+    MPI_Finalize();
+    return errs;
+}
+


### PR DESCRIPTION
Deprecate the current OMPI-specific MPI_Info key definitions for
MPI_Comm_spawn and replace them with their PMIx equivalents. Issue a
deprecation/conversion warning as this is done. Also issue deprecation
warnings for options such as "ompi_non_mpi" that are no longer used.

Handle both cases where the user might pass either the PMIx attribute
name itself (e.g., "PMIX_MAPBY") or the string value of the attribute
(e.g., PMIX_MAPBY, which translates to "pmix.mapby"). This can only be
done for PMIx v4 and above, so protect that code.

Silence a couple of Coverity warnings and add a test along the way.

Fixes #7658 

Signed-off-by: Ralph Castain <rhc@pmix.org>