### PR TITLE
ompi_info: trim some redundant output

### DIFF
--- a/ompi/runtime/ompi_info_support.c
+++ b/ompi/runtime/ompi_info_support.c
@@ -123,9 +123,6 @@ void ompi_info_show_ompi_version(const char *scope)
     opal_info_out("Open MPI release date", tmp, OMPI_RELEASE_DATE);
     free(tmp);
 
-    /* show the opal version */
-    opal_info_show_opal_version(scope);
-
     tmp2 = opal_info_make_version_str(scope,
                                       MPI_VERSION, MPI_SUBVERSION,
                                       0, "", "");

--- a/ompi/tools/ompi_info/ompi_info.c
+++ b/ompi/tools/ompi_info/ompi_info.c
@@ -167,7 +167,6 @@ int main(int argc, char *argv[])
         ompi_info_show_ompi_version(opal_info_ver_full);
         opal_info_show_path(opal_info_path_prefix, opal_install_dirs.prefix);
         opal_info_do_arch();
-        opal_info_do_hostname();
         ompi_info_do_config(false);
         opal_info_show_component_version(&mca_types, &component_map, opal_info_type_all,
                                          opal_info_component_all, opal_info_ver_full,

--- a/ompi/tools/ompi_info/param.c
+++ b/ompi/tools/ompi_info/param.c
@@ -308,7 +308,7 @@ void ompi_info_do_config(bool want_all)
     /* output values */
     opal_info_out("Configured by", "config:user", OPAL_CONFIGURE_USER);
     opal_info_out("Configured on", "config:timestamp", OPAL_CONFIGURE_DATE);
-    opal_info_out("Configure host", "config:host", OPAL_CONFIGURE_HOST);
+    opal_info_do_hostname();
     opal_info_out("Configure command line", "config:cli", OPAL_CONFIGURE_CLI);
 
     opal_info_out("Built by", "build:user", OMPI_BUILD_USER);


### PR DESCRIPTION
- Remove a duplicate "Configure host" output line
- No longer show the OPAL version.  Since OPAL has never separated
  into its own project, its version is always the same as Open MPI.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>