### PR TITLE
Accept UCX 1.8 in configure of btl/uct

### DIFF
--- a/opal/mca/btl/uct/configure.m4
+++ b/opal/mca/btl/uct/configure.m4
@@ -6,7 +6,7 @@
 # Copyright (c) 2004-2005 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+# Copyright (c) 2004-2020 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2006 The Regents of the University of California.
 #                         All rights reserved.
@@ -52,7 +52,7 @@ dnl
     fi
 
     max_allowed_uct_major=1
-    max_allowed_uct_minor=7
+    max_allowed_uct_minor=8
     if test "$btl_uct_happy" = "yes" && test "$enable_uct_version_check" != "no"; then
         AC_MSG_CHECKING([UCT version compatibility])
         OPAL_VAR_SCOPE_PUSH([CPPFLAGS_save])


### PR DESCRIPTION
The configure script for the btl uct component reports an error for
the new UCX 1.8.0 versions as it was fixed up to UCX 1.7.

This fixes #7612

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>