### PR TITLE
OMPI/HCOLL: fixed typo in vars description

### DIFF
--- a/ompi/mca/coll/hcoll/coll_hcoll_component.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_component.c
@@ -170,7 +170,7 @@ static int hcoll_register(void)
                   0));
 
     CHECK(reg_int("datatype_fallback",NULL,
-                  "[1|0|] Enable/Disable user defined dattypes fallback",
+                  "[1|0|] Enable/Disable user defined datatypes fallback",
                   1,
                   &mca_coll_hcoll_component.hcoll_datatype_fallback,
                   0));


### PR DESCRIPTION
- fixed typo in vars description