### PR TITLE
v4.0.x: opal/hwloc: fix a typo in parsing locality string

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -2312,7 +2312,7 @@ char* opal_hwloc_base_get_location(char *locality,
             } else if (2 == index) {
                 srch = "L2";
             } else {
-                srch = "L0";
+                srch = "L1";
             }
             break;
 #else
@@ -2323,7 +2323,7 @@ char* opal_hwloc_base_get_location(char *locality,
             srch = "L2";
             break;
         case HWLOC_OBJ_L1CACHE:
-            srch = "L0";
+            srch = "L1";
             break;
 #endif
         case HWLOC_OBJ_CORE:


### PR DESCRIPTION
Fix a typo in parsing locality string: L0 changed to L1.

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>
(cherry picked from commit 4708458d6b12d1b7a8e11fa3c3f784c545780707)