### PR TITLE
Second take on fixing the Intel _Atomic atomic operation warning

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -151,7 +151,7 @@ AC_DEFUN([OPAL_SETUP_CC],[
     AC_REQUIRE([_OPAL_PROG_CC])
     AC_REQUIRE([AM_PROG_CC_C_O])
 
-    OPAL_VAR_SCOPE_PUSH([opal_prog_cc_c11_helper__Thread_local_available opal_prog_cc_c11_helper_atomic_var_available opal_prog_cc_c11_helper__Atomic_available opal_prog_cc_c11_helper__static_assert_available opal_prog_cc_c11_helper__Generic_available opal_prog_cc__thread_available opal_prog_cc_c11_helper_atomic_fetch_xor_explicit_available])
+    OPAL_VAR_SCOPE_PUSH([opal_prog_cc_c11_helper__Thread_local_available opal_prog_cc_c11_helper_atomic_var_available opal_prog_cc_c11_helper__Atomic_available opal_prog_cc_c11_helper__static_assert_available opal_prog_cc_c11_helper__Generic_available opal_prog_cc__thread_available opal_prog_cc_c11_helper_atomic_fetch_xor_explicit_available opal_prog_cc_c11_helper_proper__Atomic_support_in_atomics])
 
     # AC_PROG_CC_C99 changes CC (instead of CFLAGS) so save CC (without c99
     # flags) for use in our wrappers.
@@ -228,6 +228,20 @@ AC_DEFUN([OPAL_SETUP_CC],[
 # undef _GNU_SOURCE
 #endif])
            AC_DEFINE([_GNU_SOURCE])])
+
+    AS_IF([test "$opal_cv_c_compiler_vendor" = "intel"],
+          [OPAL_CC_HELPER([if $CC is Intel < 20200310 (lacks proper support for atomic operations on _Atomic variables)], [opal_prog_cc_c11_helper_proper__Atomic_support_in_atomics],
+                          [],[[
+                   #ifdef __INTEL_COMPILER
+                   #if __INTEL_COMPILER_BUILD_DATE <= 20200310
+                   #error Lacks support for proper atomic operations on _Atomic variables.
+                   #endif  /* __INTEL_COMPILER_BUILD_DATE <= 20200310 */
+                   #endif  /* __INTEL_COMPILER */
+                             ]])],
+          [opal_prog_cc_c11_helper_proper__Atomic_support_in_atomics=1])
+
+    AC_DEFINE_UNQUOTED([OPAL_C_HAVE_ATOMIC_SUPPORT_FOR__ATOMIC], [$opal_prog_cc_c11_helper_proper__Atomic_support_in_atomics],
+                       [Whether C compiler supports atomic operations on _Atomic variables without warnings])
 
     # Do we want code coverage
     if test "$WANT_COVERAGE" = "1"; then

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -59,7 +59,7 @@
 #include "opal/sys/architecture.h"
 #include "opal_stdatomic.h"
 
-#if OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_C11
+#if OPAL_ASSEMBLY_BUILTIN == OPAL_BUILTIN_C11 && !defined(__INTEL_COMPILER)
 
 #include "atomic_stdc.h"
 

--- a/opal/include/opal_stdatomic.h
+++ b/opal/include/opal_stdatomic.h
@@ -14,7 +14,7 @@
 
 #include "opal_stdint.h"
 
-#if OPAL_ASSEMBLY_BUILTIN != OPAL_BUILTIN_C11
+#if (OPAL_ASSEMBLY_BUILTIN != OPAL_BUILTIN_C11) || defined(__INTEL_COMPILER)
 
 typedef volatile int opal_atomic_int_t;
 typedef volatile long opal_atomic_long_t;
@@ -32,6 +32,12 @@ typedef volatile uintptr_t opal_atomic_uintptr_t;
 #else /* OPAL_HAVE_C__ATOMIC */
 
 #include <stdatomic.h>
+
+#ifdef __INTEL_COMPILER
+#if __INTEL_COMPILER_BUILD_DATE <= 20200310
+#warning C11 _Atomic type not fully supported. The C11 atomic support should have been disabled.
+#endif
+#endif
 
 typedef atomic_int opal_atomic_int_t;
 typedef atomic_long opal_atomic_long_t;
@@ -51,7 +57,7 @@ typedef _Atomic uintptr_t opal_atomic_uintptr_t;
 #if HAVE_OPAL_INT128_T
 
 /* do not use C11 atomics for __int128 if they are not lock free */
-#if OPAL_HAVE_C11_CSWAP_INT128
+#if OPAL_HAVE_C11_CSWAP_INT128 && ! defined(__INTEL_COMPILER)
 
 typedef _Atomic opal_int128_t opal_atomic_int128_t;
 


### PR DESCRIPTION
We completely disable C11 atomic op support for _Atomic for
all Intel compiler prior to 20200310 (which is currently the
latest released), by switching to our pre-C11 atomic operations.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>