### PR TITLE
mpi_f08: fix Fortran-8-byte-INTEGER vs. C-4-byte-int issue

### DIFF
--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
@@ -74,8 +74,18 @@ module mpi_f08_types
       integer :: MPI_SOURCE
       integer :: MPI_TAG
       integer :: MPI_ERROR
-      integer(C_INT)    OMPI_PRIVATE :: c_cancelled
-      integer(C_SIZE_T) OMPI_PRIVATE :: c_count
+      ! The mpif.h interface uses MPI_STATUS_SIZE to know how long of
+      ! an array of INTEGERs is necessary to hold a C MPI_Status.
+      ! Effectively do the same thing here: pad out this datatype with
+      ! as many INTEGERs as there are C int's can fit in
+      ! sizeof(MPI_Status) bytes -- see MPI_Status_ctof() for an
+      ! explanation why.
+      !
+      ! This padding makes this F08 Type(MPI_Status) be the same size
+      ! as the mpif.h status (i.e., an array of MPI_STATUS_SIZE
+      ! INTEGERs), which is critical for MPI_Status_ctof() to not
+      ! overwrite memory.
+      integer OMPI_PRIVATE :: internal(MPI_STATUS_SIZE - 3)
    end type MPI_Status
 
   !


### PR DESCRIPTION
It is important to have the mpi_f08 Type(MPI_Status) be the same
length (in bytes) as the mpif.h status (which is an array of
MPI_STATUS_SIZE INTEGERs).  The reason is because MPI_Status_ctof()
basically does the following:

```
MPI_Fint *f_status = ...;
int *s = (int*) &c_status;
for i=0..sizeof(MPI_Status)/sizeof(int)
   f_status[i] = c_status[i];
```

Meaning: the Fortran status needs to be able to hold as many INTEGERs
are there are C int's that can fit in sizeof(MPI_Status) bytes.

This is because a Fortran INTEGER may be larger than a C int (e.g.,
Fortran 8 bytes vs. C 4 bytes).  Hence, the assignment on the Fortran
side will take sizeof(INTEGER) bytes for each sizeof(int) bytes in the
C MPI_Status.

This commit pads out the mpi_f08 Type(MPI_Status) with enough INTEGERs
to make it the same size as an array of MPI_TYPE_SIZE INTEGERs.
Hence, MPI_Status_ctof() will work properly, regardless of whether it
is assinging to an mpi_f08 Type(MPI_Status) or an mpif.h array of
MPI_STATUS_SIZE INTEGERs.

Thanks to @ahaichen for reporting the issue.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #7918 