### PR TITLE
bug fix: des->tag = hdr->frag, should be hdr->tag

### DIFF
--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -642,7 +642,7 @@ void mca_btl_sm_poll_handle_frag (mca_btl_sm_hdr_t *hdr, struct mca_btl_base_end
     const mca_btl_active_message_callback_t *reg = mca_btl_base_active_message_trigger + hdr->tag;
     mca_btl_base_segment_t segments[2] = {[0] = {.seg_addr.pval = (void *) (hdr + 1), .seg_len = hdr->len}};
     mca_btl_base_receive_descriptor_t frag = {.endpoint = endpoint, .des_segments = segments,
-                                              .des_segment_count = 1, .tag = hdr->frag,
+                                              .des_segment_count = 1, .tag = hdr->tag,
                                               .cbdata = reg->cbdata};
 
     if (hdr->flags & MCA_BTL_SM_FLAG_SINGLE_COPY) {


### PR DESCRIPTION
Small bug got introduced in pr #7913, where the des->tag gets initialized with the wrong value in the sm btl.

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>