### PR TITLE
Fix potential out-of-bounds write in opal_progress_unregister

### DIFF
--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -474,8 +474,8 @@ static int _opal_progress_unregister (opal_progress_callback_t cb, volatile opal
         (void) opal_atomic_swap_ptr ((opal_atomic_intptr_t *) (callback_array + i), (intptr_t) callback_array[i+1]);
     }
 
-    callback_array[*callback_array_len] = fake_cb;
     --*callback_array_len;
+    callback_array[*callback_array_len] = fake_cb;
 
     return OPAL_SUCCESS;
 }


### PR DESCRIPTION
Fix a potential OOB write that may occur if the number of registered callbacks equals the size of the array holding the callbacks. The chances of this occurring in the wild seem fairly slim and probably only affects finalization.

The `callback_array_len` holds the number of active callbacks in the array and thus if `len == size` points one past the last element.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>