### PR TITLE
V4.1.x btl/ofi backport disabling EFA and ofi_rxm providers

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -85,6 +85,14 @@ static int validate_info(struct fi_info *info, uint64_t required_caps,
         return OPAL_ERROR;
     }
 
+    /* ofi_rxm does not fulfill FI_DELIVERY_COMPLETE requirements. Thus we
+     * exclude it if it's detected.
+     */
+    if (strstr(info->fabric_attr->prov_name, "ofi_rxm")) {
+        BTL_VERBOSE(("ofi_rxm does not support FI_DELIVERY_COMPLETE"));
+        return OPAL_ERROR;
+    }
+
     /* we need exactly all the required bits */
     if ((info->caps & required_caps) != required_caps) {
         BTL_VERBOSE(("unsupported caps"));

--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -74,6 +74,17 @@ static int validate_info(struct fi_info *info, uint64_t required_caps,
 
     BTL_VERBOSE(("validating device: %s", info->domain_attr->name));
 
+    /* EFA does not fulfill FI_DELIVERY_COMPLETE requirements in prior libfabric
+     * versions. The prov version is set as:
+     * FI_VERSION(FI_MAJOR_VERSION * 100 + FI_MINOR_VERSION, FI_REVISION_VERSION * 10)
+     * Thus, FI_VERSION(112,0) corresponds to libfabric 1.12.0
+     */
+    if (!strncasecmp(info->fabric_attr->prov_name, "efa", 3)
+        && FI_VERSION_LT(info->fabric_attr->prov_version, FI_VERSION(112,0))) {
+        BTL_VERBOSE(("unsupported libfabric efa version"));
+        return OPAL_ERROR;
+    }
+
     /* we need exactly all the required bits */
     if ((info->caps & required_caps) != required_caps) {
         BTL_VERBOSE(("unsupported caps"));


### PR DESCRIPTION
commit 27c252e2113222dcb0035ca44a1829b8c5b06fb9
Author: William Zhang <wilzhang@amazon.com>
Date:   Tue Aug 11 13:59:26 2020 -0700

    btl/ofi: Disable ofi_rxm provider
    
    The ofi_rxm provider is dependent upon the underlying hardware for its
    implementation of FI_DELIVERY_COMPLETE. Since this can lead to early
    completions, we disable the provider to avoid correctness issues.
    
    This is not an issue in the mtl/ofi as it does not require
    FI_DELIVERY_COMPLETE.
    
    Signed-off-by: William Zhang <wilzhang@amazon.com>
    (cherry picked from commit 41acfee2bbfc5495aeeeae4b72f385ca8d1d8cee)

commit 357ac2e2f5c8ad7fa1a3dafb1f33d23b9b8918d3
Author: William Zhang <wilzhang@amazon.com>
Date:   Tue Jul 28 09:24:36 2020 -0700

    btl/ofi: Disable EFA provider in versions earlier than libfabric 1.12.0
    
    EFA incorrectly implements FI_DELIVERY_COMPLETE in earlier libfabric
    versions. While FI_DELIVERY_COMPLETE would be advertised by the
    provider, completions would return too early by not accounting for
    bounce buffers on the receive side. This would cause the BTL
    to receive early completions that lead to correctness issues.
    
    This is not an issue in the mtl/ofi as it does not require
    FI_DELIVERY_COMPLETE.
    
    Signed-off-by: William Zhang <wilzhang@amazon.com>
    (cherry picked from commit a7dcfd98742d7f44d96d74a60a38529894d4099c)