### PR TITLE
Some fixups for issues detected by clang-tidy

### DIFF
--- a/ompi/attribute/attribute.c
+++ b/ompi/attribute/attribute.c
@@ -979,6 +979,7 @@ int ompi_attr_copy_all(ompi_attribute_type_t type, void *old_object,
         /* Did the callback return non-MPI_SUCCESS? */
         if (0 != err) {
             ret = err;
+            OBJ_RELEASE(new_attr);
             goto out;
         }
 

--- a/ompi/mca/coll/base/coll_base_allgather.c
+++ b/ompi/mca/coll/base/coll_base_allgather.c
@@ -178,19 +178,19 @@ int ompi_coll_base_allgather_intra_bruck(const void *sbuf, int scount,
         /* 1. copy blocks [0 .. (size - rank - 1)] from rbuf to shift buffer */
         err = ompi_datatype_copy_content_same_ddt(rdtype, ((ptrdiff_t)(size - rank) * (ptrdiff_t)rcount),
                                                   shift_buf, rbuf);
-        if (err < 0) { line = __LINE__; goto err_hndl;  }
+        if (err < 0) { line = __LINE__; free(free_buf); goto err_hndl;  }
 
         /* 2. move blocks [(size - rank) .. size] from rbuf to the begining of rbuf */
         tmpsend = (char*) rbuf + (ptrdiff_t)(size - rank) * (ptrdiff_t)rcount * rext;
         err = ompi_datatype_copy_content_same_ddt(rdtype, (ptrdiff_t)rank * (ptrdiff_t)rcount,
                                                   rbuf, tmpsend);
-        if (err < 0) { line = __LINE__; goto err_hndl;  }
+        if (err < 0) { line = __LINE__; free(free_buf); goto err_hndl;  }
 
         /* 3. copy blocks from shift buffer back to rbuf starting at block [rank]. */
         tmprecv = (char*) rbuf + (ptrdiff_t)rank * (ptrdiff_t)rcount * rext;
         err = ompi_datatype_copy_content_same_ddt(rdtype, (ptrdiff_t)(size - rank) * (ptrdiff_t)rcount,
                                                   tmprecv, shift_buf);
-        if (err < 0) { line = __LINE__; goto err_hndl;  }
+        if (err < 0) { line = __LINE__; free(free_buf); goto err_hndl;  }
 
         free(free_buf);
     }

--- a/ompi/mca/coll/base/coll_base_reduce.c
+++ b/ompi/mca/coll/base/coll_base_reduce.c
@@ -688,6 +688,9 @@ ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, int count
         if (NULL != free_buffer) {
             free(free_buffer);
         }
+        if (NULL != inplace_temp_free) {
+            free(inplace_temp_free);
+        }
         return err;
     }
 
@@ -703,6 +706,9 @@ ompi_coll_base_reduce_intra_basic_linear(const void *sbuf, void *rbuf, int count
             if (MPI_SUCCESS != err) {
                 if (NULL != free_buffer) {
                     free(free_buffer);
+                }
+                if (NULL != inplace_temp_free) {
+                    free(inplace_temp_free);
                 }
                 return err;
             }

--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -1333,14 +1333,12 @@ int mca_common_ompio_prepare_to_group(ompio_file_t *fh,
        if (NULL == aggr_bytes_per_group_tmp) {
           opal_output (1, "OUT OF MEMORY\n");
           ret = OMPI_ERR_OUT_OF_RESOURCE;
-          free(end_offsets_tmp);
           goto exit;
        }
     decision_list_tmp = (int* )malloc (fh->f_init_num_aggrs * sizeof(int));
     if (NULL == decision_list_tmp) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;
-        free(end_offsets_tmp);
         if (NULL != aggr_bytes_per_group_tmp) {
             free(aggr_bytes_per_group_tmp);
         }

--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
+++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
@@ -1303,12 +1303,14 @@ int mca_common_ompio_prepare_to_group(ompio_file_t *fh,
                                            fh->f_comm);
     if ( OMPI_SUCCESS != ret ) {
         opal_output (1, "mca_common_ompio_prepare_to_group: error in ompi_fcoll_base_coll_allgather_array\n");
+        free(start_offsets_lens_tmp);
         goto exit;
     }
     end_offsets_tmp = (OMPI_MPI_OFFSET_TYPE* )malloc (fh->f_init_procs_per_group * sizeof(OMPI_MPI_OFFSET_TYPE));
     if (NULL == end_offsets_tmp) {
         opal_output (1, "OUT OF MEMORY\n");
-        goto exit;
+        free(start_offsets_lens_tmp);
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
     for( k = 0 ; k < fh->f_init_procs_per_group; k++){
         end_offsets_tmp[k] = start_offsets_lens_tmp[3*k] + start_offsets_lens_tmp[3*k+1];

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -133,7 +133,7 @@ static inline int ddt_put_get(ompi_osc_ucx_module_t *module,
         ret = create_iov_list(origin_addr, origin_count, origin_dt,
                               &origin_ucx_iov, &origin_ucx_iov_count);
         if (ret != OMPI_SUCCESS) {
-            return ret;
+            goto cleanup;
         }
     }
 
@@ -141,7 +141,7 @@ static inline int ddt_put_get(ompi_osc_ucx_module_t *module,
         ret = create_iov_list(NULL, target_count, target_dt,
                               &target_ucx_iov, &target_ucx_iov_count);
         if (ret != OMPI_SUCCESS) {
-            return ret;
+            goto cleanup;
         }
     }
 
@@ -161,7 +161,8 @@ static inline int ddt_put_get(ompi_osc_ucx_module_t *module,
                                                 remote_addr + (uint64_t)(target_ucx_iov[target_ucx_iov_idx].addr));
             if (OPAL_SUCCESS != status) {
                 OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_putget failed: %d", status);
-                return OMPI_ERROR;
+                ret = OMPI_ERROR;
+                goto cleanup;
             }
 
             origin_ucx_iov[origin_ucx_iov_idx].addr = (void *)((intptr_t)origin_ucx_iov[origin_ucx_iov_idx].addr + curr_len);
@@ -195,7 +196,8 @@ static inline int ddt_put_get(ompi_osc_ucx_module_t *module,
                                                 remote_addr + target_lb + prev_len);
             if (OPAL_SUCCESS != status) {
                 OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_putget failed: %d", status);
-                return OMPI_ERROR;
+                ret = OMPI_ERROR;
+                goto cleanup;
             }
 
             prev_len += origin_ucx_iov[origin_ucx_iov_idx].len;
@@ -217,13 +219,16 @@ static inline int ddt_put_get(ompi_osc_ucx_module_t *module,
                                                 remote_addr + (uint64_t)(target_ucx_iov[target_ucx_iov_idx].addr));
             if (OPAL_SUCCESS != status) {
                 OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_putget failed: %d", status);
-                return OMPI_ERROR;
+                ret = OMPI_ERROR;
+                goto cleanup;
             }
 
             prev_len += target_ucx_iov[target_ucx_iov_idx].len;
             target_ucx_iov_idx++;
         }
     }
+
+cleanup:
 
     if (origin_ucx_iov != NULL) {
         free(origin_ucx_iov);
@@ -291,12 +296,14 @@ static inline int get_dynamic_win_info(uint64_t remote_addr, ompi_osc_ucx_module
                                        len, remote_state_addr);
     if (OPAL_SUCCESS != ret) {
         OSC_UCX_VERBOSE(1, "opal_common_ucx_mem_putget failed: %d", ret);
-        return OMPI_ERROR;
+        ret = OMPI_ERROR;
+        goto cleanup;
     }
 
     ret = opal_common_ucx_wpmem_flush(module->state_mem, OPAL_COMMON_UCX_SCOPE_EP, target);
-    if (ret != OMPI_SUCCESS) {
-        return ret;
+    if (ret != OPAL_SUCCESS) {
+        ret = OMPI_ERROR;
+        goto cleanup;
     }
 
     memcpy(&win_count, temp_buf, sizeof(uint64_t));
@@ -318,6 +325,7 @@ static inline int get_dynamic_win_info(uint64_t remote_addr, ompi_osc_ucx_module
            temp_dynamic_wins[contain].mem_addr, OMPI_OSC_UCX_MEM_ADDR_MAX_LEN);
     module->local_dynamic_win_info[contain].mem->mem_displs[target] = target * OMPI_OSC_UCX_MEM_ADDR_MAX_LEN;
 
+cleanup:
     free(temp_buf);
 
     return ret;
@@ -486,11 +494,13 @@ int ompi_osc_ucx_accumulate(const void *origin_addr, int origin_count,
         ret = ompi_osc_ucx_get(temp_addr, (int)temp_count, temp_dt,
                                target, target_disp, target_count, target_dt, win);
         if (ret != OMPI_SUCCESS) {
+            free(temp_addr);
             return ret;
         }
 
         ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_EP, target);
         if (ret != OMPI_SUCCESS) {
+            free(temp_addr);
             return ret;
         }
 
@@ -504,6 +514,7 @@ int ompi_osc_ucx_accumulate(const void *origin_addr, int origin_count,
             ret = create_iov_list(origin_addr, origin_count, origin_dt,
                                   &origin_ucx_iov, &origin_ucx_iov_count);
             if (ret != OMPI_SUCCESS) {
+                free(temp_addr);
                 return ret;
             }
 
@@ -541,11 +552,13 @@ int ompi_osc_ucx_accumulate(const void *origin_addr, int origin_count,
         ret = ompi_osc_ucx_put(temp_addr, (int)temp_count, temp_dt, target, target_disp,
                                target_count, target_dt, win);
         if (ret != OMPI_SUCCESS) {
+            free(temp_addr);
             return ret;
         }
 
         ret = opal_common_ucx_wpmem_flush(module->mem, OPAL_COMMON_UCX_SCOPE_EP, target);
         if (ret != OMPI_SUCCESS) {
+            free(temp_addr);
             return ret;
         }
 

--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -204,6 +204,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
          * and create a duplicate of the original communicator */
         free(vpids);
         free(colors);
+        free(lindex_to_grank);
         goto fallback; /* return with success */
     }
     /* compute local roots ranks in comm_old */
@@ -250,6 +251,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
     }
     if( (0 == num_objs_in_node) || (0 == num_pus_in_node) ) {  /* deal with bozo cases: COVERITY 1418505 */
         free(colors);
+        free(lindex_to_grank);
         goto fallback; /* return with success */
     }
     /* Check for oversubscribing */
@@ -288,6 +290,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
             object = hwloc_get_obj_by_depth(opal_hwloc_topology, effective_depth, obj_rank);
             if( NULL == object) {
                 free(colors);
+                free(lindex_to_grank);
                 hwloc_bitmap_free(set);
                 goto fallback;  /* return with success */
             }
@@ -315,6 +318,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
         OPAL_OUTPUT_VERBOSE((10, ompi_topo_base_framework.framework_output,
                              "Oversubscribing PUs resources => Rank Reordering Impossible \n"));
         free(colors);
+        free(lindex_to_grank);
         hwloc_bitmap_free(set);
         goto fallback;  /* return with success */
     }

--- a/opal/mca/base/mca_base_alias.c
+++ b/opal/mca/base/mca_base_alias.c
@@ -143,10 +143,12 @@ int mca_base_alias_register (const char *project, const char *framework, const c
 
         opal_hash_table_set_value_ptr (alias_hash_table, name, strlen(name), alias);
         free (name);
+        name = NULL;
     }
 
     mca_base_alias_item_t *alias_item = OBJ_NEW(mca_base_alias_item_t);
     if (NULL == alias_item) {
+        if (NULL != name) free(name);
         return OPAL_ERR_OUT_OF_RESOURCE;
     }
     

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -1234,6 +1234,7 @@ static int mca_btl_tcp_component_exchange(void)
                                  opal_net_get_hostname(addr));
          } else {
              BTL_ERROR(("Unexpected address family: %d", addr->sa_family));
+             free(addrs);
              return OPAL_ERR_BAD_PARAM;
          }
 

--- a/opal/mca/reachable/base/reachable_base_alloc.c
+++ b/opal/mca/reachable/base/reachable_base_alloc.c
@@ -44,7 +44,10 @@ opal_reachable_t * opal_reachable_allocate(unsigned int num_local,
        malloc, rather than a bunch of little allocations */
     memory = malloc(sizeof(int*) * num_local +
                     num_local * (sizeof(int) * num_remote));
-    if (memory == NULL) return NULL;
+    if (memory == NULL) {
+        OBJ_RELEASE(reachable);
+        return NULL;
+    }
 
     reachable->memory = (void*)memory;
     reachable->weights = (int**)reachable->memory;


### PR DESCRIPTION
Out of curiosity, I applied `clang-tidy` to Open MPI and found a bunch of issues. Many are false positives, quite a few are dead stores that likely will be optimized by DSE, some warnings are related to unsafe buffer handling functions such as `strcat`, and some are related to memory management. This PR tries to fix most of the detected potential memory leaks. All of them are missing free/release calls in error handling branches so the impact should be minimal. Still I thought this could be a useful patch.

Please review thoroughly as I am hunting in unknown territory here. I've split the changes into several commits for clarity but I'm happy to squash them before the merge.