### PR TITLE
v4.1.x: common/ofi: added address format check to fix provider selection

### DIFF
--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -172,7 +172,8 @@ check_provider_attr(struct fi_info *provider_info,
         !check_rx_attr(provider_info->rx_attr, provider->rx_attr) &&
         !check_ep_attr(provider_info->ep_attr, provider->ep_attr) &&
         !(provider_info->caps & ~(provider->caps)) &&
-        !(provider_info->mode & ~(provider->mode))) {
+        !(provider_info->mode & ~(provider->mode)) &&
+        provider_info->addr_format == provider->addr_format) {
         return 0;
     } else {
         return OPAL_ERROR;


### PR DESCRIPTION
bugfix: provider selection would not differentiate between ipv4
and ipv6 addresses which would cause some nodes to be unable
to communicate between each other. Adding a check for address
format to provider selection to ensure that all nodes use the
same address format.

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>
(cherry picked from commit 7e463713014ae58f7e78d7a5b49e9e63d62e374e)