### PR TITLE
btl: change argument type of BTL receive callbacks

### DIFF
--- a/ompi/mca/pml/ob1/pml_ob1.h
+++ b/ompi/mca/pml/ob1/pml_ob1.h
@@ -311,8 +311,8 @@ void mca_pml_ob1_process_pending_rdma(void);
  * Compute the total number of bytes on supplied descriptor
  */
 static inline size_t
-mca_pml_ob1_compute_segment_length_base(mca_btl_base_segment_t *segments,
-                                        size_t count, size_t hdrlen)
+mca_pml_ob1_compute_segment_length_base (const mca_btl_base_segment_t *segments,
+                                         size_t count, size_t hdrlen)
 {
     size_t i, length = 0;
 
@@ -323,7 +323,7 @@ mca_pml_ob1_compute_segment_length_base(mca_btl_base_segment_t *segments,
 }
 
 static inline size_t
-mca_pml_ob1_compute_segment_length_remote (size_t seg_size, void *segments,
+mca_pml_ob1_compute_segment_length_remote (size_t seg_size, const void *segments,
                                            size_t count, ompi_proc_t *rem_proc)
 {
     mca_btl_base_segment_t *segment = (mca_btl_base_segment_t *) segments;

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.c
@@ -19,6 +19,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Sandia National Laboratories
  *                         All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,7 +76,7 @@ OBJ_CLASS_INSTANCE( mca_pml_ob1_recv_frag_t,
 
 static void
 append_frag_to_list(opal_list_t *queue, mca_btl_base_module_t *btl,
-                    mca_pml_ob1_match_hdr_t *hdr, mca_btl_base_segment_t* segments,
+                    const mca_pml_ob1_match_hdr_t *hdr, const mca_btl_base_segment_t *segments,
                     size_t num_segments, mca_pml_ob1_recv_frag_t* frag)
 {
     if(NULL == frag) {
@@ -89,7 +90,7 @@ append_frag_to_list(opal_list_t *queue, mca_btl_base_module_t *btl,
 
 static void
 append_frag_to_umq(custom_match_umq *queue, mca_btl_base_module_t *btl,
-                   mca_pml_ob1_match_hdr_t *hdr, mca_btl_base_segment_t* segments,
+                   const mca_pml_ob1_match_hdr_t *hdr, const mca_btl_base_segment_t *segments,
                    size_t num_segments, mca_pml_ob1_recv_frag_t* frag)
 {
   if(NULL == frag) {
@@ -113,20 +114,18 @@ append_frag_to_umq(custom_match_umq *queue, mca_btl_base_module_t *btl,
  * messages. On the vertical layer, messages with contiguous sequence
  * number organize themselves in a way to minimize the search space.
  */
-void
-append_frag_to_ordered_list(mca_pml_ob1_recv_frag_t** queue,
-                            mca_pml_ob1_recv_frag_t *frag,
-                            uint16_t seq)
+void append_frag_to_ordered_list (mca_pml_ob1_recv_frag_t **queue,
+                                  mca_pml_ob1_recv_frag_t *frag,
+                                  uint16_t seq)
 {
     mca_pml_ob1_recv_frag_t  *prior, *next;
-    mca_pml_ob1_match_hdr_t *hdr;
+    const mca_pml_ob1_match_hdr_t *hdr = &frag->hdr.hdr_match;
 
     frag->super.super.opal_list_next = (opal_list_item_t*)frag;
     frag->super.super.opal_list_prev = (opal_list_item_t*)frag;
     frag->range = NULL;
-    hdr = &frag->hdr.hdr_match;
 
-    if( NULL == *queue ) {  /* no pending fragments yet */
+    if (NULL == *queue) {  /* no pending fragments yet */
         *queue = frag;
         return;
     }
@@ -292,11 +291,11 @@ remove_head_from_ordered_list(mca_pml_ob1_recv_frag_t** queue)
  * @param type (IN)                 Type of the message header.
  * @return                          OMPI_SUCCESS or error status on failure.
  */
-static int mca_pml_ob1_recv_frag_match( mca_btl_base_module_t *btl,
-                                        mca_pml_ob1_match_hdr_t *hdr,
-                                        mca_btl_base_segment_t* segments,
+static int mca_pml_ob1_recv_frag_match (mca_btl_base_module_t *btl,
+                                        const mca_pml_ob1_match_hdr_t *hdr,
+                                        const mca_btl_base_segment_t *segments,
                                         size_t num_segments,
-                                        int type );
+                                        int type);
 
 /**
  * Match incoming frags against posted receives. If frag is not NULL then we assume
@@ -312,24 +311,23 @@ static int mca_pml_ob1_recv_frag_match( mca_btl_base_module_t *btl,
  * @return                          OMPI_SUCCESS or error status on failure.
  */
 static int
-mca_pml_ob1_recv_frag_match_proc( mca_btl_base_module_t *btl,
-                                  ompi_communicator_t* comm_ptr,
+mca_pml_ob1_recv_frag_match_proc (mca_btl_base_module_t *btl,
+                                  ompi_communicator_t *comm_ptr,
                                   mca_pml_ob1_comm_proc_t *proc,
-                                  mca_pml_ob1_match_hdr_t *hdr,
-                                  mca_btl_base_segment_t* segments,
+                                  const mca_pml_ob1_match_hdr_t *hdr,
+                                  const mca_btl_base_segment_t *segments,
                                   size_t num_segments,
                                   int type,
-                                  mca_pml_ob1_recv_frag_t* frag );
+                                  mca_pml_ob1_recv_frag_t *frag);
 
-static mca_pml_ob1_recv_request_t*
-match_one(mca_btl_base_module_t *btl,
-          mca_pml_ob1_match_hdr_t *hdr, mca_btl_base_segment_t* segments,
-          size_t num_segments, ompi_communicator_t *comm_ptr,
-          mca_pml_ob1_comm_proc_t *proc,
-          mca_pml_ob1_recv_frag_t* frag);
+static mca_pml_ob1_recv_request_t *match_one (mca_btl_base_module_t *btl,
+                                              const mca_pml_ob1_match_hdr_t *hdr,
+                                              const mca_btl_base_segment_t *segments,
+                                              size_t num_segments, ompi_communicator_t *comm_ptr,
+                                              mca_pml_ob1_comm_proc_t *proc,
+                                              mca_pml_ob1_recv_frag_t *frag);
 
-mca_pml_ob1_recv_frag_t*
-check_cantmatch_for_match(mca_pml_ob1_comm_proc_t *proc)
+mca_pml_ob1_recv_frag_t *check_cantmatch_for_match (mca_pml_ob1_comm_proc_t *proc)
 {
     mca_pml_ob1_recv_frag_t *frag = proc->frags_cant_match;
 
@@ -339,23 +337,21 @@ check_cantmatch_for_match(mca_pml_ob1_comm_proc_t *proc)
     return NULL;
 }
 
-void mca_pml_ob1_recv_frag_callback_match(mca_btl_base_module_t* btl,
-                                          mca_btl_base_tag_t tag,
-                                          mca_btl_base_descriptor_t* des,
-                                          void* cbdata )
+void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
+                                           const mca_btl_base_receive_descriptor_t *descriptor)
 {
-    mca_btl_base_segment_t* segments = des->des_segments;
-    mca_pml_ob1_match_hdr_t* hdr = (mca_pml_ob1_match_hdr_t*)segments->seg_addr.pval;
+    const mca_btl_base_segment_t *segments = descriptor->des_segments;
+    const mca_pml_ob1_match_hdr_t *hdr = (const mca_pml_ob1_match_hdr_t *) segments->seg_addr.pval;
     ompi_communicator_t *comm_ptr;
     mca_pml_ob1_recv_request_t *match = NULL;
     mca_pml_ob1_comm_t *comm;
     mca_pml_ob1_comm_proc_t *proc;
-    size_t num_segments = des->des_segment_count;
+    size_t num_segments = descriptor->des_segment_count;
     size_t bytes_received = 0;
 
     assert(num_segments <= MCA_BTL_DES_MAX_SEGMENTS);
 
-    if( OPAL_UNLIKELY(segments->seg_len < OMPI_PML_OB1_MATCH_HDR_LEN) ) {
+    if (OPAL_UNLIKELY(segments->seg_len < OMPI_PML_OB1_MATCH_HDR_LEN)) {
         return;
     }
     ob1_hdr_ntoh(((mca_pml_ob1_hdr_t*) hdr), MCA_PML_OB1_HDR_TYPE_MATCH);
@@ -513,63 +509,51 @@ void mca_pml_ob1_recv_frag_callback_match(mca_btl_base_module_t* btl,
             OB1_MATCHING_UNLOCK(&comm->matching_lock);
         }
     }
-
-    return;
 }
 
 
-void mca_pml_ob1_recv_frag_callback_rndv(mca_btl_base_module_t* btl,
-                                         mca_btl_base_tag_t tag,
-                                         mca_btl_base_descriptor_t* des,
-                                         void* cbdata )
+void mca_pml_ob1_recv_frag_callback_rndv (mca_btl_base_module_t *btl,
+                                          const mca_btl_base_receive_descriptor_t *descriptor)
 {
-    mca_btl_base_segment_t* segments = des->des_segments;
-    mca_pml_ob1_hdr_t* hdr = (mca_pml_ob1_hdr_t*)segments->seg_addr.pval;
+    const mca_btl_base_segment_t *segments = descriptor->des_segments;
+    const mca_pml_ob1_hdr_t *hdr = (mca_pml_ob1_hdr_t *) segments->seg_addr.pval;
 
     if( OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t)) ) {
         return;
     }
     ob1_hdr_ntoh(hdr, MCA_PML_OB1_HDR_TYPE_RNDV);
     mca_pml_ob1_recv_frag_match(btl, &hdr->hdr_match, segments,
-                                des->des_segment_count, MCA_PML_OB1_HDR_TYPE_RNDV);
-    return;
+                                descriptor->des_segment_count, MCA_PML_OB1_HDR_TYPE_RNDV);
 }
 
-void mca_pml_ob1_recv_frag_callback_rget(mca_btl_base_module_t* btl,
-                                         mca_btl_base_tag_t tag,
-                                         mca_btl_base_descriptor_t* des,
-                                         void* cbdata )
+void mca_pml_ob1_recv_frag_callback_rget (mca_btl_base_module_t *btl,
+                                          const mca_btl_base_receive_descriptor_t *descriptor)
 {
-    mca_btl_base_segment_t* segments = des->des_segments;
-    mca_pml_ob1_hdr_t* hdr = (mca_pml_ob1_hdr_t*)segments->seg_addr.pval;
+    const mca_btl_base_segment_t *segments = descriptor->des_segments;
+    const mca_pml_ob1_hdr_t *hdr = (mca_pml_ob1_hdr_t *) segments->seg_addr.pval;
 
     if( OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t)) ) {
         return;
     }
     ob1_hdr_ntoh(hdr, MCA_PML_OB1_HDR_TYPE_RGET);
     mca_pml_ob1_recv_frag_match(btl, &hdr->hdr_match, segments,
-                                des->des_segment_count, MCA_PML_OB1_HDR_TYPE_RGET);
-    return;
+                                descriptor->des_segment_count, MCA_PML_OB1_HDR_TYPE_RGET);
 }
 
-
-
-void mca_pml_ob1_recv_frag_callback_ack(mca_btl_base_module_t* btl,
-                                        mca_btl_base_tag_t tag,
-                                        mca_btl_base_descriptor_t* des,
-                                        void* cbdata )
+void mca_pml_ob1_recv_frag_callback_ack (mca_btl_base_module_t *btl,
+                                         const mca_btl_base_receive_descriptor_t *descriptor)
 {
-    mca_btl_base_segment_t* segments = des->des_segments;
-    mca_pml_ob1_hdr_t* hdr = (mca_pml_ob1_hdr_t*)segments->seg_addr.pval;
+    const mca_btl_base_segment_t *segments = descriptor->des_segments;
+    const mca_pml_ob1_hdr_t *hdr = (mca_pml_ob1_hdr_t *) segments->seg_addr.pval;
     mca_pml_ob1_send_request_t* sendreq;
     size_t size;
 
-    if( OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t)) ) {
+    if (OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t))) {
          return;
     }
 
     ob1_hdr_ntoh(hdr, MCA_PML_OB1_HDR_TYPE_ACK);
-    sendreq = (mca_pml_ob1_send_request_t*)hdr->hdr_ack.hdr_src_req.pval;
+    sendreq = (mca_pml_ob1_send_request_t *) hdr->hdr_ack.hdr_src_req.pval;
     sendreq->req_recv = hdr->hdr_ack.hdr_dst_req;
 
     /* if the request should be delivered entirely by copy in/out
@@ -615,21 +599,18 @@ void mca_pml_ob1_recv_frag_callback_ack(mca_btl_base_module_t* btl,
     }
 #endif /* OPAL_CUDA_SUPPORT */
 
-    if(send_request_pml_complete_check(sendreq) == false)
+    if (send_request_pml_complete_check(sendreq) == false)
         mca_pml_ob1_send_request_schedule(sendreq);
-
-    return;
 }
 
-void mca_pml_ob1_recv_frag_callback_frag(mca_btl_base_module_t* btl,
-                                         mca_btl_base_tag_t tag,
-                                         mca_btl_base_descriptor_t* des,
-                                         void* cbdata ) {
-    mca_btl_base_segment_t* segments = des->des_segments;
-    mca_pml_ob1_hdr_t* hdr = (mca_pml_ob1_hdr_t*)segments->seg_addr.pval;
+void mca_pml_ob1_recv_frag_callback_frag (mca_btl_base_module_t *btl,
+                                          const mca_btl_base_receive_descriptor_t *descriptor)
+{
+    const mca_btl_base_segment_t *segments = descriptor->des_segments;
+    const mca_pml_ob1_hdr_t *hdr = (mca_pml_ob1_hdr_t *) segments->seg_addr.pval;
     mca_pml_ob1_recv_request_t* recvreq;
 
-    if( OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t)) ) {
+    if (OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t))) {
         return;
     }
 
@@ -643,54 +624,47 @@ void mca_pml_ob1_recv_frag_callback_frag(mca_btl_base_module_t* btl,
         assert(btl->btl_flags & MCA_BTL_FLAGS_CUDA_COPY_ASYNC_RECV);
 
         /* This will trigger the opal_convertor_pack to start asynchronous copy. */
-        mca_pml_ob1_recv_request_frag_copy_start(recvreq,btl,segments,des->des_segment_count,des);
+        mca_pml_ob1_recv_request_frag_copy_start(recvreq,btl,segments,descriptor->des_segment_count,des);
 
         /* Let BTL know that it CANNOT free the frag */
-        des->des_flags |= MCA_BTL_DES_FLAGS_CUDA_COPY_ASYNC;
+        descriptor->des_flags |= MCA_BTL_DES_FLAGS_CUDA_COPY_ASYNC;
 
         return;
     }
 #endif /* OPAL_CUDA_SUPPORT */
 
-    mca_pml_ob1_recv_request_progress_frag(recvreq,btl,segments,des->des_segment_count);
-
-    return;
+    mca_pml_ob1_recv_request_progress_frag(recvreq,btl,segments,descriptor->des_segment_count);
 }
 
 
-void mca_pml_ob1_recv_frag_callback_put(mca_btl_base_module_t* btl,
-                                        mca_btl_base_tag_t tag,
-                                        mca_btl_base_descriptor_t* des,
-                                        void* cbdata ) {
-    mca_btl_base_segment_t* segments = des->des_segments;
-    mca_pml_ob1_hdr_t* hdr = (mca_pml_ob1_hdr_t*)segments->seg_addr.pval;
-    mca_pml_ob1_send_request_t* sendreq;
+void mca_pml_ob1_recv_frag_callback_put (mca_btl_base_module_t *btl,
+                                         const mca_btl_base_receive_descriptor_t *descriptor)
+{
+    const mca_btl_base_segment_t *segments = descriptor->des_segments;
+    const mca_pml_ob1_hdr_t *hdr = (mca_pml_ob1_hdr_t *) segments->seg_addr.pval;
+    mca_pml_ob1_send_request_t *sendreq;
 
-    if( OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t)) ) {
+    if (OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_common_hdr_t))) {
         return;
     }
 
-    ob1_hdr_ntoh(hdr, MCA_PML_OB1_HDR_TYPE_PUT);
-    sendreq = (mca_pml_ob1_send_request_t*)hdr->hdr_rdma.hdr_req.pval;
-    mca_pml_ob1_send_request_put(sendreq,btl,&hdr->hdr_rdma);
-
-    return;
+    ob1_hdr_ntoh (hdr, MCA_PML_OB1_HDR_TYPE_PUT);
+    sendreq = (mca_pml_ob1_send_request_t *) hdr->hdr_rdma.hdr_req.pval;
+    mca_pml_ob1_send_request_put (sendreq, btl, &hdr->hdr_rdma);
 }
 
-
-void mca_pml_ob1_recv_frag_callback_fin(mca_btl_base_module_t* btl,
-                                        mca_btl_base_tag_t tag,
-                                        mca_btl_base_descriptor_t* des,
-                                        void* cbdata ) {
-    mca_btl_base_segment_t* segments = des->des_segments;
-    mca_pml_ob1_fin_hdr_t* hdr = (mca_pml_ob1_fin_hdr_t *) segments->seg_addr.pval;
+void mca_pml_ob1_recv_frag_callback_fin(mca_btl_base_module_t *btl,
+                                        const mca_btl_base_receive_descriptor_t *descriptor)
+{
+    const mca_btl_base_segment_t *segments = descriptor->des_segments;
+    const mca_pml_ob1_fin_hdr_t *hdr = (mca_pml_ob1_fin_hdr_t *) segments->seg_addr.pval;
     mca_pml_ob1_rdma_frag_t *frag;
 
-    if( OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_fin_hdr_t)) ) {
+    if (OPAL_UNLIKELY(segments->seg_len < sizeof(mca_pml_ob1_fin_hdr_t))) {
         return;
     }
 
-    ob1_hdr_ntoh((union mca_pml_ob1_hdr_t *)hdr, MCA_PML_OB1_HDR_TYPE_FIN);
+    ob1_hdr_ntoh ((union mca_pml_ob1_hdr_t *) hdr, MCA_PML_OB1_HDR_TYPE_FIN);
     frag = (mca_pml_ob1_rdma_frag_t *) hdr->hdr_frag.pval;
     frag->cbfunc (frag, hdr->hdr_size);
 }
@@ -719,9 +693,9 @@ static inline mca_pml_ob1_recv_request_t* get_next_posted_recv(
     return (mca_pml_ob1_recv_request_t*)i;
 }
 
-static mca_pml_ob1_recv_request_t *match_incomming(
-        mca_pml_ob1_match_hdr_t *hdr, mca_pml_ob1_comm_t *comm,
-        mca_pml_ob1_comm_proc_t *proc)
+static mca_pml_ob1_recv_request_t *match_incomming(const mca_pml_ob1_match_hdr_t *hdr,
+                                                   mca_pml_ob1_comm_t *comm,
+                                                   mca_pml_ob1_comm_proc_t *proc)
 {
 #if !MCA_PML_OB1_CUSTOM_MATCH
     mca_pml_ob1_recv_request_t *specific_recv, *wild_recv;
@@ -772,9 +746,9 @@ static mca_pml_ob1_recv_request_t *match_incomming(
 }
 
 #if !MCA_PML_OB1_CUSTOM_MATCH
-static mca_pml_ob1_recv_request_t *match_incomming_no_any_source (
-        mca_pml_ob1_match_hdr_t *hdr, mca_pml_ob1_comm_t *comm,
-        mca_pml_ob1_comm_proc_t *proc)
+static mca_pml_ob1_recv_request_t *match_incomming_no_any_source (const mca_pml_ob1_match_hdr_t *hdr,
+                                                                  mca_pml_ob1_comm_t *comm,
+                                                                  mca_pml_ob1_comm_proc_t *proc)
 {
     mca_pml_ob1_recv_request_t *recv_req;
     int tag = hdr->hdr_tag;
@@ -794,12 +768,12 @@ static mca_pml_ob1_recv_request_t *match_incomming_no_any_source (
 }
 #endif
 
-static mca_pml_ob1_recv_request_t*
-match_one(mca_btl_base_module_t *btl,
-          mca_pml_ob1_match_hdr_t *hdr, mca_btl_base_segment_t* segments,
-          size_t num_segments, ompi_communicator_t *comm_ptr,
-          mca_pml_ob1_comm_proc_t *proc,
-          mca_pml_ob1_recv_frag_t* frag)
+static mca_pml_ob1_recv_request_t *match_one (mca_btl_base_module_t *btl,
+                                              const mca_pml_ob1_match_hdr_t *hdr,
+                                              const mca_btl_base_segment_t *segments,
+                                              size_t num_segments, ompi_communicator_t *comm_ptr,
+                                              mca_pml_ob1_comm_proc_t *proc,
+                                              mca_pml_ob1_recv_frag_t* frag)
 {
 #if SPC_ENABLE == 1
     opal_timer_t timer = 0;
@@ -905,9 +879,9 @@ match_one(mca_btl_base_module_t *btl,
  *   - fragments may be corrupt
  *   - this routine may be called simultaneously by more than one thread
  */
-static int mca_pml_ob1_recv_frag_match( mca_btl_base_module_t *btl,
-                                        mca_pml_ob1_match_hdr_t *hdr,
-                                        mca_btl_base_segment_t* segments,
+static int mca_pml_ob1_recv_frag_match (mca_btl_base_module_t *btl,
+                                        const mca_pml_ob1_match_hdr_t *hdr,
+                                        const mca_btl_base_segment_t *segments,
                                         size_t num_segments,
                                         int type)
 {
@@ -989,17 +963,17 @@ static int mca_pml_ob1_recv_frag_match( mca_btl_base_module_t *btl,
  * ATTENTION: THIS FUNCTION MUST BE CALLED WITH COMMUNICATOR LOCK HELD.
  * THE LOCK WILL BE RELEASED UPON RETURN. USE WITH CARE. */
 static int
-mca_pml_ob1_recv_frag_match_proc( mca_btl_base_module_t *btl,
+mca_pml_ob1_recv_frag_match_proc (mca_btl_base_module_t *btl,
                                   ompi_communicator_t* comm_ptr,
                                   mca_pml_ob1_comm_proc_t *proc,
-                                  mca_pml_ob1_match_hdr_t *hdr,
-                                  mca_btl_base_segment_t* segments,
+                                  const mca_pml_ob1_match_hdr_t *hdr,
+                                  const mca_btl_base_segment_t *segments,
                                   size_t num_segments,
                                   int type,
-                                  mca_pml_ob1_recv_frag_t* frag )
+                                  mca_pml_ob1_recv_frag_t *frag)
 {
     /* local variables */
-    mca_pml_ob1_comm_t* comm = (mca_pml_ob1_comm_t *)comm_ptr->c_pml_comm;
+    mca_pml_ob1_comm_t *comm = (mca_pml_ob1_comm_t *)comm_ptr->c_pml_comm;
     mca_pml_ob1_recv_request_t *match = NULL;
 
     /* If we are here, this is the sequence number we were expecting,

--- a/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvfrag.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -113,60 +114,49 @@ do {                                                                    \
  *  Callback from BTL on receipt of a recv_frag (match).
  */
 
-extern void mca_pml_ob1_recv_frag_callback_match( mca_btl_base_module_t *btl,
-                                                  mca_btl_base_tag_t tag,
-                                                  mca_btl_base_descriptor_t* descriptor,
-                                                  void* cbdata );
+extern void mca_pml_ob1_recv_frag_callback_match (mca_btl_base_module_t *btl,
+                                                  const mca_btl_base_receive_descriptor_t *descriptor);
 
 /**
  *  Callback from BTL on receipt of a recv_frag (rndv).
  */
 
-extern void mca_pml_ob1_recv_frag_callback_rndv( mca_btl_base_module_t *btl,
-                                                 mca_btl_base_tag_t tag,
-                                                 mca_btl_base_descriptor_t* descriptor,
-                                                 void* cbdata );
+extern void mca_pml_ob1_recv_frag_callback_rndv (mca_btl_base_module_t *btl,
+                                                 const mca_btl_base_receive_descriptor_t *descriptor);
 /**
  *  Callback from BTL on receipt of a recv_frag (rget).
  */
 
-extern void mca_pml_ob1_recv_frag_callback_rget( mca_btl_base_module_t *btl,
-                                                 mca_btl_base_tag_t tag,
-                                                 mca_btl_base_descriptor_t* descriptor,
-                                                 void* cbdata );
+extern void mca_pml_ob1_recv_frag_callback_rget (mca_btl_base_module_t *btl,
+                                                 const mca_btl_base_receive_descriptor_t *descriptor);
 
 /**
  *  Callback from BTL on receipt of a recv_frag (ack).
  */
 
-extern void mca_pml_ob1_recv_frag_callback_ack( mca_btl_base_module_t *btl,
-                                                mca_btl_base_tag_t tag,
-                                                mca_btl_base_descriptor_t* descriptor,
-                                                void* cbdata );
+extern void mca_pml_ob1_recv_frag_callback_ack (mca_btl_base_module_t *btl,
+                                                const mca_btl_base_receive_descriptor_t *descriptor);
+
 /**
  *  Callback from BTL on receipt of a recv_frag (frag).
  */
 
-extern void mca_pml_ob1_recv_frag_callback_frag( mca_btl_base_module_t *btl,
-                                                 mca_btl_base_tag_t tag,
-                                                 mca_btl_base_descriptor_t* descriptor,
-                                                 void* cbdata );
+extern void mca_pml_ob1_recv_frag_callback_frag (mca_btl_base_module_t *btl,
+                                                 const mca_btl_base_receive_descriptor_t *descriptor);
+
 /**
  *  Callback from BTL on receipt of a recv_frag (put).
  */
 
-extern void mca_pml_ob1_recv_frag_callback_put( mca_btl_base_module_t *btl,
-                                                mca_btl_base_tag_t tag,
-                                                mca_btl_base_descriptor_t* descriptor,
-                                                void* cbdata );
+extern void mca_pml_ob1_recv_frag_callback_put (mca_btl_base_module_t *btl,
+                                                const mca_btl_base_receive_descriptor_t *descriptor);
+
 /**
  *  Callback from BTL on receipt of a recv_frag (fin).
  */
 
-extern void mca_pml_ob1_recv_frag_callback_fin( mca_btl_base_module_t *btl,
-                                                mca_btl_base_tag_t tag,
-                                                mca_btl_base_descriptor_t* descriptor,
-                                                void* cbdata );
+extern void mca_pml_ob1_recv_frag_callback_fin (mca_btl_base_module_t *btl,
+                                                const mca_btl_base_receive_descriptor_t *descriptor);
 
 /**
  * Extract the next fragment from the cant_match ordered list. This fragment

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.c
@@ -20,6 +20,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Sandia National Laboratories
  *                         All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -517,7 +518,7 @@ int mca_pml_ob1_recv_request_get_frag (mca_pml_ob1_rdma_frag_t *frag)
 
 void mca_pml_ob1_recv_request_progress_frag( mca_pml_ob1_recv_request_t* recvreq,
                                              mca_btl_base_module_t* btl,
-                                             mca_btl_base_segment_t* segments,
+                                             const mca_btl_base_segment_t* segments,
                                              size_t num_segments )
 {
     size_t bytes_received, data_offset = 0;
@@ -652,7 +653,7 @@ void mca_pml_ob1_recv_request_frag_copy_finished( mca_btl_base_module_t* btl,
 
 void mca_pml_ob1_recv_request_progress_rget( mca_pml_ob1_recv_request_t* recvreq,
                                              mca_btl_base_module_t* btl,
-                                             mca_btl_base_segment_t* segments,
+                                             const mca_btl_base_segment_t* segments,
                                              size_t num_segments )
 {
     mca_pml_ob1_rget_hdr_t* hdr = (mca_pml_ob1_rget_hdr_t*)segments->seg_addr.pval;
@@ -806,7 +807,7 @@ void mca_pml_ob1_recv_request_progress_rget( mca_pml_ob1_recv_request_t* recvreq
 
 void mca_pml_ob1_recv_request_progress_rndv( mca_pml_ob1_recv_request_t* recvreq,
                                              mca_btl_base_module_t* btl,
-                                             mca_btl_base_segment_t* segments,
+                                             const mca_btl_base_segment_t* segments,
                                              size_t num_segments )
 {
     size_t bytes_received = 0;
@@ -876,7 +877,7 @@ void mca_pml_ob1_recv_request_progress_rndv( mca_pml_ob1_recv_request_t* recvreq
  */
 void mca_pml_ob1_recv_request_progress_match( mca_pml_ob1_recv_request_t* recvreq,
                                               mca_btl_base_module_t* btl,
-                                              mca_btl_base_segment_t* segments,
+                                              const mca_btl_base_segment_t* segments,
                                               size_t num_segments )
 {
     size_t bytes_received, data_offset = 0;
@@ -932,7 +933,7 @@ void mca_pml_ob1_recv_request_progress_match( mca_pml_ob1_recv_request_t* recvre
 
 void mca_pml_ob1_recv_request_matched_probe( mca_pml_ob1_recv_request_t* recvreq,
                                              mca_btl_base_module_t* btl,
-                                             mca_btl_base_segment_t* segments,
+                                             const mca_btl_base_segment_t* segments,
                                              size_t num_segments )
 {
     size_t bytes_packed = 0;

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -239,7 +240,7 @@ static inline void prepare_recv_req_converter(mca_pml_ob1_recv_request_t *req)
     recv_req_matched(request, hdr)
 
 static inline void recv_req_matched(mca_pml_ob1_recv_request_t *req,
-                                    mca_pml_ob1_match_hdr_t *hdr)
+                                    const mca_pml_ob1_match_hdr_t *hdr)
 {
     req->req_recv.req_base.req_ompi.req_status.MPI_SOURCE = hdr->hdr_src;
     req->req_recv.req_base.req_ompi.req_status.MPI_TAG = hdr->hdr_tag;
@@ -278,7 +279,7 @@ do {                                                                            
         uint32_t iov_count = 0;                                                   \
         size_t max_data = bytes_received;                                         \
         size_t n, offset = seg_offset;                                            \
-        mca_btl_base_segment_t* segment = segments;                               \
+        const mca_btl_base_segment_t *segment = segments;                         \
                                                                                   \
         for( n = 0; n < num_segments; n++, segment++ ) {                          \
             if(offset >= segment->seg_len) {                                      \
@@ -314,7 +315,7 @@ do {                                                                            
 void mca_pml_ob1_recv_request_progress_match(
     mca_pml_ob1_recv_request_t* req,
     struct mca_btl_base_module_t* btl,
-    mca_btl_base_segment_t* segments,
+    const mca_btl_base_segment_t* segments,
     size_t num_segments);
 
 /**
@@ -324,7 +325,7 @@ void mca_pml_ob1_recv_request_progress_match(
 void mca_pml_ob1_recv_request_progress_frag(
     mca_pml_ob1_recv_request_t* req,
     struct mca_btl_base_module_t* btl,
-    mca_btl_base_segment_t* segments,
+    const mca_btl_base_segment_t* segments,
     size_t num_segments);
 
 #if OPAL_CUDA_SUPPORT
@@ -347,7 +348,7 @@ void mca_pml_ob1_recv_request_frag_copy_finished(struct mca_btl_base_module_t* b
 void mca_pml_ob1_recv_request_progress_rndv(
     mca_pml_ob1_recv_request_t* req,
     struct mca_btl_base_module_t* btl,
-    mca_btl_base_segment_t* segments,
+    const mca_btl_base_segment_t* segments,
     size_t num_segments);
 
 /**
@@ -357,7 +358,7 @@ void mca_pml_ob1_recv_request_progress_rndv(
 void mca_pml_ob1_recv_request_progress_rget(
     mca_pml_ob1_recv_request_t* req,
     struct mca_btl_base_module_t* btl,
-    mca_btl_base_segment_t* segments,
+    const mca_btl_base_segment_t* segments,
     size_t num_segments);
 
 /**
@@ -367,7 +368,7 @@ void mca_pml_ob1_recv_request_progress_rget(
 void mca_pml_ob1_recv_request_matched_probe(
     mca_pml_ob1_recv_request_t* req,
     struct mca_btl_base_module_t* btl,
-    mca_btl_base_segment_t* segments,
+    const mca_btl_base_segment_t* segments,
     size_t num_segments);
 
 /**

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.c
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.c
@@ -1216,9 +1216,9 @@ int mca_pml_ob1_send_request_put_frag( mca_pml_ob1_rdma_frag_t *frag )
  *  (3) Queue the RDMA put
  */
 
-void mca_pml_ob1_send_request_put( mca_pml_ob1_send_request_t* sendreq,
-                                   mca_btl_base_module_t* btl,
-                                   mca_pml_ob1_rdma_hdr_t* hdr )
+void mca_pml_ob1_send_request_put (mca_pml_ob1_send_request_t *sendreq,
+                                   mca_btl_base_module_t *btl,
+                                   const mca_pml_ob1_rdma_hdr_t *hdr)
 {
     mca_bml_base_endpoint_t *bml_endpoint = sendreq->req_endpoint;
     mca_pml_ob1_rdma_frag_t* frag;

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -512,9 +512,9 @@ mca_pml_ob1_send_request_start( mca_pml_ob1_send_request_t* sendreq )
  *  Initiate a put scheduled by the receiver.
  */
 
-void mca_pml_ob1_send_request_put( mca_pml_ob1_send_request_t* sendreq,
-                                   mca_btl_base_module_t* btl,
-                                   mca_pml_ob1_rdma_hdr_t* hdr );
+void mca_pml_ob1_send_request_put (mca_pml_ob1_send_request_t *sendreq,
+                                   mca_btl_base_module_t *btl,
+                                   const mca_pml_ob1_rdma_hdr_t *hdr);
 
 int mca_pml_ob1_send_request_put_frag(mca_pml_ob1_rdma_frag_t* frag);
 

--- a/opal/mca/btl/self/btl_self.c
+++ b/opal/mca/btl/self/btl_self.c
@@ -15,6 +15,7 @@
  *                         reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -204,12 +205,16 @@ static int mca_btl_self_send (struct mca_btl_base_module_t *btl,
                               struct mca_btl_base_descriptor_t *des,
                               mca_btl_base_tag_t tag)
 {
-    mca_btl_active_message_callback_t* reg;
+    mca_btl_active_message_callback_t *reg = mca_btl_base_active_message_trigger + tag;
+    mca_btl_base_receive_descriptor_t recv_desc = {.endpoint = endpoint,
+                                                   .des_segments = des->des_segments,
+                                                   .des_segment_count = des->des_segment_count,
+                                                   .tag = tag,
+                                                   .cbdata = reg->cbdata};
     int btl_ownership = (des->des_flags & MCA_BTL_DES_FLAGS_BTL_OWNERSHIP);
 
     /* upcall */
-    reg = mca_btl_base_active_message_trigger + tag;
-    reg->cbfunc( btl, tag, des, reg->cbdata );
+    reg->cbfunc (btl, &recv_desc);
 
     /* send completion */
     if( des->des_flags & MCA_BTL_DES_SEND_ALWAYS_CALLBACK ) {

--- a/opal/mca/btl/sm/btl_sm_fbox.h
+++ b/opal/mca/btl/sm/btl_sm_fbox.h
@@ -211,9 +211,11 @@ static inline bool mca_btl_sm_check_fboxes (void)
             /* the 0xff tag indicates we should skip the rest of the buffer */
             if (OPAL_LIKELY((0xfe & hdr.data.tag) != 0xfe)) {
                 mca_btl_base_segment_t segment;
-                mca_btl_base_descriptor_t desc = {.des_segments = &segment, .des_segment_count = 1};
                 const mca_btl_active_message_callback_t *reg =
                     mca_btl_base_active_message_trigger + hdr.data.tag;
+                mca_btl_base_receive_descriptor_t desc = {.endpoint = ep, .des_segments = &segment,
+                                                          .des_segment_count = 1, .tag = hdr.data.tag,
+                                                          .cbdata = reg->cbdata};
 
                 /* fragment fits entirely in the remaining buffer space. some
                  * btl users do not handle fragmented data so we can't split
@@ -224,7 +226,7 @@ static inline bool mca_btl_sm_check_fboxes (void)
                 segment.seg_addr.pval = (void *) (ep->fbox_in.buffer + start + sizeof (hdr));
 
                 /* call the registered callback function */
-                reg->cbfunc(&mca_btl_sm.super, hdr.data.tag, &desc, reg->cbdata);
+                reg->cbfunc(&mca_btl_sm.super, &desc);
             } else if (OPAL_LIKELY(0xfe == hdr.data.tag)) {
                 /* process fragment header */
                 fifo_value_t *value = (fifo_value_t *)(ep->fbox_in.buffer + start + sizeof (hdr));

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -68,14 +68,6 @@ extern opal_event_base_t* mca_btl_tcp_event_base;
             MCA_BTL_TCP_FRAG_RETURN(frag);                              \
         }                                                               \
     } while (0)
-#define MCA_BTL_TCP_RECV_TRIGGER_CB(frag)                               \
-    do {                                                                \
-        if( MCA_BTL_TCP_HDR_TYPE_SEND == frag->hdr.type ) {             \
-            mca_btl_active_message_callback_t* reg;                     \
-            reg = mca_btl_base_active_message_trigger + frag->hdr.base.tag; \
-            reg->cbfunc(&frag->endpoint->endpoint_btl->super, frag->hdr.base.tag, &frag->base, reg->cbdata); \
-        }                                                               \
-    } while (0)
 
 extern opal_list_t mca_btl_tcp_ready_frag_pending_queue;
 extern opal_mutex_t mca_btl_tcp_ready_frag_mutex;

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -15,6 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1016,9 +1018,15 @@ static void mca_btl_tcp_endpoint_recv_handler(int sd, short flags, void* user)
             } else {
                 btl_endpoint->endpoint_recv_frag = NULL;
                 if( MCA_BTL_TCP_HDR_TYPE_SEND == frag->hdr.type ) {
-                    mca_btl_active_message_callback_t* reg;
-                    reg = mca_btl_base_active_message_trigger + frag->hdr.base.tag;
-                    reg->cbfunc(&frag->btl->super, frag->hdr.base.tag, &frag->base, reg->cbdata);
+                    mca_btl_active_message_callback_t *reg =
+                      mca_btl_base_active_message_trigger + frag->hdr.base.tag;
+                    const mca_btl_base_receive_descriptor_t desc =
+                      {.endpoint = btl_endpoint,
+                       .des_segments = frag->base.des_segments,
+                       .des_segment_count = frag->base.des_segment_count,
+                       .tag = frag->hdr.base.tag,
+                       .cbdata = reg->cbdata};
+                    reg->cbfunc(&frag->btl->super, &desc);
                 }
 #if MCA_BTL_TCP_ENDPOINT_CACHE
                 if( 0 != btl_endpoint->endpoint_cache_length ) {

--- a/opal/mca/btl/ugni/btl_ugni.h
+++ b/opal/mca/btl/ugni/btl_ugni.h
@@ -303,10 +303,10 @@ OPAL_MODULE_DECLSPEC extern mca_btl_ugni_module_t mca_btl_ugni_module;
 
 static inline uint32_t mca_btl_ugni_ep_get_device_index (mca_btl_ugni_module_t *ugni_module)
 {
-    static volatile uint32_t device_index = (uint32_t) 0;
+    static opal_atomic_int64_t device_index = 0;
 
     /* don't really care if the device index is atomically updated */
-    return opal_atomic_fetch_add_32 ((volatile int32_t *) &device_index, 1) % mca_btl_ugni_component.virtual_device_count;
+    return (uint32_t) (opal_atomic_fetch_add_64 (&device_index, 1) % mca_btl_ugni_component.virtual_device_count);
 }
 
 /**

--- a/opal/mca/btl/usnic/btl_usnic_frag.h
+++ b/opal/mca/btl/usnic/btl_usnic_frag.h
@@ -199,7 +199,7 @@ struct opal_btl_usnic_endpoint_t;
  */
 typedef struct opal_btl_usnic_recv_segment_t {
     opal_btl_usnic_segment_t rs_base;
-    mca_btl_base_descriptor_t rs_desc;
+    mca_btl_base_receive_descriptor_t rs_desc;
     mca_btl_base_segment_t rs_segment;
 
     /* receive segments have protocol header prepended */

--- a/opal/mca/btl/usnic/btl_usnic_recv.h
+++ b/opal/mca/btl/usnic/btl_usnic_recv.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2013-2017 Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
@@ -329,8 +330,10 @@ opal_btl_usnic_dump_hex(15, USNIC_OUT, bseg->us_btl_header, bseg->us_btl_header-
          */
         reg = mca_btl_base_active_message_trigger + bseg->us_btl_header->tag;
         seg->rs_segment.seg_len = bseg->us_btl_header->payload_len;
-        reg->cbfunc(&module->super, bseg->us_btl_header->tag,
-                    &seg->rs_desc, reg->cbdata);
+        seg->rs_desc.endpoint = endpoint;
+        seg->rs_desc.tag = bseg->us_btl_header->tag;
+        seg->rs_desc.cbdata = reg->cbdata;
+        reg->cbfunc(&module->super, &seg->rs_desc);
 
 drop:
         channel->chan_deferred_recv = seg;
@@ -437,8 +440,9 @@ opal_btl_usnic_recv(opal_btl_usnic_module_t *module,
          */
         reg = mca_btl_base_active_message_trigger + bseg->us_btl_header->tag;
         seg->rs_segment.seg_len = bseg->us_btl_header->payload_len;
-        reg->cbfunc(&module->super, bseg->us_btl_header->tag,
-                    &seg->rs_desc, reg->cbdata);
+        seg->rs_desc.tag = bseg->us_btl_header->tag;
+        seg->rs_desc.cbdata = reg->cbdata;
+        reg->cbfunc(&module->super, &seg->rs_desc);
 
     }
 


### PR DESCRIPTION
This commit updates the btl interface to change the parameters
passed to receive callbacks. The interface used to pass the tag,
a btl base descriptor, and the callback context. Most of the
values in the btl base descriptor were unused and only helped
simplify the callbacks from the self btl. All of the arguments
have now been replaced with a single receive callback descriptor.
This descriptor contains the incoming endpoint, data segment(s),
tag, and callback context. All btls have been updated to use
the new callback and the btl interface version has been bumped
to v3.2.0.

As part of this change the descriptor argument (and the segments
contained within it) have been marked as const. The were treated
as const before but this change could allow the compiler to make
better optimization decisions and will enforce that the callback
does not attempt to change the data in the descriptor.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>