### PR TITLE
Backports/v4.1.x psm2 updates

### DIFF
--- a/README
+++ b/README
@@ -696,7 +696,7 @@ Network Support
   - "cm" supports a smaller number of networks (and they cannot be
     used together), but may provide better overall MPI performance:
 
-    - Intel Omni-Path PSM2
+    - Intel Omni-Path PSM2 (version 11.2.173 or later)
     - Intel True Scale PSM (QLogic InfiniPath)
     - OpenFabrics Interfaces ("libfabric" tag matching)
     - Portals 4

--- a/config/ompi_check_psm2.m4
+++ b/config/ompi_check_psm2.m4
@@ -76,7 +76,15 @@ AC_DEFUN([OMPI_CHECK_PSM2],[
                [AC_MSG_WARN([glob.h not found.  Can not build component.])
                ompi_check_psm2_happy="no"])])
 
-	OPAL_SUMMARY_ADD([[Transports]],[[Intel Omnipath (PSM2)]],[$1],[$ompi_check_psm2_happy])
+        AS_IF([test "$ompi_check_psm2_happy" = "yes"],
+              [AC_CHECK_DECL([PSM2_LIB_REFCOUNT_CAP],
+                        [],
+                        [AC_MSG_WARN([PSM2 needs to be version 11.2.173 or later. Disabling MTL.])
+                         ompi_check_psm2_happy="no"],
+                        [#include <psm2.h>])
+              ])
+
+        OPAL_SUMMARY_ADD([[Transports]],[[Intel Omnipath (PSM2)]],[$1],[$ompi_check_psm2_happy])
     fi
 
     AS_IF([test "$ompi_check_psm2_happy" = "yes"],

--- a/ompi/mca/mtl/psm2/mtl_psm2_component.c
+++ b/ompi/mca/mtl/psm2/mtl_psm2_component.c
@@ -194,6 +194,18 @@ ompi_mtl_psm2_component_open(void)
 static int
 ompi_mtl_psm2_component_query(mca_base_module_t **module, int *priority)
 {
+
+    /*
+     * Mixing the PSM2 MTL with the OFI BTL (using PSM2) 
+     * can cause an issue when they both call psm2_finalize
+     * in older versions of libpsm2.
+     */
+    if (!psm2_get_capability_mask(PSM2_LIB_REFCOUNT_CAP)) {
+        opal_output_verbose(2, ompi_mtl_base_framework.framework_output, 
+            "This version of the PSM2 MTL needs version 11.2.173 or later of the libpsm2 library for correct operation.\n");
+        return OMPI_ERR_FATAL;
+    }   
+
     /*
      * if we get here it means that PSM2 is available so give high priority
      */


### PR DESCRIPTION
These cherry-pick's from master are needed if we intent do include the OFI BTL in 4.1.x. 