### PR TITLE
osc rdma: check for outstanding fragments before completing a request (II) (v4.1.x)

### DIFF
--- a/ompi/mca/osc/rdma/osc_rdma_comm.c
+++ b/ompi/mca/osc/rdma/osc_rdma_comm.c
@@ -422,8 +422,10 @@ static void ompi_osc_rdma_put_complete_flush (struct mca_btl_base_module_t *btl,
         ompi_osc_rdma_request_t *request = request = (ompi_osc_rdma_request_t *) ((intptr_t) context & ~1);
         module = request->module;
 
-        /* NTH -- TODO: better error handling */
-        ompi_osc_rdma_request_complete (request, status);
+        if (0 == OPAL_THREAD_ADD_FETCH32 (&request->outstanding_requests, -1)) {
+            /* NTH -- TODO: better error handling */
+            ompi_osc_rdma_request_complete (request, status);
+        }
     }
 
     OSC_RDMA_VERBOSE(status ? MCA_BASE_VERBOSE_ERROR : MCA_BASE_VERBOSE_TRACE, "btl put complete on module %p. local "


### PR DESCRIPTION
This PR fixes the same issue as #7829 but for a different code path (`ompi_osc_rdma_put_complete_flush`, taken when using `btl/uct` for example).

Cherry-pick of #7882 to v4.1.x

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>
(cherry picked from commit caed3b2eed478c76f34d56b5d0495bf26e44a9bb)