### PR TITLE
opal/util: fix opal_str_to_bool()

### DIFF
--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -14,8 +14,8 @@
  * Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2015-2017 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2020 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation. All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -359,13 +359,13 @@ opal_str_to_bool(char *str)
     char *ptr;
 
     /* Trim whitespace */
-    ptr = str + sizeof(str) - 1;
+    ptr = str + strlen(str) - 1;
     while (ptr >= str && isspace(*ptr)) {
         *ptr = '\0';
         --ptr;
     }
     ptr = str;
-    while (ptr < str + sizeof(str) - 1 && *ptr != '\0' &&
+    while (ptr < str + strlen(str) - 1 && *ptr != '\0' &&
            isspace(*ptr)) {
         ++ptr;
     }


### PR DESCRIPTION
correctly use strlen(char *) instead of sizeof(char *)

Refs. open-mpi/ompi#7772

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>