### PR TITLE
Missing function to populate java errors_abort handler

### DIFF
--- a/ompi/mpi/java/java/Errhandler.java
+++ b/ompi/mpi/java/java/Errhandler.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2005 The University of Tennessee and The University
+ * Copyright (c) 2004-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -55,6 +55,7 @@ public final class Errhandler
 	protected long handle;
 
 	protected static native long getFatal();
+	protected static native long getAbort();
 	protected static native long getReturn();
 
 	protected Errhandler(long handle)


### PR DESCRIPTION
Corrects the following compile error when using --enable-mpi-java

```
Making all in java
make[3]: Entering directory `/home/bouteill/ompi/master.debug/ompi/mpi/java/java'
  JAVAC    MPI.class
../../../../../master/ompi/mpi/java/java/MPI.java:336: error: cannot find symbol
                ERRORS_ABORT     = new Errhandler(Errhandler.getAbort());
                                                            ^
  symbol:   method getAbort()
  location: class Errhandler
1 error
make[3]: *** [mpi/MPI.class] Error 1
```