### PR TITLE
Fix icc 2330 warning for stdatomic.h

### DIFF
--- a/ompi/communicator/comm_request.c
+++ b/ompi/communicator/comm_request.c
@@ -99,7 +99,7 @@ int ompi_comm_request_schedule_append (ompi_comm_request_t *request, ompi_comm_r
 static int ompi_comm_request_progress (void)
 {
     ompi_comm_request_t *request, *next;
-    static opal_atomic_int32_t progressing = 0;
+    static volatile int32_t progressing = 0;
     int completed = 0;
 
     /* don't allow re-entry */

--- a/ompi/datatype/ompi_datatype.h
+++ b/ompi/datatype/ompi_datatype.h
@@ -76,7 +76,7 @@ struct ompi_datatype_t {
     struct opal_hash_table_t *d_keyhash;         /**< Attribute fields */
 
     void*              args;                     /**< Data description for the user */
-    opal_atomic_intptr_t packed_description;     /**< Packed description of the datatype */
+    volatile intptr_t  packed_description;     /**< Packed description of the datatype */
     uint64_t           pml_data;                 /**< PML-specific information */
     /* --- cacheline 6 boundary (384 bytes) --- */
     char               name[MPI_MAX_OBJECT_NAME];/**< Externally visible name */

--- a/ompi/datatype/ompi_datatype_args.c
+++ b/ompi/datatype/ompi_datatype_args.c
@@ -45,7 +45,7 @@ __ompi_datatype_create_from_args( int32_t* i, ptrdiff_t * a,
                                   ompi_datatype_t** d, int32_t type );
 
 typedef struct __dt_args {
-    opal_atomic_int32_t ref_count;
+    volatile int32_t   ref_count;
     int32_t            create_type;
     size_t             total_pack_size;
     int32_t            ci;

--- a/ompi/group/group.h
+++ b/ompi/group/group.h
@@ -356,7 +356,7 @@ static inline struct ompi_proc_t *ompi_group_dense_lookup (ompi_group_t *group, 
         ompi_proc_t *real_proc =
             (ompi_proc_t *) ompi_proc_for_name (ompi_proc_sentinel_to_name ((uintptr_t) proc));
 
-        if (opal_atomic_compare_exchange_strong_ptr ((opal_atomic_intptr_t *)(group->grp_proc_pointers + peer_id),
+        if (opal_atomic_compare_exchange_strong_ptr ((volatile intptr_t *)(group->grp_proc_pointers + peer_id),
                                                      (intptr_t *) &proc, (intptr_t) real_proc)) {
             OBJ_RETAIN(real_proc);
         }

--- a/ompi/mca/coll/libnbc/coll_libnbc.h
+++ b/ompi/mca/coll/libnbc/coll_libnbc.h
@@ -82,7 +82,7 @@ struct ompi_coll_libnbc_component_t {
     mca_coll_base_component_2_0_0_t super;
     opal_free_list_t requests;
     opal_list_t active_requests;
-    opal_atomic_int32_t active_comms;
+    volatile int32_t active_comms;
     opal_mutex_t lock;                /* protect access to the active_requests list */
 };
 typedef struct ompi_coll_libnbc_component_t ompi_coll_libnbc_component_t;

--- a/ompi/mca/coll/monitoring/coll_monitoring.h
+++ b/ompi/mca/coll/monitoring/coll_monitoring.h
@@ -36,7 +36,7 @@ struct mca_coll_monitoring_module_t {
     mca_coll_base_module_t super;
     mca_coll_base_comm_coll_t real;
     mca_monitoring_coll_data_t*data;
-    opal_atomic_int32_t is_initialized;
+    volatile int32_t is_initialized;
 };
 typedef struct mca_coll_monitoring_module_t mca_coll_monitoring_module_t;
 OMPI_DECLSPEC OBJ_CLASS_DECLARATION(mca_coll_monitoring_module_t);

--- a/ompi/mca/coll/sm/coll_sm.h
+++ b/ompi/mca/coll/sm/coll_sm.h
@@ -114,7 +114,7 @@ BEGIN_C_DECLS
     typedef struct mca_coll_sm_in_use_flag_t {
         /** Number of processes currently using this set of
             segments */
-        opal_atomic_uint32_t mcsiuf_num_procs_using;
+        volatile uint32_t mcsiuf_num_procs_using;
         /** Must match data->mcb_count */
         volatile uint32_t mcsiuf_operation_count;
     } mca_coll_sm_in_use_flag_t;
@@ -152,7 +152,7 @@ BEGIN_C_DECLS
         /** Pointer to my parent's barrier control pages (will be NULL
             for communicator rank 0; odd index pages are "in", even
             index pages are "out") */
-        opal_atomic_uint32_t *mcb_barrier_control_parent;
+        volatile uint32_t *mcb_barrier_control_parent;
 
         /** Pointers to my childrens' barrier control pages (they're
             contiguous in memory, so we only point to the base -- the

--- a/ompi/mca/coll/sm/coll_sm_barrier.c
+++ b/ompi/mca/coll/sm/coll_sm_barrier.c
@@ -57,7 +57,7 @@ int mca_coll_sm_barrier_intra(struct ompi_communicator_t *comm,
     mca_coll_sm_comm_t *data;
     uint32_t i, num_children;
     volatile uint32_t *me_in, *me_out, *children = NULL;
-    opal_atomic_uint32_t *parent;
+    volatile uint32_t *parent;
     int uint_control_size;
     mca_coll_sm_module_t *sm_module = (mca_coll_sm_module_t*) module;
 

--- a/ompi/mca/coll/sm/coll_sm_module.c
+++ b/ompi/mca/coll/sm/coll_sm_module.c
@@ -374,7 +374,7 @@ int ompi_coll_sm_lazy_enable(mca_coll_base_module_t *module,
     data->mcb_barrier_control_me = (uint32_t*)
         (base + (rank * control_size * num_barrier_buffers * 2));
     if (data->mcb_tree[rank].mcstn_parent) {
-        data->mcb_barrier_control_parent = (opal_atomic_uint32_t*)
+        data->mcb_barrier_control_parent = (uint32_t*)
             (base +
              (data->mcb_tree[rank].mcstn_parent->mcstn_id * control_size *
               num_barrier_buffers * 2));

--- a/ompi/mca/common/monitoring/common_monitoring_coll.c
+++ b/ompi/mca/common/monitoring/common_monitoring_coll.c
@@ -30,12 +30,12 @@ struct mca_monitoring_coll_data_t {
     int world_rank;
     int is_released;
     ompi_communicator_t*p_comm;
-    opal_atomic_size_t o2a_count;
-    opal_atomic_size_t o2a_size;
-    opal_atomic_size_t a2o_count;
-    opal_atomic_size_t a2o_size;
-    opal_atomic_size_t a2a_count;
-    opal_atomic_size_t a2a_size;
+    volatile size_t o2a_count;
+    volatile size_t o2a_size;
+    volatile size_t a2o_count;
+    volatile size_t a2o_size;
+    volatile size_t a2a_count;
+    volatile size_t a2a_size;
 };
 
 /* Collectives operation monitoring */

--- a/ompi/mca/common/ompio/common_ompio_buffer.c
+++ b/ompi/mca/common/ompio/common_ompio_buffer.c
@@ -34,7 +34,7 @@ static opal_mutex_t     mca_common_ompio_buffer_mutex;      /* lock for thread s
 static mca_allocator_base_component_t* mca_common_ompio_allocator_component=NULL;
 static mca_allocator_base_module_t* mca_common_ompio_allocator=NULL;  
 
-static opal_atomic_int32_t  mca_common_ompio_buffer_init = 0;
+static volatile int32_t  mca_common_ompio_buffer_init = 0;
 static int32_t  mca_common_ompio_pagesize=4096;
 static void* mca_common_ompio_buffer_alloc_seg ( void *ctx, size_t *size );
 static void mca_common_ompio_buffer_free_seg ( void *ctx, void *buf );

--- a/ompi/mca/osc/monitoring/osc_monitoring_module.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_module.h
@@ -50,7 +50,7 @@
     OSC_MONITORING_SET_TEMPLATE_FCT_NAME(template) (ompi_osc_base_module_t*module) \
     {                                                                   \
         /* Define the ompi_osc_monitoring_module_## template ##_init_done variable */ \
-        opal_atomic_int32_t init_done = 0;                              \
+        volatile int32_t init_done = 0;                                 \
         /* Define and set the ompi_osc_monitoring_## template           \
          * ##_template variable. The functions recorded here are        \
          * linked to the original functions of the original             \

--- a/ompi/mca/osc/rdma/osc_rdma.h
+++ b/ompi/mca/osc/rdma/osc_rdma.h
@@ -271,7 +271,7 @@ struct ompi_osc_rdma_module_t {
     unsigned long get_retry_count;
 
     /** outstanding atomic operations */
-    opal_atomic_int32_t pending_ops;
+    volatile int32_t pending_ops;
 };
 typedef struct ompi_osc_rdma_module_t ompi_osc_rdma_module_t;
 OMPI_MODULE_DECLSPEC extern ompi_osc_rdma_component_t mca_osc_rdma_component;

--- a/ompi/mca/osc/rdma/osc_rdma_accumulate.c
+++ b/ompi/mca/osc/rdma/osc_rdma_accumulate.c
@@ -686,7 +686,7 @@ static void ompi_osc_rdma_cas_put_complete (struct mca_btl_base_module_t *btl, s
  *
  * This function is necessary to support compare-and-swap on types larger
  * than 64-bits. As of MPI-3.1 this can include MPI_INTEGER16 and possibly
- * MPI_LON_LONG_INT. The former is a 128-bit value and the later *may*
+ * MPI_LONG_LONG_INT. The former is a 128-bit value and the later *may*
  * be depending on the platform, compiler, etc. This function currently
  * blocks until the operation is complete.
  */

--- a/ompi/mca/osc/rdma/osc_rdma_frag.h
+++ b/ompi/mca/osc/rdma/osc_rdma_frag.h
@@ -72,7 +72,7 @@ static inline int ompi_osc_rdma_frag_alloc (ompi_osc_rdma_module_t *module, size
             }
         }
 
-        if (!opal_atomic_compare_exchange_strong_ptr ((opal_atomic_intptr_t *) &module->rdma_frag, &(intptr_t){0}, (intptr_t) curr)) {
+        if (!opal_atomic_compare_exchange_strong_ptr ((intptr_t*)&module->rdma_frag, &(intptr_t){0}, (intptr_t) curr)) {
             ompi_osc_rdma_deregister (module, curr->handle);
             curr->handle = NULL;
 

--- a/ompi/mca/osc/rdma/osc_rdma_peer.h
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.h
@@ -43,7 +43,7 @@ struct ompi_osc_rdma_peer_t {
     int rank;
 
     /** peer flags */
-    opal_atomic_int32_t flags;
+    volatile int32_t flags;
 };
 typedef struct ompi_osc_rdma_peer_t ompi_osc_rdma_peer_t;
 

--- a/ompi/mca/osc/rdma/osc_rdma_request.h
+++ b/ompi/mca/osc/rdma/osc_rdma_request.h
@@ -40,7 +40,7 @@ struct ompi_osc_rdma_request_t {
     void *origin_addr;
 
     ompi_osc_rdma_module_t *module;
-    opal_atomic_int32_t outstanding_requests;
+    volatile int32_t outstanding_requests;
     bool internal;
 
     ptrdiff_t offset;

--- a/ompi/mca/osc/rdma/osc_rdma_types.h
+++ b/ompi/mca/osc/rdma/osc_rdma_types.h
@@ -25,7 +25,7 @@ struct ompi_osc_rdma_peer_t;
 typedef int64_t osc_rdma_base_t;
 typedef int64_t osc_rdma_size_t;
 typedef int64_t osc_rdma_counter_t;
-typedef opal_atomic_int64_t osc_rdma_atomic_counter_t;
+typedef volatile int64_t osc_rdma_atomic_counter_t;
 
 #define ompi_osc_rdma_counter_add opal_atomic_add_fetch_64
 
@@ -34,7 +34,7 @@ typedef opal_atomic_int64_t osc_rdma_atomic_counter_t;
 typedef int32_t osc_rdma_base_t;
 typedef int32_t osc_rdma_size_t;
 typedef int32_t osc_rdma_counter_t;
-typedef opal_atomic_int32_t osc_rdma_atomic_counter_t;
+typedef volatile int32_t osc_rdma_atomic_counter_t;
 
 #define ompi_osc_rdma_counter_add opal_atomic_add_fetch_32
 
@@ -45,9 +45,9 @@ typedef opal_atomic_int32_t osc_rdma_atomic_counter_t;
 #define OMPI_OSC_RDMA_LOCK_EXCLUSIVE   0x8000000000000000l
 
 typedef int64_t  ompi_osc_rdma_lock_t;
-typedef opal_atomic_int64_t  ompi_osc_rdma_atomic_lock_t;
+typedef volatile int64_t  ompi_osc_rdma_atomic_lock_t;
 
-static inline int64_t ompi_osc_rdma_lock_add (opal_atomic_int64_t *p, int64_t value)
+static inline int64_t ompi_osc_rdma_lock_add (volatile int64_t *p, int64_t value)
 {
     int64_t new;
 
@@ -58,7 +58,7 @@ static inline int64_t ompi_osc_rdma_lock_add (opal_atomic_int64_t *p, int64_t va
     return new;
 }
 
-static inline int ompi_osc_rdma_lock_compare_exchange (opal_atomic_int64_t *p, int64_t *comp, int64_t value)
+static inline int ompi_osc_rdma_lock_compare_exchange (volatile int64_t *p, int64_t *comp, int64_t value)
 {
     int ret;
 
@@ -74,9 +74,9 @@ static inline int ompi_osc_rdma_lock_compare_exchange (opal_atomic_int64_t *p, i
 #define OMPI_OSC_RDMA_LOCK_EXCLUSIVE 0x80000000l
 
 typedef int32_t  ompi_osc_rdma_lock_t;
-typedef opal_atomic_int32_t  ompi_osc_rdma_atomic_lock_t;
+typedef volatile int32_t  ompi_osc_rdma_atomic_lock_t;
 
-static inline int32_t ompi_osc_rdma_lock_add (opal_atomic_int32_t *p, int32_t value)
+static inline int32_t ompi_osc_rdma_lock_add (volatile int32_t *p, int32_t value)
 {
     int32_t new;
 
@@ -88,7 +88,7 @@ static inline int32_t ompi_osc_rdma_lock_add (opal_atomic_int32_t *p, int32_t va
     return new;
 }
 
-static inline int ompi_osc_rdma_lock_compare_exchange (opal_atomic_int32_t *p, int32_t *comp, int32_t value)
+static inline int ompi_osc_rdma_lock_compare_exchange (volatile int32_t *p, int32_t *comp, int32_t value)
 {
     int ret;
 
@@ -217,11 +217,11 @@ struct ompi_osc_rdma_frag_t {
     opal_free_list_item_t super;
 
     /* Number of operations which have started writing into the frag, but not yet completed doing so */
-    opal_atomic_int32_t pending;
+    volatile int32_t pending;
 #if OPAL_HAVE_ATOMIC_MATH_64
-    opal_atomic_int64_t curr_index;
+    volatile int64_t curr_index;
 #else
-    opal_atomic_int32_t curr_index;
+    volatile int32_t curr_index;
 #endif
 
     struct ompi_osc_rdma_module_t *module;

--- a/ompi/mca/osc/sm/osc_sm.h
+++ b/ompi/mca/osc/sm/osc_sm.h
@@ -55,7 +55,7 @@ struct ompi_osc_sm_lock_t {
 typedef struct ompi_osc_sm_lock_t ompi_osc_sm_lock_t;
 
 struct ompi_osc_sm_node_state_t {
-    opal_atomic_int32_t complete_count;
+    volatile int32_t complete_count;
     ompi_osc_sm_lock_t lock;
     opal_atomic_lock_t accumulate_lock;
 };

--- a/ompi/mca/pml/base/pml_base_bsend.c
+++ b/ompi/mca/pml/base/pml_base_bsend.c
@@ -51,7 +51,7 @@ static size_t           mca_pml_bsend_size;       /* adjusted size of user buffe
 static size_t           mca_pml_bsend_count;      /* number of outstanding requests */
 static size_t           mca_pml_bsend_pagesz;     /* mmap page size */
 static int              mca_pml_bsend_pagebits;   /* number of bits in pagesz */
-static opal_atomic_int32_t          mca_pml_bsend_init = 0;
+static volatile int32_t mca_pml_bsend_init = 0;
 
 /* defined in pml_base_open.c */
 extern char *ompi_pml_base_bsend_allocator_name;

--- a/ompi/mca/pml/ob1/pml_ob1_comm.h
+++ b/ompi/mca/pml/ob1/pml_ob1_comm.h
@@ -44,7 +44,7 @@ struct mca_pml_ob1_comm_proc_t {
     opal_object_t super;
     struct ompi_proc_t* ompi_proc;
     uint16_t expected_sequence;    /**< send message sequence number - receiver side */
-    opal_atomic_int32_t send_sequence; /**< send side sequence number */
+    volatile int32_t send_sequence; /**< send side sequence number */
     struct mca_pml_ob1_recv_frag_t* frags_cant_match;  /**< out-of-order fragment queues */
 #if !MCA_PML_OB1_CUSTOM_MATCH
     opal_list_t specific_receives; /**< queues of unmatched specific receives */

--- a/ompi/mca/pml/ob1/pml_ob1_progress.c
+++ b/ompi/mca/pml/ob1/pml_ob1_progress.c
@@ -53,7 +53,7 @@ static inline int mca_pml_ob1_process_pending_cuda_async_copies(void)
 }
 #endif /* OPAL_CUDA_SUPPORT */
 
-static opal_atomic_int32_t mca_pml_ob1_progress_needed = 0;
+static volatile int32_t mca_pml_ob1_progress_needed = 0;
 int mca_pml_ob1_enable_progress(int32_t count)
 {
     int32_t progress_count = OPAL_ATOMIC_ADD_FETCH32(&mca_pml_ob1_progress_needed, count);

--- a/ompi/mca/pml/ob1/pml_ob1_rdmafrag.h
+++ b/ompi/mca/pml/ob1/pml_ob1_rdmafrag.h
@@ -47,7 +47,7 @@ struct mca_pml_ob1_rdma_frag_t {
     mca_pml_ob1_hdr_t rdma_hdr;
     mca_pml_ob1_rdma_state_t rdma_state;
     size_t rdma_length;  /* how much the fragment will transfer */
-    opal_atomic_size_t rdma_bytes_remaining;  /* how much is left to be transferred */
+    volatile size_t rdma_bytes_remaining;  /* how much is left to be transferred */
     void *rdma_req;
     uint32_t retries;
     mca_pml_ob1_rdma_frag_callback_t cbfunc;

--- a/ompi/mca/pml/ob1/pml_ob1_recvreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_recvreq.h
@@ -41,9 +41,9 @@ BEGIN_C_DECLS
 struct mca_pml_ob1_recv_request_t {
     mca_pml_base_recv_request_t req_recv;
     opal_ptr_t remote_req_send;
-    opal_atomic_int32_t  req_lock;
-    opal_atomic_int32_t  req_pipeline_depth;
-    opal_atomic_size_t   req_bytes_received;  /**< amount of data transferred into the user buffer */
+    volatile int32_t  req_lock;
+    volatile int32_t  req_pipeline_depth;
+    volatile size_t   req_bytes_received;  /**< amount of data transferred into the user buffer */
     size_t   req_bytes_expected; /**< local size of the data as suggested by the user */
     size_t   req_rdma_offset;
     size_t   req_send_offset;

--- a/ompi/mca/pml/ob1/pml_ob1_sendreq.h
+++ b/ompi/mca/pml/ob1/pml_ob1_sendreq.h
@@ -47,11 +47,11 @@ struct mca_pml_ob1_send_request_t {
     mca_pml_base_send_request_t req_send;
     mca_bml_base_endpoint_t* req_endpoint;
     opal_ptr_t req_recv;
-    opal_atomic_int32_t  req_state;
-    opal_atomic_int32_t  req_lock;
+    volatile int32_t  req_state;
+    volatile int32_t  req_lock;
     bool     req_throttle_sends;
-    opal_atomic_int32_t  req_pipeline_depth;
-    opal_atomic_size_t   req_bytes_delivered;
+    volatile int32_t  req_pipeline_depth;
+    volatile size_t   req_bytes_delivered;
     uint32_t req_rdma_cnt;
     mca_pml_ob1_send_pending_t req_pending;
     opal_mutex_t req_send_range_lock;

--- a/ompi/runtime/mpiruntime.h
+++ b/ompi/runtime/mpiruntime.h
@@ -52,7 +52,7 @@ struct ompi_predefined_datatype_t;
 /** Mutex to protect all the _init and _finalize variables */
 OMPI_DECLSPEC extern opal_mutex_t ompi_mpi_bootstrap_mutex;
 /** Did MPI start to initialize? */
-OMPI_DECLSPEC extern opal_atomic_int32_t ompi_mpi_state;
+OMPI_DECLSPEC extern volatile int32_t ompi_mpi_state;
 /** Has the RTE been initialized? */
 OMPI_DECLSPEC extern volatile bool ompi_rte_initialized;
 

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -130,7 +130,7 @@ const char ompi_version_string[] = OMPI_IDENT_STRING;
  * Global variables and symbols for the MPI layer
  */
 
-opal_atomic_int32_t ompi_mpi_state = OMPI_MPI_STATE_NOT_INITIALIZED;
+volatile int32_t ompi_mpi_state = OMPI_MPI_STATE_NOT_INITIALIZED;
 volatile bool ompi_rte_initialized = false;
 
 bool ompi_mpi_thread_multiple = false;

--- a/ompi/runtime/ompi_spc.h
+++ b/ompi/runtime/ompi_spc.h
@@ -166,7 +166,7 @@ typedef enum ompi_spc_counters {
 /* There is currently no support for atomics on long long values so we will default to
  * size_t for now until support for such atomics is implemented.
  */
-typedef opal_atomic_size_t ompi_spc_value_t;
+typedef volatile size_t ompi_spc_value_t;
 
 /* A structure for storing the event data */
 typedef struct ompi_spc_s{

--- a/opal/class/opal_interval_tree.c
+++ b/opal/class/opal_interval_tree.c
@@ -131,7 +131,7 @@ static opal_interval_tree_token_t opal_interval_tree_reader_get_token (opal_inte
         }
     }
 
-    while (!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32((opal_atomic_int32_t *) &tree->reader_epochs[token],
+    while (!OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_32(&tree->reader_epochs[token],
                                                    &(int32_t) {UINT_MAX}, tree->epoch));
 
     return token;

--- a/opal/class/opal_interval_tree.h
+++ b/opal/class/opal_interval_tree.h
@@ -84,10 +84,10 @@ struct opal_interval_tree_t {
     opal_list_t gc_list;          /**< list of nodes that need to be released */
     uint32_t epoch;               /**< current update epoch */
     opal_atomic_size_t tree_size;    /**< the current size of the tree */
-    opal_atomic_int32_t lock;        /**< update lock */
-    opal_atomic_int32_t reader_count;    /**< current highest reader slot to check */
+    volatile int32_t lock;        /**< update lock */
+    volatile int32_t reader_count;    /**< current highest reader slot to check */
     volatile uint32_t reader_id;  /**< next reader slot to check */
-    opal_atomic_uint32_t reader_epochs[OPAL_INTERVAL_TREE_MAX_READERS];
+    volatile uint32_t reader_epochs[OPAL_INTERVAL_TREE_MAX_READERS];
 };
 typedef struct opal_interval_tree_t opal_interval_tree_t;
 

--- a/opal/class/opal_lifo.h
+++ b/opal/class/opal_lifo.h
@@ -48,7 +48,7 @@ union opal_counted_pointer_t {
         /** update counter used when cmpset_128 is available */
         uint64_t counter;
         /** list item pointer */
-        volatile opal_atomic_intptr_t item;
+        volatile intptr_t item;
     } data;
 #if OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 && HAVE_OPAL_INT128_T
     /** used for atomics when there is a cmpset that can operate on

--- a/opal/class/opal_list.h
+++ b/opal/class/opal_list.h
@@ -111,7 +111,7 @@ struct opal_list_item_t
 
 #if OPAL_ENABLE_DEBUG
     /** Atomic reference count for debugging */
-    opal_atomic_int32_t opal_list_item_refcount;
+    volatile int32_t opal_list_item_refcount;
     /** The list this item belong to */
     volatile struct opal_list_t* opal_list_item_belong_to;
 #endif

--- a/opal/class/opal_object.h
+++ b/opal/class/opal_object.h
@@ -198,7 +198,7 @@ struct opal_object_t {
     uint64_t obj_magic_id;
 #endif
     opal_class_t *obj_class;            /**< class descriptor */
-    opal_atomic_int32_t obj_reference_count;   /**< reference count */
+    volatile int32_t obj_reference_count;   /**< reference count */
 #if OPAL_ENABLE_DEBUG
    const char* cls_init_file_name;        /**< In debug mode store the file where the object get contructed */
    int   cls_init_lineno;           /**< In debug mode store the line number where the object get contructed */

--- a/opal/class/opal_tree.h
+++ b/opal/class/opal_tree.h
@@ -120,7 +120,7 @@ typedef struct opal_tree_item_t
 
 #if OPAL_ENABLE_DEBUG
     /** Atomic reference count for debugging */
-    opal_atomic_int32_t opal_tree_item_refcount;
+    volatile int32_t opal_tree_item_refcount;
     /** The tree this item belong to */
     struct opal_tree_t* opal_tree_item_belong_to;
 #endif

--- a/opal/datatype/opal_datatype_unpack.c
+++ b/opal/datatype/opal_datatype_unpack.c
@@ -391,7 +391,7 @@ opal_generic_simple_unpack_function( opal_convertor_t* pConvertor,
             opal_unpack_partial_datatype( pConvertor, pElem,
                                           iov_ptr, 0, iov_len_local,
                                           &temp );
-                
+
             pConvertor->partial_length = iov_len_local;
             iov_len_local = 0;
         }

--- a/opal/include/opal_stdatomic.h
+++ b/opal/include/opal_stdatomic.h
@@ -46,6 +46,12 @@ typedef _Atomic ssize_t opal_atomic_ssize_t;
 typedef _Atomic intptr_t opal_atomic_intptr_t;
 typedef _Atomic uintptr_t opal_atomic_uintptr_t;
 
+#ifdef __INTEL_COMPILER
+typedef volatile _Bool opal_atomic_lock_t;
+#else
+typedef atomic_flag opal_atomic_lock_t;
+#endif
+
 #endif /* OPAL_HAVE_C__ATOMIC */
 
 #if HAVE_OPAL_INT128_T

--- a/opal/mca/btl/sm/btl_sm.h
+++ b/opal/mca/btl/sm/btl_sm.h
@@ -125,7 +125,7 @@ struct mca_btl_sm_component_t {
     char *my_segment;                       /**< this rank's base pointer */
     size_t segment_size;                    /**< size of my_segment */
     int32_t num_smp_procs;                  /**< current number of smp procs on this host */
-    opal_atomic_int32_t local_rank;         /**< current rank index at add_procs() time */
+    volatile int32_t local_rank;         /**< current rank index at add_procs() time */
     opal_free_list_t sm_frags_eager;     /**< free list of sm send frags */
     opal_free_list_t sm_frags_max_send;  /**< free list of sm max send frags (large fragments) */
     opal_free_list_t sm_frags_user;      /**< free list of small inline frags */

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -750,7 +750,7 @@ static void mca_btl_sm_progress_endpoints (void)
 
 static int mca_btl_sm_component_progress (void)
 {
-    static opal_atomic_int32_t lock = 0;
+    static volatile int32_t lock = 0;
     int count = 0;
 
     if (opal_using_threads()) {

--- a/opal/mca/btl/sm/btl_sm_endpoint.h
+++ b/opal/mca/btl/sm/btl_sm_endpoint.h
@@ -66,7 +66,7 @@ typedef struct mca_btl_base_endpoint_t {
 
     int32_t peer_smp_rank;  /**< my peer's SMP process rank.  Used for accessing
                              *   SMP specfic data structures. */
-    opal_atomic_size_t send_count;    /**< number of fragments sent to this peer */
+    volatile size_t send_count;    /**< number of fragments sent to this peer */
     char *segment_base;     /**< start of the peer's segment (in the address space
                              *   of this process) */
 

--- a/opal/mca/btl/sm/btl_sm_fifo.h
+++ b/opal/mca/btl/sm/btl_sm_fifo.h
@@ -31,23 +31,23 @@
 #include "btl_sm_endpoint.h"
 #include "btl_sm_frag.h"
 
-#define sm_item_compare_exchange(x, y, z) opal_atomic_compare_exchange_strong_ptr ((opal_atomic_intptr_t *) (x), (intptr_t *) (y), (intptr_t) (z))
+#define sm_item_compare_exchange(x, y, z) opal_atomic_compare_exchange_strong_ptr ((volatile intptr_t *) (x), (intptr_t *) (y), (intptr_t) (z))
 
 #if SIZEOF_VOID_P == 8
-#define sm_item_swap(x, y)      opal_atomic_swap_64((opal_atomic_int64_t *)(x), (int64_t)(y))
+#define sm_item_swap(x, y)      opal_atomic_swap_64((volatile int64_t *)(x), (int64_t)(y))
 
 #define MCA_BTL_SM_OFFSET_MASK 0xffffffffll
 #define MCA_BTL_SM_OFFSET_BITS 32
 #define MCA_BTL_SM_BITNESS     64
 #else
-#define sm_item_swap(x, y)      opal_atomic_swap_32((opal_atomic_int32_t *)(x), (int32_t)(y))
+#define sm_item_swap(x, y)      opal_atomic_swap_32((volatile int32_t *)(x), (int32_t)(y))
 
 #define MCA_BTL_SM_OFFSET_MASK 0x00ffffffl
 #define MCA_BTL_SM_OFFSET_BITS 24
 #define MCA_BTL_SM_BITNESS     32
 #endif
 
-typedef opal_atomic_intptr_t atomic_fifo_value_t;
+typedef volatile intptr_t atomic_fifo_value_t;
 typedef intptr_t fifo_value_t;
 
 #define SM_FIFO_FREE  ((fifo_value_t)-2)
@@ -70,7 +70,7 @@ typedef intptr_t fifo_value_t;
 typedef struct sm_fifo_t {
     atomic_fifo_value_t fifo_head;
     atomic_fifo_value_t fifo_tail;
-    opal_atomic_int32_t fbox_available;
+    volatile int32_t fbox_available;
 } sm_fifo_t;
 
 /* large enough to ensure the fifo is on its own cache line */

--- a/opal/mca/btl/sm/btl_sm_sc_emu.c
+++ b/opal/mca/btl/sm/btl_sm_sc_emu.c
@@ -13,7 +13,7 @@
 #include "btl_sm_frag.h"
 
 #if OPAL_HAVE_ATOMIC_MATH_64
-static void mca_btl_sm_sc_emu_atomic_64 (int64_t *operand, opal_atomic_int64_t *addr, mca_btl_base_atomic_op_t op)
+static void mca_btl_sm_sc_emu_atomic_64 (int64_t *operand, volatile int64_t *addr, mca_btl_base_atomic_op_t op)
 {
     int64_t result = 0;
 
@@ -52,7 +52,7 @@ static void mca_btl_sm_sc_emu_atomic_64 (int64_t *operand, opal_atomic_int64_t *
 #endif
 
 #if OPAL_HAVE_ATOMIC_MATH_32
-static void mca_btl_sm_sc_emu_atomic_32 (int32_t *operand, opal_atomic_int32_t *addr, mca_btl_base_atomic_op_t op)
+static void mca_btl_sm_sc_emu_atomic_32 (int32_t *operand, volatile int32_t *addr, mca_btl_base_atomic_op_t op)
 {
     int32_t result = 0;
 
@@ -123,10 +123,10 @@ static void mca_btl_sm_sc_emu_rdma (mca_btl_base_module_t *btl, mca_btl_base_tag
 #if OPAL_HAVE_ATOMIC_MATH_64
     case MCA_BTL_SM_OP_CSWAP:
         if (!(hdr->flags & MCA_BTL_ATOMIC_FLAG_32BIT)) {
-            opal_atomic_compare_exchange_strong_64 ((opal_atomic_int64_t *) hdr->addr, &hdr->operand[0], hdr->operand[1]);
+            opal_atomic_compare_exchange_strong_64 ((volatile int64_t *) hdr->addr, &hdr->operand[0], hdr->operand[1]);
 #if OPAL_HAVE_ATOMIC_MATH_32
         } else {
-            opal_atomic_compare_exchange_strong_32 ((opal_atomic_int32_t *) hdr->addr, (int32_t *) &hdr->operand[0],
+            opal_atomic_compare_exchange_strong_32 ((volatile int32_t *) hdr->addr, (int32_t *) &hdr->operand[0],
                                                     (int32_t) hdr->operand[1]);
 #else
         } else {

--- a/opal/mca/btl/smcuda/btl_smcuda.h
+++ b/opal/mca/btl/smcuda/btl_smcuda.h
@@ -159,8 +159,8 @@ struct mca_btl_smcuda_component_t {
     struct mca_btl_base_endpoint_t **sm_peers;
 
     opal_free_list_t pending_send_fl;
-    opal_atomic_int32_t num_outstanding_frags;         /**< number of fragments sent but not yet returned to free list */
-    opal_atomic_int32_t num_pending_sends;             /**< total number on all of my pending-send queues */
+    volatile int32_t num_outstanding_frags;         /**< number of fragments sent but not yet returned to free list */
+    volatile int32_t num_pending_sends;             /**< total number on all of my pending-send queues */
     int mem_node;
     int num_mem_nodes;
 

--- a/opal/mca/common/sm/common_sm.h
+++ b/opal/mca/common/sm/common_sm.h
@@ -43,13 +43,13 @@ typedef struct mca_common_sm_seg_header_t {
     /* lock to control atomic access */
     opal_atomic_lock_t seg_lock;
     /* indicates whether or not the segment is ready for use */
-    opal_atomic_int32_t seg_inited;
+    volatile int32_t seg_inited;
     /* number of local processes that are attached to the shared memory segment.
      * this is primarily used as a way of determining whether or not it is safe
      * to unlink the shared memory backing store. for example, once seg_att
      * is equal to the number of local processes, then we can safely unlink.
      */
-    opal_atomic_size_t seg_num_procs_inited;
+    volatile size_t seg_num_procs_inited;
     /* offset to next available memory location available for allocation */
     size_t seg_offset;
     /* total size of the segment */

--- a/opal/mca/mpool/hugepage/mpool_hugepage.h
+++ b/opal/mca/mpool/hugepage/mpool_hugepage.h
@@ -46,7 +46,7 @@ struct mca_mpool_hugepage_component_t {
     opal_list_t huge_pages;
     mca_mpool_hugepage_module_t *modules;
     int module_count;
-    opal_atomic_size_t bytes_allocated;
+    volatile size_t bytes_allocated;
 };
 typedef struct mca_mpool_hugepage_component_t mca_mpool_hugepage_component_t;
 
@@ -62,7 +62,7 @@ struct mca_mpool_hugepage_hugepage_t {
     /** path for mmapped files */
     char            *path;
     /** counter to help ensure unique file names for mmaped files */
-    opal_atomic_int32_t count;
+    volatile int32_t count;
     /** some platforms allow allocation of hugepages through mmap flags */
     int              mmap_flags;
 };

--- a/opal/mca/rcache/grdma/rcache_grdma_module.c
+++ b/opal/mca/rcache/grdma/rcache_grdma_module.c
@@ -187,7 +187,7 @@ static inline mca_rcache_base_registration_t *mca_rcache_grdma_remove_lru_head(m
             /* registration has been selected for removal and is no longer in the LRU. mark it
              * as such. */
             new_flags = (old_flags & ~MCA_RCACHE_GRDMA_REG_FLAG_IN_LRU) | MCA_RCACHE_FLAGS_INVALID;
-            if (opal_atomic_compare_exchange_strong_32((opal_atomic_int32_t*)&old_reg->flags, &old_flags, new_flags)) {
+            if (opal_atomic_compare_exchange_strong_32(&old_reg->flags, &old_flags, new_flags)) {
                 break;
             }
         } while (1);
@@ -248,7 +248,7 @@ static inline void mca_rcache_grdma_add_to_lru (mca_rcache_grdma_module_t *rcach
     opal_atomic_wmb ();
 
     /* mark this registration as being in the LRU */
-    opal_atomic_fetch_or_32 ((opal_atomic_int32_t *) &grdma_reg->flags, MCA_RCACHE_GRDMA_REG_FLAG_IN_LRU);
+    opal_atomic_fetch_or_32 (&grdma_reg->flags, MCA_RCACHE_GRDMA_REG_FLAG_IN_LRU);
 
     opal_mutex_unlock (&rcache_grdma->cache->vma_module->vma_lock);
 }
@@ -294,7 +294,7 @@ static int mca_rcache_grdma_check_cached (mca_rcache_base_registration_t *grdma_
     }
 
     /* This segment fits fully within an existing segment. */
-    (void) opal_atomic_fetch_add_32 ((opal_atomic_int32_t *) &rcache_grdma->stat_cache_hit, 1);
+    (void) opal_atomic_fetch_add_32 (&rcache_grdma->stat_cache_hit, 1);
     OPAL_OUTPUT_VERBOSE((MCA_BASE_VERBOSE_TRACE, opal_rcache_base_framework.framework_output,
                          "returning existing registration %p. references %d", (void *) grdma_reg, ref_cnt));
     return 1;
@@ -352,7 +352,7 @@ static int mca_rcache_grdma_register (mca_rcache_base_module_t *rcache, void *ad
         /* get updated access flags */
         access_flags = find_args.access_flags;
 
-        OPAL_THREAD_ADD_FETCH32((opal_atomic_int32_t *) &rcache_grdma->stat_cache_miss, 1);
+        OPAL_THREAD_ADD_FETCH32(&rcache_grdma->stat_cache_miss, 1);
     }
 
     item = opal_free_list_get_mt (&rcache_grdma->reg_list);
@@ -478,7 +478,7 @@ typedef struct gc_add_args_t gc_add_args_t;
 static int mca_rcache_grdma_add_to_gc (mca_rcache_base_registration_t *grdma_reg)
 {
     mca_rcache_grdma_module_t *rcache_grdma = (mca_rcache_grdma_module_t *) grdma_reg->rcache;
-    uint32_t flags = opal_atomic_fetch_or_32 ((opal_atomic_int32_t *) &grdma_reg->flags, MCA_RCACHE_FLAGS_INVALID);
+    uint32_t flags = opal_atomic_fetch_or_32 (&grdma_reg->flags, MCA_RCACHE_FLAGS_INVALID);
 
     if ((flags & MCA_RCACHE_FLAGS_INVALID) || 0 != grdma_reg->ref_count) {
         /* nothing to do */

--- a/opal/mca/rcache/rcache.h
+++ b/opal/mca/rcache/rcache.h
@@ -92,9 +92,9 @@ struct mca_rcache_base_registration_t {
     /** artifact of old mpool/rcache architecture. used by cuda code */
     unsigned char *alloc_base;
     /** number of outstanding references */
-    opal_atomic_int32_t ref_count;
+    volatile int32_t ref_count;
     /** registration flags */
-    opal_atomic_uint32_t flags;
+    volatile uint32_t flags;
     /** internal rcache context */
     void *rcache_context;
 #if OPAL_CUDA_GDR_SUPPORT

--- a/opal/mca/threads/argobots/threads_argobots_wait_sync.c
+++ b/opal/mca/threads/argobots/threads_argobots_wait_sync.c
@@ -21,7 +21,7 @@
 static opal_mutex_t wait_sync_lock = OPAL_MUTEX_STATIC_INIT;
 static ompi_wait_sync_t *wait_sync_list = NULL;
 
-static opal_atomic_int32_t num_thread_in_progress = 0;
+static volatile int32_t num_thread_in_progress = 0;
 
 #define WAIT_SYNC_PASS_OWNERSHIP(who)                  \
     do {                                               \

--- a/opal/mca/threads/pthreads/threads_pthreads_wait_sync.c
+++ b/opal/mca/threads/pthreads/threads_pthreads_wait_sync.c
@@ -20,7 +20,7 @@
 static opal_mutex_t wait_sync_lock = OPAL_MUTEX_STATIC_INIT;
 static ompi_wait_sync_t *wait_sync_list = NULL;
 
-static opal_atomic_int32_t num_thread_in_progress = 0;
+static volatile int32_t num_thread_in_progress = 0;
 
 #define WAIT_SYNC_PASS_OWNERSHIP(who)           \
     do {                                        \

--- a/opal/mca/threads/pthreads/threads_pthreads_wait_sync.h
+++ b/opal/mca/threads/pthreads/threads_pthreads_wait_sync.h
@@ -28,7 +28,7 @@
 #define OPAL_MCA_THREADS_PTHREADS_THREADS_PTHREADS_WAIT_SYNC_H
 
 typedef struct ompi_wait_sync_t {
-    opal_atomic_int32_t count;
+    volatile int32_t count;
     int32_t status;
     pthread_cond_t condition;
     pthread_mutex_t lock;

--- a/opal/mca/threads/thread_usage.h
+++ b/opal/mca/threads/thread_usage.h
@@ -97,7 +97,7 @@ static inline bool opal_set_using_threads(bool have)
 
 #define OPAL_THREAD_DEFINE_ATOMIC_OP(type, name, operator, suffix)          \
 static inline type opal_thread_ ## name ## _fetch_ ## suffix                \
-        (opal_atomic_ ## type *addr, type delta)                            \
+        (volatile type *addr, type delta)                            \
 {                                                                           \
     if (OPAL_UNLIKELY(opal_using_threads())) {                              \
         return opal_atomic_ ## name ## _fetch_ ## suffix (addr, delta);     \
@@ -108,7 +108,7 @@ static inline type opal_thread_ ## name ## _fetch_ ## suffix                \
 }                                                                           \
                                                                             \
 static inline type opal_thread_fetch_ ## name ## _ ## suffix                \
-        (opal_atomic_ ## type *addr, type delta)                            \
+        (volatile type *addr, type delta)                            \
 {                                                                           \
     if (OPAL_UNLIKELY(opal_using_threads())) {                              \
         return opal_atomic_fetch_ ## name ## _ ## suffix (addr, delta);     \
@@ -119,13 +119,13 @@ static inline type opal_thread_fetch_ ## name ## _ ## suffix                \
     return old;                                                             \
 }
 
-#define OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(type, addr_type, suffix) \
+#define OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(type, suffix)            \
 static inline bool opal_thread_compare_exchange_strong_ ## suffix           \
-        (opal_atomic_ ## addr_type *addr, type *compare, type value)        \
+        (volatile type *addr, type *compare, type value)             \
 {                                                                           \
     if (OPAL_UNLIKELY(opal_using_threads())) {                              \
         return opal_atomic_compare_exchange_strong_ ## suffix               \
-                (addr, (addr_type *)compare, (addr_type)value);             \
+                (addr, compare, value);                                     \
     }                                                                       \
                                                                             \
     if ((type) *addr == *compare) {                                         \
@@ -138,13 +138,13 @@ static inline bool opal_thread_compare_exchange_strong_ ## suffix           \
     return false;                                                           \
 }
 
-#define OPAL_THREAD_DEFINE_ATOMIC_SWAP(type, addr_type, suffix)             \
+#define OPAL_THREAD_DEFINE_ATOMIC_SWAP(type, suffix)                        \
 static inline type opal_thread_swap_ ## suffix                              \
-        (opal_atomic_ ## addr_type *ptr, type newvalue)                     \
+        (volatile type *ptr, type newvalue)                          \
 {                                                                           \
     if (opal_using_threads ()) {                                            \
         return (type) opal_atomic_swap_ ## suffix                           \
-                (ptr, (addr_type) newvalue);                                \
+                (ptr, newvalue);                                            \
     }                                                                       \
                                                                             \
     type old = ((type *)ptr)[0];                                            \
@@ -161,10 +161,10 @@ OPAL_THREAD_DEFINE_ATOMIC_OP(int32_t, xor, ^, 32)
 OPAL_THREAD_DEFINE_ATOMIC_OP(int32_t, sub, -, 32)
 OPAL_THREAD_DEFINE_ATOMIC_OP(size_t, sub, -, size_t)
 
-OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int32_t, int32_t, 32)
-OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(intptr_t, intptr_t, ptr)
-OPAL_THREAD_DEFINE_ATOMIC_SWAP(int32_t, int32_t, 32)
-OPAL_THREAD_DEFINE_ATOMIC_SWAP(intptr_t, intptr_t, ptr)
+OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(intptr_t, ptr)
+OPAL_THREAD_DEFINE_ATOMIC_SWAP(int32_t, 32)
+OPAL_THREAD_DEFINE_ATOMIC_SWAP(intptr_t, ptr)
 
 #define OPAL_THREAD_ADD_FETCH32 opal_thread_add_fetch_32
 #define OPAL_ATOMIC_ADD_FETCH32 opal_thread_add_fetch_32
@@ -208,7 +208,7 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(intptr_t, intptr_t, ptr)
     opal_thread_compare_exchange_strong_32
 
 #define OPAL_THREAD_COMPARE_EXCHANGE_STRONG_PTR(x, y, z) \
-    opal_thread_compare_exchange_strong_ptr ((opal_atomic_intptr_t *) x, \
+    opal_thread_compare_exchange_strong_ptr ((volatile intptr_t *) x, \
                                              (intptr_t *) y, (intptr_t) z)
 #define OPAL_ATOMIC_COMPARE_EXCHANGE_STRONG_PTR \
         OPAL_THREAD_COMPARE_EXCHANGE_STRONG_PTR
@@ -217,7 +217,7 @@ OPAL_THREAD_DEFINE_ATOMIC_SWAP(intptr_t, intptr_t, ptr)
 #define OPAL_ATOMIC_SWAP_32 opal_thread_swap_32
 
 #define OPAL_THREAD_SWAP_PTR(x, y) \
-    opal_thread_swap_ptr ((opal_atomic_intptr_t *) x, (intptr_t) y)
+    opal_thread_swap_ptr ((volatile intptr_t *) x, (intptr_t) y)
 #define OPAL_ATOMIC_SWAP_PTR OPAL_THREAD_SWAP_PTR
 
 /* define 64-bit macros is 64-bit atomic math is available */
@@ -228,8 +228,8 @@ OPAL_THREAD_DEFINE_ATOMIC_OP(int64_t, and, &, 64)
 OPAL_THREAD_DEFINE_ATOMIC_OP(int64_t, or, |, 64)
 OPAL_THREAD_DEFINE_ATOMIC_OP(int64_t, xor, ^, 64)
 OPAL_THREAD_DEFINE_ATOMIC_OP(int64_t, sub, -, 64)
-OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int64_t, int64_t, 64)
-OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_COMPARE_EXCHANGE(int64_t, 64)
+OPAL_THREAD_DEFINE_ATOMIC_SWAP(int64_t, 64)
 
 #define OPAL_THREAD_ADD_FETCH64 opal_thread_add_fetch_64
 #define OPAL_ATOMIC_ADD_FETCH64 opal_thread_add_fetch_64

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -80,7 +80,7 @@ static int32_t event_progress_delta = 0;
 #endif
 /* users of the event library from MPI cause the tick rate to
    be every time */
-static opal_atomic_int32_t num_event_users = 0;
+static volatile int32_t num_event_users = 0;
 
 #if OPAL_ENABLE_DEBUG
 static int debug_output = -1;
@@ -171,7 +171,7 @@ opal_progress_init(void)
 
 static int opal_progress_events(void)
 {
-    static opal_atomic_int32_t lock = 0;
+    static volatile int32_t lock = 0;
     int events = 0;
 
     if( opal_progress_event_flag != 0 && !OPAL_THREAD_SWAP_32(&lock, 1) ) {


### PR DESCRIPTION
The root of the issue is the the Intel compiler makes a strong distinction between _Atomic and volatile variables, in the sense that these two qualified are conflicting. According to the C11 standard this should be correct, except that atomic operations can be applied to _Atomic variables (they should be inherently volatile).

This is a potential path to fix this issue.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>