### PR TITLE
btl: remove unused descriptor flags

### DIFF
--- a/opal/mca/btl/btl.h
+++ b/opal/mca/btl/btl.h
@@ -491,11 +491,6 @@ OPAL_DECLSPEC OBJ_CLASS_DECLARATION(mca_btl_base_descriptor_t);
  */
 #define MCA_BTL_DES_FLAGS_CUDA_COPY_ASYNC   0x0008
 
-/* Type of transfer that will be done with this frag.
- */
-#define MCA_BTL_DES_FLAGS_PUT               0x0010
-#define MCA_BTL_DES_FLAGS_GET               0x0020
-
 /* Ask the BTL to wake the remote process (send/sendi) or local process
  * (put/get) to handle this message. The BTL may ignore this flag if
  * signaled operations are not supported.

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2018      Intel, Inc, All rights reserved
  *
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -169,9 +170,8 @@ void mca_btl_ofi_rcache_init (mca_btl_ofi_module_t *module)
  * @param endpoint(IN)     BTL addressing information (or NULL for all endpoints)
  * @param base (IN)        Pointer to start of region
  * @param size (IN)        Size of region
- * @param flags (IN)       Flags indicating what operation will be performed. Valid
- *                         values are MCA_BTL_DES_FLAGS_PUT, MCA_BTL_DES_FLAGS_GET,
- *                         and MCA_BTL_DES_FLAGS_ATOMIC
+ * @param flags (IN)       Flags indicating what memory access level is requested.
+ *                         See opal/mca/rcache/rcache.h for valid access flags.
  *
  * @returns a memory registration handle valid for both local and remote operations
  * @returns NULL if the region could not be registered

--- a/opal/mca/btl/template/btl_template.c
+++ b/opal/mca/btl/template/btl_template.c
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -349,9 +350,8 @@ int mca_btl_template_get (struct mca_btl_base_module_t *btl,
  * @param endpoint(IN)     BTL addressing information (or NULL for all endpoints)
  * @param base (IN)        Pointer to start of region
  * @param size (IN)        Size of region
- * @param flags (IN)       Flags indicating what operation will be performed. Valid
- *                         values are MCA_BTL_DES_FLAGS_PUT, MCA_BTL_DES_FLAGS_GET,
- *                         and MCA_BTL_DES_FLAGS_ATOMIC
+ * @param flags (IN)       Flags indicating what memory access level is requested.
+ *                         See opal/mca/rcache/rcache.h for valid access flags.
  *
  * @returns a memory registration handle valid for both local and remote operations
  * @returns NULL if the region could not be registered

--- a/opal/mca/btl/template/btl_template.h
+++ b/opal/mca/btl/template/btl_template.h
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -268,9 +269,8 @@ int mca_btl_template_get (struct mca_btl_base_module_t *btl,
  * @param endpoint(IN)     BTL addressing information (or NULL for all endpoints)
  * @param base (IN)        Pointer to start of region
  * @param size (IN)        Size of region
- * @param flags (IN)       Flags indicating what operation will be performed. Valid
- *                         values are MCA_BTL_DES_FLAGS_PUT, MCA_BTL_DES_FLAGS_GET,
- *                         and MCA_BTL_DES_FLAGS_ATOMIC
+ * @param flags (IN)       Flags indicating what memory access level is requested.
+ *                         See opal/mca/rcache/rcache.h for valid access flags.
  *
  * @returns a memory registration handle valid for both local and remote operations
  * @returns NULL if the region could not be registered

--- a/opal/mca/btl/uct/btl_uct_module.c
+++ b/opal/mca/btl/uct/btl_uct_module.c
@@ -12,6 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2018 Los Alamos National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -149,9 +150,8 @@ static int mca_btl_uct_del_procs (mca_btl_base_module_t *btl, size_t nprocs,
  * @param endpoint(IN)     BTL addressing information (or NULL for all endpoints)
  * @param base (IN)        Pointer to start of region
  * @param size (IN)        Size of region
- * @param flags (IN)       Flags indicating what operation will be performed. Valid
- *                         values are MCA_BTL_DES_FLAGS_PUT, MCA_BTL_DES_FLAGS_GET,
- *                         and MCA_BTL_DES_FLAGS_ATOMIC
+ * @param flags (IN)       Flags indicating what memory access level is requested.
+ *                         See opal/mca/rcache/rcache.h for valid access flags.
  *
  * @returns a memory registration handle valid for both local and remote operations
  * @returns NULL if the region could not be registered


### PR DESCRIPTION
This PR removes the MCA_BTL_DES_FLAGS_PUT and MCA_BTL_DES_FLAGS_GET
descriptor flags. At some point these had some meaning but they were
replaced by the rcache access flags.

Signed-off-by: Nathan Hjelm <hjelmn@google.com>