### PR TITLE
Add check for PSM2 reference counting to PSM2 MTL #7721

### DIFF
--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -76,7 +76,15 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
                [AC_MSG_WARN([glob.h not found.  Can not build component.])
                ompi_check_psm2_happy="no"])])
 
-	OPAL_SUMMARY_ADD([[Transports]],[[Intel Omnipath (PSM2)]],[$1],[$ompi_check_psm2_happy])
+        AS_IF([test "$ompi_check_psm2_happy" = "yes"],
+              [AC_CHECK_DECL([PSM2_LIB_REFCOUNT_CAP],
+                        [],
+                        [AC_MSG_WARN([PSM2 needs to be version 11.2.173 or later. Disabling MTL.])
+                         ompi_check_psm2_happy="no"],
+                        [#include <psm2.h>])
+              ])
+
+        OPAL_SUMMARY_ADD([[Transports]],[[Intel Omnipath (PSM2)]],[$1],[$ompi_check_psm2_happy])
     fi
 
     AS_IF([test "$ompi_check_psm2_happy" = "yes"],

--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -323,6 +323,18 @@ ompi_mtl_psm2_component_open(void)
 static int
 ompi_mtl_psm2_component_query(mca_base_module_t **module, int *priority)
 {
+
+    /*
+     * Mixing the PSM2 MTL with the OFI BTL (using PSM2) 
+     * can cause an issue when they both call psm2_finalize
+     * in older versions of libpsm2.
+     */
+    if (!psm2_get_capability_mask(PSM2_LIB_REFCOUNT_CAP)) {
+        opal_output_verbose(2, ompi_mtl_base_framework.framework_output, 
+            "This version of the PSM2 MTL needs version 11.2.173 or later of the libpsm2 library for correct operation.\n");
+        return OMPI_ERR_FATAL;
+    }   
+
     /*
      * if we get here it means that PSM2 is available so give high priority
      */


### PR DESCRIPTION
As discussed, a feature is being added to libpsm2 to correctly handle
the case where the library is opened by multiple OMPI transports in the same
process. (For example, the OFI BTL and the PSM2 MTL).

Signed-off-by: Michael Heinz <michael.william.heinz@intel.com>