### PR TITLE
configure.ac: remove "tar-ustar" from AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ OPAL_VAR_SCOPE_POP
 #
 # Init automake
 #
-AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4 tar-ustar])
+AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4])
 
 # SILENT_RULES is new in AM 1.11, but we require 1.11 or higher via
 # autogen.  Limited testing shows that calling SILENT_RULES directly


### PR DESCRIPTION
Commit a348da4eee7db969b5ab487c09e2efc4c77a3872 introduced the use of
`tar-ustar`, but unfortunately didn't say *why* it was introduced.

We have actually run into a developer who has run into a documented
problem with the ustar format: it doesn't support UIDs greater than 21
bits in length, causing `make dist` to fail (and his UID is greater
than 21 bits).

After some testing, it looks like not specifying a `tar-*` option to
`AM_INIT_AUTOMAKE` causes Automake to not pass the `--format` option
to `tar`, which -- at least with GNU `tar` -- defaults to
`--format=gnu`.  This format has wide portability -- e.g., it works on
old versions of NetBSD where tarballs created with the `tar-pax`
Automake option do not work.

See https://github.com/openpmix/prrte/pull/579#issuecomment-632849426
for a little more detail.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>