### PR TITLE
Fix unexpected optimizations detected by STACK

### DIFF
--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -789,8 +789,7 @@ ompi_report_comm_methods(int called_from_location) // 1 = from init, 2 = from fi
                     if (majority_method_offhost == -1) {
                         majority_method_offhost = this_method;
                     }
-                    if (majority_method_offhost != -1 &&
-                        this_method != majority_method_offhost)
+                    if (this_method != majority_method_offhost)
                     {
                         uniformity_offhost = 0;
                     }

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -241,10 +241,8 @@ static inline int ompi_osc_rdma_gacc_contig (ompi_osc_rdma_sync_t *sync, const v
             return ompi_osc_rdma_put_contig (sync, peer, target_address, target_handle, ptr, len, request);
         }
 
-        if (request) {
-            /* nothing more to do for this request */
-            ompi_osc_rdma_request_complete (request, MPI_SUCCESS);
-        }
+        /* nothing more to do for this request */
+        ompi_osc_rdma_request_complete (request, MPI_SUCCESS);
 
         return OMPI_SUCCESS;
     }

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -538,14 +538,7 @@ select_unlock:
 error:
     if (module->disp_units) free(module->disp_units);
     if (module->comm) ompi_comm_free(&module->comm);
-    /* We update the modules count and (if need) registering a callback right
-     * prior to memory allocation for the module.
-     * So we use it as an indirect sign here
-     */
-    if (module) {
-        free(module);
-        ompi_osc_ucx_unregister_progress();
-    }
+    free(module);
 
 error_nomem:
     if (env_initialized == true) {
@@ -553,6 +546,8 @@ error_nomem:
         OBJ_DESTRUCT(&mca_osc_ucx_component.requests);
         mca_osc_ucx_component.env_initialized = false;
     }
+
+    ompi_osc_ucx_unregister_progress();
     return ret;
 }
 

--- a/ompi/mca/topo/treematch/treematch/tm_malloc.c
+++ b/ompi/mca/topo/treematch/treematch/tm_malloc.c
@@ -210,12 +210,13 @@ void *tm_realloc(void *old_ptr, size_t size, char *file, int line){
 }
 
 void tm_free(void *ptr){
-  byte *original_ptr = ((byte *)ptr) - EXTRA_BYTE;
+  byte *original_ptr;
   size_t size;
 
   if(!ptr)
     return;
 
+  original_ptr = ((byte *)ptr) - EXTRA_BYTE;
   size = retreive_size(original_ptr);
 
   if((bcmp(original_ptr ,extra_data, EXTRA_BYTE)) && ((tm_get_verbose_level()>=ERROR))){


### PR DESCRIPTION
I applied the STACK tool to Open MPI to detect unintended or unexpected optimizations the compiler may apply based on undefined behavior [1]

1) `hook_comm_method_fns.c`: the check for `majority_method_offhost == -1` is always true because if it was `-1` before it was assigned the value of `this_method`, which has previously been used as index to `method_count` (https://github.com/open-mpi/ompi/compare/master...devreal:stack-fixes?expand=1#diff-f6b14d507479e3f54ae4f4d35681de08L785)

2) `osc_rdma_accumulate.c`: The check for `request` is assumed always true because of its previous dereference in line 217 (https://github.com/open-mpi/ompi/compare/master...devreal:stack-fixes?expand=1#diff-afdeeadc6df49f4ca2feee4ff3bda9a3L217)

3)  `osc_ucx_component.c`: Similar to the above, the check for `module` is always true since `module` has previously been dereferenced (https://github.com/open-mpi/ompi/compare/master...devreal:stack-fixes?expand=1#diff-f66f881fe0e7f40ffad2c3027e42c637L540) 

~4) `opal_cr.c`: This is the most interesting one. The check for `event >= OPAL_CR_INC_MAX` is always true because `event` is previously being used as index into a static array of size `OPAL_CR_INC_MAX`. Swapping the two checks fixes this.~ Removed in favor of https://github.com/open-mpi/ompi/pull/7848

5) `tm_malloc.c`: The pointer arithmetic on `ptr` causes the compiler to drop the following check for `NULL`.

[1] https://css.csail.mit.edu/stack/

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>