### PR TITLE
PSM2 update to use PRRTE instead of ORTE

### DIFF
--- a/ompi/mca/mtl/psm2/help-mtl-psm2.txt
+++ b/ompi/mca/mtl/psm2/help-mtl-psm2.txt
@@ -25,7 +25,7 @@ active on the node and the hardware is functioning.
   Error: %s
 #
 [no uuid present]
-Error obtaining unique transport key from ORTE (orte_precondition_transports %s
+Error obtaining unique transport key from PMIX (PMIX_MCA_opa_precondition_transports %s
 the environment).
 
   Local host: %s

--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -101,7 +101,7 @@ int ompi_mtl_psm2_module_init(int local_rank, int num_local_procs) {
     char env_string[256];
     int rc;
 
-    generated_key = getenv(OPAL_MCA_PREFIX"orte_precondition_transports");
+    generated_key = getenv("PMIX_MCA_opa_precondition_transports");
     memset(uu, 0, sizeof(psm2_uuid_t));
 
     if (!generated_key || (strlen(generated_key) != 33) ||

--- a/ompi/mca/mtl/psm2/mtl_psm2.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2.c
@@ -101,7 +101,7 @@ int ompi_mtl_psm2_module_init(int local_rank, int num_local_procs) {
     char env_string[256];
     int rc;
 
-    generated_key = getenv("PMIX_MCA_opa_precondition_transports");
+    generated_key = getenv("OPA_TRANSPORT_KEY");
     memset(uu, 0, sizeof(psm2_uuid_t));
 
     if (!generated_key || (strlen(generated_key) != 33) ||

--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -348,7 +348,7 @@ get_local_rank(int *out_rank)
 {
     *out_rank = 0;
 
-    if (OMPI_NODE_RANK_INVALID == ompi_process_info.my_node_rank) {
+    if (UINT16_MAX == ompi_process_info.my_node_rank) {
         return OMPI_ERROR;
     }
     *out_rank = (int)ompi_process_info.my_node_rank;


### PR DESCRIPTION
Replace obsolete references to OMPI_NODE_RANK_INVALID and orte_precondition_transports.

Fixes #7700 

Signed-off-by: Michael Heinz <michael.william.heinz@intel.com>