### PR TITLE
config: add support for setting the wrapper C compiler

### DIFF
--- a/config/opal_setup_cc.m4
+++ b/config/opal_setup_cc.m4
@@ -153,11 +153,6 @@ AC_DEFUN([OPAL_SETUP_CC],[
 
     OPAL_VAR_SCOPE_PUSH([opal_prog_cc_c11_helper__Thread_local_available opal_prog_cc_c11_helper_atomic_var_available opal_prog_cc_c11_helper__Atomic_available opal_prog_cc_c11_helper__static_assert_available opal_prog_cc_c11_helper__Generic_available opal_prog_cc__thread_available opal_prog_cc_c11_helper_atomic_fetch_xor_explicit_available])
 
-    # AC_PROG_CC_C99 changes CC (instead of CFLAGS) so save CC (without c99
-    # flags) for use in our wrappers.
-    WRAPPER_CC="$CC"
-    AC_SUBST([WRAPPER_CC])
-
     OPAL_PROG_CC_C11
 
     OPAL_CHECK_CC_IQUOTE

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -77,6 +77,32 @@ AC_DEFUN([OPAL_WRAPPER_FLAGS_ADD], [
 #     <flag>_prefix, configure is not.  There's no known use case for
 #     doing so, and we'd like to force the issue.
 AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
+    OPAL_VAR_SCOPE_PUSH([wrapper_cc_tmp])
+    # AC_PROG_CC_C99 changes CC (instead of CFLAGS) so this method
+    # must be called before OPAL_SETUP_CC.
+    AC_ARG_WITH([wrapper_cc],
+		[AC_HELP_STRING([--with-wrapper-cc=path],
+				[Set a different wrapper C compiler than the one used to build Open MPI])],
+		[], [with_wrapper_cc="$CC"])
+
+    AC_MSG_CHECKING([for wrapper C compiler])
+
+    if test "$with_wrapper_cc" = "yes" || test "$with_wrapper_cc" = "no" ; then
+	AC_MSG_ERROR([--with-wrapper-cc must have an argument.])
+    fi
+
+    # Get the full path to the wrapper compiler. If it doesn't exist
+    # assume that the path is not currently valid.
+    wrapper_tmp="$(type -p "$with_wrapper_cc")"
+    WRAPPER_CC="${wrapper_tmp:-$with_wrapper_cc}"
+    if test -z "$wrapper_tmp" ; then
+	AC_MSG_WARN([could not find \"$with_wrapper_cc\" in path])
+    fi
+
+    AC_MSG_RESULT([$WRAPPER_CC])
+
+    AC_SUBST([WRAPPER_CC])
+
     AC_ARG_WITH([wrapper-cflags],
                 [AC_HELP_STRING([--with-wrapper-cflags],
                                 [Extra flags to add to CFLAGS when using mpicc])])
@@ -142,6 +168,7 @@ AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
 
     AS_IF([test "$enable_wrapper_rpath" = "no" && test "$enable_wrapper_runpath" = "yes"],
           [AC_MSG_ERROR([--enable-wrapper-runpath cannot be selected with --disable-wrapper-rpath])])
+    OPAL_VAR_SCOPE_POP
 ])
 
 # OPAL_LIBTOOL_CONFIG(libtool-variable, result-variable,

--- a/configure.ac
+++ b/configure.ac
@@ -305,6 +305,8 @@ m4_ifdef([project_ompi],
 AM_ENABLE_SHARED
 AM_DISABLE_STATIC
 
+# Must be called before OPAL_SETUP_CC to get the value of CC
+# before it is modified by the C99/C11 checks.
 OPAL_SETUP_WRAPPER_INIT
 
 ##################################


### PR DESCRIPTION
This PR adds a new configure option: --with-wrapper-cc.
This option allows the user to set the compiler that will
be invoked by mpicc, shmemcc, etc. This allows the user
to build Open MPI with one compiler (a C standards compliant
compiler like clang or gcc) and have the wrapper use
another compiler (icc for example). This allows building
Open MPI with the best available compiler while still
supporting compiling Open MPI for a specific compiler
suite.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>