### PR TITLE
Go back to using opal_string_copy in opal_info_get

### DIFF
--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -781,13 +781,13 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
     int have_wdir=0;
     int flag=0;
     char cwd[OPAL_PATH_MAX];
-    char host[OPAL_MAX_INFO_VAL];  /*** should define OMPI_HOST_MAX ***/
-    char init_errh[OPAL_MAX_INFO_VAL];
-    char prefix[OPAL_MAX_INFO_VAL];
-    char stdin_target[OPAL_MAX_INFO_VAL];
-    char params[OPAL_MAX_INFO_VAL];
-    char mapper[OPAL_MAX_INFO_VAL];
-    char slot_list[OPAL_MAX_INFO_VAL];
+    char host[OPAL_MAX_INFO_VAL+1];  /*** should define OMPI_HOST_MAX ***/
+    char init_errh[OPAL_MAX_INFO_VAL+1];
+    char prefix[OPAL_MAX_INFO_VAL+1];
+    char stdin_target[OPAL_MAX_INFO_VAL+1];
+    char params[OPAL_MAX_INFO_VAL+1];
+    char mapper[OPAL_MAX_INFO_VAL+1];
+    char slot_list[OPAL_MAX_INFO_VAL+1];
     uint32_t ui32;
     bool personality = false;
     char *tmp;
@@ -983,9 +983,9 @@ int ompi_dpm_spawn(int count, const char *array_of_commands[],
 
             /* non-standard keys
              * Keys that correspond to prun/mpiexec parameters
-             * do not deprecate PMIX unprefixed forms to remain identical 
+             * do not deprecate PMIX unprefixed forms to remain identical
              * to the command line parameter;
-             * Keys that are not corresponding to an mpiexec parameter are 
+             * Keys that are not corresponding to an mpiexec parameter are
              * deprecated in the non-prefixed form */
 
             /* check for 'hostfile' */

--- a/ompi/mca/common/ompio/common_ompio_file_open.c
+++ b/ompi/mca/common/ompio/common_ompio_file_open.c
@@ -415,7 +415,7 @@ int mca_common_ompio_set_file_defaults (ompio_file_t *fh)
 {
 
    if (NULL != fh) {
-       char char_stripe[MPI_MAX_INFO_VAL];
+       char char_stripe[128];
        ompi_datatype_t *types[2];
        int blocklen[2] = {1, 1};
        ptrdiff_t d[2], base;
@@ -426,7 +426,7 @@ int mca_common_ompio_set_file_defaults (ompio_file_t *fh)
        fh->f_flags = 0;
        
        fh->f_bytes_per_agg = OMPIO_MCA_GET(fh, bytes_per_agg);
-       opal_info_get (fh->f_info, "cb_buffer_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+       opal_info_get (fh->f_info, "cb_buffer_size", sizeof(char_stripe)-1, char_stripe, &flag);
        if ( flag ) {
            /* Info object trumps mca parameter value */
            sscanf ( char_stripe, "%d", &fh->f_bytes_per_agg  );

--- a/ompi/mca/common/ompio/common_ompio_file_view.c
+++ b/ompi/mca/common/ompio/common_ompio_file_view.c
@@ -200,16 +200,16 @@ int mca_common_ompio_set_view (ompio_file_t *fh,
        }
     }
 
-    char char_stripe[MPI_MAX_INFO_VAL];
+    char char_stripe[128];
     /* Check the info object set during File_open */
-    opal_info_get (fh->f_info, "cb_nodes", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (fh->f_info, "cb_nodes", sizeof(char_stripe)-1, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &num_cb_nodes );
         OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", char_stripe, "");
     }
     else {
         /* Check the info object set during file_set_view */
-        opal_info_get (info, "cb_nodes", MPI_MAX_INFO_VAL, char_stripe, &flag);
+        opal_info_get (info, "cb_nodes", sizeof(char_stripe)-1, char_stripe, &flag);
         if ( flag ) {
             sscanf ( char_stripe, "%d", &num_cb_nodes );
             OMPIO_MCA_PRINT_INFO(fh, "cb_nodes", char_stripe, "");

--- a/ompi/mca/fs/lustre/fs_lustre_file_open.c
+++ b/ompi/mca/fs/lustre/fs_lustre_file_open.c
@@ -69,19 +69,19 @@ mca_fs_lustre_file_open (struct ompi_communicator_t *comm,
     int flag;
     int fs_lustre_stripe_size = -1;
     int fs_lustre_stripe_width = -1;
-    char char_stripe[MPI_MAX_INFO_KEY];
+    char char_stripe[128];
 
     struct lov_user_md *lump=NULL;
 
     perm = mca_fs_base_get_file_perm(fh);
     amode = mca_fs_base_get_file_amode(fh->f_rank, access_mode);
 
-    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_size", sizeof(char_stripe)-1, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_size );
     }
 
-    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_width", sizeof(char_stripe)-1, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_lustre_stripe_width );
     }

--- a/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
+++ b/ompi/mca/fs/pvfs2/fs_pvfs2_file_open.c
@@ -74,7 +74,7 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
     struct ompi_datatype_t *types[2] = {&ompi_mpi_int.dt, &ompi_mpi_byte.dt};
     int lens[2] = {1, sizeof(PVFS_object_ref)};
     ptrdiff_t offsets[2];
-    char char_stripe[MPI_MAX_INFO_KEY];
+    char char_stripe[128];
     int flag;
     int fs_pvfs2_stripe_size = -1;
     int fs_pvfs2_stripe_width = -1;
@@ -109,12 +109,12 @@ mca_fs_pvfs2_file_open (struct ompi_communicator_t *comm,
        update mca_fs_pvfs2_stripe_width and mca_fs_pvfs2_stripe_size
        before calling fake_an_open() */
 
-    opal_info_get (info, "stripe_size", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_size", sizeof(char_stripe)-1, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_size );
     }
 
-    opal_info_get (info, "stripe_width", MPI_MAX_INFO_VAL, char_stripe, &flag);
+    opal_info_get (info, "stripe_width", sizeof(char_stripe)-1, char_stripe, &flag);
     if ( flag ) {
         sscanf ( char_stripe, "%d", &fs_pvfs2_stripe_width );
     }

--- a/ompi/mca/osc/portals4/osc_portals4_component.c
+++ b/ompi/mca/osc/portals4/osc_portals4_component.c
@@ -111,36 +111,21 @@ check_config_value_bool(char *key, opal_info_t *info)
 {
     char *value_string;
     int value_len, ret, flag, param;
-    const bool *flag_value;
     bool result;
 
-    ret = opal_info_get_valuelen(info, key, &value_len, &flag);
-    if (OMPI_SUCCESS != ret) goto info_not_found;
-    if (flag == 0) goto info_not_found;
-    value_len++;
+    ret = opal_info_get_bool(info, key, &result, &flag);
 
-    value_string = (char*)malloc(sizeof(char) * value_len + 1); /* Should malloc 1 char for NUL-termination */
-    if (NULL == value_string) goto info_not_found;
-
-    ret = opal_info_get(info, key, value_len, value_string, &flag);
-    if (OMPI_SUCCESS != ret) {
-        free(value_string);
-        goto info_not_found;
-    }
-    assert(flag != 0);
-    ret = opal_info_value_to_bool(value_string, &result);
-    free(value_string);
-    if (OMPI_SUCCESS != ret) goto info_not_found;
+    if (OMPI_SUCCESS != ret || !flag) goto info_not_found;
     return result;
 
  info_not_found:
     param = mca_base_var_find("ompi", "osc", "portals4", key);
     if (0 > param) return false;
 
-    ret = mca_base_var_get_value(param, &flag_value, NULL, NULL);
+    ret = mca_base_var_get_value(param, &result, NULL, NULL);
     if (OMPI_SUCCESS != ret) return false;
 
-    return flag_value[0];
+    return result;
 }
 
 
@@ -153,32 +138,17 @@ check_config_value_equal(char *key, opal_info_t *info, char *value)
     bool result = false;
 
     ret = opal_info_get_valuelen(info, key, &value_len, &flag);
-    if (OMPI_SUCCESS != ret) goto info_not_found;
-    if (flag == 0) goto info_not_found;
-    value_len++;
+    if (OMPI_SUCCESS != ret || !flag) return false;
 
-    value_string = (char*)malloc(sizeof(char) * value_len + 1); /* Should malloc 1 char for NUL-termination */
-    if (NULL == value_string) goto info_not_found;
+    value_string = (char*)malloc(sizeof(char) * (value_len + 1)); /* Should malloc 1 char for NUL-termination */
+    if (NULL == value_string) return false;
 
     ret = opal_info_get(info, key, value_len, value_string, &flag);
-    if (OMPI_SUCCESS != ret) {
-        free(value_string);
-        goto info_not_found;
+    if (OMPI_SUCCESS == ret) {
+        assert(flag != 0);
+        if (0 == strcmp(value_string, value)) result = true;
     }
-    assert(flag != 0);
-    if (0 == strcmp(value_string, value)) result = true;
     free(value_string);
-    return result;
-
- info_not_found:
-    param = mca_base_var_find("ompi", "osc", "portals4", key);
-    if (0 > param) return false;
-
-    ret = mca_base_var_get_value(param, &flag_value, NULL, NULL);
-    if (OMPI_SUCCESS != ret) return false;
-
-    if (0 == strcmp(value_string, value)) result = true;
-
     return result;
 }
 
@@ -411,6 +381,7 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
     ptl_md_t md;
     ptl_me_t me;
     char *name;
+    bool accumulate_ordering_none;
 
     if (MPI_WIN_FLAVOR_SHARED == flavor) return OMPI_ERR_NOT_SUPPORTED;
 
@@ -566,11 +537,12 @@ component_select(struct ompi_win_t *win, void **base, size_t size, int disp_unit
 
     module->opcount = 0;
     module->match_bits = module->comm->c_contextid;
-    module->atomic_max = (check_config_value_equal("accumulate_ordering", info, "none")) ?
+    accumulate_ordering_none = check_config_value_equal("accumulate_ordering", info, "none");
+    module->atomic_max = accumulate_ordering_none ?
         mca_osc_portals4_component.matching_atomic_max :
         MIN(mca_osc_portals4_component.matching_atomic_max,
             mca_osc_portals4_component.matching_atomic_ordered_size);
-    module->fetch_atomic_max = (check_config_value_equal("accumulate_ordering", info, "none")) ?
+    module->fetch_atomic_max = accumulate_ordering_none ?
         mca_osc_portals4_component.matching_fetch_atomic_max :
         MIN(mca_osc_portals4_component.matching_fetch_atomic_max,
             mca_osc_portals4_component.matching_atomic_ordered_size);

--- a/ompi/mca/sharedfp/individual/sharedfp_individual.c
+++ b/ompi/mca/sharedfp/individual/sharedfp_individual.c
@@ -76,9 +76,6 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_individual_component_file
     bool wronly_flag=false;
     bool relaxed_order_flag=false;
     opal_info_t *info;
-    int flag;
-    int valuelen;
-    char value[MPI_MAX_INFO_VAL+1];
     *priority = 0;
 
     /*test, and update priority*/
@@ -87,32 +84,33 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_individual_component_file
     amode = fh->f_amode;
     if ( amode & MPI_MODE_WRONLY || amode & MPI_MODE_RDWR ) {
         wronly_flag=true;
-	if ( mca_sharedfp_individual_verbose ) {
+        if ( mca_sharedfp_individual_verbose ) {
             opal_output(ompi_sharedfp_base_framework.framework_output,
                         "mca_sharedfp_individual_component_file_query: "
                         "MPI_MODE_WRONLY[true=%d,false=%d]=%d\n",true,false,wronly_flag);
-	}
+        }
     } else {
         wronly_flag=false;
-	if ( mca_sharedfp_individual_verbose ) {
+        if ( mca_sharedfp_individual_verbose ) {
             opal_output(ompi_sharedfp_base_framework.framework_output,
-			"mca_sharedfp_individual_component_file_query: Can not run!, "
-			"MPI_MODE_WRONLY[true=%d,false=%d]=%d\n",true,false,wronly_flag);
-	}
+                        "mca_sharedfp_individual_component_file_query: Can not run!, "
+                        "MPI_MODE_WRONLY[true=%d,false=%d]=%d\n",true,false,wronly_flag);
+        }
     }
 
     /*---------------------------------------------------------*/
     /* 2. Did the user specify MPI_INFO relaxed ordering flag? */
     info = fh->f_info;
     if ( info != &(MPI_INFO_NULL->super) ){
-        valuelen = MPI_MAX_INFO_VAL;
-        opal_info_get ( info,"OMPIO_SHAREDFP_RELAXED_ORDERING", valuelen, value, &flag);
+        int flag;
+        char value[MPI_MAX_INFO_VAL+1];
+        opal_info_get ( info,"OMPIO_SHAREDFP_RELAXED_ORDERING", sizeof(value)-1, value, &flag);
         if ( flag ) {
-           if ( mca_sharedfp_individual_verbose ) {
+            if ( mca_sharedfp_individual_verbose ) {
                 opal_output(ompi_sharedfp_base_framework.framework_output,
                         "mca_sharedfp_individual_component_file_query: "
                         "OMPIO_SHAREDFP_RELAXED_ORDERING=%s\n",value);
-	    }
+            }
             /* flag - Returns true if key defined, false if not (boolean). */
             relaxed_order_flag=true;
         }
@@ -122,17 +120,17 @@ struct mca_sharedfp_base_module_1_0_0_t * mca_sharedfp_individual_component_file
                         "mca_sharedfp_individual_component_file_query: "
                         "OMPIO_SHAREDFP_RELAXED_ORDERING MPI_Info key not set. "
                         "Set this key in order to increase this component's priority value.\n");
-	    }
-	}
+            }
+        }
     }
     else {
-	if ( mca_sharedfp_individual_verbose ) {
+        if ( mca_sharedfp_individual_verbose ) {
             opal_output(ompi_sharedfp_base_framework.framework_output,
                  "mca_sharedfp_individual_component_file_query: "
                  "OMPIO_SHAREDFP_RELAXED_ORDERING MPI_Info key not set, "
                  "got MPI_INFO_NULL. Set this key in order to increase "
                  "this component's priority value.\n");
-	}
+        }
     }
 
     /*For now, this algorithm will not run if the file is not opened write only.

--- a/ompi/mpi/c/lookup_name.c
+++ b/ompi/mpi/c/lookup_name.c
@@ -48,7 +48,7 @@ static const char FUNC_NAME[] = "MPI_Lookup_name";
 
 int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name)
 {
-    char range[OPAL_MAX_INFO_VAL];
+    char range[OPAL_MAX_INFO_VAL+1];
     int flag=0, ret;
     pmix_status_t rc;
     pmix_pdata_t pdat;

--- a/ompi/mpi/c/publish_name.c
+++ b/ompi/mpi/c/publish_name.c
@@ -49,7 +49,7 @@ int MPI_Publish_name(const char *service_name, MPI_Info info,
                      const char *port_name)
 {
     int ret;
-    char range[OPAL_MAX_INFO_VAL];
+    char range[OPAL_MAX_INFO_VAL+1];
     int flag=0;
     pmix_status_t rc;
     pmix_info_t pinfo[3];

--- a/ompi/mpi/c/unpublish_name.c
+++ b/ompi/mpi/c/unpublish_name.c
@@ -50,7 +50,7 @@ int MPI_Unpublish_name(const char *service_name, MPI_Info info,
                        const char *port_name)
 {
     int ret;
-    char range[OPAL_MAX_INFO_VAL];
+    char range[OPAL_MAX_INFO_VAL+1];
     int flag=0;
     pmix_status_t rc;
     pmix_info_t pinfo;

--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -104,9 +104,11 @@ static void opal_info_get_nolock (opal_info_t *info, const char *key, int valuel
         /*
          * We have found the element, so we can return the value
          * Set the flag and value
+         * NOTE: the interface states that "'valuelen' should be one less than
+         *       the allocated space to allow for the null terminator."
          */
         *flag = 1;
-        opal_string_copy(value, search->ie_value, valuelen);
+        opal_string_copy(value, search->ie_value, valuelen+1);
     }
 }
 
@@ -135,7 +137,7 @@ static int opal_info_set_nolock (opal_info_t *info, const char *key, const char 
             OPAL_THREAD_UNLOCK(info->i_lock);
             return OPAL_ERR_OUT_OF_RESOURCE;
         }
-        opal_string_copy (new_info->ie_key, key, OPAL_MAX_INFO_KEY);
+        opal_string_copy (new_info->ie_key, key, OPAL_MAX_INFO_KEY+1);
         new_info->ie_value = new_value;
         opal_list_append (&(info->super), (opal_list_item_t *) new_info);
     }

--- a/opal/util/info.c
+++ b/opal/util/info.c
@@ -106,13 +106,7 @@ static void opal_info_get_nolock (opal_info_t *info, const char *key, int valuel
          * Set the flag and value
          */
         *flag = 1;
-        // Note: we copy exactly (valuelen) characters, because that's
-        // what the caller asked for.  Don't use opal_string_copy()
-        // here, because that will guarantee to \0-terminate what is
-        // copied (i.e., potentially copy (valuelen-1) chars and then
-        // an additional \0).  Instead: copy over exactly (valuelen)
-        // characters, and if that's not \0-terminated, then so be it.
-        memcpy(value, search->ie_value, valuelen);
+        opal_string_copy(value, search->ie_value, valuelen);
     }
 }
 

--- a/opal/util/info.h
+++ b/opal/util/info.h
@@ -40,7 +40,7 @@
 
 struct opal_info_t {
   opal_list_t   super;
-  opal_mutex_t	*i_lock;
+  opal_mutex_t *i_lock;
 };
 
 /**
@@ -240,7 +240,7 @@ OPAL_DECLSPEC int opal_info_get_value_enum (opal_info_t *info, const char *key,
  *   @retval OPAL_SUCCESS
  *
  *   In C and C++, 'valuelen' should be one less than the allocated
- *   space to allow for for the null terminator.
+ *   space to allow for the null terminator.
  */
 OPAL_DECLSPEC int opal_info_get (opal_info_t *info, const char *key, int valuelen,
                                  char *value, int *flag);


### PR DESCRIPTION
This PR fixes the handling of info values throughout the code. In particular:

1) It reverts a "fix" introduced in https://github.com/open-mpi/ompi/commit/9b88e60fc8bcfdf8bd190770a1d51dddcd0988e3, which was meant to force `opal_info_get` to always copy the full info value but could lead to out-of-bounds reads and potentially non-terminated strings because it does not match the description of the interface in the header file. The interface expects a buffer of `valuelen+1` bytes, where `valuelen` is the maximum expected length of the info value. The info value may be shorter than that. 
2) It fixes the allocation of stack buffers in several places to include the extra byte required for the null-terminator while allowing for the full `OPAL_MAX_INFO_VAL` string length. In  ompio, I opted to limit the length of the buffer to 128B where it is clear that the info value should contain a numeric value (e.g., stripe size). If the value is larger than that it cannot be properly handled anyway. I'm happy to revert that change (the previous implementation was missing the extra byte though).
3) It fixes the info handling in the osc/portals4 component, which was too complicated and tried to read non-existing mca parameters.

The PR also fixes some whitespace issues I found (tabs and trailing spaces). I'll be happy to take them out if that is an issue.

Fixes #7961