### PR TITLE
fs/gpfs: Bring over GPFS component from master to v4.1

### DIFF
--- a/config/ompi_check_gpfs.m4
+++ b/config/ompi_check_gpfs.m4
@@ -1,0 +1,69 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2018 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2006 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2018      University of Houston. All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# OMPI_CHECK_GPFS(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if GPFS support can be found.  sets prefix_{CPPFLAGS,
+# LDFLAGS, LIBS} as needed and runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([OMPI_CHECK_GPFS],[
+
+    check_gpfs_CPPFLAGS=
+    check_gpfs_LDFLAGS=
+    check_gpfs_LIBS=
+
+    check_gpfs_save_LIBS="$LIBS"
+    check_gpfs_save_LDFLAGS="$LDFLAGS"
+    check_gpfs_save_CPPFLAGS="$CPPFLAGS"
+
+    check_gpfs_configuration="none"
+    ompi_check_gpfs_happy="yes"
+
+    # Get some configuration information
+    AC_ARG_WITH([gpfs],
+        [AC_HELP_STRING([--with-gpfs(=DIR)],
+             [Build Gpfs support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+    OPAL_CHECK_WITHDIR([gpfs], [$with_gpfs], [include/gpfs.h])
+
+    AS_IF([test "$with_gpfs" = "no"],
+        [ompi_check_gpfs_happy="no"],
+        [AS_IF([test -z "$with_gpfs" || test "$with_gpfs" = "yes"],
+                [ompi_check_gpfs_dir="/usr"],
+                [ompi_check_gpfs_dir=$with_gpfs])
+            
+            if test -e "$ompi_check_gpfs_dir/lib64" ; then
+                ompi_check_gpfs_libdir="$ompi_check_gpfs_dir/lib64"
+            else
+                ompi_check_gpfs_libdir="$ompi_check_gpfs_dir/lib"
+            fi
+            
+            # Add correct -I and -L flags
+            OPAL_CHECK_PACKAGE([$1], [gpfs.h], [gpfs], [gpfs_lib_init], 
+                [], [$ompi_check_gpfs_dir], [$ompi_check_gpfs_libdir], 
+                [ompi_check_gpfs_happy="yes"],
+                [ompi_check_gpfs_happy="no"])
+  ])          
+
+    AS_IF([test "$ompi_check_gpfs_happy" = "yes"],
+          [$2],
+          [AS_IF([test ! -z "$with_gpfs" && test "$with_gpfs" != "no"],
+                 [AC_MSG_ERROR([GPFS support requested but not found.  Aborting])])
+           $3])
+])

--- a/ompi/mca/common/ompio/common_ompio.h
+++ b/ompi/mca/common/ompio/common_ompio.h
@@ -106,7 +106,8 @@ enum ompio_fs_type
     UFS = 1,
     PVFS2 = 2,
     LUSTRE = 3,
-    PLFS = 4
+    PLFS = 4,
+    GPFS = 6
 };
 
 typedef struct mca_common_ompio_io_array_t {

--- a/ompi/mca/fs/base/base.h
+++ b/ompi/mca/fs/base/base.h
@@ -52,6 +52,9 @@ OMPI_DECLSPEC int mca_fs_base_init_file (struct ompio_file_t *file);
 OMPI_DECLSPEC int mca_fs_base_get_param (struct ompio_file_t *file, int keyval);
 OMPI_DECLSPEC void mca_fs_base_get_parent_dir (char *filename, char **dirnamep);
 OMPI_DECLSPEC int  mca_fs_base_get_fstype(char *fname);
+OMPI_DECLSPEC int mca_fs_base_get_mpi_err(int errno_val);
+OMPI_DECLSPEC int mca_fs_base_get_file_perm(ompio_file_t *fh);
+OMPI_DECLSPEC int mca_fs_base_get_file_amode(int rank, int access_mode);
 
 OMPI_DECLSPEC int mca_fs_base_file_delete (char* file_name, struct opal_info_t *info);
 OMPI_DECLSPEC int mca_fs_base_file_sync (ompio_file_t *fh);

--- a/ompi/mca/fs/gpfs/Makefile.am
+++ b/ompi/mca/fs/gpfs/Makefile.am
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2011 University of Houston. All rights reserved.
+# $COPYRIGHT$
+# 
+# Additional copyrights may follow
+# 
+# $HEADER$
+#
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_ompi_fs_gpfs_DSO
+component_noinst =
+component_install = mca_fs_gpfs.la
+else
+component_noinst = libmca_fs_gpfs.la
+component_install =
+endif
+
+# Source files
+
+fs_gpfs_sources = \
+		fs_gpfs_component.c \
+		fs_gpfs_file_open.c \
+		fs_gpfs_file_set_info.c\
+		fs_gpfs_file_get_info.c\
+		fs_gpfs.c \
+		fs_gpfs.h
+
+AM_CPPFLAGS = $(fs_gpfs_CPPFLAGS)
+
+mcacomponentdir = $(pkglibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_fs_gpfs_la_SOURCES = $(fs_gpfs_sources)
+mca_fs_gpfs_la_LIBADD = $(fs_gpfs_LIBS)
+mca_fs_gpfs_la_LDFLAGS = -module -avoid-version $(fs_gpfs_LDFLAGS)
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_fs_gpfs_la_SOURCES = $(fs_gpfs_sources)
+libmca_fs_gpfs_la_LIBADD = $(fs_gpfs_LIBS)
+libmca_fs_gpfs_la_LDFLAGS = -module -avoid-version $(fs_gpfs_LDFLAGS)
+

--- a/ompi/mca/fs/gpfs/configure.m4
+++ b/ompi/mca/fs/gpfs/configure.m4
@@ -1,0 +1,45 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2012 University of Houston. All rights reserved.
+# $COPYRIGHT$
+# 
+# Additional copyrights may follow
+# 
+# $HEADER$
+#
+
+
+# MCA_fs_gpfs_CONFIG(action-if-can-compile, 
+#                        [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_ompi_fs_gpfs_CONFIG],[
+    AC_CONFIG_FILES([ompi/mca/fs/gpfs/Makefile])
+
+    OMPI_CHECK_GPFS([fs_gpfs],
+                     [fs_gpfs_happy="yes"],
+                     [fs_gpfs_happy="no"])
+
+    AS_IF([test "$fs_gpfs_happy" = "yes"],
+           [fs_gpfs_WRAPPER_EXTRA_LDFLAGS="$fs_gpfs_LDFLAGS"
+           fs_gpfs_WRAPPER_EXTRA_LIBS="$fs_gpfs_LIBS"
+           $1],
+          [$2])
+
+    OPAL_SUMMARY_ADD([[OMPIO File Systems]],[[IBM Spectrum Scale/GPFS]],[$1],[$fs_gpfs_happy])
+
+    # substitute in the things needed to build gpfs
+    AC_SUBST([fs_gpfs_CPPFLAGS])
+    AC_SUBST([fs_gpfs_LDFLAGS])
+    AC_SUBST([fs_gpfs_LIBS])
+])dnl

--- a/ompi/mca/fs/gpfs/fs_gpfs.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2017 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2018 University of Houston. All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics. Since linkers generally pull in symbols by object fules,
+ * keeping these symbols as the only symbols in this file prevents
+ * utility programs such as "ompi_info" from having to import entire
+ * modules just to query their version and parameters
+ */
+
+#include "ompi_config.h"
+#include "mpi.h"
+#include "ompi/mca/fs/fs.h"
+#include "ompi/mca/fs/base/base.h"
+#include "ompi/mca/fs/gpfs/fs_gpfs.h"
+
+#ifdef HAVE_SYS_STATFS_H
+#include <sys/statfs.h> /* or <sys/vfs.h> */
+#endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#ifdef HAVE_SYS_MOUNT_H
+#include <sys/mount.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+
+#include <sys/ioctl.h>
+
+/*
+ * *******************************************************************
+ * ************************ actions structure ************************
+ * *******************************************************************
+ */
+static mca_fs_base_module_1_0_0_t gpfs =  {
+    mca_fs_gpfs_module_init, /* initalise after being selected */
+    mca_fs_gpfs_module_finalize, /* close a module on a communicator */
+    mca_fs_gpfs_file_open,
+    mca_fs_base_file_close,
+    mca_fs_base_file_delete,
+    mca_fs_base_file_set_size,
+    mca_fs_base_file_get_size,
+    mca_fs_base_file_sync
+};
+/*
+ * *******************************************************************
+ * ************************* structure ends **************************
+ * *******************************************************************
+ */
+
+int mca_fs_gpfs_component_init_query(bool enable_progress_threads,
+                                      bool enable_mpi_threads)
+{
+    /* Nothing to do */
+
+   return OMPI_SUCCESS;
+}
+
+struct mca_fs_base_module_1_0_0_t *
+mca_fs_gpfs_component_file_query (ompio_file_t *fh, int *priority)
+{
+    char *tmp;
+
+    /* The code in this function is based on the ADIO FS selection in ROMIO
+     *   Copyright (C) 1997 University of Chicago.
+     *   See COPYRIGHT notice in top-level directory.
+     */
+
+    *priority = mca_fs_gpfs_priority;
+
+    tmp = strchr (fh->f_filename, ':');
+    if (!tmp) {
+        if (OMPIO_ROOT == fh->f_rank) {
+            fh->f_fstype = mca_fs_base_get_fstype ( (char *) fh->f_filename );
+        }
+        if (MPI_COMM_NULL != fh->f_comm) {
+            fh->f_comm->c_coll->coll_bcast (&(fh->f_fstype),
+                              				       1,
+                              				       MPI_INT,
+                              				       OMPIO_ROOT,
+                              				       fh->f_comm,
+                              				       fh->f_comm->c_coll->coll_bcast_module);
+        }
+    }
+    else {
+	if (!strncmp(fh->f_filename, "gpfs:", 5) ||
+	    !strncmp(fh->f_filename, "GPFS:", 5)) {
+            fh->f_fstype = GPFS;
+        }
+    }
+
+   if (GPFS == fh->f_fstype) {
+       if (*priority < 50) {
+           *priority = 50;
+	   return &gpfs;
+       }
+   }
+
+   return NULL;
+}
+
+int mca_fs_gpfs_component_file_unquery (ompio_file_t *file)
+{
+   /* This function might be needed for some purposes later. for now it
+    * does not have anything to do since there are no steps which need
+    * to be undone if this module is not selected */
+
+    return OMPI_SUCCESS;
+}
+
+int mca_fs_gpfs_module_init (ompio_file_t *file)
+{
+    /* Make sure the file type is not overwritten by the last queried
+	 * component */
+    file->f_fstype = GPFS;
+    return OMPI_SUCCESS;
+}
+
+
+int mca_fs_gpfs_module_finalize (ompio_file_t *file)
+{
+    return OMPI_SUCCESS;
+}

--- a/ompi/mca/fs/gpfs/fs_gpfs.h
+++ b/ompi/mca/fs/gpfs/fs_gpfs.h
@@ -1,0 +1,68 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2015 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2012 University of Houston. All rights reserved.
+ * $COPYRIGHT$
+ * 
+ * Additional copyrights may follow
+ * 
+ * $HEADER$
+ */
+
+#ifndef MCA_FS_GPFS_H
+#define MCA_FS_GPFS_H
+
+#include "ompi_config.h"
+#include "opal/mca/mca.h"
+#include "ompi/mca/fs/fs.h"
+#include "ompi/mca/io/ompio/io_ompio.h"
+
+#include <gpfs.h>
+
+extern int mca_fs_gpfs_priority;
+
+BEGIN_C_DECLS
+
+int mca_fs_gpfs_component_init_query(bool enable_progress_threads,
+		bool enable_mpi_threads);
+struct mca_fs_base_module_1_0_0_t *
+mca_fs_gpfs_component_file_query(ompio_file_t *fh, int *priority);
+int mca_fs_gpfs_component_file_unquery(ompio_file_t *file);
+
+int mca_fs_gpfs_module_init(ompio_file_t *file);
+int mca_fs_gpfs_module_finalize(ompio_file_t *file);
+OMPI_MODULE_DECLSPEC extern mca_fs_base_component_2_0_0_t mca_fs_gpfs_component;
+
+/*
+ * ******************************************************************
+ * ********* functions which are implemented in this module *********
+ * ******************************************************************
+ */
+
+int mca_fs_gpfs_file_open(struct ompi_communicator_t *comm, const char *filename,
+		int amode, struct opal_info_t *info, struct ompio_file_t *fh);
+int mca_fs_gpfs_file_set_info(struct ompio_file_t *fh,
+		struct ompi_info_t *info);
+int mca_fs_gpfs_file_get_info(struct ompio_file_t *fh,
+		struct ompi_info_t **info_used);
+int mca_fs_gpfs_io_selection(ompio_file_t *fh,
+		struct ompi_info_t *info, struct ompi_info_t *info_selected);
+
+/*
+ * ******************************************************************
+ * ************ functions implemented in this module end ************
+ * ******************************************************************
+ */
+
+END_C_DECLS
+
+#endif /* MCA_FS_GPFS_H */

--- a/ompi/mca/fs/gpfs/fs_gpfs_component.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_component.c
@@ -1,0 +1,78 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "ompi_config.h"
+#include "fs_gpfs.h"
+#include "mpi.h"
+
+/*
+ * Public string showing the fs gpfs component version number
+ */
+const char *mca_fs_gpfs_component_version_string =
+  "OMPI/MPI gpfs FS MCA component version " OMPI_VERSION;
+
+static int gpfs_register(void);
+
+int mca_fs_gpfs_priority = 20;
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+mca_fs_base_component_2_0_0_t mca_fs_gpfs_component = {
+
+    /* First, the mca_component_t struct containing meta information
+       about the component itself */
+
+    .fsm_version = {
+        MCA_FS_BASE_VERSION_2_0_0,
+
+        /* Component name and version */
+        .mca_component_name = "gpfs",
+        MCA_BASE_MAKE_VERSION(component, OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION,
+                              OMPI_RELEASE_VERSION),
+        .mca_register_component_params = gpfs_register,
+    },
+    .fsm_data = {
+        /* This component is checkpointable */
+      MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+    .fsm_init_query = mca_fs_gpfs_component_init_query,      /* get thread level */
+    .fsm_file_query = mca_fs_gpfs_component_file_query,      /* get priority and actions */
+    .fsm_file_unquery = mca_fs_gpfs_component_file_unquery,  /* undo what was done by previous function */
+};
+
+static int gpfs_register(void)
+{
+    mca_fs_gpfs_priority = 20;
+    (void) mca_base_component_var_register(&mca_fs_gpfs_component.fsm_version,
+                                           "priority", "Priority of the gpfs fs component",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY, &mca_fs_gpfs_priority);
+    return OMPI_SUCCESS;
+}

--- a/ompi/mca/fs/gpfs/fs_gpfs_file_get_info.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_file_get_info.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2015 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "fs_gpfs.h"
+#include "mpi.h"
+#include "ompi/constants.h"
+#include "ompi/mca/fs/fs.h"
+
+#include <unistd.h>
+#include <string.h>
+
+#include <gpfs.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <gpfs_fcntl.h>
+
+/*
+ *  file_get_info_gpfs
+ *
+ *  Function:   - get_info of a file
+ *  Accepts:    - same arguments as MPI_File_get_info()
+ *  Returns:    - new info object
+ */
+
+int mca_fs_gpfs_file_get_info(ompio_file_t *fh,
+                        ompi_info_t **info_used)
+{
+    int ret = OMPI_SUCCESS;
+
+    *info_used = OBJ_NEW(ompi_info_t);
+    if (NULL == *info_used) {
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
+
+    ret = ompi_info_dup ((ompi_info_t *)fh->f_info, info_used);
+
+    return ret;
+}

--- a/ompi/mca/fs/gpfs/fs_gpfs_file_open.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_file_open.c
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                          University Research and Technology
+ *                          Corporation.  All rights reserved.
+ *  Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                          of Tennessee Research Foundation.  All rights
+ *                          reserved.
+ *  Copyright (c) 2004-2015 High Performance Computing Center Stuttgart,
+ *                          University of Stuttgart.  All rights reserved.
+ *  Copyright (c) 2004-2005 The Regents of the University of California.
+ *                          All rights reserved.
+ *  Copyright (c) 2008-2012 University of Houston. All rights reserved.
+ *  $COPYRIGHT$
+ *  
+ *  Additional copyrights may follow
+ *  
+ *  $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/communicator/communicator.h"
+#include "ompi/info/info.h"
+#include "ompi/file/file.h"
+#include "ompi/mca/fs/fs.h"
+#include "ompi/mca/fs/base/base.h"
+#include "ompi/mca/fcoll/fcoll.h"
+#include "ompi/mca/fcoll/base/base.h"
+#include "ompi/mca/fbtl/fbtl.h"
+#include "ompi/mca/fbtl/base/base.h"
+#include "fs_gpfs.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <unistd.h>
+#include <gpfs.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <gpfs_fcntl.h>
+
+int
+mca_fs_gpfs_file_open (struct ompi_communicator_t *comm,
+                        const char* filename,
+                        int access_mode,
+                        struct opal_info_t *info,
+                        ompio_file_t *fh)
+{
+    int perm, amode;
+    int ret = OMPI_SUCCESS;
+
+    perm = mca_fs_base_get_file_perm(fh);
+    amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
+
+    if(OMPIO_ROOT == fh->f_rank) {
+        fh->fd = open (filename, amode, perm);
+        if ( 0 > fh->fd ) {
+            ret = mca_fs_base_get_mpi_err(errno);
+        }
+    }
+
+    comm->c_coll->coll_bcast ( &ret, 1, MPI_INT, 0, comm, comm->c_coll->coll_bcast_module);
+    if ( OMPI_SUCCESS != ret ) {
+        fh->fd = -1;
+        return ret;
+    }
+
+    if (OMPIO_ROOT != fh->f_rank) {
+        fh->fd = open (filename, amode, perm);
+        if ( 0 > fh->fd) {
+            return mca_fs_base_get_mpi_err(errno);
+        }
+    }
+
+    fh->f_amode=access_mode;
+    mca_fs_gpfs_file_set_info(fh, (struct ompi_info_t *) info);
+
+    return OMPI_SUCCESS;
+}

--- a/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c
+++ b/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c
@@ -1,0 +1,594 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2015 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2011 University of Houston. All rights reserved.
+ * $COPYRIGHT$
+ * 
+ * Additional copyrights may follow
+ * 
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+#include "fs_gpfs.h"
+#include "mpi.h"
+#include "ompi/constants.h"
+#include "ompi/mca/fs/fs.h"
+#include "ompi/mca/fs/base/base.h"
+
+#include <unistd.h>
+#include <string.h>
+
+#include <gpfs.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <gpfs_fcntl.h>
+
+/*
+ *  file_set_info_gpfs
+ *
+ *  Function:   - set_info of a file
+ *  Accepts:    - same arguments as MPI_File_set_info()
+ *  Returns:    - Success if info is set
+ */
+
+int mca_fs_gpfs_file_set_info(ompio_file_t *fh, struct ompi_info_t *info)
+{
+    int rc = 0;
+    int flag;
+    int valueLen = MPI_MAX_INFO_VAL;
+    char value[MPI_MAX_INFO_VAL + 1];
+    char gpfsHintsKey[50];
+    const char* split = ",";
+    char* token;
+    int ret = OMPI_SUCCESS;
+    ompi_info_t *info_selected;
+    info_selected = info;
+    gpfs_file_t gpfs_file_handle = fh->fd;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsAccessRange_t gpfsAccessRange;
+    } gpfs_hint_AccessRange;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsFreeRange_t gpfsFreeRange;
+    } gpfs_hint_FreeRange;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsClearFileCache_t gpfsClearFileCache;
+    } gpfs_hint_ClearFileCache;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsCancelHints_t gpfsCancelHints;
+    } gpfs_hint_CancelHints;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsSetReplication_t gpfsSetReplication;
+    } gpfs_hint_SetReplication;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsByteRange_t gpfsByteRange;
+    } gpfs_hint_ByteRange;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsRestripeData_t gpfsRestripeData;
+    } gpfs_hint_RestripeData;
+
+    //CN: TODO: Implement the following currently unused GPFS hints
+    /*
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsRestripeRange_t gpfsRestripeRange;
+    } gpfs_hint_RestripeRange;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsGetReplication_t gpfsGetReplication;
+    } gpfs_hint_GetReplication;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsGetStoragePool_t gpfsGetStoragePool;
+    } gpfs_hint_GetStoragePool;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsGetFilesetName_t gpfsGetFilesetName;
+    } gpfs_hint_GetFilesetName;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsGetSnapshotName_t gpfsGetSnapshotName;
+    } gpfs_hint_GetSnapshotName;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsSetImmutable_t gpfsSetImmutable;
+    } gpfs_hint_SetImmutable;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsGetImmutable_t gpfsGetImmutable;
+    } gpfs_hint_GetImmutable;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsSetExpTime_t gpfsSetExpTime;
+    } gpfs_hint_SetExpTime;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsGetExpTime_t gpfsGetExpTime;
+    } gpfs_hint_GetExpTime;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsSetAppendOnly_t gpfsSetAppendOnly;
+    } gpfs_hint_SetAppendOnly;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsGetAppendOnly_t gpfsGetAppendOnly;
+    } gpfs_hint_GetAppendOnly;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsSetStoragePool_t gpfsSetStoragePool;
+    } gpfs_hint_SetStoragePool;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsRangeArray_t gpfsRangeArray;
+    } gpfs_hint_RangeArray;
+
+    struct {
+        gpfsFcntlHeader_t gpfsFcntlHeader;
+        gpfsMultipleAccessRange_t gpfsMultipleAccessRange;
+    } gpfs_hint_MultipleAccessRange;
+    */
+
+    strcpy(gpfsHintsKey, "useSIOXLib");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag) {
+        if(strcmp(value, "true") == 0) {
+            //using the SIOX lib and the I/O pattern selection
+            ret = mca_fs_gpfs_io_selection(fh, info, info_selected);
+            if (ret != OMPI_SUCCESS)
+                return ret;
+        }
+        else {
+            //CN: Is there something left to do here?
+            //TODO Sending the MPI_INFO to SIOX for knowledgebase
+        }
+    }
+
+    //Setting GPFS Hint - gpfsAccessRange
+    strcpy(gpfsHintsKey, "gpfsAccessRange");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag) {
+        opal_output(ompi_fs_base_framework.framework_output,
+                    "GPFS Access Range is set: %s: %s\n", gpfsHintsKey, value);
+        gpfs_hint_AccessRange.gpfsFcntlHeader.totalLength = sizeof(gpfs_hint_AccessRange);
+        gpfs_hint_AccessRange.gpfsFcntlHeader.fcntlVersion = GPFS_FCNTL_CURRENT_VERSION;
+        gpfs_hint_AccessRange.gpfsFcntlHeader.fcntlReserved = 0;
+
+        gpfs_hint_AccessRange.gpfsAccessRange.structLen =
+                sizeof(gpfs_hint_AccessRange.gpfsAccessRange);
+        gpfs_hint_AccessRange.gpfsAccessRange.structType = GPFS_ACCESS_RANGE;
+        token = strtok(value, split);
+        gpfs_hint_AccessRange.gpfsAccessRange.start = atol(token);
+        token = strtok(NULL, split);
+        gpfs_hint_AccessRange.gpfsAccessRange.length = atol(token);
+        token = strtok(NULL, split);
+        gpfs_hint_AccessRange.gpfsAccessRange.isWrite = atoi(token);
+
+        rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_AccessRange);
+        if (rc != 0) {
+            rc = errno;
+            opal_output(ompi_fs_base_framework.framework_output,
+                    "gpfs_hint_AccessRange gpfs_fcntl(file handle: %d): Error number is %d, %s\n",
+                    gpfs_file_handle, rc, strerror(rc));
+            ret = OMPI_ERROR;
+        }
+    }
+
+    //Setting GPFS Hint - gpfsFreeRange
+    strcpy(gpfsHintsKey, "gpfsFreeRange");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag) {
+        opal_output(ompi_fs_base_framework.framework_output,
+                    "GPFS Free Range is set: %s: %s\n", gpfsHintsKey, value);
+        gpfs_hint_FreeRange.gpfsFcntlHeader.totalLength = sizeof(gpfs_hint_FreeRange);
+        gpfs_hint_FreeRange.gpfsFcntlHeader.fcntlVersion = GPFS_FCNTL_CURRENT_VERSION;
+        gpfs_hint_FreeRange.gpfsFcntlHeader.fcntlReserved = 0;
+
+        gpfs_hint_FreeRange.gpfsFreeRange.structLen =
+                sizeof(gpfs_hint_FreeRange.gpfsFreeRange);
+        gpfs_hint_FreeRange.gpfsFreeRange.structType = GPFS_FREE_RANGE;
+        token = strtok(value, split);
+        gpfs_hint_FreeRange.gpfsFreeRange.start = atol(token);
+        token = strtok(NULL, split);
+        gpfs_hint_FreeRange.gpfsFreeRange.length = atol(token);
+
+        rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_FreeRange);
+        if (rc != 0) {
+            rc = errno;
+            opal_output(ompi_fs_base_framework.framework_output,
+                    "gpfs_hint_FreeRange gpfs_fcntl(file handle: %d): Error number is %d, %s\n",
+                    gpfs_file_handle, rc, strerror(rc));
+            ret = OMPI_ERROR;
+        }
+    }
+
+    //CN: TODO
+    //Setting GPFS Hint - gpfsRangeArray
+    //Setting GPFS Hint - gpfsMultipleAccessRange
+
+    //Setting GPFS Hint - gpfsClearFileCache
+    strcpy(gpfsHintsKey, "gpfsClearFileCache");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag & (strcmp(value, "true") == 0)) {
+        opal_output(ompi_fs_base_framework.framework_output,
+                    "GPFS Clear File Cache is set: %s: %s\n", gpfsHintsKey, value);
+        gpfs_hint_ClearFileCache.gpfsFcntlHeader.totalLength = sizeof(gpfs_hint_ClearFileCache);
+        gpfs_hint_ClearFileCache.gpfsFcntlHeader.fcntlVersion = GPFS_FCNTL_CURRENT_VERSION;
+        gpfs_hint_ClearFileCache.gpfsFcntlHeader.fcntlReserved = 0;
+
+        gpfs_hint_ClearFileCache.gpfsClearFileCache.structLen =
+                sizeof(gpfs_hint_ClearFileCache.gpfsClearFileCache);
+        gpfs_hint_ClearFileCache.gpfsClearFileCache.structType = GPFS_CLEAR_FILE_CACHE;
+
+        rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_ClearFileCache);
+        if (rc != 0) {
+            rc = errno;
+            opal_output(ompi_fs_base_framework.framework_output,
+                    "gpfs_hint_ClearFileCache gpfs_fcntl(file handle: %d): Error number is %d, %s\n",
+                    gpfs_file_handle, rc, strerror(rc));
+            ret = OMPI_ERROR;
+        }
+    }
+
+    //Setting GPFS Hint - gpfsCancelHints
+    strcpy(gpfsHintsKey, "gpfsCancelHints");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag & (strcmp(value, "true") == 0)) {
+        opal_output(ompi_fs_base_framework.framework_output,
+                    "GPFS Cancel Hints is set: %s: %s\n", gpfsHintsKey, value);
+        gpfs_hint_CancelHints.gpfsFcntlHeader.totalLength = sizeof(gpfs_hint_CancelHints);
+        gpfs_hint_CancelHints.gpfsFcntlHeader.fcntlVersion = GPFS_FCNTL_CURRENT_VERSION;
+        gpfs_hint_CancelHints.gpfsFcntlHeader.fcntlReserved = 0;
+
+        gpfs_hint_CancelHints.gpfsCancelHints.structLen =
+                sizeof(gpfs_hint_CancelHints.gpfsCancelHints);
+        gpfs_hint_CancelHints.gpfsCancelHints.structType = GPFS_CANCEL_HINTS;
+
+        rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_CancelHints);
+        if (rc != 0) {
+            rc = errno;
+            opal_output(ompi_fs_base_framework.framework_output,
+                    "gpfs_hint_CancelHints gpfs_fcntl(file handle: %d): Error number is %d, %s\n",
+                    gpfs_file_handle, rc, strerror(rc));
+            ret = OMPI_ERROR;
+        }
+    }
+
+    //Setting GPFS Hint - gpfsSetReplication
+    strcpy(gpfsHintsKey, "gpfsSetReplication");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag) {
+        opal_output(ompi_fs_base_framework.framework_output,
+                    "GPFS Set Replication is set: %s: %s\n", gpfsHintsKey, value);
+        gpfs_hint_SetReplication.gpfsFcntlHeader.totalLength = sizeof(gpfs_hint_SetReplication);
+        gpfs_hint_SetReplication.gpfsFcntlHeader.fcntlVersion = GPFS_FCNTL_CURRENT_VERSION;
+        gpfs_hint_SetReplication.gpfsFcntlHeader.fcntlReserved = 0;
+
+        gpfs_hint_SetReplication.gpfsSetReplication.structLen =
+                sizeof(gpfs_hint_SetReplication.gpfsSetReplication);
+        gpfs_hint_SetReplication.gpfsSetReplication.structType = GPFS_FCNTL_SET_REPLICATION;
+        token = strtok(value, split);
+        gpfs_hint_SetReplication.gpfsSetReplication.metadataReplicas = atoi(token);
+        gpfs_hint_SetReplication.gpfsSetReplication.maxMetadataReplicas = atoi(token);
+        gpfs_hint_SetReplication.gpfsSetReplication.dataReplicas = atoi(token);
+        gpfs_hint_SetReplication.gpfsSetReplication.maxDataReplicas = atoi(token);
+        gpfs_hint_SetReplication.gpfsSetReplication.reserved = 0;
+
+        rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_SetReplication);
+        if (rc != 0) {
+            rc = errno;
+            opal_output(ompi_fs_base_framework.framework_output,
+                    "gpfs_hint_SetReplication gpfs_fcntl(file handle: %d): Error number is %d, %s\n",
+                    gpfs_file_handle, rc, strerror(rc));
+            ret = OMPI_ERROR;
+        }
+    }
+
+    //CN: TODO
+    //Setting GPFS Hint - gpfsSetStoragePool
+
+    //Setting GPFS Hint - gpfsByteRange
+    strcpy(gpfsHintsKey, "gpfsByteRange");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag) {
+        opal_output(ompi_fs_base_framework.framework_output,
+                    "GPFS Byte Range is set: %s: %s\n", gpfsHintsKey, value);
+        gpfs_hint_ByteRange.gpfsFcntlHeader.totalLength = sizeof(gpfs_hint_ByteRange);
+        gpfs_hint_ByteRange.gpfsFcntlHeader.fcntlVersion = GPFS_FCNTL_CURRENT_VERSION;
+        gpfs_hint_ByteRange.gpfsFcntlHeader.fcntlReserved = 0;
+
+        token = strtok(value, split);
+        gpfs_hint_ByteRange.gpfsByteRange.startOffset = atol(token);
+        token = strtok(value, split);
+        gpfs_hint_ByteRange.gpfsByteRange.numOfBlks = atol(token);
+
+        rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_ByteRange);
+        if (rc != 0) {
+            rc = errno;
+            opal_output(ompi_fs_base_framework.framework_output,
+                    "gpfs_hint_ByteRange gpfs_fcntl(file handle: %d): Error number is %d, %s\n",
+                    gpfs_file_handle, rc, strerror(rc));
+            ret = OMPI_ERROR;
+        }
+    }
+
+    //Setting GPFS Hint - gpfsRestripeData
+    strcpy(gpfsHintsKey, "gpfsRestripeData");
+    ompi_info_get(info_selected, gpfsHintsKey, valueLen, value, &flag);
+    if (flag) {
+        opal_output(ompi_fs_base_framework.framework_output,
+                    "GPFS Restripe Data is set: %s: %s\n", gpfsHintsKey, value);
+        gpfs_hint_RestripeData.gpfsFcntlHeader.totalLength = sizeof(gpfs_hint_RestripeData);
+        gpfs_hint_RestripeData.gpfsFcntlHeader.fcntlVersion = GPFS_FCNTL_CURRENT_VERSION;
+        gpfs_hint_RestripeData.gpfsFcntlHeader.fcntlReserved = 0;
+
+        gpfs_hint_RestripeData.gpfsRestripeData.structLen =
+                sizeof(gpfs_hint_RestripeData.gpfsRestripeData);
+        gpfs_hint_RestripeData.gpfsRestripeData.structType = GPFS_FCNTL_RESTRIPE_DATA;
+        token = strtok(value, split);
+        gpfs_hint_RestripeData.gpfsRestripeData.options = atoi(token);
+        gpfs_hint_RestripeData.gpfsRestripeData.reserved1 = 0;
+        gpfs_hint_RestripeData.gpfsRestripeData.reserved2 = 0;
+
+        rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_RestripeData);
+        if (rc != 0) {
+            rc = errno;
+            opal_output(ompi_fs_base_framework.framework_output,
+                    "gpfs_hint_RestripeData gpfs_fcntl(file handle: %d): Error number is %d, %s\n",
+                    gpfs_file_handle, rc, strerror(rc));
+            ret = OMPI_ERROR;
+        }
+    }
+
+    //CN: TODO
+    //Setting GPFS Hint - gpfsRestripeRange
+    //Setting GPFS Hint - gpfsGetReplication
+    //Setting GPFS Hint - gpfsGetStoragePool
+    //Setting GPFS Hint - gpfsGetFilesetName
+    //Setting GPFS Hint - gpfsGetSnapshotName
+    //Setting GPFS Hint - gpfsSetImmutable
+    //Setting GPFS Hint - gpfsGetImmutable
+    //Setting GPFS Hint - gpfsSetExpTime
+    //Setting GPFS Hint - gpfsGetExpTime
+    //Setting GPFS Hint - gpfsSetAppendOnly
+    //Setting GPFS Hint - gpfsGetAppendOnly
+
+    return ret;
+}
+
+//CN: Will this function set info keys with siox prefix?
+//CN: Where shall the knowledge of the optimization of GPFS hints go? Into Open MPI or into SIOX?
+//CN: Never ever exit! Open MPI requires error propagation.
+int mca_fs_gpfs_io_selection(ompio_file_t *fh,
+        struct ompi_info_t *info, struct ompi_info_t *info_selected) {
+
+//CN: configure option to enable/disable SIOX support?
+#ifdef HAVE_C_SIOX_H
+    char value[MPI_MAX_INFO_VAL + 1], sioxHintsKey[50], optimal_value_str[MPI_MAX_INFO_VAL + 1];
+    int rc = 0, valueLen = MPI_MAX_INFO_VAL, flag;
+    //START SIOX initialization
+    if (siox_gpfs_uiid == SIOX_INVALID_ID){
+        siox_gpfs_uiid = siox_system_information_lookup_interface_id("MPI",
+            "Generic");
+        if (!siox_component_is_registered(siox_gpfs_uiid)){
+            fprintf(stderr, "SIOX Component MPI Generic is NOT registered!\n");
+            siox_gpfs_component = siox_component_register(siox_gpfs_uiid, "GPFS");
+        }
+        siox_gpfs_component_activity = siox_component_register_activity(
+            siox_gpfs_uiid, "MPI_File_open");
+    }
+    //DEBUG: fprintf(stderr, "Beginning the SIOX_activity in mca_fs_gpfs_siox_io_selection()\n");
+
+    fh->f_siox_component = siox_gpfs_component;
+    fh->f_siox_activity = siox_activity_begin(siox_gpfs_component,
+            siox_gpfs_component_activity);
+    siox_activity_start(fh->f_siox_activity);
+    //END SIOX initialization
+
+    info_selected = info;
+
+    //DEBUG: fprintf(stderr, "Starting setting the SIOX_activity_attribute\n");
+//CN: Why we need all attributes as an dynamic array?
+//CN: Only one element used at a time to be added to mpi_info object at a time
+    siox_attribute **siox_attribute_array;
+    //START Registering the SIOX activities' attributes
+    //Make sure how many SIOX activities' attributes should be registered
+    int i = 0;
+    int number_of_info = opal_list_get_size(&(info_selected->super));
+    //DEBUG: fprintf(stderr, "The size of number_of_info is: %d\n", number_of_info);
+
+//CN: Why we need all attributes as an dynamic array?
+//CN: Where is the corresponding free?
+    siox_attribute_array = (siox_attribute **) malloc(
+                           sizeof(siox_attribute*) * number_of_info);
+    if (siox_attribute_array == 0) {
+        //DEBUG: fprintf(stderr, "assign siox_attribute_array fail, out of memory!\n");
+        return OMPI_ERROR;
+    }
+    //END Registering the SIOX activities' attributes
+    // Setting the fileNameAttribute
+    siox_attribute_array[i] = siox_ontology_register_attribute("MPI",
+                "descriptor/filename", SIOX_STORAGE_STRING);
+    siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], fh->f_filename);
+    i++;
+
+//CN: Code duplication en mass (9 times same code block wich changing key!)
+//CN: do this with a loop over a list of sioxHintsKeys
+    //START setting the siox activity attributes
+    strcpy(sioxHintsKey, "sioxAccessRange");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        printf("Setting sioxAccessRange hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxAccessRange", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            printf("Getting optimal value of sioxAccessRange hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxFreeRange");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        //DEBUG: fprintf(stderr, "Setting sioxFreeRange hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxFreeRange", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            //DEBUG: fprintf(stderr, "Getting optimal value of sioxFreeRange hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxClearFileCache");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        //DEBUG: fprintf(stderr, "Setting sioxClearFileCache hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxClearFileCache", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            printf("Getting optimal value of sioxClearFileCache hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxCancelHints");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        //DEBUG: fprintf(stderr, "Setting sioxCancelHints hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxCancelHints", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            //DEBUG: fprintf(stderr, "Getting optimal value of sioxCancelHints hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxDataShipStart");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        //DEBUG: fprintf(stderr, "Setting sioxDataShipStart hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxDataShipStart", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            printf("Getting optimal value of sioxDataShipStart hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxDataShipStop");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        printf("Setting sioxDataShipStop hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxDataShipStop", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            //DEBUG: fprintf(stderr, "Getting optimal value of sioxDataShipStop hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxSetReplication");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        //DEBUG: fprintf(stderr, "Setting sioxSetReplication hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxSetReplication", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            //DEBUG: fprintf(stderr, "Getting optimal value of sioxSetReplication hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxByteRange");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        //DEBUG: fprintf(stderr, "Setting sioxByteRange hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxByteRange", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            //DEBUG: fprintf(stderr, "Getting optimal value of sioxByteRange hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    strcpy(sioxHintsKey, "sioxRestripeData");
+    ompi_info_get(info_selected, sioxHintsKey, valueLen, value, &flag);
+    if (flag) {
+        //DEBUG: fprintf(stderr, "Setting sioxRestripeData hints to SIOX activity attribute.\n");
+        siox_attribute_array[i] = siox_ontology_register_attribute("GPFS",
+                "sioxRestripeData", SIOX_STORAGE_STRING);
+        siox_activity_set_attribute(fh->f_siox_activity,
+                siox_attribute_array[i], &value);
+        if(siox_suggest_optimal_value_for_str(fh->f_siox_component, siox_attribute_array[i], fh->f_siox_activity, optimal_value_str, valueLen)) {
+            //DEBUG: fprintf(stderr, "Getting optimal value of sioxRestripeData hints from SIOX: %s \n", optimal_value_str);
+            ompi_info_set(info_selected, sioxHintsKey, optimal_value_str);
+        }
+        i++;
+    }
+
+    //DEBUG: fprintf(stderr, "Stopping and ending the SIOX activity in mca_fs_gpfs_siox_io_selection()\n");
+    siox_activity_stop(fh->f_siox_activity);
+    siox_activity_end(fh->f_siox_activity);
+#else
+    info_selected = info;
+#endif /* HAVE_C_SIOX_H */
+    return OMPI_SUCCESS;
+}


### PR DESCRIPTION
Bring over GPFS component from master compatible with the version 4.1.
This pull request contains the equivalent of all commits in master related to GPFS:

b1dc58eeb2a799528f4be7366a825acc8556ace4, d3c11396fdc8da28a4accfdeec6b5aa4461a4568, cd76e5347921f5fed2f557a93375b435b41cb56c, 8d31ba3a098e21914bb3f19da971d8ce2a7660a2, 715a6e8c2750f988e89f6462bfe46b6d4f360b78, a2b1a03e7b4d17f18451b1e6bd9e57887ec8e41a, 5988297bd896e5229c18d896289a0a4c7b9ce79d, 
7b2d83c898bf43def11b16762d7f8403b72f3a7b : This commits contains a code cleaning of different fs component: In order to minimize the impact of these changes, I applied the changes only to gpfs component.
9ba6ab82092f1601e3c9f4d3f8c36f049d964b63, f46cfc120d24c3f9c8bc82845648375283979919  


Signed-off-by: raafatfeki <fekiraafat@gmail.com>