### PR TITLE
oshmem/mca/sshmem: Fix build with `--enable-mem-debug`

### DIFF
--- a/oshmem/mca/memheap/base/memheap_base_alloc.c
+++ b/oshmem/mca/memheap/base/memheap_base_alloc.c
@@ -84,7 +84,7 @@ int mca_memheap_alloc_with_hint(size_t size, long hint, void** ptr)
             /* Do not fall back to default allocator since it will break the
              * symmetry between PEs
              */
-            return s->allocator->realloc(s, size, NULL, ptr);
+            return s->allocator->sa_realloc(s, size, NULL, ptr);
         }
     }
 

--- a/oshmem/mca/sshmem/sshmem_types.h
+++ b/oshmem/mca/sshmem/sshmem_types.h
@@ -124,8 +124,8 @@ typedef struct map_segment {
 } map_segment_t;
 
 struct segment_allocator {
-    int      (*realloc)(map_segment_t*, size_t newsize, void *, void **);
-    int         (*free)(map_segment_t*, void*);
+    int      (*sa_realloc)(map_segment_t*, size_t newsize, void *, void **);
+    int         (*sa_free)(map_segment_t*, void*);
 };
 
 END_C_DECLS

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
@@ -98,8 +98,8 @@ module_finalize(void)
 /* ////////////////////////////////////////////////////////////////////////// */
 
 static segment_allocator_t sshmem_ucx_allocator = {
-    .realloc = sshmem_ucx_memheap_realloc,
-    .free    = sshmem_ucx_memheap_free
+    .sa_realloc = sshmem_ucx_memheap_realloc,
+    .sa_free    = sshmem_ucx_memheap_free
 };
 
 static int

--- a/oshmem/shmem/c/shmem_free.c
+++ b/oshmem/shmem/c/shmem_free.c
@@ -62,7 +62,7 @@ static inline void _shfree(void* ptr)
     }
 
     if (s && s->allocator) {
-        rc = s->allocator->free(s, ptr);
+        rc = s->allocator->sa_free(s, ptr);
     } else {
         rc = MCA_MEMHEAP_CALL(free(ptr));
     }

--- a/oshmem/shmem/c/shmem_realloc.c
+++ b/oshmem/shmem/c/shmem_realloc.c
@@ -56,7 +56,7 @@ static inline void* _shrealloc(void *ptr, size_t size)
     }
 
     if (s && s->allocator) {
-        rc = s->allocator->realloc(s, size, ptr, &pBuff);
+        rc = s->allocator->sa_realloc(s, size, ptr, &pBuff);
     } else {
         rc = MCA_MEMHEAP_CALL(realloc(size, ptr, &pBuff));
     }


### PR DESCRIPTION
`--enable-mem-debug` `#define`s `realloc`/`free` as macros, though macros
are also matched if they appear in references to members. Rename the
members to avoid this matching.

See #6995