### PR TITLE
Fix language in CUDA error

### DIFF
--- a/opal/mca/common/cuda/help-mpi-common-cuda.txt
+++ b/opal/mca/common/cuda/help-mpi-common-cuda.txt
@@ -165,10 +165,10 @@ If you need CUDA support, reconfigure Open MPI with dynamic library support enab
 The library attempted to open the following supporting CUDA libraries,
 but each of them failed.  CUDA-aware support is disabled.
 %s
-If you are not interested in CUDA-aware support, then run with
---mca opal_warn_on_missing_libcuda 0 to suppress this message.  If you are interested
-in CUDA-aware support, then try setting LD_LIBRARY_PATH to the location
-of libcuda.so.1 to get passed this issue.
+If you do not require CUDA-aware support, then run with
+--mca opal_warn_on_missing_libcuda 0 to suppress this message.  If you do
+require CUDA-aware support, then try setting LD_LIBRARY_PATH to the location
+of libcuda.so.1 to resolve this issue.
 #
 [dlsym failed]
 An error occurred while trying to map in the address of a function.


### PR DESCRIPTION
Removes a malapropism (passed should be past), and hopefully makes it a bit clearer.