### PR TITLE
Fix null pointer arithmetic resulting in potential undefined behavior

### DIFF
--- a/opal/class/opal_free_list.c
+++ b/opal/class/opal_free_list.c
@@ -272,7 +272,9 @@ int opal_free_list_grow_st (opal_free_list_t* flist, size_t num_elements, opal_f
         }
 
         ptr += head_size;
-        payload_ptr += elem_size;
+        if (NULL != payload_ptr) {
+            payload_ptr += elem_size;
+        }
     }
 
     if (OPAL_SUCCESS != rc && 0 == num_elements) {


### PR DESCRIPTION
NULL pointer arithmetic is undefined behaviour in c.
The payload_ptr can be NULL in the moment when mpool is not initialized.

References from the c11 standard:
- 6.5.6 Additive operators
- 6.3.2.3 Pointers

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>