### PR TITLE
OSC UCX: make sure no-op fetch in rget/rput is properly aligned (v4.1.x)

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -904,9 +904,10 @@ int ompi_osc_ucx_rput(const void *origin_addr, int origin_count,
         return OMPI_ERROR;
     }
 
+    /* TODO: investigate whether ucp_worker_flush_nb is a better choice here */
     internal_req = ucp_atomic_fetch_nb(ep, UCP_ATOMIC_FETCH_OP_FADD, 0,
                                        &(module->req_result), sizeof(uint64_t),
-                                       remote_addr, rkey, req_completion);
+                                       remote_addr & (~0x7), rkey, req_completion);
 
     if (UCS_PTR_IS_PTR(internal_req)) {
         internal_req->external_req = ucx_req;
@@ -965,9 +966,10 @@ int ompi_osc_ucx_rget(void *origin_addr, int origin_count,
         return OMPI_ERROR;
     }
 
+    /* TODO: investigate whether ucp_worker_flush_nb is a better choice here */
     internal_req = ucp_atomic_fetch_nb(ep, UCP_ATOMIC_FETCH_OP_FADD, 0,
                                        &(module->req_result), sizeof(uint64_t),
-                                       remote_addr, rkey, req_completion);
+                                       remote_addr & (~0x7), rkey, req_completion);
 
     if (UCS_PTR_IS_PTR(internal_req)) {
         internal_req->external_req = ucx_req;


### PR DESCRIPTION
Starting with version 1.8.0, UCX barks at misaligned atomic operations so make sure the fetch-and-op used in rget/rput to acquire a UCX request uses properly aligned target memory. Also add a comment on whether this can be replaced with non-blocking flushes.

Cherry-pick of #7871 to v4.1.x

See #7813 for the initial report.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>
(cherry picked from commit c1f7776341254b825a1b5f12fb93088c73c2c2ef)