### PR TITLE
add a common ofi include/exclude list

### DIFF
--- a/ompi/mca/mtl/ofi/Makefile.am
+++ b/ompi/mca/mtl/ofi/Makefile.am
@@ -7,6 +7,8 @@
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2019      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2020      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/ompi/mca/mtl/ofi/mtl_ofi.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi.c
@@ -112,7 +112,7 @@ ompi_mtl_ofi_add_procs(struct mca_mtl_base_module_t *mtl,
      */
     count = fi_av_insert(ompi_mtl_ofi.av, ep_names, nprocs, fi_addrs, 0, NULL);
     if ((count < 0) || (nprocs != (size_t)count)) {
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+        opal_output_verbose(1, opal_common_ofi.output,
                             "%s:%d: fi_av_insert failed: %d\n",
                             __FILE__, __LINE__, count);
         ret = OMPI_ERROR;
@@ -125,7 +125,7 @@ ompi_mtl_ofi_add_procs(struct mca_mtl_base_module_t *mtl,
     for (i = 0; i < nprocs; ++i) {
         endpoint = OBJ_NEW(mca_mtl_ofi_endpoint_t);
         if (NULL == endpoint) {
-            opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+            opal_output_verbose(1, opal_common_ofi.output,
                                 "%s:%d: mtl/ofi: could not allocate endpoint"
                                 " structure\n",
                                 __FILE__, __LINE__);
@@ -170,7 +170,7 @@ ompi_mtl_ofi_del_procs(struct mca_mtl_base_module_t *mtl,
             endpoint = procs[i]->proc_endpoints[OMPI_PROC_ENDPOINT_TAG_MTL];
             ret = fi_av_remove(ompi_mtl_ofi.av, &endpoint->peer_fiaddr, 1, 0);
             if (ret) {
-                opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+                opal_output_verbose(1, opal_common_ofi.output,
                         "%s:%d: fi_av_remove failed: %s\n", __FILE__, __LINE__, fi_strerror(errno));
                 return ret;
             }

--- a/ompi/mca/mtl/ofi/mtl_ofi.h
+++ b/ompi/mca/mtl/ofi/mtl_ofi.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved
  * Copyright (c) 2017      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2019      Triad National Security, LLC. All rights
+ * Copyright (c) 2019-2020 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates. All rights
  *                         reserved.
@@ -38,6 +38,7 @@
 #include "ompi/mca/mtl/base/base.h"
 #include "ompi/mca/mtl/base/mtl_base_datatype.h"
 #include "ompi/message/message.h"
+#include "opal/mca/common/ofi/common_ofi.h"
 
 #include "mtl_ofi_opt.h"
 #include "mtl_ofi_types.h"
@@ -235,7 +236,7 @@ ompi_mtl_ofi_progress(void)
 
 #define MTL_OFI_LOG_FI_ERR(err, string)                                     \
     do {                                                                    \
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,    \
+        opal_output_verbose(1, opal_common_ofi.output,                      \
                             "%s:%d:%s: %s\n",                               \
                             __FILE__, __LINE__, string, fi_strerror(-err)); \
     } while(0);
@@ -377,7 +378,7 @@ ompi_mtl_ofi_ssend_recv(ompi_mtl_ofi_request_t *ack_req,
                                       0, /* Exact match, no ignore bits */
                                       (void *) &ack_req->ctx), ret);
     if (OPAL_UNLIKELY(0 > ret)) {
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+        opal_output_verbose(1, opal_common_ofi.output,
                             "%s:%d: fi_trecv failed: %s(%zd)",
                             __FILE__, __LINE__, fi_strerror(-ret), ret);
         free(ack_req);
@@ -663,7 +664,7 @@ ompi_mtl_ofi_recv_callback(struct fi_cq_tagged_entry *wc,
     status->_ucount = wc->len;
 
     if (OPAL_UNLIKELY(wc->len > ofi_req->length)) {
-        opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+        opal_output_verbose(1, opal_common_ofi.output,
                             "truncate expected: %ld %ld",
                             wc->len, ofi_req->length);
         status->MPI_ERROR = MPI_ERR_TRUNCATE;
@@ -677,7 +678,7 @@ ompi_mtl_ofi_recv_callback(struct fi_cq_tagged_entry *wc,
                                             ofi_req->buffer,
                                             wc->len);
         if (OPAL_UNLIKELY(OMPI_SUCCESS != ompi_ret)) {
-            opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+            opal_output_verbose(1, opal_common_ofi.output,
                                 "%s:%d: ompi_mtl_datatype_unpack failed: %d",
                                 __FILE__, __LINE__, ompi_ret);
             status->MPI_ERROR = ompi_ret;
@@ -1330,7 +1331,7 @@ init_regular_ep:
     if (MPI_COMM_WORLD == comm) {
         ret = opal_progress_register(ompi_mtl_ofi_progress_no_inline);
         if (OMPI_SUCCESS != ret) {
-            opal_output_verbose(1, ompi_mtl_base_framework.framework_output,
+            opal_output_verbose(1, opal_common_ofi.output,
                                 "%s:%d: opal_progress_register failed: %d\n",
                                 __FILE__, __LINE__, ret);
             goto init_error;

--- a/opal/mca/btl/ofi/Makefile.am
+++ b/opal/mca/btl/ofi/Makefile.am
@@ -13,6 +13,8 @@
 # Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2018      Intel, inc. All rights reserved
+# Copyright (c) 2020      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -14,6 +14,9 @@
  *                         reserved.
  * Copyright (c) 2018      Intel, Inc, All rights reserved
  *
+ * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2020      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,7 +44,6 @@
 
 #define MCA_BTL_OFI_REQUESTED_MR_MODE   (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR)
 
-static char *prov_include;
 static char *ofi_progress_mode;
 static bool disable_sep;
 static int mca_btl_ofi_init_device(struct fi_info *info);
@@ -107,20 +109,6 @@ static int mca_btl_ofi_component_register(void)
                                           MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_btl_ofi_component.mode);
 
-    /* fi_getinfo with prov_name == NULL means ALL provider.
-     * Since now we are using the first valid info returned, I'm not sure
-     * if we need to provide the support for comma limited provider list. */
-    prov_include = NULL;
-    (void) mca_base_component_var_register(&mca_btl_ofi_component.super.btl_version,
-                                          "provider_include",
-                                          "OFI provider that ofi btl will query for. This parameter only "
-                                          "accept ONE provider name. "
-                                          "(e.g., \"psm2\"; an empty value means that all providers will "
-                                          "be considered.",
-                                          MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                          OPAL_INFO_LVL_4,
-                                          MCA_BASE_VAR_SCOPE_READONLY,
-                                          &prov_include);
 
     mca_btl_ofi_component.num_cqe_read = MCA_BTL_OFI_NUM_CQE_READ;
     (void) mca_base_component_var_register(&mca_btl_ofi_component.super.btl_version,
@@ -185,6 +173,8 @@ static int mca_btl_ofi_component_register(void)
     /* for now we want this component to lose to the MTL. */
     module->super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_HIGH - 50;
 
+    opal_common_ofi_register_mca_variables(&mca_btl_ofi_component.super.btl_version);
+
     return mca_btl_base_param_register (&mca_btl_ofi_component.super.btl_version,
                                         &module->super);
 }
@@ -200,7 +190,8 @@ static int mca_btl_ofi_component_open(void)
  */
 static int mca_btl_ofi_component_close(void)
 {
-    /* If we don't sleep, sockets provider freaks out. */
+    opal_common_ofi_mca_deregister();
+    /* If we don't sleep, sockets provider freaks out. Ummm this is a scary comment */
     sleep(1);
     return OPAL_SUCCESS;
 }
@@ -225,6 +216,7 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
     uint64_t progress_mode;
     unsigned resource_count = 0;
     struct mca_btl_base_module_t **base_modules;
+    char **include_list = NULL;
 
     BTL_VERBOSE(("initializing ofi btl"));
 
@@ -247,6 +239,8 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
     struct fi_domain_attr domain_attr = {0};
     uint64_t required_caps;
 
+    opal_common_ofi_mca_register();
+
     switch (mca_btl_ofi_component.mode) {
 
         case MCA_BTL_OFI_MODE_TWO_SIDED:
@@ -266,8 +260,12 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
             break;
     }
 
-    /* Select the provider */
-    fabric_attr.prov_name = prov_include;
+    fabric_attr.prov_name = NULL;
+    /* Select the provider - sort of.  we just take first element in list for now */
+    if (NULL != *opal_common_ofi.prov_include) {
+        include_list = opal_argv_split(*opal_common_ofi.prov_include, ',');
+        fabric_attr.prov_name = include_list[0];
+    }
 
     domain_attr.mr_mode = MCA_BTL_OFI_REQUESTED_MR_MODE;
 
@@ -312,8 +310,12 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
     rc = fi_getinfo(FI_VERSION(1, 5), NULL, NULL, 0, &hints, &info_list);
     if (0 != rc) {
         BTL_VERBOSE(("fi_getinfo failed with code %d: %s",rc, fi_strerror(-rc)));
+        if (NULL != include_list) {
+            opal_argv_free(include_list);
+        }
         return NULL;
     }
+
 
     /* count the number of resources/ */
     info = info_list;
@@ -356,6 +358,9 @@ static mca_btl_base_module_t **mca_btl_ofi_component_init (int *num_btl_modules,
 
     /* We are done with the returned info. */
     fi_freeinfo(info_list);
+    if (NULL != include_list) {
+        opal_argv_free(include_list);
+    }
 
     /* pass module array back to caller */
     base_modules = calloc (mca_btl_ofi_component.module_count, sizeof (*base_modules));

--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Los Alamos National Security, LLC.  All rights
  *                         reserved.
+ * Copyright (c) 2020      Triad National Security, LLC. All rights
+ *                         reserved.
+ *
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -12,9 +15,31 @@
 
 #ifndef OPAL_MCA_COMMON_OFI_H
 #define OPAL_MCA_COMMON_OFI_H
+
+#include "opal_config.h"
+#include "opal/mca/base/mca_base_var.h"
+#include "opal/mca/base/mca_base_framework.h"
 #include <rdma/fabric.h>
 
-OPAL_DECLSPEC int mca_common_ofi_register_mca_variables(void);
+BEGIN_C_DECLS
+
+typedef struct opal_common_ofi_module {
+    char **prov_include;
+    char **prov_exclude;
+    int verbose;
+    int registered;
+    int output;
+} opal_common_ofi_module_t;
+
+extern opal_common_ofi_module_t opal_common_ofi;
+
+OPAL_DECLSPEC int opal_common_ofi_register_mca_variables(const mca_base_component_t *component);
+OPAL_DECLSPEC void opal_common_ofi_mca_register(void);
+OPAL_DECLSPEC void opal_common_ofi_mca_deregister(void);
+OPAL_DECLSPEC struct fi_info* opal_common_ofi_select_ofi_provider(struct fi_info *providers, 
+                                                                  char *framework_name);
+
+END_C_DECLS
 
 struct fi_info* opal_mca_common_ofi_select_provider(struct fi_info *provider_list, int rank);
 


### PR DESCRIPTION
also add common verbose variable.

Note the verbosity thing is a little tricky owing to the way the MCA frameworks and components are registered and
and initialized.  The BTL's are registered/initialized prior to the MTL components even getting registered.

Here's the change in ofi mtl mca parameters.  Before commit:

            MCA mtl ofi: parameter "mtl_ofi_provider_include" (current value: "psm2", data source: environment, level: 1 user/basic, type: string)
                          Comma-delimited list of OFI providers that are considered for use (e.g., "psm,psm2"; an empty value means that all providers will be considered). Mutually exclusive with mtl_ofi_provider_exclude.
             MCA mtl ofi: parameter "mtl_ofi_provider_exclude" (current value: "shm,sockets,tcp,udp,rstream", data source: default, level: 1 user/basic, type: string)
                          Comma-delimited list of OFI providers that are not considered for use (default: "sockets,mxm"; empty value means that all providers will be considered). Mutually exclusive with mtl_ofi_provider_include.

After commit:

             MCA btl ofi: parameter "btl_ofi_provider_include" (current value: "", data source: default, level: 1 user/basic, type: string, synonym of: opal_common_ofi_provider_include)
                          Comma-delimited list of OFI providers that are considered for use (e.g., "psm,psm2"; an empty value means that all providers will be considered). Mutually exclusive with mtl_ofi_provider_exclude.
             MCA btl ofi: parameter "btl_ofi_provider_exclude" (current value: "shm,sockets,tcp,udp,rstream", data source: default, level: 1 user/basic, type: string, synonym of: opal_common_ofi_provider_exclude)
                          Comma-delimited list of OFI providers that are not considered for use (default: "sockets,mxm"; empty value means that all providers will be considered). Mutually exclusive with mtl_ofi_provider_include.
             MCA mtl ofi: parameter "mtl_ofi_provider_exclude" (current value: "shm,sockets,tcp,udp,rstream", data source: default, level: 1 user/basic, type: string, synonym of: opal_common_ofi_provider_exclude)
                          Comma-delimited list of OFI providers that are not considered for use (default: "sockets,mxm"; empty value means that all providers will be considered). Mutually exclusive with mtl_ofi_provider_include.
             MCA mtl ofi: parameter "mtl_ofi_verbose" (current value: "0", data source: default, level: 3 user/all, type: int, synonym of: opal_common_ofi_verbose)

related to #7755

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 9f1081a07ac3c7b7277a27277ed970ed713207c9)
(cherry picked from commit 45b643d0cfa46f1abb9a5f43cf0ff304cf6a5fea)