### PR TITLE
Use correct conditional variable initializer in opal/mca/pmix/base

### DIFF
--- a/opal/mca/pmix/base/base.h
+++ b/opal/mca/pmix/base/base.h
@@ -46,7 +46,7 @@ typedef struct {
 
 extern opal_pmix_base_t opal_pmix_base;
 
-#define OPAL_PMIX_CONDITION_STATIC_INIT PTHREAD_COND_INITIALIZER
+#define OPAL_PMIX_CONDITION_STATIC_INIT OPAL_CONDITION_STATIC_INIT
 
 END_C_DECLS
 


### PR DESCRIPTION
`opal_pmix_lock_t` has a member of type `opal_cond_t` so use `OPAL_CONDITION_STATIC_INIT` for static initialization instead of using `PTHREAD_COND_INITIALIZER` directly.

Signed-off-by: Joseph Schuchart <schuchart@hlrs.de>