### PR TITLE
OSC UCX: Remove stale free from merge conflict

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -753,7 +753,6 @@ do_atomic_compare_and_swap(const void *origin_addr, const void *compare_addr,
     if (!module->acc_single_intrinsic) {
         ret = start_atomicity(module, target, &lock_acquired);
         if (ret != OMPI_SUCCESS) {
-            free(temp_addr);
             return ret;
         }
     }


### PR DESCRIPTION
There was a merge conflict between https://github.com/open-mpi/ompi/pull/6980 and https://github.com/open-mpi/ompi/pull/7843 that inserted a stray call to `free`.

Fixes https://github.com/open-mpi/ompi/issues/7874

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>