### PR TITLE
v4.1.x: tests/asm/run_tests: fix basename usage

### DIFF
--- a/test/asm/run_tests
+++ b/test/asm/run_tests
@@ -1,26 +1,39 @@
 #!/bin/sh
+# Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
 
 retval=-1
+argv=$*
 
-progname="`basename $*`"
+set $*
+while shift; do
+    if test "$1" = "--test-name"; then
+        progname=`basename $2`
+        break
+    fi
+done
 echo "--> Testing $progname"
 
 for threads in 1 2 4 5 8 ; do
-    $* $threads
+    $argv $threads
     result=$?
     if test "$result" = "0" ; then
        echo "    - $threads threads: Passed"
-       if test "$retval" = "-1" ; then
+       if test $retval -eq -1 ; then
        	  retval=0
        fi
     elif test "$result" = "77" ; then
        echo "    - $threads threads: Skipped"
-       if test "$retval" = "-1" ; then
+       if test $retval -eq -1 ; then
        	  retval=77
        fi
     else
        echo "    - $threads threads: Failed"
-       retval="$result"
+       retval=$result
     fi
 done
 


### PR DESCRIPTION
Looks like this script was left over from quite a long time ago, and
was expecting CLI params from the "old"-style Automake test engine.
Update it to look for `--test-name` to get the test name, and update a
few other minor style things.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit e8277d9d0605ee8cd9a6e6b3b63b22526aef9c38)

Refs #7804