### PR TITLE
opal/mca/threads/argobots: fix compilation error

### DIFF
--- a/opal/mca/threads/argobots/threads_argobots_mutex.c
+++ b/opal/mca/threads/argobots/threads_argobots_mutex.c
@@ -105,7 +105,7 @@ void opal_mutex_create(struct opal_mutex_t *m)
         }
         void *null_ptr = OPAL_ABT_MUTEX_NULL;
         if (opal_atomic_compare_exchange_strong_ptr(
-             (intptr_t *)&m->m_lock_argobots, (intptr_t *)&null_ptr,
+             (opal_atomic_intptr_t *)&m->m_lock_argobots, (intptr_t *)&null_ptr,
              (intptr_t)abt_mutex)) {
             /* mutex is successfully created and substituted. */
             return;
@@ -121,7 +121,7 @@ static void opal_cond_create(opal_cond_t *cond)
         ABT_cond new_cond;
         ABT_cond_create(&new_cond);
         void *null_ptr = OPAL_ABT_COND_NULL;
-        if (opal_atomic_compare_exchange_strong_ptr((intptr_t *)cond,
+        if (opal_atomic_compare_exchange_strong_ptr((opal_atomic_intptr_t *)cond,
                                                     (intptr_t *)&null_ptr,
                                                     (intptr_t)new_cond)) {
             /* cond is successfully created and substituted. */


### PR DESCRIPTION
This patch fixes #7697 by properly using OPAL's atomic type.
I confirmed that it works with Clang 7, Clang 9, GCC 4.8.5, and ICC 17 on an Intel server.

Signed-off-by: Shintaro Iwasaki <siwasaki@anl.gov>
