### PR TITLE
OSC UCX: make sure no-op fetch in rget/rput is properly aligned

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -814,9 +814,10 @@ int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
     }
 
     mca_osc_ucx_component.num_incomplete_req_ops++;
+    /* TODO: investigate whether ucp_worker_flush_nb is a better choice here */
     ret = opal_common_ucx_wpmem_fetch_nb(module->mem, UCP_ATOMIC_FETCH_OP_FADD,
                                          0, target, &(module->req_result),
-                                         sizeof(uint64_t), remote_addr,
+                                         sizeof(uint64_t), remote_addr & (~0x7),
                                          req_completion, ucx_req);
     if (ret != OMPI_SUCCESS) {
         return ret;
@@ -865,9 +866,10 @@ int ompi_osc_ucx_rget(void *origin_addr, int origin_count,
     }
 
     mca_osc_ucx_component.num_incomplete_req_ops++;
+    /* TODO: investigate whether ucp_worker_flush_nb is a better choice here */
     ret = opal_common_ucx_wpmem_fetch_nb(module->mem, UCP_ATOMIC_FETCH_OP_FADD,
                                          0, target, &(module->req_result),
-                                         sizeof(uint64_t), remote_addr,
+                                         sizeof(uint64_t), remote_addr & (~0x7),
                                          req_completion, ucx_req);
     if (ret != OMPI_SUCCESS) {
         return ret;


### PR DESCRIPTION
Starting with version 1.8.0, UCX barks at misaligned atomic operations so make sure the fetch-and-op used in rget/rput to acquire a UCX request uses properly aligned target memory. Also add a comment on whether this can be replaced with non-blocking flushes.

This fix should go into the next 4.0.x and 4.1.x releases as this issue breaks `MPI_Rput` and `MPI_Rget` for 32-bit integer when using osc/ucx, hence the quick fix.

See #7813 for the initial report.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>