### PR TITLE
OPAL/UCX: enabling new API provided by UCX - v4.0

### DIFF
--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -128,6 +128,14 @@ AC_DEFUN([OMPI_CHECK_UCX],[
                                  [AC_DEFINE([HAVE_UCP_WORKER_ADDRESS_FLAGS], [1],
                                             [have worker address attribute])], [],
                                  [#include <ucp/api/ucp.h>])
+                  AC_CHECK_DECLS([ucp_tag_send_nbx,
+                                  ucp_tag_send_sync_nbx,
+                                  ucp_tag_recv_nbx],
+                                 [], [],
+                                 [#include <ucp/api/ucp.h>])
+                  AC_CHECK_TYPES([ucp_request_param_t],
+                                 [], [],
+                                 [[#include <ucp/api/ucp.h>]])
                   CPPFLAGS=$old_CPPFLAGS
 
                   OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])])])

--- a/ompi/mca/pml/ucx/pml_ucx_datatype.c
+++ b/ompi/mca/pml/ucx/pml_ucx_datatype.c
@@ -8,12 +8,20 @@
  */
 
 #include "pml_ucx_datatype.h"
+#include "pml_ucx_request.h"
 
 #include "ompi/runtime/mpiruntime.h"
 #include "ompi/attribute/attribute.h"
 
 #include <inttypes.h>
+#include <math.h>
 
+#ifdef HAVE_UCP_REQUEST_PARAM_T
+#define PML_UCX_DATATYPE_SET_VALUE(_datatype, _val) \
+    (_datatype)->op_param.send._val; \
+    (_datatype)->op_param.bsend._val; \
+    (_datatype)->op_param.recv._val;
+#endif
 
 static void* pml_ucx_generic_datatype_start_pack(void *context, const void *buffer,
                                                  size_t count)
@@ -133,31 +141,78 @@ int mca_pml_ucx_datatype_attr_del_fn(ompi_datatype_t* datatype, int keyval,
 {
     ucp_datatype_t ucp_datatype = (ucp_datatype_t)attr_val;
 
+#ifdef HAVE_UCP_REQUEST_PARAM_T
+    free((void*)datatype->pml_data);
+#else
     PML_UCX_ASSERT((uint64_t)ucp_datatype == datatype->pml_data);
-
+#endif
     ucp_dt_destroy(ucp_datatype);
     datatype->pml_data = PML_UCX_DATATYPE_INVALID;
     return OMPI_SUCCESS;
 }
 
-ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+__opal_attribute_always_inline__
+static inline int mca_pml_ucx_datatype_is_contig(ompi_datatype_t *datatype)
 {
-    ucp_datatype_t ucp_datatype;
-    ucs_status_t status;
     ptrdiff_t lb;
-    size_t size;
-    int ret;
 
     ompi_datatype_type_lb(datatype, &lb);
 
-    if ((datatype->super.flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) &&
-        (datatype->super.flags & OPAL_DATATYPE_FLAG_NO_GAPS) &&
-        (lb == 0))
-    {
+    return (datatype->super.flags & OPAL_DATATYPE_FLAG_CONTIGUOUS) &&
+           (datatype->super.flags & OPAL_DATATYPE_FLAG_NO_GAPS) &&
+           (lb == 0);
+}
+
+#ifdef HAVE_UCP_REQUEST_PARAM_T
+__opal_attribute_always_inline__ static inline
+pml_ucx_datatype_t *mca_pml_ucx_init_nbx_datatype(ompi_datatype_t *datatype,
+                                                  ucp_datatype_t ucp_datatype,
+                                                  size_t size)
+{
+    pml_ucx_datatype_t *pml_datatype;
+    int is_contig_pow2;
+
+    pml_datatype = malloc(sizeof(*pml_datatype));
+    if (pml_datatype == NULL) {
+        PML_UCX_ERROR("Failed to allocate datatype structure");
+        ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
+    }
+
+    pml_datatype->datatype                    = ucp_datatype;
+    pml_datatype->op_param.send.op_attr_mask  = UCP_OP_ATTR_FIELD_CALLBACK;
+    pml_datatype->op_param.send.cb.send       = mca_pml_ucx_send_nbx_completion;
+    pml_datatype->op_param.bsend.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK;
+    pml_datatype->op_param.bsend.cb.send      = mca_pml_ucx_bsend_nbx_completion;
+    pml_datatype->op_param.recv.op_attr_mask  = UCP_OP_ATTR_FIELD_CALLBACK |
+                                                UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
+    pml_datatype->op_param.recv.cb.recv       = mca_pml_ucx_recv_nbx_completion;
+
+    is_contig_pow2 = mca_pml_ucx_datatype_is_contig(datatype) &&
+                     !(size & (size - 1)); /* is_pow2(size) */
+    if (is_contig_pow2) {
+        pml_datatype->size_shift = (int)(log(size) / log(2.0)); /* log2(size) */
+    } else {
+        pml_datatype->size_shift = 0;
+        PML_UCX_DATATYPE_SET_VALUE(pml_datatype, op_attr_mask |= UCP_OP_ATTR_FIELD_DATATYPE);
+        PML_UCX_DATATYPE_SET_VALUE(pml_datatype, datatype = ucp_datatype);
+    }
+
+    return pml_datatype;
+}
+#endif
+
+ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
+{
+    size_t size = 0; /* init to suppress compiler warning */
+    ucp_datatype_t ucp_datatype;
+    ucs_status_t status;
+    int ret;
+
+    if (mca_pml_ucx_datatype_is_contig(datatype)) {
         ompi_datatype_type_size(datatype, &size);
         PML_UCX_ASSERT(size > 0);
-        datatype->pml_data = ucp_dt_make_contig(size);
-        return datatype->pml_data;
+        ucp_datatype = ucp_dt_make_contig(size);
+        goto out;
     }
 
     status = ucp_dt_create_generic(&pml_ucx_generic_datatype_ops,
@@ -166,8 +221,6 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
         PML_UCX_ERROR("Failed to create UCX datatype for %s", datatype->name);
         ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
     }
-
-    datatype->pml_data = ucp_datatype;
 
     /* Add custom attribute, to clean up UCX resources when OMPI datatype is
      * released.
@@ -185,8 +238,17 @@ ucp_datatype_t mca_pml_ucx_init_datatype(ompi_datatype_t *datatype)
             ompi_mpi_abort(&ompi_mpi_comm_world.comm, 1);
         }
     }
-
+out:
     PML_UCX_VERBOSE(7, "created generic UCX datatype 0x%"PRIx64, ucp_datatype)
+
+#ifdef HAVE_UCP_REQUEST_PARAM_T
+    UCS_STATIC_ASSERT(sizeof(datatype->pml_data) >= sizeof(pml_ucx_datatype_t*));
+    datatype->pml_data = (uint64_t)mca_pml_ucx_init_nbx_datatype(datatype,
+                                                                 ucp_datatype,
+                                                                 size);
+#else
+    datatype->pml_data = ucp_datatype;
+#endif
 
     return ucp_datatype;
 }

--- a/ompi/mca/pml/ucx/pml_ucx_request.c
+++ b/ompi/mca/pml/ucx/pml_ucx_request.c
@@ -34,7 +34,8 @@ static int mca_pml_ucx_request_cancel(ompi_request_t *req, int flag)
     return OMPI_SUCCESS;
 }
 
-void mca_pml_ucx_send_completion(void *request, ucs_status_t status)
+__opal_attribute_always_inline__ static inline void
+mca_pml_ucx_send_completion_internal(void *request, ucs_status_t status)
 {
     ompi_request_t *req = request;
 
@@ -46,7 +47,8 @@ void mca_pml_ucx_send_completion(void *request, ucs_status_t status)
     ompi_request_complete(req, true);
 }
 
-void mca_pml_ucx_bsend_completion(void *request, ucs_status_t status)
+__opal_attribute_always_inline__ static inline void
+mca_pml_ucx_bsend_completion_internal(void *request, ucs_status_t status)
 {
     ompi_request_t *req = request;
 
@@ -59,8 +61,9 @@ void mca_pml_ucx_bsend_completion(void *request, ucs_status_t status)
     mca_pml_ucx_request_free(&req);
 }
 
-void mca_pml_ucx_recv_completion(void *request, ucs_status_t status,
-                                 ucp_tag_recv_info_t *info)
+__opal_attribute_always_inline__ static inline void
+mca_pml_ucx_recv_completion_internal(void *request, ucs_status_t status,
+                                     const ucp_tag_recv_info_t *info)
 {
     ompi_request_t *req = request;
 
@@ -71,6 +74,41 @@ void mca_pml_ucx_recv_completion(void *request, ucs_status_t status,
     mca_pml_ucx_set_recv_status(&req->req_status, status, info);
     PML_UCX_ASSERT( !(REQUEST_COMPLETE(req)));
     ompi_request_complete(req, true);
+}
+
+void mca_pml_ucx_send_completion(void *request, ucs_status_t status)
+{
+    mca_pml_ucx_send_completion_internal(request, status);
+}
+
+void mca_pml_ucx_bsend_completion(void *request, ucs_status_t status)
+{
+    mca_pml_ucx_bsend_completion_internal(request, status);
+}
+
+void mca_pml_ucx_recv_completion(void *request, ucs_status_t status,
+                                 ucp_tag_recv_info_t *info)
+{
+    mca_pml_ucx_recv_completion_internal(request, status, info);
+}
+
+void mca_pml_ucx_send_nbx_completion(void *request, ucs_status_t status,
+                                     void *user_data)
+{
+    mca_pml_ucx_send_completion_internal(request, status);
+}
+
+void mca_pml_ucx_bsend_nbx_completion(void *request, ucs_status_t status,
+                                      void *user_data)
+{
+    mca_pml_ucx_bsend_completion_internal(request, status);
+}
+
+void mca_pml_ucx_recv_nbx_completion(void *request, ucs_status_t status,
+                                     const ucp_tag_recv_info_t *info,
+                                     void *user_data)
+{
+    mca_pml_ucx_recv_completion_internal(request, status, info);
 }
 
 static void mca_pml_ucx_persistent_request_detach(mca_pml_ucx_persistent_request_t *preq,

--- a/ompi/mca/pml/ucx/pml_ucx_request.h
+++ b/ompi/mca/pml/ucx/pml_ucx_request.h
@@ -126,6 +126,16 @@ void mca_pml_ucx_bsend_completion(void *request, ucs_status_t status);
 void mca_pml_ucx_precv_completion(void *request, ucs_status_t status,
                                   ucp_tag_recv_info_t *info);
 
+void mca_pml_ucx_send_nbx_completion(void *request, ucs_status_t status,
+                                     void *user_data);
+
+void mca_pml_ucx_bsend_nbx_completion(void *request, ucs_status_t status,
+                                      void *user_data);
+
+void mca_pml_ucx_recv_nbx_completion(void *request, ucs_status_t status,
+                                     const ucp_tag_recv_info_t *info,
+                                     void *user_data);
+
 void mca_pml_ucx_persistent_request_complete(mca_pml_ucx_persistent_request_t *preq,
                                              ompi_request_t *tmp_req);
 
@@ -141,8 +151,9 @@ static inline void mca_pml_ucx_request_reset(ompi_request_t *req)
     req->req_complete          = REQUEST_PENDING;
 }
 
-static void mca_pml_ucx_set_send_status(ompi_status_public_t* mpi_status,
-                                        ucs_status_t status)
+__opal_attribute_always_inline__
+static inline void mca_pml_ucx_set_send_status(ompi_status_public_t* mpi_status,
+                                               ucs_status_t status)
 {
     if (OPAL_LIKELY(status == UCS_OK)) {
         mpi_status->MPI_ERROR  = MPI_SUCCESS;


### PR DESCRIPTION
- added detection of new API into configuration
- added tag_send call implemented using new API
- added MPI_Send/MPI_Isend/MPI_Recv/MPI_Irecv implementations

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>
(cherry picked from commit 75bda25ddbeea18bb001f367a712dc72592e1e58)