### PR TITLE
Fix typos in OSC RDMA BTL allowlist

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -245,7 +245,7 @@ static int ompi_osc_rdma_component_register (void)
                                             MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_rdma_component.locking_mode);
     OBJ_RELEASE(new_enum);
 
-    ompi_osc_rdma_btl_names = "openib,ugni,uct,ucp";
+    ompi_osc_rdma_btl_names = "ugni,uct,tcp";
     opal_asprintf(&description_str, "Comma-delimited list of BTL component names to allow without verifying "
              "connectivity. Do not add a BTL to to this list unless it can reach all "
              "processes in any communicator used with an MPI window (default: %s)",


### PR DESCRIPTION
OSC rdma had a reference to `openib`, which no longer exists on master.  It also had a typo for the `tcp` BTL (but even after fixing that typo, OSC rdma does not activate itself when the TCP BTL is used).