### PR TITLE
mtl-portals4: use the active PML to call add_procs()

### DIFF
--- a/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
+++ b/ompi/mca/mtl/portals4/mtl_portals4_endpoint.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010      Sandia National Laboratories.  All rights reserved.
+ * Copyright (c) 2010-2020 Sandia National Laboratories.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -20,6 +20,7 @@
 #ifndef OMPI_MTL_PORTALS_ENDPOINT_H
 #define OMPI_MTL_PORTALS_ENDPOINT_H
 
+#include "ompi/mca/pml/pml.h"
 #include "ompi/mca/mtl/portals4/mtl_portals4.h"
 
 struct mca_mtl_base_endpoint_t {
@@ -31,7 +32,10 @@ static inline mca_mtl_base_endpoint_t *
 ompi_mtl_portals4_get_endpoint (struct mca_mtl_base_module_t* mtl, ompi_proc_t *ompi_proc)
 {
     if (OPAL_UNLIKELY(NULL == ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4])) {
-        ompi_mtl_portals4_add_procs (mtl, 1, &ompi_proc);
+        int rc;
+        if (OPAL_UNLIKELY(OMPI_SUCCESS != (rc = MCA_PML_CALL(add_procs(&ompi_proc, 1))))) {
+            ompi_rte_abort(rc,"ompi_mtl_portals4_get_endpoint(): pml->add_procs() failed.  Aborting.\n");
+        }
     }
 
     return ompi_proc->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_PORTALS4];


### PR DESCRIPTION
ompi_mtl_portals4_get_endpoint() was incorrectly making a direct
call to ompi_mtl_portals4_add_procs().  Instead use the actve PML
to call add_procs().  If add_procs() fails, call ompi_rte_abort()
to terminate the job.

Closes https://github.com/open-mpi/ompi/issues/7763
