### PR TITLE
Trivial helper script to git clean submodules

### DIFF
--- a/contrib/git-clean.sh
+++ b/contrib/git-clean.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+# 
+# Trivial helper script to git clean a tree and all of its submodules.
+
+set -euo pipefail
+
+# Top git dir
+root=$(git rev-parse --show-toplevel)
+cd $root
+
+# Clean the top-level dir
+echo "=== Cleaning top-level git directory"
+git clean -dfx .
+
+submodule_dirs=$(git submodule status | awk '{print $2}')
+if test -z "$submodule_dirs"; then
+    echo "No submodules to clean"
+    exit 0
+fi
+
+for dir in $submodule_dirs; do
+    echo "=== Cleaning submodule: $dir"
+    cd $dir
+    git clean -dfx .
+    cd $root
+done


### PR DESCRIPTION
Since we added the use of git submodules recently, this trivial script has been helpful to me to "git clean" not only the top-level Open MPI repo, but also all the included submodules, too.

NOTE: this script does the (harsh) "git clean -dfx" command, which deletes everything that git does not know about.  Use with care!

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

This is just a script that is helpful to me (as a developer of Open MPI).  I open it here as a PR on the off chance that it might be helpful to other developers, too.