### PR TITLE
More carefully test "alternate" short float type in configure

### DIFF
--- a/config/opal_check_alt_short_float.m4
+++ b/config/opal_check_alt_short_float.m4
@@ -9,10 +9,10 @@ dnl
 dnl $HEADER$
 dnl
 
-# Check whether the user wants to use an alternate type of C 'short float'.
+dnl Check whether the user wants to use an alternate type of C 'short float'.
 
-# OPAL_CHECK_ALT_SHORT_FLOAT
-# ------------------------------------------------------------
+dnl OPAL_CHECK_ALT_SHORT_FLOAT
+dnl ------------------------------------------------------------
 AC_DEFUN([OPAL_CHECK_ALT_SHORT_FLOAT], [
     AC_CHECK_TYPES(_Float16)
     AC_MSG_CHECKING([if want alternate C type of short float])

--- a/ompi/mpiext/shortfloat/README.txt
+++ b/ompi/mpiext/shortfloat/README.txt
@@ -23,3 +23,13 @@ that of MPICH.
 This extension is enabled only if the C compiler supports 'short float'
 or '_Float16', or the '--enable-alt-short-float=TYPE' option is passed
 to the configure script.
+
+NOTE: The Clang 6.0.x and 7.0.x compilers support the "_Float16" type
+(via software emulation), but require an additional linker flag to
+function properly.  If you wish to enable Clang 6.0.x or 7.0.x's
+software emulation of _Float16, use the following CLI options to Open
+MPI configure script:
+
+    ./configure \
+        LDFLAGS=--rtlib=compiler-rt \
+        --with-wrapper-ldflags=--rtlib=compiler-rt ...


### PR DESCRIPTION
Out of the box, Clang 6.0.x and 7.0.x nominally support the `_Float16` type.  Hence, checks like `AC_CHECK_TYPE(_Float16)` will pass.

But if you try to do any mathematical operations on variables of type `_Float16`, Clang 6 and 7 will fail to link the application, citing missing symbols such as `__gnu_h2f_ieee` and `__gnu_f2h_ieee`.  For example (on x86_64):

```
$ clang --version
clang version 7.0.0 (tags/RELEASE_700/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /cm/shared/apps/clang/7.0.0/bin
$ cat foo.c
#include <stdio.h>

int main(int argc, char *argv[])
{
    _Float16 a, b, c;

    a = 3.8;
    b = 2.5;
    c = a - b;

    return 0;
}
$ clang foo.c
/tmp/foo-3c5f99.o: In function `main':
foo.c:(.text+0x2c): undefined reference to `__gnu_h2f_ieee'
foo.c:(.text+0x3a): undefined reference to `__gnu_h2f_ieee'
foo.c:(.text+0x4b): undefined reference to `__gnu_f2h_ieee'
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```

I'm not sure what those functions are, or if Clang optionally supports using some GNU library for half-precision mathematics, but the point is that there are cases where Clang 6 and 7 either require some kind of external library for half-precision math or just don't work.

So when the compiler passes checks like `AC_CHECK_TYPE(_Float16)`, also try linking a trivial program to make sure that that also works.  If it does, then go ahead and use the type.

This PR fixes Cisco MTT runs with Clang 6 and 7 ([see these sample MTT results](https://mtt.open-mpi.org/index.php?do_redir=3236)).