### PR TITLE
v3.1.x: adding op-codes for syscall ipc for shmat/shmdt

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,6 +58,18 @@ included in the vX.Y.Z section and be denoted as:
 3.1.7 -- Never
 --------------
 
+v3.1.7 will likely never be released.  The Open MPI team encourages
+all users to upgrade to later release series, if possible.  For users
+with critical bugs that cannot upgrade beyond the v3.1.x series,
+nightly snapshot tarballs of subsequent builds are available at
+https://www.open-mpi.org/nightly/v3.1.x/.
+
+- Fixed an issue with the memory patcher's ability to intercept
+  shmat() and shmdt() that could cause memory corruption in a specific
+  scenario.  For more information, please see
+  https://github.com/open-mpi/ompi/pull/7778.
+
+
 3.1.6 -- March, 2020
 --------------------
 

--- a/opal/mca/memory/patcher/memory_patcher_component.c
+++ b/opal/mca/memory/patcher/memory_patcher_component.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2019 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -332,6 +332,18 @@ static int intercept_brk (void *addr)
     return result;
 }
 
+#endif
+
+// These op codes used to be in bits/ipc.h but were removed in glibc in 2015
+// with a comment saying they should be defined in internal headers:
+// https://sourceware.org/bugzilla/show_bug.cgi?id=18560
+// and when glibc uses that syscall it seems to do so from its own definitions:
+// https://github.com/bminor/glibc/search?q=IPCOP_shmat&unscoped_q=IPCOP_shmat
+#ifndef IPCOP_shmat
+#define IPCOP_shmat                21
+#endif
+#ifndef IPCOP_shmdt
+#define IPCOP_shmdt                22
 #endif
 
 #define HAS_SHMDT (defined(SYS_shmdt) || \


### PR DESCRIPTION
These op codes used to be in bits/ipc.h but were removed in glibc in 2015
with a comment saying they should be defined in internal headers:
https://sourceware.org/bugzilla/show_bug.cgi?id=18560
and when glibc uses that syscall it seems to do so from its own definitions:
https://github.com/bminor/glibc/search?q=IPCOP_shmat&unscoped_q=IPCOP_shmat

So I think using #ifndef and defining them if they're not already defined
using the values from glibc is the best option.

At IBM it was the testing on redhat 8 that found this as an issue
(the opcodes being undefined on the system made it select the
left undefined so shmat/shmdt memory events went unintercepted).

Signed-off-by: Mark Allen <markalle@us.ibm.com>
(cherry picked from commit e8fab058dac7300569cb54b08e5500115f8bab8f)
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>