### PR TITLE
In a job without a wdir, we would double reference proc_session_dir in wdir

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -726,6 +726,7 @@ int ompi_rte_init(int *pargc, char ***pargv)
     OPAL_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_PROCDIR, &OPAL_PROC_MY_NAME, &val, PMIX_STRING);
     if (OPAL_SUCCESS == rc && NULL != val) {
         opal_process_info.proc_session_dir = val;
+        val = NULL;
     } else {
         /* we need to create something */
         rc = _setup_proc_session_dir(&opal_process_info.proc_session_dir);


### PR DESCRIPTION
val from reading proc_session_dir would spillover and initialize  iinitial_wdir with the same string (hence, resulting in having wdir set to proc-session-dir,  which in turn does free the string twice during finalize). 

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>