### PR TITLE
MPI-4: Initial error handler

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2017 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -135,8 +135,8 @@ int ompi_comm_init(void)
     ompi_mpi_comm_world.comm.c_remote_group = group;
     OBJ_RETAIN(ompi_mpi_comm_world.comm.c_remote_group);
     ompi_mpi_comm_world.comm.c_cube_dim     = opal_cube_dim((int)size);
-    ompi_mpi_comm_world.comm.error_handler  = &ompi_mpi_errors_are_fatal.eh;
-    OBJ_RETAIN( &ompi_mpi_errors_are_fatal.eh );
+    ompi_mpi_comm_world.comm.error_handler  = ompi_initial_error_handler_eh;
+    OBJ_RETAIN( ompi_mpi_comm_world.comm.error_handler );
     OMPI_COMM_SET_PML_ADDED(&ompi_mpi_comm_world.comm);
     opal_pointer_array_set_item (&ompi_mpi_communicators, 0, &ompi_mpi_comm_world);
 
@@ -188,8 +188,8 @@ int ompi_comm_init(void)
     ompi_mpi_comm_self.comm.c_local_group  = group;
     ompi_mpi_comm_self.comm.c_remote_group = group;
     OBJ_RETAIN(ompi_mpi_comm_self.comm.c_remote_group);
-    ompi_mpi_comm_self.comm.error_handler  = &ompi_mpi_errors_are_fatal.eh;
-    OBJ_RETAIN( &ompi_mpi_errors_are_fatal.eh );
+    ompi_mpi_comm_self.comm.error_handler  = ompi_initial_error_handler_eh;
+    OBJ_RETAIN( ompi_mpi_comm_self.comm.error_handler );
     OMPI_COMM_SET_PML_ADDED(&ompi_mpi_comm_self.comm);
     opal_pointer_array_set_item (&ompi_mpi_communicators, 1, &ompi_mpi_comm_self);
 
@@ -214,8 +214,10 @@ int ompi_comm_init(void)
     ompi_mpi_comm_null.comm.c_contextid    = 2;
     ompi_mpi_comm_null.comm.c_my_rank      = MPI_PROC_NULL;
 
+    /* unlike world, self, and parent, comm_null does not inherit the initial error
+     * handler */
     ompi_mpi_comm_null.comm.error_handler  = &ompi_mpi_errors_are_fatal.eh;
-    OBJ_RETAIN( &ompi_mpi_errors_are_fatal.eh );
+    OBJ_RETAIN( ompi_mpi_comm_null.comm.error_handler );
     opal_pointer_array_set_item (&ompi_mpi_communicators, 2, &ompi_mpi_comm_null);
 
     opal_string_copy(ompi_mpi_comm_null.comm.c_name, "MPI_COMM_NULL",
@@ -228,6 +230,8 @@ int ompi_comm_init(void)
     OBJ_RETAIN(&ompi_mpi_comm_null);
     OBJ_RETAIN(&ompi_mpi_group_null.group);
     OBJ_RETAIN(&ompi_mpi_errors_are_fatal.eh);
+    /* During dyn_init, the comm_parent error handler will be set to the same
+     * as comm_world (thus, the initial error handler). */
 
     /* initialize communicator requests (for ompi_comm_idup) */
     ompi_comm_request_init ();

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -782,6 +782,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
     int flag=0;
     char cwd[OPAL_PATH_MAX];
     char host[OPAL_MAX_INFO_VAL];  /*** should define OMPI_HOST_MAX ***/
+    char init_errh[OPAL_MAX_INFO_VAL];
     char prefix[OPAL_MAX_INFO_VAL];
     char stdin_target[OPAL_MAX_INFO_VAL];
     char params[OPAL_MAX_INFO_VAL];
@@ -814,6 +815,7 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
        - "file": filename, where additional information is provided.
        - "soft": see page 92 of MPI-2.
        - "host": desired host where to spawn the processes
+       - "mpi_initial_errhandler": the error handler attached to predefined communicators.
       Non-standard keys:
        - "hostfile": hostfile containing hosts where procs are
        to be spawned
@@ -967,6 +969,15 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
                 continue;
             }
 #endif
+
+            /* check for 'mpi_initial_errhandler' */
+            ompi_info_get (array_of_info[i], "mpi_initial_errhandler", sizeof(init_errh) - 1, init_errh, &flag);
+            if ( flag ) {
+                /* this is set as an environment because it must be available
+                 * before pmix_init */
+                opal_setenv("OMPI_MCA_mpi_initial_errhandler", init_errh, true, &app->env);
+                continue;
+            }
 
             /* 'path', 'arch', 'file', 'soft'  -- to be implemented */
 

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -233,7 +233,9 @@ struct ompi_request_t;
         int32_t state = ompi_mpi_state;                                 \
         if (OPAL_UNLIKELY(state < OMPI_MPI_STATE_INIT_COMPLETED ||      \
                           state > OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT)) { \
-            ompi_mpi_errors_are_fatal_comm_handler(NULL, NULL, name);   \
+            ompi_errhandler_invoke(NULL, NULL, -1,                       \
+                                   ompi_errcode_get_mpi_code(MPI_ERR_ARG), \
+                                   name);                               \
         }                                                               \
     }
 

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -185,6 +185,26 @@ OMPI_DECLSPEC extern ompi_predefined_errhandler_t ompi_mpi_errors_throw_exceptio
  */
 OMPI_DECLSPEC extern opal_pointer_array_t ompi_errhandler_f_to_c_table;
 
+/**
+ * This function selects the initial error handler.
+ * It may be called during MPI_INIT, or during the first MPI call
+ * that raises an error. This function does not allocate memory,
+ * and will only populate the ompi_initial_error_handler_eh and
+ * ompi_initial_error_handler pointers with predefined error handler
+ * and error handler functions aliases.
+ */
+OMPI_DECLSPEC int ompi_initial_errhandler_init(void);
+/**
+ * The initial error handler pointer. Will be set to alias one of the
+ * predefined error handlers through launch keys during the first MPI call,
+ * and will then be attached to predefined communicators.
+ */
+OMPI_DECLSPEC extern ompi_errhandler_t* ompi_initial_error_handler_eh;
+/**
+ * The initial error handler function pointer. Will be called when an error
+ * is raised before MPI_INIT or after MPI_FINALIZE.
+ */
+OMPI_DECLSPEC extern void (*ompi_initial_error_handler)(struct ompi_communicator_t **comm, int *error_code, ...);
 
 /**
  * Forward declaration so that we don't have to include

--- a/ompi/info/info.c
+++ b/ompi/info/info.c
@@ -131,6 +131,12 @@ int ompi_mpiinfo_init(void)
     opal_info_set(&ompi_mpi_info_env.info.super, "soft", cptr);
     free(cptr);
 
+    /* the initial error handler, set it as requested (nothing if not
+     * requested) */
+    if (NULL != ompi_process_info.initial_errhandler) {
+        opal_info_set(&ompi_mpi_info_env.info.super, "mpi_initial_errhandler", ompi_process_info.initial_errhandler);
+    }
+
     /* local host name */
     opal_info_set(&ompi_mpi_info_env.info.super, "host", ompi_process_info.nodename);
 

--- a/ompi/mpi/c/error_string.c
+++ b/ompi/mpi/c/error_string.c
@@ -47,11 +47,22 @@ int MPI_Error_string(int errorcode, char *string, int *resultlen)
     OPAL_CR_NOOP_PROGRESS();
 
     if ( MPI_PARAM_CHECK ) {
-        OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-
         if ( ompi_mpi_errcode_is_invalid(errorcode)) {
-            return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
-                                          FUNC_NAME);
+            /* If we have an error, the action that we take depends on
+               whether we're currently (after MPI_Init and before
+               MPI_Finalize) or not */
+            int32_t state = ompi_mpi_state;
+            if (state >= OMPI_MPI_STATE_INIT_COMPLETED &&
+                state < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
+               return OMPI_ERRHANDLER_INVOKE(MPI_COMM_WORLD, MPI_ERR_ARG,
+                                              FUNC_NAME);
+            } else {
+                /* We have no MPI object here so call ompi_errhandle_invoke
+                 * directly */
+                return ompi_errhandler_invoke(NULL, NULL, -1,
+                                              ompi_errcode_get_mpi_code(MPI_ERR_ARG),
+                                              FUNC_NAME);
+            }
         }
     }
 

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -751,12 +751,6 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
         goto error;
     }
 
-    /* initialize info */
-    if (OMPI_SUCCESS != (ret = ompi_mpiinfo_init())) {
-        error = "ompi_info_init() failed";
-        goto error;
-    }
-
     /* initialize error handlers */
     if (OMPI_SUCCESS != (ret = ompi_errhandler_init())) {
         error = "ompi_errhandler_init() failed";
@@ -772,6 +766,12 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
     /* initialize internal error codes */
     if (OMPI_SUCCESS != (ret = ompi_errcode_intern_init())) {
         error = "ompi_errcode_intern_init() failed";
+        goto error;
+    }
+
+    /* initialize info */
+    if (OMPI_SUCCESS != (ret = ompi_mpiinfo_init())) {
+        error = "ompi_info_init() failed";
         goto error;
     }
 

--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -935,6 +935,11 @@ int ompi_rte_finalize(void)
         opal_process_info.initial_wdir = NULL;
     }
 
+    if (NULL != opal_process_info.initial_errhandler) {
+        free(opal_process_info.initial_errhandler);
+        opal_process_info.initial_errhandler = NULL;
+    }
+
     /* cleanup our internal nspace hack */
     opal_pmix_finalize_nspace_tracker();
 

--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -51,7 +51,8 @@ opal_process_info_t opal_process_info = {
     .num_apps = 0,
     .initial_wdir = NULL,
     .reincarnation = 0,
-    .proc_is_bound = false
+    .proc_is_bound = false,
+    .initial_errhandler = NULL,
 };
 
 static opal_proc_t opal_local_proc = {

--- a/opal/util/proc.h
+++ b/opal/util/proc.h
@@ -126,6 +126,7 @@ typedef struct opal_process_info_t {
     char *initial_wdir;
     uint32_t reincarnation;
     bool proc_is_bound;
+    char *initial_errhandler;
 } opal_process_info_t;
 OPAL_DECLSPEC extern opal_process_info_t opal_process_info;
 

--- a/test/simple/Makefile
+++ b/test/simple/Makefile
@@ -1,4 +1,4 @@
-PROGS = mpi_no_op mpi_barrier hello hello_nodename abort multi_abort comm_abort simple_spawn \
+PROGS = mpi_no_op mpi_barrier hello hello_nodename abort multi_abort comm_abort initial_errh simple_spawn \
 		concurrent_spawn spawn_multiple mpi_spin delayed_abort loop_spawn loop_child \
 		bad_exit pubsub hello_barrier segv accept connect hello_output hello_show_help \
 		crisscross read_write ziatest slave reduce-hang ziaprobe ziatest bcast_loop \

--- a/test/simple/initial_errh.c
+++ b/test/simple/initial_errh.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2020      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "mpi.h"
+
+#define print1(format...) if(0 == rank) printf(format)
+
+int main_child(int argc, char *argv[]);
+
+int main(int argc, char *argv[])
+{
+    int rank=MPI_PROC_NULL, rc;
+    /* info_env and error handlers */
+    char init_errh_info[MPI_MAX_INFO_VAL+1]; int flag;
+    MPI_Errhandler errh;
+    /* error ops */
+    int eclass=MPI_SUCCESS;
+    char estr[MPI_MAX_ERROR_STRING]="NOT UPDATED"; int slen;
+    /* spawn params */
+    char* spawn_argv[3];
+    MPI_Info spawn_info;
+    int spawn_err[2] = {MPI_SUCCESS};
+    MPI_Comm icomm = MPI_COMM_NULL;
+
+    /* We will verify pre-init behavior in a spawnee to avoid aborting early in
+     * implementations with only partial support.
+     */
+    if(argc > 1 && 0 == strcmp(argv[1], "preinit-error")) {
+        return main_child(argc, argv);
+    }
+
+    /* Lets assume everything goes fine until we inject our own errors, no
+     * error checking */
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    print1(
+"# This test checks compliance with MPI-4 initial error handler.\n"
+"# This test assumes that the command line parameter '-initial-errhandler mpi_errors_return'\n"
+"# is passed to 'mpiexec', in which case, a compliant implementation will:\n"
+"#   * Set the MPI_INFO_ENV key to the requested error handler.\n"
+"#   * The requested handler is set on the predefined communicators MPI_COMM_SELF, MPI_COMM_WORLD,\n"
+"#     and the communicator returned from MPI_COMM_GET_PARENT.\n"
+"# In a high quality implementation:\n"
+"#   * Errors reported from calls during, before, and after MPI_INIT and MPI_FINALIZE also invoke the\n"
+"#     initial error handler.\n"
+"#   * MPI_ERROR_STRING and MPI_ERROR_CLASS provide useful information before/after MPI_INIT and\n"
+"#     MPI_FINALIZE respectively.\n\n");
+
+    print1("MPI_INFO_ENV for key 'mpi_initial_errhandler'\n");
+    MPI_Info_get(MPI_INFO_ENV, "mpi_initial_errhandler", MPI_MAX_INFO_VAL, init_errh_info, &flag);
+    if(flag) {
+        print1("  MPI-4 COMPLIANT:\tMPI_INFO_ENV value set for key 'mpi_initial_errhandler' = %s\n\n", init_errh_info);
+    }
+    else {
+        print1("  NOT MPI-4 COMPLIANT:\tMPI_INFO_ENV has no value set for key 'mpi_initial_errhandler'\n\n");
+    }
+
+    print1("MPI_COMM_GET_ERRHANDLER:\n");
+    MPI_Comm_get_errhandler(MPI_COMM_SELF, &errh);
+    if(MPI_ERRORS_RETURN == errh) {
+        print1("  MPI-4 COMPLIANT:\tMPI_COMM_SELF error handler set to MPI_ERRORS_RETURN.\n\n");
+    }
+    else
+    if(MPI_ERRORS_ABORT == errh) {
+        print1("  UNEXPECTED:\tMPI_COMM_SELF error handler set to MPI_ERRORS_ABORT.\n\n");
+    }
+    else
+    if(MPI_ERRORS_ARE_FATAL == errh) {
+        print1("  NOT MPI-4 COMPLIANT:\tMPI_COMM_SELF error handler set to MPI_ERRORS_ARE_FATAL.\n\n");
+    }
+    else {
+        print1("  UNEXPECTED:\tMPI_COMM_SELF error handler is not one of the predefined ones.\n\n");
+    }
+
+    sleep(1);
+
+    MPI_Info_create(&spawn_info);
+    MPI_Info_set(spawn_info, "mpi_initial_errhandler", "mpi_errors_return");
+    spawn_argv[0] = argv[0];
+    spawn_argv[1] = "preinit-error";
+    spawn_argv[2] = NULL;
+    MPI_Comm_spawn(argv[0], &spawn_argv[1], 1, spawn_info, 0, MPI_COMM_WORLD, &icomm, spawn_err);
+
+    /* wait for the spawnee completion before testing post-finalize error
+     * handling */
+    MPI_Barrier(icomm);
+    MPI_Comm_disconnect(&icomm);
+    sleep(2);
+
+    /* set error handler to fatal before FINALIZE */
+    rc = MPI_Comm_set_errhandler(MPI_COMM_SELF, MPI_ERRORS_ARE_FATAL);
+    if(MPI_SUCCESS != rc) {
+        MPI_Error_string(rc, estr, &slen);
+        fprintf(stderr, "  UNEXPECTED: An error occured during MPI_COMM_SETERRHANDLER(SELF) rc=%d: %s\n", rc, estr);
+        return rc;
+    }
+    /* FINALIZE should force reversion to the initial errhandler, so we need to
+     * check again (though we did not insert errors so all should go smooth). */
+    rc = MPI_Finalize();
+    if(MPI_SUCCESS != rc) {
+        MPI_Error_string(rc, estr, &slen);
+        fprintf(stderr, "  UNEXPECTED: An error occured during MPI_FINALIZE rc=%d: %s\n", rc, estr);
+        return rc;
+    }
+
+    printf("Post-finalize MPI_ERROR_STRING call:\n");
+    rc = MPI_Error_string(MPI_ERR_WIN, estr, &slen);
+    if(MPI_SUCCESS != rc) {
+        fprintf(stderr, "  NOT MPI-4 COMPLIANT:\tpost-finalize MPI_ERROR_STRING returned %d (expected MPI_SUCCESS)\n", rc);
+    }
+    else if(0 == strcmp(estr, "NOT UPDATED")) {
+        fprintf(stderr, "  NOT MPI-4 COMPLIANT:\tpost-finalize MPI_ERROR_STRING did not set a valid string.\n");
+    }
+    else {
+        /* We can't further check if the error string makes sense; In any
+         * case, any string is compliant, even low-quality non-informative
+         * generic strings. So we just print it. */
+        printf("  MPI-4 COMPLIANT:\tpost-finalize MPI_ERROR_STRING for MPI_ERR_WIN: %s\n", estr);
+    }
+    return 0;
+}
+
+int main_child(int argc, char *argv[]) {
+    int rank=0, rc;
+    MPI_Comm icomm=MPI_COMM_NULL;
+    int eclass=MPI_SUCCESS;
+    char estr[MPI_MAX_ERROR_STRING]="NOT UPDATED"; int slen;
+
+    /* ERROR_CLASS and ERROR_STRING are callable before MPI_INIT */
+
+    printf("Pre-init MPI_ERROR_CLASS call:\n");
+    rc = MPI_Error_class(MPI_ERR_WIN, &eclass);
+    if(MPI_SUCCESS != rc) {
+        fprintf(stderr, "  NOT MPI-4 COMPLIANT:\tpre-init MPI_ERROR_CLASS returned %d (expected MPI_SUCCESS)\n", rc);
+    }
+    else if(MPI_ERR_WIN != eclass) {
+        fprintf(stderr, "  NOT MPI-4 COMPLIANT:\tpre-init MPI_ERROR_CLASS set eclass=%d (expected %d)\n", eclass, MPI_ERR_WIN);
+    }
+    else {
+        printf("  MPI-4 COMPLIANT:\tPre-init MPI_ERROR_CLASS\n");
+    }
+
+    print1("Pre-init MPI_ERROR_STRING call:\n");
+    rc = MPI_Error_string(MPI_ERR_WIN, estr, &slen);
+    if(MPI_SUCCESS != rc) {
+        fprintf(stderr, "  NOT MPI-4 COMPLIANT:\tpre-init MPI_ERROR_STRING returned %d (expected MPI_SUCCESS)\n", rc);
+    }
+    else if(0 == strcmp(estr, "NOT UPDATED")) {
+        fprintf(stderr, "  NOT MPI-4 COMPLIANT:\tpre-init MPI_ERROR_STRING did not set a valid string.\n");
+    }
+    else {
+        /* We can't further check if the error string makes sense; In any
+         * case, any string is compliant, even low-quality non-informative
+         * generic strings. So we just print it. */
+        printf("  MPI-4 COMPLIANT:\tPre-init MPI_ERROR_STRING for MPI_ERR_WIN: %s\n", estr);
+    }
+
+    printf("Pre-init error in a call: compliant if it does not abort\n");
+    rc = MPI_Error_class(MPI_ERR_LASTCODE+1, &eclass);
+    eclass = rc;
+    rc = MPI_Error_string(eclass, estr, &slen);
+    if(MPI_SUCCESS != rc) {
+        printf("  MPI-4 COMPLIANT:\tPre-init MPI_ERROR_CLASS with erroneous arguments returned (LOW QUALITY: error code=%d caused error %d in MPI_ERROR_STRING).\n", eclass, rc);
+    }
+    else {
+        printf("  MPI-4 COMPLIANT:\tPre-init MPI_ERROR_STRING for non-existing code returned %d: %s\n", eclass, estr);
+    }
+
+    printf("Initializing MPI and setting error handlers on predefined communicators.\n");
+    rc = MPI_Init(&argc, &argv);
+    if(MPI_SUCCESS != rc) {
+        MPI_Error_string(rc, estr, &slen);
+        fprintf(stderr, "  UNEXPECTED: An error occured during MPI_INIT rc=%d: %s\n", rc, estr);
+        return rc;
+    }
+
+    /* sync-up with parent */
+    MPI_Comm_get_parent(&icomm);
+    rc = MPI_Comm_set_errhandler(icomm, MPI_ERRORS_ARE_FATAL);
+    if(MPI_SUCCESS != rc) {
+        MPI_Error_string(rc, estr, &slen);
+        fprintf(stderr, "  UNEXPECTED: An error occured during MPI_COMM_SETERRHANDLER(PARENT) rc=%d: %s\n", rc, estr);
+        return rc;
+    }
+    MPI_Barrier(icomm);
+    MPI_Comm_disconnect(&icomm);
+
+    MPI_Finalize();
+    return 0;
+}


### PR DESCRIPTION
MPI-4 will introduce the concept of the 'initial error handler'. This is the error handler  that is set before MPI is initialized and after MPI is finalized, and can be selected from mpiexec/SPAWN info key parameters.

This also adds  MPI_ERROR_CLASS, and MPI_ERROR_STRING to the functions that can be called before/after MPI_INIT and are always thread safe.

More details from the MPI Forum site:
https://github.com/mpi-forum/mpi-standard/pull/50
https://github.com/mpi-forum/mpi-issues/issues/102 (if you do not have access to the standard repo).

