### PR TITLE
PSM2: Call add_procs through PML

### DIFF
--- a/ompi/mca/mtl/psm2/mtl_psm2_endpoint.h
+++ b/ompi/mca/mtl/psm2/mtl_psm2_endpoint.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      QLogic Corporation. All rights reserved.
- * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2020 Intel, Inc. All rights reserved
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,7 +58,10 @@ OBJ_CLASS_DECLARATION(mca_mtl_psm2_endpoint);
 static inline mca_mtl_psm2_endpoint_t *ompi_mtl_psm2_get_endpoint (struct mca_mtl_base_module_t* mtl, ompi_proc_t *ompi_proc)
 {
     if (OPAL_UNLIKELY(NULL == ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL])) {
-	ompi_mtl_psm2_add_procs (mtl, 1, &ompi_proc);
+        int rc;
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != (rc = MCA_PML_CALL(add_procs(&ompi_proc, 1))))) {
+            ompi_rte_abort(rc,"Error in ompi_mtl_psm2_get_endpoint.\n");
+        }
     }
 
     return ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];


### PR DESCRIPTION
Fixes issue #7699 .
Change ompi_mtl_ofi_get_endpoint() to call the active PML's add_procs()
rather than the OFI MTL add_procs() directly when discovering a new
process during operation.

Functionally, this has no impact in correct operation. However, the
current behavior means that the heterogenous and active PML checks
are not being executed in the dynamic discovery case.

Signed-off-by: Michael Heinz <michael.william.heinz@intel.com>