### PR TITLE
Add minimum library version needed to use PSM2 in OMPI #7779

### DIFF
--- a/README
+++ b/README
@@ -680,7 +680,7 @@ Network Support
   - "cm" supports a smaller number of networks (and they cannot be
     used together), but may provide better overall MPI performance:
 
-    - Intel Omni-Path PSM2
+    - Intel Omni-Path PSM2 (version 11.2.173 or later)
     - Intel True Scale PSM (QLogic InfiniPath)
     - OpenFabrics Interfaces ("libfabric" tag matching)
     - Portals 4


### PR DESCRIPTION
Updates the README to specify the minimum required version of libpsm2.

Signed-off-by: Michael Heinz <michael.william.heinz@intel.com>