### PR TITLE
v4.1.x: btl/ofi: Use common provider include/exclude list

### DIFF
--- a/ompi/mca/mtl/ofi/mtl_ofi_component.c
+++ b/ompi/mca/mtl/ofi/mtl_ofi_component.c
@@ -306,26 +306,6 @@ ompi_mtl_ofi_progress_no_inline(void)
 	return ompi_mtl_ofi_progress();
 }
 
-static int
-is_in_list(char **list, char *item)
-{
-    int i = 0;
-
-    if ((NULL == list) || (NULL == item)) {
-        return 0;
-    }
-
-    while (NULL != list[i]) {
-        if (0 == strncasecmp(item, list[i], strlen(list[i]))) {
-            return 1;
-        } else {
-            i++;
-        }
-    }
-
-    return 0;
-}
-
 static struct fi_info*
 select_ofi_provider(struct fi_info *providers,
                     char **include_list, char **exclude_list)
@@ -334,7 +314,7 @@ select_ofi_provider(struct fi_info *providers,
 
     if (NULL != include_list) {
         while ((NULL != prov) &&
-               (!is_in_list(include_list, prov->fabric_attr->prov_name))) {
+               (!opal_common_ofi_is_in_list(include_list, prov->fabric_attr->prov_name))) {
             opal_output_verbose(1, opal_common_ofi.output,
                                 "%s:%d: mtl:ofi: \"%s\" not in include list\n",
                                 __FILE__, __LINE__,
@@ -343,7 +323,7 @@ select_ofi_provider(struct fi_info *providers,
         }
     } else if (NULL != exclude_list) {
         while ((NULL != prov) &&
-               (is_in_list(exclude_list, prov->fabric_attr->prov_name))) {
+               (opal_common_ofi_is_in_list(exclude_list, prov->fabric_attr->prov_name))) {
             opal_output_verbose(1, opal_common_ofi.output,
                                 "%s:%d: mtl:ofi: \"%s\" in exclude list\n",
                                 __FILE__, __LINE__,
@@ -733,8 +713,8 @@ ompi_mtl_ofi_component_init(bool enable_progress_threads,
      * this logic if the user specifies an include list without EFA or adds EFA
      * to the exclude list.
      */
-    if ((include_list && is_in_list(include_list, "efa")) ||
-        (exclude_list && !is_in_list(exclude_list, "efa"))) {
+    if ((include_list && opal_common_ofi_is_in_list(include_list, "efa")) ||
+        (exclude_list && !opal_common_ofi_is_in_list(exclude_list, "efa"))) {
         hints_dup = fi_dupinfo(hints);
         hints_dup->caps &= ~(FI_LOCAL_COMM | FI_REMOTE_COMM);
         hints_dup->fabric_attr->prov_name = strdup("efa");

--- a/opal/mca/common/ofi/common_ofi.c
+++ b/opal/mca/common/ofi/common_ofi.c
@@ -33,6 +33,25 @@ OPAL_DECLSPEC opal_common_ofi_module_t opal_common_ofi = {
 
 static const char default_prov_exclude_list[] = "shm,sockets,tcp,udp,rstream";
 
+OPAL_DECLSPEC int opal_common_ofi_is_in_list(char **list, char *item)
+{
+    int i = 0;
+
+    if ((NULL == list) || (NULL == item)) {
+        return 0;
+    }
+
+    while (NULL != list[i]) {
+        if (0 == strncasecmp(item, list[i], strlen(list[i]))) {
+            return 1;
+        } else {
+            i++;
+        }
+    }
+
+    return 0;
+}
+
 OPAL_DECLSPEC int opal_common_ofi_register_mca_variables(const mca_base_component_t *component)
 {
     static int registered = 0;

--- a/opal/mca/common/ofi/common_ofi.h
+++ b/opal/mca/common/ofi/common_ofi.h
@@ -38,6 +38,21 @@ OPAL_DECLSPEC void opal_common_ofi_mca_register(void);
 OPAL_DECLSPEC void opal_common_ofi_mca_deregister(void);
 OPAL_DECLSPEC struct fi_info* opal_common_ofi_select_ofi_provider(struct fi_info *providers, 
                                                                   char *framework_name);
+/*
+ * @param list (IN)    List of strings corresponding to lower providers.
+ * @param item (IN)    Single string corresponding to a provider.
+ *
+ * @return 0           The lower provider of the item string is not in
+ *                     list or an input was NULL
+ * @return 1           The lower provider of the item string matches
+ *                     a string in the item list.
+ *
+ * This function will take a provider name string and a list of lower
+ * provider name strings as inputs. It will return true if the lower
+ * provider in the item string matches a lower provider in the list.
+ *
+ */
+OPAL_DECLSPEC int opal_common_ofi_is_in_list(char **list, char *item);
 
 END_C_DECLS
 


### PR DESCRIPTION
The btl/ofi does not currently utilize the common ofi include/exclude
list. Added verification code similar to the mtl/ofi that will check if
the info object is in the include or exclude list. If it isn't in the
include list or is in the exclude list, validate_info will return
OPAL_ERROR. The btl/ofi will no longer pass a provider name as a hint
when calling getinfo, instead filtering the provider during
validate_info.

This patch also moves the is_in_list MTL function into common code and
adds additional debugging output to the BTL to match the MTL standard.

Signed-off-by: William Zhang <wilzhang@amazon.com>
(cherry picked from commit 9b8f463a768206a26e5b1dcea0612a403462b1d0)