### PR TITLE
VERSION: Bump to 5.0.0a1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -15,8 +15,8 @@
 # major, minor, and release are generally combined in the form
 # <major>.<minor>.<release>.
 
-major=4
-minor=1
+major=5
+minor=0
 release=0
 
 # greek is generally used for alpha or beta release tags.  If it is


### PR DESCRIPTION
Now that we have an actual 4.1.x branch, we shouldn't be calling
master "v4.1.0a1" any more.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>