### PR TITLE
osc/ucx: Make wpctx global

### DIFF
--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -28,6 +28,7 @@
 typedef struct ompi_osc_ucx_component {
     ompi_osc_base_component_t super;
     opal_common_ucx_wpool_t *wpool;
+    opal_common_ucx_ctx_t *wpctx;
     bool enable_mpi_threads;
     opal_free_list_t requests; /* request free list for the r* communication variants */
     bool env_initialized; /* UCX environment is initialized or not */

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -465,7 +465,6 @@ select_unlock:
     }
 
     /* Populate addr table */
-    _osc_ucx_init_lock();
     ret = opal_common_ucx_wpool_update_addr(mca_osc_ucx_component.wpool, comm_size,
                                          &exchange_len_info, &get_proc_vpid, (void *)module->comm);
     _osc_ucx_init_unlock();

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -467,7 +467,6 @@ select_unlock:
     /* Populate addr table */
     ret = opal_common_ucx_wpool_update_addr(mca_osc_ucx_component.wpool, comm_size,
                                          &exchange_len_info, &get_proc_vpid, (void *)module->comm);
-    _osc_ucx_init_unlock();
     if (ret != OMPI_SUCCESS) {
         goto error;
     }

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -808,7 +808,7 @@ opal_common_ucx_tlocal_fetch_spath(opal_common_ucx_wpmem_t *mem, int target)
     /* Obtain the rkey */
     if (OPAL_UNLIKELY(NULL == mem_rec->rkeys[target])) {
         /* Create the rkey */
-        rc = _tlocal_mem_create_rkey(mem_rec, ep, target, proc_vpid);
+        rc = _tlocal_mem_create_rkey(mem_rec, ep, target);
         if (rc) {
             return rc;
         }

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -333,7 +333,6 @@ opal_common_ucx_wpool_progress(opal_common_ucx_wpool_t *wpool)
             ucp_worker_progress(wpool->dflt_worker);
         }
     }
-    opal_mutex_unlock(&wpool->mutex);
     return completed;
 }
 

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -676,7 +676,6 @@ static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ct
     opal_common_ucx_ctx_t   *gctx  = ctx_rec->gctx;
     opal_common_ucx_wpool_t *wpool = gctx->wpool;
     ucs_status_t status;
-    unsigned int proc_vpid;
 
     memset(&ep_params, 0, sizeof(ucp_ep_params_t));
     ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -795,7 +795,7 @@ opal_common_ucx_tlocal_fetch_spath(opal_common_ucx_wpmem_t *mem, int target)
 
     /* Obtain the endpoint */
     if (OPAL_UNLIKELY(NULL == winfo->endpoints[proc_vpid])) {
-        rc = _tlocal_ctx_connect(mem, ctx_rec, target);
+        rc = _tlocal_ctx_connect(mem, ctx_rec, proc_vpid);
         if (rc != OPAL_SUCCESS) {
             return rc;
         }

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -669,7 +669,7 @@ error1:
     return NULL;
 }
 
-static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ctx_rec, int target)
+static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ctx_rec, unsigned int proc_vpid)
 {
     ucp_ep_params_t ep_params;
     opal_common_ucx_winfo_t *winfo = ctx_rec->winfo;

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -170,15 +170,9 @@ opal_common_ucx_wpool_update_addr(opal_common_ucx_wpool_t *wpool, size_t comm_si
         curr_addr=(curr_addr+recv_worker_lens[i]);
     }
 
-    if (NULL != recv_worker_addrs) {
-        free(recv_worker_addrs);
-    }
-    if (NULL != recv_worker_displs) {
-        free(recv_worker_displs);
-    }
-    if (NULL != recv_worker_lens) {
-        free(recv_worker_lens);
-    }
+    free(recv_worker_addrs);
+    free(recv_worker_displs);
+    free(recv_worker_lens);
     return ret;
 }
 

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -332,6 +332,7 @@ opal_common_ucx_wpool_progress(opal_common_ucx_wpool_t *wpool)
         if (!active_workers && opal_list_get_size(&wpool->idle_workers)) {
             ucp_worker_progress(wpool->dflt_worker);
         }
+        opal_mutex_unlock(&wpool->mutex);
     }
     return completed;
 }

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -757,7 +757,7 @@ static _mem_record_t *_tlocal_add_mem_rec(opal_common_ucx_wpmem_t *mem, _ctx_rec
 }
 
 static int
-_tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int target, int proc_vpid)
+_tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int target)
 {
     opal_common_ucx_wpmem_t *gmem = mem_rec->gmem;
     int displ = gmem->mem_displs[target];

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -683,8 +683,6 @@ static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ct
 
     opal_mutex_lock(&winfo->mutex);
     
-    proc_vpid = gctx->get_proc_vpid_func(wpmem->metadata, target);
-
     ep_params.address = (ucp_address_t *)wpool->recv_worker_addrs[proc_vpid];
     status = ucp_ep_create(winfo->worker, &ep_params, &winfo->endpoints[proc_vpid]);
     if (status != UCS_OK) {

--- a/opal/mca/common/ucx/common_ucx_wpool.h
+++ b/opal/mca/common/ucx/common_ucx_wpool.h
@@ -223,8 +223,6 @@ opal_common_ucx_tlocal_fetch(opal_common_ucx_wpmem_t *mem, int target,
                                 ucp_ep_h *_ep, ucp_rkey_h *_rkey,
                                 opal_common_ucx_winfo_t **_winfo)
 {
-    static unsigned long ucx_tlocal_fetch = 0;
-    ucx_tlocal_fetch++;
     _mem_record_t *mem_rec = NULL;
     int is_ready;
     int rc = OPAL_SUCCESS;

--- a/opal/mca/common/ucx/common_ucx_wpool_int.h
+++ b/opal/mca/common/ucx/common_ucx_wpool_int.h
@@ -5,8 +5,8 @@
 #include "common_ucx.h"
 #include "common_ucx_wpool.h"
 
-static int _tlocal_ctx_connect(_ctx_record_t *ctx_rec, int target);
-static int _tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int target);
+static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ctx_rec, int target);
+static int _tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int target, int proc_vpid);
 
 /* Sorted declarations */
 

--- a/opal/mca/common/ucx/common_ucx_wpool_int.h
+++ b/opal/mca/common/ucx/common_ucx_wpool_int.h
@@ -5,7 +5,7 @@
 #include "common_ucx.h"
 #include "common_ucx_wpool.h"
 
-static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ctx_rec, int target);
+static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ctx_rec, unsigned int proc_vpid);
 static int _tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int target, int proc_vpid);
 
 /* Sorted declarations */

--- a/opal/mca/common/ucx/common_ucx_wpool_int.h
+++ b/opal/mca/common/ucx/common_ucx_wpool_int.h
@@ -6,7 +6,7 @@
 #include "common_ucx_wpool.h"
 
 static int _tlocal_ctx_connect(opal_common_ucx_wpmem_t *wpmem, _ctx_record_t *ctx_rec, unsigned int proc_vpid);
-static int _tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int target, int proc_vpid);
+static int _tlocal_mem_create_rkey(_mem_record_t *mem_rec, ucp_ep_h ep, int target);
 
 /* Sorted declarations */
 


### PR DESCRIPTION
Further resource optimizations:
wpctx struct and ucx worker address table is global.
Add necessary functionality to support world_comm rank translation:

Co-authored-by: Artem Y. Polyakov <artemp@mellanox.com>

Signed-off-by: Tomislav Janjusic <tomislavj@mellanox.com>