### PR TITLE
Fix shifting signed integer

### DIFF
--- a/opal/util/arch.c
+++ b/opal/util/arch.c
@@ -67,7 +67,7 @@ static inline int32_t opal_arch_ldisintel( void )
             j = j-1;
         }
     }
-    return (pui[j] & (1 << i) ? 1 : 0);
+    return ((pui[j] & (1u << i)) ? 1 : 0);
 }
 
 static inline void opal_arch_setmask ( uint32_t *var, uint32_t mask)

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -202,7 +202,7 @@ opal_net_init(void)
 uint32_t
 opal_net_prefix2netmask(uint32_t prefixlen)
 {
-    return htonl (((1 << prefixlen) - 1) << (32 - prefixlen));
+    return htonl (((1u << prefixlen) - 1u) << (32 - prefixlen));
 }
 
 


### PR DESCRIPTION
Shifting signed int will lead to undefined behavior in case of 1<<31 here

Signed-off-by: Christoph Niethammer niethammer@hlrs.de