### PR TITLE
Fix initialization warning reported by clang-10

### DIFF
--- a/opal/util/proc.c
+++ b/opal/util/proc.c
@@ -47,7 +47,6 @@ opal_process_info_t opal_process_info = {
     .univ_size = 0,
     .app_sizes = NULL,
     .app_ldrs = NULL,
-    .cpuset = NULL,
     .command = NULL,
     .num_apps = 0,
     .initial_wdir = NULL,


### PR DESCRIPTION
Delete duplicate initializer for cpuset in opal_process_info.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>