### PR TITLE
Export/ulfm to ompi5

### DIFF
--- a/README.FT.ULFM.md
+++ b/README.FT.ULFM.md
@@ -1,0 +1,483 @@
+ULFM Open MPI
+
+This README.md documents the features and options specific to the
+**User Level Failure Mitigation (ULFM)** Open MPI implementation.
+The upstream (i.e. non-resilient) Open MPI directions also apply to
+this release, except when specified here, and can be found in its
+README file.
+
+[TOC]
+
+Features
+========
+This implementation conforms to the User Level Failure Mitigation (ULFM)
+MPI Standard draft proposal. The ULFM proposal is developed by the MPI
+Forum's Fault Tolerance Working Group to support the continued operation of
+MPI programs after crash (node failures) have impacted the execution. The key
+principle is that no MPI call (point-to-point, collective, RMA, IO, ...) can
+block indefinitely after a failure, but must either succeed or raise an MPI
+error.
+
+This implementation produces the three supplementary error codes and five
+supplementary interfaces defined in the communicator section of the
+[http://fault-tolerance.org/wp-content/uploads/2012/10/20170221-ft.pdf]
+(ULFM chapter) standard draft document.
+
++ `MPIX_ERR_PROC_FAILED` when a process failure prevents the completion of
+  an MPI operation.
++ `MPIX_ERR_PROC_FAILED_PENDING` when a potential sender matching a non-blocking
+  wildcard source receive has failed.
++ `MPIX_ERR_REVOKED` when one of the ranks in the application has invoked the
+  `MPI_Comm_revoke` operation on the communicator.
++ `MPIX_Comm_revoke(MPI_Comm comm)` Interrupts any communication pending on
+  the communicator at all ranks.
++ `MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm* newcomm)` creates a new
+  communicator where dead processes in comm were removed.
++ `MPIX_Comm_agree(MPI_Comm comm, int *flag)` performs a consensus (i.e. fault
+  tolerant allreduce operation) on flag (with the operation bitwise AND).
++ `MPIX_Comm_failure_get_acked(MPI_Comm, MPI_Group*)` obtains the group of
+  currently acknowledged failed processes.
++ `MPIX_Comm_failure_ack(MPI_Comm)` acknowledges that the application intends
+  to ignore the effect of currently known failures on wildcard receive
+  completions and agreement return values.
+
+## Supported Systems
+There are several MPI engines available in Open MPI,
+notably, PML "ob1", "cm", "ucx", and MTL "ofi", "portals4", "psm2".
+At this point, only "ob1" is adapted to support fault tolerance.
+
+"ob1" uses BTL ("Byte Transfer Layer") components for each supported
+network. "ob1" supports a variety of networks that can be used in
+combination with each other. Collective operations (blocking and
+non-blocking) use an optimized implementation on top of "ob1".
+
+- Loopback (send-to-self)
+- TCP
+- UCT (InfiniBand)
+- uGNI (Cray Gemini, Aries)
+- Shared Memory (FT supported w/CMA and XPmem; KNEM is untested)
+- Tuned and non-blocking collective communications
+
+A full list of supported, untested and disabled components is provided
+later in this document.
+
+## More Information
+More information (tutorials, examples, build instructions for leading
+top500 systems) is also available in the Fault Tolerance Research
+Hub website:
+  <https://fault-tolerance.org>
+
+## Bibliographic References
+If you are looking for, or want to cite a general reference for ULFM,
+please use
+
+_Wesley Bland, Aurelien Bouteiller, Thomas Herault, George Bosilca, Jack
+J. Dongarra: Post-failure recovery of MPI communication capability: Design
+and rationale. IJHPCA 27(3): 244-254 (2013)._
+
+Available from: http://journals.sagepub.com/doi/10.1177/1094342013488238.
+___________________________________________________________________________
+
+Building ULFM Open MPI
+======================
+```bash
+./configure --with-ft [...options...]
+#    use --with-ft to enable building with ULFM (default),
+#        --without-ft to disable it
+make [-j N] all install
+#    use an integer value of N for parallel builds
+```
+There are many available configure options (see `./configure --help`
+for a full list); a summary of the more commonly used ones is included
+in the upstream Open MPI README file. The following paragraph gives a
+summary of ULFM Open MPI specific options behavior.
+
+## Configure options
++ `--with-ft=TYPE`
+  Specify the type of fault tolerance to enable.  Options: mpi (ULFM MPI
+  draft standard).  Fault tolerance build support is **enabled by default**.
+
++ `--enable-mca-no-build=LIST`
+  Comma-separated list of _<type>-<component>_ pairs that will not be built.
+  For example, `--enable-mca-no-build=btl-portals,oob-ud` will disable
+  building the _portals BTL_ and the _ud OOB_ component. You can use this
+  option to disable components that are known to prevent supporting failure
+  management __when built-in__. By default, this list is empty, as ulfm has
+  a separate mechanism to warn about, or disable loading a component that
+  are poorly tested or known to cause breakage when fault-tolerance is
+  selected at runtime.
+
++ `--with-pmi`
+  `--with-slurm`
+  Force the building of SLURM scheduler support.
+  Slurm with fault tolerance is tested. **Do not use `srun`**, otherwise your
+  application gets killed by the scheduler upon the first failure. Instead,
+  **Use `mpirun` in an `salloc/sbatch`**.
+
++ `-with-lsf`
+  This is untested with fault tolerance.
+
++ `--with-alps`
+  `--with-tm`
+  Force the building of PBS/Torque scheduler support.
+  PBS is tested with fault tolerance. **Use `mpirun` in a `qsub`
+  allocation.**
+
++ `--disable-oshmem`
+  Disable building the OpenSHMEM implementation (by default, it is
+  enabled).
+  ULFM Fault Tolerance does not apply to OpenSHMEM.
+___________________________________________________________________________
+
+## Modified, Untested and Disabled Components
+Frameworks and components which are not listed in the following list are
+unmodified and support fault tolerance. Listed frameworks may be **modified**
+(and work after a failure), **untested** (and work before a failure, but may
+malfunction after a failure), or **disabled** (they cause unspecified behavior
+all around when FT is enabled).
+
+All runtime disabled components are listed in the `ft-mpi` aggregate MCA param file
+`$installdir/share/openmpi/amca-param-sets/ft-mpi`. You can tune the runtime behavior
+with ULFM by either setting or unsetting variables in this file (or by overiding
+the variable on the command line (e.g., ``--omca btl ofi,self``). Note that if FT is
+runtime disabled, these components will load normally (this may change observed
+performance when comparing with and without fault tolerance).
+
+- **pml** MPI point-to-point management layer
+    - "ob1" modified to **handle errors**
+    - "monitoring", "v" unmodified, **untested**
+    - "cm", "crcpw", "ucx" **disabled**
+
+- **btl** Point-to-point Byte Transfer Layer
+    - "ugni", "uct", "tcp", "sm(+cma,+xpmem)" modified to **handle errors** (removed
+      unconditional abort on error, expect performance similar to upstream)
+    - "ofi", "portals4", "smcuda", "usnic", "sm(+knem)" unmodified,
+      **untested** (may work properly, please report)
+
+- **mtl** Matching transport layer Used for MPI point-to-point messages on
+  some types of networks
+    - All "mtl" components are **disabled**
+
+- **coll** MPI collective algorithms
+    - "base", "basic", "tuned", "nbc" modified to **handle errors**
+    - "cuda", "inter", "sync", "sm" unmodified, **untested** (expect correct post-failure behavior)
+    - "hcoll", "portals4" unmodified, **disabled** (expect
+      unspecified post-failure behavior)
+
+- **osc** MPI one-sided communications
+    - Unmodified, **untested** (expect unspecified post-failure behavior)
+
+- **io** MPI I/O and dependent components
+    - _fs_ File system functions for MPI I/O
+    - _fbtl_ File byte transfer layer: abstraction for individual read/write
+      operations for OMPIO
+    - _fcoll_ Collective read and write operations for MPI I/O
+    - _sharedfp_ Shared file pointer operations for MPI I/O
+    - All components in these frameworks are unmodified, **untested**
+      (expect clean post-failure abort)
+
+- **vprotocol** Checkpoint/Restart components
+    - unmodified **untested**
+
+- **threads** `wait-sync` Multithreaded wait-synchronization object
+    - "pthreads" modified to **handle errors** (added a global interrupt to 
+       trigger all wait_sync objects)
+    - "argotbots", "qthreads" unmodified, **disabled** (expect post-failure
+      deadlock)
+
+___________________________________________________________________________
+
+Running ULFM Open MPI
+=====================
+
+## Building your application
+
+As ULFM is still an extension to the MPI standard, you will need to
+`#include <mpi-ext.h>` in C, or `use mpi_ext` in Fortran to access the
+supplementary error codes and functions.
+
+Compile your application as usual, using the provided `mpicc`, `mpif90`, or
+`mpicxx` wrappers.
+
+## Running your application
+
+You can launch your application with fault tolerance by simply using the
+provided `mpiexec`. Beware that your distribution may already provide a
+version of MPI, make sure to set your `PATH` and `LD_LIBRARY_PATH` properly.
+Note that fault tolerance is disabled by default in ULFM Open MPI; you can
+enable the fault tolerance components by launching your application with
+`mpiexec --enable-recovery`.
+
+## Running under a batch scheduler
+
+ULFM can operate under a job/batch scheduler, and is tested routinely with
+both ALPS, PBS and Slurm. One difficulty comes from the fact that many job
+schedulers will "cleanup" the application as soon as a process fails. In
+order to avoid this problem, it is preferred that you use `mpiexec`
+within an allocation (e.g. `salloc`, `sbatch`, `qsub`) rather than
+a direct launch (e.g. `srun`).
+
+## Run-time tuning knobs
+
+ULFM comes with a variety of knobs for controlling how it runs. The default
+parameters are sane and should result in very good performance in most
+cases. You can change the default settings with `--omca mpi_ft_foo <value>`
+for OMPI options, and with `--prtemca errmgr_detector_bar <value>` for
+PRTE options.
+
+### PRTE level options
+
+- `prrte_enable_recovery <true|false> (default: false)` controls automatic
+  cleanup of apps with failed processes within mpirun. Enabling this option 
+  also enable `mpi_ft_enable`.
+- `errmgr_detector_priority <int> (default 1005`) selects the prte-based
+  failure detector. Only available when `prte_enable_recovery` is `true`. You
+  can set this to `0` when using the (experimental) OMPI detector instead.
+- err`mgr_detector_heartbeat_period <float> (default: 5e0)` controls the
+  heartbeat period. Recommended value is 1/2 of the timeout.
+- `errmgr_detector_heartbeat_timeout <float> (default: 1e1 seconds)` heartbeat
+  timeout (i.e. failure detection speed). Recommended value is 2 times
+  the heartbeat period. The default setup is tuned for failure-free
+  performance at the expense of fault detection reactivity. In environments
+  where faults are expected to be common, less conservative values can be
+  used (e.g., 100ms); Values lower than the TCP poll rate (typically 10ms)
+  can cause false positive.
+
+### OMPI level options
+
+- `mpi_ft_enable <true|false> (default: same as prrte_enable_recovery)`
+  permits turning on/off fault tolerance at runtime. When false, failure
+  detection is disabled; Interfaces defined by the fault tolerance extensions
+  are substituted with dummy non-fault tolerant implementations (e.g.,
+  `MPIX_Comm_agree` is implemented with `MPI_Allreduce`); All other controls
+  below become irrelevant.
+- `mpi_ft_verbose <int> (default: 0)` increases the output of the fault
+  tolerance activities. A value of 1 will report detected failures.
+- `mpi_ft_detector <true|false> (default: false)`, EXPERIMENTAL, controls
+  the activation of the OMPI level failure detector. When this detector
+  is turned off, all failure detection is delegated to PRTE (see above).
+  The OMPI level fault detector is experimental. There is a tradeoff between
+  failure detection accuracy and performance with this detector. Users that
+  experience accuracy issues may enable a more precise mode.
+  See the tuning knobs below to adjust to taste;
+  The OMPI failure detector operates on MPI_COMM_WORLD exclusively.
+  Processes connected from MPI_COMM_CONNECT/ACCEPT and MPI_COMM_SPAWN may
+  occasionally not be detected when they fail.
+- `mpi_ft_detector_thread <true|false> (default: false)` controls the use
+  of a thread to emit and receive failure detector's heartbeats. _Setting
+  this value to "true" will also set `MPI_THREAD_MULTIPLE` support, which
+  has a noticeable effect on latency (typically 1us increase)._ You may
+  want to **enable this option if you experience false positive**
+  processes incorrectly reported as failed with the OMPI failure detector.
+- `mpi_ft_detector_period <float> (default: 3e0 seconds)` heartbeat
+  period. Recommended value is 1/3 of the timeout. _Values lower than
+  100us may impart a noticeable effect on latency (typically a 3us
+  increase)._
+- `mpi_ft_detector_timeout <float> (default: 1e1 seconds)` heartbeat
+  timeout (i.e. failure detection speed). Recommended value is 3 times
+  the heartbeat period.
+
+## Known Limitations in ULFM
+
+- Infiniband support is provided through the OpenIB or UCT BTL, fault
+  tolerant operation over the UCX PML is not yet supported.
+- TOPO, FILE, RMA are not fault tolerant. They are expected to work properly
+  before the occurence of the first failure.
+
+___________________________________________________________________________
+
+
+Changelog
+=========
+
+## ULFM Integrated in Open MPI
+ULFM is now integrated in Open MPI. This text will be updated when a new 
+Open MPI release is made.
+
+## ULFM Standalone Release 4.0.2u1
+This is a stability and upstream parity upgrade. It is based on the most
+current Open MPI Release (v4.0.2, October 2019).
+
+- This release is based on Open MPI release v4.0.2 (ompi #cb5f4e737a).
+- This release is based on ULFM master (ulfm #0e249ca1).
+- New features
+    - Support for the UCT BTL enters beta stage.
+- Bugfixes
+    - High sensitivity to noise in the failure detector.
+    - Deadlocks when revoking while BTL progress threads are updating messages.
+    - A case where the failure detector would keep observing a dead process forever.
+    - Disable the use of external pmix/libevent by default (the internals are modified
+      to handle error cases).
+    - Clean error paths leaving some rdma registration dangling.
+    - Do not remove the orte job/proc session dir prematurely upon error.
+
+## ULFM Standalone Release 4.0.1u1
+This is a stability and upstream parity upgrade. It improves stability, 
+performance and is based on the most current Open MPI Release (v4.0.1,
+May 2019).
+
+- This release is based on Open MPI release v4.0.1 (ompi #b780667).
+- This release is based on ULFM master (ulfm #cf8dc43f).
+- New features
+    - Addition of the `MPI_Comm_is_revoked` function
+    - Renamed `ftbasic` collective component to `ftagree`
+    - Restored the `pcollreq` extension
+- Bugfixes
+    - Failures of node-local siblings were not always detected
+    - Failure propagation and detection was slowed down by trying to 
+      notify known dead processes
+    - There were deadlocks in multithreaded programs
+    - There were issues with PMPI when compiling Fortran Interfaces
+    - There were deadlocks on OS-X
+
+## ULFM Standalone Release 2.1
+This release is a bugfix and upstream parity upgrade. It improves stability,
+performance and is based on the most current Open MPI master (November 2018).
+
+- ULFM is now based upon Open MPI master branch (#37954b5f).
+- ULFM tuning MCA parameters are exposed by `ompi_info`.
+- Fortran 90 bindings have been updated
+- Bugfixes:
+    - Correct the behavior of process placement during an MPI_COMM_SPAWN when 
+      some slots were occcupied by failed processes.
+    - MPI_COMM_SPAWN accepts process placement directives in the Info object.
+    - Fixed deadlocks in some NBC collective operations.
+    - Crashes and deadlocks in MPI_FINALIZE have been resolved.
+    - Any-source requests that returned with an error status of 
+      MPIX_PROC_FAILED_PENDING can now correctly complete during 
+      later MPI_WAIT/TEST.
+
+## ULFM Standalone Release 2.0
+Focus has been toward integration with current Open MPI master (November 2017),
+performance, and stability.
+
+- ULFM is now based upon Open MPI master branch (#689f1be9). It will be
+  regularly updated until it will eventually be merged.
+- Fault Tolerance is enabled by default and is controlled with MCA variables.
+- Added support for multithreaded modes (MPI_THREAD_MULTIPLE, etc.)
+- Added support for non-blocking collective operations (NBC).
+- Added support for CMA shared memory transport (Vader).
+- Added support for advanced failure detection at the MPI level.
+  Implements the algorithm described in "Failure detection and
+  propagation in HPC systems." <https://doi.org/10.1109/SC.2016.26>.
+- Removed the need for special handling of CID allocation.
+- Non-usable components are automatically removed from the build during configure
+- RMA, FILES, and TOPO components are enabled by default, and usage in a fault
+  tolerant execution warns that they may cause undefined behavior after a failure.
+- Bugfixes:
+    - Code cleanup and performance cleanup in non-FT builds; --without-ft at
+      configure time gives an almost stock Open MPI.
+    - Code cleanup and performance cleanup in FT builds with FT runtime disabled;
+      --mca ft_enable_mpi false thoroughly disables FT runtime activities.
+    - Some error cases would return ERR_PENDING instead of ERR_PROC_FAILED in
+      collective operations.
+    - Some test could set ERR_PENDING or ERR_PROC_FAILED instead of
+      ERR_PROC_FAILED_PENDING for ANY_SOURCE receptions.
+___________________________________________________________________________
+
+## ULFM Standalone Release 1.1
+Focus has been toward improving stability, feature coverage for intercomms,
+and following the updated specification for MPI_ERR_PROC_FAILED_PENDING.
+
+- Forked from Open MPI 1.5.5 devel branch
+- Addition of the MPI_ERR_PROC_FAILED_PENDING error code, as per newer specification
+  revision. Properly returned from point-to-point, non-blocking ANY_SOURCE operations.
+- Alias MPI_ERR_PROC_FAILED, MPI_ERR_PROC_FAILED_PENDING and MPI_ERR_REVOKED to the
+  corresponding standard blessed -extension- names MPIX_ERR_xxx.
+- Support for Intercommunicators:
+    - Support for the blocking version of the agreement, MPI_COMM_AGREE on Intercommunicators.
+    - MPI_COMM_REVOKE tested on intercommunicators.
+- Disabled completely (.ompi_ignore) many untested components.
+- Changed the default ORTE failure notification propagation aggregation delay from 1s to 25ms.
+- Added an OMPI internal failure propagator; failure propagation between SM domains is now
+  immediate.
+- Bugfixes:
+    - SendRecv would not always report MPI_ERR_PROC_FAILED correctly.
+    - SendRecv could incorrectly update the status with errors pertaining to the Send portion
+      of the Sendrecv.
+    - Revoked send operations are now always completed or remote cancelled and may not
+      deadlock anymore.
+    - Cancelled send operations to a dead peer will not trigger an assert when the BTL reports
+      that same failure.
+    - Repeat calls to operations returning MPI_ERR_PROC_FAILED will eventually return
+      MPI_ERR_REVOKED when another process revokes the communicator.
+___________________________________________________________________________
+
+## ULFM Standalone Release 1.0
+Focus has been toward improving performance, both before and after the occurence of failures.
+The list of new features includes:
+
+- Support for the non-blocking version of the agreement, MPI_COMM_IAGREE.
+- Compliance with the latest ULFM specification draft. In particular, the
+  MPI_COMM_(I)AGREE semantic has changed.
+- New algorithm to perform agreements, with a truly logarithmic complexity in number of
+  ranks, which translates into huge performance boosts in MPI_COMM_(I)AGREE and
+  MPI_COMM_SHRINK.
+- New algorithm to perform communicator revocation. MPI_COMM_REVOKE performs a reliable
+  broadcast with a fixed maximum output degree, which scales logarithmically with the
+  number of ranks.
+- Improved support for our traditional network layer:
+    - TCP: fully tested
+    - SM: fully tested (with the exception of XPMEM, which remains unsupported)
+- Added support for High Performance networks
+    - Open IB: reasonably tested
+    - uGNI: reasonably tested
+- The tuned collective module is now enabled by default (reasonably tested), expect a
+  huge performance boost compared to the former basic default setting
+    - Back-ported PBS/ALPS fixes from Open MPI
+    - Back-ported OpenIB bug/performance fixes from Open MPI
+    - Improve Context ID allocation algorithm to reduce overheads of Shrink
+    - Miscellaneous bug fixes
+___________________________________________________________________________
+
+## Binary Compatibility
+ULFM Open MPI is binary compatible with any version of Open MPI compatible
+with the underlying Open MPI master branch or release (see
+the binary compatibility and version number section in the upstream Open MPI
+README). That is, applications compiled with a compatible Open MPI can run
+with the ULFM Open MPI `mpirun` and MPI libraries. Conversely, _as long as
+the application does not employ one of the MPIX functions_, which are
+exclusively defined in ULFM Open MPI, an application compiled with
+ULFM Open MPI can be launched with a compatible Open MPI `mpirun` and run
+with the non-fault tolerant MPI library.
+___________________________________________________________________________
+
+Contacting the Authors
+======================
+Found a bug?  Got a question?  Want to make a suggestion?  Want to
+contribute to ULFM Open MPI?  Working on a cool use-case?
+Please let us know!
+
+The best way to report bugs, send comments, or ask questions is to
+sign up on the user's mailing list:
+  <ulfm+subscribe@googlegroups.com>
+
+Because of spam, only subscribers are allowed to post to these lists
+(ensure that you subscribe with and post from exactly the same e-mail
+address -- joe@example.com is considered different than
+joe@mycomputer.example.com!).  Visit these pages to subscribe to the
+lists:
+  <https://groups.google.com/forum/#!forum/ulfm>
+
+When submitting questions and problems, be sure to include as much
+extra information as possible.  This web page details all the
+information that we request in order to provide assistance:
+  <http://www.open-mpi.org/community/help/>
+
+Thanks for your time.
+___________________________________________________________________________
+
+Copyright
+=========
+
+```
+Copyright (c) 2012-2020 The University of Tennessee and The University
+                        of Tennessee Research Foundation.  All rights
+                        reserved.
+
+$COPYRIGHT$
+
+Additional copyrights may follow
+
+$HEADER$
+```

--- a/config/ompi_setup_prrte.m4
+++ b/config/ompi_setup_prrte.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
 #                         Corporation.  All rights reserved.
-# Copyright (c) 2004-2005 The University of Tennessee and The University
+# Copyright (c) 2004-2021 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -139,6 +139,9 @@ AC_DEFUN([OMPI_SETUP_PRRTE_INTERNAL], [
 
     # add the extra libs
     internal_prrte_args="$internal_prrte_args --with-prte-extra-lib=\"$internal_prrte_libs\" --with-prte-extra-ltlib=\"$internal_prrte_libs\""
+    AS_IF([test "$with_ft" != "no"],
+          [internal_prrte_args="--enable-prte-ft $internal_prrte_args"],
+          [])
 
     # Pass all our compiler/linker flags to PRRTE, so that it
     # picks up how to build an internal HWLOC, libevent, and PMIx, plus

--- a/config/opal_setup_ft.m4
+++ b/config/opal_setup_ft.m4
@@ -1,4 +1,8 @@
 dnl
+dnl Copyright (c) 2004-2020 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2009-2012 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2013-2014 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
@@ -12,11 +16,15 @@ dnl
 #
 # --with-ft=TYPE
 #  TYPE:
+#    - mpi (synonym for 'ulfm')
 #    - LAM (synonym for 'cr' currently)
 #    - cr
 #  /* General FT sections */
 #  #if OPAL_ENABLE_FT == 0 /* FT Disabled globaly */
 #  #if OPAL_ENABLE_FT == 1 /* FT Enabled globaly */
+#  /* ULFM Specific sections */
+#  #if OPAL_ENABLE_FT_MPI == 0 /* FT ULFM Disabled */
+#  #if OPAL_ENABLE_FT_MPI == 1 /* FT ULFM Enabled */
 #  /* CR Specific sections */
 #  #if OPAL_ENABLE_FT_CR == 0 /* FT Ckpt/Restart Disabled */
 #  #if OPAL_ENABLE_FT_CR == 1 /* FT Ckpt/Restart Enabled */
@@ -28,14 +36,13 @@ AC_DEFUN([OPAL_SETUP_FT_BANNER],[
 ])
 
 AC_DEFUN([OPAL_SETUP_FT_OPTIONS],[
-    AC_REQUIRE([OPAL_SETUP_FT_BANNER])
     # define a variable that tells us that these options were enabled
     opal_setup_ft_options="yes"
     AC_ARG_WITH(ft,
                 [AC_HELP_STRING([--with-ft=TYPE],
-                [Specify the type of fault tolerance to enable. Options: LAM (LAM/MPI-like), cr (Checkpoint/Restart), (default: disabled)])],
-                [opal_want_ft=1],
-                [opal_want_ft=0])
+                [Specify the type of fault tolerance to enable. Options: mpi (ULFM), LAM (LAM/MPI-like), cr (Checkpoint/Restart) (default: mpi)])],
+                [],
+                [with_ft=auto]) # If not specified act as if --with-ft=mpi, but make external prte support failure only if hard requested
 
     #
     # Checkpoint/restart enabled debugging
@@ -60,12 +67,15 @@ AC_DEFUN([OPAL_SETUP_FT_OPTIONS],[
 ])
 
 AC_DEFUN([OPAL_SETUP_FT],[
+    AC_REQUIRE([OPAL_SETUP_FT_BANNER])
     if test "$opal_setup_ft_options" = "yes"; then
         AC_MSG_CHECKING([if want fault tolerance])
     fi
-    if test "x$with_ft" != "x" || test "$opal_want_ft" = "1"; then
+
+    if test x"$with_ft" != "xno"; then
         opal_want_ft=1
         opal_want_ft_cr=0
+        opal_want_ft_mpi=0
         opal_want_ft_type=none
 
         as_save_IFS=$IFS
@@ -74,8 +84,18 @@ AC_DEFUN([OPAL_SETUP_FT],[
             IFS=$as_save_IFS
 
             # Default value
-            if test "$opt" = "" || test "$opt" = "yes"; then
-                opal_want_ft_cr=1
+            if test "$opt" = "auto"; then
+                opal_want_ft_mpi=1
+            elif test "$opt" = "yes"; then
+                opal_want_ft_mpi=1
+            elif test "$opt" = "ULFM"; then
+                opal_want_ft_mpi=1
+            elif test "$opt" = "ulfm"; then
+                opal_want_ft_mpi=1
+            elif test "$opt" = "MPI"; then
+                opal_want_ft_mpi=1
+            elif test "$opt" = "mpi"; then
+                opal_want_ft_mpi=1
             elif test "$opt" = "LAM"; then
                 opal_want_ft_cr=1
             elif test "$opt" = "lam"; then
@@ -89,18 +109,44 @@ AC_DEFUN([OPAL_SETUP_FT],[
                 AC_MSG_ERROR([Cannot continue])
             fi
         done
-        if test "$opal_want_ft_cr" = 1; then
+        if test "$opal_want_ft_mpi" = 1; then
+            opal_want_ft_type="mpi"
+        elif test "$opal_want_ft_cr" = 1; then
             opal_want_ft_type="cr"
         fi
 
+        # If we use external PRTE, does it support FT?
+        AS_IF([test "$internal_prrte_build" = "0" -a "$opal_want_ft_type" != "none"], [
+            AS_IF([prte_info | $GREP "Resilience support: yes"], [], [
+                AS_IF([test "$with_ft" != auto], [
+                    AC_MSG_ERROR([Requested enabling fault-tolerance and using external launcher, but external PRTE doesn't support resilience; you can either use the internal PRTE, recompile the external PRTE with fault-tolerance, or disable fault-tolerance. ABORTING.])
+                ], [
+                    AC_MSG_WARN([**************************************************])
+                    AC_MSG_WARN([*** Requested external PRTE which doesn't have   *])
+                    AC_MSG_WARN([*** Resilience compiled-in.                      *])
+                    AC_MSG_WARN([*** To enable Open MPI Fault-Tolerance, either   *])
+                    AC_MSG_WARN([***   use the internal PRTE, or                  *])
+                    AC_MSG_WARN([***   compile the external PRTE with resilience  *])
+                    AC_MSG_WARN([*** DISABLING FAULT TOLERANCE SUPPORT.           *])
+                    AC_MSG_WARN([**************************************************])
+                    opal_want_ft_mpi=0
+                    opal_want_ft_cr=0
+                    opal_want_ft_type="none"
+                ])
+            ])
+        ])
         AC_MSG_RESULT([Enabled $opal_want_ft_type (Specified $with_ft)])
-        AC_MSG_WARN([**************************************************])
-        AC_MSG_WARN([*** Fault Tolerance Integration into Open MPI is *])
-        AC_MSG_WARN([*** a research quality implementation, and care  *])
-        AC_MSG_WARN([*** should be used when choosing to enable it.   *])
-        AC_MSG_WARN([**************************************************])
+        AS_IF([test "$opal_want_ft_type" != "none"], [
+            AC_MSG_WARN([**************************************************])
+            AC_MSG_WARN([*** Fault Tolerance Integration into Open MPI is *])
+            AC_MSG_WARN([*** compiled-in, but off by default. Use mpiexec *])
+            AC_MSG_WARN([*** and MCA parameters to turn it on.            *])
+            AC_MSG_WARN([*** Not all components support fault tolerance.  *])
+            AC_MSG_WARN([**************************************************])
+        ])
     else
         opal_want_ft=0
+        opal_want_ft_mpi=0
         opal_want_ft_cr=0
         if test "$opal_setup_ft_options" = "yes"; then
             AC_MSG_RESULT([Disabled fault tolerance])
@@ -108,9 +154,12 @@ AC_DEFUN([OPAL_SETUP_FT],[
     fi
     AC_DEFINE_UNQUOTED([OPAL_ENABLE_FT], [$opal_want_ft],
                        [Enable fault tolerance general components and logic])
+    AC_DEFINE_UNQUOTED([OPAL_ENABLE_FT_MPI], [$opal_want_ft_mpi],
+                       [Enable fault tolerance MPI ULFM components and logic])
     AC_DEFINE_UNQUOTED([OPAL_ENABLE_FT_CR], [$opal_want_ft_cr],
                        [Enable fault tolerance checkpoint/restart components and logic])
     AM_CONDITIONAL(WANT_FT, test "$opal_want_ft" = "1")
+    AM_CONDITIONAL(WANT_FT_MPI, test "$opal_want_ft_mpi" = "1")
     AM_CONDITIONAL(WANT_FT_CR,  test "$opal_want_ft_cr" = "1")
 
     if test "$opal_setup_ft_options" = "yes"; then
@@ -175,4 +224,5 @@ AC_DEFUN([OPAL_SETUP_FT],[
     AC_DEFINE_UNQUOTED([OPAL_ENABLE_FT_THREAD], [$opal_want_ft_thread],
                        [Enable fault tolerance thread in Open PAL])
     AM_CONDITIONAL(WANT_FT_THREAD, test "$opal_want_ft_thread" = "1")
+    OPAL_SUMMARY_ADD([[Miscellaneous]],[[Fault Tolerance support]],[unnecessary], [$opal_want_ft_type])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -1116,29 +1116,11 @@ AC_INCLUDES_DEFAULT
 # checkpoint results
 AC_CACHE_SAVE
 
-###########################################################
+##################################
 #        Fault Tolerance
-#
-# The FT code in the OMPI trunk is currently broken. We don't
-# have an active maintainer for it at this time, and it isn't
-# clear if/when we will return to it. We have therefore removed
-# the configure options supporting it until such time as it
-# can be fixed.
-#
-# However, we recognize that there are researchers who use this
-# option on their independent branches. In such cases, simply
-# uncomment the line below to render the FT configure options
-# visible again
-#
-###########################################################
-dnl OPAL_SETUP_FT_OPTIONS
-###########################################################
-# The following line is always required as it contains the
-# AC_DEFINE and AM_CONDITIONAL calls that set variables used
-# throughout the build system. If the above line is commented
-# out, then those variables will be set to "off". Otherwise,
-# they are controlled by the options
-OPAL_SETUP_FT
+# Part1: must happen before prte
+##################################
+OPAL_SETUP_FT_OPTIONS
 
 ##################################
 # 3rd-party packages not called ROMIO
@@ -1159,6 +1141,12 @@ AC_SUBST(OPAL_3RDPARTY_SUBDIRS)
 AC_SUBST(OPAL_3RDPARTY_DIST_SUBDIRS)
 AC_SUBST(OPAL_3RDPARTY_EXTRA_DIST)
 AC_SUBST(OPAL_3RDPARTY_DISTCLEAN_DIRS)
+
+##################################
+#        Fault Tolerance
+# Part2: must happen after prte
+##################################
+OPAL_SETUP_FT
 
 ##################################
 # MCA

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -27,6 +27,10 @@
 amca_paramdir = $(AMCA_PARAM_SETS_DIR)
 dist_amca_param_DATA = amca-param-sets/example.conf
 
+if WANT_FT_MPI
+dist_amca_param_DATA += amca-param-sets/ft-mpi
+endif # WANT_FT_MPI
+
 if WANT_FT_CR
 dist_amca_param_DATA += \
 	amca-param-sets/ft-enable-cr \

--- a/contrib/amca-param-sets/ft-mpi
+++ b/contrib/amca-param-sets/ft-mpi
@@ -1,0 +1,89 @@
+#
+# Copyright (c) 2020     The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# An Aggregate MCA Parameter Set to setup an environment that can support
+# User-Level Failure Mitigation (ULFM) fault tolerance (must also be 
+# compiled in with --with-ft=mpi).
+#
+# Usage:
+#   shell$ mpirun --tune ft-mpi ./app
+#
+
+mpi_ft_enable=true
+
+# Since failures are expected, reduce the verbosity of the transport errors
+btl_base_warn_peer_error=false
+
+#
+# Performance tuning parameters (default shown)
+# By default the PRTE failure detector is used (see README.ULFM.md)
+#mpi_ft_detector=false
+#mpi_ft_detector_thread=false
+#mpi_ft_detector_rdma_heartbeat=false
+#mpi_ft_detector_period=3.
+#mpi_ft_detector_timeout=10.
+#
+
+
+#
+# Select only ULFM ready components
+# disabling non-tested and known broken components in FT-MPI builds
+#
+
+#
+# The following frameworks/components are TESTED
+# They handle faults amd should be prefered when running with FT.
+#   pml     ob1
+#   btl     tcp, self, sm(+xpmem,+cma), ugni, uct
+#   coll    base/basic, tuned, ftagree, libnbc
+pml=ob1
+threads=pthreads
+
+#
+# The following frameworks/components are UNTESTED, but **may** work.
+# They should run without faults, and **may** work with faults.
+# You may try and report if successfull.
+#   btl     ofi, portals4, smcuda, usnic, sm(+knem)
+#   coll    inter, sm, sync, cuda, monitoring
+#   pml     monitoring, v/vprotocol
+# We will disable only the components for which good components are known to exist.
+btl=^usnic
+# older versions of xpmem generate bus errors when the other end is dead.
+#btl_sm_single_copy_mechanism=cma
+
+
+#
+# The following frameworks/components are UNTESTED, and probably won't work.
+# They should run without faults, and will probably crash/deadlock after a fault.
+# You may try at your own risk.
+#   coll    hcoll, portals4
+#   topo    (all)
+#   osc     (all)
+#   io      (all)
+#   fcoll   (all)
+#   fbtl    (all)
+# We will disable only the components for which good components are known to exist.
+# Other untested components are selectable but will issue a runtime warning at
+# initiation if FT is enabled.
+coll=^hcoll,portals4
+
+#
+# The following frameworks/components are NOT WORKING. Do not enable these with FT.
+#   mtl     (all)
+#   pml     cm, crcpw, ucx
+mtl=^ofi,portals4,psm2
+# allready enforced by pml=ob1 above
+#pml=^cm,crcpw,ucx
+# allready enforced by threads=pthreads above
+#threads=^argobots,qthreads
+# There is a bug in libevent with the "select" backend that causes an infinite loop
+# when an unplanned disconnect happens. Use something else, or bail.
+opal_event_include=epoll,devpoll,kqueue,evport,poll
+

--- a/ompi/communicator/Makefile.am
+++ b/ompi/communicator/Makefile.am
@@ -3,7 +3,7 @@
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
 #                         Corporation.  All rights reserved.
-# Copyright (c) 2004-2005 The University of Tennessee and The University
+# Copyright (c) 2004-2020 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -33,4 +33,9 @@ lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
 	communicator/comm.c \
 	communicator/comm_cid.c \
 	communicator/comm_request.c
+
+if WANT_FT_MPI
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
+	communicator/ft/comm_ft.c communicator/ft/comm_ft_reliable_bcast.c communicator/ft/comm_ft_propagator.c communicator/ft/comm_ft_detector.c communicator/ft/comm_ft_revoke.c
+endif # WANT_FT_MPI
 

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -67,6 +67,16 @@ struct ompi_comm_cid_context_t {
 
     int nextcid;
     int nextlocal_cid;
+#if OPAL_ENABLE_FT_MPI
+    /* Revoke messages are unexpected and can be received even after a
+     * communicator has been freed locally. If a new communicator reuses the
+     * cid, we need to avoid revoking that new communicator instead of the
+     * previous (freed) one, when a stall revoke message is received. An
+     * epoch is attached to any cid, so that we can recognize which
+     * communicator (cid, epoch) we want to revoke. MPI matching is not
+     * modified. */
+    int nextcid_epoch;
+#endif /* OPAL_ENABLE_FT_MPI */
     int start;
     int flag, rflag;
     int local_leader;
@@ -156,6 +166,21 @@ static int ompi_comm_allreduce_intra_bridge_nb (int *inbuf, int *outbuf, int cou
                                                 struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
                                                 ompi_request_t **req);
 
+#if OPAL_ENABLE_FT_MPI
+static int ompi_comm_ft_allreduce_intra_nb(int *inbuf, int *outbuf, int count,
+                                           struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
+                                           ompi_request_t **req);
+
+static int ompi_comm_ft_allreduce_inter_nb(int *inbuf, int *outbuf, int count,
+                                           struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
+                                           ompi_request_t **req);
+
+static int ompi_comm_ft_allreduce_intra_pmix_nb(int *inbuf, int *outbuf, int count,
+                                                struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
+                                                ompi_request_t **req);
+#endif /* OPAL_ENABLE_FT_MPI */
+
+
 static opal_mutex_t ompi_cid_lock = OPAL_MUTEX_STATIC_INIT;
 
 
@@ -207,6 +232,17 @@ static ompi_comm_cid_context_t *mca_comm_cid_context_alloc (ompi_communicator_t 
         context->local_leader = ((int *) arg0)[0];
         context->remote_leader = ((int *) arg1)[0];
         break;
+#if OPAL_ENABLE_FT_MPI
+    case OMPI_COMM_CID_INTRA_FT:
+        context->allreduce_fn = ompi_comm_ft_allreduce_intra_nb;
+        break;
+    case OMPI_COMM_CID_INTER_FT:
+        context->allreduce_fn = ompi_comm_ft_allreduce_inter_nb;
+        break;
+    case OMPI_COMM_CID_INTRA_PMIX_FT:
+        context->allreduce_fn = ompi_comm_ft_allreduce_intra_pmix_nb;
+        break;
+#endif /* OPAL_ENABLE_FT_MPI */
     default:
         OBJ_RELEASE(context);
         return NULL;
@@ -247,6 +283,9 @@ static int ompi_comm_checkcid (ompi_comm_request_t *request);
 static int ompi_comm_nextcid_check_flag (ompi_comm_request_t *request);
 
 static volatile int64_t ompi_comm_cid_lowest_id = INT64_MAX;
+#if OPAL_ENABLE_FT_MPI
+static int ompi_comm_cid_epoch = INT_MAX;
+#endif /* OPAL_ENABLE_FT_MPI */
 
 int ompi_comm_nextcid_nb (ompi_communicator_t *newcomm, ompi_communicator_t *comm,
                           ompi_communicator_t *bridgecomm, const void *arg0, const void *arg1,
@@ -270,6 +309,7 @@ int ompi_comm_nextcid_nb (ompi_communicator_t *newcomm, ompi_communicator_t *com
     }
 
     request->context = &context->super;
+    request->super.req_mpi_object.comm = context->comm;
 
     ompi_comm_request_schedule_append (request, ompi_comm_allreduce_getnextcid, NULL, 0);
     ompi_comm_request_start (request);
@@ -333,8 +373,18 @@ static int ompi_comm_allreduce_getnextcid (ompi_comm_request_t *request)
                 break;
             }
         }
+#if OPAL_ENABLE_FT_MPI
+        context->nextcid_epoch = ompi_comm_cid_epoch - 1;
+        if (0 == context->nextcid_epoch) {
+            /* out of epochs, force an error by setting nextlocalcid */
+            context->nextlocal_cid = mca_pml.pml_max_contextid;
+        }
+#endif /* OPAL_ENABLE_FT_MPI */
     } else {
         context->nextlocal_cid = 0;
+#if OPAL_ENABLE_FT_MPI
+        context->nextcid_epoch = INT_MAX;
+#endif /* OPAL_ENABLE_FT_MPI */
     }
 
     ret = context->allreduce_fn (&context->nextlocal_cid, &context->nextcid, 1, MPI_MAX,
@@ -395,6 +445,12 @@ static int ompi_comm_checkcid (ompi_comm_request_t *request)
         }
     }
 
+#if OPAL_ENABLE_FT_MPI
+    if (context->flag) {
+        context->flag = context->nextcid_epoch;
+    }
+#endif /* OPAL_ENABLE_FT_MPI */
+
     ++context->iter;
 
     ret = context->allreduce_fn (&context->flag, &context->rflag, 1, MPI_MIN, context, &subreq);
@@ -448,6 +504,10 @@ static int ompi_comm_nextcid_check_flag (ompi_comm_request_t *request)
 
         /* set the according values to the newcomm */
         context->newcomm->c_contextid = context->nextcid;
+#if OPAL_ENABLE_FT_MPI
+        context->newcomm->c_epoch = INT_MAX - context->rflag; /* reorder for simpler debugging */
+        ompi_comm_cid_epoch -= 1; /* protected by the cid_lock */
+#endif /* OPAL_ENABLE_FT_MPI */
         opal_pointer_array_set_item (&ompi_mpi_communicators, context->nextcid, context->newcomm);
 
         /* unlock the cid generator */
@@ -1163,3 +1223,97 @@ static int ompi_comm_allreduce_group_nb (int *inbuf, int *outbuf, int count,
 
     return OMPI_SUCCESS;
 }
+
+#if OPAL_ENABLE_FT_MPI
+
+/**
+ * Reduction operation using an agreement, to ensure that all processes
+ *  agree on the same list.
+ */
+static int ompi_comm_ft_allreduce_agree_completion(ompi_comm_request_t* request) {
+    int rc = request->super.req_status.MPI_ERROR;
+    ompi_comm_allreduce_context_t *context = (ompi_comm_allreduce_context_t*) request->context;
+    ompi_group_t **failed_group = (ompi_group_t**)&context->inbuf;
+
+    /* Previous agreement found new failures, do another round */
+    if(OPAL_UNLIKELY( MPI_ERR_PROC_FAILED == rc )) {
+        ompi_communicator_t *comm = context->cid_context->comm;
+        ompi_request_t *subreq;
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle, "ft_allreduce found a dead process during previous round; redo"));
+        rc = comm->c_coll->coll_iagree(context->outbuf, context->count, &ompi_mpi_int.dt, context->op,
+                                       failed_group, true,
+                                       comm, &subreq, comm->c_coll->coll_iagree_module);
+        if( OPAL_LIKELY(OMPI_SUCCESS == rc) ) {
+            request->super.req_status.MPI_ERROR = MPI_SUCCESS;
+            return ompi_comm_request_schedule_append(request, ompi_comm_ft_allreduce_agree_completion, &subreq, 1);
+        }
+    }
+    OBJ_RELEASE(*failed_group);
+    return rc;
+}
+
+static int ompi_comm_ft_allreduce_intra_nb(int *inbuf, int *outbuf, int count,
+                                           struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
+                                           ompi_request_t **req) {
+    int rc;
+    ompi_comm_allreduce_context_t *context;
+    ompi_comm_request_t *request;
+    ompi_request_t *subreq;
+    ompi_communicator_t *comm = cid_context->comm;
+
+    context = ompi_comm_allreduce_context_alloc(inbuf, outbuf, count, op, cid_context);
+    if(OPAL_UNLIKELY( NULL == context )) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    request = ompi_comm_request_get ();
+    if(OPAL_UNLIKELY( NULL == request )) {
+        OBJ_RELEASE(context);
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+    request->context = &context->super;
+    request->super.req_mpi_object.comm = comm;
+
+    /** Because the agreement operates "in place",
+     *  one needs first to copy the inbuf into the outbuf
+     */
+    if( inbuf != outbuf ) {
+        memcpy(outbuf, inbuf, count * sizeof(int));
+    }
+
+    /** Repurpose the inbuf to store the failed_group */
+    ompi_group_t** failed_group = (ompi_group_t**) &context->inbuf;
+    opal_mutex_lock(&ompi_group_afp_mutex);
+    ompi_group_intersection(comm->c_remote_group, ompi_group_all_failed_procs, failed_group);
+    opal_mutex_unlock(&ompi_group_afp_mutex);
+
+    rc = comm->c_coll->coll_iagree(context->outbuf, context->count, &ompi_mpi_int.dt, context->op,
+                                   failed_group, true,
+                                   comm, &subreq, comm->c_coll->coll_iagree_module);
+    if( OPAL_UNLIKELY(OMPI_SUCCESS != rc) ) {
+        OBJ_RELEASE(*failed_group);
+        ompi_comm_request_return(request);
+        return rc;
+    }
+
+    ompi_comm_request_schedule_append (request, ompi_comm_ft_allreduce_agree_completion, &subreq, 1);
+    ompi_comm_request_start (request);
+    *req = &request->super;
+    return OMPI_SUCCESS;
+}
+
+static int ompi_comm_ft_allreduce_inter_nb(int *inbuf, int *outbuf, int count,
+                                           struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
+                                           ompi_request_t **req) {
+    return MPI_ERR_UNSUPPORTED_OPERATION;
+}
+
+static int ompi_comm_ft_allreduce_intra_pmix_nb(int *inbuf, int *outbuf, int count,
+                                                struct ompi_op_t *op, ompi_comm_cid_context_t *cid_context,
+                                                ompi_request_t **req) {
+    //TODO: CID_INTRA_PMIX_FT needs an implementation, using the non-ft for now...
+    return ompi_comm_allreduce_intra_pmix_nb(inbuf, outbuf, count, op, cid_context, req);
+}
+
+#endif /* OPAL_ENABLE_FT_MPI */
+

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2006-2017 University of Houston. All rights reserved.
  * Copyright (c) 2007-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
@@ -394,6 +395,15 @@ static void ompi_comm_construct(ompi_communicator_t* comm)
     comm->c_peruse_handles = NULL;
 #endif
     OBJ_CONSTRUCT(&comm->c_lock, opal_mutex_t);
+
+#if OPAL_ENABLE_FT_MPI
+    comm->any_source_enabled  = true;
+    comm->any_source_offset   = 0;
+    comm->comm_revoked        = false;
+    comm->coll_revoked        = false;
+    comm->c_epoch             = 0;
+    comm->agreement_specific  = NULL;
+#endif
 }
 
 static void ompi_comm_destruct(ompi_communicator_t* comm)
@@ -455,6 +465,12 @@ static void ompi_comm_destruct(ompi_communicator_t* comm)
         OBJ_RELEASE ( comm->error_handler );
         comm->error_handler = NULL;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    if( NULL != comm->agreement_specific ) {
+        OBJ_RELEASE( comm->agreement_specific );
+    }
+#endif  /* OPAL_ENABLE_FT_MPI */
 
     /* mark this cid as available */
     if ( MPI_UNDEFINED != (int)comm->c_contextid &&

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2006-2017 University of Houston.  All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2011-2013 Inria.  All rights reserved.
  * Copyright (c) 2011-2013 Universite Bordeaux 1
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
@@ -38,6 +39,7 @@
 #include "ompi/errhandler/errhandler.h"
 #include "opal/mca/threads/mutex.h"
 #include "ompi/communicator/comm_request.h"
+#include "ompi/mca/coll/base/coll_tags.h"
 
 #include "mpi.h"
 #include "ompi/group/group.h"
@@ -86,13 +88,6 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_SET_EXTRA_RETAIN(comm) ((comm)->c_flags |= OMPI_COMM_EXTRA_RETAIN)
 #define OMPI_COMM_SET_MAPBY_NODE(comm) ((comm)->c_flags |= OMPI_COMM_MAPBY_NODE)
 
-/* a set of special tags: */
-
-/*  to recognize an MPI_Comm_join in the comm_connect_accept routine. */
-#define OMPI_COMM_ALLGATHER_TAG -31078
-#define OMPI_COMM_BARRIER_TAG   -31079
-#define OMPI_COMM_ALLREDUCE_TAG -31080
-
 #define OMPI_COMM_ASSERT_NO_ANY_TAG     0x00000001
 #define OMPI_COMM_ASSERT_NO_ANY_SOURCE  0x00000002
 #define OMPI_COMM_ASSERT_EXACT_LENGTH   0x00000004
@@ -116,6 +111,11 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 #define OMPI_COMM_CID_INTRA_BRIDGE 0x00000080
 #define OMPI_COMM_CID_INTRA_PMIX   0x00000100
 #define OMPI_COMM_CID_GROUP        0x00000200
+#if OPAL_ENABLE_FT_MPI
+#define OMPI_COMM_CID_INTRA_FT        0x00000400
+#define OMPI_COMM_CID_INTER_FT        0x00000800
+#define OMPI_COMM_CID_INTRA_PMIX_FT   0x00001000
+#endif /* OPAL_ENABLE_FT_MPI */
 
 /**
  * The block of CIDs allocated for MPI_COMM_WORLD
@@ -127,9 +127,31 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION(ompi_communicator_t);
 /* A macro comparing two CIDs */
 #define OMPI_COMM_CID_IS_LOWER(comm1,comm2) ( ((comm1)->c_contextid < (comm2)->c_contextid)? 1:0)
 
-
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_communicators;
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_comm_f_to_c_table;
+#if OPAL_ENABLE_FT_MPI
+/**
+ * This array holds the number of time each id has been used. In the case where a communicator
+ * is revoked, this reference count acts as an epoch, and prevents us from revoking newly created
+ * communicators that use an id that is similar to others communicators that are still being revoked.
+ */
+OMPI_DECLSPEC extern opal_pointer_array_t ompi_mpi_comm_epoch;
+
+/*
+ * Callback function that should be called when there is a fault.
+ *
+ * This callback function will be used anytime (other than during finalize) the
+ * runtime or BTLs detects and handles a process failure. The function is called
+ * once per communicator that possess the failed process, and per process failure.
+ *
+ * @param[in] comm the communicator to which the failed process belongs
+ * @param[in] rank the rank of the failed process in that communicator
+ * @param[in] remote is true iff rank is a remote process
+ */
+typedef void (ompi_comm_rank_failure_callback_t)(struct ompi_communicator_t *comm, int rank, bool remote);
+
+OMPI_DECLSPEC extern ompi_comm_rank_failure_callback_t *ompi_rank_failure_cbfunc;
+#endif  /* OPAL_ENABLE_FT_MPI */
 
 struct ompi_communicator_t {
     opal_infosubscriber_t      super;
@@ -146,6 +168,8 @@ struct ompi_communicator_t {
                to a child*/
     int c_id_start_index; /* the starting index of the block of cids
                  allocated to this communicator*/
+    uint32_t c_epoch;  /* Identifier used to differenciate between two communicators
+                          using the same c_contextid (not at the same time, obviously) */
 
     ompi_group_t        *c_local_group;
     ompi_group_t       *c_remote_group;
@@ -194,6 +218,19 @@ struct ompi_communicator_t {
      * collective coexists using multiple backends).
      */
     opal_atomic_int32_t c_nbc_tag;
+
+#if OPAL_ENABLE_FT_MPI
+    /** MPI_ANY_SOURCE Failed Group Offset - OMPI_Comm_failure_get_acked */
+    int                      any_source_offset;
+    /** agreement caching info for topology and previous returned decisions */
+    opal_object_t           *agreement_specific;
+    /** Are MPI_ANY_SOURCE operations enabled? - OMPI_Comm_failure_ack */
+    bool                     any_source_enabled;
+    /** Has this communicator been revoked - OMPI_Comm_revoke() */
+    bool                     comm_revoked;
+    /** Force errors to collective pt2pt operations? */
+    bool                     coll_revoked;
+#endif /* OPAL_ENABLE_FT_MPI */
 };
 typedef struct ompi_communicator_t ompi_communicator_t;
 
@@ -397,6 +434,187 @@ static inline struct ompi_proc_t* ompi_comm_peer_lookup(ompi_communicator_t* com
     /*return comm->c_remote_group->grp_proc_pointers[peer_id];*/
     return ompi_group_peer_lookup(comm->c_remote_group,peer_id);
 }
+
+#if OPAL_ENABLE_FT_MPI
+/*
+ * Support for MPI_ANY_SOURCE point-to-point operations
+ */
+static inline bool ompi_comm_is_any_source_enabled(ompi_communicator_t* comm)
+{
+    return (comm->any_source_enabled);
+}
+
+/*
+ * Are collectives still active on this communicator?
+ */
+static inline bool ompi_comm_coll_revoked(ompi_communicator_t* comm)
+{
+    return (comm->coll_revoked);
+}
+
+/*
+ * Has this communicator been revoked?
+ */
+static inline bool ompi_comm_is_revoked(ompi_communicator_t* comm)
+{
+    return (comm->comm_revoked);
+}
+
+/*
+ * Acknowledge failures and re-enable MPI_ANY_SOURCE
+ * Related to OMPI_Comm_failure_ack() and OMPI_Comm_failure_get_acked()
+ */
+OMPI_DECLSPEC int ompi_comm_failure_ack_internal(ompi_communicator_t* comm);
+
+/*
+ * Return the acknowledged group of failures
+ * Related to OMPI_Comm_failure_ack() and OMPI_Comm_failure_get_acked()
+ */
+OMPI_DECLSPEC int ompi_comm_failure_get_acked_internal(ompi_communicator_t* comm, ompi_group_t **group );
+
+/*
+ * Revoke the communicator
+ */
+OMPI_DECLSPEC int ompi_comm_revoke_internal(ompi_communicator_t* comm);
+
+/*
+ * Shrink the communicator
+ */
+OMPI_DECLSPEC int ompi_comm_shrink_internal(ompi_communicator_t* comm, ompi_communicator_t** newcomm);
+
+/*
+ * Check if the process is active
+ */
+OMPI_DECLSPEC bool ompi_comm_is_proc_active(ompi_communicator_t *comm, int peer_id, bool remote);
+
+/*
+ * Register a new process failure
+ */
+OMPI_DECLSPEC int ompi_comm_set_rank_failed(ompi_communicator_t *comm, int peer_id, bool remote);
+
+/*
+ * Returns true if point-to-point communications with the target process
+ * are supported (this means if the process is a valid peer, if the
+ * communicator is not revoked and if the peer is not already marked as
+ * a dead process).
+ */
+static inline bool ompi_comm_iface_p2p_check_proc(ompi_communicator_t *comm, int peer_id, int *err)
+{
+    if( OPAL_UNLIKELY(ompi_comm_is_revoked(comm)) ) {
+        *err = MPI_ERR_REVOKED;
+        return false;
+    }
+    if( OPAL_UNLIKELY(!ompi_comm_is_proc_active(comm, peer_id, OMPI_COMM_IS_INTER(comm))) ) {
+        /* make sure to progress the revoke engine */
+        opal_progress();
+        *err = MPI_ERR_PROC_FAILED;
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Returns true if the communicator is locally valid for collective communications
+ */
+static inline bool ompi_comm_iface_coll_check(ompi_communicator_t *comm, int *err)
+{
+    if( OPAL_UNLIKELY(ompi_comm_is_revoked(comm)) ) {
+        *err = MPI_ERR_REVOKED;
+        return false;
+    }
+    if( OPAL_UNLIKELY(ompi_comm_coll_revoked(comm)) ) {
+        /* make sure to progress the revoke engine */
+        opal_progress();
+        *err = MPI_ERR_PROC_FAILED;
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Returns true if the communicator can be used by traditional MPI functions
+ * as an underlying communicator to create new communicators. The only
+ * communicator creation function that can help if this function returns
+ * false is MPI_Comm_shrink.
+ */
+static inline bool ompi_comm_iface_create_check(ompi_communicator_t *comm, int *err)
+{
+    return ompi_comm_iface_coll_check(comm, err);
+}
+
+/*
+ * Communicator creation support collectives
+ * - Agreement style allreduce
+ */
+int ompi_comm_allreduce_intra_ft( int *inbuf, int* outbuf,
+                                  int count, struct ompi_op_t *op,
+                                  ompi_communicator_t *comm,
+                                  ompi_communicator_t *bridgecomm,
+                                  void* local_leader,
+                                  void* remote_ledaer,
+                                  int send_first, char *tag, int iter );
+int ompi_comm_allreduce_inter_ft( int *inbuf, int* outbuf,
+                                  int count, struct ompi_op_t *op,
+                                  ompi_communicator_t *comm,
+                                  ompi_communicator_t *bridgecomm,
+                                  void* local_leader,
+                                  void* remote_ledaer,
+                                  int send_first, char *tag, int iter );
+int ompi_comm_allreduce_intra_pmix_ft( int *inbuf, int* outbuf,
+                                  int count, struct ompi_op_t *op,
+                                  ompi_communicator_t *comm,
+                                  ompi_communicator_t *bridgecomm,
+                                  void* local_leader,
+                                  void* remote_ledaer,
+                                  int send_first, char *tag, int iter );
+
+/*
+ * Reliable Bcast infrastructure
+ */
+OMPI_DECLSPEC int ompi_comm_rbcast_register_params(void);
+OMPI_DECLSPEC int ompi_comm_rbcast_init(void);
+OMPI_DECLSPEC int ompi_comm_rbcast_finalize(void);
+
+typedef struct ompi_comm_rbcast_message_t {
+    uint32_t cid;
+    uint32_t epoch;
+    uint8_t  type;
+} ompi_comm_rbcast_message_t;
+
+typedef int (*ompi_comm_rbcast_cb_t)(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg);
+
+OMPI_DECLSPEC int ompi_comm_rbcast_register_cb_type(ompi_comm_rbcast_cb_t callback);
+OMPI_DECLSPEC int ompi_comm_rbcast_unregister_cb_type(int type);
+
+extern int (*ompi_comm_rbcast)(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size);
+int ompi_comm_rbcast_send_msg(
+        ompi_proc_t* proc,
+        ompi_comm_rbcast_message_t* msg,
+        size_t size);
+
+/*
+ * Setup/Shutdown 'failure propagator' handler
+ */
+OMPI_DECLSPEC int ompi_comm_failure_propagator_register_params(void);
+OMPI_DECLSPEC int ompi_comm_failure_propagator_init(void);
+OMPI_DECLSPEC int ompi_comm_failure_propagator_finalize(void);
+OMPI_DECLSPEC int ompi_comm_failure_propagate(ompi_communicator_t* comm, ompi_proc_t* proc, int state);
+
+/*
+ * Setup/Shutdown 'failure detector' handler
+ */
+OMPI_DECLSPEC int ompi_comm_failure_detector_register_params(void);
+OMPI_DECLSPEC int ompi_comm_failure_detector_init(void);
+OMPI_DECLSPEC int ompi_comm_failure_detector_start(void);
+OMPI_DECLSPEC int ompi_comm_failure_detector_finalize(void);
+
+/*
+ * Setup/Shutdown 'revoke' handler
+ */
+OMPI_DECLSPEC int ompi_comm_revoke_init(void);
+OMPI_DECLSPEC int ompi_comm_revoke_finalize(void);
+
+#endif /* OPAL_ENABLE_FT_MPI */
 
 static inline bool ompi_comm_peer_invalid(ompi_communicator_t* comm, int peer_id)
 {
@@ -694,6 +912,12 @@ int ompi_comm_overlapping_groups (int size, struct ompi_proc_t ** lprocs,
 int ompi_comm_determine_first ( ompi_communicator_t *intercomm,
                                 int high );
 
+/**
+ * This is a routine determining wether the local or the
+ * remote group will be first in the new intra-comm.
+ * It does not communicate to exchange the "high" values; used in Agree
+ */
+int ompi_comm_determine_first_auto ( ompi_communicator_t* intercomm );
 
 OMPI_DECLSPEC int ompi_comm_activate (ompi_communicator_t **newcomm, ompi_communicator_t *comm,
                                       ompi_communicator_t *bridgecomm, const void *arg0,

--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2011-2020 The University of Tennessee and The University
+ *
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal/dss/dss.h"
+
+#include "ompi/runtime/params.h"
+#include "ompi/group/group.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/op/op.h"
+#include "ompi/mca/pml/pml.h"
+#include "ompi/mca/bml/bml.h"
+#include "ompi/mca/bml/base/base.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+
+
+ompi_comm_rank_failure_callback_t *ompi_rank_failure_cbfunc = NULL;
+
+/**
+ * The handling of known failed processes is based on a two level process. On one
+ * side the MPI library itself must know the failed processes (in order to be able
+ * to correctly handle complex operations such as shrink). On the other side, the
+ * failed processes acknowledged by the users shuould not be altered during any of
+ * the internal calls, as they must only be updated upon user request.
+ * Thus, the global list (ompi_group_all_failed_procs) is the list of all known
+ * failed processes (by the MPI library internals), and it is allegedly updated
+ * by the MPI library whenever new failure are noticed. However, the user interact
+ * with this list via the MPI functions, and all failure notifications are reported
+ * in the context of a communicator. Thus, using a single index to know the user-level
+ * acknowledged failure is the simplest solution.
+ */
+int ompi_comm_failure_ack_internal(ompi_communicator_t* comm)
+{
+    opal_mutex_lock(&ompi_group_afp_mutex);
+    /* Fix offset in the global failed list */
+    comm->any_source_offset = ompi_group_size(ompi_group_all_failed_procs);
+    /* Re-enable ANY_SOURCE */
+    comm->any_source_enabled = true;
+    /* use the AFP lock implicit memory barrier to propagate the update to
+     * any_source_enabled at the same time.
+     */
+    opal_mutex_unlock(&ompi_group_afp_mutex);
+
+    return OMPI_SUCCESS;
+}
+
+int ompi_comm_failure_get_acked_internal(ompi_communicator_t* comm, ompi_group_t **group )
+{
+    int ret, exit_status = OMPI_SUCCESS;
+    int range[3];
+    ompi_group_t *tmp_sub_group = NULL;
+
+    /*
+     * If no failure present, then return the empty group
+     */
+    if( 0 == comm->any_source_offset ) {
+        *group = MPI_GROUP_EMPTY;
+        OBJ_RETAIN(MPI_GROUP_EMPTY);
+        exit_status = OMPI_SUCCESS;
+        goto cleanup;
+    }
+
+    tmp_sub_group = OBJ_NEW(ompi_group_t);
+
+    /*
+     * Access just the offset number of failures
+     */
+    opal_mutex_lock(&ompi_group_afp_mutex);
+    range[0] = 0;
+    range[1] = comm->any_source_offset - 1;
+    range[2] = 1;
+
+    ret = ompi_group_range_incl(ompi_group_all_failed_procs, 1, &range, &tmp_sub_group);
+    opal_mutex_unlock(&ompi_group_afp_mutex);
+    if( OMPI_SUCCESS != ret ) {
+        exit_status = ret;
+        goto cleanup;
+    }
+
+    /*
+     * Access the intersection between the failed subgroup and our group
+     */
+    if( OMPI_COMM_IS_INTER(comm) ) {
+        ret = ompi_group_intersection(tmp_sub_group,
+                                      comm->c_local_group,
+                                      group);
+    } else {
+        ret = ompi_group_intersection(tmp_sub_group,
+                                      comm->c_remote_group,
+                                      group);
+    }
+
+    if( OMPI_SUCCESS != ret ) {
+        exit_status = ret;
+        goto cleanup;
+    }
+
+ cleanup:
+    if( NULL != tmp_sub_group ) {
+        OBJ_RELEASE(tmp_sub_group);
+        tmp_sub_group = NULL;
+    }
+
+    return exit_status;
+}
+
+int ompi_comm_shrink_internal(ompi_communicator_t* comm, ompi_communicator_t** newcomm)
+{
+    int ret, exit_status = OMPI_SUCCESS;
+    int flag = 1;
+    ompi_group_t *failed_group = NULL, *comm_group = NULL, *alive_group = NULL, *alive_rgroup = NULL;
+    ompi_communicator_t *newcomp = NULL;
+    int mode;
+    double start, stop;
+
+    *newcomm = MPI_COMM_NULL;
+
+    /*
+     * Step 1: Agreement on failed group in comm
+     */
+    /* --------------------------------------------------------- */
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: Agreement on failed processes",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME) ));
+    start = PMPI_Wtime();
+    opal_mutex_lock(&ompi_group_afp_mutex);
+    ompi_group_intersection(comm->c_remote_group, ompi_group_all_failed_procs, &failed_group);
+    opal_mutex_unlock(&ompi_group_afp_mutex);
+    stop = PMPI_Wtime();
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: group_inter: %g seconds",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), stop-start));
+    start = PMPI_Wtime();
+    do {
+        /* We need to create the list of alive processes. Thus, we don't care about
+         * the value of flag, instead we are only using the globally consistent
+         * return value.
+         */
+        ret = comm->c_coll->coll_agree( &flag,
+                                        1,
+                                        &ompi_mpi_int.dt,
+                                        &ompi_mpi_op_band.op,
+                                        &failed_group, true,
+                                        comm,
+                                        comm->c_coll->coll_agree_module);
+    } while( MPI_ERR_PROC_FAILED == ret );
+    stop = PMPI_Wtime();
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: AGREE: %g seconds",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), stop-start));
+    if(OMPI_SUCCESS != ret) {
+        opal_output(0, "%s:%d Agreement failure: %d\n", __FILE__, __LINE__, ret);
+        exit_status = ret;
+        goto cleanup;
+    }
+
+    /*
+     * Step 2: Determine ranks for new communicator
+     */
+    /* --------------------------------------------------------- */
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: Determine ranking for new communicator",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME) ));
+    start = PMPI_Wtime();
+
+    /* Create 'alive' groups */
+    mode = OMPI_COMM_CID_INTRA_FT;
+    comm_group = comm->c_local_group;
+    ret = ompi_group_difference(comm_group, failed_group, &alive_group);
+    if( OMPI_SUCCESS != ret ) {
+        exit_status = ret;
+        goto cleanup;
+    }
+    if( OMPI_COMM_IS_INTER(comm) ) {
+        mode = OMPI_COMM_CID_INTER_FT;
+        comm_group = comm->c_remote_group;
+        ret = ompi_group_difference(comm_group, failed_group, &alive_rgroup);
+        if( OMPI_SUCCESS != ret ) {
+            exit_status = ret;
+            goto cleanup;
+        }
+    }
+    ret = ompi_comm_set( &newcomp,                 /* new comm */
+                         comm,                     /* old comm */
+                         0,                        /* local_size */
+                         NULL,                     /* local_ranks */
+                         0,                        /* remote_size */
+                         NULL,                     /* remote_ranks */
+                         comm->c_keyhash,          /* attrs */
+                         comm->error_handler,      /* error handler */
+                         NULL,                     /* topo component */
+                         alive_group,              /* local group */
+                         alive_rgroup              /* remote group */
+                       );
+    if( OMPI_SUCCESS != ret ) {
+        exit_status = ret;
+        goto cleanup;
+    }
+    if( NULL == newcomp ) {
+        exit_status = MPI_ERR_INTERN;
+        goto cleanup;
+    }
+    stop = PMPI_Wtime();
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: GRP COMPUTATION: %g seconds\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), stop-start));
+    /*
+     * Step 3: Determine context id
+     */
+    /* --------------------------------------------------------- */
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: Determine context id",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME) ));
+    start = PMPI_Wtime();
+    ret = ompi_comm_nextcid( newcomp,  /* new communicator */
+                             comm,     /* old comm */
+                             NULL,     /* bridge comm */
+                             NULL,     /* local leader */
+                             NULL,     /* remote_leader */
+                             -1,       /* send_first */
+                             mode);    /* mode */
+    if( OMPI_SUCCESS != ret ) {
+        opal_output_verbose(1, ompi_ftmpi_output_handle,
+                            "%s ompi: comm_shrink: Determine context id failed with error %d",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), ret);
+        exit_status = ret;
+        goto cleanup;
+    }
+    stop = PMPI_Wtime();
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: NEXT CID: %g seconds\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), stop-start));
+    /*
+     * Step 4: Activate the communicator
+     */
+    /* --------------------------------------------------------- */
+    /* Set name for debugging purposes */
+    snprintf(newcomp->c_name, MPI_MAX_OBJECT_NAME, "MPI COMMUNICATOR %d SHRUNK FROM %d",
+             newcomp->c_contextid, comm->c_contextid );
+    start = PMPI_Wtime();
+    /* activate communicator and init coll-module */
+    ret = ompi_comm_activate( &newcomp, /* new communicator */
+                              comm,
+                              NULL,
+                              NULL,
+                              NULL,
+                              -1,
+                              mode);
+    if( OMPI_SUCCESS != ret ) {
+        exit_status = ret;
+        goto cleanup;
+    }
+    stop = PMPI_Wtime();
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ompi: comm_shrink: COLL SELECT: %g seconds\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), stop-start));
+
+    /** Step 5: assign the output communicator */
+    *newcomm = newcomp;
+
+ cleanup:
+    if( NULL != failed_group ) {
+        OBJ_RELEASE(failed_group);
+        failed_group = NULL;
+    }
+    if( NULL != alive_group ) {
+        OBJ_RELEASE(alive_group);
+        alive_group = NULL;
+    }
+    if( NULL != alive_rgroup ) {
+        OBJ_RELEASE(alive_rgroup);
+        alive_rgroup = NULL;
+    }
+
+    return exit_status;
+}
+
+
+bool ompi_comm_is_proc_active(ompi_communicator_t *comm, int peer_id, bool remote)
+{
+    ompi_proc_t* ompi_proc;
+
+    /* Check MPI_ANY_SOURCE differently */
+    if( OPAL_UNLIKELY(peer_id == MPI_ANY_SOURCE) ) {
+        return ompi_comm_is_any_source_enabled(comm);
+    }
+    /* PROC_NULL is always 'ok' */
+    if( OPAL_UNLIKELY(peer_id == MPI_PROC_NULL) ) {
+        return true;
+    }
+#if OPAL_ENABLE_DEBUG
+    /* Sanity check. Only valid ranks are accepted.  */
+    if( (peer_id < 0) ||
+        (!OMPI_COMM_IS_INTRA(comm) && peer_id >= ompi_comm_remote_size(comm)) ||
+        ( OMPI_COMM_IS_INTRA(comm) && peer_id >= ompi_comm_size(comm) ) ) {
+        return false;
+    }
+#endif
+    ompi_proc = ompi_group_get_proc_ptr((remote ? comm->c_remote_group : comm->c_local_group),
+                                        peer_id, false);
+    /* If the proc is not known yet (get_proc_ptr returns NULL for a valid
+     * peer_id), then we assume that the proc is alive. When it is dead, the
+     * proc will exist. */
+    return (NULL == ompi_proc) ? true : ompi_proc_is_active(ompi_proc);
+}
+
+int ompi_comm_set_rank_failed(ompi_communicator_t *comm, int peer_id, bool remote)
+{
+    /* Disable ANY_SOURCE */
+    comm->any_source_enabled = false;
+    opal_atomic_wmb(); /* non-locked update needs a memory barrier to propagate */
+
+    /* Disable collectives */
+    MCA_PML_CALL(revoke_comm(comm, true));
+
+    if( NULL != ompi_rank_failure_cbfunc ) {
+        (*ompi_rank_failure_cbfunc)(comm, peer_id, remote);
+    }
+
+    return OMPI_SUCCESS;
+}

--- a/ompi/communicator/ft/comm_ft_detector.c
+++ b/ompi/communicator/ft/comm_ft_detector.c
@@ -1,0 +1,725 @@
+/*
+ * Copyright (c) 2016-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "opal/mca/base/mca_base_var.h"
+#include "opal/mca/timer/base/base.h"
+#include "opal/mca/threads/threads.h"
+
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/pml/pml.h"
+#include "ompi/mca/bml/bml.h"
+#include "ompi/mca/bml/base/base.h"
+
+#include <math.h>
+
+typedef struct {
+    ompi_communicator_t* comm;
+    opal_event_t* fd_event; /* to trigger timeouts with opal_events */
+    int hb_observing; /* the rank of the process we observe */
+    int hb_observer; /* the rank of the process that observes us */
+    double hb_lastpeek; /* the date of the last event looking at rstamp */
+    double hb_rstamp; /* the date of the last hb reception */
+    double hb_timeout; /* the timeout before we start suspecting observed process as dead (delta) */
+    double hb_period; /* the time spacing between heartbeat emission (eta) */
+    double hb_sstamp; /* the date at which the last hb emission was done */
+    /* caching for RDMA put heartbeats */
+    mca_bml_base_btl_t *hb_rdma_bml_btl_observer;
+    /* caching for registration removal */
+    mca_bml_base_btl_t *hb_rdma_bml_btl_observing;
+    int hb_rdma_rank; /* my rank */
+    mca_btl_base_registration_handle_t* hb_rdma_rank_lreg;
+    volatile int hb_rdma_flag; /* set to -1 when read locally, set to observing sets it to its rank through rdma */
+    mca_btl_base_registration_handle_t* hb_rdma_flag_lreg;
+    uint64_t hb_rdma_raddr; /* write-to remote flag address */
+    mca_btl_base_registration_handle_t* hb_rdma_rreg;
+    opal_mutex_t fd_mutex; /* protect the structure while we change observer */
+} comm_detector_t;
+
+static comm_detector_t comm_world_detector = {
+    .comm = &ompi_mpi_comm_world.comm,
+    .fd_event = NULL,
+    .hb_observing = MPI_PROC_NULL,
+    .hb_observer = MPI_PROC_NULL,
+    .hb_rstamp = 0.0,
+    .hb_timeout = INFINITY,
+    .hb_period = INFINITY,
+    .hb_sstamp = 0.0,
+    .hb_rdma_bml_btl_observer = NULL,
+    .hb_rdma_bml_btl_observing = NULL,
+    .hb_rdma_rank = MPI_PROC_NULL,
+    .hb_rdma_rank_lreg = NULL,
+    .hb_rdma_flag = -3,
+    .hb_rdma_flag_lreg = NULL,
+    .hb_rdma_raddr = (int64_t)NULL,
+    .hb_rdma_rreg = NULL,
+    .fd_mutex = OPAL_MUTEX_STATIC_INIT
+};
+
+typedef struct fd_heartbeat_t {
+    ompi_comm_rbcast_message_t super;
+    int from;
+} ompi_comm_heartbeat_message_t;
+
+typedef struct fd_heartbeat_req_t {
+    ompi_comm_rbcast_message_t super;
+    int from;
+    uint64_t rdma_raddr;
+    char rdma_rreg[];
+} ompi_comm_heartbeat_req_t;
+
+static int fd_heartbeat_request(comm_detector_t* detector);
+static int fd_heartbeat_request_cb(ompi_communicator_t* comm, ompi_comm_heartbeat_req_t* msg);
+static int fd_heartbeat_rdma_put(comm_detector_t* detector);
+static int fd_heartbeat_send(comm_detector_t* detector);
+static int fd_heartbeat_recv_cb(ompi_communicator_t* comm, ompi_comm_heartbeat_message_t* msg);
+
+static bool comm_detector_enable = false;
+static int comm_detector_use_rdma_hb = false;
+static double comm_heartbeat_period = 3e0;
+static double comm_heartbeat_timeout = 1e1;
+static opal_event_base_t* fd_event_base = NULL;
+static void fd_event_cb(int fd, short flags, void* pdetector);
+
+static bool comm_detector_use_thread = false;
+static opal_atomic_int32_t fd_thread_active = 0;
+static opal_thread_t fd_thread;
+static void* fd_progress(opal_object_t* obj);
+
+static int comm_heartbeat_recv_cb_type = -1;
+static int comm_heartbeat_request_cb_type = -1;
+
+/* rdma btl alignment */
+#define ALIGNMENT_MASK(x) ((x) ? (x) - 1 : 0)
+
+int ompi_comm_start_detector(ompi_communicator_t* comm);
+static double startdate;
+
+
+int ompi_comm_failure_detector_register_params(void) {
+    (void) mca_base_var_register ("ompi", "mpi", "ft", "detector",
+                                  "Use the OMPI heartbeat based failure detector, or disable it and use only RTE and in-band detection (slower)",
+                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &comm_detector_enable);
+    (void) mca_base_var_register ("ompi", "mpi", "ft", "detector_thread",
+                                  "Delegate failure detector to a separate thread",
+                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &comm_detector_use_thread);
+    /* If we have a detector thread, set the default timeout to be more
+     * aggressive (w/o detector thread, lower values may cause false positives) */
+    if( comm_detector_use_thread ) {
+        comm_heartbeat_period *= 1e-1;
+        comm_heartbeat_timeout *= 1e-1;
+    }
+    (void) mca_base_var_register ("ompi", "mpi", "ft", "detector_period",
+                                  "Period of heartbeat emission (s)",
+                                  MCA_BASE_VAR_TYPE_DOUBLE, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &comm_heartbeat_period);
+    (void) mca_base_var_register ("ompi", "mpi", "ft", "detector_timeout",
+                                  "Timeout before we start suspecting a process after the last heartbeat reception (must be larger than 3*ompi_mpi_ft_detector_period)",
+                                  MCA_BASE_VAR_TYPE_DOUBLE, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &comm_heartbeat_timeout);
+    (void) mca_base_var_register ("ompi", "mpi", "ft", "detector_rdma_heartbeat",
+                                  "Use rdma put to deposit heartbeats into the observer memory",
+                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &comm_detector_use_rdma_hb);
+    return OMPI_SUCCESS;
+}
+
+
+int ompi_comm_failure_detector_init(void) {
+    int ret;
+    fd_event_base = opal_sync_event_base;
+
+    if( !ompi_ftmpi_enabled || !comm_detector_enable ) return OMPI_SUCCESS;
+
+    /* using rbcast to transmit messages (cb must always return the noforward 'false' flag) */
+    /* registering the cb types */
+    ret = ompi_comm_rbcast_register_cb_type((ompi_comm_rbcast_cb_t)fd_heartbeat_recv_cb);
+    if( 0 > ret ) goto cleanup;
+    comm_heartbeat_recv_cb_type = ret;
+    ret = ompi_comm_rbcast_register_cb_type((ompi_comm_rbcast_cb_t)fd_heartbeat_request_cb);
+    if( 0 > ret ) goto cleanup;
+    comm_heartbeat_request_cb_type = ret;
+
+    if( comm_detector_use_thread ) {
+        fd_event_base = opal_event_base_create();
+        if( NULL == fd_event_base ) {
+            fd_event_base = opal_sync_event_base;
+            ret = OMPI_ERR_OUT_OF_RESOURCE;
+            goto cleanup;
+        }
+        opal_event_use_threads();
+        opal_set_using_threads(true);
+        OBJ_CONSTRUCT(&fd_thread, opal_thread_t);
+        fd_thread.t_run = fd_progress;
+        fd_thread.t_arg = NULL;
+        ret = opal_thread_start(&fd_thread);
+        if( OPAL_SUCCESS != ret ) goto cleanup;
+        while( 0 == fd_thread_active ); /* wait for the fd thread initialization */
+        if( 0 > fd_thread_active ) goto cleanup;
+    }
+
+    return OMPI_SUCCESS;
+
+  cleanup:
+    ompi_comm_failure_detector_finalize();
+    return ret;
+}
+
+int ompi_comm_failure_detector_start(void) {
+    /* fd not wanted */
+    if( -1 == comm_heartbeat_recv_cb_type ) return OMPI_SUCCESS;
+
+    if( comm_detector_use_thread ) {
+        OPAL_THREAD_ADD_FETCH32(&fd_thread_active, 1);
+        return OMPI_SUCCESS;
+    }
+
+    /* setting up the default detector on comm_world */
+    return ompi_comm_start_detector(&ompi_mpi_comm_world.comm);
+}
+
+#define FD_LOCAL_PROCS 1
+
+int ompi_comm_failure_detector_finalize(void) {
+    int observing;
+    comm_detector_t* detector = &comm_world_detector;
+
+    /* Tell our observer that we won't put anymore */
+    if( MPI_PROC_NULL != detector->hb_observer ) {
+        detector->hb_rdma_rank = detector->hb_observer;
+        fd_heartbeat_send(detector);
+        detector->hb_period = INFINITY;
+        detector->hb_observer = MPI_PROC_NULL;
+        opal_atomic_mb();
+    }
+    /* wait until the observed process confirms he is not putting in our
+     * memory (or everybody else is dead) */
+    while( MPI_PROC_NULL != (observing = detector->hb_observing) ) {
+        ompi_proc_t* proc = ompi_comm_peer_lookup(detector->comm, observing);
+        assert( NULL != proc );
+#if !FD_LOCAL_PROCS
+        if( OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags) ) {
+            break;
+        }
+#endif
+        while( observing == detector->hb_observing ) {
+            /* If observed process changed, recheck if local*/
+            if( !(0 < fd_thread_active) )
+            {
+                opal_progress();
+            }
+        }
+    }
+
+    if( 0 < fd_thread_active ) {
+        void* tret;
+        /* this is not a race condition. Accesses are serialized, we use the
+         * atomic for the mfence part of it. */
+        OPAL_THREAD_ADD_FETCH32(&fd_thread_active, -fd_thread_active);
+        opal_event_base_loopbreak(fd_event_base);
+        opal_thread_join(&fd_thread, &tret);
+    }
+
+    if( NULL != detector->fd_event ) {
+        opal_event_del(detector->fd_event);
+        opal_event_free(detector->fd_event);
+        detector->fd_event = NULL;
+    }
+    if( opal_sync_event_base != fd_event_base ) opal_event_base_free(fd_event_base);
+
+    /* Remove rdma registrations, if any */
+    if( NULL != detector->hb_rdma_rank_lreg ) {
+        mca_bml_base_deregister_mem(detector->hb_rdma_bml_btl_observer, detector->hb_rdma_rank_lreg);
+    }
+    if( NULL != detector->hb_rdma_flag_lreg ) {
+        mca_bml_base_deregister_mem(detector->hb_rdma_bml_btl_observing, detector->hb_rdma_flag_lreg);
+    }
+
+    /* ignore heartbeats and heartbeats requests from now on */
+    detector->hb_observer = detector->hb_observing = MPI_PROC_NULL;
+
+    return OMPI_SUCCESS;
+}
+
+int ompi_comm_start_detector(ompi_communicator_t* comm) {
+    /* TODO: not implemented for other comms yet */
+    if( &ompi_mpi_comm_world.comm != comm ) return OMPI_ERR_NOT_IMPLEMENTED;
+    comm_detector_t* detector = &comm_world_detector;
+
+    int rank, np;
+    startdate = PMPI_Wtime();
+    detector->comm = comm;
+    np = ompi_comm_size(comm);
+    rank = ompi_comm_rank(comm);
+    detector->hb_observing = (np+rank-1) % np;
+    detector->hb_observer = (np+rank+1) % np;
+    detector->hb_period = comm_heartbeat_period;
+    detector->hb_timeout = comm_heartbeat_timeout;
+    if(comm_heartbeat_timeout <= comm_heartbeat_period) {
+        detector->hb_period = comm_heartbeat_timeout / 3.;
+    }
+    detector->hb_lastpeek = startdate;
+    detector->hb_sstamp = 0.;
+    detector->hb_rstamp = PMPI_Wtime()+comm_heartbeat_timeout+1.+log((double)np); /* give some slack for MPI_Init */
+
+    detector->hb_rdma_bml_btl_observer = NULL;
+    detector->hb_rdma_bml_btl_observing = NULL;
+    detector->hb_rdma_rank = rank;
+    detector->hb_rdma_rank_lreg = NULL;
+    detector->hb_rdma_flag_lreg = NULL;
+    detector->hb_rdma_raddr = 0;
+    detector->hb_rdma_rreg = NULL;
+
+    OBJ_CONSTRUCT(&detector->fd_mutex, opal_mutex_t);
+
+    detector->fd_event = opal_event_new(fd_event_base, -1, OPAL_EV_TIMEOUT | OPAL_EV_PERSIST, fd_event_cb, detector);
+    struct timeval tv;
+    /* wake up the ev loop at 10x the heartbeat period to ensure
+     * accurate heartbeat emission rate (otherwise random sampling
+     * would cause drifts in emissions). */
+    tv.tv_sec = (int)(detector->hb_period / 10.);
+    tv.tv_usec = (-tv.tv_sec + (detector->hb_period / 10.)) * 1e6;
+    OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                         "%s %s: Installing an event every %g for a detector with period %g %s",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                         detector->hb_period / 10., detector->hb_period,
+                         comm_detector_use_thread?"(in a thread)":""));
+    opal_event_add(detector->fd_event, &tv);
+    if( 10e-6 > detector->hb_period ) {
+        /* do not overpoll the event progress loop except if
+         * super aggressive heartbeat rate is required */
+        opal_progress_event_users_increment();
+    }
+
+    if( comm_detector_use_rdma_hb ) {
+        fd_heartbeat_request(detector);
+    }
+    else {
+        fd_heartbeat_send(detector);
+    }
+
+    return OMPI_SUCCESS;
+}
+
+static int fd_heartbeat_request(comm_detector_t* detector) {
+    assert( -1 != comm_heartbeat_request_cb_type /* initialized */);
+    ompi_communicator_t* comm = detector->comm;
+
+    if( -2 < detector->hb_rdma_flag /* initialization for values -2, -3 */
+     && ompi_comm_is_proc_active(comm, detector->hb_observing, OMPI_COMM_IS_INTER(comm)) ) {
+        /* already observing a live process, so nothing to do. */
+        return OMPI_SUCCESS;
+    }
+
+    int ret = OMPI_SUCCESS;
+    int np = ompi_comm_size(comm);
+    int rank;
+    size_t regsize = 0;
+
+    for( rank = (np+detector->hb_observing) % np;
+         true;
+         rank = (np+rank-1) % np ) {
+        ompi_proc_t* proc = ompi_comm_peer_lookup(comm, rank);
+        assert( NULL != proc );
+        if( !ompi_proc_is_active(proc) ) continue;
+
+        /* if everybody else is dead, I don't need to monitor myself. */
+        if( rank == comm->c_my_rank ) {
+            OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                             "%s %s: Every other node is dead on communicator %3d:%d",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, comm->c_contextid, comm->c_epoch));
+            detector->hb_observer = detector->hb_observing = MPI_PROC_NULL;
+            detector->hb_rstamp = INFINITY;
+            detector->hb_period = INFINITY;
+            opal_atomic_mb();
+            return OMPI_SUCCESS;
+        }
+#if !FD_LOCAL_PROCS
+        /* do not heartbeat on sm domain, PMIx will detect for us */
+        if( OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags) ) {
+            detector->hb_observing = rank;
+            return OMPI_SUCCESS;
+        }
+#endif
+
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                             "%s %s: Sending observe request to %d on communicator %3d:%d stamp %g",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, rank, comm->c_contextid, comm->c_epoch, detector->hb_rstamp-startdate ));
+
+        if( comm_detector_use_rdma_hb ) {
+            mca_bml_base_endpoint_t* endpoint = mca_bml_base_get_endpoint(proc);
+            assert( NULL != endpoint );
+            mca_bml_base_btl_t *bml_btl = mca_bml_base_btl_array_get_index(&endpoint->btl_rdma, 0);
+            assert( NULL != bml_btl );
+
+            /* register mem for the flag and cache the reg key */
+            /* remove previous registration if any */
+            if( NULL != detector->hb_rdma_flag_lreg ) {
+                mca_bml_base_deregister_mem(detector->hb_rdma_bml_btl_observing, detector->hb_rdma_flag_lreg);
+            }
+            if( NULL != bml_btl->btl->btl_register_mem ) {
+                assert( !((size_t)&detector->hb_rdma_flag & ALIGNMENT_MASK(bml_btl->btl->btl_put_alignment)) );
+                mca_bml_base_register_mem(bml_btl, (void*)&detector->hb_rdma_flag, sizeof(int),
+                        MCA_BTL_REG_FLAG_LOCAL_WRITE | MCA_BTL_REG_FLAG_REMOTE_WRITE, &detector->hb_rdma_flag_lreg);
+                assert( NULL != detector->hb_rdma_flag_lreg );
+                regsize = bml_btl->btl->btl_registration_handle_size;
+            }
+            detector->hb_rdma_bml_btl_observing = bml_btl;
+        }
+        detector->hb_observing = rank;
+
+        ompi_comm_heartbeat_req_t* msg = calloc(sizeof(*msg)+regsize, 1);
+        msg->super.cid = comm->c_contextid;
+        msg->super.epoch = comm->c_epoch;
+        msg->super.type = comm_heartbeat_request_cb_type;
+        msg->from = comm->c_my_rank;
+        if( regsize ) {
+            /* send the rdma addr and registration key to the observed */
+            memcpy(&msg->rdma_rreg[0], detector->hb_rdma_flag_lreg, regsize);
+            msg->rdma_raddr = (uint64_t)&detector->hb_rdma_flag;
+        }
+        ret = ompi_comm_rbcast_send_msg(proc, &msg->super, sizeof(*msg)+regsize);
+        free(msg);
+        break;
+    }
+    detector->hb_rstamp = PMPI_Wtime()+detector->hb_timeout; /* we add one timeout slack to account for the send time */
+    return ret;
+}
+
+static int fd_heartbeat_request_cb(ompi_communicator_t* comm, ompi_comm_heartbeat_req_t* msg) {
+    assert( &ompi_mpi_comm_world.comm == comm );
+    comm_detector_t* detector = &comm_world_detector;
+
+    int np, rr, ro;
+    np = ompi_comm_size(comm);
+    rr = (np-comm->c_my_rank+msg->from) % np; /* translate msg->from in circular space so that myrank==0 */
+    ro = (np-comm->c_my_rank+detector->hb_observer) % np; /* same for the observer rank */
+    if( rr < ro ) {
+        opal_output_verbose(1, ompi_ftmpi_output_handle,
+                             "%s %s: Received heartbeat request from %d on communicator %3d:%d but I am monitored by %d -- this is stall information, ignoring.",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->from, comm->c_contextid, comm->c_epoch, detector->hb_observer );
+        return false; /* never forward on the rbcast */
+    }
+    OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                         "%s %s: Recveived heartbeat request from %d on communicator %3d:%d",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->from, comm->c_contextid, comm->c_epoch));
+    detector->hb_observer = msg->from;
+    detector->hb_sstamp = 0.;
+
+    if( comm_detector_use_rdma_hb ) {
+        ompi_communicator_t* comm = detector->comm;
+        ompi_proc_t* proc = ompi_comm_peer_lookup(comm, msg->from);
+        assert( NULL != proc );
+        mca_bml_base_endpoint_t* endpoint = mca_bml_base_get_endpoint(proc);
+        assert( NULL != endpoint );
+        mca_bml_base_btl_t *bml_btl = mca_bml_base_btl_array_get_index(&endpoint->btl_rdma, 0);
+        assert( NULL != bml_btl );
+
+        OPAL_THREAD_LOCK(&detector->fd_mutex);
+        /* registration for the local rank */
+        /* remove previous registration, if any */
+        if( NULL != detector->hb_rdma_rank_lreg ) {
+            mca_bml_base_deregister_mem(detector->hb_rdma_bml_btl_observer, detector->hb_rdma_rank_lreg);
+        }
+        if( NULL != bml_btl->btl->btl_register_mem ) {
+            assert( !((size_t)&detector->hb_rdma_rank & ALIGNMENT_MASK(bml_btl->btl->btl_put_alignment)) );
+            mca_bml_base_register_mem(bml_btl, &detector->hb_rdma_rank, sizeof(int), 0, &detector->hb_rdma_rank_lreg);
+            assert( NULL != detector->hb_rdma_rank_lreg );
+            /* registration for the remote flag */
+            if( NULL != detector->hb_rdma_rreg ) free(detector->hb_rdma_rreg);
+            size_t regsize = bml_btl->btl->btl_registration_handle_size;
+            detector->hb_rdma_rreg = malloc(regsize);
+            assert( NULL != detector->hb_rdma_rreg );
+            memcpy(detector->hb_rdma_rreg, &msg->rdma_rreg[0], regsize);
+        }
+        /* cache the bml_btl used for put */
+        detector->hb_rdma_bml_btl_observer = bml_btl;
+        /* remote flag addr */
+        detector->hb_rdma_raddr = msg->rdma_raddr;
+        OPAL_THREAD_UNLOCK(&detector->fd_mutex);
+    }
+
+    fd_heartbeat_send(detector);
+    return false; /* never forward on the rbcast */
+}
+
+/*
+ * event loop and thread
+ */
+
+static void fd_event_cb(int fd, short flags, void* pdetector)
+{
+    comm_detector_t* detector = pdetector;;
+    double stamp = PMPI_Wtime();
+    double lastpeek = detector->hb_lastpeek;
+    detector->hb_lastpeek = stamp;
+
+    OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                         "%s %s: evtime triggered at stamp %g; observing %d (recv grace %g); observer %d (send grace %g); drift %g",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, stamp-startdate,
+                         detector->hb_observing, stamp-detector->hb_rstamp-detector->hb_timeout,
+                         detector->hb_observer, stamp-detector->hb_sstamp-detector->hb_period, 
+                         stamp-lastpeek-detector->hb_period*10.));
+
+    if( (stamp - detector->hb_sstamp) > (detector->hb_period*.9) ) {
+        fd_heartbeat_send(detector);
+    }
+
+    if( INFINITY == detector->hb_rstamp ) return;
+
+    if( comm_detector_use_rdma_hb ) {
+        int flag = detector->hb_rdma_flag;
+        int rank = ompi_comm_rank(detector->comm);
+
+        OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                             "%s:%s: read flag %d at stamp %g",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, flag, stamp-startdate));
+        if( rank == flag) {
+            /* this is a quit message from our observed process, stop the
+             * detector */
+            opal_output_verbose(10, ompi_ftmpi_output_handle,
+                                "%s %s: evtimer triggered at stamp %g, RDMA flag is set to my own rank, this is a quit message to close the detector.",
+                                OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, stamp-startdate);
+            detector->hb_observing = MPI_PROC_NULL;
+            detector->hb_rstamp = INFINITY;
+            return;
+        }
+        if( 0 <= flag ) {
+            /* We have received stamps since last time we checked */
+            detector->hb_rdma_flag = -1;
+            if( flag != detector->hb_observing ) {
+                opal_output_verbose(1, ompi_ftmpi_output_handle,
+                                    "%s %s: evtimer triggered at stamp %g, this is a rdma heartbeat from %d, but I am now observing %d, ignoring the heartbeat",
+                                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                                    stamp-startdate, flag, detector->hb_observing);
+                return;
+            }
+            OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                                 "%s %s: evtimer triggered at stamp %g, RDMA recv grace %.1e is OK from %d :)",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                                 stamp-startdate, stamp - detector->hb_rstamp, flag));
+            detector->hb_rstamp = stamp;
+            return;
+        }
+    }
+
+    ompi_proc_t* proc = ompi_comm_peer_lookup(detector->comm, detector->hb_observing);
+    if( !ompi_proc_is_active(proc) /* found dead inline (btl) or externally (pmix) */
+     || stamp > (detector->hb_rstamp + detector->hb_timeout) /* normal timeout */ ) {
+#if !FD_LOCAL_PROCS
+        /* Special case for procs on local node: we do not send or monitor
+         * heartbeats in that case. Check if this proc has been reported dead
+         * from PMIx, if so, move on to patch the ring. Otherwise, change the
+         * recv grace and do not check for another timeout, all is fine. */
+        if( OPAL_PROC_ON_LOCAL_NODE(proc->super.proc_flags)
+            && ompi_proc_is_active(proc) ) {
+            /* special case for finalize */
+            if( detector->hb_observer == MPI_PROC_NULL) {
+                OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                                     "%s %s: evtimer triggered at stamp %g, recv grace IGNORED by %.1e, proc %d is local and still active but this is FINALIZE.",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                                     stamp-startdate,
+                                     detector->hb_timeout - (stamp - detector->hb_rstamp), detector->hb_observing));
+                detector->hb_observing = MPI_PROC_NULL;
+                detector->hb_rstamp = INFINITY;
+                opal_atomic_mb();
+                return;
+            }
+            OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                                 "%s %s: evtimer triggered at stamp %g, recv grace IGNORED by %.1e, proc %d is local and still active (I am observed by %d w/ period %g).",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                                 stamp-startdate,
+                                 detector->hb_timeout - (stamp - detector->hb_rstamp), detector->hb_observing, detector->hb_observer, detector->hb_period));
+            detector->hb_rstamp = stamp;
+            return;
+        }
+#endif
+        if( ompi_proc_is_active(proc) /* not an external notice */
+         && (stamp - lastpeek) >= detector->hb_period /* and we had event jitter */
+         && lastpeek <= (detector->hb_rstamp + detector->hb_timeout) /* and granting the jitter as slack, we are still fine */ ) {
+            OPAL_OUTPUT_VERBOSE((1, ompi_ftmpi_output_handle,
+                                 "%s %s: evtimer triggered at stamp %g, recv grace IGNORED by %.1e because of drift %.1e, proc %d is still seen as active (I am observed by %d w/ period %g).",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                                 stamp-startdate,
+                                 detector->hb_timeout - (stamp - detector->hb_rstamp), stamp - lastpeek, detector->hb_observing, detector->hb_observer, detector->hb_period));
+            return;
+        }
+
+        /* this process is now suspected dead. */
+        opal_output_verbose(1, ompi_ftmpi_output_handle,
+                            "%s %s: evtimer triggered at stamp %g, recv grace MISSED by %.1e, proc %d now suspected dead.",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                            stamp-startdate,
+                            detector->hb_timeout - (stamp - detector->hb_rstamp), detector->hb_observing);
+        /* mark this process dead and forward */
+        ompi_errhandler_proc_failed(proc);
+        /* special case for finalize; avoid waiting NP timeouts */
+        if( MPI_PROC_NULL == detector->hb_observer ) {
+            detector->hb_observing = MPI_PROC_NULL;
+            detector->hb_rstamp = INFINITY;
+            opal_atomic_mb();
+            return;
+        }
+        /* change the observed proc */
+        detector->hb_rdma_flag = -2;
+        fd_heartbeat_request(detector);
+    }
+}
+
+void* fd_progress(opal_object_t* obj) {
+    int ret;
+    MPI_Request req;
+    if( OMPI_SUCCESS != ompi_comm_start_detector(&ompi_mpi_comm_world.comm)) {
+        OPAL_THREAD_ADD_FETCH32(&fd_thread_active, -1);
+        return OPAL_THREAD_CANCELLED;
+    }
+    OPAL_THREAD_ADD_FETCH32(&fd_thread_active, 1);
+    while( 1 == fd_thread_active ); /* wait for init stage 2: start_detector */
+    ret = MCA_PML_CALL(irecv(NULL, 0, MPI_BYTE, 0, MCA_COLL_BASE_TAG_FT_END, &ompi_mpi_comm_self.comm, &req));
+    while( fd_thread_active ) {
+        opal_event_loop(fd_event_base, OPAL_EVLOOP_ONCE);
+#if 0
+        /* This test disabled because rdma emulation over TCP would not work without
+         * spinning progress */
+        if( 0 == comm_world_detector.hb_rdma_raddr ) /* if RDMA hb not setup yet */
+#endif
+        {
+            /* force rbcast recv to progress */
+            int completed = 0;
+            ret = ompi_request_test(&req, &completed, MPI_STATUS_IGNORE);
+            assert( OMPI_SUCCESS == ret );
+            assert( 0 == completed );
+        }
+    }
+    ret = ompi_request_cancel(req);
+    ret = ompi_request_wait(&req, MPI_STATUS_IGNORE);
+    return OPAL_THREAD_CANCELLED;
+}
+
+static int sendseq = 0;
+
+/*
+ * RDMA put based heartbeats
+ */
+
+static void fd_heartbeat_rdma_cb(mca_btl_base_module_t* btl, struct mca_btl_base_endpoint_t* ep,
+                       void *local_address, mca_btl_base_registration_handle_t *local_handle,
+                       void *context, void *cbdata, int status) {
+    OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                        "%s %s: rdma_hb_cb status=%d",
+                        OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                        status));
+}
+
+static int fd_heartbeat_rdma_put(comm_detector_t* detector) {
+    int ret = OMPI_SUCCESS;
+
+    if( 0 == detector->hb_rdma_raddr ) return OMPI_SUCCESS; /* not initialized yet */
+    OPAL_THREAD_LOCK(&detector->fd_mutex);
+    do {
+        ret = mca_bml_base_put(detector->hb_rdma_bml_btl_observer, &detector->hb_rdma_rank, detector->hb_rdma_raddr,
+                               detector->hb_rdma_rank_lreg, detector->hb_rdma_rreg,
+                               sizeof(int), 0, MCA_BTL_NO_ORDER, fd_heartbeat_rdma_cb, NULL);
+        OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                        "%s %s: bml_put sendseq=%d, rc=%d",
+                        OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                        sendseq++, ret));
+    } while( OMPI_ERR_OUT_OF_RESOURCE == ret ); /* never give up... */
+    /* finalize case. Do it here, in the locked region */
+    if( detector->hb_observing == detector->hb_rdma_rank ) {
+        detector->hb_rdma_raddr = 0;
+    }
+    OPAL_THREAD_UNLOCK(&detector->fd_mutex);
+    return ret;
+}
+
+
+/*
+ * send eager based heartbeats
+ */
+
+static int fd_heartbeat_send(comm_detector_t* detector) {
+    assert( -1 != comm_heartbeat_recv_cb_type /* initialized */);
+    ompi_communicator_t* comm = detector->comm;
+    if( comm != &ompi_mpi_comm_world.comm ) return OMPI_ERR_NOT_IMPLEMENTED;
+
+#if !FD_LOCAL_PROCS
+    /* Do not heartbeat to local procs, PMIx will detect for us */
+    if( OPAL_PROC_ON_LOCAL_NODE(ompi_comm_peer_lookup(comm, detector->hb_observer)->super.proc_flags) ) return OMPI_SUCCESS;
+#endif
+
+    double now = PMPI_Wtime();
+    if( 0. != detector->hb_sstamp
+     && (now - detector->hb_sstamp) >= 2.*detector->hb_period ) {
+        opal_output_verbose(1, ompi_ftmpi_output_handle, "%s %s: MISSED my SEND %d deadline by %.1e, this could trigger a false suspicion for me.",
+                OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__,
+                sendseq, now-detector->hb_sstamp);
+    }
+    detector->hb_sstamp = now;
+    OPAL_OUTPUT_VERBOSE((9, ompi_ftmpi_output_handle,
+                         "%s %s: Sending heartbeat to %d on communicator %3d:%d stamp %g",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, detector->hb_observer, comm->c_contextid, comm->c_epoch, detector->hb_sstamp-startdate ));
+
+    if( comm_detector_use_rdma_hb ) return fd_heartbeat_rdma_put(detector);
+
+    /* send the heartbeat with eager send */
+    ompi_comm_heartbeat_message_t msg;
+    msg.super.cid = comm->c_contextid;
+    msg.super.epoch = comm->c_epoch;
+    msg.super.type = comm_heartbeat_recv_cb_type;
+    msg.from = detector->hb_rdma_rank; /* comm->c_my_rank; except during finalize when it is equal to detector->hb_observer */
+    ompi_proc_t* proc = ompi_comm_peer_lookup(comm, detector->hb_observer);
+    ompi_comm_rbcast_send_msg(proc, &msg.super, sizeof(msg));
+    return OMPI_SUCCESS;
+}
+
+static int fd_heartbeat_recv_cb(ompi_communicator_t* comm, ompi_comm_heartbeat_message_t* msg) {
+    assert( &ompi_mpi_comm_world.comm == comm );
+    comm_detector_t* detector = &comm_world_detector;
+
+
+    if( comm->c_my_rank == msg->from ) {
+        /* this is a quit message from our observed process, stop the
+         * detector */
+        opal_output_verbose(10, ompi_ftmpi_output_handle,
+            "%s %s: Received heartbeat from %d, which is my own rank, this is a quit message to close the detector.",
+            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->from);
+        detector->hb_observing = MPI_PROC_NULL;
+        detector->hb_rstamp = INFINITY;
+        return false;
+    }
+
+    if( msg->from != detector->hb_observing ) {
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                             "%s %s: Received heartbeat from %d on communicator %3d:%d but I am now monitoring %d -- ignored.",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->from, comm->c_contextid, comm->c_epoch, detector->hb_observing ));
+    }
+    else {
+        double stamp = PMPI_Wtime();
+        double grace = detector->hb_timeout - (stamp - detector->hb_rstamp);
+        OPAL_OUTPUT_VERBOSE((9, ompi_ftmpi_output_handle,
+                             "%s %s: Received heartbeat from %d on communicator %3d:%d at timestamp %g (remained %.1e of %.1e before suspecting)",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->from, comm->c_contextid, comm->c_epoch, stamp-startdate, grace, detector->hb_timeout ));
+        detector->hb_rstamp = stamp;
+        if( grace < 0.0 ) {
+            opal_output_verbose(1, ompi_ftmpi_output_handle,
+                        "%s %s: MISSED ( %.1e )",
+                        OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, grace );
+            // complain? This is indicative of wrong assumptions on the
+            // timeout and possibly imperfect detector suspecting live processes
+        }
+    }
+    return false; /* never forward on the rbcast */
+}
+
+

--- a/ompi/communicator/ft/comm_ft_propagator.c
+++ b/ompi/communicator/ft/comm_ft_propagator.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "opal/mca/base/mca_base_var.h"
+
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/pml/pml.h"
+
+/* TODO: aggregation of multiple failures */
+typedef struct ompi_comm_failure_propagator_message_t {
+    ompi_comm_rbcast_message_t rbcast_msg;
+    ompi_process_name_t proc_name;
+    int proc_state;
+} ompi_comm_failure_propagator_message_t;
+
+static int ompi_comm_failure_propagator_local(ompi_communicator_t* comm,
+                                             ompi_comm_failure_propagator_message_t* msg);
+
+static int comm_failure_propagator_cb_type = -1;
+static bool comm_rbcast_enable = false;
+
+int ompi_comm_failure_propagator_register_params(void) {
+    (void) mca_base_var_register ("ompi", "mpi", "ft", "propagator_with_rbcast",
+                                  "Use the OMPI reliable broadcast failure propagator, or disable it and use only RTE propagation (slower)",
+                                  MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &comm_rbcast_enable);
+    return OMPI_SUCCESS;
+}
+
+
+int ompi_comm_failure_propagator_init(void) {
+    int ret;
+
+    if( !comm_rbcast_enable || !ompi_ftmpi_enabled ) return OMPI_SUCCESS;
+
+    ret = ompi_comm_rbcast_register_cb_type((ompi_comm_rbcast_cb_t)ompi_comm_failure_propagator_local);
+    if( 0 <= ret ) {
+        comm_failure_propagator_cb_type = ret;
+        return OMPI_SUCCESS;
+    }
+    return ret;
+}
+
+int ompi_comm_failure_propagator_finalize(void) {
+    int ret;
+    if( -1 == comm_failure_propagator_cb_type ) return OMPI_SUCCESS;
+    ret = ompi_comm_rbcast_unregister_cb_type(comm_failure_propagator_cb_type);
+    comm_failure_propagator_cb_type = -1;
+    return ret;
+}
+
+/**
+ * uplevel call from the error handler to initiate a failure_propagator
+ */
+int ompi_comm_failure_propagate(ompi_communicator_t* comm, ompi_proc_t* proc, int state) {
+    int ret = OMPI_SUCCESS;
+
+    if( -1 == comm_failure_propagator_cb_type ) return OMPI_SUCCESS;
+
+    OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                         "%s %s: Initiate a propagation for failure of %s (state %d) on communicator %3d:%d",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, OMPI_NAME_PRINT(&proc->super.proc_name), state, comm->c_contextid, comm->c_epoch ));
+
+    ompi_comm_failure_propagator_message_t msg;
+    /* Broadcast the 'failure_propagator' signal to all other processes. */
+    msg.rbcast_msg.cid   = comm->c_contextid;
+    msg.rbcast_msg.epoch = comm->c_epoch;
+    msg.rbcast_msg.type  = comm_failure_propagator_cb_type;
+    msg.proc_name        = proc->super.proc_name;
+    msg.proc_state       = state;
+    ret = ompi_comm_rbcast(comm, (ompi_comm_rbcast_message_t*)&msg, sizeof(msg));
+    return ret;
+}
+
+
+/* propagator_message reception callback: invoke the errmgr with the TERMINATED
+ * status
+ */
+static int ompi_comm_failure_propagator_local(ompi_communicator_t* comm, ompi_comm_failure_propagator_message_t* msg) {
+    ompi_proc_t* proc = (ompi_proc_t*)ompi_proc_for_name(msg->proc_name);
+    if( !ompi_proc_is_active(proc) ) {
+        OPAL_OUTPUT_VERBOSE((9, ompi_ftmpi_output_handle,
+                "%s %s: failure of %s has already been propagated on comm %3d:%d",
+                OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, OMPI_NAME_PRINT(&msg->proc_name), comm->c_contextid, comm->c_epoch));
+        return false; /* already propagated, done. */
+    }
+    OPAL_OUTPUT_VERBOSE((9, ompi_ftmpi_output_handle,
+            "%s %s: failure of %s needs to be propagated on comm %3d:%d",
+            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, OMPI_NAME_PRINT(&msg->proc_name), comm->c_contextid, comm->c_epoch));
+    ompi_errhandler_proc_failed_internal(proc, msg->proc_state, false);
+    return true;
+}
+

--- a/ompi/communicator/ft/comm_ft_reliable_bcast.c
+++ b/ompi/communicator/ft/comm_ft_reliable_bcast.c
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "opal/mca/base/mca_base_var.h"
+
+#include "ompi/runtime/params.h"
+#include "ompi/group/group.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/pml/pml.h"
+#include "ompi/mca/bml/bml.h"
+#include "ompi/mca/bml/base/base.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+
+static int ompi_comm_rbcast_null(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size) { return OMPI_SUCCESS; }
+static int ompi_comm_rbcast_bmg(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size);
+static int ompi_comm_rbcast_n2(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size);
+
+       int (*ompi_comm_rbcast)      (ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size) = ompi_comm_rbcast_null;
+static int (*ompi_comm_rbcast_fw)   (ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size) = ompi_comm_rbcast_null;
+
+
+static void ompi_rbcast_bml_send_complete_cb(
+        struct mca_btl_base_module_t* module,
+        struct mca_btl_base_endpoint_t* endpoint,
+        struct mca_btl_base_descriptor_t* descriptor,
+        int status);
+
+static void ompi_comm_rbcast_bml_recv_cb(
+        struct mca_btl_base_module_t* btl,
+        const mca_btl_base_receive_descriptor_t* descriptor);
+
+
+/* Broadcast a rbcast token to the appropriate neighbors in a BMG */
+static int ompi_comm_rbcast_bmg(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size) {
+    int me, np, ret = OMPI_SUCCESS;
+    int i,d;
+    ompi_group_t* lgrp, * hgrp = NULL;
+
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s %s: rbcast on communicator %3d:%d",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch ));
+
+    if( OMPI_COMM_IS_INTER(comm) ) {
+        int first = ompi_comm_determine_first_auto(comm);
+        np = ompi_comm_size(comm) + ompi_comm_remote_size(comm);
+        lgrp = first? comm->c_local_group: comm->c_remote_group;
+        hgrp = first? comm->c_remote_group: comm->c_local_group;
+        me = first? ompi_comm_rank(comm): ompi_comm_rank(comm)+ompi_comm_remote_size(comm);
+    }
+    else {
+        np = ompi_comm_size(comm);
+        lgrp = comm->c_local_group;
+        me = ompi_comm_rank(comm);
+    }
+
+    /* d is the direction, forward (1*2^i), then backward (-1*2^i) */
+    for(i = 1; i <= np/2; i *= 2) for(d = 1; d >= -1; d -= 2) {
+        ompi_proc_t* proc;
+        int idx = (np+me+d*i)%np;
+      redo:
+        if( idx == me ) continue;
+        if(OPAL_LIKELY( idx < ompi_group_size(lgrp) )) {
+            proc = ompi_group_peer_lookup(lgrp, idx);
+        }
+        else {
+            proc = ompi_group_peer_lookup(hgrp, idx-ompi_group_size(lgrp));
+        }
+        if( ompi_proc_is_active(proc) ) {
+            ret = ompi_comm_rbcast_send_msg(proc, msg, size);
+            if(OPAL_LIKELY( OMPI_SUCCESS == ret )) {
+                continue;
+            }
+            if(OPAL_UNLIKELY( OMPI_ERR_UNREACH != ret )) {
+                return ret;
+            }
+        }
+        if( i == 1 ) {
+            /* The ring is cut, find the closest alive neighbor in that
+             * direction */
+            idx = (np+idx+d)%np;
+            /* TODO: find a way to not send twice the message if idx is one of
+             * my neighbors for i>1 */
+            goto redo;
+        }
+    }
+    return OMPI_SUCCESS;
+}
+
+/* Broadcast a rbcast token to everybody (n^2 comms) */
+static int ompi_comm_rbcast_n2(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg, size_t size) {
+    int i, ret;
+    ompi_group_t* grp;
+
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s %s: rbcast on communicator %3d:%d",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch ));
+
+    /* send a message to all procs in local_group, then all procs in
+     * remote_group (if distinct) */
+    for(grp = comm->c_local_group;
+        grp != NULL;
+        grp = (grp != comm->c_remote_group)? comm->c_remote_group: NULL)
+      for(i = 0; i < ompi_group_size(grp); i++) {
+        ompi_proc_t* proc;
+
+        proc = ompi_group_peer_lookup(grp, i);
+        if( ompi_proc_local_proc == proc ) continue;
+        ret = ompi_comm_rbcast_send_msg(proc, msg, size);
+        if(OPAL_UNLIKELY( OMPI_SUCCESS != ret )) {
+            if(OPAL_UNLIKELY( OMPI_ERR_UNREACH != ret )) {
+                return ret;
+            }
+        }
+    }
+    return OMPI_SUCCESS;
+}
+
+/*
+ * registration of callbacks
+ */
+
+#define RBCAST_CB_TYPE_MAX 7
+static ompi_comm_rbcast_cb_t ompi_comm_rbcast_cb[RBCAST_CB_TYPE_MAX+1];
+
+int ompi_comm_rbcast_register_cb_type(ompi_comm_rbcast_cb_t callback) {
+    int i;
+    for(i = 0; i < RBCAST_CB_TYPE_MAX; i++) {
+        if( NULL == ompi_comm_rbcast_cb[i] ) {
+            ompi_comm_rbcast_cb[i] = callback;
+            return i;
+        }
+    }
+    return OMPI_ERR_OUT_OF_RESOURCE;
+}
+
+int ompi_comm_rbcast_unregister_cb_type(int type) {
+    if( RBCAST_CB_TYPE_MAX < type || 0 > type ) {
+        return OMPI_ERR_BAD_PARAM;
+    }
+    ompi_comm_rbcast_cb[type] = NULL;
+    return OMPI_SUCCESS;
+}
+
+/*
+ * BML HELPERS
+ */
+
+static void ompi_comm_rbcast_bml_recv_cb(
+        struct mca_btl_base_module_t* btl,
+        const mca_btl_base_receive_descriptor_t* descriptor)
+{
+    ompi_comm_rbcast_message_t* msg;
+    mca_btl_base_tag_t tag = descriptor->tag;
+    ompi_communicator_t* comm;
+
+    /* Parse the rbcast fragment */
+    assert( MCA_BTL_TAG_FT_RBCAST == tag );
+    assert( 1 == descriptor->des_segment_count );
+    assert( sizeof(ompi_comm_rbcast_message_t) <= descriptor->des_segments->seg_len );
+    msg = (ompi_comm_rbcast_message_t*) descriptor->des_segments->seg_addr.pval;
+
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s %s: Info: Recieved rbcast tag for communicator with CID %3d:%d",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch));
+
+    /* Find the target comm */
+    comm = (ompi_communicator_t *)ompi_comm_lookup(msg->cid);
+    if(OPAL_UNLIKELY( NULL == comm )) {
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                             "%s %s: Info: Could not find the communicator with CID %3d:%d",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch));
+        return;
+    }
+    if(OPAL_UNLIKELY( msg->cid != comm->c_contextid )) {
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                             "%s %s: Info: received a late rbcast message with CID %3d:%d during an MPI_COMM_DUP that is trying to reuse that CID (thus increasing the epoch) - ignoring, nothing to do",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch));
+        return;
+    }
+    /* Check if this is a delayed rbcast for an old communicator whose CID has been reused */
+    if(OPAL_UNLIKELY( comm->c_epoch != msg->epoch )) {
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+                             "%s %s: Info: Received a late rbcast order for the communicator with CID %3d:%d when is is now at epoch %d - ignoring, nothing to do",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, msg->cid, msg->epoch, comm->c_epoch));
+        return;
+    }
+
+    /* invoke the local registered callback for the type */
+    assert( 0 <= msg->type && RBCAST_CB_TYPE_MAX >= msg->type );
+    if( NULL != ompi_comm_rbcast_cb[msg->type] ) {
+        if( ompi_comm_rbcast_cb[msg->type](comm, msg) ) {
+            /* forward the rbcast */
+            ompi_comm_rbcast_fw(comm, msg, descriptor->des_segments->seg_len);
+        }
+    }
+    else {
+        /* During finalize, we loosly synchronize so it may happen 
+         * that we keep receiving messages after we deregistered the type.
+         * Any other time, this is indicative of a problem.
+         */
+        assert(ompi_mpi_state >= OMPI_MPI_STATE_FINALIZE_STARTED);
+    }
+}
+
+int ompi_comm_rbcast_send_msg(ompi_proc_t* proc, ompi_comm_rbcast_message_t* msg, size_t size) {
+    mca_bml_base_endpoint_t* endpoint = mca_bml_base_get_endpoint(proc);
+    assert( NULL != endpoint );
+    mca_bml_base_btl_t *bml_btl = mca_bml_base_btl_array_get_index(&endpoint->btl_eager, 0);
+    assert( NULL != bml_btl );
+    mca_btl_base_descriptor_t *des;
+    int ret;
+
+    if(!ompi_proc_is_active(proc)) {
+        opal_output_verbose(5, ompi_ftmpi_output_handle,
+            "%s %s: %s is dead, dropping rbcast for comm %3d:%d",
+            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, OMPI_NAME_PRINT(&proc->super.proc_name), msg->cid, msg->epoch);
+        return OMPI_ERR_UNREACH;
+    }
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+        "%s %s: preparing a fragment to %s to rbcast %3d:%d",
+        OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, OMPI_NAME_PRINT(&proc->super.proc_name), msg->cid, msg->epoch));
+    mca_bml_base_alloc(bml_btl, &des, MCA_BTL_NO_ORDER,
+                       size,
+                       MCA_BTL_DES_FLAGS_PRIORITY | MCA_BTL_DES_FLAGS_BTL_OWNERSHIP);
+    if(OPAL_UNLIKELY(NULL == des)) {
+        opal_output(ompi_ftmpi_output_handle,
+                    "%s %s: Error: bml_base_alloc failed.",
+                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__);
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+    assert( des->des_segments->seg_len == size ) ;
+    des->des_cbfunc = ompi_rbcast_bml_send_complete_cb;
+    memcpy(des->des_segments->seg_addr.pval, msg, size);
+    ret = mca_bml_base_send(bml_btl, des, MCA_BTL_TAG_FT_RBCAST);
+    if(OPAL_LIKELY( ret >= 0 )) {
+        if(OPAL_LIKELY( 1 == ret )) {
+            OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                "%s %s: fragment to %s to rbcast %3d:%d is on the wire",
+                OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, OMPI_NAME_PRINT(&proc->super.proc_name), msg->cid, msg->epoch));
+        }
+    }
+    else {
+        mca_bml_base_free(bml_btl, des);
+        OPAL_OUTPUT_VERBOSE((2, ompi_ftmpi_output_handle,
+            "%s %s: could not send a fragment to %s to rbcast %3d (status %d)",
+            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, OMPI_NAME_PRINT(&proc->super.proc_name), msg->cid, ret));
+            return ret;
+    }
+    return OMPI_SUCCESS;
+}
+
+static void ompi_rbcast_bml_send_complete_cb(
+        struct mca_btl_base_module_t* module,
+        struct mca_btl_base_endpoint_t* endpoint,
+        struct mca_btl_base_descriptor_t* descriptor,
+        int status)
+{
+    if(OPAL_UNLIKELY( OMPI_SUCCESS != status )) {
+        opal_output_verbose(2, ompi_ftmpi_output_handle,
+            "%s %s: status %d", OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, status);
+    }
+    else {
+        OPAL_OUTPUT_VERBOSE((91, ompi_ftmpi_output_handle,
+            "%s %s: status %d", OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, status));
+    }
+    return;
+}
+
+/*
+ * Init/Finalize
+ */
+
+static bool comm_rbcast_listener_started = false;
+static int rbcast = 1;
+
+
+int ompi_comm_rbcast_register_params(void) {
+    (void) mca_base_var_register ("ompi", "mpi", "ft", "reliable_bcast",
+                                  "Reliable Broadcast algorithm (1: Binomial Graph Diffusion; 2: N^2 full graph diffusion)",
+                                  MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY, &rbcast);
+    return OMPI_SUCCESS;
+}
+
+int ompi_comm_rbcast_init(void) {
+    int ret;
+
+    switch( rbcast ) {
+        case 0:
+            return OMPI_SUCCESS;
+        case 1:
+            ompi_comm_rbcast    = ompi_comm_rbcast_bmg;
+            ompi_comm_rbcast_fw = ompi_comm_rbcast_bmg;
+            break;
+        case 2:
+            ompi_comm_rbcast    = ompi_comm_rbcast_n2;
+            ompi_comm_rbcast_fw = ompi_comm_rbcast_n2;
+            break;
+        default:
+            return OMPI_ERR_BAD_PARAM;
+    }
+
+    if( comm_rbcast_listener_started ) {
+        return OMPI_SUCCESS;
+    }
+    ret = mca_bml.bml_register(MCA_BTL_TAG_FT_RBCAST, ompi_comm_rbcast_bml_recv_cb, NULL);
+    if( OMPI_SUCCESS == ret ) {
+        comm_rbcast_listener_started = true;
+    }
+    return ret;
+}
+
+int ompi_comm_rbcast_finalize(void) {
+    return OMPI_SUCCESS;
+}
+

--- a/ompi/communicator/ft/comm_ft_revoke.c
+++ b/ompi/communicator/ft/comm_ft_revoke.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2011-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/pml/pml.h"
+
+static int ompi_comm_revoke_local(ompi_communicator_t* comm,
+                                  ompi_comm_rbcast_message_t* msg);
+
+static int comm_revoke_cb_type = -1;
+
+int ompi_comm_revoke_init(void)
+{
+    int ret;
+
+    ret = ompi_comm_rbcast_register_cb_type(ompi_comm_revoke_local);
+    if( 0 <= ret ) {
+        comm_revoke_cb_type = ret;
+        return OMPI_SUCCESS;
+    }
+    return ret;
+}
+
+int ompi_comm_revoke_finalize(void)
+{
+    int ret;
+    ret = ompi_comm_rbcast_unregister_cb_type(comm_revoke_cb_type);
+    comm_revoke_cb_type = -1;
+    return ret;
+}
+
+/** MPI_Comm_revoke(comm)
+ * uplevel call from the API to initiate a revoke
+ */
+int ompi_comm_revoke_internal(ompi_communicator_t* comm)
+{
+    int ret = OMPI_SUCCESS;;
+
+    OPAL_OUTPUT_VERBOSE((1, ompi_ftmpi_output_handle,
+                         "%s %s: Initiate a revoke on communicator %3d:%d",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, comm->c_contextid, comm->c_epoch ));
+
+    /* Mark locally revoked */
+    if( ompi_comm_revoke_local(comm, NULL) ) {
+        /* Broadcast the 'revoke' signal to all other processes. */
+        ompi_comm_rbcast_message_t msg;
+        msg.cid   = comm->c_contextid;
+        msg.epoch = comm->c_epoch;
+        msg.type  = comm_revoke_cb_type;
+        ret = ompi_comm_rbcast(comm, &msg, sizeof(msg));
+    }
+    return ret;
+}
+
+
+/* internal code to revoke the communicator structure. Can be called from the
+ * API or from receiving a revoke message */
+static int ompi_comm_revoke_local(ompi_communicator_t* comm, ompi_comm_rbcast_message_t* msg)
+{
+    if( comm->comm_revoked ) {
+        OPAL_OUTPUT_VERBOSE((9, ompi_ftmpi_output_handle,
+                             "%s %s: comm %3d:%d is already revoked, nothing to do",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, comm->c_contextid, comm->c_epoch));
+        return false;
+    }
+    OPAL_OUTPUT_VERBOSE((9, ompi_ftmpi_output_handle,
+                         "%s %s: comm %3d:%d is marked revoked locally",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), __func__, comm->c_contextid, comm->c_epoch));
+    /*
+     * Locally revoke the communicator
+     *
+     * Just to be pedantic, as the 'revoke' condition is checked first
+     * by all other communication,
+     * - Turn off collectives
+     * - Turn off ANY_SOURCE receives
+     */
+    comm->any_source_enabled = false;
+    /* purge the communicator unexpected fragments and matching logic */
+    MCA_PML_CALL(revoke_comm(comm, false));
+    /* Signal the point-to-point stack to recheck requests */
+    wait_sync_global_wakeup(MPI_ERR_REVOKED);
+    return true;
+}
+

--- a/ompi/errhandler/errcode.c
+++ b/ompi/errhandler/errcode.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      University of Houston. All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2018 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -116,6 +117,11 @@ static ompi_mpi_errcode_t ompi_err_rma_flavor;
 static ompi_mpi_errcode_t ompi_err_rma_shared;
 static ompi_mpi_errcode_t ompi_t_err_invalid;
 static ompi_mpi_errcode_t ompi_t_err_invalid_name;
+#if OPAL_ENABLE_FT_MPI
+static ompi_mpi_errcode_t ompi_err_proc_fail_stop;
+static ompi_mpi_errcode_t ompi_err_proc_fail_pending;
+static ompi_mpi_errcode_t ompi_err_revoked;
+#endif
 
 static void ompi_mpi_errcode_construct(ompi_mpi_errcode_t* errcode);
 static void ompi_mpi_errcode_destruct(ompi_mpi_errcode_t* errcode);
@@ -227,6 +233,11 @@ int ompi_mpi_errcode_init (void)
     CONSTRUCT_ERRCODE( ompi_err_rma_shared, MPI_ERR_RMA_SHARED, "MPI_ERR_RMA_SHARED: Memory cannot be shared" );
     CONSTRUCT_ERRCODE( ompi_t_err_invalid, MPI_T_ERR_INVALID, "MPI_T_ERR_INVALID: Invalid use of the interface or bad parameter value(s)" );
     CONSTRUCT_ERRCODE( ompi_t_err_invalid_name, MPI_T_ERR_INVALID_NAME, "MPI_T_ERR_INVALID_NAME: The variable or category name is invalid" );
+#if OPAL_ENABLE_FT_MPI
+    CONSTRUCT_ERRCODE( ompi_err_proc_fail_stop,  MPI_ERR_PROC_FAILED,  "MPI_ERR_PROC_FAILED: Process Failure" );
+    CONSTRUCT_ERRCODE( ompi_err_proc_fail_pending,  MPI_ERR_PROC_FAILED_PENDING,  "MPI_ERR_PROC_FAILED_PENDING: Process Failure during an MPI_ANY_SOURCE non-blocking receive, request is still active" );
+    CONSTRUCT_ERRCODE( ompi_err_revoked,  MPI_ERR_REVOKED,  "MPI_ERR_REVOKED: Communication Object Revoked" );
+#endif
 
     /* Per MPI-3 p353:27-32, MPI_LASTUSEDCODE must be >=
        MPI_ERR_LASTCODE.  So just start it as == MPI_ERR_LASTCODE. */
@@ -326,6 +337,11 @@ int ompi_mpi_errcode_finalize(void)
     OBJ_DESTRUCT(&ompi_err_rma_shared);
     OBJ_DESTRUCT(&ompi_t_err_invalid);
     OBJ_DESTRUCT(&ompi_t_err_invalid_name);
+#if OPAL_ENABLE_FT_MPI
+    OBJ_DESTRUCT(&ompi_err_proc_fail_stop);
+    OBJ_DESTRUCT(&ompi_err_proc_fail_pending);
+    OBJ_DESTRUCT(&ompi_err_revoked);
+#endif
 
     OBJ_DESTRUCT(&ompi_mpi_errcodes);
     ompi_mpi_errcode_lastpredefined = 0;

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -452,6 +452,15 @@ static inline bool ompi_errhandler_is_intrinsic(ompi_errhandler_t *errhandler)
 
     return false;
 }
+
+#if OPAL_ENABLE_FT_MPI
+struct ompi_proc_t;
+
+OMPI_DECLSPEC int ompi_errhandler_proc_failed_internal(struct ompi_proc_t *ompi_proc, int status, bool forward);
+static inline int ompi_errhandler_proc_failed(struct ompi_proc_t* ompi_proc) {
+    return ompi_errhandler_proc_failed_internal(ompi_proc, OPAL_ERR_PROC_ABORTED, true);
+}
+#endif /* OPAL_ENABLE_FT_MPI */
 
 END_C_DECLS
 

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -162,9 +162,18 @@ int ompi_errhandler_request_invoke(int count,
     for (; i < count; ++i) {
         if (MPI_REQUEST_NULL != requests[i] &&
             MPI_SUCCESS != requests[i]->req_status.MPI_ERROR) {
+#if OPAL_ENABLE_FT_MPI
+            /* Special case for MPI_ANY_SOURCE when marked as
+             * MPI_ERR_PROC_FAILED_PENDING,
+             * This request should not be freed since it is still active. */
+            if( MPI_ERR_PROC_FAILED_PENDING != requests[i]->req_status.MPI_ERROR ) {
+                ompi_request_free(&(requests[i]));
+            }
+#else
             /* Ignore the error -- what are we going to do?  We're
                already going to invoke an error */
             ompi_request_free(&(requests[i]));
+#endif /* OPAL_ENABLE_FT_MPI */
         }
     }
 

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2020 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -595,6 +595,9 @@ enum {
     MPI_WIN_DISP_UNIT,
     MPI_WIN_CREATE_FLAVOR,
     MPI_WIN_MODEL,
+
+    /* MPI-4 */
+    MPI_FT, /* used by OPAL_ENABLE_FT_MPI */
 };
 
 /*
@@ -655,6 +658,7 @@ enum {
 #define MPI_ERR_UNSUPPORTED_DATAREP   51
 #define MPI_ERR_UNSUPPORTED_OPERATION 52
 #define MPI_ERR_WIN                   53
+
 #define MPI_T_ERR_MEMORY              54
 #define MPI_T_ERR_NOT_INITIALIZED     55
 #define MPI_T_ERR_CANNOT_INIT         56
@@ -676,6 +680,11 @@ enum {
 #define MPI_T_ERR_INVALID             72
 #define MPI_T_ERR_INVALID_NAME        73
 #define MPI_ERR_PROC_ABORTED          74
+
+/* not #if conditional on OPAL_ENABLE_FT_MPI for ABI */
+#define MPI_ERR_PROC_FAILED           75
+#define MPI_ERR_PROC_FAILED_PENDING   76
+#define MPI_ERR_REVOKED               77
 
 /* Per MPI-3 p349 47, MPI_ERR_LASTCODE must be >= the last predefined
    MPI_ERR_<foo> code. Set the last code to allow some room for adding

--- a/ompi/include/mpif-values.pl
+++ b/ompi/include/mpif-values.pl
@@ -242,6 +242,7 @@ $constants->{MPI_WIN_SIZE} = 8;
 $constants->{MPI_WIN_DISP_UNIT} = 9;
 $constants->{MPI_WIN_CREATE_FLAVOR} = 10;
 $constants->{MPI_WIN_MODEL} = 11;
+$constants->{MPI_FT} = 12;
 $constants->{MPI_WIN_FLAVOR_CREATE} = 1;
 $constants->{MPI_WIN_FLAVOR_ALLOCATE} = 2;
 $constants->{MPI_WIN_FLAVOR_DYNAMIC} = 3;
@@ -327,6 +328,11 @@ $constants->{MPI_ERR_SPAWN} = 50;
 $constants->{MPI_ERR_UNSUPPORTED_DATAREP} = 51;
 $constants->{MPI_ERR_UNSUPPORTED_OPERATION} = 52;
 $constants->{MPI_ERR_WIN} = 53;
+# these errors are MPI, but we keep it with high values
+# until standardized so as to avoid changing the ABI
+$constants->{MPI_ERR_PROC_FAILED} = 75;
+$constants->{MPI_ERR_PROC_FAILED_PENDING} = 76;
+$constants->{MPI_ERR_REVOKED} = 77;
 # these error codes will never be returned by a fortran function
 # since there are no fortran bindings for MPI_T
 $constants->{MPI_T_ERR_MEMORY} = 54;
@@ -421,7 +427,7 @@ my $header = '! -*- fortran -*-
 ! Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
 !                         University Research and Technology
 !                         Corporation.  All rights reserved.
-! Copyright (c) 2004-2010 The University of Tennessee and The University
+! Copyright (c) 2004-2016 The University of Tennessee and The University
 !                         of Tennessee Research Foundation.  All rights
 !                         reserved.
 ! Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -429,7 +435,7 @@ my $header = '! -*- fortran -*-
 ! Copyright (c) 2004-2005 The Regents of the University of California.
 !                         All rights reserved.
 ! Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
-! Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+! Copyright (c) 2009-2012 Oak Ridge National Labs.  All rights reserved.
 ! Copyright (c) 2016      Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! $COPYRIGHT$
@@ -483,7 +489,7 @@ my $output = '! WARNING! THIS IS A GENERATED FILE!!
 ! Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 !                         University Research and Technology
 !                         Corporation.  All rights reserved.
-! Copyright (c) 2004-2006 The University of Tennessee and The University
+! Copyright (c) 2004-2016 The University of Tennessee and The University
 !                         of Tennessee Research Foundation.  All rights
 !                         reserved.
 ! Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -492,7 +498,7 @@ my $output = '! WARNING! THIS IS A GENERATED FILE!!
 !                         All rights reserved.
 ! Copyright (c) 2007-2009 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
-! Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+! Copyright (c) 2009-2012 Oak Ridge National Labs.  All rights reserved.
 ! Copyright (c) 2009-2012 Los Alamos National Security, LLC.
 !                         All rights reserved.
 ! Copyright (c) 2016-2019 Research Organization for Information Science

--- a/ompi/mca/coll/base/Makefile.am
+++ b/ompi/mca/coll/base/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
 #                         Corporation.  All rights reserved.
-# Copyright (c) 2004-2015 The University of Tennessee and The University
+# Copyright (c) 2004-2020 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -46,3 +46,9 @@ libmca_coll_la_SOURCES += \
         base/coll_base_reduce_scatter_block.c \
         base/coll_base_exscan.c \
         base/coll_base_scan.c
+
+if WANT_FT_MPI
+libmca_coll_la_SOURCES += \
+        base/coll_base_agree_noft.c
+endif # WANT_FT_MPI
+

--- a/ompi/mca/coll/base/coll_base_agree_noft.c
+++ b/ompi/mca/coll/base/coll_base_agree_noft.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2012-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "opal/util/bit_ops.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/coll/base/coll_base_functions.h"
+
+int
+ompi_coll_base_agree_noft(void *contrib,
+                         int dt_count,
+                         struct ompi_datatype_t *dt,
+                         struct ompi_op_t *op,
+                         struct ompi_group_t **group, bool update_grp,
+                         struct ompi_communicator_t* comm,
+                         struct mca_coll_base_module_2_3_0_t *module)
+{
+    return comm->c_coll->coll_allreduce(MPI_IN_PLACE, contrib, dt_count, dt, op,
+                                       comm, comm->c_coll->coll_allreduce_module);
+}
+
+int
+ompi_coll_base_iagree_noft(void *contrib,
+                          int dt_count,
+                          struct ompi_datatype_t *dt,
+                          struct ompi_op_t *op,
+                          struct ompi_group_t **group, bool update_grp,
+                          struct ompi_communicator_t* comm,
+                          ompi_request_t **request,
+                          struct mca_coll_base_module_2_3_0_t *module)
+{
+    return comm->c_coll->coll_iallreduce(MPI_IN_PLACE, contrib, dt_count, dt, op,
+                                        comm, request, comm->c_coll->coll_iallreduce_module);
+}

--- a/ompi/mca/coll/base/coll_base_comm_select.c
+++ b/ompi/mca/coll/base/coll_base_comm_select.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -13,8 +13,8 @@
  * Copyright (c) 2007      Lawrence Livermore National Security, LLC.  All
  *                         rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Laboratory.  All rights reserved.
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2012      Oak Ridge National Laboratory.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014      Research Organization for Information Science
@@ -224,6 +224,11 @@ int mca_coll_base_comm_select(ompi_communicator_t * comm)
             COPY(avail->ac_module, comm, neighbor_alltoallw_init);
 
             COPY(avail->ac_module, comm, reduce_local);
+
+#if OPAL_ENABLE_FT_MPI
+            COPY(avail->ac_module, comm, agree);
+            COPY(avail->ac_module, comm, iagree);
+#endif
         } else {
             /* release the original module reference and the list item */
             OBJ_RELEASE(avail->ac_module);

--- a/ompi/mca/coll/base/coll_base_comm_unselect.c
+++ b/ompi/mca/coll/base/coll_base_comm_unselect.c
@@ -2,14 +2,14 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2012      Oak Rigde National Laboratory.
+ * Copyright (c) 2010-2012 Oak Ridge National Laboratory.
  *                         All rights reserved.
  * Copyright (c) 2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
@@ -127,6 +127,11 @@ int mca_coll_base_comm_unselect(ompi_communicator_t * comm)
     CLOSE(comm, neighbor_alltoallw_init);
 
     CLOSE(comm, reduce_local);
+
+#if OPAL_ENABLE_FT_MPI
+    CLOSE(comm, agree);
+    CLOSE(comm, iagree);
+#endif
 
     for (item = opal_list_remove_first(comm->c_coll->module_list);
          NULL != item; item = opal_list_remove_first(comm->c_coll->module_list)) {

--- a/ompi/mca/coll/base/coll_tags.h
+++ b/ompi/mca/coll/base/coll_tags.h
@@ -2,13 +2,15 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ *
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +26,13 @@
  * implementing collectives via point-to-point.
  */
 
+/* a set of special tags: */
+/*  to recognize an MPI_Comm_join in the comm_connect_accept routine. */
+#define OMPI_COMM_ALLGATHER_TAG -7
+#define OMPI_COMM_BARRIER_TAG   -8
+#define OMPI_COMM_ALLREDUCE_TAG -9
+
+#define MCA_COLL_BASE_TAG_BLOCKING_BASE -7
 #define MCA_COLL_BASE_TAG_ALLGATHER -10
 #define MCA_COLL_BASE_TAG_ALLGATHERV -11
 #define MCA_COLL_BASE_TAG_ALLREDUCE -12
@@ -41,10 +50,27 @@
 #define MCA_COLL_BASE_TAG_SCAN -24
 #define MCA_COLL_BASE_TAG_SCATTER -25
 #define MCA_COLL_BASE_TAG_SCATTERV -26
-#define MCA_COLL_BASE_TAG_NONBLOCKING_BASE -27
+#define MCA_COLL_BASE_TAG_BLOCKING_END -26
+
+/* not #if conditional on OPAL_ENABLE_FT_MPI for ABI */
+#define MCA_COLL_BASE_TAG_FT_BASE                (MCA_COLL_BASE_TAG_BLOCKING_END - 1)
+#define MCA_COLL_BASE_TAG_SHRINK                 (MCA_COLL_BASE_TAG_FT_BASE - 1)
+#define MCA_COLL_BASE_TAG_AGREEMENT              (MCA_COLL_BASE_TAG_FT_BASE - 2)
+/* one extra reserved to avoid revoke for normal reqs, see request/req_ft.c*/
+#define MCA_COLL_BASE_TAG_FT_END                 (MCA_COLL_BASE_TAG_FT_BASE - 3)
+
+#define MCA_COLL_BASE_TAG_STATIC_END             MCA_COLL_BASE_TAG_FT_END
+
+
+
+#define MCA_COLL_BASE_TAG_NONBLOCKING_BASE (MCA_COLL_BASE_TAG_STATIC_END - 1)
 #define MCA_COLL_BASE_TAG_NONBLOCKING_END ((-1 * INT_MAX/2) + 1)
 #define MCA_COLL_BASE_TAG_NEIGHBOR_BASE  (MCA_COLL_BASE_TAG_NONBLOCKING_END - 1)
 #define MCA_COLL_BASE_TAG_NEIGHBOR_END   (MCA_COLL_BASE_TAG_NEIGHBOR_BASE - 1024)
 #define MCA_COLL_BASE_TAG_HCOLL_BASE (-1 * INT_MAX/2)
 #define MCA_COLL_BASE_TAG_HCOLL_END (-1 * INT_MAX)
+
+#define MCA_COLL_BASE_TAG_BASE MCA_COLL_BASE_TAG_BLOCKING_BASE
+#define MCA_COLL_BASE_TAG_END  MCA_COLL_BASE_TAG_HCOLL_END
+
 #endif /* MCA_COLL_BASE_TAGS_H */

--- a/ompi/mca/coll/basic/coll_basic_module.c
+++ b/ompi/mca/coll/basic/coll_basic_module.c
@@ -3,13 +3,14 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2016 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
@@ -134,6 +135,12 @@ mca_coll_basic_comm_query(struct ompi_communicator_t *comm,
     basic_module->super.coll_neighbor_alltoallw = mca_coll_basic_neighbor_alltoallw;
 
     basic_module->super.coll_reduce_local = mca_coll_base_reduce_local;
+
+#if OPAL_ENABLE_FT_MPI
+    /* Default to some shim mappings over allreduce */
+    basic_module->super.coll_agree   = ompi_coll_base_agree_noft;
+    basic_module->super.coll_iagree  = ompi_coll_base_iagree_noft;
+#endif
 
     return &(basic_module->super);
 }

--- a/ompi/mca/coll/ftagree/Makefile.am
+++ b/ompi/mca/coll/ftagree/Makefile.am
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2012-2020 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        coll_ftagree.h \
+        coll_ftagree_component.c \
+        coll_ftagree_module.c \
+        coll_ftagree.c \
+        coll_ftagree_era.h \
+        coll_ftagree_earlyreturning.c \
+        coll_ftagree_earlyterminating.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_ompi_coll_ftagree_DSO
+component_noinst =
+component_install = mca_coll_ftagree.la
+else
+component_noinst = libmca_coll_ftagree.la
+component_install =
+endif
+
+mcacomponentdir = $(pkglibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_coll_ftagree_la_SOURCES = $(sources)
+mca_coll_ftagree_la_LDFLAGS = -module -avoid-version
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_coll_ftagree_la_SOURCES =$(sources)
+libmca_coll_ftagree_la_LDFLAGS = -module -avoid-version

--- a/ompi/mca/coll/ftagree/coll_ftagree.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree.c
@@ -1,0 +1,41 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2012-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/constants.h"
+#include "opal/util/bit_ops.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/base/base.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/proc/proc.h"
+
+#include "ompi/mca/coll/ftagree/coll_ftagree.h"
+#include "ompi/mca/coll/ftagree/coll_ftagree_era.h"
+
+/*************************************
+ * Local Functions
+ *************************************/
+
+/*************************************
+ * Agreement Object Support
+ *************************************/
+static void mca_coll_ftagree_construct(mca_coll_ftagree_t *v_info)
+{
+    v_info->agreement_seq_num = 0;
+}
+
+OBJ_CLASS_INSTANCE(mca_coll_ftagree_t,
+                   opal_object_t,
+                   mca_coll_ftagree_construct,
+                   NULL);
+

--- a/ompi/mca/coll/ftagree/coll_ftagree.h
+++ b/ompi/mca/coll/ftagree/coll_ftagree.h
@@ -1,0 +1,160 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2012-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef MCA_COLL_FTAGREE_EXPORT_H
+#define MCA_COLL_FTAGREE_EXPORT_H
+
+#include "ompi_config.h"
+
+#include "opal/mca/mca.h"
+
+#include "opal/class/opal_bitmap.h"
+#include "opal/class/opal_free_list.h"
+
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/request/request.h"
+#include "ompi/group/group.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/op/op.h"
+#include "ompi/datatype/ompi_datatype.h"
+
+BEGIN_C_DECLS
+
+/* Globally exported variables */
+
+OMPI_MODULE_DECLSPEC extern const mca_coll_base_component_2_0_0_t
+mca_coll_ftagree_component;
+extern int mca_coll_ftagree_priority;
+
+enum mca_coll_ftagree_algorithm_t {
+    COLL_FTAGREE_NOFT = 0,
+    COLL_FTAGREE_EARLY_RETURNING   = 1,
+    COLL_FTAGREE_EARLY_TERMINATION = 2
+};
+typedef enum mca_coll_ftagree_algorithm_t mca_coll_ftagree_algorithm_t;
+
+extern mca_coll_ftagree_algorithm_t mca_coll_ftagree_algorithm;
+extern int mca_coll_ftagree_era_rebuild;
+
+/* Define this to enable testing random failures in various
+ * places in Agree. This can be used to harden the agreement 
+ * against failures that happen at various places between
+ * message events.
+ */
+#if !defined(OPAL_ENABLE_DEBUG)
+#undef FTAGREE_DEBUG_FAILURE_INJECT
+#endif
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+extern double mca_coll_ftagree_debug_inject_proba;
+#endif
+
+/*
+ * Base agreement structure
+ * Individual agreement algorithms will extend this struct as needed
+ */
+struct mca_coll_ftagree_t {
+    /* This is a general object */
+    opal_object_t super;
+
+    /* Agreement Sequence Number */
+    int agreement_seq_num;
+};
+typedef struct mca_coll_ftagree_t mca_coll_ftagree_t;
+OBJ_CLASS_DECLARATION(mca_coll_ftagree_t);
+
+struct mca_coll_ftagree_module_t {
+    mca_coll_base_module_t super;
+
+    /* Array of requests */
+    ompi_request_t **mccb_reqs;
+    int mccb_num_reqs;
+
+    /* Array of statuses */
+    ompi_status_public_t *mccb_statuses;
+    int mccb_num_statuses;
+
+    /* Pointer to the agreement structure */
+    mca_coll_ftagree_t *agreement_info;
+};
+typedef struct mca_coll_ftagree_module_t mca_coll_ftagree_module_t;
+OBJ_CLASS_DECLARATION(mca_coll_ftagree_module_t);
+
+/*
+ * API functions
+ */
+int mca_coll_ftagree_init_query(bool enable_progress_threads,
+                                bool enable_mpi_threads);
+mca_coll_base_module_t
+*mca_coll_ftagree_comm_query(struct ompi_communicator_t *comm,
+                             int *priority);
+
+int mca_coll_ftagree_module_enable(mca_coll_base_module_t *module,
+                                   struct ompi_communicator_t *comm);
+
+int mca_coll_ftagree_ft_event(int status);
+
+/*
+ * Agreement algorithms
+ */
+
+/* Early termination algorithm */
+int
+mca_coll_ftagree_eta_intra(     void* contrib,
+                                int dt_count,
+                                ompi_datatype_t *dt,
+                                ompi_op_t *op,
+                                ompi_group_t **group, bool grp_update,
+                                ompi_communicator_t* comm,
+                                mca_coll_base_module_t *module);
+/* Early returning algorithm */
+int
+mca_coll_ftagree_era_intra(     void* contrib,
+                                int dt_count,
+                                ompi_datatype_t *dt,
+                                ompi_op_t *op,
+                                ompi_group_t **group, bool grp_update,
+                                ompi_communicator_t* comm,
+                                mca_coll_base_module_t *module);
+int mca_coll_ftagree_iera_intra(void* contrib,
+                                int dt_count,
+                                ompi_datatype_t *dt,
+                                ompi_op_t *op,
+                                ompi_group_t **group, bool grp_update,
+                                ompi_communicator_t* comm,
+                                ompi_request_t **request,
+                                mca_coll_base_module_t *module);
+int mca_coll_ftagree_era_inter( void* contrib,
+                                int dt_count,
+                                ompi_datatype_t *dt,
+                                ompi_op_t *op,
+                                ompi_group_t **group, bool grp_update,
+                                ompi_communicator_t* comm,
+                                mca_coll_base_module_t *module);
+
+/*
+ * Utility functions
+ */
+static inline void mca_coll_ftagree_free_reqs(ompi_request_t ** reqs,
+                                              int count)
+{
+    int i;
+    for (i = 0; i < count; ++i) {
+        if( OMPI_REQUEST_INVALID != reqs[i]->req_state ) {
+            ompi_request_free(&reqs[i]);
+        }
+    }
+}
+
+END_C_DECLS
+
+#endif /* MCA_COLL_FTAGREE_EXPORT_H */

--- a/ompi/mca/coll/ftagree/coll_ftagree_component.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_component.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2012-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "ompi_config.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/ftagree/coll_ftagree.h"
+#include "ompi/mca/coll/ftagree/coll_ftagree_era.h"
+
+
+/*
+ * Public string showing the coll ompi_ftagree component version number
+ */
+const char *mca_coll_ftagree_component_version_string =
+    "Open MPI ftagree collective MCA component version " OMPI_VERSION;
+
+/*
+ * Global variables
+ */
+int mca_coll_ftagree_priority  = 0;
+mca_coll_ftagree_algorithm_t mca_coll_ftagree_algorithm = COLL_FTAGREE_EARLY_RETURNING;
+int mca_coll_ftagree_cur_era_topology = 1;
+int mca_coll_ftagree_era_rebuild = 0;
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+double mca_coll_ftagree_debug_inject_proba = 0.0;
+#endif
+
+/*
+ * Local function
+ */
+static int ftagree_register(void);
+static int ftagree_close(void);
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+
+const mca_coll_base_component_2_0_0_t mca_coll_ftagree_component = {
+
+    /* First, the mca_component_t struct containing meta information
+     * about the component itself */
+
+    {
+     MCA_COLL_BASE_VERSION_2_0_0,
+
+     /* Component name and version */
+     "ftagree",
+     OMPI_MAJOR_VERSION,
+     OMPI_MINOR_VERSION,
+     OMPI_RELEASE_VERSION,
+
+     /* Component open and close functions */
+     NULL,
+     ftagree_close,
+     NULL,
+     ftagree_register
+    },
+    {
+        /* The component is checkpoint ready */
+        MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+
+    /* Initialization / querying functions */
+
+    mca_coll_ftagree_init_query,
+    mca_coll_ftagree_comm_query
+};
+
+static int
+ftagree_close(void)
+{
+    if( mca_coll_ftagree_algorithm ==  COLL_FTAGREE_EARLY_RETURNING ) {
+        return mca_coll_ftagree_era_finalize();
+    }
+    return OMPI_SUCCESS;
+}
+
+static int
+ftagree_register(void)
+{
+    int value;
+
+    /* Use a low priority, but allow other components to be lower */
+    mca_coll_ftagree_priority = 30;
+    (void) mca_base_component_var_register(&mca_coll_ftagree_component.collm_version,
+                                           "priority", "Priority of the ftagree coll component",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_6,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_ftagree_priority);
+
+    if( ompi_ftmpi_enabled ) value = 1;
+    else value = 0; /* NOFT: do not initialize ERA */
+    (void) mca_base_component_var_register(&mca_coll_ftagree_component.collm_version,
+                                           "agreement", "Agreement algorithm 0: Allreduce (NOT FAULT TOLERANT); 1: Early Returning Concensus (era); 2: Early Terminating Concensus (eta)",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_6,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &value);
+    switch(value) {
+    case 0:
+        mca_coll_ftagree_algorithm = COLL_FTAGREE_NOFT;
+        opal_output_verbose(6, ompi_ftmpi_output_handle,
+                            "%s ftagree:register) Agreement Algorithm - Allreduce (NOT FAULT TOLERANT)",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME) );
+        break;
+    default:  /* Includes the valid case 1 */
+        mca_coll_ftagree_algorithm = COLL_FTAGREE_EARLY_RETURNING;
+        opal_output_verbose(6, ompi_ftmpi_output_handle,
+                            "%s ftagree:register) Agreement Algorithm - Early Returning Consensus Algorithm",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME) );
+        break;
+    case 2:
+        mca_coll_ftagree_algorithm = COLL_FTAGREE_EARLY_TERMINATION;
+        opal_output_verbose(6, ompi_ftmpi_output_handle,
+                            "%s ftagree:register) Agreement Algorithm - Early Terminating Consensus Algorithm",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME) );
+        break;
+    }
+
+    mca_coll_ftagree_cur_era_topology = 1;
+    (void) mca_base_component_var_register(&mca_coll_ftagree_component.collm_version,
+                                           "era_topology", "ERA topology 1: binary tree; 2: star tree; 3: string tree",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_6,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_ftagree_cur_era_topology);
+
+    /* TODO: add an adaptative rebuilding strategy */
+    mca_coll_ftagree_era_rebuild = 0; /* by default do not rebuild, master-worker application patterns can benefit greatly from rebuilding... */
+    (void) mca_base_component_var_register(&mca_coll_ftagree_component.collm_version,
+                                           "era_rebuild", "ERA rebuild/rebalance the tree in a first post-failure agreement 0: no rebalancing; 1: rebalance all the time",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_6,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_ftagree_era_rebuild);
+
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+    mca_coll_ftagree_rank_fault_proba = 0.0; /* by default, inject no faults */
+    (void) mca_base_component_var_register(&mca_coll_ftagree_component.collm_version,
+                                           "era_debug_fault_proba", "Inject faults with set probability at points of interest in the Agreement algorithm; For debugging only. (0.: no faults, 1.: always inject; 0.05 is typical)",
+                                           MCA_BASE_VAR_TYPE_DOUBLE, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_coll_ftagree_rank_fault_proba);
+#endif /* FTAGREE_DEBUG_FAILURE_INJECT */
+
+    return OMPI_SUCCESS;
+}
+
+
+static void
+mca_coll_ftagree_module_construct(mca_coll_ftagree_module_t *module)
+{
+    module->mccb_reqs = NULL;
+    module->mccb_num_reqs = 0;
+
+    module->mccb_statuses = NULL;
+    module->mccb_num_statuses = 0;
+
+    /* This object is managed by the agreement operation selected */
+    module->agreement_info = NULL;
+}
+
+static void
+mca_coll_ftagree_module_destruct(mca_coll_ftagree_module_t *module)
+{
+
+    /* Finalize the agreement function */
+    if( ompi_ftmpi_enabled ) {
+        switch( mca_coll_ftagree_algorithm ) {
+        case COLL_FTAGREE_EARLY_RETURNING:
+            mca_coll_ftagree_era_comm_finalize(module);
+            break;
+        default:
+            break;
+        }
+    }
+
+    /* This object is managed by the agreement operation selected */
+    module->agreement_info = NULL;
+
+    if (NULL != module->mccb_reqs) {
+        free(module->mccb_reqs);
+        module->mccb_reqs = NULL;
+    }
+
+    if( NULL != module->mccb_statuses ) {
+        free(module->mccb_statuses);
+        module->mccb_statuses = NULL;
+    }
+}
+
+
+OBJ_CLASS_INSTANCE(mca_coll_ftagree_module_t,
+                   mca_coll_base_module_t,
+                   mca_coll_ftagree_module_construct,
+                   mca_coll_ftagree_module_destruct);

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyreturning.c
@@ -1,0 +1,3371 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2014-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "opal/class/opal_free_list.h"
+#include "opal/mca/btl/btl.h"
+
+#include "ompi/constants.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/datatype/ompi_datatype_internal.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/bml/bml.h"
+#include "ompi/op/op.h"
+#include "ompi/mca/bml/base/base.h"
+
+#include "coll_ftagree.h"
+#include "coll_ftagree_era.h"
+
+
+extern int mca_coll_ftagree_cur_era_topology;
+
+static int era_inited = 0;
+static opal_hash_table_t era_passed_agreements;
+static opal_hash_table_t era_ongoing_agreements;
+static opal_hash_table_t era_incomplete_messages;
+static ompi_comm_rank_failure_callback_t *ompi_stacked_rank_failure_callback_fct = NULL;
+static uint64_t msg_seqnum = 1;
+static opal_free_list_t era_iagree_requests = {{{0}}};
+
+typedef enum {
+    MSG_UP = 1,
+    MSG_DOWN,
+    MSG_RESULT_REQUEST
+} era_msg_type_t;
+
+/**
+ * This enum defines the status of processes
+ * when the consensus has not been decided yet
+ */
+enum {
+    /* These values are for the current process */
+    NOT_CONTRIBUTED = 1,
+    GATHERING,
+    BROADCASTING,
+    COMPLETED
+};
+typedef uint32_t era_proc_status_t;
+#define OP_NOT_DEFINED     (1<<31)
+
+typedef struct {
+    union {
+        /** Order is performance critical:
+         *   Hash tables (as of June 11, 2014) consider only the lower x bits for
+         *   hash value (key & mask). As a consequence, having mostly stable entries
+         *   like epoch or contextid at the low part of the 64bits key anihilates the
+         *   performance of the hash tables. The most varying 16 bits should be kept
+         *   first (assuming little endian).
+         */
+        struct {
+            uint16_t agreementid;
+            uint16_t contextid;    /**< Although context ids are 32 bit long, only the lower 16 bits are used */
+            uint32_t epoch;
+        } fields;
+        uint64_t uint64;
+    } u;
+} era_identifier_t;
+
+static inline uint64_t hash_name(opal_process_name_t name) {
+    /** Order is performance critical:
+      *   Hash tables (as of June 11, 2014) consider only the lower x bits for
+      *   hash value (key & mask). As a consequence, having mostly stable entries
+      *   like epoch or contextid at the low part of the 64bits key anihilates the
+      *   performance of the hash tables. The most varying 16 bits should be kept
+      *   first (assuming little endian).
+      */
+    union {
+        struct {
+            uint16_t vpidlo;
+            uint16_t vpidhi;
+            uint32_t jobid;
+        } fields;
+        uint64_t uint64;
+    } hash;
+
+    hash.fields.vpidlo = name.vpid;
+    hash.fields.vpidhi = name.vpid>>16;
+    hash.fields.jobid = name.jobid;
+    return hash.uint64;
+}
+
+#define ERAID_KEY    u.uint64
+#define ERAID_FIELDS u.fields
+
+
+typedef struct {
+    int32_t  ret;                            /**< Return code */
+    uint16_t min_aid;                        /**< Used for garbage collection */
+    uint16_t max_aid;                        /**< at era_agreement_value_set_gcrange, forall this->header.min_aid <= id <= this->header.max_aid,
+                                              *     exists p in era_passed_agreements, such that
+                                              *       (this->agreement_id.contextid == key(p).contextid &&
+                                              *        this->agreement_id.epoch     == key(p).epoch &&
+                                              *        key(p).agreementid           == id)
+                                              *   at era_decide, min_passed_aid is the max over all ranks, max_passed_aid is
+                                              *   min over all ranks. */
+    int      operand;                        /**< operand applied on bytes.
+                                              *   One of OMPI_OP_BASE_FORTRAN_* values in mca/op/op.h */
+    int      dt_count;                       /**< The number of datatypes in bytes */
+    int      datatype;                       /**< Fortran index of predefined basic datatype in bytes */
+    int      nb_new_dead;                    /**< Number of newly discovered dead */
+} era_value_header_t;
+#define ERA_VALUE_BYTES_COUNT(_h) (((ompi_datatype_t*)opal_pointer_array_get_item(&ompi_datatype_f_to_c_table, (_h)->datatype))->super.size * (_h)->dt_count)
+
+/* This is the non-linearized version of the era_value_t */
+typedef struct {
+    opal_object_t        super;
+    era_value_header_t   header;
+    uint8_t             *bytes;              /**< array of size datatype_size(header.datatype) * header.dt_count
+                                              *   containing the value on which the agreement is done */
+    int                 *new_dead_array;     /**< array of header.nb_new_dead integers with the newly discovered
+                                              *   processes. */
+} era_value_t;
+
+static void  era_value_constructor (era_value_t *value)
+{
+    value->header.ret = 0;
+    value->header.operand = -1;
+    value->header.dt_count = -1;
+    value->header.datatype = -1;
+    value->header.nb_new_dead = -1;
+    value->header.min_aid = (uint16_t)-1;
+    value->header.max_aid = 0;
+    value->bytes = NULL;
+    value->new_dead_array = NULL;
+}
+
+static void  era_value_destructor (era_value_t *value)
+{
+    if( NULL != value->bytes )
+        free(value->bytes);
+    if( NULL != value->new_dead_array )
+        free(value->new_dead_array);
+}
+
+OBJ_CLASS_INSTANCE(era_value_t, opal_object_t, era_value_constructor, era_value_destructor);
+
+typedef struct {
+    era_msg_type_t      msg_type;
+    era_identifier_t    agreement_id;
+
+    /** We give the source ID as both the rank in the communicator
+     *  and the proc_name_t, because 90% of the time, the receiver
+     *  will understand what the rank means and this is a faster
+     *  operation than using the proc_name, but 10% of the time
+     *  the receiver will not understand what the rank means
+     *  and it needs to answer.
+     */
+    int                 src_comm_rank;
+    opal_process_name_t src_proc_name;
+    era_value_header_t  agreement_value_header;
+    int                 nb_ack;         /**< Informs how many of these messages types
+                                         *   will be sent upward (in case ack_failed must
+                                         *   be split in multiple messages. */
+} era_msg_header_t;
+#define ERA_MSG_SIZE(_h, _n) ( sizeof(era_msg_header_t) + ERA_VALUE_BYTES_COUNT(_h) + (_h)->nb_new_dead * sizeof(int) + (_n) * sizeof(int) )
+
+typedef struct {
+    unsigned int        bytes_received;
+    uint8_t             bytes[];
+} era_incomplete_msg_t;
+
+typedef struct {
+    opal_process_name_t       src;  /**< src + msg_seqnum build a unique (up to rotation on msg_seqnum) */
+    uint64_t           msg_seqnum;  /*   message identifier.*/
+    unsigned int          msg_len;  /**< Length of the message */
+    unsigned int      frag_offset;  /**< Offset (in bytes) of the fragment in the message */
+    unsigned int         frag_len;  /**< Length (in bytes) of that fragment */
+    uint8_t              bytes[];  /**< Variable size member, of length frag_len */
+} era_frag_t;
+
+/**
+ * Rank lists are used at variable places to keep track of who sent information.
+ */
+typedef struct {
+    opal_list_item_t super;
+    int32_t          rank;        /**< The rank of the descendent that provided information */
+} era_rank_item_t;
+
+OBJ_CLASS_INSTANCE(era_rank_item_t, opal_list_item_t, NULL, NULL /*print_destructor*/);
+
+/**
+ * topology-dependent tree structure
+ */
+typedef struct era_tree_s era_tree_t;
+
+struct era_tree_s {
+    int rank_in_comm;
+    int parent;
+    int next_sibling;
+    int first_child;
+};
+
+/**
+ * Communicator-specific Agreement persistent information
+ */
+#define AGS_TREE_DIRTY (1<<0)
+#define AGS_AFR_DIRTY  (1<<1)
+typedef struct era_comm_agreement_specific_s {
+    opal_object_t parent;
+    int          *agreed_failed_ranks;
+    int           afr_size;
+    era_tree_t   *tree;
+    int           tree_size;
+    int           acked_ra_size;
+    int          *acked_ra;
+    int           ags_status;
+} era_comm_agreement_specific_t;
+
+static void  era_agreement_comm_specific_constructor(era_comm_agreement_specific_t *comm_specific)
+{
+    comm_specific->agreed_failed_ranks = NULL;
+    comm_specific->afr_size            = 0;
+    comm_specific->tree                = NULL;
+    comm_specific->tree_size           = 0;
+    comm_specific->acked_ra            = NULL;
+    comm_specific->acked_ra_size       = 0;
+    comm_specific->ags_status          = AGS_TREE_DIRTY | AGS_AFR_DIRTY; /**< the AGS does not exist, so it needs to be created */
+}
+
+static void  era_agreement_comm_specific_destructor(era_comm_agreement_specific_t *comm_specific)
+{
+    if( NULL != comm_specific->agreed_failed_ranks ) {
+        free(comm_specific->agreed_failed_ranks );
+    }
+    if( NULL != comm_specific->tree ) {
+        free(comm_specific->tree);
+    }
+    if( NULL != comm_specific->acked_ra ) {
+        free(comm_specific->acked_ra);
+    }
+}
+
+OBJ_CLASS_INSTANCE(era_comm_agreement_specific_t,
+                   opal_object_t,
+                   era_agreement_comm_specific_constructor,
+                   era_agreement_comm_specific_destructor);
+
+#define AGS(comm)  ( (era_comm_agreement_specific_t*)(comm)->agreement_specific )
+
+/* This mutex is used for both thread safety and to prevent recursive
+ * invocation of ERA callbacks; ERA callbacks are not reentrant. Hence,
+ * all accesses to the mutex shall be using the lower-case variants
+ * (always compiled-in) of the mutex ops.
+ *
+ * The mutex is not recursive, everytime a recursive take of the mutex is
+ * possible, it should be using a trylock and bounce the event if the mutex is
+ * taken. The only place where it is safe to block in mutex_lock is from the
+ * upper level (i.e., the interface with MPI_Comm_agree in prepare_agreement).
+ */
+static opal_mutex_t era_mutex;
+/* This second mutex is used for fine-grain thread safety when accessing the
+ * incomplete_msg hash-table. This mutex may be taken from within the era_mutex,
+ * and should thus be released in the same function scope to avoid double mutex
+ * interlock.
+ */
+static opal_mutex_t era_incomplete_msg_mutex;
+
+
+typedef struct era_iagree_request_s era_iagree_request_t;
+
+/**
+ * Main structure to remember the current status of an agreement that
+ *  was started.
+ */
+typedef struct {
+    opal_object_t         super;
+    era_identifier_t      agreement_id;
+    era_value_t          *current_value;
+    era_proc_status_t     status;            /**< status of this process in that agreement. */
+    uint16_t              min_passed_aid;
+    ompi_communicator_t  *comm;              /**< Communicator related to that agreement. Might be NULL
+                                              *   if this process has not entered the agreement yet.*/
+    era_iagree_request_t *req;               /**< Request, if this is called through an iagree */
+    era_comm_agreement_specific_t *ags;      /**< Communicator-specific agreement information, at
+                                              *   the time this agreement was started (might be different
+                                              *   from comm->ags during the agreement) */
+    int                   nb_acked;          /**< size of acked */
+    int                  *acked;             /**< Last acknowledged processes when entering
+                                              *   the agreement. Used to compare with the descendents
+                                              *   acknowledged processes */
+    opal_list_t           gathered_info;     /**< The list of direct descendents that provided information (even partially) */
+    opal_list_t           waiting_res_from;  /**< A list of ranks and status, from which we requested to "restart" the
+                                              *   consensus (if the current process became root in the middle of one) */
+    opal_list_t           early_requesters;  /**< Remember anybody who requests to receive the decision as
+                                              *   the FD may be too slow to provide a symmetric view of the world,
+                                              *   and passing over the passed agreements after the decision is taken
+                                              *   is too slow */
+    int                   waiting_down_from; /**< If in BROADCAST state: who is supposed to send me the info */
+} era_agreement_info_t;
+
+static void era_build_tree_structure(era_agreement_info_t *ci);
+static int era_next_child(era_agreement_info_t *ci, int prev_child_in_comm);
+static int era_parent(era_agreement_info_t *ci);
+
+static void  era_agreement_info_constructor (era_agreement_info_t *agreement_info)
+{
+    agreement_info->agreement_id.ERAID_KEY = 0;
+    agreement_info->status = NOT_CONTRIBUTED | OP_NOT_DEFINED;
+    agreement_info->comm = NULL;
+    agreement_info->waiting_down_from = -1;
+    agreement_info->nb_acked = 0;
+    agreement_info->current_value = NULL;
+    agreement_info->acked = NULL;
+    agreement_info->req = NULL;
+
+    OBJ_CONSTRUCT(&agreement_info->gathered_info, opal_list_t);
+    OBJ_CONSTRUCT(&agreement_info->waiting_res_from, opal_list_t);
+    OBJ_CONSTRUCT(&agreement_info->early_requesters, opal_list_t);
+    OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Constructing Agreement Info %p\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         (void*)agreement_info));
+}
+
+static void  era_agreement_info_destructor (era_agreement_info_t *agreement_info)
+{
+    opal_list_item_t *li;
+    while( NULL != (li = opal_list_remove_first(&agreement_info->early_requesters)) ) {
+        OBJ_RELEASE(li);
+    }
+    OBJ_DESTRUCT(&agreement_info->early_requesters);
+    while( NULL != (li = opal_list_remove_first(&agreement_info->gathered_info)) ) {
+        OBJ_RELEASE(li);
+    }
+    OBJ_DESTRUCT(&agreement_info->gathered_info);
+    while( NULL != (li = opal_list_remove_first(&agreement_info->waiting_res_from)) ) {
+        OBJ_RELEASE(li);
+    }
+    OBJ_DESTRUCT(&agreement_info->waiting_res_from);
+    if( NULL != agreement_info->comm ) {
+        OBJ_RELEASE(agreement_info->comm);
+    }
+    if( NULL != agreement_info->acked ) {
+        free(agreement_info->acked);
+        agreement_info->acked = NULL;
+        agreement_info->nb_acked = 0;
+    }
+    if( NULL != agreement_info->current_value ) {
+        OBJ_RELEASE( agreement_info->current_value );
+        agreement_info->current_value = NULL;
+    }
+    agreement_info->req = NULL;
+}
+
+OBJ_CLASS_INSTANCE(era_agreement_info_t,
+                   opal_object_t,
+                   era_agreement_info_constructor,
+                   era_agreement_info_destructor);
+
+struct era_iagree_request_s {
+    ompi_request_t        super;
+    era_identifier_t      agreement_id;
+    void                 *contrib;
+    ompi_group_t        **outgroup;
+    era_agreement_info_t *ci;
+};
+
+OBJ_CLASS_INSTANCE(era_iagree_request_t,
+                   ompi_request_t,
+                   NULL,
+                   NULL);
+
+#if OPAL_ENABLE_DEBUG
+static const char *era_status_to_string(era_proc_status_t s) {
+    switch(s & ~OP_NOT_DEFINED) {
+    case NOT_CONTRIBUTED:
+        if( s & OP_NOT_DEFINED ) {
+            return "NOT_CONTRIBUTED | OP_NOT_DEFINED";
+        }
+        else {
+            return "NOT_CONTRIBUTED";
+        }
+    case GATHERING:
+        if( s & OP_NOT_DEFINED ) {
+            return "GATHERING | OP_NOT_DEFINED";
+        }
+        else {
+            return "GATHERING";
+        }
+    case BROADCASTING:
+        if( s & OP_NOT_DEFINED ) {
+            return "BROADCASTING | OP_NOT_DEFINED";
+        }
+        else {
+            return "BROADCASTING";
+        }
+    case COMPLETED:
+        if( s & OP_NOT_DEFINED ) {
+            return "COMPLETED | OP_NOT_DEFINED";
+        }
+        else {
+            return "COMPLETED";
+        }
+    }
+    return "UNDEFINED STATUS";
+}
+
+static const char *era_msg_type_to_string(int type) {
+    switch(type) {
+    case MSG_UP:
+        return "UP";
+    case MSG_DOWN:
+        return "DOWN";
+    case MSG_RESULT_REQUEST:
+        return "RESULT REQUEST";
+    }
+    return "UNDEFINED MESSAGE TYPE";
+}
+#endif /* OPAL_ENABLE_DEBUG */
+
+static era_agreement_info_t *era_lookup_agreement_info(era_identifier_t agreement_id)
+{
+    void *value;
+
+    if( opal_hash_table_get_value_uint64(&era_ongoing_agreements,
+                                         agreement_id.ERAID_KEY,
+                                         &value) == OPAL_SUCCESS ) {
+        return (era_agreement_info_t *)value;
+    } else {
+        return NULL;
+    }
+}
+
+static era_agreement_info_t *era_create_agreement_info(era_identifier_t agreement_id, era_value_header_t *header)
+{
+    era_agreement_info_t *ci;
+    int r;
+    size_t value_bytes;
+#if OPAL_ENABLE_DEBUG
+    void *value;
+    assert( opal_hash_table_get_value_uint64(&era_ongoing_agreements,
+                                             agreement_id.ERAID_KEY,
+                                             &value) != OPAL_SUCCESS );
+#endif /* OPAL_ENABLE_DEBUG */
+    ci = OBJ_NEW(era_agreement_info_t);
+    ci->agreement_id.ERAID_KEY = agreement_id.ERAID_KEY;
+    ci->current_value = OBJ_NEW(era_value_t);
+    memcpy(&ci->current_value->header, header, sizeof(era_value_header_t));
+
+    assert( header->datatype >= 0 && header->datatype < OMPI_DATATYPE_MPI_MAX_PREDEFINED );
+    /* ci->current_value->bytes will be filled up in combine_agreement_value, but let's allocate it here */
+    value_bytes = ERA_VALUE_BYTES_COUNT(&ci->current_value->header);
+    if( value_bytes > 0 ) {
+        ci->current_value->bytes = (uint8_t*)malloc( value_bytes );
+    }
+    if( header->nb_new_dead > 0 ) {
+        ci->current_value->new_dead_array = (int*)malloc(header->nb_new_dead * sizeof(int));
+        for(r = 0; r < header->nb_new_dead; r++)
+            ci->current_value->new_dead_array[r] = -1;
+    }
+    opal_hash_table_set_value_uint64(&era_ongoing_agreements,
+                                     agreement_id.ERAID_KEY,
+                                     ci);
+    return ci;
+}
+
+#if OPAL_ENABLE_DEBUG
+static void era_debug_print_group(int lvl, ompi_group_t *group, ompi_communicator_t *comm, char *info)
+{
+    int *gra = NULL;
+    int *cra = NULL;
+    int i, n, s, p;
+    char *str;
+
+    if( (n = ompi_group_size(group)) > 0 ) {
+        gra = (int*)malloc( n * sizeof(int) );
+        for(i = 0; i < n; i++)
+            gra[i] = i;
+        cra = (int*)malloc( n * sizeof(int) );
+        ompi_group_translate_ranks(group, n, gra, comm->c_local_group, gra);
+    }
+    s = 128 + n * 16;
+    str = (char*)malloc(s);
+    sprintf(str, "Group of size %d. Ranks in %d.%d: (", n, comm->c_contextid, comm->c_epoch);
+    p = strlen(str);
+    for(i = 0; i < n; i++) {
+        snprintf(str + p, s - p, "%d%s", gra[i], i==n-1 ? "" : ", ");
+        p = strlen(str);
+    }
+    snprintf(str + p, s-p, ")");
+    OPAL_OUTPUT_VERBOSE((lvl, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) %s: %s\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         info,
+                         str));
+    free(str);
+    if( NULL != cra )
+        free(cra);
+    if( NULL != gra )
+        free(gra);
+}
+#else /* OPAL_ENABLE_DEBUG */
+#define era_debug_print_group(g, c, i, h) do {} while(0)
+#endif /* OPAL_ENABLE_DEBUG */
+
+static void era_update_return_value(era_agreement_info_t *ci, int nb_acked, int *acked) {
+    ompi_group_t *ack_after_agreement_group, *tmp_sub_group;
+    int r, abag_array[3];
+
+    /* Simplest case: some children has decided MPI_ERR_PROC_FAILED already
+     * OR I had children during the run, and they died and were not acknowledged before I entered
+     * the agreement (see era_mark_process_failed). Then, the return value was set by
+     * era_combine_agreement_values or era_mark_process_failed
+     */
+    if( ci->current_value->header.ret == MPI_ERR_PROC_FAILED ) {
+        OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) compute local return value for Agreement ID = (%d.%d).%d: already decided FAILED at line %s:%d\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid,
+                             __FILE__, __LINE__));
+        return;
+    }
+
+    if( nb_acked >= 0 ) {
+
+#if OPAL_ENABLE_DEBUG
+        for(r = 1; r < nb_acked; r++) {
+            assert(acked[r-1] < acked[r]);
+        }
+#endif /*OPAL_ENABLE_DEBUG*/
+
+        /* I'm checking w.r.t. children or myself */
+        if( ci->acked == NULL ) {
+            /** I have not set my contribution yet, let's consider this as the base */
+            if(nb_acked > 0) {
+                ci->acked = (int*)malloc(nb_acked * sizeof(int));
+                memcpy(ci->acked, acked, nb_acked * sizeof(int));
+            }
+            ci->nb_acked = nb_acked;
+        } else {
+            /** This contribution and mine must match exactly */
+            if( nb_acked != ci->nb_acked ) {
+                OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ERA) compute local return value for Agreement ID = (%d.%d).%d: decide FAILED because the acked arrays are of different size\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     ci->agreement_id.ERAID_FIELDS.contextid,
+                                     ci->agreement_id.ERAID_FIELDS.epoch,
+                                     ci->agreement_id.ERAID_FIELDS.agreementid));
+                ci->current_value->header.ret = MPI_ERR_PROC_FAILED;
+                goto cleanup;
+            }
+
+            if( nb_acked == 0 ) {
+                return;
+            }
+            for(r = 0; r < nb_acked; r++) {
+                /** Both arrays should be globally ordered */
+                if( acked[r] != ci->acked[r] ) {
+                    OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                                         "%s ftagree:agreement (ERA) compute local return value for Agreement ID = (%d.%d).%d: decide FAILED because the acked arrays do not hold the same elements\n",
+                                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                         ci->agreement_id.ERAID_FIELDS.contextid,
+                                         ci->agreement_id.ERAID_FIELDS.epoch,
+                                         ci->agreement_id.ERAID_FIELDS.agreementid));
+                    ci->current_value->header.ret = MPI_ERR_PROC_FAILED;
+                    goto cleanup;
+                }
+            }
+        }
+
+        return;
+    }
+
+    /** This is the final check: if I reach this point, I acknowledged the same failures
+     *  as my children, and no failure prevented us to move forward. However, if I noticed
+     *  a failure in the communicator that has not been acknowledged, I must still report
+     *  an ERR_PROC_FAILED. */
+
+    opal_mutex_lock(&ompi_group_afp_mutex);
+    ompi_group_t *afp = ompi_group_all_failed_procs;
+    OBJ_RETAIN(afp);
+    opal_mutex_unlock(&ompi_group_afp_mutex);
+
+    if( ompi_group_size(afp) > ci->nb_acked ) {
+        /* New failures have been reported since I started the agreement */
+        ack_after_agreement_group = OBJ_NEW(ompi_group_t);
+        tmp_sub_group = OBJ_NEW(ompi_group_t);
+        abag_array[0] = 0;
+        /** this is >=0 since ompi_group_size(afp) > ci->nb_acked >= 0 */
+        abag_array[1] = ompi_group_size(afp) - 1;
+        abag_array[2] = 1;
+        ompi_group_range_incl(afp, 1, &abag_array, &tmp_sub_group);
+        ompi_group_intersection(tmp_sub_group,
+                                ci->comm->c_local_group,
+                                &ack_after_agreement_group);
+        OBJ_RELEASE(tmp_sub_group);
+
+        if( ompi_group_size(ack_after_agreement_group) != ci->nb_acked ) {
+            OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                                 "%s ftagree:agreement (ERA) compute local return value for Agreement ID = (%d.%d).%d: decide FAILED because new failures happened: |acked| = %d, |afp on c_local_group| = %d\n",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                 ci->agreement_id.ERAID_FIELDS.contextid,
+                                 ci->agreement_id.ERAID_FIELDS.epoch,
+                                 ci->agreement_id.ERAID_FIELDS.agreementid,
+                                 ci->nb_acked,
+                                 ompi_group_size(ack_after_agreement_group)));
+            ci->current_value->header.ret = MPI_ERR_PROC_FAILED;
+            OBJ_RELEASE(afp);
+            goto cleanup;
+        } else {
+            OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                                 "%s ftagree:agreement (ERA) compute local return value for Agreement ID = (%d.%d).%d: decide SUCCESS (1)\n",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                 ci->agreement_id.ERAID_FIELDS.contextid,
+                                 ci->agreement_id.ERAID_FIELDS.epoch,
+                                 ci->agreement_id.ERAID_FIELDS.agreementid));
+        }
+        OBJ_RELEASE(ack_after_agreement_group);
+    } else {
+        OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) compute local return value for Agreement ID = (%d.%d).%d: decide SUCCESS (2)\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid));
+    }
+
+    OBJ_RELEASE(afp);
+    assert(ci->current_value->header.ret == MPI_SUCCESS);
+    return; /** < We don't clean the list of acked processes if the result is SUCCESS as we need to communicate it */
+
+ cleanup:
+    if( ci->nb_acked > 0 ) {
+        assert(NULL != ci->acked);
+        free(ci->acked);
+        ci->acked = NULL;
+        ci->nb_acked = 0;
+    }
+}
+
+static int compare_ints(const void *a, const void *b)
+{
+    const int *ia = (const int *)a;
+    const int *ib = (const int *)b;
+    return (*ia > *ib) - (*ia < *ib);
+}
+
+static int compare_uint16_ts(const void *a, const void *b)
+{
+    const uint16_t *ia = (const uint16_t *)a;
+    const uint16_t *ib = (const uint16_t *)b;
+    return (*ia > *ib) - (*ia < *ib);
+}
+
+static void era_merge_new_dead_list(era_agreement_info_t *ci, int nb_src, int *src)
+{
+    int  s;
+    int *dst, d, nb_dst;
+    int *merge, nb_merge;
+
+    dst = ci->current_value->new_dead_array;
+    nb_dst = ci->current_value->header.nb_new_dead;
+
+#if OPAL_ENABLE_DEBUG
+        {
+            for(d = 1; d < nb_dst; d++) {
+                assert(dst[d-1] < dst[d]);
+            }
+            for(s = 1; s < nb_src; s++) {
+                assert(src[s-1] < src[s]);
+            }
+        }
+#endif /*OPAL_ENABLE_DEBUG*/
+
+    if(nb_dst + nb_src == 0) return;
+    merge = (int*)malloc((nb_dst + nb_src) * sizeof(int));
+    nb_merge = 0;
+    d = 0;
+    s = 0;
+    while(d < nb_dst && s < nb_src) {
+        assert( (NULL == ci->comm) || (dst[d] != ci->comm->c_local_group->grp_my_rank) );
+        assert( (NULL == ci->comm) || (src[s] != ci->comm->c_local_group->grp_my_rank) );
+        if( dst[d] == src[s] ) {
+            merge[nb_merge++] = dst[d];
+            d++;
+            s++;
+            continue;
+        } else if( dst[d] < src[s] ) {
+            merge[nb_merge++] = dst[d];
+            d++;
+            continue;
+        } else {
+            assert( dst[d] > src[s] );
+            merge[nb_merge++] = src[s];
+            s++;
+            continue;
+        }
+    }
+    while( d < nb_dst ) {
+        assert( (ci->comm == NULL) || (dst[d] != ci->comm->c_local_group->grp_my_rank) );
+        merge[nb_merge++] = dst[d++];
+    }
+    while( s < nb_src ) {
+        assert( (ci->comm == NULL) || (src[s] != ci->comm->c_local_group->grp_my_rank) );
+        merge[nb_merge++] = src[s++];
+    }
+
+    if( nb_merge > nb_dst ) {
+        ci->current_value->new_dead_array = (int*)realloc(ci->current_value->new_dead_array, nb_merge*sizeof(int));
+        memcpy(ci->current_value->new_dead_array, merge, nb_merge * sizeof(int));
+        ci->current_value->header.nb_new_dead = nb_merge;
+    }
+    free(merge);
+}
+
+static void era_agreement_value_set_gcrange(era_identifier_t eid, era_value_t *era_value)
+{
+    uint16_t *aid_list = NULL;
+    uint64_t key64;
+    size_t i;
+    void *value, *node;
+    size_t    aid_list_size = 0, aid_list_pos = 0;
+    int rc;
+
+    /* Deal with garbage collection management: find a contiguous range of
+     *  agreements that have been decided. */
+    for( rc = opal_hash_table_get_first_key_uint64(&era_passed_agreements, &key64, &value, &node);
+         OPAL_SUCCESS == rc;
+         rc = opal_hash_table_get_next_key_uint64(&era_passed_agreements, &key64, &value, node, &node) ) {
+        era_identifier_t pid;
+        pid.ERAID_KEY = key64;
+        assert(0 != pid.ERAID_FIELDS.agreementid);
+
+        if( pid.ERAID_FIELDS.contextid == eid.ERAID_FIELDS.contextid &&
+            pid.ERAID_FIELDS.epoch     == eid.ERAID_FIELDS.epoch ) {
+            if( aid_list_pos == aid_list_size ) {
+                aid_list_size = aid_list_size > 0 ? 2*aid_list_size : 1;
+                aid_list = (uint16_t*)realloc(aid_list, aid_list_size * sizeof(uint16_t));
+            }
+            aid_list[aid_list_pos++] = pid.ERAID_FIELDS.agreementid;
+        }
+    }
+    if( aid_list_pos > 0 ) {
+        if( aid_list_pos > 1 ) {
+            qsort(aid_list, aid_list_pos, sizeof(uint16_t), compare_uint16_ts);
+        }
+        era_value->header.min_aid = aid_list[0];
+        for(i = 1; i < aid_list_pos; i++) {
+            if( aid_list[i] != aid_list[i-1] + 1 ) {
+                break;
+            }
+        }
+        era_value->header.max_aid = aid_list[i-1];
+        free(aid_list);
+    }
+    OPAL_OUTPUT_VERBOSE((17, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) GC: agreement (%d.%d).%d: agreements %u to %u have been locally acknowledged\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         eid.ERAID_FIELDS.contextid,
+                         eid.ERAID_FIELDS.epoch,
+                         eid.ERAID_FIELDS.agreementid,
+                         era_value->header.min_aid,
+                         era_value->header.max_aid));
+
+}
+
+static void era_update_new_dead_list(era_agreement_info_t *ci)
+{
+    int *ra, s, r, t;
+    era_comm_agreement_specific_t *ags;
+    ompi_communicator_t *comm;
+
+    comm = ci->comm;
+    ags  = AGS(comm);
+    assert(ags->afr_size >= 0); /**< I should be working on an ags still attached to the communicator */
+
+    /** Worst case: all processes minus me are dead */
+    if( ompi_group_size(comm->c_local_group) == 1 ) return;
+    ra = (int*)malloc( (ompi_group_size(comm->c_local_group) - 1) * sizeof(int) );
+    t = 0;
+    r = 0;
+    for(s = 0; s < ompi_group_size(comm->c_local_group); s++) {
+        if( t < ags->afr_size && ags->agreed_failed_ranks[t] == s ) {
+            t++;
+            continue;
+        }
+        if( !ompi_comm_is_proc_active(comm, s, false) ) {
+            ra[r++] = s;
+        }
+    }
+
+    OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) agreement (%d.%d).%d -- adding %d procs to the list of newly dead processes",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         ci->agreement_id.ERAID_FIELDS.contextid,
+                         ci->agreement_id.ERAID_FIELDS.epoch,
+                         ci->agreement_id.ERAID_FIELDS.agreementid,
+                         r));
+
+#if OPAL_ENABLE_DEBUG
+    {
+        int _i, _j;
+        for(_i = 0; _i < r; _i++) {
+            assert( ra[_i] != comm->c_local_group->grp_my_rank );
+            for(_j = _i+1; _j < r; _j++)
+                assert(ra[_i] < ra[_j]);
+        }
+        for(_i = 0; _i < ags->afr_size; _i++) {
+            assert( ags->agreed_failed_ranks[_i] != comm->c_local_group->grp_my_rank );
+            for(_j = 0; _j < r; _j++)
+                assert(ra[_j] != ags->agreed_failed_ranks[_i]);
+        }
+    }
+#endif /* OPAL_ENABLE_DEBUG */
+
+    era_merge_new_dead_list(ci, r, ra);
+
+    free(ra);
+}
+
+static void era_ci_get_clean_ags_copy(era_agreement_info_t *ci)
+{
+    era_comm_agreement_specific_t *old, *new;
+
+    if( AGS(ci->comm)->ags_status & (AGS_TREE_DIRTY | AGS_AFR_DIRTY) ) {
+        old = AGS(ci->comm);
+
+        if( AGS(ci->comm)->parent.obj_reference_count > 1 ) {
+            /** Not only ci->comm points to this AGS at this time.
+             *  This means that some other ci points to it, so it's unsafe to
+             *  reuse it: create a copy for the other cis that point to it,
+             *  and attach that new copy to the communicator, then update it.
+             */
+            new = OBJ_NEW(era_comm_agreement_specific_t);
+            if( old->afr_size > 0 ) {
+                /** old does not need to remember the agreed_failed ranks, avoid allocating memory */
+                new->agreed_failed_ranks = old->agreed_failed_ranks;
+                new->afr_size            = old->afr_size;
+
+                old->agreed_failed_ranks = NULL;
+                old->afr_size            = -1;
+            }
+            /* Do not rebuild the tree if not dirty */
+            new->ags_status = old->ags_status;
+            if( ! ( new->ags_status & AGS_TREE_DIRTY ) ) {
+                new->tree_size = old->tree_size;
+                new->tree = (era_tree_t*)malloc(new->tree_size * sizeof(era_tree_t));
+                memcpy(new->tree, old->tree, new->tree_size * sizeof(era_tree_t));
+            }
+
+            ci->comm->agreement_specific = &new->parent;
+
+            old->ags_status = 0; /**< The old is clean w.r.t. the tree, and it does not need the AFR */
+            OBJ_RELEASE(old);
+        }
+
+    }
+
+    ci->ags = AGS(ci->comm);
+    OBJ_RETAIN(ci->ags);
+
+    OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: the tree structure is %s, the AFR is %s\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         ci->agreement_id.ERAID_FIELDS.contextid,
+                         ci->agreement_id.ERAID_FIELDS.epoch,
+                         ci->agreement_id.ERAID_FIELDS.agreementid,
+                         ci->ags->ags_status & AGS_TREE_DIRTY ? "dirty" : "clean",
+                         ci->ags->ags_status & AGS_AFR_DIRTY ? "dirty" : "clean"));
+
+    if( ci->ags->ags_status & AGS_TREE_DIRTY ) {
+        era_build_tree_structure(ci);
+        ci->ags->ags_status &= ~AGS_TREE_DIRTY;
+    }
+
+    if( ci->ags->ags_status & AGS_AFR_DIRTY ) {
+        era_update_new_dead_list(ci);
+        ci->ags->ags_status &= ~AGS_AFR_DIRTY;
+    }
+}
+
+static void era_agreement_info_set_comm(era_agreement_info_t *ci, ompi_communicator_t *comm, ompi_group_t *acked_group)
+{
+    int *src_ra;
+    int r, grp_size;
+
+    assert( comm->c_contextid == ci->agreement_id.ERAID_FIELDS.contextid );
+    assert( comm->c_epoch     == ci->agreement_id.ERAID_FIELDS.epoch     );
+    assert( ci->comm          == NULL                                    );
+    ci->comm = comm;
+    OBJ_RETAIN(comm);
+
+    OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: assigning to communicator %d\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         ci->agreement_id.ERAID_FIELDS.contextid,
+                         ci->agreement_id.ERAID_FIELDS.epoch,
+                         ci->agreement_id.ERAID_FIELDS.agreementid,
+                         comm->c_contextid));
+
+    if( AGS(comm) == NULL ) {
+        era_comm_agreement_specific_t *ags = OBJ_NEW(era_comm_agreement_specific_t);
+        comm->agreement_specific = &ags->parent;
+    }
+
+    /* Update the return value based on local knowledge of 'acknowleged' ranks */
+    grp_size = ompi_group_size(acked_group);
+    if( grp_size > 0 ) {
+        if( grp_size != AGS(comm)->acked_ra_size ) {
+            AGS(comm)->acked_ra      = (int*)realloc(AGS(comm)->acked_ra, grp_size * sizeof(int));
+            AGS(comm)->acked_ra_size = grp_size;
+            src_ra = (int*)malloc(grp_size * sizeof(int));
+            for(r = 0; r < grp_size; r++) {
+                src_ra[r] = r;
+            }
+            ompi_group_translate_ranks(acked_group, grp_size, src_ra, comm->c_local_group, AGS(comm)->acked_ra);
+            free(src_ra);
+            /** acked_ra must be sorted */
+            qsort(AGS(comm)->acked_ra, grp_size, sizeof(int), compare_ints);
+        }
+    }
+    era_update_return_value(ci, grp_size, AGS(comm)->acked_ra);
+
+    era_ci_get_clean_ags_copy(ci);
+}
+
+int mca_coll_ftagree_era_comm_init(ompi_communicator_t *comm, mca_coll_ftagree_module_t *module)
+{
+    mca_coll_ftagree_t *comm_ag_info;
+
+    comm_ag_info = OBJ_NEW(mca_coll_ftagree_t);
+    comm_ag_info->agreement_seq_num = 0;
+
+    module->agreement_info = comm_ag_info;
+
+    return OMPI_SUCCESS;
+}
+
+int mca_coll_ftagree_era_comm_finalize(mca_coll_ftagree_module_t *module)
+{
+    mca_coll_ftagree_t *comm_ag_info;
+    comm_ag_info = module->agreement_info;
+    OBJ_RELEASE(comm_ag_info);
+    return OMPI_SUCCESS;
+}
+
+static void send_msg(ompi_communicator_t *comm,
+                     int dst,
+                     opal_process_name_t *proc_name,
+                     era_identifier_t agreement_id,
+                     era_msg_type_t type,
+                     era_value_t *value,
+                     int          nb_up_msg,
+                     int         *ack_failed);
+
+#define ERA_TAG_AGREEMENT MCA_COLL_BASE_TAG_AGREEMENT
+
+static void era_combine_agreement_values(era_agreement_info_t *ni, era_value_t *value)
+{
+    ompi_op_t *op;
+    ompi_datatype_t *dt;
+
+    if( ni->status & OP_NOT_DEFINED ) {
+        ni->current_value->header.operand = value->header.operand;
+        ni->current_value->header.dt_count = value->header.dt_count;
+        ni->current_value->header.datatype = value->header.datatype;
+        if( ERA_VALUE_BYTES_COUNT(&value->header) > 0 ) {
+            memcpy(ni->current_value->bytes, value->bytes, ERA_VALUE_BYTES_COUNT(&value->header));
+        }
+        ni->current_value->header.ret = value->header.ret;
+        ni->current_value->header.min_aid = value->header.min_aid;
+        ni->current_value->header.max_aid = value->header.max_aid;
+        ni->status &= ~OP_NOT_DEFINED;
+    } else {
+        assert( ni->current_value->header.operand == value->header.operand );
+        assert( ni->current_value->header.dt_count == value->header.dt_count );
+        assert( ni->current_value->header.datatype == value->header.datatype );
+        op = opal_pointer_array_get_item(ompi_op_f_to_c_table,
+                                         ni->current_value->header.operand);
+        assert(NULL != op);
+        dt = opal_pointer_array_get_item(&ompi_datatype_f_to_c_table,
+                                         ni->current_value->header.datatype);
+        assert(NULL != dt); assert(dt->d_f_to_c_index == ni->current_value->header.datatype);
+        if( ni->current_value->header.dt_count > 0 ) {
+            ompi_op_reduce( op, value->bytes, ni->current_value->bytes,
+                            ni->current_value->header.dt_count, dt);
+        }
+        if( value->header.ret > ni->current_value->header.ret )
+            ni->current_value->header.ret = value->header.ret;
+
+        if( value->header.min_aid > ni->current_value->header.min_aid )
+            ni->current_value->header.min_aid = value->header.min_aid;
+        if( value->header.max_aid < ni->current_value->header.max_aid )
+            ni->current_value->header.max_aid = value->header.max_aid;
+    }
+
+    era_merge_new_dead_list(ni, value->header.nb_new_dead, value->new_dead_array);
+}
+
+
+#if OPAL_ENABLE_DEBUG
+static int tree_errors;
+
+static int era_tree_check_node(era_tree_t *tree, int tree_size, int r, int display)
+{
+    int c, nb = 0, p;
+
+    if(display) {
+        fprintf(stderr, "TC %s -- %d/%d (%d) -- Parent: %d\n",
+                OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), r, tree_size, tree[r].rank_in_comm,
+                tree[r].parent);
+    }
+
+    if( (p = tree[r].parent) != r ) {
+
+        for(c = tree[p].first_child;
+            c != r && c!=tree_size;
+            c = tree[c].next_sibling) {
+            /** Nothing */
+        }
+        if( c != r ) {
+            tree_errors++;
+            fprintf(stderr, "TC %s -- %d/%d(%d): my parent (%d) should have me in one of its children\n",
+                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), r, tree_size, tree[r].rank_in_comm, tree[r].parent);
+        }
+    }
+
+    if( tree[r].rank_in_comm <
+        tree[ tree[r].parent ].rank_in_comm ) {
+        tree_errors++;
+        fprintf(stderr, "TC %s -- %d/%d(%d): broken hiearchy as my parent is %d in the communicator\n",
+                OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), r, tree_size, tree[r].rank_in_comm, tree[tree[r].parent].rank_in_comm);
+    }
+
+    for(c = tree[r].first_child;
+        c != tree_size;
+        c = tree[c].next_sibling) {
+        nb++;
+        if( display ) {
+            fprintf(stderr, "TC %s -- %d/%d(%d) -- Child %d: %d\n",
+                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), r, tree_size, tree[r].rank_in_comm,
+                    nb, c);
+        }
+        if( tree[c].parent != r) {
+            tree_errors++;
+            fprintf(stderr, "TC %s -- %d/%d(%d): Each of my children should have me as their parent. %d has %d as parent.\n",
+                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), r, tree_size, tree[r].rank_in_comm, c,  tree[c].parent);
+        }
+        if( nb > tree_size ) {
+            tree_errors++;
+            fprintf(stderr, "TC %s -- %d/%d(%d): There is a cycle somewhere: I counted %d children, which is more than the tree size.\n",
+                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), r, tree_size, tree[r].rank_in_comm, nb);
+            break;
+        }
+    }
+
+    if(display) {
+        fprintf(stderr, "\n");
+    }
+
+    return nb;
+}
+
+static void era_tree_check(era_tree_t *tree, int tree_size, int display)
+{
+    /** Tree consistency check */
+    int root = 0;
+    int children = 0;
+    int nodes = 0;
+    int r;
+
+    tree_errors = 0;
+
+    for(r = 0; r < tree_size; r++) {
+        if( tree[r].rank_in_comm == -1 )
+            continue;
+        if( tree[r].parent == r ) {
+            root++;
+            if( tree[r].next_sibling != tree_size ) {
+                fprintf(stderr, "TC -- %d/%d: root cannot have a sibling (%d)\n",
+                        r, tree_size, tree[r].next_sibling);
+                tree_errors++;
+            }
+        }
+        nodes++;
+        children += era_tree_check_node(tree, tree_size, r, display);
+    }
+    if( root != 1 ) {
+        fprintf(stderr, "TC -- There are %d roots in this tree. That's too many\n", root);
+        tree_errors++;
+    }
+    if(children + 1 != nodes) {
+        fprintf(stderr, "TC -- There are %d nodes in this tree, and not %d\n", children+1, nodes);
+        tree_errors++;
+    }
+
+    assert(tree_errors == 0);
+}
+
+static char *era_debug_tree(era_tree_t *tree, int tree_size);
+#endif /* OPAL_ENABLE_DEBUG */
+
+static void era_tree_fn_star(era_tree_t *tree, int tree_size)
+{
+    int m;
+    for(m = 0; m < tree_size; m++) { /**< O(nb_alive) comp. overhead */
+        tree[m].parent        = 0;
+        /** For tree_size == 1, 1 is also the terminating value, so this works */
+        tree[m].first_child   = m == 0 ? 1 : tree_size;
+        tree[m].next_sibling  = m == 0 ? tree_size : m + 1;
+    }
+}
+
+static void era_tree_fn_string(era_tree_t *tree, int tree_size)
+{
+    int m;
+    for(m = 0; m < tree_size; m++) { /**< O(nb_alive) comp. overhead */
+        tree[m].parent        = m > 0 ? m-1 : 0;
+        tree[m].first_child   = m + 1;
+        tree[m].next_sibling  = tree_size;
+    }
+}
+
+static void era_tree_fn_binary(era_tree_t *tree, int tree_size)
+{
+    int m;
+
+    for(m = 0; m < tree_size; m++) { /**< O(nb_alive) comp. overhead */
+        tree[m].parent        = m > 0 ? (m-1)/2 : 0;
+        tree[m].first_child   = (2*m+1 < tree_size) ? 2*m+1 : tree_size;
+        tree[m].next_sibling  = (m%2 != 0 && m+1 < tree_size ) ? m + 1 : tree_size;
+    }
+}
+
+typedef void (*era_tree_fn_t)(era_tree_t *, int);
+static era_tree_fn_t era_tree_fn = era_tree_fn_binary;
+
+typedef struct {
+    int rep;
+    int size;
+    era_tree_t *tree;
+} hierarch_tree_info_t;
+
+static void era_call_tree_fn(era_agreement_info_t *ci)
+{
+#if 0
+    hierarch_tree_info_t *reps, *rep_p;
+    int                   rep, r, rc;
+    opal_hash_table_t *rep_table;
+    ompi_proc_t *proc;
+    orte_vpid_t  daemon_id;
+    era_tree_t  *subtree, *rep_tree;
+    int          subtree_size, rep_tree_size;
+
+    if( mca_coll_ftagree_cur_era_topology > 0 ) {
+        assert( sizeof(daemon_id) == sizeof(uint32_t) );
+
+        rep_table = OBJ_NEW(opal_hash_table_t);
+        opal_hash_table_init(rep_table, orte_process_info.num_daemons);
+
+        reps = (hierarch_tree_info_t *)malloc( (orte_process_info.num_daemons) * sizeof(hierarch_tree_info_t) );
+
+        rep = 0;
+        for(r = 0; r < AGS(ci->comm)->tree_size; r++) {
+            if( ompi_group_get_proc_name(ci->comm->c_local_group, AGS(ci->comm)->tree[r].rank_in_comm).jobid !=
+                OMPI_PROC_MY_NAME->jobid ) {
+                /* I do not know how to make a hierarch tree after
+                 * connect/accept or spawn, lets make a flat one then */
+                free(reps); OBJ_RELEASE(rep_table);
+                era_tree_fn(AGS(ci->comm)->tree, AGS(ci->comm)->tree_size);
+                return;
+            }
+            daemon_id = orte_ess.proc_get_daemon( &proc->super.proc_name );
+            assert( ORTE_VPID_INVALID != daemon_id );
+            if( opal_hash_table_get_value_uint32(rep_table, (uint32_t)daemon_id, (void**)&rep_p) != OPAL_SUCCESS ) {
+                assert(rep <= orte_process_info.num_daemons);
+                reps[rep].rep = r;
+                reps[rep].size = 1;
+                opal_hash_table_set_value_uint32(rep_table, (uint32_t)daemon_id, (void*)&reps[rep]);
+                rep++;
+            } else {
+                rep_p->size++;
+            }
+        }
+
+        subtree = (era_tree_t *)malloc( (ompi_comm_size(ci->comm) + orte_process_info.num_daemons) * sizeof(era_tree_t));
+        subtree_size = 0;
+        for(r = 0; r < rep; r++) {
+            reps[r].tree = &subtree[subtree_size];
+            subtree_size += reps[r].size;
+            reps[r].size = 0;
+        }
+        rep_tree_size = 0;
+        rep_tree = &subtree[subtree_size];
+
+        for(r = 0; r < AGS(ci->comm)->tree_size; r++) {
+            proc = ompi_group_peer_lookup(ci->comm->c_local_group, AGS(ci->comm)->tree[r].rank_in_comm);
+            daemon_id = orte_ess.proc_get_daemon( &proc->super.proc_name );
+            assert( ORTE_VPID_INVALID != daemon_id );
+            rc = opal_hash_table_get_value_uint32(rep_table, (uint32_t)daemon_id, (void**)&rep_p);
+            assert( rc == OPAL_SUCCESS );
+            rep_p->tree[rep_p->size].rank_in_comm = r;
+
+            if( rep_p->size == 0 ) {
+                rep_tree[rep_tree_size].rank_in_comm = r;
+                rep_tree_size++;
+            }
+            rep_p->size++;
+        }
+
+        for(r = 0; r < rep; r++) {
+            era_tree_fn(reps[r].tree, reps[r].size);
+#if OPAL_ENABLE_DEBUG
+            era_tree_check(reps[r].tree, reps[r].size, 0);
+            OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                                 "subtree[%d] = %s\n", r, era_debug_tree(reps[r].tree, reps[r].size)));
+#endif /* OPAL_ENABLE_DEBUG */
+        }
+
+        era_tree_fn(rep_tree, rep_tree_size);
+#if OPAL_ENABLE_DEBUG
+        era_tree_check(rep_tree, rep_tree_size, 0);
+        OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                             "overtree = %s\n", era_debug_tree(rep_tree, rep_tree_size)));
+#endif /* OPAL_ENABLE_DEBUG */
+
+        /* Merge all the subtrees in AGS(ci->comm)->tree */
+        for(r = 0; r < rep; r++) {
+            int s, rr;
+
+            /* Translate from subtrees indexes to big tree indexes */
+            for(s = 0; s < reps[r].size; s++) {
+                rr = reps[r].tree[s].rank_in_comm;
+                AGS(ci->comm)->tree[rr].parent = reps[r].tree[ reps[r].tree[s].parent ].rank_in_comm;
+
+                AGS(ci->comm)->tree[rr].next_sibling = reps[r].tree[s].next_sibling == reps[r].size ?
+                    AGS(ci->comm)->tree_size :
+                    reps[r].tree[ reps[r].tree[s].next_sibling ].rank_in_comm;
+                AGS(ci->comm)->tree[rr].first_child  = reps[r].tree[s].first_child  == reps[r].size ?
+                    AGS(ci->comm)->tree_size :
+                    reps[r].tree[ reps[r].tree[s].first_child  ].rank_in_comm;
+            }
+
+            /* Merge the subtrees according to the rep_tree */
+            rr = rep_tree[r].rank_in_comm;
+            AGS(ci->comm)->tree[rr].parent = rep_tree[ rep_tree[r].parent ].rank_in_comm;
+
+            if( rep_tree[r].next_sibling != rep_tree_size ) {
+                if( AGS(ci->comm)->tree[rr].next_sibling == AGS(ci->comm)->tree_size ) {
+                    AGS(ci->comm)->tree[rr].next_sibling = rep_tree[rep_tree[r].next_sibling].rank_in_comm;
+                } else {
+                    s = AGS(ci->comm)->tree[rr].next_sibling;
+                    do {
+                        s = AGS(ci->comm)->tree[s].next_sibling;
+                    } while( AGS(ci->comm)->tree[s].next_sibling != AGS(ci->comm)->tree_size );
+                    AGS(ci->comm)->tree[s].next_sibling = rep_tree[rep_tree[r].next_sibling].rank_in_comm;
+                }
+            }
+
+            if( rep_tree[r].first_child != rep_tree_size ) {
+                if( AGS(ci->comm)->tree[rr].first_child == AGS(ci->comm)->tree_size ) {
+                    AGS(ci->comm)->tree[rr].first_child = rep_tree[rep_tree[r].first_child].rank_in_comm;
+                } else {
+                    s = AGS(ci->comm)->tree[rr].first_child;
+                    while( AGS(ci->comm)->tree[s].next_sibling != AGS(ci->comm)->tree_size ) {
+                        s = AGS(ci->comm)->tree[s].next_sibling;
+                    }
+                    AGS(ci->comm)->tree[s].next_sibling = rep_tree[rep_tree[r].first_child].rank_in_comm;
+                }
+            }
+        }
+
+#if OPAL_ENABLE_DEBUG
+        era_tree_check(AGS(ci->comm)->tree, AGS(ci->comm)->tree_size, 0);
+        OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                             "finaltree = %s\n", era_debug_tree(AGS(ci->comm)->tree, AGS(ci->comm)->tree_size)));
+#endif /* OPAL_ENABLE_DEBUG */
+
+        opal_hash_table_remove_all(rep_table);
+        OBJ_RELEASE(rep_table);
+        free(subtree);
+    } else {
+        era_tree_fn(AGS(ci->comm)->tree, AGS(ci->comm)->tree_size);
+    }
+#else
+    /* Hierarchical tree disabled for now. ESS does not give daemon names
+     * anymore. TODO: ENABLE_FT_MPI: restore hierarchical tree capabilitiy. */
+    era_tree_fn(AGS(ci->comm)->tree, AGS(ci->comm)->tree_size);
+#endif
+}
+
+#if OPAL_ENABLE_DEBUG
+#define ERA_TREE_BUFFER_SIZE 4096
+static char era_tree_buffer[ERA_TREE_BUFFER_SIZE];
+
+static void era_debug_walk_tree(era_tree_t *tree, int tree_size, int node)
+{
+    snprintf(era_tree_buffer + strlen(era_tree_buffer), ERA_TREE_BUFFER_SIZE - strlen(era_tree_buffer),
+             "(%d", tree[node].rank_in_comm);
+    if( tree[node].first_child != tree_size ) {
+        snprintf(era_tree_buffer + strlen(era_tree_buffer), ERA_TREE_BUFFER_SIZE - strlen(era_tree_buffer),
+                 ", ");
+        era_debug_walk_tree(tree, tree_size, tree[node].first_child);
+    }
+    snprintf(era_tree_buffer + strlen(era_tree_buffer), ERA_TREE_BUFFER_SIZE - strlen(era_tree_buffer),
+             ")");
+
+    if( tree[node].next_sibling != tree_size ) {
+        snprintf(era_tree_buffer + strlen(era_tree_buffer), ERA_TREE_BUFFER_SIZE - strlen(era_tree_buffer),
+                 ", ");
+        era_debug_walk_tree(tree, tree_size, tree[node].next_sibling);
+    }
+}
+
+static char *era_debug_tree(era_tree_t *tree, int tree_size)
+{
+    int i;
+    era_tree_buffer[0]='\0';
+    for(i = 0; i < tree_size; i++) {
+        if( tree[i].parent == i ) {
+            era_debug_walk_tree(tree, tree_size, i);
+            break;
+        }
+    }
+    return era_tree_buffer;
+}
+#endif /* OPAL_ENABLE_DEBUG */
+
+static void era_build_tree_structure(era_agreement_info_t *ci)
+{
+    int m, n;
+    int offset, next_dead_idx;
+
+    n = ompi_comm_size(ci->comm);
+    AGS(ci->comm)->tree_size = n - AGS(ci->comm)->afr_size;
+    /**< O(nb_alive) memory overhead during agreement */
+    AGS(ci->comm)->tree = (era_tree_t*)realloc(AGS(ci->comm)->tree,
+                                               AGS(ci->comm)->tree_size * sizeof(era_tree_t));
+    offset = 0;
+    next_dead_idx = 0;
+    for(m = 0; m < AGS(ci->comm)->tree_size; m++) { /**< O(comm_size) comp. overhead */
+        /** This assumes that agreed_failed_ranks is maintained sorted. */
+        while( next_dead_idx < AGS(ci->comm)->afr_size && (m+offset) == AGS(ci->comm)->agreed_failed_ranks[next_dead_idx] ) {
+            next_dead_idx++;
+            offset++;
+        }
+        AGS(ci->comm)->tree[m].rank_in_comm = m + offset;
+        /** Initialize each node as a separate root by itself */
+        AGS(ci->comm)->tree[m].parent = m;
+        AGS(ci->comm)->tree[m].first_child  = AGS(ci->comm)->tree_size;
+        AGS(ci->comm)->tree[m].next_sibling = AGS(ci->comm)->tree_size;
+    }
+
+    era_call_tree_fn(ci);
+
+    if( ompi_comm_rank(ci->comm) == 0 ) {
+        OPAL_OUTPUT_VERBOSE((4, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: re-built the tree structure with size %d: %s\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid,
+                             AGS(ci->comm)->tree_size,
+                             era_debug_tree(ci->ags->tree, ci->ags->tree_size)));
+    }
+
+#if OPAL_ENABLE_DEBUG
+    era_tree_check(ci->ags->tree, ci->ags->tree_size, 0);
+#endif /* OPAL_ENABLE_DEBUG */
+}
+
+static int era_tree_rank_from_comm_rank(era_agreement_info_t *ci, int r_in_comm)
+{
+    int r_in_tree = r_in_comm >= ci->ags->tree_size ? ci->ags->tree_size-1 : r_in_comm;
+
+    /** This search is at worst O(nb_dead) */
+    while( ci->ags->tree[r_in_tree].rank_in_comm != r_in_comm ) {
+#if OPAL_ENABLE_DEBUG
+        assert( ci->ags->tree[r_in_tree].rank_in_comm == -1 || ci->ags->tree[r_in_tree].rank_in_comm > r_in_comm );
+#endif /* OPAL_ENABLE_DEBUG */
+        assert( r_in_tree > 0 );
+        r_in_tree--;
+    }
+    return r_in_tree;
+}
+
+static void era_tree_remove_node(era_agreement_info_t *ci, int r_in_tree)
+{
+    /** All indices are in tree */
+    int p, c, s, t;
+
+    p = ci->ags->tree[r_in_tree].parent;
+    if( p != r_in_tree ) {
+        /** r_in_tree has a parent */
+
+        /** First, for each children process, re-attach them to their new parent,
+         *  reminding the first child in s, and the last child in c */
+        s = c = ci->ags->tree[r_in_tree].first_child;
+        if(s != ci->ags->tree_size ) {
+            while(1) {
+                ci->ags->tree[c].parent = p;
+                if( ci->ags->tree[c].next_sibling == ci->ags->tree_size )
+                    break;
+                c = ci->ags->tree[c].next_sibling;
+            }
+        } /** If r_in_tree is a leaf, we don't need to do anything special */
+
+        /** Then, unchain r_in_tree, inserting instead the chain s -> c if it exists */
+        if( ci->ags->tree[p].first_child == r_in_tree ) {
+            if( s == ci->ags->tree_size ) {
+                ci->ags->tree[p].first_child = ci->ags->tree[r_in_tree].next_sibling;
+            } else {
+                ci->ags->tree[p].first_child = s;
+                ci->ags->tree[c].next_sibling = ci->ags->tree[r_in_tree].next_sibling;
+            }
+        } else {
+            for(t = ci->ags->tree[p].first_child;
+                ci->ags->tree[t].next_sibling != r_in_tree;
+                t = ci->ags->tree[t].next_sibling) {
+                assert(t != ci->ags->tree_size); /** r_in_tree should still be chained to its parent */
+            }
+            if( s == ci->ags->tree_size ) {
+                ci->ags->tree[t].next_sibling = ci->ags->tree[r_in_tree].next_sibling;
+            } else {
+                ci->ags->tree[t].next_sibling = s;
+                ci->ags->tree[c].next_sibling = ci->ags->tree[r_in_tree].next_sibling;
+            }
+        }
+    } else {
+        int last_sib, new_root, prev_root, first_child, next_root;
+
+        /* r_in_tree was root...*/
+        assert( ci->ags->tree[r_in_tree].next_sibling == ci->ags->tree_size );
+        assert( ci->ags->tree[r_in_tree].first_child != ci->ags->tree_size );
+
+        /* find the children with smallest rank: only it can be root */
+        new_root   = ci->ags->tree[r_in_tree].first_child;
+        last_sib = -1;
+        prev_root  = -1;
+        for( p  = ci->ags->tree[r_in_tree].first_child;
+             p != ci->ags->tree_size;
+             p  = ci->ags->tree[p].next_sibling ) {
+            if( new_root > p ) {
+                new_root = p;
+                prev_root = last_sib;
+            }
+            last_sib = p;
+        }
+        if( last_sib == new_root ) {
+            last_sib = prev_root;
+        }
+
+        next_root = ci->ags->tree[new_root].next_sibling;
+        if( prev_root != -1 ) {
+            ci->ags->tree[prev_root].next_sibling = next_root;
+        }
+        ci->ags->tree[new_root].next_sibling = ci->ags->tree_size;
+        ci->ags->tree[new_root].parent       = new_root;
+
+        if( new_root != ci->ags->tree[r_in_tree].first_child ) {
+            first_child = ci->ags->tree[r_in_tree].first_child;
+        }
+        else if( next_root != ci->ags->tree_size ) {
+            first_child = next_root;
+        }
+        else {
+            first_child = ci->ags->tree[new_root].first_child;
+        }
+
+        if( first_child != ci->ags->tree[new_root].first_child) {
+            if( last_sib != -1 ) {
+                ci->ags->tree[last_sib].next_sibling = ci->ags->tree[new_root].first_child;
+            }
+            ci->ags->tree[new_root].first_child  = first_child;
+            for(p = first_child; p != ci->ags->tree_size; p = ci->ags->tree[p].next_sibling) {
+                ci->ags->tree[p].parent = new_root;
+                if( p == last_sib) {
+                    break;
+                }
+            }
+        }
+    }
+
+#if OPAL_ENABLE_DEBUG
+    {
+        int prank = ci->ags->tree[r_in_tree].rank_in_comm;
+
+        ci->ags->tree[r_in_tree].rank_in_comm = -1;
+        ci->ags->tree[r_in_tree].parent = ci->ags->tree_size;
+        ci->ags->tree[r_in_tree].first_child = ci->ags->tree_size;
+        ci->ags->tree[r_in_tree].next_sibling = ci->ags->tree_size;
+        era_tree_check(ci->ags->tree, ci->ags->tree_size, 0);
+
+        OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: removed node %d (at position %d) from the tree structure: %s\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid,
+                             prank,
+                             r_in_tree,
+                             era_debug_tree(ci->ags->tree, ci->ags->tree_size)));
+    }
+#endif /* OPAL_ENABLE_DEBUG */
+}
+
+static int era_parent(era_agreement_info_t *ci)
+{
+    int r_in_comm = ompi_comm_rank(ci->comm);
+    int r_in_tree = era_tree_rank_from_comm_rank(ci, r_in_comm);
+    int p_in_comm, p_in_tree;
+
+    while(1) {
+        p_in_tree = ci->ags->tree[r_in_tree].parent;
+        p_in_comm = ci->ags->tree[p_in_tree].rank_in_comm;
+        if( ompi_comm_is_proc_active(ci->comm, p_in_comm, false) ) {
+            return p_in_comm;
+        }
+
+        era_tree_remove_node(ci, p_in_tree);
+        continue; /**< My new parent might be dead too: start again */
+    }
+}
+
+static int era_next_child(era_agreement_info_t *ci, int prev_child_in_comm)
+{
+    ompi_communicator_t *comm = ci->comm;
+    int prev_child_in_tree;
+    int r_in_tree, c_in_tree, c_in_comm;
+    int s_in_tree, s_in_comm;
+
+    assert(NULL != comm);
+
+    prev_child_in_tree = prev_child_in_comm == -1 ? -1 : era_tree_rank_from_comm_rank(ci, prev_child_in_comm);
+
+    if(prev_child_in_tree == -1) {
+        r_in_tree = era_tree_rank_from_comm_rank(ci, ompi_comm_rank(comm));
+        while(1) {
+            /* We search / fix the tree for the first alive child */
+            c_in_tree = ci->ags->tree[r_in_tree].first_child;
+            if( c_in_tree == ci->ags->tree_size ) {
+                return ompi_comm_size(comm); /** there are none */
+            }
+            c_in_comm = ci->ags->tree[c_in_tree].rank_in_comm;
+            if( ompi_comm_is_proc_active(comm, c_in_comm, false) ) {
+                return c_in_comm;
+            }
+            era_tree_remove_node(ci, c_in_tree);
+        }
+    } else {
+        r_in_tree = era_tree_rank_from_comm_rank(ci, prev_child_in_comm);
+        assert(r_in_tree != ci->ags->tree_size);
+        assert(ci->ags->tree[r_in_tree].rank_in_comm != -1);
+        while(1) {
+            /* We search / fix the tree for the next alive sibling of r */
+            s_in_tree = ci->ags->tree[r_in_tree].next_sibling;
+            if( s_in_tree == ci->ags->tree_size ) {
+                return ompi_comm_size(comm); /** No more */
+            }
+            s_in_comm = ci->ags->tree[s_in_tree].rank_in_comm;
+            if( ompi_comm_is_proc_active(comm, s_in_comm, false) ) {
+                return s_in_comm;
+            }
+            era_tree_remove_node(ci, s_in_tree);
+        }
+    }
+}
+
+static void era_collect_passed_agreements(era_identifier_t agreement_id, uint16_t min_aid, uint16_t max_aid)
+{
+    void *value;
+    int r;
+
+    /* Garbage collect agreements that have been decided by all */
+    OPAL_OUTPUT_VERBOSE((17, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: GC: Agreements %u to %u have been acknowledged by all and can be collected\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         agreement_id.ERAID_FIELDS.contextid,
+                         agreement_id.ERAID_FIELDS.epoch,
+                         agreement_id.ERAID_FIELDS.agreementid,
+                         min_aid,
+                         max_aid));
+    if( min_aid <= max_aid ) {
+        era_identifier_t pid;
+        pid.ERAID_FIELDS.contextid = agreement_id.ERAID_FIELDS.contextid;
+        pid.ERAID_FIELDS.epoch     = agreement_id.ERAID_FIELDS.epoch;
+        for(r = min_aid; r <= max_aid; r++) {
+            pid.ERAID_FIELDS.agreementid = r;
+            if( opal_hash_table_get_value_uint64(&era_passed_agreements, pid.ERAID_KEY, &value) == OMPI_SUCCESS ) {
+                era_value_t *av = (era_value_t*)value;
+                opal_hash_table_remove_value_uint64(&era_passed_agreements, pid.ERAID_KEY);
+                OBJ_RELEASE(av);
+                OPAL_OUTPUT_VERBOSE((17, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ERA) Agreement (%d.%d).%d: GC: collect agreement (%d.%d).%d\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     agreement_id.ERAID_FIELDS.contextid,
+                                     agreement_id.ERAID_FIELDS.epoch,
+                                     agreement_id.ERAID_FIELDS.agreementid,
+                                     pid.ERAID_FIELDS.contextid,
+                                     pid.ERAID_FIELDS.epoch,
+                                     pid.ERAID_FIELDS.agreementid));
+            }
+            /* It is possible that this agreement was freed already, if multiple are in flight */
+        }
+    }
+}
+
+static void era_decide(era_value_t *decided_value, era_agreement_info_t *ci)
+{
+    ompi_communicator_t *comm;
+    era_rank_item_t *rl;
+    int r, s, dead_size;
+    void *value;
+
+    assert( 0 != ci->agreement_id.ERAID_FIELDS.agreementid );
+
+#if OPAL_ENABLE_DEBUG
+    r = era_parent(ci);
+    if( opal_hash_table_get_value_uint64(&era_passed_agreements,
+                                         ci->agreement_id.ERAID_KEY, &value) == OMPI_SUCCESS ) {
+        /**
+         * If the value was already decided, then this DOWN message
+         * *must* provide the same decision: it can only be a dupplicate.
+         */
+        era_value_t *old_agreement_value;
+        old_agreement_value = (era_value_t*)value;
+        assert( old_agreement_value->header.ret == decided_value->header.ret &&
+                old_agreement_value->header.nb_new_dead == decided_value->header.nb_new_dead );
+    }
+#endif /* OPAL_ENABLE_DEBUG */
+
+    /** We must leave ci in the era_ongoing_agreements, because either the
+     *  iagree request or the blocking loop above need to find it for
+     *  cleanup. Thus, we may enter era_decide with the agreement_info
+     *  already completed. In that case, we return silently to avoid
+     *  flooding the network with more DOWN messages.
+     */
+    if( ci->status == COMPLETED )
+        return;
+
+    OBJ_RETAIN(decided_value);
+
+    OPAL_OUTPUT_VERBOSE(((ci->comm->c_my_rank == r)? 2: 10, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) decide %08x.%d.%d.. on agreement (%d.%d).%d\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         (0!=ERA_VALUE_BYTES_COUNT(&decided_value->header))? *(int*)decided_value->bytes: 0,
+                         decided_value->header.ret,
+                         decided_value->header.nb_new_dead,
+                         ci->agreement_id.ERAID_FIELDS.contextid,
+                         ci->agreement_id.ERAID_FIELDS.epoch,
+                         ci->agreement_id.ERAID_FIELDS.agreementid));
+
+    opal_hash_table_set_value_uint64(&era_passed_agreements,
+                                     ci->agreement_id.ERAID_KEY,
+                                     decided_value);
+
+    comm = ci->comm;
+    assert( NULL != comm );
+
+    if( decided_value->header.nb_new_dead != 0 ) {
+        OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) decide %08x.%d.%d on agreement (%d.%d).%d: adding up to %d processes to the list of agreed deaths\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             (0!=ERA_VALUE_BYTES_COUNT(&decided_value->header))? *(int*)decided_value->bytes: 0,
+                             decided_value->header.ret,
+                             decided_value->header.nb_new_dead,
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid,
+                             decided_value->header.nb_new_dead));
+
+#if OPAL_ENABLE_DEBUG
+        {
+            int _i, _j;
+            for(_i = 0; _i < decided_value->header.nb_new_dead; _i++) {
+                assert(decided_value->new_dead_array[_i] >= 0 &&
+                       decided_value->new_dead_array[_i] < ompi_comm_size(comm));
+                for(_j = _i+1; _j < decided_value->header.nb_new_dead; _j++) {
+                    assert(decided_value->new_dead_array[_i] < decided_value->new_dead_array[_j]);
+                }
+            }
+        }
+#endif /*OPAL_ENABLE_DEBUG*/
+
+        dead_size = AGS(comm)->afr_size + decided_value->header.nb_new_dead;
+        AGS(comm)->agreed_failed_ranks = (int*)realloc(AGS(comm)->agreed_failed_ranks, dead_size * sizeof(int));
+
+        for(s = 0, r = 0; r < decided_value->header.nb_new_dead; r++) {
+            while(s < AGS(comm)->afr_size && AGS(comm)->agreed_failed_ranks[s] < decided_value->new_dead_array[r] ) s++;
+            if( s == AGS(comm)->afr_size ) {
+                /** paste the remaining ints at the end of the array */
+                memcpy(AGS(comm)->agreed_failed_ranks + AGS(comm)->afr_size,
+                       decided_value->new_dead_array + r,
+                       (decided_value->header.nb_new_dead - r) * sizeof(int));
+                AGS(comm)->afr_size += decided_value->header.nb_new_dead - r;
+                if(mca_coll_ftagree_era_rebuild) AGS(comm)->ags_status |= AGS_TREE_DIRTY;
+                break;
+            } else if( AGS(comm)->agreed_failed_ranks[s] > decided_value->new_dead_array[r] ) {
+                /** make some room for one int */
+                memmove(AGS(comm)->agreed_failed_ranks + s + 1,
+                        AGS(comm)->agreed_failed_ranks + s,
+                        (AGS(comm)->afr_size - s) * sizeof(int));
+                AGS(comm)->afr_size++;
+                if(mca_coll_ftagree_era_rebuild) AGS(comm)->ags_status |= AGS_TREE_DIRTY;
+                /** and insert new_dead[r] */
+                AGS(comm)->agreed_failed_ranks[s] = decided_value->new_dead_array[r];
+            } else {
+                /** It was already in, let's skip it */
+            }
+        }
+
+#if OPAL_ENABLE_DEBUG
+        {
+            int _i, _j;
+            for(_i = 0; _i < AGS(comm)->afr_size; _i++)
+                for(_j = _i+1; _j < AGS(comm)->afr_size; _j++)
+                    assert(AGS(comm)->agreed_failed_ranks[_i] < AGS(comm)->agreed_failed_ranks[_j]);
+        }
+#endif /*OPAL_ENABLE_DEBUG*/
+    }
+
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) decide %08x.%d.%d.. on agreement (%d.%d).%d: group of agreed deaths is of size %d\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         (0!=ERA_VALUE_BYTES_COUNT(&decided_value->header))? *(int*)decided_value->bytes: 0,
+                         decided_value->header.ret,
+                         decided_value->header.nb_new_dead,
+                         ci->agreement_id.ERAID_FIELDS.contextid,
+                         ci->agreement_id.ERAID_FIELDS.epoch,
+                         ci->agreement_id.ERAID_FIELDS.agreementid,
+                         AGS(comm)->afr_size));
+
+    r = -1;
+    while( (r = era_next_child(ci, r)) < ompi_comm_size(comm) ) {
+
+        /** Cleanup the early_requesters list, to avoid sending unecessary dupplicate messages */
+        if( opal_list_get_size(&ci->early_requesters) > 0 ) {
+            for(rl = (era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
+                rl != (era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
+                rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+                if( rl->rank == r ) {
+                    opal_list_remove_item(&ci->early_requesters, &rl->super);
+                    break;
+                }
+            }
+        }
+
+        send_msg(comm, r, NULL, ci->agreement_id, MSG_DOWN, decided_value, 0, NULL);
+    }
+
+    /* In case we have some child we haven't detected yet */
+    if( opal_list_get_size(&ci->early_requesters) > 0 ) {
+        for(rl = (era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
+            rl != (era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
+            rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+            send_msg(comm, rl->rank, NULL, ci->agreement_id, MSG_DOWN, decided_value, 0, NULL);
+        }
+    }
+
+    era_collect_passed_agreements(ci->agreement_id, decided_value->header.min_aid, decided_value->header.max_aid);
+
+    opal_atomic_wmb();
+    ci->status = COMPLETED;
+    if( ci->req ) {
+        OPAL_OUTPUT_VERBOSE((50, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) calling complete for Agreement ID = (%d.%d).%d, current status = %s\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         ci->agreement_id.ERAID_FIELDS.contextid,
+                         ci->agreement_id.ERAID_FIELDS.epoch,
+                         ci->agreement_id.ERAID_FIELDS.agreementid,
+                         era_status_to_string(ci->status)));
+        ompi_request_complete(&ci->req->super, true);
+    }
+}
+
+static void era_check_status(era_agreement_info_t *ci)
+{
+    int r;
+    era_rank_item_t *rl;
+
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, current status = %s\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         ci->agreement_id.ERAID_FIELDS.contextid,
+                         ci->agreement_id.ERAID_FIELDS.epoch,
+                         ci->agreement_id.ERAID_FIELDS.agreementid,
+                         era_status_to_string(ci->status)));
+
+    assert(ci->status != BROADCASTING &&
+           ci->status != COMPLETED);
+
+    if( ci->status == NOT_CONTRIBUTED ) {
+        /* Well, I haven't contributed to this agreement yet, and you'll not make a decision without me */
+        return;
+    }
+
+    if( ci->status == GATHERING ) {
+        /* I contributed myself, and I may just have received a contribution from a child */
+        /* Let's see if it's time to pass up */
+        (void)era_parent(ci); /* Maybe I'm becoming the root, need to recheck my children. TODO: only rebuild the necessary part */
+        r = -1;
+        while( (r = era_next_child(ci, r)) < ompi_comm_size(ci->comm) ) {
+            OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                                 "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, child %d is supposed to contribute\n",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                 ci->agreement_id.ERAID_FIELDS.contextid,
+                                 ci->agreement_id.ERAID_FIELDS.epoch,
+                                 ci->agreement_id.ERAID_FIELDS.agreementid,
+                                 r));
+            for( rl =  (era_rank_item_t*)opal_list_get_first(&ci->gathered_info);
+                 rl != (era_rank_item_t*)opal_list_get_end(&ci->gathered_info);
+                 rl =  (era_rank_item_t*)opal_list_get_next(&rl->super) ) {
+                if( rl->rank == r ) {
+                    OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                                         "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, child %d has sent its message\n",
+                                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                         ci->agreement_id.ERAID_FIELDS.contextid,
+                                         ci->agreement_id.ERAID_FIELDS.epoch,
+                                         ci->agreement_id.ERAID_FIELDS.agreementid,
+                                         r));
+                    break;
+                }
+            }
+            if( rl == (era_rank_item_t*)opal_list_get_end(&ci->gathered_info) ) {
+                OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, some children have not contributed\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     ci->agreement_id.ERAID_FIELDS.contextid,
+                                     ci->agreement_id.ERAID_FIELDS.epoch,
+                                     ci->agreement_id.ERAID_FIELDS.agreementid));
+                /* We are still waiting for a message from at least a child. Let's wait */
+                return;
+            }
+        }
+
+        /* Left that loop? We're good to decide locally */
+        era_update_return_value(ci, -1, NULL);
+
+        if( ci->comm->c_my_rank == (r = era_parent(ci)) ) {
+            OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                                 "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, all children of root have contributed\n",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                 ci->agreement_id.ERAID_FIELDS.contextid,
+                                 ci->agreement_id.ERAID_FIELDS.epoch,
+                                 ci->agreement_id.ERAID_FIELDS.agreementid));
+
+            /* I'm root. I have to decide now. */
+            era_decide(ci->current_value, ci);
+        } else {
+            OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                                 "%s ftagree:agreement (ERA) check_status for Agreement ID = (%d.%d).%d, all children of non-root have contributed\n",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                 ci->agreement_id.ERAID_FIELDS.contextid,
+                                 ci->agreement_id.ERAID_FIELDS.epoch,
+                                 ci->agreement_id.ERAID_FIELDS.agreementid));
+
+            /* Let's forward up and wait for the DOWN messages */
+            ci->waiting_down_from = r;
+            send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_UP, ci->current_value,
+                     ci->nb_acked, ci->acked);
+            ci->status = BROADCASTING;
+        }
+        return;
+    }
+}
+
+static void restart_agreement_from_me(era_agreement_info_t *ci)
+{
+    int r;
+    era_rank_item_t *rc;
+    assert( NULL != ci->comm );
+    assert( 0 == opal_list_get_size(&ci->waiting_res_from) );
+
+    /* First of all, we start gathering information again */
+    ci->status = GATHERING;
+
+    /* Then, we request all the living guys that could have
+     * received the information to send it back, or send the UP
+     * back to their parent.
+     * Eventually, this information will reach me and all children
+     * will have contributed. OR somebody will have sent back
+     * the DOWN message directly to me because it got the
+     * lost result
+     */
+    r = -1;
+    while( (r = era_next_child(ci, r)) != ompi_comm_size(ci->comm) ) {
+        rc = OBJ_NEW(era_rank_item_t);
+        rc->rank = r;
+        opal_list_append(&ci->waiting_res_from, &rc->super);
+        send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_RESULT_REQUEST, ci->current_value,
+                 0, NULL);
+    }
+
+    /** I can become the root when all other living processes are
+     *  already in my subtree. In that case, I might be able to decide
+     *  now...
+     */
+    era_check_status(ci);
+}
+
+/* helper to bounce recursive errors back from to the main thread opal_progress */
+typedef struct era_error_event_s {
+    opal_event_t ev;
+    era_agreement_info_t* ci;
+    int rank;
+} era_error_event_t;
+
+static void era_mark_process_failed(era_agreement_info_t *ci, int rank);
+
+static void *era_error_event_cb(int fd, int flags, void *context) {
+    era_error_event_t *event = (era_error_event_t*) context;
+    int r = event->rank;
+    era_agreement_info_t* ci = event->ci;
+    free(event);
+    era_mark_process_failed(ci, r);
+    return NULL;
+}
+
+static void era_mark_process_failed(era_agreement_info_t *ci, int rank)
+{
+    int r;
+    era_rank_item_t *rl;
+
+    assert( ci->comm == NULL || (ci->comm->c_local_group->grp_my_rank != rank) );
+
+    if(opal_mutex_trylock(&era_mutex)) {
+        /*  Don't do recursive notifications */
+        struct timeval now = {0, 0};
+        era_error_event_t* event = malloc(sizeof(*event));
+        event->ci = ci;
+        event->rank = rank;
+        opal_event_evtimer_set(opal_sync_event_base, &event->ev, era_error_event_cb, event);
+        opal_event_add(&event->ev, &now);
+        return;
+    }
+
+    if( ci->status > NOT_CONTRIBUTED ) {
+        /* I may not have sent up yet (or I'm going to re-send up because of failures),
+         * and since I already contributed, this failure is not acknowledged yet
+         * So, the return value should be MPI_ERR_PROC_FAILED.
+         * Of course, if I have already contributed upward, the final return might still
+         * be MPI_SUCCESS
+         */
+        OPAL_OUTPUT_VERBOSE((30,  ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Handling failure of process %d: Agreement (%d.%d).%d will have to return ERR_PROC_FAILED.\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             rank,
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid));
+        ci->current_value->header.ret = MPI_ERR_PROC_FAILED;
+    }
+    if( ci->status == BROADCASTING ) {
+        OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Handling failure of process %d: Agreement (%d.%d).%d is in the BROADCASTING state.\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             rank,
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid));
+        /* We are waiting from the parent on that agreement...
+         * Is it the one that died? */
+        if( rank == ci->waiting_down_from ) {
+            /* OK, let's send my contribution again to the new parent and see if that's better */
+            r = era_parent(ci);
+            if( r == ci->comm->c_my_rank ) {
+                OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ERA) Handling failure of process %d: Restarting Agreement (%d.%d).%d as I am the new root.\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     rank,
+                                     ci->agreement_id.ERAID_FIELDS.contextid,
+                                     ci->agreement_id.ERAID_FIELDS.epoch,
+                                     ci->agreement_id.ERAID_FIELDS.agreementid));
+                /* Trouble: I'm becoming root, while I was waiting for this answer...
+                 * We need to check that nobody decided before, or if they connected to
+                 * me as a child, to ask them to re-send their up message, because I might
+                 * have ignored it, not knowing why they sent the message in the first place.
+                 */
+                restart_agreement_from_me(ci);
+            } else {
+                OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Handling failure of process %d: My parent changed to %d for Agreement (%d.%d).%d, sending the UP message to it\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     rank, r,
+                                     ci->agreement_id.ERAID_FIELDS.contextid,
+                                     ci->agreement_id.ERAID_FIELDS.epoch,
+                                     ci->agreement_id.ERAID_FIELDS.agreementid));
+                ci->waiting_down_from = r;
+                send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_UP, ci->current_value,
+                         ci->nb_acked, ci->acked);
+            }
+        }
+    } else if( ci->status == GATHERING ) {
+        OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Handling failure of process %d: Agreement (%d.%d).%d is in the GATHERING state.\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             rank,
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid));
+        OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Retaining agreement info for (%d.%d).%d while resolving failure during agreement.\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             ci->agreement_id.ERAID_FIELDS.contextid,
+                             ci->agreement_id.ERAID_FIELDS.epoch,
+                             ci->agreement_id.ERAID_FIELDS.agreementid));
+        OBJ_RETAIN(ci);
+        /* It could be one of the guys that we contacted about a restarting agreement. */
+        for(rl = (era_rank_item_t*)opal_list_get_first(&ci->waiting_res_from);
+            rl != (era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from);
+            rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+            if(rl->rank == rank) {
+                OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ERA) Handling failure of process %d: I was waiting for the contribution of that process for Agreement (%d.%d).%d.\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     rank,
+                                     ci->agreement_id.ERAID_FIELDS.contextid,
+                                     ci->agreement_id.ERAID_FIELDS.epoch,
+                                     ci->agreement_id.ERAID_FIELDS.agreementid));
+
+                /* In that case, it could be bad, as it could create a new guy waiting for the
+                 * result, or worse, the result previously computed could be under that subtree.
+                 * Remove the guy from the list of waiting_res_from,
+                 */
+                opal_list_remove_item(&ci->waiting_res_from, &rl->super);
+
+                /* and add its living children, requesting the result if it was
+                 * not done before
+                 */
+                r = -1;
+                while( (r = era_next_child(ci, r)) != ompi_comm_size(ci->comm) ) {
+                    for(rl = (era_rank_item_t*)opal_list_get_first(&ci->waiting_res_from);
+                        rl != (era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from);
+                        rl = (era_rank_item_t*)opal_list_get_next(&rl->super)) {
+                        if( rl->rank == r ) {
+                            break;
+                        }
+                    }
+
+                    if( rl == (era_rank_item_t*)opal_list_get_end(&ci->waiting_res_from) ) {
+                        OPAL_OUTPUT_VERBOSE((20,  ompi_ftmpi_output_handle,
+                                             "%s ftagree:agreement (ERA) Handling failure of process %d: Requesting contribution of process %d for Agreement (%d.%d).%d.\n",
+                                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                             rank, r,
+                                             ci->agreement_id.ERAID_FIELDS.contextid,
+                                             ci->agreement_id.ERAID_FIELDS.epoch,
+                                             ci->agreement_id.ERAID_FIELDS.agreementid));
+                        rl = OBJ_NEW(era_rank_item_t);
+                        rl->rank = r;
+                        opal_list_append(&ci->waiting_res_from, &rl->super);
+                        send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_RESULT_REQUEST, ci->current_value,
+                                 0, NULL);
+                    }
+                }
+                break;
+            }
+        }
+
+        /* It could also be a child, that's also important but taken care of by check_status */
+        era_check_status(ci);
+
+        OBJ_RELEASE(ci);
+    }
+    opal_mutex_unlock(&era_mutex);
+}
+
+static void fragment_sent_cb(struct mca_btl_base_module_t* module,
+                          struct mca_btl_base_endpoint_t* endpoint,
+                          struct mca_btl_base_descriptor_t* descriptor,
+                          int status)
+{
+    (void)module;
+    (void)endpoint;
+    (void)descriptor;
+    (void)status;
+}
+
+static void send_msg(ompi_communicator_t *comm,
+                     int dst,
+                     opal_process_name_t *proc_name,
+                     era_identifier_t agreement_id,
+                     era_msg_type_t type,
+                     era_value_t *value,
+                     int          nb_ack_failed,
+                     int         *ack_failed)
+{
+    mca_btl_base_descriptor_t *des;
+    struct iovec iov[4]; /**< message header, flag bytes, newly_dead, acknowledged */
+    long unsigned int niov = 0, b, i, copied, tocopy;
+    era_msg_header_t msg_header;
+    era_frag_t *frag;
+    ompi_proc_t *peer;
+    mca_bml_base_endpoint_t* endpoint;
+    mca_bml_base_btl_t *bml_btl;
+    struct mca_btl_base_endpoint_t *btl_endpoint;
+    mca_btl_base_module_t *btl;
+    uint64_t my_seqnum;
+    unsigned int to_send, sent;
+    long unsigned int payload_size;
+
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+    if( (double)rand() / (double)RAND_MAX < mca_coll_ftagree_rank_fault_proba ) {
+        OPAL_OUTPUT_VERBOSE((0, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) INJECT: Killing myself just before sending message [(%d.%d).%d, %s, %08x.%d.%d..] to %d/%s\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             agreement_id.ERAID_FIELDS.contextid,
+                             agreement_id.ERAID_FIELDS.epoch,
+                             agreement_id.ERAID_FIELDS.agreementid,
+                             era_msg_type_to_string(type),
+                             (0!=ERA_VALUE_BYTES_COUNT(&value->header))? *(int*)value->bytes: 0,
+                             value->header.ret,
+                             value->header.nb_new_dead,
+                             dst,
+                             NULL != proc_name ? OMPI_NAME_PRINT(proc_name) : "(null)"));
+        raise(SIGKILL);
+    }
+#endif
+
+    if( MSG_UP == type ) {
+        OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) send message [(%d.%d).%d, %s, %08x.%d.%d/%d] to %d/%s\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             agreement_id.ERAID_FIELDS.contextid,
+                             agreement_id.ERAID_FIELDS.epoch,
+                             agreement_id.ERAID_FIELDS.agreementid,
+                             era_msg_type_to_string(type),
+                             (0!=ERA_VALUE_BYTES_COUNT(&value->header))? *(int*)value->bytes: 0,
+                             value->header.ret,
+                             value->header.nb_new_dead,
+                             nb_ack_failed,
+                             dst,
+                             NULL != proc_name ? OMPI_NAME_PRINT(proc_name) : "(null)"));
+    } else {
+        OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) send message [(%d.%d).%d, %s, %08x.%d.%d..] to %d/%s\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             agreement_id.ERAID_FIELDS.contextid,
+                             agreement_id.ERAID_FIELDS.epoch,
+                             agreement_id.ERAID_FIELDS.agreementid,
+                             era_msg_type_to_string(type),
+                             (0!=ERA_VALUE_BYTES_COUNT(&value->header))? *(int*)value->bytes: 0,
+                             value->header.ret,
+                             value->header.nb_new_dead,
+                             dst,
+                             NULL != proc_name ? OMPI_NAME_PRINT(proc_name) : "(null)"));
+        assert(nb_ack_failed == 0);
+   }
+
+#if OPAL_ENABLE_DEBUG
+    if( type == MSG_DOWN ) {
+        int _i;
+        for(_i = 1; _i < value->header.nb_new_dead; _i++)
+            assert(value->new_dead_array[_i-1] < value->new_dead_array[_i]);
+    }
+#endif /* OPAL_ENABLE_DEBUG */
+
+    assert( NULL == comm || agreement_id.ERAID_FIELDS.contextid == ompi_comm_get_cid(comm) );
+    assert( NULL == comm || agreement_id.ERAID_FIELDS.epoch == comm->c_epoch );
+
+    if( NULL == comm ) {
+        assert(NULL != proc_name);
+        peer = ompi_proc_find ( proc_name );
+    } else {
+        peer = ompi_comm_peer_lookup(comm, dst);
+    }
+    assert(NULL != peer);
+    endpoint = mca_bml_base_get_endpoint(peer);
+    assert(NULL != endpoint);
+    bml_btl = mca_bml_base_btl_array_get_index(&endpoint->btl_eager, 0);
+    assert(NULL != bml_btl);
+    btl_endpoint = bml_btl->btl_endpoint;
+    assert(NULL != btl_endpoint);
+    btl = bml_btl->btl;
+    assert(NULL != btl);
+
+    to_send = ERA_MSG_SIZE(&value->header, nb_ack_failed);
+
+    /* We prepare the header, that we store in msg */
+    msg_header.msg_type = type;
+    msg_header.agreement_id.ERAID_KEY = agreement_id.ERAID_KEY;
+    memcpy(&msg_header.agreement_value_header, &value->header, sizeof(era_value_header_t));
+    if( NULL != comm ) {
+        msg_header.src_comm_rank = ompi_comm_rank(comm);
+    } else {
+        msg_header.src_comm_rank = -1;
+    }
+    msg_header.src_proc_name = *OMPI_PROC_MY_NAME;
+    if( MSG_UP == type ) {
+        msg_header.nb_ack = nb_ack_failed;
+    } else {
+        msg_header.nb_ack = 0;
+    }
+
+    iov[0].iov_base = (char*)&msg_header;
+    iov[0].iov_len = sizeof(era_msg_header_t);
+    niov = 1;
+
+    if( ERA_VALUE_BYTES_COUNT(&value->header) > 0 ) {
+        iov[niov].iov_base = value->bytes;
+        iov[niov].iov_len = ERA_VALUE_BYTES_COUNT(&value->header);
+        niov++;
+    }
+    if( value->header.nb_new_dead > 0 ) {
+        iov[niov].iov_base = value->new_dead_array;
+        iov[niov].iov_len  = value->header.nb_new_dead * sizeof(int);
+        niov++;
+    }
+    if( MSG_UP == type && nb_ack_failed > 0 ) {
+        iov[niov].iov_base = ack_failed;
+        iov[niov].iov_len  = nb_ack_failed * sizeof(int);
+        niov++;
+    }
+
+    OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) send message [(%d.%d).%d, %s, %08x.%d.%d/%d..] to %d/%s: send %d bytes through iov (nb = %lu, lens = %lu,%lu,%lu,%lu)\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         agreement_id.ERAID_FIELDS.contextid,
+                         agreement_id.ERAID_FIELDS.epoch,
+                         agreement_id.ERAID_FIELDS.agreementid,
+                         era_msg_type_to_string(type),
+                         (0!=ERA_VALUE_BYTES_COUNT(&value->header))? *(int*)value->bytes: 0,
+                         value->header.ret,
+                         value->header.nb_new_dead,
+                         msg_header.nb_ack,
+                         dst,
+                         NULL != proc_name ? OMPI_NAME_PRINT(proc_name) : "(null)",
+                         to_send,
+                         niov,
+                         iov[0].iov_len,
+                         iov[1].iov_len,
+                         iov[2].iov_len,
+                         iov[3].iov_len));
+
+#if OPAL_ENABLE_DEBUG
+            {
+                char strbytes[256];
+                long unsigned int w;
+                strbytes[0] = '\0';
+
+                i = 0;
+                w = 0;
+                b = 0;
+                do {
+                    if(b == iov[i].iov_len) {
+                        i++;
+                        w += snprintf(strbytes + strlen(strbytes), 256 - strlen(strbytes), "|");
+                        if( i == niov )
+                            break;
+                        b = 0;
+                    }
+                    w += snprintf(strbytes + strlen(strbytes), 256 - strlen(strbytes), "%02x", ((uint8_t*)iov[i].iov_base)[b]);
+                    b++;
+                } while(w < 256);
+                if( strlen(strbytes) >= 252 ) {
+                    sprintf(strbytes + 252, "...");
+                }
+
+                OPAL_OUTPUT_VERBOSE((30, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ERA) send message [(%d.%d).%d, %s, %08x.%d.%d/%d..] to %d/%s: %d bytes including header = %s\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     agreement_id.ERAID_FIELDS.contextid,
+                                     agreement_id.ERAID_FIELDS.epoch,
+                                     agreement_id.ERAID_FIELDS.agreementid,
+                                     era_msg_type_to_string(type),
+                                     (0!=ERA_VALUE_BYTES_COUNT(&value->header))? *(int*)value->bytes: 0,
+                                     value->header.ret,
+                                     value->header.nb_new_dead,
+                                     msg_header.nb_ack,
+                                     dst,
+                                     NULL != proc_name ? OMPI_NAME_PRINT(proc_name) : "(null)",
+                                     to_send,
+                                     strbytes));
+            }
+#endif /* OPAL_ENABLE_DEBUG */
+
+    sent    = 0;
+    my_seqnum = msg_seqnum++;
+    i = 0;
+    b = 0;
+    while( sent < to_send ) {
+        /** Try to send everything in one go */
+        des = btl->btl_alloc(btl, btl_endpoint, MCA_BTL_NO_ORDER, sizeof(era_frag_t) + to_send - sent,
+                             MCA_BTL_DES_FLAGS_PRIORITY | MCA_BTL_DES_FLAGS_BTL_OWNERSHIP);
+        payload_size = des->des_segments->seg_len - sizeof(era_frag_t);
+        assert( payload_size > 0 ); /** We can send at least a byte */
+
+        des->des_cbfunc = fragment_sent_cb;
+        des->des_cbdata = NULL;
+        frag = (era_frag_t*)des->des_segments->seg_addr.pval;
+        frag->src = *OMPI_PROC_MY_NAME;
+        frag->msg_seqnum  = my_seqnum;
+        frag->frag_offset = sent;
+        frag->frag_len    = payload_size;
+        frag->msg_len     = to_send;
+        copied = 0;
+        while( copied < payload_size ) {
+            if( payload_size - copied <= iov[i].iov_len - b ) {
+                tocopy = payload_size - copied;
+            }
+            else {
+                tocopy = iov[i].iov_len - b;
+            }
+            memcpy(frag->bytes + copied, ((uint8_t*)iov[i].iov_base) + b, tocopy);
+            b += tocopy;
+            if( b == iov[i].iov_len ) {
+                assert(i+1 < niov || copied + tocopy == payload_size);
+                i++;
+                b = 0;
+            }
+            copied += tocopy;
+        }
+        btl->btl_send(btl, btl_endpoint, des, MCA_BTL_TAG_FT_AGREE);
+        sent += payload_size;
+    }
+}
+
+static void result_request(era_msg_header_t *msg_header)
+{
+    void *value;
+    era_value_t *old_agreement_value;
+    era_agreement_info_t *ci;
+    int r;
+
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Received RESULT_REQUEST Message: Agreement ID = (%d.%d).%d, sender: %d/%s\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         msg_header->agreement_id.ERAID_FIELDS.contextid,
+                         msg_header->agreement_id.ERAID_FIELDS.epoch,
+                         msg_header->agreement_id.ERAID_FIELDS.agreementid,
+                         msg_header->src_comm_rank,
+                         OMPI_NAME_PRINT(&msg_header->src_proc_name)));
+
+    if( opal_hash_table_get_value_uint64(&era_passed_agreements,
+                                         msg_header->agreement_id.ERAID_KEY,
+                                         &value) == OPAL_SUCCESS ) {
+        old_agreement_value = (era_value_t*)value;
+        send_msg(NULL, msg_header->src_comm_rank, &msg_header->src_proc_name, msg_header->agreement_id, MSG_DOWN, old_agreement_value, 0, NULL);
+        return;
+    }
+    /** I should be a descendent of msg_header->src (since RESULT_REQUEST messages are sent to
+     *  people below the caller.
+     *  So, the caller is the current root (or it is dead now and a new root was selected)
+     *  Two cases: */
+
+    ci = era_lookup_agreement_info(msg_header->agreement_id);
+    if( NULL != ci &&
+        ci->status == BROADCASTING ) {
+        /** if I am in this agreement, in the BROADCASTING state, then I need
+         *  to start working with my parent again, so that the info reaches the root, eventually.
+         *  There is in fact a good chance that this guy is my parent, but not in all cases,
+         *  so I send UP again to my parent, and we'll see what happens.
+         */
+        assert(ci->comm != NULL);
+        r = era_parent(ci);
+        if(r == ci->comm->c_my_rank) {
+            /** OK, weird case: a guy sent me that request, but died before I answered, and I receive it now... */
+            /** I will deal with that when I deal with the failure notification, and start again */
+            return;
+        }
+
+        ci->waiting_down_from = r;
+        send_msg(ci->comm, r, NULL, ci->agreement_id, MSG_UP, ci->current_value,
+                 ci->nb_acked, ci->acked);
+    } else {
+        era_value_t success_value;
+        OBJ_CONSTRUCT(&success_value, era_value_t);
+        success_value.header.ret = MPI_SUCCESS;
+        success_value.header.dt_count = 0;
+        success_value.header.operand  = ompi_mpi_op_band.op.o_f_to_c_index;
+        success_value.header.datatype = ompi_mpi_int.dt.d_f_to_c_index;
+        success_value.header.nb_new_dead = 0;
+        success_value.bytes = NULL;
+        success_value.new_dead_array = NULL;
+        /** Could be an old agreement that I collected already.
+         *  If that is the case, the epoch requested should be <= the current epoch for
+         *  that contextid (modulo rotation on the epoch numbering), and then the
+         *  number of requested data must be 0, by convention on the last "flushing"
+         *  agreement that was posted during the free.
+         */
+        if( msg_header->agreement_value_header.dt_count == 0 ) {
+            /** Then, the answer is "success" */
+            send_msg(NULL, msg_header->src_comm_rank, &msg_header->src_proc_name, msg_header->agreement_id,
+                     MSG_DOWN, &success_value, 0, NULL);
+
+            OBJ_DESTRUCT(&success_value);
+        } else {
+            /** Or, I have not started this agreement, or I have started this agreement, but a child
+             *  has not given me its contribution. So, I need to wait for it to send it to me, and
+             *  then I will send my UP message to the parent, so it can wait the normal step in
+             *  the protocol
+             */
+            return;
+        }
+    }
+}
+
+static void msg_up(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead, int *ack_failed)
+{
+    era_agreement_info_t *ci;
+    era_rank_item_t *rank_item;
+    void *value;
+    era_value_t *av;
+
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Received UP Message: Agreement ID = (%d.%d).%d, sender: %d/%s, msg value: %08x.%d.%d/%d\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         msg_header->agreement_id.ERAID_FIELDS.contextid,
+                         msg_header->agreement_id.ERAID_FIELDS.epoch,
+                         msg_header->agreement_id.ERAID_FIELDS.agreementid,
+                         msg_header->src_comm_rank,
+                         OMPI_NAME_PRINT(&msg_header->src_proc_name),
+                         (0!=ERA_VALUE_BYTES_COUNT(&msg_header->agreement_value_header))? *(int*)bytes: 0,
+                         msg_header->agreement_value_header.ret,
+                         msg_header->agreement_value_header.nb_new_dead,
+                         msg_header->nb_ack));
+
+    /** It could be an UP message about a decided agreement:
+     *  a child gives me its contribution, I broadcast and receive
+     *  the decision, or decide myself, and then the child dies before
+     *  it could transmit the decision to its own children. The children
+     *  will contact me as their new parent, still in their BROADCAST phase,
+     *  so what this UP message really means is "give me the decision." */
+    if( opal_hash_table_get_value_uint64(&era_passed_agreements,
+                                         msg_header->agreement_id.ERAID_KEY,
+                                         &value) == OPAL_SUCCESS ) {
+        av = (era_value_t*)value;
+        send_msg(NULL, msg_header->src_comm_rank, &msg_header->src_proc_name, msg_header->agreement_id, MSG_DOWN, av,
+                 0, NULL);
+        return;
+    }
+
+    ci = era_lookup_agreement_info( msg_header->agreement_id );
+
+    OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Managing UP Message, agreement is %s\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         ci == NULL ? "unknown" : "known"));
+
+    if( NULL == ci ) {
+        ci = era_create_agreement_info( msg_header->agreement_id, &msg_header->agreement_value_header );
+        if( msg_header->agreement_value_header.nb_new_dead > 0 ) {
+            /* ci->new_dead_array was allocated by create_agreement_info, let's copy it */
+            memcpy(ci->current_value->new_dead_array, new_dead,
+                   msg_header->agreement_value_header.nb_new_dead * sizeof(int));
+        }
+        /* We will attach the communicator when we contribute to it */
+    }
+
+    if( ci->status == BROADCASTING ) {
+        /** This can happen: a child gives me its contribution,
+         *  I enter the broadcast phase, then it dies; its children
+         *  have not received the decision yet, I haven't received the
+         *  decision yet, so they send me their contribution again,
+         *  and I receive this UP message while in BROADCASTING state.
+         *  The children contributions have been taken into account already.
+         *  Just in case we are slow at having the same view parent / child
+         *  as this guy, let's remember it requested to receive the answer
+         *  directly.
+         */
+        OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) Managing UP Message -- Already in BROADCASTING state: ignoring message, adding %d in the requesters\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             msg_header->src_comm_rank));
+
+        /** We could receive multiple messages from msg_header->src_comm_rank, because the messages are split */
+        for(rank_item = (era_rank_item_t*)opal_list_get_first(&ci->early_requesters);
+            rank_item != (era_rank_item_t*)opal_list_get_end(&ci->early_requesters);
+            rank_item = (era_rank_item_t*)opal_list_get_next(&rank_item->super)) {
+            if( rank_item->rank == msg_header->src_comm_rank ) {
+                return;
+            }
+        }
+
+        /** If not, add it */
+        rank_item = OBJ_NEW(era_rank_item_t);
+        rank_item->rank = msg_header->src_comm_rank;
+        opal_list_append(&ci->early_requesters, &rank_item->super);
+        return;
+    }
+
+    /** Did we receive enough contributions from that rank already?
+     *  He could be re-sending his data, because of some failure that
+     *  was discovered, and I requested it because I became root (because
+     *  of another failure), but it discovered the first failure at the
+     *  same time, and started sending without me requesting.
+     */
+    for( rank_item = (era_rank_item_t *)opal_list_get_first( &ci->gathered_info );
+         rank_item != (era_rank_item_t *)opal_list_get_end( &ci->gathered_info );
+         rank_item = (era_rank_item_t *)opal_list_get_next( &rank_item->super ) ) {
+        if( rank_item->rank == msg_header->src_comm_rank ) {
+            /* We are not waiting from more messages, thank you */
+            /* Maybe you're telling me again you want me to send? Let's check if I can't */
+            era_check_status(ci);
+            return;
+        }
+    }
+
+    av = OBJ_NEW(era_value_t);
+    memcpy(&av->header, &msg_header->agreement_value_header, sizeof(era_value_header_t));
+    /* We don't allocate the arrays of bytes and new_dead ranks: we point in the message.
+     * These pointers will need to be set to NULL *before* calling RELEASE.
+     * We can do this, because combine_agreement_values does not keep a reference on av */
+    av->bytes = bytes;
+    if( av->header.nb_new_dead > 0 )
+        av->new_dead_array = new_dead;
+    else
+        av->new_dead_array = NULL;
+
+    /* ci holds the current agreement information structure */
+    era_combine_agreement_values(ci, av);
+    era_update_return_value(ci, msg_header->nb_ack, ack_failed);
+
+    av->new_dead_array = NULL;
+    av->bytes = NULL;
+    OBJ_RELEASE(av);
+
+    /* We already checked above that this process did not contribute yet */
+    rank_item = OBJ_NEW(era_rank_item_t);
+    rank_item->rank = msg_header->src_comm_rank;
+    opal_list_append(&ci->gathered_info, &rank_item->super);
+    OPAL_OUTPUT_VERBOSE((20, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Received UP Message: adding %d in list of people that contributed\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         rank_item->rank));
+
+    era_check_status(ci);
+}
+
+static void msg_down(era_msg_header_t *msg_header, uint8_t *bytes, int *new_dead)
+{
+    era_agreement_info_t *ci;
+    era_value_t *av;
+    size_t value_bytes;
+
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Received DOWN Message: Agreement ID = (%d.%d).%d, sender: %d/%s, msg value: %08x.%d.\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         msg_header->agreement_id.ERAID_FIELDS.contextid,
+                         msg_header->agreement_id.ERAID_FIELDS.epoch,
+                         msg_header->agreement_id.ERAID_FIELDS.agreementid,
+                         msg_header->src_comm_rank,
+                         OMPI_NAME_PRINT(&msg_header->src_proc_name),
+                         (0!=ERA_VALUE_BYTES_COUNT(&msg_header->agreement_value_header))? *(int*)bytes: 0,
+                         msg_header->agreement_value_header.nb_new_dead));
+
+    ci = era_lookup_agreement_info( msg_header->agreement_id );
+    if( NULL == ci ) {
+        /** This can happen, if this DOWN is the result of a REQUEST, and
+         *  we received another DOWN from another sent REQUEST, and we
+         *  decided, so stored that agreement in the passed_agreements
+         */
+        return;
+    }
+    /** if I receive a down message on an agreement I know about, I already participated. 
+     * There is a non-erroneous code; erroneous execution that may also trigger this assert:
+     * consider the following case with false detection:
+     *   1. some ancestor A has detected the current process C as failed
+     *   2. C has not failed, obviously, since it is executing this assert (false detection)
+     *   3. Because C is considered failed, A (or its ancestors) decide without C
+     *   4. C's parent P has not detected C as failed (yet)
+     *   5. A DOWN message reaches P (possible because 3.)
+     *   6. P forwards the down message to its children; including C (because 4.)
+     *   7. C asserts; root cause is false detection, not an agreement bug.
+     */
+    assert( NULL != ci->comm );
+
+    av = OBJ_NEW(era_value_t);
+    memcpy(&av->header, &msg_header->agreement_value_header, sizeof(era_value_header_t));
+    /* We must allocate the arrays of bytes and new_dead ranks, because era_decide is going
+     * to keep that era_value_t */
+    value_bytes = ERA_VALUE_BYTES_COUNT(&av->header);
+    if( value_bytes > 0 ) {
+        av->bytes = (uint8_t *)malloc(value_bytes);
+        memcpy(av->bytes, bytes, value_bytes);
+    }
+    if( av->header.nb_new_dead > 0 ) {
+        av->new_dead_array = (int*)malloc(av->header.nb_new_dead * sizeof(int));
+        memcpy(av->new_dead_array, new_dead,
+               av->header.nb_new_dead * sizeof(int));
+    }
+    era_decide(av, ci);
+
+    OBJ_RELEASE(av);
+}
+
+
+typedef struct era_bounce_event_s {
+    opal_event_t ev;
+    era_msg_header_t msg;
+    uint8_t *value_bytes;
+    int *new_dead;
+    int *ack_failed;
+} era_bounce_event_t;
+
+static void era_bounce_event_cb(int fd, int flags, void* context) {
+    era_bounce_event_t *event = (era_bounce_event_t*)context;
+    era_msg_header_t *msg_header = &event->msg;
+    uint8_t *value_bytes = event->value_bytes;
+    int *new_dead = event->new_dead;
+    int *ack_failed = event->ack_failed;
+
+    if(opal_mutex_trylock(&era_mutex)) {
+        struct timeval now = {0, 0};
+        opal_event_add(&event->ev, &now);
+        return;
+    }
+    switch( msg_header->msg_type ) {
+    case MSG_RESULT_REQUEST:
+        result_request(msg_header);
+        break;
+    case MSG_UP:
+        msg_up(msg_header, value_bytes, new_dead, ack_failed);
+        break;
+    case MSG_DOWN:
+        msg_down(msg_header, value_bytes, new_dead);
+        break;
+    }
+    opal_mutex_unlock(&era_mutex);
+    free(event);
+}
+
+static void era_cb_fn(struct mca_btl_base_module_t* btl,
+                      const mca_btl_base_receive_descriptor_t* descriptor)
+{
+    era_incomplete_msg_t *incomplete_msg = NULL;
+    mca_btl_base_tag_t tag = descriptor->tag;
+    era_msg_header_t *msg_header;
+    era_frag_t *frag;
+    uint64_t src_hash;
+    void *value;
+    opal_hash_table_t *msg_table;
+    uint8_t *msg_bytes, *value_bytes;
+    int *new_dead;
+    int *ack_failed;
+
+    assert(MCA_BTL_TAG_FT_AGREE == tag);
+    assert(1 == descriptor->des_segment_count);
+
+    frag = (era_frag_t*)descriptor->des_segments->seg_addr.pval;
+
+    if( frag->msg_len == frag->frag_len ) {
+        assert(frag->frag_offset == 0);
+        msg_bytes = frag->bytes;
+    } else {
+        src_hash = hash_name(frag->src);
+        opal_mutex_lock(&era_incomplete_msg_mutex);
+        if( opal_hash_table_get_value_uint64(&era_incomplete_messages, src_hash, &value) == OMPI_SUCCESS ) {
+            msg_table = (opal_hash_table_t*)value;
+        } else {
+            msg_table = OBJ_NEW(opal_hash_table_t);
+            opal_hash_table_init(msg_table, 3 /* This should be very small: few messages should fly in parallel */);
+            opal_hash_table_set_value_uint64(&era_incomplete_messages, src_hash, (void*)msg_table);
+        }
+
+        if( opal_hash_table_get_value_uint64(msg_table, frag->msg_seqnum, &value) == OMPI_SUCCESS ) {
+            incomplete_msg = (era_incomplete_msg_t*)value;
+        } else {
+            incomplete_msg = (era_incomplete_msg_t*)malloc(frag->msg_len + sizeof(unsigned int));
+            incomplete_msg->bytes_received = 0;
+            opal_hash_table_set_value_uint64(msg_table, frag->msg_seqnum, (void*)incomplete_msg);
+        }
+        opal_mutex_unlock(&era_incomplete_msg_mutex);
+
+        memcpy( incomplete_msg->bytes + frag->frag_offset,
+                frag->bytes,
+                frag->frag_len );
+        incomplete_msg->bytes_received += frag->frag_len;
+
+        /** We receive the messages in order */
+        if( incomplete_msg->bytes_received == frag->msg_len ) {
+            msg_bytes = incomplete_msg->bytes;
+            opal_mutex_lock(&era_incomplete_msg_mutex);
+            opal_hash_table_remove_value_uint64(msg_table, frag->msg_seqnum);
+            /** We leave msg_table into the global table, as we will receive more messages */
+            opal_mutex_unlock(&era_incomplete_msg_mutex);
+        } else {
+            /** This message is incomplete */
+            return;
+        }
+    }
+
+    msg_header = (era_msg_header_t *)msg_bytes;
+    msg_bytes += sizeof(era_msg_header_t);
+
+    if( ERA_VALUE_BYTES_COUNT(&msg_header->agreement_value_header) > 0 ) {
+        value_bytes = msg_bytes;
+        msg_bytes += ERA_VALUE_BYTES_COUNT(&msg_header->agreement_value_header);
+    } else {
+        value_bytes = NULL;
+    }
+
+    if( msg_header->agreement_value_header.nb_new_dead > 0 ) {
+        new_dead = (int*)msg_bytes;
+        msg_bytes += msg_header->agreement_value_header.nb_new_dead * sizeof(int);
+    } else {
+        new_dead = NULL;
+    }
+
+    if( msg_header->nb_ack > 0 ) {
+        ack_failed = (int*)msg_bytes;
+    } else {
+        ack_failed = NULL;
+    }
+
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+    if( (double)rand() / (double)RAND_MAX < mca_coll_ftagree_rank_fault_proba ) {
+        OPAL_OUTPUT_VERBOSE((0, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) INJECT: Killing myself just before receiving message [(%d.%d).%d, %d, %08x.%d.%d...] from %d/%s\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             msg_header->agreement_id.ERAID_FIELDS.contextid,
+                             msg_header->agreement_id.ERAID_FIELDS.epoch,
+                             msg_header->agreement_id.ERAID_FIELDS.agreementid,
+                             msg_header->msg_type,
+                             (0!=ERA_VALUE_BYTES_COUNT(&msg_header->agreement_value_header))? *(int*)value_bytes: 0,
+                             msg_header->agreement_value_header.ret,
+                             msg_header->agreement_value_header.nb_new_dead,
+                             msg_header->src_comm_rank,
+                             OMPI_NAME_PRINT(&msg_header->src_proc_name)));
+        raise(SIGKILL);
+    }
+#endif
+
+    if(opal_mutex_trylock(&era_mutex)) {
+        struct timeval now = {0, 0};
+        era_bounce_event_t *event = malloc(sizeof(*event) + frag->msg_len);
+        memcpy(&event->msg, msg_header, frag->msg_len);
+        event->value_bytes = (void*)((intptr_t)&event->msg + (intptr_t)value_bytes - (intptr_t)msg_header);
+        event->new_dead = (void*)((intptr_t)&event->msg + (intptr_t)new_dead - (intptr_t)msg_header);
+        event->ack_failed = (void*)((intptr_t)&event->msg + (intptr_t)ack_failed - (intptr_t)msg_header);
+        opal_event_evtimer_set(opal_sync_event_base, &event->ev, era_bounce_event_cb, event);
+        opal_event_add(&event->ev, &now);
+    }
+    else {
+        switch( msg_header->msg_type ) {
+        case MSG_RESULT_REQUEST:
+            result_request(msg_header);
+            break;
+        case MSG_UP:
+            msg_up(msg_header, value_bytes, new_dead, ack_failed);
+            break;
+        case MSG_DOWN:
+            msg_down(msg_header, value_bytes, new_dead);
+            break;
+        }
+        opal_mutex_unlock(&era_mutex);
+    }
+
+    if( NULL != incomplete_msg ) {
+        free(incomplete_msg);
+    }
+}
+
+static void era_on_comm_rank_failure(ompi_communicator_t *comm, int rank, bool remote)
+{
+    void *value, *next_value;
+    era_agreement_info_t *ci;
+    void *node;
+    uint64_t key64, key64_2;
+    int rc;
+    era_identifier_t cid;
+    opal_process_name_t proc_name;
+    opal_hash_table_t *msg_table;
+
+    OPAL_OUTPUT_VERBOSE((4, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) %d in communicator (%d.%d) died\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         rank,
+                         comm->c_contextid,
+                         comm->c_epoch));
+
+    if( AGS(comm) != NULL ) {
+        AGS(comm)->ags_status |= AGS_AFR_DIRTY;
+    }
+
+    /** Discard incomplete messages, and remove the entry to store these messages */
+    proc_name = ompi_group_get_proc_name(remote ? comm->c_remote_group : comm->c_local_group, rank);
+    key64 = hash_name( proc_name );
+    if( opal_hash_table_get_value_uint64(&era_incomplete_messages, key64, &value) == OPAL_SUCCESS ) {
+        msg_table = (opal_hash_table_t*)value;
+        for(rc = opal_hash_table_get_first_key_uint64(msg_table, &key64_2, &value, &node);
+            OPAL_SUCCESS == rc;
+            rc = opal_hash_table_get_next_key_uint64(msg_table, &key64_2, &value, node, &node)) {
+            free( value );
+        }
+        opal_hash_table_remove_value_uint64(&era_incomplete_messages, key64);
+    }
+
+    if( opal_hash_table_get_first_key_uint64(&era_ongoing_agreements,
+                                             &key64,
+                                             &value, &node) == OPAL_SUCCESS ) {
+        do {
+            cid.ERAID_KEY = key64;
+
+            /** This is a reordered 'for' loop in which we get the next_value early on:
+             *    era_mark_process_failed may remove ci (the current value) from the hash table,
+             *    so we need to fetch it right now. */
+            rc = opal_hash_table_get_next_key_uint64(&era_ongoing_agreements,
+                                                     &key64, &next_value,
+                                                     node, &node);
+
+            if( cid.ERAID_FIELDS.contextid == comm->c_contextid &&
+                cid.ERAID_FIELDS.epoch     == comm->c_epoch ) {
+                ci = (era_agreement_info_t *)value;
+                OPAL_OUTPUT_VERBOSE((6, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ERA) Agreement ID (%d.%d).%d, rank %d died while doing the agreement\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     ci->agreement_id.ERAID_FIELDS.contextid,
+                                     ci->agreement_id.ERAID_FIELDS.epoch,
+                                     ci->agreement_id.ERAID_FIELDS.agreementid,
+                                     rank));
+                if( OMPI_COMM_IS_INTRA(comm) ) {
+                    era_mark_process_failed(ci, rank);
+                }
+                else {
+                    int shadowrank;
+                    if( ompi_comm_determine_first_auto(comm) ) {
+                        shadowrank = remote? rank+ompi_group_size(comm->c_local_group): rank;
+                    }
+                    else {
+                        shadowrank = remote? rank: rank+ompi_group_size(comm->c_remote_group);
+                    }
+                    if( NULL != ci->comm && AGS(comm) != AGS(ci->comm) ) AGS(ci->comm)->ags_status |= AGS_AFR_DIRTY;
+                    era_mark_process_failed(ci, shadowrank);
+                }
+            }
+
+            value = next_value;
+        } while( rc == OPAL_SUCCESS );
+    }
+
+    if( NULL != ompi_stacked_rank_failure_callback_fct ) {
+        (*ompi_stacked_rank_failure_callback_fct)(comm, rank, remote);
+    }
+}
+
+int mca_coll_ftagree_era_init(void)
+{
+    if( era_inited ) {
+        return OMPI_SUCCESS;
+    }
+
+    switch( mca_coll_ftagree_cur_era_topology < 0 ? -mca_coll_ftagree_cur_era_topology : mca_coll_ftagree_cur_era_topology ) {
+    case 1:
+        era_tree_fn = era_tree_fn_binary;
+        break;
+    case 2:
+        era_tree_fn = era_tree_fn_string;
+        break;
+    case 3:
+        era_tree_fn = era_tree_fn_star;
+        break;
+    default:
+        era_tree_fn = era_tree_fn_binary;
+    }
+
+    OBJ_CONSTRUCT(&era_mutex, opal_mutex_t);
+    OBJ_CONSTRUCT(&era_incomplete_msg_mutex, opal_mutex_t);
+
+    mca_bml.bml_register(MCA_BTL_TAG_FT_AGREE, era_cb_fn, NULL);
+
+    OBJ_CONSTRUCT( &era_iagree_requests, opal_free_list_t);
+    opal_free_list_init( &era_iagree_requests,
+                         sizeof(era_iagree_request_t),
+                         opal_cache_line_size,
+                         OBJ_CLASS(era_iagree_request_t),
+                         0, opal_cache_line_size,
+                         /* initial number of elements to allocate */ 0,
+                         /* maximum number of elements */ INT_MAX,
+                         /* increment */ 1,
+                         NULL, 0, /* mpool */
+                         NULL, /* unused */
+                         NULL, NULL /* elem_init */ );
+
+    OBJ_CONSTRUCT( &era_passed_agreements, opal_hash_table_t);
+    /* The garbage collection system relies on iterating over all
+     * passed agreements at the beginning of each new. It should be fast,
+     * because there should be only a small number of passed agreements, since we
+     * have garbage collection.
+     * However, iterating over all the elements in the hash table is linear with the
+     * number of buckets (see the implementation of opal_hash_table_get_next_key_uint64).
+     * Thus, we need to keep a small number of buckets for era_passed_agreements to keep
+     * good performance.
+     */
+    opal_hash_table_init(&era_passed_agreements, 32 /* We have GC, so small storage should be fine */);
+    OBJ_CONSTRUCT( &era_ongoing_agreements, opal_hash_table_t);
+    opal_hash_table_init(&era_ongoing_agreements, 16 /* We expect only a few */);
+
+    OBJ_CONSTRUCT( &era_incomplete_messages, opal_hash_table_t);
+    opal_hash_table_init(&era_incomplete_messages, 65536 /* Big Storage. Should be related to the universe size */);
+
+    ompi_stacked_rank_failure_callback_fct = ompi_rank_failure_cbfunc;
+    ompi_rank_failure_cbfunc = era_on_comm_rank_failure;
+
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Initialized\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME)));
+
+    era_inited = 1;
+
+    return OMPI_SUCCESS;
+}
+
+int mca_coll_ftagree_era_finalize(void)
+{
+    void                 *node;
+    void                 *value;
+    uint64_t              key64;
+    era_value_t          *av;
+    era_agreement_info_t *un_agreement;
+    opal_hash_table_t    *msg_table;
+    era_incomplete_msg_t *inc_msg;
+    int rc;
+
+    if( !era_inited ) {
+        return OMPI_SUCCESS;
+    }
+
+    ompi_rank_failure_cbfunc = ompi_stacked_rank_failure_callback_fct;
+
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Finalizing\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME)));
+    OPAL_OUTPUT_VERBOSE((7, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) GC: %lu passed agreements remain in the passed agreements hash table\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         opal_hash_table_get_size(&era_passed_agreements)));
+    for( rc = opal_hash_table_get_first_key_uint64(&era_passed_agreements, &key64, &value, &node);
+         OPAL_SUCCESS == rc;
+         rc = opal_hash_table_get_next_key_uint64(&era_passed_agreements, &key64, &value, node, &node) ) {
+#if OPAL_ENABLE_DEBUG
+        era_identifier_t pid;
+        pid.ERAID_KEY = key64;
+        assert(0!=pid.ERAID_FIELDS.agreementid);
+        OPAL_OUTPUT_VERBOSE((7, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) GC: agreement (%d.%d).%d belongs to the passed agreements hash table\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             pid.ERAID_FIELDS.contextid,
+                             pid.ERAID_FIELDS.epoch,
+                             pid.ERAID_FIELDS.agreementid));
+#endif /* OPAL_ENABLE_DEBUG */
+        av = (era_value_t *)value;
+        OBJ_RELEASE(av);
+    }
+    OBJ_DESTRUCT( &era_passed_agreements );
+    OBJ_DESTRUCT( &era_iagree_requests );
+
+    for( rc = opal_hash_table_get_first_key_uint64(&era_ongoing_agreements, &key64, &value, &node);
+         OPAL_SUCCESS == rc;
+         rc = opal_hash_table_get_next_key_uint64(&era_ongoing_agreements, &key64, &value, node, &node) ) {
+        un_agreement = (era_agreement_info_t *)value;
+        opal_output(0, "%s ftagree:agreement (ERA) ERRONEOUS: Agreement ID (%d.%d).%d was started by some processor, but I never completed to it\n",
+                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                    un_agreement->agreement_id.ERAID_FIELDS.contextid,
+                    un_agreement->agreement_id.ERAID_FIELDS.epoch,
+                    un_agreement->agreement_id.ERAID_FIELDS.agreementid);
+        OBJ_RELEASE(un_agreement);
+    }
+    OBJ_DESTRUCT( &era_ongoing_agreements );
+
+    for( rc = opal_hash_table_get_first_key_uint64(&era_incomplete_messages, &key64, &value, &node);
+         OPAL_SUCCESS == rc;
+         rc = opal_hash_table_get_next_key_uint64(&era_incomplete_messages, &key64, &value, node, &node) ) {
+        uint64_t key64_2;
+        void *value_2, *node_2;
+        int rc2;
+        msg_table = (opal_hash_table_t*)value;
+
+        for( rc2 = opal_hash_table_get_first_key_uint64(msg_table, &key64_2, &value_2, &node_2);
+             OPAL_SUCCESS == rc2;
+             rc2 = opal_hash_table_get_next_key_uint64(msg_table, &key64_2, &value_2, node_2, &node_2) ) {
+            inc_msg = (era_incomplete_msg_t *)value_2;
+            free(inc_msg);
+        }
+
+        OBJ_RELEASE(msg_table);
+    }
+    OBJ_DESTRUCT( &era_incomplete_messages );
+
+    OBJ_DESTRUCT( &era_mutex );
+    OBJ_DESTRUCT( &era_incomplete_msg_mutex );
+
+    era_inited = 0;
+
+    return OMPI_SUCCESS;
+}
+
+static int mca_coll_ftagree_era_prepare_agreement(ompi_communicator_t* comm,
+                                                            ompi_group_t *group,
+                                                            ompi_op_t *op,
+                                                            ompi_datatype_t *dt,
+                                                            int dt_count,
+                                                            void *contrib,
+                                                            mca_coll_base_module_t *module,
+                                                            era_identifier_t *paid,
+                                                            era_agreement_info_t **pci)
+{
+    era_agreement_info_t *ci;
+    era_identifier_t agreement_id;
+    void *value;
+    era_value_t agreement_value;
+    era_value_t *pa;
+    mca_coll_ftagree_t *ag_info;
+
+    ag_info = ( (mca_coll_ftagree_module_t *)module )->agreement_info;
+    assert( NULL != ag_info );
+
+    opal_mutex_lock(&era_mutex);
+
+    /** Avoid cycling silently */
+    if( ag_info->agreement_seq_num == UINT16_MAX ) {
+        ag_info->agreement_seq_num = 1;
+    } else {
+        ag_info->agreement_seq_num++;
+    }
+
+    /* Let's find the id of the new agreement */
+    agreement_id.ERAID_FIELDS.contextid   = comm->c_contextid;
+    agreement_id.ERAID_FIELDS.epoch       = comm->c_epoch;
+    agreement_id.ERAID_FIELDS.agreementid = (uint16_t)ag_info->agreement_seq_num;
+
+    OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Entering Agreement ID = (%d.%d).%d\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         agreement_id.ERAID_FIELDS.contextid,
+                         agreement_id.ERAID_FIELDS.epoch,
+                         agreement_id.ERAID_FIELDS.agreementid));
+    era_debug_print_group(3, group, comm, "Before Agreement");
+
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+    if( (double)rand() / (double)RAND_MAX < mca_coll_ftagree_rank_fault_proba ) {
+        OPAL_OUTPUT_VERBOSE((0, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ERA) INJECT: Killing myself just before entering the agreement (%d.%d).%d\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             agreement_id.ERAID_FIELDS.contextid,
+                             agreement_id.ERAID_FIELDS.epoch,
+                             agreement_id.ERAID_FIELDS.agreementid));
+        raise(SIGKILL);
+    }
+#endif
+
+    OBJ_CONSTRUCT(&agreement_value, era_value_t);
+
+    agreement_value.header.ret         = 0;
+    agreement_value.header.operand     = op->o_f_to_c_index;
+    agreement_value.header.dt_count    = dt_count;
+    agreement_value.header.datatype    = dt->d_f_to_c_index;
+    agreement_value.header.nb_new_dead = 0;
+
+    /* Let's create or find the current value */
+    ci = era_lookup_agreement_info(agreement_id);
+    if( NULL == ci ) {
+        ci = era_create_agreement_info(agreement_id, &agreement_value.header);
+    }
+
+    assert( NULL == ci->comm );
+    assert( NULL != group );
+    era_agreement_info_set_comm(ci, comm, group);
+
+    if( opal_hash_table_get_value_uint64(&era_passed_agreements, agreement_id.ERAID_KEY, &value) == OMPI_SUCCESS ) {
+        opal_output(0, "*** WARNING *** %s ftagree:agreement (ERA) removing old agreement (%d.%d).%d from history, due to cycling of identifiers\n",
+                    OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                    agreement_id.ERAID_FIELDS.contextid,
+                    agreement_id.ERAID_FIELDS.epoch,
+                    agreement_id.ERAID_FIELDS.agreementid);
+        assert(0 != agreement_id.ERAID_FIELDS.agreementid);
+        pa = (era_value_t*)value;
+        opal_hash_table_remove_value_uint64(&era_passed_agreements, agreement_id.ERAID_KEY);
+        OBJ_RELEASE(pa);
+    }
+
+    /* I participate */
+    agreement_value.bytes = (uint8_t*)contrib;
+
+    era_agreement_value_set_gcrange(agreement_id, &agreement_value);
+    era_combine_agreement_values(ci, &agreement_value);
+
+    agreement_value.bytes = NULL; /* We don't free &flag... */
+    OBJ_DESTRUCT(&agreement_value);
+
+    /* I start the state machine */
+    ci->status = GATHERING;
+
+    /* And follow its logic */
+    era_check_status(ci);
+
+    opal_mutex_unlock(&era_mutex);
+
+    *paid = agreement_id;
+    *pci = ci;
+    return OMPI_SUCCESS;
+}
+
+static int mca_coll_ftagree_era_complete_agreement(era_identifier_t agreement_id,
+                                                             void *contrib,
+                                                             ompi_group_t **group)
+{
+    era_value_t *av;
+    int ret;
+    int i;
+    era_agreement_info_t *ci;
+    ompi_communicator_t *comm;
+    void *value;
+
+    assert(0 != agreement_id.ERAID_FIELDS.agreementid);
+    ci = era_lookup_agreement_info(agreement_id);
+
+    /** Now, it's time to remove that guy from the ongoing agreements */
+    opal_hash_table_remove_value_uint64(&era_ongoing_agreements, agreement_id.ERAID_KEY);
+
+    comm = ci->comm;
+
+    OBJ_RELEASE(ci); /* This will take care of the content of ci too */
+
+    ret = opal_hash_table_get_value_uint64(&era_passed_agreements,
+                                           agreement_id.ERAID_KEY,
+                                           &value);
+    assert( OPAL_SUCCESS == ret);
+    av = (era_value_t *)value;
+
+    memcpy(contrib, av->bytes, ERA_VALUE_BYTES_COUNT(&av->header));
+    ret = av->header.ret;
+
+    /* We leave av in the era_passe_agreeements table, to answer future requests
+     * from slow processes */
+
+    /* Update the group of failed processes */
+    for(i = 0; i < AGS(comm)->afr_size; i++) {
+        ompi_proc_t *proc = ompi_group_get_proc_ptr(comm->c_local_group, AGS(comm)->agreed_failed_ranks[i], true);
+        ompi_errhandler_proc_failed(proc);
+    }
+
+    /* User wants the group of new failures */
+    if(NULL != group) {
+        OBJ_RELEASE(*group);
+        ompi_group_incl(comm->c_local_group, AGS(comm)->afr_size,
+                        AGS(comm)->agreed_failed_ranks, group);
+        era_debug_print_group(3, *group, comm, "After Agreement");
+    }
+
+    OPAL_OUTPUT_VERBOSE((3, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Leaving Agreement ID = (%d.%d).%d with ret = %d, 4 first bytes of flag = 0x%08x\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         agreement_id.ERAID_FIELDS.contextid,
+                         agreement_id.ERAID_FIELDS.epoch,
+                         agreement_id.ERAID_FIELDS.agreementid,
+                         ret,
+                         (0!=ERA_VALUE_BYTES_COUNT(&av->header))? *(int*)contrib: 0));
+
+    return ret;
+}
+
+/*
+ * mca_coll_ftagree_era_intra
+ *
+ * Function:	- MPI_Comm_agree()
+ * Accepts:	- same as MPI_Comm_agree()
+ * Returns:	- MPI_SUCCESS or an MPI error code
+ */
+int mca_coll_ftagree_era_intra(void *contrib,
+                                         int dt_count,
+                                         ompi_datatype_t *dt,
+                                         ompi_op_t *op,
+                                         ompi_group_t **group, bool grp_update,
+                                         ompi_communicator_t* comm,
+                                         mca_coll_base_module_t *module)
+{
+    int rc;
+    ompi_request_t* req;
+
+    rc = mca_coll_ftagree_iera_intra(contrib, dt_count, dt, op, group, grp_update, comm, &req, module);
+    if(OPAL_UNLIKELY( OMPI_SUCCESS != rc ))
+        return rc;
+    ompi_request_wait_completion(req);
+    rc = req->req_status.MPI_ERROR;
+    ompi_request_free(&req);
+    return rc;
+}
+
+/*
+ * mca_coll_ftagree_era_inter
+ *
+ * Function:	- MPI_Comm_agree()
+ * Accepts:	- same as MPI_Comm_agree()
+ * Returns:	- MPI_SUCCESS or an MPI error code
+ */
+int mca_coll_ftagree_era_inter(void *contrib,
+                                         int dt_count,
+                                         ompi_datatype_t *dt,
+                                         ompi_op_t *op,
+                                         ompi_group_t **group, bool grp_update,
+                                         ompi_communicator_t* comm,
+                                         mca_coll_base_module_t *module)
+{
+    ompi_communicator_t* shadowcomm;
+    ompi_group_t* uniongrp;
+    int contriblh[2];
+    int rc;
+    int first;
+
+    if( OPAL_UNLIKELY(op != &ompi_mpi_op_band.op
+                   || dt != &ompi_mpi_int.dt
+                   || dt_count != 1) ) {
+        return MPI_ERR_UNSUPPORTED_OPERATION;
+    }
+
+    first = ompi_comm_determine_first_auto(comm);
+    if( first ) {
+        ompi_group_union( comm->c_local_group, comm->c_remote_group, &uniongrp );
+        contriblh[0] = *(int*)contrib;
+        contriblh[1] = ~0;
+    }
+    else {
+        ompi_group_union( comm->c_remote_group, comm->c_local_group, &uniongrp );
+        contriblh[0] = ~0;
+        contriblh[1] = *(int*)contrib;
+    }
+    ompi_comm_set(&shadowcomm, comm,
+                  ompi_group_size(uniongrp), NULL, 0, NULL,
+                  NULL, comm->error_handler, NULL,
+                  uniongrp, NULL);
+    ompi_group_free(&uniongrp);
+    shadowcomm->c_contextid = comm->c_contextid;
+    shadowcomm->c_epoch = comm->c_epoch;
+    snprintf(shadowcomm->c_name, MPI_MAX_OBJECT_NAME, "SHADOW OF %s", &comm->c_name[0]);
+    shadowcomm->any_source_offset = comm->any_source_offset;
+    shadowcomm->agreement_specific = comm->agreement_specific;
+
+    rc = mca_coll_ftagree_era_intra(contriblh, dt_count*2, dt, op, group, grp_update, shadowcomm, module);
+
+    comm->agreement_specific = shadowcomm->agreement_specific;
+    if( NULL != comm->agreement_specific ) OBJ_RETAIN(comm->agreement_specific);
+    OBJ_RELEASE(shadowcomm);
+
+    *(int*)contrib = first? contriblh[1]: contriblh[0];
+    return rc;
+}
+
+static int era_iagree_req_free(struct ompi_request_t** rptr)
+{
+    era_iagree_request_t *req = (era_iagree_request_t *)*rptr;
+
+    if( NULL != req->ci )
+        req->ci->req = NULL;
+    req->ci = NULL;
+    OMPI_REQUEST_FINI(&req->super);
+    opal_free_list_return( &era_iagree_requests,
+                           (opal_free_list_item_t*)(req));
+    *rptr = MPI_REQUEST_NULL;
+    return OMPI_SUCCESS;
+}
+
+static int era_iagree_req_complete_cb(struct ompi_request_t* request)
+{
+    era_iagree_request_t *req = (era_iagree_request_t *)request;
+    int rc;
+
+    assert( req->ci != NULL );
+    assert( req->ci->status == COMPLETED );
+
+    rc = mca_coll_ftagree_era_complete_agreement(req->agreement_id, req->contrib, req->outgroup);
+    req->ci = NULL;
+    req->super.req_status.MPI_ERROR = rc;
+    return 0;
+}
+
+int mca_coll_ftagree_iera_intra(void *contrib,
+                                          int dt_count,
+                                          ompi_datatype_t *dt,
+                                          ompi_op_t *op,
+                                          ompi_group_t **group, bool grp_update,
+                                          ompi_communicator_t* comm,
+                                          ompi_request_t **request,
+                                          mca_coll_base_module_t *module)
+{
+    opal_free_list_item_t* item;
+    era_iagree_request_t *req;
+    era_identifier_t agreement_id;
+    era_agreement_info_t *ci;
+
+    item = opal_free_list_get(&era_iagree_requests);
+    if( NULL == item ) return OMPI_ERR_OUT_OF_RESOURCE;
+    req = (era_iagree_request_t*)item;
+
+    OMPI_REQUEST_INIT(&req->super, false);
+    assert(MPI_UNDEFINED == req->super.req_f_to_c_index);
+
+    mca_coll_ftagree_era_prepare_agreement(comm, *group, op, dt, dt_count, contrib, module,
+                                                     &agreement_id, &ci);
+    req->super.req_state = OMPI_REQUEST_ACTIVE;
+    req->super.req_type = OMPI_REQUEST_COLL;
+    req->super.req_status.MPI_SOURCE = MPI_ANY_SOURCE;
+    req->super.req_status.MPI_ERROR = MPI_SUCCESS;
+    req->super.req_status.MPI_TAG = MPI_ANY_TAG;
+    req->super.req_status._ucount = 0;
+    req->super.req_status._cancelled = 0;
+    req->super.req_mpi_object.comm = comm;
+    req->super.req_complete_cb_data = NULL;
+
+    req->super.req_free = era_iagree_req_free;
+    req->super.req_cancel = NULL; /**< Don't know how to cancel an immediate agreement */
+    req->super.req_complete_cb = era_iagree_req_complete_cb;
+
+    req->agreement_id = agreement_id;
+    req->contrib = contrib;
+    req->outgroup = grp_update? group: NULL;
+    req->ci = ci;
+
+    ci->req = req;
+
+    if( ci->status == COMPLETED ) {
+        /**< must call this now, since it won't have been called in prepare
+         *   as the request was not saved in ci at this time */
+        opal_mutex_lock(&era_mutex);
+        ompi_request_complete(&req->super, false);
+        opal_mutex_unlock(&era_mutex);
+    }
+
+    *request = &req->super;
+
+    return OMPI_SUCCESS;
+}
+
+int mca_coll_ftagree_era_free_comm(ompi_communicator_t* comm,
+                                   mca_coll_base_module_t *module)
+{
+    ompi_group_t* acked;
+    era_identifier_t aid;
+    int rc;
+
+    OPAL_OUTPUT_VERBOSE((4, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ERA) Freeing Communicator (%d.%d).\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                         comm->c_contextid,
+                         comm->c_epoch));
+
+    opal_mutex_lock(&ompi_group_afp_mutex);
+    ompi_group_intersection(comm->c_remote_group, ompi_group_all_failed_procs, &acked);
+    opal_mutex_unlock(&ompi_group_afp_mutex);
+    do {
+        rc = mca_coll_ftagree_era_intra(NULL,
+                                        0,
+                                        &ompi_mpi_int.dt,
+                                        &ompi_mpi_op_band.op,
+                                        &acked, true,
+                                        comm,
+                                        comm->c_coll->coll_agree_module);
+    } while(rc != MPI_SUCCESS);
+    OBJ_RELEASE(acked);
+
+    aid.ERAID_FIELDS.contextid = comm->c_contextid;
+    aid.ERAID_FIELDS.epoch     = comm->c_epoch;
+
+    opal_mutex_lock(&era_mutex);
+    /** We don't need to set aid.ERAID_FIELDS.agreementid to collect all of them */
+    era_collect_passed_agreements(aid, 0, (uint16_t)-1);
+    opal_mutex_unlock(&era_mutex);
+
+    return OMPI_SUCCESS;
+}

--- a/ompi/mca/coll/ftagree/coll_ftagree_earlyterminating.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_earlyterminating.c
@@ -1,0 +1,369 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "coll_ftagree.h"
+#include "coll_ftagree_era.h"
+
+#include "mpi.h"
+#include "ompi/constants.h"
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/datatype/ompi_datatype_internal.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/pml/pml.h"
+
+#include MCA_timer_IMPLEMENTATION_HEADER
+#include "coll_ftagree.h"
+
+/**
+ * This Agreement implements the protocol proposed in
+ *   Early Consensus in Message-passing Systems Enriched with a Perfect Failure Detector
+ *     and its Application in the Theta Model.
+ *   by Francois Bonnet, Michel Raynal
+ *   in 2010 European Dependable Computing Conference
+ */
+
+/** Those are the possible status of the process following the algorithm */
+#define STATUS_NO_INFO               0
+#define STATUS_CRASHED           (1<<0)
+#define STATUS_ACRASHED         ((1<<1) | STATUS_CRASHED)
+#define STATUS_TOLD_ME_HE_KNOWS  (1<<2)
+#define STATUS_KNOWS_I_KNOW      (1<<3)
+/** Those are used solely to track requests completion */
+#define STATUS_SEND_COMPLETE     (1<<4)
+#define STATUS_RECV_COMPLETE     (1<<5)
+
+typedef struct {
+    int knows;
+    int pf;
+    char est_value[];
+} ftagree_eta_agreement_msg_t;
+
+#define FTAGREE_ETA_TAG_AGREEMENT MCA_COLL_BASE_TAG_AGREEMENT
+
+/*
+ *	eta_intra
+ *
+ *	Function:	- MPI_Comm_agree()
+ *	Accepts:	- same as MPI_Comm_agree()
+ *	Returns:	- MPI_SUCCESS or an MPI error code
+ */
+
+int
+mca_coll_ftagree_eta_intra(void *contrib,
+                           int dt_count,
+                           ompi_datatype_t *dt,
+                           ompi_op_t *op,
+                           ompi_group_t **group, bool update_grp,
+                           ompi_communicator_t* comm,
+                           mca_coll_base_module_t *module)
+{
+    ftagree_eta_agreement_msg_t *out, *in;
+    size_t dt_size, msg_size;
+    int *proc_status; /**< char would be enough, but we use the same area to build the group of dead processes at the end */
+    ompi_request_t **reqs;
+    MPI_Status *statuses;
+    int me, i, ri, nr, np, nbrecv, rc, ret = MPI_SUCCESS, nbknow = 0, nbcrashed = 0, round;
+
+    np = ompi_comm_size(comm);
+    me = ompi_comm_rank(comm);
+    proc_status = (int *)calloc( np, sizeof(int) );
+
+    ompi_datatype_type_size(dt, &dt_size);
+    msg_size = sizeof(ftagree_eta_agreement_msg_t) + dt_count * dt_size;
+
+    /* This should go in the module query, and a module member should be used here */
+    reqs = (ompi_request_t **)calloc( 2 * np, sizeof(ompi_request_t *) ); /** < Need to calloc or set to MPI_REQUEST_NULL to ensure cleanup in all cases. */
+    statuses = (MPI_Status*)malloc( 2 * np * sizeof(MPI_Status) );
+    in = (ftagree_eta_agreement_msg_t*)calloc( np, msg_size );
+    out = (ftagree_eta_agreement_msg_t*)malloc( msg_size );
+
+    memcpy(out->est_value, contrib, dt_count * dt_size);
+    out->knows = 0;
+    out->pf = 0;
+    round = 1;
+
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ETA) Starting Agreement with message size of %lu bytes (%lu bytes for the agreement value)\n",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), msg_size, dt_count * dt_size));
+
+    { /* ignore acked failures (add them later to the result) */
+        ompi_group_t* ackedgrp = NULL; int npa; int *aranks, *cranks;
+        ackedgrp = *group;
+        if( 0 != (npa = ompi_group_size(ackedgrp)) ) {
+            aranks = calloc( npa, sizeof(int) );
+            for( i = 0; i < npa; i++ ) aranks[i] = i;
+            cranks = calloc( npa, sizeof(int) );
+            ompi_group_translate_ranks( ackedgrp, npa, aranks, comm->c_remote_group, cranks );
+            for( i = 0; i < npa; i++ ) {
+                OPAL_OUTPUT_VERBOSE((1, ompi_ftmpi_output_handle,
+                                     "%s has acknowledged rank %d, ignoring\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), cranks[i] ));
+                proc_status[cranks[i]] = STATUS_ACRASHED;
+            }
+            free(aranks);
+            free(cranks);
+        }
+    }
+
+#define NEED_TO_RECV(_i) (me != _i && (!(proc_status[_i] & STATUS_CRASHED)) && (!(proc_status[_i] & STATUS_TOLD_ME_HE_KNOWS)))
+#define NEED_TO_SEND(_i) (me != _i && (!(proc_status[_i] & STATUS_CRASHED)) && (!(proc_status[_i] & STATUS_KNOWS_I_KNOW)))
+
+    while(round <= (np + 1)) {
+        OPAL_OUTPUT_VERBOSE((50, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ETA) Starting Round %d\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), round));
+
+        /**
+         * Post all the requests, first the receives and then the sends.
+         */
+        nr = 0;
+        for(i = 0; i < np; i++) {
+
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+            if( (double)rand() / (double)RAND_MAX < mca_coll_ftagree_rank_fault_proba ) {
+                OPAL_OUTPUT_VERBOSE((0, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ETA) INJECT: Killing myself just before posting message reception to/from %d\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                                     i));
+                raise(SIGKILL);
+            }
+#endif
+
+            if( NEED_TO_RECV(i) ) {
+                /* Need to know more about this guy */
+                MCA_PML_CALL(irecv(((char*)in) + (i*msg_size), msg_size, MPI_BYTE,
+                                   i, FTAGREE_ETA_TAG_AGREEMENT, comm,
+                                   &reqs[nr++]));
+                proc_status[i] &= ~STATUS_RECV_COMPLETE;
+                OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ETA) Request for recv of rank %d is at %d(%p)\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), i, nr-1, (void*)reqs[nr-1]));
+            } else {
+                proc_status[i] |= STATUS_RECV_COMPLETE;
+            }
+            if( NEED_TO_SEND(i) ) {
+                /* Need to communicate with this guy */
+                MCA_PML_CALL(isend(out, msg_size, MPI_BYTE,
+                                   i, FTAGREE_ETA_TAG_AGREEMENT,
+                                   MCA_PML_BASE_SEND_STANDARD, comm,
+                                   &reqs[nr++]));
+                proc_status[i] &= ~STATUS_SEND_COMPLETE;
+                OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ETA) Request for send of rank %d is at %d(%p)\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), i, nr-1, (void*)reqs[nr-1]));
+            } else {
+                proc_status[i] |= STATUS_SEND_COMPLETE;
+            }
+        }
+        for(i = nr; i < 2*np; i++) {
+            reqs[i] = MPI_REQUEST_NULL;
+        }
+
+        do {
+            OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                                 "%s ftagree:agreement (ETA) Entering waitall(%d)\n",
+                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), nr));
+
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+            if( (double)rand() / (double)RAND_MAX < mca_coll_ftagree_rank_fault_proba ) {
+                OPAL_OUTPUT_VERBOSE((0, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ETA) INJECT: Killing myself just before waitall\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME)));
+                raise(SIGKILL);
+            }
+#endif
+
+            rc = ompi_request_wait_all(nr, reqs, statuses);
+
+#if defined(FTAGREE_DEBUG_FAILURE_INJECT)
+            if( (double)rand() / (double)RAND_MAX < mca_coll_ftagree_rank_fault_proba ) {
+                OPAL_OUTPUT_VERBOSE((0, ompi_ftmpi_output_handle,
+                                     "%s ftagree:agreement (ETA) INJECT: Killing myself just after waitall\n",
+                                     OMPI_NAME_PRINT(OMPI_PROC_MY_NAME)));
+                raise(SIGKILL);
+            }
+#endif
+
+            /**< If we need to re-wait on some requests, we're going to pack them at index nr */
+            nr = 0;
+
+            nbrecv = 0;
+
+            if( rc != MPI_ERR_IN_STATUS && rc != MPI_SUCCESS ) {
+                ret = rc;
+                goto clean_and_exit;
+            }
+
+            /* Long loop if somebody failed */
+            ri = 0;
+            for(i = 0; i < np; i++) {
+                if( !(proc_status[i] & STATUS_RECV_COMPLETE) ) {
+                    if( (rc == MPI_SUCCESS) || (MPI_SUCCESS == statuses[ri].MPI_ERROR) ) {
+                        assert(MPI_REQUEST_NULL == reqs[ri]);
+
+                        /* Implements the binary and of answers */
+                        ompi_op_reduce(op, in[i].est_value, out->est_value, dt_count, dt);
+
+                        /* Implements the logical or of ERR_PROC_FAILED returns */
+                        out->pf |= in[i].pf;
+                        proc_status[i] |= ( (in[i].knows * STATUS_TOLD_ME_HE_KNOWS) | STATUS_RECV_COMPLETE);
+                        nbrecv++;
+
+                        OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                                             "%s ftagree:agreement (ETA) Request %d(%p) for recv of rank %d is completed.\n",
+                                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), ri, (void*)reqs[ri], i));
+                    } else {
+                        if( (MPI_ERR_PROC_FAILED == statuses[ri].MPI_ERROR) ) {
+                            /* Failure detected */
+                            proc_status[i] |= (STATUS_CRASHED | STATUS_RECV_COMPLETE);
+                            OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                                                 "%s ftagree:agreement (ETA) recv with rank %d failed on request at index %d(%p). Mark it as dead!",
+                                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), i, ri, (void*)reqs[ri]));
+                            out->pf = 1;
+/* per spec this should already be completed; TODO remove of proven correct */
+                            /* Release the request, it can't be subsequently completed */
+                            if(MPI_REQUEST_NULL != reqs[ri])
+                                ompi_request_free(&reqs[ri]);
+                        } else if( (MPI_ERR_PENDING == statuses[ri].MPI_ERROR) ) {
+                            /* The pending request(s) will be waited on at the next iteration. */
+                            assert( ri >= nr );
+                            assert( MPI_REQUEST_NULL != reqs[ri] );
+                            assert( ri == nr || reqs[nr] == MPI_REQUEST_NULL );
+                            OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                                                 "%s ftagree:agreement (ETA) Request %d(%p) for recv of rank %d remains pending. Renaming it as Request %d\n",
+                                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), ri, (void*)reqs[ri], i, nr));
+                            reqs[nr] = reqs[ri];
+                            if( ri != nr )
+                                reqs[ri] = MPI_REQUEST_NULL;
+                            nr++;
+                        } else {
+                            ret = statuses[ri].MPI_ERROR;
+                            goto clean_and_exit;
+                        }
+                    }
+                    ri++;
+                }
+
+                if( !(proc_status[i] & STATUS_SEND_COMPLETE) ) {
+                    if( (rc == MPI_SUCCESS) || (MPI_SUCCESS == statuses[ri].MPI_ERROR) ) {
+                        assert(MPI_REQUEST_NULL == reqs[ri]);
+                        proc_status[i] |= ((out->knows * STATUS_KNOWS_I_KNOW) | STATUS_SEND_COMPLETE);
+
+                        OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                                             "%s ftagree:agreement (ETA) Request %d(%p) for send of rank %d is completed.\n",
+                                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), ri, (void*)reqs[ri], i));
+                    } else {
+                        if( (MPI_ERR_PROC_FAILED == statuses[ri].MPI_ERROR) ) {
+                            /* Failure detected */
+                            proc_status[i] |= (STATUS_CRASHED | STATUS_SEND_COMPLETE);
+
+                            OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                                                 "%s ftagree:agreement (ETA) send with rank %d failed on Request %d(%p). Mark it as dead!",
+                                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), i, ri, (void*)reqs[ri]));
+                            out->pf = 1;
+/* per spec this should already be completed; TODO understand why not */
+                            /* Release the request, it can't be subsequently completed */
+                            if(MPI_REQUEST_NULL != reqs[ri])
+                                ompi_request_free(&reqs[ri]);
+                        } else if( (MPI_ERR_PENDING == statuses[ri].MPI_ERROR) ) {
+                            /* The pending request(s) will be waited on at the next iteration. */
+                            assert( ri >= nr );
+                            assert( MPI_REQUEST_NULL != reqs[ri] );
+                            assert( ri == nr || reqs[nr] == MPI_REQUEST_NULL );
+                            OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                                                 "%s ftagree:agreement (ETA) Request %d(%p) for send of rank %d remains pending. Renaming it as Request %d\n",
+                                                 OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), ri, (void*)reqs[ri], i, nr));
+                            reqs[nr] = reqs[ri];
+                            if( ri != nr )
+                                reqs[ri] = MPI_REQUEST_NULL;
+                            nr++;
+                        } else {
+                            ret = statuses[ri].MPI_ERROR;
+                            goto clean_and_exit;
+                        }
+                    }
+                    ri++;
+                }
+
+            }
+
+        } while( 0 != nr );
+
+#undef NEED_TO_SEND
+#undef NEED_TO_RECV
+
+        nbcrashed = 0;
+        for(i = 0; i < np; i++)
+            if( proc_status[i] & STATUS_CRASHED )
+                nbcrashed++;
+        nbknow = 0;
+        for(i = 0; i < np; i++)
+            if( (!(proc_status[i] & STATUS_CRASHED)) && (proc_status[i] & STATUS_TOLD_ME_HE_KNOWS) )
+                nbknow++;
+
+        OPAL_OUTPUT_VERBOSE((50, ompi_ftmpi_output_handle,
+                             "%s ftagree:agreement (ETA) end of Round %d: nbcrashed = %d, nbknow = %d, nbrecv = %d. out.knows = %d\n",
+                             OMPI_NAME_PRINT(OMPI_PROC_MY_NAME),
+                             round, nbcrashed, nbknow, nbrecv, out->knows));
+
+        if( (nbknow + nbcrashed >= np - 1) && (out->knows == 1) ) {
+            break;
+        }
+
+        out->knows = (nbknow > 0) || (nbrecv >= np - round + 1);
+        round++;
+    }
+
+ clean_and_exit:
+    OPAL_OUTPUT_VERBOSE((10, ompi_ftmpi_output_handle,
+                "%s ftbasis:agreement (ETA) decided in %d rounds ", OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), round));
+    for (ri = 0; ri < 2*np; ++ri)
+        if( NULL != reqs[ri] && MPI_REQUEST_NULL != reqs[ri])
+            ompi_request_free( &reqs[ri] );
+    free(reqs);
+    free(statuses);
+    free(in);
+    /* Let's build the group of failed processes */
+    if( NULL != group ) {
+        int pos;
+        /* We overwrite proc_status because it is not used anymore */
+        int *failed = proc_status;
+
+        for( pos = i = 0; i < np; i++ ) {
+            if( STATUS_CRASHED & proc_status[i] ) {
+                failed[pos++] = i;
+            }
+        }
+        if( update_grp ) {
+            OBJ_RELEASE(*group);
+            ompi_group_incl(comm->c_remote_group, pos, failed, group);
+        }
+    }
+    free(proc_status);
+
+    if( (MPI_SUCCESS == ret) && out->pf ) {
+        ret = MPI_ERR_PROC_FAILED;
+    }
+
+    memcpy(contrib, out->est_value, dt_count * dt_size);
+    free(out);
+
+    OPAL_OUTPUT_VERBOSE((5, ompi_ftmpi_output_handle,
+                         "%s ftagree:agreement (ETA) return %d with 4 first bytes of result 0x%08x and dead group with %d processes",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), ret, *(int*)contrib,
+                         (NULL == group) ? 0 : (*group)->grp_proc_count));
+    return ret;
+}
+

--- a/ompi/mca/coll/ftagree/coll_ftagree_era.h
+++ b/ompi/mca/coll/ftagree/coll_ftagree_era.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015-2019 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#ifndef MCA_COLL_FTAGREE_ERA_EXPORT_H
+#define MCA_COLL_FTAGREE_ERA_EXPORT_H
+
+#include "coll_ftagree.h"
+
+BEGIN_C_DECLS
+
+/*
+ * Early Returning Specific
+ */
+int mca_coll_ftagree_era_comm_init(ompi_communicator_t *comm, mca_coll_ftagree_module_t *module);
+int mca_coll_ftagree_era_comm_finalize(mca_coll_ftagree_module_t *module);
+int mca_coll_ftagree_era_init(void);
+int mca_coll_ftagree_era_finalize(void);
+
+END_C_DECLS
+
+#endif /* MCA_COLL_FTAGREE_ERA_EXPORT_H */

--- a/ompi/mca/coll/ftagree/coll_ftagree_module.c
+++ b/ompi/mca/coll/ftagree/coll_ftagree_module.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2012-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "opal/util/bit_ops.h"
+#include "ompi/mca/coll/coll.h"
+#include "ompi/mca/coll/base/base.h"
+
+#include "coll_ftagree.h"
+#include "coll_ftagree_era.h"
+
+/*
+ * Initial query function that is invoked during MPI_INIT, allowing
+ * this component to disqualify itself if it doesn't support the
+ * required level of thread support.
+ */
+int
+mca_coll_ftagree_init_query(bool enable_progress_threads,
+                            bool enable_mpi_threads)
+{
+    if( mca_coll_ftagree_algorithm == COLL_FTAGREE_EARLY_RETURNING ) {
+        return mca_coll_ftagree_era_init();
+    }
+
+    return OMPI_SUCCESS;
+}
+
+
+/*
+ * Invoked when there's a new communicator that has been created.
+ * Look at the communicator and decide which set of functions and
+ * priority we want to return.
+ */
+mca_coll_base_module_t *
+mca_coll_ftagree_comm_query(struct ompi_communicator_t *comm,
+                            int *priority)
+{
+    int size;
+    mca_coll_ftagree_module_t *ftagree_module;
+
+    /* No FT, no need for fancy agreements */
+    if( !ompi_ftmpi_enabled ) return NULL;
+
+    ftagree_module = OBJ_NEW(mca_coll_ftagree_module_t);
+    if (NULL == ftagree_module) return NULL;
+
+    *priority = mca_coll_ftagree_priority;
+
+    /*
+     * Allocate the data that hangs off the communicator
+     * Intercommunicators not currently supported
+     */
+    if (OMPI_COMM_IS_INTER(comm)) {
+        size = ompi_comm_remote_size(comm)+ompi_comm_size(comm);
+    } else {
+        size = ompi_comm_size(comm);
+    }
+    ftagree_module->mccb_num_reqs = size * 2;
+    ftagree_module->mccb_reqs = (ompi_request_t**)
+        malloc(sizeof(ompi_request_t *) * ftagree_module->mccb_num_reqs);
+
+    ftagree_module->mccb_num_statuses = size * 2; /* x2 for alltoall */
+    ftagree_module->mccb_statuses = (ompi_status_public_t*)
+        malloc(sizeof(ompi_status_public_t) * ftagree_module->mccb_num_statuses);
+
+    /*
+     * Choose whether to use [intra|inter], and [linear|log]-based
+     * algorithms.
+     */
+    ftagree_module->super.coll_module_enable = mca_coll_ftagree_module_enable;
+    ftagree_module->super.ft_event = mca_coll_ftagree_ft_event;
+
+    /* This component does not provide any base collectives,
+     * just the FT collectives.
+     * Other function pointers are zeroed by the module constructor.
+     */
+
+    /*
+     * Agreement operation setup
+     * Intercommunicators not currently supported
+     */
+
+    /* Choose the correct operations */
+    switch( mca_coll_ftagree_algorithm ) {
+    case COLL_FTAGREE_NOFT:
+        /* These are set as default in coll_basic */
+        break;
+    case COLL_FTAGREE_EARLY_TERMINATION:
+        if( !OMPI_COMM_IS_INTER(comm) ) {
+            ftagree_module->super.coll_agree  = mca_coll_ftagree_eta_intra;
+        }
+        break;
+    default: /* Manages the COLL_FTAGREE_EARLY_RETURNING as default case too */
+        /* Init the agreement function */
+        mca_coll_ftagree_era_comm_init(comm, ftagree_module);
+        if( OMPI_COMM_IS_INTER(comm) ) {
+            ftagree_module->super.coll_agree  = mca_coll_ftagree_era_inter;
+        } else {
+            ftagree_module->super.coll_agree  = mca_coll_ftagree_era_intra;
+            ftagree_module->super.coll_iagree = mca_coll_ftagree_iera_intra;
+        }
+        break;
+    }
+
+    return &(ftagree_module->super);
+}
+
+
+/*
+ * Init module on the communicator
+ */
+int
+mca_coll_ftagree_module_enable(mca_coll_base_module_t *module,
+                             struct ompi_communicator_t *comm)
+{
+    /* All done */
+    return OMPI_SUCCESS;
+}
+
+
+int mca_coll_ftagree_ft_event(int state)
+{
+
+    /* Nothing to do for checkpoint */
+
+    return OMPI_SUCCESS;
+}

--- a/ompi/mca/coll/ftagree/configure.m4
+++ b/ompi/mca/coll/ftagree/configure.m4
@@ -1,0 +1,21 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2012-2020 The University of Tennessee and the University
+#                         of Tennessee Research Foundation.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_coll_ftagree_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_ompi_coll_ftagree_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/coll/ftagree/Makefile])
+
+    # If we don't want FT, don't compile this component
+    AS_IF([test "$opal_want_ft_mpi" = "1"],
+        [$1],
+        [$2])
+])dnl

--- a/ompi/mca/coll/ftagree/owner.txt
+++ b/ompi/mca/coll/ftagree/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: active

--- a/ompi/mca/coll/libnbc/nbc.c
+++ b/ompi/mca/coll/libnbc/nbc.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2006      The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2013-2018 The University of Tennessee and The University
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2006      The Technical University of Chemnitz. All
@@ -25,6 +25,8 @@
  * Additional copyrights may follow
  */
 #include "nbc_internal.h"
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/coll/base/coll_base_functions.h"
 #include "ompi/mca/coll/base/coll_base_util.h"
 #include "ompi/op/op.h"
 #include "ompi/mca/pml/pml.h"
@@ -334,8 +336,20 @@ int NBC_Progress(NBC_Handle *handle) {
     /* don't call ompi_request_test_all as it causes a recursive call into opal_progress */
     while (handle->req_count) {
         ompi_request_t *subreq = handle->req_array[handle->req_count - 1];
+#if OPAL_ENABLE_FT_MPI
+        if (REQUEST_COMPLETE(subreq)
+         || OPAL_UNLIKELY( ompi_request_is_failed(subreq) )) {
+#else
         if (REQUEST_COMPLETE(subreq)) {
+#endif /* OPAL_ENABLE_FT_MPI */
             if(OPAL_UNLIKELY( OMPI_SUCCESS != subreq->req_status.MPI_ERROR )) {
+#if OPAL_ENABLE_FT_MPI
+                if( MPI_ERR_PROC_FAILED == subreq->req_status.MPI_ERROR ||
+                    MPI_ERR_PROC_FAILED_PENDING == subreq->req_status.MPI_ERROR ||
+                    MPI_ERR_REVOKED == subreq->req_status.MPI_ERROR ) {
+                    NBC_DEBUG (1, "MPI Error in NBC subrequest %p : %d)", subreq, subreq->req_status.MPI_ERROR);
+                } else // this 'else' intentionally spills outside the ifdef
+#endif /* OPAL_ENABLE_FT_MPI */
                 NBC_Error ("MPI Error in NBC subrequest %p : %d", subreq, subreq->req_status.MPI_ERROR);
                 /* copy the error code from the underlying request and let the
                  * round finish */

--- a/ompi/mca/io/base/io_base_file_select.c
+++ b/ompi/mca/io/base/io_base_file_select.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -31,6 +31,7 @@
 #include "ompi/file/file.h"
 #include "opal/util/argv.h"
 #include "opal/util/output.h"
+#include "opal/util/show_help.h"
 #include "opal/util/info.h"
 #include "opal/class/opal_list.h"
 #include "opal/class/opal_object.h"
@@ -252,6 +253,17 @@ int mca_io_base_file_select(ompi_file_t *file,
     opal_output_verbose(10, ompi_io_base_framework.framework_output,
                         "io:base:file_select: Selected io module %s",
                         selected.ai_component.v2_0_0.io_version.mca_component_name);
+
+#if OPAL_ENABLE_FT_MPI
+    if(ompi_ftmpi_enabled) {
+        /* check if module is tested for FT, warn if not. */
+        const char* ft_whitelist="";
+        opal_show_help("help-mpi-ft.txt", "module:untested:failundef", true,
+            selected.ai_component.v2_0_0.io_version.mca_type_name,
+            selected.ai_component.v2_0_0.io_version.mca_component_name,
+            ft_whitelist);
+    }
+#endif /* OPAL_ENABLE_FT_MPI */
 
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/osc/base/osc_base_init.c
+++ b/ompi/mca/osc/base/osc_base_init.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University.
  *                         All rights reserved.
- * Copyright (c) 2004-2005 The Trustees of the University of Tennessee.
+ * Copyright (c) 2004-2017 The Trustees of the University of Tennessee.
  *                         All rights reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
@@ -20,6 +20,7 @@
 
 #include "ompi_config.h"
 
+#include "opal/util/show_help.h"
 #include "ompi/constants.h"
 #include "ompi/mca/mca.h"
 #include "opal/mca/base/base.h"
@@ -71,6 +72,16 @@ ompi_osc_base_select(ompi_win_t *win,
 
     if (NULL == best_component) return OMPI_ERR_NOT_SUPPORTED;
 
+#if OPAL_ENABLE_FT_MPI
+    if(ompi_ftmpi_enabled) {
+        /* check if module is tested for FT, warn if not. */
+        const char* ft_whitelist="";
+        opal_show_help("help-mpi-ft.txt", "module:untested:failundef", true,
+            best_component->osc_version.mca_type_name,
+            best_component->osc_version.mca_component_name,
+            ft_whitelist);
+    }
+#endif /* OPAL_ENABLE_FT_MPI */
     opal_output_verbose( 10, ompi_osc_base_framework.framework_output,
                          "select: component %s selected",
                          best_component->osc_version.mca_component_name );

--- a/ompi/mca/pml/base/base.h
+++ b/ompi/mca/pml/base/base.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -63,6 +63,9 @@ OMPI_DECLSPEC int mca_pml_base_pml_check_selected(const char *my_pml,
 OMPI_DECLSPEC int mca_pml_base_finalize(void);
 
 OMPI_DECLSPEC int mca_pml_base_ft_event(int state);
+
+/* not #if conditional on OPAL_ENABLE_FT_MPI for ABI */
+OMPI_DECLSPEC int mca_pml_base_revoke_comm(struct ompi_communicator_t *comm, bool coll_only);
 
 /*
  * Globals

--- a/ompi/mca/pml/base/pml_base_frame.c
+++ b/ompi/mca/pml/base/pml_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
@@ -56,6 +56,12 @@ int mca_pml_base_progress(void)
     return OMPI_SUCCESS;
 }
 
+/* not #if conditional on OPAL_ENABLE_FT_MPI for ABI */
+int mca_pml_base_revoke_comm(ompi_communicator_t *comm, bool coll_only)
+{
+    return OMPI_ERR_NOT_IMPLEMENTED;
+}
+
 #define xstringify(pml) #pml
 #define stringify(pml) xstringify(pml)
 
@@ -69,6 +75,7 @@ mca_pml_base_module_t mca_pml = {
     mca_pml_base_progress,   /* pml_progress */
     NULL,                    /* pml_add_comm */
     NULL,                    /* pml_del_comm */
+    mca_pml_base_revoke_comm,/* pml_revoke_comm */
     NULL,                    /* pml_irecv_init */
     NULL,                    /* pml_irecv */
     NULL,                    /* pml_recv */

--- a/ompi/mca/pml/base/pml_base_select.c
+++ b/ompi/mca/pml/base/pml_base_select.c
@@ -279,6 +279,14 @@ int mca_pml_base_select(bool enable_progress_threads,
         opal_progress_register(mca_pml.pml_progress);
     }
 
+#if OPAL_ENABLE_FT_MPI
+    if( NULL == mca_pml.pml_revoke_comm ) {
+        /* do not crash when calling a not implemented function after a failure is
+         * reported, return a NOT_IMPLEMENTED error */
+        mca_pml.pml_revoke_comm = mca_pml_base_revoke_comm;
+    }
+#endif /* OPAL_ENABLE_FT_MPI */
+
     /* register winner in the modex */
     ret = mca_pml_base_pml_selected(best_component->pmlm_version.mca_component_name);
 

--- a/ompi/mca/pml/base/pml_base_sendreq.h
+++ b/ompi/mca/pml/base/pml_base_sendreq.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2016 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -133,6 +133,7 @@ OMPI_DECLSPEC OBJ_CLASS_DECLARATION( mca_pml_base_send_request_t );
         (request)->req_base.req_ompi.req_complete = REQUEST_PENDING;    \
         (request)->req_base.req_ompi.req_state = OMPI_REQUEST_ACTIVE;   \
         (request)->req_base.req_ompi.req_status._cancelled = 0;         \
+        (request)->req_base.req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS; \
         MCA_PML_BASE_SEND_REQUEST_RESET(request);             \
     } while (0)
 

--- a/ompi/mca/pml/cm/pml_cm.c
+++ b/ompi/mca/pml/cm/pml_cm.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2006-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 The Regents of the University of California.
@@ -33,30 +33,30 @@
 
 ompi_pml_cm_t ompi_pml_cm = {
     {
-        mca_pml_cm_add_procs,
-        mca_pml_cm_del_procs,
-        mca_pml_cm_enable,
-        NULL, /* No progress function. The MTL register their own */
-        mca_pml_cm_add_comm,
-        mca_pml_cm_del_comm,
-        mca_pml_cm_irecv_init,
-        mca_pml_cm_irecv,
-        mca_pml_cm_recv,
-        mca_pml_cm_isend_init,
-        mca_pml_cm_isend,
-        mca_pml_cm_send,
-        mca_pml_cm_iprobe,
-        mca_pml_cm_probe,
-        mca_pml_cm_start,
-        mca_pml_cm_improbe,
-        mca_pml_cm_mprobe,
-        mca_pml_cm_imrecv,
-        mca_pml_cm_mrecv,
-        mca_pml_cm_dump,
-        NULL,
-        0,
-        0,
-        0 /* flags */
+        .pml_add_procs     = mca_pml_cm_add_procs,
+        .pml_del_procs     = mca_pml_cm_del_procs,
+        .pml_enable        = mca_pml_cm_enable,
+        .pml_progress      = NULL, /* No progress function. The MTL register their own */
+        .pml_add_comm      = mca_pml_cm_add_comm,
+        .pml_del_comm      = mca_pml_cm_del_comm,
+        .pml_irecv_init    = mca_pml_cm_irecv_init,
+        .pml_irecv         = mca_pml_cm_irecv,
+        .pml_recv          = mca_pml_cm_recv,
+        .pml_isend_init    = mca_pml_cm_isend_init,
+        .pml_isend         = mca_pml_cm_isend,
+        .pml_send          = mca_pml_cm_send,
+        .pml_iprobe        = mca_pml_cm_iprobe,
+        .pml_probe         = mca_pml_cm_probe,
+        .pml_start         = mca_pml_cm_start,
+        .pml_improbe       = mca_pml_cm_improbe,
+        .pml_mprobe        = mca_pml_cm_mprobe,
+        .pml_imrecv        = mca_pml_cm_imrecv,
+        .pml_mrecv         = mca_pml_cm_mrecv,
+        .pml_dump          = mca_pml_cm_dump,
+        .pml_ft_event      = NULL,
+        .pml_max_contextid = 0,
+        .pml_max_tag       = 0,
+        .pml_flags         = 0 /* flags */
     }
 };
 

--- a/ompi/mca/pml/crcpw/pml_crcpw_module.c
+++ b/ompi/mca/pml/crcpw/pml_crcpw_module.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -35,31 +35,30 @@
 
 mca_pml_crcpw_module_t mca_pml_crcpw_module = {
     {
-        mca_pml_crcpw_add_procs,
-        mca_pml_crcpw_del_procs,
-        mca_pml_crcpw_enable,
-        mca_pml_crcpw_progress,
-        mca_pml_crcpw_add_comm,
-        mca_pml_crcpw_del_comm,
-        mca_pml_crcpw_irecv_init,
-        mca_pml_crcpw_irecv,
-        mca_pml_crcpw_recv,
-        mca_pml_crcpw_isend_init,
-        mca_pml_crcpw_isend,
-        mca_pml_crcpw_send,
-        mca_pml_crcpw_iprobe,
-        mca_pml_crcpw_probe,
-        mca_pml_crcpw_start,
-        mca_pml_crcpw_improbe,
-        mca_pml_crcpw_mprobe,
-        mca_pml_crcpw_imrecv,
-        mca_pml_crcpw_mrecv,
-        mca_pml_crcpw_dump,
-        mca_pml_crcpw_ft_event,
-
-        32768,
-        INT_MAX,
-        0 /* flags */
+        .pml_add_procs     = mca_pml_crcpw_add_procs,
+        .pml_del_procs     = mca_pml_crcpw_del_procs,
+        .pml_enable        = mca_pml_crcpw_enable,
+        .pml_progress      = mca_pml_crcpw_progress,
+        .pml_add_comm      = mca_pml_crcpw_add_comm,
+        .pml_del_comm      = mca_pml_crcpw_del_comm,
+        .pml_irecv_init    = mca_pml_crcpw_irecv_init,
+        .pml_irecv         = mca_pml_crcpw_irecv,
+        .pml_recv          = mca_pml_crcpw_recv,
+        .pml_isend_init    = mca_pml_crcpw_isend_init,
+        .pml_isend         = mca_pml_crcpw_isend,
+        .pml_send          = mca_pml_crcpw_send,
+        .pml_iprobe        = mca_pml_crcpw_iprobe,
+        .pml_probe         = mca_pml_crcpw_probe,
+        .pml_start         = mca_pml_crcpw_start,
+        .pml_improbe       = mca_pml_crcpw_improbe,
+        .pml_mprobe        = mca_pml_crcpw_mprobe,
+        .pml_imrecv        = mca_pml_crcpw_imrecv,
+        .pml_mrecv         = mca_pml_crcpw_mrecv,
+        .pml_dump          = mca_pml_crcpw_dump,
+        .pml_ft_event      = mca_pml_crcpw_ft_event,
+        .pml_max_contextid = 32768,
+        .pml_max_tag       = INT_MAX,
+        .pml_flags         = 0 /* flags */
     }
 };
 

--- a/ompi/mca/pml/monitoring/pml_monitoring.h
+++ b/ompi/mca/pml/monitoring/pml_monitoring.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 The University of Tennessee and The University
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
@@ -40,6 +40,10 @@ OMPI_DECLSPEC extern mca_pml_base_component_2_0_0_t mca_pml_monitoring_component
 extern int mca_pml_monitoring_add_comm(struct ompi_communicator_t* comm);
 
 extern int mca_pml_monitoring_del_comm(struct ompi_communicator_t* comm);
+
+#if OPAL_ENABLE_FT_MPI
+extern int mca_pml_monitoring_revoke_comm(struct ompi_communicator_t* comm, bool coll_only);
+#endif
 
 extern int mca_pml_monitoring_add_procs(struct ompi_proc_t **procs, size_t nprocs);
 

--- a/ompi/mca/pml/monitoring/pml_monitoring_comm.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_comm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 The University of Tennessee and The University
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
@@ -25,3 +25,10 @@ int mca_pml_monitoring_del_comm(struct ompi_communicator_t* comm)
     mca_common_monitoring_coll_cache_name(comm);
     return pml_selected_module.pml_del_comm(comm);
 }
+
+#if OPAL_ENABLE_FT_MPI
+int mca_pml_monitoring_revoke_comm(struct ompi_communicator_t* comm, bool coll_only)
+{
+    return pml_selected_module.pml_revoke_comm(comm, coll_only);
+}
+#endif

--- a/ompi/mca/pml/monitoring/pml_monitoring_component.c
+++ b/ompi/mca/pml/monitoring/pml_monitoring_component.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 The University of Tennessee and The University
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Inria.  All rights reserved.
@@ -27,30 +27,33 @@ mca_pml_base_component_t pml_selected_component = {{0}};
 mca_pml_base_module_t pml_selected_module = {0};
 
 mca_pml_monitoring_module_t mca_pml_monitoring_module = {
-    mca_pml_monitoring_add_procs,
-    mca_pml_monitoring_del_procs,
-    mca_pml_monitoring_enable,
-    NULL,
-    mca_pml_monitoring_add_comm,
-    mca_pml_monitoring_del_comm,
-    mca_pml_monitoring_irecv_init,
-    mca_pml_monitoring_irecv,
-    mca_pml_monitoring_recv,
-    mca_pml_monitoring_isend_init,
-    mca_pml_monitoring_isend,
-    mca_pml_monitoring_send,
-    mca_pml_monitoring_iprobe,
-    mca_pml_monitoring_probe,
-    mca_pml_monitoring_start,
-    mca_pml_monitoring_improbe,
-    mca_pml_monitoring_mprobe,
-    mca_pml_monitoring_imrecv,
-    mca_pml_monitoring_mrecv,
-    mca_pml_monitoring_dump,
-    NULL,
-    65535,
-    INT_MAX,
-    0 /* flags */
+    .pml_add_procs          = mca_pml_monitoring_add_procs,
+    .pml_del_procs          = mca_pml_monitoring_del_procs,
+    .pml_enable             = mca_pml_monitoring_enable,
+    .pml_progress           = NULL,
+    .pml_add_comm           = mca_pml_monitoring_add_comm,
+    .pml_del_comm           = mca_pml_monitoring_del_comm,
+#if OPAL_ENABLE_FT_MPI
+    .pml_revoke_comm        = mca_pml_monitoring_revoke_comm,
+#endif
+    .pml_irecv_init         = mca_pml_monitoring_irecv_init,
+    .pml_irecv              = mca_pml_monitoring_irecv,
+    .pml_recv               = mca_pml_monitoring_recv,
+    .pml_isend_init         = mca_pml_monitoring_isend_init,
+    .pml_isend              = mca_pml_monitoring_isend,
+    .pml_send               = mca_pml_monitoring_send,
+    .pml_iprobe             = mca_pml_monitoring_iprobe,
+    .pml_probe              = mca_pml_monitoring_probe,
+    .pml_start              = mca_pml_monitoring_start,
+    .pml_improbe            = mca_pml_monitoring_improbe,
+    .pml_mprobe             = mca_pml_monitoring_mprobe,
+    .pml_imrecv             = mca_pml_monitoring_imrecv,
+    .pml_mrecv              = mca_pml_monitoring_mrecv,
+    .pml_dump               = mca_pml_monitoring_dump,
+    .pml_ft_event           = NULL,
+    .pml_max_contextid      = 65535,
+    .pml_max_tag            = INT_MAX,
+    .pml_flags              = 0 /* flags */
 };
 
 /**

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -45,6 +45,7 @@
 #include "ompi/mca/pml/base/base.h"
 #include "ompi/mca/pml/base/base.h"
 #include "ompi/mca/bml/base/base.h"
+#include "ompi/errhandler/errhandler.h"
 #include "opal/mca/pmix/pmix-internal.h"
 #include "ompi/runtime/ompi_cr.h"
 #include "ompi/runtime/ompi_spc.h"
@@ -66,6 +67,9 @@ mca_pml_ob1_t mca_pml_ob1 = {
         NULL,  /* mca_pml_ob1_progress, */
         mca_pml_ob1_add_comm,
         mca_pml_ob1_del_comm,
+#if OPAL_ENABLE_FT_MPI
+        mca_pml_ob1_revoke_comm,
+#endif
         mca_pml_ob1_irecv_init,
         mca_pml_ob1_irecv,
         mca_pml_ob1_recv,
@@ -820,6 +824,7 @@ void mca_pml_ob1_error_handler(
         return;
     }
 #endif /* OPAL_CUDA_SUPPORT */
+
     /* Some BTL report unreachable errors during normal MPI_Finalize
      * termination. Lets simply ignore such errors after MPI is not supposed to
      * be operational anyway.
@@ -827,6 +832,18 @@ void mca_pml_ob1_error_handler(
     if(ompi_mpi_state >= OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
         return;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    opal_output_verbose( 1, mca_pml_ob1_output,
+                         "PML:OB1: the error handler was invoked by the %s BTL for proc %s with info %s",
+                         btl->btl_component->btl_version.mca_component_name,
+                         (NULL == errproc ? "null" : OMPI_NAME_PRINT(&errproc->proc_name)), btlinfo);
+    if( ompi_ftmpi_enabled && (NULL != errproc) ) {
+        /* It's safe to upgrade to the OMPI type */
+        ompi_errhandler_proc_failed((ompi_proc_t*)errproc);
+        return;
+    }
+#endif /* OPAL_ENABLE_FT_MPI */
 
     /* TODO: this error should return to the caller and invoke an error
      * handler from the MPI API call.

--- a/ompi/mca/pml/ob1/pml_ob1.h
+++ b/ompi/mca/pml/ob1/pml_ob1.h
@@ -101,6 +101,13 @@ extern int mca_pml_ob1_del_comm(
     struct ompi_communicator_t* comm
 );
 
+#if OPAL_ENABLE_FT_MPI
+extern int mca_pml_ob1_revoke_comm(
+    struct ompi_communicator_t* comm,
+    bool coll_only
+);
+#endif
+
 extern int mca_pml_ob1_add_procs(
     struct ompi_proc_t **procs,
     size_t nprocs

--- a/ompi/mca/pml/ob1/pml_ob1_iprobe.c
+++ b/ompi/mca/pml/ob1/pml_ob1_iprobe.c
@@ -167,10 +167,14 @@ mca_pml_ob1_mprobe(int src,
         *status = recvreq->req_recv.req_base.req_ompi.req_status;
     }
 
-    (*message)->comm = comm;
-    (*message)->req_ptr = recvreq;
-    (*message)->peer = recvreq->req_recv.req_base.req_ompi.req_status.MPI_SOURCE;
-    (*message)->count = recvreq->req_recv.req_base.req_ompi.req_status._ucount;
-
+    if( OMPI_SUCCESS == rc ) {
+        (*message)->comm = comm;
+        (*message)->req_ptr = recvreq;
+        (*message)->peer = recvreq->req_recv.req_base.req_ompi.req_status.MPI_SOURCE;
+        (*message)->count = recvreq->req_recv.req_base.req_ompi.req_status._ucount;
+    }
+    else {
+        ompi_request_free((ompi_request_t**)&recvreq);
+    }
     return rc;
 }

--- a/ompi/mca/pml/ob1/pml_ob1_irecv.c
+++ b/ompi/mca/pml/ob1/pml_ob1_irecv.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2015 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -14,6 +14,7 @@
  *                         reserved.
  * Copyright (c) 2010-2012 Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -149,6 +150,13 @@ int mca_pml_ob1_recv(void *addr,
     }
 
     rc = recvreq->req_recv.req_base.req_ompi.req_status.MPI_ERROR;
+#if OPAL_ENABLE_FT_MPI
+    if( OPAL_UNLIKELY( MPI_ERR_PROC_FAILED_PENDING == rc )) {
+        ompi_request_cancel(&recvreq->req_recv.req_base.req_ompi);
+        ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
+        rc = MPI_ERR_PROC_FAILED;
+    }
+#endif
 
     if (recvreq->req_recv.req_base.req_pml_complete) {
         /* make buffer defined when the request is completed,
@@ -358,6 +366,13 @@ mca_pml_ob1_mrecv( void *buf,
         *status = recvreq->req_recv.req_base.req_ompi.req_status;
     }
     rc = recvreq->req_recv.req_base.req_ompi.req_status.MPI_ERROR;
+#if OPAL_ENABLE_FT_MPI
+    if( OPAL_UNLIKELY( MPI_ERR_PROC_FAILED_PENDING == rc )) {
+        ompi_request_cancel(&recvreq->req_recv.req_base.req_ompi);
+        ompi_request_wait_completion(&recvreq->req_recv.req_base.req_ompi);
+        rc = MPI_ERR_PROC_FAILED;
+    }
+#endif
     ompi_request_free( (ompi_request_t**)&recvreq );
     return rc;
 }

--- a/ompi/mca/pml/pml.h
+++ b/ompi/mca/pml/pml.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -195,6 +195,20 @@ typedef int (*mca_pml_base_module_add_comm_fn_t)(struct ompi_communicator_t* com
  * associated with the communicator.
  */
 typedef int (*mca_pml_base_module_del_comm_fn_t)(struct ompi_communicator_t* comm);
+
+/**
+ * Downcall from MPI layer when a communicator is revoked.
+ *
+ * @param comm (INOUT)      Communicator
+ * @param coll_only (IN)    Revoke only the collective operations, or all
+ *                              non-FT operations
+ * @return                  OMPI_SUCCESS or failure status.
+ *
+ * Provides the PML the opportunity to change unexpected fragments
+ * handling and purge the queues associated with the communicator.
+ */
+/* not conditional on OPAL_ENABLE_FT_MPI for ABI */
+typedef int (*mca_pml_base_module_revoke_comm_fn_t)(struct ompi_communicator_t* comm, bool coll_only);
 
 /**
  *  Initialize a persistent receive request.
@@ -499,6 +513,7 @@ struct mca_pml_base_module_1_0_1_t {
     /* downcalls from MPI to PML */
     mca_pml_base_module_add_comm_fn_t     pml_add_comm;
     mca_pml_base_module_del_comm_fn_t     pml_del_comm;
+    mca_pml_base_module_revoke_comm_fn_t  pml_revoke_comm;
     mca_pml_base_module_irecv_init_fn_t   pml_irecv_init;
     mca_pml_base_module_irecv_fn_t        pml_irecv;
     mca_pml_base_module_recv_fn_t         pml_recv;

--- a/ompi/mca/pml/ucx/pml_ucx.c
+++ b/ompi/mca/pml/ucx/pml_ucx.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2001-2011 Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
- * Copyright (c) 2016      The University of Tennessee and The University
+ * Copyright (c) 2016-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2018-2019 Research Organization for Information Science
@@ -80,7 +80,7 @@ mca_pml_ucx_module_t ompi_pml_ucx = {
         .pml_ft_event      = NULL,
         .pml_max_contextid = (1ul << (PML_UCX_CONTEXT_BITS)) - 1,
         .pml_max_tag       = (1ul << (PML_UCX_TAG_BITS - 1)) - 1,
-        0 /* flags */
+        .pml_flags         = 0 /* flags */
     },
     .ucp_context           = NULL,
     .ucp_worker            = NULL

--- a/ompi/mca/topo/base/topo_base_comm_select.c
+++ b/ompi/mca/topo/base/topo_base_comm_select.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -25,6 +25,7 @@
 #include "opal/class/opal_list.h"
 #include "opal/util/argv.h"
 #include "opal/util/output.h"
+#include "opal/util/show_help.h"
 #include "ompi/mca/mca.h"
 #include "opal/mca/base/base.h"
 
@@ -237,6 +238,16 @@ int mca_topo_base_comm_select(const ompi_communicator_t*  comm,
     opal_output_verbose(10, ompi_topo_base_framework.framework_output,
                        "select: component %s selected",
                         best_component->topoc_version.mca_component_name);
+#if OPAL_ENABLE_FT_MPI
+    if(ompi_ftmpi_enabled) {
+        /* check if module is tested for FT, warn if not. */
+        const char* ft_whitelist="";
+        opal_show_help("help-ft-mpi.txt", "module:untested:failundef", true,
+            best_component->topoc_version.mca_type_name,
+            best_component->topoc_version.mca_component_name,
+            ft_whitelist);
+    }
+#endif /* OPAL_ENABLE_FT_MPI */
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mpi/c/allgather.c
+++ b/ompi/mpi/c/allgather.c
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      University of Houston.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
@@ -95,6 +96,17 @@ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* Do we need to do anything?  Everyone had to give the same send
        signature, which means that everyone must have given a

--- a/ompi/mpi/c/allgatherv.c
+++ b/ompi/mpi/c/allgatherv.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010      University of Houston.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
@@ -119,6 +120,17 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         }
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     /* Do we need to do anything?  Everyone had to give the same
        signature, which means that everyone must have given a
        sum(recvounts) > 0 if there's anything to do. */
@@ -138,7 +150,6 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
        do not send anything, sendcount=0 only indicates that I do not send
        anything. However, other processes in my group might very well send
        something */
-
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/allreduce.c
+++ b/ompi/mpi/c/allreduce.c
@@ -10,6 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -96,6 +97,17 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* MPI-1, p114, says that each process must supply at least
        one element.  But at least the Pallas benchmarks call

--- a/ompi/mpi/c/alltoall.c
+++ b/ompi/mpi/c/alltoall.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
@@ -96,6 +97,17 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             }
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     if (! OMPI_COMM_IS_INTER(comm)) {
         ompi_datatype_type_size(recvtype, &recvtype_size);

--- a/ompi/mpi/c/alltoallv.c
+++ b/ompi/mpi/c/alltoallv.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
@@ -122,6 +123,17 @@ int MPI_Alltoallv(const void *sendbuf, const int sendcounts[],
             }
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/alltoallw.c
+++ b/ompi/mpi/c/alltoallw.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
@@ -112,6 +113,17 @@ int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
             }
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/barrier.c
+++ b/ompi/mpi/c/barrier.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -55,6 +56,17 @@ int MPI_Barrier(MPI_Comm comm)
       return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_COMM, FUNC_NAME);
     }
   }
+
+#if OPAL_ENABLE_FT_MPI
+  /*
+   * An early check, so as to return early if we are using a broken
+   * communicator. This is not absolutely necessary since we will
+   * check for this, and other, error conditions during the operation.
+   */
+  if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+      OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+  }
+#endif
 
   OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/bcast.c
+++ b/ompi/mpi/c/bcast.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -99,7 +100,18 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ROOT, FUNC_NAME);
         }
       }
+    } 
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
     }
+#endif
 
     /* If there's only one node, or if the count is 0, we're done */
 

--- a/ompi/mpi/c/bsend.c
+++ b/ompi/mpi/c/bsend.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -74,6 +75,18 @@ int MPI_Bsend(const void *buf, int count, MPI_Datatype type, int dest, int tag, 
         }
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+        /*
+         * An early check, so as to return early if we are communicating with
+         * a failed process. This is not absolutely necessary since we will
+         * check for this, and other, error conditions during the completion
+         * call in the PML.
+         */
+        if( OPAL_UNLIKELY(!ompi_comm_iface_p2p_check_proc(comm, dest, &rc)) ) {
+            OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+        }
+#endif
 
     if (MPI_PROC_NULL == dest) {
         return MPI_SUCCESS;

--- a/ompi/mpi/c/bsend_init.c
+++ b/ompi/mpi/c/bsend_init.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -78,6 +79,13 @@ int MPI_Bsend_init(const void *buf, int count, MPI_Datatype type,
         rc = ompi_request_persistent_noop_create(request);
         OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/cart_create.c
+++ b/ompi/mpi/c/cart_create.c
@@ -100,6 +100,17 @@ int MPI_Cart_create(MPI_Comm old_comm, int ndims, const int dims[],
         return err;
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(old_comm, &err)) ) {
+       OMPI_ERRHANDLER_RETURN(err, old_comm, err, FUNC_NAME);
+    }
+#endif
+
     /* Now let that topology module rearrange procs/ranks if it wants to */
     err = topo->topo.cart.cart_create(topo, old_comm,
                                       ndims, dims, periods,

--- a/ompi/mpi/c/cart_sub.c
+++ b/ompi/mpi/c/cart_sub.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -72,6 +72,18 @@ int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *new_comm)
         return OMPI_ERRHANDLER_INVOKE (comm, MPI_ERR_TOPOLOGY,
                                       FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     err = comm->c_topo->topo.cart.cart_sub(comm, remain_dims, new_comm);

--- a/ompi/mpi/c/comm_accept.c
+++ b/ompi/mpi/c/comm_accept.c
@@ -101,6 +101,16 @@ int MPI_Comm_accept(const char *port_name, MPI_Info info, int root,
      * if ( rank == root && MPI_INFO_NULL != info ) {
      * }
      */
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * We must not call ompi_comm_iface_create_check() here, because that
+     * risks leaving the connect side dangling on an unmatched operation.
+     * We will let the connect_accept logic proceed and discover the
+     * issue internally so that all sides get informed.
+     */
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     if ( rank == root ) {

--- a/ompi/mpi/c/comm_connect.c
+++ b/ompi/mpi/c/comm_connect.c
@@ -103,6 +103,15 @@ int MPI_Comm_connect(const char *port_name, MPI_Info info, int root,
      * }
      */
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * We must not call ompi_comm_iface_create_check() here, because that
+     * risks leaving the accept side dangling on an unmatched operation.
+     * We will let the connect_accept logic proceed and discover the
+     * issue internally so that all sides get informed.
+     */
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     if ( rank == root ) {

--- a/ompi/mpi/c/comm_create.c
+++ b/ompi/mpi/c/comm_create.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2008 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -60,6 +61,17 @@ int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm) {
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG,
                                           FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/comm_create_group.c
+++ b/ompi/mpi/c/comm_create_group.c
@@ -73,6 +73,17 @@ int MPI_Comm_create_group (MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *ne
         return MPI_SUCCESS;
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_create_group ((ompi_communicator_t *) comm, (ompi_group_t *) group,

--- a/ompi/mpi/c/comm_dup.c
+++ b/ompi/mpi/c/comm_dup.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2006-2008 University of Houston.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -57,6 +58,17 @@ int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm)
             return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG,
                                           FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/comm_dup_with_info.c
+++ b/ompi/mpi/c/comm_dup_with_info.c
@@ -66,6 +66,17 @@ int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm)
                                           FUNC_NAME);
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     rc = ompi_comm_dup_with_info (comm, &info->super, newcomm);

--- a/ompi/mpi/c/comm_spawn.c
+++ b/ompi/mpi/c/comm_spawn.c
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
@@ -27,6 +28,7 @@
 #include <stdio.h>
 
 #include "opal/util/show_help.h"
+#include "opal/util/printf.h"
 
 #include "ompi/info/info.h"
 #include "ompi/mpi/c/bindings.h"
@@ -53,8 +55,8 @@ int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info inf
 {
     int rank, rc=OMPI_SUCCESS, i, flag;
     bool send_first = false; /* we wait to be contacted */
-    ompi_communicator_t *newcomp=NULL;
-    char port_name[MPI_MAX_PORT_NAME];
+    ompi_communicator_t *newcomp=MPI_COMM_NULL;
+    char port_name[MPI_MAX_PORT_NAME]; char *port_string = NULL;
     bool non_mpi = false;
 
     MEMCHECKER(
@@ -81,6 +83,12 @@ int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info inf
                                           FUNC_NAME);
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &rc)) ) {
+        return OMPI_ERRHANDLER_INVOKE(comm, rc, FUNC_NAME);
+    }
+#endif
 
     rank = ompi_comm_rank ( comm );
     if ( MPI_PARAM_CHECK ) {
@@ -132,19 +140,35 @@ int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info inf
         }
     }
 
+error:
+    if (OMPI_SUCCESS != rc) {
+        /* There was an error in one of the above stages,
+         * we still need to do the connect_accept stage so that
+         * non-root ranks do not deadlock.
+         * Add the error code to the port string for connect_accept
+         * to propagate the error code. */
+        (void)opal_asprintf(&port_string, "%s:error=%d", port_name, rc);
+    }
+    else {
+        port_string = port_name;
+    }
+
     if (non_mpi) {
         newcomp = MPI_COMM_NULL;
     } else {
-        rc = ompi_dpm_connect_accept (comm, root, port_name, send_first, &newcomp);
+        rc = ompi_dpm_connect_accept (comm, root, port_string, send_first, &newcomp);
     }
 
-error:
     if (OPAL_ERR_NOT_SUPPORTED == rc) {
         opal_show_help("help-mpi-api.txt",
                        "MPI function not supported",
                        true,
                        FUNC_NAME,
                        "Underlying runtime environment does not support spawn functionality");
+    }
+
+    if(port_string != port_name) {
+        free(port_string);
     }
 
     /* close the port */

--- a/ompi/mpi/c/comm_split.c
+++ b/ompi/mpi/c/comm_split.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -63,6 +64,17 @@ int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm) {
                                           FUNC_NAME);
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/comm_split_type.c
+++ b/ompi/mpi/c/comm_split_type.c
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
@@ -86,6 +87,17 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key,
                                           FUNC_NAME);
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/dist_graph_create.c
+++ b/ompi/mpi/c/dist_graph_create.c
@@ -88,6 +88,17 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
         return OMPI_ERRHANDLER_INVOKE(comm_old, err, FUNC_NAME);
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm_old, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm_old, err, FUNC_NAME);
+    }
+#endif
+
     err = topo->topo.dist_graph.dist_graph_create(topo, comm_old, n, sources, degrees,
                                                   destinations, weights, &(info->super),
                                                   reorder, newcomm);

--- a/ompi/mpi/c/dist_graph_create_adjacent.c
+++ b/ompi/mpi/c/dist_graph_create_adjacent.c
@@ -99,6 +99,17 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
         return OMPI_ERRHANDLER_INVOKE(comm_old, err, FUNC_NAME);
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(comm_old, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm_old, err, FUNC_NAME);
+    }
+#endif
+
     err = topo->topo.dist_graph.dist_graph_create_adjacent(topo, comm_old, indegree,
                                                            sources, sourceweights, outdegree,
                                                            destinations, destweights, &(info->super),

--- a/ompi/mpi/c/exscan.c
+++ b/ompi/mpi/c/exscan.c
@@ -10,6 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
@@ -82,6 +83,17 @@ int MPI_Exscan(const void *sendbuf, void *recvbuf, int count,
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* Do we need to do anything? (MPI says that reductions have to
        have a count of at least 1, but at least IMB calls reduce with

--- a/ompi/mpi/c/gather.c
+++ b/ompi/mpi/c/gather.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2006-2007 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008      University of Houston.  All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -166,6 +167,17 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             }
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* Do we need to do anything? */
 

--- a/ompi/mpi/c/gatherv.c
+++ b/ompi/mpi/c/gatherv.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
@@ -189,6 +190,17 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             }
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/graph_create.c
+++ b/ompi/mpi/c/graph_create.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
@@ -99,6 +100,17 @@ int MPI_Graph_create(MPI_Comm old_comm, int nnodes, const int indx[],
                                                          OMPI_COMM_GRAPH))) {
         return err;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(old_comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, old_comm, err, FUNC_NAME);
+    }
+#endif
 
     /* Now let that topology module rearrange procs/ranks if it wants to */
     err = topo->topo.graph.graph_create(topo, old_comm,

--- a/ompi/mpi/c/ibsend.c
+++ b/ompi/mpi/c/ibsend.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -80,6 +81,13 @@ int MPI_Ibsend(const void *buf, int count, MPI_Datatype type, int dest,
         *request = &ompi_request_empty;
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
     MEMCHECKER (

--- a/ompi/mpi/c/improbe.c
+++ b/ompi/mpi/c/improbe.c
@@ -4,6 +4,9 @@
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -69,6 +72,13 @@ int MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag,
         *flag = 1;
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/imrecv.c
+++ b/ompi/mpi/c/imrecv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -64,6 +65,13 @@ int MPI_Imrecv(void *buf, int count, MPI_Datatype type,
         *message = MPI_MESSAGE_NULL;
         return MPI_SUCCESS;
      }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The message and associated request will be checked by the PML, and
+     * handled approprately. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/intercomm_merge.c
+++ b/ompi/mpi/c/intercomm_merge.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2013 The University of Tennessee and The University
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2006-2009 University of Houston.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Inria.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -72,6 +73,17 @@ int MPI_Intercomm_merge(MPI_Comm intercomm, int high,
             return OMPI_ERRHANDLER_INVOKE ( intercomm, MPI_ERR_ARG,
                                             FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_create_check(intercomm, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, intercomm, rc, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/iprobe.c
+++ b/ompi/mpi/c/iprobe.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2018 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -77,6 +77,13 @@ int MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status
         }
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The call will check for process failure errors during the
+     * operation. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/irecv.c
+++ b/ompi/mpi/c/irecv.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -74,6 +75,13 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype type, int source,
         *request = &ompi_request_empty;
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/irsend.c
+++ b/ompi/mpi/c/irsend.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -81,6 +82,13 @@ int MPI_Irsend(const void *buf, int count, MPI_Datatype type, int dest,
         *request = &ompi_request_empty;
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/isend.c
+++ b/ompi/mpi/c/isend.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -82,6 +83,13 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype type, int dest,
         *request = &ompi_request_empty;
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/issend.c
+++ b/ompi/mpi/c/issend.c
@@ -10,6 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -79,6 +80,13 @@ int MPI_Issend(const void *buf, int count, MPI_Datatype type, int dest,
         *request = &ompi_request_empty;
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/mprobe.c
+++ b/ompi/mpi/c/mprobe.c
@@ -1,9 +1,13 @@
 /*
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,6 +72,21 @@ int MPI_Mprobe(int source, int tag, MPI_Comm comm,
         *message = &ompi_message_no_proc.message;
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * Check here for issues with the peer, so we do not have to duplicate the
+     * functionality in the PML.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_p2p_check_proc(comm, source, &rc)) ) {
+        if (MPI_STATUS_IGNORE != status) {
+            status->MPI_SOURCE = source;
+            status->MPI_TAG    = tag;
+        }
+        *message = &ompi_message_no_proc.message;
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/mrecv.c
+++ b/ompi/mpi/c/mrecv.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -72,6 +73,13 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype type,
         *message = MPI_MESSAGE_NULL;
         return MPI_SUCCESS;
      }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The message and associated request will be checked by the PML, and
+     * handled approprately. SO no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/neighbor_allgather.c
+++ b/ompi/mpi/c/neighbor_allgather.c
@@ -123,6 +123,17 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
         return MPI_SUCCESS;
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/neighbor_allgatherv.c
+++ b/ompi/mpi/c/neighbor_allgatherv.c
@@ -139,6 +139,17 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
         }
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/neighbor_alltoall.c
+++ b/ompi/mpi/c/neighbor_alltoall.c
@@ -126,6 +126,17 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
         return MPI_SUCCESS;
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/neighbor_alltoallv.c
+++ b/ompi/mpi/c/neighbor_alltoallv.c
@@ -142,6 +142,17 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
         }
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/neighbor_alltoallw.c
+++ b/ompi/mpi/c/neighbor_alltoallw.c
@@ -138,6 +138,17 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
         }
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/probe.c
+++ b/ompi/mpi/c/probe.c
@@ -2,13 +2,14 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2018 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -76,6 +77,20 @@ int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status)
         }
         return MPI_SUCCESS;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * Check here for issues with the peer, so we do not have to duplicate the
+     * functionality in the PML.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_p2p_check_proc(comm, source, &rc)) ) {
+        if (MPI_STATUS_IGNORE != status) {
+            status->MPI_SOURCE = source;
+            status->MPI_TAG    = tag;
+        }
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/recv.c
+++ b/ompi/mpi/c/recv.c
@@ -9,6 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -69,6 +70,22 @@ int MPI_Recv(void *buf, int count, MPI_Datatype type, int source,
 
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are communicating with
+     * a failed process. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the completion
+     * call in the PML.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_p2p_check_proc(comm, source, &rc)) ) {
+        if (MPI_STATUS_IGNORE != status) {
+            status->MPI_SOURCE = source;
+            status->MPI_TAG    = tag;
+        }
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     if (MPI_PROC_NULL == source) {
         if (MPI_STATUS_IGNORE != status) {

--- a/ompi/mpi/c/recv_init.c
+++ b/ompi/mpi/c/recv_init.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
@@ -74,6 +75,13 @@ int MPI_Recv_init(void *buf, int count, MPI_Datatype type, int source,
         rc = ompi_request_persistent_noop_create(request);
         OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/reduce.c
+++ b/ompi/mpi/c/reduce.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -122,6 +123,17 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
             }
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* Do we need to do anything? (MPI says that reductions have to
        have a count of at least 1, but at least IMB calls reduce with

--- a/ompi/mpi/c/reduce_scatter.c
+++ b/ompi/mpi/c/reduce_scatter.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
@@ -111,6 +112,17 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
           OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* MPI-1, p114, says that each process must supply at least one
        element.  But at least the Pallas benchmarks call MPI_REDUCE

--- a/ompi/mpi/c/reduce_scatter_block.c
+++ b/ompi/mpi/c/reduce_scatter_block.c
@@ -98,6 +98,17 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
         return MPI_SUCCESS;
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
+
     OPAL_CR_ENTER_LIBRARY();
 
     /* Invoke the coll component to perform the back-end operation */

--- a/ompi/mpi/c/rsend.c
+++ b/ompi/mpi/c/rsend.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -73,6 +74,18 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype type, int dest, int tag, 
         }
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are communicating with
+     * a failed process. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the completion
+     * call in the PML.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_p2p_check_proc(comm, dest, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     if (MPI_PROC_NULL == dest) {
         return MPI_SUCCESS;

--- a/ompi/mpi/c/rsend_init.c
+++ b/ompi/mpi/c/rsend_init.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -79,6 +80,13 @@ int MPI_Rsend_init(const void *buf, int count, MPI_Datatype type,
         rc = ompi_request_persistent_noop_create(request);
         OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/scan.c
+++ b/ompi/mpi/c/scan.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -91,6 +92,17 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count,
         }
         OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* Do we need to do anything? (MPI says that reductions have to
        have a count of at least 1, but at least IMB calls reduce with

--- a/ompi/mpi/c/scatter.c
+++ b/ompi/mpi/c/scatter.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2006-2007 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2008      University of Houston.  All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -149,6 +150,17 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
           OMPI_ERRHANDLER_CHECK(err, comm, err, FUNC_NAME);
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     /* Do we need to do anything? */
 

--- a/ompi/mpi/c/scatterv.c
+++ b/ompi/mpi/c/scatterv.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -189,6 +190,17 @@ int MPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[]
             }
         }
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are using a broken
+     * communicator. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the operation.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_coll_check(comm, &err)) ) {
+        OMPI_ERRHANDLER_RETURN(err, comm, err, FUNC_NAME);
+    }
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/send.c
+++ b/ompi/mpi/c/send.c
@@ -10,6 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -72,6 +73,18 @@ int MPI_Send(const void *buf, int count, MPI_Datatype type, int dest,
         }
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are communicating with
+     * a failed process. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the completion
+     * call in the PML.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_p2p_check_proc(comm, dest, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     if (MPI_PROC_NULL == dest) {
         return MPI_SUCCESS;

--- a/ompi/mpi/c/send_init.c
+++ b/ompi/mpi/c/send_init.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -79,6 +80,13 @@ int MPI_Send_init(const void *buf, int count, MPI_Datatype type,
         rc = ompi_request_persistent_noop_create(request);
         OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/sendrecv.c
+++ b/ompi/mpi/c/sendrecv.c
@@ -10,6 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -48,6 +49,9 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 {
     ompi_request_t* req;
     int rc = MPI_SUCCESS;
+#if OPAL_ENABLE_FT_MPI
+    int rcs = MPI_SUCCESS;
+#endif
 
     SPC_RECORD(OMPI_SPC_SENDRECV, 1);
 
@@ -90,16 +94,38 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     if (dest != MPI_PROC_NULL) { /* send */
         rc = MCA_PML_CALL(send(sendbuf, sendcount, sendtype, dest,
                                sendtag, MCA_PML_BASE_SEND_STANDARD, comm));
+#if OPAL_ENABLE_FT_MPI
+        /* If ULFM is enabled we need to wait for the posted receive to
+         * complete, hence we cannot return here */
+        rcs = rc;
+#else
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+#endif  /* OPAL_ENABLE_FT_MPI */
     }
 
     if (source != MPI_PROC_NULL) { /* wait for recv */
         rc = ompi_request_wait(&req, status);
+#if OPAL_ENABLE_FT_MPI
+        /* Sendrecv never returns ERR_PROC_FAILED_PENDING because it is
+         * blocking. Lets complete now that irecv and promote the error
+         * to ERR_PROC_FAILED */
+        if( OPAL_UNLIKELY(MPI_ERR_PROC_FAILED_PENDING == rc) ) {
+            ompi_request_cancel(req);
+            ompi_request_wait(&req, MPI_STATUS_IGNORE);
+            rc = MPI_ERR_PROC_FAILED;
+        }
+#endif
     } else {
         if (MPI_STATUS_IGNORE != status) {
             *status = ompi_request_empty.req_status;
         }
         rc = MPI_SUCCESS;
     }
+#if OPAL_ENABLE_FT_MPI
+    if( OPAL_UNLIKELY(MPI_SUCCESS != rcs && MPI_SUCCESS == rc) ) {
+        rc = rcs;
+    }
+#endif
+
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
 }

--- a/ompi/mpi/c/sendrecv_replace.c
+++ b/ompi/mpi/c/sendrecv_replace.c
@@ -76,6 +76,13 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
 
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The final call to Sendrecv will check for process failures inside
+     * So no need to check here.
+     */
+#endif /* OPAL_ENABLE_FT_MPI */
+
     OPAL_CR_ENTER_LIBRARY();
 
     /* simple case */
@@ -125,7 +132,7 @@ int MPI_Sendrecv_replace(void * buf, int count, MPI_Datatype datatype,
     max_data = packed_size;
     iov_count = 1;
     rc = opal_convertor_pack(&convertor, &iov, &iov_count, &max_data);
-    
+
     /* recv into temporary buffer */
     rc = PMPI_Sendrecv( iov.iov_base, packed_size, MPI_PACKED, dest, sendtag, buf, count,
                         datatype, source, recvtag, comm, &recv_status );

--- a/ompi/mpi/c/ssend.c
+++ b/ompi/mpi/c/ssend.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -73,6 +74,18 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype type, int dest, int tag, 
         }
         OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * An early check, so as to return early if we are communicating with
+     * a failed process. This is not absolutely necessary since we will
+     * check for this, and other, error conditions during the completion
+     * call in the PML.
+     */
+    if( OPAL_UNLIKELY(!ompi_comm_iface_p2p_check_proc(comm, dest, &rc)) ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+#endif
 
     if (MPI_PROC_NULL == dest) {
         return MPI_SUCCESS;

--- a/ompi/mpi/c/ssend_init.c
+++ b/ompi/mpi/c/ssend_init.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -79,6 +80,13 @@ int MPI_Ssend_init(const void *buf, int count, MPI_Datatype type,
         rc = ompi_request_persistent_noop_create(request);
         OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpi/c/start.c
+++ b/ompi/mpi/c/start.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      FUJITSU LIMITED.  All rights reserved.
@@ -64,6 +65,13 @@ int MPI_Start(MPI_Request *request)
      * this case, as it is the only one knowing if the request can
      * be reused or not (it is PML completed or not?).
      */
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     switch((*request)->req_type) {
     case OMPI_REQUEST_PML:

--- a/ompi/mpi/c/startall.c
+++ b/ompi/mpi/c/startall.c
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2016 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
@@ -76,6 +77,13 @@ int MPI_Startall(int count, MPI_Request requests[])
         }
         OMPI_ERRHANDLER_NOHANDLE_CHECK(rc, rc, FUNC_NAME);
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /*
+     * The request will be checked for process failure errors during the
+     * completion calls. So no need to check here.
+     */
+#endif
 
     OPAL_CR_ENTER_LIBRARY();
 

--- a/ompi/mpiext/ftmpi/Makefile.am
+++ b/ompi/mpiext/ftmpi/Makefile.am
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2016      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+SUBDIRS = c mpif-h use-mpi use-mpi-f08
+

--- a/ompi/mpiext/ftmpi/c/Makefile.am
+++ b/ompi/mpiext/ftmpi/c/Makefile.am
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+# Copyright (c) 2016-2018 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+SUBDIRS = profile
+
+headers = \
+    mpiext_ftmpi_c.h
+
+# OMPI_BUILD_MPI_PROFILING is enabled when we want our generated MPI_* symbols
+# to be replaced by PMPI_*.
+# In this directory, we need it to be 0
+
+AM_CPPFLAGS = -DOMPI_BUILD_MPI_PROFILING=0
+
+noinst_LTLIBRARIES = libmpiext_ftmpi_c.la
+
+libmpiext_ftmpi_c_la_SOURCES = \
+    comm_revoke.c \
+    comm_is_revoked.c \
+    comm_shrink.c \
+    comm_failure_ack.c \
+    comm_failure_get_acked.c \
+    comm_agree.c \
+    comm_iagree.c
+libmpiext_ftmpi_c_la_LIBADD = \
+    profile/libpmpiext_ftmpi_c.la
+
+dist_ompidata_DATA = help-mpi-ft.txt
+
+ompidir = $(ompiincludedir)/mpiext/
+ompi_HEADERS = $(headers)
+
+MAINTAINERCLEANFILES = $(nodist_libmpiext_ftmpi_c_la_SOURCES)

--- a/ompi/mpiext/ftmpi/c/comm_agree.c
+++ b/ompi/mpiext/ftmpi/c/comm_agree.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2015-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/group/group.h"
+#include "ompi/proc/proc.h"
+#include "ompi/op/op.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_agree = PMPIX_Comm_agree
+#endif
+#define MPIX_Comm_agree PMPIX_Comm_agree
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_agree";
+
+
+int MPIX_Comm_agree(MPI_Comm comm, int *flag)
+{
+    int rc = MPI_SUCCESS;
+    ompi_group_t* acked;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        if (NULL == flag) {
+            rc = MPI_ERR_ARG;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    ompi_comm_failure_get_acked_internal( comm, &acked );
+
+    rc = comm->c_coll->coll_agree( flag,
+                                   1,
+                                   &ompi_mpi_int.dt,
+                                   &ompi_mpi_op_band.op,
+                                   &acked, false, /* Acked failures are ignored */
+                                   (ompi_communicator_t*)comm,
+                                   comm->c_coll->coll_agree_module);
+    OBJ_RELEASE( acked );
+    OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+}
+

--- a/ompi/mpiext/ftmpi/c/comm_failure_ack.c
+++ b/ompi/mpiext/ftmpi/c/comm_failure_ack.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/proc/proc.h"
+#include "ompi/errhandler/errhandler.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_failure_ack = PMPIX_Comm_failure_ack
+#endif
+#define MPIX_Comm_failure_ack PMPIX_Comm_failure_ack
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_failure_ack";
+
+
+int MPIX_Comm_failure_ack(MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    rc = ompi_comm_failure_ack_internal( (ompi_communicator_t*)comm );
+    OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+}
+

--- a/ompi/mpiext/ftmpi/c/comm_failure_get_acked.c
+++ b/ompi/mpiext/ftmpi/c/comm_failure_get_acked.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2015-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/proc/proc.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_failure_get_acked = PMPIX_Comm_failure_get_acked
+#endif
+#define MPIX_Comm_failure_get_acked PMPIX_Comm_failure_get_acked
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_failure_get_acked";
+
+int MPIX_Comm_failure_get_acked(MPI_Comm comm, MPI_Group *failedgrp)
+{
+    int rc = MPI_SUCCESS;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    rc = ompi_comm_failure_get_acked_internal( (ompi_communicator_t*)comm, (ompi_group_t**)failedgrp );
+    if( OMPI_SUCCESS != rc ) {
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+    }
+
+    return MPI_SUCCESS;
+}
+

--- a/ompi/mpiext/ftmpi/c/comm_iagree.c
+++ b/ompi/mpiext/ftmpi/c/comm_iagree.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/request/request.h"
+#include "ompi/proc/proc.h"
+#include "ompi/op/op.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_iagree = PMPIX_Comm_iagree
+#endif
+#define MPIX_Comm_iagree PMPIX_Comm_iagree
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_iagree";
+
+
+int MPIX_Comm_iagree(MPI_Comm comm, int *flag, MPI_Request *request)
+{
+    int rc = MPI_SUCCESS;
+    ompi_group_t* acked;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        if (NULL == request) {
+            rc = MPI_ERR_REQUEST;
+        }
+        else if (NULL == flag) {
+            rc = MPI_ERR_ARG;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    ompi_comm_failure_get_acked_internal( comm, &acked );
+    rc = comm->c_coll->coll_iagree( flag,
+                                    1,
+                                    &ompi_mpi_int.dt,
+                                    &ompi_mpi_op_band.op,
+                                    &acked, false,
+                                    (ompi_communicator_t*)comm,
+                                    request,
+                                    comm->c_coll->coll_iagree_module);
+    OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+}
+

--- a/ompi/mpiext/ftmpi/c/comm_is_revoked.c
+++ b/ompi/mpiext/ftmpi/c/comm_is_revoked.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/proc/proc.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_is_revoked = PMPIX_Comm_is_revoked
+#endif
+#define MPIX_Comm_is_revoked PMPIX_Comm_is_revoked
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_is_revoked";
+
+
+int MPIX_Comm_is_revoked(MPI_Comm comm, int* flag)
+{
+    int rc = MPI_SUCCESS;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        if (NULL == flag) {
+            rc = MPI_ERR_ARG;
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    *flag = ompi_comm_is_revoked( (ompi_communicator_t*)comm );
+    OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+}
+

--- a/ompi/mpiext/ftmpi/c/comm_revoke.c
+++ b/ompi/mpiext/ftmpi/c/comm_revoke.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2013-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/proc/proc.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_revoke = PMPIX_Comm_revoke
+#endif
+#define MPIX_Comm_revoke PMPIX_Comm_revoke
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_revoke";
+
+
+int MPIX_Comm_revoke(MPI_Comm comm)
+{
+    int rc = MPI_SUCCESS;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    rc = ompi_comm_revoke_internal( (ompi_communicator_t*)comm );
+    OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+}
+

--- a/ompi/mpiext/ftmpi/c/comm_shrink.c
+++ b/ompi/mpiext/ftmpi/c/comm_shrink.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/c/bindings.h"
+#include "ompi/runtime/params.h"
+#include "ompi/communicator/communicator.h"
+#include "ompi/proc/proc.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPIX_Comm_shrink = PMPIX_Comm_shrink
+#endif
+#define MPIX_Comm_shrink PMPIX_Comm_shrink
+#endif
+
+static const char FUNC_NAME[] = "MPIX_Comm_shrink";
+
+
+int MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm *newcomm)
+{
+    int rc = MPI_SUCCESS;
+
+    /* Argument checking */
+    if (MPI_PARAM_CHECK) {
+        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
+        if (ompi_comm_invalid(comm)) {
+            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_COMM, FUNC_NAME);
+        }
+        if( NULL == newcomm ) {
+            return OMPI_ERRHANDLER_INVOKE(comm, MPI_ERR_ARG,
+                                          FUNC_NAME);
+        }
+        OMPI_ERRHANDLER_CHECK(rc, comm, rc, FUNC_NAME);
+    }
+
+    rc = ompi_comm_shrink_internal(comm, newcomm);
+    OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
+}
+

--- a/ompi/mpiext/ftmpi/c/help-mpi-ft.txt
+++ b/ompi/mpiext/ftmpi/c/help-mpi-ft.txt
@@ -1,0 +1,52 @@
+# -*- text -*-
+#
+# Copyright (c) 2017      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English general help file for ULFM Open MPI.
+#
+[module:untested:failundef]
+WARNING: The selected '%s' module '%s' is not tested for post-failure
+operation, yet you have requested support for fault tolerance.
+When using this component, normal failure free operation is expected;
+However, failures may cause the application to abort, crash or deadlock.
+
+In this framework, the following components are tested to operate under
+failure scenarios: {%s}
+#
+[module:untested:failabort]
+WARNING: The selected '%s' module '%s' is not tested for post-failure
+operation, yet you have requested support for fault tolerance.
+When using this component, normal failure free operation is expected;
+However, failures will cause the application to abort.
+
+In this framework, the following components are tested to operate under
+failure scenarios: {%s}
+#
+[module:untested:shouldwork]
+The selected '%s' module '%s' is insuficiently tested in post-failure
+operation, yet you have requested support for fault tolerance.
+When using this component, normal failure free and post-failure operation
+is expected, but the module should not be used in production.
+Please report to the ULFM mailing list your experience (including positive
+ones) with the module under failure scenarios.
+
+In this framework, the following components are tested to operate under
+failure scenarios: {%s}
+#
+[module:event:selectbug]
+WARNING: The selected 'libevent' uses the 'select' method, which has 
+a known bug in post-failure operation, yet you have requested support 
+for fault tolerance. When using this component, normal failure free
+operation is expected; However, failures may cause the application to 
+deadlock.
+
+You may select a different polling method by setting the MCA parameter
+'opal_event_include' to any other method than 'select'.
+#

--- a/ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h
+++ b/ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2010-2020 The University of Tennessee and the University
+ *                         of Tennessee research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/********************************
+ * Error codes and classes
+ ********************************/
+#define MPIX_ERR_PROC_FAILED          MPI_ERR_PROC_FAILED
+#define MPIX_ERR_PROC_FAILED_PENDING  MPI_ERR_PROC_FAILED_PENDING
+#define MPIX_ERR_REVOKED              MPI_ERR_REVOKED
+#define MPIX_FT                       MPI_FT
+
+/********************************
+ * Communicators
+ ********************************/
+OMPI_DECLSPEC int MPIX_Comm_revoke(MPI_Comm comm);
+OMPI_DECLSPEC int MPIX_Comm_is_revoked(MPI_Comm comm, int *flag);
+OMPI_DECLSPEC int MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm *newcomm);
+OMPI_DECLSPEC int MPIX_Comm_failure_ack(MPI_Comm comm);
+OMPI_DECLSPEC int MPIX_Comm_failure_get_acked(MPI_Comm comm, MPI_Group *failedgrp);
+OMPI_DECLSPEC int MPIX_Comm_agree(MPI_Comm comm, int *flag);
+OMPI_DECLSPEC int MPIX_Comm_iagree(MPI_Comm comm, int *flag, MPI_Request *request);
+
+OMPI_DECLSPEC int PMPIX_Comm_revoke(MPI_Comm comm);
+OMPI_DECLSPEC int PMPIX_Comm_is_revoked(MPI_Comm comm, int *flag);
+OMPI_DECLSPEC int PMPIX_Comm_shrink(MPI_Comm comm, MPI_Comm *newcomm);
+OMPI_DECLSPEC int PMPIX_Comm_failure_ack(MPI_Comm comm);
+OMPI_DECLSPEC int PMPIX_Comm_failure_get_acked(MPI_Comm comm, MPI_Group *failedgrp);
+OMPI_DECLSPEC int PMPIX_Comm_agree(MPI_Comm comm, int *flag);
+OMPI_DECLSPEC int PMPIX_Comm_iagree(MPI_Comm comm, int *flag, MPI_Request *request);
+
+#include <stdbool.h>
+OMPI_DECLSPEC int OMPI_Comm_failure_inject(MPI_Comm comm, bool notify);
+

--- a/ompi/mpiext/ftmpi/c/profile/Makefile.am
+++ b/ompi/mpiext/ftmpi/c/profile/Makefile.am
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2016-2018 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# If OMPI_BUILD_MPI_PROFILING is enabled when we want our generated MPI_* symbols
+# to be replaced by PMPI_*.
+# In this directory, we definately need it to be 1.
+AM_CPPFLAGS = -DOMPI_BUILD_MPI_PROFILING=1
+
+noinst_LTLIBRARIES = libpmpiext_ftmpi_c.la
+
+nodist_libpmpiext_ftmpi_c_la_SOURCES = \
+    pcomm_revoke.c \
+    pcomm_is_revoked.c \
+    pcomm_shrink.c \
+    pcomm_failure_ack.c \
+    pcomm_failure_get_acked.c \
+    pcomm_agree.c \
+    pcomm_iagree.c
+
+#
+# Sym link in the sources from the real MPI directory
+#
+$(nodist_libpmpiext_ftmpi_c_la_SOURCES):
+	$(OMPI_V_LN_S) if test ! -r $@ ; then \
+		pname=`echo $@ | cut -b '2-'` ; \
+		$(LN_S) $(top_srcdir)/ompi/mpiext/ftmpi/c/$$pname $@ ; \
+	fi
+
+
+# These files were created by targets above
+
+MAINTAINERCLEANFILES = $(nodist_libpmpiext_ftmpi_c_la_SOURCES)
+
+# Don't want these targets in here
+
+tags-recursive:
+tags:
+:
+GTAGS:
+ID:

--- a/ompi/mpiext/ftmpi/configure.m4
+++ b/ompi/mpiext/ftmpi/configure.m4
@@ -1,0 +1,28 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+# Copyright (c) 2016      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OMPI_MPIEXT_ftmpi_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([OMPI_MPIEXT_ftmpi_CONFIG],[
+    AC_CONFIG_FILES([ompi/mpiext/ftmpi/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/ftmpi/c/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/ftmpi/c/profile/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/ftmpi/mpif-h/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/ftmpi/use-mpi/Makefile])
+    AC_CONFIG_FILES([ompi/mpiext/ftmpi/use-mpi-f08/Makefile])
+
+    # If we don't want FT, don't compile this component
+    AS_IF([test "$opal_want_ft_mpi" = "1"],
+        [$1],
+        [$2])
+])dnl

--- a/ompi/mpiext/ftmpi/mpif-h/Makefile.am
+++ b/ompi/mpiext/ftmpi/mpif-h/Makefile.am
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+# Copyright (c) 2016-2020 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+include $(top_srcdir)/Makefile.ompi-rules
+
+AM_CPPFLAGS = -DOMPI_COMPILING_FORTRAN_WRAPPERS=1
+
+if OMPI_BUILD_FORTRAN_MPIFH_BINDINGS
+headers = \
+    mpiext_ftmpi_mpifh.h
+
+noinst_HEADERS = prototypes_mpi.h
+
+f77_sources = \
+    comm_revoke_f.c \
+    comm_is_revoked_f.c \
+    comm_shrink_f.c \
+    comm_failure_ack_f.c \
+    comm_failure_get_acked_f.c \
+    comm_agree_f.c \
+    comm_iagree_f.c
+
+f77_lib = libmpiext_ftmpi_mpifh.la
+f77_lib_sources = $(f77_sources)
+
+libmpiext_ftmpi_mpifh_la_SOURCES = $(f77_lib_sources) $(headers)
+libmpiext_ftmpi_mpifh_la_LIBADD  = $(lib_sources)
+libmpiext_ftmpi_mpifh_la_LDFLAGS = -module -avoid-version
+
+MAINTAINERCLEANFILES = $(nodist_libmpiext_ftmpi_mpifh_la_SOURCES)
+endif
+
+noinst_LTLIBRARIES = $(f77_lib)
+
+ompidir = $(ompiincludedir)/mpiext/
+ompi_HEADERS = $(headers)

--- a/ompi/mpiext/ftmpi/mpif-h/comm_agree_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_agree_f.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2019 The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_AGREE = ompix_comm_agree_f
+#pragma weak pmpix_comm_agree = ompix_comm_agree_f
+#pragma weak pmpix_comm_agree_ = ompix_comm_agree_f
+#pragma weak pmpix_comm_agree__ = ompix_comm_agree_f
+#pragma weak PMPIX_Comm_agree_f = ompix_comm_agree_f
+#pragma weak PMPIX_Comm_agree_f08 = ompix_comm_agree_f
+
+#pragma weak MPIX_COMM_AGREE = ompix_comm_agree_f
+#pragma weak mpix_comm_agree = ompix_comm_agree_f
+#pragma weak mpix_comm_agree_ = ompix_comm_agree_f
+#pragma weak mpix_comm_agree__ = ompix_comm_agree_f
+#pragma weak MPIX_Comm_agree_f = ompix_comm_agree_f
+#pragma weak MPIX_Comm_agree_f08 = ompix_comm_agree_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_AGREE,
+                        pmpix_comm_agree,
+                        pmpix_comm_agree_,
+                        pmpix_comm_agree__,
+                        ompix_comm_agree_f,
+                        (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr),
+                        (comm, flag, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_AGREE,
+                        mpix_comm_agree,
+                        mpix_comm_agree_,
+                        mpix_comm_agree__,
+                        ompix_comm_agree_f,
+                        (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr),
+                        (comm, flag, ierr))
+#endif
+
+void ompix_comm_agree_f(MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr)
+{
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+    OMPI_LOGICAL_NAME_DECL(flag);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_agree(c_comm,
+                                             OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag)));
+}

--- a/ompi/mpiext/ftmpi/mpif-h/comm_failure_ack_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_failure_ack_f.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2019 The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_FAILURE_ACK = ompix_comm_failure_ack_f
+#pragma weak pmpix_comm_failure_ack = ompix_comm_failure_ack_f
+#pragma weak pmpix_comm_failure_ack_ = ompix_comm_failure_ack_f
+#pragma weak pmpix_comm_failure_ack__ = ompix_comm_failure_ack_f
+#pragma weak PMPIX_Comm_failure_ack_f = ompix_comm_failure_ack_f
+#pragma weak PMPIX_Comm_failure_ack_f08 = ompix_comm_failure_ack_f
+
+#pragma weak MPIX_COMM_FAILURE_ACK = ompix_comm_failure_ack_f
+#pragma weak mpix_comm_failure_ack = ompix_comm_failure_ack_f
+#pragma weak mpix_comm_failure_ack_ = ompix_comm_failure_ack_f
+#pragma weak mpix_comm_failure_ack__ = ompix_comm_failure_ack_f
+#pragma weak MPIX_Comm_failure_ack_f = ompix_comm_failure_ack_f
+#pragma weak MPIX_Comm_failure_ack_f08 = ompix_comm_failure_ack_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_FAILURE_ACK,
+                        pmpix_comm_failure_ack,
+                        pmpix_comm_failure_ack_,
+                        pmpix_comm_failure_ack__,
+                        ompix_comm_failure_ack_f,
+                        (MPI_Fint *comm, MPI_Fint *ierr),
+                        (comm, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_FAILURE_ACK,
+                        mpix_comm_failure_ack,
+                        mpix_comm_failure_ack_,
+                        mpix_comm_failure_ack__,
+                        ompix_comm_failure_ack_f,
+                        (MPI_Fint *comm, MPI_Fint *ierr),
+                        (comm, ierr))
+#endif
+
+void ompix_comm_failure_ack_f(MPI_Fint *comm, MPI_Fint *ierr)
+{
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_failure_ack(c_comm));
+}

--- a/ompi/mpiext/ftmpi/mpif-h/comm_failure_get_acked_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_failure_get_acked_f.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2010-2019 The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_FAILURE_GET_ACKED = ompix_comm_failure_get_acked_f
+#pragma weak pmpix_comm_failure_get_acked = ompix_comm_failure_get_acked_f
+#pragma weak pmpix_comm_failure_get_acked_ = ompix_comm_failure_get_acked_f
+#pragma weak pmpix_comm_failure_get_acked__ = ompix_comm_failure_get_acked_f
+#pragma weak PMPIX_Comm_failure_get_acked_f = ompix_comm_failure_get_acked_f
+#pragma weak PMPIX_Comm_failure_get_acked_f08 = ompix_comm_failure_get_acked_f
+
+#pragma weak MPIX_COMM_FAILURE_GET_ACKED = ompix_comm_failure_get_acked_f
+#pragma weak mpix_comm_failure_get_acked = ompix_comm_failure_get_acked_f
+#pragma weak mpix_comm_failure_get_acked_ = ompix_comm_failure_get_acked_f
+#pragma weak mpix_comm_failure_get_acked__ = ompix_comm_failure_get_acked_f
+#pragma weak MPIX_Comm_failure_get_acked_f = ompix_comm_failure_get_acked_f
+#pragma weak MPIX_Comm_failure_get_acked_f08 = ompix_comm_failure_get_acked_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_FAILURE_GET_ACKED,
+                        pmpix_comm_failure_get_acked,
+                        pmpix_comm_failure_get_acked_,
+                        pmpix_comm_failure_get_acked__,
+                        ompix_comm_failure_get_acked_f,
+                        (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr),
+                        (comm, group, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_FAILURE_GET_ACKED,
+                        mpix_comm_failure_get_acked,
+                        mpix_comm_failure_get_acked_,
+                        mpix_comm_failure_get_acked__,
+                        ompix_comm_failure_get_acked_f,
+                        (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr),
+                        (comm, group, ierr))
+#endif
+
+void ompix_comm_failure_get_acked_f(MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr)
+{
+    MPI_Group c_group;
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_failure_get_acked(c_comm,
+                                                         &c_group));
+    if (MPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+        *group = PMPI_Group_c2f (c_group);
+    }
+}

--- a/ompi/mpiext/ftmpi/mpif-h/comm_iagree_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_iagree_f.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2019 The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_IAGREE = ompix_comm_iagree_f
+#pragma weak pmpix_comm_iagree = ompix_comm_iagree_f
+#pragma weak pmpix_comm_iagree_ = ompix_comm_iagree_f
+#pragma weak pmpix_comm_iagree__ = ompix_comm_iagree_f
+#pragma weak PMPIX_Comm_iagree_f = ompix_comm_iagree_f
+#pragma weak PMPIX_Comm_iagree_f08 = ompix_comm_iagree_f
+
+#pragma weak MPIX_COMM_IAGREE = ompix_comm_iagree_f
+#pragma weak mpix_comm_iagree = ompix_comm_iagree_f
+#pragma weak mpix_comm_iagree_ = ompix_comm_iagree_f
+#pragma weak mpix_comm_iagree__ = ompix_comm_iagree_f
+#pragma weak MPIX_Comm_iagree_f = ompix_comm_iagree_f
+#pragma weak MPIX_Comm_iagree_f08 = ompix_comm_iagree_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_IAGREE,
+                        mpix_comm_iagree,
+                        mpix_comm_iagree_,
+                        mpix_comm_iagree__,
+                        ompix_comm_iagree_f,
+                        (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *request, MPI_Fint *ierr),
+                        (comm, flag, request, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_IAGREE,
+                        pmpix_comm_iagree,
+                        pmpix_comm_iagree_,
+                        pmpix_comm_iagree__,
+                        ompix_comm_iagree_f,
+                        (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *request, MPI_Fint *ierr),
+                        (comm, flag, request, ierr))
+#endif
+
+void ompix_comm_iagree_f(MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *request, MPI_Fint *ierr)
+{
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+    MPI_Request c_req;
+    OMPI_LOGICAL_NAME_DECL(flag);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_iagree(c_comm,
+                                              OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag),
+                                              &c_req));
+
+    if (MPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+        *request = PMPI_Request_c2f(c_req);
+    }
+}

--- a/ompi/mpiext/ftmpi/mpif-h/comm_is_revoked_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_is_revoked_f.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2010-2019 The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_IS_REVOKED = ompix_comm_is_revoked_f
+#pragma weak pmpix_comm_is_revoked = ompix_comm_is_revoked_f
+#pragma weak pmpix_comm_is_revoked_ = ompix_comm_is_revoked_f
+#pragma weak pmpix_comm_is_revoked__ = ompix_comm_is_revoked_f
+#pragma weak PMPIX_Comm_is_revoked_f = ompix_comm_is_revoked_f
+#pragma weak PMPIX_Comm_is_revoked_f08 = ompix_comm_is_revoked_f
+
+#pragma weak MPIX_COMM_IS_REVOKED = ompix_comm_is_revoked_f
+#pragma weak mpix_comm_is_revoked = ompix_comm_is_revoked_f
+#pragma weak mpix_comm_is_revoked_ = ompix_comm_is_revoked_f
+#pragma weak mpix_comm_is_revoked__ = ompix_comm_is_revoked_f
+#pragma weak MPIX_Comm_is_revoked_f = ompix_comm_is_revoked_f
+#pragma weak MPIX_Comm_is_revoked_f08 = ompix_comm_is_revoked_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_IS_REVOKED,
+                        pmpix_comm_is_revoked,
+                        pmpix_comm_is_revoked_,
+                        pmpix_comm_is_revoked__,
+                        ompix_comm_is_revoked_f,
+                        (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr),
+                        (comm, flag, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_IS_REVOKED,
+                        mpix_comm_is_revoked,
+                        mpix_comm_is_revoked_,
+                        mpix_comm_is_revoked__,
+                        ompix_comm_is_revoked_f,
+                        (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr),
+                        (comm, flag, ierr))
+#endif
+
+void ompix_comm_is_revoked_f(MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr)
+{
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+
+    OMPI_LOGICAL_NAME_DECL(flag);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_is_revoked(c_comm,
+                                                  OMPI_LOGICAL_SINGLE_NAME_CONVERT(flag)));
+}

--- a/ompi/mpiext/ftmpi/mpif-h/comm_revoke_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_revoke_f.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2019 The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_REVOKE = ompix_comm_revoke_f
+#pragma weak pmpix_comm_revoke = ompix_comm_revoke_f
+#pragma weak pmpix_comm_revoke_ = ompix_comm_revoke_f
+#pragma weak pmpix_comm_revoke__ = ompix_comm_revoke_f
+#pragma weak PMPIX_Comm_revoke_f = ompix_comm_revoke_f
+#pragma weak PMPIX_Comm_revoke_f08 = ompix_comm_revoke_f
+
+#pragma weak MPIX_COMM_REVOKE = ompix_comm_revoke_f
+#pragma weak mpix_comm_revoke = ompix_comm_revoke_f
+#pragma weak mpix_comm_revoke_ = ompix_comm_revoke_f
+#pragma weak mpix_comm_revoke__ = ompix_comm_revoke_f
+#pragma weak MPIX_Comm_revoke_f = ompix_comm_revoke_f
+#pragma weak MPIX_Comm_revoke_f08 = ompix_comm_revoke_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_REVOKE,
+                        pmpix_comm_revoke,
+                        pmpix_comm_revoke_,
+                        pmpix_comm_revoke__,
+                        ompix_comm_revoke_f,
+                        (MPI_Fint *comm, MPI_Fint *ierr),
+                        (comm, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_REVOKE,
+                        mpix_comm_revoke,
+                        mpix_comm_revoke_,
+                        mpix_comm_revoke__,
+                        ompix_comm_revoke_f,
+                        (MPI_Fint *comm, MPI_Fint *ierr),
+                        (comm, ierr))
+#endif
+
+void ompix_comm_revoke_f(MPI_Fint *comm, MPI_Fint *ierr)
+{
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_revoke(c_comm));
+}

--- a/ompi/mpiext/ftmpi/mpif-h/comm_shrink_f.c
+++ b/ompi/mpiext/ftmpi/mpif-h/comm_shrink_f.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2019 The University of Tennessee and the University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/constants.h"
+
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+#include "ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h"
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPIX_COMM_SHRINK = ompix_comm_shrink_f
+#pragma weak pmpix_comm_shrink = ompix_comm_shrink_f
+#pragma weak pmpix_comm_shrink_ = ompix_comm_shrink_f
+#pragma weak pmpix_comm_shrink__ = ompix_comm_shrink_f
+#pragma weak PMPIX_Comm_shrink_f = ompix_comm_shrink_f
+#pragma weak PMPIX_Comm_shrink_f08 = ompix_comm_shrink_f
+
+#pragma weak MPIX_COMM_SHRINK = ompix_comm_shrink_f
+#pragma weak mpix_comm_shrink = ompix_comm_shrink_f
+#pragma weak mpix_comm_shrink_ = ompix_comm_shrink_f
+#pragma weak mpix_comm_shrink__ = ompix_comm_shrink_f
+#pragma weak MPIX_Comm_shrink_f = ompix_comm_shrink_f
+#pragma weak MPIX_Comm_shrink_f08 = ompix_comm_shrink_f
+
+#else /* No weak symbols */
+OMPI_GENERATE_F77_BINDINGS(PMPIX_COMM_SHRINK,
+                        pmpix_comm_shrink,
+                        pmpix_comm_shrink_,
+                        pmpix_comm_shrink__,
+                        ompix_comm_shrink_f,
+                        (MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr),
+                        (comm, newcomm, ierr))
+
+OMPI_GENERATE_F77_BINDINGS(MPIX_COMM_SHRINK,
+                        mpix_comm_shrink,
+                        mpix_comm_shrink_,
+                        mpix_comm_shrink__,
+                        ompix_comm_shrink_f,
+                        (MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr),
+                        (comm, newcomm, ierr))
+#endif
+
+void ompix_comm_shrink_f(MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr)
+{
+    MPI_Comm c_newcomm;
+    MPI_Comm c_comm = PMPI_Comm_f2c(*comm);
+
+    *ierr = OMPI_INT_2_FINT(PMPIX_Comm_shrink(c_comm,
+                                              &c_newcomm));
+    if (MPI_SUCCESS == OMPI_FINT_2_INT(*ierr)) {
+        *newcomm = PMPI_Comm_c2f(c_newcomm);
+    }
+}

--- a/ompi/mpiext/ftmpi/mpif-h/mpiext_ftmpi_mpifh.h
+++ b/ompi/mpiext/ftmpi/mpif-h/mpiext_ftmpi_mpifh.h
@@ -1,0 +1,22 @@
+! -*- fortran -*-
+! Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+! Copyright (c) 2010-2020 The Trustees of the University of Tennessee.
+!                         All rights reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+!
+! Error codes
+!
+       integer MPIX_ERR_PROC_FAILED
+       integer MPIX_ERR_PROC_FAILED_PENDING
+       integer MPIX_ERR_REVOKED
+! These values must match the same define in mpif-common.h
+       parameter (MPIX_ERR_PROC_FAILED         = 75)
+       parameter (MPIX_ERR_PROC_FAILED_PENDING = 76)
+       parameter (MPIX_ERR_REVOKED             = 77)
+

--- a/ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h
+++ b/ompi/mpiext/ftmpi/mpif-h/prototypes_mpi.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * This file prototypes all MPI fortran functions in all four fortran
+ * symbol conventions as well as all the internal real OMPI wrapper
+ * functions (different from any of the four fortran symbol
+ * conventions for clarity, at the cost of more typing for me...).
+ * This file is included in the top-level build ONLY. The prototyping
+ * is done ONLY for MPI_* bindings
+ *
+ * Zeroth, the OMPI wrapper functions, with a ompi_ prefix and _f
+ * suffix.
+ *
+ * This is needed ONLY if the lower-level prototypes_pmpi.h has not
+ * already been included.
+ *
+ * Note about function pointers: all function pointers are prototyped
+ * here as (void*) rather than including the .h file that defines the
+ * proper type (e.g., "op/op.h" defines ompi_op_fortran_handler_fn_t,
+ * which is the function pointer type for fortran op callback
+ * functions).  This is because there is no type checking coming in
+ * from fortran, so why bother?  Also, including "op/op.h" (and
+ * friends) makes the all the f77 bindings files dependant on these
+ * files -- any change to any one of them will cause the recompilation
+ * of the entire set of f77 bindings (ugh!).
+ */
+
+#ifndef OMPI_F77_PROTOTYPES_MPIEXT_FTMPI_H
+#define OMPI_F77_PROTOTYPES_MPIEXT_FTMPI_H
+
+#include "ompi/mpi/fortran/mpif-h/prototypes_mpi.h"
+
+BEGIN_C_DECLS
+
+PN2(void, MPIX_Comm_agree, mpix_comm_agree, MPIX_COMM_AGREE, (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_failure_ack, mpix_comm_failure_ack, MPIX_COMM_FAILURE_ACK, (MPI_Fint *comm, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_failure_get_acked, mpix_comm_failure_get_acked, MPIX_COMM_FAILURE_GET_ACKED, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_iagree, mpix_comm_iagree, MPIX_COMM_IAGREE, (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *request, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_is_revoked, mpix_comm_is_revoked, MPIX_COMM_IS_REVOKED, (MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_revoke, mpix_comm_revoke, MPIX_COMM_REVOKE, (MPI_Fint *comm, MPI_Fint *ierr));
+PN2(void, MPIX_Comm_shrink, mpix_comm_shrink, MPIX_COMM_SHRINK, (MPI_Fint *comm, MPI_Fint *newcomm, MPI_Fint *ierr));
+
+END_C_DECLS
+
+#endif  /* OMPI_F77_PROTOTYPES_MPIEXT_FTMPI_H */

--- a/ompi/mpiext/ftmpi/owner.txt
+++ b/ompi/mpiext/ftmpi/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: UTK
+status: active

--- a/ompi/mpiext/ftmpi/use-mpi-f08/Makefile.am
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/Makefile.am
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017-2018 Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2018      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This file builds the use_mpi_f08-based bindings for MPI extensions.  It
+# is optional in MPI extensions.
+
+# We must set these #defines and include paths so that the inner OMPI
+# MPI prototype header files do the Right Thing.
+AM_FCFLAGS = $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/use-mpi \
+             $(OMPI_FC_MODULE_FLAG)$(top_builddir)/ompi/mpi/fortran/use-mpi-f08/mod \
+             -I$(top_builddir) -I$(top_srcdir) $(FCFLAGS_f90)
+
+# Note that the mpi_f08-based bindings are optional -- they can only
+# be built if OMPI is also building the Fortran-based bindings.  So we
+# initially set some Makefile macros to empty, and then conditionally
+# add to them later.
+noinst_LTLIBRARIES =
+
+# Use the Automake conditional to know if we're building the mpif.h
+# bindings.
+if OMPI_BUILD_FORTRAN_USEMPIF08_BINDINGS
+
+# If we are, build the convenience libtool library that will be
+# slurped up into libmpi_usempif08.la.
+noinst_LTLIBRARIES += libmpiext_ftmpi_usempif08.la
+
+# Note that no header files are installed; instead,
+# mpiext_ftmpi_usempif08.h is automatically slurped up into the
+# mpi_f08_ext module.  It must be listed so that it is included in
+# dist tarballs.
+noinst_HEADERS = mpiext_ftmpi_usempif08.h
+
+
+# Sources for the convenience libtool library.
+mpi_api_files = \
+    comm_revoke_f08.F90 \
+    comm_is_revoked_f08.F90 \
+    comm_failure_ack_f08.F90 \
+    comm_failure_get_acked_f08.F90 \
+    comm_agree_f08.F90 \
+    comm_iagree_f08.F90 \
+    comm_shrink_f08.F90
+
+pmpi_api_files = \
+    profile/pcomm_revoke_f08.F90 \
+    profile/pcomm_is_revoked_f08.F90 \
+    profile/pcomm_failure_ack_f08.F90 \
+    profile/pcomm_failure_get_acked_f08.F90 \
+    profile/pcomm_agree_f08.F90 \
+    profile/pcomm_iagree_f08.F90 \
+    profile/pcomm_shrink_f08.F90
+
+mpi_api_lo_files = $(mpi_api_files:.F90=.lo)
+pmpi_api_lo_files = $(pmpi_api_files:.F90=.lo)
+
+# Sources for the convenience libtool library.
+libmpiext_ftmpi_usempif08_la_SOURCES = \
+        $(mpi_api_files) \
+        $(pmpi_api_files)
+
+# Remove the intermediate module file
+distclean-local:
+	rm -f mpiext_ftmpi_f08.mod
+
+endif

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_agree_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_agree_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_agree_f08(comm, flag, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_agree_f(comm, flag, ierror) &
+          BIND(C, name="ompix_comm_agree_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(INOUT) :: flag
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_agree_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(INOUT) :: flag
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_agree_f(comm%MPI_VAL, flag, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_agree_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_failure_ack_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_failure_ack_f08.F90
@@ -1,0 +1,31 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_failure_ack_f08(comm, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_failure_ack_f(comm, ierror) &
+          BIND(C, name="ompix_comm_failure_ack_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_failure_ack_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_failure_ack_f(comm%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_failure_ack_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_failure_get_acked_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_failure_get_acked_f08.F90
@@ -1,0 +1,32 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_failure_get_acked_f08(comm, failedgrp, ierror)
+  use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+  implicit none
+  interface
+     subroutine ompix_comm_failure_get_acked_f(comm, failedgrp, ierror) &
+          BIND(C, name="ompix_comm_failure_get_acked_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: failedgrp, ierror
+     end subroutine ompix_comm_failure_get_acked_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_failure_get_acked_f(comm%MPI_VAL, failedgrp%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_failure_get_acked_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_iagree_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_iagree_f08.F90
@@ -1,0 +1,37 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine MPIX_Comm_iagree_f08(comm, flag, request, ierror)
+  use :: mpi_f08_types, only : MPI_Comm, MPI_Request
+  implicit none
+  interface
+     subroutine ompix_comm_iagree_f(comm, flag, request, ierror) &
+          BIND(C, name="ompix_comm_iagree_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(INOUT) :: flag
+       INTEGER, INTENT(OUT) :: request
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_iagree_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(INOUT) OMPI_ASYNCHRONOUS :: flag
+  TYPE(MPI_Request), INTENT(OUT) :: request
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_iagree_f(comm%MPI_VAL, flag, request%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_iagree_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_is_revoked_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_is_revoked_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_is_revoked_f08(comm, flag, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_is_revoked_f(comm, flag, ierror) &
+          BIND(C, name="ompix_comm_is_revoked_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: flag
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_is_revoked_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(OUT) :: flag
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_is_revoked_f(comm%MPI_VAL, flag, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_is_revoked_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_revoke_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_revoke_f08.F90
@@ -1,0 +1,31 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_revoke_f08(comm, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_revoke_f(comm, ierror) &
+          BIND(C, name="ompix_comm_revoke_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_revoke_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_revoke_f(comm%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_revoke_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/comm_shrink_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/comm_shrink_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine MPIX_Comm_shrink_f08(comm, newcomm, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_shrink_f(comm, newcomm, ierror) &
+          BIND(C, name="ompix_comm_shrink_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: newcomm
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_shrink_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_shrink_f(comm%MPI_VAL, newcomm%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine MPIX_Comm_shrink_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/mpiext_ftmpi_usempif08.h
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/mpiext_ftmpi_usempif08.h
@@ -1,0 +1,151 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+!
+! $COPYRIGHT$
+
+interface mpix_comm_revoke
+subroutine mpix_comm_revoke_f08(comm,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_revoke_f08
+end interface mpix_comm_revoke
+
+interface pmpix_comm_revoke
+subroutine pmpix_comm_revoke_f08(comm,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_revoke_f08
+end interface pmpix_comm_revoke
+
+interface mpix_comm_is_revoked
+subroutine mpix_comm_is_revoked_f08(comm,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(OUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_is_revoked_f08
+end interface mpix_comm_is_revoked
+
+interface pmpix_comm_is_revoked
+subroutine pmpix_comm_is_revoked_f08(comm,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(OUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_is_revoked_f08
+end interface pmpix_comm_is_revoked
+
+interface mpix_comm_failure_ack
+subroutine mpix_comm_failure_ack_f08(comm,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_failure_ack_f08
+end interface mpix_comm_failure_ack
+
+interface pmpix_comm_failure_ack
+subroutine pmpix_comm_failure_ack_f08(comm,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_failure_ack_f08
+end interface pmpix_comm_failure_ack
+
+interface mpix_comm_failure_get_acked
+subroutine mpix_comm_failure_get_acked_f08(comm,failedgrp,ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_failure_get_acked_f08
+end interface mpix_comm_failure_get_acked
+
+interface pmpix_comm_failure_get_acked
+subroutine pmpix_comm_failure_get_acked_f08(comm,failedgrp,ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_failure_get_acked_f08
+end interface pmpix_comm_failure_get_acked
+
+interface mpix_comm_agree
+subroutine mpix_comm_agree_f08(comm,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(INOUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_agree_f08
+end interface mpix_comm_agree
+
+interface pmpix_comm_agree
+subroutine pmpix_comm_agree_f08(comm,flag,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(INOUT) :: flag
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_agree_f08
+end interface pmpix_comm_agree
+
+interface mpix_comm_iagree
+subroutine mpix_comm_iagree_f08(comm,flag,request,ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Request
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(INOUT), ASYNCHRONOUS :: flag ! should use OMPI_ASYNCHRONOUS
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_iagree_f08
+end interface mpix_comm_iagree
+
+interface pmpix_comm_iagree
+subroutine pmpix_comm_iagree_f08(comm,flag,request,ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Request
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   INTEGER, INTENT(INOUT), ASYNCHRONOUS :: flag ! should use OMPI_ASYNCHRONOUS
+   TYPE(MPI_Request), INTENT(OUT) :: request
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_iagree_f08
+end interface pmpix_comm_iagree
+
+interface mpix_comm_shrink
+subroutine mpix_comm_shrink_f08(comm,newcomm,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine mpix_comm_shrink_f08
+end interface mpix_comm_shrink
+
+interface pmpix_comm_shrink
+subroutine pmpix_comm_shrink_f08(comm,newcomm,ierror)
+   use :: mpi_f08_types, only : MPI_Comm
+   implicit none
+   TYPE(MPI_Comm), INTENT(IN) :: comm
+   TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine pmpix_comm_shrink_f08
+end interface pmpix_comm_shrink

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_agree_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_agree_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_agree_f08(comm, flag, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_agree_f(comm, flag, ierror) &
+          BIND(C, name="ompix_comm_agree_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(INOUT) :: flag
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_agree_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(INOUT) :: flag
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_agree_f(comm%MPI_VAL, flag, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_agree_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_failure_ack_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_failure_ack_f08.F90
@@ -1,0 +1,31 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_failure_ack_f08(comm, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_failure_ack_f(comm, ierror) &
+          BIND(C, name="ompix_comm_failure_ack_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_failure_ack_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_failure_ack_f(comm%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_failure_ack_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_failure_get_acked_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_failure_get_acked_f08.F90
@@ -1,0 +1,32 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_failure_get_acked_f08(comm, failedgrp, ierror)
+  use :: mpi_f08_types, only : MPI_Comm, MPI_Group
+  implicit none
+  interface
+     subroutine ompix_comm_failure_get_acked_f(comm, failedgrp, ierror) &
+          BIND(C, name="ompix_comm_failure_get_acked_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: failedgrp, ierror
+     end subroutine ompix_comm_failure_get_acked_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  TYPE(MPI_Group), INTENT(OUT) :: failedgrp
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_failure_get_acked_f(comm%MPI_VAL, failedgrp%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_failure_get_acked_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_iagree_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_iagree_f08.F90
@@ -1,0 +1,37 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+#include "ompi/mpi/fortran/configure-fortran-output.h"
+
+subroutine PMPIX_Comm_iagree_f08(comm, flag, request, ierror)
+  use :: mpi_f08_types, only : MPI_Comm, MPI_Request
+  implicit none
+  interface
+     subroutine ompix_comm_iagree_f(comm, flag, request, ierror) &
+          BIND(C, name="ompix_comm_iagree_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(INOUT) :: flag
+       INTEGER, INTENT(OUT) :: request
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_iagree_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(INOUT) OMPI_ASYNCHRONOUS :: flag
+  TYPE(MPI_Request), INTENT(OUT) :: request
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_iagree_f(comm%MPI_VAL, flag, request%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_iagree_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_is_revoked_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_is_revoked_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_is_revoked_f08(comm, flag, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_is_revoked_f(comm, flag, ierror) &
+          BIND(C, name="ompix_comm_is_revoked_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: flag
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_is_revoked_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, INTENT(OUT) :: flag
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_is_revoked_f(comm%MPI_VAL, flag, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_is_revoked_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_revoke_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_revoke_f08.F90
@@ -1,0 +1,31 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_revoke_f08(comm, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_revoke_f(comm, ierror) &
+          BIND(C, name="ompix_comm_revoke_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_revoke_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_revoke_f(comm%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_revoke_f08

--- a/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_shrink_f08.F90
+++ b/ompi/mpiext/ftmpi/use-mpi-f08/profile/pcomm_shrink_f08.F90
@@ -1,0 +1,33 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2018-2020 The University of Tennessee and the University
+!                         of Tennessee Research Foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+subroutine PMPIX_Comm_shrink_f08(comm, newcomm, ierror)
+  use :: mpi_f08_types, only : MPI_Comm
+  implicit none
+  interface
+     subroutine ompix_comm_shrink_f(comm, newcomm, ierror) &
+          BIND(C, name="ompix_comm_shrink_f")
+       implicit none
+       INTEGER, INTENT(IN) :: comm
+       INTEGER, INTENT(OUT) :: newcomm
+       INTEGER, INTENT(OUT) :: ierror
+     end subroutine ompix_comm_shrink_f
+  end interface
+  TYPE(MPI_Comm), INTENT(IN) :: comm
+  TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+  INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+  integer :: c_ierror
+
+  call ompix_comm_shrink_f(comm%MPI_VAL, newcomm%MPI_VAL, c_ierror)
+  if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPIX_Comm_shrink_f08

--- a/ompi/mpiext/ftmpi/use-mpi/Makefile.am
+++ b/ompi/mpiext/ftmpi/use-mpi/Makefile.am
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2016      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = \
+	mpiext_ftmpi_usempi.h
+
+noinst_HEADERS = \
+        $(headers)
+

--- a/ompi/mpiext/ftmpi/use-mpi/mpiext_ftmpi_usempi.h
+++ b/ompi/mpiext/ftmpi/use-mpi/mpiext_ftmpi_usempi.h
@@ -1,0 +1,137 @@
+! -*- fortran -*-
+! Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+! Copyright (c) 2010-2020 The University of Tennessee and the University
+!                         of Tennessee research foundation.  All rights
+!                         reserved.
+! $COPYRIGHT$
+!
+! Additional copyrights may follow
+!
+! $HEADER$
+!
+
+! Include the parameters for this extension
+! Included from config/ompi_ext.m4 into mpif90-ext.f90
+! include '../mpiext/ftmpi/mpif-h/mpiext_ftmpi_mpifh.h'
+
+!
+! Communicators
+!
+interface mpix_comm_revoke
+    subroutine mpix_comm_revoke(comm, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(OUT) :: ierr
+    end subroutine mpix_comm_revoke
+end interface mpix_comm_revoke
+
+interface pmpix_comm_revoke
+    subroutine pmpix_comm_revoke(comm, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(OUT) :: ierr
+    end subroutine pmpix_comm_revoke
+end interface pmpix_comm_revoke
+
+interface mpix_comm_is_revoked
+    subroutine mpix_comm_is_revoked(comm, flag, ierr)
+      integer, intent(IN) :: comm
+      logical, intent(OUT) :: flag
+      integer, intent(OUT) :: ierr
+    end subroutine mpix_comm_is_revoked
+end interface mpix_comm_is_revoked
+
+interface pmpix_comm_is_revoked
+    subroutine pmpix_comm_is_revoked(comm, flag, ierr)
+      integer, intent(IN) :: comm
+      logical, intent(OUT) :: flag
+      integer, intent(OUT) :: ierr
+    end subroutine pmpix_comm_is_revoked
+end interface pmpix_comm_is_revoked
+
+interface mpix_comm_shrink
+    subroutine mpix_comm_shrink(comm, newcomm, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(OUT) :: newcomm, ierr
+    end subroutine mpix_comm_shrink
+end interface mpix_comm_shrink
+
+interface pmpix_comm_shrink
+    subroutine pmpix_comm_shrink(comm, newcomm, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(OUT) :: newcomm, ierr
+    end subroutine pmpix_comm_shrink
+end interface pmpix_comm_shrink
+
+interface mpix_comm_failure_ack
+    subroutine mpix_comm_failure_ack(comm, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(OUT) :: ierr
+    end subroutine mpix_comm_failure_ack
+end interface mpix_comm_failure_ack
+
+interface pmpix_comm_failure_ack
+    subroutine pmpix_comm_failure_ack(comm, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(OUT) :: ierr
+    end subroutine pmpix_comm_failure_ack
+end interface pmpix_comm_failure_ack
+
+interface mpix_comm_failure_get_acked
+    subroutine mpix_comm_failure_get_acked(comm, failedgrp, ierr)
+        integer, intent(IN) :: comm
+        integer, intent(OUT) :: failedgrp, ierr
+    end subroutine mpix_comm_failure_get_acked
+end interface mpix_comm_failure_get_acked
+
+interface pmpix_comm_failure_get_acked
+    subroutine pmpix_comm_failure_get_acked(comm, failedgrp, ierr)
+        integer, intent(IN) :: comm
+        integer, intent(OUT) :: failedgrp, ierr
+    end subroutine pmpix_comm_failure_get_acked
+end interface pmpix_comm_failure_get_acked
+
+interface mpix_comm_agree
+    subroutine mpix_comm_agree(comm, flag, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(INOUT) :: flag
+      integer, intent(OUT) :: ierr
+    end subroutine mpix_comm_agree
+end interface mpix_comm_agree
+
+interface pmpix_comm_agree
+    subroutine pmpix_comm_agree(comm, flag, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(INOUT) :: flag
+      integer, intent(OUT) :: ierr
+    end subroutine pmpix_comm_agree
+end interface pmpix_comm_agree
+
+interface mpix_comm_iagree
+    subroutine mpix_comm_iagree(comm, flag, request, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(INOUT) :: flag
+      integer, intent(OUT) :: request, ierr
+    end subroutine mpix_comm_iagree
+end interface mpix_comm_iagree
+
+interface pmpix_comm_iagree
+    subroutine pmpix_comm_iagree(comm, flag, request, ierr)
+      integer, intent(IN) :: comm
+      integer, intent(INOUT) :: flag
+      integer, intent(OUT) :: request, ierr
+    end subroutine pmpix_comm_iagree
+end interface pmpix_comm_iagree
+
+
+!
+! Validation: Windows
+! Todo
+!
+
+
+!
+! Validation: File Handles
+! Todo
+!
+
+
+!

--- a/ompi/proc/proc.c
+++ b/ompi/proc/proc.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
@@ -11,6 +11,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
@@ -66,6 +67,9 @@ OBJ_CLASS_INSTANCE(
 
 void ompi_proc_construct(ompi_proc_t* proc)
 {
+#if OPAL_ENABLE_FT_MPI
+    proc->proc_active = true;
+#endif
     bzero(proc->proc_endpoints, sizeof(proc->proc_endpoints));
 
     /* By default all processors are supposedly having the same architecture as me. Thus,

--- a/ompi/request/Makefile.am
+++ b/ompi/request/Makefile.am
@@ -3,13 +3,14 @@
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
 #                         Corporation.  All rights reserved.
-# Copyright (c) 2004-2005 The University of Tennessee and The University
+# Copyright (c) 2004-2016 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 # Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
+# Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
@@ -38,6 +39,11 @@ lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
         request/request.c \
         request/req_test.c \
         request/req_wait.c
+
+if WANT_FT_MPI
+lib@OMPI_LIBMPI_NAME@_la_SOURCES += \
+	request/req_ft.c
+endif # WANT_FT_MPI
 
 if OMPI_ENABLE_GREQUEST_EXTENSIONS
 lib@OMPI_LIBMPI_NAME@_la_SOURCES += \

--- a/ompi/request/req_ft.c
+++ b/ompi/request/req_ft.c
@@ -1,0 +1,183 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "ompi/constants.h"
+#include "ompi/request/request.h"
+#include "ompi/errhandler/errcode.h"
+
+#include "ompi/runtime/params.h"
+
+#include "ompi/mca/coll/base/coll_tags.h"
+#include "ompi/mca/pml/base/pml_base_request.h"
+#include "ompi/mca/pml/pml.h"
+
+#include "opal/mca/backtrace/backtrace.h"
+
+/**************************
+ * Support Routines
+ **************************/
+bool ompi_request_is_failed_fn(ompi_request_t *req)
+{
+    mca_pml_base_request_t* pml_req = NULL;
+
+    if( !ompi_ftmpi_enabled ) {
+        return false;
+    }
+
+    /* Pick our behavior depending upon the type of request */
+    switch(req->req_type) {
+    case OMPI_REQUEST_PML:
+        pml_req = (mca_pml_base_request_t*)req;
+        /*
+         * Toggle 'off' the MPI_ANY_SOURCE MPI_ERR_PROC_FAILED_PENDING flag
+         * We will recheck, but in the case the request is complete we
+         * need to remove the error code.
+         */
+        if( MPI_ERR_PROC_FAILED_PENDING == req->req_status.MPI_ERROR ) {
+            req->req_status.MPI_ERROR = MPI_SUCCESS;
+        }
+        break;
+    case OMPI_REQUEST_COLL:
+    case OMPI_REQUEST_COMM:
+        /* Supported by bubbling up errors from REQUEST_PML subrequests
+         * thus this type of requests never need to be interrupted */
+        return false;
+    default:
+        /* not supported yet, pretend everything is always fine */
+        return false;
+    }
+
+    /*
+     * Sanity check
+     */
+    assert( NULL != req->req_mpi_object.comm );
+
+    /*
+     * If the request is complete, then just skip it
+     */
+    if( REQUEST_COMPLETE(req) ) {
+        return false;
+    }
+
+    /*
+     * Has this communicator been 'revoked'?
+     *
+     * If so unless we are in the FT part (propagate revoke, agreement or
+     * shrink) this should fail.
+     */
+    if( OPAL_UNLIKELY(ompi_comm_is_revoked(req->req_mpi_object.comm) &&
+                      req->req_type == OMPI_REQUEST_PML && !ompi_request_tag_is_ft(pml_req->req_tag)) ) {
+        /* Do not set req->req_status.MPI_SOURCE */
+        req->req_status.MPI_ERROR  = MPI_ERR_REVOKED;
+
+        opal_output_verbose(10, ompi_ftmpi_output_handle,
+                            "%s ompi_request_is_failed: %p (peer %d, tag %d) is on communicator %s(%d) that has been revoked!",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), (void*)req, pml_req->req_peer, pml_req->req_tag,
+                            req->req_mpi_object.comm->c_name, req->req_mpi_object.comm->c_contextid);
+        goto return_with_error;
+    }
+
+    /*
+     * Collectives Check:
+     * If the request is part of a collective, then the whole communicator
+     * must be ok to continue. If not then return first failed process
+     */
+    if(OPAL_UNLIKELY( ompi_comm_coll_revoked(req->req_mpi_object.comm) &&
+                      (req->req_type == OMPI_REQUEST_PML && ompi_request_tag_is_collective(pml_req->req_tag)) )) {
+        /* Do not set req->req_status.MPI_SOURCE */
+        req->req_status.MPI_ERROR  = MPI_ERR_PROC_FAILED;
+
+        opal_output_verbose(10, ompi_ftmpi_output_handle,
+                            "%s ompi_request_is_failed: Request %p (peer %d) is part of a collective (tag %d), and some process died. (mpi_source %3d)",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), (void*)req, pml_req->req_peer, pml_req->req_tag, req->req_status.MPI_SOURCE );
+        goto return_with_error;
+    }
+
+    /* Corner-cases: two processes that can't fail (NULL and myself) */
+    if((pml_req->req_peer == MPI_PROC_NULL) ||
+       (OMPI_COMM_IS_INTRA(req->req_mpi_object.comm) && pml_req->req_peer == req->req_mpi_object.comm->c_local_group->grp_my_rank)) {
+        return false;
+    }
+
+    /* If any_source but not FT related then the request is always marked for return */
+    if( OPAL_UNLIKELY(MPI_ANY_SOURCE == pml_req->req_peer && !ompi_comm_is_any_source_enabled(req->req_mpi_object.comm)) ) {
+        if( !ompi_request_tag_is_ft(pml_req->req_tag) ) {
+            req->req_status.MPI_ERROR  = MPI_ERR_PROC_FAILED_PENDING;
+            /* If it is a probe/mprobe, escalate the error */
+            if( (MCA_PML_REQUEST_MPROBE == pml_req->req_type) ||
+                (MCA_PML_REQUEST_PROBE == pml_req->req_type) ) {
+                req->req_status.MPI_ERROR  = MPI_ERR_PROC_FAILED;
+            }
+            opal_output_verbose(10, ompi_ftmpi_output_handle,
+                                "%s ompi_request_is_failed: Request %p (peer %d, tag %d) in comm %s(%d) peer ANY_SOURCE %s!",
+                                OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), (void*)req, pml_req->req_peer, pml_req->req_tag,
+                                req->req_mpi_object.comm->c_name, req->req_mpi_object.comm->c_contextid,
+                                ompi_mpi_errnum_get_string(req->req_status.MPI_ERROR));
+            goto return_with_error;
+        }
+    }
+
+    /* Any type of request with a dead process must be terminated with error */
+    if( OPAL_UNLIKELY(!ompi_comm_is_proc_active(req->req_mpi_object.comm, pml_req->req_peer,
+                                  OMPI_COMM_IS_INTER(req->req_mpi_object.comm))) ) {
+        req->req_status.MPI_SOURCE = pml_req->req_peer;
+        req->req_status.MPI_ERROR  = MPI_ERR_PROC_FAILED;
+        assert(MPI_ANY_SOURCE != pml_req->req_peer); /* this case is handled above, so... */
+        opal_output_verbose(10, ompi_ftmpi_output_handle,
+                            "%s ompi_request_is_failed: Request %p (peer %d, tag %d) in comm %s(%d) mpi_source %3d failed - Ret %s",
+                            OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), (void*)req, pml_req->req_peer, pml_req->req_tag,
+                            req->req_mpi_object.comm->c_name, req->req_mpi_object.comm->c_contextid,
+                            req->req_status.MPI_SOURCE,
+                            ompi_mpi_errnum_get_string(req->req_status.MPI_ERROR));
+        goto return_with_error;
+    }
+
+    OPAL_OUTPUT_VERBOSE((100, ompi_ftmpi_output_handle,
+                         "%s ompi_request_is_failed: Request %p (peer %d tag %d) is still ok. (mpi_source %3d)",
+                         OMPI_NAME_PRINT(OMPI_PROC_MY_NAME), (void*)req, pml_req->req_peer, pml_req->req_tag, req->req_status.MPI_SOURCE ));
+
+    return false;
+
+ return_with_error:
+    if( MPI_ERR_PROC_FAILED_PENDING != req->req_status.MPI_ERROR ) {
+        int cancelled = req->req_status._cancelled;
+#if OPAL_ENABLE_DEBUG
+        int verbose = opal_output_get_verbosity(ompi_ftmpi_output_handle);
+        if( verbose > 90 ) {
+            opal_backtrace_print(stderr, NULL, 1);
+        }
+        if( verbose > 50 ) {
+            MCA_PML_CALL(dump(req->req_mpi_object.comm, ompi_ftmpi_output_handle));
+        }
+#endif /* OPAL_ENABLE_DEBUG */
+        /* Cancel and force completion immmediately
+         * However, for Revoked and Collective error we can't complete
+         * with an error before the buffer is unpinned (i.e. the request gets
+         * wire cancelled).
+         */
+        ompi_request_cancel(req);
+        req->req_status._cancelled = cancelled; /* This request is not user cancelled here, it is completed in error */
+        return REQUEST_COMPLETE(req); /* If this request is not complete yet, it is stil ok and needs more spinning */
+    }
+    return (MPI_SUCCESS != req->req_status.MPI_ERROR);
+}

--- a/ompi/request/req_test.c
+++ b/ompi/request/req_test.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2016 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
@@ -87,6 +87,15 @@ int ompi_request_default_test(ompi_request_t ** rptr,
            later! */
         return ompi_request_free(rptr);
     }
+#if OPAL_ENABLE_FT_MPI
+    /* Check for dead requests due to process failure */
+    /* Special case for MPI_ANY_SOURCE */
+    if(OPAL_UNLIKELY( ompi_request_is_failed(request) &&
+                      MPI_ERR_PROC_FAILED_PENDING == request->req_status.MPI_ERROR )) {
+        *completed = false;
+        return MPI_ERR_PROC_FAILED_PENDING;
+    }
+#endif
 #if OPAL_ENABLE_PROGRESS_THREADS == 0
     if( 0 == do_it_once ) {
         /**
@@ -167,6 +176,16 @@ int ompi_request_default_test_any(
                will happen later! */
             return ompi_request_free(rptr);
         }
+#if OPAL_ENABLE_FT_MPI
+        /* Check for dead requests due to process failure */
+        /* Special case for MPI_ANY_SOURCE */
+        if(OPAL_UNLIKELY( ompi_request_is_failed(request) &&
+                          MPI_ERR_PROC_FAILED_PENDING == request->req_status.MPI_ERROR )) {
+            *index = i;
+            *completed = false;
+            return MPI_ERR_PROC_FAILED_PENDING;
+        }
+#endif /* OPAL_ENABLE_FT_MPI */
     }
 
     /* Only fall through here if we found nothing */
@@ -206,6 +225,19 @@ int ompi_request_default_test_all(
             REQUEST_COMPLETE(request) ) {
             num_completed++;
         }
+#if OPAL_ENABLE_FT_MPI
+        /* Check for dead requests due to process failure */
+        /* Special case for MPI_ANY_SOURCE */
+        if(OPAL_UNLIKELY( ompi_request_is_failed(request) &&
+                          MPI_ERR_PROC_FAILED_PENDING == request->req_status.MPI_ERROR )) {
+            if (MPI_STATUSES_IGNORE != statuses) {
+                statuses[i] = request->req_status;
+                statuses[i].MPI_ERROR = MPI_ERR_PROC_FAILED_PENDING;
+            }
+            *completed = false;
+            return MPI_ERR_PROC_FAILED_PENDING;
+        }
+#endif /* OPAL_ENABLE_FT_MPI */
     }
 
     if (num_completed != count) {
@@ -254,6 +286,12 @@ int ompi_request_default_test_all(
                 }
             } else {
                 rc = MPI_ERR_IN_STATUS;
+#if OPAL_ENABLE_FT_MPI
+                if (MPI_ERR_PROC_FAILED == request->req_status.MPI_ERROR
+                 || MPI_ERR_REVOKED == request->req_status.MPI_ERROR) {
+                    rc = request->req_status.MPI_ERROR;
+                }
+#endif /* OPAL_ENABLE_FT_MPI */
             }
         }
     } else {
@@ -286,6 +324,12 @@ int ompi_request_default_test_all(
                 }
             } else {
                 rc = MPI_ERR_IN_STATUS;
+#if OPAL_ENABLE_FT_MPI
+                if (MPI_ERR_PROC_FAILED == request->req_status.MPI_ERROR
+                 || MPI_ERR_REVOKED == request->req_status.MPI_ERROR) {
+                    rc = request->req_status.MPI_ERROR;
+                }
+#endif /* OPAL_ENABLE_FT_MPI */
             }
         }
     }
@@ -322,6 +366,14 @@ int ompi_request_default_test_some(
 #endif
             indices[num_requests_done++] = i;
         }
+#if OPAL_ENABLE_FT_MPI
+        /* Check for dead requests due to process failure */
+        /* Special case for MPI_ANY_SOURCE - Error managed below */
+        if(OPAL_UNLIKELY( ompi_request_is_failed(request) &&
+                          MPI_ERR_PROC_FAILED_PENDING == request->req_status.MPI_ERROR )) {
+            indices[num_requests_done++] = i;
+        }
+#endif /* OPAL_ENABLE_FT_MPI */
     }
 
     /*
@@ -345,6 +397,18 @@ int ompi_request_default_test_some(
     for( i = 0; i < num_requests_done; i++) {
         request = requests[indices[i]];
 
+#if OPAL_ENABLE_FT_MPI
+        /* Special case for MPI_ANY_SOURCE */
+        if(OPAL_UNLIKELY( MPI_ERR_PROC_FAILED_PENDING == request->req_status.MPI_ERROR )) {
+            if (MPI_STATUSES_IGNORE != statuses) {
+                statuses[i] = request->req_status;
+                statuses[i].MPI_ERROR = MPI_ERR_PROC_FAILED_PENDING;
+            }
+            rc = MPI_ERR_PROC_FAILED_PENDING;
+            continue;
+        }
+#endif /* OPAL_ENABLE_FT_MPI */
+
         /* See note above: if a generalized request completes, we
            *have* to call the query fn, even if STATUSES_IGNORE
            was supplied */
@@ -357,6 +421,12 @@ int ompi_request_default_test_some(
 
         if (MPI_SUCCESS != request->req_status.MPI_ERROR) {
             rc = MPI_ERR_IN_STATUS;
+#if OPAL_ENABLE_FT_MPI
+            if (MPI_ERR_PROC_FAILED == request->req_status.MPI_ERROR
+             || MPI_ERR_REVOKED == request->req_status.MPI_ERROR) {
+                rc = request->req_status.MPI_ERROR;
+            }
+#endif /* OPAL_ENABLE_FT_MPI */
         }
 
         if( request->req_persistent ) {

--- a/ompi/request/request.h
+++ b/ompi/request/request.h
@@ -38,6 +38,7 @@
 #include "opal/mca/threads/condition.h"
 #include "opal/mca/threads/wait_sync.h"
 #include "ompi/constants.h"
+#include "ompi/runtime/params.h"
 
 BEGIN_C_DECLS
 
@@ -212,7 +213,7 @@ do {                                                                    \
  * @param status (OUT)   Status of completed request.
  * @return               OMPI_SUCCESS or failure status.
  *
- * Note that upon completion, the request is freed, and the
+ * Note that upon completion, the request completed without error is freed, and the
  * request handle at index set to NULL.
  */
 typedef int (*ompi_request_test_fn_t)(ompi_request_t ** rptr,
@@ -228,7 +229,7 @@ typedef int (*ompi_request_test_fn_t)(ompi_request_t ** rptr,
  * @param status (OUT)   Status of completed request.
  * @return               OMPI_SUCCESS or failure status.
  *
- * Note that upon completion, the request is freed, and the
+ * Note that upon completion, the request completed without error is freed, and the
  * request handle at index set to NULL.
  */
 typedef int (*ompi_request_test_any_fn_t)(size_t count,
@@ -245,10 +246,10 @@ typedef int (*ompi_request_test_any_fn_t)(size_t count,
  * @param statuses (OUT)  Array of completion statuses.
  * @return                OMPI_SUCCESS or failure status.
  *
- * This routine returns completed==true if all requests have completed.
- * The statuses parameter is only updated if all requests completed. Likewise,
- * the requests array is not modified (no requests freed), unless all requests
- * have completed.
+ * This routine returns completed==true if all requests completed without errors
+ * have completed. The statuses parameter is only updated if all requests completed.
+ * Likewise, the requests array is not modified (no requests freed), unless all
+ * requests have completed.
  */
 typedef int (*ompi_request_test_all_fn_t)(size_t count,
                                           ompi_request_t ** requests,
@@ -271,7 +272,10 @@ typedef int (*ompi_request_test_some_fn_t)(size_t count,
                                            int * indices,
                                            ompi_status_public_t * statuses);
 /**
- * Wait (blocking-mode) for one requests to complete.
+ * Wait (blocking-mode) for one requests to complete. This function is slightly
+ * different from the MPI counter-part as it does not release the requests
+ * completed with error. Instead, the caller is responsible to call the
+ * ompi_request_free.
  *
  * @param request (IN)    Pointer to request.
  * @param status (OUT)    Status of completed request.
@@ -281,7 +285,10 @@ typedef int (*ompi_request_test_some_fn_t)(size_t count,
 typedef int (*ompi_request_wait_fn_t)(ompi_request_t ** req_ptr,
                                       ompi_status_public_t * status);
 /**
- * Wait (blocking-mode) for one of N requests to complete.
+ * Wait (blocking-mode) for one of N requests to complete. This function is
+ * slightly different from the MPI counter-part as it does not release the
+ * requests completed with error. Instead, the caller is responsible to call
+ * the ompi_request_free.
  *
  * @param count (IN)      Number of requests
  * @param requests (IN)   Array of requests
@@ -295,7 +302,10 @@ typedef int (*ompi_request_wait_any_fn_t)(size_t count,
                                           int *index,
                                           ompi_status_public_t * status);
 /**
- * Wait (blocking-mode) for all of N requests to complete.
+ * Wait (blocking-mode) for all of N requests to complete. This function is
+ * slightly different from the MPI counter-part as it does not release the
+ * requests completed with error. Instead, the caller is responsible to call
+ * the ompi_request_free.
  *
  * @param count (IN)      Number of requests
  * @param requests (IN)   Array of requests
@@ -307,7 +317,10 @@ typedef int (*ompi_request_wait_all_fn_t)(size_t count,
                                           ompi_request_t ** requests,
                                           ompi_status_public_t * statuses);
 /**
- * Wait (blocking-mode) for some of N requests to complete.
+ * Wait (blocking-mode) for some of N requests to complete. This function is
+ * slightly different from the MPI counter-part as it does not release the
+ * requests completed with error. Instead, the caller is responsible to call
+ * the ompi_request_free.
  *
  * @param count (IN)        Number of requests
  * @param requests (INOUT)  Array of requests
@@ -392,6 +405,21 @@ static inline int ompi_request_free(ompi_request_t** request)
 #define ompi_request_wait_all   (ompi_request_functions.req_wait_all)
 #define ompi_request_wait_some  (ompi_request_functions.req_wait_some)
 
+#if OPAL_ENABLE_FT_MPI
+OMPI_DECLSPEC bool ompi_request_is_failed_fn(ompi_request_t *req);
+#define ompi_request_is_failed(req) OPAL_UNLIKELY(ompi_ftmpi_enabled? ompi_request_is_failed_fn(req): false)
+
+#include "ompi/mca/coll/base/coll_tags.h"
+
+static inline bool ompi_request_tag_is_ft(int tag) {
+    return (tag <= MCA_COLL_BASE_TAG_FT_BASE && tag >= MCA_COLL_BASE_TAG_FT_END);
+}
+
+static inline bool ompi_request_tag_is_collective(int tag) {
+    return ((tag <= MCA_COLL_BASE_TAG_BASE && tag >= MCA_COLL_BASE_TAG_END) && !ompi_request_tag_is_ft(tag));
+}
+#endif /* OPAL_ENABLE_FT_MPI */
+
 /**
  * Wait a particular request for completion
  */
@@ -399,8 +427,15 @@ static inline int ompi_request_free(ompi_request_t** request)
 static inline void ompi_request_wait_completion(ompi_request_t *req)
 {
     if (opal_using_threads () && !REQUEST_COMPLETE(req)) {
-        void *_tmp_ptr = REQUEST_PENDING;
+        void *_tmp_ptr;
         ompi_wait_sync_t sync;
+#if OPAL_ENABLE_FT_MPI
+redo:
+        if(OPAL_UNLIKELY( ompi_request_is_failed(req) )) {
+            return;
+        }
+#endif /* OPAL_ENABLE_FT_MPI */
+        _tmp_ptr = REQUEST_PENDING;
 
         WAIT_SYNC_INIT(&sync, 1);
 
@@ -411,11 +446,29 @@ static inline void ompi_request_wait_completion(ompi_request_t *req)
             WAIT_SYNC_SIGNALLED(&sync);
         }
 
+#if OPAL_ENABLE_FT_MPI
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != sync.status)) {
+            OPAL_OUTPUT_VERBOSE((50, ompi_ftmpi_output_handle, "Status %d reported for sync %p rearming req %p", sync.status, (void*)&sync, (void*)req));
+            _tmp_ptr = &sync;
+            if (OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR(&req->req_complete, &_tmp_ptr, REQUEST_PENDING)) {
+                opal_output_verbose(10, ompi_ftmpi_output_handle, "Status %d reported for sync %p rearmed req %p", sync.status, (void*)&sync, (void*)req);
+                WAIT_SYNC_RELEASE(&sync);
+                goto redo;
+            }
+        }
+#endif /* OPAL_ENABLE_FT_MPI */
         assert(REQUEST_COMPLETE(req));
         WAIT_SYNC_RELEASE(&sync);
     } else {
         while(!REQUEST_COMPLETE(req)) {
             opal_progress();
+#if OPAL_ENABLE_FT_MPI
+            /* Check to make sure that process failure did not break the
+             * request. */
+            if(OPAL_UNLIKELY( ompi_request_is_failed(req) )) {
+                break;
+            }
+#endif /* OPAL_ENABLE_FT_MPI */
         }
     }
 }

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2014 The University of Tennessee and The University
+ * Copyright (c) 2004-2019 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -361,6 +361,17 @@ static int ompi_register_mca_variables(void)
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &ompi_enable_timing);
 
+#if OPAL_ENABLE_FT_MPI
+    /* Before loading any other part of the MPI library, we need to load
+     * the ft-mpi tune file to override default component selection when
+     * FT is desired ON; this does override openmpi-params.conf, but not
+     * command line or env.
+     */
+    if( ompi_ftmpi_enabled ) {
+        mca_base_var_load_extra_files("ft-mpi", false);
+    }
+#endif /* OPAL_ENABLE_FT_MPI */
+
     return OMPI_SUCCESS;
 }
 
@@ -393,6 +404,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     volatile bool active;
     bool background_fence = false;
     pmix_info_t info[2];
+    pmix_status_t codes[1] = { PMIX_ERR_PROC_ABORTED };
     pmix_status_t rc;
     OMPI_TIMING_INIT(64);
     opal_pmix_lock_t mylock;
@@ -523,7 +535,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     /* give it a name so we can distinguish it */
     PMIX_INFO_LOAD(&info[1], PMIX_EVENT_HDLR_NAME, "MPI-Default", PMIX_STRING);
     OPAL_PMIX_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(NULL, 0, info, 2, ompi_errhandler_callback, evhandler_reg_callbk, (void*)&mylock);
+    PMIx_Register_event_handler(codes, 1, info, 2, ompi_errhandler_callback, evhandler_reg_callbk, (void*)&mylock);
     OPAL_PMIX_WAIT_THREAD(&mylock);
     rc = mylock.status;
     OPAL_PMIX_DESTRUCT_LOCK(&mylock);
@@ -856,6 +868,28 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     MCA_PML_CALL(add_comm(&ompi_mpi_comm_world.comm));
     MCA_PML_CALL(add_comm(&ompi_mpi_comm_self.comm));
 
+#if OPAL_ENABLE_FT_MPI
+    /* initialize the fault tolerant infrastructure (revoke, detector,
+     * propagator) */
+    if( ompi_ftmpi_enabled ) {
+        int rc;
+        const char *evmethod;
+        rc = ompi_comm_rbcast_init();
+        if( OMPI_SUCCESS != rc ) return rc;
+        rc = ompi_comm_revoke_init();
+        if( OMPI_SUCCESS != rc ) return rc;
+        rc = ompi_comm_failure_propagator_init();
+        if( OMPI_SUCCESS != rc ) return rc;
+        rc = ompi_comm_failure_detector_init();
+        if( OMPI_SUCCESS != rc ) return rc;
+
+        evmethod = event_base_get_method(opal_sync_event_base);
+        if( 0 == strcmp("select", evmethod) ) {
+            opal_show_help("help-mpi-ft.txt", "module:event:selectbug", true);
+        }
+    }
+#endif
+
     /*
      * Dump all MCA parameters if requested
      */
@@ -993,6 +1027,15 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
         error = "ompi_mpiext_init";
         goto error;
     }
+
+#if OPAL_ENABLE_FT_MPI
+    /* start the failure detector */
+    if( ompi_ftmpi_enabled ) {
+        int rc;
+        rc = ompi_comm_failure_detector_start();
+        if( OMPI_SUCCESS != rc ) return rc;
+    }
+#endif
 
     /* Fall through */
  error:

--- a/ompi/runtime/params.h
+++ b/ompi/runtime/params.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2013      Intel, Inc. All rights reserved
  * $COPYRIGHT$
@@ -152,6 +153,11 @@ OMPI_DECLSPEC extern bool ompi_async_mpi_init;
 
 /* EXPERIMENTAL: do not perform an RTE barrier at the beginning of MPI_Finalize */
 OMPI_DECLSPEC extern bool ompi_async_mpi_finalize;
+
+#if OPAL_ENABLE_FT_MPI
+OMPI_DECLSPEC extern int ompi_ftmpi_output_handle;
+OMPI_DECLSPEC extern bool ompi_ftmpi_enabled;
+#endif /* OPAL_ENABLE_FT_MPI */
 
 /**
  * A comma delimited list of SPC counters to turn on or 'attach'.  To turn

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2016 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2017 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2009-2012 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
@@ -124,6 +124,8 @@ void ompi_info_do_config(bool want_all)
     char *wtime_support;
     char *symbol_visibility;
     char *ft_support;
+    char *ft_mpi_support;
+    char *ft_cr_support;
     char *crdebug_support;
     char *topology_support;
     char *ipv6_support;
@@ -299,8 +301,15 @@ void ompi_info_do_config(bool want_all)
     (void)opal_asprintf(&threads, "%s (MPI_THREAD_MULTIPLE: yes, OPAL support: yes, OMPI progress: %s, Event lib: yes)",
                    "posix", OPAL_ENABLE_PROGRESS_THREADS ? "yes" : "no");
 
-    (void)opal_asprintf(&ft_support, "%s (checkpoint thread: %s)",
-                   OPAL_ENABLE_FT ? "yes" : "no", OPAL_ENABLE_FT_THREAD ? "yes" : "no");
+    (void)opal_asprintf(&ft_support, "%s",
+                   OPAL_ENABLE_FT ? "yes" : "no" );
+
+    (void)opal_asprintf(&ft_mpi_support, "%s",
+                   OPAL_ENABLE_FT_MPI ? "yes" : "no");
+
+    (void)opal_asprintf(&ft_cr_support, "%s (checkpoint thread: %s)",
+                   OPAL_ENABLE_FT_CR ? "yes" : "no",
+                   OPAL_ENABLE_FT_THREAD ? "yes" : "no");
 
     (void)opal_asprintf(&crdebug_support, "%s",
                    OPAL_ENABLE_CRDEBUG ? "yes" : "no");
@@ -635,8 +644,14 @@ void ompi_info_do_config(bool want_all)
 
     opal_info_out("MPI extensions", "options:mpi_ext", OMPI_MPIEXT_COMPONENTS);
 
-    opal_info_out("FT Checkpoint support", "options:ft_support", ft_support);
+    opal_info_out("Fault Tolerance support", "options:ft_support", ft_support);
     free(ft_support);
+
+    opal_info_out("FT MPI support", "options:ft_mpi_support", ft_mpi_support);
+    free(ft_mpi_support);
+
+    opal_info_out("FT Checkpoint/Restart", "options:ft_cr_support", ft_cr_support);
+    free(ft_cr_support);
 
     opal_info_out("C/R Enabled Debugging", "options:crdebug_support", crdebug_support);
     free(crdebug_support);

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -412,6 +412,13 @@ static void resolve_relative_paths(char **file_prefix, char *file_path, bool rel
     }
 }
 
+int mca_base_var_load_extra_files(char* files, bool rel_path_search) {
+    char *tmp1=strdup(files);
+    resolve_relative_paths(&tmp1, mca_base_param_file_path, rel_path_search, &mca_base_var_files, OPAL_ENV_SEP);
+    read_files (tmp1, &mca_base_var_file_values, ',');
+    free(tmp1);
+}
+
 int mca_base_var_cache_files(bool rel_path_search)
 {
     char *tmp = NULL;

--- a/opal/mca/base/mca_base_var.h
+++ b/opal/mca/base/mca_base_var.h
@@ -746,6 +746,7 @@ OPAL_DECLSPEC int mca_base_var_process_env_list_from_file(char ***argv);
  * Initialize any file-based params
  */
 OPAL_DECLSPEC int mca_base_var_cache_files(bool rel_path_search);
+OPAL_DECLSPEC int mca_base_var_load_extra_files(char* files, bool rel_path_search);
 
 
 extern char *mca_base_env_list;

--- a/opal/mca/btl/base/btl_base_error.h
+++ b/opal/mca/btl/base/btl_base_error.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -32,6 +32,7 @@
 #include "opal/util/proc.h"
 
 OPAL_DECLSPEC extern int mca_btl_base_verbose;
+OPAL_DECLSPEC extern int mca_btl_base_warn_peer_error;
 
 OPAL_DECLSPEC extern int mca_btl_base_err(const char*, ...) __opal_attribute_format__(__printf__, 1, 2);
 OPAL_DECLSPEC extern int mca_btl_base_out(const char*, ...) __opal_attribute_format__(__printf__, 1, 2);
@@ -59,18 +60,21 @@ OPAL_DECLSPEC extern int mca_btl_base_out(const char*, ...) __opal_attribute_for
 
 #define BTL_PEER_ERROR(proc, args)                              \
     do {                                                        \
-        char *errhost;                                          \
-        mca_btl_base_err("%s[%s:%d:%s] from %s ",               \
+        if( mca_btl_base_warn_peer_error                        \
+         || mca_btl_base_verbose > 0 ) { /* warn if verbose */  \
+            char *errhost;                                      \
+            mca_btl_base_err("[%s]%s[%s:%d:%s] ",               \
+                         opal_process_info.nodename,            \
                          OPAL_NAME_PRINT(OPAL_PROC_MY_NAME),    \
-                         __FILE__, __LINE__, __func__,          \
-                         opal_process_info.nodename);           \
-        if (proc) {                                             \
-            errhost = opal_get_proc_hostname(proc);             \
-            mca_btl_base_err("to: %s ", errhost);               \
-            free(errhost);                                      \
+                         __FILE__, __LINE__, __func__);         \
+            if (proc) {                                         \
+                errhost = opal_get_proc_hostname(proc);         \
+                mca_btl_base_err("peer: %s ", errhost);         \
+                free(errhost);                                  \
+            }                                                   \
+            mca_btl_base_err args;                              \
+            mca_btl_base_err("\n");                             \
         }                                                       \
-        mca_btl_base_err args;                                  \
-        mca_btl_base_err("\n");                                 \
     } while(0);
 
 

--- a/opal/mca/btl/base/btl_base_frame.c
+++ b/opal/mca/btl/base/btl_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2007 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -116,6 +116,7 @@ OBJ_CLASS_INSTANCE(
 char* mca_btl_base_include = NULL;
 char* mca_btl_base_exclude = NULL;
 int mca_btl_base_warn_component_unused = 1;
+int mca_btl_base_warn_peer_error = true;
 opal_list_t mca_btl_base_modules_initialized = {{0}};
 bool mca_btl_base_thread_multiple_override = false;
 
@@ -142,6 +143,12 @@ static int mca_btl_base_register(mca_base_register_flag_t flags)
                                  OPAL_INFO_LVL_9,
                                  MCA_BASE_VAR_SCOPE_READONLY,
                                  &mca_btl_base_exclude);
+    (void) mca_base_var_register("opal", "btl", "base", "warn_peer_error",
+                                 "This parameter is used to turn on warning messages when peers disconnect unexpectedly",
+                                 MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                 OPAL_INFO_LVL_9,
+                                 MCA_BASE_VAR_SCOPE_READONLY,
+                                 &mca_btl_base_warn_peer_error);
     (void) mca_base_var_register("opal", "btl", "base", "warn_component_unused",
                                  "This parameter is used to turn on warning messages when certain NICs are not used",
                                  MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,

--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -179,6 +179,10 @@ typedef uint8_t mca_btl_base_tag_t;
  */
 #define MCA_BTL_AM_FRAMEWORK_MASK   0xD0
 #define MCA_BTL_TAG_BTL             0x20
+#if OPAL_ENABLE_FT_MPI
+#define MCA_BTL_TAG_FT_RBCAST       0x30
+#define MCA_BTL_TAG_FT_AGREE        0x31
+#endif
 #define MCA_BTL_TAG_PML             0x40
 #define MCA_BTL_TAG_OSC_RDMA        0x60
 #define MCA_BTL_TAG_USR             0x80

--- a/opal/mca/btl/sm/btl_sm_get.c
+++ b/opal/mca/btl/sm/btl_sm_get.c
@@ -5,6 +5,9 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Google, Inc. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,7 +98,12 @@ int mca_btl_sm_get_cma (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *end
     do {
         ret = process_vm_readv (endpoint->segment_data.other.seg_ds->seg_cpid, &dst_iov, 1, &src_iov, 1, 0);
         if (0 > ret) {
-            opal_output(0, "Read %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno);
+            if (ESRCH == errno) {
+                BTL_PEER_ERROR(NULL,
+                        ("CMA read %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno));
+                return OPAL_ERROR;
+            }
+            BTL_ERROR(("CMA read %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno));
             return OPAL_ERROR;
         }
         src_iov.iov_base = (void *)((char *)src_iov.iov_base + ret);

--- a/opal/mca/btl/sm/btl_sm_put.c
+++ b/opal/mca/btl/sm/btl_sm_put.c
@@ -5,6 +5,9 @@
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Google, Inc. All rights reserved.
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,7 +77,12 @@ int mca_btl_sm_put_cma (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *end
     do {
         ret = process_vm_writev (endpoint->segment_data.other.seg_ds->seg_cpid, &src_iov, 1, &dst_iov, 1, 0);
         if (0 > ret) {
-            opal_output(0, "Wrote %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno);
+            if (ESRCH == errno) {
+                BTL_PEER_ERROR(NULL,
+                        ("CMA wrote %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno));
+                return OPAL_ERROR;
+            }
+            BTL_ERROR(("CMA wrote %ld, expected %lu, errno = %d\n", (long)ret, (unsigned long)size, errno));
             return OPAL_ERROR;
         }
         src_iov.iov_base = (void *)((char *)src_iov.iov_base + ret);

--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -563,7 +563,7 @@ int mca_btl_tcp_recv_blocking(int sd, void* data, size_t size)
             if (opal_socket_errno != EINTR &&
                 opal_socket_errno != EAGAIN &&
                 opal_socket_errno != EWOULDBLOCK) {
-                BTL_ERROR(("recv(%d) failed: %s (%d)", sd, strerror(opal_socket_errno), opal_socket_errno));
+                BTL_VERBOSE(("recv(%d) failed: %s (%d)", sd, strerror(opal_socket_errno), opal_socket_errno));
                 break;
             }
             continue;
@@ -590,7 +590,7 @@ int mca_btl_tcp_send_blocking(int sd, const void* data, size_t size)
             if (opal_socket_errno != EINTR &&
                 opal_socket_errno != EAGAIN &&
                 opal_socket_errno != EWOULDBLOCK) {
-                BTL_ERROR(("send() failed: %s (%d)", strerror(opal_socket_errno), opal_socket_errno));
+                BTL_VERBOSE(("send() failed: %s (%d)", strerror(opal_socket_errno), opal_socket_errno));
                 return -1;
             }
             continue;

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -881,15 +881,18 @@ static int mca_btl_tcp_endpoint_complete_connect(mca_btl_base_endpoint_t* btl_en
         return OPAL_SUCCESS;
     }
     if(so_error != 0) {
-        char *msg;
-        opal_asprintf(&msg, "connect() to %s:%d failed",
+        if( mca_btl_base_warn_peer_error
+         || mca_btl_base_verbose > 0 ) {
+            char *msg;
+            opal_asprintf(&msg, "connect() to %s:%d failed",
                  opal_net_get_hostname((struct sockaddr*) &endpoint_addr),
                  ntohs(((struct sockaddr_in*) &endpoint_addr)->sin_port));
-        opal_show_help("help-mpi-btl-tcp.txt", "client connect fail",
+            opal_show_help("help-mpi-btl-tcp.txt", "client connect fail",
                        true, opal_process_info.nodename,
                        getpid(), msg,
                        strerror(so_error), so_error);
-        free(msg);
+            free(msg);
+        }
         btl_endpoint->endpoint_state = MCA_BTL_TCP_FAILED;
         mca_btl_tcp_endpoint_close(btl_endpoint);
         return OPAL_ERROR;

--- a/opal/mca/btl/tcp/btl_tcp_frag.c
+++ b/opal/mca/btl/tcp/btl_tcp_frag.c
@@ -136,7 +136,7 @@ bool mca_btl_tcp_frag_send(mca_btl_tcp_frag_t* frag, int sd)
                 mca_btl_tcp_endpoint_close(frag->endpoint);
                 return false;
             default:
-                BTL_ERROR(("mca_btl_tcp_frag_send: writev failed: %s (%d)",
+                BTL_PEER_ERROR(frag->endpoint->endpoint_proc->proc_opal, ("mca_btl_tcp_frag_send: writev failed: %s (%d)",
                            strerror(opal_socket_errno),
                            opal_socket_errno));
                 /* send_lock held by caller */
@@ -236,14 +236,17 @@ bool mca_btl_tcp_frag_recv(mca_btl_tcp_frag_t* frag, int sd)
                        strerror(opal_socket_errno), (unsigned long) frag->iov_cnt));
             break;
         case ECONNRESET:
-            errhost = opal_get_proc_hostname(btl_endpoint->endpoint_proc->proc_opal);
-            opal_show_help("help-mpi-btl-tcp.txt", "peer hung up",
+            if( mca_btl_base_warn_peer_error
+             || mca_btl_base_verbose > 0 ) {
+                errhost = opal_get_proc_hostname(btl_endpoint->endpoint_proc->proc_opal);
+                opal_show_help("help-mpi-btl-tcp.txt", "peer hung up",
                            true, opal_process_info.nodename,
                            getpid(), errhost);
-            free(errhost);
+                free(errhost);
+            }
             break;
         default:
-            BTL_ERROR(("mca_btl_tcp_frag_recv: readv failed: %s (%d)",
+            BTL_PEER_ERROR(frag->endpoint->endpoint_proc->proc_opal, ("mca_btl_tcp_frag_recv: readv failed: %s (%d)",
                        strerror(opal_socket_errno),
                        opal_socket_errno));
             break;

--- a/opal/mca/threads/pthreads/threads_pthreads_wait_sync.c
+++ b/opal/mca/threads/pthreads/threads_pthreads_wait_sync.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 The University of Tennessee and The University
+ * Copyright (c) 2014-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -18,7 +18,34 @@
 #include "opal/mca/threads/wait_sync.h"
 
 static opal_mutex_t wait_sync_lock = OPAL_MUTEX_STATIC_INIT;
-static ompi_wait_sync_t *wait_sync_list = NULL;
+ompi_wait_sync_t *wait_sync_list = NULL; /* not static for inline "wait_sync_st" */
+
+
+void wait_sync_global_wakeup_st(int status)
+{
+    ompi_wait_sync_t* sync;
+    for( sync = wait_sync_list; sync != NULL; sync = sync->next ) {
+        wait_sync_update(sync, 0, status);
+    }
+}
+
+void wait_sync_global_wakeup_mt(int status)
+{
+    ompi_wait_sync_t* sync;
+    opal_mutex_lock(&wait_sync_lock);
+    for( sync = wait_sync_list; sync != NULL; sync = sync->next ) {
+        /* sync_update is going to  take the sync->lock from within 
+         * the wait_sync_lock. Thread lightly here: Idealy we should 
+         * find a way to not take a lock in a lock as this is deadlock prone,
+         * but as of today we are the only place doing this so it is safe. 
+         */
+        wait_sync_update(sync, 0, status);
+        if( sync->next == wait_sync_list ) break; /* special case for rings */
+    }
+    opal_mutex_unlock(&wait_sync_lock);
+}
+
+
 
 static opal_atomic_int32_t num_thread_in_progress = 0;
 

--- a/opal/mca/threads/pthreads/threads_pthreads_wait_sync.h
+++ b/opal/mca/threads/pthreads/threads_pthreads_wait_sync.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2006 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -77,12 +77,22 @@ typedef struct ompi_wait_sync_t {
         (sync)->signaling = false;                    \
     }
 
+
+/* not static for inline "wait_sync_st" */
+OPAL_DECLSPEC extern ompi_wait_sync_t *wait_sync_list;
+
 OPAL_DECLSPEC int ompi_sync_wait_mt(ompi_wait_sync_t *sync);
 static inline int sync_wait_st(ompi_wait_sync_t *sync)
 {
+    assert( NULL == wait_sync_list );
+    assert( NULL == sync->next );
+    wait_sync_list = sync;
+
     while (sync->count > 0) {
         opal_progress();
     }
+    wait_sync_list = NULL;
+
     return sync->status;
 }
 
@@ -98,5 +108,14 @@ static inline int sync_wait_st(ompi_wait_sync_t *sync)
             pthread_mutex_init(&(sync)->lock, NULL);            \
         }                                                       \
     } while (0)
+
+/**
+ * Wake up all syncs with a particular status. If status is OMPI_SUCCESS this
+ * operation is a NO-OP. Otherwise it will trigger the "error condition" from
+ * all registered sync.
+ */
+OPAL_DECLSPEC void wait_sync_global_wakeup_st(int status);
+OPAL_DECLSPEC void wait_sync_global_wakeup_mt(int status);
+#define wait_sync_global_wakeup(st) (opal_using_threads()? wait_sync_global_wakeup_mt(st): wait_sync_global_wakeup_st(st))
 
 #endif /* OPAL_MCA_THREADS_PTHREADS_THREADS_PTHREADS_WAIT_SYNC_H */

--- a/opal/mca/threads/wait_sync.h
+++ b/opal/mca/threads/wait_sync.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 The University of Tennessee and The University
+ * Copyright (c) 2014-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -45,7 +45,7 @@ static inline void wait_sync_update(ompi_wait_sync_t *sync, int updates,
         }
     } else {
         /* this is an error path so just use the atomic */
-        sync->status = OPAL_ERROR;
+        sync->status = status;
         opal_atomic_wmb();
         opal_atomic_swap_32(&sync->count, 0);
     }


### PR DESCRIPTION
Features
 ========
 This implementation conforms to the User Level Failure Mitigation (ULFM)
 MPI Standard draft proposal. The ULFM proposal is developed by the MPI
 Forum's Fault Tolerance Working Group to support the continued operation of
 MPI programs after crash (node failures) have impacted the execution. The key
 principle is that no MPI call (point-to-point, collective, RMA, IO, ...) can
 block indefinitely after a failure, but must either succeed or raise an MPI
 error.

 This implementation produces the three supplementary error codes and five
 supplementary interfaces defined in the communicator section of the
 [http://fault-tolerance.org/wp-content/uploads/2012/10/20170221-ft.pdf]
 (ULFM chapter) standard draft document.

 + `MPIX_ERR_PROC_FAILED` when a process failure prevents the completion of
   an MPI operation.
 + `MPIX_ERR_PROC_FAILED_PENDING` when a potential sender matching a non-blocking
   wildcard source receive has failed.
 + `MPIX_ERR_REVOKED` when one of the ranks in the application has invoked the
   `MPI_Comm_revoke` operation on the communicator.
 + `MPIX_Comm_revoke(MPI_Comm comm)` Interrupts any communication pending on
   the communicator at all ranks.
 + `MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm* newcomm)` creates a new
   communicator where dead processes in comm were removed.
 + `MPIX_Comm_agree(MPI_Comm comm, int *flag)` performs a consensus (i.e. fault
   tolerant allreduce operation) on flag (with the operation bitwise AND).
 + `MPIX_Comm_failure_get_acked(MPI_Comm, MPI_Group*)` obtains the group of
   currently acknowledged failed processes.
 + `MPIX_Comm_failure_ack(MPI_Comm)` acknowledges that the application intends
   to ignore the effect of currently known failures on wildcard receive
   completions and agreement return values.

 ## Supported Systems
 There are several MPI engines available in Open MPI,
 notably, PML "ob1", "cm", "ucx", and MTL "ofi", "portals4", "psm2".
 At this point, only "ob1" is adapted to support fault tolerance.

 "ob1" uses BTL ("Byte Transfer Layer") components for each supported
 network. "ob1" supports a variety of networks that can be used in
 combination with each other. Collective operations (blocking and
 non-blocking) use an optimized implementation on top of "ob1".

 - Loopback (send-to-self)
 - TCP
 - UCT (InfiniBand)
 - uGNI (Cray Gemini, Aries)
 - Shared Memory (FT supported w/CMA and XPmem; KNEM is untested)
 - Tuned and non-blocking collective communications

More details available in README.FT.ULFM.md



## Performance tests

### For p2p operations 

Each solid line represents an IMB-MPI1 run with Open MPI master. ucx/ib between ranks located at two different nodes, ucx/sm between two ranks located on sibling cores on a single node. The performance of pr7740 is overlayed with dashed lines and squares/circles. 

Left column is latency (lower is better); Right column is bandwidth (higher is better).

Graph rows alternate between the default setting on that machine (pml=ucx), for validation only, and  mode that supports runtime ft=on (pml=ob1/uct).

The patch introduces no substantive changes to the UCX pml pathway, so we expect no difference (which is what we see), and we cannot run with ft=on.

The PML ob1 pathway supports FT, and we see no performance difference with ft=off, and maybe a very slight effect with ft=on.

![pr7740-p2p](https://user-images.githubusercontent.com/5197733/82580862-c35ae800-9b5d-11ea-8551-cef82f9d927d.png)

### For coll operations

In this set of tests we run a selection of IMB collective benchmarks. We present only the pml=ob1 case (ucx case shows no difference). sm+cma is used for communication between cores, uct/mlx5 is used between nodes, map-by slot  (all other settings default, thus coll=tuned). 

 The results are a bit more variable as is illustrated by the fact that it happens that ft=on is faster in some instances than ft=off or master. We would need more statistics to cleanup the look of the curves, but overall the performance impact appears non-measurable. 

![pr7740-coll](https://user-images.githubusercontent.com/5197733/82580840-ba6a1680-9b5d-11ea-9bcc-7e6bbbe65e18.png)


### Aries systems

This is a set of tests that compares ULFM with its upstream master  (an older version) on Cori (ugni). This graph aggregates a log of data as each violin point is the aggregate of hundred of IMB runs. Blue is master reference, orange is ulfm ft=on. We present the distribution of multiple runs per message size.

Again, the difference is minuscule, if any. 

![UvO-pingpongbw](https://user-images.githubusercontent.com/5197733/82581276-53992d00-9b5e-11ea-8d76-1adece62ce19.png)

