### PR TITLE
osc rdma: check for outstanding fragments before completing a request (v4.1.x)

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -391,8 +391,10 @@ static void ompi_osc_rdma_put_complete (struct mca_btl_base_module_t *btl, struc
         ompi_osc_rdma_request_t *request = request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
         sync = request->sync;
 
-        /* NTH -- TODO: better error handling */
-        ompi_osc_rdma_request_complete (request, status);
+        if (0 == OPAL_THREAD_ADD_FETCH32 (&request->outstanding_requests, -1)) {
+            /* NTH -- TODO: better error handling */
+            ompi_osc_rdma_request_complete (request, status);
+        }
     }
 
     OSC_RDMA_VERBOSE(status ? MCA_BASE_VERBOSE_ERROR : MCA_BASE_VERBOSE_TRACE, "btl put complete on sync %p. local "


### PR DESCRIPTION
With non-contiguous RMA transfers, the operation is chunked up in multiple transfers. So far, osc/rdma did not check that all outstanding transfers have completed before releasing the associated request. This PR decrements the transfer counter and conditionally releases the request if all are completed.

See #7813 for the test case that triggers it.

Cherry-pick of #7829 to the v4.1.x branch.

Signed-off-by: Joseph Schuchart schuchart@hlrs.de