### PR TITLE
Shmem: rename realloc/free in segment_allocator to avoid name clash with memory debugging

### DIFF
--- a/oshmem/mca/memheap/base/memheap_base_alloc.c
+++ b/oshmem/mca/memheap/base/memheap_base_alloc.c
@@ -84,7 +84,7 @@ int mca_memheap_alloc_with_hint(size_t size, long hint, void** ptr)
             /* Do not fall back to default allocator since it will break the
              * symmetry between PEs
              */
-            return s->allocator->realloc(s, size, NULL, ptr);
+            return s->allocator->reallocate(s, size, NULL, ptr);
         }
     }
 

--- a/oshmem/mca/sshmem/sshmem_types.h
+++ b/oshmem/mca/sshmem/sshmem_types.h
@@ -124,8 +124,8 @@ typedef struct map_segment {
 } map_segment_t;
 
 struct segment_allocator {
-    int      (*realloc)(map_segment_t*, size_t newsize, void *, void **);
-    int         (*free)(map_segment_t*, void*);
+    int   (*reallocate)(map_segment_t*, size_t newsize, void *, void **);
+    int      (*release)(map_segment_t*, void*);
 };
 
 END_C_DECLS

--- a/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
+++ b/oshmem/mca/sshmem/ucx/sshmem_ucx_module.c
@@ -98,8 +98,8 @@ module_finalize(void)
 /* ////////////////////////////////////////////////////////////////////////// */
 
 static segment_allocator_t sshmem_ucx_allocator = {
-    .realloc = sshmem_ucx_memheap_realloc,
-    .free    = sshmem_ucx_memheap_free
+    .reallocate = sshmem_ucx_memheap_realloc,
+    .release    = sshmem_ucx_memheap_free
 };
 
 static int

--- a/oshmem/shmem/c/shmem_free.c
+++ b/oshmem/shmem/c/shmem_free.c
@@ -62,7 +62,7 @@ static inline void _shfree(void* ptr)
     }
 
     if (s && s->allocator) {
-        rc = s->allocator->free(s, ptr);
+        rc = s->allocator->release(s, ptr);
     } else {
         rc = MCA_MEMHEAP_CALL(free(ptr));
     }

--- a/oshmem/shmem/c/shmem_realloc.c
+++ b/oshmem/shmem/c/shmem_realloc.c
@@ -56,7 +56,7 @@ static inline void* _shrealloc(void *ptr, size_t size)
     }
 
     if (s && s->allocator) {
-        rc = s->allocator->realloc(s, size, ptr, &pBuff);
+        rc = s->allocator->reallocate(s, size, ptr, &pBuff);
     } else {
         rc = MCA_MEMHEAP_CALL(realloc(size, ptr, &pBuff));
     }


### PR DESCRIPTION
The tokens `realloc` and `free` are overridden by Open MPI's memory debugging facility, leading to build errors if enabled. This PR renames struct members in the shmem `segment_allocator` to `reallocate` and `release` to avoid the name clash.

Fixes #7925 

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>