### PR TITLE
mtl_btl_ofi_rcache_init() before creating domain

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -417,6 +417,12 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
     ep_attr = ofi_info->ep_attr;
     domain_attr = ofi_info->domain_attr;
 
+    /* mtl_btl_ofi_rcache_init() initializes patcher which should only
+     * take place things are single threaded.  OFI providers may start
+     * spawn threads, so initialize the rcache before creating OFI objects
+     * to prevent races. */
+    mca_btl_ofi_rcache_init(module);
+
     linux_device_name = info->domain_attr->name;
     BTL_VERBOSE(("initializing dev:%s provider:%s",
                     linux_device_name,
@@ -546,9 +552,6 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
         ofi_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
         module->use_virt_addr = true;
     }
-
-    /* initialize the rcache */
-    mca_btl_ofi_rcache_init(module);
 
     /* create endpoint list */
     OBJ_CONSTRUCT(&module->endpoints, opal_list_t);


### PR DESCRIPTION
mtl_btl_ofi_rcache_init() initializes patcher which should only take
place things are single threaded.  OFI providers may start spawn threads,
so initialize the rcache before creating OFI objects to prevent races.

Authored-by: John L. Byrne <john.l.byrne@hpe.com>
Signed-off-by: Harumi Kuno <harumi.kuno@hpe.com>