### PR TITLE
Fix buildrpm.sh "-r" option used for RPM options specification

### DIFF
--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -185,7 +185,7 @@ while getopts bn:omif:t:dc:r:sR:h flag; do
          ;;
       c) configure_options="$configure_options $OPTARG"
          ;;
-      r) configure_options="$rpmbuild_options $OPTARG"
+      r) rpmbuild_options="$rpmbuild_options $OPTARG"
          ;;
       R) rpmtopdir="$OPTARG"
          ;;


### PR DESCRIPTION
The "-r" option now concatenates using the rpmbuild_options
variable. The "-r" option in prior versions of buildrpm.sh
concatenated using the configure_options variable, which uses special
delineation for Autoconf options (first word of argument string is
"configure_options"). This resulted in an RPM build failure as the
Autoconf options would contain nested RPM option statements.

Signed-off-by: John K. McIver III <john.mciver.iii@gmail.com>