### PR TITLE
Master: new thread-specific-data (tsd) api

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -78,7 +78,7 @@ static int _setup_proc_session_dir(char **sdir);
 #define OPAL_PRINT_NAME_ARG_NUM_BUFS    16
 
 static bool fns_init=false;
-static opal_tsd_key_t print_args_tsd_key;
+static opal_tsd_tracked_key_t print_args_tsd_key;
 static char* opal_print_args_null = "NULL";
 typedef struct {
     char *buffers[OPAL_PRINT_NAME_ARG_NUM_BUFS];
@@ -108,14 +108,12 @@ get_print_name_buffer(void)
 
     if (!fns_init) {
         /* setup the print_args function */
-        if (OPAL_SUCCESS != (ret = opal_tsd_key_create(&print_args_tsd_key, buffer_cleanup))) {
-            OPAL_ERROR_LOG(ret);
-            return NULL;
-        }
+        OBJ_CONSTRUCT(&print_args_tsd_key, opal_tsd_tracked_key_t);
+        opal_tsd_tracked_key_set_destructor(&print_args_tsd_key, buffer_cleanup);
         fns_init = true;
     }
 
-    ret = opal_tsd_get(print_args_tsd_key, (void**)&ptr);
+    ret = opal_tsd_tracked_key_get(&print_args_tsd_key, (void**)&ptr);
     if (OPAL_SUCCESS != ret) return NULL;
 
     if (NULL == ptr) {
@@ -124,7 +122,7 @@ get_print_name_buffer(void)
             ptr->buffers[i] = (char *) malloc((OPAL_PRINT_NAME_ARGS_MAX_SIZE+1) * sizeof(char));
         }
         ptr->cntr = 0;
-        ret = opal_tsd_set(print_args_tsd_key, (void*)ptr);
+        ret = opal_tsd_tracked_key_set(&print_args_tsd_key, (void*)ptr);
     }
 
     return (opal_print_args_buffers_t*) ptr;
@@ -938,6 +936,10 @@ int ompi_rte_finalize(void)
     if (NULL != opal_process_info.initial_errhandler) {
         free(opal_process_info.initial_errhandler);
         opal_process_info.initial_errhandler = NULL;
+    }
+
+    if (fns_init) {
+        OBJ_DESTRUCT(&print_args_tsd_key);
     }
 
     /* cleanup our internal nspace hack */

--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -115,7 +115,7 @@ get_print_name_buffer(void)
         fns_init = true;
     }
 
-    ret = opal_tsd_getspecific(print_args_tsd_key, (void**)&ptr);
+    ret = opal_tsd_get(print_args_tsd_key, (void**)&ptr);
     if (OPAL_SUCCESS != ret) return NULL;
 
     if (NULL == ptr) {
@@ -124,7 +124,7 @@ get_print_name_buffer(void)
             ptr->buffers[i] = (char *) malloc((OPAL_PRINT_NAME_ARGS_MAX_SIZE+1) * sizeof(char));
         }
         ptr->cntr = 0;
-        ret = opal_tsd_setspecific(print_args_tsd_key, (void*)ptr);
+        ret = opal_tsd_set(print_args_tsd_key, (void*)ptr);
     }
 
     return (opal_print_args_buffers_t*) ptr;

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -726,7 +726,7 @@ static _tlocal_table_t* _common_ucx_tls_init(opal_common_ucx_wpool_t *wpool)
         return NULL;
     }
 
-    opal_tsd_setspecific(wpool->tls_key, tls);
+    opal_tsd_set(wpool->tls_key, tls);
 
     return tls;
 }
@@ -734,7 +734,7 @@ static _tlocal_table_t* _common_ucx_tls_init(opal_common_ucx_wpool_t *wpool)
 static inline _tlocal_table_t *
 _tlocal_get_tls(opal_common_ucx_wpool_t *wpool){
     _tlocal_table_t *tls;
-    int rc = opal_tsd_getspecific(wpool->tls_key, (void**)&tls);
+    int rc = opal_tsd_get(wpool->tls_key, (void**)&tls);
 
     if (OPAL_SUCCESS != rc) {
         return NULL;
@@ -795,7 +795,7 @@ static void _common_ucx_tls_cleanup(_tlocal_table_t *tls)
         free(tls->ctx_tbl[i]);
     }
 
-    opal_tsd_setspecific(tls->wpool->tls_key, NULL);
+    opal_tsd_set(tls->wpool->tls_key, NULL);
 
     OBJ_RELEASE(tls);
     return;
@@ -1051,7 +1051,7 @@ static _tlocal_mem_t *_tlocal_add_mem(_tlocal_table_t *tls,
             calloc(1, sizeof(*tls->mem_tbl[free_idx]->mem_tls_ptr));
     tls->mem_tbl[free_idx]->mem_tls_ptr->winfo = ctx_rec->winfo;
     tls->mem_tbl[free_idx]->mem_tls_ptr->rkeys = tls->mem_tbl[free_idx]->mem->rkeys;
-    opal_tsd_setspecific(mem->mem_tls_key, tls->mem_tbl[free_idx]->mem_tls_ptr);
+    opal_tsd_set(mem->mem_tls_key, tls->mem_tbl[free_idx]->mem_tls_ptr);
 
     /* Make sure that we completed all the data structures before
      * placing the item to the list

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -201,7 +201,7 @@ opal_common_ucx_tlocal_fetch(opal_common_ucx_wpmem_t *mem, int target,
     int rc = OPAL_SUCCESS;
 
     /* First check the fast-path */
-    rc = opal_tsd_getspecific(mem->mem_tls_key, (void**)&fp);
+    rc = opal_tsd_get(mem->mem_tls_key, (void**)&fp);
     if (OPAL_SUCCESS != rc) {
         return rc;
     }
@@ -212,7 +212,7 @@ opal_common_ucx_tlocal_fetch(opal_common_ucx_wpmem_t *mem, int target,
         if (OPAL_SUCCESS != rc) {
             return rc;
         }
-        rc = opal_tsd_getspecific(mem->mem_tls_key, (void**)&fp);
+        rc = opal_tsd_get(mem->mem_tls_key, (void**)&fp);
         if (OPAL_SUCCESS != rc) {
             return rc;
         }

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -48,7 +48,7 @@ typedef struct {
 
     /* Thread-local key to allow each thread to have
      * local information assisiated with this wpool */
-    opal_tsd_key_t tls_key;
+    opal_tsd_tracked_key_t tls_key;
 
     /* Bookkeeping information */
     opal_list_t idle_workers;
@@ -107,7 +107,7 @@ typedef struct {
     /* TLS item that allows each thread to
      * store endpoints and rkey arrays
      * for faster access */
-    opal_tsd_key_t mem_tls_key;
+    opal_tsd_tracked_key_t mem_tls_key;
 } opal_common_ucx_wpmem_t;
 
 /* The structure that wraps UCP worker and holds the state that is required
@@ -201,7 +201,7 @@ opal_common_ucx_tlocal_fetch(opal_common_ucx_wpmem_t *mem, int target,
     int rc = OPAL_SUCCESS;
 
     /* First check the fast-path */
-    rc = opal_tsd_get(mem->mem_tls_key, (void**)&fp);
+    rc = opal_tsd_tracked_key_get(&mem->mem_tls_key, (void**)&fp);
     if (OPAL_SUCCESS != rc) {
         return rc;
     }
@@ -212,7 +212,7 @@ opal_common_ucx_tlocal_fetch(opal_common_ucx_wpmem_t *mem, int target,
         if (OPAL_SUCCESS != rc) {
             return rc;
         }
-        rc = opal_tsd_get(mem->mem_tls_key, (void**)&fp);
+        rc = opal_tsd_tracked_key_get(&mem->mem_tls_key, (void**)&fp);
         if (OPAL_SUCCESS != rc) {
             return rc;
         }

--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -243,11 +243,18 @@ static int opal_hwloc_base_open(mca_base_open_flag_t flags)
     return OPAL_SUCCESS;
 }
 
+static opal_tsd_tracked_key_t *print_tsd_key = NULL;
+
 static int opal_hwloc_base_close(void)
 {
     int ret;
     if (!opal_hwloc_base_inited) {
         return OPAL_SUCCESS;
+    }
+
+    if (NULL != print_tsd_key) {
+        OBJ_RELEASE(print_tsd_key);
+        print_tsd_key = NULL;
     }
 
     /* no need to close the component as it was statically opened */
@@ -277,7 +284,6 @@ static int opal_hwloc_base_close(void)
 }
 
 static bool fns_init=false;
-static opal_tsd_key_t print_tsd_key;
 char* opal_hwloc_print_null = "NULL";
 
 static void buffer_cleanup(void *value)
@@ -301,13 +307,12 @@ opal_hwloc_print_buffers_t *opal_hwloc_get_print_buffer(void)
 
     if (!fns_init) {
         /* setup the print_args function */
-        if (OPAL_SUCCESS != (ret = opal_tsd_key_create(&print_tsd_key, buffer_cleanup))) {
-            return NULL;
-        }
+        print_tsd_key = OBJ_NEW(opal_tsd_tracked_key_t);
+        opal_tsd_tracked_key_set_destructor(print_tsd_key, buffer_cleanup);
         fns_init = true;
     }
 
-    ret = opal_tsd_get(print_tsd_key, (void**)&ptr);
+    ret = opal_tsd_tracked_key_get(print_tsd_key, (void**)&ptr);
     if (OPAL_SUCCESS != ret) return NULL;
 
     if (NULL == ptr) {
@@ -316,7 +321,7 @@ opal_hwloc_print_buffers_t *opal_hwloc_get_print_buffer(void)
             ptr->buffers[i] = (char *) malloc((OPAL_HWLOC_PRINT_MAX_SIZE+1) * sizeof(char));
         }
         ptr->cntr = 0;
-        ret = opal_tsd_set(print_tsd_key, (void*)ptr);
+        ret = opal_tsd_tracked_key_set(print_tsd_key, (void*)ptr);
     }
 
     return (opal_hwloc_print_buffers_t*) ptr;

--- a/opal/mca/hwloc/base/hwloc_base_frame.c
+++ b/opal/mca/hwloc/base/hwloc_base_frame.c
@@ -307,7 +307,7 @@ opal_hwloc_print_buffers_t *opal_hwloc_get_print_buffer(void)
         fns_init = true;
     }
 
-    ret = opal_tsd_getspecific(print_tsd_key, (void**)&ptr);
+    ret = opal_tsd_get(print_tsd_key, (void**)&ptr);
     if (OPAL_SUCCESS != ret) return NULL;
 
     if (NULL == ptr) {
@@ -316,7 +316,7 @@ opal_hwloc_print_buffers_t *opal_hwloc_get_print_buffer(void)
             ptr->buffers[i] = (char *) malloc((OPAL_HWLOC_PRINT_MAX_SIZE+1) * sizeof(char));
         }
         ptr->cntr = 0;
-        ret = opal_tsd_setspecific(print_tsd_key, (void*)ptr);
+        ret = opal_tsd_set(print_tsd_key, (void*)ptr);
     }
 
     return (opal_hwloc_print_buffers_t*) ptr;

--- a/opal/mca/threads/argobots/threads_argobots_tsd.h
+++ b/opal/mca/threads/argobots/threads_argobots_tsd.h
@@ -37,14 +37,14 @@ static inline int opal_tsd_key_delete(opal_tsd_key_t key)
     return ABT_SUCCESS == ret ? OPAL_SUCCESS : OPAL_ERROR;
 }
 
-static inline int opal_tsd_setspecific(opal_tsd_key_t key, void *value)
+static inline int opal_tsd_set(opal_tsd_key_t key, void *value)
 {
     opal_threads_argobots_ensure_init();
     int ret = ABT_key_set(key, value);
     return ABT_SUCCESS == ret ? OPAL_SUCCESS : OPAL_ERROR;
 }
 
-static inline int opal_tsd_getspecific(opal_tsd_key_t key, void **valuep)
+static inline int opal_tsd_get(opal_tsd_key_t key, void **valuep)
 {
     int ret = ABT_key_get(key, valuep);
     return ABT_SUCCESS == ret ? OPAL_SUCCESS : OPAL_ERROR;

--- a/opal/mca/threads/base/Makefile.am
+++ b/opal/mca/threads/base/Makefile.am
@@ -22,4 +22,5 @@ headers += \
         base/base.h
 
 libmca_threads_la_SOURCES += \
-        base/threads_base.c
+        base/threads_base.c \
+        base/tsd.c

--- a/opal/mca/threads/base/tsd.c
+++ b/opal/mca/threads/base/tsd.c
@@ -1,0 +1,78 @@
+#include "opal/mca/threads/tsd.h"
+
+static void _tracked_destructor(void *arg) {
+    opal_tsd_list_item_t *tsd = NULL;
+    opal_tsd_tracked_key_t *key = NULL;
+    if (NULL == arg) {
+        return;
+    }
+
+    tsd = (opal_tsd_list_item_t *)arg;
+    key = tsd->tracked_key;
+  
+    opal_mutex_lock(&key->mutex);
+    opal_list_remove_item(&key->tsd_list, &tsd->super);
+    opal_mutex_unlock(&key->mutex);
+
+    if (NULL != key->user_destructor) {
+        key->user_destructor(tsd->data);
+    }
+    OBJ_RELEASE(tsd);
+}
+
+void opal_tsd_tracked_key_constructor(opal_tsd_tracked_key_t *key) {
+    OBJ_CONSTRUCT(&key->mutex, opal_mutex_t);
+    OBJ_CONSTRUCT(&key->tsd_list, opal_list_t);
+    key->user_destructor = NULL;
+    opal_tsd_key_create(&key->key, _tracked_destructor);
+}
+
+void opal_tsd_tracked_key_destructor(opal_tsd_tracked_key_t *key)
+{
+    opal_tsd_list_item_t *tsd, *next;
+
+    opal_tsd_key_delete(key->key);
+    OPAL_LIST_FOREACH_SAFE(tsd, next, &key->tsd_list, opal_tsd_list_item_t) {
+        opal_list_remove_item(&key->tsd_list, &tsd->super);
+        if (NULL != key->user_destructor) {
+            key->user_destructor(tsd->data);
+        }
+        OBJ_RELEASE(tsd);
+    }
+    OBJ_DESTRUCT(&key->mutex);
+    OBJ_DESTRUCT(&key->tsd_list);
+}
+
+int opal_tsd_tracked_key_set(opal_tsd_tracked_key_t *key, void *p)
+{
+    assert( NULL != key);
+   
+    opal_tsd_list_item_t *tsd = NULL;
+    opal_tsd_get(key->key, (void **)&tsd); 
+
+    if (NULL == tsd) {
+        tsd = OBJ_NEW(opal_tsd_list_item_t);
+        if (NULL == tsd) {
+            return OPAL_ERR_OUT_OF_RESOURCE;
+        }
+
+        opal_mutex_lock(&key->mutex);
+        opal_list_append(&key->tsd_list, &tsd->super);
+        opal_mutex_unlock(&key->mutex);
+    }
+
+    tsd->data = p;
+    tsd->tracked_key = key;
+
+    return opal_tsd_set(key->key, (void *)tsd);
+}
+
+void opal_tsd_tracked_key_set_destructor(opal_tsd_tracked_key_t *key, opal_tsd_destructor_t destructor)
+{
+    assert (NULL != key);
+    key->user_destructor = destructor;
+}
+
+OBJ_CLASS_INSTANCE(opal_tsd_list_item_t, opal_list_item_t, NULL, NULL);
+OBJ_CLASS_INSTANCE(opal_tsd_tracked_key_t, opal_object_t,
+        opal_tsd_tracked_key_constructor, opal_tsd_tracked_key_destructor);

--- a/opal/mca/threads/pthreads/threads_pthreads_module.c
+++ b/opal/mca/threads/pthreads/threads_pthreads_module.c
@@ -32,16 +32,6 @@
 #include "opal/mca/threads/threads.h"
 #include "opal/mca/threads/tsd.h"
 
-struct opal_tsd_key_value {
-    opal_tsd_key_t key;
-    opal_tsd_destructor_t destructor;
-};
-
-static opal_mutex_t opal_tsd_lock = OPAL_MUTEX_STATIC_INIT;
-static struct opal_tsd_key_value *opal_tsd_key_values = NULL;
-static int opal_tsd_key_values_count = 0;
-static int opal_tsd_key_values_size = 0;
-
 /*
  * Constructor
  */
@@ -93,45 +83,7 @@ int opal_tsd_key_create(opal_tsd_key_t *key, opal_tsd_destructor_t destructor)
 {
     int rc;
     rc = pthread_key_create(key, destructor);
-    if (0 == rc) {
-        opal_mutex_lock(&opal_tsd_lock);
-        if (opal_tsd_key_values_size <= opal_tsd_key_values_count) {
-            opal_tsd_key_values_size = opal_tsd_key_values_size == 0
-                                       ? 1 : opal_tsd_key_values_size * 2;
-            opal_tsd_key_values = (struct opal_tsd_key_value *)
-                realloc(opal_tsd_key_values, opal_tsd_key_values_size *
-                                             sizeof(struct opal_tsd_key_value));
-        }
-        opal_tsd_key_values[opal_tsd_key_values_count].key = *key;
-        opal_tsd_key_values[opal_tsd_key_values_count].destructor = destructor;
-        opal_tsd_key_values_count++;
-        opal_mutex_unlock(&opal_tsd_lock);
-    }
     return 0 == rc ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
-}
-
-int opal_tsd_keys_destruct(void)
-{
-    int i;
-    void *ptr;
-    opal_mutex_lock(&opal_tsd_lock);
-    for (i = 0; i < opal_tsd_key_values_count; i++) {
-        if (OPAL_SUCCESS ==
-            opal_tsd_getspecific(opal_tsd_key_values[i].key, &ptr)) {
-            if (NULL != opal_tsd_key_values[i].destructor) {
-                opal_tsd_key_values[i].destructor(ptr);
-                opal_tsd_setspecific(opal_tsd_key_values[i].key, NULL);
-            }
-        }
-    }
-    if (0 < opal_tsd_key_values_count) {
-        free(opal_tsd_key_values);
-        opal_tsd_key_values = NULL;
-        opal_tsd_key_values_count = 0;
-        opal_tsd_key_values_size = 0;
-    }
-    opal_mutex_unlock(&opal_tsd_lock);
-    return OPAL_SUCCESS;
 }
 
 void opal_thread_set_main(void)

--- a/opal/mca/threads/pthreads/threads_pthreads_tsd.h
+++ b/opal/mca/threads/pthreads/threads_pthreads_tsd.h
@@ -38,13 +38,13 @@ static inline int opal_tsd_key_delete(opal_tsd_key_t key)
     return 0 == ret ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
 }
 
-static inline int opal_tsd_setspecific(opal_tsd_key_t key, void *value)
+static inline int opal_tsd_set(opal_tsd_key_t key, void *value)
 {
     int ret = pthread_setspecific(key, value);
     return 0 == ret ? OPAL_SUCCESS : OPAL_ERR_IN_ERRNO;
 }
 
-static inline int opal_tsd_getspecific(opal_tsd_key_t key, void **valuep)
+static inline int opal_tsd_get(opal_tsd_key_t key, void **valuep)
 {
     *valuep = pthread_getspecific(key);
     return OPAL_SUCCESS;

--- a/opal/mca/threads/qthreads/threads_qthreads_module.c
+++ b/opal/mca/threads/qthreads/threads_qthreads_module.c
@@ -85,8 +85,3 @@ int opal_tsd_key_create(opal_tsd_key_t *key, opal_tsd_destructor_t destructor)
 {
     return OPAL_ERR_NOT_IMPLEMENTED;
 }
-
-int opal_tsd_keys_destruct(void)
-{
-    return OPAL_ERR_NOT_IMPLEMENTED;
-}

--- a/opal/mca/threads/qthreads/threads_qthreads_tsd.h
+++ b/opal/mca/threads/qthreads/threads_qthreads_tsd.h
@@ -38,12 +38,12 @@ static inline int opal_tsd_key_delete(opal_tsd_key_t key)
     return 0 == qthread_key_delete(&key) ? OPAL_SUCCESS : OPAL_ERROR;
 }
 
-static inline int opal_tsd_setspecific(opal_tsd_key_t key, void *value)
+static inline int opal_tsd_set(opal_tsd_key_t key, void *value)
 {
     return 0 == qthread_setspecific(key, value) ? OPAL_SUCCESS : OPAL_ERROR;
 }
 
-static inline int opal_tsd_getspecific(opal_tsd_key_t key, void **valuep)
+static inline int opal_tsd_get(opal_tsd_key_t key, void **valuep)
 {
     qthread_getspecific(key);
     return OPAL_SUCCESS;

--- a/opal/mca/threads/tsd.h
+++ b/opal/mca/threads/tsd.h
@@ -180,21 +180,6 @@ OPAL_DECLSPEC void opal_tsd_tracked_key_set_destructor(
 OPAL_DECLSPEC int opal_tsd_key_create(opal_tsd_key_t *key,
                                       opal_tsd_destructor_t destructor);
 
-
-/**
- * Destruct all thread-specific data keys
- *
- * Destruct all thread-specific data keys and invoke the destructor
- *
- * This should only be invoked in the main thread.
- * This is made necessary since destructors are not invoked on the
- * keys of the main thread, since there is no such thing as
- * pthread_join(main_thread)
- *
- * @retval OPAL_SUCCESS  Success
- */
-OPAL_DECLSPEC int opal_tsd_keys_destruct(void);
-
 END_C_DECLS
 
 #endif /* OPAL_MCA_THREADS_TSD_H */

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -659,7 +659,6 @@ opal_init(int* pargc, char*** pargv)
     opal_finalize_set_domain (&opal_init_domain);
 
     opal_finalize_register_cleanup_arg (mca_base_framework_close_list, opal_init_frameworks);
-    opal_finalize_register_cleanup (opal_tsd_keys_destruct);
 
     ret = mca_base_framework_open_list (opal_init_frameworks, 0);
     if (OPAL_UNLIKELY(OPAL_SUCCESS != ret)) {

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -105,7 +105,7 @@ typedef struct private_ipv4_t {
 static private_ipv4_t* private_ipv4 = NULL;
 
 #if OPAL_ENABLE_IPV6
-static opal_tsd_key_t hostname_tsd_key;
+static opal_tsd_tracked_key_t *hostname_tsd_key = NULL;
 
 
 static void
@@ -121,12 +121,12 @@ get_hostname_buffer(void)
     void *buffer;
     int ret;
 
-    ret = opal_tsd_get(hostname_tsd_key, &buffer);
+    ret = opal_tsd_tracked_key_get(hostname_tsd_key, &buffer);
     if (OPAL_SUCCESS != ret) return NULL;
 
     if (NULL == buffer) {
         buffer = (void*) malloc((NI_MAXHOST + 1) * sizeof(char));
-        ret = opal_tsd_set(hostname_tsd_key, buffer);
+        ret = opal_tsd_tracked_key_set(hostname_tsd_key, buffer);
     }
 
     return (char*) buffer;
@@ -144,6 +144,12 @@ get_hostname_buffer(void)
  */
 static void opal_net_finalize (void)
 {
+#if OPAL_ENABLE_IPV6
+    if (NULL != hostname_tsd_key) {
+        OBJ_RELEASE(hostname_tsd_key);
+        hostname_tsd_key = NULL;
+    }
+#endif
     free(private_ipv4);
     private_ipv4 = NULL;
 }
@@ -192,10 +198,10 @@ opal_net_init(void)
 
  do_local_init:
 #if OPAL_ENABLE_IPV6
-    return opal_tsd_key_create(&hostname_tsd_key, hostname_cleanup);
-#else
-    return OPAL_SUCCESS;
+    hostname_tsd_key = OBJ_NEW(opal_tsd_tracked_key_t);
+    opal_tsd_tracked_key_set_destructor(hostname_tsd_key, hostname_cleanup);
 #endif
+    return OPAL_SUCCESS;
 }
 
 /* convert a CIDR prefixlen to netmask (in network byte order) */

--- a/opal/util/net.c
+++ b/opal/util/net.c
@@ -121,12 +121,12 @@ get_hostname_buffer(void)
     void *buffer;
     int ret;
 
-    ret = opal_tsd_getspecific(hostname_tsd_key, &buffer);
+    ret = opal_tsd_get(hostname_tsd_key, &buffer);
     if (OPAL_SUCCESS != ret) return NULL;
 
     if (NULL == buffer) {
         buffer = (void*) malloc((NI_MAXHOST + 1) * sizeof(char));
-        ret = opal_tsd_setspecific(hostname_tsd_key, buffer);
+        ret = opal_tsd_set(hostname_tsd_key, buffer);
     }
 
     return (char*) buffer;


### PR DESCRIPTION
This PR adds a new opal/thread/tsd API interface that avoids storing keys in a global structure.
Instead we introduce 2 types of API:
* Low-level, close to the thread primitives
* Convenience API that keeps track of all allocated TLS’s and ensures their proper cleanup 

The user of the convenience API is responsible of calling the destruction explicitly instead of relying on MPI_Finalize (as it happens currently).

We also update/fix existing usages of the old API to retain functionality.

As is, this compiles, but hasn't been tested.
It's here to advance the discussion regarding the opal thread api changes that we're proposing.
I will be closing #7877 in favor of this PR.