### PR TITLE
Updating README to include WARNING about ABI break

### DIFF
--- a/README
+++ b/README
@@ -8,11 +8,11 @@ Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
                         University of Stuttgart.  All rights reserved.
 Copyright (c) 2004-2007 The Regents of the University of California.
                         All rights reserved.
-Copyright (c) 2006-2018 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved.
 Copyright (c) 2006-2011 Mellanox Technologies. All rights reserved.
 Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
 Copyright (c) 2007      Myricom, Inc.  All rights reserved.
-Copyright (c) 2008-2019 IBM Corporation.  All rights reserved.
+Copyright (c) 2008-2020 IBM Corporation.  All rights reserved.
 Copyright (c) 2010      Oak Ridge National Labs.  All rights reserved.
 Copyright (c) 2011      University of Houston. All rights reserved.
 Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
@@ -66,10 +66,28 @@ Much, much more information is also available in the Open MPI FAQ:
 ===========================================================================
 
 The following abbreviated list of release notes applies to this code
-base as of this writing (February 2019):
+base as of this writing (May 2020):
 
 General notes
 -------------
+
+- WARNING - Open MPI v4.0.0-4.0.3 accidentally did not include some
+  constants from the mpi_f08 module interface (mostly dealing with C and
+  C++ datatypes).
+
+  Additionally, v4.0.3 specifically dropped some constants from the
+  mpi_f08 module interface that were previously included in v4.0.0-v4.0.2.
+
+  All mpi_f08 symbols have been restored in v4.0.4.
+
+  There are two consequences to this sequence of events:
+    1. There was an ABI break introduced in v4.0.3 (i.e., some
+       mpi_f08 symbols were dropped).
+    2. New mpi_f08 symbols were introduced in v4.0.4 (i.e., all missing
+       symbols were restored).  Applications who use these symbols and
+       who compile against v4.0.4 will not be able to successfully
+       run-time link against the libmpi_usempif08.so shared library
+       from prior versions of the v4.0.x series.
 
 - Open MPI now includes two public software layers: MPI and OpenSHMEM.
   Throughout this document, references to Open MPI implicitly include


### PR DESCRIPTION
This commit adds a blurb to the README for v4.0.4, suggesting
that users of libmpi_usempif08.so skip over v4.0.3.

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>